### PR TITLE
Use a lock when reading or writing to artifactsStates

### DIFF
--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -192,7 +192,9 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 			// them from the tracking map
 			for id, state := range artifactsStates {
 				statesToUpload[id] = state
+				p.Lock()
 				delete(artifactsStates, id)
+				p.Unlock()
 			}
 
 			if len(statesToUpload) > 0 {
@@ -267,7 +269,9 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 				state = "finished"
 			}
 
+			p.Lock()
 			artifactsStates[artifact.ID] = state
+			p.Unlock()
 		})
 	}
 


### PR DESCRIPTION
I see the agent hanging occasionally after all artifacts have been uploaded. It appears the background goroutine that uploads state changes using the Buildkite API is waiting for more state changes.

Looking into this, I noticed that the `artifactsStates` map is accessed and modified in different goroutines without first acquiring a lock, which appears to be unsafe. See:

https://golang.org/doc/faq#atomic_maps

Adding `p.Lock()` and `p.Unlock()` fixes the hangs for me.

Note: This uses the pool's `sync.Mutex`. I think we only need a `sync.RWMutex`, which allows multiple parallel readers---but that would require a bigger change.