### PR TITLE
Fix a regression where artifact uploader returns error on no match

### DIFF
--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -82,7 +82,9 @@ func (a *ArtifactUploader) Collect() (artifacts []*api.Artifact, err error) {
 
 		// Resolve the globs (with * and ** in them)
 		files, err := zglob.Glob(globPath)
-		if err != nil {
+		if err == os.ErrNotExist {
+			return nil, nil
+		} else if err != nil {
 			return nil, err
 		}
 

--- a/agent/artifact_uploader_test.go
+++ b/agent/artifact_uploader_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/buildkite/agent/api"
@@ -70,4 +71,22 @@ func TestCollect(t *testing.T) {
 	assert.Equal(t, a.GlobPath, filepath.Join(root, "test/fixtures/artifacts/**/*.gif"))
 	assert.Equal(t, int(a.FileSize), 2038453)
 	assert.Equal(t, a.Sha1Sum, "bd4caf2e01e59777744ac1d52deafa01c2cb9bfd")
+}
+
+func TestCollectThatDoesntMatchAnyFiles(t *testing.T) {
+	wd, _ := os.Getwd()
+	root := filepath.Join(wd, "..")
+	os.Chdir(root)
+
+	uploader := ArtifactUploader{Paths: strings.Join([]string{
+		filepath.Join("log", "*"),
+		filepath.Join("tmp", "capybara", "**", "*"),
+		filepath.Join("mkmf.log"),
+		filepath.Join("log", "mkmf.log"),
+	}, ";")}
+
+	artifacts, err := uploader.Collect()
+
+	assert.Nil(t, err)
+	assert.Equal(t, len(artifacts), 0)
 }


### PR DESCRIPTION
This fixes an issue raised by @patrobinson:

>:wave: we updated to v2.6.7 recently and it seems while previously uploading an artifact that didn’t exist, not it causes a fatal error:

```$ buildkite-agent artifact upload log/\*\;\ tmp/capybara/\*\*/\*\;\ mkmf.log
2017-11-23 22:54:21 FATAL  Failed to upload artifacts: file does not exist
🚨 Buildkite Error    0s
Unable to upload artifacts
```

This was introduced when we moved to zglob in https://github.com/buildkite/agent/commit/7e1320bbbcdec75fc98beb2600e63308b12c1333. 