### PR TITLE
Build docker image as part of agent pipeline

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -21,16 +21,3 @@ steps:
       CODENAME: "experimental"
     agents:
       queue: "deploy"
-
-  - wait
-
-  - name: ":whale: docker"
-    trigger: docker-buildkite-agent
-    branches: master
-    async: true
-    build:
-      message: "Update Docker images"
-      commit: "HEAD"
-      branch: "master"
-      env:
-        CODENAME: "experimental"

--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -21,3 +21,10 @@ steps:
       CODENAME: "experimental"
     agents:
       queue: "deploy"
+
+  - name: ":docker:"
+    command: "scripts/publish-docker-images.sh"
+    env:
+      CODENAME: "experimental"
+    agents:
+      queue: "deploy"

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -27,14 +27,3 @@ steps:
     agents:
       queue: "deploy"
 
-  - wait
-
-  - name: ":whale:"
-    trigger: docker-buildkite-agent
-    async: true
-    build:
-      message: "Update Docker images"
-      commit: "HEAD"
-      branch: "master"
-      env:
-        CODENAME: "stable"

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -30,6 +30,6 @@ steps:
   - name: ":docker:"
     command: "scripts/publish-docker-images.sh"
     env:
-      CODENAME: "unstable"
+      CODENAME: "stable"
     agents:
       queue: "deploy"

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -27,3 +27,9 @@ steps:
     agents:
       queue: "deploy"
 
+  - name: ":docker:"
+    command: "scripts/publish-docker-images.sh"
+    env:
+      CODENAME: "unstable"
+    agents:
+      queue: "deploy"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -34,18 +34,6 @@ steps:
 
   - wait
 
-  - name: ":whale:"
-    trigger: docker-buildkite-agent
-    async: true
-    build:
-      message: "Update Docker images"
-      commit: "HEAD"
-      branch: "master"
-      env:
-        CODENAME: "stable"
-
-  - wait
-
   - name: ":beer:"
     command: "scripts/release-homebrew.sh"
     artifact_paths: "pkg/*.rb;pkg/*.json"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -32,6 +32,13 @@ steps:
     agents:
       queue: "deploy"
 
+  - name: ":docker:"
+    command: "scripts/publish-docker-images.sh"
+    env:
+      CODENAME: "unstable"
+    agents:
+      queue: "deploy"
+
   - wait
 
   - name: ":beer:"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -125,8 +125,6 @@ steps:
 
   - name: ":docker: build"
     command: "scripts/build-docker-images.sh"
-    agents:
-      queue: "deploy"
 
   - name: ":debian: build"
     command: "scripts/build-debian-packages.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -123,6 +123,11 @@ steps:
 
   - wait
 
+  - name: ":docker: build"
+    command: "scripts/build-docker-images.sh"
+    agents:
+      queue: "deploy"
+
   - name: ":debian: build"
     command: "scripts/build-debian-packages.sh"
     artifact_paths: "deb/**/*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+## Development docker image for buildkite-agent
 FROM golang:1.10
 WORKDIR /go/src/github.com/buildkite/agent
 COPY . .

--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -1,3 +1,4 @@
+## Development docker image for buildkite-agent on windows
 FROM microsoft/windowsservercore:latest
 
 ENV ChocolateyUseWindowsCompression false

--- a/packaging/docker/linux/Dockerfile
+++ b/packaging/docker/linux/Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && curl -Lfs -o /usr/local/bin/ssh-env-config.sh https://raw.githubusercontent.com/buildkite/docker-ssh-env-config/master/ssh-env-config.sh \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
-COPY ./buildkite-agent usr/local/bin/buildkite-agent
+COPY ./buildkite-agent /usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
 
 VOLUME /buildkite

--- a/packaging/docker/linux/Dockerfile
+++ b/packaging/docker/linux/Dockerfile
@@ -1,0 +1,34 @@
+FROM alpine:3.6
+
+RUN apk add --no-cache \
+    tini \
+    bash \
+    git \
+    perl \
+    rsync \
+    openssh-client \
+    curl \
+    docker \
+    jq \
+    su-exec \
+    py-pip \
+    libc6-compat \
+    run-parts \
+    && \
+    pip install docker-compose
+
+ENV BUILDKITE_BUILD_PATH=/buildkite/builds \
+    BUILDKITE_HOOKS_PATH=/buildkite/hooks \
+    BUILDKITE_PLUGINS_PATH=/buildkite/plugins
+
+RUN curl -Lfs -o /usr/local/bin/buildkite-agent https://download.buildkite.com/agent/experimental/latest/buildkite-agent-linux-amd64 \
+    && chmod +x /usr/local/bin/buildkite-agent \
+    && mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
+    && curl -Lfs -o /usr/local/bin/ssh-env-config.sh https://raw.githubusercontent.com/buildkite/docker-ssh-env-config/master/ssh-env-config.sh \
+    && chmod +x /usr/local/bin/ssh-env-config.sh
+
+COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
+
+VOLUME /buildkite
+ENTRYPOINT ["buildkite-agent-entrypoint"]
+CMD ["start"]

--- a/packaging/docker/linux/Dockerfile
+++ b/packaging/docker/linux/Dockerfile
@@ -1,32 +1,32 @@
 FROM alpine:3.6
 
 RUN apk add --no-cache \
-    tini \
-    bash \
-    git \
-    perl \
-    rsync \
-    openssh-client \
-    curl \
-    docker \
-    jq \
-    su-exec \
-    py-pip \
-    libc6-compat \
-    run-parts \
+      tini \
+      bash \
+      git \
+      perl \
+      rsync \
+      openssh-client \
+      curl \
+      docker \
+      jq \
+      su-exec \
+      py-pip \
+      libc6-compat \
+      run-parts \
     && \
+    pip install --upgrade pip && \
     pip install docker-compose
 
 ENV BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks \
     BUILDKITE_PLUGINS_PATH=/buildkite/plugins
 
-RUN curl -Lfs -o /usr/local/bin/buildkite-agent https://download.buildkite.com/agent/experimental/latest/buildkite-agent-linux-amd64 \
-    && chmod +x /usr/local/bin/buildkite-agent \
-    && mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
+RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && curl -Lfs -o /usr/local/bin/ssh-env-config.sh https://raw.githubusercontent.com/buildkite/docker-ssh-env-config/master/ssh-env-config.sh \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
+COPY ./buildkite-agent usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
 
 VOLUME /buildkite

--- a/packaging/docker/linux/entrypoint.sh
+++ b/packaging/docker/linux/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+DIR=/docker-entrypoint.d
+
+if [[ -d "$DIR" ]] ; then
+  echo "Executing scripts in $DIR"
+  /bin/run-parts --exit-on-error "$DIR"
+fi
+
+exec /sbin/tini -g -- ssh-env-config.sh /usr/local/bin/buildkite-agent "$@"

--- a/scripts/build-docker-images.sh
+++ b/scripts/build-docker-images.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+echo '--- Getting agent version from build meta data'
+
+export FULL_AGENT_VERSION; FULL_AGENT_VERSION=$(buildkite-agent meta-data get "agent-version-full")
+export AGENT_VERSION; AGENT_VERSION=$(buildkite-agent meta-data get "agent-version")
+export BUILD_VERSION; BUILD_VERSION=$(buildkite-agent meta-data get "agent-version-build")
+
+echo "Full agent version: $FULL_AGENT_VERSION"
+echo "Agent version: $AGENT_VERSION"
+echo "Build version: $BUILD_VERSION"
+
+rm -rf pkg
+mkdir -p pkg
+
+echo '--- Downloading :linux: binaries'
+
+buildkite-agent artifact download "pkg/buildkite-agent-linux-amd64" .
+
+image_tag="buildkite-agent-linux-build-${BUILDKITE_BUILD_NUMBER}"
+
+echo '--- Building :linux: :docker: image'
+
+docker build --tag "$image_tag" packaging/docker/linux

--- a/scripts/build-docker-images.sh
+++ b/scripts/build-docker-images.sh
@@ -22,4 +22,5 @@ image_tag="buildkite-agent-linux-build-${BUILDKITE_BUILD_NUMBER}"
 
 echo '--- Building :linux: :docker: image'
 
+cp pkg/buildkite-agent-linux-amd64  packaging/docker/linux/buildkite-agent
 docker build --tag "$image_tag" packaging/docker/linux

--- a/scripts/build-docker-images.sh
+++ b/scripts/build-docker-images.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-image_tag="buildkiteci/agent:buildkite-agent-linux-build-${BUILDKITE_BUILD_NUMBER}"
+image_tag="buildkiteci/agent:alpine-build-${BUILDKITE_BUILD_NUMBER}"
 
 rm -rf pkg
 mkdir -p pkg
@@ -23,5 +23,5 @@ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock --entrypoint "docke
 echo "--- :hammer: Testing $image_tag has docker-compose"
 docker run --rm --entrypoint "docker-compose" "$image_tag" --version
 
-echo '--- Pushing :docker: image'
+echo '--- Pushing :docker: image to buildkiteci/agent'
 docker push "$image_tag"

--- a/scripts/build-docker-images.sh
+++ b/scripts/build-docker-images.sh
@@ -10,7 +10,8 @@ echo '--- Downloading :linux: binaries'
 buildkite-agent artifact download "pkg/buildkite-agent-linux-amd64" .
 
 echo '--- Building :docker: image'
-cp pkg/buildkite-agent-linux-amd64  packaging/docker/linux/buildkite-agent
+cp pkg/buildkite-agent-linux-amd64 packaging/docker/linux/buildkite-agent
+chmod +x packaging/docker/linux/buildkite-agent
 docker build --tag "$image_tag" packaging/docker/linux
 
 echo "--- :hammer: Testing $image_tag can run"

--- a/scripts/publish-docker-images.sh
+++ b/scripts/publish-docker-images.sh
@@ -52,8 +52,8 @@ if [[ "$DOCKER_PULL" =~ (true|1) ]] ; then
   docker pull "$PREBUILT_IMAGE"
 fi
 
-# variants of edge/unstable
-if [[ "$CODENAME" == "unstable" ]] ; then
+# variants of edge/experimental
+if [[ "$CODENAME" == "experimental" ]] ; then
   release_image "edge-build-${BUILDKITE_BUILD_NUMBER}"
   release_image "edge"
 fi
@@ -65,8 +65,8 @@ if [[ "$CODENAME" == "stable" ]] ; then
   done
 fi
 
-# variants of beta/experimental - e.g 3.0-beta.16
-if [[ "$CODENAME" == "experimental" ]] ; then
+# variants of beta/unstable - e.g 3.0-beta.16
+if [[ "$CODENAME" == "unstable" ]] ; then
   for tag in beta $(parse_version "$AGENT_VERSION") ; do
     if is_stable_version "$tag" ; then
       echo "--- :docker: Skipping tagging stable ${DOCKER_IMAGE}:${tag}"

--- a/scripts/publish-docker-images.sh
+++ b/scripts/publish-docker-images.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${DOCKER_IMAGE:=buildkite/agent}"
+: "${DOCKER_PUSH:=1}"
+: "${DOCKER_PULL:=1}"
+: "${PREBUILT_IMAGE:=buildkiteci/agent:alpine-build-${BUILDKITE_BUILD_NUMBER}}"
+: "${CODENAME:=stable}"
+: "${STABLE_VERSION:=2}"
+
+# Convert 2.3.2 into [ 2.3.2 2.3 2 ] or 3.0-beta.42 in [ 3.0-beta.42 3.0 3 ]
+parse_version() {
+  local v="$1"
+  IFS='.' read -r -a parts <<< "${v%-*}"
+
+  for idx in $(seq 1 ${#parts[*]}) ; do
+    sed -e 's/ /./g' <<< "${parts[@]:0:$idx}"
+  done
+
+  [[ "${v%-*}" == "$v" ]] || echo "$v"
+}
+
+is_stable_version() {
+  local v="$1"
+  for stable_tag in $(parse_version "$STABLE_VERSION") ; do
+    if [[ "$v" == "$stable_tag" ]] ; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+release_image() {
+  local tag="$1"
+  echo "--- :docker: Taggng ${DOCKER_IMAGE}:${tag}"
+  docker tag "$PREBUILT_IMAGE" "${DOCKER_IMAGE}:$tag"
+  if [[ "$DOCKER_PUSH" =~ (true|1) ]] ; then
+    docker push "${DOCKER_IMAGE}:$tag"
+  fi
+}
+
+# echo "Parsing $AGENT_VERSION into $(parse_version "$AGENT_VERSION")"
+
+if [[ -z "${AGENT_VERSION:-}" ]] ; then
+  echo '--- Getting agent version from build meta data'
+  AGENT_VERSION=$(buildkite-agent meta-data get "agent-version")
+  echo "Agent version: $AGENT_VERSION"
+fi
+
+if [[ "$DOCKER_PULL" =~ (true|1) ]] ; then
+  echo '--- :docker: Pulling prebuilt image'
+  docker pull "$PREBUILT_IMAGE"
+fi
+
+# variants of edge/unstable
+if [[ "$CODENAME" == "unstable" ]] ; then
+  release_image "edge-build-${BUILDKITE_BUILD_NUMBER}"
+  release_image "edge"
+fi
+
+# variants of stable - e.g 2.3.2
+if [[ "$CODENAME" == "stable" ]] ; then
+  for tag in latest stable $(parse_version "$AGENT_VERSION") ; do
+    release_image "$tag"
+  done
+fi
+
+# variants of beta/experimental - e.g 3.0-beta.16
+if [[ "$CODENAME" == "experimental" ]] ; then
+  for tag in beta $(parse_version "$AGENT_VERSION") ; do
+    if is_stable_version "$tag" ; then
+      echo "--- :docker: Skipping tagging stable ${DOCKER_IMAGE}:${tag}"
+      continue
+    fi
+    release_image "$tag"
+  done
+fi


### PR DESCRIPTION
Currently docker images are build via an async trigger to a pipeline that builds from https://github.com/buildkite/docker-buildkite-agent.

That repository builds images for all our versions (beta, stable and edge), regardless of what was actually built. 

This moves the docker packaging and building into the agent pipeline and only builds images for the current agent version. The following tags are created:

* For beta releases: 3.0-beta.42.2243 is tagged as beta, 3.0-beta.42, 3.0 and 3
* For edge releases: 3.0-beta.42.2243 is tagged as edge and edge-build-2243
* For stable release: 2.6.10 is tagged as stable, latest, 2.6.10, 2.6 and 2

Once this is in place, we can probably entirely remove the old https://github.com/buildkite/docker-buildkite-agent repo. 