### PR TITLE
Add BUILDKITE_GIT_CLEAN_FLAGS

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -867,11 +867,11 @@ func (b *Bootstrap) Start() error {
 		}
 
 		// Clean up the repository
-		b.runCommand("git", "clean", b.env.Get("BUILDKITE_GIT_CLEAN_FLAGS"))
+		b.runCommand("git", "clean", b.GitCleanFlags)
 
 		// Also clean up submodules if we can
 		if b.GitSubmodules {
-			b.runCommand("git", "submodule", "foreach", "--recursive", "git", "clean", b.env.Get("BUILDKITE_GIT_CLEAN_FLAGS"))
+			b.runCommand("git", "submodule", "foreach", "--recursive", "git", "clean", b.GitCleanFlags)
 		}
 
 		// If a refspec is provided then use it instead.

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -43,6 +43,7 @@ type BootstrapConfig struct {
 	AutomaticArtifactUploadPaths string `cli:"artifact-upload-paths"`
 	ArtifactUploadDestination    string `cli:"artifact-upload-destination"`
 	CleanCheckout                bool   `cli:"clean-checkout"`
+	GitCleanFlags                string `cli:"git-clean-flags"`
 	BinPath                      string `cli:"bin-path" normalize:"filepath"`
 	BuildPath                    string `cli:"build-path" normalize:"filepath" validate:"required"`
 	HooksPath                    string `cli:"hooks-path" normalize:"filepath"`
@@ -151,6 +152,12 @@ var BootstrapCommand = cli.Command{
 			Name:   "clean-checkout",
 			Usage:  "Whether or not the bootstrap should remove the existing repository before running the command",
 			EnvVar: "BUILDKITE_CLEAN_CHECKOUT",
+		},
+		cli.StringFlag{
+			Name:   "git-clean-flags",
+			Value:  "-fdq",
+			Usage:  "Flags to pass to \"git clean\" command",
+			EnvVar: "BUILDKITE_GIT_CLEAN_FLAGS",
 		},
 		cli.StringFlag{
 			Name:   "bin-path",

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -221,10 +221,11 @@ else
     buildkite-run "git clone -v -- \"$BUILDKITE_REPO\" ."
   fi
 
-  buildkite-run "git clean -fdq"
+  BUILDKITE_GIT_CLEAN_FLAGS=${BUILDKITE_GIT_CLEAN_FLAGS:--fdq}
+  buildkite-run "git clean \"$BUILDKITE_GIT_CLEAN_FLAGS\""
 
   if [[ -z "${BUILDKITE_DISABLE_GIT_SUBMODULES:-}" ]]; then
-    buildkite-run "git submodule foreach --recursive git clean -fdq"
+    buildkite-run "git submodule foreach --recursive git clean \"$BUILDKITE_GIT_CLEAN_FLAGS\""
   fi
 
   # If a refspec is provided then use it instead.


### PR DESCRIPTION
:rocket: #240 

> The default `git clean` flags are `-fdq`. It's useful to be able to configure this. For example, `-x` can be used to remove gitignore'd files. Or `-e` can be used to exclude specific directories.
>
> Introduce an environment variable `BUILDKITE_GIT_CLEAN_FLAGS` to control this behavior. This can then be set in an `environment` hook.