### PR TITLE
Add support for Git 2.3's GIT_TERMINAL_PROMPT

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -122,6 +122,9 @@ if [[ ! -z "${BUILDKITE_AUTO_SSH_FINGERPRINT_VERIFICATION:-}" ]] && [[ "$BUILDKI
   fi
 fi
 
+# Disable any interactive Git/SSH prompting
+export GIT_TERMINAL_PROMPT=0
+
 # Do we need to do a git checkout?
 if [[ ! -d ".git" ]]; then
   buildkite-run "git clone \"$BUILDKITE_REPO\" . -qv"


### PR DESCRIPTION
Prevents builds from hanging if git needs to auth in some way.

This means if users don't have the correct keys set up, their build will just fail instead of hanging on username/password or other auth prompt.

> The credential subsystem is now friendlier to scripting
> When Git needs a password (e.g., to connect to a remote repository over http), it uses the credential subsystem to query any helpers (like the OS X Keychain helper), and then finally prompts the user on the terminal. When Git is run from an automated process like a cron job, there is usually no terminal available and Git will skip the prompt. However, if there is a terminal available, Git may hang forever, waiting for the user to type something. Scripts which do not expect user input can now set `GIT_TERMINAL_PROMPT=0` in the environment to avoid this behavior.

https://github.com/gitster/git/commit/86362f7205a31188846de0aed94620c1f0776931