### PR TITLE
Match header expansion with trailing whitespace

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -50,7 +50,7 @@ type Process struct {
 // If you change header parsing here make sure to change it in the
 // buildkite.com frontend logic, too
 
-var headerExpansionRegex = regexp.MustCompile("^(?:\\^\\^\\^\\s+\\+\\+\\+)$")
+var headerExpansionRegex = regexp.MustCompile("^(?:\\^\\^\\^\\s+\\+\\+\\+)\\s*$")
 
 func (p *Process) Start() error {
 	args, err := shellwords.Parse(p.Script)


### PR DESCRIPTION
**Problem**
In https://github.com/buildkite/agent/pull/438 I added a `regex` which insures the timestamp option (`--timestamp-lines=true`) does not prefix header expansion directives (`^^^ +++`). At some point since that PR this feature has broken again, and timestamps are being added therefore failing to expand headers.

**Solution**
Modify the `regex` to accept optional trailing whitespace.

**Steps to reproduce**
Run agent as follows:

> ./buildkite-agent start --build-path=/tmp --debug --token "FOOBAR" --tags=queue=my-debug-queue --timestamp-lines=true

With this simple pipeline:

```
#!/usr/bin/env bash
set -e

echo "Hello world"
echo "--- My first group"
echo "foobar"
echo "--- My second group"
echo "foobar"
echo "^^^ +++"
echo "--- My third group"
echo "foobar"
```

The second group will **not** be expanded because `^^^ +++` is prefixed with a timestamp.

**Cause**
The problem is limited to running with `--timestamp-lines=true` and the `pty` option enabled (default). When dumping the raw lines obtained by `bufio.Readline` we get:

> "^^^ +++\r\r\n"

Note that `bufio.ReadLine` will strip `\r\n` but the first `\r` will prevent the regex from matching.

I'm not sure why this is happening but if you run with `--no-pty` the second `\r` is not present.

@keithpitt @toolmantim 

