### PR TITLE
Artifact upload destination env

### DIFF
--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -38,7 +38,7 @@ Example:
 
 type ArtifactUploadConfig struct {
 	UploadPaths      string `cli:"arg:0" label:"upload paths" validate:"required"`
-	Destination      string `cli:"arg:1" label:"destination"`
+	Destination      string `cli:"arg:1" label:"destination" env:"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"`
 	Job              string `cli:"job" validate:"required"`
 	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
 	Endpoint         string `cli:"endpoint" validate:"required"`

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -163,6 +163,17 @@ func (l Loader) setFieldValueFromCLI(fieldName string, cliName string) error {
 		if len(l.CLI.Args()) > argIndex {
 			value = l.CLI.Args()[argIndex]
 		}
+
+		// Otherwise see if we can pull it from an environment variable
+		// (and fail gracefuly if we can't)
+		if value == nil {
+			envName, err := reflections.GetFieldTag(l.Config, fieldName, "env")
+			if err == nil {
+				if envValue, envSet := os.LookupEnv(envName); envSet {
+					value = envValue
+				}
+			}
+		}
 	} else {
 		// If the cli name didn't have the special format, then we need to
 		// either load from the context's flags, or from a config file.

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -27,7 +27,7 @@ type Loader struct {
 	File *File
 }
 
-var ArgCliNameRegexp = regexp.MustCompile(`arg:(\d+)`)
+var argCliNameRegexp = regexp.MustCompile(`arg:(\d+)`)
 
 // A shortcut for loading a config from the CLI
 func Load(c *cli.Context, cfg interface{}) error {
@@ -148,7 +148,7 @@ func (l Loader) setFieldValueFromCLI(fieldName string, cliName string) error {
 	var value interface{}
 
 	// See the if the cli option is using the arg format i.e. (arg:1)
-	argMatch := ArgCliNameRegexp.FindStringSubmatch(cliName)
+	argMatch := argCliNameRegexp.FindStringSubmatch(cliName)
 	if len(argMatch) > 0 {
 		argNum := argMatch[1]
 

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -27,7 +27,7 @@ type Loader struct {
 	File *File
 }
 
-var CLISpecialNameRegex = regexp.MustCompile(`(arg):(\d+)`)
+var ArgCliNameRegexp = regexp.MustCompile(`arg:(\d+)`)
 
 // A shortcut for loading a config from the CLI
 func Load(c *cli.Context, cfg interface{}) error {
@@ -147,23 +147,21 @@ func (l Loader) setFieldValueFromCLI(fieldName string, cliName string) error {
 
 	var value interface{}
 
-	// See the if the cli option is using the special format i.e. (arg:1)
-	special := CLISpecialNameRegex.FindStringSubmatch(cliName)
-	if len(special) == 3 {
-		// Should this cli option be loaded from the CLI arguments?
-		if special[1] == "arg" {
-			// Convert the arg position to an integer
-			i, err := strconv.Atoi(special[2])
-			if err != nil {
-				return fmt.Errorf("Failed to convert string to int: %s", err)
-			}
+	// See the if the cli option is using the arg format i.e. (arg:1)
+	argMatch := ArgCliNameRegexp.FindStringSubmatch(cliName)
+	if len(argMatch) > 0 {
+		argNum := argMatch[1]
 
-			// Only set the value if the args are long enough for
-			// the position to exist.
-			if len(l.CLI.Args()) > i {
-				// Get the value from the args
-				value = l.CLI.Args()[i]
-			}
+		// Convert the arg position to an integer
+		argIndex, err := strconv.Atoi(argNum)
+		if err != nil {
+			return fmt.Errorf("Failed to convert string to int: %s", err)
+		}
+
+		// Only set the value if the args are long enough for
+		// the position to exist.
+		if len(l.CLI.Args()) > argIndex {
+			value = l.CLI.Args()[argIndex]
 		}
 	} else {
 		// If the cli name didn't have the special format, then we need to


### PR DESCRIPTION
@mcgain was trying to setup a custom s3 bucket for artifact uploads and noticed that `$BUILDKITE_ARTIFACT_UPLOAD_DESTINATION` is only respected in the bootstrap's default artifact uploader, and not when using `buildkite-agent artifact upload ...` manually. It seems the destination arg is not a normal flag and doesn't ingest environment variable values by default, so if the argument is not supplied positionally then it always uses the default buildkite artifact bucket. I've added support to our arg parser so that positional args can also fall through to environment variables, which doesn't seem to be available in the codegangsta cli package.

@mcgain, care to give it a go and confirm it's working now?