### PR TITLE
Set Content-Disposition on uploads to GCS

### DIFF
--- a/agent/gs_uploader.go
+++ b/agent/gs_uploader.go
@@ -84,8 +84,9 @@ func (u *GSUploader) Upload(artifact *api.Artifact) error {
 			u.artifactPath(artifact), u.BucketName(), permission)
 	}
 	object := &storage.Object{
-		Name:        u.artifactPath(artifact),
-		ContentType: u.mimeType(artifact),
+		Name:               u.artifactPath(artifact),
+		ContentType:        u.mimeType(artifact),
+		ContentDisposition: u.contentDisposition(artifact),
 	}
 	file, err := os.Open(artifact.AbsolutePath)
 	if err != nil {
@@ -148,4 +149,8 @@ func (u *GSUploader) mimeType(a *api.Artifact) string {
 	} else {
 		return "binary/octet-stream"
 	}
+}
+
+func (u *GSUploader) contentDisposition(a *api.Artifact) string {
+	return fmt.Sprintf("inline; filename=\"%s\"", filepath.Base(a.Path))
 }


### PR DESCRIPTION
Closes #634 

This makes the default filenames more sensible when downloading from GCS in a browser:

![2018-01-22 at 14 03](https://user-images.githubusercontent.com/398706/35224613-7b0b99b0-ff7d-11e7-810d-650af5a77da3.gif)

I have tested this with directory trees and files with spaces in the name, they are handled correctly.