### PR TITLE
S3 streaming and zero size fixes

### DIFF
--- a/vendor/github.com/AdRoll/goamz/s3/s3.go
+++ b/vendor/github.com/AdRoll/goamz/s3/s3.go
@@ -1151,6 +1151,9 @@ func (s3 *S3) setupHttpRequest(req *request) (*http.Request, error) {
 	if v, ok := req.headers["Content-Length"]; ok {
 		hreq.ContentLength, _ = strconv.ParseInt(v[0], 10, 64)
 		delete(req.headers, "Content-Length")
+		if hreq.ContentLength == 0 {
+			req.payload = nil
+		}
 	}
 	if req.payload != nil {
 		hreq.Body = ioutil.NopCloser(req.payload)


### PR DESCRIPTION
Removes our wholesale buffering of s3 uploaded artifacts into memory by using PutReader (which is what goamz is doing under the hood anyway), and patches an issue introduced by newer Golang's net/http which was fixed upstream in https://github.com/goamz/goamz/pull/135. 

From [net/http docs](https://golang.org/pkg/net/http/):

> ContentLength records the length of the associated content.
>
> For client requests, a value of 0 with a non-nil Body is  also treated as unknown.

This is not an issue in master (v3 beta) because we've replaced goamz with the official aws-sdk.