### PR TITLE
Install arch flag

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ echo -e "\033[33m
 
 echo -e "Finding latest release..."
 
+ARCH="386"
 UNAME=`uname -sp | awk '{print tolower($0)}'`
 
 if [[ ($UNAME == *"mac os x"*) || ($UNAME == *darwin*) ]]; then
@@ -30,11 +31,19 @@ else
   PLATFORM="linux"
 fi
 
-case $UNAME in
-  *x86_64*) ARCH="amd64" ;;
-  *arm*)    ARCH="arm"   ;;
-  *)        ARCH="386"   ;;
-esac
+if [ -n "$BUILDKITE_INSTALL_ARCH" ]; then
+
+  ARCH=$(echo "$BUILDKITE_INSTALL_ARCH")
+  echo "Using explicit arch '$ARCH'"
+
+else
+
+  case $UNAME in
+    *x86_64*) ARCH="amd64" ;;
+    *arm*)    ARCH="arm"   ;;
+  esac
+
+fi
 
 if [[ "$BETA" == "true" ]]; then
   RELEASE_INFO_URL="https://buildkite.com/agent/releases/latest?platform=$PLATFORM&arch=$ARCH&prerelease=true"

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ echo -e "\033[33m
 echo -e "Finding latest release..."
 
 ARCH="386"
-UNAME=`uname -sp | awk '{print tolower($0)}'`
+UNAME=`uname -sm | awk '{print tolower($0)}'`
 
 if [[ ($UNAME == *"mac os x"*) || ($UNAME == *darwin*) ]]; then
   PLATFORM="darwin"


### PR DESCRIPTION
This PR proposes :

- BUILDKITE_INSTALL_ARCH be added for explicitly choosing an arch on install.sh
- Using `uname -m` instead of `uname -p` which can report false info.

Each commit includes detailed descriptions, I can split the commits to separate PR's if preferred.