### PR TITLE
add arm support for install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,11 +30,11 @@ else
   PLATFORM="linux"
 fi
 
-if [[ ($UNAME == *x86_64*) || ($UNAME == *amd64*) ]]; then
-  ARCH="amd64"
-else
-  ARCH="386"
-fi
+case $UNAME in
+  *x86_64*) ARCH="amd64" ;;
+  *arm*)    ARCH="arm"   ;;
+  *)        ARCH="386"   ;;
+esac
 
 if [[ "$BETA" == "true" ]]; then
   RELEASE_INFO_URL="https://buildkite.com/agent/releases/latest?platform=$PLATFORM&arch=$ARCH&prerelease=true"


### PR DESCRIPTION
Currently the install script fallback to 386 unless the arch is x86_64.
As arm binaries are officially released, a simple case statement in the install script fix the issue.