### PR TITLE
Add a `--spawn` option to spawn multiple parallel agents

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -34,6 +34,7 @@ type AgentPool struct {
 	DisableHTTP2          bool
 	AgentConfiguration    *AgentConfiguration
 	MetricsCollector      *metrics.Collector
+	Workers               int
 
 	interruptCount int
 	signalLock     sync.Mutex
@@ -50,16 +51,32 @@ func (r *AgentPool) Start() error {
 		DisableHTTP2: r.DisableHTTP2,
 	}.Create()
 
-	// Create the agent template. We use pass this template to the register
-	// call, at which point we get back a real agent.
-	template := r.CreateAgentTemplate()
+	var wg sync.WaitGroup
 
-	logger.Info("Registering agent with Buildkite...")
+	for i := 0; i < r.Workers; i++ {
+		if r.Workers == 1 {
+			logger.Info("Registering agent with Buildkite...")
+		} else {
+			logger.Info("Registering agent %d of %d with Buildkite...", i+1, r.Workers)
+		}
 
-	// Register the agent
-	registered, err := r.RegisterAgent(template)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := r.startWorker(); err != nil {
+				logger.Fatal("%v", err)
+			}
+		}()
+	}
+
+	wg.Wait()
+	return nil
+}
+
+func (r *AgentPool) startWorker() error {
+	registered, err := r.RegisterAgent(r.CreateAgentTemplate())
 	if err != nil {
-		logger.Fatal("%s", err)
+		return err
 	}
 
 	logger.Info("Successfully registered agent \"%s\" with tags [%s]", registered.Name,
@@ -81,7 +98,7 @@ func (r *AgentPool) Start() error {
 
 	logger.Info("Connecting to Buildkite...")
 	if err := worker.Connect(); err != nil {
-		logger.Fatal("%s", err)
+		return err
 	}
 
 	logger.Info("Agent successfully connected")
@@ -117,15 +134,16 @@ func (r *AgentPool) Start() error {
 		}
 	})
 
-	// Starts the agent worker. This will block until the agent has
-	// finished or is stopped.
+	// Starts the agent worker.
 	if err := worker.Start(); err != nil {
-		logger.Fatal("%s", err)
+		return err
 	}
 
 	// Now that the agent has stopped, we can disconnect it
 	logger.Info("Disconnecting %s...", worker.Agent.Name)
-	worker.Disconnect()
+	if err := worker.Disconnect(); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -34,7 +34,7 @@ type AgentPool struct {
 	DisableHTTP2          bool
 	AgentConfiguration    *AgentConfiguration
 	MetricsCollector      *metrics.Collector
-	Workers               int
+	Spawn                 int
 
 	interruptCount int
 	signalLock     sync.Mutex
@@ -53,11 +53,11 @@ func (r *AgentPool) Start() error {
 
 	var wg sync.WaitGroup
 
-	for i := 0; i < r.Workers; i++ {
-		if r.Workers == 1 {
+	for i := 0; i < r.Spawn; i++ {
+		if r.Spawn == 1 {
 			logger.Info("Registering agent with Buildkite...")
 		} else {
-			logger.Info("Registering agent %d of %d with Buildkite...", i+1, r.Workers)
+			logger.Info("Registering agent %d of %d with Buildkite...", i+1, r.Spawn)
 		}
 
 		wg.Add(1)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -292,8 +292,9 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_METRICS_DATADOG_HOST",
 			Value:  "127.0.0.1:8125",
 		cli.IntFlag{
-			Name:   "workers",
-			Usage:  "The number of parallel workers to run within this agent",
+			Name: "workers",
+			Usage: "The number of agent workers to run, each of which can handle a job concurrently. " +
+				"Each worker will register as a separate agent with a unique name.",
 			Value:  1,
 			EnvVar: "BUILDKITE_AGENT_WORKERS",
 		},

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -291,6 +291,7 @@ var AgentStartCommand = cli.Command{
 			Usage:  "The dogstatsd instance to send metrics to via udp",
 			EnvVar: "BUILDKITE_METRICS_DATADOG_HOST",
 			Value:  "127.0.0.1:8125",
+		},
 		cli.IntFlag{
 			Name:   "spawn",
 			Usage:  "The number of agents to spawn in parallel",
@@ -413,7 +414,6 @@ var AgentStartCommand = cli.Command{
 			WaitForEC2TagsTimeout: ec2TagTimeout,
 			Endpoint:              cfg.Endpoint,
 			DisableHTTP2:          cfg.NoHTTP2,
-			Workers:               cfg.Workers,
 			Spawn:                 cfg.Spawn,
 			AgentConfiguration: &agent.AgentConfiguration{
 				BootstrapScript:           cfg.BootstrapScript,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -74,7 +74,7 @@ type AgentStartConfig struct {
 	Experiments               []string `cli:"experiment" normalize:"list"`
 	MetricsDatadog            bool     `cli:"metrics-datadog"`
 	MetricsDatadogHost        string   `cli:"metrics-datadog-host"`
-	Workers                   int      `cli:"workers"`
+	Spawn                     int      `cli:"spawn"`
 
 	/* Deprecated */
 	NoSSHFingerprintVerification bool     `cli:"no-automatic-ssh-fingerprint-verification" deprecated-and-renamed-to:"NoSSHKeyscan"`
@@ -292,10 +292,10 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_METRICS_DATADOG_HOST",
 			Value:  "127.0.0.1:8125",
 		cli.IntFlag{
-			Name:   "workers",
-			Usage:  "The number of workers to run. Workers will register as separate agents, with unique names, and can run different jobs in parallel.",
+			Name:   "spawn",
+			Usage:  "The number of agents to spawn in parallel",
 			Value:  1,
-			EnvVar: "BUILDKITE_AGENT_WORKERS",
+			EnvVar: "BUILDKITE_AGENT_SPAWN",
 		},
 		ExperimentsFlag,
 		EndpointFlag,
@@ -414,6 +414,7 @@ var AgentStartCommand = cli.Command{
 			Endpoint:              cfg.Endpoint,
 			DisableHTTP2:          cfg.NoHTTP2,
 			Workers:               cfg.Workers,
+			Spawn:                 cfg.Spawn,
 			AgentConfiguration: &agent.AgentConfiguration{
 				BootstrapScript:           cfg.BootstrapScript,
 				BuildPath:                 cfg.BuildPath,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -74,6 +74,7 @@ type AgentStartConfig struct {
 	Experiments               []string `cli:"experiment" normalize:"list"`
 	MetricsDatadog            bool     `cli:"metrics-datadog"`
 	MetricsDatadogHost        string   `cli:"metrics-datadog-host"`
+	Workers                   int      `cli:"workers"`
 
 	/* Deprecated */
 	NoSSHFingerprintVerification bool     `cli:"no-automatic-ssh-fingerprint-verification" deprecated-and-renamed-to:"NoSSHKeyscan"`
@@ -290,6 +291,11 @@ var AgentStartCommand = cli.Command{
 			Usage:  "The dogstatsd instance to send metrics to via udp",
 			EnvVar: "BUILDKITE_METRICS_DATADOG_HOST",
 			Value:  "127.0.0.1:8125",
+		cli.IntFlag{
+			Name:   "workers",
+			Usage:  "The number of parallel workers to run within this agent",
+			Value:  1,
+			EnvVar: "BUILDKITE_AGENT_WORKERS",
 		},
 		ExperimentsFlag,
 		EndpointFlag,
@@ -407,6 +413,7 @@ var AgentStartCommand = cli.Command{
 			WaitForEC2TagsTimeout: ec2TagTimeout,
 			Endpoint:              cfg.Endpoint,
 			DisableHTTP2:          cfg.NoHTTP2,
+			Workers:               cfg.Workers,
 			AgentConfiguration: &agent.AgentConfiguration{
 				BootstrapScript:           cfg.BootstrapScript,
 				BuildPath:                 cfg.BuildPath,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -292,9 +292,8 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_METRICS_DATADOG_HOST",
 			Value:  "127.0.0.1:8125",
 		cli.IntFlag{
-			Name: "workers",
-			Usage: "The number of agent workers to run, each of which can handle a job concurrently. " +
-				"Each worker will register as a separate agent with a unique name.",
+			Name:   "workers",
+			Usage:  "The number of workers to run. Workers will register as separate agents, with unique names, and can run different jobs in parallel.",
 			Value:  1,
 			EnvVar: "BUILDKITE_AGENT_WORKERS",
 		},


### PR DESCRIPTION
Inspired by the long dormant https://github.com/buildkite/agent/tree/lol-workers and the need for high-concurrency agents for testing lockfiles, I added a hidden ~~`--workers`~~`--spawn` flag that specifies how many concurrent workers to run. 

Have been giving it a workout with `-race` on and have sorted out the various leaks. 