### PR TITLE
Fix bug where env export had trailing \r on windows

### DIFF
--- a/env/export.go
+++ b/env/export.go
@@ -42,6 +42,9 @@ func FromExport(body string) *Environment {
 	// Remove any white space at the start and the end of the export string
 	body = strings.TrimSpace(body)
 
+	// Normalize \r\n to just \n
+	body = strings.Replace(body, "\r\n", "\n", -1)
+
 	// Split up the export into lines
 	lines := strings.Split(body, "\n")
 

--- a/env/export_test.go
+++ b/env/export_test.go
@@ -1,157 +1,238 @@
 package env
 
 import (
+	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
-func TestFromExport(t *testing.T) {
-	// Handles new lines
-	env := FromExport(`declare -x USER="keithpitt"
-declare -x VAR1="boom\nboom\nshake\nthe\nroom"
-declare -x VAR2="hello
-friends"
-declare -x VAR3="hello
-friends
-OMG=foo
-test"
-declare -x SOMETHING="0"
-declare -x VAR4="ends with a space "
-declare -x VAR5="ends with
-another space "
-declare -x VAR6="ends with a quote \"
-and a new line \""
-declare -x _="/usr/local/bin/watch"`)
-	assert.Equal(t, []string{
-		"SOMETHING=0",
-		"USER=keithpitt",
-		"VAR1=boom\\nboom\\nshake\\nthe\\nroom",
-		"VAR2=hello\nfriends",
-		"VAR3=hello\nfriends\nOMG=foo\ntest",
-		"VAR4=ends with a space ",
-		"VAR5=ends with\nanother space ",
-		"VAR6=ends with a quote \"\nand a new line \"",
-		"_=/usr/local/bin/watch",
-	}, env.ToSlice())
+func TestFromExportHandlesNewlines(t *testing.T) {
+	var lines = []string{
+		`declare -x USER="keithpitt"`,
+		`declare -x VAR1="boom\nboom\nshake\nthe\nroom"`,
+		`declare -x VAR2="hello`,
+		`friends"`,
+		`declare -x VAR3="hello`,
+		`friends`,
+		`OMG=foo`,
+		`test"`,
+		`declare -x SOMETHING="0"`,
+		`declare -x VAR4="ends with a space "`,
+		`declare -x VAR5="ends with`,
+		`another space "`,
+		`declare -x VAR6="ends with a quote \"`,
+		`and a new line \""`,
+		`declare -x _="/usr/local/bin/watch"`,
+	}
 
-	// Escapes stuff
-	env = FromExport(`declare -x DOLLARS="i love \$money"
-declare -x WITH_NEW_LINE="i have a \\n new line"
-declare -x CARRIAGE_RETURN="i have a \\r carriage"
-declare -x TOTES="with a \" quote"`)
+	env := FromExport(strings.Join(lines, "\n"))
 
-	assertEqualEnv(t, "DOLLARS", "i love $money", env)
-	assertEqualEnv(t, "WITH_NEW_LINE", `i have a \n new line`, env)
-	assertEqualEnv(t, "CARRIAGE_RETURN", `i have a \r carriage`, env)
-	assertEqualEnv(t, "TOTES", `with a " quote`, env)
-
-	// Handles environment variables with no "=" in them
-	env = FromExport(`declare -x THING_TOTES
-declare -x HTTP_PROXY="http://proxy.example.com:1234/"
-declare -x LANG="en_US.UTF-8"
-declare -x LOGNAME="buildkite-agent"
-declare -x SOME_VALUE="this is my value"
-declare -x OLDPWD
-declare -x SOME_OTHER_VALUE="this is my value across
-new
-lines"
-declare -x OLDPWD2
-declare -x GONNA_TRICK_YOU="the next line is a string
-declare -x WITH_A_STRING="I'm a string!!
-"
-declare -x PATH="/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-declare -x PWD="/"
-`)
-
-	assertEqualEnv(t, "LANG", "en_US.UTF-8", env)
-	assertEqualEnv(t, "LOGNAME", `buildkite-agent`, env)
-	assertEqualEnv(t, "SOME_VALUE", `this is my value`, env)
-	assertEqualEnv(t, "OLDPWD", ``, env)
-	assertEqualEnv(t, "SOME_OTHER_VALUE", "this is my value across\nnew\nlines", env)
-	assertEqualEnv(t, "OLDPWD2", ``, env)
-	assertEqualEnv(t, "GONNA_TRICK_YOU", "the next line is a string\ndeclare -x WITH_A_STRING=\"I'm a string!!\n", env)
-	assertEqualEnv(t, "PATH", `/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`, env)
-	assertEqualEnv(t, "PWD", `/`, env)
-
-	// Disregards new lines at the start and end of the export
-	env = FromExport(`
-
-
-
-declare -x DOLLARS="i love \$money"
-declare -x WITH_NEW_LINE="i have a \\n new line"
-declare -x CARRIAGE_RETURN="i have a \\r carriage"
-declare -x TOTES="with a \" quote"
-
-
-
-`)
-
-	assertEqualEnv(t, "DOLLARS", "i love $money", env)
-	assertEqualEnv(t, "WITH_NEW_LINE", `i have a \n new line`, env)
-	assertEqualEnv(t, "CARRIAGE_RETURN", `i have a \r carriage`, env)
-	assertEqualEnv(t, "TOTES", `with a " quote`, env)
-
-	// Handles JSON
-	env = FromExport(`declare -x FOO="{
-  \"key\": \"test\",
-  \"hello\": [
-    1,
-    2,
-    3
-  ]
-}"`)
-
-	assertEqualEnv(t, "FOO", `{
-  "key": "test",
-  "hello": [
-    1,
-    2,
-    3
-  ]
-}`, env)
-
-	// Works with Windows output
-	env = FromExport(`SESSIONNAME=Console
-SystemDrive=C:
-SystemRoot=C:\Windows
-TEMP=C:\Users\IEUser\AppData\Local\Temp
-TMP=C:\Users\IEUser\AppData\Local\Temp
-USERDOMAIN=IE11WIN10`)
-
-	assert.Equal(t, []string{
-		"SESSIONNAME=Console",
-		"SystemDrive=C:",
-		"SystemRoot=C:\\Windows",
-		"TEMP=C:\\Users\\IEUser\\AppData\\Local\\Temp",
-		"TMP=C:\\Users\\IEUser\\AppData\\Local\\Temp",
-		"USERDOMAIN=IE11WIN10",
-	}, env.ToSlice())
-
-	// Works with Windows output that has spaces at the start and end
-	env = FromExport(`
-
-SESSIONNAME=Console
-SystemDrive=C:
-SystemRoot=C:\Windows
-TEMP=C:\Users\IEUser\AppData\Local\Temp
-TMP=C:\Users\IEUser\AppData\Local\Temp
-USERDOMAIN=IE11WIN10
-
-`)
-
-	assert.Equal(t, []string{
-		"SESSIONNAME=Console",
-		"SystemDrive=C:",
-		"SystemRoot=C:\\Windows",
-		"TEMP=C:\\Users\\IEUser\\AppData\\Local\\Temp",
-		"TMP=C:\\Users\\IEUser\\AppData\\Local\\Temp",
-		"USERDOMAIN=IE11WIN10",
-	}, env.ToSlice())
+	for k, expected := range map[string]string{
+		`SOMETHING`: `0`,
+		`USER`:      `keithpitt`,
+		`VAR1`:      "boom\\nboom\\nshake\\nthe\\nroom",
+		`VAR2`:      "hello\nfriends",
+		`VAR3`:      "hello\nfriends\nOMG=foo\ntest",
+		`VAR4`:      `ends with a space `,
+		`VAR5`:      "ends with\nanother space ",
+		`VAR6`:      "ends with a quote \"\nand a new line \"",
+		`_`:         `/usr/local/bin/watch`,
+	} {
+		val, _ := env.Get(k)
+		if val != expected {
+			t.Fatalf("Expected %s to be %q, got %q", k, expected, val)
+		}
+	}
 }
 
-func assertEqualEnv(t *testing.T, key string, expected string, env *Environment) {
-	v, _ := env.Get(key)
-	assert.Equal(t, expected, v)
+func TestFromExportHandlesEscapedCharacters(t *testing.T) {
+	var lines = []string{
+		`declare -x DOLLARS="i love \$money"`,
+		`declare -x WITH_NEW_LINE="i have a \\n new line"`,
+		`declare -x CARRIAGE_RETURN="i have a \\r carriage"`,
+		`declare -x TOTES="with a \" quote"`,
+	}
+
+	env := FromExport(strings.Join(lines, "\n"))
+
+	for k, expected := range map[string]string{
+		`DOLLARS`:         `i love $money`,
+		`WITH_NEW_LINE`:   `i have a \n new line`,
+		`CARRIAGE_RETURN`: `i have a \r carriage`,
+		`TOTES`:           `with a " quote`,
+	} {
+		val, _ := env.Get(k)
+		if val != expected {
+			t.Fatalf("Expected %s to be %q, got %q", k, expected, val)
+		}
+	}
+}
+
+func TestFromExportWithVariablesWithoutEquals(t *testing.T) {
+	var lines = []string{
+		`declare -x THING_TOTES`,
+		`declare -x HTTP_PROXY="http://proxy.example.com:1234/"`,
+		`declare -x LANG="en_US.UTF-8"`,
+		`declare -x LOGNAME="buildkite-agent"`,
+		`declare -x SOME_VALUE="this is my value"`,
+		`declare -x OLDPWD`,
+		`declare -x SOME_OTHER_VALUE="this is my value across`,
+		`new`,
+		`lines"`,
+		`declare -x OLDPWD2`,
+		`declare -x GONNA_TRICK_YOU="the next line is a string`,
+		`declare -x WITH_A_STRING="I'm a string!!`,
+		`"`,
+		`declare -x PATH="/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"`,
+		`declare -x PWD="/"`,
+	}
+
+	env := FromExport(strings.Join(lines, "\n"))
+
+	for k, expected := range map[string]string{
+		"LANG":             "en_US.UTF-8",
+		"LOGNAME":          `buildkite-agent`,
+		"SOME_VALUE":       `this is my value`,
+		"OLDPWD":           ``,
+		"SOME_OTHER_VALUE": "this is my value across\nnew\nlines",
+		"OLDPWD2":          ``,
+		"GONNA_TRICK_YOU":  "the next line is a string\ndeclare -x WITH_A_STRING=\"I'm a string!!\n",
+		"PATH":             `/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`,
+		"PWD":              `/`,
+	} {
+		val, _ := env.Get(k)
+		if val != expected {
+			t.Fatalf("Expected %s to be %q, got %q", k, expected, val)
+		}
+	}
+}
+
+func TestFromExportWithLeadingAndTrailingWhitespace(t *testing.T) {
+	var lines = []string{
+		``,
+		``,
+		``,
+		`declare -x DOLLARS="i love \$money"`,
+		`declare -x WITH_NEW_LINE="i have a \\n new line"`,
+		`declare -x CARRIAGE_RETURN="i have a \\r carriage"`,
+		`declare -x TOTES="with a \" quote"`,
+		``,
+		``,
+		``,
+		``,
+	}
+	env := FromExport(strings.Join(lines, "\n"))
+
+	if env.Length() != 4 {
+		t.Fatalf("Expected length of 4, got %d", env.Length())
+	}
+
+	for k, expected := range map[string]string{
+		`DOLLARS`:         "i love $money",
+		`WITH_NEW_LINE`:   `i have a \n new line`,
+		`CARRIAGE_RETURN`: `i have a \r carriage`,
+		`TOTES`:           `with a " quote`,
+	} {
+		val, _ := env.Get(k)
+		if val != expected {
+			t.Fatalf("Expected %s to be %q, got %q", k, expected, val)
+		}
+	}
+}
+
+func TestFromExportJSONInside(t *testing.T) {
+	var lines = []string{
+		`declare -x FOO="{`,
+		`	\"key\": \"test\",`,
+		`	\"hello\": [`,
+		`	  1,`,
+		`	  2,`,
+		`	  3`,
+		`	]`,
+		`  }"`,
+	}
+
+	var expected = []string{
+		`{`,
+		`	"key": "test",`,
+		`	"hello": [`,
+		`	  1,`,
+		`	  2,`,
+		`	  3`,
+		`	]`,
+		`  }`,
+	}
+
+	env := FromExport(strings.Join(lines, "\n"))
+
+	if actual, _ := env.Get("FOO"); actual != strings.Join(expected, "\n") {
+		t.Fatalf("Expected %q, got %q", actual, strings.Join(expected, "\n"))
+	}
+}
+
+func TestFromExportFromWindows(t *testing.T) {
+	var lines = []string{
+		`SESSIONNAME=Console`,
+		`SystemDrive=C:`,
+		`SystemRoot=C:\Windows`,
+		`TEMP=C:\Users\IEUser\AppData\Local\Temp`,
+		`TMP=C:\Users\IEUser\AppData\Local\Temp`,
+		`USERDOMAIN=IE11WIN10`,
+	}
+
+	env := FromExport(strings.Join(lines, "\r\n"))
+
+	if env.Length() != 6 {
+		t.Fatalf("Expected length of 6, got %d", env.Length())
+	}
+
+	for k, expected := range map[string]string{
+		`SESSIONNAME`: "Console",
+		`SystemDrive`: "C:",
+		`SystemRoot`:  "C:\\Windows",
+		`TEMP`:        "C:\\Users\\IEUser\\AppData\\Local\\Temp",
+		`TMP`:         "C:\\Users\\IEUser\\AppData\\Local\\Temp",
+		`USERDOMAIN`:  "IE11WIN10",
+	} {
+		val, _ := env.Get(k)
+		if val != expected {
+			t.Fatalf("Expected %s to be %q, got %q", k, expected, val)
+		}
+	}
+}
+
+func TestFromExportFromWindowsWithLeadingAndTrailingSpaces(t *testing.T) {
+	var lines = []string{
+		``,
+		``,
+		``,
+		`SESSIONNAME=Console`,
+		`SystemDrive=C:`,
+		`SystemRoot=C:\Windows`,
+		`TEMP=C:\Users\IEUser\AppData\Local\Temp`,
+		`TMP=C:\Users\IEUser\AppData\Local\Temp`,
+		`USERDOMAIN=IE11WIN10`,
+		``,
+		``,
+		``,
+	}
+
+	env := FromExport(strings.Join(lines, "\r\n"))
+
+	if env.Length() != 6 {
+		t.Fatalf("Expected length of 6, got %d", env.Length())
+	}
+
+	for k, expected := range map[string]string{
+		`SESSIONNAME`: "Console",
+		`SystemDrive`: "C:",
+		`SystemRoot`:  "C:\\Windows",
+		`TEMP`:        "C:\\Users\\IEUser\\AppData\\Local\\Temp",
+		`TMP`:         "C:\\Users\\IEUser\\AppData\\Local\\Temp",
+		`USERDOMAIN`:  "IE11WIN10",
+	} {
+		val, _ := env.Get(k)
+		if val != expected {
+			t.Fatalf("Expected %s to be %q, got %q", k, expected, val)
+		}
+	}
 }

--- a/env/export_test.go
+++ b/env/export_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFromExportHandlesNewlines(t *testing.T) {
@@ -153,7 +153,9 @@ func TestFromExportFromWindows(t *testing.T) {
 
 	env := FromExport(strings.Join(lines, "\r\n"))
 
-	require.Equal(t, env.Length(), 6)
+	if !assert.Equal(t, env.Length(), 6) {
+		t.FailNow()
+	}
 
 	assertEqualEnv(t, `SESSIONNAME`, "Console", env)
 	assertEqualEnv(t, `SystemDrive`, "C:", env)
@@ -181,7 +183,9 @@ func TestFromExportFromWindowsWithLeadingAndTrailingSpaces(t *testing.T) {
 
 	env := FromExport(strings.Join(lines, "\r\n"))
 
-	require.Equal(t, env.Length(), 6)
+	if !assert.Equal(t, env.Length(), 6) {
+		t.FailNow()
+	}
 
 	assertEqualEnv(t, `SESSIONNAME`, "Console", env)
 	assertEqualEnv(t, `SystemDrive`, "C:", env)
@@ -194,5 +198,7 @@ func TestFromExportFromWindowsWithLeadingAndTrailingSpaces(t *testing.T) {
 func assertEqualEnv(t *testing.T, key string, expected string, env *Environment) {
 	t.Helper()
 	v, _ := env.Get(key)
-	require.Equal(t, expected, v)
+	if !assert.Equal(t, expected, v) {
+		t.FailNow()
+	}
 }


### PR DESCRIPTION
See bug reported in https://github.com/buildkite/agent/pull/569.