### PR TITLE
Fix plugin checkout from bootstrap rewrite

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -433,11 +433,6 @@ func (b *Bootstrap) PluginPhase() error {
 			// Switch to the version if we need to
 			if p.Version != "" {
 				b.shell.Commentf("Checking out `%s`", p.Version)
-
-				if err = b.shell.Run("git clone -v -- %q .", repo); err != nil {
-					return err
-				}
-
 				if err = b.shell.Run("git checkout -f %q", p.Version); err != nil {
 					return err
 				}

--- a/bootstrap/knownhosts.go
+++ b/bootstrap/knownhosts.go
@@ -54,7 +54,7 @@ func findKnownHosts(sh *shell.Shell) (*knownHosts, error) {
 func (kh *knownHosts) Contains(host string) (bool, error) {
 	sshToolsDir, err := findSSHToolsDir(kh.shell)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Grab the generated keys for the repo host

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -175,7 +175,7 @@ func (s *Shell) executeCommand(cmd *exec.Cmd, w io.Writer, silent bool) error {
 		}
 	}()
 
-	cmdStr := process.FormatCommand(cmd.Path, cmd.Args)
+	cmdStr := process.FormatCommand(cmd.Path, cmd.Args[1:])
 	if silent {
 		s.Promptf("%s", cmdStr)
 	}


### PR DESCRIPTION
I broke checkout of plugins with versions in #530 with a bad merge. This fixes it as well as cleaning up a few other things I noticed. 