### PR TITLE
Move windows agent tests back to asynch

### DIFF
--- a/.buildkite/pipeline.windows.yml
+++ b/.buildkite/pipeline.windows.yml
@@ -1,0 +1,5 @@
+steps:
+  - name: ":hammer: :windows:"
+    command: "docker-compose -f docker-compose.windows.yml run --rm -T agent .\\scripts\\tests.bat"
+    agents:
+      queue: "windows"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,11 +11,11 @@ steps:
 
   - name: ":hammer: :windows:"
     trigger: agent-windows
-      async: true
-      build:
-        message: "${BUILDKITE_MESSAGE}"
-        commit: "${BUILDKITE_COMMIT}"
-        branch: "${BUILDKITE_BRANCH}"
+    async: true
+    build:
+      message: "${BUILDKITE_MESSAGE}"
+      commit: "${BUILDKITE_COMMIT}"
+      branch: "${BUILDKITE_BRANCH}"
 
   - wait: ~
     continue_on_failure: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,9 +10,12 @@ steps:
         run: agent
 
   - name: ":hammer: :windows:"
-    command: "docker-compose -f docker-compose.windows.yml run --rm -T agent .\\scripts\\tests.bat"
-    agents:
-      queue: "windows"
+    trigger: agent-windows
+      async: true
+      build:
+        message: "${BUILDKITE_MESSAGE}"
+        commit: "${BUILDKITE_COMMIT}"
+        branch: "${BUILDKITE_BRANCH}"
 
   - wait: ~
     continue_on_failure: true


### PR DESCRIPTION
Due to recent issues with our windows instances being flakey, this moves things back to an asynch pipeline trigger of the windows-agent pipeline.