### PR TITLE
Docker and fig support

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -82,21 +82,21 @@ then
   buildbox-run "docker run --name buildbox-$BUILDBOX_JOB_ID-container buildbox-$BUILDBOX_JOB_ID-image ./$BUILDBOX_SCRIPT_PATH"
 
 ## Fig
-elif [ "$BUILDBOX_FIG_SERVICE" != "" ]
+elif [ "$BUILDBOX_FIG_CONTAINER" != "" ]
 then
   if [ ! -a "fig.yml" ]
   then
-    echo "You must have a fig.yml to use BUILDBOX_FIG_SERVICE"
+    echo "You must have a fig.yml to use BUILDBOX_FIG_CONTAINER"
     exit 1
   fi
 
   # Build the Docker images using Fig, namespaced to the job
   buildbox-run "fig -p $BUILDBOX_JOB_ID build"
 
-  echo "--- running $BUILDBOX_SCRIPT_PATH (in Fig container '$BUILDBOX_FIG_SERVICE')"
+  echo "--- running $BUILDBOX_SCRIPT_PATH (in Fig container '$BUILDBOX_FIG_CONTAINER')"
 
-  # Run the build script command in the service specified in BUILDBOX_FIG_SERVICE
-  buildbox-run "fig -p buildbox-$BUILDBOX_JOB_ID run $BUILDBOX_FIG_SERVICE ./$BUILDBOX_SCRIPT_PATH"
+  # Run the build script command in the service specified in BUILDBOX_FIG_CONTAINER
+  buildbox-run "fig -p buildbox-$BUILDBOX_JOB_ID run $BUILDBOX_FIG_CONTAINER ./$BUILDBOX_SCRIPT_PATH"
 
 ## Standard
 else
@@ -161,7 +161,7 @@ then
   buildbox-run "docker rm -f buildbox-$BUILDBOX_JOB_ID-container > /dev/null 2>&1"
   # Delete the Docker image
   buildbox-run "docker rmi buildbox-$BUILDBOX_JOB_ID-image > /dev/null 2>&1"
-elif [ "$BUILDBOX_FIG_SERVICE" != "" ]
+elif [ "$BUILDBOX_FIG_CONTAINER" != "" ]
 then
   # Kill the Fig Docker containers
   buildbox-run "fig -p buildbox-$BUILDBOX_JOB_ID kill > /dev/null 2>&1"


### PR DESCRIPTION
This adds Docker and Fig support to the bootstrap.sh
## Docker support

By setting the `BUILDBOX_DOCKER` environment variable in your build pipeline, this will automatically build and run your build scripts in a docker container, and clean up afterwards.

For example, say you had a `Dockerfile`:

```
FROM ubuntu
ADD . /app
WORKDIR /app
```

and a `script/tests` file.

Creating a build step for `./script/tests` with env variable `BUILDBOX_DOCKER=true` would cause the agent to run the `script/tests` script in a one-off Docker container.
## Fig support

By setting the `BUILDBOX_FIG_CONTAINER` environment variable in your build pipeline, this will automatically build and run your build scripts using Fig, and clean up afterwards.

For example, say you had a `fig.yml`:

```
app:
  build: .
  links:
    - db:db
db:
  image: postgres
```

and a `Dockerfile`:

```
FROM ubuntu
RUN apt-get update -qq
RUN apt-get install -y postgresql-client
ADD . /app
WORKDIR /app
```

and a `script/db_tests` file.

Creating a build step for `./script/db_tests` with env variable `BUILDBOX_FIG_CONTAINER=app` would cause the agent to run the `script/db_tests` script in a one-off "app" Fig container, with the db service linked and available to that container.
