### PR TITLE
Added support for environment variable substitution in pipeline files

### DIFF
--- a/agent/pipeline_parser.go
+++ b/agent/pipeline_parser.go
@@ -1,0 +1,126 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+type PipelineParser struct {
+	Data []byte
+}
+
+var variablesWithBracketsRegex = regexp.MustCompile(`([\\\$]?\$\{(.+[^\\])})`)
+var variablesWithNoBracketsRegex = regexp.MustCompile(`([\\\$]?\$[a-zA-Z0-9_]+)`)
+
+func (p PipelineParser) Parse() (parsed []byte, err error) {
+	// Do a parse and handle ENV variables with the ${} syntax, i.e. ${FOO}
+	parsed = variablesWithBracketsRegex.ReplaceAllFunc(p.Data, func(part []byte) []byte {
+		v := string(part[:])
+
+		if !p.isPrefixedWithEscapeSequence(v) && err == nil {
+			err = p.isValidPosixEnvironmentVariable(v)
+			if err != nil {
+				return []byte(v)
+			}
+
+			key, option := p.extractKeyAndOptionFromVariable(v)
+			vv, isEnvironmentVariableSet := os.LookupEnv(key)
+
+			switch {
+			case strings.HasPrefix(option, "?"):
+				if vv == "" {
+					errorMessage := option[1:]
+					if errorMessage == "" {
+						errorMessage = "not set"
+					}
+					err = fmt.Errorf("$%s: %s", key, errorMessage)
+				}
+
+			case strings.HasPrefix(option, ":-"):
+				if vv == "" {
+					vv = option[2:]
+				}
+
+			case strings.HasPrefix(option, "-"):
+				if !isEnvironmentVariableSet {
+					vv = option[1:]
+				}
+
+			case option != "":
+				err = fmt.Errorf("Invalid option `%s` for environment variable `%s`", option, key)
+			}
+
+			v = vv
+		}
+
+		return []byte(v)
+	})
+
+	// If there was an error while parsing the more complicated environment
+	// variables, bail out now with the error.
+
+	// Another parse but this time target ENV variables without the {}
+	// surrounding it, i.e. $FOO. These ones are super simple to replace.
+	parsed = variablesWithNoBracketsRegex.ReplaceAllFunc(parsed, func(part []byte) []byte {
+		v := string(part[:])
+
+		if !p.isPrefixedWithEscapeSequence(v) && err == nil {
+			err = p.isValidPosixEnvironmentVariable(v)
+			if err != nil {
+				return []byte(v)
+			}
+
+			key, _ := p.extractKeyAndOptionFromVariable(v)
+			v = os.Getenv(key)
+		}
+
+		return []byte(v)
+	})
+
+	return
+}
+
+func (p PipelineParser) isPrefixedWithEscapeSequence(variable string) bool {
+	return strings.HasPrefix(variable, "$$") || strings.HasPrefix(variable, "\\$")
+}
+
+var validPosixEnvironmentVariablePrefixRegex = regexp.MustCompile(`\A\${1}\{?[a-zA-Z]`)
+
+// Returns true if the variable is a valid POSIX environment variale. It will
+// return false if the variable begins with a number, or it starts with two $$
+// characters.
+func (p PipelineParser) isValidPosixEnvironmentVariable(variable string) error {
+	if validPosixEnvironmentVariablePrefixRegex.MatchString(variable) {
+		return nil
+	} else {
+		return fmt.Errorf("Invalid environment variable `%s` - they can only start with a letter", variable)
+	}
+}
+
+var firstNonEnvironmentVariableCharacterRegex = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+
+// Takes an environment variable, and extracts the variable name and a suffixed
+// option.  For example, ${BEST_COMMAND:-lol} will be turned split into
+// "BEST_COMMAND" and ":-lol". Regualr environment variables like $FOO will
+// return "FOO" as the `key`, and a blank string as the `option`.
+func (p PipelineParser) extractKeyAndOptionFromVariable(variable string) (key string, option string) {
+	if strings.HasPrefix(variable, "${") {
+		// Trim the first 2 characters `${` and the last character `}`
+		trimmed := variable[2 : len(variable)-1]
+
+		optionsIndicies := firstNonEnvironmentVariableCharacterRegex.FindStringIndex(trimmed)
+		if len(optionsIndicies) > 0 {
+			key = trimmed[0:optionsIndicies[0]]
+			option = trimmed[optionsIndicies[0]:len(trimmed)]
+		} else {
+			key = trimmed
+		}
+	} else {
+		// Trim the first character `$`
+		key = variable[1:]
+	}
+
+	return
+}

--- a/agent/pipeline_parser_test.go
+++ b/agent/pipeline_parser_test.go
@@ -1,0 +1,174 @@
+package agent
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func parse(s string) (string, error) {
+	parsed, err := PipelineParser{Data: []byte(s)}.Parse()
+
+	return string(parsed[:]), err
+}
+
+func TestPipelineParser(t *testing.T) {
+	var result string
+	var err error
+
+	// It does nothing to byte slices with no environmnet variables
+	result, err = parse("foo")
+	assert.Nil(t, err)
+	assert.Equal(t, result, "foo")
+
+	// It does nothing to empty strings
+	result, err = parse("")
+	assert.Nil(t, err)
+	assert.Equal(t, result, "")
+
+	// It parses regular env vars
+	os.Setenv("WHO", "World!")
+	result, err = parse(`
+	  steps:
+	    - command: "Hello $WHO"
+	`)
+	assert.Nil(t, err)
+	assert.Equal(t, result, `
+	  steps:
+	    - command: "Hello World!"
+	`)
+
+	// It inserts a blank string if the var hasn't been set
+	result, err = parse(`
+	  steps:
+	    - command: "Hello $WHO_REALLY"
+	`)
+	assert.Nil(t, err)
+	assert.Equal(t, result, `
+	  steps:
+	    - command: "Hello "
+	`)
+
+	// It returns an error with an invalid looking env var
+	result, err = parse(`
+	  steps:
+	    - command: "Hello $123"
+	`)
+	assert.NotNil(t, err)
+	assert.Equal(t, string(err.Error()), "Invalid environment variable `$123` - they can only start with a letter")
+
+	// They can be embedded in strings and keys
+	os.Setenv("KEY", "command")
+	os.Setenv("END_OF_HELLO", "llo")
+	result, err = parse(`
+	  steps:
+	    - $KEY: "He$END_OF_HELLO"
+	`)
+	assert.Nil(t, err)
+	assert.Equal(t, result, `
+	  steps:
+	    - command: "Hello"
+	`)
+
+	// The parser supports the other type of env variable
+	os.Setenv("TODAY", "Sunday")
+	os.Setenv("TOMORROW", "Monday")
+	result, err = parse(`
+	  steps:
+	    - command: "echo 'Today is ${TODAY}'"
+	    - command: "echo 'Tomorrow is ${TOMORROW}'"
+	`)
+	assert.Nil(t, err)
+	assert.Equal(t, result, `
+	  steps:
+	    - command: "echo 'Today is Sunday'"
+	    - command: "echo 'Tomorrow is Monday'"
+	`)
+
+	// You can provide default values
+	os.Unsetenv("TODAY")
+	os.Unsetenv("TOMORROW")
+	result, err = parse(`
+	  steps:
+	    - command: "echo 'Today is ${TODAY-Tuesday}'"
+	    - command: "echo 'Tomorrow is ${TOMORROW-Wednesday}'"
+	`)
+	assert.Nil(t, err)
+	assert.Equal(t, result, `
+	  steps:
+	    - command: "echo 'Today is Tuesday'"
+	    - command: "echo 'Tomorrow is Wednesday'"
+	`)
+
+	// You can toggle the defaulting behaviour between "use default if
+	// value is null" or "use default if value is unset"
+	os.Setenv("THIS_VAR_IS_NULL", "")
+	result, err = parse(`
+	  steps:
+            - command: "Do this ${THIS_VAR_IS_NULL:-great thing}"
+	    - command: "Do this ${THIS_VAR_IS_NULL-wont show up}"
+	    - command: "Don't do this ${THIS_VAR_DOESNT_EXIST:-please}"
+	    - command: "Don't do this ${THIS_VAR_DOESNT_EXIST-please (this will show)}"
+	`)
+	assert.Nil(t, err)
+	assert.Equal(t, result, `
+	  steps:
+            - command: "Do this great thing"
+	    - command: "Do this "
+	    - command: "Don't do this please"
+	    - command: "Don't do this please (this will show)"
+	`)
+
+	// It allows you to require some variables
+	result, err = parse(`
+	  steps:
+	    - command: "Hello ${REQUIRED_VAR?}"
+	`)
+	assert.NotNil(t, err)
+	assert.Equal(t, string(err.Error()), "$REQUIRED_VAR: not set")
+
+	// The error message for them can be customized
+	result, err = parse(`
+	  steps:
+	    - command: "Hello ${REQUIRED_VAR?y u no set me? :-{}"
+	`)
+	assert.NotNil(t, err)
+	assert.Equal(t, string(err.Error()), "$REQUIRED_VAR: y u no set me? :-{")
+
+	// Lets you escape variables using 2 different syntaxes
+	result, err = parse(`
+	  steps:
+            - command: "Do this $$ESCAPE_PARTY"
+            - command: "Do this \$ESCAPE_PARTY"
+            - command: "Do this $${SUCH_ESCAPE}"
+            - command: "Do this \${SUCH_ESCAPE}"
+	`)
+	assert.Nil(t, err)
+	assert.Equal(t, result, `
+	  steps:
+            - command: "Do this $$ESCAPE_PARTY"
+            - command: "Do this \$ESCAPE_PARTY"
+            - command: "Do this $${SUCH_ESCAPE}"
+            - command: "Do this \${SUCH_ESCAPE}"
+	`)
+
+	// Lets you use special characters in the default env var option
+	result, err = parse(`
+	  steps:
+	    - command: "${THIS_VAR_IS_NULL:--:{}}"
+	`)
+	assert.Nil(t, err)
+	assert.Equal(t, result, `
+	  steps:
+	    - command: "-:{}"
+	`)
+
+	// Lets you use special characters in the required var option
+	result, err = parse(`
+	  steps:
+	    - command: "Hello ${REQUIRED_VAR?{}}"
+	`)
+	assert.NotNil(t, err)
+	assert.Equal(t, string(err.Error()), "$REQUIRED_VAR: {}")
+}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -157,6 +157,16 @@ var PipelineUploadCommand = cli.Command{
 			logger.Fatal("Config file is empty")
 		}
 
+		var parsed []byte
+
+		logger.Debug("Parsing pipeline...")
+
+		// Parse the pipeline and prepare it for upload
+		parsed, err = agent.PipelineParser{Data: input}.Parse()
+		if err != nil {
+			logger.Fatal("Pipeline parsing of \"%s\" failed (%s)", filename, err)
+		}
+
 		// Create the API client
 		client := agent.APIClient{
 			Endpoint: cfg.Endpoint,
@@ -170,7 +180,7 @@ var PipelineUploadCommand = cli.Command{
 
 		// Retry the pipeline upload a few times before giving up
 		err = retry.Do(func(s *retry.Stats) error {
-			_, err = client.Pipelines.Upload(cfg.Job, &api.Pipeline{UUID: uuid, Data: input, FileName: filename, Replace: cfg.Replace})
+			_, err = client.Pipelines.Upload(cfg.Job, &api.Pipeline{UUID: uuid, Data: parsed, FileName: filename, Replace: cfg.Replace})
 			if err != nil {
 				logger.Warn("%s (%s)", err, s)
 			}


### PR DESCRIPTION
Added support for POSIX like environment variable substitution. This fixes https://github.com/buildkite/agent/issues/205

We now support:

```bash
$REGULAR_ENV
${ENV_LIKE_THIS}

export ONES_WITH_DEFAULT_IF_NULL="" # this is "set" but it's value is null

${ONES_WITH_DEFAULT_IF_NULL:-this value will show}
${ONES_WITH_DEFAULT_IF_NULL-but this value won't}

${EVEN_REQUIRE_ONES?}
#=> $EVEN_REQUIRE_ONES: not set

export AND_CUSTOM_ERROR_MESSAGES="" # nulls are treated as empty

${AND_CUSTOM_ERROR_MESSAGES?y u no set me}
#=> $AND_CUSTOM_ERROR_MESSAGES: y u no set me
```

:warning: This change introduces a somewhat breaking change. Any customer who already have `$SOMETHING` and `${SOMETHING}` in their pipeline files will need to escape them to `\$SOMETHING` and `\${SOMETHING}`.

We should probably release this in a 2.2? Maybe scrap the idea of the current 2.2? Or do you think that we could get away with just another 2.1 release?