### PR TITLE
Fix git fetch tags

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -887,7 +887,12 @@ func (b *Bootstrap) Start() error {
 			commentf("Fetch and checkout commit")
 			gitFetchExitStatus := b.runCommandGracefully("git", "fetch", "origin", b.Commit)
 			if gitFetchExitStatus != 0 {
-				b.runCommand("git", "fetch", "origin", "--tags")
+				// By default `git fetch origin` will only fetch tags which are
+				// reachable from a fetches branch. git 1.9.0+ changed `--tags` to
+				// fetch all tags in addition to the default refspec, but pre 1.9.0 it
+				// excludes the default refspec.
+				gitFetchRefspec, _ := b.runCommandSilentlyAndCaptureOutput("git", "config", "remote.origin.fetch")
+				b.runCommand("git", "fetch", "origin", gitFetchRefspec, "+refs/tags/*:refs/tags/*")
 			}
 			b.runCommand("git", "checkout", "-f", b.Commit)
 		}

--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -861,7 +861,7 @@ func (b *Bootstrap) Start() error {
 		// i.e. `refs/not/a/head`
 		if b.RefSpec != "" {
 			commentf("Fetch and checkout custom refspec")
-			b.runCommand("git", "fetch", "origin", b.RefSpec)
+			b.runCommand("git", "fetch", "-v", "origin", b.RefSpec)
 			b.runCommand("git", "checkout", "-f", b.Commit)
 
 		// GitHub has a special ref which lets us fetch a pull request head, whether
@@ -870,14 +870,14 @@ func (b *Bootstrap) Start() error {
 		// https://help.github.com/articles/checking-out-pull-requests-locally/#modifying-an-inactive-pull-request-locally
 		} else if b.PullRequest != "false" && strings.Contains(b.PipelineProvider, "github") {
 			commentf("Fetch and checkout pull request head")
-			b.runCommand("git", "fetch", "origin", "refs/pull/" + b.PullRequest + "/head")
+			b.runCommand("git", "fetch", "-v", "origin", "refs/pull/" + b.PullRequest + "/head")
 			b.runCommand("git", "checkout", "-f", b.Commit)
 
 		// If the commit is "HEAD" then we can't do a commit-specific fetch and will
 		// need to fetch the remote head and checkout the fetched head explicitly.
 		} else if b.Commit == "HEAD" {
 			commentf("Fetch and checkout remote branch HEAD commit")
-			b.runCommand("git", "fetch", "origin", b.Branch)
+			b.runCommand("git", "fetch", "-v", "origin", b.Branch)
 			b.runCommand("git", "checkout", "-f", "FETCH_HEAD")
 
 		// Otherwise fetch and checkout the commit directly. Some repositories don't
@@ -885,14 +885,14 @@ func (b *Bootstrap) Start() error {
 		// and tags, hoping that the commit is included.
 		} else {
 			commentf("Fetch and checkout commit")
-			gitFetchExitStatus := b.runCommandGracefully("git", "fetch", "origin", b.Commit)
+			gitFetchExitStatus := b.runCommandGracefully("git", "fetch", "-v", "origin", b.Commit)
 			if gitFetchExitStatus != 0 {
 				// By default `git fetch origin` will only fetch tags which are
 				// reachable from a fetches branch. git 1.9.0+ changed `--tags` to
 				// fetch all tags in addition to the default refspec, but pre 1.9.0 it
 				// excludes the default refspec.
 				gitFetchRefspec, _ := b.runCommandSilentlyAndCaptureOutput("git", "config", "remote.origin.fetch")
-				b.runCommand("git", "fetch", "origin", gitFetchRefspec, "+refs/tags/*:refs/tags/*")
+				b.runCommand("git", "fetch", "-v", "origin", gitFetchRefspec, "+refs/tags/*:refs/tags/*")
 			}
 			b.runCommand("git", "checkout", "-f", b.Commit)
 		}

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -230,7 +230,7 @@ else
   # If a refspec is provided then use it instead.
   # i.e. `refs/not/a/head`
   if [[ -n "${BUILDKITE_REFSPEC:-}" ]]; then
-    buildkite-run "git fetch origin \"$BUILDKITE_REFSPEC\""
+    buildkite-run "git fetch -v origin \"$BUILDKITE_REFSPEC\""
     buildkite-run "git checkout -f \"$BUILDKITE_COMMIT\""
 
   # GitHub has a special ref which lets us fetch a pull request head, whether
@@ -238,13 +238,13 @@ else
   # references the commit. We presume a commit sha is provided. See:
   # https://help.github.com/articles/checking-out-pull-requests-locally/#modifying-an-inactive-pull-request-locally
   elif [[ "$BUILDKITE_PULL_REQUEST" != "false" ]] && [[ "$BUILDKITE_PROJECT_PROVIDER" == *"github"* ]]; then
-    buildkite-run "git fetch origin \"refs/pull/$BUILDKITE_PULL_REQUEST/head\""
+    buildkite-run "git fetch -v origin \"refs/pull/$BUILDKITE_PULL_REQUEST/head\""
     buildkite-run "git checkout -f \"$BUILDKITE_COMMIT\""
 
   # If the commit is "HEAD" then we can't do a commit-specific fetch and will
   # need to fetch the remote head and checkout the fetched head explicitly.
   elif [[ "$BUILDKITE_COMMIT" == "HEAD" ]]; then
-    buildkite-run "git fetch origin \"$BUILDKITE_BRANCH\""
+    buildkite-run "git fetch -v origin \"$BUILDKITE_BRANCH\""
     buildkite-run "git checkout -f FETCH_HEAD"
 
   # Otherwise fetch and checkout the commit directly. Some repositories don't
@@ -255,7 +255,7 @@ else
     # from a fetches branch. git 1.9.0+ changed `--tags` to fetch all tags in
     # addition to the default refspec, but pre 1.9.0 it excludes the default
     # refspec.
-    buildkite-run "git fetch origin \"$BUILDKITE_COMMIT\" || git fetch origin \"$(git config remote.origin.fetch)\" \"+refs/tags/*:refs/tags/*\""
+    buildkite-run "git fetch -v origin \"$BUILDKITE_COMMIT\" || git fetch -v origin \"$(git config remote.origin.fetch)\" \"+refs/tags/*:refs/tags/*\""
     buildkite-run "git checkout -f \"$BUILDKITE_COMMIT\""
   fi
 

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -251,7 +251,11 @@ else
   # support fetching a specific commit so we fall back to fetching all heads
   # and tags, hoping that the commit is included.
   else
-    buildkite-run "git fetch origin \"$BUILDKITE_COMMIT\" || git fetch origin --tags"
+    # By default `git fetch origin` will only fetch tags which are reachable
+    # from a fetches branch. git 1.9.0+ changed `--tags` to fetch all tags in
+    # addition to the default refspec, but pre 1.9.0 it excludes the default
+    # refspec.
+    buildkite-run "git fetch origin \"$BUILDKITE_COMMIT\" || git fetch origin \"$(git config remote.origin.fetch)\" \"+refs/tags/*:refs/tags/*\""
     buildkite-run "git checkout -f \"$BUILDKITE_COMMIT\""
   fi
 


### PR DESCRIPTION
Prior to git 1.9.0, `git fetch --tags` would only fetch tags, not in addition to the default refspec. So replace it with an explicit set of refspecs.

Also, turn on verbose fetching for easier diagnostics.