### PR TITLE
Upgrade Stable to Golang 1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5
+FROM golang:1.6
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		autoconf \


### PR DESCRIPTION
We should recompile the agent with Golang v1.6 and do another stable release. The latest version of Golang has some performance & security fixes.

(btw, is this style of pull request a good idea? opening a pull request from my rando branch to the stable branch?)