### PR TITLE
Use git clone --single-branch

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -243,7 +243,11 @@ else
   if [[ -d ".git" ]]; then
     buildkite-run "git remote set-url origin \"$BUILDKITE_REPO\""
   else
-    buildkite-run "git clone \"$BUILDKITE_REPO\" . -qv"
+    if git clone --help | grep -- --single-branch &> /dev/null; then
+      buildkite-run "git clone -qv --single-branch \"$BUILDKITE_BRANCH\" -- \"$BUILDKITE_REPO\" ."
+    else
+      buildkite-run "git clone -qv -- \"$BUILDKITE_REPO\" ."
+    fi
   fi
 
   buildkite-run "git clean -fdq"


### PR DESCRIPTION
This avoid pulling all the branch during the clone.

It does require Git `1.7.10` thought: https://github.com/Shopify/shipit-engine/blob/45d0225276715b6352159b043c3bb4aa07845c2a/lib/stack_commands.rb#L50-L53

@keithpitt @toolmantim for review please.