### PR TITLE
Skip directories when collecting artifacts

### DIFF
--- a/buildbox/artifact.go
+++ b/buildbox/artifact.go
@@ -109,6 +109,12 @@ func CollectArtifacts(job *Job, artifactPaths string) (artifacts []*Artifact, er
 					return nil, err
 				}
 
+				fileInfo, err := os.Stat(absolutePath)
+				if fileInfo.IsDir() {
+					Logger.Debugf("Skipping directory %s", file)
+					continue
+				}
+
 				artifact, err := BuildArtifact(file, absolutePath, glob)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
We're frequently getting messages like:

```
2014-06-23 20:20:38 [ERROR] Error uploading artifact /opt/buildbox/builds/envato-marketplaces/marketplace/results/features (read /opt/buildbox/builds/envato-marketplaces/marketplace/results/features: is a directory)
```

And then the directories still appear in the artifacts list and can't be viewed (because they haven't been uploaded).

This skips directories during the collection phase.
