### PR TITLE
Add a virtual provides to the RPM package

### DIFF
--- a/scripts/build-rpm-package.sh
+++ b/scripts/build-rpm-package.sh
@@ -64,6 +64,7 @@ bundle exec fpm -s "dir" \
   --after-upgrade "packaging/linux/scripts/after-install-and-upgrade.sh" \
   -p "$PACKAGE_PATH" \
   -v "$VERSION" \
+  --provides "$NAME-${VERSION%%.*}" \
   --iteration "$REVISION" \
   "./$BUILD_BINARY_PATH=/usr/bin/buildkite-agent" \
   "packaging/linux/root/=/"


### PR DESCRIPTION
Allow package to be matched as `buildkite-agent-<major version>` ie
`yum install buildkite-agent-2`