### PR TITLE
Expect plugin hooks to live in a hooks dir

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -583,7 +583,7 @@ func (b *Bootstrap) pluginHookPath(plugin *Plugin, name string) string {
 		exitf("%s", err)
 	}
 
-	return filepath.Join(b.PluginsPath, id, dir, name)
+	return filepath.Join(b.PluginsPath, id, dir, "hooks", name)
 }
 
 // Executes a plugin hook gracefully


### PR DESCRIPTION
This changes the plugin gear to expect hooks in a hooks dir instead of the repo root:

```
buildkite-plugins/docker-compose/
buildkite-plugins/docker-compose/hooks/
buildkite-plugins/docker-compose/hooks/command
```