### PR TITLE
Allow scripts sent from Buildkite to be evaluated

### DIFF
--- a/buildkite/agent.go
+++ b/buildkite/agent.go
@@ -30,6 +30,9 @@ type Agent struct {
 	// fingerprints
 	AutoSSHFingerprintVerification bool
 
+	// If this agent is allowed to perform script evaluation
+	ScriptEval bool
+
 	// Run jobs in a PTY
 	RunInPty bool
 

--- a/buildkite/agent_registration.go
+++ b/buildkite/agent_registration.go
@@ -15,6 +15,9 @@ type AgentRegistration struct {
 	// Operating system for this machine
 	OS string `json:"os"`
 
+	// If this agent is allowed to perform script evaluation
+	ScriptEval bool `json:"script_eval_enabled"`
+
 	// The priority of the agent
 	Priority string `json:"priority,omitempty"`
 
@@ -25,7 +28,7 @@ type AgentRegistration struct {
 	MetaData []string `json:"meta_data"`
 }
 
-func (c *Client) AgentRegister(name string, priority string, metaData []string) (string, error) {
+func (c *Client) AgentRegister(name string, priority string, metaData []string, scriptEval bool) (string, error) {
 	os, err := MachineOSDump()
 	hostname, err := MachineHostname()
 
@@ -36,6 +39,7 @@ func (c *Client) AgentRegister(name string, priority string, metaData []string) 
 	registration.Hostname = hostname
 	registration.OS = os
 	registration.MetaData = metaData
+	registration.ScriptEval = scriptEval
 
 	Logger.WithFields(logrus.Fields{
 		"name":      registration.Name,

--- a/command/agent_start.go
+++ b/command/agent_start.go
@@ -101,7 +101,7 @@ func AgentStartCommandAction(c *cli.Context) {
 	}
 
 	// Register the agent
-	agentAccessToken, err := client.AgentRegister(c.String("name"), c.String("priority"), agentMetaData)
+	agentAccessToken, err := client.AgentRegister(c.String("name"), c.String("priority"), agentMetaData, agent.ScriptEval)
 	if err != nil {
 		buildkite.Logger.Fatal(err)
 	}

--- a/command/agent_start.go
+++ b/command/agent_start.go
@@ -88,12 +88,6 @@ func AgentStartCommandAction(c *cli.Context) {
 		}
 	}
 
-	// Register the agent
-	agentAccessToken, err := client.AgentRegister(c.String("name"), c.String("priority"), agentMetaData)
-	if err != nil {
-		buildkite.Logger.Fatal(err)
-	}
-
 	// Set the agent options
 	var agent buildkite.Agent
 	agent.BootstrapScript = bootstrapScript
@@ -101,6 +95,16 @@ func AgentStartCommandAction(c *cli.Context) {
 	agent.RunInPty = !c.Bool("no-pty")
 	agent.AutoSSHFingerprintVerification = !c.Bool("no-automatic-ssh-fingerprint-verification")
 	agent.ScriptEval = !c.Bool("no-script-eval")
+
+	if !agent.ScriptEval {
+		buildkite.Logger.Info("Evaluating scripts has been disabled for this agent")
+	}
+
+	// Register the agent
+	agentAccessToken, err := client.AgentRegister(c.String("name"), c.String("priority"), agentMetaData)
+	if err != nil {
+		buildkite.Logger.Fatal(err)
+	}
 
 	// Client specific options
 	agent.Client.AuthorizationToken = agentAccessToken

--- a/command/agent_start.go
+++ b/command/agent_start.go
@@ -100,6 +100,7 @@ func AgentStartCommandAction(c *cli.Context) {
 	agent.BuildPath = buildPath
 	agent.RunInPty = !c.Bool("no-pty")
 	agent.AutoSSHFingerprintVerification = !c.Bool("no-automatic-ssh-fingerprint-verification")
+	agent.ScriptEval = !c.Bool("no-script-eval")
 
 	// Client specific options
 	agent.Client.AuthorizationToken = agentAccessToken

--- a/commands.go
+++ b/commands.go
@@ -168,6 +168,10 @@ func init() {
 					Name:  "no-automatic-ssh-fingerprint-verification",
 					Usage: "Don't automatically verify SSH fingerprints",
 				},
+				cli.BoolFlag{
+					Name:  "no-script-eval",
+					Usage: "Don't allow this agent to evaluate scripts from Buildkite. Only scripts that exist on the file system will be allowed to run",
+				},
 				cli.StringFlag{
 					Name:   "endpoint",
 					Value:  "https://agent.buildkite.com/v2",

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -143,7 +143,7 @@ buildkite-agent build-data set "buildkite:git:branch" "`git branch --contains "$
 if [[ "$BUILDKITE_SCRIPT_MODE" == "eval" ]]; then
   BUILDKITE_SCRIPT_PATH="buildkite-script-$BUILDKITE_JOB_ID"
 
-  echo $BUILDKITE_SCRIPT_TEXT > $BUILDKITE_SCRIPT_PATH
+  echo "$BUILDKITE_SCRIPT_TEXT" > $BUILDKITE_SCRIPT_PATH
 fi
 
 # Double check the file exists we want to run

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -139,10 +139,21 @@ buildkite-agent build-data set "buildkite:git:branch" "`git branch --contains "$
 #
 ##############################################################
 
+# If we're evaluating a script, save it to the filesystem first
+if [[ "$BUILDKITE_SCRIPT_MODE" == "eval" ]]; then
+  BUILDKITE_SCRIPT_PATH="buildkite-script-$BUILDKITE_JOB_ID"
+
+  echo $BUILDKITE_SCRIPT > $BUILDKITE_SCRIPT_PATH
+fi
+
+# Double check the file exists we want to run
 if [[ "$BUILDKITE_SCRIPT_PATH" == "" ]]; then
   echo "ERROR: No script to run. Please go to \"Project Settings\" and configure your build step's \"Script to Run\""
   exit 1
 fi
+
+# Make sure the script we're going to run is executable
+chmod +x $BUILDKITE_SCRIPT_PATH
 
 ## Docker
 if [[ ! -z "${BUILDKITE_DOCKER:-}" ]] && [[ "$BUILDKITE_DOCKER" != "" ]]; then

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -23,11 +23,13 @@ set -u
 
 BUILDKITE_PROMPT="\033[90m$\033[0m"
 
+# Shows the command being run, and runs it
 function buildkite-prompt-and-run {
   echo -e "$BUILDKITE_PROMPT $1"
   eval $1
 }
 
+# Shows the command about to be run, and exits if it fails
 function buildkite-run {
   echo -e "$BUILDKITE_PROMPT $1"
   eval $1
@@ -35,6 +37,28 @@ function buildkite-run {
 
   if [[ $EVAL_EXIT_STATUS -ne 0 ]]; then
     exit $EVAL_EXIT_STATUS
+  fi
+}
+
+# Only shows the command if DEBUG is on
+function buildkite-run-debug {
+  if [[ "$BUILDKITE_AGENT_DEBUG" == "true" ]]; then
+    echo -e "$BUILDKITE_PROMPT $1"
+    eval $1
+  else
+    eval $1
+  fi
+}
+
+# Outputs a header
+function buildkite-header {
+  echo -e "--- $1"
+}
+
+# Outputs a header only if DEBUG is on
+function buildkite-header-debug {
+  if [[ "$BUILDKITE_AGENT_DEBUG" == "true" ]]; then
+    buildkite-header "$1"
   fi
 }
 
@@ -129,8 +153,9 @@ buildkite-run "git submodule update --init --recursive"
 buildkite-run "git submodule foreach --recursive git reset --hard"
 
 # Grab author and commit information and send it back to Buildkite
-buildkite-agent build-data set "buildkite:git:commit" "`git show "$BUILDKITE_COMMIT" -s --format=fuller --no-color`"
-buildkite-agent build-data set "buildkite:git:branch" "`git branch --contains "$BUILDKITE_COMMIT" --no-color`"
+buildkite-header-debug "Saving Git information"
+buildkite-run-debug "buildkite-agent build-data set \"buildkite:git:commit\" \"\`git show \"$BUILDKITE_COMMIT\" -s --format=fuller --no-color\`\""
+buildkite-run-debug "buildkite-agent build-data set \"buildkite:git:branch\" \"\`git branch --contains \"$BUILDKITE_COMMIT\" --no-color\`\""
 
 ##############################################################
 #

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -143,7 +143,7 @@ buildkite-agent build-data set "buildkite:git:branch" "`git branch --contains "$
 if [[ "$BUILDKITE_SCRIPT_MODE" == "eval" ]]; then
   BUILDKITE_SCRIPT_PATH="buildkite-script-$BUILDKITE_JOB_ID"
 
-  echo $BUILDKITE_SCRIPT > $BUILDKITE_SCRIPT_PATH
+  echo $BUILDKITE_SCRIPT_TEXT > $BUILDKITE_SCRIPT_PATH
 fi
 
 # Double check the file exists we want to run


### PR DESCRIPTION
This will allow you to store your scripts on Buildkite, and have the agent execute them (instead of having to commit them to your source repository).

Because this could be a potential security risk, this feature can be turned off with `--no-script-eval`