### PR TITLE
Add an agent config for no-local-hooks

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -12,6 +12,7 @@ type AgentConfiguration struct {
 	SSHKeyscan                bool
 	CommandEval               bool
 	PluginsEnabled            bool
+	LocalHooksEnabled         bool
 	RunInPty                  bool
 	TimestampLines            bool
 	DisconnectAfterJob        bool

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -232,6 +232,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	env["BUILDKITE_GIT_SUBMODULES"] = fmt.Sprintf("%t", r.AgentConfiguration.GitSubmodules)
 	env["BUILDKITE_COMMAND_EVAL"] = fmt.Sprintf("%t", r.AgentConfiguration.CommandEval)
 	env["BUILDKITE_PLUGINS_ENABLED"] = fmt.Sprintf("%t", r.AgentConfiguration.PluginsEnabled)
+	env["BUILDKITE_LOCAL_HOOKS_ENABLED"] = fmt.Sprintf("%t", r.AgentConfiguration.LocalHooksEnabled)
 	env["BUILDKITE_GIT_CLONE_FLAGS"] = r.AgentConfiguration.GitCloneFlags
 	env["BUILDKITE_GIT_CLEAN_FLAGS"] = r.AgentConfiguration.GitCleanFlags
 	env["BUILDKITE_SHELL"] = r.AgentConfiguration.Shell

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -76,6 +76,9 @@ type Config struct {
 	// Are plugins enabled?
 	PluginsEnabled bool
 
+	// Are local hooks enabled?
+	LocalHooksEnabled bool
+
 	// Path where the builds will be run
 	BuildPath string
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -60,6 +60,7 @@ type AgentStartConfig struct {
 	NoColor                   bool     `cli:"no-color"`
 	NoSSHKeyscan              bool     `cli:"no-ssh-keyscan"`
 	NoCommandEval             bool     `cli:"no-command-eval"`
+	NoLocalHooks              bool     `cli:"no-local-hooks"`
 	NoPlugins                 bool     `cli:"no-plugins"`
 	NoPTY                     bool     `cli:"no-pty"`
 	TimestampLines            bool     `cli:"timestamp-lines"`
@@ -248,6 +249,11 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_NO_PLUGINS",
 		},
 		cli.BoolFlag{
+			Name:   "no-local-hooks",
+			Usage:  "Don't allow local hooks to be run from checked out repositories",
+			EnvVar: "BUILDKITE_NO_LOCAL_HOOKS",
+		},
+		cli.BoolFlag{
 			Name:   "no-git-submodules",
 			Usage:  "Don't automatically checkout git submodules",
 			EnvVar: "BUILDKITE_NO_GIT_SUBMODULES,BUILDKITE_DISABLE_GIT_SUBMODULES",
@@ -315,8 +321,8 @@ var AgentStartCommand = cli.Command{
 			cfg.BootstrapScript = fmt.Sprintf("%s bootstrap", shellwords.Quote(os.Args[0]))
 		}
 
-		// Turning off command eval will also turn off plugins.
-		if cfg.NoCommandEval {
+		// Turning off command eval or local hooks will also turn off plugins.
+		if cfg.NoCommandEval || cfg.NoLocalHooks {
 			cfg.NoPlugins = true
 		}
 
@@ -361,6 +367,7 @@ var AgentStartCommand = cli.Command{
 				SSHKeyscan:                !cfg.NoSSHKeyscan,
 				CommandEval:               !cfg.NoCommandEval,
 				PluginsEnabled:            !cfg.NoPlugins,
+				LocalHooksEnabled:         !cfg.NoLocalHooks,
 				RunInPty:                  !cfg.NoPTY,
 				TimestampLines:            cfg.TimestampLines,
 				DisconnectAfterJob:        cfg.DisconnectAfterJob,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -52,6 +52,7 @@ type BootstrapConfig struct {
 	PluginsPath                  string `cli:"plugins-path" normalize:"filepath"`
 	CommandEval                  bool   `cli:"command-eval"`
 	PluginsEnabled               bool   `cli:"plugins-enabled"`
+	LocalHooksEnabled            bool   `cli:"local-hooks-enabled"`
 	PTY                          bool   `cli:"pty"`
 	Debug                        bool   `cli:"debug"`
 	Shell                        string `cli:"shell"`

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -204,6 +204,11 @@ var BootstrapCommand = cli.Command{
 			EnvVar: "BUILDKITE_PLUGINS_ENABLED",
 		},
 		cli.BoolTFlag{
+			Name:   "local-hooks-enabled",
+			Usage:  "Allow local hooks to be run",
+			EnvVar: "BUILDKITE_LOCAL_HOOKS_ENABLED",
+		},
+		cli.BoolTFlag{
 			Name:   "ssh-keyscan",
 			Usage:  "Automatically run ssh-keyscan before checkout",
 			EnvVar: "BUILDKITE_SSH_KEYSCAN",
@@ -271,6 +276,7 @@ var BootstrapCommand = cli.Command{
 				RunInPty:                     runInPty,
 				CommandEval:                  cfg.CommandEval,
 				PluginsEnabled:               cfg.PluginsEnabled,
+				LocalHooksEnabled:            cfg.LocalHooksEnabled,
 				SSHKeyscan:                   cfg.SSHKeyscan,
 				Shell:                        cfg.Shell,
 			},


### PR DESCRIPTION
This adds a `no-local-hooks` config for the agent. Global hooks can still set `BUILDKITE_NO_LOCAL_HOOKS` on a case-by-case basis.