### PR TITLE
Use SHA512 for Debian signing

### DIFF
--- a/scripts/utils/publish-debian-package.sh
+++ b/scripts/utils/publish-debian-package.sh
@@ -57,7 +57,7 @@ GPG_PASSPHRASE=`openssl aes-256-cbc -k "$GPG_PASSPHRASE_PASSWORD" -in "$GPG_PASS
 bundle exec deb-s3 upload \
   --preserve-versions \
   --sign $GPG_SIGNING_KEY \
-  --gpg-options "\-\-passphrase $GPG_PASSPHRASE" \
+  --gpg-options "\-\-digest-algo SHA512 \-\-passphrase $GPG_PASSPHRASE" \
   --bucket $DEB_S3_BUCKET \
   --codename $CODENAME \
   --component $COMPONENT \


### PR DESCRIPTION
SHA1 is being removed, and is already broken on Ubuntu 16.04:
https://wiki.debian.org/Teams/Apt/Sha1Removal

Fixes #295

Needs backporting to 2-1-stable