### PR TITLE
Use meta-data for docker build image name

### DIFF
--- a/scripts/build-docker-images.sh
+++ b/scripts/build-docker-images.sh
@@ -25,3 +25,5 @@ docker run --rm --entrypoint "docker-compose" "$image_tag" --version
 
 echo '--- Pushing :docker: image to buildkiteci/agent'
 docker push "$image_tag"
+
+buildkite-agent meta-data set "agent-docker-image-alpine" "$image_tag"

--- a/scripts/publish-docker-images.sh
+++ b/scripts/publish-docker-images.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 : "${DOCKER_IMAGE:=buildkite/agent}"
 : "${DOCKER_PUSH:=1}"
 : "${DOCKER_PULL:=1}"
-: "${PREBUILT_IMAGE:=buildkiteci/agent:alpine-build-${BUILDKITE_BUILD_NUMBER}}"
+: "${PREBUILT_IMAGE:=}"
 : "${CODENAME:=stable}"
 : "${STABLE_VERSION:=2}"
 
@@ -38,6 +38,12 @@ release_image() {
     docker push "${DOCKER_IMAGE}:$tag"
   fi
 }
+
+if [[ -z "${PREBUILT_IMAGE}" ]] ; then
+  echo '--- Getting prebuilt docker image from build meta data'
+  AGENT_VERSION=$(buildkite-agent meta-data get "agent-docker-image-alpine")
+  echo "Docker image: $PREBUILT_IMAGE"
+fi
 
 # echo "Parsing $AGENT_VERSION into $(parse_version "$AGENT_VERSION")"
 

--- a/scripts/publish-docker-images.sh
+++ b/scripts/publish-docker-images.sh
@@ -32,7 +32,7 @@ is_stable_version() {
 
 release_image() {
   local tag="$1"
-  echo "--- :docker: Taggng ${DOCKER_IMAGE}:${tag}"
+  echo "--- :docker: Tagging ${DOCKER_IMAGE}:${tag}"
   docker tag "$PREBUILT_IMAGE" "${DOCKER_IMAGE}:$tag"
   if [[ "$DOCKER_PUSH" =~ (true|1) ]] ; then
     docker push "${DOCKER_IMAGE}:$tag"


### PR DESCRIPTION
Previously the prebuilt image name was built with $BUILDKITE_BUILD_NUMBER, which doesn't work when triggered in the release pipelines.