### PR TITLE
Add `token-script` param for start command that allows external agent-token loading

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -17,6 +17,7 @@ type AgentPool struct {
 	APIClient          *api.Client
 	Token              string
 	Token              TokenReader
+	TokenScript        string
 	ConfigFilePath     string
 	Name               string
 	Priority           string
@@ -32,8 +33,19 @@ func (r *AgentPool) Start() error {
 	// Show the welcome banner and config options used
 	r.ShowBanner()
 
+	var token TokenReader = StringToken(r.Token)
+	var err error
+
+	// Support lazily reading agent token from a script / executable
+	if r.TokenScript != "" {
+		token, err = ScriptTokenFromString(r.TokenScript)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Create the agent registration API Client
-	r.APIClient = APIClient{Endpoint: r.Endpoint, Token: r.Token}.Create()
+	r.APIClient = APIClient{Endpoint: r.Endpoint, Token: token}.Create()
 
 	// Create the agent template. We use pass this template to the register
 	// call, at which point we get back a real agent.

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -15,9 +15,7 @@ import (
 
 type AgentPool struct {
 	APIClient          *api.Client
-	Token              string
 	Token              TokenReader
-	TokenScript        string
 	ConfigFilePath     string
 	Name               string
 	Priority           string
@@ -33,19 +31,8 @@ func (r *AgentPool) Start() error {
 	// Show the welcome banner and config options used
 	r.ShowBanner()
 
-	var token TokenReader = StringToken(r.Token)
-	var err error
-
-	// Support lazily reading agent token from a script / executable
-	if r.TokenScript != "" {
-		token, err = ScriptTokenFromString(r.TokenScript)
-		if err != nil {
-			return err
-		}
-	}
-
 	// Create the agent registration API Client
-	r.APIClient = APIClient{Endpoint: r.Endpoint, Token: token}.Create()
+	r.APIClient = APIClient{Endpoint: r.Endpoint, Token: r.Token}.Create()
 
 	// Create the agent template. We use pass this template to the register
 	// call, at which point we get back a real agent.

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -16,6 +16,7 @@ import (
 type AgentPool struct {
 	APIClient          *api.Client
 	Token              string
+	Token              TokenReader
 	ConfigFilePath     string
 	Name               string
 	Priority           string

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -53,7 +53,7 @@ func (a AgentWorker) Create() AgentWorker {
 		endpoint = a.Endpoint
 	}
 
-	a.APIClient = APIClient{Endpoint: endpoint, Token: a.Agent.AccessToken}.Create()
+	a.APIClient = APIClient{Endpoint: endpoint, Token: StringToken(a.Agent.AccessToken)}.Create()
 
 	return a
 }
@@ -249,7 +249,7 @@ func (a *AgentWorker) Ping() {
 		// Before switching to the new one, do a ping test to make sure it's
 		// valid. If it is, switch and carry on, otherwise ignore the switch
 		// for now.
-		newAPIClient := APIClient{Endpoint: ping.Endpoint, Token: a.Agent.AccessToken}.Create()
+		newAPIClient := APIClient{Endpoint: ping.Endpoint, Token: StringToken(a.Agent.AccessToken)}.Create()
 		newPing, _, err := newAPIClient.Pings.Get()
 		if err != nil {
 			logger.Warn("Failed to ping the new endpoint %s - ignoring switch for now (%s)", ping.Endpoint, err)

--- a/agent/api_client.go
+++ b/agent/api_client.go
@@ -15,7 +15,7 @@ var debug = false
 
 type APIClient struct {
 	Endpoint string
-	Token    string
+	Token    TokenReader
 }
 
 func APIClientEnableHTTPDebug() {

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -50,7 +50,7 @@ func (r JobRunner) Create() (runner *JobRunner, err error) {
 	runner = &r
 
 	// Our own APIClient using the endpoint and the agents access token
-	runner.APIClient = APIClient{Endpoint: r.Endpoint, Token: r.Agent.AccessToken}.Create()
+	runner.APIClient = APIClient{Endpoint: r.Endpoint, Token: StringToken(r.Agent.AccessToken)}.Create()
 
 	// // Create our header times struct
 	runner.headerTimesStreamer = &HeaderTimesStreamer{UploadCallback: r.onUploadHeaderTime}

--- a/agent/token.go
+++ b/agent/token.go
@@ -1,0 +1,19 @@
+package agent
+
+import "errors"
+
+var errEmptyToken = errors.New("Invalid token, empty string supplied")
+
+type TokenReader interface {
+	Read() (string, error)
+}
+
+type StringToken string
+
+func (s StringToken) Read() (string, error) {
+	str := string(s)
+	if str == "" {
+		return str, errEmptyToken
+	}
+	return str, nil
+}

--- a/agent/token.go
+++ b/agent/token.go
@@ -1,6 +1,12 @@
 package agent
 
-import "errors"
+import (
+	"errors"
+	"os"
+	"os/exec"
+
+	shellwords "github.com/mattn/go-shellwords"
+)
 
 var errEmptyToken = errors.New("Invalid token, empty string supplied")
 
@@ -8,6 +14,7 @@ type TokenReader interface {
 	Read() (string, error)
 }
 
+// stringToken provides a token that is simply a string
 type StringToken string
 
 func (s StringToken) Read() (string, error) {
@@ -16,4 +23,31 @@ func (s StringToken) Read() (string, error) {
 		return str, errEmptyToken
 	}
 	return str, nil
+}
+
+// scriptToken delegates to the output of a script to return a token
+type ScriptToken struct {
+	name string
+	args []string
+}
+
+// Creates a scriptToken by parsing a string like `ls -lsa`
+func ScriptTokenFromString(str string) (*ScriptToken, error) {
+	args, err := shellwords.Parse(str)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ScriptToken{name: args[0], args: args[1:]}, nil
+}
+
+func (s ScriptToken) Read() (string, error) {
+	cmd := exec.Command(s.name, s.args...)
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	return string(out), nil
 }

--- a/agent/token_test.go
+++ b/agent/token_test.go
@@ -1,0 +1,15 @@
+package agent
+
+import "testing"
+
+func TestStringTokenErrorsWhenEmpty(t *testing.T) {
+	tok, err := StringToken("").Read()
+
+	if err != errEmptyToken {
+		t.Fatalf("Read should fail when token empty")
+	}
+
+	if tok != "" {
+		t.Fatalf("Read should return empty string when token empty")
+	}
+}

--- a/agent/token_test.go
+++ b/agent/token_test.go
@@ -1,6 +1,11 @@
 package agent
 
-import "testing"
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+)
 
 func TestStringTokenErrorsWhenEmpty(t *testing.T) {
 	tok, err := StringToken("").Read()
@@ -12,4 +17,38 @@ func TestStringTokenErrorsWhenEmpty(t *testing.T) {
 	if tok != "" {
 		t.Fatalf("Read should return empty string when token empty")
 	}
+}
+
+func TestScriptTokenReturnsOutput(t *testing.T) {
+	st := ScriptToken{
+		name: os.Args[0],
+		args: []string{"-scripttoken:output=llamasrock", "-test.run=TestMainForAgentTokenScript"},
+	}
+
+	tok, err := st.Read()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tok != "llamasrock" {
+		t.Fatalf("Expected command output to be llamasrock, got %q", tok)
+	}
+}
+
+var scriptTokenOutput string
+
+func init() {
+	flag.StringVar(&scriptTokenOutput, "scripttoken:output", "", "custom script-token output")
+	flag.Parse()
+}
+
+// This is a hack that uses the compiled test binary as a script for testing script-token, as
+// such, it's not actually a test
+func TestMainForAgentTokenScript(t *testing.T) {
+	if scriptTokenOutput == "" {
+		return
+	}
+	defer os.Exit(0)
+	fmt.Printf(scriptTokenOutput)
 }

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -276,8 +276,6 @@ var AgentStartCommand = cli.Command{
 		// Setup the agent
 		pool := agent.AgentPool{
 			Name:            cfg.Name,
-			Token:           cfg.Token,
-			TokenScript:     cfg.TokenScript,
 			Priority:        cfg.Priority,
 			Tags:            cfg.Tags,
 			TagsFromEC2:     cfg.TagsFromEC2,
@@ -297,6 +295,17 @@ var AgentStartCommand = cli.Command{
 				DisconnectAfterJob:         cfg.DisconnectAfterJob,
 				DisconnectAfterJobTimeout:  cfg.DisconnectAfterJobTimeout,
 			},
+		}
+
+		pool.Token = agent.StringToken(cfg.Token)
+		var err error
+
+		// Support lazily reading agent token from a script / executable
+		if cfg.TokenScript != "" {
+			pool.Token, err = agent.ScriptTokenFromString(cfg.TokenScript)
+			if err != nil {
+				logger.Fatal("%s", err)
+			}
 		}
 
 		// Store the loaded config file path on the pool so we can

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -263,10 +263,21 @@ var AgentStartCommand = cli.Command{
 			logger.Fatal("The timeout for `disconnect-after-job` must be at least 120 seconds")
 		}
 
+		// Make sure either a Token or a TokenScript is provided
+		if cfg.Token == "" && cfg.TokenScript == "" {
+			logger.Fatal("Must provide either `token` or `token-script`")
+		}
+
+		// Only allow one of Token and TokenScript
+		if cfg.Token != "" && cfg.TokenScript != "" {
+			logger.Fatal("Can't provide both `token` and `token-script`")
+		}
+
 		// Setup the agent
 		pool := agent.AgentPool{
-			Token:           cfg.Token,
 			Name:            cfg.Name,
+			Token:           cfg.Token,
+			TokenScript:     cfg.TokenScript,
 			Priority:        cfg.Priority,
 			Tags:            cfg.Tags,
 			TagsFromEC2:     cfg.TagsFromEC2,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -30,7 +30,8 @@ Example:
 
 type AgentStartConfig struct {
 	Config                       string   `cli:"config"`
-	Token                        string   `cli:"token" validate:"required"`
+	Token                        string   `cli:"token"`
+	TokenScript                  string   `cli:"token-script"`
 	Name                         string   `cli:"name"`
 	Priority                     string   `cli:"priority"`
 	DisconnectAfterJob           bool     `cli:"disconnect-after-job"`
@@ -101,6 +102,12 @@ var AgentStartCommand = cli.Command{
 			Value:  "",
 			Usage:  "Your account agent token",
 			EnvVar: "BUILDKITE_AGENT_TOKEN",
+		},
+		cli.StringFlag{
+			Name:   "token-script",
+			Value:  "",
+			Usage:  "Path to a script that will return an agent token",
+			EnvVar: "BUILDKITE_AGENT_TOKEN_SCRIPT",
 		},
 		cli.StringFlag{
 			Name:   "name",

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -126,7 +126,7 @@ var AnnotateCommand = cli.Command{
 		// Create the API client
 		client := agent.APIClient{
 			Endpoint: cfg.Endpoint,
-			Token:    cfg.AgentAccessToken,
+			Token:    agent.StringToken(cfg.AgentAccessToken),
 		}.Create()
 
 		// Create the annotation we'll send to the Buildkite API

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -83,7 +83,7 @@ var ArtifactDownloadCommand = cli.Command{
 		downloader := agent.ArtifactDownloader{
 			APIClient: agent.APIClient{
 				Endpoint: cfg.Endpoint,
-				Token:    cfg.AgentAccessToken,
+				Token:    agent.StringToken(cfg.AgentAccessToken),
 			}.Create(),
 			Query:       cfg.Query,
 			Destination: cfg.Destination,

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -85,7 +85,7 @@ var ArtifactShasumCommand = cli.Command{
 		searcher := agent.ArtifactSearcher{
 			APIClient: agent.APIClient{
 				Endpoint: cfg.Endpoint,
-				Token:    cfg.AgentAccessToken,
+				Token:    agent.StringToken(cfg.AgentAccessToken),
 			}.Create(),
 			BuildID: cfg.Build,
 		}

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -80,7 +80,7 @@ var ArtifactUploadCommand = cli.Command{
 		uploader := agent.ArtifactUploader{
 			APIClient: agent.APIClient{
 				Endpoint: cfg.Endpoint,
-				Token:    cfg.AgentAccessToken,
+				Token:    agent.StringToken(cfg.AgentAccessToken),
 			}.Create(),
 			JobID:       cfg.Job,
 			Paths:       cfg.UploadPaths,

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -67,7 +67,7 @@ var MetaDataExistsCommand = cli.Command{
 		// Create the API client
 		client := agent.APIClient{
 			Endpoint: cfg.Endpoint,
-			Token:    cfg.AgentAccessToken,
+			Token:    agent.StringToken(cfg.AgentAccessToken),
 		}.Create()
 
 		// Find the meta data value

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -72,7 +72,7 @@ var MetaDataGetCommand = cli.Command{
 		// Create the API client
 		client := agent.APIClient{
 			Endpoint: cfg.Endpoint,
-			Token:    cfg.AgentAccessToken,
+			Token:    agent.StringToken(cfg.AgentAccessToken),
 		}.Create()
 
 		// Find the meta data value

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -84,7 +84,7 @@ var MetaDataSetCommand = cli.Command{
 		// Create the API client
 		client := agent.APIClient{
 			Endpoint: cfg.Endpoint,
-			Token:    cfg.AgentAccessToken,
+			Token:    agent.StringToken(cfg.AgentAccessToken),
 		}.Create()
 
 		// Create the meta data to set

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -167,7 +167,7 @@ var PipelineUploadCommand = cli.Command{
 		// Create the API client
 		client := agent.APIClient{
 			Endpoint: cfg.Endpoint,
-			Token:    cfg.AgentAccessToken,
+			Token:    agent.StringToken(cfg.AgentAccessToken),
 		}.Create()
 
 		// Generate a UUID that will identifiy this pipeline change. We


### PR DESCRIPTION
After some discussion with the GitHub folks and #458, I thought it might be interesting to look at adding a mechanism to load the agent-token from an external script.

Whilst I don't love the idea of adding complexity for agent-token over a more general solution(for instance a wrapper around buildkite-agent that sets env, or a PreStart script in systemd), I think that the nature of the agent token is that it's currently the "keys to the kingdom" and I think that this approach allows for much stricter security constraints around agent tokens.

I was inspired by openssh's recent addition of [AuthorizedKeysCommand](https://linux.die.net/man/5/sshd_config) that let's you specify an external command for loading AuthorizedKeys. 

Usage of it would be something like:

```bash
buildkite-agent start --token-script ./get_token_from_vault.sh
```
