### PR TITLE
Fix incorrect polarity on IsTerminal check

### DIFF
--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -108,7 +108,7 @@ var AnnotateCommand = cli.Command{
 
 		if cfg.Body != "" {
 			body = cfg.Body
-		} else if terminal.IsTerminal(int(os.Stdin.Fd())) {
+		} else if !terminal.IsTerminal(int(os.Stdin.Fd())) {
 			logger.Info("Reading annotation body from STDIN")
 
 			// Actually read the file from STDIN

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -103,7 +103,7 @@ var PipelineUploadCommand = cli.Command{
 			if err != nil {
 				logger.Fatal("Failed to read file: %s", err)
 			}
-		} else if terminal.IsTerminal(int(os.Stdin.Fd())) {
+		} else if !terminal.IsTerminal(int(os.Stdin.Fd())) {
 			logger.Info("Reading pipeline config from STDIN")
 
 			// Actually read the file from STDIN


### PR DESCRIPTION
I broke pipeline uploads from stdin in #636. I removed the previous `IsStdin` technology in favour of  https://godoc.org/golang.org/x/crypto/ssh/terminal#IsTerminal, but I neglected to account for them having opposite meanings. 😓