### PR TITLE
Fixed typo in line 5 - Missing 'd' in buildkite

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2,7 +2,7 @@ $installDir = "C:\buildkite-agent"
 $arch = "amd64"
 $beta = $env:buildkiteAgentBeta
 $token = $env:buildkiteAgentToken
-$tags = $env:builkiteAgentTags
+$tags = $env:buildkiteAgentTags
 
 if ([string]::IsNullOrEmpty($token)) {
     throw "No token specified, set `$env:buildkiteAgentToken"


### PR DESCRIPTION
Hi guys,

I discovered a typo in the naming convention of an environment variable ($env:buildkiteAgentTags) which is missing the letter 'd'.

Mark.