### PR TITLE
Disable CGO

### DIFF
--- a/scripts/utils/build-binary.sh
+++ b/scripts/utils/build-binary.sh
@@ -36,6 +36,9 @@ if [[ "$GOOS" == "windows" ]]; then
   BINARY_FILENAME="$BINARY_FILENAME.exe"
 fi
 
+# Disable CGO completely
+export CGO_ENABLED=0
+
 mkdir -p $BUILD_PATH
 go build -v -ldflags "-X github.com/buildkite/agent/agent.buildVersion=$BUILD_VERSION" -o $BUILD_PATH/$BINARY_FILENAME *.go
 


### PR DESCRIPTION
We really want to ship an entirely static binary to make it as easy as possible for folks to run the buildkite-agent without worrying about glibc etc. So let's disable CGO entirely.

This means the system's networking configuration may not be entirely honoured. On *nix systems Go will read /etc/resolv.conf and use those dns servers, but otherwise skip any other name resolution mechanisms like mDNS. This includes losing Bonjour/mDNS on macOS.

At the moment this also means we lose process titles, but they've only been available on amd64 linux until now and we have [a pure Go solution to that in the works](https://github.com/buildkite/agent/pull/373).

For Windows, this shouldn't cause any change.

/cc @toolmantim 