### PR TITLE
Fix custom artifact bucket segfault

### DIFF
--- a/agent/s3.go
+++ b/agent/s3.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -46,15 +47,6 @@ func (e *credentialsProvider) IsExpired() bool {
 	return !e.retrieved
 }
 
-func awsS3Credentials() *credentials.Credentials {
-	return credentials.NewChainCredentials(
-		[]credentials.Provider{
-			&credentialsProvider{},
-			&credentials.EnvProvider{},
-			&ec2rolecreds.EC2RoleProvider{},
-		})
-}
-
 func awsS3RegionFromEnv() (region string, err error) {
 	regionName := "us-east-1"
 	if os.Getenv("BUILDKITE_S3_DEFAULT_REGION") != "" {
@@ -82,17 +74,34 @@ func awsS3RegionFromEnv() (region string, err error) {
 	return "", fmt.Errorf("Unknown AWS S3 Region %q", regionName)
 }
 
+func awsS3Session(region string) (*session.Session, error) {
+	// Chicken and egg... but this is kinda how they do it in the sdk
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	sess.Config.Region = aws.String(region)
+
+	sess.Config.Credentials = credentials.NewChainCredentials(
+		[]credentials.Provider{
+			&credentialsProvider{},
+			&credentials.EnvProvider{},
+			&ec2rolecreds.EC2RoleProvider{
+				Client: ec2metadata.New(sess),
+			},
+		})
+
+	return sess, nil
+}
+
 func newS3Client(bucket string) (*s3.S3, error) {
-	// Generate the AWS config used by the S3 client
 	region, err := awsS3RegionFromEnv()
 	if err != nil {
 		return nil, err
 	}
 
-	sess, err := session.NewSession(&aws.Config{
-		Credentials: awsS3Credentials(),
-		Region:      aws.String(region),
-	})
+	sess, err := awsS3Session(region)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -7,8 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -87,9 +86,8 @@ func awsS3Session(region string) (*session.Session, error) {
 		[]credentials.Provider{
 			&credentialsProvider{},
 			&credentials.EnvProvider{},
-			&ec2rolecreds.EC2RoleProvider{
-				Client: ec2metadata.New(sess),
-			},
+			// EC2 and ECS meta-data providers
+			defaults.RemoteCredProvider(*sess.Config, sess.Handlers),
 		})
 
 	return sess, nil


### PR DESCRIPTION
When using a custom artifact bucket which constructs an S3 client the agent can segfault when falling through to obtaining AWS credentials for an instance role from EC2 meta-data because it's missing a Client. Looking deeper into how it's done within the aws-sdk it [looks like they use RemoteCredProvider](https://github.com/buildkite/agent/blob/fix-artifact-segfault/vendor/github.com/aws/aws-sdk-go/aws/session/session.go#L460) which also supports ECS, so I've switched to that.