### PR TITLE
Retry EC2 tags fetch in case of rate limits

### DIFF
--- a/agent/ec2_tags.go
+++ b/agent/ec2_tags.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/AdRoll/goamz/aws"
 	"github.com/AdRoll/goamz/ec2"
+
+	"github.com/buildkite/agent/logger"
+	"github.com/buildkite/agent/retry"
 )
 
 type EC2Tags struct {
@@ -30,8 +33,16 @@ func (e EC2Tags) Get() (map[string]string, error) {
 	filter := ec2.NewFilter()
 	filter.Add("resource-id", aws.InstanceId())
 
-	// Describe the tags for the current instance
-	resp, err := ec2Client.DescribeTags(filter)
+	// Describe the tags for the current instance, retrying in case of rate
+	// limits et al
+	var resp *ec2.DescribeTagsResp
+	err = retry.Do(func(s *retry.Stats) error {
+		resp, err = ec2Client.DescribeTags(filter)
+		if err != nil {
+			logger.Warn("Error downloading tags: %s (%s)", err, s)
+		}
+		return err
+	}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
 	if err != nil {
 		return tags, errors.New(fmt.Sprintf("Error downloading tags: %s", err.Error()))
 	}


### PR DESCRIPTION
If we're asked to fetch EC2 tags as agent tags/meta-data then try a couple of times in the face of failure in case we hit rate limits or network problems.