### PR TITLE
Homebrew 64-bit binaries

### DIFF
--- a/scripts/release-homebrew.sh
+++ b/scripts/release-homebrew.sh
@@ -48,7 +48,7 @@ else
   BREW_RELEASE_TYPE="stable"
 fi
 
-BINARY_ARCH="386"
+BINARY_ARCH="amd64"
 BINARY_NAME="buildkite-agent-darwin-${BINARY_ARCH}-${AGENT_VERSION}.tar.gz"
 
 DOWNLOAD_URL="https://github.com/buildkite/agent/releases/download/v$GITHUB_RELEASE_VERSION/$BINARY_NAME"


### PR DESCRIPTION
The next version of macOS will [not fully support 32-bit binaries](https://developer.apple.com/news/?id=06282017a), but we're still shipping a 32-bit buildkite agent via Homebrew. This improves the script a little and adds portability, mostly so I could test it on a darwin system, then changes the arch to amd64.