### PR TITLE
Increase timeouts

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -154,7 +154,8 @@ func (r *AgentPool) RegisterAgent(agent *api.Agent) (*api.Agent, error) {
 		return err
 	}
 
-	err = retry.Do(register, &retry.Config{Maximum: 30, Interval: 1 * time.Second})
+	// Try to register, retrying every 10 seconds for a maximum of 30 attempts (5 minutes)
+	err = retry.Do(register, &retry.Config{Maximum: 30, Interval: 10 * time.Second})
 
 	return registered, err
 }

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -263,7 +263,7 @@ func (a *AgentWorker) Ping() {
 		}
 
 		return err
-	}, &retry.Config{Maximum: 30, Interval: 1 * time.Second})
+	}, &retry.Config{Maximum: 30, Interval: 5 * time.Second})
 
 	// If `accepted` is nil, then the job was never accepted
 	if accepted == nil {

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -182,7 +182,7 @@ func (a *AgentWorker) Heartbeat() error {
 			logger.Warn("%s (%s)", err, s)
 		}
 		return err
-	}, &retry.Config{Maximum: 5, Interval: 1 * time.Second})
+	}, &retry.Config{Maximum: 5, Interval: 5 * time.Second})
 
 	if err != nil {
 		return err

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -167,7 +167,7 @@ func (a *AgentWorker) Connect() error {
 		}
 
 		return err
-	}, &retry.Config{Maximum: 10, Interval: 1 * time.Second})
+	}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
 }
 
 // Performs a heatbeat

--- a/agent/api_client.go
+++ b/agent/api_client.go
@@ -39,7 +39,7 @@ func (a APIClient) Create() *api.Client {
 
 	// From the transport, create the a http client
 	httpClient := transport.Client()
-	httpClient.Timeout = 10 * time.Second
+	httpClient.Timeout = 60 * time.Second
 
 	// Create the Buildkite Agent API Client
 	client := api.NewClient(httpClient)

--- a/agent/artifact_batch_creator.go
+++ b/agent/artifact_batch_creator.go
@@ -60,7 +60,7 @@ func (a *ArtifactBatchCreator) Create() ([]*api.Artifact, error) {
 			}
 
 			return err
-		}, &retry.Config{Maximum: 10, Interval: 1 * time.Second})
+		}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
 
 		// Did the batch creation eventually fail?
 		if err != nil {

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -219,7 +219,7 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 					}
 
 					return err
-				}, &retry.Config{Maximum: 10, Interval: 1 * time.Second})
+				}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
 
 				if err != nil {
 					logger.Error("Error uploading artifact states: %s", err)
@@ -261,7 +261,7 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 				}
 
 				return err
-			}, &retry.Config{Maximum: 10, Interval: 1 * time.Second})
+			}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
 
 			var state string
 

--- a/agent/download.go
+++ b/agent/download.go
@@ -41,7 +41,7 @@ func (d Download) Start() error {
 			logger.Warn("Error trying to download %s (%s) %s", d.URL, err, s)
 		}
 		return err
-	}, &retry.Config{Maximum: d.Retries, Interval: 1 * time.Second})
+	}, &retry.Config{Maximum: d.Retries, Interval: 5 * time.Second})
 }
 
 func (d Download) try() error {

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -203,7 +203,7 @@ func (r *JobRunner) startJob(startedAt time.Time) error {
 		}
 
 		return err
-	}, &retry.Config{Maximum: 30, Interval: 1 * time.Second})
+	}, &retry.Config{Maximum: 30, Interval: 5 * time.Second})
 }
 
 // Finishes the job in the Buildkite Agent API. This call will keep on retrying
@@ -294,7 +294,7 @@ func (r *JobRunner) onUploadHeaderTime(cursor int, total int, times map[string]s
 		}
 
 		return err
-	}, &retry.Config{Maximum: 10, Interval: 1 * time.Second})
+	}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
 }
 
 // Call when a chunk is ready for upload. It retry the chunk upload with an
@@ -312,5 +312,5 @@ func (r *JobRunner) onUploadChunk(chunk *LogStreamerChunk) error {
 		}
 
 		return err
-	}, &retry.Config{Maximum: 10, Interval: 1 * time.Second})
+	}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
 }

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -84,7 +84,7 @@ var MetaDataExistsCommand = cli.Command{
 			}
 
 			return err
-		}, &retry.Config{Maximum: 10, Interval: 1 * time.Second})
+		}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
 		if err != nil {
 			logger.Fatal("Failed to see if meta-data exists: %s", err)
 		}

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -84,7 +84,7 @@ var MetaDataGetCommand = cli.Command{
 			}
 
 			return err
-		}, &retry.Config{Maximum: 10, Interval: 1 * time.Second})
+		}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
 		if err != nil {
 			logger.Fatal("Failed to get meta-data: %s", err)
 		}

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -86,7 +86,7 @@ var MetaDataSetCommand = cli.Command{
 			}
 
 			return err
-		}, &retry.Config{Maximum: 10, Interval: 1 * time.Second})
+		}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
 		if err != nil {
 			logger.Fatal("Failed to set meta-data: %s", err)
 		}


### PR DESCRIPTION
This increases our HTTP response timeout to 1 minute, and decreases retry frequency for API calls from once every 1 second to once every 5 seconds.

This means the agent will now wait 10 seconds for a http connection, 60 seconds for a response, and then it'll wait 5 seconds before retrying. For network situations, or downtime, this means things will attempting to retry every 5 seconds instead of every second.