### PR TITLE
Rename meta-data to tags

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -14,16 +14,16 @@ import (
 )
 
 type AgentPool struct {
-	APIClient      *api.Client
-	Token          string
-	ConfigFilePath string
-	Name           string
-	Priority       string
-	Tags           []string
-	EC2            bool
-	EC2Tags        bool
-	GCPTags        bool
-	Endpoint       string
+	APIClient       *api.Client
+	Token           string
+	ConfigFilePath  string
+	Name            string
+	Priority        string
+	Tags            []string
+	TagsFromEC2     bool
+	TagsFromEC2Tags bool
+	TagsFromGCP     bool
+	Endpoint        string
 	AgentConfiguration *AgentConfiguration
 }
 
@@ -112,7 +112,7 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 	}
 
 	// Attempt to add the EC2 tags
-	if r.EC2 {
+	if r.TagsFromEC2 {
 		logger.Info("Fetching EC2 meta-data...")
 
 		err := retry.Do(func(s *retry.Stats) error {
@@ -137,7 +137,7 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 	}
 
 	// Attempt to add the EC2 tags
-	if r.EC2Tags {
+	if r.TagsFromEC2Tags {
 		logger.Info("Fetching EC2 tags...")
 
 		// same as above
@@ -163,7 +163,7 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 	}
 
 	// Attempt to add the Google Cloud meta-data
-	if r.GCPTags {
+	if r.TagsFromGCP {
 		tags, err := GCPMetaData{}.Get()
 		if err != nil {
 			// Don't blow up if we can't find them, just show a nasty error.

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -14,16 +14,16 @@ import (
 )
 
 type AgentPool struct {
-	APIClient          *api.Client
-	Token              string
-	ConfigFilePath     string
-	Name               string
-	Priority           string
-	MetaData           []string
-	MetaDataEC2        bool
-	MetaDataEC2Tags    bool
-	MetaDataGCP        bool
-	Endpoint           string
+	APIClient      *api.Client
+	Token          string
+	ConfigFilePath string
+	Name           string
+	Priority       string
+	Tags           []string
+	EC2            bool
+	EC2Tags        bool
+	GCPTags        bool
+	Endpoint       string
 	AgentConfiguration *AgentConfiguration
 }
 
@@ -46,7 +46,7 @@ func (r *AgentPool) Start() error {
 		logger.Fatal("%s", err)
 	}
 
-	logger.Info("Successfully registered agent \"%s\" with meta-data %s", registered.Name, registered.MetaData)
+	logger.Info("Successfully registered agent \"%s\" with tags %s", registered.Name, registered.Tags)
 
 	logger.Debug("Ping interval: %ds", registered.PingInterval)
 	logger.Debug("Job status interval: %ds", registered.JobStatusInterval)
@@ -103,7 +103,7 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 	agent := &api.Agent{
 		Name:              r.Name,
 		Priority:          r.Priority,
-		MetaData:          r.MetaData,
+		Tags:              r.Tags,
 		ScriptEvalEnabled: r.AgentConfiguration.CommandEval,
 		Version:           Version(),
 		Build:             BuildVersion(),
@@ -111,8 +111,8 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 		Arch:              runtime.GOARCH,
 	}
 
-	// Attempt to add the EC2 meta-data
-	if r.MetaDataEC2 {
+	// Attempt to add the EC2 tags
+	if r.EC2 {
 		logger.Info("Fetching EC2 meta-data...")
 
 		err := retry.Do(func(s *retry.Stats) error {
@@ -122,7 +122,7 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 			} else {
 				logger.Info("Successfully fetched EC2 meta-data")
 				for tag, value := range tags {
-					agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))
+					agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
 				}
 				s.Break()
 			}
@@ -137,7 +137,7 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 	}
 
 	// Attempt to add the EC2 tags
-	if r.MetaDataEC2Tags {
+	if r.EC2Tags {
 		logger.Info("Fetching EC2 tags...")
 
 		// same as above
@@ -148,7 +148,7 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 			} else {
 				logger.Info("Successfully fetched EC2 tags")
 				for tag, value := range tags {
-					agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))
+					agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
 				}
 				s.Break()
 			}
@@ -163,14 +163,14 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 	}
 
 	// Attempt to add the Google Cloud meta-data
-	if r.MetaDataGCP {
+	if r.GCPTags {
 		tags, err := GCPMetaData{}.Get()
 		if err != nil {
 			// Don't blow up if we can't find them, just show a nasty error.
 			logger.Error(fmt.Sprintf("Failed to fetch Google Cloud meta-data: %s", err.Error()))
 		} else {
 			for tag, value := range tags {
-				agent.MetaData = append(agent.MetaData, fmt.Sprintf("%s=%s", tag, value))
+				agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
 			}
 		}
 	}

--- a/api/agents.go
+++ b/api/agents.go
@@ -27,7 +27,7 @@ type Agent struct {
 	Priority          string   `json:"priority,omitempty" msgpack:"priority,omitempty"`
 	Version           string   `json:"version" msgpack:"version"`
 	Build             string   `json:"build" msgpack:"build"`
-	MetaData          []string `json:"meta_data" msgpack:"meta_data"`
+	Tags              []string `json:"tags" msgpack:"tags"`
 	PID               int      `json:"pid,omitempty" msgpack:"pid,omitempty"`
 }
 

--- a/api/agents.go
+++ b/api/agents.go
@@ -27,7 +27,7 @@ type Agent struct {
 	Priority          string   `json:"priority,omitempty" msgpack:"priority,omitempty"`
 	Version           string   `json:"version" msgpack:"version"`
 	Build             string   `json:"build" msgpack:"build"`
-	Tags              []string `json:"tags" msgpack:"tags"`
+	Tags              []string `json:"meta_data" msgpack:"meta_data"`
 	PID               int      `json:"pid,omitempty" msgpack:"pid,omitempty"`
 }
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -133,7 +133,7 @@ var AgentStartCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name:  "tags-from-ec2",
-			Usage: "Include the host's EC2 meta-data as tags (instance-id, instance-type, and ami-id) as meta-data",
+			Usage: "Include the host's EC2 meta-data as tags (instance-id, instance-type, and ami-id)",
 			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_EC2",
 		},
 		cli.BoolFlag{

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -128,7 +128,7 @@ var AgentStartCommand = cli.Command{
 		cli.StringSliceFlag{
 			Name:   "tags",
 			Value:  &cli.StringSlice{},
-			Usage:  "A comma-separated list of tags for the agent (e.g. \"linux\" or \"linux,docker=true\")",
+			Usage:  "A comma-separated list of tags for the agent (e.g. \"linux\" or \"mac,xcode=8\")",
 			EnvVar: "BUILDKITE_AGENT_TAGS",
 		},
 		cli.BoolFlag{

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -206,23 +206,27 @@ var AgentStartCommand = cli.Command{
 		cli.StringSliceFlag{
 			Name:   "meta-data",
 			Value:  &cli.StringSlice{},
+			Hidden: true, /* Seems to have no effect, so we include Usage */
+			Usage:  "Deprecated. Renamed to --tags",
 			EnvVar: "BUILDKITE_AGENT_META_DATA",
-			Hidden: true,
 		},
 		cli.BoolFlag{
 			Name:  "meta-data-ec2",
+			Hidden: true, /* Seems to have no effect, so we include Usage */
+			Usage:  "Deprecated. Renamed to --tags-from-ec2",
 			EnvVar: "BUILDKITE_AGENT_META_DATA_EC2",
-			Hidden: true,
 		},
 		cli.BoolFlag{
 			Name:  "meta-data-ec2-tags",
+			Hidden: true, /* Seems to have no effect, so we include Usage */
+			Usage:  "Deprecated. Renamed to --tags-from-ec2-tags",
 			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_EC2_TAGS",
-			Hidden: true,
 		},
 		cli.BoolFlag{
 			Name:  "meta-data-gcp",
+			Hidden: true, /* Seems to have no effect, so we include Usage */
+			Usage:  "Deprecated. Renamed to --tags-from-gcp",
 			EnvVar: "BUILDKITE_AGENT_META_DATA_GCP",
-			Hidden: true,
 		},
 	},
 	Action: func(c *cli.Context) {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -128,7 +128,7 @@ var AgentStartCommand = cli.Command{
 		cli.StringSliceFlag{
 			Name:   "tags",
 			Value:  &cli.StringSlice{},
-			Usage:  "Tags for the agent (default is \"queue=default\")",
+			Usage:  "A comma-separated list of tags for the agent (e.g. \"linux\" or \"linux,docker=true\")",
 			EnvVar: "BUILDKITE_AGENT_TAGS",
 		},
 		cli.BoolFlag{

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -40,10 +40,9 @@ type AgentStartConfig struct {
 	HooksPath                    string   `cli:"hooks-path" normalize:"filepath"`
 	PluginsPath                  string   `cli:"plugins-path" normalize:"filepath"`
 	Tags                         []string `cli:"tags"`
-	Experiments                  []string `cli:"experiment"`
-	EC2                          bool     `cli:"ec2"`
-	EC2Tags                      bool     `cli:"ec2-tags"`
-	GCPTags                      bool     `cli:"gcp"`
+	TagsFromEC2                  bool     `cli:"tags-from-ec2"`
+	TagsFromEC2Tags              bool     `cli:"tags-from-ec2-tags"`
+	TagsFromGCP                  bool     `cli:"tags-from-gcp"`
 	GitCloneFlags                string   `cli:"git-clone-flags"`
 	GitCleanFlags                string   `cli:"git-clean-flags"`
 	NoColor                      bool     `cli:"no-color"`
@@ -53,6 +52,7 @@ type AgentStartConfig struct {
 	Endpoint                     string   `cli:"endpoint" validate:"required"`
 	Debug                        bool     `cli:"debug"`
 	DebugHTTP                    bool     `cli:"debug-http"`
+	Experiments                  []string `cli:"experiment"`
 }
 
 func DefaultConfigFilePaths() (paths []string) {
@@ -127,19 +127,19 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_AGENT_META_DATA",
 		},
 		cli.BoolFlag{
-			Name:  "meta-data-ec2",
+			Name:  "tags-from-ec2",
 			Usage: "Include the host's EC2 meta-data as tags (instance-id, instance-type, and ami-id) as meta-data",
-			EnvVar: "BUILDKITE_AGENT_META_DATA_EC2",
+			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_EC2",
 		},
 		cli.BoolFlag{
-			Name:  "meta-data-ec2-tags",
+			Name:  "tags-from-ec2-tags",
 			Usage: "Include the host's EC2 tags as tags",
-			EnvVar: "BUILDKITE_AGENT_META_DATA_EC2_TAGS",
+			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_EC2_TAGS",
 		},
 		cli.BoolFlag{
-			Name:  "meta-data-gcp",
-			Usage: "Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone) as meta-data",
-			EnvVar: "BUILDKITE_AGENT_META_DATA_GCP",
+			Name:  "tags-from-gcp",
+			Usage: "Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)",
+			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_GCP",
 		},
 		cli.StringFlag{
 			Name:   "git-clone-flags",
@@ -235,9 +235,9 @@ var AgentStartCommand = cli.Command{
 			Name:            cfg.Name,
 			Priority:        cfg.Priority,
 			Tags:            cfg.Tags,
-			EC2:             cfg.EC2,
-			EC2Tags:         cfg.EC2Tags,
-			GCP:             cfg.GCP,
+			TagsFromEC2:     cfg.TagsFromEC2,
+			TagsFromEC2Tags: cfg.TagsFromEC2Tags,
+			TagsFromGCP:     cfg.TagsFromGCP,
 			Endpoint:        cfg.Endpoint,
 			AgentConfiguration: &agent.AgentConfiguration{
 				BootstrapScript:            cfg.BootstrapScript,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -206,26 +206,22 @@ var AgentStartCommand = cli.Command{
 		cli.StringSliceFlag{
 			Name:   "meta-data",
 			Value:  &cli.StringSlice{},
-			Hidden: true, /* Seems to have no effect, so we include Usage */
-			Usage:  "Deprecated. Renamed to --tags",
+			Hidden: true,
 			EnvVar: "BUILDKITE_AGENT_META_DATA",
 		},
 		cli.BoolFlag{
 			Name:  "meta-data-ec2",
-			Hidden: true, /* Seems to have no effect, so we include Usage */
-			Usage:  "Deprecated. Renamed to --tags-from-ec2",
+			Hidden: true,
 			EnvVar: "BUILDKITE_AGENT_META_DATA_EC2",
 		},
 		cli.BoolFlag{
 			Name:  "meta-data-ec2-tags",
-			Hidden: true, /* Seems to have no effect, so we include Usage */
-			Usage:  "Deprecated. Renamed to --tags-from-ec2-tags",
+			Hidden: true,
 			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_EC2_TAGS",
 		},
 		cli.BoolFlag{
 			Name:  "meta-data-gcp",
-			Hidden: true, /* Seems to have no effect, so we include Usage */
-			Usage:  "Deprecated. Renamed to --tags-from-gcp",
+			Hidden: true,
 			EnvVar: "BUILDKITE_AGENT_META_DATA_GCP",
 		},
 	},

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -53,6 +53,11 @@ type AgentStartConfig struct {
 	Debug                        bool     `cli:"debug"`
 	DebugHTTP                    bool     `cli:"debug-http"`
 	Experiments                  []string `cli:"experiment"`
+	/* Deprecated */
+	MetaData                     []string `cli:"meta-data" deprecated-and-renamed-to:"Tags"`
+	MetaDataEC2                  bool     `cli:"meta-data-ec2" deprecated-and-renamed-to:"TagsFromEC2"`
+	MetaDataEC2Tags              bool     `cli:"meta-data-ec2-tags" deprecated-and-renamed-to:"TagsFromEC2Tags"`
+	MetaDataGCP                  bool     `cli:"meta-data-gcp" deprecated-and-renamed-to:"TagsFromGCP"`
 }
 
 func DefaultConfigFilePaths() (paths []string) {
@@ -124,7 +129,7 @@ var AgentStartCommand = cli.Command{
 			Name:   "tags",
 			Value:  &cli.StringSlice{},
 			Usage:  "Tags for the agent (default is \"queue=default\")",
-			EnvVar: "BUILDKITE_AGENT_META_DATA",
+			EnvVar: "BUILDKITE_AGENT_TAGS",
 		},
 		cli.BoolFlag{
 			Name:  "tags-from-ec2",
@@ -197,6 +202,28 @@ var AgentStartCommand = cli.Command{
 		NoColorFlag,
 		DebugFlag,
 		DebugHTTPFlag,
+		/* Deprecated flags which will be removed in v4 */
+		cli.StringSliceFlag{
+			Name:   "meta-data",
+			Value:  &cli.StringSlice{},
+			EnvVar: "BUILDKITE_AGENT_META_DATA",
+			Hidden: true,
+		},
+		cli.BoolFlag{
+			Name:  "meta-data-ec2",
+			EnvVar: "BUILDKITE_AGENT_META_DATA_EC2",
+			Hidden: true,
+		},
+		cli.BoolFlag{
+			Name:  "meta-data-ec2-tags",
+			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_EC2_TAGS",
+			Hidden: true,
+		},
+		cli.BoolFlag{
+			Name:  "meta-data-gcp",
+			EnvVar: "BUILDKITE_AGENT_META_DATA_GCP",
+			Hidden: true,
+		},
 	},
 	Action: func(c *cli.Context) {
 		// The configuration will be loaded into this struct

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -39,11 +39,11 @@ type AgentStartConfig struct {
 	BuildPath                    string   `cli:"build-path" normalize:"filepath" validate:"required"`
 	HooksPath                    string   `cli:"hooks-path" normalize:"filepath"`
 	PluginsPath                  string   `cli:"plugins-path" normalize:"filepath"`
-	MetaData                     []string `cli:"meta-data"`
+	Tags                         []string `cli:"tags"`
 	Experiments                  []string `cli:"experiment"`
-	MetaDataEC2                  bool     `cli:"meta-data-ec2"`
-	MetaDataEC2Tags              bool     `cli:"meta-data-ec2-tags"`
-	MetaDataGCP                  bool     `cli:"meta-data-gcp"`
+	EC2                          bool     `cli:"ec2"`
+	EC2Tags                      bool     `cli:"ec2-tags"`
+	GCPTags                      bool     `cli:"gcp"`
 	GitCloneFlags                string   `cli:"git-clone-flags"`
 	GitCleanFlags                string   `cli:"git-clean-flags"`
 	NoColor                      bool     `cli:"no-color"`
@@ -121,24 +121,24 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_AGENT_DISCONNECT_AFTER_JOB_TIMEOUT",
 		},
 		cli.StringSliceFlag{
-			Name:   "meta-data",
+			Name:   "tags",
 			Value:  &cli.StringSlice{},
-			Usage:  "Meta-data for the agent (default is \"queue=default\")",
+			Usage:  "Tags for the agent (default is \"queue=default\")",
 			EnvVar: "BUILDKITE_AGENT_META_DATA",
 		},
 		cli.BoolFlag{
 			Name:  "meta-data-ec2",
-			Usage: "Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as meta-data",
+			Usage: "Include the host's EC2 meta-data as tags (instance-id, instance-type, and ami-id) as meta-data",
 			EnvVar: "BUILDKITE_AGENT_META_DATA_EC2",
 		},
 		cli.BoolFlag{
 			Name:  "meta-data-ec2-tags",
-			Usage: "Include the host's EC2 tags as meta-data",
+			Usage: "Include the host's EC2 tags as tags",
 			EnvVar: "BUILDKITE_AGENT_META_DATA_EC2_TAGS",
 		},
 		cli.BoolFlag{
 			Name:  "meta-data-gcp",
-			Usage: "Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, region, and zone) as meta-data",
+			Usage: "Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone) as meta-data",
 			EnvVar: "BUILDKITE_AGENT_META_DATA_GCP",
 		},
 		cli.StringFlag{
@@ -234,10 +234,10 @@ var AgentStartCommand = cli.Command{
 			Token:           cfg.Token,
 			Name:            cfg.Name,
 			Priority:        cfg.Priority,
-			MetaData:        cfg.MetaData,
-			MetaDataEC2:     cfg.MetaDataEC2,
-			MetaDataEC2Tags: cfg.MetaDataEC2Tags,
-			MetaDataGCP:     cfg.MetaDataGCP,
+			Tags:            cfg.Tags,
+			EC2:             cfg.EC2,
+			EC2Tags:         cfg.EC2Tags,
+			GCP:             cfg.GCP,
 			Endpoint:        cfg.Endpoint,
 			AgentConfiguration: &agent.AgentConfiguration{
 				BootstrapScript:            cfg.BootstrapScript,

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -109,7 +109,7 @@ func (l *Loader) Load() error {
 			if !l.fieldValueIsEmpty(fieldName) {
 				renamedFieldCliName, _ := reflections.GetFieldTag(l.Config, renamedToFieldName, "cli")
 				if renamedFieldCliName != "" {
-					logger.Notice("The config option `%s` has been renamed to `%s` and will be removed from the next version of Buildkite Agent", cliName, renamedFieldCliName)
+					logger.Warn("The config option `%s` has been renamed to `%s`. Please update your configuration.", cliName, renamedFieldCliName)
 				}
 
 				// Fetch the value of the deprecated config, and set the renamed

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -112,9 +112,16 @@ func (l *Loader) Load() error {
 					logger.Warn("The config option `%s` has been renamed to `%s`. Please update your configuration.", cliName, renamedFieldCliName)
 				}
 
+				// Error if they specify the deprecated version and the new version
+				renamedFieldValue, _ := reflections.GetField(l.Config, renamedToFieldName)
+				if renamedFieldValue != "" {
+					return fmt.Errorf("Can't set config option `%s` because `%s=%v` has already been set", cliName, renamedFieldCliName, renamedFieldValue)
+				}
+
 				// Fetch the value of the deprecated config, and set the renamed
 				// config based on its value
 				value, _ := reflections.GetField(l.Config, fieldName)
+
 				if value != nil {
 					err := reflections.SetField(l.Config, renamedToFieldName, value)
 					if err != nil {
@@ -133,7 +140,7 @@ func (l *Loader) Load() error {
 				return fmt.Errorf(deprecationError)
 			}
 		}
-
+		
 		// Perform validations
 		validationRules, _ := reflections.GetFieldTag(l.Config, fieldName, "validate")
 		if validationRules != "" {

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -112,16 +112,15 @@ func (l *Loader) Load() error {
 					logger.Warn("The config option `%s` has been renamed to `%s`. Please update your configuration.", cliName, renamedFieldCliName)
 				}
 
-				// Error if they specify the deprecated version and the new version
-				renamedFieldValue, _ := reflections.GetField(l.Config, renamedToFieldName)
-				if renamedFieldValue != "" {
-					return fmt.Errorf("Can't set config option `%s` because `%s=%v` has already been set", cliName, renamedFieldCliName, renamedFieldValue)
-				}
-
-				// Fetch the value of the deprecated config, and set the renamed
-				// config based on its value
 				value, _ := reflections.GetField(l.Config, fieldName)
 
+				// Error if they specify the deprecated version and the new version
+				if !l.fieldValueIsEmpty(renamedToFieldName) {
+					renamedFieldValue, _ := reflections.GetField(l.Config, renamedToFieldName)
+					return fmt.Errorf("Can't set config option `%s=%v` because `%s=%v` has already been set", cliName, value, renamedFieldCliName, renamedFieldValue)
+				}
+
+				// Set the proper config based on the deprecated value
 				if value != nil {
 					err := reflections.SetField(l.Config, renamedToFieldName, value)
 					if err != nil {
@@ -140,7 +139,7 @@ func (l *Loader) Load() error {
 				return fmt.Errorf(deprecationError)
 			}
 		}
-		
+
 		// Perform validations
 		validationRules, _ := reflections.GetFieldTag(l.Config, fieldName, "validate")
 		if validationRules != "" {

--- a/main.go
+++ b/main.go
@@ -23,15 +23,15 @@ Use "{{.Name}} <command> --help" for more information about a command.
 
 var SubcommandHelpTemplate = `Usage:
 
-  {{.Name}} {{if .Flags}}<command>{{end}} [arguments...]
+  {{.Name}} {{if .VisibleFlags}}<command>{{end}} [arguments...]
 
 Available commands are:
 
    {{range .Commands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
-   {{end}}{{if .Flags}}
+   {{end}}{{if .VisibleFlags}}
 Options:
 
-   {{range .Flags}}{{.}}
+   {{range .VisibleFlags}}{{.}}
    {{end}}{{end}}
 `
 
@@ -39,7 +39,7 @@ var CommandHelpTemplate = `{{.Description}}
 
 Options:
 
-   {{range .Flags}}{{.}}
+   {{range .VisibleFlags}}{{.}}
    {{end}}
 `
 

--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -7,17 +7,17 @@ name="%hostname-%n"
 # The priority of the agent (higher priorities are assigned work first)
 # priority=1
 
-# Meta-data for the agent (default is "queue=default")
-# meta-data="key1=val2,key2=val2"
+# Tags for the agent (default is "queue=default")
+# tags="key1=val2,key2=val2"
 
-# Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as meta-data
-# meta-data-ec2=true
+# Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as tags
+# ec2=true
 
-# Include the host's EC2 tags as meta-data
-# meta-data-ec2-tags=true
+# Include the host's EC2 tags as tags
+# ec2-tags=true
 
-# Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, region, and zone) as meta-data
-# meta-data-gcp=true
+# Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, region, and zone) as tags
+# gcp=true
 
 # Path to the bootstrap script. You should avoid changing this file as it will
 # be overridden when you update your agent. If you need to make changes to this

--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -10,14 +10,14 @@ name="%hostname-%n"
 # Tags for the agent (default is "queue=default")
 # tags="key1=val2,key2=val2"
 
-# Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as tags
-# ec2=true
+# Include the host's EC2 meta-data as tags (instance-id, instance-type, and ami-id)
+# tags-from-ec2=true
 
 # Include the host's EC2 tags as tags
-# ec2-tags=true
+# tags-from-ec2-tags=true
 
-# Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, region, and zone) as tags
-# gcp=true
+# Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
+# tags-from-gcp=true
 
 # Path to the bootstrap script. You should avoid changing this file as it will
 # be overridden when you update your agent. If you need to make changes to this

--- a/packaging/github/windows/buildkite-agent.cfg
+++ b/packaging/github/windows/buildkite-agent.cfg
@@ -7,8 +7,8 @@ name="%hostname-%n"
 # The priority of the agent (higher priorities are assigned work first)
 # priority=1
 
-# Meta data for the agent (default is "queue=default")
-# meta-data="key1=val2,key2=val2"
+# Tags for the agent (default is "queue=default")
+# tags="key1=val2,key2=val2"
 
 # Path to the bootstrap command.
 bootstrap-script="buildkite-agent.exe bootstrap"

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -7,17 +7,17 @@ name="%hostname-%n"
 # The priority of the agent (higher priorities are assigned work first)
 # priority=1
 
-# Meta-data for the agent (default is "queue=default")
-# meta-data="key1=val2,key2=val2"
+# Tags for the agent (default is "queue=default")
+# tags="key1=val2,key2=val2"
 
-# Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as meta-data
-# meta-data-ec2=true
+# Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as tags
+# ec2=true
 
-# Include the host's EC2 tags as meta-data
-# meta-data-ec2-tags=true
+# Include the host's EC2 tags as tags
+# ec2-tags=true
 
-# Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, region, and zone) as meta-data
-# meta-data-gcp=true
+# Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, region, and zone) as tags
+# gcp=true
 
 # Path to the bootstrap script. You should avoid changing this file as it will
 # be overridden when you update your agent. If you need to make changes to this

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -10,14 +10,14 @@ name="%hostname-%n"
 # Tags for the agent (default is "queue=default")
 # tags="key1=val2,key2=val2"
 
-# Include the host's EC2 meta-data (instance-id, instance-type, and ami-id) as tags
-# ec2=true
+# Include the host's EC2 meta-data as tags (instance-id, instance-type, and ami-id)
+# tags-from-ec2=true
 
 # Include the host's EC2 tags as tags
-# ec2-tags=true
+# tags-from-ec2-tags=true
 
-# Include the host's Google Cloud meta-data (instance-id, machine-type, preemptible, project-id, region, and zone) as tags
-# gcp=true
+# Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
+# tags-from-gcp=true
 
 # Path to the bootstrap script. You should avoid changing this file as it will
 # be overridden when you update your agent. If you need to make changes to this


### PR DESCRIPTION
There has been a long proposed change to the Buildkite Agent terminology and command line API for rename "meta-data" to "tags".

This would change:

```bash
buildkite-agent start \
  --meta-data docker \
  --meta-data postgres=9 \
  --meta-data postgres=9.4 \
  --meta-data queue=runner \
  --meta-data queue=docker
```

to:

```bash
buildkite-agent start \
  --tag docker \
  --tag postgres=9 \
  --tag postgres=9.4 \
  --tag queue=runner \
  --tag queue=docker
```

- [x] First cut at the code
- [x] General feedback
- [x] Show we add `queue` as it's own command line arg? - answer: maybe, but let's move to a different PR
- [x] Should we add support for comma or space separation, for easier setting of multiple values via an env var? e.g. `export BUILDKITE_AGENT_TAG=docker,postgres=9,postgres=9.4` - answer: it works already
- [x] Do we want/need to version bump the agent API? - answer: nope
- [x] Should we add backwards compatibility? Do we support existing config files, env vars, and/or command line args? - answer: yes
- [x] How does this map to the `pipeline.yml` agent targeting rules? - answer: no changes
- [x] Second cut at the code
- [x] Add backwards compatibility