### PR TITLE
Publish binaries to download.buildkite.com/agent

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,7 @@ steps:
     env:
       CODENAME: "experimental"
     agents:
-      queue: "deploy" 
+      queue: "deploy"
 
   -
     name: ":redhat: experimental"
@@ -72,7 +72,7 @@ steps:
     env:
       CODENAME: "unstable"
     agents:
-      queue: "deploy" 
+      queue: "deploy"
 
   -
     name: ":whale:"
@@ -119,7 +119,7 @@ steps:
     env:
       CODENAME: "stable"
     agents:
-      queue: "deploy" 
+      queue: "deploy"
 
   -
     name: ":whale:"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,6 +27,15 @@ steps:
   - wait
 
   -
+    name: ":s3: publish binaries"
+    command: "scripts/publish-to-s3.sh"
+    branches: "master *-stable"
+    env:
+      CODENAME: "experimental"
+    agents:
+      queue: "deploy" 
+
+  -
     name: ":redhat: experimental"
     command: "scripts/rpm-package.sh"
     artifact_paths: "rpm/**/*"
@@ -55,6 +64,15 @@ steps:
           run: agent
 
   - wait
+
+  -
+    name: ":s3: publish binaries"
+    command: "scripts/publish-to-s3.sh"
+    branches: "master *-stable"
+    env:
+      CODENAME: "unstable"
+    agents:
+      queue: "deploy" 
 
   -
     name: ":whale:"
@@ -93,6 +111,15 @@ steps:
       queue: "deploy"
 
   - wait
+
+  -
+    name: ":s3: publish binaries"
+    command: "scripts/publish-to-s3.sh"
+    branches: "master *-stable"
+    env:
+      CODENAME: "stable"
+    agents:
+      queue: "deploy" 
 
   -
     name: ":whale:"

--- a/scripts/publish-to-s3.sh
+++ b/scripts/publish-to-s3.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+version=$(buildkite-agent meta-data get "agent-version")
+
+echo "--- :package: Downloading built binaries"
+
+rm -rf pkg/*
+buildkite-agent artifact download "pkg/*" .
+cd pkg
+
+echo "--- :s3: Publishing $version to download.buildkite.com"
+
+s3_base_url="s3://download.buildkite.com/agent/$CODENAME"
+
+for binary in buildkite-agent-*; do
+  binary_s3_url="$s3_base_url/$version/$binary"
+
+  echo "Publishing $binary to $binary_s3_url"
+  aws s3 cp --acl "public-read" "$binary" "$binary_s3_url"
+done
+
+echo "--- :s3: Updating latest"
+
+latest_version=$(aws s3 ls --page-size 1000 "$s3_base_url/" | grep PRE | awk '{print $2}' | awk -F '/' '{print $1}' | ruby -pe 'readlines.map {|s| Gem::Version.new(s)}.max')
+
+latest_version_s3_url="$s3_base_url/$latest_version/"
+latest_s3_url="$s3_base_url/latest/"
+
+echo "Copying $latest_version_s3_url to $latest_s3_url"
+
+aws s3 cp --acl public-read-write --recursive "$latest_version_s3_url" "$latest_s3_url"
+
+echo "--- :tada: All done!"

--- a/scripts/publish-to-s3.sh
+++ b/scripts/publish-to-s3.sh
@@ -34,7 +34,7 @@ done
 
 echo "--- :s3: Copying /$version to /latest"
 
-latest_version=$(aws s3 ls --page-size 1000 "$s3_base_url/" | grep PRE | awk '{print $2}' | awk -F '/' '{print $1}' | ruby -pe 'readlines.map {|s| Gem::Version.new(s)}.max')
+latest_version=$(aws s3 ls --page-size 1000 "$s3_base_url/" | grep PRE | awk '{print $2}' | awk -F '/' '{print $1}' | ruby ../scripts/utils/latest_version.rb)
 latest_version_s3_url="$s3_base_url/$latest_version/"
 latest_s3_url="$s3_base_url/latest/"
 

--- a/scripts/publish-to-s3.sh
+++ b/scripts/publish-to-s3.sh
@@ -3,6 +3,11 @@
 set -eo pipefail
 
 version=$(buildkite-agent meta-data get "agent-version")
+build=$(buildkite-agent meta-data get "agent-version-build")
+
+if [[ "$CODENAME" == "experimental" ]]; then
+  version="$version.$build"
+fi
 
 echo "--- :package: Downloading built binaries"
 

--- a/scripts/publish-to-s3.sh
+++ b/scripts/publish-to-s3.sh
@@ -23,23 +23,23 @@ for binary in buildkite-agent-*; do
   binary_s3_url="$s3_base_url/$version/$binary"
 
   echo "Publishing $binary to $binary_s3_url"
-  aws s3 cp --acl "public-read" "$binary" "$binary_s3_url"
+  aws s3 --region "us-east-1" cp --acl "public-read" "$binary" "$binary_s3_url"
 
   echo "Fetching SHA1"
   buildkite-agent artifact shasum "pkg/$binary" > "$binary.sha1"
 
   echo "Publishing $binary.sha1 to $binary_s3_url.sha1"
-  aws s3 cp --acl "public-read" --content-type "text/plain" "$binary.sha1" "$binary_s3_url.sha1"
+  aws s3 cp --region "us-east-1" --acl "public-read" --content-type "text/plain" "$binary.sha1" "$binary_s3_url.sha1"
 done
 
 echo "--- :s3: Copying /$version to /latest"
 
-latest_version=$(aws s3 ls --page-size 1000 "$s3_base_url/" | grep PRE | awk '{print $2}' | awk -F '/' '{print $1}' | ruby ../scripts/utils/latest_version.rb)
+latest_version=$(aws s3 ls --region "us-east-1" "$s3_base_url/" | grep PRE | awk '{print $2}' | awk -F '/' '{print $1}' | ruby ../scripts/utils/latest_version.rb)
 latest_version_s3_url="$s3_base_url/$latest_version/"
 latest_s3_url="$s3_base_url/latest/"
 
 echo "Copying $latest_version_s3_url to $latest_s3_url"
 
-aws s3 cp --acl public-read-write --recursive "$latest_version_s3_url" "$latest_s3_url"
+aws s3 cp --region "us-east-1" --acl "public-read" --recursive "$latest_version_s3_url" "$latest_s3_url"
 
 echo "--- :llama::sparkles::llama: All done!"

--- a/scripts/publish-to-s3.sh
+++ b/scripts/publish-to-s3.sh
@@ -24,12 +24,17 @@ for binary in buildkite-agent-*; do
 
   echo "Publishing $binary to $binary_s3_url"
   aws s3 cp --acl "public-read" "$binary" "$binary_s3_url"
+
+  echo "Fetching SHA1"
+  buildkite-agent artifact shasum "pkg/$binary" > "$binary.sha1"
+
+  echo "Publishing $binary.sha1 to $binary_s3_url.sha1"
+  aws s3 cp --acl "public-read" --content-type "text/plain" "$binary.sha1" "$binary_s3_url.sha1"
 done
 
-echo "--- :s3: Updating latest"
+echo "--- :s3: Copying /$version to /latest"
 
 latest_version=$(aws s3 ls --page-size 1000 "$s3_base_url/" | grep PRE | awk '{print $2}' | awk -F '/' '{print $1}' | ruby -pe 'readlines.map {|s| Gem::Version.new(s)}.max')
-
 latest_version_s3_url="$s3_base_url/$latest_version/"
 latest_s3_url="$s3_base_url/latest/"
 
@@ -37,4 +42,4 @@ echo "Copying $latest_version_s3_url to $latest_s3_url"
 
 aws s3 cp --acl public-read-write --recursive "$latest_version_s3_url" "$latest_s3_url"
 
-echo "--- :tada: All done!"
+echo "--- :llama::sparkles::llama: All done!"

--- a/scripts/utils/latest_version.rb
+++ b/scripts/utils/latest_version.rb
@@ -1,0 +1,66 @@
+# Takes a list of versions like so, and returns the latest (and greatest) one:
+#
+# 1
+# 1.0
+# 1.0.0
+# 1.0.0.1
+# 3.0.0-beta.1-810
+# 3.0.0-beta.1-811
+# 3.0.0-beta.1-812
+# 3.0.0-beta.2-813
+# 3.0.0
+# 3.1.0.2-alpha.1-814
+# 3.1.0.2-beta.1-814
+# 3.1.0.2
+
+def parse(version_string)
+  pattern = %r{
+    # Major is required
+    (?<major>\d+)
+    # All these numbers are optional
+    (\.(?<minor>\d+))?
+    (\.(?<patch>\d+))?
+    (\.(?<tiny>\d+))?
+    # Pre is a string like alpha, beta, etc
+    (\-(?<prerelease>[a-z]+))?
+    # The rest are numbers, and we dont care if its dashes or dots
+    ([\-\.](?<prerelease_major>\d+))?
+    ([\-\.](?<prerelease_minor>\d+))?
+    ([\-\.](?<prerelease_patch>\d+))?
+    ([\-\.](?<prerelease_tiny>\d+))?
+  }x
+
+  if m = pattern.match(version_string)
+    {
+      # Parse all the integer strings. If it's nil, make it 0
+      # (i.e. "2" becomes "2.0.0")
+      major:            m[:major].to_i,
+      minor:            m[:minor].to_i,
+      patch:            m[:patch].to_i,
+      tiny:             m[:tiny].to_i,
+      prerelease:       m[:prerelease],
+      prerelease_major: m[:prerelease_major].to_i,
+      prerelease_minor: m[:prerelease_minor].to_i,
+      prerelease_patch: m[:prerelease_patch].to_i,
+      prerelease_tiny:  m[:prerelease_tiny].to_i
+    }
+  end
+end
+
+def sort(v1, v2)
+  # We need to special case the major/minor/patch/tiny being the same, but one
+  # being a prerelease. i.e. 2.3.2 > 2.3.2-beta.2 and 2.3.2-beta.2 < 2.3.2
+  if v1.values.first(4) == v2.values.first(4) && (!v1[:prerelease] || !v2[:prerelease])
+    v1[:prerelease] ? -1 : 1
+  # Otherwise we can just let Ruby sort all the parts against both (including
+  # prerelease strings as alphabetical)
+  else
+    v1.values <=> v2.values
+  end
+end
+
+lines = STDIN.readlines.map(&:strip).compact.sort {|line_1, line_2|
+  sort(parse(line_1), parse(line_2))
+}
+
+puts lines.last


### PR DESCRIPTION
This publishes the buildkite agent binaries to download.buildkite.com. Each release will look like:

```
# Stable
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-darwin-386
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-darwin-386.sha1
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-darwin-amd64
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-darwin-amd64.sha1
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-freebsd-386
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-freebsd-386.sha1
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-freebsd-amd64
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-freebsd-amd64.sha1
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-linux-386
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-linux-386.sha1
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-linux-arm
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-linux-arm.sha1
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-linux-arm64
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-linux-arm64.sha1
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-linux-armhf
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-linux-armhf.sha1
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-windows-386.exe
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-windows-386.exe.sha1
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-windows-amd64.exe
https://download.buildkite.com/agent/stable/2.1.10/buildkite-agent-windows-amd64.exe.sha1

# Unstable (beta builds)
https://download.buildkite.com/agent/unstable/3.0.0-beta.1/buildkite-agent-darwin-386
...

# Experimental (master commit builds)
https://download.buildkite.com/agent/experimental/3.0.0-beta.1-812/buildkite-agent-darwin-386
...
```

To download the latest buildkite-agent for a platform you can just construct the correct URL yourself:

```
curl -L https://download.buildkite.com/agent/stable/latest/buildkite-agent-darwin-386 > /usr/local/bin/buildkite-agent
```

Once we've got some binaries up there for testing, we can set up S3 redirect rules with mappings to let you do:

```
curl -L https://download.buildkite.com/agent/stable/latest/buildkite-agent-`uname -s`-`uname -m` > /usr/local/bin/buildkite-agent
```

The `latest` version is done by `s3 cp`'ing all the files from the release into the `latest` path for the moment.