### PR TITLE
Default value for BUILDKITE_COMMIT

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -187,8 +187,9 @@ else
   if [[ "$BUILDKITE_PULL_REQUEST" != "false" ]] && [[ "$BUILDKITE_PROJECT_PROVIDER" == *"github"* ]]; then
     buildkite-run "git fetch origin \"+refs/pull/$BUILDKITE_PULL_REQUEST/head:\""
   elif [[ "$BUILDKITE_TAG" == "" ]]; then
-    # Default empty branch names
+    # Default empty branch name and commit
     : ${BUILDKITE_BRANCH:=master}
+    : ${BUILDKITE_COMMIT:=$BUILDKITE_BRANCH}
 
     buildkite-run "git reset --hard origin/$BUILDKITE_BRANCH"
   fi

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -194,7 +194,9 @@ else
     buildkite-run "git reset --hard origin/$BUILDKITE_BRANCH"
   fi
 
-  buildkite-run "git checkout -qf \"$BUILDKITE_COMMIT\""
+  if [[ "$BUILDKITE_BRANCH" != "$BUILDKITE_COMMIT" ]]; then
+    buildkite-run "git checkout -qf \"$BUILDKITE_COMMIT\""
+  fi
 
   # `submodule sync` will ensure the .git/config matches the .gitmodules file
   buildkite-run "git submodule sync"


### PR DESCRIPTION
bootstrap failed if no `BUILDKITE_COMMIT` was given, as most of the time, you would only specify the branch name, this PR set the `BUILDKITE_COMMIT` to be the `BUILDKITE_BRANCH` by default.

And unless I'm missing something, line 197 seems to be redundant in the case of `BUILDKITE_COMMIT` being the same as `BUILDKITE_BRANCH`.