### PR TITLE
Support hashed hostnames in .ssh/known_hosts

### DIFF
--- a/bootstrap/knownhosts.go
+++ b/bootstrap/knownhosts.go
@@ -79,7 +79,7 @@ func (kh *knownHosts) Contains(host string) (bool, error) {
 			continue
 		}
 		for _, addr := range strings.Split(fields[0], ",") {
-			if addr == normalized {
+			if addr == normalized || addr == knownhosts.HashHostname(normalized) {
 				return true, nil
 			}
 		}


### PR DESCRIPTION
I forgot to support this in the initial implementation, this adds support for hashed hostnames. 