### PR TITLE
Added defer'd flush of the body to ensure connection reuse.

### DIFF
--- a/api/buildkite.go
+++ b/api/buildkite.go
@@ -168,6 +168,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 	logger.Debug("↳ %s %s (%s %s)", req.Method, req.URL, resp.Status, time.Now().Sub(ts))
 
 	defer resp.Body.Close()
+	defer io.Copy(ioutil.Discard, resp.Body)
 
 	response := newResponse(resp)
 


### PR DESCRIPTION
Pretty small change to ensure the Body is ALWAYS flushed, it seems the JSON decoder is only reading enough to satisfy the decoder and not triggering the final EOF on the stream.

From the golang http library documentation.

```
	// The default HTTP client's Transport does not
	// attempt to reuse HTTP/1.0 or HTTP/1.1 TCP connections
	// ("keep-alive") unless the Body is read to completion and is
	// closed. 
```

So this change makes sure that happens.