### PR TITLE
Fix bug I introduced with (BK)_(DC)_LEAVE_VOLUMES

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -419,7 +419,7 @@ else
 
     function compose-cleanup {
       REMOVE_VOLUME_FLAG="-v"
-      if [[ "$BUILDKITE_DOCKER_COMPOSE_LEAVE_VOLUMES" != "true" ]]; then
+      if [[ "${BUILDKITE_DOCKER_COMPOSE_LEAVE_VOLUMES:-false}" == "true" ]]; then
         REMOVE_VOLUME_FLAG=""
       fi
 


### PR DESCRIPTION
No idea what I was thinking with the initial version of this change, given the semantics were inversed and it was very broken on non-bash shells.