### PR TITLE
Don't require a command argument for the bootstrap

### DIFF
--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -25,7 +25,7 @@ Example:
    $ buildkite-agent bootstrap --build-path builds`
 
 type BootstrapConfig struct {
-	Command                      string `cli:"command" validate:"required"`
+	Command                      string `cli:"command"`
 	JobID                        string `cli:"job" validate:"required"`
 	Repository                   string `cli:"repository" validate:"required"`
 	Commit                       string `cli:"commit" validate:"required"`


### PR DESCRIPTION
To run "command-less plugins" such as docker-compose (ones that override the command hook), currently you need to do this:

```yml
steps:
  - name: ":docker: :package:"
    command: ignored
    plugins:
      docker-compose:
        build: app
```

If you leave out the command you get this when you run the step:

```
2016-06-15 20:53:46 FATAL  Missing command. See: `buildkite-agent bootstrap --help`
exit status 1
```

With this PR you're able to leave out the dummy command:

```yml
steps:
  - name: ":docker: :package:"
    plugins:
      docker-compose:
        build: app
```

(though currently you need to also add `type: script`, but there'll be another PR to infer that if there's a `plugins` property)