### PR TITLE
Add a configurable cancel-grace-period

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -18,5 +18,6 @@ type AgentConfiguration struct {
 	TimestampLines            bool
 	DisconnectAfterJob        bool
 	DisconnectAfterJobTimeout int
+	CancelGracePeriod         int
 	Shell                     string
 }

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -250,11 +250,11 @@ func (r *JobRunner) Kill() error {
 	defer r.killLock.Unlock()
 
 	if !r.cancelled {
-		logger.Info("Canceling job %s", r.Job.ID)
+		logger.Info("Canceling job %s with a grace period of %ds", r.Job.ID, r.AgentConfiguration.CancelGracePeriod)
 		r.cancelled = true
 
 		if r.process != nil {
-			r.process.Kill()
+			r.process.Kill(time.Second * time.Duration(r.AgentConfiguration.CancelGracePeriod))
 		} else {
 			logger.Error("No process to kill")
 		}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -46,6 +46,7 @@ type AgentStartConfig struct {
 	DisconnectAfterJob        bool     `cli:"disconnect-after-job"`
 	DisconnectAfterJobTimeout int      `cli:"disconnect-after-job-timeout"`
 	BootstrapScript           string   `cli:"bootstrap-script" normalize:"commandpath"`
+	CancelGracePeriod         int      `cli:"cancel-grace-period"`
 	BuildPath                 string   `cli:"build-path" normalize:"filepath" validate:"required"`
 	HooksPath                 string   `cli:"hooks-path" normalize:"filepath"`
 	PluginsPath               string   `cli:"plugins-path" normalize:"filepath"`
@@ -162,6 +163,12 @@ var AgentStartCommand = cli.Command{
 			Value:  120,
 			Usage:  "When --disconnect-after-job is specified, the number of seconds to wait for a job before shutting down",
 			EnvVar: "BUILDKITE_AGENT_DISCONNECT_AFTER_JOB_TIMEOUT",
+		},
+		cli.IntFlag{
+			Name:   "cancel-grace-period",
+			Value:  10,
+			Usage:  "The number of seconds running processes are given to gracefully terminate before they are killed when a job is cancelled",
+			EnvVar: "BUILDKITE_CANCEL_GRACE_PERIOD",
 		},
 		cli.StringFlag{
 			Name:   "shell",
@@ -433,6 +440,7 @@ var AgentStartCommand = cli.Command{
 				TimestampLines:            cfg.TimestampLines,
 				DisconnectAfterJob:        cfg.DisconnectAfterJob,
 				DisconnectAfterJobTimeout: cfg.DisconnectAfterJobTimeout,
+				CancelGracePeriod:         cfg.CancelGracePeriod,
 				Shell:                     cfg.Shell,
 			},
 			MetricsCollector: &metrics.Collector{

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -99,7 +99,7 @@ func TestProcessIsKilledGracefully(t *testing.T) {
 		// give the signal handler some time to install
 		time.Sleep(time.Millisecond * 50)
 
-		p.Kill()
+		p.Kill(time.Millisecond * 20)
 	}()
 
 	if err := p.Start(); err != nil {


### PR DESCRIPTION
This makes the time between `SIGTERM` and `SIGKILL` when a job is cancelled configurable. 

This allows people who have workloads with things like `packer` and `docker-compose` (which can often take 20-30 seconds to gracefully shutdown) to configure when they are forcefully killed. The alternative is often having to write cleanup scripts outside of the agent.

Ideally, this would be a setting which could be configured at a step/yaml level to and passed down to the job runner vs the blunt-force agent-wide config. 