### PR TITLE
New artifact upload/download syntax

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -7,4 +7,5 @@ type AgentConfiguration struct {
 	AutoSSHFingerprintVerification bool
 	CommandEval                    bool
 	RunInPty                       bool
+	ArtifactUnixSyntax             bool
 }

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -198,4 +198,10 @@ func (r *AgentPool) ShowBanner() {
 	if !r.AgentConfiguration.RunInPty {
 		logger.Debug("Running builds within a pseudoterminal (PTY) has been disabled")
 	}
+
+	if r.AgentConfiguration.ArtifactUnixSyntax {
+		logger.Debug("Using the new unix sytnax for artifact uploads and downloads")
+	} else {
+		logger.Warn("The `buildkite-agent artifact` command is set to use the deprecated upload/download syntax. This syntax will be deprecated in 3.0. See http://buildkite.dev/docs/agent/build-artifacts#unix-upload-download-syntax on how upgrade, then restart the agent with --artifact-unix-syntax")
+	}
 }

--- a/agent/artifact_downloader.go
+++ b/agent/artifact_downloader.go
@@ -25,6 +25,9 @@ type ArtifactDownloader struct {
 
 	// Where we'll be downloading artifacts to
 	Destination string
+
+	// Whether to use the unix like sytanx
+	UnixSyntax bool
 }
 
 func (a *ArtifactDownloader) Download() error {

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -30,6 +30,9 @@ type ArtifactUploader struct {
 
 	// Where we'll be uploading artifacts
 	Destination string
+
+	// Whether to use the unix like sytanx
+	UnixSyntax bool
 }
 
 func (a *ArtifactUploader) Upload() error {

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -165,6 +165,7 @@ func (r *JobRunner) createEnvironment() []string {
 	env["BUILDKITE_HOOKS_PATH"] = r.AgentConfiguration.HooksPath
 	env["BUILDKITE_AUTO_SSH_FINGERPRINT_VERIFICATION"] = fmt.Sprintf("%t", r.AgentConfiguration.AutoSSHFingerprintVerification)
 	env["BUILDKITE_COMMAND_EVAL"] = fmt.Sprintf("%t", r.AgentConfiguration.CommandEval)
+	env["BUILDKITE_ARTIFACT_UNIX_SYNTAX"] = fmt.Sprintf("%t", r.AgentConfiguration.ArtifactUnixSyntax)
 
 	// Convert the env map into a slice (which is what the script gear
 	// needs)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -42,6 +42,7 @@ type AgentStartConfig struct {
 	NoAutoSSHFingerprintVerification bool     `cli:"no-automatic-ssh-fingerprint-verification"`
 	NoCommandEval                    bool     `cli:"no-command-eval"`
 	NoPTY                            bool     `cli:"no-pty"`
+	ArtifactUnixSyntax               bool     `cli:"artifact-unix-syntax"`
 	Endpoint                         string   `cli:"endpoint" validate:"required"`
 	Debug                            bool     `cli:"debug"`
 	DebugHTTP                        bool     `cli:"debug-http"`
@@ -144,6 +145,11 @@ var AgentStartCommand = cli.Command{
 			Usage:  "Don't allow this agent to run arbitrary console commands",
 			EnvVar: "BUILDKITE_NO_COMMAND_EVAL",
 		},
+		cli.BoolFlag{
+			Name:   "artifact-unix-syntax",
+			EnvVar: "BUILDKITE_ARTIFACT_UNIX_SYNTAX",
+			Usage:  "The artifact upload/download syntax matches that of regular unix tools like cp and mv. This will be the default in 3.0",
+		},
 		EndpointFlag,
 		NoColorFlag,
 		DebugFlag,
@@ -191,6 +197,7 @@ var AgentStartCommand = cli.Command{
 				AutoSSHFingerprintVerification: !cfg.NoAutoSSHFingerprintVerification,
 				CommandEval:                    !cfg.NoCommandEval,
 				RunInPty:                       !cfg.NoPTY,
+				ArtifactUnixSyntax:             cfg.ArtifactUnixSyntax,
 			},
 		}
 

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -38,6 +38,7 @@ type ArtifactDownloadConfig struct {
 	Destination      string `cli:"arg:1" label:"artifact download path" validate:"required"`
 	Step             string `cli:"step"`
 	Build            string `cli:"build" validate:"required"`
+	UnixSyntax       bool   `cli:"unix-syntax"`
 	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
 	Endpoint         string `cli:"endpoint" validate:"required"`
 	NoColor          bool   `cli:"no-color"`
@@ -60,6 +61,11 @@ var ArtifactDownloadCommand = cli.Command{
 			Value:  "",
 			EnvVar: "BUILDKITE_BUILD_ID",
 			Usage:  "The build that the artifacts were uploaded to",
+		},
+		cli.BoolFlag{
+			Name:   "unix-syntax",
+			EnvVar: "BUILDKITE_ARTIFACT_UNIX_SYNTAX",
+			Usage:  "The upload syntax matches that of regular unix tools like cp and mv. This will be the default in 3.0",
 		},
 		AgentAccessTokenFlag,
 		EndpointFlag,
@@ -89,6 +95,7 @@ var ArtifactDownloadCommand = cli.Command{
 			Destination: cfg.Destination,
 			BuildID:     cfg.Build,
 			Step:        cfg.Step,
+			UnixSyntax:  cfg.UnixSyntax,
 		}
 
 		// Download the artifacts

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -35,6 +35,7 @@ type ArtifactUploadConfig struct {
 	UploadPaths      string `cli:"arg:0" label:"upload paths" validate:"required"`
 	Destination      string `cli:"arg:1" label:"destination"`
 	Job              string `cli:"job" validate:"required"`
+	UnixSyntax       bool   `cli:"unix-syntax"`
 	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
 	Endpoint         string `cli:"endpoint" validate:"required"`
 	NoColor          bool   `cli:"no-color"`
@@ -52,6 +53,11 @@ var ArtifactUploadCommand = cli.Command{
 			Value:  "",
 			Usage:  "Which job should the artifacts be uploaded to",
 			EnvVar: "BUILDKITE_JOB_ID",
+		},
+		cli.BoolFlag{
+			Name:   "unix-syntax",
+			EnvVar: "BUILDKITE_ARTIFACT_UNIX_SYNTAX",
+			Usage:  "The download syntax matches that of regular unix tools like cp and mv. This will be the default in 3.0",
 		},
 		AgentAccessTokenFlag,
 		EndpointFlag,
@@ -80,6 +86,7 @@ var ArtifactUploadCommand = cli.Command{
 			JobID:       cfg.Job,
 			Paths:       cfg.UploadPaths,
 			Destination: cfg.Destination,
+			UnixSyntax:  cfg.UnixSyntax,
 		}
 
 		// Upload the artifacts


### PR DESCRIPTION
Currently the syntax for uploading and downloading files is inconsistent and confusing. This PR switches us to a model that replicates `cp` and `mv`

- [x] Add option
- [ ] Rewrite file collection
- [ ] Rewrite file downloading
- [ ] Ensure download logic is contained within a seperate module so it can be used by the S3 downloader

This change will address: https://github.com/buildkite/agent/issues/91 https://github.com/buildkite/agent/issues/96 and https://github.com/buildkite/agent/issues/108