### PR TITLE
Update path to ssh tools for Windows

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -446,10 +446,6 @@ func (b *Bootstrap) addRepositoryHostToSSHKnownHosts(repository string) {
 					break
 				}
 			}
-
-			if sshToolBinaryPath == "" {
-				warningf("Could not find `ssh-keygen`")
-			}
 		}
 	}
 

--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -433,7 +433,7 @@ func (b *Bootstrap) addRepositoryHostToSSHKnownHosts(repository string) {
 	if runtime.GOOS == "windows" {
 		gitExecPathOutput, _ := b.runCommandSilentlyAndCaptureOutput("git", "--exec-path")
 		if gitExecPathOutput != "" {
-			sshToolBinaryPath = filepath.Join(gitExecPathOutput, "..", "..", "bin")
+			sshToolBinaryPath = filepath.Join(gitExecPathOutput, "..", "..", "..", "usr", "bin")
 		}
 	}
 


### PR DESCRIPTION
Spent some time trying to set up an agent on Windows and ran into this. Here's my VM showing that `ssh-keygen.exe` is in `C:\Program Files\Git\usr\bin` and didn't match the path traversal that the agent is trying to do. This is from Windows Server 2012 running in Vagrant:

<img width="682" alt="screen shot 2016-11-07 at 22 07 33" src="https://cloud.githubusercontent.com/assets/808808/20088782/4d1d283a-a537-11e6-91b7-8a4c3a71340b.png">

Git was installed via Chef. Not sure that this is the right fix since the current path could be right for other install methods. Just wanted to attach some code in case it turns out to be right.