### PR TITLE
Use a default value for bootstrap-script

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1,6 +1,7 @@
 package clicommand
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -36,7 +37,7 @@ type AgentStartConfig struct {
 	Priority                     string   `cli:"priority"`
 	DisconnectAfterJob           bool     `cli:"disconnect-after-job"`
 	DisconnectAfterJobTimeout    int      `cli:"disconnect-after-job-timeout"`
-	BootstrapScript              string   `cli:"bootstrap-script" normalize:"filepath" validate:"required"`
+	BootstrapScript              string   `cli:"bootstrap-script" normalize:"filepath"`
 	BuildPath                    string   `cli:"build-path" normalize:"filepath" validate:"required"`
 	HooksPath                    string   `cli:"hooks-path" normalize:"filepath"`
 	PluginsPath                  string   `cli:"plugins-path" normalize:"filepath"`
@@ -170,7 +171,7 @@ var AgentStartCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name:   "bootstrap-script",
-			Value:  "buildkite-agent bootstrap",
+			Value:  "",
 			Usage:  "Path to the bootstrap script",
 			EnvVar: "BUILDKITE_BOOTSTRAP_SCRIPT_PATH",
 		},
@@ -269,6 +270,11 @@ var AgentStartCommand = cli.Command{
 		// yet)
 		if runtime.GOOS == "windows" {
 			cfg.NoPTY = true
+		}
+
+		// Set a useful default for the bootstrap script
+		if cfg.BootstrapScript == "" {
+			cfg.BootstrapScript = fmt.Sprintf("%q bootstrap", os.Args[0])
 		}
 
 		// Make sure the DisconnectAfterJobTimeout value is correct

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -172,7 +172,7 @@ var AgentStartCommand = cli.Command{
 		cli.StringFlag{
 			Name:   "bootstrap-script",
 			Value:  "",
-			Usage:  "Path to the bootstrap script",
+			Usage:  "The command that is executed for bootstrapping a job, defaults to the bootstrap sub-command of this binary",
 			EnvVar: "BUILDKITE_BOOTSTRAP_SCRIPT_PATH",
 		},
 		cli.StringFlag{

--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -19,10 +19,9 @@ name="%hostname-%n"
 # Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
 # tags-from-gcp=true
 
-# Path to the bootstrap script. You should avoid changing this file as it will
-# be overridden when you update your agent. If you need to make changes to this
-# file: use the hooks provided, or copy the file and reference it here.
-bootstrap-script="$HOME/.buildkite-agent/bin/buildkite-agent bootstrap"
+# Path to a custom boostrap command to run. By default this is `buildkite-agent bootstrap`.
+# This allows you to override the entire execution of a job. Generally you should use hooks instead!
+# bootstrap-script="/path/to/script.sh"
 
 # Path to where the builds will run from
 build-path="$HOME/.buildkite-agent/builds"

--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -21,6 +21,7 @@ name="%hostname-%n"
 
 # Path to a custom boostrap command to run. By default this is `buildkite-agent bootstrap`.
 # This allows you to override the entire execution of a job. Generally you should use hooks instead!
+# See https://buildkite.com/docs/agent/hooks
 # bootstrap-script="/path/to/script.sh"
 
 # Path to where the builds will run from

--- a/packaging/github/windows/buildkite-agent.cfg
+++ b/packaging/github/windows/buildkite-agent.cfg
@@ -10,8 +10,9 @@ name="%hostname-%n"
 # Tags for the agent (default is "queue=default")
 # tags="key1=val2,key2=val2"
 
-# Path to the bootstrap command.
-bootstrap-script="buildkite-agent.exe bootstrap"
+# Path to a custom boostrap command to run. By default this is `buildkite-agent bootstrap`.
+# This allows you to override the entire execution of a job. Generally you should use hooks instead!
+# bootstrap-script="/path/to/script.bat"
 
 # Path to where the builds will run from
 build-path="builds"

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -24,11 +24,10 @@ name="%hostname-%n"
 # file: use the hooks provided, or copy the file and reference it here.
 
 # DEPRECATION: As of v3 we've removed the shell version of bootstrap.sh file.
-# We've re-written it in Go so we can have better cross-platform support, and
-# add new features such as plugin support - which is much harder to write in
-# bash. You can still use your own custom bootstrap-script now, and that feature
-# will stick around for v3.x, so if you need to use it, just uncommment the line
-# below :)
+# We've re-written it in Go (accessible via buildkite-agent bootstrap) so we
+# can have better cross-platform support.
+# You can still use your own custom bootstrap-script now, and that feature
+# will stick around for v3.x, so if you need to use it, just uncommment below
 # bootstrap-script="/path/to/custom/bootstrap.sh"
 
 # Path to where the builds will run from


### PR DESCRIPTION
Automatically detects the path to the running binary and uses that as a default for the bootstrap-script path. This makes it a little easier to develop against as `go run` will work.