### PR TITLE
Add --recursive to git submodule sync

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -213,7 +213,7 @@ else
   buildkite-run "git checkout -qf \"$BUILDKITE_COMMIT\""
 
   # `submodule sync` will ensure the .git/config matches the .gitmodules file
-  buildkite-run "git submodule sync"
+  buildkite-run "git submodule sync --recursive"
   buildkite-run "git submodule update --init --recursive"
   buildkite-run "git submodule foreach --recursive git reset --hard"
 


### PR DESCRIPTION
Reported by @alanjrogers, the line after `git submodule sync` can fail because the the sync is missing the `--recursive` that all the other submodule commands have.