### PR TITLE
Add `pre-exit` hook support

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -1258,6 +1258,12 @@ func (b *Bootstrap) Start() error {
 		b.executePluginHook(plugins, "post-artifact")
 	}
 
+	// Run the `before-exit` local hook
+	b.executeLocalHook("before-exit")
+
+	// Run the `before-exit` plugin hook
+	b.executePluginHook(plugins, "before-exit")
+
 	// Be sure to exit this script with the same exit status that the users
 	// build script exited with.
 	os.Exit(commandExitStatus)

--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -1258,6 +1258,9 @@ func (b *Bootstrap) Start() error {
 		b.executePluginHook(plugins, "post-artifact")
 	}
 
+	// Run the `before-exit` global hook
+	b.executeGlobalHook("before-exit")
+
 	// Run the `before-exit` local hook
 	b.executeLocalHook("before-exit")
 

--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -1258,14 +1258,14 @@ func (b *Bootstrap) Start() error {
 		b.executePluginHook(plugins, "post-artifact")
 	}
 
-	// Run the `before-exit` global hook
-	b.executeGlobalHook("before-exit")
+	// Run the `pre-exit` global hook
+	b.executeGlobalHook("pre-exit")
 
-	// Run the `before-exit` local hook
-	b.executeLocalHook("before-exit")
+	// Run the `pre-exit` local hook
+	b.executeLocalHook("pre-exit")
 
-	// Run the `before-exit` plugin hook
-	b.executePluginHook(plugins, "before-exit")
+	// Run the `pre-exit` plugin hook
+	b.executePluginHook(plugins, "pre-exit")
 
 	// Be sure to exit this script with the same exit status that the users
 	// build script exited with.

--- a/packaging/linux/root/usr/share/buildkite-agent/hooks/post-artifact.sample
+++ b/packaging/linux/root/usr/share/buildkite-agent/hooks/post-artifact.sample
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# The `post-artifact` hook will run just after artifacts are uploaded
+
+set -e

--- a/packaging/linux/root/usr/share/buildkite-agent/hooks/pre-artifact.sample
+++ b/packaging/linux/root/usr/share/buildkite-agent/hooks/pre-artifact.sample
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# The `pre-artifact` hook will run just artifacts are uploaded
+# The `pre-artifact` hook will run just before artifacts are uploaded
 
 set -e

--- a/packaging/linux/root/usr/share/buildkite-agent/hooks/pre-exit.sample
+++ b/packaging/linux/root/usr/share/buildkite-agent/hooks/pre-exit.sample
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# The `pre-exit` hook will run just before your build job finishes
+
+set -e


### PR DESCRIPTION
This extends our [list of hooks](https://buildkite.com/docs/agent/hooks) to add another hook: `pre-exit`. The `pre-exit` hook runs before the command exits, allowing you to perform cleanup tasks.

`post-artifact` isn't suitable for performing general cleanup tasks, because it's only run if an artifact upload pattern has been specified.