### PR TITLE
Prevent incorrect corrupt git checkout detection on fresh checkout dir creation

### DIFF
--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -34,7 +34,6 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 
 	// But assert which ones are called
 	git.ExpectAll([][]interface{}{
-		{"rev-parse"},
 		{"clone", "-v", "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"submodule", "foreach", "--recursive", "git", "clean", "-fdq"},


### PR DESCRIPTION
The agent is currently incorrectly detecting newly created checkout dirs as corrupt (#574). Not a huge impact, but creates noisy output with `git-revparse` on every checkout.

This moves the corrupt detection into the defaultCheckout method, so that it's retried and also so that you can opt-out of it by overriding the checkout hook.