### PR TITLE
Only keyscan git/ssh urls

### DIFF
--- a/bootstrap/knownhosts.go
+++ b/bootstrap/knownhosts.go
@@ -135,8 +135,8 @@ func (kh *knownHosts) AddFromRepository(repository string) error {
 		return err
 	}
 
-	// File uri's don't need a host added
-	if u.Host == "" || u.Scheme == "file" {
+	// We only need to keyscan ssh repository urls
+	if u.Scheme != "ssh" {
 		return nil
 	}
 


### PR DESCRIPTION
This skips trying to ssh-keyscan urls that aren't git/ssh.