### PR TITLE
Add logs to debug an edge case in getExitStatus

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -316,6 +316,8 @@ func getExitStatus(waitResult error) string {
 			} else {
 				logger.Error("[Process] Unimplemented for system where exec.ExitError.Sys() is not syscall.WaitStatus.")
 			}
+		} else {
+			logger.Errorf("[Process] Unexpected error type in getExitStatus: %#v", waitResult)
 		}
 	} else {
 		exitStatus = 0


### PR DESCRIPTION
We recently had a job marked as failed with status `-1`, but from the script output it seemed to have done just fine.

I believe it is due to the server trying to shutdown (which makes it hard to reproduce), but still there is something weird in the agent code.

The logs:
```
2016-05-18_18:35:43.55852 2016-05-18 18:35:43 DEBUG  GET https://agent.buildkite.com/v3/jobs/fa8da290-8a83-48b6-afa1-70c768cdea24
2016-05-18_18:35:43.58236 2016-05-18 18:35:43 DEBUG  ↳ GET https://agent.buildkite.com/v3/jobs/fa8da290-8a83-48b6-afa1-70c768cdea24 (200 OK 23.842189ms)
2016-05-18_18:35:46.58264 2016-05-18 18:35:46 DEBUG  GET https://agent.buildkite.com/v3/jobs/fa8da290-8a83-48b6-afa1-70c768cdea24
2016-05-18_18:35:46.59274 2016-05-18 18:35:46 DEBUG  ↳ GET https://agent.buildkite.com/v3/jobs/fa8da290-8a83-48b6-afa1-70c768cdea24 (200 OK 10.032093ms)
2016-05-18_18:35:49.59318 2016-05-18 18:35:49 DEBUG  GET https://agent.buildkite.com/v3/jobs/fa8da290-8a83-48b6-afa1-70c768cdea24
2016-05-18_18:35:49.60836 2016-05-18 18:35:49 DEBUG  ↳ GET https://agent.buildkite.com/v3/jobs/fa8da290-8a83-48b6-afa1-70c768cdea24 (200 OK 15.234256ms)
2016-05-18_18:35:51.12174 2016-05-18 18:35:51 DEBUG  Received signal `TERM`
2016-05-18_18:35:51.12176 2016-05-18 18:35:51 WARN   Agent is already gracefully stopping...
2016-05-18_18:35:51.12177 2016-05-18 18:35:51 DEBUG  Received signal `TERM`
2016-05-18_18:35:51.12177 2016-05-18 18:35:51 WARN   Agent is already gracefully stopping...
2016-05-18_18:35:51.12178 2016-05-18 18:35:51 DEBUG  [Process] PTY has finished being copied to the buffer
2016-05-18_18:35:51.12179 2016-05-18 18:35:51 INFO   Process with PID: 34022 finished with Exit Status: -1
2016-05-18_18:35:51.12179 2016-05-18 18:35:51 DEBUG  [Process] Waiting for routines to finish
2016-05-18_18:35:51.12180 2016-05-18 18:35:51 DEBUG  [LineScanner] Encountered EOF
2016-05-18_18:35:51.12181 2016-05-18 18:35:51 DEBUG  [LineScanner] Finished
2016-05-18_18:35:51.12181 2016-05-18 18:35:51 DEBUG  [HeaderTimesStreamer] Waiting for all the lines to be scanned
2016-05-18_18:35:51.12182 2016-05-18 18:35:51 DEBUG  [HeaderTimesStreamer] Waiting for all the header times to be uploaded
2016-05-18_18:35:51.12182 2016-05-18 18:35:51 DEBUG  [LogStreamer] Waiting for all the chunks to be uploaded
2016-05-18_18:35:51.12183 2016-05-18 18:35:51 DEBUG  [LogStreamer] Shutting down all workers
2016-05-18_18:35:51.12184 2016-05-18 18:35:51 DEBUG  PUT https://agent.buildkite.com/v3/jobs/fa8da290-8a83-48b6-afa1-70c768cdea24/finish
2016-05-18_18:35:51.12184 2016-05-18 18:35:51 DEBUG  [LogStreamer/Worker#2] Worker has shutdown
2016-05-18_18:35:51.12186 2016-05-18 18:35:51 DEBUG  [LogStreamer/Worker#1] Worker has shutdown
2016-05-18_18:35:51.12187 2016-05-18 18:35:51 DEBUG  [LogStreamer/Worker#0] Worker has shutdown
2016-05-18_18:35:51.13478 2016-05-18 18:35:51 DEBUG  ↳ PUT https://agent.buildkite.com/v3/jobs/fa8da290-8a83-48b6-afa1-70c768cdea24/finish (200 OK 63.842078ms)
```

Looking at the code (we run `buildkite-agent version 2.2-beta.1, build 939`), it seems that there is an edge case that isn't handled, nor logged.

In [`getExitStatus`](https://github.com/buildkite/agent/blob/4c645758ce5ca49710f02fcf4ae778164f965674/process/process.go#L307-L325), if `waitResult` isn't a `exec.ExitError`, then the job will be considered as exited with `-1`.

[A bit higher the stack](https://github.com/buildkite/agent/blob/4c645758ce5ca49710f02fcf4ae778164f965674/process/process.go#L182) we can see `waitResult` is the return value of `Cmd.Wait()`. 

And from [`Cmd.Wait()` documentation](https://golang.org/pkg/os/exec/#Cmd.Wait):

> If the command fails to run or doesn't complete successfully, the error is of type *ExitError. Other error types may be returned for I/O problems.

It's not clear as what "other error types" nor "I/O problems" exactly indicate, but I believe it would be worth logging those errors.

@keithpitt @toolmantim for review please.

cc @wvanbergen @burke