### PR TITLE
Add plugin support for HTTP repositories with .git extensions

### DIFF
--- a/agent/plugin.go
+++ b/agent/plugin.go
@@ -118,6 +118,7 @@ func (p *Plugin) Name() string {
 		name = strings.ToLower(name)
 		name = regexp.MustCompile(`\s+`).ReplaceAllString(name, " ")
 		name = regexp.MustCompile(`[^a-zA-Z0-9]`).ReplaceAllString(name, "-")
+		name = strings.Replace(name, "-buildkite-plugin-git", "", -1)
 		name = strings.Replace(name, "-buildkite-plugin", "", -1)
 
 		return name

--- a/agent/plugin_test.go
+++ b/agent/plugin_test.go
@@ -55,6 +55,9 @@ func TestCreatePluginsFromJSON(t *testing.T) {
 func TestPluginName(t *testing.T) {
 	var plugin *Plugin
 
+	plugin = &Plugin{Location: "github.com/buildkite-plugins/docker-compose-buildkite-plugin.git"}
+	assert.Equal(t, plugin.Name(), "docker-compose")
+
 	plugin = &Plugin{Location: "github.com/buildkite-plugins/docker-compose-buildkite-plugin"}
 	assert.Equal(t, plugin.Name(), "docker-compose")
 
@@ -246,9 +249,9 @@ func pluginEnvFromConfig(t *testing.T, configJson string) (*shell.Environment, e
 	jsonString := fmt.Sprintf(`[ { "%s": %s } ]`, "github.com/buildkite-plugins/docker-compose-buildkite-plugin", configJson)
 
 	plugins, err := CreatePluginsFromJSON(jsonString)
-	
+
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(plugins))
-	
+
 	return plugins[0].ConfigurationToEnvironment()
 }

--- a/agent/plugin_test.go
+++ b/agent/plugin_test.go
@@ -56,31 +56,31 @@ func TestPluginName(t *testing.T) {
 	var plugin *Plugin
 
 	plugin = &Plugin{Location: "github.com/buildkite-plugins/docker-compose-buildkite-plugin.git"}
-	assert.Equal(t, plugin.Name(), "docker-compose")
+	assert.Equal(t, "docker-compose", plugin.Name())
 
 	plugin = &Plugin{Location: "github.com/buildkite-plugins/docker-compose-buildkite-plugin"}
-	assert.Equal(t, plugin.Name(), "docker-compose")
+	assert.Equal(t, "docker-compose", plugin.Name())
 
 	plugin = &Plugin{Location: "github.com/my-org/docker-compose-buildkite-plugin"}
-	assert.Equal(t, plugin.Name(), "docker-compose")
+	assert.Equal(t, "docker-compose", plugin.Name())
 
 	plugin = &Plugin{Location: "github.com/buildkite/plugins/docker-compose"}
-	assert.Equal(t, plugin.Name(), "docker-compose")
+	assert.Equal(t, "docker-compose", plugin.Name())
 
 	plugin = &Plugin{Location: "github.com/buildkite/my-plugin"}
-	assert.Equal(t, plugin.Name(), "my-plugin")
+	assert.Equal(t, "my-plugin", plugin.Name())
 
 	plugin = &Plugin{Location: "~/Development/plugins/test"}
-	assert.Equal(t, plugin.Name(), "test")
+	assert.Equal(t, "test", plugin.Name())
 
 	plugin = &Plugin{Location: "~/Development/plugins/UPPER     CASE_party"}
-	assert.Equal(t, plugin.Name(), "upper-case-party")
+	assert.Equal(t, "upper-case-party", plugin.Name())
 
 	plugin = &Plugin{Location: "vendor/src/vendored with a space"}
-	assert.Equal(t, plugin.Name(), "vendored-with-a-space")
+	assert.Equal(t, "vendored-with-a-space", plugin.Name())
 
 	plugin = &Plugin{Location: ""}
-	assert.Equal(t, plugin.Name(), "")
+	assert.Equal(t, "", plugin.Name())
 }
 
 func TestIdentifier(t *testing.T) {


### PR DESCRIPTION
Github now uses `.git` on their HTTP git urls. For example, https://github.com/buildkite-plugins/docker-compose-buildkite-plugin.git instead of https://github.com/buildkite-plugins/docker-compose-buildkite-plugin.

If you use the HTTP version of plugin configuration, such as this:

```yml
steps:
  - command: test.sh
    plugins:
      https://github.com/buildkite-plugins/docker-compose-buildkite-plugin.git#v1.1
        config:
          test/docker-compose.yml
```

you'll get environment variables with the extra `_GIT` in them. For example:

```bash
BUILDKITE_PLUGIN_DOCKER_COMPOSE_GIT_CONFIG=test/docker-compose.yml
```

instead of:

```bash
BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG=test/docker-compose.yml
```

This updates our plugin configuration gear to support the new `.git` URLs.

- [x] Test
- [x] Code