### PR TITLE
Fix boolean plugin config parsing

### DIFF
--- a/agent/plugin.go
+++ b/agent/plugin.go
@@ -192,6 +192,8 @@ func (p *Plugin) ConfigurationToEnvironment() (*shell.Environment, error) {
 		switch vv := v.(type) {
 		case string:
 			env = append(env, fmt.Sprintf("%s=%s", name, vv))
+		case bool:
+			env = append(env, fmt.Sprintf("%s=%t", name, vv))
 		case json.Number:
 			env = append(env, fmt.Sprintf("%s=%s", name, vv.String()))
 		case []string:

--- a/agent/plugin_test.go
+++ b/agent/plugin_test.go
@@ -217,6 +217,13 @@ func TestConfigurationToEnvironment(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"BUILDKITE_PLUGIN_DOCKER_COMPOSE_AND_WITH_A_NUMBER=12"}, env.ToSlice())
 
+	env, err = pluginEnvFromConfig(t, `{ "bool-true-key": true, "bool-false-key": false }`)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{
+		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_BOOL_TRUE_KEY=true",
+		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_BOOL_FALSE_KEY=false"},
+		env.ToSlice())
+	
 	env, err = pluginEnvFromConfig(t, `{ "array-key": [ "array-val-1", "array-val-2" ] }`)
 	assert.Nil(t, err)
 	assert.Equal(t, []string{

--- a/agent/plugin_test.go
+++ b/agent/plugin_test.go
@@ -220,8 +220,8 @@ func TestConfigurationToEnvironment(t *testing.T) {
 	env, err = pluginEnvFromConfig(t, `{ "bool-true-key": true, "bool-false-key": false }`)
 	assert.Nil(t, err)
 	assert.Equal(t, []string{
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_BOOL_TRUE_KEY=true",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_BOOL_FALSE_KEY=false"},
+		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_BOOL_FALSE_KEY=false",
+		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_BOOL_TRUE_KEY=true"},
 		env.ToSlice())
 	
 	env, err = pluginEnvFromConfig(t, `{ "array-key": [ "array-val-1", "array-val-2" ] }`)


### PR DESCRIPTION
If you use booleans in your plugin config YAML (such as the `verbose: true` flag in the [docker-compose plugin](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin)) you get a warning printed after your build output:

<img width="624" alt="untitled 4" src="https://user-images.githubusercontent.com/153/28450232-50eab12e-6e29-11e7-98ca-d17233134e62.png">

The only way to specify a boolean at the moment is with the string version (`"true"`).

This adds boolean handling, so it sets an env var value of `"true"` for `true` and `"false"` for `false`. 

For example:

```yaml
steps:
  - plugins:
      docker-compose#v1.4.0:
        run: tests
        verbose: true
```

becomes:

```bash
BUILDKITE_PLUGIN_DOCKER_COMPOSE_VERBOSE=true
```

…and:

```yaml
steps:
  - plugins:
      docker-compose#v1.4.0:
        run: tests
        verbose: false
```

…becomes:

```bash
BUILDKITE_PLUGIN_DOCKER_COMPOSE_VERBOSE=false
```