### PR TITLE
Bump our Docker image base to alpine v3.7

### DIFF
--- a/Dockerfile-github-release
+++ b/Dockerfile-github-release
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.7
 
 # We need buildkite-agent to download artifacts, and zip for Windows zipping
 RUN apk --no-cache add bash zip curl \

--- a/packaging/docker/linux/Dockerfile
+++ b/packaging/docker/linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 RUN apk add --no-cache \
       tini \


### PR DESCRIPTION
Per buildkite/feedback#348, it's all on the 🥫