### PR TITLE
Option to automatically accept RSA fingerprints when git cloning.

### DIFF
--- a/buildkite/agent.go
+++ b/buildkite/agent.go
@@ -26,6 +26,9 @@ type Agent struct {
 	// The path to the run the builds in
 	BuildPath string
 
+	// Whether or not the agent is allowed to run an ssh keyscan
+	SSHKeyScan bool
+
 	// Run jobs in a PTY
 	RunInPty bool
 

--- a/buildkite/agent.go
+++ b/buildkite/agent.go
@@ -26,8 +26,9 @@ type Agent struct {
 	// The path to the run the builds in
 	BuildPath string
 
-	// Whether or not the agent is allowed to run an ssh keyscan
-	SSHKeyScan bool
+	// Whether or not the agent is allowed to automatically accept SSH
+	// fingerprints
+	AutoSSHFingerprintVerification bool
 
 	// Run jobs in a PTY
 	RunInPty bool

--- a/buildkite/job.go
+++ b/buildkite/job.go
@@ -109,7 +109,7 @@ func (j *Job) Run(agent *Agent) error {
 	env = append(env, fmt.Sprintf("BUILDKITE_BUILD_PATH=%s", agent.BuildPath))
 
 	// The ssh-keyscan config gear
-	env = append(env, fmt.Sprintf("BUILDKITE_ENABLE_SSH_KEYSCAN=%t", agent.SSHKeyScan))
+	env = append(env, fmt.Sprintf("BUILDKITE_AUTO_SSH_FINGERPRINT_VERIFICATION=%t", agent.AutoSSHFingerprintVerification))
 
 	// Add the rest environment variables from the API to the process
 	for key, value := range j.Env {

--- a/buildkite/job.go
+++ b/buildkite/job.go
@@ -102,7 +102,7 @@ func (j *Job) Run(agent *Agent) error {
 
 	// Add agent environment variables
 	env["BUILDKITE_AGENT_ENDPOINT"] = agent.Client.URL
-	env["BUILDKITE_AGENT_ACCESS_TOKEN=%s"] = agent.Client.AuthorizationToken
+	env["BUILDKITE_AGENT_ACCESS_TOKEN"] = agent.Client.AuthorizationToken
 	env["BUILDKITE_AGENT_VERSION"] = Version()
 	env["BUILDKITE_AGENT_DEBUG"] = fmt.Sprintf("%t", InDebugMode())
 

--- a/buildkite/job.go
+++ b/buildkite/job.go
@@ -108,6 +108,9 @@ func (j *Job) Run(agent *Agent) error {
 	// Also add the BUILDKITE_BUILD_PATH
 	env = append(env, fmt.Sprintf("BUILDKITE_BUILD_PATH=%s", agent.BuildPath))
 
+	// The ssh-keyscan config gear
+	env = append(env, fmt.Sprintf("BUILDKITE_ENABLE_SSH_KEYSCAN=%t", agent.SSHKeyScan))
+
 	// Add the rest environment variables from the API to the process
 	for key, value := range j.Env {
 		env = append(env, fmt.Sprintf("%s=%s", key, value))

--- a/buildkite/script.go
+++ b/buildkite/script.go
@@ -51,7 +51,9 @@ func InitProcess(scriptPath string, env []string, runInPty bool, callback func(*
 	process.command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	// Copy the current processes ENV and merge in the new ones. We do this
-	// so the sub process gets PATH and stuff.
+	// so the sub process gets PATH and stuff. We merge our path in over
+	// the top of the current one so the ENV from Buildkite and the agent
+	// take precedence over the agent
 	currentEnv := os.Environ()
 	process.command.Env = append(currentEnv, env...)
 

--- a/command/agent_start.go
+++ b/command/agent_start.go
@@ -99,7 +99,7 @@ func AgentStartCommandAction(c *cli.Context) {
 	agent.BootstrapScript = bootstrapScript
 	agent.BuildPath = buildPath
 	agent.RunInPty = !c.Bool("no-pty")
-	agent.SSHKeyScan = !c.Bool("no-ssh-keyscan")
+	agent.AutoSSHFingerprintVerification = !c.Bool("no-automatic-ssh-fingerprint-verification")
 
 	// Client specific options
 	agent.Client.AuthorizationToken = agentAccessToken

--- a/command/agent_start.go
+++ b/command/agent_start.go
@@ -94,29 +94,23 @@ func AgentStartCommandAction(c *cli.Context) {
 		buildkite.Logger.Fatal(err)
 	}
 
-	// Start the agent using the token we have
-	agent := setupAgent(agentAccessToken, bootstrapScript, buildPath, !c.Bool("no-pty"), c.String("endpoint"))
+	// Set the agent options
+	var agent buildkite.Agent
+	agent.BootstrapScript = bootstrapScript
+	agent.BuildPath = buildPath
+	agent.RunInPty = !c.Bool("no-pty")
+	agent.SSHKeyScan = !c.Bool("no-ssh-keyscan")
+
+	// Client specific options
+	agent.Client.AuthorizationToken = agentAccessToken
+	agent.Client.URL = c.String("endpoint")
+
+	// Setup the agent
+	agent.Setup()
 
 	// Setup signal monitoring
 	agent.MonitorSignals()
 
 	// Start the agent
 	agent.Start()
-}
-
-func setupAgent(agentAccessToken string, bootstrapScript string, buildPath string, runInPty bool, url string) *buildkite.Agent {
-	// Set the agent options
-	var agent buildkite.Agent
-	agent.BootstrapScript = bootstrapScript
-	agent.BuildPath = buildPath
-	agent.RunInPty = runInPty
-
-	// Client specific options
-	agent.Client.AuthorizationToken = agentAccessToken
-	agent.Client.URL = url
-
-	// Setup the agent
-	agent.Setup()
-
-	return &agent
 }

--- a/commands.go
+++ b/commands.go
@@ -165,8 +165,8 @@ func init() {
 					Usage: "Do not run jobs within a pseudo terminal",
 				},
 				cli.BoolFlag{
-					Name:  "no-ssh-keyscan",
-					Usage: "Don't automatically perform an ssh-keyscan on hosts before cloning",
+					Name:  "no-automatic-ssh-fingerprint-verification",
+					Usage: "Don't automatically verify SSH fingerprints",
 				},
 				cli.StringFlag{
 					Name:   "endpoint",

--- a/commands.go
+++ b/commands.go
@@ -144,6 +144,10 @@ func init() {
 					Usage:  "Meta data for the agent",
 					EnvVar: "BUILDKITE_AGENT_META_DATA",
 				},
+				cli.BoolFlag{
+					Name:  "meta-data-ec2-tags",
+					Usage: "Populate the meta data from the current instances EC2 Tags",
+				},
 				cli.StringFlag{
 					Name:   "bootstrap-script",
 					Value:  bootstrapScriptLocation,
@@ -156,19 +160,19 @@ func init() {
 					Usage:  "Path to where the builds will run from",
 					EnvVar: "BUILDKITE_BUILD_PATH",
 				},
+				cli.BoolFlag{
+					Name:  "no-pty",
+					Usage: "Do not run jobs within a pseudo terminal",
+				},
+				cli.BoolFlag{
+					Name:  "no-ssh-keyscan",
+					Usage: "Don't automatically perform an ssh-keyscan on hosts before cloning",
+				},
 				cli.StringFlag{
 					Name:   "endpoint",
 					Value:  "https://agent.buildkite.com/v2",
 					Usage:  "The agent API endpoint",
 					EnvVar: "BUILDKITE_AGENT_ENDPOINT",
-				},
-				cli.BoolFlag{
-					Name:  "meta-data-ec2-tags",
-					Usage: "Populate the meta data from the current instances EC2 Tags",
-				},
-				cli.BoolFlag{
-					Name:  "no-pty",
-					Usage: "Do not run jobs within a pseudo terminal",
 				},
 				cli.BoolFlag{
 					Name:   "debug",

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -81,8 +81,8 @@ buildkite-run "cd \"$BUILDKITE_BUILD_CHECKOUT_PATH\""
 
 # If enabled, automatically run an ssh-keyscan on the git ssh host, to prevent
 # a yes/no promp from appearing when cloning/fetching
-if [[ ! -z "${BUILDKITE_ENABLE_SSH_KEYSCAN:-}" ]] && [[ "$BUILDKITE_ENABLE_SSH_KEYSCAN" == "true" ]]; then
-  if [[ ! -z "${BUILDKITE_ENABLE_SSH_KEYSCAN:-}" ]]; then
+if [[ ! -z "${BUILDKITE_AUTO_SSH_FINGERPRINT_VERIFICATION:-}" ]] && [[ "$BUILDKITE_AUTO_SSH_FINGERPRINT_VERIFICATION" == "true" ]]; then
+  if [[ ! -z "${BUILDKITE_AUTO_SSH_FINGERPRINT_VERIFICATION:-}" ]]; then
     : ${BUILDKITE_SSH_DIRECTORY:="$HOME/.ssh"}
     : ${BUILDKITE_SSH_KNOWN_HOST_PATH:="$BUILDKITE_SSH_DIRECTORY/known_hosts"}
 

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -53,6 +53,12 @@ SANITIZED_AGENT_NAME=$(echo $BUILDKITE_AGENT_NAME | tr -d '"')
 PROJECT_FOLDER_NAME="$SANITIZED_AGENT_NAME/$BUILDKITE_PROJECT_SLUG"
 BUILDKITE_BUILD_CHECKOUT_PATH="$BUILDKITE_BUILD_PATH/$PROJECT_FOLDER_NAME"
 
+if [[ "$BUILDKITE_AGENT_DEBUG" == "true" ]]; then
+  echo '--- Build environment variables'
+
+  buildkite-run "env | grep BUILDKITE"
+fi
+
 ##############################################################
 #
 # REPOSITORY HANDLING
@@ -73,12 +79,27 @@ echo '--- Preparing build folder'
 buildkite-run "mkdir -p \"$BUILDKITE_BUILD_CHECKOUT_PATH\""
 buildkite-run "cd \"$BUILDKITE_BUILD_CHECKOUT_PATH\""
 
+# If enabled, automatically run an ssh-keyscan on the git ssh host, to prevent
+# a yes/no promp from appearing when cloning/fetching
+if [[ ! -z "${BUILDKITE_ENABLE_SSH_KEYSCAN:-}" ]] && [[ "$BUILDKITE_ENABLE_SSH_KEYSCAN" == "true" ]]; then
+  if [[ ! -z "${BUILDKITE_ENABLE_SSH_KEYSCAN:-}" ]]; then
+    : ${BUILDKITE_SSH_DIRECTORY:="$HOME/.ssh"}
+    : ${BUILDKITE_SSH_KNOWN_HOST_PATH:="$BUILDKITE_SSH_DIRECTORY/known_hosts"}
+
+    # Ensure the known_hosts file exists
+    mkdir -p $BUILDKITE_SSH_DIRECTORY
+    touch $BUILDKITE_SSH_KNOWN_HOST_PATH
+
+    # Only add the output from ssh-keyscan if it doesn't already exist in the
+    # known_hosts file
+    if ! ssh-keygen -H -F "$BUILDKITE_REPO_SSH_HOST" | grep --quiet "$BUILDKITE_REPO_SSH_HOST"; then
+      buildkite-run "ssh-keyscan \"$BUILDKITE_REPO_SSH_HOST\" >> \"$BUILDKITE_SSH_KNOWN_HOST_PATH\""
+    fi
+  fi
+fi
+
 # Do we need to do a git checkout?
 if [[ ! -d ".git" ]]; then
-  # If it's a first time SSH git clone it will prompt to accept the host's
-  # fingerprint. To avoid this add the host's key to ~/.ssh/known_hosts ahead
-  # of time:
-  #   ssh-keyscan -H host.com >> ~/.ssh/known_hosts
   buildkite-run "git clone \"$BUILDKITE_REPO\" . -qv"
 fi
 

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -56,7 +56,7 @@ BUILDKITE_BUILD_CHECKOUT_PATH="$BUILDKITE_BUILD_PATH/$PROJECT_FOLDER_NAME"
 if [[ "$BUILDKITE_AGENT_DEBUG" == "true" ]]; then
   echo '--- Build environment variables'
 
-  buildkite-run "env | grep BUILDKITE"
+  buildkite-run "env | grep BUILDKITE | sort"
 fi
 
 ##############################################################


### PR DESCRIPTION
This change will allow the agent to automatically accept the RSA fingerprints when cloning from an ssh based git repository:

![image](https://cloud.githubusercontent.com/assets/25882/5959724/6f9aa2dc-a80b-11e4-91d5-a08cff4a389e.png)

- [ ] Add support for `BUILDKITE_REPO_SSH_HOST` on buildkite.com
- [ ] Decide on the right argument name. Is `--no-ssh-keyscan` correct? Or is there another name? `--no-ssh-accept` or something?