### PR TITLE
Fix stdin detection on windows

### DIFF
--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -6,13 +6,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/buildkite/agent/stdin"
+
 	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/cliconfig"
 	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/retry"
 	"github.com/urfave/cli"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 var AnnotateHelpDescription = `Usage:
@@ -108,7 +109,7 @@ var AnnotateCommand = cli.Command{
 
 		if cfg.Body != "" {
 			body = cfg.Body
-		} else if !terminal.IsTerminal(int(os.Stdin.Fd())) {
+		} else if stdin.IsReadable() {
 			logger.Info("Reading annotation body from STDIN")
 
 			// Actually read the file from STDIN

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -13,8 +13,8 @@ import (
 	"github.com/buildkite/agent/cliconfig"
 	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/retry"
+	"github.com/buildkite/agent/stdin"
 	"github.com/urfave/cli"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 var PipelineUploadHelpDescription = `Usage:
@@ -103,7 +103,7 @@ var PipelineUploadCommand = cli.Command{
 			if err != nil {
 				logger.Fatal("Failed to read file: %s", err)
 			}
-		} else if !terminal.IsTerminal(int(os.Stdin.Fd())) {
+		} else if stdin.IsReadable() {
 			logger.Info("Reading pipeline config from STDIN")
 
 			// Actually read the file from STDIN

--- a/stdin/main_test.go
+++ b/stdin/main_test.go
@@ -1,0 +1,53 @@
+package stdin_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/buildkite/agent/stdin"
+)
+
+func TestMain(m *testing.M) {
+	switch os.Getenv("GO_TEST_MODE") {
+	case "":
+		// Normal test mode
+		os.Exit(m.Run())
+
+	case "stdin_check":
+		fmt.Printf("%v", stdin.IsReadable())
+		os.Exit(0)
+	}
+}
+
+func TestIsStdinIsNotReadable(t *testing.T) {
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = []string{"GO_TEST_MODE=stdin_check"}
+	cmd.Stdin = nil
+
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if g, e := string(output), "false"; g != e {
+		t.Errorf("stdin_check: want %q, got %q", e, g)
+	}
+}
+
+func TestIsStdinIsReadable(t *testing.T) {
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = []string{"GO_TEST_MODE=stdin_check"}
+	cmd.Stdin = bytes.NewBufferString("llamas")
+
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if g, e := string(output), "true"; g != e {
+		t.Errorf("stdin_check: want %q, got %q", e, g)
+	}
+}

--- a/stdin/stdin.go
+++ b/stdin/stdin.go
@@ -1,0 +1,16 @@
+package stdin
+
+import (
+	"os"
+)
+
+func IsReadable() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	if fi.Mode()&os.ModeNamedPipe == 0 {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
This goes back to how we used to handle stdin, with a simple `stdin` package and a basic golang check vs `golang.org/x/crypto/ssh/terminal`.

It also adds tests!

Closes  #655.