### PR TITLE
Build debs once, publish in stages

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,6 +17,16 @@ steps:
   - wait
 
   -
+    name: ":debian:"
+    command: "scripts/build-debian-packages.sh"
+    artifact_paths: "deb/**/*"
+    branches: "master"
+    agents:
+      queue: "deploy"
+
+  - wait
+
+  -
     name: ":redhat: experimental"
     command: "scripts/rpm-package.sh"
     artifact_paths: "rpm/**/*"
@@ -28,8 +38,7 @@ steps:
 
   -
     name: ":debian: experimental"
-    command: "scripts/debian-package.sh"
-    artifact_paths: "deb/**/*"
+    command: "scripts/publish-debian-package.sh"
     branches: "master"
     env:
       CODENAME: "experimental"
@@ -75,7 +84,7 @@ steps:
 
   -
     name: ":debian:"
-    command: "scripts/debian-package.sh"
+    command: "scripts/publish-debian-package.sh"
     branches: "master"
     env:
       CODENAME: "unstable"
@@ -113,7 +122,7 @@ steps:
 
   -
     name: ":debian:"
-    command: "scripts/debian-package.sh"
+    command: "scripts/publish-debian-package.sh"
     branches: "master"
     env:
       CODENAME: "stable"

--- a/scripts/build-debian-packages.sh
+++ b/scripts/build-debian-packages.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 set -e
 
-if [[ "$CODENAME" == "" ]]; then
-  echo "Error: Missing \$CODENAME (stable or unstable)"
-  exit 1
-fi
-
 echo '--- Getting agent version from build meta data'
 
 export FULL_AGENT_VERSION=$(buildkite-agent meta-data get "agent-version-full")
@@ -31,15 +26,6 @@ function build() {
   ./scripts/utils/build-linux-package.sh "deb" $2 $BINARY_FILENAME $AGENT_VERSION $BUILD_VERSION
 }
 
-function publish() {
-  echo "+++ Shipping $1"
-
-  ./scripts/utils/publish-debian-package.sh $1 $CODENAME
-}
-
-# Export the function so we can use it in xargs
-export -f publish
-
 echo '--- Installing dependencies'
 bundle
 
@@ -52,6 +38,3 @@ build "linux" "386"
 build "linux" "arm"
 build "linux" "armhf"
 build "linux" "arm64"
-
-# Loop over all the .deb files and publish them
-ls deb/*.deb | xargs -I {} bash -c "publish {}"

--- a/scripts/publish-debian-package.sh
+++ b/scripts/publish-debian-package.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+if [[ "$CODENAME" == "" ]]; then
+  echo "Error: Missing \$CODENAME (stable or unstable)"
+  exit 1
+fi
+
+echo '--- Downloading built debian packages'
+buildkite-agent artifact download "deb/*.deb" "."
+
+echo '--- Installing dependencies'
+bundle
+
+# Loop over all the .deb files and publish them
+for file in deb/*.deb; do
+  echo "+++ Shipping $file"
+  ./scripts/utils/publish-debian-package.sh $file $CODENAME
+done

--- a/scripts/publish-debian-package.sh
+++ b/scripts/publish-debian-package.sh
@@ -7,7 +7,9 @@ if [[ "$CODENAME" == "" ]]; then
 fi
 
 echo '--- Downloading built debian packages'
-buildkite-agent artifact download "deb/*.deb" "."
+rm -rf deb
+mkdir -p deb
+buildkite-agent artifact download "deb/*.deb" deb/
 
 echo '--- Installing dependencies'
 bundle


### PR DESCRIPTION
@sj26 & @toolmantim paired on fixing our debian archives becoming corrupted. Turns out we were building the debian packages multiple times but they go in the same place on the archive so were overwriting each other and causing the wrong file sizes/hashes. So we build them once instead, then publish the same packages into each subsequent archive: experimental, unstable, stable.