### PR TITLE
retries for grabbing ec2 metadata

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -113,7 +113,7 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 			tags, err := EC2MetaData{}.Get()
 			if err != nil {
 				// retry.Do will sleep 1s per configuration and we tack on a few random ms
-				time.Sleep(1000 * r.Float32() * time.Millisecond)
+				time.Sleep(time.Duration(1000 * r.Float32()) * time.Millisecond)
 			} else {
 				for tag, value := range tags {
 					agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))
@@ -136,7 +136,7 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 		err := retry.Do(func(s *retry.Stats) error {
 			tags, err := EC2Tags{}.Get()
 			if err != nil {
-				time.Sleep(1000 * r.Float32() * time.Millisecond)
+				time.Sleep(time.Duration(1000 * r.Float32()) * time.Millisecond)
 			} else {
 				for tag, value := range tags {
 					agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -105,7 +105,7 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 		Arch:              runtime.GOARCH,
 	}
 
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	
 	// Attempt to add the EC2 meta-data
 	if r.MetaDataEC2 {
@@ -113,7 +113,7 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 			tags, err := EC2MetaData{}.Get()
 			if err != nil {
 				// retry.Do will sleep 1s per configuration and we tack on a few random ms
-				time.Sleep(time.Duration(1000 * r.Float32()) * time.Millisecond)
+				time.Sleep(time.Duration(1000 * random.Float32()) * time.Millisecond)
 			} else {
 				for tag, value := range tags {
 					agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))
@@ -136,7 +136,7 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 		err := retry.Do(func(s *retry.Stats) error {
 			tags, err := EC2Tags{}.Get()
 			if err != nil {
-				time.Sleep(time.Duration(1000 * r.Float32()) * time.Millisecond)
+				time.Sleep(time.Duration(1000 * random.Float32()) * time.Millisecond)
 			} else {
 				for tag, value := range tags {
 					agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -125,7 +125,9 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 		}, &retry.Config{Maximum: 10, Interval: 1 * time.Second})
 		
 		// Don't blow up if we can't find them, just show a nasty error.
-		logger.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
+		if err != nil {
+			logger.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
+		}
 	}
 
 	// Attempt to add the EC2 tags
@@ -146,7 +148,9 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 		}, &retry.Config{Maximum: 10, Interval: 1 * time.Second})
 		
 		// Don't blow up if we can't find them, just show a nasty error.
-		logger.Error(fmt.Sprintf("Failed to find EC2 Tags: %s", err.Error()))
+		if err != nil {
+			logger.Error(fmt.Sprintf("Failed to find EC2 Tags: %s", err.Error()))
+		}
 	}
 
 	// Attempt to add the Google Cloud meta-data

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"runtime"
 	"time"
+	"math/rand"
 
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/logger"
@@ -104,28 +105,38 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 		Arch:              runtime.GOARCH,
 	}
 
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	
 	// Attempt to add the EC2 meta-data
 	if r.MetaDataEC2 {
-		tags, err := EC2MetaData{}.Get()
-		if err != nil {
-			// Don't blow up if we can't find them, just show a nasty error.
-			logger.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
-		} else {
-			for tag, value := range tags {
-				agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))
+		for i := 0; i < 10; i++ {
+			tags, err := EC2MetaData{}.Get()
+			if err != nil {
+				// Don't blow up if we can't find them, just show a nasty error.
+				logger.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
+				time.Sleep((1000 + r.Float32() * 1000) * time.Millisecond)
+			} else {
+				for tag, value := range tags {
+					agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))
+				}
+				break
 			}
 		}
 	}
 
 	// Attempt to add the EC2 tags
 	if r.MetaDataEC2Tags {
-		tags, err := EC2Tags{}.Get()
-		if err != nil {
-			// Don't blow up if we can't find them, just show a nasty error.
-			logger.Error(fmt.Sprintf("Failed to find EC2 Tags: %s", err.Error()))
-		} else {
-			for tag, value := range tags {
-				agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))
+		for i := 0; i < 10; i++ {
+			tags, err := EC2Tags{}.Get()
+			if err != nil {
+				// Don't blow up if we can't find them, just show a nasty error.
+				logger.Error(fmt.Sprintf("Failed to find EC2 Tags: %s", err.Error()))
+				time.Sleep((1000 + r.Float32() * 1000) * time.Millisecond)
+			} else {
+				for tag, value := range tags {
+					agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))
+				}
+				break
 			}
 		}
 	}


### PR DESCRIPTION
When starting several agents in quick succession some of the agents fail to populate with the proper EC2 metadata for tags. I suspect it has something to do with grabbing IAM credentials and throttling on AWS side. Retries with some random delay should fix the problem.