### PR TITLE
Use a sanitized agent name for git checkout

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -176,6 +176,11 @@ func addExecutePermissiontoFile(filename string) {
 	}
 }
 
+func dirForAgentName(agentName string) string {
+	badCharsPattern := regexp.MustCompile("[[:^alnum:]]")
+	return badCharsPattern.ReplaceAllString(agentName, "-")
+}
+
 var tempFileNumber int
 
 // Creates a temporary file. Implementation has been copied from
@@ -671,11 +676,7 @@ func (b *Bootstrap) Start() error {
 		b.env.Set("PATH", fmt.Sprintf("%s%s%s", b.BinPath, string(os.PathListSeparator), b.env.Get("PATH")))
 	}
 
-	// Come up with the place that the repository will be checked out to
-	var agentNameCleanupRegex = regexp.MustCompile("\"")
-	cleanedUpAgentName := agentNameCleanupRegex.ReplaceAllString(b.AgentName, "-")
-
-	b.env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", filepath.Join(b.BuildPath, cleanedUpAgentName, b.OrganizationSlug, b.PipelineSlug))
+	b.env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", filepath.Join(b.BuildPath, dirForAgentName(b.AgentName), b.OrganizationSlug, b.PipelineSlug))
 
 	if b.Debug {
 		// Convert the env to a sorted slice

--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -1,0 +1,21 @@
+package agent
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+var agentNameTests = []struct {
+	agentName   string
+	expected    string
+}{
+	{"My Agent", "My-Agent"},
+	{":docker: My Agent", "-docker--My-Agent"},
+	{"My \"Agent\"", "My--Agent-"},
+}
+
+func TestDirForAgentName(t *testing.T) {
+	for _, test := range agentNameTests {
+		assert.Equal(t, test.expected, dirForAgentName(test.agentName))
+	}
+}


### PR DESCRIPTION
Ports #293 to the golang bootstrap.

I've opted to keep the case, and not collapse down any leading or duplicate `-` characters to stop unexpected clashes. `my-agent` will be different to `My-Agent` (on Linux). Is that sensible?