### PR TITLE
Add support for artifacts on Google Cloud Storage

### DIFF
--- a/agent/artifact_downloader.go
+++ b/agent/artifact_downloader.go
@@ -75,7 +75,7 @@ func (a *ArtifactDownloader) Download() error {
 				} else if strings.HasPrefix(artifact.UploadDestination, "gs://") {
 					err = GSDownloader{
 						Path:        artifact.Path,
-						URL:         artifact.URL,
+						Bucket:      artifact.UploadDestination,
 						Destination: downloadDestination,
 						Retries:     5,
 						DebugHTTP:   a.APIClient.DebugHTTP,

--- a/agent/artifact_downloader.go
+++ b/agent/artifact_downloader.go
@@ -63,11 +63,19 @@ func (a *ArtifactDownloader) Download() error {
 			p.Spawn(func() {
 				var err error
 
-				// Handle downloading from S3
+				// Handle downloading from S3 and GS
 				if strings.HasPrefix(artifact.UploadDestination, "s3://") {
 					err = S3Downloader{
 						Path:        artifact.Path,
 						Bucket:      artifact.UploadDestination,
+						Destination: downloadDestination,
+						Retries:     5,
+						DebugHTTP:   a.APIClient.DebugHTTP,
+					}.Start()
+				} else if strings.HasPrefix(artifact.UploadDestination, "gs://") {
+					err = GSDownloader{
+						Path:        artifact.Path,
+						URL:         artifact.URL,
 						Destination: downloadDestination,
 						Retries:     5,
 						DebugHTTP:   a.APIClient.DebugHTTP,

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -139,6 +139,8 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 	if a.Destination != "" {
 		if strings.HasPrefix(a.Destination, "s3://") {
 			uploader = new(S3Uploader)
+		} else if strings.HasPrefix(a.Destination, "gs://") {
+			uploader = new(GSUploader)
 		} else {
 			return errors.New("Unknown upload destination: " + a.Destination)
 		}

--- a/agent/download.go
+++ b/agent/download.go
@@ -15,6 +15,9 @@ import (
 )
 
 type Download struct {
+	// The HTTP client to use for downloading
+	Client http.Client
+
 	// The actual URL to get the file from
 	URL string
 
@@ -74,7 +77,7 @@ func (d Download) try() error {
 	logger.Debug("Downloading %s to %s", d.URL, targetFile)
 
 	// Start by downloading the file
-	response, err := http.Get(d.URL)
+	response, err := d.Client.Get(d.URL)
 	if err != nil {
 		return fmt.Errorf("Error while downloading %s (%T: %v)", d.URL, err, err)
 	}

--- a/agent/gs_downloader.go
+++ b/agent/gs_downloader.go
@@ -36,7 +36,7 @@ func (d GSDownloader) Start() error {
 	// We can now cheat and pass the URL onto our regular downloader
 	return Download{
 		Client:      *client,
-		URL:         d.URL + "?alt=media",
+		URL:         d.URL,
 		Path:        d.Path,
 		Destination: d.Destination,
 		Retries:     d.Retries,

--- a/agent/gs_downloader.go
+++ b/agent/gs_downloader.go
@@ -1,0 +1,45 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
+	storage "google.golang.org/api/storage/v1"
+)
+
+type GSDownloader struct {
+	// The URL
+	URL string
+
+	// The root directory of the download
+	Destination string
+
+	// The relative path that should be preserved in the download folder,
+	// also it's location in the bucket
+	Path string
+
+	// How many times should it retry the download before giving up
+	Retries int
+
+	// If failed responses should be dumped to the log
+	DebugHTTP bool
+}
+
+func (d GSDownloader) Start() error {
+	client, err := google.DefaultClient(context.Background(), storage.DevstorageReadOnlyScope)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Error creating Google Cloud Storage client: %v", err))
+	}
+
+	// We can now cheat and pass the URL onto our regular downloader
+	return Download{
+		Client:      *client,
+		URL:         d.URL + "?alt=media",
+		Path:        d.Path,
+		Destination: d.Destination,
+		Retries:     d.Retries,
+		DebugHTTP:   d.DebugHTTP,
+	}.Start()
+}

--- a/agent/gs_downloader.go
+++ b/agent/gs_downloader.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
@@ -10,8 +11,8 @@ import (
 )
 
 type GSDownloader struct {
-	// The URL
-	URL string
+	// The name of the bucket
+	Bucket string
 
 	// The root directory of the download
 	Destination string
@@ -33,13 +34,80 @@ func (d GSDownloader) Start() error {
 		return errors.New(fmt.Sprintf("Error creating Google Cloud Storage client: %v", err))
 	}
 
+	url := "https://www.googleapis.com/storage/v1/b/" + d.BucketName() + "/o/" + escape(d.BucketFileLocation()) + "?alt=media"
+
 	// We can now cheat and pass the URL onto our regular downloader
 	return Download{
 		Client:      *client,
-		URL:         d.URL,
+		URL:         url,
 		Path:        d.Path,
 		Destination: d.Destination,
 		Retries:     d.Retries,
 		DebugHTTP:   d.DebugHTTP,
 	}.Start()
+}
+
+func (d GSDownloader) BucketFileLocation() string {
+	if d.BucketPath() != "" {
+		return strings.TrimSuffix(d.BucketPath(), "/") + "/" + strings.TrimPrefix(d.Path, "/")
+	} else {
+		return d.Path
+	}
+}
+
+func (d GSDownloader) BucketPath() string {
+	return strings.Join(d.destinationParts()[1:len(d.destinationParts())], "/")
+}
+
+func (d GSDownloader) BucketName() string {
+	return d.destinationParts()[0]
+}
+
+func (d GSDownloader) destinationParts() []string {
+	trimmed := strings.TrimPrefix(d.Bucket, "gs://")
+
+	return strings.Split(trimmed, "/")
+}
+
+func escape(s string) string {
+	// See https://golang.org/src/net/url/url.go
+	hexCount := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if shouldEscape(c) {
+			hexCount++
+		}
+	}
+
+	if hexCount == 0 {
+		return s
+	}
+
+	t := make([]byte, len(s)+2*hexCount)
+	j := 0
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case shouldEscape(c):
+			t[j] = '%'
+			t[j+1] = "0123456789ABCDEF"[c>>4]
+			t[j+2] = "0123456789ABCDEF"[c&15]
+			j += 3
+		default:
+			t[j] = s[i]
+			j++
+		}
+	}
+	return string(t)
+}
+
+func shouldEscape(c byte) bool {
+	// See https://cloud.google.com/storage/docs/json_api/#encoding
+	if 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' {
+		return false
+	}
+	switch c {
+	case '-', '.', '_', '~', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=', ':', '@':
+		return false
+	}
+	return true
 }

--- a/agent/gs_uploader.go
+++ b/agent/gs_uploader.go
@@ -1,0 +1,159 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/buildkite/agent/api"
+	"github.com/buildkite/agent/logger"
+	"github.com/buildkite/agent/mime"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
+	storage "google.golang.org/api/storage/v1"
+)
+
+type GSUploader struct {
+	// The destination which includes the GS bucket name and the path.
+	// gs://my-bucket-name/foo/bar
+	Destination string
+
+	// Whether or not HTTP calls shoud be debugged
+	DebugHTTP bool
+
+	// The GS service
+	Service *storage.Service
+}
+
+func (u *GSUploader) Setup(destination string, debugHTTP bool) error {
+	u.Destination = destination
+	u.DebugHTTP = debugHTTP
+
+	client, err := google.DefaultClient(context.Background(), storage.DevstorageFullControlScope)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Error creating Google Cloud Storage client: %v", err))
+	}
+	service, err := storage.New(client)
+	if err != nil {
+		return err
+	}
+	u.Service = service
+
+	return nil
+}
+
+func (u *GSUploader) URL(artifact *api.Artifact) string {
+	// We could use url.QueryEscape() instead of escape(), but the
+	// former escapes a few more characters than necessary.
+	return "https://www.googleapis.com/storage/v1/b/" + u.BucketName() + "/o/" + escape(u.artifactPath(artifact))
+}
+
+func (u *GSUploader) Upload(artifact *api.Artifact) error {
+	permission := "publicRead"
+	if os.Getenv("BUILDKITE_GS_ACL") != "" {
+		permission = os.Getenv("BUILDKITE_GS_ACL")
+	}
+
+	// The dirtiest validation method ever...
+	if permission != "authenticatedRead" &&
+		permission != "private" &&
+		permission != "projectPrivate" &&
+		permission != "publicRead" &&
+		permission != "publicReadWrite" {
+		logger.Fatal("Invalid GS ACL `%s`", permission)
+	}
+
+	logger.Debug("Uploading \"%s\" to bucket \"%s\" with permission \"%s\"",
+		u.artifactPath(artifact), u.BucketName(), permission)
+	object := &storage.Object{
+		Name:        u.artifactPath(artifact),
+		ContentType: u.mimeType(artifact),
+	}
+	file, err := os.Open(artifact.AbsolutePath)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Failed to open file \"%q\" (%v)", artifact.AbsolutePath, err))
+	}
+	if res, err := u.Service.Objects.Insert(u.BucketName(), object).PredefinedAcl(permission).Media(file).Do(); err == nil {
+		logger.Debug("Created object %v at location %v\n\n", res.Name, res.SelfLink)
+	} else {
+		return errors.New(fmt.Sprintf("Failed to PUT file \"%s\" (%v)", u.artifactPath(artifact), err))
+	}
+
+	return nil
+}
+
+func (u *GSUploader) artifactPath(artifact *api.Artifact) string {
+	parts := []string{u.BucketPath(), artifact.Path}
+
+	return strings.Join(parts, "/")
+}
+
+func (u *GSUploader) BucketPath() string {
+	return strings.Join(u.destinationParts()[1:len(u.destinationParts())], "/")
+}
+
+func (u *GSUploader) BucketName() string {
+	return u.destinationParts()[0]
+}
+
+func (u *GSUploader) destinationParts() []string {
+	trimmed := strings.TrimPrefix(u.Destination, "gs://")
+
+	return strings.Split(trimmed, "/")
+}
+
+func (u *GSUploader) mimeType(a *api.Artifact) string {
+	extension := filepath.Ext(a.Path)
+	mimeType := mime.TypeByExtension(extension)
+
+	if mimeType != "" {
+		return mimeType
+	} else {
+		return "binary/octet-stream"
+	}
+}
+
+func shouldEscape(c byte) bool {
+	// See https://cloud.google.com/storage/docs/json_api/#encoding
+	if 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' {
+		return false
+	}
+	switch c {
+	case '-', '.', '_', '~', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=', ':', '@':
+		return false
+	}
+	return true
+}
+
+func escape(s string) string {
+	// See https://golang.org/src/net/url/url.go
+	hexCount := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if shouldEscape(c) {
+			hexCount++
+		}
+	}
+
+	if hexCount == 0 {
+		return s
+	}
+
+	t := make([]byte, len(s)+2*hexCount)
+	j := 0
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case shouldEscape(c):
+			t[j] = '%'
+			t[j+1] = "0123456789ABCDEF"[c>>4]
+			t[j+2] = "0123456789ABCDEF"[c&15]
+			j += 3
+		default:
+			t[j] = s[i]
+			j++
+		}
+	}
+	return string(t)
+}

--- a/agent/gs_uploader_test.go
+++ b/agent/gs_uploader_test.go
@@ -1,0 +1,23 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGSUploaderBucketPath(t *testing.T) {
+	gsUploader := GSUploader{Destination: "gs://my-bucket-name/foo/bar"}
+	assert.Equal(t, gsUploader.BucketPath(), "foo/bar")
+
+	gsUploader.Destination = "gs://starts-with-an-s/and-this-is-its/folder"
+	assert.Equal(t, gsUploader.BucketPath(), "and-this-is-its/folder")
+}
+
+func TestGSUploaderBucketName(t *testing.T) {
+	gsUploader := GSUploader{Destination: "gs://my-bucket-name/foo/bar"}
+	assert.Equal(t, gsUploader.BucketName(), "my-bucket-name")
+
+	gsUploader.Destination = "gs://starts-with-an-s"
+	assert.Equal(t, gsUploader.BucketName(), "starts-with-an-s")
+}

--- a/agent/s3_downloader.go
+++ b/agent/s3_downloader.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -58,6 +59,7 @@ func (d S3Downloader) Start() error {
 
 	// We can now cheat and pass the URL onto our regular downloader
 	return Download{
+		Client:      *http.DefaultClient,
 		URL:         signedURL,
 		Path:        d.Path,
 		Destination: d.Destination,

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -33,7 +33,7 @@ Example:
 
    Or upload directly to Google Cloud Storage:
 
-   $ export BUILDKITE_GS_ACL=private # default is publicRead
+   $ export BUILDKITE_GS_ACL=private
    $ buildkite-agent artifact upload "log/**/*.log" gs://name-of-your-gs-bucket/$BUILDKITE_JOB_ID`
 
 type ArtifactUploadConfig struct {

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -29,7 +29,12 @@ Example:
    $ export BUILDKITE_S3_SECRET_ACCESS_KEY=yyy
    $ export BUILDKITE_S3_DEFAULT_REGION=eu-central-1 # default is us-east-1
    $ export BUILDKITE_S3_ACL=private # default is public-read
-   $ buildkite-agent artifact upload "log/**/*.log" s3://name-of-your-s3-bucket/$BUILDKITE_JOB_ID`
+   $ buildkite-agent artifact upload "log/**/*.log" s3://name-of-your-s3-bucket/$BUILDKITE_JOB_ID
+
+   Or upload directly to Google Cloud Storage:
+
+   $ export BUILDKITE_GS_ACL=private # default is publicRead
+   $ buildkite-agent artifact upload "log/**/*.log" gs://name-of-your-gs-bucket/$BUILDKITE_JOB_ID`
 
 type ArtifactUploadConfig struct {
 	UploadPaths      string `cli:"arg:0" label:"upload paths" validate:"required"`


### PR DESCRIPTION
The Buildkite agent currently allows storing artifacts in an S3 bucket
with the `s3://` scheme. This change adds support for Google Cloud
Storage buckets with the `gs://` scheme. Details:

* GS authentication is handled using Google's OAuth2 library, which
  searches for the credentials in various locations. See:

    https://godoc.org/golang.org/x/oauth2/google#DefaultClient

* GS ACLs are similar to S3 ACLs. The default GS ACL is `publicRead`,
  which is analagous to S3's `public-read`. I'd actually prefer if it
  was safer and defaulted to `private` for both GS and S3, but I left
  it this way for consistency.

* GS downloading is handled by reusing `download.go`, similar to S3
  downloading. An `http.Client` field is now passed in via the
  `Download` struct. This allows the GS code to pass in a client that
  was created by Google's OAuth2 library and automatically adds an
  appropriate `Authorization` header to requests.

* There are basically no test cases yet for GS uploading and
  downloading. I borrowed a few from S3 in `gs_uploader_test.go`, but
  I'm not sure if they make sense for GS.

* This change adds dependencies on the following imports:

    `golang.org/x/net/context`
    `golang.org/x/oauth2/google`
    `google.golang.org/api/storage/v1`

  These should be commited under the `vendor` directory, probably in a
  separate change.