### PR TITLE
Renamed the PipelineParser to be envvar.Interpolate

### DIFF
--- a/envvar/interpolator_test.go
+++ b/envvar/interpolator_test.go
@@ -1,4 +1,4 @@
-package agent
+package envvar
 
 import (
 	"os"
@@ -7,31 +7,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func parse(s string) (string, error) {
-	parsed, err := PipelineParser{Data: []byte(s)}.Parse()
-
-	return string(parsed[:]), err
-}
-
 func TestSubstringExpansion(t *testing.T) {
 	var result string
 	var err error
 
 	// Missing parameter value:
 
-	result, err = parse("${BUILDKITE_COMMIT:0}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:0}")
 	assert.Nil(t, err)
 	assert.Equal(t, "", result)
 
-	result, err = parse("${BUILDKITE_COMMIT:0:7}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:0:7}")
 	assert.Nil(t, err)
 	assert.Equal(t, "", result)
 
-	result, err = parse("${BUILDKITE_COMMIT:7}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:7}")
 	assert.Nil(t, err)
 	assert.Equal(t, "", result)
 
-	result, err = parse("${BUILDKITE_COMMIT:7:14}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:7:14}")
 	assert.Nil(t, err)
 	assert.Equal(t, "", result)
 
@@ -39,67 +33,67 @@ func TestSubstringExpansion(t *testing.T) {
 
 	os.Setenv("BUILDKITE_COMMIT", "1adf998e39f647b4b25842f107c6ed9d30a3a7c7")
 
-	result, err = parse("${BUILDKITE_COMMIT:0}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:0}")
 	assert.Nil(t, err)
 	assert.Equal(t, "1adf998e39f647b4b25842f107c6ed9d30a3a7c7", result)
 
-	result, err = parse("${BUILDKITE_COMMIT:7}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:7}")
 	assert.Nil(t, err)
 	assert.Equal(t, "e39f647b4b25842f107c6ed9d30a3a7c7", result)
 
-	result, err = parse("${BUILDKITE_COMMIT:-7}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:-7}")
 	assert.Nil(t, err)
 	assert.Equal(t, "0a3a7c7", result)
 
 	// Out of range offsets:
 
-	result, err = parse("${BUILDKITE_COMMIT:-128}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:-128}")
 	assert.Nil(t, err)
 	assert.Equal(t, "1adf998e39f647b4b25842f107c6ed9d30a3a7c7", result)
 
-	result, err = parse("${BUILDKITE_COMMIT:128}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:128}")
 	assert.Nil(t, err)
 	assert.Equal(t, "", result)
 
 	// Including lengths:
 
-	result, err = parse("${BUILDKITE_COMMIT:0:7}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:0:7}")
 	assert.Nil(t, err)
 	assert.Equal(t, "1adf998", result)
 
-	result, err = parse("${BUILDKITE_COMMIT:7:7}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:7:7}")
 	assert.Nil(t, err)
 	assert.Equal(t, "e39f647", result)
 
-	result, err = parse("${BUILDKITE_COMMIT:7:-7}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:7:-7}")
 	assert.Nil(t, err)
 	assert.Equal(t, "e39f647b4b25842f107c6ed9d3", result)
 
 	// Zero-sized:
 
-	result, err = parse("${BUILDKITE_COMMIT:0:0}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:0:0}")
 	assert.Nil(t, err)
 	assert.Equal(t, "", result)
 
-	result, err = parse("${BUILDKITE_COMMIT:7:0}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:7:0}")
 	assert.Nil(t, err)
 	assert.Equal(t, "", result)
 
 	// Out of range lengths:
 
-	result, err = parse("${BUILDKITE_COMMIT:0:128}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:0:128}")
 	assert.Nil(t, err)
 	assert.Equal(t, "1adf998e39f647b4b25842f107c6ed9d30a3a7c7", result)
 
-	result, err = parse("${BUILDKITE_COMMIT:7:128}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:7:128}")
 	assert.Nil(t, err)
 	assert.Equal(t, "e39f647b4b25842f107c6ed9d30a3a7c7", result)
 
-	result, err = parse("${BUILDKITE_COMMIT:0:-128}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:0:-128}")
 	assert.Nil(t, err)
 	assert.Equal(t, "", result)
 
-	result, err = parse("${BUILDKITE_COMMIT:7:-128}")
+	result, err = Interpolate("${BUILDKITE_COMMIT:7:-128}")
 	assert.Nil(t, err)
 	assert.Equal(t, "", result)
 }
@@ -109,18 +103,18 @@ func TestPipelineParser(t *testing.T) {
 	var err error
 
 	// It does nothing to byte slices with no environmnet variables
-	result, err = parse("foo")
+	result, err = Interpolate("foo")
 	assert.Nil(t, err)
 	assert.Equal(t, result, "foo")
 
 	// It does nothing to empty strings
-	result, err = parse("")
+	result, err = Interpolate("")
 	assert.Nil(t, err)
 	assert.Equal(t, result, "")
 
 	// It parses regular env vars
 	os.Setenv("WHO", "World!")
-	result, err = parse(`
+	result, err = Interpolate(`
 	  steps:
 	    - command: "Hello $WHO"
 	`)
@@ -131,7 +125,7 @@ func TestPipelineParser(t *testing.T) {
 	`)
 
 	// It inserts a blank string if the var hasn't been set
-	result, err = parse(`
+	result, err = Interpolate(`
 	  steps:
 	    - command: "Hello $WHO_REALLY"
 	`)
@@ -142,7 +136,7 @@ func TestPipelineParser(t *testing.T) {
 	`)
 
 	// It returns an error with an invalid looking env var
-	result, err = parse(`
+	result, err = Interpolate(`
 	  steps:
 	    - command: "Hello $123"
 	`)
@@ -152,7 +146,7 @@ func TestPipelineParser(t *testing.T) {
 	// They can be embedded in strings and keys
 	os.Setenv("KEY", "command")
 	os.Setenv("END_OF_HELLO", "llo")
-	result, err = parse(`
+	result, err = Interpolate(`
 	  steps:
 	    - $KEY: "He$END_OF_HELLO"
 	`)
@@ -165,7 +159,7 @@ func TestPipelineParser(t *testing.T) {
 	// The parser supports the other type of env variable
 	os.Setenv("TODAY", "Sunday")
 	os.Setenv("TOMORROW", "Monday")
-	result, err = parse(`
+	result, err = Interpolate(`
 	  steps:
 	    - command: "echo 'Today is ${TODAY}'"
 	    - command: "echo 'Tomorrow is ${TOMORROW}'"
@@ -180,7 +174,7 @@ func TestPipelineParser(t *testing.T) {
 	// You can provide default values
 	os.Unsetenv("TODAY")
 	os.Unsetenv("TOMORROW")
-	result, err = parse(`
+	result, err = Interpolate(`
 	  steps:
 	    - command: "echo 'Today is ${TODAY-Tuesday}'"
 	    - command: "echo 'Tomorrow is ${TOMORROW-Wednesday}'"
@@ -195,7 +189,7 @@ func TestPipelineParser(t *testing.T) {
 	// You can toggle the defaulting behaviour between "use default if
 	// value is null" or "use default if value is unset"
 	os.Setenv("THIS_VAR_IS_NULL", "")
-	result, err = parse(`
+	result, err = Interpolate(`
 	  steps:
             - command: "Do this ${THIS_VAR_IS_NULL:-great thing}"
 	    - command: "Do this ${THIS_VAR_IS_NULL-wont show up}"
@@ -212,7 +206,7 @@ func TestPipelineParser(t *testing.T) {
 	`)
 
 	// It allows you to require some variables
-	result, err = parse(`
+	result, err = Interpolate(`
 	  steps:
 	    - command: "Hello ${REQUIRED_VAR?}"
 	`)
@@ -220,7 +214,7 @@ func TestPipelineParser(t *testing.T) {
 	assert.Equal(t, string(err.Error()), "$REQUIRED_VAR: not set")
 
 	// The error message for them can be customized
-	result, err = parse(`
+	result, err = Interpolate(`
 	  steps:
 	    - command: "Hello ${REQUIRED_VAR?y u no set me? :-{}"
 	`)
@@ -228,7 +222,7 @@ func TestPipelineParser(t *testing.T) {
 	assert.Equal(t, string(err.Error()), "$REQUIRED_VAR: y u no set me? :-{")
 
 	// Lets you escape variables using 2 different syntaxes
-	result, err = parse(`
+	result, err = Interpolate(`
 	  steps:
             - command: "Do this $$ESCAPE_PARTY"
             - command: "Do this \$ESCAPE_PARTY"
@@ -245,7 +239,7 @@ func TestPipelineParser(t *testing.T) {
 	`)
 
 	// Lets you use special characters in the default env var option
-	result, err = parse(`
+	result, err = Interpolate(`
 	  steps:
 	    - command: "${THIS_VAR_IS_NULL:--:{}}"
 	`)
@@ -258,7 +252,7 @@ func TestPipelineParser(t *testing.T) {
 	// Lets you use special characters in the required var option. In this
 	// example, the first `}` character is what is used to complete the ${}
 	// var, and the last one is just ignored.
-	result, err = parse(`
+	result, err = Interpolate(`
 	  steps:
 	    - command: "Hello ${REQUIRED_VAR?{}}"
 	`)
@@ -267,7 +261,7 @@ func TestPipelineParser(t *testing.T) {
 
 	// Lets you parse a full looking pipeline
 	os.Setenv("BUILDKITE_COMMIT", "1adf998e39f647b4b25842f107c6ed9d30a3a7c7")
-	result, err = parse(`
+	result, err = Interpolate(`
           env:
             IMAGE: registry.dev.example.com/app:${BUILDKITE_COMMIT}
             REVISION: ${BUILDKITE_COMMIT}
@@ -285,14 +279,13 @@ func TestPipelineParser(t *testing.T) {
               command: docker build -t $IMAGE --build-arg REVISION=$BUILDKITE_COMMIT .
 	`)
 
-
 	// The regex isn't greedy. The result of ENV_1 doesn't contain the
 	// `BUILDKITE_COMMIT` value, because the interpolator sees the actual
 	// variable key as being `BUILDKITE_COMMIT_`. To get this working, the
 	// user has to use the ${} syntax.
 	os.Setenv("BUILDKITE_COMMIT", "cfeeee3fa7fa1a6311723f5cbff95b738ec6e683")
 	os.Setenv("BUILDKITE_PARALLEL_JOB", "456")
-	result, err = parse(`
+	result, err = Interpolate(`
 	  steps:
             - command: echo "ENV_1=test_$BUILDKITE_COMMIT_$BUILDKITE_PARALLEL_JOB"
             - command: echo "ENV_2=test_${BUILDKITE_COMMIT}_${BUILDKITE_PARALLEL_JOB}"


### PR DESCRIPTION
It also now just talks strings instead of `[]byte`