### PR TITLE
Do not timestamp header expansion directives

### DIFF
--- a/agent/header_times_streamer.go
+++ b/agent/header_times_streamer.go
@@ -134,14 +134,16 @@ func (h *HeaderTimesStreamer) Stop() {
 	h.streamingMutex.Unlock()
 }
 
-func (h *HeaderTimesStreamer) LineIsHeader(line string) bool {
+func (h *HeaderTimesStreamer) LinePreProcessor(line string) string {
 	// Make sure all ANSI colors are removed from the string before we
 	// check to see if it's a header (sometimes a color escape sequence may
 	// be the first thing on the line, which will cause the regex to ignore
 	// it)
-	sanitized := ANSIColorRegex.ReplaceAllString(line, "")
+	return ANSIColorRegex.ReplaceAllString(line, "")
+}
 
+func (h *HeaderTimesStreamer) LineIsHeader(line string) bool {
 	// To avoid running the regex over every single line, we'll first do a
 	// length check. Hopefully there are no heeaders over 500 characters!
-	return len(line) < 500 && HeaderRegex.MatchString(sanitized)
+	return len(line) < 500 && HeaderRegex.MatchString(line)
 }

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -67,6 +67,7 @@ func (r JobRunner) Create() (runner *JobRunner, err error) {
 		Timestamp:          r.AgentConfiguration.TimestampLines,
 		StartCallback:      r.onProcessStartCallback,
 		LineCallback:       runner.headerTimesStreamer.Scan,
+		LinePreProcessor:   runner.headerTimesStreamer.LinePreProcessor,
 		LineCallbackFilter: runner.headerTimesStreamer.LineIsHeader,
 	}.Create()
 

--- a/process/process.go
+++ b/process/process.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -38,6 +39,7 @@ type Process struct {
 	// For every line in the process output, this callback will be called
 	// with the contents of the line if its filter returns true.
 	LineCallback       func(string)
+	LinePreProcessor   func(string) string
 	LineCallbackFilter func(string) bool
 
 	// Running is stored as an int32 so we can use atomic operations to
@@ -63,6 +65,8 @@ func (p Process) Create() *Process {
 
 	return &p
 }
+
+var headerExpansionRegex = regexp.MustCompile("^(?:\\^\\^\\^\\s+\\+\\+\\+)$")
 
 func (p *Process) Start() error {
 	var waitGroup sync.WaitGroup
@@ -185,13 +189,13 @@ func (p *Process) Start() error {
 
 			checkedForCallback := false
 			lineHasCallback := false
-			lineString := string(line)
+			lineString := p.LinePreProcessor(string(line))
 
 			// Create the prefixed buffer
 			if p.Timestamp {
 				lineHasCallback = p.LineCallbackFilter(lineString)
 				checkedForCallback = true
-				if lineHasCallback {
+				if lineHasCallback || headerExpansionRegex.MatchString(lineString) {
 					// Don't timestamp special lines (e.g. header)
 					p.buffer.WriteString(fmt.Sprintf("%s\n", line))
 				} else {


### PR DESCRIPTION
**What:**
In https://github.com/buildkite/agent/pull/430 I introduced the line timestamp feature, but there is a bug where `^^^ +++` gets timestamped and consequently fails to expand the previous group. The PR resolves this issue.

**How:**
The [documentation](https://buildkite.com/docs/builds/managing-log-output) indicates `^^^ +++` can be used to expand a header group.

Currently this line will be time stamped because it does not pass the header regex. However, this line is not actually a header, and should not be reported as one to the Buildkite backend. Instead, a special check is made to avoid timestamping these special lines.

*Pros:* Fixes the bug!
*Cons:* Even more coupling between `header_times_streamer` and `process`.

**Review:**
@keithpitt 
