### PR TITLE
Environment Interpolation Fixes

### DIFF
--- a/agent/pipeline_parser.go
+++ b/agent/pipeline_parser.go
@@ -11,7 +11,7 @@ type PipelineParser struct {
 	Data []byte
 }
 
-var variablesWithBracketsRegex = regexp.MustCompile(`([\\\$]?\$\{(.+[^\\])})`)
+var variablesWithBracketsRegex = regexp.MustCompile(`([\\\$]?\$\{([^}]+?)})`)
 var variablesWithNoBracketsRegex = regexp.MustCompile(`([\\\$]?\$[a-zA-Z0-9_]+)`)
 
 func (p PipelineParser) Parse() (parsed []byte, err error) {

--- a/agent/pipeline_parser_test.go
+++ b/agent/pipeline_parser_test.go
@@ -147,10 +147,10 @@ func TestPipelineParser(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, result, `
 	  steps:
-            - command: "Do this $$ESCAPE_PARTY"
-            - command: "Do this \$ESCAPE_PARTY"
-            - command: "Do this $${SUCH_ESCAPE}"
-            - command: "Do this \${SUCH_ESCAPE}"
+            - command: "Do this $ESCAPE_PARTY"
+            - command: "Do this $ESCAPE_PARTY"
+            - command: "Do this ${SUCH_ESCAPE}"
+            - command: "Do this ${SUCH_ESCAPE}"
 	`)
 
 	// Lets you use special characters in the default env var option


### PR DESCRIPTION
This PR fixes 2 bugs with ENV interpolation:

- `${BUILDKITE_COMMIT}_${BUILDKITE_PARALLEL_JOB}` would be considered as 1 environment variable
- `$$ESCAPED_VAR` would result in `$$ESCAPED_VAR` after parsing - when it should have been `$ESCAPED_VAR`