### PR TITLE
Add BUILDKITE_GCS_ACCESS_HOST for GCS Host choice

### DIFF
--- a/agent/gs_uploader.go
+++ b/agent/gs_uploader.go
@@ -50,10 +50,14 @@ func (u *GSUploader) Setup(destination string, debugHTTP bool) error {
 }
 
 func (u *GSUploader) URL(artifact *api.Artifact) string {
-	// If not publicly accessible, GET on this URL results in 403.
+	host := "storage.googleapis.com"
+	if os.Getenv("BUILDKITE_GCS_ACCESS_HOST") != "" {
+		host = os.Getenv("BUILDKITE_GCS_ACCESS_HOST")
+	}
+
 	var artifactURL = &url.URL{
 		Scheme: "https",
-		Host:   "storage.googleapis.com",
+		Host:   host,
 		Path:   u.BucketName() + "/" + u.artifactPath(artifact),
 	}
 	return artifactURL.String()


### PR DESCRIPTION
Problem
---
- The URL for artifacts uploaded to GCS are api links.
- Following the link in browser yields an XML error page.
- The URL buildkite puts is under `storage.googleapis.com` but to leverage the oath prompt mentioned above users need to access objects under `storage.cloud.google.com`.
- I couldn't find anything from buildkite's doc equivalent to BUILDKITE_S3_ACCESS_URL for Google Cloud.

Alternatives
---
- When a user clicks a link in browser, you should use `storage.cloud.google.com`.
  - This flow is for humans, not machines - so it should be optimized for that experience
- When a user fetches a link via API, you should use `storage.googleapis.com`
  - This flow is for machines, not humans - so it should be optimized for that experience

This change would be simple but allow for us to easily leverage oAuth and API when needed.

Looking at our internal issue again, I think @mcgain has asked about this - so best to get his input 😄  I saw this pattern in S3 Uploader, so I copied. 

cc @keithpitt @toolmantim 