### PR TITLE
Run scripts via the shell, rather than invoking with exec

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -905,7 +905,7 @@ func (b *Bootstrap) defaultCommandPhase() error {
 		}
 
 		b.shell.Headerf("Running script")
-		cmd = []string{pathToCommand}
+		cmd = append(shell, b.Command)
 	} else {
 		b.shell.Headerf("Running commands")
 		cmd = append(shell, b.Command)


### PR DESCRIPTION
Otherwise scripts must have a shebang, or they fail silently. It's the difference between ./my_script and bash -e -c "./my_script". This is currently broken in beta 40.

Note: bash is smart enough to not create another shell when the only argument to -c is another shell script. 👌🏻