### PR TITLE
Add basic plugin definition parsing

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -12,6 +12,7 @@ type AgentConfiguration struct {
 	SSHKeyscan                bool
 	CommandEval               bool
 	PluginsEnabled            bool
+	PluginValidation          bool
 	LocalHooksEnabled         bool
 	RunInPty                  bool
 	TimestampLines            bool

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -308,6 +308,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	env["BUILDKITE_GIT_SUBMODULES"] = fmt.Sprintf("%t", r.AgentConfiguration.GitSubmodules)
 	env["BUILDKITE_COMMAND_EVAL"] = fmt.Sprintf("%t", r.AgentConfiguration.CommandEval)
 	env["BUILDKITE_PLUGINS_ENABLED"] = fmt.Sprintf("%t", r.AgentConfiguration.PluginsEnabled)
+	env["BUILDKITE_PLUGIN_VALIDATION"] = fmt.Sprintf("%t", r.AgentConfiguration.PluginValidation)
 	env["BUILDKITE_LOCAL_HOOKS_ENABLED"] = fmt.Sprintf("%t", r.AgentConfiguration.LocalHooksEnabled)
 	env["BUILDKITE_GIT_CLONE_FLAGS"] = r.AgentConfiguration.GitCloneFlags
 	env["BUILDKITE_GIT_CLEAN_FLAGS"] = r.AgentConfiguration.GitCleanFlags

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -308,11 +308,23 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	env["BUILDKITE_GIT_SUBMODULES"] = fmt.Sprintf("%t", r.AgentConfiguration.GitSubmodules)
 	env["BUILDKITE_COMMAND_EVAL"] = fmt.Sprintf("%t", r.AgentConfiguration.CommandEval)
 	env["BUILDKITE_PLUGINS_ENABLED"] = fmt.Sprintf("%t", r.AgentConfiguration.PluginsEnabled)
-	env["BUILDKITE_PLUGIN_VALIDATION"] = fmt.Sprintf("%t", r.AgentConfiguration.PluginValidation)
 	env["BUILDKITE_LOCAL_HOOKS_ENABLED"] = fmt.Sprintf("%t", r.AgentConfiguration.LocalHooksEnabled)
 	env["BUILDKITE_GIT_CLONE_FLAGS"] = r.AgentConfiguration.GitCloneFlags
 	env["BUILDKITE_GIT_CLEAN_FLAGS"] = r.AgentConfiguration.GitCleanFlags
 	env["BUILDKITE_SHELL"] = r.AgentConfiguration.Shell
+
+	enablePluginValidation := r.AgentConfiguration.PluginValidation
+
+	// Allow BUILDKITE_PLUGIN_VALIDATION to be enabled from env for easier
+	// per-pipeline testing
+	if pluginValidation, ok := env["BUILDKITE_PLUGIN_VALIDATION"]; ok {
+		switch pluginValidation {
+		case "true", "1", "on":
+			enablePluginValidation = true
+		}
+	}
+
+	env["BUILDKITE_PLUGIN_VALIDATION"] = fmt.Sprintf("%t", enablePluginValidation)
 
 	// Convert the env map into a slice (which is what the script gear
 	// needs)

--- a/agent/plugin/definition.go
+++ b/agent/plugin/definition.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/buildkite/agent/yamltojson"
 	"github.com/qri-io/jsonschema"
@@ -139,6 +140,10 @@ func (v Validator) Validate(def *Definition, config map[string]interface{}) Vali
 type ValidateResult struct {
 	Valid  bool
 	Errors []string
+}
+
+func (vr ValidateResult) Error() string {
+	return "Validation errors: " + strings.Join(vr.Errors, ", ")
 }
 
 func commandExists(command string) bool {

--- a/agent/plugin/definition.go
+++ b/agent/plugin/definition.go
@@ -129,8 +129,7 @@ func (v Validator) Validate(def *Definition, config map[string]interface{}) Vali
 		if len(valErrors) > 0 {
 			result.Valid = false
 			for _, err := range valErrors {
-				result.Errors = append(result.Errors,
-					fmt.Sprintf("Plugin validation failed at %v", err.Error()))
+				result.Errors = append(result.Errors, err.Error())
 			}
 		}
 	}
@@ -144,7 +143,7 @@ type ValidateResult struct {
 }
 
 func (vr ValidateResult) Error() string {
-	return "Validation errors: " + strings.Join(vr.Errors, ", ")
+	return strings.Join(vr.Errors, ", ")
 }
 
 func commandExists(command string) bool {

--- a/agent/plugin/definition.go
+++ b/agent/plugin/definition.go
@@ -1,0 +1,59 @@
+package plugin
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/buildkite/yaml"
+)
+
+var ErrDefinitionNotFound = errors.New("Definition file not found")
+
+// Definition defines the plugin.yml file that each plugin has
+type Definition struct {
+	Name         string   `yaml:"name"`
+	Requirements []string `yaml:"requirements"`
+}
+
+// ParseDefinition parses either yaml or json bytes into a Definition
+func ParseDefinition(b []byte) (*Definition, error) {
+	var def Definition
+
+	if err := yaml.Unmarshal(b, &def); err != nil {
+		return nil, err
+	}
+
+	return &def, nil
+}
+
+// LoadDefinitionFromDir looks in a directory for either a plugin.json or a plugin.yml
+func LoadDefinitionFromDir(dir string) (*Definition, error) {
+	f, err := findDefinitionFile(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := ioutil.ReadFile(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseDefinition(b)
+}
+
+// findDefinitionFile searches for known plugin definition files
+func findDefinitionFile(dir string) (string, error) {
+	var possibleFilenames = []string{
+		filepath.Join(dir, `plugin.json`),
+		filepath.Join(dir, `plugin.yaml`),
+		filepath.Join(dir, `plugin.yml`),
+	}
+	for _, filename := range possibleFilenames {
+		if _, err := os.Stat(filename); os.IsExist(err) {
+			return filename, nil
+		}
+	}
+	return "", ErrDefinitionNotFound
+}

--- a/agent/plugin/definition.go
+++ b/agent/plugin/definition.go
@@ -79,7 +79,7 @@ func findDefinitionFile(dir string) (string, error) {
 		filepath.Join(dir, `plugin.yml`),
 	}
 	for _, filename := range possibleFilenames {
-		if _, err := os.Stat(filename); os.IsExist(err) {
+		if _, err := os.Stat(filename); err == nil {
 			return filename, nil
 		}
 	}
@@ -109,11 +109,13 @@ func (v Validator) Validate(def *Definition, config map[string]interface{}) Vali
 	}
 
 	// validate that the required commands exist
-	for _, command := range def.Requirements {
-		if !commandExistsFunc(command) {
-			result.Valid = false
-			result.Errors = append(result.Errors,
-				fmt.Sprintf(`Required command %q isn't in PATH`, command))
+	if def.Requirements != nil {
+		for _, command := range def.Requirements {
+			if !commandExistsFunc(command) {
+				result.Valid = false
+				result.Errors = append(result.Errors,
+					fmt.Sprintf(`Required command %q isn't in PATH`, command))
+			}
 		}
 	}
 
@@ -127,7 +129,6 @@ func (v Validator) Validate(def *Definition, config map[string]interface{}) Vali
 		if len(valErrors) > 0 {
 			result.Valid = false
 			for _, err := range valErrors {
-				// fmt.Printf("%#v", err)
 				result.Errors = append(result.Errors,
 					fmt.Sprintf("Plugin validation failed at %v", err.Error()))
 			}

--- a/agent/plugin/definition_test.go
+++ b/agent/plugin/definition_test.go
@@ -39,7 +39,7 @@ func TestDefinitionParsesYaml(t *testing.T) {
 
 func TestDefinitionValidationFailsIfDependenciesNotMet(t *testing.T) {
 	validator := &Validator{
-		CommandExists: func(cmd string) bool {
+		commandExists: func(cmd string) bool {
 			return false
 		},
 	}
@@ -50,7 +50,7 @@ func TestDefinitionValidationFailsIfDependenciesNotMet(t *testing.T) {
 
 	res := validator.Validate(def, nil)
 
-	assert.False(t, res.Valid)
+	assert.False(t, res.Valid())
 	assert.Equal(t, res.Errors, []string{
 		`Required command "llamas" isn't in PATH`,
 	})
@@ -58,7 +58,7 @@ func TestDefinitionValidationFailsIfDependenciesNotMet(t *testing.T) {
 
 func TestDefinitionValidatesConfiguration(t *testing.T) {
 	validator := &Validator{
-		CommandExists: func(cmd string) bool {
+		commandExists: func(cmd string) bool {
 			return false
 		},
 	}
@@ -82,7 +82,7 @@ func TestDefinitionValidatesConfiguration(t *testing.T) {
 		"llamas": "always",
 	})
 
-	assert.False(t, res.Valid)
+	assert.False(t, res.Valid())
 	assert.Equal(t, res.Errors, []string{
 		`/: {"llamas":"always"} "alpacas" value is required`,
 	})

--- a/agent/plugin/definition_test.go
+++ b/agent/plugin/definition_test.go
@@ -84,6 +84,6 @@ func TestDefinitionValidatesConfiguration(t *testing.T) {
 
 	assert.False(t, res.Valid)
 	assert.Equal(t, res.Errors, []string{
-		`Plugin validation failed at /: {"llamas":"always"} "alpacas" value is required`,
+		`/: {"llamas":"always"} "alpacas" value is required`,
 	})
 }

--- a/agent/plugin/definition_test.go
+++ b/agent/plugin/definition_test.go
@@ -1,0 +1,40 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var testPluginDef = `
+name: test-plugin
+description: A test plugin
+author: https://github.com/buildkite
+requirements:
+  - docker
+  - docker-compose
+configuration:
+  properties:
+    run:
+      type: string
+    build:
+      type: [ string, array ]
+      minimum: 1
+  oneOf:
+    - required:
+      - run
+    - required:
+      - build
+  additionalProperties: false
+`
+
+func TestDefinitionParsesYaml(t *testing.T) {
+	def, err := ParseDefinition([]byte(testPluginDef))
+
+	assert.NoError(t, err)
+	assert.Equal(t, def.Name, `test-plugin`)
+	assert.Equal(t, def.Requirements, []string{`docker`, `docker-compose`})
+
+	// j, err := json.Marshal(result)
+	// assert.Equal(t, `{"steps":[{"label":"hello \"friend\""}]}`, string(j))
+}

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -1,4 +1,4 @@
-package agent
+package plugin
 
 import (
 	"encoding/json"
@@ -55,7 +55,7 @@ func CreatePlugin(location string, config map[string]interface{}) (*Plugin, erro
 }
 
 // Given a JSON structure, convert it to an array of plugins
-func CreatePluginsFromJSON(j string) ([]*Plugin, error) {
+func CreateFromJSON(j string) ([]*Plugin, error) {
 	// Use more versatile number decoding
 	decoder := json.NewDecoder(strings.NewReader(j))
 	decoder.UseNumber()

--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -1,4 +1,4 @@
-package agent
+package plugin
 
 import (
 	"encoding/json"
@@ -9,13 +9,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreatePluginsFromJSON(t *testing.T) {
+func TestCreateFromJSON(t *testing.T) {
 	t.Parallel()
 
 	var plugins []*Plugin
 	var err error
 
-	plugins, err = CreatePluginsFromJSON(`[{"http://github.com/buildkite/plugins/docker-compose#a34fa34":{"container":"app"}}, "github.com/buildkite/plugins/ping#master"]`)
+	plugins, err = CreateFromJSON(`[{"http://github.com/buildkite/plugins/docker-compose#a34fa34":{"container":"app"}}, "github.com/buildkite/plugins/ping#master"]`)
 	assert.Equal(t, len(plugins), 2)
 	assert.Nil(t, err)
 
@@ -29,7 +29,7 @@ func TestCreatePluginsFromJSON(t *testing.T) {
 	assert.Equal(t, plugins[1].Scheme, "")
 	assert.Equal(t, plugins[1].Configuration, map[string]interface{}{})
 
-	plugins, err = CreatePluginsFromJSON(`["ssh://git:foo@github.com/buildkite/plugins/docker-compose#a34fa34"]`)
+	plugins, err = CreateFromJSON(`["ssh://git:foo@github.com/buildkite/plugins/docker-compose#a34fa34"]`)
 	assert.Equal(t, len(plugins), 1)
 	assert.Nil(t, err)
 
@@ -38,17 +38,17 @@ func TestCreatePluginsFromJSON(t *testing.T) {
 	assert.Equal(t, plugins[0].Scheme, "ssh")
 	assert.Equal(t, plugins[0].Authentication, "git:foo")
 
-	plugins, err = CreatePluginsFromJSON(`blah`)
+	plugins, err = CreateFromJSON(`blah`)
 	assert.Equal(t, len(plugins), 0)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "invalid character 'b' looking for beginning of value")
 
-	plugins, err = CreatePluginsFromJSON(`{"foo": "bar"}`)
+	plugins, err = CreateFromJSON(`{"foo": "bar"}`)
 	assert.Equal(t, len(plugins), 0)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "JSON structure was not an array")
 
-	plugins, err = CreatePluginsFromJSON(`["github.com/buildkite/plugins/ping#master#lololo"]`)
+	plugins, err = CreateFromJSON(`["github.com/buildkite/plugins/ping#master#lololo"]`)
 	assert.Equal(t, len(plugins), 0)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "Too many #'s in \"github.com/buildkite/plugins/ping#master#lololo\"")
@@ -271,7 +271,7 @@ func pluginEnvFromConfig(t *testing.T, configJson string) (*env.Environment, err
 
 	jsonString := fmt.Sprintf(`[ { "%s": %s } ]`, "github.com/buildkite-plugins/docker-compose-buildkite-plugin", configJson)
 
-	plugins, err := CreatePluginsFromJSON(jsonString)
+	plugins, err := CreateFromJSON(jsonString)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(plugins))

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -588,6 +588,14 @@ func (b *Bootstrap) checkoutPlugin(p *agent.Plugin) (*pluginCheckout, error) {
 		}
 	}
 
+	// Load the plugin definition
+	checkout.Definition, err = plugin.LoadDefinitionFromDir(directory)
+	if err == plugin.ErrDefinitionNotFound {
+		b.shell.Warningf("Failed to find plugin definition")
+	} else if err != nil {
+		return nil, err
+	}
+
 	return checkout, nil
 }
 
@@ -1151,6 +1159,7 @@ func (b *Bootstrap) ignoredEnv() []string {
 
 type pluginCheckout struct {
 	*plugin.Plugin
+	*plugin.Definition
 	CheckoutDir string
 	HooksDir    string
 }

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -480,19 +480,19 @@ func (b *Bootstrap) PluginPhase() error {
 	if b.Config.PluginValidation {
 		for _, checkout := range b.plugins {
 			if b.Debug {
-				b.shell.Commentf("Validating plugin configuration for %q", checkout.Label())
-				json, _ := json.MarshalIndent(checkout.Definition, "", "  ")
-				b.shell.Printf("%s", json)
+				json, _ := json.Marshal(checkout.Definition)
+				b.shell.Commentf("Plugin configuration JSON is %s", json)
 			}
 
 			val := &plugin.Validator{}
 			result := val.Validate(checkout.Definition, checkout.Plugin.Configuration)
 
 			if !result.Valid {
-				b.shell.Commentf("Validation plugin config of %q failed", checkout.Label())
+				b.shell.Headerf("Plugin validation failed for %q", checkout.Label())
+				b.shell.Commentf("Plugin JSON is %s", b.Plugins)
 				return result
 			} else {
-				b.shell.Commentf("Validation plugin config of %q succeeded", checkout.Label())
+				b.shell.Commentf("Valid plugin configuration for %q", checkout.Label())
 			}
 		}
 	}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -487,7 +487,7 @@ func (b *Bootstrap) PluginPhase() error {
 			val := &plugin.Validator{}
 			result := val.Validate(checkout.Definition, checkout.Plugin.Configuration)
 
-			if !result.Valid {
+			if !result.Valid() {
 				b.shell.Headerf("Plugin validation failed for %q", checkout.Plugin.Name())
 				json, _ := json.Marshal(checkout.Plugin.Configuration)
 				b.shell.Commentf("Plugin configuration JSON is %s", json)

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/agent"
+	"github.com/buildkite/agent/agent/plugin"
 	"github.com/buildkite/agent/bootstrap/shell"
 	"github.com/buildkite/agent/env"
 	"github.com/buildkite/agent/process"
@@ -449,7 +450,7 @@ func (b *Bootstrap) PluginPhase() error {
 		}
 	}
 
-	plugins, err := agent.CreatePluginsFromJSON(b.Plugins)
+	plugins, err := plugin.CreateFromJSON(b.Plugins)
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse plugin definition")
 	}
@@ -1149,7 +1150,7 @@ func (b *Bootstrap) ignoredEnv() []string {
 }
 
 type pluginCheckout struct {
-	*agent.Plugin
+	*plugin.Plugin
 	CheckoutDir string
 	HooksDir    string
 }

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/agent/plugin"
 	"github.com/buildkite/agent/bootstrap/shell"
 	"github.com/buildkite/agent/env"
@@ -497,7 +496,7 @@ func (b *Bootstrap) hasPluginHook(name string) bool {
 }
 
 // Checkout a given plugin to the plugins directory and return that directory
-func (b *Bootstrap) checkoutPlugin(p *agent.Plugin) (*pluginCheckout, error) {
+func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	// Get the identifer for the plugin
 	id, err := p.Identifier()
 	if err != nil {

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -76,6 +76,9 @@ type Config struct {
 	// Are plugins enabled?
 	PluginsEnabled bool
 
+	// Whether to validate plugin configuration
+	PluginValidation bool
+
 	// Are local hooks enabled?
 	LocalHooksEnabled bool
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -63,6 +63,7 @@ type AgentStartConfig struct {
 	NoCommandEval             bool     `cli:"no-command-eval"`
 	NoLocalHooks              bool     `cli:"no-local-hooks"`
 	NoPlugins                 bool     `cli:"no-plugins"`
+	NoPluginValidation        bool     `cli:"no-plugin-validation"`
 	NoPTY                     bool     `cli:"no-pty"`
 	TimestampLines            bool     `cli:"timestamp-lines"`
 	Endpoint                  string   `cli:"endpoint" validate:"required"`
@@ -255,6 +256,11 @@ var AgentStartCommand = cli.Command{
 			Usage:  "Don't allow this agent to load plugins",
 			EnvVar: "BUILDKITE_NO_PLUGINS",
 		},
+		cli.BoolTFlag{
+			Name:   "no-plugin-validation",
+			Usage:  "Don't validate plugin configuration and requirements",
+			EnvVar: "BUILDKITE_NO_PLUGIN_VALIDATION",
+		},
 		cli.BoolFlag{
 			Name:   "no-local-hooks",
 			Usage:  "Don't allow local hooks to be run from checked out repositories",
@@ -391,6 +397,7 @@ var AgentStartCommand = cli.Command{
 				SSHKeyscan:                !cfg.NoSSHKeyscan,
 				CommandEval:               !cfg.NoCommandEval,
 				PluginsEnabled:            !cfg.NoPlugins,
+				PluginValidation:          !cfg.NoPluginValidation,
 				LocalHooksEnabled:         !cfg.NoLocalHooks,
 				RunInPty:                  !cfg.NoPTY,
 				TimestampLines:            cfg.TimestampLines,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -63,6 +63,7 @@ type BootstrapConfig struct {
 	PluginsPath                  string   `cli:"plugins-path" normalize:"filepath"`
 	CommandEval                  bool     `cli:"command-eval"`
 	PluginsEnabled               bool     `cli:"plugins-enabled"`
+	PluginValidation             bool     `cli:"plugin-validation"`
 	LocalHooksEnabled            bool     `cli:"local-hooks-enabled"`
 	PTY                          bool     `cli:"pty"`
 	Debug                        bool     `cli:"debug"`
@@ -216,6 +217,11 @@ var BootstrapCommand = cli.Command{
 			Usage:  "Allow plugins to be run",
 			EnvVar: "BUILDKITE_PLUGINS_ENABLED",
 		},
+		cli.BoolFlag{
+			Name:   "plugin-validation",
+			Usage:  "Validate plugin configuration",
+			EnvVar: "BUILDKITE_PLUGIN_VALIDATION",
+		},
 		cli.BoolTFlag{
 			Name:   "local-hooks-enabled",
 			Usage:  "Allow local hooks to be run",
@@ -301,6 +307,7 @@ var BootstrapCommand = cli.Command{
 				BinPath:                      cfg.BinPath,
 				HooksPath:                    cfg.HooksPath,
 				PluginsPath:                  cfg.PluginsPath,
+				PluginValidation:             cfg.PluginValidation,
 				Debug:                        cfg.Debug,
 				RunInPty:                     runInPty,
 				CommandEval:                  cfg.CommandEval,

--- a/vendor/github.com/qri-io/jsonpointer/LICENSE
+++ b/vendor/github.com/qri-io/jsonpointer/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Brendan O'Brien
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/qri-io/jsonpointer/README.md
+++ b/vendor/github.com/qri-io/jsonpointer/README.md
@@ -1,0 +1,62 @@
+[![Qri](https://img.shields.io/badge/made%20by-qri-magenta.svg?style=flat-square)](https://qri.io)
+[![GoDoc](https://godoc.org/github.com/qri-io/jsonpointer?status.svg)](http://godoc.org/github.com/qri-io/jsonpointer)
+[![License](https://img.shields.io/github/license/qri-io/jsonpointer.svg?style=flat-square)](./LICENSE)
+[![Codecov](https://img.shields.io/codecov/c/github/qri-io/jsonpointer.svg?style=flat-square)](https://codecov.io/gh/qri-io/jsonpointer)
+[![CI](https://img.shields.io/circleci/project/github/qri-io/jsonpointer.svg?style=flat-square)](https://circleci.com/gh/qri-io/jsonpointer)
+[![Go Report Card](https://goreportcard.com/badge/github.com/qri-io/jsonpointer)](https://goreportcard.com/report/github.com/qri-io/jsonpointer)
+
+
+# jsonpointer
+golang implementation of [IETF RFC6901](https://tools.ietf.org/html/rfc6901):
+_JSON Pointer defines a string syntax for identifying a specific value within a JavaScript Object Notation (JSON) document._
+
+### Installation
+install with:
+`go get -u github.com/qri-io/jsonpointer`
+
+
+### Usage
+Here's a quick example pulled from the [godoc](https://godoc.org/github.com/qri-io/jsonpointer):
+
+```go
+import (
+  "encoding/json"
+  "fmt"
+  "github.com/qri-io/jsonpointer"
+)
+
+var document = []byte(`{ 
+  "foo": {
+    "bar": {
+      "baz": [0,"hello!"]
+    }
+  }
+}`)
+
+func main() {
+  parsed := map[string]interface{}{}
+  // be sure to handle errors in real-world code!
+  json.Unmarshal(document, &parsed)
+
+  // parse a json pointer. Pointers can also be url fragments
+  // the following are equivelent pointers:
+  // "/foo/bar/baz/1"
+  // "#/foo/bar/baz/1"
+  // "http://example.com/document.json#/foo/bar/baz/1"
+  ptr, _ := jsonpointer.Parse("/foo/bar/baz/1")
+
+  // evaluate the pointer against the document
+  // evaluation always starts at the root of the document
+  got, _ := ptr.Eval(parsed)
+
+  fmt.Println(got)
+  // Output: hello!
+}
+
+```
+
+### License
+MIT
+
+### Issues & Contributions
+Contributions & Issues are more than welcome! Everything happens over on this repo's [github page](https://github.com/qri-io/jsonpointer)

--- a/vendor/github.com/qri-io/jsonpointer/codecov.yml
+++ b/vendor/github.com/qri-io/jsonpointer/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  ci:
+    - "ci/circle-ci"
+  notify:
+    require_ci_to_pass: no
+    after_n_builds: 2
+coverage:
+  range: "80...100"
+comment: off

--- a/vendor/github.com/qri-io/jsonpointer/pointer.go
+++ b/vendor/github.com/qri-io/jsonpointer/pointer.go
@@ -1,0 +1,150 @@
+// Package jsonpointer implements IETF rfc6901
+// JSON Pointers are a string syntax for
+// identifying a specific value within a JavaScript Object Notation
+// (JSON) document [RFC4627].  JSON Pointer is intended to be easily
+// expressed in JSON string values as well as Uniform Resource
+// Identifier (URI) [RFC3986] fragment identifiers.
+//
+// this package is intended to work like net/url from the go
+// standard library
+package jsonpointer
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Parse parses str into a Pointer structure.
+// str may be a pointer or a url string.
+// If a url string, Parse will use the URL's fragment component
+// (the bit after the '#' symbol)
+func Parse(str string) (Pointer, error) {
+	// fast paths that skip url parse step
+	if len(str) == 0 || str == "#" {
+		return Pointer{}, nil
+	} else if str[0] == '/' {
+		return parse(str)
+	}
+
+	u, err := url.Parse(str)
+	if err != nil {
+		return nil, err
+	}
+	return parse(u.Fragment)
+}
+
+// The ABNF syntax of a JSON Pointer is:
+// json-pointer    = *( "/" reference-token )
+// reference-token = *( unescaped / escaped )
+// unescaped       = %x00-2E / %x30-7D / %x7F-10FFFF
+//    ; %x2F ('/') and %x7E ('~') are excluded from 'unescaped'
+// escaped         = "~" ( "0" / "1" )
+//   ; representing '~' and '/', respectively
+func parse(str string) (Pointer, error) {
+	if len(str) == 0 {
+		return Pointer{}, nil
+	}
+
+	if str[0] != '/' {
+		return nil, fmt.Errorf("non-empty references must begin with a '/' character")
+	}
+	str = str[1:]
+
+	toks := strings.Split(str, separator)
+	for i, t := range toks {
+		toks[i] = unescapeToken(t)
+	}
+	return Pointer(toks), nil
+}
+
+// Pointer represents a parsed JSON pointer
+type Pointer []string
+
+// String implements the stringer interface for Pointer,
+// giving the escaped string
+func (p Pointer) String() (str string) {
+	for _, tok := range p {
+		str += "/" + escapeToken(tok)
+	}
+	return
+}
+
+// Eval evaluates a json pointer against a given root JSON document
+// Evaluation of a JSON Pointer begins with a reference to the root
+// value of a JSON document and completes with a reference to some value
+// within the document.  Each reference token in the JSON Pointer is
+// evaluated sequentially.
+func (p Pointer) Eval(data interface{}) (result interface{}, err error) {
+	result = data
+	for _, tok := range p {
+		if result, err = p.evalToken(tok, result); err != nil {
+			return nil, err
+		}
+	}
+	return
+}
+
+// Descendant returns a new pointer to a descendant of the current pointer
+// parsing the input path into components
+func (p Pointer) Descendant(path string) (Pointer, error) {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	dpath, err := parse(path)
+	if err != nil {
+		return p, err
+	}
+
+	if p.String() == "/" {
+		return dpath, nil
+	}
+
+	return append(p, dpath...), nil
+}
+
+// Evaluation of each reference token begins by decoding any escaped
+// character sequence.  This is performed by first transforming any
+// occurrence of the sequence '~1' to '/', and then transforming any
+// occurrence of the sequence '~0' to '~'.  By performing the
+// substitutions in this order, an implementation avoids the error of
+// turning '~01' first into '~1' and then into '/', which would be
+// incorrect (the string '~01' correctly becomes '~1' after
+// transformation).
+// The reference token then modifies which value is referenced according
+// to the following scheme:
+func (p Pointer) evalToken(tok string, data interface{}) (interface{}, error) {
+	switch ch := data.(type) {
+	case map[string]interface{}:
+		return ch[tok], nil
+	case []interface{}:
+		i, err := strconv.Atoi(tok)
+		if err != nil {
+			return nil, fmt.Errorf("invalid array index: %s", tok)
+		}
+		if i >= len(ch) {
+			return nil, fmt.Errorf("index %d exceeds array length of %d", i, len(ch))
+		}
+		return ch[i], nil
+	default:
+		return nil, fmt.Errorf("invalid JSON pointer: %s", p.String())
+	}
+}
+
+const (
+	separator        = "/"
+	escapedSeparator = "~1"
+	tilde            = "~"
+	escapedTilde     = "~0"
+)
+
+func unescapeToken(tok string) string {
+	tok = strings.Replace(tok, escapedSeparator, separator, -1)
+	return strings.Replace(tok, escapedTilde, tilde, -1)
+}
+
+func escapeToken(tok string) string {
+	tok = strings.Replace(tok, tilde, escapedTilde, -1)
+	return strings.Replace(tok, separator, escapedSeparator, -1)
+}

--- a/vendor/github.com/qri-io/jsonpointer/traversal.go
+++ b/vendor/github.com/qri-io/jsonpointer/traversal.go
@@ -1,0 +1,99 @@
+package jsonpointer
+
+import (
+	"reflect"
+)
+
+// JSONContainer returns any existing child value for a given JSON property string
+type JSONContainer interface {
+	// JSONProp takes a string reference for a given JSON property.
+	// implementations must return any matching property of that name,
+	// nil if no such subproperty exists.
+	// Note that implementations on slice-types are expected to convert
+	// prop to an integer value
+	JSONProp(prop string) interface{}
+}
+
+// JSONParent is an interface that enables tree traversal by listing
+// all immediate children of an object
+type JSONParent interface {
+	// JSONChildren should return all immidiate children of this element
+	// with json property names as keys, go types as values
+	// Note that implementations on slice-types are expected to convert
+	// integers to string keys
+	JSONProps() map[string]interface{}
+}
+
+// WalkJSON calls visit on all elements in a tree of decoded json
+func WalkJSON(tree interface{}, visit func(elem interface{}) error) error {
+	if tree == nil {
+		return nil
+	}
+
+	if err := visit(tree); err != nil {
+		return err
+	}
+
+	if con, ok := tree.(JSONParent); ok {
+		for _, ch := range con.JSONProps() {
+			if err := WalkJSON(ch, visit); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// fast-path for common json types
+	switch t := tree.(type) {
+	case map[string]interface{}:
+		for _, val := range t {
+			if err := WalkJSON(val, visit); err != nil {
+				return err
+			}
+		}
+		return nil
+	case []interface{}:
+		for _, val := range t {
+			if err := WalkJSON(val, visit); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	return walkValue(reflect.ValueOf(tree), visit)
+}
+
+func walkValue(v reflect.Value, visit func(elem interface{}) error) error {
+	switch v.Kind() {
+	case reflect.Invalid:
+		return nil
+	case reflect.Ptr:
+		if !v.IsNil() {
+			walkValue(v.Elem(), visit)
+		}
+	case reflect.Map:
+		for _, key := range v.MapKeys() {
+			mi := v.MapIndex(key)
+			if mi.CanInterface() {
+				WalkJSON(mi.Interface(), visit)
+			}
+		}
+	case reflect.Struct:
+		// t := v.Type()
+		// TypeOf returns the reflection Type that represents the dynamic type of variable.
+		// If variable is a nil interface value, TypeOf returns nil.
+		for i := 0; i < v.NumField(); i++ {
+			f := v.Field(i)
+			// fmt.Printf("%d: %s %s %s = %v\n", i, t.Field(i).Name, f.Type(), t.Field(i).Tag.Get("json"), f.CanInterface())
+			if f.CanInterface() {
+				WalkJSON(f.Interface(), visit)
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			WalkJSON(v.Index(i).Interface(), visit)
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/qri-io/jsonschema/DEVELOPERS.md
+++ b/vendor/github.com/qri-io/jsonschema/DEVELOPERS.md
@@ -1,0 +1,125 @@
+# Developing go-jsonschema
+
+* [Development Setup](#setup)
+* [Commit Message Guidelines](#commits)
+* [Writing Documentation](#documentation)
+
+## <a name="setup"> Development Setup
+
+This document describes how to set up your development environment to build and test jsonschema
+
+### Installing Dependencies
+
+Before you can build jsonschema, you must install and configure the following dependencies on your
+machine:
+
+* [Git](http://git-scm.com/): The [Github Guide to
+  Installing Git][git-setup] is a good source of information.
+
+* [The Go Programming Language](https://golang.org): see golang.org to get started
+
+### Forking jsonschema on Github
+
+To contribute code to jsonschema, you must have a GitHub account so you can push code to your own
+fork of jsonschema and open Pull Requests in the [GitHub Repository][github].
+
+To create a Github account, follow the instructions [here](https://github.com/signup/free).
+Afterwards, go ahead and [fork](http://help.github.com/forking) the
+[jsonschema frontend repository][github].
+
+### Building jsonschema
+
+To build jsonschema, you clone the source code repository and use Yarn to run the electron app:
+
+```shell
+# Clone your Github repository:
+git clone https://github.com/<github username>/jsonschema.git
+
+# Go to the jsonschema directory:
+cd jsonschema
+
+# Build the qri binary
+go install
+```
+
+
+## <a name="commits"></a> Git Commit Guidelines
+
+We have very precise rules over how our git commit messages can be formatted.  This leads to **more
+readable messages** that are easy to follow when looking through the **project history**.  But also,
+we use the git commit messages to **generate the Qri change log**.
+
+### Commit Message Format
+Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
+format that includes a **type**, a **scope** and a **subject**:
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The **header** is mandatory and the **scope** of the header is optional.
+
+Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
+to read on GitHub as well as in various git tools.
+
+### Revert
+If the commit reverts a previous commit, it should begin with `revert: `, followed by the header
+of the reverted commit.
+In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit
+being reverted.
+A commit with this format is automatically created by the [`git revert`][git-revert] command.
+
+### Type
+Must be one of the following:
+
+* **feat**: A new feature
+* **fix**: A bug fix
+* **docs**: Documentation only changes
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
+  semi-colons, etc)
+* **refactor**: A code change that neither fixes a bug nor adds a feature
+* **perf**: A code change that improves performance
+* **test**: Adding missing or correcting existing tests
+* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation
+  generation
+
+### Scope
+The scope could be anything specifying place of the commit change. For example **NEED TO MAKE DECISION ABOUT THIS** , etc...
+
+You can use `*` when the change affects more than a single scope.
+
+### Subject
+The subject contains succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize first letter
+* no dot (.) at the end
+
+### Body
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
+The body should include the motivation for the change and contrast this with previous behavior.
+
+### Footer
+The footer should contain any information about **Breaking Changes** and is also the place to
+[reference GitHub issues that this commit closes][closing-issues].
+
+**Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines.
+The rest of the commit message is then used for this.
+
+A detailed explanation can be found in this [document][commit-message-format].
+
+
+[closing-issues]: https://help.github.com/articles/closing-issues-via-commit-messages/
+[commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#
+[git-revert]: https://git-scm.com/docs/git-revert
+[git-setup]: https://help.github.com/articles/set-up-git
+[github]: https://github.com/qri-io/frontend
+[style]: https://standardjs.com
+[yarn-install]: https://yarnpkg.com/en/docs/install
+
+
+###### This documentation has been adapted from the [Data Together](https://github.com/datatogether/datatogether), [Hyper](https://github.com/zeit/hyper), and [AngularJS](https://github.com/angular/angularJS) documentation, all of which are projects we :heart:

--- a/vendor/github.com/qri-io/jsonschema/LICENSE
+++ b/vendor/github.com/qri-io/jsonschema/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Brendan O'Brien
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/qri-io/jsonschema/README.md
+++ b/vendor/github.com/qri-io/jsonschema/README.md
@@ -1,0 +1,160 @@
+# jsonschema
+[![Qri](https://img.shields.io/badge/made%20by-qri-magenta.svg?style=flat-square)](https://qri.io)
+[![GoDoc](https://godoc.org/github.com/qri-io/jsonschema?status.svg)](http://godoc.org/github.com/qri-io/jsonschema)
+[![License](https://img.shields.io/github/license/qri-io/jsonschema.svg?style=flat-square)](./LICENSE)
+[![Codecov](https://img.shields.io/codecov/c/github/qri-io/jsonschema.svg?style=flat-square)](https://codecov.io/gh/qri-io/jsonschema)
+[![CI](https://img.shields.io/circleci/project/github/qri-io/jsonschema.svg?style=flat-square)](https://circleci.com/gh/qri-io/jsonschema)
+[![Go Report Card](https://goreportcard.com/badge/github.com/qri-io/jsonschema)](https://goreportcard.com/report/github.com/qri-io/jsonschema)
+
+golang implementation of the [JSON Schema Specification](http://json-schema.org/), which lets you write JSON that validates some other json. Rad.
+
+### Package Features
+
+* Encode schemas back to JSON
+* Supply Your own Custom Validators
+* Uses Standard Go idioms
+
+### Getting Involved
+
+We would love involvement from more people! If you notice any errors or would
+like to submit changes, please see our
+[Contributing Guidelines](./.github/CONTRIBUTING.md).
+
+### Developing
+
+We've set up a separate document for [developer guidelines](https://github.com/qri-io/jsonschema/blob/master/DEVELOPERS.md)!
+
+## Basic Usage
+
+Here's a quick example pulled from the [godoc](https://godoc.org/github.com/qri-io/jsonschema):
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/qri-io/jsonschema"
+)
+
+func main() {
+	var schemaData = []byte(`{
+      "title": "Person",
+      "type": "object",
+      "properties": {
+          "firstName": {
+              "type": "string"
+          },
+          "lastName": {
+              "type": "string"
+          },
+          "age": {
+              "description": "Age in years",
+              "type": "integer",
+              "minimum": 0
+          },
+          "friends": {
+            "type" : "array",
+            "items" : { "title" : "REFERENCE", "$ref" : "#" }
+          }
+      },
+      "required": ["firstName", "lastName"]
+    }`)
+
+	rs := &jsonschema.RootSchema{}
+	if err := json.Unmarshal(schemaData, rs); err != nil {
+		panic("unmarshal schema: " + err.Error())
+	}
+
+	var valid = []byte(`{
+    "firstName" : "George",
+    "lastName" : "Michael"
+    }`)
+
+	if errors := rs.ValidateBytes(valid); len(errors) > 0 {
+		panic(err)
+	}
+
+	var invalidPerson = []byte(`{
+    "firstName" : "Prince"
+    }`)
+	if errors := rs.ValidateBytes(invalidPerson); len(errors) > 0 {
+  	fmt.Println(errs[0].Error())
+  }
+
+	var invalidFriend = []byte(`{
+    "firstName" : "Jay",
+    "lastName" : "Z",
+    "friends" : [{
+      "firstName" : "Nas"
+      }]
+    }`)
+	if errors := rs.ValidateBytes(invalidFriend); len(errors) > 0 {
+  	fmt.Println(errors[0].Error())
+  }
+}
+```
+
+## Custom Validators
+
+The [godoc](https://godoc.org/github.com/qri-io/jsonschema) gives an example of how to supply your own validators to extend the standard keywords supported by the spec.
+
+It involves two steps that should happen _before_ allocating any RootSchema instances that use the validator:
+1. create a custom type that implements the `Validator` interface
+2. call RegisterValidator with the keyword you'd like to detect in JSON, and a `ValMaker` function.
+
+
+```go
+package main
+
+import (
+  "encoding/json"
+  "fmt"
+  "github.com/qri-io/jsonschema"
+)
+
+// your custom validator
+type IsFoo bool
+
+// newIsFoo is a jsonschama.ValMaker
+func newIsFoo() jsonschema.Validator {
+  return new(IsFoo)
+}
+
+// Validate implements jsonschema.Validator
+func (f IsFoo) Validate(data interface{}) []jsonschema.ValError {
+  if str, ok := data.(string); ok {
+    if str != "foo" {
+      return []jsonschema.ValError{
+        {Message: fmt.Sprintf("'%s' is not foo. It should be foo. plz make '%s' == foo. plz", str, str)},
+      }
+    }
+  }
+  return nil
+}
+
+func main() {
+  // register a custom validator by supplying a function
+  // that creates new instances of your Validator.
+  jsonschema.RegisterValidator("foo", newIsFoo)
+
+  schBytes := []byte(`{ "foo": true }`)
+
+  // parse a schema that uses your custom keyword
+  rs := new(jsonschema.RootSchema)
+  if err := json.Unmarshal(schBytes, rs); err != nil {
+    // Real programs handle errors.
+    panic(err)
+  }
+
+  // validate some JSON
+  errors := rs.ValidateBytes([]byte(`"bar"`))
+
+  // print le error
+  fmt.Println(errs[0].Error())
+
+  // Output: 'bar' is not foo. It should be foo. plz make 'bar' == foo. plz
+}
+```
+

--- a/vendor/github.com/qri-io/jsonschema/code_of_conduct.md
+++ b/vendor/github.com/qri-io/jsonschema/code_of_conduct.md
@@ -1,0 +1,13 @@
+# Code of Conduct
+
+Online or off, we promote a harrassment-free environment for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion or technical skill level. We do not tolerate harassment of participants in any form.
+
+Harassment includes verbal comments that reinforce social structures of domination related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
+
+If a participant engages in harassing behaviour, the organizers may take any action they deem appropriate, including warning the offender or expulsion from events and online forums.
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the organizing team immediately.
+
+At offline events, organizers will identify themselves, and will help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event. We value your participation!
+
+This document is based on a similar code from [EDGI](https://envirodatagov.org/) and [Civic Tech Toronto](http://civictech.ca/about-us/), itself derived from the [Recurse Center’s Social Rules](https://www.recurse.com/manual#sec-environment), and the [anti-harassment policy from the Geek Feminism Wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).

--- a/vendor/github.com/qri-io/jsonschema/codecov.yml
+++ b/vendor/github.com/qri-io/jsonschema/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  ci:
+    - "ci/circle-ci"
+  notify:
+    require_ci_to_pass: no
+    after_n_builds: 1
+coverage:
+  range: "80...100"
+comment: off

--- a/vendor/github.com/qri-io/jsonschema/keywords.go
+++ b/vendor/github.com/qri-io/jsonschema/keywords.go
@@ -1,0 +1,240 @@
+package jsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// primitiveTypes is a map of strings to check types against
+var primitiveTypes = map[string]bool{
+	"null":    true,
+	"boolean": true,
+	"object":  true,
+	"array":   true,
+	"number":  true,
+	"string":  true,
+	"integer": true,
+}
+
+// DataType gives the primitive json type of a standard json-decoded value, plus the special case
+// "integer" for when numbers are whole
+func DataType(data interface{}) string {
+	switch v := data.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return "boolean"
+	case float64:
+		if float64(int(v)) == v {
+			return "integer"
+		}
+		return "number"
+	case string:
+		return "string"
+	case []interface{}:
+		return "array"
+	case map[string]interface{}:
+		return "object"
+	default:
+		return "unknown"
+	}
+}
+
+// Type specifies one of the six json primitive types.
+// The value of this keyword MUST be either a string or an array.
+// If it is an array, elements of the array MUST be strings and MUST be unique.
+// String values MUST be one of the six primitive types ("null", "boolean", "object", "array", "number", or "string"), or
+// "integer" which matches any number with a zero fractional part.
+// An instance validates if and only if the instance is in any of the sets listed for this keyword.
+type Type struct {
+	BaseValidator
+	strVal bool // set to true if Type decoded from a string, false if an array
+	vals   []string
+}
+
+// NewType creates a new Type Validator
+func NewType() Validator {
+	return &Type{}
+}
+
+// String returns the type(s) as a string, or unknown if there is no known type.
+func (t Type) String() string {
+	if len(t.vals) == 0 {
+		return "unknown"
+	}
+	return strings.Join(t.vals, ",")
+}
+
+// Validate checks to see if input data satisfies the type constraint
+func (t Type) Validate(propPath string, data interface{}, errs *[]ValError) {
+	jt := DataType(data)
+	for _, typestr := range t.vals {
+		if jt == typestr || jt == "integer" && typestr == "number" {
+			return
+		}
+	}
+	if len(t.vals) == 1 {
+		t.AddError(errs, propPath, data, fmt.Sprintf(`type should be %s`, t.vals[0]))
+		return
+	}
+
+	str := ""
+	for _, ts := range t.vals {
+		str += ts + ","
+	}
+
+	t.AddError(errs, propPath, data, fmt.Sprintf(`type should be one of: %s`, str[:len(str)-1]))
+}
+
+// JSONProp implements JSON property name indexing for Type
+func (t Type) JSONProp(name string) interface{} {
+	idx, err := strconv.Atoi(name)
+	if err != nil {
+		return nil
+	}
+	if idx > len(t.vals) || idx < 0 {
+		return nil
+	}
+	return t.vals[idx]
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for Type
+func (t *Type) UnmarshalJSON(data []byte) error {
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		*t = Type{strVal: true, vals: []string{single}}
+	} else {
+		var set []string
+		if err := json.Unmarshal(data, &set); err == nil {
+			*t = Type{vals: set}
+		} else {
+			return err
+		}
+	}
+
+	for _, pr := range t.vals {
+		if !primitiveTypes[pr] {
+			return fmt.Errorf(`"%s" is not a valid type`, pr)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface for Type
+func (t Type) MarshalJSON() ([]byte, error) {
+	if t.strVal {
+		return json.Marshal(t.vals[0])
+	}
+	return json.Marshal(t.vals)
+}
+
+// Enum validates successfully against this keyword if its value is equal to one of the
+// elements in this keyword's array value.
+// Elements in the array SHOULD be unique.
+// Elements in the array might be of any value, including null.
+type Enum []Const
+
+// NewEnum creates a new Enum Validator
+func NewEnum() Validator {
+	return &Enum{}
+}
+
+// String implements the stringer interface for Enum
+func (e Enum) String() string {
+	str := "["
+	for _, c := range e {
+		str += c.String() + ", "
+	}
+	return str[:len(str)-2] + "]"
+}
+
+// Path gives a jsonpointer path to the validator
+func (e Enum) Path() string {
+	return ""
+}
+
+// Validate implements the Validator interface for Enum
+func (e Enum) Validate(propPath string, data interface{}, errs *[]ValError) {
+	for _, v := range e {
+		test := &[]ValError{}
+		v.Validate(propPath, data, test)
+		if len(*test) == 0 {
+			return
+		}
+	}
+
+	AddError(errs, propPath, data, fmt.Sprintf("should be one of %s", e.String()))
+}
+
+// JSONProp implements JSON property name indexing for Enum
+func (e Enum) JSONProp(name string) interface{} {
+	idx, err := strconv.Atoi(name)
+	if err != nil {
+		return nil
+	}
+	if idx > len(e) || idx < 0 {
+		return nil
+	}
+	return e[idx]
+}
+
+// JSONChildren implements the JSONContainer interface for Enum
+func (e Enum) JSONChildren() (res map[string]JSONPather) {
+	res = map[string]JSONPather{}
+	for i, bs := range e {
+		res[strconv.Itoa(i)] = bs
+	}
+	return
+}
+
+// Const MAY be of any type, including null.
+// An instance validates successfully against this keyword if its
+// value is equal to the value of the keyword.
+type Const json.RawMessage
+
+// NewConst creates a new Const Validator
+func NewConst() Validator {
+	return &Const{}
+}
+
+// Path gives a jsonpointer path to the validator
+func (c Const) Path() string {
+	return ""
+}
+
+// Validate implements the validate interface for Const
+func (c Const) Validate(propPath string, data interface{}, errs *[]ValError) {
+	var con interface{}
+	if err := json.Unmarshal(c, &con); err != nil {
+		AddError(errs, propPath, data, err.Error())
+		return
+	}
+
+	if !reflect.DeepEqual(con, data) {
+		AddError(errs, propPath, data, fmt.Sprintf(`must equal %s`, InvalidValueString(data)))
+	}
+}
+
+// JSONProp implements JSON property name indexing for Const
+func (c Const) JSONProp(name string) interface{} {
+	return nil
+}
+
+// String implements the Stringer interface for Const
+func (c Const) String() string {
+	return string(c)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for Const
+func (c *Const) UnmarshalJSON(data []byte) error {
+	*c = data
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for Const
+func (c Const) MarshalJSON() ([]byte, error) {
+	return json.Marshal(json.RawMessage(c))
+}

--- a/vendor/github.com/qri-io/jsonschema/keywords_arrays.go
+++ b/vendor/github.com/qri-io/jsonschema/keywords_arrays.go
@@ -1,0 +1,269 @@
+package jsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/qri-io/jsonpointer"
+)
+
+// Items MUST be either a valid JSON Schema or an array of valid JSON Schemas.
+// This keyword determines how child instances validate for arrays, and does not directly validate the
+// immediate instance itself.
+// * If "Items" is a schema, validation succeeds if all elements in the array successfully validate
+//   against that schema.
+// * If "Items" is an array of schemas, validation succeeds if each element of the instance validates
+//   against the schema at the same position, if any.
+// * Omitting this keyword has the same behavior as an empty schema.
+type Items struct {
+	// need to track weather user specficied a single object or arry
+	// b/c it affects AdditionalItems validation semantics
+	single  bool
+	Schemas []*Schema
+}
+
+// NewItems creates a new Items validator
+func NewItems() Validator {
+	return &Items{}
+}
+
+// Validate implements the Validator interface for Items
+func (it Items) Validate(propPath string, data interface{}, errs *[]ValError) {
+	jp, err := jsonpointer.Parse(propPath)
+	if err != nil {
+		AddError(errs, propPath, nil, fmt.Sprintf("invalid property path: %s", err.Error()))
+	}
+
+	if arr, ok := data.([]interface{}); ok {
+		if it.single {
+			for i, elem := range arr {
+				d, _ := jp.Descendant(strconv.Itoa(i))
+				it.Schemas[0].Validate(d.String(), elem, errs)
+			}
+		} else {
+			for i, vs := range it.Schemas {
+				if i < len(arr) {
+					d, _ := jp.Descendant(strconv.Itoa(i))
+					vs.Validate(d.String(), arr[i], errs)
+				}
+			}
+		}
+	}
+}
+
+// JSONProp implements JSON property name indexing for Items
+func (it Items) JSONProp(name string) interface{} {
+	idx, err := strconv.Atoi(name)
+	if err != nil {
+		return nil
+	}
+	if idx > len(it.Schemas) || idx < 0 {
+		return nil
+	}
+	return it.Schemas[idx]
+}
+
+// JSONChildren implements the JSONContainer interface for Items
+func (it Items) JSONChildren() (res map[string]JSONPather) {
+	res = map[string]JSONPather{}
+	for i, sch := range it.Schemas {
+		res[strconv.Itoa(i)] = sch
+	}
+	return
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for Items
+func (it *Items) UnmarshalJSON(data []byte) error {
+	s := &Schema{}
+	if err := json.Unmarshal(data, s); err == nil {
+		*it = Items{single: true, Schemas: []*Schema{s}}
+		return nil
+	}
+	ss := []*Schema{}
+	if err := json.Unmarshal(data, &ss); err != nil {
+		return err
+	}
+	*it = Items{Schemas: ss}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface for Items
+func (it Items) MarshalJSON() ([]byte, error) {
+	if it.single {
+		return json.Marshal(it.Schemas[0])
+	}
+	return json.Marshal([]*Schema(it.Schemas))
+}
+
+// AdditionalItems determines how child instances validate for arrays, and does not directly validate the immediate
+// instance itself.
+// If "Items" is an array of schemas, validation succeeds if every instance element at a position greater than
+// the size of "Items" validates against "AdditionalItems".
+// Otherwise, "AdditionalItems" MUST be ignored, as the "Items" schema (possibly the default value of an empty schema) is applied to all elements.
+// Omitting this keyword has the same behavior as an empty schema.
+type AdditionalItems struct {
+	startIndex int
+	Schema     *Schema
+}
+
+// NewAdditionalItems creates a new AdditionalItems validator
+func NewAdditionalItems() Validator {
+	return &AdditionalItems{}
+}
+
+// Validate implements the Validator interface for AdditionalItems
+func (a *AdditionalItems) Validate(propPath string, data interface{}, errs *[]ValError) {
+	jp, err := jsonpointer.Parse(propPath)
+	if err != nil {
+		AddError(errs, propPath, nil, fmt.Sprintf("invalid property path: %s", err.Error()))
+	}
+
+	if a.startIndex >= 0 {
+		if arr, ok := data.([]interface{}); ok {
+			for i, elem := range arr {
+				if i < a.startIndex {
+					continue
+				}
+				d, _ := jp.Descendant(strconv.Itoa(i))
+				a.Schema.Validate(d.String(), elem, errs)
+			}
+		}
+	}
+}
+
+// JSONProp implements JSON property name indexing for AdditionalItems
+func (a *AdditionalItems) JSONProp(name string) interface{} {
+	return a.Schema.JSONProp(name)
+}
+
+// JSONChildren implements the JSONContainer interface for AdditionalItems
+func (a *AdditionalItems) JSONChildren() (res map[string]JSONPather) {
+	if a.Schema == nil {
+		return map[string]JSONPather{}
+	}
+	return a.Schema.JSONChildren()
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for AdditionalItems
+func (a *AdditionalItems) UnmarshalJSON(data []byte) error {
+	sch := &Schema{}
+	if err := json.Unmarshal(data, sch); err != nil {
+		return err
+	}
+	// begin with -1 as default index to prevent AdditionalItems from evaluating
+	// unless startIndex is explicitly set
+	*a = AdditionalItems{startIndex: -1, Schema: sch}
+	return nil
+}
+
+// MaxItems MUST be a non-negative integer.
+// An array instance is valid against "MaxItems" if its size is less than, or equal to, the value of this keyword.
+type MaxItems int
+
+// NewMaxItems creates a new MaxItems validator
+func NewMaxItems() Validator {
+	return new(MaxItems)
+}
+
+// Validate implements the Validator interface for MaxItems
+func (m MaxItems) Validate(propPath string, data interface{}, errs *[]ValError) {
+	if arr, ok := data.([]interface{}); ok {
+		if len(arr) > int(m) {
+			AddError(errs, propPath, data, fmt.Sprintf("array length %d exceeds %d max", len(arr), m))
+			return
+		}
+	}
+}
+
+// MinItems MUST be a non-negative integer.
+// An array instance is valid against "MinItems" if its size is greater than, or equal to, the value of this keyword.
+// Omitting this keyword has the same behavior as a value of 0.
+type MinItems int
+
+// NewMinItems creates a new MinItems validator
+func NewMinItems() Validator {
+	return new(MinItems)
+}
+
+// Validate implements the Validator interface for MinItems
+func (m MinItems) Validate(propPath string, data interface{}, errs *[]ValError) {
+	if arr, ok := data.([]interface{}); ok {
+		if len(arr) < int(m) {
+			AddError(errs, propPath, data, fmt.Sprintf("array length %d below %d minimum items", len(arr), m))
+			return
+		}
+	}
+}
+
+// UniqueItems requires array instance elements be unique
+// If this keyword has boolean value false, the instance validates successfully. If it has
+// boolean value true, the instance validates successfully if all of its elements are unique.
+// Omitting this keyword has the same behavior as a value of false.
+type UniqueItems bool
+
+// NewUniqueItems creates a new UniqueItems validator
+func NewUniqueItems() Validator {
+	return new(UniqueItems)
+}
+
+// Validate implements the Validator interface for UniqueItems
+func (u *UniqueItems) Validate(propPath string, data interface{}, errs *[]ValError) {
+	if arr, ok := data.([]interface{}); ok {
+		found := []interface{}{}
+		for _, elem := range arr {
+			for _, f := range found {
+				if reflect.DeepEqual(f, elem) {
+					AddError(errs, propPath, data, fmt.Sprintf("array items must be unique. duplicated entry: %v", elem))
+					return
+				}
+			}
+			found = append(found, elem)
+		}
+	}
+}
+
+// Contains validates that an array instance is valid against "Contains" if at
+// least one of its elements is valid against the given schema.
+type Contains Schema
+
+// NewContains creates a new Contains validator
+func NewContains() Validator {
+	return &Contains{}
+}
+
+// Validate implements the Validator interface for Contains
+func (c *Contains) Validate(propPath string, data interface{}, errs *[]ValError) {
+	v := Schema(*c)
+	if arr, ok := data.([]interface{}); ok {
+		for _, elem := range arr {
+			test := &[]ValError{}
+			v.Validate(propPath, elem, test)
+			if len(*test) == 0 {
+				return
+			}
+		}
+		AddError(errs, propPath, data, fmt.Sprintf("must contain at least one of: %v", c))
+	}
+}
+
+// JSONProp implements JSON property name indexing for Contains
+func (c Contains) JSONProp(name string) interface{} {
+	return Schema(c).JSONProp(name)
+}
+
+// JSONChildren implements the JSONContainer interface for Contains
+func (c Contains) JSONChildren() (res map[string]JSONPather) {
+	return Schema(c).JSONChildren()
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for Contains
+func (c *Contains) UnmarshalJSON(data []byte) error {
+	var sch Schema
+	if err := json.Unmarshal(data, &sch); err != nil {
+		return err
+	}
+	*c = Contains(sch)
+	return nil
+}

--- a/vendor/github.com/qri-io/jsonschema/keywords_booleans.go
+++ b/vendor/github.com/qri-io/jsonschema/keywords_booleans.go
@@ -1,0 +1,185 @@
+package jsonschema
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// AllOf MUST be a non-empty array. Each item of the array MUST be a valid JSON Schema.
+// An instance validates successfully against this keyword if it validates successfully against all schemas defined by this keyword's value.
+type AllOf []*Schema
+
+// NewAllOf creates a new AllOf validator
+func NewAllOf() Validator {
+	return &AllOf{}
+}
+
+// Validate implements the validator interface for AllOf
+func (a AllOf) Validate(propPath string, data interface{}, errs *[]ValError) {
+	for _, sch := range a {
+		sch.Validate(propPath, data, errs)
+	}
+}
+
+// JSONProp implements JSON property name indexing for AllOf
+func (a AllOf) JSONProp(name string) interface{} {
+	idx, err := strconv.Atoi(name)
+	if err != nil {
+		return nil
+	}
+	if idx > len(a) || idx < 0 {
+		return nil
+	}
+	return a[idx]
+}
+
+// JSONChildren implements the JSONContainer interface for AllOf
+func (a AllOf) JSONChildren() (res map[string]JSONPather) {
+	res = map[string]JSONPather{}
+	for i, sch := range a {
+		res[strconv.Itoa(i)] = sch
+	}
+	return
+}
+
+// AnyOf MUST be a non-empty array. Each item of the array MUST be a valid JSON Schema.
+// An instance validates successfully against this keyword if it validates successfully against at
+// least one schema defined by this keyword's value.
+type AnyOf []*Schema
+
+// NewAnyOf creates a new AnyOf validator
+func NewAnyOf() Validator {
+	return &AnyOf{}
+}
+
+// Validate implements the validator interface for AnyOf
+func (a AnyOf) Validate(propPath string, data interface{}, errs *[]ValError) {
+	for _, sch := range a {
+		test := &[]ValError{}
+		sch.Validate(propPath, data, test)
+		if len(*test) == 0 {
+			return
+		}
+	}
+	AddError(errs, propPath, data, "did Not match any specified AnyOf schemas")
+}
+
+// JSONProp implements JSON property name indexing for AnyOf
+func (a AnyOf) JSONProp(name string) interface{} {
+	idx, err := strconv.Atoi(name)
+	if err != nil {
+		return nil
+	}
+	if idx > len(a) || idx < 0 {
+		return nil
+	}
+	return a[idx]
+}
+
+// JSONChildren implements the JSONContainer interface for AnyOf
+func (a AnyOf) JSONChildren() (res map[string]JSONPather) {
+	res = map[string]JSONPather{}
+	for i, sch := range a {
+		res[strconv.Itoa(i)] = sch
+	}
+	return
+}
+
+// OneOf MUST be a non-empty array. Each item of the array MUST be a valid JSON Schema.
+// An instance validates successfully against this keyword if it validates successfully against exactly one schema defined by this keyword's value.
+type OneOf []*Schema
+
+// NewOneOf creates a new OneOf validator
+func NewOneOf() Validator {
+	return &OneOf{}
+}
+
+// Validate implements the validator interface for OneOf
+func (o OneOf) Validate(propPath string, data interface{}, errs *[]ValError) {
+	matched := false
+	for _, sch := range o {
+		test := &[]ValError{}
+		sch.Validate(propPath, data, test)
+		if len(*test) == 0 {
+			if matched {
+				AddError(errs, propPath, data, "matched more than one specified OneOf schemas")
+				return
+			}
+			matched = true
+		}
+	}
+	if !matched {
+		AddError(errs, propPath, data, "did not match any of the specified OneOf schemas")
+	}
+}
+
+// JSONProp implements JSON property name indexing for OneOf
+func (o OneOf) JSONProp(name string) interface{} {
+	idx, err := strconv.Atoi(name)
+	if err != nil {
+		return nil
+	}
+	if idx > len(o) || idx < 0 {
+		return nil
+	}
+	return o[idx]
+}
+
+// JSONChildren implements the JSONContainer interface for OneOf
+func (o OneOf) JSONChildren() (res map[string]JSONPather) {
+	res = map[string]JSONPather{}
+	for i, sch := range o {
+		res[strconv.Itoa(i)] = sch
+	}
+	return
+}
+
+// Not MUST be a valid JSON Schema.
+// An instance is valid against this keyword if it fails to validate successfully against the schema defined
+// by this keyword.
+type Not Schema
+
+// NewNot creates a new Not validator
+func NewNot() Validator {
+	return &Not{}
+}
+
+// Validate implements the validator interface for Not
+func (n *Not) Validate(propPath string, data interface{}, errs *[]ValError) {
+	sch := Schema(*n)
+	test := &[]ValError{}
+	sch.Validate(propPath, data, test)
+	if len(*test) == 0 {
+		// TODO - make this error actually make sense
+		AddError(errs, propPath, data, "cannot match schema")
+	}
+}
+
+// JSONProp implements JSON property name indexing for Not
+func (n Not) JSONProp(name string) interface{} {
+	return Schema(n).JSONProp(name)
+}
+
+// JSONChildren implements the JSONContainer interface for Not
+func (n Not) JSONChildren() (res map[string]JSONPather) {
+	if n.Ref != "" {
+		s := Schema(n)
+		return map[string]JSONPather{"$ref": &s}
+	}
+	return Schema(n).JSONChildren()
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for Not
+func (n *Not) UnmarshalJSON(data []byte) error {
+	var sch Schema
+	if err := json.Unmarshal(data, &sch); err != nil {
+		return err
+	}
+	*n = Not(sch)
+	return nil
+}
+
+// MarshalJSON implements json.Marshaller for Not
+func (n Not) MarshalJSON() ([]byte, error) {
+	return json.Marshal(Schema(n))
+}

--- a/vendor/github.com/qri-io/jsonschema/keywords_conditionals.go
+++ b/vendor/github.com/qri-io/jsonschema/keywords_conditionals.go
@@ -1,0 +1,142 @@
+package jsonschema
+
+import (
+	"encoding/json"
+)
+
+// If MUST be a valid JSON Schema.
+// Instances that successfully validate against this keyword's subschema MUST also be valid against the subschema value of the "Then" keyword, if present.
+// Instances that fail to validate against this keyword's subschema MUST also be valid against the subschema value of the "Elsee" keyword.
+// Validation of the instance against this keyword on its own always succeeds, regardless of the validation outcome of against its subschema.
+type If struct {
+	Schema Schema
+	Then   *Then
+	Else   *Else
+}
+
+// NewIf allocates a new If validator
+func NewIf() Validator {
+	return &If{}
+}
+
+// Validate implements the Validator interface for If
+func (i *If) Validate(propPath string, data interface{}, errs *[]ValError) {
+	test := &[]ValError{}
+	i.Schema.Validate(propPath, data, test)
+	if len(*test) == 0 {
+		if i.Then != nil {
+			s := Schema(*i.Then)
+			sch := &s
+			sch.Validate(propPath, data, errs)
+			return
+		}
+	} else {
+		if i.Else != nil {
+			s := Schema(*i.Else)
+			sch := &s
+			sch.Validate(propPath, data, errs)
+			return
+		}
+	}
+}
+
+// JSONProp implements JSON property name indexing for If
+func (i If) JSONProp(name string) interface{} {
+	return Schema(i.Schema).JSONProp(name)
+}
+
+// JSONChildren implements the JSONContainer interface for If
+func (i If) JSONChildren() (res map[string]JSONPather) {
+	return i.Schema.JSONChildren()
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for If
+func (i *If) UnmarshalJSON(data []byte) error {
+	var sch Schema
+	if err := json.Unmarshal(data, &sch); err != nil {
+		return err
+	}
+	*i = If{Schema: sch}
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for If
+func (i If) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.Schema)
+}
+
+// Then MUST be a valid JSON Schema.
+// When present alongside of "if", the instance successfully validates against this keyword if it validates against both the "if"'s subschema and this keyword's subschema.
+// When "if" is absent, or the instance fails to validate against its subschema, validation against this keyword always succeeds. Implementations SHOULD avoid attempting to validate against the subschema in these cases.
+type Then Schema
+
+// NewThen allocates a new Then validator
+func NewThen() Validator {
+	return &Then{}
+}
+
+// Validate implements the Validator interface for Then
+func (t *Then) Validate(propPath string, data interface{}, errs *[]ValError) {}
+
+// JSONProp implements JSON property name indexing for Then
+func (t Then) JSONProp(name string) interface{} {
+	return Schema(t).JSONProp(name)
+}
+
+// JSONChildren implements the JSONContainer interface for If
+func (t Then) JSONChildren() (res map[string]JSONPather) {
+	return Schema(t).JSONChildren()
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for Then
+func (t *Then) UnmarshalJSON(data []byte) error {
+	var sch Schema
+	if err := json.Unmarshal(data, &sch); err != nil {
+		return err
+	}
+	*t = Then(sch)
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for Then
+func (t Then) MarshalJSON() ([]byte, error) {
+	return json.Marshal(Schema(t))
+}
+
+// Else MUST be a valid JSON Schema.
+// When present alongside of "if", the instance successfully validates against this keyword if it fails to validate against the "if"'s subschema, and successfully validates against this keyword's subschema.
+// When "if" is absent, or the instance successfully validates against its subschema, validation against this keyword always succeeds. Implementations SHOULD avoid attempting to validate against the subschema in these cases.
+type Else Schema
+
+// NewElse allocates a new Else validator
+func NewElse() Validator {
+	return &Else{}
+}
+
+// Validate implements the Validator interface for Else
+func (e *Else) Validate(propPath string, data interface{}, err *[]ValError) {}
+
+// JSONProp implements JSON property name indexing for Else
+func (e Else) JSONProp(name string) interface{} {
+	return Schema(e).JSONProp(name)
+}
+
+// JSONChildren implements the JSONContainer interface for Else
+func (e Else) JSONChildren() (res map[string]JSONPather) {
+	return Schema(e).JSONChildren()
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for Else
+func (e *Else) UnmarshalJSON(data []byte) error {
+	var sch Schema
+	if err := json.Unmarshal(data, &sch); err != nil {
+		return err
+	}
+	*e = Else(sch)
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for Else
+func (e Else) MarshalJSON() ([]byte, error) {
+	return json.Marshal(Schema(e))
+}

--- a/vendor/github.com/qri-io/jsonschema/keywords_format.go
+++ b/vendor/github.com/qri-io/jsonschema/keywords_format.go
@@ -1,0 +1,332 @@
+package jsonschema
+
+import (
+	// "encoding/json"
+	"fmt"
+	"net"
+	"net/mail"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	hostname       string = `^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$`
+	unescapedTilda        = `\~[^01]`
+	endingTilda           = `\~$`
+	schemePrefix          = `^[^\:]+\:`
+	uriTemplate           = `\{[^\{\}\\]*\}`
+)
+
+var (
+	// emailPattern           = regexp.MustCompile(email)
+	hostnamePattern        = regexp.MustCompile(hostname)
+	unescaptedTildaPattern = regexp.MustCompile(unescapedTilda)
+	endingTildaPattern     = regexp.MustCompile(endingTilda)
+	schemePrefixPattern    = regexp.MustCompile(schemePrefix)
+	uriTemplatePattern     = regexp.MustCompile(uriTemplate)
+
+	disallowedIdnChars = map[string]bool{"\u0020": true, "\u002D": true, "\u00A2": true, "\u00A3": true, "\u00A4": true, "\u00A5": true, "\u034F": true, "\u0640": true, "\u07FA": true, "\u180B": true, "\u180C": true, "\u180D": true, "\u200B": true, "\u2060": true, "\u2104": true, "\u2108": true, "\u2114": true, "\u2117": true, "\u2118": true, "\u211E": true, "\u211F": true, "\u2123": true, "\u2125": true, "\u2282": true, "\u2283": true, "\u2284": true, "\u2285": true, "\u2286": true, "\u2287": true, "\u2288": true, "\u2616": true, "\u2617": true, "\u2619": true, "\u262F": true, "\u2638": true, "\u266C": true, "\u266D": true, "\u266F": true, "\u2752": true, "\u2756": true, "\u2758": true, "\u275E": true, "\u2761": true, "\u2775": true, "\u2794": true, "\u2798": true, "\u27AF": true, "\u27B1": true, "\u27BE": true, "\u3004": true, "\u3012": true, "\u3013": true, "\u3020": true, "\u302E": true, "\u302F": true, "\u3031": true, "\u3032": true, "\u3035": true, "\u303B": true, "\u3164": true, "\uFFA0": true}
+)
+
+// for json pointers
+
+// func FormatType(data interface{}) string {
+// 	switch
+// }
+// Note: Date and time Format names are derived from RFC 3339, section
+// 5.6  [RFC3339].
+// http://json-schema.org/latest/json-schema-validation.html#RFC3339
+
+// Format implements semantic validation from section 7 of jsonschema draft 7
+// The "format" keyword functions as both an annotation (Section 3.3) and as an assertion (Section 3.2).
+// While no special effort is required to implement it as an annotation conveying semantic meaning,
+// implementing validation is non-trivial.
+// Implementations MAY support the "format" keyword as a validation assertion. Should they choose to do so:
+//    they SHOULD implement validation for attributes defined below;
+//    they SHOULD offer an option to disable validation for this keyword.
+// Implementations MAY add custom format attributes. S
+// ave for agreement between parties, schema authors SHALL NOT expect a peer implementation to support
+// this keyword and/or custom format attributes.
+type Format string
+
+// NewFormat allocates a new Format validator
+func NewFormat() Validator {
+	return new(Format)
+}
+
+// Validate validates input against a keyword
+func (f Format) Validate(propPath string, data interface{}, errs *[]ValError) {
+	var err error
+	if str, ok := data.(string); ok {
+		switch f {
+		case "date-time":
+			err = isValidDateTime(str)
+		case "date":
+			err = isValidDate(str)
+		case "email":
+			err = isValidEmail(str)
+		case "hostname":
+			err = isValidHostname(str)
+		case "idn-email":
+			err = isValidIDNEmail(str)
+		case "idn-hostname":
+			err = isValidIDNHostname(str)
+		case "ipv4":
+			err = isValidIPv4(str)
+		case "ipv6":
+			err = isValidIPv6(str)
+		case "iri-reference":
+			err = isValidIriRef(str)
+		case "iri":
+			err = isValidIri(str)
+		case "json-pointer":
+			err = isValidJSONPointer(str)
+		case "regex":
+			err = isValidRegex(str)
+		case "relative-json-pointer":
+			err = isValidRelJSONPointer(str)
+		case "time":
+			err = isValidTime(str)
+		case "uri-reference":
+			err = isValidURIRef(str)
+		case "uri-template":
+			err = isValidURITemplate(str)
+		case "uri":
+			err = isValidURI(str)
+		default:
+			err = nil
+		}
+		if err != nil {
+			AddError(errs, propPath, data, fmt.Sprintf("invalid %s: %s", f, err.Error()))
+		}
+	}
+}
+
+// A string instance is valid against "date-time" if it is a valid
+// representation according to the "date-time" production derived
+// from RFC 3339, section 5.6 [RFC3339]
+// https://tools.ietf.org/html/rfc3339#section-5.6
+func isValidDateTime(dateTime string) error {
+	if _, err := time.Parse(time.RFC3339, dateTime); err != nil {
+		return fmt.Errorf("date-time incorrectly Formatted: %s", err.Error())
+	}
+	return nil
+}
+
+// A string instance is valid against "date" if it is a valid
+// representation according to the "full-date" production derived
+// from RFC 3339, section 5.6 [RFC3339]
+// https://tools.ietf.org/html/rfc3339#section-5.6
+func isValidDate(date string) error {
+	arbitraryTime := "T08:30:06.283185Z"
+	dateTime := fmt.Sprintf("%s%s", date, arbitraryTime)
+	return isValidDateTime(dateTime)
+}
+
+// A string instance is valid against "email" if it is a valid
+// representation as defined by RFC 5322, section 3.4.1 [RFC5322].
+// https://tools.ietf.org/html/rfc5322#section-3.4.1
+func isValidEmail(email string) error {
+	// if !emailPattern.MatchString(email) {
+	// 	return fmt.Errorf("invalid email Format")
+	// }
+	if _, err := mail.ParseAddress(email); err != nil {
+		return fmt.Errorf("email address incorrectly Formatted: %s", err.Error())
+	}
+	return nil
+}
+
+// A string instance is valid against "hostname" if it is a valid
+// representation as defined by RFC 1034, section 3.1 [RFC1034],
+// including host names produced using the Punycode algorithm
+// specified in RFC 5891, section 4.4 [RFC5891].
+// https://tools.ietf.org/html/rfc1034#section-3.1
+// https://tools.ietf.org/html/rfc5891#section-4.4
+func isValidHostname(hostname string) error {
+	if !hostnamePattern.MatchString(hostname) || len(hostname) > 255 {
+		return fmt.Errorf("invalid hostname string")
+	}
+	return nil
+}
+
+// A string instance is valid against "idn-email" if it is a valid
+// representation as defined by RFC 6531 [RFC6531]
+// https://tools.ietf.org/html/rfc6531
+func isValidIDNEmail(idnEmail string) error {
+	if _, err := mail.ParseAddress(idnEmail); err != nil {
+		return fmt.Errorf("email address incorrectly Formatted: %s", err.Error())
+	}
+	return nil
+}
+
+// A string instance is valid against "hostname" if it is a valid
+// representation as defined by either RFC 1034 as for hostname, or
+// an internationalized hostname as defined by RFC 5890, section
+// 2.3.2.3 [RFC5890].
+// https://tools.ietf.org/html/rfc1034
+// https://tools.ietf.org/html/rfc5890#section-2.3.2.3
+// https://pdfs.semanticscholar.org/9275/6bcecb29d3dc407e23a997b256be6ff4149d.pdf
+func isValidIDNHostname(idnHostname string) error {
+	if len(idnHostname) > 255 {
+		return fmt.Errorf("invalid idn hostname string")
+	}
+	for _, r := range idnHostname {
+		s := string(r)
+		if disallowedIdnChars[s] {
+			return fmt.Errorf("invalid hostname: contains illegal character %#U", r)
+		}
+	}
+	return nil
+}
+
+// A string instance is valid against "ipv4" if it is a valid
+// representation of an IPv4 address according to the "dotted-quad"
+// ABNF syntax as defined in RFC 2673, section 3.2 [RFC2673].
+// https://tools.ietf.org/html/rfc2673#section-3.2
+func isValidIPv4(ipv4 string) error {
+	parsedIP := net.ParseIP(ipv4)
+	hasDots := strings.Contains(ipv4, ".")
+	if !hasDots || parsedIP == nil {
+		return fmt.Errorf("invalid IPv4 address")
+	}
+	return nil
+}
+
+// A string instance is valid against "ipv6" if it is a valid
+// representation of an IPv6 address as defined in RFC 4291, section
+// 2.2 [RFC4291].
+// https://tools.ietf.org/html/rfc4291#section-2.2
+func isValidIPv6(ipv6 string) error {
+	parsedIP := net.ParseIP(ipv6)
+	hasColons := strings.Contains(ipv6, ":")
+	if !hasColons || parsedIP == nil {
+		return fmt.Errorf("invalid IPv4 address")
+	}
+	return nil
+}
+
+// A string instance is a valid against "iri-reference" if it is a
+// valid IRI Reference (either an IRI or a relative-reference),
+// according to [RFC3987].
+// https://tools.ietf.org/html/rfc3987
+func isValidIriRef(iriRef string) error {
+	return isValidURIRef(iriRef)
+}
+
+// A string instance is a valid against "iri" if it is a valid IRI,
+// according to [RFC3987].
+// https://tools.ietf.org/html/rfc3987
+func isValidIri(iri string) error {
+	return isValidURI(iri)
+}
+
+// A string instance is a valid against "json-pointer" if it is a
+// valid JSON string representation of a JSON Pointer, according to
+// RFC 6901, section 5 [RFC6901].
+// https://tools.ietf.org/html/rfc6901#section-5
+func isValidJSONPointer(jsonPointer string) error {
+	if len(jsonPointer) == 0 {
+		return nil
+	}
+	if jsonPointer[0] != '/' {
+		return fmt.Errorf("non-empty references must begin with a '/' character")
+	}
+	str := jsonPointer[1:]
+	if unescaptedTildaPattern.MatchString(str) {
+		return fmt.Errorf("unescaped tilda error")
+	}
+	if endingTildaPattern.MatchString(str) {
+		return fmt.Errorf("unescaped tilda error")
+	}
+	return nil
+}
+
+// A string instance is a valid against "regex" if it is a valid
+// regular expression according to the ECMA 262 [ecma262] regular
+// expression dialect. Implementations that validate Formats MUST
+// accept at least the subset of ECMA 262 defined in the Regular
+// Expressions [regexInterop] section of this specification, and
+// SHOULD accept all valid ECMA 262 expressions.
+// http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf
+// http://json-schema.org/latest/jsoxn-schema-validation.html#regexInterop
+// https://tools.ietf.org/html/rfc7159
+func isValidRegex(regex string) error {
+	if _, err := regexp.Compile(regex); err != nil {
+		return fmt.Errorf("invalid regex expression")
+	}
+	return nil
+}
+
+// A string instance is a valid against "relative-json-pointer" if it
+// is a valid Relative JSON Pointer [relative-json-pointer].
+// https://tools.ietf.org/html/draft-handrews-relative-json-pointer-00
+func isValidRelJSONPointer(relJSONPointer string) error {
+	parts := strings.Split(relJSONPointer, "/")
+	if len(parts) == 1 {
+		parts = strings.Split(relJSONPointer, "#")
+	}
+	if i, err := strconv.Atoi(parts[0]); err != nil || i < 0 {
+		return fmt.Errorf("RJP must begin with positive integer")
+	}
+	//skip over first part
+	str := relJSONPointer[len(parts[0]):]
+	if len(str) > 0 && str[0] == '#' {
+		return nil
+	}
+	return isValidJSONPointer(str)
+}
+
+// A string instance is valid against "time" if it is a valid
+// representation according to the "full-time" production derived
+// from RFC 3339, section 5.6 [RFC3339]
+// https://tools.ietf.org/html/rfc3339#section-5.6
+func isValidTime(time string) error {
+	arbitraryDate := "1963-06-19"
+	dateTime := fmt.Sprintf("%sT%s", arbitraryDate, time)
+	return isValidDateTime(dateTime)
+	return nil
+}
+
+// A string instance is a valid against "uri-reference" if it is a
+// valid URI Reference (either a URI or a relative-reference),
+// according to [RFC3986].
+// https://tools.ietf.org/html/rfc3986
+func isValidURIRef(uriRef string) error {
+	if _, err := url.Parse(uriRef); err != nil {
+		return fmt.Errorf("uri incorrectly Formatted: %s", err.Error())
+	}
+	if strings.Contains(uriRef, "\\") {
+		return fmt.Errorf("invalid uri")
+	}
+	return nil
+}
+
+// A string instance is a valid against "uri-template" if it is a
+// valid URI Template (of any level), according to [RFC6570]. Note
+// that URI Templates may be used for IRIs; there is no separate IRI
+// Template specification.
+// https://tools.ietf.org/html/rfc6570
+func isValidURITemplate(uriTemplate string) error {
+	arbitraryValue := "aaa"
+	uriRef := uriTemplatePattern.ReplaceAllString(uriTemplate, arbitraryValue)
+	if strings.Contains(uriRef, "{") || strings.Contains(uriRef, "}") {
+		return fmt.Errorf("invalid uri template")
+	}
+	return isValidURIRef(uriRef)
+}
+
+// A string instance is a valid against "uri" if it is a valid URI,
+// according to [RFC3986].
+// https://tools.ietf.org/html/rfc3986
+func isValidURI(uri string) error {
+	if _, err := url.Parse(uri); err != nil {
+		return fmt.Errorf("uri incorrectly Formatted: %s", err.Error())
+	}
+	if !schemePrefixPattern.MatchString(uri) {
+		return fmt.Errorf("uri missing scheme prefix")
+	}
+	return nil
+}

--- a/vendor/github.com/qri-io/jsonschema/keywords_numeric.go
+++ b/vendor/github.com/qri-io/jsonschema/keywords_numeric.go
@@ -1,0 +1,99 @@
+package jsonschema
+
+import (
+	"fmt"
+)
+
+// MultipleOf MUST be a number, strictly greater than 0.
+// MultipleOf validates that a numeric instance is valid only if division
+// by this keyword's value results in an integer.
+type MultipleOf float64
+
+// NewMultipleOf allocates a new MultipleOf validator
+func NewMultipleOf() Validator {
+	return new(MultipleOf)
+}
+
+// Validate implements the Validator interface for MultipleOf
+func (m MultipleOf) Validate(propPath string, data interface{}, errs *[]ValError) {
+	if num, ok := data.(float64); ok {
+		div := num / float64(m)
+		if float64(int(div)) != div {
+			AddError(errs, propPath, data, fmt.Sprintf("must be a multiple of %f", m))
+		}
+	}
+}
+
+// Maximum MUST be a number, representing an inclusive upper limit
+// for a numeric instance.
+// If the instance is a number, then this keyword validates only if the instance is less than or exactly equal to "Maximum".
+type Maximum float64
+
+// NewMaximum allocates a new Maximum validator
+func NewMaximum() Validator {
+	return new(Maximum)
+}
+
+// Validate implements the Validator interface for Maximum
+func (m Maximum) Validate(propPath string, data interface{}, errs *[]ValError) {
+	if num, ok := data.(float64); ok {
+		if num > float64(m) {
+			AddError(errs, propPath, data, fmt.Sprintf("must be less than or equal to %f", m))
+		}
+	}
+}
+
+// ExclusiveMaximum MUST be number, representing an exclusive upper limit for a numeric instance.
+// If the instance is a number, then the instance is valid only if it has a value
+// strictly less than (not equal to) "Exclusivemaximum".
+type ExclusiveMaximum float64
+
+// NewExclusiveMaximum allocates a new ExclusiveMaximum validator
+func NewExclusiveMaximum() Validator {
+	return new(ExclusiveMaximum)
+}
+
+// Validate implements the Validator interface for ExclusiveMaximum
+func (m ExclusiveMaximum) Validate(propPath string, data interface{}, errs *[]ValError) {
+	if num, ok := data.(float64); ok {
+		if num >= float64(m) {
+			AddError(errs, propPath, data, fmt.Sprintf("must be less than %f", m))
+		}
+	}
+}
+
+// Minimum MUST be a number, representing an inclusive lower limit for a numeric instance.
+// If the instance is a number, then this keyword validates only if the instance is greater than or exactly equal to "Minimum".
+type Minimum float64
+
+// NewMinimum allocates a new Minimum validator
+func NewMinimum() Validator {
+	return new(Minimum)
+}
+
+// Validate implements the Validator interface for Minimum
+func (m Minimum) Validate(propPath string, data interface{}, errs *[]ValError) {
+	if num, ok := data.(float64); ok {
+		if num < float64(m) {
+			AddError(errs, propPath, data, fmt.Sprintf("must be greater than or equal to %f", m))
+		}
+	}
+}
+
+// ExclusiveMinimum MUST be number, representing an exclusive lower limit for a numeric instance.
+// If the instance is a number, then the instance is valid only if it has a value strictly greater than (not equal to) "ExclusiveMinimum".
+type ExclusiveMinimum float64
+
+// NewExclusiveMinimum allocates a new ExclusiveMinimum validator
+func NewExclusiveMinimum() Validator {
+	return new(ExclusiveMinimum)
+}
+
+// Validate implements the Validator interface for ExclusiveMinimum
+func (m ExclusiveMinimum) Validate(propPath string, data interface{}, errs *[]ValError) {
+	if num, ok := data.(float64); ok {
+		if num <= float64(m) {
+			AddError(errs, propPath, data, fmt.Sprintf("must be greater than %f", m))
+		}
+	}
+}

--- a/vendor/github.com/qri-io/jsonschema/keywords_objects.go
+++ b/vendor/github.com/qri-io/jsonschema/keywords_objects.go
@@ -1,0 +1,454 @@
+package jsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/qri-io/jsonpointer"
+	"regexp"
+	"strconv"
+)
+
+// MaxProperties MUST be a non-negative integer.
+// An object instance is valid against "MaxProperties" if its number of Properties is less than, or equal to, the value of this keyword.
+type MaxProperties int
+
+// NewMaxProperties allocates a new MaxProperties validator
+func NewMaxProperties() Validator {
+	return new(MaxProperties)
+}
+
+// Validate implements the validator interface for MaxProperties
+func (m MaxProperties) Validate(propPath string, data interface{}, errs *[]ValError) {
+	if obj, ok := data.(map[string]interface{}); ok {
+		if len(obj) > int(m) {
+			AddError(errs, propPath, data, fmt.Sprintf("%d object Properties exceed %d maximum", len(obj), m))
+		}
+	}
+}
+
+// minProperties MUST be a non-negative integer.
+// An object instance is valid against "minProperties" if its number of Properties is greater than, or equal to, the value of this keyword.
+// Omitting this keyword has the same behavior as a value of 0.
+type minProperties int
+
+// NewMinProperties allocates a new MinProperties validator
+func NewMinProperties() Validator {
+	return new(minProperties)
+}
+
+// Validate implements the validator interface for minProperties
+func (m minProperties) Validate(propPath string, data interface{}, errs *[]ValError) {
+	if obj, ok := data.(map[string]interface{}); ok {
+		if len(obj) < int(m) {
+			AddError(errs, propPath, data, fmt.Sprintf("%d object Properties below %d minimum", len(obj), m))
+		}
+	}
+}
+
+// Required ensures that for a given object instance, every item in the array is the name of a property in the instance.
+// The value of this keyword MUST be an array. Elements of this array, if any, MUST be strings, and MUST be unique.
+// Omitting this keyword has the same behavior as an empty array.
+type Required []string
+
+// NewRequired allocates a new Required validator
+func NewRequired() Validator {
+	return &Required{}
+}
+
+// Validate implements the validator interface for Required
+func (r Required) Validate(propPath string, data interface{}, errs *[]ValError) {
+	if obj, ok := data.(map[string]interface{}); ok {
+		for _, key := range r {
+			if val, ok := obj[key]; val == nil && !ok {
+				AddError(errs, propPath, data, fmt.Sprintf(`"%s" value is required`, key))
+			}
+		}
+	}
+}
+
+// JSONProp implements JSON property name indexing for Required
+func (r Required) JSONProp(name string) interface{} {
+	idx, err := strconv.Atoi(name)
+	if err != nil {
+		return nil
+	}
+	if idx > len(r) || idx < 0 {
+		return nil
+	}
+	return r[idx]
+}
+
+// Properties MUST be an object. Each value of this object MUST be a valid JSON Schema.
+// This keyword determines how child instances validate for objects, and does not directly validate
+// the immediate instance itself.
+// Validation succeeds if, for each name that appears in both the instance and as a name within this
+// keyword's value, the child instance for that name successfully validates against the corresponding schema.
+// Omitting this keyword has the same behavior as an empty object.
+type Properties map[string]*Schema
+
+// NewProperties allocates a new Properties validator
+func NewProperties() Validator {
+	return &Properties{}
+}
+
+// Validate implements the validator interface for Properties
+func (p Properties) Validate(propPath string, data interface{}, errs *[]ValError) {
+	jp, err := jsonpointer.Parse(propPath)
+	if err != nil {
+		AddError(errs, propPath, nil, "invalid property path")
+		return
+	}
+
+	if obj, ok := data.(map[string]interface{}); ok {
+		for key, val := range obj {
+			if p[key] != nil {
+				d, _ := jp.Descendant(key)
+				p[key].Validate(d.String(), val, errs)
+			}
+		}
+	}
+}
+
+// JSONProp implements JSON property name indexing for Properties
+func (p Properties) JSONProp(name string) interface{} {
+	return p[name]
+}
+
+// JSONChildren implements the JSONContainer interface for Properties
+func (p Properties) JSONChildren() (res map[string]JSONPather) {
+	res = map[string]JSONPather{}
+	for key, sch := range p {
+		res[key] = sch
+	}
+	return
+}
+
+// PatternProperties determines how child instances validate for objects, and does not directly validate the immediate instance itself.
+// Validation of the primitive instance type against this keyword always succeeds.
+// Validation succeeds if, for each instance name that matches any regular expressions that appear as a property name in this
+// keyword's value, the child instance for that name successfully validates against each schema that corresponds to a matching
+// regular expression.
+// Each property name of this object SHOULD be a valid regular expression,
+// according to the ECMA 262 regular expression dialect.
+// Each property value of this object MUST be a valid JSON Schema.
+// Omitting this keyword has the same behavior as an empty object.
+type PatternProperties []patternSchema
+
+// NewPatternProperties allocates a new PatternProperties validator
+func NewPatternProperties() Validator {
+	return &PatternProperties{}
+}
+
+type patternSchema struct {
+	key    string
+	re     *regexp.Regexp
+	schema *Schema
+}
+
+// Validate implements the validator interface for PatternProperties
+func (p PatternProperties) Validate(propPath string, data interface{}, errs *[]ValError) {
+	jp, err := jsonpointer.Parse(propPath)
+	if err != nil {
+		AddError(errs, propPath, nil, "invalid property path")
+		return
+	}
+
+	if obj, ok := data.(map[string]interface{}); ok {
+		for key, val := range obj {
+			for _, ptn := range p {
+				if ptn.re.Match([]byte(key)) {
+					d, _ := jp.Descendant(key)
+					ptn.schema.Validate(d.String(), val, errs)
+				}
+			}
+		}
+	}
+	return
+}
+
+// JSONProp implements JSON property name indexing for PatternProperties
+func (p PatternProperties) JSONProp(name string) interface{} {
+	for _, pp := range p {
+		if pp.key == name {
+			return pp.schema
+		}
+	}
+	return nil
+}
+
+// JSONChildren implements the JSONContainer interface for PatternProperties
+func (p PatternProperties) JSONChildren() (res map[string]JSONPather) {
+	res = map[string]JSONPather{}
+	for i, pp := range p {
+		res[strconv.Itoa(i)] = pp.schema
+	}
+	return
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for PatternProperties
+func (p *PatternProperties) UnmarshalJSON(data []byte) error {
+	var props map[string]*Schema
+	if err := json.Unmarshal(data, &props); err != nil {
+		return err
+	}
+
+	ptn := make(PatternProperties, len(props))
+	i := 0
+	for key, sch := range props {
+		re, err := regexp.Compile(key)
+		if err != nil {
+			return fmt.Errorf("invalid pattern: %s: %s", key, err.Error())
+		}
+		ptn[i] = patternSchema{
+			key:    key,
+			re:     re,
+			schema: sch,
+		}
+		i++
+	}
+
+	*p = ptn
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for PatternProperties
+func (p PatternProperties) MarshalJSON() ([]byte, error) {
+	obj := map[string]interface{}{}
+	for _, prop := range p {
+		obj[prop.key] = prop.schema
+	}
+	return json.Marshal(obj)
+}
+
+// AdditionalProperties determines how child instances validate for objects, and does not directly validate the immediate instance itself.
+// Validation with "AdditionalProperties" applies only to the child values of instance names that do not match any names in "Properties",
+// and do not match any regular expression in "PatternProperties".
+// For all such Properties, validation succeeds if the child instance validates against the "AdditionalProperties" schema.
+// Omitting this keyword has the same behavior as an empty schema.
+type AdditionalProperties struct {
+	Properties *Properties
+	patterns   *PatternProperties
+	Schema     *Schema
+}
+
+// NewAdditionalProperties allocates a new AdditionalProperties validator
+func NewAdditionalProperties() Validator {
+	return &AdditionalProperties{}
+}
+
+// Validate implements the validator interface for AdditionalProperties
+func (ap AdditionalProperties) Validate(propPath string, data interface{}, errs *[]ValError) {
+	jp, err := jsonpointer.Parse(propPath)
+	if err != nil {
+		AddError(errs, propPath, nil, "invalid property path")
+		return
+	}
+
+	if obj, ok := data.(map[string]interface{}); ok {
+	KEYS:
+		for key, val := range obj {
+			if ap.Properties != nil {
+				for propKey := range *ap.Properties {
+					if propKey == key {
+						continue KEYS
+					}
+				}
+			}
+			if ap.patterns != nil {
+				for _, ptn := range *ap.patterns {
+					if ptn.re.Match([]byte(key)) {
+						continue KEYS
+					}
+				}
+			}
+			// c := len(*errs)
+			d, _ := jp.Descendant(key)
+			ap.Schema.Validate(d.String(), val, errs)
+			// if len(*errs) > c {
+			// 	// fmt.Sprintf("object key %s AdditionalProperties error: %s", key, err.Error())
+			// 	return
+			// }
+		}
+	}
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for AdditionalProperties
+func (ap *AdditionalProperties) UnmarshalJSON(data []byte) error {
+	sch := &Schema{}
+	if err := json.Unmarshal(data, sch); err != nil {
+		return err
+	}
+	// fmt.Println("unmarshal:", sch.Ref)
+	*ap = AdditionalProperties{Schema: sch}
+	return nil
+}
+
+// JSONProp implements JSON property name indexing for AdditionalProperties
+func (ap *AdditionalProperties) JSONProp(name string) interface{} {
+	return ap.Schema.JSONProp(name)
+}
+
+// JSONChildren implements the JSONContainer interface for AdditionalProperties
+func (ap *AdditionalProperties) JSONChildren() (res map[string]JSONPather) {
+	if ap.Schema.Ref != "" {
+		return map[string]JSONPather{"$ref": ap.Schema}
+	}
+	return ap.Schema.JSONChildren()
+}
+
+// MarshalJSON implements json.Marshaler for AdditionalProperties
+func (ap AdditionalProperties) MarshalJSON() ([]byte, error) {
+	return json.Marshal(ap.Schema)
+}
+
+// Dependencies : [CREF1]
+// This keyword specifies rules that are evaluated if the instance is an object and contains a
+// certain property.
+// This keyword's value MUST be an object. Each property specifies a Dependency.
+// Each Dependency value MUST be an array or a valid JSON Schema.
+// If the Dependency value is a subschema, and the Dependency key is a property in the instance,
+// the entire instance must validate against the Dependency value.
+// If the Dependency value is an array, each element in the array, if any, MUST be a string,
+// and MUST be unique. If the Dependency key is a property in the instance, each of the items
+// in the Dependency value must be a property that exists in the instance.
+// Omitting this keyword has the same behavior as an empty object.
+type Dependencies map[string]Dependency
+
+// NewDependencies allocates a new Dependencies validator
+func NewDependencies() Validator {
+	return &Dependencies{}
+}
+
+// Validate implements the validator interface for Dependencies
+func (d Dependencies) Validate(propPath string, data interface{}, errs *[]ValError) {
+	jp, err := jsonpointer.Parse(propPath)
+	if err != nil {
+		AddError(errs, propPath, nil, "invalid property path")
+		return
+	}
+
+	if obj, ok := data.(map[string]interface{}); ok {
+		for key, val := range d {
+			if obj[key] != nil {
+				d, _ := jp.Descendant(key)
+				val.Validate(d.String(), obj, errs)
+			}
+		}
+	}
+	return
+}
+
+// JSONProp implements JSON property name indexing for Dependencies
+func (d Dependencies) JSONProp(name string) interface{} {
+	return d[name]
+}
+
+// JSONChildren implements the JSONContainer interface for Dependencies
+// func (d Dependencies) JSONChildren() (res map[string]JSONPather) {
+// 	res = map[string]JSONPather{}
+// 	for key, dep := range d {
+// 		if dep.schema != nil {
+// 			res[key] = dep.schema
+// 		}
+// 	}
+// 	return
+// }
+
+// Dependency is an instance used only in the Dependencies proprty
+type Dependency struct {
+	schema *Schema
+	props  []string
+}
+
+// Validate implements the validator interface for Dependency
+func (d Dependency) Validate(propPath string, data interface{}, errs *[]ValError) {
+	if obj, ok := data.(map[string]interface{}); ok {
+		if d.schema != nil {
+			d.schema.Validate(propPath, data, errs)
+		} else if len(d.props) > 0 {
+			for _, k := range d.props {
+				if obj[k] == nil {
+					AddError(errs, propPath, data, fmt.Sprintf("Dependency property %s is Required", k))
+				}
+			}
+		}
+	}
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for Dependencies
+func (d *Dependency) UnmarshalJSON(data []byte) error {
+	props := []string{}
+	if err := json.Unmarshal(data, &props); err == nil {
+		*d = Dependency{props: props}
+		return nil
+	}
+	sch := &Schema{}
+	err := json.Unmarshal(data, sch)
+
+	if err == nil {
+		*d = Dependency{schema: sch}
+	}
+	return err
+}
+
+// MarshalJSON implements json.Marshaler for Dependency
+func (d Dependency) MarshalJSON() ([]byte, error) {
+	if d.schema != nil {
+		return json.Marshal(d.schema)
+	}
+	return json.Marshal(d.props)
+}
+
+// PropertyNames checks if every property name in the instance validates against the provided schema
+// if the instance is an object.
+// Note the property name that the schema is testing will always be a string.
+// Omitting this keyword has the same behavior as an empty schema.
+type PropertyNames Schema
+
+// NewPropertyNames allocates a new PropertyNames validator
+func NewPropertyNames() Validator {
+	return &PropertyNames{}
+}
+
+// Validate implements the validator interface for PropertyNames
+func (p PropertyNames) Validate(propPath string, data interface{}, errs *[]ValError) {
+	jp, err := jsonpointer.Parse(propPath)
+	if err != nil {
+		AddError(errs, propPath, nil, "invalid property path")
+		return
+	}
+
+	sch := Schema(p)
+	if obj, ok := data.(map[string]interface{}); ok {
+		for key := range obj {
+			// TODO - adjust error message & prop path
+			d, _ := jp.Descendant(key)
+			sch.Validate(d.String(), key, errs)
+		}
+	}
+}
+
+// JSONProp implements JSON property name indexing for Properties
+func (p PropertyNames) JSONProp(name string) interface{} {
+	return Schema(p).JSONProp(name)
+}
+
+// JSONChildren implements the JSONContainer interface for PropertyNames
+func (p PropertyNames) JSONChildren() (res map[string]JSONPather) {
+	return Schema(p).JSONChildren()
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for PropertyNames
+func (p *PropertyNames) UnmarshalJSON(data []byte) error {
+	var sch Schema
+	if err := json.Unmarshal(data, &sch); err != nil {
+		return err
+	}
+	*p = PropertyNames(sch)
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for PropertyNames
+func (p PropertyNames) MarshalJSON() ([]byte, error) {
+	return json.Marshal(Schema(p))
+}

--- a/vendor/github.com/qri-io/jsonschema/keywords_strings.go
+++ b/vendor/github.com/qri-io/jsonschema/keywords_strings.go
@@ -1,0 +1,91 @@
+package jsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"unicode/utf8"
+)
+
+// MaxLength MUST be a non-negative integer.
+// A string instance is valid against this keyword if its length is less than, or equal to, the value of this keyword.
+// The length of a string instance is defined as the number of its characters as defined by RFC 7159 [RFC7159].
+type MaxLength int
+
+// NewMaxLength allocates a new MaxLength validator
+func NewMaxLength() Validator {
+	return new(MaxLength)
+}
+
+// Validate implements the Validator interface for MaxLength
+func (m MaxLength) Validate(propPath string, data interface{}, errs *[]ValError) {
+	if str, ok := data.(string); ok {
+		if utf8.RuneCountInString(str) > int(m) {
+			AddError(errs, propPath, data, fmt.Sprintf("max length of %d characters exceeded: %s", m, str))
+		}
+	}
+}
+
+// MinLength MUST be a non-negative integer.
+// A string instance is valid against this keyword if its length is greater than, or equal to, the value of this keyword.
+// The length of a string instance is defined as the number of its characters as defined by RFC 7159 [RFC7159].
+// Omitting this keyword has the same behavior as a value of 0.
+type MinLength int
+
+// NewMinLength allocates a new MinLength validator
+func NewMinLength() Validator {
+	return new(MinLength)
+}
+
+// Validate implements the Validator interface for MinLength
+func (m MinLength) Validate(propPath string, data interface{}, errs *[]ValError) {
+	if str, ok := data.(string); ok {
+		if utf8.RuneCountInString(str) < int(m) {
+			AddError(errs, propPath, data, fmt.Sprintf("min length of %d characters required: %s", m, str))
+		}
+	}
+}
+
+// Pattern MUST be a string. This string SHOULD be a valid regular expression,
+// according to the ECMA 262 regular expression dialect.
+// A string instance is considered valid if the regular expression matches the instance successfully.
+// Recall: regular expressions are not implicitly anchored.
+type Pattern regexp.Regexp
+
+// NewPattern allocates a new Pattern validator
+func NewPattern() Validator {
+	return &Pattern{}
+}
+
+// Validate implements the Validator interface for Pattern
+func (p Pattern) Validate(propPath string, data interface{}, errs *[]ValError) {
+	re := regexp.Regexp(p)
+	if str, ok := data.(string); ok {
+		if !re.Match([]byte(str)) {
+			AddError(errs, propPath, data, fmt.Sprintf("regexp pattrn %s mismatch on string: %s", re.String(), str))
+		}
+	}
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for Pattern
+func (p *Pattern) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+
+	ptn, err := regexp.Compile(str)
+	if err != nil {
+		return err
+	}
+
+	*p = Pattern(*ptn)
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for Pattern
+func (p Pattern) MarshalJSON() ([]byte, error) {
+	re := regexp.Regexp(p)
+	rep := &re
+	return json.Marshal(rep.String())
+}

--- a/vendor/github.com/qri-io/jsonschema/schema.go
+++ b/vendor/github.com/qri-io/jsonschema/schema.go
@@ -1,0 +1,631 @@
+// Package jsonschema implements draft-handrews-json-schema-validation-00
+// JSON Schema (application/schema+json) has several purposes, one of
+// which is JSON instance validation. This document specifies a
+// vocabulary for JSON Schema to describe the meaning of JSON
+// documents, provide hints for user interfaces working with JSON
+// data, and to make assertions about what a valid document must look
+// like.
+package jsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/qri-io/jsonpointer"
+	"net/http"
+	"net/url"
+)
+
+// Must turns a JSON string into a *RootSchema, panicing if parsing fails.
+// Useful for declaring Schemas in Go code.
+func Must(jsonString string) *RootSchema {
+	rs := &RootSchema{}
+	if err := rs.UnmarshalJSON([]byte(jsonString)); err != nil {
+		panic(err)
+	}
+	return rs
+}
+
+// DefaultSchemaPool is a package level map of schemas by identifier
+// remote references are cached here.
+var DefaultSchemaPool = Definitions{}
+
+// RootSchema is a top-level Schema.
+type RootSchema struct {
+	Schema
+	// The "$schema" keyword is both used as a JSON Schema version
+	// identifier and the location of a resource which is itself a JSON
+	// Schema, which describes any schema written for this particular
+	// version. The value of this keyword MUST be a URI [RFC3986]
+	// (containing a scheme) and this URI MUST be normalized. The
+	// current schema MUST be valid against the meta-schema identified
+	// by this URI. If this URI identifies a retrievable resource, that
+	// resource SHOULD be of media type "application/schema+json". The
+	// "$schema" keyword SHOULD be used in a root schema. Values for
+	// this property are defined in other documents and by other
+	// parties. JSON Schema implementations SHOULD implement support
+	// for current and previous published drafts of JSON Schema
+	// vocabularies as deemed reasonable.
+	SchemaURI string `json:"$schema"`
+}
+
+// TopLevelType returns a string representing the schema's top-level type.
+func (rs *RootSchema) TopLevelType() string {
+	if t, ok := rs.Schema.Validators["type"].(*Type); ok {
+		return t.String()
+	}
+	return "unknown"
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for
+// RootSchema
+func (rs *RootSchema) UnmarshalJSON(data []byte) error {
+	sch := &Schema{}
+	if err := json.Unmarshal(data, sch); err != nil {
+		return err
+	}
+
+	if sch.schemaType == schemaTypeFalse || sch.schemaType == schemaTypeTrue {
+		*rs = RootSchema{Schema: *sch}
+		return nil
+	}
+
+	suri := struct {
+		SchemaURI string `json:"$schema"`
+	}{}
+	if err := json.Unmarshal(data, &suri); err != nil {
+		return err
+	}
+
+	root := &RootSchema{
+		Schema:     *sch,
+		SchemaURI:  suri.SchemaURI,
+	}
+
+	// collect IDs for internal referencing:
+	ids := map[string]*Schema{}
+	if err := walkJSON(sch, func(elem JSONPather) error {
+		if sch, ok := elem.(*Schema); ok {
+			if sch.ID != "" {
+				ids[sch.ID] = sch
+
+				// For the record, I think this is rediculous.
+				if u, err := url.Parse(sch.ID); err == nil {
+					ids[u.Path[1:]] = sch
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// pass a pointer to the schema component in here (instead of the
+	// RootSchema struct) to ensure root is evaluated for references
+	if err := walkJSON(sch, func(elem JSONPather) error {
+		if sch, ok := elem.(*Schema); ok {
+			if sch.Ref != "" {
+				if ids[sch.Ref] != nil {
+					sch.ref = ids[sch.Ref]
+					return nil
+				}
+
+				ptr, err := jsonpointer.Parse(sch.Ref)
+				if err != nil {
+					return fmt.Errorf("error evaluating json pointer: %s: %s", err.Error(), sch.Ref)
+				}
+				res, err := root.evalJSONValidatorPointer(ptr)
+				if err != nil {
+					return err
+				}
+				if val, ok := res.(Validator); ok {
+					sch.ref = val
+				} else {
+					return fmt.Errorf("%s : %s, %v is not a json pointer to a json schema", sch.Ref, ptr.String(), ptr)
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	*rs = RootSchema{
+		Schema:     *sch,
+		SchemaURI:  suri.SchemaURI,
+	}
+	return nil
+}
+
+// FetchRemoteReferences grabs any url-based schema references that
+// cannot be locally resolved via network requests
+func (rs *RootSchema) FetchRemoteReferences() error {
+	sch := &rs.Schema
+
+	refs := DefaultSchemaPool
+
+	if err := walkJSON(sch, func(elem JSONPather) error {
+		if sch, ok := elem.(*Schema); ok {
+			ref := sch.Ref
+			if ref != "" {
+				if refs[ref] == nil && ref[0] != '#' {
+					if u, err := url.Parse(ref); err == nil {
+						if res, err := http.Get(u.String()); err == nil {
+							s := &RootSchema{}
+							if err := json.NewDecoder(res.Body).Decode(s); err != nil {
+								return err
+							}
+							refs[ref] = &s.Schema
+						}
+					}
+				}
+
+				if refs[ref] != nil {
+					sch.ref = refs[ref]
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	rs.Schema = *sch
+	return nil
+}
+
+// ValidateBytes performs schema validation against a slice of json
+// byte data
+func (rs *RootSchema) ValidateBytes(data []byte) ([]ValError, error) {
+	var doc interface{}
+	errs := []ValError{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return errs, fmt.Errorf("error parsing JSON bytes: %s", err.Error())
+	}
+	rs.Validate("/", doc, &errs)
+	return errs, nil
+}
+
+func (rs *RootSchema) evalJSONValidatorPointer(ptr jsonpointer.Pointer) (res interface{}, err error) {
+	res = rs
+	for _, token := range ptr {
+		if adr, ok := res.(JSONPather); ok {
+			res = adr.JSONProp(token)
+		} else if !ok {
+			err = fmt.Errorf("invalid pointer: %s", ptr)
+			return
+		}
+	}
+	return
+}
+
+type schemaType int
+
+const (
+	schemaTypeObject schemaType = iota
+	schemaTypeFalse
+	schemaTypeTrue
+)
+
+// Schema is the root JSON-schema struct
+// A JSON Schema vocabulary is a set of keywords defined for a
+// particular purpose. The vocabulary specifies the meaning of its
+// keywords as assertions, annotations, and/or any vocabulary-defined
+// keyword category.
+//
+// The two companion standards to this document each define a
+// vocabulary: One for instance validation, and one for hypermedia
+// annotations.
+//
+// Vocabularies are the primary mechanism for extensibility within
+// the JSON Schema media type. Vocabularies may be defined by any
+// entity. Vocabulary authors SHOULD take care to avoid keyword name
+// collisions if the vocabulary is intended for broad use, and
+// potentially combined with other vocabularies. JSON Schema does not
+// provide any formal namespacing system, but also does not constrain
+// keyword names, allowing for any number of namespacing approaches.
+//
+// Vocabularies may build on each other, such as by defining the
+// behavior of their keywords with respect to the behavior of
+// keywords from another vocabulary,  or by using a keyword from
+// another vocabulary with a restricted or expanded set of acceptable
+// values. Not all such vocabulary re-use will result in a new
+// vocabulary that is compatible with the vocabulary on which it is
+// built.
+//
+// Vocabulary authors SHOULD clearly document what level of
+// compatibility, if any, is expected. A schema that itself describes
+// a schema is called a meta-schema. Meta-schemas are used to
+// validate JSON Schemas and specify which vocabulary it is using.
+// [CREF1] A JSON Schema MUST be an object or a boolean.
+type Schema struct {
+	// internal tracking for true/false/{...} schemas
+	schemaType schemaType
+	// The "$id" keyword defines a URI for the schema, and the base URI
+	// that other URI references within the schema are resolved
+	// against. A subschema's "$id" is resolved against the base URI of
+	// its parent schema. If no parent sets an explicit base with
+	// "$id", the base URI is that of the entire document, as
+	// determined per RFC 3986 section 5 [RFC3986].
+	ID string `json:"$id,omitempty"`
+	// Title and description can be used to decorate a user interface
+	// with information about the data produced by this user interface.
+	// A title will preferably be short.
+	Title string `json:"title,omitempty"`
+	// Description provides an explanation about the purpose
+	// of the instance described by this schema.
+	Description string `json:"description,omitempty"`
+	// There are no restrictions placed on the value of this keyword.
+	// When multiple occurrences of this keyword are applicable to a
+	// single sub-instance, implementations SHOULD remove duplicates.
+	// This keyword can be used to supply a default JSON value
+	// associated with a particular schema. It is RECOMMENDED that a
+	// default value be valid against the associated schema.
+	Default interface{} `json:"default,omitempty"`
+	// The value of this keyword MUST be an array. There are no
+	// restrictions placed on the values within the array. When
+	// multiple occurrences of this keyword are applicable to a single
+	// sub-instance, implementations MUST provide a flat array of all
+	// values rather than an array of arrays. This keyword can be used
+	// to provide sample JSON values associated with a particular
+	// schema, for the purpose of illustrating usage. It is
+	// RECOMMENDED that these values be valid against the associated
+	// schema. Implementations MAY use the value(s) of "default", if
+	// present, as an additional example. If "examples" is absent,
+	// "default" MAY still be used in this manner.
+	Examples []interface{} `json:"examples,omitempty"`
+	// If "readOnly" has a value of boolean true, it indicates that the
+	// value of the instance is managed exclusively by the owning
+	// authority, and attempts by an application to modify the value of
+	// this property are expected to be ignored or rejected by that
+	// owning authority. An instance document that is marked as
+	// "readOnly for the entire document MAY be ignored if sent to the
+	// owning authority, or MAY result in an error, at the authority's
+	// discretion. For example, "readOnly" would be used to mark a
+	// database-generated serial number as read-only, while "writeOnly"
+	// would be used to mark a password input field. These keywords can
+	// be used to assist in user interface instance generation. In
+	// particular, an application MAY choose to use a widget that hides
+	// input values as they are typed for write-only fields. Omitting
+	// these keywords has the same behavior as values of false.
+	ReadOnly *bool `json:"readOnly,omitempty"`
+	// If "writeOnly" has a value of boolean true, it indicates that
+	// the value is never present when the instance is retrieved from
+	// the owning authority. It can be present when sent to the owning
+	// authority to update or create the document (or the resource it
+	// represents), but it will not be included in any updated or newly
+	// created version of the instance. An instance document that is
+	// marked as "writeOnly" for the entire document MAY be returned as
+	// a blank document of some sort, or MAY produce an error upon
+	// retrieval, or have the retrieval request ignored, at the
+	// authority's discretion.
+	WriteOnly *bool `json:"writeOnly,omitempty"`
+	// This keyword is reserved for comments from schema authors to
+	// readers or maintainers of the schema. The value of this keyword
+	// MUST be a string. Implementations MUST NOT present this string
+	// to end users. Tools for editing schemas SHOULD support
+	// displaying and editing this keyword. The value of this keyword
+	// MAY be used in debug or error output which is intended for
+	// developers making use of schemas. Schema vocabularies SHOULD
+	// allow "$comment" within any object containing vocabulary
+	// keywords. Implementations MAY assume "$comment" is allowed
+	// unless the vocabulary specifically forbids it. Vocabularies MUST
+	// NOT specify any effect of "$comment" beyond what is described in
+	// this specification.
+	Comment string `json:"comment,omitempty"`
+	// Ref is used to reference a schema, and provides the ability to
+	// validate recursive structures through self-reference. An object
+	// schema with a "$ref" property MUST be interpreted as a "$ref"
+	// reference. The value of the "$ref" property MUST be a URI
+	// Reference. Resolved against the current URI base, it identifies
+	// the URI of a schema to use. All other properties in a "$ref"
+	// object MUST be ignored. The URI is not a network locator, only
+	// an identifier. A schema need not be downloadable from the
+	// address if it is a network-addressable URL, and implementations
+	// SHOULD NOT assume they should perform a network operation when
+	// they encounter a network-addressable URI. A schema MUST NOT be
+	// run into an infinite loop against a schema. For example, if two
+	// schemas "#alice" and "#bob" both have an "allOf" property that
+	// refers to the other, a naive validator might get stuck in an
+	// infinite recursive loop trying to validate the instance. Schemas
+	// SHOULD NOT make use of infinite recursive nesting like this; the
+	// behavior is undefined.
+	Ref string `json:"$ref,omitempty"`
+	// Format functions as both an annotation (Section 3.3) and as an
+	// assertion (Section 3.2).
+	// While no special effort is required to implement it as an
+	// annotation conveying semantic meaning,
+	// implementing validation is non-trivial.
+	Format string `json:"format,omitempty"`
+
+	ref Validator
+
+	// Definitions provides a standardized location for schema authors
+	// to inline re-usable JSON Schemas into a more general schema. The
+	// keyword does not directly affect the validation result.
+	Definitions Definitions `json:"definitions,omitempty"`
+
+	// TODO - currently a bit of a hack to handle arbitrary JSON data
+	// outside the spec
+	extraDefinitions Definitions
+
+	Validators map[string]Validator
+}
+
+// Path gives a jsonpointer path to the validator
+func (s *Schema) Path() string {
+	return ""
+}
+
+// Validate uses the schema to check an instance, collecting validation
+// errors in a slice
+func (s *Schema) Validate(propPath string, data interface{}, errs *[]ValError) {
+	if s.Ref != "" && s.ref != nil {
+		s.ref.Validate(propPath, data, errs)
+		return
+	} else if s.Ref != "" && s.ref == nil {
+		AddError(errs, propPath, data, fmt.Sprintf("%s reference is nil for data: %v", s.Ref, data))
+		return
+	}
+
+	// TODO - so far all default.json tests pass when no use of
+	// "default" is made.
+	// Is this correct?
+
+	for _, v := range s.Validators {
+		v.Validate(propPath, data, errs)
+	}
+}
+
+// JSONProp implements the JSONPather for Schema
+func (s Schema) JSONProp(name string) interface{} {
+	switch name {
+	case "$id":
+		return s.ID
+	case "title":
+		return s.Title
+	case "description":
+		return s.Description
+	case "default":
+		return s.Default
+	case "examples":
+		return s.Examples
+	case "readOnly":
+		return s.ReadOnly
+	case "writeOnly":
+		return s.WriteOnly
+	case "comment":
+		return s.Comment
+	case "$ref":
+		return s.Ref
+	case "definitions":
+		return s.Definitions
+	case "format":
+		return s.Format
+	default:
+		prop := s.Validators[name]
+		if prop == nil && s.extraDefinitions[name] != nil {
+			prop = s.extraDefinitions[name]
+		}
+		return prop
+	}
+}
+
+// JSONChildren implements the JSONContainer interface for Schema
+func (s Schema) JSONChildren() (ch map[string]JSONPather) {
+	ch = map[string]JSONPather{}
+
+	if s.extraDefinitions != nil {
+		for key, val := range s.extraDefinitions {
+			ch[key] = val
+		}
+	}
+
+	if s.Definitions != nil {
+		ch["definitions"] = s.Definitions
+	}
+
+	if s.Validators != nil {
+		for key, val := range s.Validators {
+			if jp, ok := val.(JSONPather); ok {
+				ch[key] = jp
+			}
+		}
+	}
+
+	return
+}
+
+// _schema is an internal struct for encoding & decoding purposes
+type _schema struct {
+	ID          string             `json:"$id,omitempty"`
+	Title       string             `json:"title,omitempty"`
+	Description string             `json:"description,omitempty"`
+	Default     interface{}        `json:"default,omitempty"`
+	Examples    []interface{}      `json:"examples,omitempty"`
+	ReadOnly    *bool              `json:"readOnly,omitempty"`
+	WriteOnly   *bool              `json:"writeOnly,omitempty"`
+	Comment     string             `json:"comment,omitempty"`
+	Ref         string             `json:"$ref,omitempty"`
+	Definitions map[string]*Schema `json:"definitions,omitempty"`
+	Format      string             `json:"format,omitempty"`
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for Schema
+func (s *Schema) UnmarshalJSON(data []byte) error {
+	// support simple true false schemas that always pass or fail
+	var b bool
+	if err := json.Unmarshal(data, &b); err == nil {
+		if b {
+			// boolean true Always passes validation, as if the empty schema {}
+			*s = Schema{schemaType: schemaTypeTrue}
+			return nil
+		}
+		// boolean false Always fails validation, as if the schema { "not":{} }
+		*s = Schema{schemaType: schemaTypeFalse, Validators: map[string]Validator{"not": &Not{}}}
+		return nil
+	}
+
+	_s := _schema{}
+	if err := json.Unmarshal(data, &_s); err != nil {
+		return err
+	}
+
+	sch := &Schema{
+		ID:          _s.ID,
+		Title:       _s.Title,
+		Description: _s.Description,
+		Default:     _s.Default,
+		Examples:    _s.Examples,
+		ReadOnly:    _s.ReadOnly,
+		WriteOnly:   _s.WriteOnly,
+		Comment:     _s.Comment,
+		Ref:         _s.Ref,
+		Definitions: _s.Definitions,
+		Format:      _s.Format,
+		Validators:  map[string]Validator{},
+	}
+
+	// if a reference is present everything else is *supposed to be* ignored
+	// but the tests seem to require that this is not the case
+	// I'd like to do this:
+	// if sch.Ref != "" {
+	// 	*s = Schema{Ref: sch.Ref}
+	// 	return nil
+	// }
+	// but returning the full struct makes tests pass, because things like
+	// testdata/draft7/ref.json#/4/schema
+	// mean we should return the full object
+
+	valprops := map[string]json.RawMessage{}
+	if err := json.Unmarshal(data, &valprops); err != nil {
+		return err
+	}
+
+	for prop, rawmsg := range valprops {
+		var val Validator
+		if mk, ok := DefaultValidators[prop]; ok {
+			val = mk()
+		} else {
+			switch prop {
+			// skip any already-parsed props
+			case "$schema", "$id", "title", "description", "default", "examples", "readOnly", "writeOnly", "comment", "$ref", "definitions", "format":
+				continue
+			default:
+				// assume non-specified props are "extra definitions"
+				if sch.extraDefinitions == nil {
+					sch.extraDefinitions = Definitions{}
+				}
+				s := new(Schema)
+				if err := json.Unmarshal(rawmsg, s); err != nil {
+					return fmt.Errorf("error unmarshaling %s from json: %s", prop, err.Error())
+				}
+				sch.extraDefinitions[prop] = s
+				continue
+			}
+		}
+		if err := json.Unmarshal(rawmsg, val); err != nil {
+			return fmt.Errorf("error unmarshaling %s from json: %s", prop, err.Error())
+		}
+		sch.Validators[prop] = val
+	}
+
+	if sch.Validators["if"] != nil {
+		if ite, ok := sch.Validators["if"].(*If); ok {
+			if s, ok := sch.Validators["then"].(*Then); ok {
+				ite.Then = s
+			}
+			if s, ok := sch.Validators["else"].(*Else); ok {
+				ite.Else = s
+			}
+		}
+	}
+
+	// TODO - replace all these assertions with methods on Schema that return proper types
+	if sch.Validators["items"] != nil && sch.Validators["additionalItems"] != nil && !sch.Validators["items"].(*Items).single {
+		sch.Validators["additionalItems"].(*AdditionalItems).startIndex = len(sch.Validators["items"].(*Items).Schemas)
+	}
+	if sch.Validators["properties"] != nil && sch.Validators["additionalProperties"] != nil {
+		sch.Validators["additionalProperties"].(*AdditionalProperties).Properties = sch.Validators["properties"].(*Properties)
+	}
+	if sch.Validators["patternProperties"] != nil && sch.Validators["additionalProperties"] != nil {
+		sch.Validators["additionalProperties"].(*AdditionalProperties).patterns = sch.Validators["patternProperties"].(*PatternProperties)
+	}
+
+	*s = Schema(*sch)
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface for Schema
+func (s Schema) MarshalJSON() ([]byte, error) {
+	switch s.schemaType {
+	case schemaTypeFalse:
+		return []byte("false"), nil
+	case schemaTypeTrue:
+		return []byte("true"), nil
+	default:
+		obj := map[string]interface{}{}
+
+		if s.ID != "" {
+			obj["$id"] = s.ID
+		}
+		if s.Title != "" {
+			obj["title"] = s.Title
+		}
+		if s.Description != "" {
+			obj["description"] = s.Description
+		}
+		if s.Default != nil {
+			obj["default"] = s.Default
+		}
+		if s.Examples != nil {
+			obj["examples"] = s.Examples
+		}
+		if s.ReadOnly != nil {
+			obj["readOnly"] = s.ReadOnly
+		}
+		if s.WriteOnly != nil {
+			obj["writeOnly"] = s.WriteOnly
+		}
+		if s.Comment != "" {
+			obj["comment"] = s.Comment
+		}
+		if s.Ref != "" {
+			obj["$ref"] = s.Ref
+		}
+		if s.Definitions != nil {
+			obj["definitions"] = s.Definitions
+		}
+		if s.Format != "" {
+			obj["format"] = s.Format
+		}
+		if s.Definitions != nil {
+			obj["definitions"] = s.Definitions
+		}
+
+		for k, v := range s.Validators {
+			obj[k] = v
+		}
+		for k, v := range s.extraDefinitions {
+			obj[k] = v
+		}
+		return json.Marshal(obj)
+	}
+}
+
+// Definitions implements a map of schemas while also satsfying the JSON
+// traversal methods
+type Definitions map[string]*Schema
+
+// JSONProp implements the JSONPather for Definitions
+func (d Definitions) JSONProp(name string) interface{} {
+	return d[name]
+}
+
+// JSONChildren implements the JSONContainer interface for Definitions
+func (d Definitions) JSONChildren() (r map[string]JSONPather) {
+	r = map[string]JSONPather{}
+	for key, val := range d {
+		r[key] = val
+	}
+	return
+}

--- a/vendor/github.com/qri-io/jsonschema/traversal.go
+++ b/vendor/github.com/qri-io/jsonschema/traversal.go
@@ -1,0 +1,35 @@
+package jsonschema
+
+// JSONPather makes validators traversible by JSON-pointers,
+// which is required to support references in JSON schemas.
+type JSONPather interface {
+	// JSONProp take a string references for a given JSON property
+	// implementations must return any matching property of that name
+	// or nil if no such subproperty exists.
+	// Note this also applies to array values, which are expected to interpret
+	// valid numbers as an array index
+	JSONProp(name string) interface{}
+}
+
+// JSONContainer is an interface that enables tree traversal by listing
+// the immideate children of an object
+type JSONContainer interface {
+	// JSONChildren should return all immidiate children of this element
+	JSONChildren() map[string]JSONPather
+}
+
+func walkJSON(elem JSONPather, fn func(elem JSONPather) error) error {
+	if err := fn(elem); err != nil {
+		return err
+	}
+
+	if con, ok := elem.(JSONContainer); ok {
+		for _, ch := range con.JSONChildren() {
+			if err := walkJSON(ch, fn); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/qri-io/jsonschema/validate.go
+++ b/vendor/github.com/qri-io/jsonschema/validate.go
@@ -1,0 +1,160 @@
+package jsonschema
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// MaxValueErrStringLen sets how long a value can be before it's length is truncated
+// when printing error strings
+// a special value of -1 disables output trimming
+var MaxValueErrStringLen = 20
+
+// Validator is an interface for anything that can validate.
+// JSON-Schema keywords are all examples of validators
+type Validator interface {
+	// Validate checks decoded JSON data and writes
+	// validation errors (if any) to an outparam slice of ValErrors
+	// propPath indicates the position of data in the json tree
+	Validate(propPath string, data interface{}, errs *[]ValError)
+}
+
+// ValError represents a single error in an instance of a schema
+// The only absolutely-required property is Message.
+type ValError struct {
+	// PropertyPath is a string path that leads to the
+	// property that produced the error
+	PropertyPath string `json:"propertyPath,omitempty"`
+	// InvalidValue is the value that returned the error
+	InvalidValue interface{} `json:"invalidValue,omitempty"`
+	// RulePath is the path to the rule that errored
+	RulePath string `json:"rulePath,omitempty"`
+	// Message is a human-readable description of the error
+	Message string `json:"message"`
+}
+
+// Error implements the error interface for ValError
+func (v ValError) Error() string {
+	// [propPath]: [value] [message]
+	if v.PropertyPath != "" && v.InvalidValue != nil {
+		return fmt.Sprintf("%s: %s %s", v.PropertyPath, InvalidValueString(v.InvalidValue), v.Message)
+	} else if v.PropertyPath != "" {
+		return fmt.Sprintf("%s: %s", v.PropertyPath, v.Message)
+	}
+	return v.Message
+}
+
+// InvalidValueString returns the errored value as a string
+func InvalidValueString(data interface{}) string {
+	bt, err := json.Marshal(data)
+	if err != nil {
+		return ""
+	}
+	bt = bytes.Replace(bt, []byte{'\n', '\r'}, []byte{' '}, -1)
+	if MaxValueErrStringLen != -1 && len(bt) > MaxValueErrStringLen {
+		bt = append(bt[:MaxValueErrStringLen], []byte("...")...)
+	}
+	return string(bt)
+}
+
+// BaseValidator is a foundation for building a validator
+type BaseValidator struct {
+	path string
+}
+
+// SetPath sets base validator's path
+func (b *BaseValidator) SetPath(path string) {
+	b.path = path
+}
+
+// Path gives this validator's path
+func (b BaseValidator) Path() string {
+	return b.path
+}
+
+// AddError is a convenience method for appending a new error to an existing error slice
+func (b BaseValidator) AddError(errs *[]ValError, propPath string, data interface{}, msg string) {
+	*errs = append(*errs, ValError{
+		PropertyPath: propPath,
+		RulePath:     b.Path(),
+		InvalidValue: data,
+		Message:      msg,
+	})
+}
+
+// AddError creates and appends a ValError to errs
+func AddError(errs *[]ValError, propPath string, data interface{}, msg string) {
+	*errs = append(*errs, ValError{
+		PropertyPath: propPath,
+		InvalidValue: data,
+		Message:      msg,
+	})
+}
+
+// ValMaker is a function that generates instances of a validator.
+// Calls to ValMaker will be passed directly to json.Marshal,
+// so the returned value should be a pointer
+type ValMaker func() Validator
+
+// RegisterValidator adds a validator to DefaultValidators.
+// Custom Validators should satisfy the validator interface,
+// and be able to get cleanly endcode/decode to JSON
+func RegisterValidator(propName string, maker ValMaker) {
+	// TODO - should this call the function and panic if
+	// the result can't be fed to json.Umarshal?
+	DefaultValidators[propName] = maker
+}
+
+// DefaultValidators is a map of JSON keywords to Validators
+// to draw from when decoding schemas
+var DefaultValidators = map[string]ValMaker{
+	// standard keywords
+	"type":  NewType,
+	"enum":  NewEnum,
+	"const": NewConst,
+
+	// numeric keywords
+	"multipleOf":       NewMultipleOf,
+	"maximum":          NewMaximum,
+	"exclusiveMaximum": NewExclusiveMaximum,
+	"minimum":          NewMinimum,
+	"exclusiveMinimum": NewExclusiveMinimum,
+
+	// string keywords
+	"maxLength": NewMaxLength,
+	"minLength": NewMinLength,
+	"pattern":   NewPattern,
+
+	// boolean keywords
+	"allOf": NewAllOf,
+	"anyOf": NewAnyOf,
+	"oneOf": NewOneOf,
+	"not":   NewNot,
+
+	// array keywords
+	"items":           NewItems,
+	"additionalItems": NewAdditionalItems,
+	"maxItems":        NewMaxItems,
+	"minItems":        NewMinItems,
+	"uniqueItems":     NewUniqueItems,
+	"contains":        NewContains,
+
+	// object keywords
+	"maxProperties":        NewMaxProperties,
+	"minProperties":        NewMinProperties,
+	"required":             NewRequired,
+	"properties":           NewProperties,
+	"patternProperties":    NewPatternProperties,
+	"additionalProperties": NewAdditionalProperties,
+	"dependencies":         NewDependencies,
+	"propertyNames":        NewPropertyNames,
+
+	// conditional keywords
+	"if":   NewIf,
+	"then": NewThen,
+	"else": NewElse,
+
+	//optional formats
+	"format": NewFormat,
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -117,6 +117,12 @@
 			"revisionTime": "2016-01-10T10:55:54Z"
 		},
 		{
+			"checksumSHA1": "K9mWrMyui/HocxkCyBc+cmgjCUE=",
+			"path": "github.com/qri-io/jsonschema",
+			"revision": "d0d3b10ec792d814d556802e806b842e095fcd9c",
+			"revisionTime": "2018-06-07T15:06:48Z"
+		},
+		{
 			"checksumSHA1": "tQwMcYthmiC7TdBtZAFhlnG8Nxo=",
 			"path": "github.com/sasha-s/go-deadlock",
 			"revision": "237a9547c8a576b7afb19288c59fa34e005856ca",

--- a/yamltojson/yaml.go
+++ b/yamltojson/yaml.go
@@ -1,0 +1,51 @@
+package yamltojson
+
+import (
+	"fmt"
+
+	// This is a fork of gopkg.in/yaml.v2 that fixes anchors with MapSlice
+	"github.com/buildkite/yaml"
+)
+
+// Unmarshal YAML to map[string]interface{} instead of map[interface{}]interface{}, such that
+// we can Marshal cleanly into JSON
+// Via https://github.com/go-yaml/yaml/issues/139#issuecomment-220072190
+func UnmarshalAsStringMap(in []byte, out interface{}) error {
+	var res interface{}
+
+	if err := yaml.Unmarshal(in, &res); err != nil {
+		return err
+	}
+	*out.(*interface{}) = cleanupMapValue(res)
+
+	return nil
+}
+
+func cleanupInterfaceArray(in []interface{}) []interface{} {
+	res := make([]interface{}, len(in))
+	for i, v := range in {
+		res[i] = cleanupMapValue(v)
+	}
+	return res
+}
+
+func cleanupInterfaceMap(in map[interface{}]interface{}) map[string]interface{} {
+	res := make(map[string]interface{})
+	for k, v := range in {
+		res[fmt.Sprintf("%v", k)] = cleanupMapValue(v)
+	}
+	return res
+}
+
+func cleanupMapValue(v interface{}) interface{} {
+	switch v := v.(type) {
+	case []interface{}:
+		return cleanupInterfaceArray(v)
+	case map[interface{}]interface{}:
+		return cleanupInterfaceMap(v)
+	case nil, bool, string, int, float64:
+		return v
+	default:
+		panic("Unhandled map type " + fmt.Sprintf("%T", v))
+	}
+}


### PR DESCRIPTION
This parses `plugin.yml` files like https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/blob/5e764199256d66e9064eae16d62e7a0a6c26e475/plugin.yml as part of the plugin checkout process in the bootstrap.

This will include: 

* [x] A non-fatal warning if a plugin definition doesn't exist
* [x] Check `requirements` (required command-line tools)
* [x] Check `configuration` json schema against provided plugin configuration from pipeline
* [x] Allow plugin validation to be disabled (`--no-plugin-validation`)
* [x] Allow `BUILDKITE_PLUGIN_VALIDATION` from pipeline env for per-pipeline rollout 

Failure looks like:

![image](https://user-images.githubusercontent.com/15758/42793927-c0f0ed46-89bf-11e8-997f-9e7fc13ed92a.png)

Suggestions welcomed on how to present errors, getting super user friendly JSON schema errors is hard.