### PR TITLE
Build only the specified Docker image

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -436,7 +436,11 @@ else
     # Build the Docker images using Compose, namespaced to the job
     echo "~~~ Building Docker images"
 
-    buildkite-run "$COMPOSE_COMMAND build $BUILDKITE_DOCKER_COMPOSE_CONTAINER"
+    if [[ ! -z "${BUILDKITE_DOCKER_COMPOSE_BUILD_ALL:-}" ]] && [[ "$BUILDKITE_DOCKER_COMPOSE_BUILD_ALL" != "" ]]; then
+      buildkite-run "$COMPOSE_COMMAND build"
+    else
+      buildkite-run "$COMPOSE_COMMAND build $BUILDKITE_DOCKER_COMPOSE_CONTAINER"
+    fi
 
     # Run the build script command in the service specified in BUILDKITE_DOCKER_COMPOSE_CONTAINER
     echo "~~~ $BUILDKITE_COMMAND_ACTION (in Docker Compose container)"

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -436,7 +436,7 @@ else
     # Build the Docker images using Compose, namespaced to the job
     echo "~~~ Building Docker images"
 
-    buildkite-run "$COMPOSE_COMMAND build"
+    buildkite-run "$COMPOSE_COMMAND build $BUILDKITE_DOCKER_COMPOSE_CONTAINER"
 
     # Run the build script command in the service specified in BUILDKITE_DOCKER_COMPOSE_CONTAINER
     echo "~~~ $BUILDKITE_COMMAND_ACTION (in Docker Compose container)"

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -436,7 +436,7 @@ else
     # Build the Docker images using Compose, namespaced to the job
     echo "~~~ Building Docker images"
 
-    if [[ ! -z "${BUILDKITE_DOCKER_COMPOSE_BUILD_ALL:-}" ]] && [[ "$BUILDKITE_DOCKER_COMPOSE_BUILD_ALL" != "" ]]; then
+    if [[ "${BUILDKITE_DOCKER_COMPOSE_BUILD_ALL:-false}" == "true" ]]; then
       buildkite-run "$COMPOSE_COMMAND build"
     else
       buildkite-run "$COMPOSE_COMMAND build $BUILDKITE_DOCKER_COMPOSE_CONTAINER"


### PR DESCRIPTION
Some people have more buildable services in their docker-compose.yml, and building images other than the specified in `BUILDKITE_DOCKER_COMPOSE_CONTAINER` takes unnecessary build time.