### PR TITLE
Trim environment variables to avoid unexpected line endings on windows

### DIFF
--- a/agent/s3.go
+++ b/agent/s3.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -21,14 +22,14 @@ type credentialsProvider struct {
 func (e *credentialsProvider) Retrieve() (creds credentials.Value, err error) {
 	e.retrieved = false
 
-	creds.AccessKeyID = os.Getenv("BUILDKITE_S3_ACCESS_KEY_ID")
+	creds.AccessKeyID = strings.TrimSpace(os.Getenv("BUILDKITE_S3_ACCESS_KEY_ID"))
 	if creds.AccessKeyID == "" {
-		creds.AccessKeyID = os.Getenv("BUILDKITE_S3_ACCESS_KEY")
+		creds.AccessKeyID = strings.TrimSpace(os.Getenv("BUILDKITE_S3_ACCESS_KEY"))
 	}
 
-	creds.SecretAccessKey = os.Getenv("BUILDKITE_S3_SECRET_ACCESS_KEY")
+	creds.SecretAccessKey = strings.TrimSpace(os.Getenv("BUILDKITE_S3_SECRET_ACCESS_KEY"))
 	if creds.SecretAccessKey == "" {
-		creds.SecretAccessKey = os.Getenv("BUILDKITE_S3_SECRET_KEY")
+		creds.SecretAccessKey = strings.TrimSpace(os.Getenv("BUILDKITE_S3_SECRET_KEY"))
 	}
 
 	if creds.AccessKeyID == "" {
@@ -49,7 +50,7 @@ func (e *credentialsProvider) IsExpired() bool {
 func awsS3RegionFromEnv() (region string, err error) {
 	regionName := "us-east-1"
 	if os.Getenv("BUILDKITE_S3_DEFAULT_REGION") != "" {
-		regionName = os.Getenv("BUILDKITE_S3_DEFAULT_REGION")
+		regionName = strings.TrimSpace(os.Getenv("BUILDKITE_S3_DEFAULT_REGION"))
 	} else {
 		var err error
 		regionName, err = awsRegion()

--- a/agent/s3_uploader.go
+++ b/agent/s3_uploader.go
@@ -58,9 +58,9 @@ func (u *S3Uploader) URL(artifact *api.Artifact) string {
 func (u *S3Uploader) Upload(artifact *api.Artifact) error {
 	permission := "public-read"
 	if os.Getenv("BUILDKITE_S3_ACL") != "" {
-		permission = os.Getenv("BUILDKITE_S3_ACL")
+		permission = strings.TrimSpace(os.Getenv("BUILDKITE_S3_ACL"))
 	} else if os.Getenv("AWS_S3_ACL") != "" {
-		permission = os.Getenv("AWS_S3_ACL")
+		permission = strings.TrimSpace(os.Getenv("AWS_S3_ACL"))
 	}
 
 	// The dirtiest validation method ever...

--- a/agent/s3_uploader.go
+++ b/agent/s3_uploader.go
@@ -45,7 +45,7 @@ func (u *S3Uploader) URL(artifact *api.Artifact) string {
 	baseUrl := "https://" + u.BucketName() + ".s3.amazonaws.com"
 
 	if os.Getenv("BUILDKITE_S3_ACCESS_URL") != "" {
-		baseUrl = os.Getenv("BUILDKITE_S3_ACCESS_URL")
+		baseUrl = strings.TrimSpace(os.Getenv("BUILDKITE_S3_ACCESS_URL"))
 	}
 
 	url, _ := url.Parse(baseUrl)

--- a/agent/s3_uploader.go
+++ b/agent/s3_uploader.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"runtime"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -28,7 +29,7 @@ type S3Uploader struct {
 }
 
 func (u *S3Uploader) Setup(destination string, debugHTTP bool) error {
-	u.Destination = destination
+	u.Destination = strings.TrimSpace(destination)
 	u.DebugHTTP = debugHTTP
 
 	// Initialize the s3 client, and authenticate it
@@ -111,7 +112,11 @@ func (u *S3Uploader) Upload(artifact *api.Artifact) error {
 }
 
 func (u *S3Uploader) artifactPath(artifact *api.Artifact) string {
-	parts := []string{u.BucketPath(), artifact.Path}
+	artifactPath := artifact.Path
+	if runtime.GOOS == "windows" {
+	    artifactPath = strings.Replace(artifactPath, "\\", "/", -1)
+	}
+	parts := []string{u.BucketPath(), artifactPath}
 
 	return strings.Join(parts, "/")
 }


### PR DESCRIPTION
When running on windows machine S3* variables initialized from environment.bat are incorrect. They have tailing '\r' symbol. Not depending on what line endings used in bat file. Errors are like following:
 FATAL  Failed to upload artifacts: Unknown AWS S3 Region "us-east-1\r"
Changes below just trim strings.
