### PR TITLE
Add the EC2 instance ID to the automatic metadata

### DIFF
--- a/agent/ec2_tags.go
+++ b/agent/ec2_tags.go
@@ -41,5 +41,8 @@ func (e EC2Tags) Get() (map[string]string, error) {
 		tags[tag.Key] = tag.Value
 	}
 
+	// We set this manually, it's not a standard tag
+	tags["aws:instance-id"] = aws.InstanceId()
+
 	return tags, nil
 }


### PR DESCRIPTION
It's not one of the standard meta-data values… but it'd be super handy for debugging, lining up with cloudwatch logs, etc etc