### PR TITLE
Go 1.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   agent:
-    image: golang:1.6
+    image: golang:1.7
     working_dir: /go/src/github.com/buildkite/agent
     volumes:
       - ./:/go/src/github.com/buildkite/agent


### PR DESCRIPTION
This updates to [Go 1.7](https://tip.golang.org/doc/go1.7)

Fixes #378 (macOS Sierra compatibility)