### PR TITLE
Support branch and pipeline scope for metadata

### DIFF
--- a/api/meta_data.go
+++ b/api/meta_data.go
@@ -10,10 +10,14 @@ type MetaDataService struct {
 	client *Client
 }
 
+// DefaultMetadataScope is the default scope used for metadata
+const DefaultMetadataScope = "build"
+
 // MetaData represents a Buildkite Agent API MetaData
 type MetaData struct {
 	Key   string `json:"key,omitempty"`
 	Value string `json:"value,omitempty"`
+	Scope string `json:"scope,omitempty"`
 }
 
 // MetaDataExists represents a Buildkite Agent API MetaData Exists check
@@ -35,9 +39,9 @@ func (ps *MetaDataService) Set(jobId string, metaData *MetaData) (*Response, err
 }
 
 // Gets the meta data value
-func (ps *MetaDataService) Get(jobId string, key string) (*MetaData, *Response, error) {
+func (ps *MetaDataService) Get(jobId string, key string, scope string) (*MetaData, *Response, error) {
 	u := fmt.Sprintf("jobs/%s/data/get", jobId)
-	m := &MetaData{Key: key}
+	m := &MetaData{Key: key, Scope: scope}
 
 	req, err := ps.client.NewRequest("POST", u, m)
 	if err != nil {
@@ -53,9 +57,9 @@ func (ps *MetaDataService) Get(jobId string, key string) (*MetaData, *Response, 
 }
 
 // Returns true if the meta data key has been set, false if it hasn't.
-func (ps *MetaDataService) Exists(jobId string, key string) (*MetaDataExists, *Response, error) {
+func (ps *MetaDataService) Exists(jobId string, key string, scope string) (*MetaDataExists, *Response, error) {
 	u := fmt.Sprintf("jobs/%s/data/exists", jobId)
-	m := &MetaData{Key: key}
+	m := &MetaData{Key: key, Scope: scope}
 
 	req, err := ps.client.NewRequest("POST", u, m)
 	if err != nil {

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -30,6 +30,7 @@ type MetaDataExistsConfig struct {
 	Job              string `cli:"job" validate:"required"`
 	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
 	Endpoint         string `cli:"endpoint" validate:"required"`
+	Scope            string `cli:"scope"`
 	NoColor          bool   `cli:"no-color"`
 	Debug            bool   `cli:"debug"`
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -45,6 +46,12 @@ var MetaDataExistsCommand = cli.Command{
 			Value:  "",
 			Usage:  "Which job should the meta-data be checked for",
 			EnvVar: "BUILDKITE_JOB_ID",
+		},
+		cli.StringFlag{
+			Name:   "scope",
+			Value:  "build",
+			Usage:  "What scope should the meta-data be read from, either build (default), branch or pipeline",
+			EnvVar: "BUILDKITE_METADATA_SCOPE",
 		},
 		AgentAccessTokenFlag,
 		EndpointFlag,
@@ -75,7 +82,7 @@ var MetaDataExistsCommand = cli.Command{
 		var exists *api.MetaDataExists
 		var resp *api.Response
 		err = retry.Do(func(s *retry.Stats) error {
-			exists, resp, err = client.MetaData.Exists(cfg.Job, cfg.Key)
+			exists, resp, err = client.MetaData.Exists(cfg.Job, cfg.Key, cfg.Scope)
 			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404) {
 				s.Break()
 			}


### PR DESCRIPTION
Based on a conversation with @keithpitt and I, we realized that supporting metadata scoped wider than the current build scope would be pretty straightforward. 

The thinking was to add "scope" as a concept, which currently defaults to `build`. In other words, currently metadata that you set is scoped to builds. Anyone with access to the build can read it. 

We are adding a `branch` scope, which means that you can shared metadata between different builds/jobs in the same branch of the same pipeline.

The `pipeline` scope is available from anything running in the same pipeline.

Future scopes might include `team` or `organization`, but there are permissions dragons there.

![Llama bouncing](https://media.giphy.com/media/fUMhF7Vp5iLVm/giphy.gif)