### PR TITLE
Bump interpolate library. Closes #585.

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,10 +15,10 @@
 			"revisionTime": "2017-02-17T01:53:35Z"
 		},
 		{
-			"checksumSHA1": "fmX02MaNcpetPq33vKO09KmZ64A=",
+			"checksumSHA1": "8mzUiJrhQ0COz4r98YlDICpWqsw=",
 			"path": "github.com/buildkite/interpolate",
-			"revision": "90db4cdaceb18147784c48c2350fbd53fb69881b",
-			"revisionTime": "2017-11-08T04:00:46Z"
+			"revision": "3a807e47135c4139351425cae51d4bd485150282",
+			"revisionTime": "2017-11-14T09:02:18Z"
 		},
 		{
 			"checksumSHA1": "bplZOqTp6JAbkn25zHEPIob25WI=",


### PR DESCRIPTION
There was a parser bug in the new expansion interpolator (https://github.com/buildkite/interpolate). This caused infinite loops when trying to interpolate certain strings like `\` or `$`.  