### PR TITLE
Remove gitignore'd files on clean

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -844,11 +844,11 @@ func (b *Bootstrap) Start() error {
 		}
 
 		// Clean up the repository
-		b.runCommand("git", "clean", "-fdq")
+		b.runCommand("git", "clean", "-fdqx")
 
 		// Also clean up submodules if we can
 		if b.GitSubmodules {
-			b.runCommand("git", "submodule", "foreach", "--recursive", "git", "clean", "-fdq")
+			b.runCommand("git", "submodule", "foreach", "--recursive", "git", "clean", "-fdqx")
 		}
 
 		// Allow checkouts of forked pull requests on GitHub only. See:


### PR DESCRIPTION
For ages we've spoken about changing the default behaviour so that it cleans all the files between jobs. This updates the golang bootstrap to remove all files, even those that are git ignored.

Something to consider: how do you achieve wanting to keep files around between builds? Do you just use the artifact gear, or your own `cp` commands on the file system, if you want to assume a single box? We could add it as an agent config if we really wanted.

Closes #173 