### PR TITLE
Typo/spelling on 'configuration'.

### DIFF
--- a/command/agent_start.go
+++ b/command/agent_start.go
@@ -80,7 +80,7 @@ var AgentStartCommand = cli.Command{
 		cli.StringFlag{
 			Name:   "config",
 			Value:  "",
-			Usage:  "Path to a configration file",
+			Usage:  "Path to a configuration file",
 			EnvVar: "BUILDKITE_AGENT_CONFIG",
 		},
 		cli.StringFlag{


### PR DESCRIPTION
Non-important change, but it was causing me to twitch whenever I saw it :grin:  