### PR TITLE
Add a message to build output when the agent is killed

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -135,6 +135,13 @@ func (r *JobRunner) Kill() error {
 		r.cancelled = true
 
 		if r.process != nil {
+			// send the user a nice message in the build output to tell them what has happened
+			if r.logStreamer != nil {
+				r.logStreamer.Process(fmt.Sprintf(
+					"\033[33m⚠️ Buildkite Warning: %s\033[0m\n^^^ +++",
+					"The agent has been forcefully shutdown, all process will be terminated",
+				))
+			}
 			r.process.Kill()
 		} else {
 			logger.Error("No process to kill")


### PR DESCRIPTION
The agent kills it's subprocesses when it's forcefully killed. This currently just looks like "Agent exited with -1" in the user interface.

This adds a message "The agent has been forcefully shutdown, all process will be terminated".