### PR TITLE
Support multiple docker compose files

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -417,7 +417,12 @@ else
   elif [[ -n "${BUILDKITE_DOCKER_COMPOSE_CONTAINER:-}" ]]; then
     # Compose strips dashes and underscores, so we'll remove them to match the docker container names
     COMPOSE_PROJ_NAME="buildkite${BUILDKITE_JOB_ID//-}"
-    COMPOSE_COMMAND=(docker-compose -f "${BUILDKITE_DOCKER_COMPOSE_FILE:-docker-compose.yml}" -p "$COMPOSE_PROJ_NAME")
+    COMPOSE_COMMAND=(docker-compose)
+    IFS=":" read -ra COMPOSE_FILES <<< "${BUILDKITE_DOCKER_COMPOSE_FILE:-docker-compose.yml}"
+    for FILE in "${COMPOSE_FILES[@]}"; do
+      COMPOSE_COMMAND+=(-f "$FILE")
+    done
+    COMPOSE_COMMAND+=(-p "$COMPOSE_PROJ_NAME")
 
     function compose-cleanup {
       if [[ "${BUILDKITE_DOCKER_COMPOSE_LEAVE_VOLUMES:-false}" == "true" ]]; then


### PR DESCRIPTION
> [@porty] hello! we're currently using https://docs.docker.com/compose/extends/ to merge a base docker-compose file with a buildkite-specific one (agent v2.1.10) via `BUILDKITE_DOCKER_COMPOSE_FILE: "docker-compose.yml -f docker-compose.buildkite.yml"` (a bit of a hack)
> I see in v2.1.13 that env var is now being escaped, and so thats failing - is there a proper way to load more than one docker-compose file in a step?
>
> [@sj26] @porty: we did escape some more stuff so that commands are a little more locked down, yeah. unfortunately it stops hacks like yours, too — sorry!
> maybe you’d like to add the services you need for buildkite into your main compose and then specify which service you want as an entry point for builds
> or you could copy the services, but have to maintain two compose files which is a little :disappointed:
> looks like an oft-requested feature in docker-compose, haha: https://github.com/docker/compose/issues/318
> one option might be to make `BUILDKITE_DOCKER_COMPOSE_FILE` accept multiple config files separated by `:` or something?

This makes `$BUILDKITE_DOCKER_COMPOSE_FILE` able to parse multiple docker compose files separated by `:`.

<img width="574" alt="screencapture-buildkite-dev-test-test-builds-2-1469425707106" src="https://cloud.githubusercontent.com/assets/14028/17091795/082912a6-5281-11e6-956f-b7e990c5fc67.png">

🙌