### PR TITLE
Add agent-wide plugin support

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -5,6 +5,7 @@ type AgentConfiguration struct {
 	BuildPath                  string
 	HooksPath                  string
 	PluginsPath                string
+	Plugins                    []string
 	GitCloneFlags              string
 	GitCleanFlags              string
 	SSHFingerprintVerification bool

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -40,6 +40,7 @@ type AgentStartConfig struct {
 	BuildPath                    string   `cli:"build-path" normalize:"filepath" validate:"required"`
 	HooksPath                    string   `cli:"hooks-path" normalize:"filepath"`
 	PluginsPath                  string   `cli:"plugins-path" normalize:"filepath"`
+	Plugins                      []string `cli:"plugins"`
 	Tags                         []string `cli:"tags"`
 	TagsFromEC2                  bool     `cli:"tags-from-ec2"`
 	TagsFromEC2Tags              bool     `cli:"tags-from-ec2-tags"`
@@ -192,6 +193,12 @@ var AgentStartCommand = cli.Command{
 			Usage:  "Directory where the plugins are saved to",
 			EnvVar: "BUILDKITE_PLUGINS_PATH",
 		},
+		cli.StringSliceFlag{
+			Name:   "plugins",
+			Value:  &cli.StringSlice{},
+			Usage:  "A comma-separated list of plugins to preload for all jobs on this agent (e.g s3-secrets#1.1.0)",
+			EnvVar: "BUILDKITE_PLUGINS",
+		},
 		cli.BoolFlag{
 			Name:   "timestamp-lines",
 			Usage:  "Prepend timestamps on each line of output.",
@@ -301,6 +308,7 @@ var AgentStartCommand = cli.Command{
 				BuildPath:                  cfg.BuildPath,
 				HooksPath:                  cfg.HooksPath,
 				PluginsPath:                cfg.PluginsPath,
+				Plugins:                    cfg.Plugins,
 				GitCloneFlags:              cfg.GitCloneFlags,
 				GitCleanFlags:              cfg.GitCleanFlags,
 				SSHFingerprintVerification: !cfg.NoSSHFingerprintVerification,


### PR DESCRIPTION
One outstanding issue with our plugins is that there is a chicken-and-egg issue with plugins that are needed before you have your source code, for instance getting git credentials for checkout. 

This adds a new top-level configuration and env for adding agent plugins that are then loaded for every job that the agent processes:

```
--plugins value                              
A comma-separated list of plugins to preload for all jobs on this agent (e.g s3-secrets#1.1.0) [$BUILDKITE_PLUGINS]
```

This is then merged with whatever plugins are brought in via the pipeline. The agent-wide ones trump the pipeline ones. 

I'm not entirely comfortable with the name for these two. An agent plugin vs a pipeline plugin? Feels @keithpitt @toolmantim @sj26?
