### PR TITLE
`meta-data get --default` support

### DIFF
--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -95,14 +95,13 @@ var MetaDataGetCommand = cli.Command{
 
 		// Deal with the error if we got one
 		if err != nil {
-			// Buildkite returns a 400 if the key doesn't exist or
-			// if one isn't supplied. If we get this status, and
-			// we've got a default - return that instead and bail
-			// early.
+			// Buildkite returns a 404 if the key doesn't exist. If
+			// we get this status, and we've got a default - return
+			// that instead and bail early.
 			//
 			// We also use `IsSet` instead of `cfg.Default != ""`
 			// to allow people to use a default of a blank string.
-			if resp.StatusCode == 400 && c.IsSet("default") {
+			if resp.StatusCode == 404 && c.IsSet("default") {
 				logger.Warn("No meta-data value exists with key `%s`, returning the supplied default \"%s\"", cfg.Key, cfg.Default)
 
 				fmt.Print(cfg.Default)

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -26,6 +26,7 @@ Example:
 
 type MetaDataGetConfig struct {
 	Key              string `cli:"arg:0" label:"meta-data key" validate:"required"`
+	Default          string `cli:"default"`
 	Job              string `cli:"job" validate:"required"`
 	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
 	Endpoint         string `cli:"endpoint" validate:"required"`
@@ -39,6 +40,11 @@ var MetaDataGetCommand = cli.Command{
 	Usage:       "Get data from a build",
 	Description: MetaDataGetHelpDescription,
 	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "default",
+			Value: "",
+			Usage: "If the meta-data value doesn't exist return this instead",
+		},
 		cli.StringFlag{
 			Name:   "job",
 			Value:  "",
@@ -78,6 +84,7 @@ var MetaDataGetCommand = cli.Command{
 			// Don't bother retrying if the response was one of these statuses
 			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 400) {
 				s.Break()
+				return err
 			}
 			if err != nil {
 				logger.Warn("%s (%s)", err, s)
@@ -85,8 +92,24 @@ var MetaDataGetCommand = cli.Command{
 
 			return err
 		}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
+
+		// Deal with the error if we got one
 		if err != nil {
-			logger.Fatal("Failed to get meta-data: %s", err)
+			// Buildkite returns a 400 if the key doesn't exist or
+			// if one isn't supplied. If we get this status, and
+			// we've got a default - return that instead and bail
+			// early.
+			//
+			// We also use `IsSet` instead of `cfg.Default != ""`
+			// to allow people to use a default of a blank string.
+			if resp.StatusCode == 400 && c.IsSet("default") {
+				logger.Warn("No meta-data value exists with key `%s`, returning the supplied default \"%s\"", cfg.Key, cfg.Default)
+
+				fmt.Print(cfg.Default)
+				return
+			} else {
+				logger.Fatal("Failed to get meta-data: %s", err)
+			}
 		}
 
 		// Output the value to STDOUT


### PR DESCRIPTION
This allows peeps to supply a default to the `meta-data get` command - so instead of the command returning an error - it will return the supplied default.

```shell
❯ go run *.go meta-data get "buildkite:git:branch:lol" --agent-access-token xxx --job yyy --debug --endpoint "http://agent.buildkite.dev/v3" --default "lol"
2017-03-23 14:27:39 DEBUG  Debug mode enabled
2017-03-23 14:27:39 DEBUG  POST http://agent.buildkite.dev/v3/jobs/yyy/data/get
2017-03-23 14:27:39 DEBUG  ↳ POST http://agent.buildkite.dev/v3/jobs/yyy/data/get (400 Bad Request 271.648123ms)
2017-03-23 14:27:39 WARN   No meta-data value exists with key `buildkite:git:branch:lol`, returning the supplied default "lol"
lol%
```