### PR TITLE
agent: Avoid starting a new job in graceful stop mode

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -84,7 +84,9 @@ func (a *AgentWorker) Start() error {
 	// Continue this loop until the the ticker is stopped, and we received
 	// a message on the stop channel.
 	for {
-		a.Ping()
+		if !a.stopping {
+			a.Ping()
+		}
 
 		select {
 		case <-a.ticker.C:


### PR DESCRIPTION
The normal agent loop uses a `select` statement to wait on two channels: The first channel receives a value at a regular ping interval, and the second channel receives a value to indicate we are stopping:

    for {
        a.Ping()

        select {
        case <-a.ticker.C:
            continue
        case <-a.stop:
            a.ticker.Stop()
            return nil
        }
    }

I believe there is a race condition here:

1. Suppose Job A is currently running, so we are inside `Ping()`.

2. A "graceful stop" signal is received, and a value is sent on the `a.stop` channel.

3. The ticker sends a new value on the `a.ticker.C` channel.

4. Job A finishes, so we exit `Ping()`.

5. The `select` statement executes with both channels ready, and [it chooses one at random](https://golang.org/ref/spec#Select_statements). Suppose it chooses the ticker, and we continue on to the next iteration of the loop.

6. `Ping()` runs again and picks up Job B.

We can prevent this by guarding `Ping()` with a check on `a.stopping`.

Fixes #402.