### PR TITLE
Fix up init scripts for CentOS-6 and Amazon Linux

### DIFF
--- a/packaging/linux/scripts/after-install-and-upgrade.sh
+++ b/packaging/linux/scripts/after-install-and-upgrade.sh
@@ -58,9 +58,14 @@ BK_IS_UBUNTU_14_10=$?
 command -v initctl > /dev/null
 BK_UPSTART_EXISTS=$?
 
-# Check if the system is Amazon linux which has an old and broken upstart.
-[ -f /etc/system-release ] && grep -qi "Amazon Linux" /etc/system-release
-BK_IS_AMAZON_LINUX=$?
+# Check if upstart is version 0.6.5 as seen on Amazon linux, RHEL6 & CentOS-6
+BK_UPSTART_TOO_OLD=0
+if [ $BK_UPSTART_EXISTS -eq 0 ]; then
+  BK_UPSTART_VERSION="$(initctl --version | awk 'BEGIN{FS="[ ()]"} NR==1{print $4}')"
+  if [ "$BK_UPSTART_VERSION" = "0.6.5" ]; then
+    BK_UPSTART_TOO_OLD=1
+  fi
+fi
 
 # Install the relevant system process
 if [ $BK_SYSTEMD_EXISTS -eq 0 ] && [ $BK_IS_UBUNTU_14_10 -eq 1 ]; then
@@ -69,7 +74,7 @@ if [ $BK_SYSTEMD_EXISTS -eq 0 ] && [ $BK_IS_UBUNTU_14_10 -eq 1 ]; then
   fi
 
   START_COMMAND="sudo systemctl enable buildkite-agent && sudo systemctl start buildkite-agent"
-elif [ $BK_UPSTART_EXISTS -eq 0 ] && [ $BK_IS_AMAZON_LINUX -eq 1 ]; then
+elif [ $BK_UPSTART_EXISTS -eq 0 ] && [ $BK_UPSTART_TOO_OLD -eq 0 ]; then
   if [ ! -f /etc/init/buildkite-agent.conf ]; then
     # If the system has the old .env file, install the old upstart script, and
     # let them know they should upgrade. Because the upstart script is no

--- a/packaging/linux/scripts/after-install-and-upgrade.sh
+++ b/packaging/linux/scripts/after-install-and-upgrade.sh
@@ -121,6 +121,7 @@ elif [ $BK_UPSTART_EXISTS -eq 0 ] && [ $BK_UPSTART_TOO_OLD -eq 0 ]; then
 elif [ -d /etc/init.d ]; then
   if [ ! -f /etc/init.d/buildkite-agent ]; then
     cp /usr/share/buildkite-agent/lsb/buildkite-agent.sh /etc/init.d/buildkite-agent
+    command -v chkconfig > /dev/null && chkconfig --add buildkite-agent
   fi
 
   START_COMMAND="sudo /etc/init.d/buildkite-agent start"

--- a/packaging/linux/scripts/after-remove.sh
+++ b/packaging/linux/scripts/after-remove.sh
@@ -1,8 +1,10 @@
 # Remove the system service we installed
 if command -v systemctl > /dev/null; then
   rm -f /lib/systemd/system/buildkite-agent.service
-elif [ -d /etc/init ]; then
+fi
+if [ -f /etc/init/buildkite-agent.conf ]; then
   rm -f /etc/init/buildkite-agent.conf
-elif [ -d /etc/init.d ]; then
+fi
+if [ -f /etc/init.d/buildkite-agent ]; then
   rm -f /etc/init.d/buildkite-agent
 fi

--- a/packaging/linux/scripts/before-remove.sh
+++ b/packaging/linux/scripts/before-remove.sh
@@ -1,9 +1,22 @@
+# Check if upstart exists
+command -v initctl > /dev/null
+BK_UPSTART_EXISTS=$?
+
+# Check if upstart is version 0.6.5 as seen on Amazon linux, RHEL6 & CentOS-6
+BK_UPSTART_TOO_OLD=0
+if [ $BK_UPSTART_EXISTS -eq 0 ]; then
+  BK_UPSTART_VERSION="$(initctl --version | awk 'BEGIN{FS="[ ()]"} NR==1{print $4}')"
+  if [ "$BK_UPSTART_VERSION" = "0.6.5" ]; then
+    BK_UPSTART_TOO_OLD=1
+  fi
+fi
+
 if command -v systemctl > /dev/null; then
   echo "Stopping buildkite-agent systemd service"
 
   systemctl --no-reload disable buildkite-agent || :
     systemctl stop buildkite-agent || :
-elif [ -d /etc/init ]; then
+elif [ $BK_UPSTART_EXISTS -eq 0 ] && [ $BK_UPSTART_TOO_OLD -eq 0 ]; then
   echo "Stopping buildkite-agent upstart service"
 
   service buildkite-agent stop || :
@@ -11,4 +24,5 @@ elif [ -d /etc/init.d ]; then
   echo "Stopping buildkite-agent init.d script"
 
   /etc/init.d/buildkite-agent stop || :
+  command -v chkconfig > /dev/null && chkconfig --del buildkite-agent
 fi


### PR DESCRIPTION
Tested on Amazon Linux, CentOS-6 and CentOS-7 (systemd). Have not tested upstart version != 0.6.5