### PR TITLE
`sha1` has been deprecated in latest homebrew

### DIFF
--- a/scripts/release-homebrew.sh
+++ b/scripts/release-homebrew.sh
@@ -46,10 +46,8 @@ echo "--- :package: Calculating SHAs for releases/$BINARY_NAME"
 
 buildkite-agent artifact download "releases/$BINARY_NAME" .
 
-RELEASE_SHA1=$(sha1sum "releases/$BINARY_NAME" | cut -d" " -f1)
 RELEASE_SHA256=$(sha256sum "releases/$BINARY_NAME" | cut -d" " -f1)
 
-echo "Release SHA1: $RELEASE_SHA1"
 echo "Release SHA256: $RELEASE_SHA256"
 
 echo "--- :octocat: Fetching current homebrew formula from Github Contents API"
@@ -66,11 +64,10 @@ echo "--- :ruby: Updating formula file"
 echo "Homebrew release type: $BREW_RELEASE_TYPE"
 echo "Homebrew release version: $GITHUB_RELEASE_VERSION"
 echo "Homebrew release download URL: $DOWNLOAD_URL"
-echo "Homebrew release download SHA1: $RELEASE_SHA1"
 echo "Homebrew release download SHA256: $RELEASE_SHA256"
 
 cat $FORMULA_FILE |
-  ./scripts/utils/update-homebrew-formula.rb $BREW_RELEASE_TYPE $GITHUB_RELEASE_VERSION $DOWNLOAD_URL $RELEASE_SHA1 $RELEASE_SHA256 \
+  ./scripts/utils/update-homebrew-formula.rb $BREW_RELEASE_TYPE $GITHUB_RELEASE_VERSION $DOWNLOAD_URL $RELEASE_SHA256 \
   > $UPDATED_FORMULA_FILE
 
 echo "--- :rocket: Commiting new formula to master via Github Contents API"

--- a/scripts/utils/update-homebrew-formula.rb
+++ b/scripts/utils/update-homebrew-formula.rb
@@ -7,26 +7,23 @@
 #   stable do
 #     version "..."
 #     url     "..."
-#     sha1    "..."
 #     sha256  "..."
 #   end
 #
 #   devel do
 #     version "..."
 #     url     "..."
-#     sha1    "..."
 #     sha256  "..."
 #   end
 
-release, version, url, sha1, sha256 = ARGV
+release, version, url, sha256 = ARGV
 
 print $stdin.read.sub(%r{
   (
     #{release} \s+ do      .*?
       version \s+ ").*?("  .*?
       url     \s+ ").*?("  .*?
-      sha1    \s+ ").*?("  .*?
       sha256  \s+ ").*?("  .*?
     end
   )
-}xm, "\\1#{version}\\2#{url}\\3#{sha1}\\4#{sha256}\\5")
+}xm, "\\1#{version}\\2#{url}\\3#{sha256}\\4")


### PR DESCRIPTION
I believe the `sha1` call in homebrew has been deprecated! (see: https://github.com/buildkite/homebrew-buildkite/issues/4)

This PR removes the auto-updating of it - next step will be to remove it entirely from the homebrew repo.

@toolmantim does this look OK to you?