### PR TITLE
Fix broken tests for windows

### DIFF
--- a/bootstrap/hook_test.go
+++ b/bootstrap/hook_test.go
@@ -1,7 +1,7 @@
 package bootstrap
 
 import (
-	"io"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -14,18 +14,27 @@ import (
 )
 
 func TestRunningHookDetectsChangedEnvironment(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skipf("Not tested on windows yet")
-	}
-
 	t.Parallel()
 
-	wrapper := newTestHookWrapper(t, []string{
-		"#!/bin/bash",
-		"export LLAMAS=rock",
-		"export Alpacas=\"are ok\"",
-		"echo hello world",
-	})
+	var script []string
+
+	if runtime.GOOS != "windows" {
+		script = []string{
+			"#!/bin/bash",
+			"export LLAMAS=rock",
+			"export Alpacas=\"are ok\"",
+			"echo hello world",
+		}
+	} else {
+		script = []string{
+			"@echo off",
+			"set LLAMAS=rock",
+			"set Alpacas=are ok",
+			"echo hello world",
+		}
+	}
+
+	wrapper := newTestHookWrapper(t, script)
 	defer os.Remove(wrapper.Path())
 
 	sh := newTestShell(t)
@@ -45,10 +54,6 @@ func TestRunningHookDetectsChangedEnvironment(t *testing.T) {
 }
 
 func TestRunningHookDetectsChangedWorkingDirectory(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skipf("Not tested on windows yet")
-	}
-
 	t.Parallel()
 
 	tempDir, err := ioutil.TempDir("", "hookwrapperdir")
@@ -57,12 +62,25 @@ func TestRunningHookDetectsChangedWorkingDirectory(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	wrapper := newTestHookWrapper(t, []string{
-		"#!/bin/bash",
-		"mkdir mysubdir",
-		"cd mysubdir",
-		"echo hello world",
-	})
+	var script []string
+
+	if runtime.GOOS != "windows" {
+		script = []string{
+			"#!/bin/bash",
+			"mkdir mysubdir",
+			"cd mysubdir",
+			"echo hello world",
+		}
+	} else {
+		script = []string{
+			"@echo off",
+			"mkdir mysubdir",
+			"cd mysubdir",
+			"echo hello world",
+		}
+	}
+
+	wrapper := newTestHookWrapper(t, script)
 	defer os.Remove(wrapper.Path())
 
 	sh := newTestShell(t)
@@ -103,13 +121,18 @@ func newTestShell(t *testing.T) *shell.Shell {
 }
 
 func newTestHookWrapper(t *testing.T, script []string) *hookScriptWrapper {
-	hookFile, err := ioutil.TempFile("", "hookwrapper")
+	hookName := "hookwrapper"
+	if runtime.GOOS == "windows" {
+		hookName += ".bat"
+	}
+
+	hookFile, err := shell.TempFileWithExtension(hookName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, line := range script {
-		if _, err = io.WriteString(hookFile, line+"\n"); err != nil {
+		if _, err = fmt.Fprintln(hookFile, line); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/bootstrap/integration/bootstrap_tester.go
+++ b/bootstrap/integration/bootstrap_tester.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -97,6 +98,18 @@ func NewBootstrapTester() (*BootstrapTester, error) {
 		PluginsDir: pluginsDir,
 	}
 
+	// Windows requires certain env variables to be present
+	if runtime.GOOS == "windows" {
+		bt.Env = append(bt.Env,
+			"SystemRoot="+os.Getenv("SystemRoot"),
+			"WINDIR="+os.Getenv("WINDIR"),
+			"COMSPEC="+os.Getenv("COMSPEC"),
+			"PATHEXT="+os.Getenv("PATHEXT"),
+			"TMP="+os.Getenv("TMP"),
+			"TEMP="+os.Getenv("TEMP"),
+		)
+	}
+
 	if err = bt.LinkCommonCommands(); err != nil {
 		return nil, err
 	}
@@ -113,6 +126,9 @@ func NewBootstrapTester() (*BootstrapTester, error) {
 
 // LinkLocalCommand creates a symlink for commands into the tester PATH
 func (b *BootstrapTester) LinkLocalCommand(name string) error {
+	if runtime.GOOS == "windows" && !strings.HasSuffix(name, ".exe") {
+		name += ".exe"
+	}
 	if !filepath.IsAbs(name) {
 		var err error
 		name, err = exec.LookPath(name)
@@ -120,19 +136,23 @@ func (b *BootstrapTester) LinkLocalCommand(name string) error {
 			return err
 		}
 	}
+	// Good grief windows, symlinks for executables are a shitshow, writing batch works
+	if runtime.GOOS == "windows" {
+		batchPath := strings.TrimSuffix(filepath.Join(b.PathDir, filepath.Base(name)), ".exe") + ".bat"
+		return ioutil.WriteFile(batchPath, []byte(fmt.Sprintf("@\"%s\" %%*", name)), 0777)
+	}
+
 	return os.Symlink(name, filepath.Join(b.PathDir, filepath.Base(name)))
 }
 
 // Link common commands from system path, these can be mocked as needed
 func (b *BootstrapTester) LinkCommonCommands() error {
-	if runtime.GOOS != "windows" {
-		for _, bin := range []string{
-			"ls", "tr", "mkdir", "cp", "sed", "basename", "uname", "chmod",
-			"touch", "env", "grep", "sort", "cat", "true", "git", "ssh-keyscan",
-		} {
-			if err := b.LinkLocalCommand(bin); err != nil {
-				return err
-			}
+	for _, bin := range []string{
+		"ls", "tr", "mkdir", "cp", "sed", "basename", "uname", "chmod",
+		"touch", "env", "grep", "sort", "cat", "true", "false", "git", "ssh-keyscan",
+	} {
+		if err := b.LinkLocalCommand(bin); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -148,7 +168,7 @@ func (b *BootstrapTester) Mock(name string) (*bintest.Mock, error) {
 	b.mocks = append(b.mocks, mock)
 
 	// move the mock into our path
-	if err := os.Rename(mock.Path, filepath.Join(b.PathDir, name)); err != nil {
+	if err := os.Rename(mock.Path, filepath.Join(b.PathDir, filepath.Base(mock.Path))); err != nil {
 		return mock, err
 	}
 
@@ -168,7 +188,7 @@ func (b *BootstrapTester) MustMock(t *testing.T, name string) *bintest.Mock {
 // HasMock returns true if a mock has been created by that name
 func (b *BootstrapTester) HasMock(name string) bool {
 	for _, m := range b.mocks {
-		if m.Name == name {
+		if strings.TrimSuffix(m.Name, filepath.Ext(m.Name)) == name {
 			return true
 		}
 	}
@@ -177,9 +197,15 @@ func (b *BootstrapTester) HasMock(name string) bool {
 
 // writeHookScript generates a buildkite-agent hook script that calls a mock binary
 func (b *BootstrapTester) writeHookScript(m *bintest.Mock, name string, dir string, args ...string) (string, error) {
-	// TODO: support windows tests
 	hookScript := filepath.Join(dir, name)
-	body := "#!/bin/sh\n" + strings.Join(append([]string{m.Path}, args...), " ")
+	body := ""
+
+	if runtime.GOOS == "windows" {
+		body = fmt.Sprintf("@\"%s\" %s", m.Path, strings.Join(args, " "))
+		hookScript += ".bat"
+	} else {
+		body = "#!/bin/sh\n" + strings.Join(append([]string{m.Path}, args...), " ")
+	}
 
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return "", err
@@ -236,13 +262,18 @@ func (b *BootstrapTester) Run(t *testing.T, env ...string) error {
 			AndExitWith(0)
 	}
 
-	cmd := exec.Command(b.Name, b.Args...)
+	path, err := exec.LookPath(b.Name)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(path, b.Args...)
 	buf := &buffer{}
 	cmd.Stdout = io.MultiWriter(buf, w)
 	cmd.Stderr = io.MultiWriter(buf, w)
 	cmd.Env = append(b.Env, env...)
 
-	err := cmd.Run()
+	err = cmd.Run()
 	b.Output = buf.String()
 	return err
 }

--- a/bootstrap/integration/hooks_integration_test.go
+++ b/bootstrap/integration/hooks_integration_test.go
@@ -21,17 +21,26 @@ func TestEnvironmentVariablesPassBetweenHooks(t *testing.T) {
 	}
 	defer tester.Close()
 
-	if runtime.GOOS == "windows" {
-		t.Skip("Not implemented for windows yet")
-	}
+	if runtime.GOOS != "windows" {
+		var script = []string{
+			"#!/bin/bash",
+			"export LLAMAS_ROCK=absolutely",
+		}
 
-	var script = []string{
-		"#!/bin/bash",
-		"export LLAMAS_ROCK=absolutely",
-	}
+		if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "environment"),
+			[]byte(strings.Join(script, "\n")), 0700); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		var script = []string{
+			"@echo off",
+			"set LLAMAS_ROCK=absolutely",
+		}
 
-	if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "environment"), []byte(strings.Join(script, "\n")), 0700); err != nil {
-		t.Fatal(err)
+		if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "environment.bat"),
+			[]byte(strings.Join(script, "\r\n")), 0700); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	git := tester.MustMock(t, "git").PassthroughToLocalCommand().Before(func(i bintest.Invocation) error {

--- a/bootstrap/integration/main_test.go
+++ b/bootstrap/integration/main_test.go
@@ -24,6 +24,7 @@ func compileBootstrap(dir string) string {
 	}
 
 	cmd := exec.Command("go", "build", "-o", binPath, "main.go")
+	cmd.Env = os.Environ()
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Dir = projectRoot

--- a/bootstrap/integration/main_test.go
+++ b/bootstrap/integration/main_test.go
@@ -19,6 +19,10 @@ func compileBootstrap(dir string) string {
 	projectRoot := filepath.Join(filepath.Dir(filename), "..", "..")
 	binPath := filepath.Join(dir, "buildkite-agent")
 
+	if runtime.GOOS == "windows" {
+		binPath += ".exe"
+	}
+
 	cmd := exec.Command("go", "build", "-o", binPath, "main.go")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/bootstrap/integration/plugin_integration_test.go
+++ b/bootstrap/integration/plugin_integration_test.go
@@ -1,10 +1,12 @@
 package integration
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -23,13 +25,25 @@ func TestRunningPlugins(t *testing.T) {
 
 	pluginMock := tester.MustMock(t, "my-plugin")
 
-	p := createTestPlugin(t, map[string][]string{
-		"environment": []string{
-			"#!/bin/bash",
-			"export LLAMAS_ROCK=absolutely",
-			pluginMock.Path + " testing",
-		},
-	})
+	var p *testPlugin
+
+	if runtime.GOOS == "windows" {
+		p = createTestPlugin(t, map[string][]string{
+			"environment.bat": []string{
+				"@echo off",
+				"set LLAMAS_ROCK=absolutely",
+				pluginMock.Path + " testing",
+			},
+		})
+	} else {
+		p = createTestPlugin(t, map[string][]string{
+			"environment": []string{
+				"#!/bin/bash",
+				"export LLAMAS_ROCK=absolutely",
+				pluginMock.Path + " testing",
+			},
+		})
+	}
 
 	json, err := p.ToJSON()
 	if err != nil {
@@ -97,5 +111,16 @@ func (tp *testPlugin) ToJSON() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(`[{"%s#%s":{"setting":"blah"}}]`, tp.Path, strings.TrimSpace(commitHash)), nil
+	normalizedPath := strings.TrimPrefix(strings.Replace(tp.Path, "\\", "/", -1), "/")
+
+	var p = []interface{}{map[string]interface{}{
+		fmt.Sprintf(`file:///%s#%s`, normalizedPath, strings.TrimSpace(commitHash)): map[string]string{
+			"settings": "blah",
+		},
+	}}
+	b, err := json.Marshal(&p)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }

--- a/bootstrap/shell/shell_test.go
+++ b/bootstrap/shell/shell_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -68,7 +69,12 @@ func TestRun(t *testing.T) {
 
 	actual := out.String()
 
-	if expected := "$ " + sshKeygen.Path + " -f my_hosts -F llamas.com\nLlama party! 🎉\n"; actual != expected {
+	promptPrefix := "$"
+	if runtime.GOOS == "windows" {
+		promptPrefix = ">"
+	}
+
+	if expected := promptPrefix + " " + sshKeygen.Path + " -f my_hosts -F llamas.com\nLlama party! 🎉\n"; actual != expected {
 		t.Fatalf("Expected %q, got %q", expected, actual)
 	}
 }

--- a/bootstrap/shell/shell_test.go
+++ b/bootstrap/shell/shell_test.go
@@ -99,7 +99,10 @@ func TestWorkingDir(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// macos has a symlinked temp dir
-	tempDir, _ = filepath.EvalSymlinks(tempDir)
+	if runtime.GOOS == "darwin" {
+		tempDir, _ = filepath.EvalSymlinks(tempDir)
+	}
+
 	dirs := []string{tempDir, "my", "test", "dirs"}
 
 	if err := os.MkdirAll(filepath.Join(dirs...), 0700); err != nil {
@@ -109,7 +112,7 @@ func TestWorkingDir(t *testing.T) {
 	currentWd, _ := os.Getwd()
 
 	sh, err := shell.New()
-	sh.Logger = shell.DiscardLogger
+	sh.Logger = shell.TestingLogger{t}
 
 	if err != nil {
 		t.Fatal(err)
@@ -126,9 +129,19 @@ func TestWorkingDir(t *testing.T) {
 			t.Fatalf("Expected working dir %q, got %q", dir, actual)
 		}
 
-		out, err := sh.RunAndCapture("pwd")
-		if err != nil {
-			t.Fatal(err)
+		var out string
+
+		// there is no pwd for windows, and getting it requires using a shell builtin
+		if runtime.GOOS == "windows" {
+			out, err = sh.RunAndCapture("cmd", "/c", "echo", "%cd%")
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			out, err = sh.RunAndCapture("pwd")
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 
 		if actual := out; actual != dir {


### PR DESCRIPTION
Now that there is a windows test suite and dedicated agent, this fixes all of the broken tests.

I don't love how we have to generate test scripts for windows/nix in the integration tests, but it was the simplest way forward. When #636 lands, we can possibly ditch them, although I think exercising our code with windows batch files is probably worthwhile.