### PR TITLE
bootstrap: Add support for BUILDKITE_REFSPEC

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -41,6 +41,9 @@ type Bootstrap struct {
 	// The tag of the job commit
 	Tag string
 
+	// A refspec to fetch
+	RefSpec string
+
 	// Plugin definition for the job
 	Plugins string
 
@@ -858,6 +861,8 @@ func (b *Bootstrap) Start() error {
 		// https://help.github.com/articles/checking-out-pull-requests-locally/#modifying-an-inactive-pull-request-locally
 		if b.PullRequest != "false" && strings.Contains(b.PipelineProvider, "github") {
 			b.runCommand("git", "fetch", "-q", "origin", "+refs/pull/"+b.PullRequest+"/head:")
+		} else if b.RefSpec != "" {
+			b.runCommand("git", "fetch", "-q", "origin", b.RefSpec)
 		} else {
 			// If the commit is HEAD, we can't do a commit-only
 			// fetch, we'll need to use the branch instead.  During

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -31,6 +31,7 @@ type BootstrapConfig struct {
 	Commit                       string `cli:"commit" validate:"required"`
 	Branch                       string `cli:"branch" validate:"required"`
 	Tag                          string `cli:"tag"`
+	RefSpec                      string `cli:"refspec"`
 	Plugins                      string `cli:"plugins"`
 	PullRequest                  string `cli:"pullrequest"`
 	GitSubmodules                bool   `cli:"git-submodules"`
@@ -91,6 +92,12 @@ var BootstrapCommand = cli.Command{
 			Value:  "",
 			Usage:  "The tag the commit",
 			EnvVar: "BUILDKITE_TAG",
+		},
+		cli.StringFlag{
+			Name:   "refspec",
+			Value:  "",
+			Usage:  "The refspec this commit belonged to",
+			EnvVar: "BUILDKITE_REFSPEC",
 		},
 		cli.StringFlag{
 			Name:   "plugins",

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -231,6 +231,8 @@ else
   # https://help.github.com/articles/checking-out-pull-requests-locally/#modifying-an-inactive-pull-request-locally
   if [[ "$BUILDKITE_PULL_REQUEST" != "false" ]] && [[ "$BUILDKITE_PIPELINE_PROVIDER" == *"github"* ]]; then
     buildkite-run "git fetch origin \"+refs/pull/$BUILDKITE_PULL_REQUEST/head:\""
+  elif [[ "${BUILDKITE_REFSPEC:-}" != "" ]]; then
+    buildkite-run "git fetch origin \"$BUILDKITE_REFSPEC\""
   else
     # If the commit is HEAD, we can't do a commit-only fetch, we'll need to use
     # the branch instead.


### PR DESCRIPTION
This is useful to integrating Buildkite with Gerrit. Basically, in the Gerrit workflow commits for patchsets are not done on branches. Instead, they each have a ref of the form:

    refs/changes/XX/XX/XX

In order to build the commit, you must first pull the ref. So add support for a new environment variable BUILDKITE_REFSPEC that can be set to indicate the refspec that Buildkite should pull.

This is a generalization of the support for building pull requests from GitHub. In that case Buildkite figures out the ref automatically from GITHUB_PULL_REQUEST environment variable.