### PR TITLE
Substring expansion

### DIFF
--- a/agent/pipeline_parser_test.go
+++ b/agent/pipeline_parser_test.go
@@ -13,6 +13,97 @@ func parse(s string) (string, error) {
 	return string(parsed[:]), err
 }
 
+func TestSubstringExpansion(t *testing.T) {
+	var result string
+	var err error
+
+	// Missing parameter value:
+
+	result, err = parse("${BUILDKITE_COMMIT:0}")
+	assert.Nil(t, err)
+	assert.Equal(t, "", result)
+
+	result, err = parse("${BUILDKITE_COMMIT:0:7}")
+	assert.Nil(t, err)
+	assert.Equal(t, "", result)
+
+	result, err = parse("${BUILDKITE_COMMIT:7}")
+	assert.Nil(t, err)
+	assert.Equal(t, "", result)
+
+	result, err = parse("${BUILDKITE_COMMIT:7:14}")
+	assert.Nil(t, err)
+	assert.Equal(t, "", result)
+
+	// Basic offsets:
+
+	os.Setenv("BUILDKITE_COMMIT", "1adf998e39f647b4b25842f107c6ed9d30a3a7c7")
+
+	result, err = parse("${BUILDKITE_COMMIT:0}")
+	assert.Nil(t, err)
+	assert.Equal(t, "1adf998e39f647b4b25842f107c6ed9d30a3a7c7", result)
+
+	result, err = parse("${BUILDKITE_COMMIT:7}")
+	assert.Nil(t, err)
+	assert.Equal(t, "e39f647b4b25842f107c6ed9d30a3a7c7", result)
+
+	result, err = parse("${BUILDKITE_COMMIT:-7}")
+	assert.Nil(t, err)
+	assert.Equal(t, "0a3a7c7", result)
+
+	// Out of range offsets:
+
+	result, err = parse("${BUILDKITE_COMMIT:-128}")
+	assert.Nil(t, err)
+	assert.Equal(t, "1adf998e39f647b4b25842f107c6ed9d30a3a7c7", result)
+
+	result, err = parse("${BUILDKITE_COMMIT:128}")
+	assert.Nil(t, err)
+	assert.Equal(t, "", result)
+
+	// Including lengths:
+
+	result, err = parse("${BUILDKITE_COMMIT:0:7}")
+	assert.Nil(t, err)
+	assert.Equal(t, "1adf998", result)
+
+	result, err = parse("${BUILDKITE_COMMIT:7:7}")
+	assert.Nil(t, err)
+	assert.Equal(t, "e39f647", result)
+
+	result, err = parse("${BUILDKITE_COMMIT:7:-7}")
+	assert.Nil(t, err)
+	assert.Equal(t, "e39f647b4b25842f107c6ed9d3", result)
+
+	// Zero-sized:
+
+	result, err = parse("${BUILDKITE_COMMIT:0:0}")
+	assert.Nil(t, err)
+	assert.Equal(t, "", result)
+
+	result, err = parse("${BUILDKITE_COMMIT:7:0}")
+	assert.Nil(t, err)
+	assert.Equal(t, "", result)
+
+	// Out of range lengths:
+
+	result, err = parse("${BUILDKITE_COMMIT:0:128}")
+	assert.Nil(t, err)
+	assert.Equal(t, "1adf998e39f647b4b25842f107c6ed9d30a3a7c7", result)
+
+	result, err = parse("${BUILDKITE_COMMIT:7:128}")
+	assert.Nil(t, err)
+	assert.Equal(t, "e39f647b4b25842f107c6ed9d30a3a7c7", result)
+
+	result, err = parse("${BUILDKITE_COMMIT:0:-128}")
+	assert.Nil(t, err)
+	assert.Equal(t, "", result)
+
+	result, err = parse("${BUILDKITE_COMMIT:7:-128}")
+	assert.Nil(t, err)
+	assert.Equal(t, "", result)
+}
+
 func TestPipelineParser(t *testing.T) {
 	var result string
 	var err error


### PR DESCRIPTION
Enables substring expansion in pipeline.yml files, like this practical example:

```yaml
steps:
  - name: ":docker: :hammer:"
    plugins:
      docker-compose:
        build: app
        tags:
          - ${BUILDKITE_COMMIT:0:7}
```

This follows the conventions of [linux shell parameter substring expansion](http://www.tldp.org/LDP/abs/html/parameter-substitution.html#EXPREPL1) and embraces the [bash version](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html) which allows negative offsets and lengths, too.