### PR TITLE
Bootstrap script fetch logic tweaks

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -227,11 +227,17 @@ else
     buildkite-run "git submodule foreach --recursive git clean -fdq"
   fi
 
+  # If a refspec is provided then use it instead.
+  # i.e. `refs/not/a/head`
+  if [[ -n "${BUILDKITE_REFSPEC:-}" ]]; then
+    buildkite-run "git fetch origin \"$BUILDKITE_REFSPEC\""
+    buildkite-run "git checkout -f \"$BUILDKITE_COMMIT\""
+
   # GitHub has a special ref which lets us fetch a pull request head, whether
   # or not there is a current head in this repository or another which
   # references the commit. We presume a commit sha is provided. See:
   # https://help.github.com/articles/checking-out-pull-requests-locally/#modifying-an-inactive-pull-request-locally
-  if [[ "$BUILDKITE_PULL_REQUEST" != "false" ]] && [[ "$BUILDKITE_PROJECT_PROVIDER" == *"github"* ]]; then
+  elif [[ "$BUILDKITE_PULL_REQUEST" != "false" ]] && [[ "$BUILDKITE_PROJECT_PROVIDER" == *"github"* ]]; then
     buildkite-run "git fetch origin \"refs/pull/$BUILDKITE_PULL_REQUEST/head\""
     buildkite-run "git checkout -f \"$BUILDKITE_COMMIT\""
 

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -235,11 +235,11 @@ else
     # If the commit is HEAD, we can't do a commit-only fetch, we'll need to use
     # the branch instead.
     if [[ "$BUILDKITE_COMMIT" == "HEAD" ]]; then
-      buildkite-run "git fetch origin $BUILDKITE_BRANCH 2> /dev/null || git fetch"
+      buildkite-run "git fetch origin $BUILDKITE_BRANCH 2> /dev/null || git fetch origin --tags"
     else
       # First try to fetch the commit only (because it's usually much faster).
       # If that doesn't work, just resort back to a regular fetch.
-      buildkite-run "git fetch origin $BUILDKITE_COMMIT 2> /dev/null || git fetch"
+      buildkite-run "git fetch origin $BUILDKITE_COMMIT 2> /dev/null || git fetch origin --tags"
     fi
 
     if [[ "$BUILDKITE_TAG" == "" ]]; then

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -218,7 +218,7 @@ else
   if [[ -d ".git" ]]; then
     buildkite-run "git remote set-url origin \"$BUILDKITE_REPO\""
   else
-    buildkite-run "git clone -qv -- \"$BUILDKITE_REPO\" ."
+    buildkite-run "git clone -v -- \"$BUILDKITE_REPO\" ."
   fi
 
   buildkite-run "git clean -fdq"
@@ -235,11 +235,11 @@ else
     # If the commit is HEAD, we can't do a commit-only fetch, we'll need to use
     # the branch instead.
     if [[ "$BUILDKITE_COMMIT" == "HEAD" ]]; then
-      buildkite-run "git fetch -q origin $BUILDKITE_BRANCH 2> /dev/null || git fetch -q"
+      buildkite-run "git fetch origin $BUILDKITE_BRANCH 2> /dev/null || git fetch"
     else
       # First try to fetch the commit only (because it's usually much faster).
       # If that doesn't work, just resort back to a regular fetch.
-      buildkite-run "git fetch -q origin $BUILDKITE_COMMIT 2> /dev/null || git fetch -q"
+      buildkite-run "git fetch origin $BUILDKITE_COMMIT 2> /dev/null || git fetch"
     fi
 
     if [[ "$BUILDKITE_TAG" == "" ]]; then
@@ -249,7 +249,7 @@ else
     fi
   fi
 
-  buildkite-run "git checkout -qf \"$BUILDKITE_COMMIT\""
+  buildkite-run "git checkout -f \"$BUILDKITE_COMMIT\""
 
   if [[ -z "${BUILDKITE_DISABLE_GIT_SUBMODULES:-}" ]]; then
     # `submodule sync` will ensure the .git/config matches the .gitmodules file.

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -268,8 +268,8 @@ else
   # Check to see if the meta data exists before setting it
   buildkite-run-debug "buildkite-agent meta-data exists \"buildkite:git:commit\""
   if [[ $? -ne 0 ]]; then
-    buildkite-run-debug "buildkite-agent meta-data set \"buildkite:git:commit\" \"\`git show \"$BUILDKITE_COMMIT\" -s --format=fuller --no-color\`\""
-    buildkite-run-debug "buildkite-agent meta-data set \"buildkite:git:branch\" \"\`git branch --contains \"$BUILDKITE_COMMIT\" --no-color\`\""
+    buildkite-run-debug "buildkite-agent meta-data set \"buildkite:git:commit\" \"\`git show HEAD -s --format=fuller --no-color\`\""
+    buildkite-run-debug "buildkite-agent meta-data set \"buildkite:git:branch\" \"\`git branch --contains HEAD --no-color\`\""
   fi
 fi
 

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -227,29 +227,27 @@ else
     buildkite-run "git submodule foreach --recursive git clean -fdq"
   fi
 
-  # Allow checkouts of forked pull requests on GitHub only. See:
+  # GitHub has a special ref which lets us fetch a pull request head, whether
+  # or not there is a current head in this repository or another which
+  # references the commit. We presume a commit sha is provided. See:
   # https://help.github.com/articles/checking-out-pull-requests-locally/#modifying-an-inactive-pull-request-locally
   if [[ "$BUILDKITE_PULL_REQUEST" != "false" ]] && [[ "$BUILDKITE_PROJECT_PROVIDER" == *"github"* ]]; then
-    buildkite-run "git fetch origin \"+refs/pull/$BUILDKITE_PULL_REQUEST/head:\""
+    buildkite-run "git fetch origin \"refs/pull/$BUILDKITE_PULL_REQUEST/head\""
+    buildkite-run "git checkout -f \"$BUILDKITE_COMMIT\""
+
+  # If the commit is "HEAD" then we can't do a commit-specific fetch and will
+  # need to fetch the remote head and checkout the fetched head explicitly.
+  elif [[ "$BUILDKITE_COMMIT" == "HEAD" ]]; then
+    buildkite-run "git fetch origin \"$BUILDKITE_BRANCH\""
+    buildkite-run "git checkout -f FETCH_HEAD"
+
+  # Otherwise fetch and checkout the commit directly. Some repositories don't
+  # support fetching a specific commit so we fall back to fetching all heads
+  # and tags, hoping that the commit is included.
   else
-    # If the commit is HEAD, we can't do a commit-only fetch, we'll need to use
-    # the branch instead.
-    if [[ "$BUILDKITE_COMMIT" == "HEAD" ]]; then
-      buildkite-run "git fetch origin $BUILDKITE_BRANCH 2> /dev/null || git fetch origin --tags"
-    else
-      # First try to fetch the commit only (because it's usually much faster).
-      # If that doesn't work, just resort back to a regular fetch.
-      buildkite-run "git fetch origin $BUILDKITE_COMMIT 2> /dev/null || git fetch origin --tags"
-    fi
-
-    if [[ "$BUILDKITE_TAG" == "" ]]; then
-      # Default empty branch names
-      : "${BUILDKITE_BRANCH:=master}"
-      buildkite-run "git reset --hard origin/$BUILDKITE_BRANCH"
-    fi
+    buildkite-run "git fetch origin \"$BUILDKITE_COMMIT\" || git fetch origin --tags"
+    buildkite-run "git checkout -f \"$BUILDKITE_COMMIT\""
   fi
-
-  buildkite-run "git checkout -f \"$BUILDKITE_COMMIT\""
 
   if [[ -z "${BUILDKITE_DISABLE_GIT_SUBMODULES:-}" ]]; then
     # `submodule sync` will ensure the .git/config matches the .gitmodules file.


### PR DESCRIPTION
Change the git fetch and checkout behaviour to be a little more explicit.

There are a few discrete scenarios which are commented. There's also an additional ability to specify your own refspec, as suggested in #237.

I've tested this in several scenarios, with and without clean checkouts:

 * Building a master push using a github webhook
 * Building "master" at "HEAD" using web ui
 * Building a pushed tag with a commit unreachable from any head ref via webhook
 * Building a "proposed" branch triggerd via push
 * Building a "proposed" branch with "HEAD" triggered via web UI
 * Building a pull request via webhook
 * Building a pull request from a fork via webhook
 * Building a weird ref using `BUILDKITE_REFSPEC` in env and commit `FETCH_HEAD` via web UI

Hopefully this will provide more resilient checkout results, and more debug information if things go awry.

This should fix at least these scenarios:

* Fetching a git commit directly by sha then trying to reset hard to a branch we didn't actually fetch
* Fetching tags which don't appear on any head