### PR TITLE
Upload github release and homebrew in beta/stable pipelines

### DIFF
--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -13,6 +13,13 @@ steps:
     agents:
       queue: "deploy"
 
+  - name: ":octocat: :rocket:"
+    command: "scripts/github-release.sh"
+    env:
+      CODENAME: "stable"
+    agents:
+      queue: "deploy"
+
   - name: ":redhat:"
     command: "scripts/publish-rpm-package.sh"
     env:
@@ -33,3 +40,14 @@ steps:
       CODENAME: "stable"
     agents:
       queue: "deploy"
+
+  - wait
+
+  - name: ":beer:"
+    command: "scripts/release-homebrew.sh"
+    artifact_paths: "pkg/*.rb;pkg/*.json"
+    env:
+      CODENAME: "stable"
+    agents:
+      queue: "deploy"
+

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -15,6 +15,8 @@ steps:
 
   - name: ":octocat: :rocket:"
     command: "scripts/github-release.sh"
+    env:
+      CODENAME: "unstable"
     agents:
       queue: "deploy"
 
@@ -44,6 +46,8 @@ steps:
   - name: ":beer:"
     command: "scripts/release-homebrew.sh"
     artifact_paths: "pkg/*.rb;pkg/*.json"
+    env:
+      CODENAME: "unstable"
     agents:
       queue: "deploy"
 

--- a/scripts/extract-agent-version-metadata.sh
+++ b/scripts/extract-agent-version-metadata.sh
@@ -6,12 +6,19 @@ build_version=${BUILDKITE_BUILD_NUMBER:-1}
 full_agent_version="buildkite-agent version ${agent_version}, build ${build_version}"
 docker_alpine_image_tag="buildkiteci/agent:alpine-build-${BUILDKITE_BUILD_NUMBER}"
 
+is_prerelease=0
+if [[ "$agent_version" =~ (alpha|beta|rc) ]] ; then
+  is_prerelease=1
+fi
+
 echo "Full agent version: $full_agent_version"
 echo "Agent version: $agent_version"
 echo "Build version: $build_version"
 echo "Docker Alpine Image Tag: $docker_alpine_image_tag"
+echo "Is prerelease? $is_prerelease"
 
 buildkite-agent meta-data set "agent-version" "$agent_version"
 buildkite-agent meta-data set "agent-version-full" "$full_agent_version"
 buildkite-agent meta-data set "agent-version-build" "$build_version"
 buildkite-agent meta-data set "agent-docker-image-alpine" "$docker_alpine_image_tag"
+buildkite-agent meta-data set "agent-is-prerelease" "$is_prerelease"

--- a/scripts/github-release.sh
+++ b/scripts/github-release.sh
@@ -19,10 +19,22 @@ echo '--- Getting agent version from build meta data'
 export FULL_AGENT_VERSION=$(buildkite-agent meta-data get "agent-version-full")
 export AGENT_VERSION=$(buildkite-agent meta-data get "agent-version")
 export BUILD_VERSION=$(buildkite-agent meta-data get "agent-version-build")
+export IS_PRERELEASE=$(buildkite-agent meta-data get "agent-is-prerelease")
 
 echo "Full agent version: $FULL_AGENT_VERSION"
 echo "Agent version: $AGENT_VERSION"
 echo "Build version: $BUILD_VERSION"
+echo "Is prerelease?: $IS_PRERELEASE"
+
+if [[ "$CODENAME" == "unstable" && "$IS_PRERELEASE" == "0" ]] ; then
+  echo "Skipping github release, will happen in stable pipeline"
+  exit 0
+fi
+
+if [[ "$CODENAME" == "stable" && "$IS_PRERELEASE" == "1" ]] ; then
+  echo "Skipping github release, should have happened in unstable pipeline"
+  exit 0
+fi
 
 echo '--- Downloading releases'
 
@@ -36,18 +48,18 @@ echo "Version is $FULL_AGENT_VERSION"
 
 export GITHUB_RELEASE_REPOSITORY="buildkite/agent"
 
-if [[ "$AGENT_VERSION" == *"beta"* || "$AGENT_VERSION" == *"alpha"* ]]; then
+if [[ "$IS_PRERELEASE" == "1" ]]; then
   echo "--- 🚀 $AGENT_VERSION (prerelease)"
 
   buildkite-agent meta-data set github_release_type "prerelease"
-  buildkite-agent meta-data set github_release_version $AGENT_VERSION
+  buildkite-agent meta-data set github_release_version "$AGENT_VERSION"
 
   dry_run github-release "v$AGENT_VERSION" releases/* --commit "$(git rev-parse HEAD)" --prerelease
 else
   echo "--- 🚀 $AGENT_VERSION"
 
   buildkite-agent meta-data set github_release_type "stable"
-  buildkite-agent meta-data set github_release_version $AGENT_VERSION
+  buildkite-agent meta-data set github_release_version "$AGENT_VERSION"
 
   dry_run github-release "v$AGENT_VERSION" releases/* --commit "$(git rev-parse HEAD)"
 fi

--- a/scripts/upload-release-steps.sh
+++ b/scripts/upload-release-steps.sh
@@ -29,6 +29,7 @@ trigger_step() {
         agent-version-build: "${build_version}"
         agent-version-full:  "${full_agent_version}"
         agent-docker-image-alpine: "${agent_docker_image_alpine}"
+        agent-is-prerelease: "${agent_is_prerelease}"
       env:
         DRY_RUN: "${DRY_RUN:-false}"
 YAML
@@ -73,6 +74,7 @@ agent_version=$(buildkite-agent meta-data get "agent-version")
 build_version=$(buildkite-agent meta-data get "agent-version-build")
 full_agent_version=$(buildkite-agent meta-data get "agent-version-full")
 agent_docker_image_alpine=$(buildkite-agent meta-data get "agent-docker-image-alpine")
+agent_is_prerelease=$(buildkite-agent meta-data get "agent-is-prerelease")
 
 # If there is already a release (which means a tag), we want to avoid trying to create
 # another one, as this will fail and cause partial broken releases


### PR DESCRIPTION
Previously we were doing the github release and homebrew release only in the beta pipeline, which meant that when we released 3.0.0 it shipped even before the stable release pipeline was unlocked, which was very unexpected (for me).

This looks at the pipeline and skips the github and homebrew step depending on whether the version is a pre-release or not.