### PR TITLE
Make sure we initialize the GitCleanFlags

### DIFF
--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -232,6 +232,7 @@ var BootstrapCommand = cli.Command{
 			Plugins:                      cfg.Plugins,
 			GitSubmodules:                cfg.GitSubmodules,
 			PullRequest:                  cfg.PullRequest,
+			GitCleanFlags:								cfg.GitCleanFlags,
 			AgentName:                    cfg.AgentName,
 			PipelineProvider:             cfg.PipelineProvider,
 			PipelineSlug:                 cfg.PipelineSlug,


### PR DESCRIPTION
Unfortunately #270 was broken in that it didn't initialize `GitCleanFlags`, so `git clean` would error with:

```
$ git clean
fatal: clean.requireForce defaults to true and neither -i, -n, nor -f given; refusing to clean
```

This fixes it so it works as expected.