### PR TITLE
Add docker-compose 1.7 support

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -416,9 +416,10 @@ else
     COMPOSE_COMMAND="docker-compose -f ${BUILDKITE_DOCKER_COMPOSE_FILE:-docker-compose.yml} -p $COMPOSE_PROJ_NAME"
 
     function compose-cleanup {
-      REMOVE_VOLUME_FLAG="-v"
       if [[ "${BUILDKITE_DOCKER_COMPOSE_LEAVE_VOLUMES:-false}" == "true" ]]; then
         REMOVE_VOLUME_FLAG=""
+      else
+        REMOVE_VOLUME_FLAG="-v"
       fi
 
       echo "~~~ Cleaning up Docker containers"


### PR DESCRIPTION
This adds support for docker-compose 1.7 using the `down` support for removing networks and `rm --all` for remove adhoc containers. Closes #277

Also included:

* Adds `--pull` to the build command, so that it always attempt to pull a new version of any base images that exist
* Expands the `Running command` output group by defaults