### PR TITLE
Prune when fetching with a refspec

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1026,7 +1026,7 @@ func (b *Bootstrap) Start() error {
 		// i.e. `refs/not/a/head`
 		if b.RefSpec != "" {
 			commentf("Fetch and checkout custom refspec")
-			b.runCommand("git", "fetch", "-v", "origin", b.RefSpec)
+			b.runCommand("git", "fetch", "-v", "--prune", "origin", b.RefSpec)
 			b.runCommand("git", "checkout", "-f", b.Commit)
 
 			// GitHub has a special ref which lets us fetch a pull request head, whether
@@ -1047,7 +1047,7 @@ func (b *Bootstrap) Start() error {
 			// need to fetch the remote head and checkout the fetched head explicitly.
 		} else if b.Commit == "HEAD" {
 			commentf("Fetch and checkout remote branch HEAD commit")
-			b.runCommand("git", "fetch", "-v", "origin", b.Branch)
+			b.runCommand("git", "fetch", "-v", "--prune", "origin", b.Branch)
 			b.runCommand("git", "checkout", "-f", "FETCH_HEAD")
 
 			// Otherwise fetch and checkout the commit directly. Some repositories don't
@@ -1062,7 +1062,7 @@ func (b *Bootstrap) Start() error {
 				// fetch all tags in addition to the default refspec, but pre 1.9.0 it
 				// excludes the default refspec.
 				gitFetchRefspec, _ := b.runCommandSilentlyAndCaptureOutput("git", "config", "remote.origin.fetch")
-				b.runCommand("git", "fetch", "-v", "origin", gitFetchRefspec, "+refs/tags/*:refs/tags/*")
+				b.runCommand("git", "fetch", "-v", "--prune", "origin", gitFetchRefspec, "+refs/tags/*:refs/tags/*")
 			}
 			b.runCommand("git", "checkout", "-f", b.Commit)
 		}


### PR DESCRIPTION
https://github.com/buildkite/agent/issues/507

The `Fetch and checkout commit` codepath (the last one) is the one that I actually saw the problem affect and this change fix, but the other paths look like they might get caught by the same scenario.
I left the `refs/pull/…/head` and `commit-sha` fetches unchanged because I figure that they wouldn't need the pruning.