### PR TITLE
Get local docker container working

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+docker-compose*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM golang:1.8
-
 WORKDIR /go/src/github.com/buildkite/agent
 COPY . .
-
-RUN go build -o buildkite-agent *.go
-
-ENTRYPOINT ["./buildkite-agent"]
+RUN go build -i -o /go/bin/buildkite-agent github.com/buildkite/agent
+CMD ["buildkite-agent", "start"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,10 +1,16 @@
-version: '2'
+version: '2.1'
 
 services:
   agent:
-    build: .
-    working_dir: /go/src/github.com/buildkite/agent
-    volumes:
-      - ./:/go/src/github.com/buildkite/agent
+    command: "buildkite-agent start --endpoint http://agent.buildkite.dev/v3"
     environment:
-      BUILDKITE_BUILD_NUMBER:
+      BUILDKITE_AGENT_TAGS: queue=default
+      BUILDKITE_AGENT_TOKEN: test
+      BUILDKITE_BUILD_PATH: /buildkite
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+networks:
+  default:
+    external:
+      name: buildkite_default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
-version: '2'
+version: '2.1'
 
 services:
   agent:
-    image: golang:1.8
+    build: .
     working_dir: /go/src/github.com/buildkite/agent
     volumes:
       - ./:/go/src/github.com/buildkite/agent
     environment:
       BUILDKITE_BUILD_NUMBER:
-


### PR DESCRIPTION
The docker container for the buildkite-agent wasn't working, I suspect because the volume mount was clobbering the binary that was built.

This cleans it up and also sets up the command so that it connects to our local dev environment when in development (e.g when the .override.yml is loaded).