### PR TITLE
Ensure git clean removes gitignore'd files

### DIFF
--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -155,7 +155,7 @@ var BootstrapCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name:   "git-clean-flags",
-			Value:  "-fdq",
+			Value:  "-fxdq",
 			Usage:  "Flags to pass to \"git clean\" command",
 			EnvVar: "BUILDKITE_GIT_CLEAN_FLAGS",
 		},


### PR DESCRIPTION
The new default is to clean all files, including those in the `.gitignore`, using `git clean -fdqx`

This can be overridden using the config var or `BUILDKITE_GIT_CLEAN_FLAGS`