### PR TITLE
Revert "Add option to timestamp lines" for 2.3

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -7,7 +7,6 @@ type AgentConfiguration struct {
 	AutoSSHFingerprintVerification bool
 	CommandEval                    bool
 	RunInPty                       bool
-	TimestampLines                 bool
 	GitCleanFlags                  string
 	GitCloneFlags                  string
 }

--- a/agent/header_times_streamer.go
+++ b/agent/header_times_streamer.go
@@ -73,16 +73,18 @@ func (h *HeaderTimesStreamer) Scan(line string) {
 	h.scanWaitGroup.Add(1)
 	defer h.scanWaitGroup.Done()
 
-	logger.Debug("[HeaderTimesStreamer] Found header %q", line)
+	if h.lineIsHeader(line) {
+		logger.Debug("[HeaderTimesStreamer] Found header %q", line)
 
-	// Aquire a lock on the times and then add the current time to
-	// our times slice.
-	h.timesMutex.Lock()
-	h.times = append(h.times, time.Now().UTC().Format(time.RFC3339Nano))
-	h.timesMutex.Unlock()
+		// Aquire a lock on the times and then add the current time to
+		// our times slice.
+		h.timesMutex.Lock()
+		h.times = append(h.times, time.Now().UTC().Format(time.RFC3339Nano))
+		h.timesMutex.Unlock()
 
-	// Add the time to the wait group
-	h.uploadWaitGroup.Add(1)
+		// Add the time to the wait group
+		h.uploadWaitGroup.Add(1)
+	}
 }
 
 func (h *HeaderTimesStreamer) Upload() {
@@ -134,7 +136,7 @@ func (h *HeaderTimesStreamer) Stop() {
 	h.streamingMutex.Unlock()
 }
 
-func (h *HeaderTimesStreamer) LineIsHeader(line string) bool {
+func (h *HeaderTimesStreamer) lineIsHeader(line string) bool {
 	// Make sure all ANSI colors are removed from the string before we
 	// check to see if it's a header (sometimes a color escape sequence may
 	// be the first thing on the line, which will cause the regex to ignore

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -61,13 +61,11 @@ func (r JobRunner) Create() (runner *JobRunner, err error) {
 
 	// The process that will run the bootstrap script
 	runner.process = process.Process{
-		Script:             r.AgentConfiguration.BootstrapScript,
-		Env:                r.createEnvironment(),
-		PTY:                r.AgentConfiguration.RunInPty,
-		Timestamp:          r.AgentConfiguration.TimestampLines,
-		StartCallback:      r.onProcessStartCallback,
-		LineCallback:       runner.headerTimesStreamer.Scan,
-		LineCallbackFilter: runner.headerTimesStreamer.LineIsHeader,
+		Script:        r.AgentConfiguration.BootstrapScript,
+		Env:           r.createEnvironment(),
+		PTY:           r.AgentConfiguration.RunInPty,
+		StartCallback: r.onProcessStartCallback,
+		LineCallback:  runner.headerTimesStreamer.Scan,
 	}.Create()
 
 	return

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -44,7 +44,6 @@ type AgentStartConfig struct {
 	NoAutoSSHFingerprintVerification bool     `cli:"no-automatic-ssh-fingerprint-verification"`
 	NoCommandEval                    bool     `cli:"no-command-eval"`
 	NoPTY                            bool     `cli:"no-pty"`
-	TimestampLines                   bool     `cli:"timestamp-lines"`
 	GitCleanFlags                    string   `cli:"git-clean-flags"`
 	GitCloneFlags                    string   `cli:"git-clone-flags"`
 	Endpoint                         string   `cli:"endpoint" validate:"required"`
@@ -113,13 +112,13 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_AGENT_META_DATA",
 		},
 		cli.BoolFlag{
-			Name:   "meta-data-ec2",
-			Usage:  "Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as meta-data",
+			Name:  "meta-data-ec2",
+			Usage: "Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as meta-data",
 			EnvVar: "BUILDKITE_AGENT_META_DATA_EC2",
 		},
 		cli.BoolFlag{
-			Name:   "meta-data-ec2-tags",
-			Usage:  "Include the host's EC2 tags as meta-data",
+			Name:  "meta-data-ec2-tags",
+			Usage: "Include the host's EC2 tags as meta-data",
 			EnvVar: "BUILDKITE_AGENT_META_DATA_EC2_TAGS",
 		},
 		cli.BoolFlag{
@@ -156,11 +155,6 @@ var AgentStartCommand = cli.Command{
 			Value:  "",
 			Usage:  "Directory where the hook scripts are found",
 			EnvVar: "BUILDKITE_HOOKS_PATH",
-		},
-		cli.BoolFlag{
-			Name:   "timestamp-lines",
-			Usage:  "Prepend timestamps on each line of output.",
-			EnvVar: "BUILDKITE_TIMESTAMP_LINES",
 		},
 		cli.BoolFlag{
 			Name:   "no-pty",
@@ -228,7 +222,6 @@ var AgentStartCommand = cli.Command{
 				AutoSSHFingerprintVerification: !cfg.NoAutoSSHFingerprintVerification,
 				CommandEval:                    !cfg.NoCommandEval,
 				RunInPty:                       !cfg.NoPTY,
-				TimestampLines:                 cfg.TimestampLines,
 				GitCleanFlags:                  cfg.GitCleanFlags,
 				GitCloneFlags:                  cfg.GitCloneFlags,
 			},

--- a/process/process.go
+++ b/process/process.go
@@ -23,7 +23,6 @@ import (
 type Process struct {
 	Pid        int
 	PTY        bool
-	Timestamp  bool
 	Script     string
 	Env        []string
 	ExitStatus string
@@ -36,9 +35,8 @@ type Process struct {
 	StartCallback func()
 
 	// For every line in the process output, this callback will be called
-	// with the contents of the line if its filter returns true.
-	LineCallback       func(string)
-	LineCallbackFilter func(string) bool
+	// with the contents of the line
+	LineCallback func(string)
 
 	// Running is stored as an int32 so we can use atomic operations to
 	// set/get it (it's accessed by multiple goroutines)
@@ -69,12 +67,7 @@ func (p *Process) Start() error {
 
 	lineReaderPipe, lineWriterPipe := io.Pipe()
 
-	var multiWriter io.Writer
-	if p.Timestamp {
-		multiWriter = io.MultiWriter(lineWriterPipe)
-	} else {
-		multiWriter = io.MultiWriter(&p.buffer, lineWriterPipe)
-	}
+	multiWriter := io.MultiWriter(&p.buffer, lineWriterPipe)
 
 	logger.Info("Starting to run script: %s", p.command.Path)
 
@@ -178,37 +171,11 @@ func (p *Process) Start() error {
 				}
 			}
 
-			// If we're timestamping this main thread will take
-			// the hit of running the regex so we can build up
-			// the timestamped buffer without breaking headers,
-			// otherwise we let the goroutines take the perf hit.
-
-			checkedForCallback := false
-			lineHasCallback := false
-			lineString := string(line)
-
-			// Create the prefixed buffer
-			if p.Timestamp {
-				lineHasCallback = p.LineCallbackFilter(lineString)
-				checkedForCallback = true
-				if lineHasCallback {
-					// Don't timestamp special lines (e.g. header)
-					p.buffer.WriteString(fmt.Sprintf("%s\n", line))
-				} else {
-					currentTime := time.Now().UTC().Format(time.RFC3339)
-					p.buffer.WriteString(fmt.Sprintf("[%s] %s\n", currentTime, line))
-				}
-			}
-
-			if lineHasCallback || !checkedForCallback {
-				lineCallbackWaitGroup.Add(1)
-				go func(line string) {
-					defer lineCallbackWaitGroup.Done()
-					if (checkedForCallback && lineHasCallback) || p.LineCallbackFilter(lineString) {
-						p.LineCallback(line)
-					}
-				}(lineString)
-			}
+			lineCallbackWaitGroup.Add(1)
+			go func(line string) {
+				defer lineCallbackWaitGroup.Done()
+				p.LineCallback(line)
+			}(string(line))
 		}
 
 		// We need to make sure all the line callbacks have finish before


### PR DESCRIPTION
I've moved the option to a 2.4 release, so I'm reverting the change from the 2.3 branch to historical reasons.