### PR TITLE
Only run git submodule operations if there is a .gitmodules

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -687,14 +687,6 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 		return err
 	}
 
-	var gitSubmodules bool
-	if !b.GitSubmodules && hasGitSubmodules(b.shell) {
-		b.shell.Warningf("This repository has submodules, but submodules are disabled at an agent level")
-	} else if b.GitSubmodules && hasGitSubmodules(b.shell) {
-		b.shell.Commentf("Git submodules detected")
-		gitSubmodules = true
-	}
-
 	// If a refspec is provided then use it instead.
 	// i.e. `refs/not/a/head`
 	if b.RefSpec != "" {
@@ -756,6 +748,16 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 		if err := b.shell.Run("git", "checkout", "-f", b.Commit); err != nil {
 			return err
 		}
+	}
+
+	var gitSubmodules bool
+	if !b.GitSubmodules && hasGitSubmodules(b.shell) {
+		b.shell.Warningf("This repository has submodules, but submodules are disabled at an agent level")
+	} else if b.GitSubmodules && hasGitSubmodules(b.shell) {
+		b.shell.Commentf("Git submodules detected")
+		gitSubmodules = true
+	} else if !hasGitSubmodules(b.shell) {
+		b.shell.Commentf("No git submodules detected")
 	}
 
 	if gitSubmodules {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -643,6 +643,10 @@ func (b *Bootstrap) CheckoutPhase() error {
 	return nil
 }
 
+func hasGitSubmodules(sh *shell.Shell) bool {
+	return fileExists(filepath.Join(sh.Getwd(), ".gitmodules"))
+}
+
 // defaultCheckoutPhase is called by the CheckoutPhase if no global or plugin checkout
 // hook exists. It performs the default checkout on the Repository provided in the config
 func (b *Bootstrap) defaultCheckoutPhase() error {
@@ -673,8 +677,22 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 	}
 
 	// Git clean prior to checkout
-	if err := gitClean(b.shell, b.GitCleanFlags, b.GitSubmodules); err != nil {
+	if hasGitSubmodules(b.shell) {
+		if err := gitCleanSubmodules(b.shell, b.GitCleanFlags); err != nil {
+			return err
+		}
+	}
+
+	if err := gitClean(b.shell, b.GitCleanFlags); err != nil {
 		return err
+	}
+
+	var gitSubmodules bool
+	if !b.GitSubmodules && hasGitSubmodules(b.shell) {
+		b.shell.Warningf("This repository has submodules, but submodules are disabled at an agent level")
+	} else if b.GitSubmodules && hasGitSubmodules(b.shell) {
+		b.shell.Commentf("Git submodules detected")
+		gitSubmodules = true
 	}
 
 	// If a refspec is provided then use it instead.
@@ -740,7 +758,7 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 		}
 	}
 
-	if b.GitSubmodules {
+	if gitSubmodules {
 		// submodules might need their fingerprints verified too
 		if b.SSHKeyscan {
 			b.shell.Commentf("Checking to see if submodule urls need to be added to known_hosts")
@@ -773,8 +791,14 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 	}
 
 	// Git clean after checkout
-	if err := gitClean(b.shell, b.GitCleanFlags, b.GitSubmodules); err != nil {
+	if err := gitClean(b.shell, b.GitCleanFlags); err != nil {
 		return err
+	}
+
+	if gitSubmodules {
+		if err := gitCleanSubmodules(b.shell, b.GitCleanFlags); err != nil {
+			return err
+		}
 	}
 
 	if _, hasToken := b.shell.Env.Get("BUILDKITE_AGENT_ACCESS_TOKEN"); !hasToken {

--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -50,7 +50,7 @@ func gitCleanSubmodules(sh *shell.Shell, gitCleanFlags string) error {
 		return err
 	}
 
-	commandArgs := append([]string{"submodule", "foreach", "--recursive", "git"}, individualCleanFlags...)
+	commandArgs := append([]string{"submodule", "foreach", "--recursive", "git", "clean"}, individualCleanFlags...)
 
 	if err = sh.Run("git", commandArgs...); err != nil {
 		return err

--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -28,7 +28,7 @@ func gitClone(sh *shell.Shell, gitCloneFlags, repository, dir string) error {
 	return nil
 }
 
-func gitClean(sh *shell.Shell, gitCleanFlags string, gitSubmodules bool) error {
+func gitClean(sh *shell.Shell, gitCleanFlags string) error {
 	individualCleanFlags, err := shellwords.Split(gitCleanFlags)
 	if err != nil {
 		return err
@@ -41,13 +41,19 @@ func gitClean(sh *shell.Shell, gitCleanFlags string, gitSubmodules bool) error {
 		return err
 	}
 
-	// Also clean up submodules if we can
-	if gitSubmodules {
-		commandArgs = append([]string{"submodule", "foreach", "--recursive", "git"}, commandArgs...)
+	return nil
+}
 
-		if err = sh.Run("git", commandArgs...); err != nil {
-			return err
-		}
+func gitCleanSubmodules(sh *shell.Shell, gitCleanFlags string) error {
+	individualCleanFlags, err := shellwords.Split(gitCleanFlags)
+	if err != nil {
+		return err
+	}
+
+	commandArgs := append([]string{"submodule", "foreach", "--recursive", "git"}, individualCleanFlags...)
+
+	if err = sh.Run("git", commandArgs...); err != nil {
+		return err
 	}
 
 	return nil

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -67,6 +67,22 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 	}
 	defer tester.Close()
 
+	submoduleRepo, err := createTestGitRespository()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer submoduleRepo.Close()
+
+	out, err := tester.Repo.Execute("submodule", "add", submoduleRepo.Path)
+	if err != nil {
+		t.Fatalf("Adding submodule failed: %s", out)
+	}
+
+	out, err = tester.Repo.Execute("commit", "-am", "Add example submodule")
+	if err != nil {
+		t.Fatalf("Committing submodule failed: %s", out)
+	}
+
 	env := []string{
 		"BUILDKITE_GIT_CLONE_FLAGS=-v",
 		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
@@ -117,22 +133,6 @@ func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer tester.Close()
-
-	submoduleRepo, err := createTestGitRespository()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer submoduleRepo.Close()
-
-	out, err := tester.Repo.Execute("submodule", "add", submoduleRepo.Path)
-	if err != nil {
-		t.Fatalf("Adding submodule failed: %s", out)
-	}
-
-	out, err = tester.Repo.Execute("commit", "-am", "Add example submodule")
-	if err != nil {
-		t.Fatalf("Committing submodule failed: %s", out)
-	}
 
 	agent := tester.MustMock(t, "buildkite-agent")
 	agent.


### PR DESCRIPTION
Currently we run a lot of git operations that deal with submodules, regardless of whether there are submodules or not. These are particularly slow on windows.

This change only runs git submodule operations if there is a `.gitmodules` file.
