### PR TITLE
Fix the homebrew sha recipe updating

### DIFF
--- a/scripts/release-homebrew.sh
+++ b/scripts/release-homebrew.sh
@@ -42,12 +42,15 @@ DOWNLOAD_URL="https://github.com/buildkite/agent/releases/download/v$GITHUB_RELE
 FORMULA_FILE=./pkg/buildkite-agent.rb
 UPDATED_FORMULA_FILE=./pkg/buildkite-agent-updated.rb
 
-echo "--- :package: Fetching artifact SHA from Github release step"
+echo "--- :package: Calculating SHAs for releases/$BINARY_NAME"
 
-echo "Fetching SHA"
-RELEASE_SHA=$(buildkite-agent artifact shasum "releases/$BINARY_NAME")
+buildkite-agent artifact download "releases/$BINARY_NAME" .
 
-echo "Release SHA1: $RELEASE_SHA"
+RELEASE_SHA1=$(sha1sum "releases/$BINARY_NAME" | cut -d" " -f1)
+RELEASE_SHA256=$(sha256sum "releases/$BINARY_NAME" | cut -d" " -f1)
+
+echo "Release SHA1: $RELEASE_SHA1"
+echo "Release SHA256: $RELEASE_SHA256"
 
 echo "--- :octocat: Fetching current homebrew formula from Github Contents API"
 
@@ -63,10 +66,11 @@ echo "--- :ruby: Updating formula file"
 echo "Homebrew release type: $BREW_RELEASE_TYPE"
 echo "Homebrew release version: $GITHUB_RELEASE_VERSION"
 echo "Homebrew release download URL: $DOWNLOAD_URL"
-echo "Homebrew release download SHA: $RELEASE_SHA"
+echo "Homebrew release download SHA1: $RELEASE_SHA1"
+echo "Homebrew release download SHA256: $RELEASE_SHA256"
 
 cat $FORMULA_FILE |
-  ./scripts/utils/update-homebrew-formula.rb $BREW_RELEASE_TYPE $GITHUB_RELEASE_VERSION $DOWNLOAD_URL $RELEASE_SHA \
+  ./scripts/utils/update-homebrew-formula.rb $BREW_RELEASE_TYPE $GITHUB_RELEASE_VERSION $DOWNLOAD_URL $RELEASE_SHA1 $RELEASE_SHA256 \
   > $UPDATED_FORMULA_FILE
 
 echo "--- :rocket: Commiting new formula to master via Github Contents API"

--- a/scripts/utils/update-homebrew-formula.rb
+++ b/scripts/utils/update-homebrew-formula.rb
@@ -8,12 +8,14 @@
 #     version "..."
 #     url     "..."
 #     sha1    "..."
+#     sha256  "..."
 #   end
 #
 #   devel do
 #     version "..."
 #     url     "..."
 #     sha1    "..."
+#     sha256  "..."
 #   end
 
 release, version, url, sha1 = ARGV
@@ -24,6 +26,7 @@ print $stdin.read.sub(%r{
       version \s+ ").*?("  .*?
       url     \s+ ").*?("  .*?
       sha1    \s+ ").*?("  .*?
+      sha256  \s+ ").*?("  .*?
     end
   )
-}xm, "\\1#{version}\\2#{url}\\3#{sha1}\\4")
+}xm, "\\1#{version}\\2#{url}\\3#{sha1}\\4#{sha256}\\5")


### PR DESCRIPTION
It looks like we might have manually fixed the homebrew recipe last time in https://github.com/buildkite/homebrew-buildkite/commit/dba6b14688555b4bb741599dda62340e32fcaf6f  but didn't fix it here, so this adds SHA256 updating to the homebrew recipe updater.

I had to move away from using `buildkite-agent artifact shasum` because it doesn't support 256 yet, so we just pull down the release artifact again and calculate it ourselves.