### PR TITLE
Add `set -e` to ensure errored commands fail the job

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -1066,7 +1066,7 @@ func (b *Bootstrap) Start() error {
 					}
 				}
 			} else {
-				buildScriptContents = "#!/bin/bash\n"
+				buildScriptContents = "#!/bin/bash\nset -e\n"
 				for _, k := range strings.Split(b.Command, "\n") {
 					if k != "" {
 						buildScriptContents = buildScriptContents +

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -349,9 +349,9 @@ else
     # this inside the script we generate because it fails within Docker:
     # https://github.com/docker/docker/issues/9547
     buildkite-run-debug "chmod +x \"$BUILDKITE_COMMAND\""
-    echo -e '#!/bin/bash'"\n./\"$BUILDKITE_COMMAND\"" > "$BUILDKITE_SCRIPT_PATH"
+    echo -e '#!/bin/bash'"\nset -e\n./\"$BUILDKITE_COMMAND\"" > "$BUILDKITE_SCRIPT_PATH"
   else
-    echo -e '#!/bin/bash'"\n$BUILDKITE_COMMAND" > "$BUILDKITE_SCRIPT_PATH"
+    echo -e '#!/bin/bash'"\nset -e\n$BUILDKITE_COMMAND" > "$BUILDKITE_SCRIPT_PATH"
   fi
 
   if [[ "$BUILDKITE_AGENT_DEBUG" == "true" ]]; then


### PR DESCRIPTION
As reported in #223, in both edge and stable if you run specify multiple commands without explicitly adding `&&` in the command, the job will still pass and all commands will be run. This is unexpected and incorrect.

This fixes the issue by ensuring the generated script includes the `set -e` bash flag to exit with an error as soon as any command fails.

Current badness:

<img width="1167" alt="bad" src="https://cloud.githubusercontent.com/assets/153/13838996/08effe8c-ec6c-11e5-8d22-1d38e64a8674.png">

Fixed goodness:

<img width="1159" alt="good" src="https://cloud.githubusercontent.com/assets/153/13838998/0bb7a084-ec6c-11e5-8270-d0703274fa75.png">

Fixes #223