### PR TITLE
Allow the shell interpreter to be configured

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -14,4 +14,5 @@ type AgentConfiguration struct {
 	TimestampLines             bool
 	DisconnectAfterJob         bool
 	DisconnectAfterJobTimeout  int
+	Shell                      string
 }

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -67,7 +67,7 @@ func (r JobRunner) Create() (runner *JobRunner, err error) {
 	runner.logStreamer = LogStreamer{MaxChunkSizeBytes: r.Job.ChunksMaxSizeBytes, Callback: r.onUploadChunk}.New()
 
 	// Prepare a file to recieve the given job environment
-	if file, err := ioutil.TempFile("", fmt.Sprintf("job-env-%s", runner.Job.ID)) ; err != nil {
+	if file, err := ioutil.TempFile("", fmt.Sprintf("job-env-%s", runner.Job.ID)); err != nil {
 		return runner, err
 	} else {
 		logger.Debug("[JobRunner] Created env file: %s", file.Name())
@@ -188,7 +188,7 @@ func (r *JobRunner) createEnvironment() []string {
 	// We present only the clean environment - i.e only variables configured
 	// on the job upstream - and expose the path in another environment variable.
 	if r.envFile != nil {
-		for key, value := range(env) {
+		for key, value := range env {
 			r.envFile.WriteString(fmt.Sprintf("%s=%s\n", key, value))
 		}
 		r.envFile.Close()
@@ -215,6 +215,7 @@ func (r *JobRunner) createEnvironment() []string {
 	env["BUILDKITE_PLUGINS_ENABLED"] = fmt.Sprintf("%t", r.AgentConfiguration.PluginsEnabled)
 	env["BUILDKITE_GIT_CLONE_FLAGS"] = r.AgentConfiguration.GitCloneFlags
 	env["BUILDKITE_GIT_CLEAN_FLAGS"] = r.AgentConfiguration.GitCleanFlags
+	env["BUILDKITE_SHELL"] = r.AgentConfiguration.Shell
 
 	// Convert the env map into a slice (which is what the script gear
 	// needs)

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -96,6 +96,9 @@ type Config struct {
 
 	// Whether or not to automatically authorize SSH key hosts
 	SSHFingerprintVerification bool
+
+	// The shell used to execute commands
+	Shell string
 }
 
 // ReadFromEnvironment reads configuration from the Environment, returns a map

--- a/bootstrap/integration/docker_integration_test.go
+++ b/bootstrap/integration/docker_integration_test.go
@@ -1,19 +1,10 @@
 package integration
 
 import (
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/lox/bintest/proxy"
 )
-
-func jobScriptName(jobId string) string {
-	if runtime.GOOS == "windows" {
-		return filepath.FromSlash("./buildkite-script-"+jobId) + ".bat"
-	}
-	return filepath.FromSlash("./buildkite-script-" + jobId)
-}
 
 func TestRunningCommandWithDocker(t *testing.T) {
 	tester, err := NewBootstrapTester()
@@ -39,7 +30,7 @@ func TestRunningCommandWithDocker(t *testing.T) {
 	docker := tester.MustMock(t, "docker")
 	docker.ExpectAll([][]interface{}{
 		{"build", "-f", "Dockerfile", "-t", imageId, "."},
-		{"run", "--name", containerId, imageId, jobScriptName(jobId)},
+		{"run", "--name", containerId, imageId, "true"},
 		{"rm", "-f", "-v", containerId},
 	})
 
@@ -73,7 +64,7 @@ func TestRunningCommandWithDockerAndCustomDockerfile(t *testing.T) {
 	docker := tester.MustMock(t, "docker")
 	docker.ExpectAll([][]interface{}{
 		{"build", "-f", "Dockerfile.llamas", "-t", imageId, "."},
-		{"run", "--name", containerId, imageId, jobScriptName(jobId)},
+		{"run", "--name", containerId, imageId, "true"},
 		{"rm", "-f", "-v", containerId},
 	})
 
@@ -109,7 +100,7 @@ func TestRunningFailingCommandWithDocker(t *testing.T) {
 		{"rm", "-f", "-v", containerId},
 	})
 
-	docker.Expect("run", "--name", containerId, imageId, jobScriptName(jobId)).
+	docker.Expect("run", "--name", containerId, imageId, "true").
 		AndExitWith(1)
 
 	expectCommandHooks("1", t, tester)
@@ -138,13 +129,12 @@ func TestRunningCommandWithDockerCompose(t *testing.T) {
 		"BUILDKITE_DOCKER_COMPOSE_CONTAINER=llamas",
 	}
 
-	jobId := "1111-1111-1111-1111"
 	projectName := "buildkite1111111111111111"
 
 	dockerCompose := tester.MustMock(t, "docker-compose")
 	dockerCompose.ExpectAll([][]interface{}{
 		{"-f", "docker-compose.yml", "-p", projectName, "--verbose", "build", "--pull", "llamas"},
-		{"-f", "docker-compose.yml", "-p", projectName, "--verbose", "run", "llamas", jobScriptName(jobId)},
+		{"-f", "docker-compose.yml", "-p", projectName, "--verbose", "run", "llamas", "true"},
 		{"-f", "docker-compose.yml", "-p", projectName, "--verbose", "kill"},
 		{"-f", "docker-compose.yml", "-p", projectName, "--verbose", "rm", "--force", "--all", "-v"},
 		{"-f", "docker-compose.yml", "-p", projectName, "--verbose", "down"},
@@ -172,7 +162,6 @@ func TestRunningFailingCommandWithDockerCompose(t *testing.T) {
 		"BUILDKITE_DOCKER_COMPOSE_CONTAINER=llamas",
 	}
 
-	jobId := "1111-1111-1111-1111"
 	projectName := "buildkite1111111111111111"
 
 	dockerCompose := tester.MustMock(t, "docker-compose")
@@ -183,7 +172,7 @@ func TestRunningFailingCommandWithDockerCompose(t *testing.T) {
 		{"-f", "docker-compose.yml", "-p", projectName, "--verbose", "down"},
 	})
 
-	dockerCompose.Expect("-f", "docker-compose.yml", "-p", projectName, "--verbose", "run", "llamas", jobScriptName(jobId)).
+	dockerCompose.Expect("-f", "docker-compose.yml", "-p", projectName, "--verbose", "run", "llamas", "true").
 		AndWriteToStderr("Nope!").
 		AndExitWith(1)
 
@@ -214,13 +203,12 @@ func TestRunningCommandWithDockerComposeAndExtraConfig(t *testing.T) {
 		"BUILDKITE_DOCKER_COMPOSE_FILE=dc1.yml:dc2.yml:dc3.yml",
 	}
 
-	jobId := "1111-1111-1111-1111"
 	projectName := "buildkite1111111111111111"
 
 	dockerCompose := tester.MustMock(t, "docker-compose")
 	dockerCompose.ExpectAll([][]interface{}{
 		{"-f", "dc1.yml", "-f", "dc2.yml", "-f", "dc3.yml", "-p", projectName, "--verbose", "build", "--pull", "llamas"},
-		{"-f", "dc1.yml", "-f", "dc2.yml", "-f", "dc3.yml", "-p", projectName, "--verbose", "run", "llamas", jobScriptName(jobId)},
+		{"-f", "dc1.yml", "-f", "dc2.yml", "-f", "dc3.yml", "-p", projectName, "--verbose", "run", "llamas", "true"},
 		{"-f", "dc1.yml", "-f", "dc2.yml", "-f", "dc3.yml", "-p", projectName, "--verbose", "kill"},
 		{"-f", "dc1.yml", "-f", "dc2.yml", "-f", "dc3.yml", "-p", projectName, "--verbose", "rm", "--force", "--all", "-v"},
 		{"-f", "dc1.yml", "-f", "dc2.yml", "-f", "dc3.yml", "-p", projectName, "--verbose", "down"},

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -67,9 +67,13 @@ type AgentStartConfig struct {
 }
 
 func DefaultShell() string {
-	if runtime.GOOS == "windows" {
-		return `C:\Windows\System32\CMD.EXE /S /C`
-	} else {
+	// https://github.com/golang/go/blob/master/src/go/build/syslist.go#L7
+	switch runtime.GOOS {
+	case "windows":
+		return `C:\Windows\System32\CMD.exe /S /C`
+	case "freebsd", "openbsd", "netbsd":
+		return `/usr/local/bin/bash -e -c`
+	default:
 		return `/bin/bash -e -c`
 	}
 }

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -68,10 +68,9 @@ type AgentStartConfig struct {
 
 func DefaultShell() string {
 	if runtime.GOOS == "windows" {
-		return "C:\\Windows\\System32\\CMD.EXE /S /C"
+		return `C:\Windows\System32\CMD.EXE /S /C`
 	} else {
-		return "/bin/bash -c"
-
+		return `/bin/bash -e -c`
 	}
 }
 
@@ -297,6 +296,8 @@ var AgentStartCommand = cli.Command{
 		if cfg.Shell == "" {
 			cfg.Shell = DefaultShell()
 		}
+
+		logger.Debug("Using shell %q", cfg.Shell)
 
 		// Make sure the DisconnectAfterJobTimeout value is correct
 		if cfg.DisconnectAfterJob && cfg.DisconnectAfterJobTimeout < 120 {

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -54,6 +54,7 @@ type BootstrapConfig struct {
 	PluginsEnabled               bool   `cli:"plugins-enabled"`
 	PTY                          bool   `cli:"pty"`
 	Debug                        bool   `cli:"debug"`
+	Shell                        string `cli:"shell"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -217,6 +218,11 @@ var BootstrapCommand = cli.Command{
 			Usage:  "Run jobs within a pseudo terminal",
 			EnvVar: "BUILDKITE_NO_PTY",
 		},
+		cli.StringFlag{
+			Name:   "shell",
+			Usage:  "The shell to use to interpret build commands",
+			EnvVar: "BUILDKITE_SHELL",
+		},
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
@@ -265,6 +271,7 @@ var BootstrapCommand = cli.Command{
 				CommandEval:                  cfg.CommandEval,
 				PluginsEnabled:               cfg.PluginsEnabled,
 				SSHFingerprintVerification:   cfg.SSHFingerprintVerification,
+				Shell: cfg.Shell,
 			},
 		}
 

--- a/process/format.go
+++ b/process/format.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"fmt"
 	"strings"
 	"unicode/utf8"
 )
@@ -22,8 +23,7 @@ func FormatCommand(command string, args []string) string {
 	s := []string{command}
 	for _, a := range args {
 		if strings.Contains(a, "\n") || strings.Contains(a, " ") {
-			aa := strings.Replace(strings.Replace(a, "\n", "", -1), "\"", "\\", -1)
-			s = append(s, "\""+truncate(aa, 40)+"\"")
+			s = append(s, fmt.Sprintf("%q", truncate(a, 120)))
 		} else {
 			s = append(s, a)
 		}


### PR DESCRIPTION
Currently the agent guesses the shell based on your operating system, either `/bin/bash` on nix or `cmd` on windows.

This allows for the shell used for interpreting `$BUILDKITE_COMMAND` to be configured. 

IMO eventually we should default to `/bin/sh`, but for backwards compat, we will go with `/bin/bash`.

This controversially also ditches the behaviour where we write a shellscript for each command to be executed. 

![image](https://user-images.githubusercontent.com/15758/36662372-561d9b5a-1b32-11e8-8d1e-a62d43214343.png)
