### PR TITLE
Actually apply the Stdout/Stderr flags in shell.executeCommand

### DIFF
--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -315,9 +315,16 @@ func (s *Shell) executeCommand(cmd *exec.Cmd, w io.Writer, flags executeFlags) e
 			// See https://github.com/buildkite/agent/pull/34#issuecomment-46080419
 		}
 	} else {
-		cmd.Stdout = w
+		cmd.Stdout = nil
 		cmd.Stderr = nil
 		cmd.Stdin = nil
+
+		if flags.Stdout {
+			cmd.Stdout = w
+		}
+		if flags.Stderr {
+			cmd.Stderr = w
+		}
 
 		if s.Debug {
 			stdOutStreamer := NewLoggerStreamer(s.Logger)

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -321,20 +321,17 @@ func (s *Shell) executeCommand(cmd *exec.Cmd, w io.Writer, flags executeFlags) e
 
 		if flags.Stdout {
 			cmd.Stdout = w
-		}
-		if flags.Stderr {
-			cmd.Stderr = w
-		}
-
-		if s.Debug {
+		} else if s.Debug {
 			stdOutStreamer := NewLoggerStreamer(s.Logger)
 			defer stdOutStreamer.Close()
+			cmd.Stdout = stdOutStreamer
+		}
 
+		if flags.Stderr {
+			cmd.Stderr = w
+		} else if s.Debug {
 			stdErrStreamer := NewLoggerStreamer(s.Logger)
 			defer stdErrStreamer.Close()
-
-			// write the stdout to the writer and stream both stdout and stderr to the logger
-			cmd.Stdout = io.MultiWriter(stdOutStreamer, w)
 			cmd.Stderr = stdErrStreamer
 		}
 


### PR DESCRIPTION
Ooops. Actually implement the branch logic that was supposed to be core in #625.