### PR TITLE
Remove buildkite:git:branch meta-data

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -847,15 +847,7 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 			return err
 		}
 
-		gitBranchOutput, err := b.shell.RunAndCapture("git", "--no-pager", "branch", "--contains", "HEAD", "--no-color")
-		if err != nil {
-			return err
-		}
-
 		if err = b.shell.Run("buildkite-agent", "meta-data", "set", "buildkite:git:commit", gitCommitOutput); err != nil {
-			return err
-		}
-		if err = b.shell.Run("buildkite-agent", "meta-data", "set", "buildkite:git:branch", gitBranchOutput); err != nil {
 			return err
 		}
 	}

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -41,7 +41,6 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
 		{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color"},
-		{"--no-pager", "branch", "--contains", "HEAD", "--no-color"},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -51,9 +50,6 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 		AndExitWith(1)
 	agent.
 		Expect("meta-data", "set", "buildkite:git:commit", bintest.MatchAny()).
-		AndExitWith(0)
-	agent.
-		Expect("meta-data", "set", "buildkite:git:branch", bintest.MatchAny()).
 		AndExitWith(0)
 
 	tester.RunAndCheck(t, env...)
@@ -113,7 +109,6 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 		{"submodule", "foreach", "--recursive", "git", "clean", "-fdq"},
 		{"submodule", "foreach", "--recursive", "git", "ls-remote", "--get-url"},
 		{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color"},
-		{"--no-pager", "branch", "--contains", "HEAD", "--no-color"},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -123,9 +118,6 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 		AndExitWith(1)
 	agent.
 		Expect("meta-data", "set", "buildkite:git:commit", bintest.MatchAny()).
-		AndExitWith(0)
-	agent.
-		Expect("meta-data", "set", "buildkite:git:branch", bintest.MatchAny()).
 		AndExitWith(0)
 
 	tester.RunAndCheck(t, env...)
@@ -148,11 +140,6 @@ func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite(t *testing.T) {
 	agent.
 		Expect("meta-data", "set", "buildkite:git:commit",
 			bintest.MatchPattern(`^commit`)).
-		AndExitWith(0)
-
-	agent.
-		Expect("meta-data", "set", "buildkite:git:branch",
-			bintest.MatchPattern(`^\* \(HEAD detached at FETCH_HEAD\)`)).
 		AndExitWith(0)
 
 	tester.RunAndCheck(t)

--- a/vendor/github.com/buildkite/bintest/README.md
+++ b/vendor/github.com/buildkite/bintest/README.md
@@ -22,9 +22,6 @@ agent.
 agent.
   Expect("meta-data", "set", mock.MatchAny()).
   AndExitWith(0)
-agent.
-  Expect("meta-data", "set", "buildkite:git:branch", mock.MatchAny()).
-  AndExitWith(0)
 
 agent.AssertExpectations(t)
 ```


### PR DESCRIPTION
We've never used this information, and it's useless anyway because we're doing detached checkouts so all it returns is:

    * (HEAD detached at FETCH_HEAD)

or

    * (no branch)

Turns out it can take a long time to run on big repos to tell us nothing, so just remove it.