### PR TITLE
Support `--no-interpolation` option in `pipeline upload`

### DIFF
--- a/agent/pipeline_parser.go
+++ b/agent/pipeline_parser.go
@@ -15,9 +15,10 @@ import (
 )
 
 type PipelineParser struct {
-	Env      *env.Environment
-	Filename string
-	Pipeline []byte
+	Env             *env.Environment
+	Filename        string
+	Pipeline        []byte
+	NoInterpolation bool
 }
 
 func (p PipelineParser) Parse() (interface{}, error) {
@@ -30,6 +31,15 @@ func (p PipelineParser) Parse() (interface{}, error) {
 		errPrefix = "Failed to parse pipeline"
 	} else {
 		errPrefix = fmt.Sprintf("Failed to parse %s", p.Filename)
+	}
+
+	// If interpolation is disabled, just parse and return
+	if p.NoInterpolation {
+		var result interface{}
+		if err := unmarshalAsStringMap([]byte(p.Pipeline), &result); err != nil {
+			return nil, fmt.Errorf("%s: %v", errPrefix, formatYAMLError(err))
+		}
+		return result, nil
 	}
 
 	var pipeline interface{}

--- a/agent/pipeline_parser_test.go
+++ b/agent/pipeline_parser_test.go
@@ -23,6 +23,18 @@ func TestPipelineParserParsesYaml(t *testing.T) {
 	assert.Equal(t, `{"steps":[{"label":"hello \"friend\""}]}`, string(j))
 }
 
+func TestPipelineParserParsesYamlWithNoInterpolation(t *testing.T) {
+	result, err := PipelineParser{
+		Filename:        "awesome.yml",
+		Pipeline:        []byte("steps:\n  - label: \"hello ${ENV_VAR_FRIEND}\""),
+		NoInterpolation: true,
+	}.Parse()
+
+	assert.NoError(t, err)
+	j, err := json.Marshal(result)
+	assert.Equal(t, `{"steps":[{"label":"hello ${ENV_VAR_FRIEND}"}]}`, string(j))
+}
+
 func TestPipelineParserSupportsYamlMergesAndAnchors(t *testing.T) {
 	complexYAML := `---
 base_step: &base_step

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -166,9 +166,9 @@ var PipelineUploadCommand = cli.Command{
 
 		// Parse the pipeline
 		parsed, err = agent.PipelineParser{
-			Filename:       filename,
-			Pipeline:       input,
-			NoInterolation: cfg.NoInterpolation,
+			Filename:        filename,
+			Pipeline:        input,
+			NoInterpolation: cfg.NoInterpolation,
 		}.Parse()
 		if err != nil {
 			logger.Fatal("Pipeline parsing of \"%s\" failed (%s)", filename, err)

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -50,6 +50,7 @@ type PipelineUploadConfig struct {
 	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
 	Endpoint         string `cli:"endpoint" validate:"required"`
 	NoColor          bool   `cli:"no-color"`
+	NoInterpolation  bool   `cli:"no-interpolation"`
 	Debug            bool   `cli:"debug"`
 	DebugHTTP        bool   `cli:"debug-http"`
 }
@@ -69,6 +70,11 @@ var PipelineUploadCommand = cli.Command{
 			Value:  "",
 			Usage:  "The job that is making the changes to it's build",
 			EnvVar: "BUILDKITE_JOB_ID",
+		},
+		cli.BoolFlag{
+			Name:   "no-interpolation",
+			Usage:  "Skip variable interpolation the pipeline when uploaded",
+			EnvVar: "BUILDKITE_PIPELINE_NO_INTERPOLATION",
 		},
 		AgentAccessTokenFlag,
 		EndpointFlag,
@@ -159,7 +165,11 @@ var PipelineUploadCommand = cli.Command{
 		var parsed interface{}
 
 		// Parse the pipeline
-		parsed, err = agent.PipelineParser{Filename: filename, Pipeline: input}.Parse()
+		parsed, err = agent.PipelineParser{
+			Filename:       filename,
+			Pipeline:       input,
+			NoInterolation: cfg.NoInterpolation,
+		}.Parse()
 		if err != nil {
 			logger.Fatal("Pipeline parsing of \"%s\" failed (%s)", filename, err)
 		}


### PR DESCRIPTION
This allows for interpolation to be disabled in `buildkite-agent pipeline upload`.

Closes #715.