### PR TITLE
Add a windows testing step

### DIFF
--- a/.buildkite/pipeline.windows.yml
+++ b/.buildkite/pipeline.windows.yml
@@ -1,5 +1,5 @@
 steps:
   - name: ":hammer: :windows:"
-    command: "docker-compose -f docker-compose.yml run --rm agent .\\scripts\\tests.bat"
+    command: "docker-compose -f docker-compose.windows.yml run --rm agent .\\scripts\\tests.bat"
     agents:
       queue: "windows"

--- a/.buildkite/pipeline.windows.yml
+++ b/.buildkite/pipeline.windows.yml
@@ -1,0 +1,5 @@
+steps:
+  - name: ":hammer: :windows:"
+    command: ".\\scripts\\tests.bat"
+    agents:
+      queue: "windows"

--- a/.buildkite/pipeline.windows.yml
+++ b/.buildkite/pipeline.windows.yml
@@ -1,5 +1,5 @@
 steps:
   - name: ":hammer: :windows:"
-    command: "docker-compose -f docker-compose.windows.yml run --rm agent .\\scripts\\tests.bat"
+    command: "docker-compose -f docker-compose.windows.yml run --rm -T agent .\\scripts\\tests.bat"
     agents:
       queue: "windows"

--- a/.buildkite/pipeline.windows.yml
+++ b/.buildkite/pipeline.windows.yml
@@ -1,5 +1,5 @@
 steps:
   - name: ":hammer: :windows:"
-    command: ".\\scripts\\tests.bat"
+    command: "docker-compose -f docker-compose.yml run --rm agent .\\scripts\\tests.bat"
     agents:
       queue: "windows"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,11 +2,19 @@ env:
   DRY_RUN: false # set to true to disable publishing releases
 
 steps:
-  - name: ":hammer:"
+  - name: ":hammer: :linux:"
     command: "scripts/tests.sh"
     plugins:
       docker-compose#v1.5.0:
         run: agent
+
+  - name: ":hammer: :windows:"
+    trigger: agent-windows
+    async: true
+    build:
+      message: "${BUILDKITE_MESSAGE}"
+      commit: "${BUILDKITE_COMMIT}"
+      branch: "${BUILDKITE_BRANCH}"
 
   - wait
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 Dockerfile
 Dockerfile*
 docker-compose*
+.vagrant
+packaging

--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -1,6 +1,5 @@
-FROM microsoft/windowsservercore:latest   
+FROM microsoft/windowsservercore:latest
 
-#ENV chocolateyVersion 0.10.3
 ENV ChocolateyUseWindowsCompression false
 
 # Set your PowerShell execution policy
@@ -19,7 +18,7 @@ ENV GOPATH=c:/gopath
 WORKDIR c:/gopath/src/github.com/buildkite/agent
 COPY . .
 
-# Build agent
-RUN go build -v -i -o c:/gopath/bin/buildkite-agent.exe
+# Build agent and put binary in a dir in the PATH (remarkably hard to add to path)
+RUN go build -i -o .\buildkite-agent.exe
 
-CMD ["c:/gopath/bin/buildkite-agent.exe", "start"]
+CMD ["./buildkite-agent.exe", "start"]

--- a/README.md
+++ b/README.md
@@ -68,16 +68,14 @@ To test the commands locally:
 go run main.go start --debug --token "abc123"
 ```
 
-### Testing Windows via Vagrant and VMWare Fusion
+### Windows via Vagrant
 
-This requires either Virtualbox (free) or VMWare Fusion (paid) + Vagrant VMWare Fusion plugin (paid).
+This requires either Virtualbox (free) or VMWare Fusion + Vagrant VMWare Fusion plugin (paid).
 
-It assumes that you have Docker for Mac or similar installed. Based on [StefanScherer/windows-docker-machine](https://github.com/StefanScherer/windows-docker-machine).
+It assumes that you have Docker for Mac or similar installed. The following commands are run on your local machine. Expect things to take a long time, the vagrant box is 10GB and the docker base image is 3.4GB.
 
 ```bash
-brew cask install vmware-fusion vagrant
-vagrant plugin install vagrant-vmware-fusion
-vagrant up --provider vmware_fusion
+vagrant up
 eval $(docker-machine env windows-2016)
 docker-compose -f docker-compose.windows.yml run agent cmd
 C:\gopath\src\github.com\buildkite\agent> go run main.go start --token xxx --debug

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -12,7 +12,7 @@ services:
     environment:
       - BUILDKITE_BUILD_NUMBER
       - "BUILDKITE_AGENT_TAGS=queue=default"
-      - "BUILDKITE_BUILD_PATH=/buildkite"
+      - "BUILDKITE_BUILD_PATH=c:\\buildkite"
 
 networks:
   default:

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -1,4 +1,7 @@
-version: '2.1'
+version: "3.2"
+
+# This is a docker-compose file designed to be called in macOS and translate through to windows
+# Binding is basically impossible, see https://github.com/docker/compose/issues/5371
 
 services:
   agent:
@@ -6,11 +9,10 @@ services:
       dockerfile: Dockerfile-windows
       context: .
     working_dir: C:/gopath/src/github.com/buildkite/agent
-    # volumes:
-    #   - ./:C:/gopath/src/github.com/buildkite/agent
     environment:
-      BUILDKITE_BUILD_NUMBER:
-
+      - BUILDKITE_BUILD_NUMBER
+      - "BUILDKITE_AGENT_TAGS=queue=default"
+      - "BUILDKITE_BUILD_PATH=/buildkite"
 
 networks:
   default:

--- a/scripts/tests.bat
+++ b/scripts/tests.bat
@@ -1,0 +1,3 @@
+@echo off
+echo +++ Running tests
+go test -race -v .\...

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
 set -euo pipefail
-
 echo '+++ Running tests'
-
-go test -v -race ./...
+go test -race -v ./...


### PR DESCRIPTION
This adds a step that runs the tests on a Windows 2016 w/ Containers instance in another asynchronous pipeline. This means we can still see windows failures while we iterate on fixing them.

For the actual infrastructure, I created a hand-rolled m4.large windows instance running Windows 2016 Server. Will replace with something more scalable when we need it. 