### PR TITLE
Pre-process pipelines before uploading

### DIFF
--- a/agent/pipeline_parser.go
+++ b/agent/pipeline_parser.go
@@ -1,0 +1,209 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"reflect"
+
+	"github.com/buildkite/agent/envvar"
+	"github.com/buildkite/agent/logger"
+	"github.com/ghodss/yaml"
+)
+
+type PipelineParser struct {
+	Filename string
+	Format   string
+	Pipeline []byte
+}
+
+func (p PipelineParser) Parse() (pipeline interface{}, err error) {
+	format := p.Format
+
+	// If no format is passed, figure it out based on the filename
+	if format == "" {
+		logger.Debug("Pipeline format not supplied, inferring from filename `%s`", p.Filename)
+
+		format, err = inferFormatFromFilename(p.Filename)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Unmarshal the pipeline into an actual data structure
+	unmarshaled, err := unmarshal(p.Pipeline, format)
+	if err != nil {
+		return nil, err
+	}
+
+	// Recursivly go through the entire pipeline and perform environment
+	// variable interpolation on strings
+	interpolated, err := interpolate(unmarshaled)
+	if err != nil {
+		return nil, err
+	}
+
+	return interpolated, nil
+}
+
+func inferFormatFromFilename(filename string) (string, error) {
+	// Make sure we've got a filename in the first place
+	if filename == "" {
+		return "", fmt.Errorf("No filename to infer a format from")
+	}
+
+	// Get the file extension
+	extension := filepath.Ext(filename)
+	if extension == "" {
+		return "", fmt.Errorf("No extension could be inferred from filename `%s`", filename)
+	}
+
+	// Figure out the format from the extension
+	if extension == ".yaml" || extension == ".yml" {
+		return "yaml", nil
+	} else if extension == ".json" {
+		return "json", nil
+	} else {
+		return "", fmt.Errorf("Could not infer a pipeline from `%s` with extension `%s`. To force a format, please use `--format`", filename, extension)
+	}
+}
+
+func unmarshal(pipeline []byte, format string) (interface{}, error) {
+	var unmarshaled interface{}
+
+	if format == "yaml" {
+		logger.Debug("Parsing pipeline configuration as YAML")
+
+		err := yaml.Unmarshal(pipeline, &unmarshaled)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse YAML: %s", err)
+		}
+	} else if format == "json" {
+		logger.Debug("Parsing pipeline configuration as JSON")
+
+		err := json.Unmarshal(pipeline, &unmarshaled)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse JSON: %s", err)
+		}
+	} else {
+		if format == "" {
+			return nil, fmt.Errorf("No format was supplied or one could not be inferred")
+		} else {
+			return nil, fmt.Errorf("Unknown format `%s`", format)
+		}
+	}
+
+	return unmarshaled, nil
+}
+
+// interpolate function inspired from: https://gist.github.com/hvoecking/10772475
+
+func interpolate(obj interface{}) (interface{}, error) {
+	// Wrap the original in a reflect.Value
+	original := reflect.ValueOf(obj)
+
+	copy := reflect.New(original.Type()).Elem()
+
+	err := interpolateRecursive(copy, original)
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove the reflection wrapper
+	return copy.Interface(), nil
+}
+
+func interpolateRecursive(copy, original reflect.Value) error {
+	switch original.Kind() {
+	// If it is a pointer we need to unwrap and call once again
+	case reflect.Ptr:
+		// To get the actual value of the original we have to call Elem()
+		// At the same time this unwraps the pointer so we don't end up in
+		// an infinite recursion
+		originalValue := original.Elem()
+
+		// Check if the pointer is nil
+		if !originalValue.IsValid() {
+			return nil
+		}
+
+		// Allocate a new object and set the pointer to it
+		copy.Set(reflect.New(originalValue.Type()))
+
+		// Unwrap the newly created pointer
+		err := interpolateRecursive(copy.Elem(), originalValue)
+		if err != nil {
+			return err
+		}
+
+	// If it is an interface (which is very similar to a pointer), do basically the
+	// same as for the pointer. Though a pointer is not the same as an interface so
+	// note that we have to call Elem() after creating a new object because otherwise
+	// we would end up with an actual pointer
+	case reflect.Interface:
+		// Get rid of the wrapping interface
+		originalValue := original.Elem()
+
+		// Create a new object. Now new gives us a pointer, but we want the value it
+		// points to, so we have to call Elem() to unwrap it
+		copyValue := reflect.New(originalValue.Type()).Elem()
+
+		err := interpolateRecursive(copyValue, originalValue)
+		if err != nil {
+			return err
+		}
+
+		copy.Set(copyValue)
+
+	// If it is a struct we interpolate each field
+	case reflect.Struct:
+		for i := 0; i < original.NumField(); i += 1 {
+			err := interpolateRecursive(copy.Field(i), original.Field(i))
+			if err != nil {
+				return err
+			}
+		}
+
+	// If it is a slice we create a new slice and interpolate each element
+	case reflect.Slice:
+		copy.Set(reflect.MakeSlice(original.Type(), original.Len(), original.Cap()))
+
+		for i := 0; i < original.Len(); i += 1 {
+			err := interpolateRecursive(copy.Index(i), original.Index(i))
+			if err != nil {
+				return err
+			}
+		}
+
+	// If it is a map we create a new map and interpolate each value
+	case reflect.Map:
+		copy.Set(reflect.MakeMap(original.Type()))
+
+		for _, key := range original.MapKeys() {
+			originalValue := original.MapIndex(key)
+
+			// New gives us a pointer, but again we want the value
+			copyValue := reflect.New(originalValue.Type()).Elem()
+			err := interpolateRecursive(copyValue, originalValue)
+			if err != nil {
+				return err
+			}
+
+			copy.SetMapIndex(key, copyValue)
+		}
+
+	// If it is a string interpolate it (yay finally we're doing what we came for)
+	case reflect.String:
+		interpolated, err := envvar.Interpolate(original.Interface().(string))
+		if err != nil {
+			return err
+		}
+		copy.SetString(interpolated)
+
+	// And everything else will simply be taken from the original
+	default:
+		copy.Set(original)
+	}
+
+	return nil
+}

--- a/agent/pipeline_parser_test.go
+++ b/agent/pipeline_parser_test.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPipelineParser(t *testing.T) {
+	var err error
+	var result interface{}
+	var j []byte
+
+	os.Setenv("ENV_VAR_FRIEND", "\"friend\"")
+
+	// It parses pipelines with .yml filenames
+	result, err = PipelineParser{Filename: "awesome.yml", Pipeline: []byte("steps:\n  - label: \"hello ${ENV_VAR_FRIEND}\"")}.Parse()
+	assert.Nil(t, err)
+	j, err = json.Marshal(result)
+	assert.Equal(t, string(j), `{"steps":[{"label":"hello \"friend\""}]}`)
+
+	// It parses pipelines with .yaml filenames
+	result, err = PipelineParser{Filename: "awesome.yaml", Pipeline: []byte("steps:\n  - label: \"hello ${ENV_VAR_FRIEND}\"")}.Parse()
+	assert.Nil(t, err)
+	j, err = json.Marshal(result)
+	assert.Equal(t, string(j), `{"steps":[{"label":"hello \"friend\""}]}`)
+
+	// Returns YAML parsing errors
+	result, err = PipelineParser{Filename: "awesome.yml", Pipeline: []byte("steps: %blah%")}.Parse()
+	assert.NotNil(t, err)
+	assert.Equal(t, fmt.Sprintf("%s", err), `Failed to parse YAML: [while scanning for the next token] found character that cannot start any token at line 1, column 8`)
+
+	// Returns JSON parsing errors
+	result, err = PipelineParser{Filename: "awesome.json", Pipeline: []byte("{")}.Parse()
+	assert.NotNil(t, err)
+	assert.Equal(t, fmt.Sprintf("%s", err), `Failed to parse JSON: unexpected end of JSON input`)
+
+	// It parses pipelines with .json filenames
+	result, err = PipelineParser{Filename: "thing.json", Pipeline: []byte("\n\n     \n  { \"foo\": \"bye ${ENV_VAR_FRIEND}\" }\n")}.Parse()
+	assert.Nil(t, err)
+	j, err = json.Marshal(result)
+	assert.Equal(t, string(j), `{"foo":"bye \"friend\""}`)
+
+	// It parses unknown YAML
+	result, err = PipelineParser{Pipeline: []byte("steps:\n  - label: \"hello ${ENV_VAR_FRIEND}\"")}.Parse()
+	assert.Nil(t, err)
+	j, err = json.Marshal(result)
+	assert.Equal(t, string(j), `{"steps":[{"label":"hello \"friend\""}]}`)
+
+	// Returns YAML parsing errors if the content looks like YAML
+	result, err = PipelineParser{Pipeline: []byte("steps: %blah%")}.Parse()
+	assert.NotNil(t, err)
+	assert.Equal(t, fmt.Sprintf("%s", err), `Failed to parse YAML: [while scanning for the next token] found character that cannot start any token at line 1, column 8`)
+
+	// It parses unknown JSON objects
+	result, err = PipelineParser{Pipeline: []byte("\n\n     \n  { \"foo\": \"bye ${ENV_VAR_FRIEND}\" }\n")}.Parse()
+	assert.Nil(t, err)
+	j, err = json.Marshal(result)
+	assert.Equal(t, string(j), `{"foo":"bye \"friend\""}`)
+
+	// It parses unknown JSON arrays
+	result, err = PipelineParser{Pipeline: []byte("\n\n     \n  [ { \"foo\": \"bye ${ENV_VAR_FRIEND}\" } ]\n")}.Parse()
+	assert.Nil(t, err)
+	j, err = json.Marshal(result)
+	assert.Equal(t, string(j), `[{"foo":"bye \"friend\""}]`)
+
+	// Returns JSON parsing errors if the content looks like JSON
+	result, err = PipelineParser{Pipeline: []byte("{")}.Parse()
+	assert.NotNil(t, err)
+	assert.Equal(t, fmt.Sprintf("%s", err), `Failed to parse JSON: unexpected end of JSON input`)
+}

--- a/api/pipelines.go
+++ b/api/pipelines.go
@@ -1,13 +1,6 @@
 package api
 
-import (
-	"bytes"
-	"fmt"
-	"mime/multipart"
-	"path/filepath"
-
-	"github.com/buildkite/agent/mime"
-)
+import "fmt"
 
 // PipelinesService handles communication with the pipeline related methods of the
 // Buildkite Agent API.
@@ -17,57 +10,20 @@ type PipelinesService struct {
 
 // Pipeline represents a Buildkite Agent API Pipeline
 type Pipeline struct {
-	UUID     string
-	Data     []byte
-	FileName string
-	Replace  bool
+	UUID     string      `json:"uuid"`
+	Pipeline interface{} `json:"pipeline"`
+	Replace  bool        `json:"replace,omitempty"`
 }
 
 // Uploads the pipeline to the Buildkite Agent API. This request doesn't use JSON,
 // but a multi-part HTTP form upload
 func (cs *PipelinesService) Upload(jobId string, pipeline *Pipeline) (*Response, error) {
-	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
-
-	// Default the filename
-	fileName := pipeline.FileName
-	if fileName == "" {
-		fileName = "pipeline"
-	}
-
-	// Calculate the mime type based on the filename
-	extension := filepath.Ext(fileName)
-	contentType := mime.TypeByExtension(extension)
-	if contentType == "" {
-		contentType = "binary/octet-stream"
-	}
-
-	// Write the pipeline to the form
-	part, _ := createFormFileWithContentType(writer, "pipeline", fileName, contentType)
-	part.Write([]byte(pipeline.Data))
-
-	// Add the replace option
-	writer.WriteField("replace", fmt.Sprintf("%t", pipeline.Replace))
-
-	// The pipeline upload endpoint requires a way for it to uniquely
-	// identify this upload (because it's an idempotent endpoint). If a job
-	// tries to upload a pipeline that matches a previously uploaded one
-	// with a matching uuid, then it'll just return and not do anything.
-	writer.WriteField("uuid", pipeline.UUID)
-
-	// Close the writer because we don't need to add any more values to it
-	err := writer.Close()
-	if err != nil {
-		return nil, err
-	}
-
 	u := fmt.Sprintf("jobs/%s/pipelines", jobId)
-	req, err := cs.client.NewFormRequest("POST", u, body)
+
+	req, err := cs.client.NewRequest("POST", u, pipeline)
 	if err != nil {
 		return nil, err
 	}
-
-	req.Header.Add("Content-Type", writer.FormDataContentType())
 
 	return cs.client.Do(req, nil)
 }

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -41,11 +41,10 @@ Example:
 
    $ buildkite-agent pipeline upload
    $ buildkite-agent pipeline upload my-custom-pipeline.yml
-   $ ./script/dynamic_step_generator | buildkite-agent pipeline upload --format json`
+   $ ./script/dynamic_step_generator | buildkite-agent pipeline upload`
 
 type PipelineUploadConfig struct {
 	FilePath         string `cli:"arg:0" label:"upload paths"`
-	Format           string `cli:"format"`
 	Replace          bool   `cli:"replace"`
 	Job              string `cli:"job" validate:"required"`
 	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
@@ -60,12 +59,6 @@ var PipelineUploadCommand = cli.Command{
 	Usage:       "Uploads a description of a build pipeline adds it to the currently running build after the current job.",
 	Description: PipelineUploadHelpDescription,
 	Flags: []cli.Flag{
-		cli.StringFlag{
-			Name:   "format",
-			Value:  "",
-			Usage:  "The file format of the pipeline (yaml, json). This argument is required when reading a build pipeline via STDIN.",
-			EnvVar: "BUILDKITE_PIPELINE_FORMAT",
-		},
 		cli.BoolFlag{
 			Name:   "replace",
 			Usage:  "Replace the rest of the existing pipeline with the steps uploaded. Jobs that are already running are not removed.",
@@ -113,14 +106,7 @@ var PipelineUploadCommand = cli.Command{
 		} else if stdin.IsPipe() {
 			logger.Info("Reading pipeline config from STDIN")
 
-			// Make sure a format was passed
-			if cfg.Format == "" {
-				logger.Fatal("A format defined with `--format (yaml or json)` is required when reading a config via STDIN, for example (./script/dynamic_step_generator | buildkite-agent pipeline upload --format json). See `buildkite-agent pipeline upload --help` for more information.")
-			} else if cfg.Format != "yaml" && cfg.Format != "json" {
-				logger.Fatal("Unknown pipeline format `%s` - only `yaml` and `json` are supported. See `buildkite-agent pipeline upload --help` for more information.", cfg.Format)
-			}
-
-			// Now we can read from STDIN
+			// Actually read the file from STDIN
 			input, err = ioutil.ReadAll(os.Stdin)
 			if err != nil {
 				logger.Fatal("Failed to read from STDIN: %s", err)
@@ -173,7 +159,7 @@ var PipelineUploadCommand = cli.Command{
 		var parsed interface{}
 
 		// Parse the pipeline
-		parsed, err = agent.PipelineParser{Format: cfg.Format, Filename: filename, Pipeline: input}.Parse()
+		parsed, err = agent.PipelineParser{Filename: filename, Pipeline: input}.Parse()
 		if err != nil {
 			logger.Fatal("Pipeline parsing of \"%s\" failed (%s)", filename, err)
 		}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -143,11 +143,6 @@ var PipelineUploadCommand = cli.Command{
 
 			logger.Info("Found config file \"%s\"", found)
 
-			// Warn about the deprecated steps.json
-			if found == filepath.FromSlash(".buildkite/steps.json") {
-				logger.Warn("The default steps.json file has been deprecated and will be removed in v2.2. Please rename to .buildkite/pipeline.json and wrap the steps array in a `steps` property: { \"steps\": [ ... ] } }")
-			}
-
 			// Read the default file
 			filename = path.Base(found)
 			input, err = ioutil.ReadFile(found)


### PR DESCRIPTION
This PR is making a few big changes to how pipelines are uploaded to the BK API:

- Instead of uploading the pipeline files "as-is", we parse them first (either as YAML or as JSON) and upload them to the Agent API as JSON all the time. This gives us the benefit of catching JSON or YAML syntax errors before even hitting the Agent API
- Instead of doing an Environment Variable Interpolation across the entire pipeline as a whole, we recursively go through the entire config and do it for strings only, after the first parse. This solves many quoting issues (Fixes #346)
- When piping a pipeline in via STDIN, you must now tell the agent what format it's in `--format yaml` or `--format json`
- We now accept `.buildkite/pipeline.yaml` (not just `.yml`) files as default file. Apparently `.yaml` is actually the _official_ extension, but no one seems to care?
- `.buildkite/steps.json` has officially been removed

There's a few more things I need to do before I can merge this in:

- [x] Add the YAML parsing library to `master` and merge in
- [x] Fix the tests
- [x] Write some tests
- [x] Move the EnvironmentVariableInterpolator into the it's own package (done in master)