### PR TITLE
Exec the command within the shell

### DIFF
--- a/packaging/linux/root/usr/share/buildkite-agent/lsb/buildkite-agent.sh
+++ b/packaging/linux/root/usr/share/buildkite-agent/lsb/buildkite-agent.sh
@@ -36,7 +36,7 @@ case "$1" in
         echo "Already started"
     else
         echo "Starting $name"
-        su --login --shell /bin/sh "$user" --command "$cmd" >>"$log" 2>&1 &
+        su --login --shell /bin/sh "$user" --command "exec $cmd" >>"$log" 2>&1 &
         echo $! > "$pid_file"
         if ! is_running; then
             echo "Unable to start, see $log"


### PR DESCRIPTION
@npaufler noticed that on Debian wheezy using the lsb init script the buildkite-agent doesn't stop correctly:

```
sj26@debian:~$ sudo /etc/init.d/buildkite-agent start
Starting buildkite-agent

sj26@debian:~$ cat /var/run/buildkite-agent.pid
6825

sj26@debian:~$ ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
...
root      6825  0.0  0.2  37160  1364 pts/1    S    11:52   0:00 su --login --shell /bin/sh buildkite-agent
999       6828  0.0  0.1   4188   576 ?        Ss   11:52   0:00 -su -c /usr/bin/buildkite-agent start
999       6832  0.0  1.6  14848  8560 ?        Sl   11:52   0:00 /usr/bin/buildkite-agent start
sj26      6838  0.0  0.2  16844  1284 pts/1    R+   11:55   0:00 ps aux

sj26@debian:~$ sudo /etc/init.d/buildkite-agent stop
Stopping buildkite-agent..
Stopped

sj26@debian:~$ cat /var/run/buildkite-agent.pid
cat: /var/run/buildkite-agent.pid: No such file or directory

sj26@debian:~$ ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
...
999       6832  0.0  1.7  14848  8812 ?        Sl   11:52   0:00 /usr/bin/buildkite-agent start
sj26      6857  0.0  0.2  16844  1284 pts/1    R+   11:56   0:00 ps aux
```

So we're capturing the pid of the `su` process, and the `su` process fowards the term signal to the interior shell correctly, but the shell doesn't forward the signal to the agent.

If we prefix the shell command with `exec` then the shell itself disappears and execs the agent process directly, so the `su` will forward the signal to the agent process instead. This seems to fix stop:

```
sj26@debian:~$ sudo /etc/init.d/buildkite-agent start
Starting buildkite-agent

sj26@debian:~$ cat /var/run/buildkite-agent.pid
6863

sj26@debian:~$ ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
...
root      6863  0.0  0.2  37160  1364 pts/1    S    12:00   0:00 su --login --shell /bin/sh buildkite-agent --command exec /usr
999       6866  0.1  1.5  14784  8048 ?        Ssl  12:00   0:00 /usr/bin/buildkite-agent start
sj26      6885  0.0  0.2  16844  1284 pts/1    R+   12:01   0:00 ps aux

sj26@debian:~$ sudo /etc/init.d/buildkite-agent stop
Stopping buildkite-agent...
Stopped

sj26@debian:~$ cat /var/run/buildkite-agent.pid
cat: /var/run/buildkite-agent.pid: No such file or directory

sj26@debian:~$ ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
...
(no buildkite-agent)
sj26      6904  0.0  0.2  16844  1280 pts/1    R+   12:01   0:00 ps aux
```

💯 