### PR TITLE
Expose the instance number as env-var

### DIFF
--- a/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent@.service
+++ b/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent@.service
@@ -8,6 +8,7 @@ After=network.target
 Type=simple
 User=buildkite-agent
 Environment=HOME=/var/lib/buildkite-agent
+Environment=BUILDKITE_AGENT_INSTANCE_NUMBER=%i
 ExecStart=/usr/bin/buildkite-agent start
 RestartSec=5
 Restart=on-failure

--- a/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent@.service
+++ b/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent@.service
@@ -8,7 +8,7 @@ After=network.target
 Type=simple
 User=buildkite-agent
 Environment=HOME=/var/lib/buildkite-agent
-Environment=BUILDKITE_AGENT_INSTANCE_NUMBER=%i
+Environment=BUILDKITE_AGENT_SYSTEMD_INSTANCE_NUMBER=%i
 ExecStart=/usr/bin/buildkite-agent start
 RestartSec=5
 Restart=on-failure


### PR DESCRIPTION
(Haven't tried this out yet).

It would be convenient to make the instance number available as an environment variable, since then I can export it to centralised logging as a field in its own right without needing to parse the `BUILDKITE_AGENT_NAME` one, which tacks it onto the end of the hostname.

I think this might also end up helping with autoscaling, since it could be exposed via `buildkite-metrics` and allow me to choose an un-busy node to terminate when scaling down?