### PR TITLE
Wait for EC2 tags to be available before registering the agent

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -142,10 +143,11 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 		logger.Info("Fetching EC2 tags...")
 		err := retry.Do(func(s *retry.Stats) error {
 			tags, err := EC2Tags{}.Get()
+			if err == nil && len(tags) == 0 {
+				err = errors.New("No EC2 tags were found yet")
+			}
 			if err != nil {
 				logger.Warn("%s (%s)", err, s)
-			} else if len(tags) == 0 {
-				logger.Warn("Tags were empty")
 			} else {
 				logger.Info("Successfully fetched EC2 tags")
 				for tag, value := range tags {

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -143,6 +143,8 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 		logger.Info("Fetching EC2 tags...")
 		err := retry.Do(func(s *retry.Stats) error {
 			tags, err := EC2Tags{}.Get()
+			// EC2 tags are apparently "eventually consistent" and sometimes take several seconds
+			// to be applied to instances. This error will cause retries.
 			if err == nil && len(tags) == 0 {
 				err = errors.New("No EC2 tags were found yet")
 			}

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -146,7 +146,7 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 			// EC2 tags are apparently "eventually consistent" and sometimes take several seconds
 			// to be applied to instances. This error will cause retries.
 			if err == nil && len(tags) == 0 {
-				err = errors.New("No EC2 tags were found yet")
+				err = errors.New("EC2 tags are empty")
 			}
 			if err != nil {
 				logger.Warn("%s (%s)", err, s)


### PR DESCRIPTION
This addresses #491. TL;DR is that AWS often takes quite some time to apply tags to a running instance, specifically when in an Autoscaling Group.

**Update**
Based on feedback this has changed to be the default behaviour with a timeout to opt-out of. This means if you enable `tags-from-ec2-tags` then we will wait up to 15 seconds for tags (any tags) to be made available. If you don't set tags, but you set `tags-from-ec2-tags` YOU WILL WAIT 15 SECONDS. 
