### PR TITLE
Don't retry pipeline uploads on 422 responses

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -180,6 +180,12 @@ var PipelineUploadCommand = cli.Command{
 			_, err = client.Pipelines.Upload(cfg.Job, &api.Pipeline{UUID: uuid, Pipeline: parsed, Replace: cfg.Replace})
 			if err != nil {
 				logger.Warn("%s (%s)", err, s)
+				apierr := err.(*api.ErrorResponse)
+				// 422 responses will always fail no need to retry
+				if apierr.Response.StatusCode == 422 {
+					logger.Error("Unrecoverable error, skipping retries")
+					s.Break()
+				}
 			}
 
 			return err


### PR DESCRIPTION
Some example 422 responses on pipeline upload:

```
WARN   POST https://agent.buildkite.com/v3/jobs/<uuid>/pipelines: 422 One of the steps you provided was invalid: can't be blank, The step type supplied is not supported (Attempt 1/5 Retrying in 1s)
WARN   POST https://agent.buildkite.com/v3/jobs/<uuid>/pipelines: 422 One of the steps you provided was invalid: The reason provided to `skip` is too long. The maximum length is 70 characters (Attempt 1/5 Retrying in 1s)
```

These will never succeed on retry, so save some time by bailing early.
 

