### PR TITLE
Log chunk as request body

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -49,7 +49,7 @@ func (r *AgentPool) Start() error {
 	logger.Debug("Ping interval: %ds", registered.PingInterval)
 	logger.Debug("Heartbeat interval: %ds", registered.HearbeatInterval)
 
-	// Now that we have a registereted agent, we can connect it to the API,
+	// Now that we have a registered agent, we can connect it to the API,
 	// and start running jobs.
 	worker := AgentWorker{Agent: registered, AgentConfiguration: r.AgentConfiguration, Endpoint: r.Endpoint}.Create()
 

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -304,6 +304,8 @@ func (r *JobRunner) onUploadChunk(chunk *LogStreamerChunk) error {
 		_, err := r.APIClient.Chunks.Upload(r.Job.ID, &api.Chunk{
 			Data:     chunk.Data,
 			Sequence: chunk.Order,
+			Offset:   chunk.Offset,
+			Size:     chunk.Size,
 		})
 		if err != nil {
 			logger.Warn("%s (%s)", err, s)

--- a/agent/log_streamer.go
+++ b/agent/log_streamer.go
@@ -46,6 +46,12 @@ type LogStreamerChunk struct {
 
 	// The sequence number of this chunk
 	Order int
+
+	// The byte offset of this chunk
+	Offset int
+
+	// The byte size of this chunk
+	Size int
 }
 
 // Creates a new instance of the log streamer
@@ -105,6 +111,8 @@ func (ls *LogStreamer) Process(output string) error {
 			chunk := LogStreamerChunk{
 				Data:  partialChunk,
 				Order: ls.order,
+				Offset: ls.bytes,
+				Size: bytes - ls.bytes,
 			}
 
 			ls.queue <- &chunk

--- a/api/chunks.go
+++ b/api/chunks.go
@@ -25,33 +25,23 @@ type Chunk struct {
 // but a multi-part HTTP form upload
 func (cs *ChunksService) Upload(jobId string, chunk *Chunk) (*Response, error) {
 	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
+	gzipper := gzip.NewWriter(body)
+	writer := multipart.NewWriter(gzipper)
 
 	// Write the sequence, offset and size values to the form
 	writer.WriteField("sequence", fmt.Sprintf("%d", chunk.Sequence))
 	writer.WriteField("offset", fmt.Sprintf("%d", chunk.Offset))
 	writer.WriteField("size", fmt.Sprintf("%d", chunk.Size))
 
-	// Gzip the chunk data
-	var b bytes.Buffer
-	gz := gzip.NewWriter(&b)
-	if _, err := gz.Write([]byte(chunk.Data)); err != nil {
-		return nil, err
-	}
-	if err := gz.Flush(); err != nil {
-		return nil, err
-	}
-	if err := gz.Close(); err != nil {
-		return nil, err
-	}
-
 	// Write the chunk to the form
-	part, _ := writer.CreateFormFile("chunk", "chunk.gz")
-	part.Write(b.Bytes())
+	part, _ := writer.CreateFormFile("chunk", "chunk")
+	part.Write([]byte(chunk.Data))
 
-	// Close the writer because we don't need to add any more values to it
-	err := writer.Close()
-	if err != nil {
+	// Close the writer and gzipper to finalise the buffer
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	if err := gzipper.Close(); err != nil {
 		return nil, err
 	}
 
@@ -62,6 +52,7 @@ func (cs *ChunksService) Upload(jobId string, chunk *Chunk) (*Response, error) {
 	}
 
 	req.Header.Add("Content-Type", writer.FormDataContentType())
+	req.Header.Add("Content-Encoding", "gzip")
 
 	return cs.client.Do(req, nil)
 }


### PR DESCRIPTION
This uses much less memory on the receiving end than processing multipart form uploads because rails. We're using http content-encoding for gzip compression, too, so can eventually transparently offload into a terminator instead of the app.