### PR TITLE
Fix errors from non-GNU grep

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -194,7 +194,7 @@ else
 
       # Only add the output from ssh-keyscan if it doesn't already exist in the
       # known_hosts file
-      if ! ssh-keygen -H -F "$BUILDKITE_REPO_SSH_HOST" | grep --quiet "$BUILDKITE_REPO_SSH_HOST"; then
+      if ! ssh-keygen -H -F "$BUILDKITE_REPO_SSH_HOST" | grep -q "$BUILDKITE_REPO_SSH_HOST"; then
         buildkite-run "ssh-keyscan \"$BUILDKITE_REPO_SSH_HOST\" >> \"$BUILDKITE_SSH_KNOWN_HOST_PATH\""
       fi
     fi


### PR DESCRIPTION
I'm all for the use of longer forms of command-line options in scripts, but in this case it breaks on Alpine Linux:

Alpine Linux uses Busybox' `grep`, which doesn't understand the long-form `--quiet` flag:

```
$ grep --quiet
unrecognized option `--quiet'
BusyBox v1.22.1 (2015-03-20 11:09:37 GMT) multi-call binary.
 
Usage: grep [-HhnlLoqvsriwFE] [-m N] [-A/B/C N] PATTERN/-e PATTERN.../-f FILE [FILE]...

Search for PATTERN in FILEs (or stdin)
 
    -H    Add 'filename:' prefix
    -h    Do not add 'filename:' prefix
    -n    Add 'line_no:' prefix
    -l    Show only names of files that match
    -L    Show only names of files that don't match
    -c    Show only count of matching lines
    -o    Show only the matching part of line
    -q    Quiet. Return 0 if PATTERN is found, 1 otherwise
    -v    Select non-matching lines
    -s    Suppress open and read errors
    -r    Recurse
    -i    Ignore case
    -w    Match whole words only
    -x    Match whole lines only
    -F    PATTERN is a literal (not regexp)
    -E    PATTERN is an extended regexp
    -m N    Match up to N times per file
    -A N    Print N lines of trailing context
    -B N    Print N lines of leading context
    -C N    Same as '-A N -B N'
    -e PTRN    Pattern to match
    -f FILE    Read pattern from file
```