### PR TITLE
Add bootstrap-script path back to default config

### DIFF
--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -13,6 +13,11 @@ name="%hostname-%n"
 # Populate the meta data from the current instances EC2 Tags
 # meta-data-ec2-tags=true
 
+# Path to the bootstrap script. You should avoid changing this file as it will
+# be overridden when you update your agent. If you need to make changes to this
+# file: use the hooks provided, or copy the file and reference it here.
+bootstrap-script="/usr/share/buildkite-agent/bootstrap.sh"
+
 # Path to where the builds will run from
 build-path="/var/lib/buildkite-agent/builds"
 


### PR DESCRIPTION
This was removed in 80373be618fc6aacbda88f756e16dcc5c3725612, but is still required in 2.1.x agents. Without this, after `apt-get install buildkite-agent` you will _not_ be able to start the agent.