### PR TITLE
Debug output during git fetch for pull request

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -289,6 +289,7 @@ else
   # https://help.github.com/articles/checking-out-pull-requests-locally/#modifying-an-inactive-pull-request-locally
   elif [[ "$BUILDKITE_PULL_REQUEST" != "false" ]] && [[ "$BUILDKITE_PROJECT_PROVIDER" == *"github"* ]]; then
     buildkite-run git fetch -v origin "refs/pull/$BUILDKITE_PULL_REQUEST/head"
+    buildkite-comment "FETCH_HEAD is now $(git rev-parse FETCH_HEAD)"
     buildkite-run git checkout -f "$BUILDKITE_COMMIT"
 
   # If the commit is "HEAD" then we can't do a commit-specific fetch and will


### PR DESCRIPTION
Show the fetched commit sha when performing a git fetch for a pull request head. For a successful case this looks like:

<img width="1104" alt="screen shot 2017-07-18 at 3 11 40 pm" src="https://user-images.githubusercontent.com/14028/28301703-ecc95d94-6bcb-11e7-92e8-996c26e5d8f5.png">

For a problematic case this looks like:

<img width="1105" alt="screen shot 2017-07-18 at 3 13 25 pm" src="https://user-images.githubusercontent.com/14028/28301710-f4aa82ae-6bcb-11e7-9e90-a9314b69b945.png">

This should help us determine whether stale pull request heads are the cause of these "reference is not a tree" issue, and potentially give us a workaround.

I'll add the same behaviour to the beta agent once this is merged.