### PR TITLE
Handle upgrading bootstrap-path from old 2.x shell script

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -1,6 +1,7 @@
 package agent
 
 type AgentConfiguration struct {
+	ConfigPath                string
 	BootstrapScript           string
 	BuildPath                 string
 	HooksPath                 string

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -207,6 +207,7 @@ func (r *JobRunner) createEnvironment() []string {
 	env["BUILDKITE_BIN_PATH"] = dir
 
 	// Add options from the agent configuration
+	env["BUILDKITE_CONFIG_PATH"] = r.AgentConfiguration.ConfigPath
 	env["BUILDKITE_BUILD_PATH"] = r.AgentConfiguration.BuildPath
 	env["BUILDKITE_HOOKS_PATH"] = r.AgentConfiguration.HooksPath
 	env["BUILDKITE_PLUGINS_PATH"] = r.AgentConfiguration.PluginsPath

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -324,12 +324,6 @@ var AgentStartCommand = cli.Command{
 			}
 		}
 
-		// Grab the path to the config file
-		var configPath string
-		if loader.File != nil {
-			configPath = loader.File.Path
-		}
-
 		// Setup the agent
 		pool := agent.AgentPool{
 			Token:                 cfg.Token,
@@ -342,7 +336,6 @@ var AgentStartCommand = cli.Command{
 			WaitForEC2TagsTimeout: ec2TagTimeout,
 			Endpoint:              cfg.Endpoint,
 			AgentConfiguration: &agent.AgentConfiguration{
-				ConfigPath:                configPath,
 				BootstrapScript:           cfg.BootstrapScript,
 				BuildPath:                 cfg.BuildPath,
 				HooksPath:                 cfg.HooksPath,
@@ -360,10 +353,11 @@ var AgentStartCommand = cli.Command{
 			},
 		}
 
-		// Store the loaded config file path on the pool so we can
-		// show it when the agent starts
+		// Store the loaded config file path on the pool and agent config so we can
+		// show it when the agent starts and set an env
 		if loader.File != nil {
 			pool.ConfigFilePath = loader.File.Path
+			pool.AgentConfiguration.ConfigPath = loader.File.Path
 		}
 
 		// Start the agent pool

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -324,6 +324,12 @@ var AgentStartCommand = cli.Command{
 			}
 		}
 
+		// Grab the path to the config file
+		var configPath string
+		if loader.File != nil {
+			configPath = loader.File.Path
+		}
+
 		// Setup the agent
 		pool := agent.AgentPool{
 			Token:                 cfg.Token,
@@ -336,6 +342,7 @@ var AgentStartCommand = cli.Command{
 			WaitForEC2TagsTimeout: ec2TagTimeout,
 			Endpoint:              cfg.Endpoint,
 			AgentConfiguration: &agent.AgentConfiguration{
+				ConfigPath:                configPath,
 				BootstrapScript:           cfg.BootstrapScript,
 				BuildPath:                 cfg.BuildPath,
 				HooksPath:                 cfg.HooksPath,

--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -22,7 +22,7 @@ name="%hostname-%n"
 # Path to a custom boostrap command to run. By default this is `buildkite-agent bootstrap`.
 # This allows you to override the entire execution of a job. Generally you should use hooks instead!
 # See https://buildkite.com/docs/agent/hooks
-# bootstrap-script="/path/to/script.sh"
+# bootstrap-script=""
 
 # Path to where the builds will run from
 build-path="$HOME/.buildkite-agent/builds"
@@ -47,6 +47,9 @@ plugins-path="$HOME/.buildkite-agent/plugins"
 
 # Don't allow this agent to run arbitrary console commands
 # no-command-eval=true
+
+# Don't allow this agent to run plugins
+# no-plugins=true
 
 # Enable debug mode
 # debug=true

--- a/packaging/github/windows/buildkite-agent.cfg
+++ b/packaging/github/windows/buildkite-agent.cfg
@@ -12,7 +12,8 @@ name="%hostname-%n"
 
 # Path to a custom boostrap command to run. By default this is `buildkite-agent bootstrap`.
 # This allows you to override the entire execution of a job. Generally you should use hooks instead!
-# bootstrap-script="/path/to/script.bat"
+# See https://buildkite.com/docs/agent/hooks
+# bootstrap-script=""
 
 # Path to where the builds will run from
 build-path="builds"
@@ -34,6 +35,9 @@ plugins-path="plugins"
 
 # Don't allow this agent to run arbitrary console commands (2.2 and above with `buildkite bootstrap`)
 # no-command-eval=true
+
+# Don't allow this agent to run plugins
+# no-plugins=true
 
 # Enable debug mode
 # debug=true

--- a/packaging/linux/root/usr/share/buildkite-agent/bootstrap.sh
+++ b/packaging/linux/root/usr/share/buildkite-agent/bootstrap.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# This is a shim to make the upgrade process from v2 -> v3 smoother as
+# v2 configurations will still have bootstrap-path=/usr/share/buildkite-agent/bootstrap.sh
+# which will cause all sorts of wierd behaviour
+
+echo "+++ :warning: Your agent configuration contains an outdated bootstrap-path reference. It can be safely removed."
+exec buildkite-agent bootstrap "$@"

--- a/packaging/linux/root/usr/share/buildkite-agent/bootstrap.sh
+++ b/packaging/linux/root/usr/share/buildkite-agent/bootstrap.sh
@@ -7,7 +7,7 @@
 echo "+++ :warning: Your buildkite-agent.cfg file contains a deprecated bootstrap.sh"
 echo "As part of the upgrade from Agent v2 to v3, a bootstrap-script compatibility shim was added to your buildkite-agent.cfg."
 echo ""
-echo "To silence this warning, you can comment our the bootstrap-script line in your buildkite-agent.cfg file."
+echo "To silence this warning, you can comment out the bootstrap-script line in ${BUILDKITE_CONFIG_PATH:-buildkite-agent.cfg}."
 echo ""
 echo "For more information, see our Buildkite Agent 3.0 upgrade guide:"
 echo "https://buildkite.com/docs/agent/upgrading-to-v3"

--- a/packaging/linux/root/usr/share/buildkite-agent/bootstrap.sh
+++ b/packaging/linux/root/usr/share/buildkite-agent/bootstrap.sh
@@ -4,5 +4,12 @@
 # v2 configurations will still have bootstrap-path=/usr/share/buildkite-agent/bootstrap.sh
 # which will cause all sorts of wierd behaviour
 
-echo "+++ :warning: Your agent configuration contains an outdated bootstrap-path reference. It can be safely removed."
+echo "+++ :warning: Your buildkite-agent.cfg file contains a deprecated bootstrap.sh"
+echo "As part of the upgrade from Agent v2 to v3, a bootstrap-script compatibility shim was added to your buildkite-agent.cfg."
+echo ""
+echo "To silence this warning, you can comment our the bootstrap-script line in your buildkite-agent.cfg file."
+echo ""
+echo "For more information, see our Buildkite Agent 3.0 upgrade guide:"
+echo "https://buildkite.com/docs/agent/upgrading-to-v3"
+
 exec buildkite-agent bootstrap "$@"

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -19,16 +19,10 @@ name="%hostname-%n"
 # Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
 # tags-from-gcp=true
 
-# Path to the bootstrap script. You should avoid changing this file as it will
-# be overridden when you update your agent. If you need to make changes to this
-# file: use the hooks provided, or copy the file and reference it here.
-
-# DEPRECATION: As of v3 we've removed the shell version of bootstrap.sh file.
-# We've re-written it in Go (accessible via buildkite-agent bootstrap) so we
-# can have better cross-platform support.
-# You can still use your own custom bootstrap-script now, and that feature
-# will stick around for v3.x, so if you need to use it, just uncommment below
-# bootstrap-script="/path/to/custom/bootstrap.sh"
+# Path to a custom boostrap command to run. By default this is `buildkite-agent bootstrap`.
+# This allows you to override the entire execution of a job. Generally you should use hooks instead!
+# See https://buildkite.com/docs/agent/hooks
+# bootstrap-script=""
 
 # Path to where the builds will run from
 build-path="/var/lib/buildkite-agent/builds"
@@ -53,6 +47,9 @@ plugins-path="/etc/buildkite-agent/plugins"
 
 # Don't allow this agent to run arbitrary console commands
 # no-command-eval=true
+
+# Don't allow this agent to run plugins
+# no-plugins=true
 
 # Enable debug mode
 # debug=true

--- a/scripts/utils/build-github-release.sh
+++ b/scripts/utils/build-github-release.sh
@@ -56,6 +56,9 @@ else
   cp $BINARY_PATH $TMP_RELEASE_DIRECTORY/buildkite-agent
   chmod +x $TMP_RELEASE_DIRECTORY/buildkite-agent
 
+  info "Copying bootstrap"
+  cp $PACKAGING_DIRECTORY/linux/root/usr/share/buildkite-agent/bootstrap.sh $TMP_RELEASE_DIRECTORY
+
   info "Copying config"
   cp $PACKAGING_DIRECTORY/github/linux/buildkite-agent.cfg $TMP_RELEASE_DIRECTORY
 


### PR DESCRIPTION
This adds a bootstrap.sh shim that gets installed at the same location as the old v2.x bootstrap that prints a warning and then runs `buildkite-agent bootstrap`. This should mean that users that upgrade from v2 -> v3 don't run into problems because their config still refers to the v2 bootstrap.sh.