### PR TITLE
Add --disconnect-after-job command line arg

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -11,4 +11,5 @@ type AgentConfiguration struct {
 	CommandEval                bool
 	RunInPty                   bool
 	DisconnectAfterJob         bool
+	DisconnectAfterJobTimeout  int
 }

--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -10,5 +10,5 @@ type AgentConfiguration struct {
 	SSHFingerprintVerification bool
 	CommandEval                bool
 	RunInPty                   bool
-	ExitAfterJob               bool
+	DisconnectAfterJob         bool
 }

--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -10,4 +10,5 @@ type AgentConfiguration struct {
 	SSHFingerprintVerification bool
 	CommandEval                bool
 	RunInPty                   bool
+	ExitAfterJob               bool
 }

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -258,4 +258,8 @@ func (r *AgentPool) ShowBanner() {
 	if !r.AgentConfiguration.RunInPty {
 		logger.Debug("Running builds within a pseudoterminal (PTY) has been disabled")
 	}
+
+	if r.AgentConfiguration.ExitAfterJob {
+		logger.Debug("Agent will exit after a job run has completed")
+	}
 }

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -63,7 +63,13 @@ func (r *AgentPool) Start() error {
 
 	logger.Info("Agent successfully connected")
 	logger.Info("You can press Ctrl-C to stop the agent")
-	logger.Info("Waiting for work...")
+
+	if r.AgentConfiguration.DisconnectAfterJob {
+		logger.Info("Waiting for first job to be assigned...")
+		logger.Info("The agent will automatically disconnect after %d seconds if no job is assigned", r.AgentConfiguration.DisconnectAfterJobTimeout)
+	} else {
+		logger.Info("Waiting for work...")
+	}
 
 	// Start a signalwatcher so we can monitor signals and handle shutdowns
 	signalwatcher.Watch(func(sig signalwatcher.Signal) {
@@ -260,6 +266,6 @@ func (r *AgentPool) ShowBanner() {
 	}
 
 	if r.AgentConfiguration.DisconnectAfterJob {
-		logger.Debug("Agent will disconnect after a job run has completed")
+		logger.Debug("Agent will disconnect after a job run has completed with a timeout of %d seconds", r.AgentConfiguration.DisconnectAfterJobTimeout)
 	}
 }

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -65,7 +65,7 @@ func (r *AgentPool) Start() error {
 	logger.Info("You can press Ctrl-C to stop the agent")
 
 	if r.AgentConfiguration.DisconnectAfterJob {
-		logger.Info("Waiting for first job to be assigned...")
+		logger.Info("Waiting for job to be assigned...")
 		logger.Info("The agent will automatically disconnect after %d seconds if no job is assigned", r.AgentConfiguration.DisconnectAfterJobTimeout)
 	} else {
 		logger.Info("Waiting for work...")

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -259,7 +259,7 @@ func (r *AgentPool) ShowBanner() {
 		logger.Debug("Running builds within a pseudoterminal (PTY) has been disabled")
 	}
 
-	if r.AgentConfiguration.ExitAfterJob {
-		logger.Debug("Agent will exit after a job run has completed")
+	if r.AgentConfiguration.DisconnectAfterJob {
+		logger.Debug("Agent will disconnect after a job run has completed")
 	}
 }

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -294,6 +294,11 @@ func (a *AgentWorker) Ping() {
 
 	// No more job, no more runner.
 	a.jobRunner = nil
+
+	if a.AgentConfiguration.ExitAfterJob {
+		logger.Info("Job finished. Exiting...")
+		a.Stop(true);
+	}
 }
 
 // Disconnects the agent from the Buildkite Agent API, doesn't bother retrying

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -320,7 +320,7 @@ func (a *AgentWorker) Ping() {
 
 	// Woo! We've got a job, and successfully accepted it, let's kill our auto-disconnect timer
 	if(a.disconnectTimeoutTimer != nil) {
-		logger.Debug("Stopping disconnection timer...")
+		logger.Debug("[DisconnectionTimer] A job was assigned and accepted, stopping timer...")
 		a.disconnectTimeoutTimer.Stop()
 	}
 

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -231,7 +231,7 @@ func (a *AgentWorker) Ping() {
 		// ping again after the interval.
 		logger.Warn("Failed to ping: %s", err)
 
-		// When the ping fails, we do wan to reset our disconnection
+		// When the ping fails, we wan't to reset our disconnection
 		// timer. It wouldnt' be very nice if we just killed the agent
 		// because Buildkite was having some connection issues.
 		if(a.disconnectTimeoutTimer != nil) {

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -295,8 +295,8 @@ func (a *AgentWorker) Ping() {
 	// No more job, no more runner.
 	a.jobRunner = nil
 
-	if a.AgentConfiguration.ExitAfterJob {
-		logger.Info("Job finished. Exiting...")
+	if a.AgentConfiguration.DisconnectAfterJob {
+		logger.Info("Job finished. Disconnecting...")
 		a.Stop(true);
 	}
 }

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -33,7 +33,7 @@ type AgentStartConfig struct {
 	Token                        string   `cli:"token" validate:"required"`
 	Name                         string   `cli:"name"`
 	Priority                     string   `cli:"priority"`
-	ExitAfterJob                 bool     `cli:"exit-after-job"`
+	DisconnectAfterJob           bool     `cli:"disconnect-after-job"`
 	BootstrapScript              string   `cli:"bootstrap-script" normalize:"filepath" validate:"required"`
 	BuildPath                    string   `cli:"build-path" normalize:"filepath" validate:"required"`
 	HooksPath                    string   `cli:"hooks-path" normalize:"filepath"`
@@ -109,9 +109,9 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_AGENT_PRIORITY",
 		},
 		cli.BoolFlag{
-			Name:   "exit-after-job",
-			Usage:  "Shutdown the agent after running a job",
-			EnvVar: "BUILDKITE_AGENT_EXIT_AFTER_JOB",
+			Name:   "disconnect-after-job",
+			Usage:  "Disconnect the agent after running a job",
+			EnvVar: "BUILDKITE_AGENT_DISCONNECT_AFTER_JOB",
 		},
 		cli.StringSliceFlag{
 			Name:   "meta-data",
@@ -237,7 +237,7 @@ var AgentStartCommand = cli.Command{
 				SSHFingerprintVerification: !cfg.NoSSHFingerprintVerification,
 				CommandEval:                !cfg.NoCommandEval,
 				RunInPty:                   !cfg.NoPTY,
-				ExitAfterJob:               cfg.ExitAfterJob,
+				DisconnectAfterJob:         cfg.DisconnectAfterJob,
 			},
 		}
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -224,6 +224,11 @@ var AgentStartCommand = cli.Command{
 			cfg.NoPTY = true
 		}
 
+		// Make sure the DisconnectAfterJobTimeout value is correct
+		if cfg.DisconnectAfterJob && cfg.DisconnectAfterJobTimeout < 120 {
+			logger.Fatal("The timeout for `disconnect-after-job` must be at least 120 seconds")
+		}
+
 		// Setup the agent
 		pool := agent.AgentPool{
 			Token:           cfg.Token,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -33,6 +33,7 @@ type AgentStartConfig struct {
 	Token                        string   `cli:"token" validate:"required"`
 	Name                         string   `cli:"name"`
 	Priority                     string   `cli:"priority"`
+	ExitAfterJob                 bool     `cli:"exit-after-job"`
 	BootstrapScript              string   `cli:"bootstrap-script" normalize:"filepath" validate:"required"`
 	BuildPath                    string   `cli:"build-path" normalize:"filepath" validate:"required"`
 	HooksPath                    string   `cli:"hooks-path" normalize:"filepath"`
@@ -106,6 +107,11 @@ var AgentStartCommand = cli.Command{
 			Value:  "",
 			Usage:  "The priority of the agent (higher priorities are assigned work first)",
 			EnvVar: "BUILDKITE_AGENT_PRIORITY",
+		},
+		cli.BoolFlag{
+			Name:   "exit-after-job",
+			Usage:  "Shutdown the agent after running a job",
+			EnvVar: "BUILDKITE_AGENT_EXIT_AFTER_JOB",
 		},
 		cli.StringSliceFlag{
 			Name:   "meta-data",
@@ -231,6 +237,7 @@ var AgentStartCommand = cli.Command{
 				SSHFingerprintVerification: !cfg.NoSSHFingerprintVerification,
 				CommandEval:                !cfg.NoCommandEval,
 				RunInPty:                   !cfg.NoPTY,
+				ExitAfterJob:               cfg.ExitAfterJob,
 			},
 		}
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -34,6 +34,7 @@ type AgentStartConfig struct {
 	Name                         string   `cli:"name"`
 	Priority                     string   `cli:"priority"`
 	DisconnectAfterJob           bool     `cli:"disconnect-after-job"`
+	DisconnectAfterJobTimeout    int      `cli:"disconnect-after-job-timeout"`
 	BootstrapScript              string   `cli:"bootstrap-script" normalize:"filepath" validate:"required"`
 	BuildPath                    string   `cli:"build-path" normalize:"filepath" validate:"required"`
 	HooksPath                    string   `cli:"hooks-path" normalize:"filepath"`
@@ -112,6 +113,12 @@ var AgentStartCommand = cli.Command{
 			Name:   "disconnect-after-job",
 			Usage:  "Disconnect the agent after running a job",
 			EnvVar: "BUILDKITE_AGENT_DISCONNECT_AFTER_JOB",
+		},
+		cli.IntFlag{
+			Name:   "disconnect-after-job-timeout",
+			Value:  120,
+			Usage:  "When --disconnect-after-job is specified, the number of seconds to wait for a job before shutting down",
+			EnvVar: "BUILDKITE_AGENT_DISCONNECT_AFTER_JOB_TIMEOUT",
 		},
 		cli.StringSliceFlag{
 			Name:   "meta-data",
@@ -238,6 +245,7 @@ var AgentStartCommand = cli.Command{
 				CommandEval:                !cfg.NoCommandEval,
 				RunInPty:                   !cfg.NoPTY,
 				DisconnectAfterJob:         cfg.DisconnectAfterJob,
+				DisconnectAfterJobTimeout:  cfg.DisconnectAfterJobTimeout,
 			},
 		}
 

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -189,6 +189,8 @@ func (l Loader) setFieldValueFromCLI(fieldName string, cliName string) error {
 					value = strings.Split(configFileValue, ",")
 				} else if fieldKind == reflect.Bool {
 					value, _ = strconv.ParseBool(configFileValue)
+				} else if fieldKind == reflect.Int {
+					value, _ = strconv.Atoi(configFileValue)
 				} else {
 					return fmt.Errorf("Unable to convert string to type %s", fieldKind)
 				}
@@ -204,6 +206,8 @@ func (l Loader) setFieldValueFromCLI(fieldName string, cliName string) error {
 				value = l.CLI.StringSlice(cliName)
 			} else if fieldKind == reflect.Bool {
 				value = l.CLI.Bool(cliName)
+			} else if fieldKind == reflect.Int {
+				value = l.CLI.Int(cliName)
 			} else {
 				return fmt.Errorf("Unable to handle type: %s", fieldKind)
 			}


### PR DESCRIPTION
When creating container-based schedulers and runners you often want the runner to exit after running the job (e.g. [hyper-buildkite-agent](https://github.com/toolmantim/hyper-buildkite-agent))

This adds a command line flag that causes the agent to shut down once it's completed a job.

- [x] Add `--disconnect-after-job` command line flag
- [x] Add `--disconnect-after-job-timeout` command line flag