### PR TITLE
Have buildkite-agent install a systemd template for instances.

### DIFF
--- a/packaging/linux/scripts/after-install-and-upgrade.sh
+++ b/packaging/linux/scripts/after-install-and-upgrade.sh
@@ -71,6 +71,7 @@ fi
 if [ $BK_SYSTEMD_EXITS -eq 0 ] && [ $BK_IS_UBUNTU_14_10 -eq 1 ]; then
   if [ ! -f /lib/systemd/system/buildkite-agent.service ]; then
     cp /usr/share/buildkite-agent/systemd/buildkite-agent.service /lib/systemd/system/buildkite-agent.service
+    cp /usr/share/buildkite-agent/systemd/buildkite-agent.service /lib/systemd/system/buildkite-agent@.service
   fi
 
   START_COMMAND="sudo systemctl enable buildkite-agent && sudo systemctl start buildkite-agent"

--- a/packaging/linux/scripts/after-remove.sh
+++ b/packaging/linux/scripts/after-remove.sh
@@ -1,6 +1,7 @@
 # Remove the system service we installed
 if command -v systemctl > /dev/null; then
   rm -f /lib/systemd/system/buildkite-agent.service
+  rm -f /lib/systemd/system/buildkite-agent@.service
 fi
 if [ -f /etc/init/buildkite-agent.conf ]; then
   rm -f /etc/init/buildkite-agent.conf

--- a/packaging/linux/scripts/before-remove.sh
+++ b/packaging/linux/scripts/before-remove.sh
@@ -16,6 +16,7 @@ if command -v systemctl > /dev/null; then
 
   systemctl --no-reload disable buildkite-agent || :
     systemctl stop buildkite-agent || :
+    systemctl stop 'buildkite-agent@*' || :
 elif [ $BK_UPSTART_EXISTS -eq 0 ] && [ $BK_UPSTART_TOO_OLD -eq 0 ]; then
   echo "Stopping buildkite-agent upstart service"
 


### PR DESCRIPTION
I comment on this in buildkite/docs#46 as well, but this is a change which would have buildkite-agent install a systemd 'template' unit, which would allow users to start additional agents by simply running:

```bash
sudo systemctl start buildkite-agent@2
sudo systemctl start buildkite-agent@3
sudo systemctl start buildkite-agent@arbitrary-string
...
```

Note how the user doesn't have to copy the unit file in order to spawn multiple workers.

Note that they can be stopped or monitored en-masse by using (for example):
`sudo systemctl status 'buildkite-agent@*'`

This also has the advantage that the 'buildkite-agent@.service' file can be version controlled/package managed by buildkite-agent, which the currently suggested ad-hoc copies (buildkite-agent-2.service, etc.) cannot.

In this pull request I leave the original 'buildkite-agent.service' around for compatibility reasons.