### PR TITLE
Static link

### DIFF
--- a/scripts/utils/build-binary.sh
+++ b/scripts/utils/build-binary.sh
@@ -29,7 +29,7 @@ if [[ "$GOOS" == "windows" ]]; then
 fi
 
 mkdir -p $BUILD_PATH
-go build -v -ldflags "-extldflags '-static' -X github.com/buildkite/agent/agent.buildVersion $BUILD_VERSION" -o $BUILD_PATH/$BINARY_FILENAME *.go
+go build -v -ldflags "-extldflags '-static' -X github.com/buildkite/agent/agent.buildVersion=$BUILD_VERSION" -o $BUILD_PATH/$BINARY_FILENAME *.go
 
 chmod +x $BUILD_PATH/$BINARY_FILENAME
 

--- a/scripts/utils/build-binary.sh
+++ b/scripts/utils/build-binary.sh
@@ -29,7 +29,7 @@ if [[ "$GOOS" == "windows" ]]; then
 fi
 
 mkdir -p $BUILD_PATH
-go build -v -ldflags "-X github.com/buildkite/agent/agent.buildVersion $BUILD_VERSION" -o $BUILD_PATH/$BINARY_FILENAME *.go
+go build -v -ldflags "-extldflags '-static' -X github.com/buildkite/agent/agent.buildVersion $BUILD_VERSION" -o $BUILD_PATH/$BINARY_FILENAME *.go
 
 chmod +x $BUILD_PATH/$BINARY_FILENAME
 


### PR DESCRIPTION
This doesn't seem to have much effect for windows or mac, but it stops linux from dynamically linking libc so we can restore Debian 7 compatibility. It doesn't seem to add a huge about of weight to the binary.

If all good I'll backport to 2-1-stable.