### PR TITLE
Read BUILDKITE_S3_ACCESS_URL and use to override URL of artifact sent…

### DIFF
--- a/agent/s3_uploader.go
+++ b/agent/s3_uploader.go
@@ -62,7 +62,11 @@ func (u *S3Uploader) Setup(destination string, debugHTTP bool) error {
 }
 
 func (u *S3Uploader) URL(artifact *api.Artifact) string {
-	url, _ := url.Parse("http://" + u.bucketName() + ".s3.amazonaws.com")
+	baseUrl := "http://" + u.bucketName() + ".s3.amazonaws.com"
+	if os.Getenv("BUILDKITE_S3_ACCESS_URL") != "" {
+		baseUrl = os.Getenv("BUILDKITE_S3_ACCESS_URL")
+	}
+	url, _ := url.Parse(baseUrl)
 
 	url.Path += u.artifactPath(artifact)
 


### PR DESCRIPTION
Modification to accept environment variable BUILDKITE_S3_ACCESS_URL so that artifacts uploaded to a custom S3 bucket can be linked from buildkite using the base URL specified in that environment variable instead of http://{bucketName}.s3.amazonaws.com.

This allows static web hosting to be turned off on the bucket and instead serving artifacts from http://www.s3auth.com/ or using https://github.com/pottava/aws-s3-proxy so that artifacts can be more securely restricted than just be IP address. This will also fix #236 by specifying BUILDKITE_S3_ACCESS_URL as https://{bucketName}.s3.amazonaws.com.