### PR TITLE
Catch Docker failures

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -18,6 +18,9 @@ function buildkite-flags-reset {
   # Causes this script to exit if a variable isn't present
   set -u
 
+  # Ensure command pipes fail if any command fails (e.g. fail-cmd | success-cmd == fail)
+  set -o pipefail
+
   # Turn off debugging
   set +x
 


### PR DESCRIPTION
Now that we pipe to `cat` (as of 1c4241c3c9153dda168748c0821d927773aaf73b) any failure exit status codes in docker and docker-compose are masked. This change sets `pipefail` so non-zero exit statuses are bubbled through the command pipeline.