### PR TITLE
Update buildkite-agent.cfg to show new defaults for git-clean-flags

### DIFF
--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -37,7 +37,7 @@ plugins-path="$HOME/.buildkite-agent/plugins"
 # git-clone-flags=-v
 
 # Flags to pass to the `git clean` command
-# git-clean-flags=-fdq
+# git-clean-flags=-fxdq
 
 # Do not run jobs within a pseudo terminal
 # no-pty=true

--- a/packaging/github/windows/buildkite-agent.cfg
+++ b/packaging/github/windows/buildkite-agent.cfg
@@ -26,7 +26,7 @@ plugins-path="plugins"
 # git-clone-flags=-v
 
 # Flags to pass to the `git clean` command
-# git-clean-flags=-fdq
+# git-clean-flags=-fxdq
 
 # Don't automatically verify SSH fingerprints (2.2 and above with `buildkite bootstrap`)
 # no-automatic-ssh-fingerprint-verification=true

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -44,7 +44,7 @@ plugins-path="/etc/buildkite-agent/plugins"
 # git-clone-flags=-v
 
 # Flags to pass to the `git clean` command
-# git-clean-flags=-fdq
+# git-clean-flags=-fxdq
 
 # Do not run jobs within a pseudo terminal
 # no-pty=true


### PR DESCRIPTION
As part of v3, we updated the defaults for `git-clean-flags` to add `-x`. It doesn't look like this is reflected in the packaging default configs. This updates them.