### PR TITLE
Add plugins-path to the config

### DIFF
--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -30,6 +30,9 @@ build-path="$HOME/.buildkite-agent/builds"
 # Directory where the hook scripts are found
 hooks-path="$HOME/.buildkite-agent/hooks"
 
+# Directory where plugins will be installed
+plugins-path="$HOME/.buildkite-agent/plugins"
+
 # Flags to pass to the `git clone` command
 # git-clone-flags=-v
 

--- a/packaging/github/windows/buildkite-agent.cfg
+++ b/packaging/github/windows/buildkite-agent.cfg
@@ -19,6 +19,9 @@ build-path="builds"
 # Directory where the hook scripts are found
 hooks-path="hooks"
 
+# Directory where plugins will be installed
+plugins-path="plugins"
+
 # Flags to pass to the `git clone` command
 # git-clone-flags=-v
 


### PR DESCRIPTION
The buildkite-agent.cfg in the tar.gz for the v3 betas still contain the bootstrap.sh config line, and lack the plugins path. And because of this, if you install buildkite-agent via homebrew using `--devel` it doesn't include `plugins-path` in the config.

This was been updated:
https://github.com/buildkite/agent/blob/master/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg

But these haven't:
https://github.com/buildkite/agent/blob/master/packaging/github/linux/buildkite-agent.cfg
https://github.com/buildkite/agent/blob/master/packaging/github/windows/buildkite-agent.cfg

Presumably because the bootstrap config line has already been updated in these files, it's safe to include this change here too.