### PR TITLE
Expose no-git-submodules config and arg to start

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -8,6 +8,7 @@ type AgentConfiguration struct {
 	PluginsPath               string
 	GitCloneFlags             string
 	GitCleanFlags             string
+	GitSubmodules             bool
 	SSHKeyscan                bool
 	CommandEval               bool
 	PluginsEnabled            bool

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -229,6 +229,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	env["BUILDKITE_HOOKS_PATH"] = r.AgentConfiguration.HooksPath
 	env["BUILDKITE_PLUGINS_PATH"] = r.AgentConfiguration.PluginsPath
 	env["BUILDKITE_SSH_KEYSCAN"] = fmt.Sprintf("%t", r.AgentConfiguration.SSHKeyscan)
+	env["BUILDKITE_GIT_SUBMODULES"] = fmt.Sprintf("%t", r.AgentConfiguration.GitSubmodules)
 	env["BUILDKITE_COMMAND_EVAL"] = fmt.Sprintf("%t", r.AgentConfiguration.CommandEval)
 	env["BUILDKITE_PLUGINS_ENABLED"] = fmt.Sprintf("%t", r.AgentConfiguration.PluginsEnabled)
 	env["BUILDKITE_GIT_CLONE_FLAGS"] = r.AgentConfiguration.GitCloneFlags

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -31,6 +31,12 @@ Example:
 
    $ buildkite-agent start --token xxx`
 
+// Adding config requires changes in a few different spots
+// - The AgentStartConfig struct with a cli parameter
+// - As a flag in the AgentStartCommand (with matching env)
+// - Into an env to be passed to the bootstrap in agent/job_runner.go, createEnvironment()
+// - Into clicommand/bootstrap.go to read it from the env into the bootstrap config
+
 type AgentStartConfig struct {
 	Config                    string   `cli:"config"`
 	Token                     string   `cli:"token" validate:"required"`
@@ -50,6 +56,7 @@ type AgentStartConfig struct {
 	WaitForEC2TagsTimeout     string   `cli:"wait-for-ec2-tags-timeout"`
 	GitCloneFlags             string   `cli:"git-clone-flags"`
 	GitCleanFlags             string   `cli:"git-clean-flags"`
+	NoGitSubmodules           bool     `cli:"no-git-submodules"`
 	NoColor                   bool     `cli:"no-color"`
 	NoSSHKeyscan              bool     `cli:"no-ssh-keyscan"`
 	NoCommandEval             bool     `cli:"no-command-eval"`
@@ -240,6 +247,11 @@ var AgentStartCommand = cli.Command{
 			Usage:  "Don't allow this agent to load plugins",
 			EnvVar: "BUILDKITE_NO_PLUGINS",
 		},
+		cli.BoolFlag{
+			Name:   "no-git-submodules",
+			Usage:  "Don't automatically checkout git submodules",
+			EnvVar: "BUILDKITE_NO_GIT_SUBMODULES,BUILDKITE_DISABLE_GIT_SUBMODULES",
+		},
 		ExperimentsFlag,
 		EndpointFlag,
 		NoColorFlag,
@@ -345,6 +357,7 @@ var AgentStartCommand = cli.Command{
 				PluginsPath:               cfg.PluginsPath,
 				GitCloneFlags:             cfg.GitCloneFlags,
 				GitCleanFlags:             cfg.GitCleanFlags,
+				GitSubmodules:             !cfg.NoGitSubmodules,
 				SSHKeyscan:                !cfg.NoSSHKeyscan,
 				CommandEval:               !cfg.NoCommandEval,
 				PluginsEnabled:            !cfg.NoPlugins,


### PR DESCRIPTION
The v2 bootstrap used to support `BUILDKITE_DISABLE_GIT_SUBMODULES` (via #168). 

This exposes that option (also `BUILDKITE_NO_GIT_SUBMODULES`).