### PR TITLE
Try to help people that forget to quote their upload globs

### DIFF
--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -175,7 +175,7 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 		} else if strings.HasPrefix(a.Destination, "gs://") {
 			uploader = new(GSUploader)
 		} else {
-			return errors.New("Unknown upload destination: " + a.Destination)
+			return errors.New(fmt.Sprintf("Invalid upload destination: '%v'. Only s3:// and gs:// upload destinations are allowed. Did you forget to surround your artifact upload pattern in double quotes?", a.Destination))
 		}
 	} else {
 		uploader = new(FormUploader)


### PR DESCRIPTION
I did this in a script, to upload some JUnit xml files:

```bash
buildkite-agent artifact upload *.xml
```

and it failed with this error message:

![image](https://user-images.githubusercontent.com/153/39102804-4f86a12c-46ea-11e8-88f7-7b13d51dcee2.png)

This had me very confused for a few hours, until I realised that there was a second argument to upload called "upload destination" — I had assumed that the error message on upload destination was that I had misconfigured my agent, or it was a backend problem.

What I needed to do was:

```bash
buildkite-agent artifact upload "*.xml"
```

This PR tries to provide a less confusing error message if people accidentally provide a second argument to the `artifact upload` command.