### PR TITLE
Set TERM and PWD for commands that get executed in shell

### DIFF
--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -26,6 +26,10 @@ var (
 	lockRetryDuration = time.Second
 )
 
+const (
+	termType = `xterm-256color`
+)
+
 // Shell represents a virtual shell, handles logging, executing commands and
 // provides hooks for capturing output and exit conditions.
 //
@@ -281,6 +285,11 @@ func (s *Shell) buildCommand(name string, arg ...string) (*exec.Cmd, error) {
 	cmd.Env = s.Env.ToSlice()
 	cmd.Dir = s.wd
 
+	// Add env that commands expect a shell to set
+	cmd.Env = append(cmd.Env,
+		`PWD=`+s.wd,
+	)
+
 	return cmd, nil
 }
 
@@ -336,6 +345,9 @@ func (s *Shell) executeCommand(cmd *exec.Cmd, w io.Writer, flags executeFlags) e
 			// that it closed successfully.
 			// See https://github.com/buildkite/agent/pull/34#issuecomment-46080419
 		}
+
+		// Commands like tput expect a TERM value for a PTY
+		cmd.Env = append(cmd.Env, `TERM=`+termType)
 	} else {
 		cmd.Stdout = nil
 		cmd.Stderr = nil


### PR DESCRIPTION
The move to a golang bootstrap in 3.0 has meant that we miss out on a few things that the previous bash bootstrap was giving us that we didn't realize. 

In this PR I am setting `TERM` when a tty is created and `PWD`. The other minimum env that a shell gets is usually `PATH`, `HOME` and `HOSTNAME`, but these are up to `login` to set, which for us I think is in the systemd config or similar. 

I verified these were a thing with: 

```
docker run --rm alpine:3.3 env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=978593e25f81
HOME=/root
```

```
docker run --rm -it alpine:3.3 env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=032e49df3771
TERM=xterm
HOME=/root
```

```
docker run --rm -it alpine:3.3 sh -c env
HOSTNAME=dfd4924645b5
SHLVL=1
HOME=/root
TERM=xterm
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
PWD=/
```

