### PR TITLE
Use latest golang 1.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.9
 WORKDIR /go/src/github.com/buildkite/agent
 COPY . .
 RUN go build -i -o /go/bin/buildkite-agent github.com/buildkite/agent


### PR DESCRIPTION
This bumps the docker container to the latest golang, which means our binaries get built with it. Impact should be absolutely minimal. 