### PR TITLE
Support older git versions with submodules

### DIFF
--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -89,7 +89,7 @@ func gitEnumerateSubmoduleURLs(sh *shell.Shell) ([]string, error) {
 	// Entering 'vendor/frontend/vendor/emojis'
 	// git@github.com:buildkite/emojis.git
 	output, err := sh.RunAndCapture(
-		"git", "submodule", "foreach", "--recursive", "git", "remote", "get-url", "origin")
+		"git", "submodule", "foreach", "--recursive", "git", "config", "--get", "remote.origin.url")
 	if err != nil {
 		return nil, err
 	}

--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -89,7 +89,7 @@ func gitEnumerateSubmoduleURLs(sh *shell.Shell) ([]string, error) {
 	// Entering 'vendor/frontend/vendor/emojis'
 	// git@github.com:buildkite/emojis.git
 	output, err := sh.RunAndCapture(
-		"git", "submodule", "foreach", "--recursive", "git", "config", "--get", "remote.origin.url")
+		"git", "submodule", "foreach", "--recursive", "git", "ls-remote", "--get-url")
 	if err != nil {
 		return nil, err
 	}

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -42,7 +42,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 		{"submodule", "foreach", "--recursive", "git", "reset", "--hard"},
 		{"clean", "-fdq"},
 		{"submodule", "foreach", "--recursive", "git", "clean", "-fdq"},
-		{"submodule", "foreach", "--recursive", "git", "remote", "get-url", "origin"},
+		{"submodule", "foreach", "--recursive", "git", "config", "--get", "remote.origin.url"},
 		{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color"},
 		{"--no-pager", "branch", "--contains", "HEAD", "--no-color"},
 	})

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -42,7 +42,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 		{"submodule", "foreach", "--recursive", "git", "reset", "--hard"},
 		{"clean", "-fdq"},
 		{"submodule", "foreach", "--recursive", "git", "clean", "-fdq"},
-		{"submodule", "foreach", "--recursive", "git", "config", "--get", "remote.origin.url"},
+		{"submodule", "foreach", "--recursive", "git", "ls-remote", "--get-url"},
 		{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color"},
 		{"--no-pager", "branch", "--contains", "HEAD", "--no-color"},
 	})


### PR DESCRIPTION
Previously `git remote get-url origin` was used to determine the origin url for submodules. This was only introduced in git 2.7, so it caused errors on older installations (e.g Ubuntu 14.04). 

This replaces it with `git config --get remote.origin.url`, which from what I can tell should be backwards compatible and acomplish the same thing.

Closes #602.