### PR TITLE
Revert "Use /bin/sh instead of /bin/bash (2.1 stable)"

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -417,7 +417,7 @@ else
 
     # We'll actually run a temporary file with pipefail and exit-on-fail
     # containing the full script body, printed literally through printf
-    printf "#!/bin/sh\nset -eo pipefail\n%s\n" "$BUILDKITE_COMMAND" > "$BUILDKITE_COMMAND_PATH"
+    printf "#!/bin/bash\nset -eo pipefail\n%s\n" "$BUILDKITE_COMMAND" > "$BUILDKITE_COMMAND_PATH"
 
     if [[ "$BUILDKITE_AGENT_DEBUG" == "true" ]]; then
       buildkite-run cat "./$BUILDKITE_COMMAND_PATH"


### PR DESCRIPTION
Reverts buildkite/agent#449 - this should have been in 2-5-stable