### PR TITLE
Move the buildkite bin to the end of $PATH

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -139,7 +139,7 @@ function buildkite-local-hook {
 ##############################################################
 
 # Add the $BUILDKITE_BIN_PATH to the $PATH
-export PATH="$BUILDKITE_BIN_PATH:$PATH"
+export PATH="$PATH:$BUILDKITE_BIN_PATH"
 
 # Come up with the place that the repository will be checked out to
 SANITIZED_AGENT_NAME=$(echo "$BUILDKITE_AGENT_NAME" | tr -d '"')


### PR DESCRIPTION
The buildkite bin might be /usr/bin on some systems, and then you end up with an unusual path. There's no need for ours to be at the front.

Closes #216