### PR TITLE
Allow fetching meta-data from Google Cloud metadata

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -22,6 +22,7 @@ type AgentPool struct {
 	MetaData           []string
 	MetaDataEC2        bool
 	MetaDataEC2Tags    bool
+	MetaDataGCP        bool
 	Endpoint           string
 	AgentConfiguration *AgentConfiguration
 }
@@ -122,6 +123,19 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 		if err != nil {
 			// Don't blow up if we can't find them, just show a nasty error.
 			logger.Error(fmt.Sprintf("Failed to find EC2 Tags: %s", err.Error()))
+		} else {
+			for tag, value := range tags {
+				agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))
+			}
+		}
+	}
+
+	// Attempt to add the Google Cloud meta-data
+	if r.MetaDataGCP {
+		tags, err := GCPMetaData{}.Get()
+		if err != nil {
+			// Don't blow up if we can't find them, just show a nasty error.
+			logger.Error(fmt.Sprintf("Failed to fetch Google Cloud meta-data: %s", err.Error()))
 		} else {
 			for tag, value := range tags {
 				agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))

--- a/agent/gcp_meta_data.go
+++ b/agent/gcp_meta_data.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"strings"
+
+	"google.golang.org/cloud/compute/metadata"
+)
+
+type GCPMetaData struct {
+}
+
+func (e GCPMetaData) Get() (map[string]string, error) {
+	result := make(map[string]string)
+
+	instanceId, err := metadata.Get("instance/id")
+	if err != nil {
+		return result, err
+	}
+	result["gcp:instance-id"] = instanceId
+
+	machineType, err := machineType()
+	if err != nil {
+		return result, err
+	}
+	result["gcp:machine-type"] = machineType
+
+	preemptible, err := metadata.Get("instance/scheduling/preemptible")
+	if err != nil {
+		return result, err
+	}
+	result["gcp:preemptible"] = strings.ToLower(preemptible)
+
+	projectId, err := metadata.ProjectID()
+	if err != nil {
+		return result, err
+	}
+	result["gcp:project-id"] = projectId
+
+	zone, err := metadata.Zone()
+	if err != nil {
+		return result, err
+	}
+	result["gcp:zone"] = zone
+
+	return result, nil
+}
+
+func machineType() (string, error) {
+	machType, err := metadata.Get("instance/machine-type")
+	// machType is of the form "projects/<projNum>/machineTypes/<machType>".
+	if err != nil {
+		return "", err
+	}
+	return machType[strings.LastIndex(machType, "/")+1:], nil
+}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -122,7 +122,7 @@ var AgentStartCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name:  "meta-data-gcp",
-			Usage: "Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, and zone) as meta-data",
+			Usage: "Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, region, and zone) as meta-data",
 		},
 		cli.StringFlag{
 			Name:   "git-clone-flags",

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -40,6 +40,7 @@ type AgentStartConfig struct {
 	MetaData                     []string `cli:"meta-data"`
 	MetaDataEC2                  bool     `cli:"meta-data-ec2"`
 	MetaDataEC2Tags              bool     `cli:"meta-data-ec2-tags"`
+	MetaDataGCP                  bool     `cli:"meta-data-gcp"`
 	GitCloneFlags                string   `cli:"git-clone-flags"`
 	GitCleanFlags                string   `cli:"git-clean-flags"`
 	NoColor                      bool     `cli:"no-color"`
@@ -118,6 +119,10 @@ var AgentStartCommand = cli.Command{
 		cli.BoolFlag{
 			Name:  "meta-data-ec2-tags",
 			Usage: "Include the host's EC2 tags as meta-data",
+		},
+		cli.BoolFlag{
+			Name:  "meta-data-gcp",
+			Usage: "Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, and zone) as meta-data",
 		},
 		cli.StringFlag{
 			Name:   "git-clone-flags",
@@ -209,6 +214,7 @@ var AgentStartCommand = cli.Command{
 			MetaData:        cfg.MetaData,
 			MetaDataEC2:     cfg.MetaDataEC2,
 			MetaDataEC2Tags: cfg.MetaDataEC2Tags,
+			MetaDataGCP:     cfg.MetaDataGCP,
 			Endpoint:        cfg.Endpoint,
 			AgentConfiguration: &agent.AgentConfiguration{
 				BootstrapScript:            cfg.BootstrapScript,

--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -16,7 +16,7 @@ name="%hostname-%n"
 # Include the host's EC2 tags as meta-data
 # meta-data-ec2-tags=true
 
-# Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, and zone) as meta-data
+# Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, region, and zone) as meta-data
 # meta-data-gcp=true
 
 # Path to the bootstrap script. You should avoid changing this file as it will

--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -16,6 +16,9 @@ name="%hostname-%n"
 # Include the host's EC2 tags as meta-data
 # meta-data-ec2-tags=true
 
+# Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, and zone) as meta-data
+# meta-data-gcp=true
+
 # Path to the bootstrap script. You should avoid changing this file as it will
 # be overridden when you update your agent. If you need to make changes to this
 # file: use the hooks provided, or copy the file and reference it here.

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -16,7 +16,7 @@ name="%hostname-%n"
 # Include the host's EC2 tags as meta-data
 # meta-data-ec2-tags=true
 
-# Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, and zone) as meta-data
+# Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, region, and zone) as meta-data
 # meta-data-gcp=true
 
 # Path to the bootstrap script. You should avoid changing this file as it will

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -16,6 +16,9 @@ name="%hostname-%n"
 # Include the host's EC2 tags as meta-data
 # meta-data-ec2-tags=true
 
+# Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, and zone) as meta-data
+# meta-data-gcp=true
+
 # Path to the bootstrap script. You should avoid changing this file as it will
 # be overridden when you update your agent. If you need to make changes to this
 # file: use the hooks provided, or copy the file and reference it here.


### PR DESCRIPTION
Add `--meta-data-gcp` flag that fetches metadata from Google Compute Engine and populates it as Buildkite agent meta-data. The following keys are used: `instance-id`, `machine-type`, `preemptible`, `project-id`, and `zone`.