### PR TITLE
Process top level env block in dependency order

### DIFF
--- a/agent/pipeline_parser.go
+++ b/agent/pipeline_parser.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/interpolate"
 	"github.com/ghodss/yaml"
+	toposort "github.com/philopon/go-toposort"
 )
 
 type PipelineParser struct {
@@ -37,11 +38,10 @@ func (p PipelineParser) Parse() (pipeline interface{}, err error) {
 		return nil, err
 	}
 
-	// Preprocess any env that are defined in the top level block and place them into env for
-	// later interpolation. We do this a few times so that you can reference env vars in other env vars
+	// Preprocess any env that are defined in the top level block
 	if unmarshaledMap, ok := unmarshaled.(map[string]interface{}); ok {
 		if envMap, ok := unmarshaledMap["env"].(map[string]interface{}); ok {
-			if err = p.interpolateEnvBlock(envMap); err != nil {
+			if err = p.interpolateTopLevelEnvBlock(envMap); err != nil {
 				return nil, err
 			}
 		}
@@ -57,26 +57,51 @@ func (p PipelineParser) Parse() (pipeline interface{}, err error) {
 	return interpolated, nil
 }
 
-func (p PipelineParser) interpolateEnvBlock(envMap map[string]interface{}) error {
-	// do a first pass without interpolation
-	for k, v := range envMap {
-		switch tv := v.(type) {
-		case string, int, bool:
-			p.Env.Set(k, fmt.Sprintf("%v", tv))
+func (p PipelineParser) interpolateTopLevelEnvBlock(envMap map[string]interface{}) error {
+	graph := toposort.NewGraph(10)
+
+	// create nodes in a graph for the env keys
+	for key := range envMap {
+		graph.AddNode(key)
+	}
+
+	// add edges for the dependencies that are needed to be interpolated
+	for key, val := range envMap {
+		ids, err := interpolate.Identifiers(fmt.Sprintf("%s", val))
+		if err != nil {
+			return err
+		}
+
+		for _, id := range ids {
+			if key != id {
+				graph.AddEdge(id, key)
+			}
 		}
 	}
 
-	// next do a pass of interpolation and read the results
-	for k, v := range envMap {
+	// sort by dependency order
+	result, ok := graph.Toposort()
+	if !ok {
+		return fmt.Errorf("Cycle detected in ENV variables")
+	}
+
+	// process env variables in dependency order
+	for _, envKey := range result {
+		v, ok := envMap[envKey]
+		if !ok {
+			return fmt.Errorf("Missing env key for %s", envKey)
+		}
+
 		switch tv := v.(type) {
 		case string:
 			interpolated, err := interpolate.Interpolate(p.Env, tv)
 			if err != nil {
 				return err
 			}
-			p.Env.Set(k, interpolated)
+			p.Env.Set(envKey, interpolated)
 		}
 	}
+
 	return nil
 }
 

--- a/vendor/github.com/buildkite/interpolate/interpolate.go
+++ b/vendor/github.com/buildkite/interpolate/interpolate.go
@@ -17,14 +17,28 @@ func Interpolate(env Env, str string) (string, error) {
 	return expr.Expand(env)
 }
 
+// Indentifiers parses the identifiers from any expansions in the provided string
+func Identifiers(str string) ([]string, error) {
+	expr, err := NewParser(str).Parse()
+	if err != nil {
+		return nil, err
+	}
+	return expr.Identifiers(), nil
+}
+
 // An expansion is something that takes in ENV and returns a string or an error
 type Expansion interface {
 	Expand(env Env) (string, error)
+	Identifiers() []string
 }
 
 // VariableExpansion represents either $VAR or ${VAR}, our simplest expansion
 type VariableExpansion struct {
 	Identifier string
+}
+
+func (e VariableExpansion) Identifiers() []string {
+	return []string{e.Identifier}
 }
 
 func (e VariableExpansion) Expand(env Env) (string, error) {
@@ -36,6 +50,10 @@ func (e VariableExpansion) Expand(env Env) (string, error) {
 type EmptyValueExpansion struct {
 	Identifier string
 	Content    Expression
+}
+
+func (e EmptyValueExpansion) Identifiers() []string {
+	return append([]string{e.Identifier}, e.Content.Identifiers()...)
 }
 
 func (e EmptyValueExpansion) Expand(env Env) (string, error) {
@@ -52,6 +70,10 @@ type UnsetValueExpansion struct {
 	Content    Expression
 }
 
+func (e UnsetValueExpansion) Identifiers() []string {
+	return []string{e.Identifier}
+}
+
 func (e UnsetValueExpansion) Expand(env Env) (string, error) {
 	val, ok := env.Get(e.Identifier)
 	if !ok {
@@ -66,6 +88,10 @@ type SubstringExpansion struct {
 	Offset     int
 	Length     int
 	HasLength  bool
+}
+
+func (e SubstringExpansion) Identifiers() []string {
+	return []string{e.Identifier}
 }
 
 func (e SubstringExpansion) Expand(env Env) (string, error) {
@@ -121,6 +147,10 @@ type RequiredExpansion struct {
 	Message    Expression
 }
 
+func (e RequiredExpansion) Identifiers() []string {
+	return []string{e.Identifier}
+}
+
 func (e RequiredExpansion) Expand(env Env) (string, error) {
 	val, ok := env.Get(e.Identifier)
 	if !ok {
@@ -138,6 +168,16 @@ func (e RequiredExpansion) Expand(env Env) (string, error) {
 
 // Expression is a collection of either Text or Expansions
 type Expression []ExpressionItem
+
+func (e Expression) Identifiers() []string {
+	identifiers := []string{}
+	for _, item := range e {
+		if item.Expansion != nil {
+			identifiers = append(identifiers, item.Expansion.Identifiers()...)
+		}
+	}
+	return identifiers
+}
 
 func (e Expression) Expand(env Env) (string, error) {
 	buf := &bytes.Buffer{}

--- a/vendor/github.com/philopon/go-toposort/LICENSE
+++ b/vendor/github.com/philopon/go-toposort/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2017 Hirotomo Moriwaki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/philopon/go-toposort/README.md
+++ b/vendor/github.com/philopon/go-toposort/README.md
@@ -1,0 +1,53 @@
+go-toposort
+==
+[![Build Status](https://travis-ci.org/philopon/go-toposort.svg?branch=master)](https://travis-ci.org/philopon/go-toposort)
+[![GoDoc](https://godoc.org/github.com/philopon/go-toposort?status.svg)](https://godoc.org/github.com/philopon/go-toposort)
+
+deterministic topological sort implementation for golang
+
+Example
+--
+
+```.go
+package main
+
+import (
+	"fmt"
+
+	toposort "github.com/philopon/go-toposort"
+)
+
+func main() {
+	graph := toposort.NewGraph(8)
+	graph.AddNodes("2", "3", "5", "7", "8", "9", "10", "11")
+
+	graph.AddEdge("7", "8")
+	graph.AddEdge("7", "11")
+
+	graph.AddEdge("5", "11")
+
+	graph.AddEdge("3", "8")
+	graph.AddEdge("3", "10")
+
+	graph.AddEdge("11", "2")
+	graph.AddEdge("11", "9")
+	graph.AddEdge("11", "10")
+
+	graph.AddEdge("8", "9")
+
+	result, ok := graph.Toposort()
+	if !ok {
+		panic("cycle detected")
+	}
+
+	fmt.Println(result)
+}
+```
+
+```
+[3 5 7 8 11 2 9 10]
+```
+
+License
+--
+MIT

--- a/vendor/github.com/philopon/go-toposort/toposort.go
+++ b/vendor/github.com/philopon/go-toposort/toposort.go
@@ -1,0 +1,101 @@
+package toposort
+
+type Graph struct {
+	nodes   []string
+	outputs map[string]map[string]int
+	inputs  map[string]int
+}
+
+func NewGraph(cap int) *Graph {
+	return &Graph{
+		nodes:   make([]string, 0, cap),
+		inputs:  make(map[string]int),
+		outputs: make(map[string]map[string]int),
+	}
+}
+
+func (g *Graph) AddNode(name string) bool {
+	g.nodes = append(g.nodes, name)
+
+	if _, ok := g.outputs[name]; ok {
+		return false
+	}
+	g.outputs[name] = make(map[string]int)
+	g.inputs[name] = 0
+	return true
+}
+
+func (g *Graph) AddNodes(names ...string) bool {
+	for _, name := range names {
+		if ok := g.AddNode(name); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *Graph) AddEdge(from, to string) bool {
+	m, ok := g.outputs[from]
+	if !ok {
+		return false
+	}
+
+	m[to] = len(m) + 1
+	g.inputs[to]++
+
+	return true
+}
+
+func (g *Graph) unsafeRemoveEdge(from, to string) {
+	delete(g.outputs[from], to)
+	g.inputs[to]--
+}
+
+func (g *Graph) RemoveEdge(from, to string) bool {
+	if _, ok := g.outputs[from]; !ok {
+		return false
+	}
+	g.unsafeRemoveEdge(from, to)
+	return true
+}
+
+func (g *Graph) Toposort() ([]string, bool) {
+	L := make([]string, 0, len(g.nodes))
+	S := make([]string, 0, len(g.nodes))
+
+	for _, n := range g.nodes {
+		if g.inputs[n] == 0 {
+			S = append(S, n)
+		}
+	}
+
+	for len(S) > 0 {
+		var n string
+		n, S = S[0], S[1:]
+		L = append(L, n)
+
+		ms := make([]string, len(g.outputs[n]))
+		for m, i := range g.outputs[n] {
+			ms[i-1] = m
+		}
+
+		for _, m := range ms {
+			g.unsafeRemoveEdge(n, m)
+
+			if g.inputs[m] == 0 {
+				S = append(S, m)
+			}
+		}
+	}
+
+	N := 0
+	for _, v := range g.inputs {
+		N += v
+	}
+
+	if N > 0 {
+		return L, false
+	}
+
+	return L, true
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -21,10 +21,10 @@
 			"revisionTime": "2018-02-27T22:21:32Z"
 		},
 		{
-			"checksumSHA1": "8mzUiJrhQ0COz4r98YlDICpWqsw=",
+			"checksumSHA1": "S97KA7bbFepIS2ZFHr9ImA4uEGQ=",
 			"path": "github.com/buildkite/interpolate",
-			"revision": "3a807e47135c4139351425cae51d4bd485150282",
-			"revisionTime": "2017-11-14T09:02:18Z"
+			"revision": "c1c376f870d259871fcc9bf3bcfd4889b999ed1a",
+			"revisionTime": "2018-02-15T13:27:03Z"
 		},
 		{
 			"checksumSHA1": "bplZOqTp6JAbkn25zHEPIob25WI=",
@@ -91,6 +91,12 @@
 			"path": "github.com/petermattis/goid",
 			"revision": "b0b1615b78e5ee59739545bb38426383b2cda4c9",
 			"revisionTime": "2018-02-02T15:45:49Z"
+		},
+		{
+			"checksumSHA1": "xu9jD9+X17GL8ZlMipeoYjgaHEo=",
+			"path": "github.com/philopon/go-toposort",
+			"revision": "9be86dbd762f98b5b9a4eca110a3f40ef31d0375",
+			"revisionTime": "2017-06-20T08:54:41Z"
 		},
 		{
 			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",


### PR DESCRIPTION
Because maps in golang are processed in a random order, we get the map form of `env` blocks in pipelines in random order. 

This is ok for step level env, but we pre-process top level env to expose it for interpolation into the subsequent steps. This means blocks like the following won't work:

```yaml
env:
  ACCOUNT: "${ACCOUNT?is not set. Please specify an account}"
  ENVIRONMENT: "${ENVIRONMENT?is not set. Please specify an environment}"
  BUILD_NUMBER: "${BUILDKITE_BUILD_NUMBER}"
  COMMENT: "Build #${BUILD_NUMBER}"

steps:
  - name: ":docker: Build ${ENVIRONMENT}"
    command: ".buildkite/steps/build"
```

This change orders variables into a dependency graph and then uses a topological sort on them so that we get a solveable order for them. 

This made my head hurt.

Closes #647.
