### PR TITLE
Don't set defaults in the cfg that don't need to be set

### DIFF
--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -2,7 +2,7 @@
 token="xxx"
 
 # The name of the agent
-name="%hostname-%n"
+# name="%hostname-%n"
 
 # The priority of the agent (higher priorities are assigned work first)
 # priority=1
@@ -13,16 +13,11 @@ name="%hostname-%n"
 # Populate the meta data from the current instances EC2 Tags
 # meta-data-ec2-tags=true
 
-# Path to the bootstrap script. You should avoid changing this file as it will
-# be overridden when you update your agent. If you need to make changes to this
-# file: use the hooks provided, or copy the file and reference it here.
-bootstrap-script="$HOME/.buildkite-agent/bootstrap.sh"
-
 # Path to where the builds will run from
-build-path="$HOME/.buildkite-agent/builds"
+# build-path="$HOME/.buildkite-agent/builds"
 
 # Directory where the hook scripts are found
-hooks-path="$HOME/.buildkite-agent/hooks"
+# hooks-path="$HOME/.buildkite-agent/hooks"
 
 # Do not run jobs within a pseudo terminal
 # no-pty=true
@@ -38,3 +33,8 @@ hooks-path="$HOME/.buildkite-agent/hooks"
 
 # Don't show colors in logging
 # no-color=true
+
+# Path to the bootstrap script. You should avoid changing this file as it will
+# be overridden when you update your agent. If you need to make changes to this
+# file: use the hooks provided, or copy the file and reference it here.
+# bootstrap-script="$HOME/.buildkite-agent/bootstrap.sh"


### PR DESCRIPTION
This moves the bootstrap config line down to the bottom, because it's not important and we don't want people changing it. This also comments out the defaults that are picked up by the agent anyways, which prevents me from commenting them out using bash voodoo in the homebrew (which should "just work" without any custom bootstrap path set in the config file)