### PR TITLE
Pass working dir between hooks

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -139,24 +139,24 @@ func (b *Bootstrap) executeHook(name string, hookPath string, extraEnviron *env.
 	}
 
 	// Get changed environent
-	changes, err := script.ChangedEnvironment()
+	changes, err := script.Changes()
 	if err != nil {
 		return errors.Wrapf(err, "Failed to get environment")
 	}
 
 	// Finally, apply changes to the current shell and config
-	b.applyEnvironmentChanges(changes)
+	b.applyEnvironmentChanges(changes.Env, changes.Dir)
 	return nil
 }
 
-func (b *Bootstrap) applyEnvironmentChanges(environ *env.Environment) {
-	// `environ` shouldn't ever be `nil`, but we'll just be cautious and guard against it.
-	if environ == nil {
-		return
+func (b *Bootstrap) applyEnvironmentChanges(environ *env.Environment, dir string) {
+	if dir != "" {
+		b.shell.Commentf("Applying working directory change: %s", dir)
+		_ = b.shell.Chdir(dir)
 	}
 
 	// Do we even have any environment variables to change?
-	if environ.Length() > 0 {
+	if environ != nil && environ.Length() > 0 {
 		// First, let see any of the environment variables are supposed
 		// to change the bootstrap configuration at run time.
 		bootstrapConfigEnvChanges := b.Config.ReadFromEnvironment(environ)

--- a/bootstrap/shell/shell_test.go
+++ b/bootstrap/shell/shell_test.go
@@ -3,6 +3,9 @@ package shell_test
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/buildkite/agent/bootstrap/shell"
@@ -71,5 +74,68 @@ func TestRun(t *testing.T) {
 
 	if expected := "$ " + sshKeygen.Path + " -f my_hosts -F llamas.com\nLlama party! 🎉\n"; actual != expected {
 		t.Fatalf("Expected %q, got %q", expected, actual)
+	}
+}
+
+func TestDefaultWorkingDirFromSystem(t *testing.T) {
+	sh, err := shell.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	currentWd, _ := os.Getwd()
+	if actual := sh.Getwd(); actual != currentWd {
+		t.Fatalf("Expected working dir %q, got %q", currentWd, actual)
+	}
+}
+
+func TestWorkingDir(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "shelltest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// macos has a symlinked temp dir
+	tempDir, _ = filepath.EvalSymlinks(tempDir)
+	dirs := []string{tempDir, "my", "test", "dirs"}
+
+	if err := os.MkdirAll(filepath.Join(dirs...), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	currentWd, _ := os.Getwd()
+
+	sh, err := shell.New()
+	sh.Logger = shell.DiscardLogger
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for idx := range dirs {
+		dir := filepath.Join(dirs[0 : idx+1]...)
+
+		if err := sh.Chdir(dir); err != nil {
+			t.Fatal(err)
+		}
+
+		if actual := sh.Getwd(); actual != dir {
+			t.Fatalf("Expected working dir %q, got %q", dir, actual)
+		}
+
+		out, err := sh.RunAndCapture("pwd")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if actual := out; actual != dir {
+			t.Fatalf("Expected working dir (from pwd command) %q, got %q", dir, actual)
+		}
+	}
+
+	afterWd, _ := os.Getwd()
+	if afterWd != currentWd {
+		t.Fatalf("Expected working dir to be the same as before shell commands ran")
 	}
 }

--- a/vendor/github.com/lox/bintest/mock.go
+++ b/vendor/github.com/lox/bintest/mock.go
@@ -83,6 +83,7 @@ func (m *Mock) invoke(call *proxy.Call) {
 	var invocation = Invocation{
 		Args: call.Args,
 		Env:  call.Env,
+		Dir:  call.Dir,
 	}
 
 	// Before we execute any invocations, run the before funcs
@@ -283,6 +284,7 @@ func (m *Mock) Close() error {
 type Invocation struct {
 	Args        []string
 	Env         []string
+	Dir         string
 	Expectation *Expectation
 }
 

--- a/vendor/github.com/lox/bintest/proxy/compiler.go
+++ b/vendor/github.com/lox/bintest/proxy/compiler.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 //go:generate go-bindata -pkg proxy data/
@@ -31,11 +32,14 @@ func compile(dest string, src string, vars []string) error {
 		args = append(args, strings.Join(vars, " "))
 	}
 
+	t := time.Now()
+
 	output, err := exec.Command("go", append(args, src)...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("Compile of %s failed: %s", src, output)
 	}
 
+	debugf("Compile %#v finished in %s", args, time.Now().Sub(t))
 	return nil
 }
 

--- a/vendor/github.com/lox/bintest/proxy/proxy.go
+++ b/vendor/github.com/lox/bintest/proxy/proxy.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -42,6 +43,10 @@ func New(path string) (*Proxy, error) {
 			return nil, fmt.Errorf("Error creating temp dir: %v", err)
 		}
 		path = filepath.Join(tempDir, path)
+	}
+
+	if runtime.GOOS == "windows" && !strings.HasSuffix(path, ".exe") {
+		path += ".exe"
 	}
 
 	p := &Proxy{

--- a/vendor/github.com/lox/bintest/proxy/server.go
+++ b/vendor/github.com/lox/bintest/proxy/server.go
@@ -105,6 +105,7 @@ func startServer(p *Proxy) (*server, error) {
 		handlers: map[int64]callHandler{},
 	}
 
+	debugf("Starting server on %s", l.Addr().String())
 	go http.Serve(l, s)
 	return s, nil
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -51,16 +51,16 @@
 			"revisionTime": "2016-07-16T20:46:20Z"
 		},
 		{
-			"checksumSHA1": "Y0QC+7xyacZ2md2g9Q08ZVq1jYo=",
+			"checksumSHA1": "GLNCOdn8jAHeCQSuDNdgSIYNlhM=",
 			"path": "github.com/lox/bintest",
-			"revision": "824f2376cf5de146199e5c6bce31590996b230c9",
-			"revisionTime": "2017-10-04T23:01:35Z"
+			"revision": "04ae4ffc42d49c49caa97d26c7c88795251144f4",
+			"revisionTime": "2017-11-08T00:12:52Z"
 		},
 		{
-			"checksumSHA1": "2rruuNOMEmtMVEinz1LRxAdet+8=",
+			"checksumSHA1": "vtvVqCnKI84k5jo9sfuGsNlFUKM=",
 			"path": "github.com/lox/bintest/proxy",
-			"revision": "824f2376cf5de146199e5c6bce31590996b230c9",
-			"revisionTime": "2017-10-04T23:01:35Z"
+			"revision": "04ae4ffc42d49c49caa97d26c7c88795251144f4",
+			"revisionTime": "2017-11-08T00:12:52Z"
 		},
 		{
 			"checksumSHA1": "R8z+BOS81hOWgcqymuVWHNta/yc=",


### PR DESCRIPTION
It's common in v2 agent hooks to change directories and expect it to affect subsequent hooks, for instance you might want to change the working directory in a `pre-command` hook for a monorepo. 

This PR makes that happen.