### PR TITLE
Add support for a fetch hook

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1022,9 +1022,19 @@ func (b *Bootstrap) Start() error {
 		// Git clean prior to checkout
 		b.gitClean()
 
+		// If they've provided their own optimized fetch
+		if fileExists(b.globalHookPath("fetch")) {
+			b.executeGlobalHook("fetch")
+			b.runCommand("git", "checkout", "-f", b.Commit)
+
+		// If a plugin has provided it's own optimized fetch
+		} else if b.pluginHookExists(plugins, "fetch") {
+			b.executePluginHook(plugins, "fetch")
+			b.runCommand("git", "checkout", "-f", b.Commit)
+
 		// If a refspec is provided then use it instead.
 		// i.e. `refs/not/a/head`
-		if b.RefSpec != "" {
+		} else if b.RefSpec != "" {
 			commentf("Fetch and checkout custom refspec")
 			b.runCommand("git", "fetch", "-v", "origin", b.RefSpec)
 			b.runCommand("git", "checkout", "-f", b.Commit)


### PR DESCRIPTION
If people want to optimise the `git fetch` for performance sensitive or quirky environments (e.g. #504), it requires overriding the entire `git checkout` hook. Even if we exposed the original checkout hook for calling, it wouldn't allow you to optimise just the `git fetch`.

To help, this adds a new hook called `fetch` allowing you to provide your own logic.

- [x] Code
- [ ] Feedback
- [ ] Run some tests