### PR TITLE
Format go test output and output junit xml

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
     artifact_paths: "tmp/junit-*.xml"
     command: "scripts/tests.sh"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         run: agent
 
   - name: ":hammer: :windows:"
@@ -23,98 +23,98 @@ steps:
     command: "scripts/build-binary.sh windows 386"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         run: agent
 
   - name: ":windows: amd64"
     command: "scripts/build-binary.sh windows amd64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         run: agent
 
   - name: ":linux: amd64"
     command: "scripts/build-binary.sh linux amd64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         run: agent
 
   - name: ":linux: 386"
     command: "scripts/build-binary.sh linux 386"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         run: agent
 
   - name: ":linux: arm"
     command: "scripts/build-binary.sh linux arm"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         run: agent
 
   - name: ":linux: armhf"
     command: "scripts/build-binary.sh linux armhf"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         run: agent
 
   - name: ":linux: arm64"
     command: "scripts/build-binary.sh linux arm64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         run: agent
 
   - name: ":mac: 386"
     command: "scripts/build-binary.sh darwin 386"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         run: agent
 
   - name: ":mac: amd64"
     command: "scripts/build-binary.sh darwin amd64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         run: agent
 
   - name: ":freebsd: amd64"
     command: "scripts/build-binary.sh freebsd amd64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         run: agent
 
   - name: ":freebsd: 386"
     command: "scripts/build-binary.sh freebsd 386"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         run: agent
 
   - name: ":openbsd: amd64"
     command: "scripts/build-binary.sh openbsd amd64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         run: agent
 
   - name: ":openbsd: 386"
     command: "scripts/build-binary.sh openbsd 386"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         run: agent
 
   - name: ":dragonflybsd: amd64"
     command: "scripts/build-binary.sh dragonfly amd64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         run: agent
 
   - wait
@@ -140,7 +140,7 @@ steps:
     command: "scripts/build-github-release.sh"
     artifact_paths: "releases/**/*"
     plugins:
-      docker-compose#v1.5.0:
+      docker-compose#v1.8.0:
         config: docker-compose.release.yml
         run: github-release
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,7 @@ env:
 
 steps:
   - name: ":hammer: :linux:"
+    artifact_paths: "tmp/junit-*.xml"
     command: "scripts/tests.sh"
     plugins:
       docker-compose#v1.5.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,6 +17,13 @@ steps:
       commit: "${BUILDKITE_COMMIT}"
       branch: "${BUILDKITE_BRANCH}"
 
+  - wait: ~
+    continue_on_failure: true
+
+  - label: ":junit:"
+    commands:
+      - "scripts/junit.sh"
+
   - wait
 
   - name: ":windows: 386"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,6 @@ services:
       - ./:/go/src/github.com/buildkite/agent:cached
     environment:
       - BUILDKITE_BUILD_NUMBER
+      - BUILDKITE_JOB_ID
       - "BUILDKITE_AGENT_TAGS=queue=default"
       - "BUILDKITE_BUILD_PATH=/buildkite"

--- a/scripts/junit.sh
+++ b/scripts/junit.sh
@@ -6,7 +6,7 @@ echo "--- :junit: Download the junits"
 buildkite-agent artifact download tmp/junit-*.xml tmp
 
 echo "--- :junit::golang: Processing the junits"
-docker run --rm -v "$(pwd):/app" -w /app gugahoi/junit-report-converter > tmp/annotation.md
+docker run --rm -v "${PWD}:${PWD}" -w "$PWD" gugahoi/junit-report-converter tmp/junit-*.xml > tmp/annotation.md
 
 echo "--- :buildkite: Creating annotation"
 buildkite-agent annotate --context junit --style error < tmp/annotation.md

--- a/scripts/junit.sh
+++ b/scripts/junit.sh
@@ -8,5 +8,7 @@ buildkite-agent artifact download tmp/junit-*.xml tmp
 echo "--- :junit::golang: Processing the junits"
 docker run --rm -v "${PWD}:${PWD}" -w "$PWD" gugahoi/junit-report-converter tmp/junit-*.xml > tmp/annotation.md
 
-echo "--- :buildkite: Creating annotation"
-buildkite-agent annotate --context junit --style error < tmp/annotation.md
+if [[ -s tmp/annotation.md ]] ; then
+  echo "--- :buildkite: Creating annotation"
+  buildkite-agent annotate --context junit --style error < tmp/annotation.md
+fi

--- a/scripts/junit.sh
+++ b/scripts/junit.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+mkdir -p tmp
+
+echo "--- :junit: Download the junits"
+buildkite-agent artifact download tmp/junit-*.xml tmp
+
+echo "--- :junit::golang: Processing the junits"
+docker run --rm -v "$(pwd):/app" -w /app gugahoi/junit-report-converter > tmp/annotation.md
+
+echo "--- :buildkite: Creating annotation"
+buildkite-agent annotate --context junit --style error < tmp/annotation.md

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+mkdir tmp/
 
 echo "~~~ Installing test dependencies"
 go get github.com/kyoh86/richgo

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
 set -euo pipefail
+
+echo "~~~ Installing test dependencies"
+go get github.com/kyoh86/richgo
+go get github.com/jstemmer/go-junit-report
+
 echo '+++ Running tests'
-go test -race -v ./...
+go test -race ./... 2>&1 | tee tmp/output.txt | richgo testfilter
+
+echo "~~~ Creating junit output"
+go-junit-report < tmp/output.txt > "tmp/junit-${BUILDKITE_JOB_ID}.xml"


### PR DESCRIPTION
Currently the go test output gets mangled by our header detection. This uses richgo and also grabs the junit xml output.