### PR TITLE
Add a windows-dev docker-compose for development

### DIFF
--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -13,6 +13,11 @@ RUN choco install -y git.install -params '"/GitAndUnixToolsOnPath"' && \
   choco install -y openssh && \
   choco install -y golang
 
+# Hack for mounting in code later (Use G:)
+# See https://github.com/moby/moby/issues/27537#issuecomment-271546031
+VOLUME c:/data
+RUN powershell set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'G:' -Value '\??\C:\data' -Type String
+
 # Copy across the agent source
 ENV GOPATH=c:/gopath
 WORKDIR c:/gopath/src/github.com/buildkite/agent

--- a/docker-compose.windows-dev.yml
+++ b/docker-compose.windows-dev.yml
@@ -1,0 +1,32 @@
+version: "3.2"
+
+# This is a docker-compose file designed to be called in macOS and translate through to windows
+
+# Windows docker has some challenges, namely that bind mounts can't be over existing directories and
+# symlinks are used, so we need to do create a new gopath and mount it at the root of the gopath. This
+# means we count on $GOPATH having a single entry and it being under your macOS user directory. Mine
+# is /Users/lachlan/go.
+
+# See https://github.com/docker/compose/issues/5371 and https://github.com/moby/moby/issues/27537#issuecomment-271546031
+# for some details of the horrors within
+
+services:
+  agent:
+    build:
+      dockerfile: Dockerfile-windows
+      context: .
+    working_dir: G:/src/github.com/buildkite/agent
+    environment:
+      - BUILDKITE_BUILD_NUMBER
+      - "BUILDKITE_AGENT_TAGS=queue=default"
+      - "BUILDKITE_BUILD_PATH=c:\\buildkite"
+      - "GOPATH=G:\\"
+    volumes:
+      - type: bind
+        source: "C:${GOPATH}"
+        target: "C:/data"
+
+networks:
+  default:
+    external:
+      name: nat

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -1,7 +1,6 @@
 version: "3.2"
 
 # This is a docker-compose file designed to be called in macOS and translate through to windows
-# Binding is basically impossible, see https://github.com/docker/compose/issues/5371
 
 services:
   agent:


### PR DESCRIPTION
This took me ages, it's now a working environment for mounting in code from macOS all the way through to a VMWare-based windows VM. Makes iterating on windows stuff much easier.