### PR TITLE
Add a --meta-data-ec2 flag

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -105,14 +105,9 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 
 	// Attempt to add the EC2 meta-data
 	if r.MetaDataEC2 {
-		tags, err := EC2MetaData{}.Get()
-		if err != nil {
-			// Don't blow up if we can't find them, just show a nasty error.
-			logger.Error(fmt.Sprintf("Failed to find EC2 meta-data: %s", err.Error()))
-		} else {
-			for tag, value := range tags {
-				agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))
-			}
+		tags := EC2MetaData{}.Get()
+		for tag, value := range tags {
+			agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))
 		}
 	}
 

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -105,9 +105,14 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 
 	// Attempt to add the EC2 meta-data
 	if r.MetaDataEC2 {
-		tags := EC2MetaData{}.Get()
-		for tag, value := range tags {
-			agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))
+		tags, err := EC2MetaData{}.Get()
+		if err != nil {
+			// Don't blow up if we can't find them, just show a nasty error.
+			logger.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
+		} else {
+			for tag, value := range tags {
+				agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))
+			}
 		}
 	}
 

--- a/agent/ec2_meta_data.go
+++ b/agent/ec2_meta_data.go
@@ -1,0 +1,30 @@
+package agent
+
+import (
+	"fmt"
+
+	"github.com/AdRoll/goamz/aws"
+	"github.com/buildkite/agent/logger"
+)
+
+type EC2MetaData struct {
+}
+
+func (e EC2MetaData) Get() map[string]string {
+	metaData := make(map[string]string)
+
+	fetchMetaData(metaData, "instance-id")
+	fetchMetaData(metaData, "instance-type")
+	fetchMetaData(metaData, "ami-id")
+
+	return metaData
+}
+
+func fetchMetaData(metaData map[string]string, propertyName string) {
+	value, err := aws.GetMetaData(propertyName)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Fetching EC2 %s failed: %s", propertyName, err.Error()))
+	} else {
+		metaData["aws:"+propertyName] = string(value)
+	}
+}

--- a/agent/ec2_meta_data.go
+++ b/agent/ec2_meta_data.go
@@ -1,30 +1,32 @@
 package agent
 
 import (
-	"fmt"
-
 	"github.com/AdRoll/goamz/aws"
-	"github.com/buildkite/agent/logger"
 )
 
 type EC2MetaData struct {
 }
 
-func (e EC2MetaData) Get() map[string]string {
+func (e EC2MetaData) Get() (map[string]string, error) {
 	metaData := make(map[string]string)
 
-	fetchMetaData(metaData, "instance-id")
-	fetchMetaData(metaData, "instance-type")
-	fetchMetaData(metaData, "ami-id")
-
-	return metaData
-}
-
-func fetchMetaData(metaData map[string]string, propertyName string) {
-	value, err := aws.GetMetaData(propertyName)
+	instanceId, err := aws.GetMetaData("instance-id")
 	if err != nil {
-		logger.Error(fmt.Sprintf("Fetching EC2 %s failed: %s", propertyName, err.Error()))
-	} else {
-		metaData["aws:"+propertyName] = string(value)
+		return metaData, err
 	}
+	metaData["aws:instance-id"] = string(instanceId)
+
+	instanceType, err := aws.GetMetaData("instance-type")
+	if err != nil {
+		return metaData, err
+	}
+	metaData["aws:instance-type"] = string(instanceType)
+
+	amiId, err := aws.GetMetaData("ami-id")
+	if err != nil {
+		return metaData, err
+	}
+	metaData["aws:ami-id"] = string(amiId)
+
+	return metaData, nil
 }

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -38,6 +38,7 @@ type AgentStartConfig struct {
 	HooksPath                    string   `cli:"hooks-path" normalize:"filepath"`
 	PluginsPath                  string   `cli:"plugins-path" normalize:"filepath"`
 	MetaData                     []string `cli:"meta-data"`
+	MetaDataEC2                  bool     `cli:"meta-data-ec2"`
 	MetaDataEC2Tags              bool     `cli:"meta-data-ec2-tags"`
 	NoColor                      bool     `cli:"no-color"`
 	NoSSHFingerprintVerification bool     `cli:"no-automatic-ssh-fingerprint-verification"`
@@ -105,12 +106,16 @@ var AgentStartCommand = cli.Command{
 		cli.StringSliceFlag{
 			Name:   "meta-data",
 			Value:  &cli.StringSlice{},
-			Usage:  "Meta data for the agent (default is \"queue=default\")",
+			Usage:  "Meta-data for the agent (default is \"queue=default\")",
 			EnvVar: "BUILDKITE_AGENT_META_DATA",
 		},
 		cli.BoolFlag{
+			Name:  "meta-data-ec2",
+			Usage: "Include the host's EC2 meta-data (such instance-id, instance-type, and ami-id) as meta-data",
+		},
+		cli.BoolFlag{
 			Name:  "meta-data-ec2-tags",
-			Usage: "Populate the meta data from the current instances EC2 Tags",
+			Usage: "Include the host's EC2 tags as meta-data",
 		},
 		cli.StringFlag{
 			Name:   "bootstrap-script",
@@ -188,6 +193,7 @@ var AgentStartCommand = cli.Command{
 			Name:            cfg.Name,
 			Priority:        cfg.Priority,
 			MetaData:        cfg.MetaData,
+			MetaDataEC2:     cfg.MetaDataEC2,
 			MetaDataEC2Tags: cfg.MetaDataEC2Tags,
 			Endpoint:        cfg.Endpoint,
 			AgentConfiguration: &agent.AgentConfiguration{

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -111,7 +111,7 @@ var AgentStartCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name:  "meta-data-ec2",
-			Usage: "Include the host's EC2 meta-data (such instance-id, instance-type, and ami-id) as meta-data",
+			Usage: "Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as meta-data",
 		},
 		cli.BoolFlag{
 			Name:  "meta-data-ec2-tags",

--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -7,10 +7,13 @@ name="%hostname-%n"
 # The priority of the agent (higher priorities are assigned work first)
 # priority=1
 
-# Meta data for the agent (default is "queue=default")
+# Meta-data for the agent (default is "queue=default")
 # meta-data="key1=val2,key2=val2"
 
-# Populate the meta data from the current instances EC2 Tags
+# Include the host's EC2 meta-data (such instance-id, instance-type, and ami-id) as meta-data
+# meta-data-ec2=true
+
+# Include the host's EC2 tags as meta-data
 # meta-data-ec2-tags=true
 
 # Path to the bootstrap script. You should avoid changing this file as it will

--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -10,7 +10,7 @@ name="%hostname-%n"
 # Meta-data for the agent (default is "queue=default")
 # meta-data="key1=val2,key2=val2"
 
-# Include the host's EC2 meta-data (such instance-id, instance-type, and ami-id) as meta-data
+# Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as meta-data
 # meta-data-ec2=true
 
 # Include the host's EC2 tags as meta-data

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -7,10 +7,13 @@ name="%hostname-%n"
 # The priority of the agent (higher priorities are assigned work first)
 # priority=1
 
-# Meta data for the agent (default is "queue=default")
+# Meta-data for the agent (default is "queue=default")
 # meta-data="key1=val2,key2=val2"
 
-# Populate the meta data from the current instances EC2 Tags
+# Include the host's EC2 meta-data (such instance-id, instance-type, and ami-id) as meta-data
+# meta-data-ec2=true
+
+# Include the host's EC2 tags as meta-data
 # meta-data-ec2-tags=true
 
 # Path to the bootstrap script. You should avoid changing this file as it will

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -10,7 +10,7 @@ name="%hostname-%n"
 # Meta-data for the agent (default is "queue=default")
 # meta-data="key1=val2,key2=val2"
 
-# Include the host's EC2 meta-data (such instance-id, instance-type, and ami-id) as meta-data
+# Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as meta-data
 # meta-data-ec2=true
 
 # Include the host's EC2 tags as meta-data


### PR DESCRIPTION
This adds a ` --meta-data-ec2` option to automatically populate the agent's meta-data with EC2 meta-data such as `aws:ami-id`, `aws:instance-id` and `aws:instance-type`. This will mean that buildkite/buildkite-aws-stack#67 and the like can just use `--meta-data-ec2`.

```
$ buildkite-agent start --token xxx --meta-data-ec2

  _           _ _     _ _    _ _                                _
 | |         (_) |   | | |  (_) |                              | |
 | |__  _   _ _| | __| | | ___| |_ ___    __ _  __ _  ___ _ __ | |_
 | '_ \| | | | | |/ _` | |/ / | __/ _ \  / _` |/ _` |/ _ \ '_ \| __|
 | |_) | |_| | | | (_| |   <| | ||  __/ | (_| | (_| |  __/ | | | |_
 |_.__/ \__,_|_|_|\__,_|_|\_\_|\__\___|  \__,_|\__, |\___|_| |_|\__|
                                                __/ |
 http://buildkite.com/agent                    |___/

2016-05-15 13:32:51 NOTICE Starting buildkite-agent v3.0-beta.1 with PID: 2558
2016-05-15 13:32:51 NOTICE The agent source code can be found here: https://github.com/buildkite/agent
2016-05-15 13:32:51 NOTICE For questions and support, email us at: hello@buildkite.com
2016-05-15 13:32:51 INFO   Registering agent with Buildkite...
2016-05-15 13:32:51 INFO   Successfully registered agent "ip-172-31-60-230" with meta-data [aws:instance-id=i-575f61ca aws:instance-type=t2.nano aws:ami-id=ami-f5f41398]
2016-05-15 13:32:51 INFO   Connecting to Buildkite...
2016-05-15 13:32:51 INFO   Agent successfully connected
2016-05-15 13:32:51 INFO   You can press Ctrl-C to stop the agent
2016-05-15 13:32:51 INFO   Waiting for work...
```

<img width="593" alt="agent" src="https://cloud.githubusercontent.com/assets/153/15274489/45b373c2-1af6-11e6-9e99-702d42c847cc.png">

If you try to use the flag on a non-EC2 machine you just get some errors in the log:

```
$ buildkite-agent start --token xxx --meta-data-ec2

  _           _ _     _ _    _ _                                _
 | |         (_) |   | | |  (_) |                              | |
 | |__  _   _ _| | __| | | ___| |_ ___    __ _  __ _  ___ _ __ | |_
 | '_ \| | | | | |/ _` | |/ / | __/ _ \  / _` |/ _` |/ _ \ '_ \| __|
 | |_) | |_| | | | (_| |   <| | ||  __/ | (_| | (_| |  __/ | | | |_
 |_.__/ \__,_|_|_|\__,_|_|\_\_|\__\___|  \__,_|\__, |\___|_| |_|\__|
                                                __/ |
 http://buildkite.com/agent                    |___/

2016-05-15 23:35:30 NOTICE Starting buildkite-agent v3.0-beta.1 with PID: 54918
2016-05-15 23:35:30 NOTICE The agent source code can be found here: https://github.com/buildkite/agent
2016-05-15 23:35:30 NOTICE For questions and support, email us at: hello@buildkite.com
2016-05-15 23:35:32 ERROR  Fetching EC2 instance-id failed: Get http://169.254.169.254/latest/meta-data/instance-id: dial tcp 169.254.169.254:80: i/o timeout
2016-05-15 23:35:34 ERROR  Fetching EC2 instance-type failed: Get http://169.254.169.254/latest/meta-data/instance-type: dial tcp 169.254.169.254:80: i/o timeout
2016-05-15 23:35:36 ERROR  Fetching EC2 ami-id failed: Get http://169.254.169.254/latest/meta-data/ami-id: dial tcp 169.254.169.254:80: i/o timeout
2016-05-15 23:35:36 INFO   Registering agent with Buildkite...
2016-05-15 23:35:38 INFO   Successfully registered agent "tim.local-1" with meta-data []
2016-05-15 23:35:38 INFO   Connecting to Buildkite...
2016-05-15 23:35:39 INFO   Agent successfully connected
2016-05-15 23:35:39 INFO   You can press Ctrl-C to stop the agent
2016-05-15 23:35:39 INFO   Waiting for work...
```