### PR TITLE
Don't set Content-Encoding on s3 upload

### DIFF
--- a/agent/s3_uploader.go
+++ b/agent/s3_uploader.go
@@ -78,7 +78,7 @@ func (u *S3Uploader) Upload(artifact *api.Artifact) error {
 	if err != nil {
 		return err
 	}
-  
+
 	// Create an uploader with the session and default options
 	uploader := s3manager.NewUploaderWithClient(s3Client)
 
@@ -89,22 +89,14 @@ func (u *S3Uploader) Upload(artifact *api.Artifact) error {
 		return fmt.Errorf("failed to open file %q (%v)", artifact.AbsolutePath, err)
 	}
 
-  var contentEncoding *string
-  
-  // Detect content encoding and send it for the file
-	if ce := u.contentEncoding(artifact); ce != "" {
-    contentEncoding = aws.String(ce)
-	}
-  
 	// Upload the file to S3.
 	logger.Debug("Uploading \"%s\" to bucket with permission `%s`", u.artifactPath(artifact), permission)
 	_, err = uploader.Upload(&s3manager.UploadInput{
-		Bucket:          aws.String(u.BucketName()),
-		Key:             aws.String(u.artifactPath(artifact)),
-		ContentType:     aws.String(u.mimeType(artifact)),
-    ContentEncoding: contentEncoding,
-		ACL:             aws.String(permission),
-		Body:            f,
+		Bucket:      aws.String(u.BucketName()),
+		Key:         aws.String(u.artifactPath(artifact)),
+		ContentType: aws.String(u.mimeType(artifact)),
+		ACL:         aws.String(permission),
+		Body:        f,
 	})
 
 	return err
@@ -139,9 +131,4 @@ func (u *S3Uploader) mimeType(a *api.Artifact) string {
 	} else {
 		return "binary/octet-stream"
 	}
-}
-
-func (u *S3Uploader) contentEncoding(a *api.Artifact) string {
-	extension := filepath.Ext(a.Path)
-	return mime.EncodingByExtension(extension)
 }

--- a/agent/s3_uploader_test.go
+++ b/agent/s3_uploader_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"testing"
 
-	"github.com/buildkite/agent/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,13 +20,4 @@ func TestS3UploaderBucketName(t *testing.T) {
 
 	s3Uploader.Destination = "s3://starts-with-an-s"
 	assert.Equal(t, s3Uploader.BucketName(), "starts-with-an-s")
-}
-
-func TestS3UploaderContentEncoding(t *testing.T) {
-	s3Uploader := S3Uploader{Destination: "s3://my-bucket-name/foo/bar"}
-	artifact := api.Artifact{Path: "foo/bar/thing.csv"}
-	assert.Equal(t, s3Uploader.contentEncoding(&artifact), "")
-
-	gzipArtifact := api.Artifact{Path: "foo/bar/thing.csv.gz"}
-	assert.Equal(t, s3Uploader.contentEncoding(&gzipArtifact), "gzip")
 }

--- a/mime/mime.go
+++ b/mime/mime.go
@@ -25,15 +25,6 @@ func TypeByExtension(ext string) string {
 	return mime.TypeByExtension(ext)
 }
 
-func EncodingByExtension(ext string) string {
-	encoding, ok := encodings[ext]
-	if ok {
-		return encoding
-	} else {
-		return ""
-	}
-}
-
 var types = []string{
 	"ez", "application/andrew-inset",
 	"anx", "application/annodex",
@@ -576,9 +567,4 @@ var types = []string{
 	"vrm", "x-world/x-vrml",
 	"vrml", "x-world/x-vrml",
 	"wrl", "x-world/x-vrml",
-}
-
-var encodings = map[string]string{
-	".gzip": "gzip",
-	".gz":   "gzip",
 }


### PR DESCRIPTION
This reverts #494, is it creates a confusing behaviour where when you uploading a gzipped artifact and then download it in a later step the file gets un-gzipped. 