### PR TITLE
Check hook script write

### DIFF
--- a/bootstrap/hook.go
+++ b/bootstrap/hook.go
@@ -115,7 +115,10 @@ func newHookScriptWrapper(hookPath string) (*hookScriptWrapper, error) {
 	}
 
 	// Write the hook script to the runner then close the file so we can run it
-	h.scriptFile.WriteString(script)
+	_, err = h.scriptFile.WriteString(script)
+	if err != nil {
+		return nil, err
+	}
 
 	// Make script executable
 	if err = addExecutePermissionToFile(h.scriptFile.Name()); err != nil {

--- a/bootstrap/hook.go
+++ b/bootstrap/hook.go
@@ -64,6 +64,7 @@ func newHookScriptWrapper(hookPath string) (*hookScriptWrapper, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer h.scriptFile.Close()
 
 	// We'll pump the ENV before the hook into this temp file
 	h.beforeEnvFile, err = shell.TempFileWithExtension(
@@ -115,7 +116,6 @@ func newHookScriptWrapper(hookPath string) (*hookScriptWrapper, error) {
 
 	// Write the hook script to the runner then close the file so we can run it
 	h.scriptFile.WriteString(script)
-	h.scriptFile.Close()
 
 	// Make script executable
 	if err = addExecutePermissionToFile(h.scriptFile.Name()); err != nil {

--- a/bootstrap/hook.go
+++ b/bootstrap/hook.go
@@ -121,7 +121,8 @@ func newHookScriptWrapper(hookPath string) (*hookScriptWrapper, error) {
 	}
 
 	// Make script executable
-	if err = addExecutePermissionToFile(h.scriptFile.Name()); err != nil {
+	err = addExecutePermissionToFile(h.scriptFile.Name())
+	if err != nil {
 		return h, err
 	}
 


### PR DESCRIPTION
If a disk fills up or for some other reason we fail to write this hook file contents the bootstrap just plods along anyway, running an empty script file. So check for errors during the write. Also a couple of other little tweaks nearby.