### PR TITLE
Add an example to environment hook for providing inline_image function

### DIFF
--- a/packaging/linux/root/usr/share/buildkite-agent/hooks/environment.sample
+++ b/packaging/linux/root/usr/share/buildkite-agent/hooks/environment.sample
@@ -4,8 +4,14 @@
 # to set up secrets, data, etc. Anything exported in hooks will be available
 # to the build script.
 #
-# For example:
+# Examples:
 #
+### Set an environment variable
 # export SECRET_VAR=token
+#
+### Export inline_image function for bash scripts, to embed images in logs
+# function inline_image { printf '\033]1338;url='"$1"';alt='"$2"'\a\n'; }
+# export -f inline_image
+#
 
 set -e


### PR DESCRIPTION
Extend the commented examples in the environment hook sample, with a sample export of the inline_image function, so that it can be easily called in bash scripts.