### PR TITLE
Fix ssh keyscan for urls with ports

### DIFF
--- a/bootstrap/knownhosts.go
+++ b/bootstrap/knownhosts.go
@@ -127,9 +127,9 @@ func newGittableURL(ref string) (*url.URL, error) {
 // Clean up the SSH host and remove any key identifiers. See:
 // git@github.com-custom-identifier:foo/bar.git
 // https://buildkite.com/docs/agent/ssh-keys#creating-multiple-ssh-keys
-var repoSSHKeySwitcherRegex = regexp.MustCompile(`-[a-z0-9\-]+$`)
-func repoSSHKeySwitcherStrip(host string) (string) {
-	return repoSSHKeySwitcherRegex.ReplaceAllString(host, "")
+var gitHostAliasRegexp = regexp.MustCompile(`-[a-z0-9\-]+$`)
+func stripAliasesFromGitHost(host string) (string) {
+	return gitHostAliasRegexp.ReplaceAllString(host, "")
 }
 
 // AddFromRepository takes a git repo url, extracts the host and adds it
@@ -141,7 +141,7 @@ func (kh *knownHosts) AddFromRepository(repository string) error {
 		return err
 	}
 
-	host := repoSSHKeySwitcherStrip(url.Hostname())
+	host := stripAliasesFromGitHost(url.Hostname())
 
 	if err = kh.Add(host); err != nil {
 		return fmt.Errorf("Failed to add `%s` to known_hosts file `%s`: %v'", host, url, err)


### PR DESCRIPTION
[Hostname()](https://golang.org/pkg/net/url/#URL.Hostname) returns Host without any port number.

This shouldn't clash with #561 looking at the diff, but should be complementary.

Closes #564.