### PR TITLE
Add health check endpoint

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -2,14 +2,13 @@ package agent
 
 import (
 	"fmt"
-	"os"
-	"time"
-
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/health"
 	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/retry"
 	"github.com/buildkite/agent/signalwatcher"
+	"os"
+	"time"
 )
 
 type AgentPool struct {

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -1,10 +1,11 @@
 package agent
 
 import (
+	"time"
+
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/retry"
-	"time"
 )
 
 type AgentWorker struct {
@@ -19,6 +20,9 @@ type AgentWorker struct {
 
 	// The configuration of the agent from the CLI
 	AgentConfiguration *AgentConfiguration
+
+	// Function which is used to notify other subsystems of job status changes
+	JobUpdateFunc func(job api.Job)
 
 	// Used by the Start call to control the looping of the pings
 	ticker *time.Ticker
@@ -129,6 +133,7 @@ func (a *AgentWorker) Ping() {
 		Agent:              a.Agent,
 		AgentConfiguration: a.AgentConfiguration,
 		Job:                accepted,
+		JobUpdateFunc:      a.JobUpdateFunc,
 	}.Create()
 
 	// Was there an error creating the job runner?

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -1,11 +1,10 @@
 package agent
 
 import (
-	"time"
-
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/retry"
+	"time"
 )
 
 type AgentWorker struct {

--- a/agent/api_client.go
+++ b/agent/api_client.go
@@ -1,13 +1,12 @@
 package agent
 
 import (
-	"net/url"
-	"runtime"
-	"time"
-
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/logger"
 	"github.com/facebookgo/httpcontrol"
+	"net/url"
+	"runtime"
+	"time"
 )
 
 type APIClient struct {

--- a/agent/api_client.go
+++ b/agent/api_client.go
@@ -1,16 +1,19 @@
 package agent
 
 import (
+	"net/url"
+	"runtime"
+	"time"
+
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/logger"
 	"github.com/facebookgo/httpcontrol"
-	"net/url"
-	"runtime"
 )
 
 type APIClient struct {
-	Endpoint string
-	Token    string
+	Endpoint   string
+	Token      string
+	StatusFunc func(status string, timeTaken time.Duration)
 }
 
 func (a APIClient) Create() *api.Client {
@@ -21,7 +24,10 @@ func (a APIClient) Create() *api.Client {
 			RetryAfterTimeout: true,
 			MaxTries:          10,
 			Stats: func(s *httpcontrol.Stats) {
-				logger.Debug("%s (%s)", s, s.Duration.Header+s.Duration.Body)
+				logger.Info("%s (%s)", s, s.Duration.Header+s.Duration.Body)
+				if a.StatusFunc != nil {
+					a.StatusFunc(s.String(), s.Duration.Header+s.Duration.Body)
+				}
 			},
 		},
 	}

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -2,15 +2,14 @@ package agent
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
-	"sync"
-	"time"
-
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/process"
 	"github.com/buildkite/agent/retry"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
 )
 
 type JobRunner struct {

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -2,14 +2,15 @@ package agent
 
 import (
 	"fmt"
-	"github.com/buildkite/agent/api"
-	"github.com/buildkite/agent/logger"
-	"github.com/buildkite/agent/process"
-	"github.com/buildkite/agent/retry"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/buildkite/agent/api"
+	"github.com/buildkite/agent/logger"
+	"github.com/buildkite/agent/process"
+	"github.com/buildkite/agent/retry"
 )
 
 type JobRunner struct {
@@ -27,6 +28,9 @@ type JobRunner struct {
 
 	// The configuration of the agent from the CLI
 	AgentConfiguration *AgentConfiguration
+
+	// Function which is used to notify other subsystems of job status changes
+	JobUpdateFunc func(job api.Job)
 
 	// The interal process of the job
 	process *process.Process
@@ -81,6 +85,9 @@ func (r *JobRunner) Run() error {
 		return err
 	}
 
+	// update the other components on the state of the job
+	r.JobUpdateFunc(*r.Job)
+
 	// Start the log streamer
 	if err := r.logStreamer.Start(); err != nil {
 		return err
@@ -120,6 +127,9 @@ func (r *JobRunner) Run() error {
 	r.wg.Wait()
 
 	logger.Info("Finished job %s", r.Job.ID)
+
+	// update the other components on the state of the job
+	r.JobUpdateFunc(*r.Job)
 
 	return nil
 }

--- a/health/health.go
+++ b/health/health.go
@@ -1,0 +1,75 @@
+package health
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/buildkite/agent/api"
+)
+
+var currentAgentHealth = &agentHealth{}
+
+type lastJobStatus struct {
+	ID                string `json:"id"`
+	State             string `json:"state"`
+	ExitStatus        string `json:"exit_status,omitempty"`
+	StartedAt         string `json:"started_at,omitempty"`
+	FinishedAt        string `json:"finished_at,omitempty"`
+	ChunksFailedCount int    `json:"chunks_failed_count"`
+}
+
+func (lj *lastJobStatus) Update(job api.Job) {
+	lj.ID = job.ID
+	lj.State = job.State
+	lj.ExitStatus = job.ExitStatus
+	lj.StartedAt = job.StartedAt
+	lj.FinishedAt = job.FinishedAt
+	lj.ChunksFailedCount = job.ChunksFailedCount
+}
+
+type lastAPICall struct {
+	Status    string `json:"status,omitempty"`
+	TimeTaken string `json:"timeTaken,omitempty"`
+}
+
+func (la *lastAPICall) Update(status string, timeTaken time.Duration) {
+	la.Status = status
+	la.TimeTaken = fmt.Sprintf("%s", timeTaken)
+}
+
+type agentHealth struct {
+	LastJobStatus *lastJobStatus `json:"lastJobStatus,omitempty"`
+	LastAPICall   *lastAPICall   `json:"lastApiCall,omitempty"`
+}
+
+type healthResponse struct {
+	Response agentHealth `json:"data,omitempty"` // wrapped response
+}
+
+// InitHealthCheck setup the health check and ensure it is bound
+func InitHealthCheck(addr string) error {
+
+	http.HandleFunc("/status", checkHandler)
+
+	return http.ListenAndServe(addr, nil)
+}
+
+func UpdateJobStatus(job api.Job) {
+	if currentAgentHealth.LastJobStatus == nil {
+		currentAgentHealth.LastJobStatus = &lastJobStatus{}
+	}
+	currentAgentHealth.LastJobStatus.Update(job)
+}
+
+func UpdateAPIStatus(status string, timeTaken time.Duration) {
+	if currentAgentHealth.LastAPICall == nil {
+		currentAgentHealth.LastAPICall = &lastAPICall{}
+	}
+	currentAgentHealth.LastAPICall.Update(status, timeTaken)
+}
+
+func checkHandler(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(currentAgentHealth)
+}


### PR DESCRIPTION
This is the health check we discussed.

I have the basic health check working, I need to add a flag, rejig the structure and add some tests.

The aim is to expose the last job, and it's status and the last api request and it's status.

Ideally you would add some other information as requested in the future.

Looks like: 

```json
{
  "lastApiCall": {
    "status": "POST https://agent.buildkite.com/v2/register got response with status 200 OK",
    "timeTaken": "1.421656691s"
  }
}
```