### PR TITLE
Enabling `no-command-eval` will also disable use of plugins

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -272,18 +272,22 @@ func (r *AgentPool) ShowBanner() {
 	logger.Debug("Plugins directory: %s", r.AgentConfiguration.PluginsPath)
 
 	if !r.AgentConfiguration.SSHKeyscan {
-		logger.Debug("Automatic ssh-keyscan has been disabled")
+		logger.Info("Automatic ssh-keyscan has been disabled")
 	}
 
 	if !r.AgentConfiguration.CommandEval {
-		logger.Debug("Evaluating console commands has been disabled")
+		logger.Info("Evaluating console commands has been disabled")
+	}
+
+	if !r.AgentConfiguration.PluginsEnabled {
+		logger.Info("Plugins have been disabled")
 	}
 
 	if !r.AgentConfiguration.RunInPty {
-		logger.Debug("Running builds within a pseudoterminal (PTY) has been disabled")
+		logger.Info("Running builds within a pseudoterminal (PTY) has been disabled")
 	}
 
 	if r.AgentConfiguration.DisconnectAfterJob {
-		logger.Debug("Agent will disconnect after a job run has completed with a timeout of %d seconds", r.AgentConfiguration.DisconnectAfterJobTimeout)
+		logger.Info("Agent will disconnect after a job run has completed with a timeout of %d seconds", r.AgentConfiguration.DisconnectAfterJobTimeout)
 	}
 }

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -379,7 +379,11 @@ func (b *Bootstrap) PluginPhase() error {
 
 	// Check if we can run plugins (disabled via --no-plugins)
 	if b.Plugins != "" && !b.Config.PluginsEnabled {
-		return fmt.Errorf("This agent isn't allowed to run plugins. To allow this, re-run this agent without the `--no-plugins` option.")
+		if !b.Config.CommandEval {
+			return fmt.Errorf("Plugins have been disabled on this agent with `--no-command-eval`")
+		} else {
+			return fmt.Errorf("Plugins have been disabled on this agent with `--no-plugins`")
+		}
 	}
 
 	plugins, err := agent.CreatePluginsFromJSON(b.Plugins)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -231,7 +231,7 @@ var AgentStartCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name:   "no-command-eval",
-			Usage:  "Don't allow this agent to run arbitrary console commands. Turning off command eval will also disallow this agent to use plugins.",
+			Usage:  "Don't allow this agent to run arbitrary console commands, including plugins",
 			EnvVar: "BUILDKITE_NO_COMMAND_EVAL",
 		},
 		cli.BoolFlag{

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -231,7 +231,7 @@ var AgentStartCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name:   "no-command-eval",
-			Usage:  "Don't allow this agent to run arbitrary console commands",
+			Usage:  "Don't allow this agent to run arbitrary console commands. Turning off command eval will also disallow this agent to use plugins.",
 			EnvVar: "BUILDKITE_NO_COMMAND_EVAL",
 		},
 		cli.BoolFlag{
@@ -301,6 +301,11 @@ var AgentStartCommand = cli.Command{
 		// Set a useful default for the bootstrap script
 		if cfg.BootstrapScript == "" {
 			cfg.BootstrapScript = fmt.Sprintf("%q bootstrap", filepath.ToSlash(os.Args[0]))
+		}
+
+		// Turning off command eval will also turn off plugins.
+		if cfg.NoCommandEval {
+			cfg.NoPlugins = true
 		}
 
 		// Guess the shell if none is provided


### PR DESCRIPTION
Fixes https://github.com/buildkite/agent/issues/674