### PR TITLE
Stop making hook files executable

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -115,9 +115,6 @@ function buildkite-hook {
   HOOK_SCRIPT_PATH="$2"
 
   if [[ -e "$HOOK_SCRIPT_PATH" ]]; then
-    # Make sure the script path is executable
-    chmod +x "$HOOK_SCRIPT_PATH"
-
     # Print to the screen we're going to run the hook
     echo "~~~ Running $HOOK_LABEL hook"
     buildkite-prompt "$HOOK_SCRIPT_PATH"


### PR DESCRIPTION
Hooks are invoked using the `source` keyword in `bootstrap.sh`. Before they are sourced, they are made executable. I believe this is unnecessary:

```
# echo 'date' > /tmp/sourceme
# chmod -x /tmp/sourceme
# source /tmp/sourceme
Wed Aug  2 06:58:06 UTC 2017
```

This unnecessary `chmod` is causing me some trouble when mounting my hooks on a read only filesystem.

Firstly, this error appears before every hook:

> chmod: changing permissions of '/buildkite/hooks/environment': Read-only file system

Secondly, the UI indents things weirdly:

![screen shot 2017-08-02 at 4 40 32 pm](https://user-images.githubusercontent.com/13476365/28861053-7c17cd6e-77a2-11e7-9db7-20df99ac00c8.png)

Lastly, here's a cat in a sink:

![cat-sinks-08](https://user-images.githubusercontent.com/13476365/28861180-1d2489b8-77a3-11e7-8407-2f00ee59be3c.jpg)