### PR TITLE
Fix buffer corruption

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -161,7 +161,12 @@ func (p *Process) Start() error {
 			// has ended.
 			if isPrefix && appending == nil {
 				logger.Debug("[LineScanner] Line is too long to read, going to buffer it until it finishes")
-				appending = line
+				// bufio.ReadLine returns a slice which is only valid until the next invocation
+				// since it points to its own internal buffer array. To accumulate the entire
+				// result we make a copy of the first prefix, and insure there is spare capacity
+				// for future appends to minimize the need for resizing on append.
+				appending = make([]byte, len(line), (cap(line))*2)
+				copy(appending, line)
 
 				continue
 			}


### PR DESCRIPTION
**Overview**

My Buildkite users have reported that ANSI escape codes are not always rendered properly, for example:

<img width="636" alt="screen shot 2017-03-23 at 9 24 43 pm" src="https://cloud.githubusercontent.com/assets/1356314/24278724/f2ec0c82-101b-11e7-9c9e-bf367afe2729.png">

This PR resolves a memory corruption issue stemming from incorrect use of the `bufio.Readline` API.

**Details**

At first I assumed this was a bug related my change in https://github.com/buildkite/agent/pull/430, however re-running my minimal test case sometimes produced seemingly correct output:

<img width="642" alt="screen shot 2017-03-23 at 9 24 25 pm" src="https://cloud.githubusercontent.com/assets/1356314/24278829/97e1c25e-101c-11e7-908e-fa2fc5cb178c.png">

I started investigating the buffering code inside `process.go` and found the cause for the random corrupted output. This is a trace:

**Iteration 1: Fill line buffer**
```
017-03-23 22:21:06 INFO   [LineScanner] Line is too long to read, going to buffer it until it finishes

"\x1b[?25l\r\x1b[K    2% |\u2589                               | 10kB 40.6MB/s eta 0:00:01\r\x1b[K    5% |\u2588\u258a                              | 20kB 40.9MB/s eta 0:00:01\r\x1b[K    7% |\u2588\u2588\u258c                             | 30kB 47.9MB/s eta 0:00:01\r\x1b[K    10% |\u2588\u2588\u2588\u258d                            | 40kB 10.0MB/s eta 0:00:01\r\x1b[K    13% |\u2588\u2588\u2588\u2588\u258f                           | 51kB 10.1MB/s eta 0:00:01\r\x1b[K    15% |\u2588\u2588\u2588\u2588\u2588                           | 61kB 11.5MB/s eta 0:00:01\r\x1b[K    18% |\u2588\u2588\u2588\u2588\u2588\u2588                          | 71kB 7.1MB/s eta 0:00:01\r\x1b[K    21% |\u2588\u2588\u2588\u2588\u2588\u2588\u258a                         | 81kB 6.9MB/s eta 0:00:01\r\x1b[K    23% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258b                        | 92kB 7.7MB/s eta 0:00:01\r\x1b[K    26% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258d                       | 102kB 5.1MB/s eta 0:00:01\r\x1b[K    28% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258e                      | 112kB 5.2MB/s eta 0:00:01\r\x1b[K    31% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588                      | 122kB 4.6MB/s eta 0:00:01\r\x1b[K    34% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588                     | 133kB 4.1MB/s eta 0:00:01\r\x1b[K    36% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589                    | 143kB 4.7MB/s eta 0:00:01\r\x1b[K    39% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258b                   | 153kB 4.1MB/s eta 0:00:01\r\x1b[K    42% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258c                  | 163kB 4.1MB/s eta 0:00:01\r\x1b[K    44% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258e                 | 174kB 5.0MB/s eta 0:00:01\r\x1b[K    47% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258f                | 184kB 4.5MB/s eta 0:00:01\r\x1b[K    49% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588                | 194kB 4.5MB/s eta 0:00:01\r\x1b[K    52% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589               | 204kB 6.1MB/s eta 0:00:01\r\x1b[K    55% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258a              | 215kB 4.8MB/s eta 0:00:01\r\x1b[K    57% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258c             | 225kB 5.4MB/s eta 0:00:01\r\x1b[K    60% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258d            | 235kB 5.3MB/s eta 0:00:01\r\x1b[K    63% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258f           | 245kB 4.9MB/s eta 0:00:01\r\x1b[K    65% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588           | 256kB 6.0MB/s eta 0:00:01\r\x1b[K    68% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589          | 266kB 5.4MB/s eta 0:00:01\r\x1b[K    71% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258a         | 276kB 5.4MB/s eta 0:00:01\r\x1b[K    73% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258b        | 286kB 5.8MB/s eta 0:00:01\r\x1b[K    76% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258d       | 296kB 5.1MB/s eta 0:00:01\r\x1b[K    78% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258e      | 307kB 5.7MB/s eta 0:00:01\r\x1b[K    81% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588      | 317kB 6.5MB/s eta 0:00:01\r\x1b[K    84% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588     | 327kB 5.9MB/s eta 0:00:01\r\x1b[K    86% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258a    | 337kB 7.0MB/s eta 0:00:01\r\x1b[K    89% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258b   | 348kB 7.0MB/s eta 0:00:01\r\x1b[K    92% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258c  | 358kB 7.0MB/s eta 0:00:01\r\x1b[K    94% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258e | 368kB 6.7MB/s eta 0:00:01\r\x1b[K    97% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258f| 378kB 5.9MB/s eta 0:00:01\r\x1b[K    99% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 389kB 6.8MB/s eta 0:00:01\r\x1b[K    100% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\xe2"

```

**Iteration 2**: 

**Finish filling line buffer**

```
"\x96\x88\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 399kB 8.1MB/s "
```

**Final buffer contents**
```
"\x96\x88\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 399kB 8.1MB/s \r\n        | 10kB 40.6MB/s eta 0:00:01\r\x1b[K    5% |\u2588\u258a                              | 20kB 40.9MB/s eta 0:00:01\r\x1b[K    7% |\u2588\u2588\u258c                             | 30kB 47.9MB/s eta 0:00:01\r\x1b[K    10% |\u2588\u2588\u2588\u258d                            | 40kB 10.0MB/s eta 0:00:01\r\x1b[K    13% |\u2588\u2588\u2588\u2588\u258f                           | 51kB 10.1MB/s eta 0:00:01\r\x1b[K    15% |\u2588\u2588\u2588\u2588\u2588                           | 61kB 11.5MB/s eta 0:00:01\r\x1b[K    18% |\u2588\u2588\u2588\u2588\u2588\u2588                          | 71kB 7.1MB/s eta 0:00:01\r\x1b[K    21% |\u2588\u2588\u2588\u2588\u2588\u2588\u258a                         | 81kB 6.9MB/s eta 0:00:01\r\x1b[K    23% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258b                        | 92kB 7.7MB/s eta 0:00:01\r\x1b[K    26% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258d                       | 102kB 5.1MB/s eta 0:00:01\r\x1b[K    28% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258e                      | 112kB 5.2MB/s eta 0:00:01\r\x1b[K    31% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588                      | 122kB 4.6MB/s eta 0:00:01\r\x1b[K    34% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588                     | 133kB 4.1MB/s eta 0:00:01\r\x1b[K    36% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589                    | 143kB 4.7MB/s eta 0:00:01\r\x1b[K    39% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258b                   | 153kB 4.1MB/s eta 0:00:01\r\x1b[K    42% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258c                  | 163kB 4.1MB/s eta 0:00:01\r\x1b[K    44% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258e                 | 174kB 5.0MB/s eta 0:00:01\r\x1b[K    47% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258f                | 184kB 4.5MB/s eta 0:00:01\r\x1b[K    49% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588                | 194kB 4.5MB/s eta 0:00:01\r\x1b[K    52% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589               | 204kB 6.1MB/s eta 0:00:01\r\x1b[K    55% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258a              | 215kB 4.8MB/s eta 0:00:01\r\x1b[K    57% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258c             | 225kB 5.4MB/s eta 0:00:01\r\x1b[K    60% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258d            | 235kB 5.3MB/s eta 0:00:01\r\x1b[K    63% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258f           | 245kB 4.9MB/s eta 0:00:01\r\x1b[K    65% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588           | 256kB 6.0MB/s eta 0:00:01\r\x1b[K    68% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2589          | 266kB 5.4MB/s eta 0:00:01\r\x1b[K    71% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258a         | 276kB 5.4MB/s eta 0:00:01\r\x1b[K    73% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258b        | 286kB 5.8MB/s eta 0:00:01\r\x1b[K    76% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258d       | 296kB 5.1MB/s eta 0:00:01\r\x1b[K    78% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258e      | 307kB 5.7MB/s eta 0:00:01\r\x1b[K    81% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588      | 317kB 6.5MB/s eta 0:00:01\r\x1b[K    84% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588     | 327kB 5.9MB/s eta 0:00:01\r\x1b[K    86% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258a    | 337kB 7.0MB/s eta 0:00:01\r\x1b[K    89% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258b   | 348kB 7.0MB/s eta 0:00:01\r\x1b[K    92% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258c  | 358kB 7.0MB/s eta 0:00:01\r\x1b[K    94% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258e | 368kB 6.7MB/s eta 0:00:01\r\x1b[K    97% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258f| 378kB 5.9MB/s eta 0:00:01\r\x1b[K    99% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 389kB 6.8MB/s eta 0:00:01\r\x1b[K    100% |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 399kB 8.1MB/s "

```

Notice how the final buffer begins with `\x96\x88`, this is an invalid escape sequence that is actually a piece of the unicode glyph:

```
U+2588	█	\xe2\x96\x88
```

This means the character's bytes are somehow getting split, but why are they appended to both the beginning and the end of the final buffer? We can see the same effect visually:

![problem](https://cloud.githubusercontent.com/assets/1356314/24279372/cd944b62-101f-11e7-930f-ad4e8434211a.png)

Notice the repeated line!

At this point it started smelling like a circular buffer was somehow being used. Here is the BK agent code:

```
for {
   line, isPrefix, err := reader.ReadLine()
   ...
   appending = append(appending, line...)
}
```



Reading the docs shows:

> The returned buffer is only valid until the next call to ReadLine.

But in this case the buffer is being appended to **in a loop**! This is entirely incorrect because the buffer points to the same underlying memory structure not allocated by `process.go`. 

Instead, to fix this issue we *copy* the slice, now the output is no longer corrupted or repeated:

<img width="767" alt="screen shot 2017-03-23 at 10 48 45 pm" src="https://cloud.githubusercontent.com/assets/1356314/24279473/6dd56516-1020-11e7-8be9-c18c54909b03.png">

Review: @keithpitt


