### PR TITLE
No command eval working dir only

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -1100,8 +1100,8 @@ func (b *Bootstrap) Start() error {
 			exitf("No command has been defined. Please go to \"Pipeline Settings\" and configure your build step's \"Command\"")
 		}
 
-		pathToCommand := filepath.Join(b.currentWorkingDirectory(), strings.Replace(b.Command, "\n", "", -1))
-		commandIsScript := fileExists(pathToCommand)
+		pathToCommand, err := filepath.Abs(filepath.Join(b.currentWorkingDirectory(), strings.Replace(b.Command, "\n", "", -1)))
+		commandIsScript := err == nil && fileExists(pathToCommand)
 
 		// If the command isn't a script, then it's something we need
 		// to eval. But before we even try running it, we should double

--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -170,16 +170,18 @@ func normalizeScriptFileName(filename string) string {
 	}
 }
 
-// Changes the permission of a file so it can be executed
+// Makes sure a file is executable
 func addExecutePermissiontoFile(filename string) {
 	s, err := os.Stat(filename)
 	if err != nil {
 		exitf("Failed to retrieve file information of \"%s\" (%s)", filename, err)
 	}
 
-	err = os.Chmod(filename, s.Mode()|0100)
-	if err != nil {
-		exitf("Failed to mark \"%s\" as executable (%s)", filename, err)
+	if s.Mode() & 0100 == 0 {
+		err = os.Chmod(filename, s.Mode()|0100)
+		if err != nil {
+			exitf("Failed to mark \"%s\" as executable (%s)", filename, err)
+		}
 	}
 }
 

--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -1112,7 +1112,7 @@ func (b *Bootstrap) Start() error {
 
 		// Also make sure that the script we've resolved is definitely within this
 		// repository checkout and isn't elsewhere on the system.
-		if commandIsScript && !b.CommandEval && !strings.HasPrefix(pathToCommand, b.currentWorkingDirectory()) {
+		if commandIsScript && !b.CommandEval && !strings.HasPrefix(pathToCommand, b.currentWorkingDirectory() + string(os.PathSeparator)) {
 			exitf("This agent is only allowed to run scripts within your repository. To allow this, re-run this agent without the `--no-command-eval` option, or specify a script within your repository to run instead (such as scripts/test.sh).")
 		}
 

--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -1110,6 +1110,12 @@ func (b *Bootstrap) Start() error {
 			exitf("This agent is not allowed to evaluate console commands. To allow this, re-run this agent without the `--no-command-eval` option, or specify a script within your repository to run instead (such as scripts/test.sh).")
 		}
 
+		// Also make sure that the script we've resolved is definitely within this
+		// repository checkout and isn't elsewhere on the system.
+		if commandIsScript && !b.CommandEval && !strings.HasPrefix(pathToCommand, b.currentWorkingDirectory()) {
+			exitf("This agent is only allowed to run scripts within your repository. To allow this, re-run this agent without the `--no-command-eval` option, or specify a script within your repository to run instead (such as scripts/test.sh).")
+		}
+
 		var headerLabel string
 		var buildScriptPath string
 		var promptDisplay string


### PR DESCRIPTION
This makes sure that agents with `--no-command-eval` switched on can't execute files outside the working directory (the repository checkout).

![image](https://cloud.githubusercontent.com/assets/14028/20699393/3edc6ea4-b65b-11e6-8b0b-be745f60f7a7.png)

I also had to modify the chmod call to only chmod if the execute bit was missing, otherwise I got `Failed to mark "/usr/bin/true" as executable (Permission denied)`