### PR TITLE
Go 1.8

### DIFF
--- a/agent/gs_downloader.go
+++ b/agent/gs_downloader.go
@@ -1,11 +1,11 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	storage "google.golang.org/api/storage/v1"
 )

--- a/agent/gs_uploader.go
+++ b/agent/gs_uploader.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -13,7 +14,6 @@ import (
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/mime"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/googleapi"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   agent:
-    image: golang:1.7
+    image: golang:1.8
     working_dir: /go/src/github.com/buildkite/agent
     volumes:
       - ./:/go/src/github.com/buildkite/agent


### PR DESCRIPTION
Bump agent to building with Go 1.8.

Mainly exciting for reducing GC pauses: https://golang.org/doc/go1.8#gc