### PR TITLE
freebsd: fix architecture detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,7 @@ if [ -n "$BUILDKITE_INSTALL_ARCH" ]; then
   echo "Using explicit arch '$ARCH'"
 else
   case $UNAME in
+    *amd64*)  ARCH="amd64" ;;
     *x86_64*) ARCH="amd64" ;;
     *armv8*)  ARCH="arm64" ;;
     *armv7*)  ARCH="armhf" ;;


### PR DESCRIPTION
FreeBSD's `uname -sm` returns `FreeBSD amd64` not `x86_64`, so we need 
to ensure that the agent installs the 64-bit version on 64-bit flavours.