### PR TITLE
Fix bug where a failing glob would cause later globs to be ignored

### DIFF
--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -80,10 +80,11 @@ func (a *ArtifactUploader) Collect() (artifacts []*api.Artifact, err error) {
 
 		logger.Debug("Searching for %s", globPath)
 
-		// Resolve the globs (with * and ** in them)
+		// Resolve the globs (with * and ** in them), if it's a non-globbed path and doesn't exists
+		// then we will get the ErrNotExist that is handled below
 		files, err := zglob.Glob(globPath)
 		if err == os.ErrNotExist {
-			logger.Info("No files matched glob: %s", globPath)
+			logger.Info("File not found: %s", globPath)
 			continue
 		} else if err != nil {
 			return nil, err

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -83,7 +83,8 @@ func (a *ArtifactUploader) Collect() (artifacts []*api.Artifact, err error) {
 		// Resolve the globs (with * and ** in them)
 		files, err := zglob.Glob(globPath)
 		if err == os.ErrNotExist {
-			return nil, nil
+			logger.Info("No files matched glob: %s", globPath)
+			continue
 		} else if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This also brings in a revamped test for the uploader that I've been working on for windows compatibility. 

Closes #619.  