### PR TITLE
Add log extension with type of 'text/plain'

### DIFF
--- a/mime/mime.go
+++ b/mime/mime.go
@@ -497,6 +497,7 @@ var types = []string{
 	"pot", "text/plain",
 	"brf", "text/plain",
 	"srt", "text/plain",
+	"log", "text/plain",
 	"rtx", "text/richtext",
 	"sct", "text/scriptlet",
 	"wsc", "text/scriptlet",


### PR DESCRIPTION
We have a lot of these :) I can't find a good central authority for default mime types, but at least python will detect `text/plain`, so we won't be blazing a trail.

```
Python 2.7.13 (default, Dec 18 2016, 07:03:39)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import mimetypes
>>> mimetypes.guess_type('foo.log')
('text/plain', None)
```