### PR TITLE
Fix error detection on Windows

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -1128,7 +1128,8 @@ func (b *Bootstrap) Start() error {
 					if k != "" {
 						buildScriptContents = buildScriptContents +
 							fmt.Sprintf("ECHO %s\n", windows.BatchEscape("\033[90m>\033[0m "+k)) +
-							k + "\n"
+							k + "\n" +
+							"if %errorlevel% neq 0 exit /b %errorlevel%\n"
 					}
 				}
 			} else {


### PR DESCRIPTION
Windows builds failed to report an error if it didn't occur
on the last command of the build. Batch files have no equivalent
for "set -e"; instead we need to check after each command for
the return value and exit if it is non-zero.

Fix for #391 