### PR TITLE
Fix race condition in process.Process

### DIFF
--- a/process/process_test.go
+++ b/process/process_test.go
@@ -3,19 +3,30 @@ package process_test
 import (
 	"fmt"
 	"os"
+	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/buildkite/agent/process"
 )
 
-func TestProcessRuns(t *testing.T) {
-	var processStarted bool
+const longTestOutput = `+++ My header
+llamas
+and more llamas
+a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line
+and some alpacas
+`
+
+func TestProcessRunsAndCallsStartCallback(t *testing.T) {
+	var started int32
 
 	p := process.Process{
 		Script: os.Args[0],
 		Env:    []string{"TEST_MAIN=tester"},
 		StartCallback: func() {
-			processStarted = true
+			atomic.AddInt32(&started, 1)
 		},
 		LineCallback:       func(s string) {},
 		LinePreProcessor:   func(s string) string { return s },
@@ -26,8 +37,87 @@ func TestProcessRuns(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !processStarted {
-		t.Fatal("StartCallback wasn't called")
+	if startedVal := atomic.LoadInt32(&started); startedVal != 1 {
+		t.Fatalf("Expected started to be 1, got %d", startedVal)
+	}
+
+	if exitStatus := p.ExitStatus; exitStatus != "0" {
+		t.Fatalf("Expected ExitStatus of 0, got %v", exitStatus)
+	}
+
+	output := p.Output()
+	if output != string(longTestOutput) {
+		t.Fatalf("Output was unexpected:\nWanted: %q\nGot:    %q\n", longTestOutput, output)
+	}
+}
+
+func TestProcessCallsLineCallbacksForEachOutputLine(t *testing.T) {
+	var lineCounter int32
+	var lines []string
+	var linesLock sync.Mutex
+
+	p := process.Process{
+		Script:        os.Args[0],
+		Env:           []string{"TEST_MAIN=tester"},
+		StartCallback: func() {},
+		LineCallback: func(s string) {
+			linesLock.Lock()
+			defer linesLock.Unlock()
+			lines = append(lines, s)
+		},
+		LinePreProcessor: func(s string) string {
+			lineNumber := atomic.AddInt32(&lineCounter, 1)
+			return fmt.Sprintf("#%d: chars %d", lineNumber, len(s))
+		},
+		LineCallbackFilter: func(s string) bool {
+			return true
+		},
+	}
+
+	if err := p.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	linesLock.Lock()
+
+	var expected = []string{
+		`#1: chars 13`,
+		`#2: chars 6`,
+		`#3: chars 15`,
+		`#4: chars 237`,
+		`#5: chars 16`,
+	}
+
+	if !reflect.DeepEqual(expected, lines) {
+		t.Fatalf("Lines was unexpected:\nWanted: %v\nGot:    %v\n", expected, lines)
+	}
+}
+
+func TestProcessOutputIsSafeFromRaces(t *testing.T) {
+	p := process.Process{
+		Script:             os.Args[0],
+		Env:                []string{"TEST_MAIN=tester"},
+		LineCallback:       func(s string) {},
+		LinePreProcessor:   func(s string) string { return s },
+		LineCallbackFilter: func(s string) bool { return true },
+	}
+
+	// the job_runner has a for loop that calls IsRunning and Output, so this checks those are safe from races
+	p.StartCallback = func() {
+		for p.IsRunning() {
+			t.Logf("Output: %s", p.Output())
+			time.Sleep(time.Millisecond * 20)
+		}
+		t.Logf("Not running anymore")
+	}
+
+	if err := p.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := p.Output()
+	if output != string(longTestOutput) {
+		t.Fatalf("Output was unexpected:\nWanted: %q\nGot:    %q\n", longTestOutput, output)
 	}
 }
 
@@ -35,7 +125,8 @@ func TestProcessRuns(t *testing.T) {
 func TestMain(m *testing.M) {
 	switch os.Getenv("TEST_MAIN") {
 	case "tester":
-		fmt.Println("Llamas are the best")
+		fmt.Printf(longTestOutput)
+		time.Sleep(time.Millisecond * 50)
 		os.Exit(0)
 	default:
 		os.Exit(m.Run())

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -1,0 +1,43 @@
+package process_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/buildkite/agent/process"
+)
+
+func TestProcessRuns(t *testing.T) {
+	var processStarted bool
+
+	p := process.Process{
+		Script: os.Args[0],
+		Env:    []string{"TEST_MAIN=tester"},
+		StartCallback: func() {
+			processStarted = true
+		},
+		LineCallback:       func(s string) {},
+		LinePreProcessor:   func(s string) string { return s },
+		LineCallbackFilter: func(s string) bool { return true },
+	}
+
+	if err := p.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !processStarted {
+		t.Fatal("StartCallback wasn't called")
+	}
+}
+
+// Invoked by `go test`, switch between helper and running tests based on env
+func TestMain(m *testing.M) {
+	switch os.Getenv("TEST_MAIN") {
+	case "tester":
+		fmt.Println("Llamas are the best")
+		os.Exit(0)
+	default:
+		os.Exit(m.Run())
+	}
+}

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 echo '+++ Running tests'
 
-go test $(go list ./... | grep -v /vendor/)
+go test -v -race ./...


### PR DESCRIPTION
This adds test coverage for `process.Process` and fixes a race that is caused by the jobRunner calling `process.Output()` in go routine: https://github.com/buildkite/agent/blob/e3fa0d1ed2f46fd001382586dfcd478bed97ce99/agent/job_runner.go#L259-L273
The fix is a `bytes.Buffer` that is wrapped with a RWMutex. 

Originally part of https://github.com/buildkite/agent/pull/599. 