### PR TITLE
Run the global environment hook before checking out plugins

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -788,6 +788,22 @@ func (b *Bootstrap) Start() error {
 
 	//////////////////////////////////////////////////////////////
 	//
+	// ENVIRONMENT SETUP
+	// A place for people to set up environment variables that
+	// might be needed for their build scripts, such as secret
+	// tokens and other information.
+	//
+	//////////////////////////////////////////////////////////////
+
+	// The global environment hook
+	//
+	// It's important to do this before checking out plugins, in case you want
+	// to use the global environment hook to whitelist the plugins that are
+	// allowed to be used.
+	b.executeGlobalHook("environment")
+
+	//////////////////////////////////////////////////////////////
+	//
 	// PLUGIN SETUP
 	//
 	//////////////////////////////////////////////////////////////
@@ -888,19 +904,7 @@ func (b *Bootstrap) Start() error {
 		}
 	}
 
-	//////////////////////////////////////////////////////////////
-	//
-	// ENVIRONMENT SETUP
-	// A place for people to set up environment variables that
-	// might be needed for their build scripts, such as secret
-	// tokens and other information.
-	//
-	//////////////////////////////////////////////////////////////
-
-	// The global environment hook
-	b.executeGlobalHook("environment")
-
-	// The plugin environment hook
+	// Now we can run plugin environment hooks too
 	b.executePluginHook(plugins, "environment")
 
 	//////////////////////////////////////////////////////////////


### PR DESCRIPTION
To go with the updated "Securing your Agent" documentation in buildkite/docs#101, this allows you to prevent plugin code being checked out onto the agent machine by doing whitelisting/validation in your global environment hook.