### PR TITLE
fallback to TASKKILL on windows

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -13,6 +13,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -265,7 +267,12 @@ func (p *Process) Output() string {
 
 func (p *Process) Kill() error {
 	// Send a sigterm
-	err := p.signal(syscall.SIGTERM)
+	var err error
+	if runtime.GOOS == "windows" {
+		err = exec.Command("CMD", "/C", "TASKKILL", "/F", "/PID", strconv.Itoa(p.Pid)).Run()
+	} else {
+		err = p.signal(syscall.SIGTERM)
+	}
 	if err != nil {
 		return err
 	}

--- a/process/process.go
+++ b/process/process.go
@@ -266,11 +266,13 @@ func (p *Process) Output() string {
 }
 
 func (p *Process) Kill() error {
-	// Send a sigterm
 	var err error
 	if runtime.GOOS == "windows" {
+		// Sending Interrupt on Windows is not implemented.
+		// https://golang.org/src/os/exec.go?s=3842:3884#L110
 		err = exec.Command("CMD", "/C", "TASKKILL", "/F", "/PID", strconv.Itoa(p.Pid)).Run()
 	} else {
+		// Send a sigterm
 		err = p.signal(syscall.SIGTERM)
 	}
 	if err != nil {


### PR DESCRIPTION
👋 

This may be too much of a kludge for you folks but at Discord we've been frustrated by the inability to cancel Windows jobs for ages. This fallback seems to work and I wonder if you are interested in merging it until a proper long-term fix is available?

Related issues: https://github.com/buildkite/agent/issues/213 https://github.com/buildkite/agent/issues/345

For any drive-by readers I've hosted build 2.6.6 + this fix over on [our fork](https://github.com/discordapp/buildkite-agent/releases/tag/discord-v2.6.6-1). YMMV, caveat emptor, etc.