### PR TITLE
Add a dockerfile for local development

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - name: ":hammer:"
     command: "scripts/tests.sh"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
         run: agent
 
   - wait
@@ -11,98 +11,98 @@ steps:
     command: "scripts/build-binary.sh windows 386"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
         run: agent
 
   - name: ":windows: amd64"
     command: "scripts/build-binary.sh windows amd64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
         run: agent
 
   - name: ":linux: amd64"
     command: "scripts/build-binary.sh linux amd64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
         run: agent
 
   - name: ":linux: 386"
     command: "scripts/build-binary.sh linux 386"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
         run: agent
 
   - name: ":linux: arm"
     command: "scripts/build-binary.sh linux arm"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
         run: agent
 
   - name: ":linux: armhf"
     command: "scripts/build-binary.sh linux armhf"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
         run: agent
 
   - name: ":linux: arm64"
     command: "scripts/build-binary.sh linux arm64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
         run: agent
 
   - name: ":mac: 386"
     command: "scripts/build-binary.sh darwin 386"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
         run: agent
 
   - name: ":mac: amd64"
     command: "scripts/build-binary.sh darwin amd64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
         run: agent
 
   - name: ":freebsd: amd64"
     command: "scripts/build-binary.sh freebsd amd64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
         run: agent
 
   - name: ":freebsd: 386"
     command: "scripts/build-binary.sh freebsd 386"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
         run: agent
 
   - name: ":openbsd: amd64"
     command: "scripts/build-binary.sh openbsd amd64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
         run: agent
 
   - name: ":openbsd: 386"
     command: "scripts/build-binary.sh openbsd 386"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
         run: agent
 
   - name: ":dragonflybsd: amd64"
     command: "scripts/build-binary.sh dragonfly amd64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
         run: agent
 
   - wait
@@ -151,7 +151,8 @@ steps:
     artifact_paths: "releases/**/*"
     branches: "master 2-1-stable"
     plugins:
-      docker-compose#e8ce6c1:
+      docker-compose#v1.5.0:
+        config: docker-compose.release.yml
         run: github-release
 
   - wait

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.8
+
+WORKDIR /go/src/github.com/buildkite/agent
+COPY . .
+
+RUN go build -o buildkite-agent *.go
+
+ENTRYPOINT ["./buildkite-agent"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,10 +2,9 @@ version: '2'
 
 services:
   agent:
-    image: golang:1.8
+    build: .
     working_dir: /go/src/github.com/buildkite/agent
     volumes:
       - ./:/go/src/github.com/buildkite/agent
     environment:
       BUILDKITE_BUILD_NUMBER:
-

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -1,0 +1,17 @@
+version: '2'
+
+services:
+
+  github-release:
+    build:
+      context: .
+      dockerfile: Dockerfile-github-release
+    volumes:
+      - ./:/app
+      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
+    working_dir: /app
+    environment:
+      - BUILDKITE_AGENT_ACCESS_TOKEN
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_BUILD_ID
+      - BUILDKITE_BUILD_NUMBER


### PR DESCRIPTION
This adds a local Dockerfile that will compile the agent during development. 

It doesn't aim to replace https://github.com/buildkite/docker-buildkite-agent