### PR TITLE
Fix ssh keyscan

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -205,7 +205,7 @@ else
 
       # Only add the output from ssh-keyscan if it doesn't already exist in the
       # known_hosts file
-      if ! ssh-keygen -H -F "$BUILDKITE_REPO_SSH_HOST" | grep -q "$BUILDKITE_REPO_SSH_HOST"; then
+      if ! ssh-keygen -f "$BUILDKITE_SSH_KNOWN_HOST_PATH" -H -F "$BUILDKITE_REPO_SSH_HOST" | grep -q "$BUILDKITE_REPO_SSH_HOST"; then
         buildkite-run "ssh-keyscan \"$BUILDKITE_REPO_SSH_HOST\" >> \"$BUILDKITE_SSH_KNOWN_HOST_PATH\""
       fi
     fi

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -204,10 +204,10 @@ else
       touch "$BUILDKITE_SSH_KNOWN_HOST_PATH"
 
       # Only add the output from ssh-keyscan if it doesn't already exist in the
-      # known_hosts file
-      if ! ssh-keygen -f "$BUILDKITE_SSH_KNOWN_HOST_PATH" -H -F "$BUILDKITE_REPO_SSH_HOST" > /dev/null; then
+      # known_hosts file (unhashed or hashed).
+      ssh-keygen -f "$BUILDKITE_SSH_KNOWN_HOST_PATH" -F "$BUILDKITE_REPO_SSH_HOST" > /dev/null ||
+        ssh-keygen -f "$BUILDKITE_SSH_KNOWN_HOST_PATH" -F "$BUILDKITE_REPO_SSH_HOST" -H > /dev/null ||
         buildkite-run "ssh-keyscan \"$BUILDKITE_REPO_SSH_HOST\" >> \"$BUILDKITE_SSH_KNOWN_HOST_PATH\""
-      fi
     fi
   fi
 

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -205,7 +205,7 @@ else
 
       # Only add the output from ssh-keyscan if it doesn't already exist in the
       # known_hosts file
-      if ! ssh-keygen -f "$BUILDKITE_SSH_KNOWN_HOST_PATH" -H -F "$BUILDKITE_REPO_SSH_HOST" | grep -q "$BUILDKITE_REPO_SSH_HOST"; then
+      if ! ssh-keygen -f "$BUILDKITE_SSH_KNOWN_HOST_PATH" -H -F "$BUILDKITE_REPO_SSH_HOST" > /dev/null; then
         buildkite-run "ssh-keyscan \"$BUILDKITE_REPO_SSH_HOST\" >> \"$BUILDKITE_SSH_KNOWN_HOST_PATH\""
       fi
     fi


### PR DESCRIPTION
There were a few edge cases here which meant that we could be scanning every single time we run a job, and the ssh known hosts file would fill with duplicates.

These changes should make sure that we only scan for know hosts once, whether HashKnownHosts is set or not (see [ssh_config(5)](http://man.openbsd.org/ssh_config)).