### PR TITLE
Remove -buildkite-plugin from the name

### DIFF
--- a/agent/plugin.go
+++ b/agent/plugin.go
@@ -114,6 +114,7 @@ func (p *Plugin) Name() string {
 		name = strings.ToLower(name)
 		name = regexp.MustCompile(`\s+`).ReplaceAllString(name, " ")
 		name = regexp.MustCompile(`[^a-zA-Z0-9]`).ReplaceAllString(name, "-")
+		name = strings.Replace(name, "-buildkite-plugin", "", -1)
 
 		return name
 	} else {

--- a/agent/plugin_test.go
+++ b/agent/plugin_test.go
@@ -53,6 +53,12 @@ func TestCreatePluginsFromJSON(t *testing.T) {
 func TestPluginName(t *testing.T) {
 	var plugin *Plugin
 
+	plugin = &Plugin{Location: "github.com/buildkite-plugins/docker-compose-buildkite-plugin"}
+	assert.Equal(t, plugin.Name(), "docker-compose")
+
+	plugin = &Plugin{Location: "github.com/my-org/docker-compose-buildkite-plugin"}
+	assert.Equal(t, plugin.Name(), "docker-compose")
+
 	plugin = &Plugin{Location: "github.com/buildkite/plugins/docker-compose"}
 	assert.Equal(t, plugin.Name(), "docker-compose")
 


### PR DESCRIPTION
This means environment variables won't have config vars named `BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILDKITE_PLUGIN`