### PR TITLE
Add option to timestamp lines

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -7,6 +7,7 @@ type AgentConfiguration struct {
 	AutoSSHFingerprintVerification bool
 	CommandEval                    bool
 	RunInPty                       bool
+	TimestampLines                 bool
 	GitCleanFlags                  string
 	GitCloneFlags                  string
 }

--- a/agent/header_times_streamer.go
+++ b/agent/header_times_streamer.go
@@ -73,18 +73,16 @@ func (h *HeaderTimesStreamer) Scan(line string) {
 	h.scanWaitGroup.Add(1)
 	defer h.scanWaitGroup.Done()
 
-	if h.lineIsHeader(line) {
-		logger.Debug("[HeaderTimesStreamer] Found header %q", line)
+	logger.Debug("[HeaderTimesStreamer] Found header %q", line)
 
-		// Aquire a lock on the times and then add the current time to
-		// our times slice.
-		h.timesMutex.Lock()
-		h.times = append(h.times, time.Now().UTC().Format(time.RFC3339Nano))
-		h.timesMutex.Unlock()
+	// Aquire a lock on the times and then add the current time to
+	// our times slice.
+	h.timesMutex.Lock()
+	h.times = append(h.times, time.Now().UTC().Format(time.RFC3339Nano))
+	h.timesMutex.Unlock()
 
-		// Add the time to the wait group
-		h.uploadWaitGroup.Add(1)
-	}
+	// Add the time to the wait group
+	h.uploadWaitGroup.Add(1)
 }
 
 func (h *HeaderTimesStreamer) Upload() {
@@ -136,7 +134,7 @@ func (h *HeaderTimesStreamer) Stop() {
 	h.streamingMutex.Unlock()
 }
 
-func (h *HeaderTimesStreamer) lineIsHeader(line string) bool {
+func (h *HeaderTimesStreamer) LineIsHeader(line string) bool {
 	// Make sure all ANSI colors are removed from the string before we
 	// check to see if it's a header (sometimes a color escape sequence may
 	// be the first thing on the line, which will cause the regex to ignore

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
@@ -59,11 +60,17 @@ func (r JobRunner) Create() (runner *JobRunner, err error) {
 	// the Buildkite Agent API
 	runner.logStreamer = LogStreamer{MaxChunkSizeBytes: r.Job.ChunksMaxSizeBytes, Callback: r.onUploadChunk}.New()
 
+	timestamp, err := strconv.ParseBool(os.Getenv("BUILDKITE_TIMESTAMP_LINES"))
+	if err != nil {
+		timestamp = false
+	}
+
 	// The process that will run the bootstrap script
 	runner.process = process.Process{
 		Script:        r.AgentConfiguration.BootstrapScript,
 		Env:           r.createEnvironment(),
 		PTY:           r.AgentConfiguration.RunInPty,
+		Timestamp:     timestamp,
 		StartCallback: r.onProcessStartCallback,
 		LineCallback:  runner.headerTimesStreamer.Scan,
 	}.Create()

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -67,12 +67,13 @@ func (r JobRunner) Create() (runner *JobRunner, err error) {
 
 	// The process that will run the bootstrap script
 	runner.process = process.Process{
-		Script:        r.AgentConfiguration.BootstrapScript,
-		Env:           r.createEnvironment(),
-		PTY:           r.AgentConfiguration.RunInPty,
-		Timestamp:     timestamp,
-		StartCallback: r.onProcessStartCallback,
-		LineCallback:  runner.headerTimesStreamer.Scan,
+		Script:             r.AgentConfiguration.BootstrapScript,
+		Env:                r.createEnvironment(),
+		PTY:                r.AgentConfiguration.RunInPty,
+		Timestamp:          timestamp,
+		StartCallback:      r.onProcessStartCallback,
+		LineCallback:       runner.headerTimesStreamer.Scan,
+		LineCallbackFilter: runner.headerTimesStreamer.LineIsHeader,
 	}.Create()
 
 	return

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"sync"
 	"time"
 
@@ -60,17 +59,12 @@ func (r JobRunner) Create() (runner *JobRunner, err error) {
 	// the Buildkite Agent API
 	runner.logStreamer = LogStreamer{MaxChunkSizeBytes: r.Job.ChunksMaxSizeBytes, Callback: r.onUploadChunk}.New()
 
-	timestamp, err := strconv.ParseBool(os.Getenv("BUILDKITE_TIMESTAMP_LINES"))
-	if err != nil {
-		timestamp = false
-	}
-
 	// The process that will run the bootstrap script
 	runner.process = process.Process{
 		Script:             r.AgentConfiguration.BootstrapScript,
 		Env:                r.createEnvironment(),
 		PTY:                r.AgentConfiguration.RunInPty,
-		Timestamp:          timestamp,
+		Timestamp:          r.AgentConfiguration.TimestampLines,
 		StartCallback:      r.onProcessStartCallback,
 		LineCallback:       runner.headerTimesStreamer.Scan,
 		LineCallbackFilter: runner.headerTimesStreamer.LineIsHeader,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -43,6 +43,7 @@ type AgentStartConfig struct {
 	NoAutoSSHFingerprintVerification bool     `cli:"no-automatic-ssh-fingerprint-verification"`
 	NoCommandEval                    bool     `cli:"no-command-eval"`
 	NoPTY                            bool     `cli:"no-pty"`
+	TimestampLines                   bool     `cli:"timestamp-lines"`
 	GitCleanFlags                    string   `cli:"git-clean-flags"`
 	GitCloneFlags                    string   `cli:"git-clone-flags"`
 	Endpoint                         string   `cli:"endpoint" validate:"required"`
@@ -111,13 +112,13 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_AGENT_META_DATA",
 		},
 		cli.BoolFlag{
-			Name:  "meta-data-ec2",
-			Usage: "Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as meta-data",
+			Name:   "meta-data-ec2",
+			Usage:  "Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as meta-data",
 			EnvVar: "BUILDKITE_AGENT_META_DATA_EC2",
 		},
 		cli.BoolFlag{
-			Name:  "meta-data-ec2-tags",
-			Usage: "Include the host's EC2 tags as meta-data",
+			Name:   "meta-data-ec2-tags",
+			Usage:  "Include the host's EC2 tags as meta-data",
 			EnvVar: "BUILDKITE_AGENT_META_DATA_EC2_TAGS",
 		},
 		cli.StringFlag{
@@ -149,6 +150,11 @@ var AgentStartCommand = cli.Command{
 			Value:  "",
 			Usage:  "Directory where the hook scripts are found",
 			EnvVar: "BUILDKITE_HOOKS_PATH",
+		},
+		cli.BoolFlag{
+			Name:   "timestamp-lines",
+			Usage:  "Prepend timestamps on each line of output.",
+			EnvVar: "BUILDKITE_TIMESTAMP_LINES",
 		},
 		cli.BoolFlag{
 			Name:   "no-pty",
@@ -215,6 +221,7 @@ var AgentStartCommand = cli.Command{
 				AutoSSHFingerprintVerification: !cfg.NoAutoSSHFingerprintVerification,
 				CommandEval:                    !cfg.NoCommandEval,
 				RunInPty:                       !cfg.NoPTY,
+				TimestampLines:                 cfg.TimestampLines,
 				GitCleanFlags:                  cfg.GitCleanFlags,
 				GitCloneFlags:                  cfg.GitCloneFlags,
 			},

--- a/process/process.go
+++ b/process/process.go
@@ -36,8 +36,9 @@ type Process struct {
 	StartCallback func()
 
 	// For every line in the process output, this callback will be called
-	// with the contents of the line
-	LineCallback func(string)
+	// with the contents of the line if its filter returns true.
+	LineCallback       func(string)
+	LineCallbackFilter func(string) bool
 
 	// Running is stored as an int32 so we can use atomic operations to
 	// set/get it (it's accessed by multiple goroutines)
@@ -177,17 +178,37 @@ func (p *Process) Start() error {
 				}
 			}
 
+			// If we're timestamping this main thread will take
+			// the hit of running the regex so we can build up
+			// the timestamped buffer without breaking headers,
+			// otherwise we let the goroutines take the perf hit.
+
+			checkedForCallback := false
+			lineHasCallback := false
+			lineString := string(line)
+
 			// Create the prefixed buffer
 			if p.Timestamp {
-				currentTime := time.Now().UTC().Format(time.RFC3339)
-				p.buffer.WriteString(fmt.Sprintf("[%s] %s\n", currentTime, line))
+				lineHasCallback = p.LineCallbackFilter(lineString)
+				checkedForCallback = true
+				if lineHasCallback {
+					// Don't timestamp special lines (e.g. header)
+					p.buffer.WriteString(fmt.Sprintf("%s\n", line))
+				} else {
+					currentTime := time.Now().UTC().Format(time.RFC3339)
+					p.buffer.WriteString(fmt.Sprintf("[%s] %s\n", currentTime, line))
+				}
 			}
 
-			lineCallbackWaitGroup.Add(1)
-			go func(line string) {
-				defer lineCallbackWaitGroup.Done()
-				p.LineCallback(line)
-			}(string(line))
+			if lineHasCallback || !checkedForCallback {
+				lineCallbackWaitGroup.Add(1)
+				go func(line string) {
+					defer lineCallbackWaitGroup.Done()
+					if (checkedForCallback && lineHasCallback) || p.LineCallbackFilter(lineString) {
+						p.LineCallback(line)
+					}
+				}(lineString)
+			}
 		}
 
 		// We need to make sure all the line callbacks have finish before


### PR DESCRIPTION
***Background:*** 
The issue in https://github.com/buildkite/feedback/issues/80 has become a showstopper for me. I am supporting a Buildkite based container building service which allows users to provide their own complex build scripts. There are often performance problems that must be diagnosed. Since I do not control the individual build steps I cannot add group header to their build output in order to get timing information. I require an option to timestamp each line of output so we can profile any part of the build.

I've tried ad-hoc solutions involving `ts` and `unbuffer` but they are not drop-in replacements, this feature is needed in the agent itself.

***Changes:***
This PR adds a `BUILDKITE_TIMESTAMP_LINES` environment variable. If set to one of ` 1, t, T, TRUE, true, True, 0, f, F` each line of output will be prefixed with an RFC3339 UTC timestamp. 

Note that the header groups are not affected.

I've tried to avoid introducing perf hits (due to single-threaded regex parsing) if the option is not enabled. The code became a bit complex as the header API appears to only transmit a list of timestamps and their matching headers must be parsed a second time by the backend, so they cannot be prefixed. Unfortunately this approach does introduce more coupling between `process.go` and `header_times_streamer.go`.

I made this PR against `2-3-stable` because that's what we're using. If you want me to port it to `master` please let me know.

***Review:***
Would greatly appreciate some comments from @keithpitt @toolmantim.
cc: @camilo @n1koo