### PR TITLE
Hotfix breakages from new aws sdk

### DIFF
--- a/agent/aws.go
+++ b/agent/aws.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+var awsSess *session.Session
+
+// The aws sdk relies on being given a region, which is a breaking change for us
+// This applies a heuristic that detects where the agent might be based on the env
+// but also the local isntance metadata if available
+func awsRegion() (string, error) {
+	if r := os.Getenv("AWS_REGION"); r != "" {
+		return r, nil
+	}
+
+	if r := os.Getenv("AWS_DEFAULT_REGION"); r != "" {
+		return r, nil
+	}
+
+	// The metadata service seems to want a session
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-east-1"),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	meta := ec2metadata.New(sess)
+	if meta.Available() {
+		return meta.Region()
+	}
+
+	return "", aws.ErrMissingRegion
+}
+
+func awsSession() (*session.Session, error) {
+	region, err := awsRegion()
+	if err != nil {
+		return nil, err
+	}
+
+	if awsSess == nil {
+		awsSess, err = session.NewSession(&aws.Config{
+			Region: aws.String(region),
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return awsSess, nil
+}

--- a/agent/aws.go
+++ b/agent/aws.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/buildkite/agent/logger"
 )
 
 var awsSess *session.Session
@@ -32,7 +33,11 @@ func awsRegion() (string, error) {
 
 	meta := ec2metadata.New(sess)
 	if meta.Available() {
-		return meta.Region()
+		region, err := meta.Region()
+		if err == nil {
+			logger.Debug("Detected AWS region %s", region)
+		}
+		return region, err
 	}
 
 	return "", aws.ErrMissingRegion

--- a/agent/ec2_meta_data.go
+++ b/agent/ec2_meta_data.go
@@ -2,14 +2,24 @@ package agent
 
 import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 type EC2MetaData struct {
+	sess *session.Session
 }
 
 func (e EC2MetaData) Get() (map[string]string, error) {
+	if e.sess == nil {
+		sess, err := session.NewSession()
+		if err != nil {
+			return nil, err
+		}
+		e.sess = sess
+	}
+
 	metaData := make(map[string]string)
-	ec2metadataClient := ec2metadata.New(nil)
+	ec2metadataClient := ec2metadata.New(e.sess)
 
 	instanceId, err := ec2metadataClient.GetMetadata("instance-id")
 	if err != nil {

--- a/agent/ec2_meta_data.go
+++ b/agent/ec2_meta_data.go
@@ -2,24 +2,19 @@ package agent
 
 import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 type EC2MetaData struct {
-	sess *session.Session
 }
 
 func (e EC2MetaData) Get() (map[string]string, error) {
-	if e.sess == nil {
-		sess, err := session.NewSession()
-		if err != nil {
-			return nil, err
-		}
-		e.sess = sess
+	sess, err := awsSession()
+	if err != nil {
+		return nil, err
 	}
 
 	metaData := make(map[string]string)
-	ec2metadataClient := ec2metadata.New(e.sess)
+	ec2metadataClient := ec2metadata.New(sess)
 
 	instanceId, err := ec2metadataClient.GetMetadata("instance-id")
 	if err != nil {

--- a/agent/ec2_tags.go
+++ b/agent/ec2_tags.go
@@ -3,25 +3,20 @@ package agent
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
 type EC2Tags struct {
-	sess *session.Session
 }
 
 func (e EC2Tags) Get() (map[string]string, error) {
-	if e.sess == nil {
-		sess, err := session.NewSession()
-		if err != nil {
-			return nil, err
-		}
-		e.sess = sess
+	sess, err := awsSession()
+	if err != nil {
+		return nil, err
 	}
 
 	tags := make(map[string]string)
-	ec2metadataClient := ec2metadata.New(e.sess)
+	ec2metadataClient := ec2metadata.New(sess)
 
 	// Grab the current instances id
 	instanceId, err := ec2metadataClient.GetMetadata("instance-id")
@@ -29,7 +24,7 @@ func (e EC2Tags) Get() (map[string]string, error) {
 		return tags, err
 	}
 
-	svc := ec2.New(e.sess)
+	svc := ec2.New(sess)
 
 	// Describe the tags of the current instance
 	resp, err := svc.DescribeTags(&ec2.DescribeTagsInput{

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -59,8 +59,12 @@ func awsS3RegionFromEnv() (region string, err error) {
 	regionName := "us-east-1"
 	if os.Getenv("BUILDKITE_S3_DEFAULT_REGION") != "" {
 		regionName = os.Getenv("BUILDKITE_S3_DEFAULT_REGION")
-	} else if os.Getenv("AWS_DEFAULT_REGION") != "" {
-		regionName = os.Getenv("AWS_DEFAULT_REGION")
+	} else {
+		var err error
+		regionName, err = awsRegion()
+		if err != nil {
+			return "", err
+		}
 	}
 
 	// Check to make sure the region exists.

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -85,10 +85,13 @@ func newS3Client(bucket string) (*s3.S3, error) {
 		return nil, err
 	}
 
-	sess := session.Must(session.NewSession(&aws.Config{
+	sess, err := session.NewSession(&aws.Config{
 		Credentials: awsS3Credentials(),
 		Region:      aws.String(region),
-	}))
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	logger.Debug("Authorizing S3 credentials and finding bucket `%s` in region `%s`...", bucket, region)
 


### PR DESCRIPTION
This creates a session for the ec2 metadata and tags api calls, nil is no longer ok.

Also, I noticed that there is a regression where the new sdk needs `AWS_REGION` or `AWS_DEFAULT_REGION` set, otherwise it fails. I added a heuristic similar to what we used previously, e.g if it's running in AWS then use that region.