### PR TITLE
Fix `lookPath` and `env.Get` on Windows

### DIFF
--- a/shell/command.go
+++ b/shell/command.go
@@ -42,16 +42,20 @@ func (c *Command) AbsolutePath() (string, error) {
 	}
 
 	var envPath string
+	var fileExtensions string // For searching .exe, .bat, etc on Windows
 
-	// Use the command environment's PATH if possible, or the global one
-	if c.Env != nil && c.Env.Get("PATH") != "" {
-		envPath = c.Env.Get("PATH")
-	} else {
+	// Default to the operation system's PATH if a custom environment
+	// hasn't been provided
+	if c.Env == nil {
 		envPath = os.Getenv("PATH")
+		fileExtensions = os.Getenv("PATHEXT")
+	} else {
+		envPath = c.Env.Get("PATH")
+		fileExtensions = c.Env.Get("PATHEXT")
 	}
 
 	// Use our custom lookPath that takes a specific path
-	absolutePath, err := lookPath(c.Command, envPath)
+	absolutePath, err := lookPath(c.Command, envPath, fileExtensions)
 
 	if err != nil {
 		return "", err

--- a/shell/lookpath.go
+++ b/shell/lookpath.go
@@ -1,3 +1,13 @@
+// +build !windows
+
+// This file (along with it's Windows counterpart) have been taken from:
+//
+// https://github.com/golang/go/blob/master/src/os/exec/lp.go
+//
+// Their implemenations are exactly the same, however in this version - the
+// paths to search in (along with file extensions to look at) can be
+// customized.
+
 package shell
 
 import (
@@ -18,7 +28,9 @@ func findExecutable(file string) error {
 	return os.ErrPermission
 }
 
-func lookPath(file string, path string) (string, error) {
+// Note that `fileExtensions` are ignored in the *nix implementation of `lookPath`
+// (they're used in the Windows version however!)
+func lookPath(file string, path string, fileExtensions string) (string, error) {
 	if strings.Contains(file, "/") {
 		err := findExecutable(file)
 		if err == nil {

--- a/shell/lookpath_windows.go
+++ b/shell/lookpath_windows.go
@@ -1,0 +1,92 @@
+// This file (along with it's *nix counterpart) have been taken from:
+//
+// https://github.com/golang/go/blob/master/src/os/exec/lp_windows.go
+//
+// Their implemenations are exactly the same, however in this version - the
+// paths to search in (along with file extensions to look at) can be
+// customized.
+
+package shell
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func chkStat(file string) error {
+	d, err := os.Stat(file)
+	if err != nil {
+		return err
+	}
+	if d.IsDir() {
+		return os.ErrPermission
+	}
+	return nil
+}
+
+func hasExt(file string) bool {
+	i := strings.LastIndex(file, ".")
+	if i < 0 {
+		return false
+	}
+	return strings.LastIndexAny(file, `:\/`) < i
+}
+
+func findExecutable(file string, exts []string) (string, error) {
+	if len(exts) == 0 {
+		return file, chkStat(file)
+	}
+	if hasExt(file) {
+		if chkStat(file) == nil {
+			return file, nil
+		}
+	}
+	for _, e := range exts {
+		if f := file + e; chkStat(f) == nil {
+			return f, nil
+		}
+	}
+	return "", os.ErrNotExist
+}
+
+// LookPath searches for an executable binary named file
+// in the directories named by the PATH environment variable.
+// If file contains a slash, it is tried directly and the PATH is not consulted.
+// LookPath also uses PATHEXT environment variable to match
+// a suitable candidate.
+// The result may be an absolute path or a path relative to the current directory.
+func lookPath(file string, path string, fileExtensions string) (string, error) {
+	var exts []string
+	if fileExtensions != "" {
+		for _, e := range strings.Split(strings.ToLower(fileExtensions), `;`) {
+			if e == "" {
+				continue
+			}
+			if e[0] != '.' {
+				e = "." + e
+			}
+			exts = append(exts, e)
+		}
+	} else {
+		exts = []string{".com", ".exe", ".bat", ".cmd"}
+	}
+
+	if strings.ContainsAny(file, `:\/`) {
+		if f, err := findExecutable(file, exts); err == nil {
+			return f, nil
+		} else {
+			return "", &exec.Error{file, err}
+		}
+	}
+	if f, err := findExecutable(filepath.Join(".", file), exts); err == nil {
+		return f, nil
+	}
+	for _, dir := range filepath.SplitList(path) {
+		if f, err := findExecutable(filepath.Join(dir, file), exts); err == nil {
+			return f, nil
+		}
+	}
+	return "", &exec.Error{file, exec.ErrNotFound}
+}


### PR DESCRIPTION
We had a regression in Windows with some of the environment path handling (pretty much, all the things broke). This PR changes:

- `lookPath` needed to respect file extensions such as `.exe`, `.bat`, etc.
- `env.Get`, `env.Set`, etc need to ignore key case on Windows

So everything should be working again!