### PR TITLE
Adds prune flag to git fetch

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -220,7 +220,7 @@ else
     buildkite-run "git submodule foreach --recursive git clean -fdq"
   fi
 
-  buildkite-run "git fetch -q"
+  buildkite-run "git fetch -qp"
 
   # Allow checkouts of forked pull requests on GitHub only. See:
   # https://help.github.com/articles/checking-out-pull-requests-locally/#modifying-an-inactive-pull-request-locally
@@ -453,7 +453,7 @@ if [[ "$BUILDKITE_ARTIFACT_PATHS" != "" ]]; then
     echo "^^^ +++"
     exit 1
   fi
-  
+
   # Run the per-checkout `post-artifact` hook
   buildkite-local-hook "post-artifact"
 


### PR DESCRIPTION
Adds prune flag to `git fetch`. On active repos we receive warnings from `git fetch` to run `git prune`.

```
$ git fetch -q
Auto packing the repository for optimum performance. You may also
run "git gc" manually. See "git help gc" for more information.
Nothing new to pack.
Checking connectivity: 1429273, done.
warning: There are too many unreachable loose objects; run 'git prune' to remove them.
``` 

@keithpitt @xthexder