### PR TITLE
Windows artifact upload fails if the buildkite-agent path has a space in it

### DIFF
--- a/templates/bootstrap.bat
+++ b/templates/bootstrap.bat
@@ -92,11 +92,11 @@ IF NOT "%BUILDKITE_ARTIFACT_PATHS%" == "" (
   REM Show the output of the artifact uploder when in debug mode
   IF "%BUILDKITE_AGENT_DEBUG%" == "true" (
     ECHO --- Uploading Artifacts
-    ECHO ^> %BUILDKITE_DIR%\buildkite-agent artifact upload "%BUILDKITE_ARTIFACT_PATHS%"
-    call %BUILDKITE_DIR%\buildkite-agent artifact upload "%BUILDKITE_ARTIFACT_PATHS%"
+    ECHO ^> "%BUILDKITE_DIR%\buildkite-agent" artifact upload "%BUILDKITE_ARTIFACT_PATHS%"
+    call "%BUILDKITE_DIR%\buildkite-agent" artifact upload "%BUILDKITE_ARTIFACT_PATHS%"
     IF !ERRORLEVEL! NEQ 0 EXIT !ERRORLEVEL!
   ) ELSE (
-    call %BUILDKITE_DIR%\buildkite-agent artifact upload "%BUILDKITE_ARTIFACT_PATHS%" > nul 2>&1
+    call "%BUILDKITE_DIR%\buildkite-agent" artifact upload "%BUILDKITE_ARTIFACT_PATHS%" > nul 2>&1
     IF !ERRORLEVEL! NEQ 0 EXIT !ERRORLEVEL!
   )
 )


### PR DESCRIPTION
I knew I’d miss one.