### PR TITLE
Add BUILDKITE_DOCKER_COMPOSE_LEAVE_VOLUMES

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -417,12 +417,17 @@ else
     COMPOSE_COMMAND="docker-compose -f ${BUILDKITE_DOCKER_COMPOSE_FILE:-docker-compose.yml} -p $COMPOSE_PROJ_NAME"
 
     function compose-cleanup {
+      REMOVE_VOLUME_FLAG="-v"
+      if [[ "$BUILDKITE_DOCKER_COMPOSE_LEAVE_VOLUMES" != "true" ]]; then
+        REMOVE_VOLUME_FLAG=""
+      fi
+
       echo "~~~ Cleaning up Docker containers"
       buildkite-run "$COMPOSE_COMMAND kill || true"
-      buildkite-run "$COMPOSE_COMMAND rm --force -v || true"
-
+      buildkite-run "$COMPOSE_COMMAND rm --force $REMOVE_VOLUME_FLAG || true"
+  
       # The adhoc run container isn't cleaned up by compose, so we have to do it ourselves
-      buildkite-run "docker rm -f -v ${COMPOSE_CONTAINER_NAME}_run_1 || true"
+      buildkite-run "docker rm -f $REMOVE_VOLUME_FLAG ${COMPOSE_CONTAINER_NAME}_run_1 || true"
     }
 
     trap compose-cleanup EXIT


### PR DESCRIPTION
At present the agent is eager in deleting volumes attached to containers, which is the right thing to do in general to save space.

For speed reasons, we use a persistent Named Volume (holding ruby gems) and that volume shouldn't be deleted. But docker doesn't natively provide a way to say that it's persistent. So we need a flag to tell the agent not to ask docker to delete volumes. Hence `BUILDKITE_DOCKER_COMPOSE_LEAVE_VOLUMES`.

In general this is dangerous because it's bad for disk space, so those using the flag need to acknowledge the risks.