### PR TITLE
Support git clean and git clone flags with spaces

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -158,11 +158,11 @@ function buildkite-local-hook {
 }
 
 function buildkite-git-clean {
-  BUILDKITE_GIT_CLEAN_FLAGS=${BUILDKITE_GIT_CLEAN_FLAGS:--fdq}
-  buildkite-run git clean "$BUILDKITE_GIT_CLEAN_FLAGS"
+  BUILDKITE_GIT_CLEAN_FLAGS=(${BUILDKITE_GIT_CLEAN_FLAGS:--fdq})
+  buildkite-run git clean "${BUILDKITE_GIT_CLEAN_FLAGS[@]}"
 
   if [[ -z "${BUILDKITE_DISABLE_GIT_SUBMODULES:-}" ]]; then
-    buildkite-run git submodule foreach --recursive git clean "$BUILDKITE_GIT_CLEAN_FLAGS"
+    buildkite-run git submodule foreach --recursive git clean "${BUILDKITE_GIT_CLEAN_FLAGS[@]}"
   fi
 }
 
@@ -270,8 +270,8 @@ else
   if [[ -d ".git" ]]; then
     buildkite-run git remote set-url origin "$BUILDKITE_REPO"
   else
-    BUILDKITE_GIT_CLONE_FLAGS=${BUILDKITE_GIT_CLONE_FLAGS:--v}
-    buildkite-run git clone "$BUILDKITE_GIT_CLONE_FLAGS" -- "$BUILDKITE_REPO" .
+    BUILDKITE_GIT_CLONE_FLAGS=(${BUILDKITE_GIT_CLONE_FLAGS:--v})
+    buildkite-run git clone "${BUILDKITE_GIT_CLONE_FLAGS[@]}" -- "$BUILDKITE_REPO" .
   fi
 
   # Git clean prior to checkout


### PR DESCRIPTION
Previously the GIT_CLEAN_FLAGS and GIT_CLONE_FLAGS were wrapped in quotes, which doesn't work if there are multiple flags or they have spaces in them. This wordsplits them into an array and then interpolates them as multiple words.

An example of what this breaks is the long args string that the secrets plugin puts in:

https://github.com/buildkite-plugins/s3-secrets-buildkite-plugin/blob/85347a8ca961e0eb43356188cd5ab3704a134961/hooks/environment#L111-L112

