### PR TITLE
Pass jobs an authenticated unix socket rather than an access token 

### DIFF
--- a/agent/api_client.go
+++ b/agent/api_client.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"bufio"
+	"errors"
 	"net"
 	"net/http"
 	"net/url"
@@ -8,6 +10,7 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/api"
+	"github.com/buildkite/agent/logger"
 	"golang.org/x/net/http2"
 )
 
@@ -23,6 +26,15 @@ func APIClientEnableHTTPDebug() {
 }
 
 func (a APIClient) Create() *api.Client {
+	u, err := url.Parse(a.Endpoint)
+	if err != nil {
+		logger.Warn("Failed to parse %q: %v", a.Endpoint, err)
+	}
+
+	if u != nil && u.Scheme == `unix` {
+		return a.createFromSocket(u.Path)
+	}
+
 	httpTransport := &http.Transport{
 		Proxy:              http.ProxyFromEnvironment,
 		DisableKeepAlives:  false,
@@ -35,14 +47,11 @@ func (a APIClient) Create() *api.Client {
 	}
 	http2.ConfigureTransport(httpTransport)
 
-	// Create the transport used when making the Buildkite Agent API calls
-	transport := &api.AuthenticatedTransport{
+	// Configure the HTTP client
+	httpClient := &http.Client{Transport: &api.AuthenticatedTransport{
 		Token:     a.Token,
 		Transport: httpTransport,
-	}
-
-	// From the transport, create the a http client
-	httpClient := transport.Client()
+	}}
 	httpClient.Timeout = 60 * time.Second
 
 	// Create the Buildkite Agent API Client
@@ -54,6 +63,64 @@ func (a APIClient) Create() *api.Client {
 	return client
 }
 
+func (a APIClient) createFromSocket(socket string) *api.Client {
+	httpClient := &http.Client{
+		Transport: &api.AuthenticatedTransport{
+			Token: a.Token,
+			Transport: &socketTransport{
+				Socket:      socket,
+				DialTimeout: 30 * time.Second,
+			},
+		},
+	}
+
+	// Create the Buildkite Agent API Client
+	client := api.NewClient(httpClient)
+	client.BaseURL, _ = url.Parse(`http+unix://buildkite-agent`)
+	client.UserAgent = a.UserAgent()
+	client.DebugHTTP = debug
+
+	return client
+}
+
 func (a APIClient) UserAgent() string {
 	return "buildkite-agent/" + Version() + "." + BuildVersion() + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
+}
+
+// Transport is a http.RoundTripper that connects to Unix domain sockets.
+type socketTransport struct {
+	DialTimeout           time.Duration
+	RequestTimeout        time.Duration
+	ResponseHeaderTimeout time.Duration
+	Socket                string
+}
+
+// RoundTrip executes a single HTTP transaction. See net/http.RoundTripper.
+func (t *socketTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL == nil {
+		return nil, errors.New("http+unix: nil Request.URL")
+	}
+	if req.URL.Scheme != `http+unix` {
+		return nil, errors.New("unsupported protocol scheme: " + req.URL.Scheme)
+	}
+	if req.URL.Host == "" {
+		return nil, errors.New("http+unix: no Host in request URL")
+	}
+
+	c, err := net.DialTimeout("unix", t.Socket, t.DialTimeout)
+	if err != nil {
+		return nil, err
+	}
+	r := bufio.NewReader(c)
+	if t.RequestTimeout > 0 {
+		c.SetWriteDeadline(time.Now().Add(t.RequestTimeout))
+	}
+	if err := req.Write(c); err != nil {
+		return nil, err
+	}
+	if t.ResponseHeaderTimeout > 0 {
+		c.SetReadDeadline(time.Now().Add(t.ResponseHeaderTimeout))
+	}
+	resp, err := http.ReadResponse(r, req)
+	return resp, err
 }

--- a/agent/api_proxy.go
+++ b/agent/api_proxy.go
@@ -1,0 +1,130 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/buildkite/agent/api"
+	"github.com/buildkite/agent/logger"
+)
+
+// APIProxy provides either a unix socket or a tcp socket listener with a proxy
+// that will authenticate to the Buildkite Agent API
+type APIProxy struct {
+	UpstreamToken    string
+	UpstreamEndpoint string
+
+	token    string
+	socket   *os.File
+	listener net.Listener
+}
+
+// Listen on either a tcp socket (for windows) or a unix socket
+func (p *APIProxy) Listen() error {
+	var err error
+
+	// generate a per-proxy secret to give to the bootstrap
+	p.token = fmt.Sprintf("%x", sha256.Sum256([]byte(string(time.Now().UnixNano()))))
+
+	// windows doesn't support unix sockets, so we fall back to a tcp socket
+	if runtime.GOOS == `windows` {
+		p.listener, err = p.listenOnTCPSocket()
+	} else {
+		p.listener, p.socket, err = p.listenOnUnixSocket()
+	}
+
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := url.Parse(p.UpstreamEndpoint)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		proxy := httputil.NewSingleHostReverseProxy(endpoint)
+		proxy.Transport = &api.AuthenticatedTransport{Token: p.UpstreamToken}
+
+		// customize the reverse proxy director so that we can make some changes to the request
+		director := proxy.Director
+		proxy.Director = func(req *http.Request) {
+			director(req)
+
+			// set the host header whilst proxying
+			req.Host = req.URL.Host
+		}
+
+		// serve traffic, proxy off to the reverse proxy
+		_ = http.Serve(p.listener, http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			if r.Header.Get(`Authorization`) != `Token `+p.token {
+				http.Error(rw, "Invalid authorization token", http.StatusBadRequest)
+				return
+			}
+			proxy.ServeHTTP(rw, r)
+		}))
+	}()
+
+	return nil
+}
+
+func (p *APIProxy) listenOnUnixSocket() (net.Listener, *os.File, error) {
+	socket, err := ioutil.TempFile("", "agent-socket")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Servers should unlink the socket path name prior to binding it.
+	// https://troydhanson.github.io/network/Unix_domain_sockets.html
+	_ = os.Remove(socket.Name())
+
+	logger.Debug("[APIProxy] Listening on unix socket %s", socket.Name())
+
+	// create a unix socket to do the listening
+	l, err := net.Listen("unix", socket.Name())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Restrict to owner r+w permissions
+	if err = os.Chmod(socket.Name(), 0600); err != nil {
+		return nil, nil, err
+	}
+
+	return l, socket, nil
+}
+
+func (p *APIProxy) listenOnTCPSocket() (net.Listener, error) {
+	// Listen on the first available non-privileged port
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debug("[APIProxy] Listening on tcp socket %s", l.Addr().String())
+	return l, nil
+}
+
+// Close any listeners or internal files
+func (p *APIProxy) Close() error {
+	return p.listener.Close()
+}
+
+func (p *APIProxy) Endpoint() string {
+	if p.socket != nil {
+		return `unix://` + p.listener.Addr().String()
+	}
+	return `http://` + p.listener.Addr().String()
+}
+
+func (p *APIProxy) AccessToken() string {
+	return p.token
+}

--- a/agent/api_proxy_test.go
+++ b/agent/api_proxy_test.go
@@ -1,0 +1,70 @@
+package agent
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAPIProxy(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(`Authorization`) != `Token llamas` {
+			http.Error(w, "Invalid authorization token", http.StatusUnauthorized)
+			return
+		}
+		fmt.Fprintln(w, `{"message": "ok"}`)
+	}))
+	defer ts.Close()
+
+	// create proxy to our fake api
+	proxy := NewAPIProxy(ts.URL, `llamas`)
+	go proxy.Listen()
+	proxy.Wait()
+	defer proxy.Close()
+
+	// create a client to talk to our proxy api
+	client := APIClient{
+		Endpoint: proxy.Endpoint(),
+		Token:    proxy.AccessToken(),
+	}.Create()
+
+	// fire a ping via the proxy
+	p, _, err := client.Pings.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if p.Message != `ok` {
+		t.Fatalf("Expected message to be `ok`, got %q", p.Message)
+	}
+}
+
+func TestAPIProxyFailsWithoutAccessToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(`Authorization`) != `Token llamas` {
+			http.Error(w, "Invalid authorization token", http.StatusUnauthorized)
+			return
+		}
+		fmt.Fprintln(w, `{"message": "ok"}`)
+	}))
+	defer ts.Close()
+
+	// create proxy to our fake api
+	proxy := NewAPIProxy(ts.URL, `llamas`)
+	go proxy.Listen()
+	proxy.Wait()
+	defer proxy.Close()
+
+	// create a client to talk to our proxy api, but with incorrect access token
+	client := APIClient{
+		Endpoint: proxy.Endpoint(),
+		Token:    `xxx`,
+	}.Create()
+
+	// fire a ping via the proxy
+	_, _, err := client.Pings.Get()
+	if err == nil {
+		t.Fatalf("Expected an error without an access token")
+	}
+}

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -64,8 +64,8 @@ func (r JobRunner) Create() (runner *JobRunner, err error) {
 	// Our own APIClient using the endpoint and the agents access token
 	runner.APIClient = APIClient{Endpoint: r.Endpoint, Token: r.Agent.AccessToken}.Create()
 
-	// A proxy for our APIClient that is expose to the bootstrap
-	runner.APIProxy = &APIProxy{UpstreamEndpoint: r.Endpoint, UpstreamToken: r.Agent.AccessToken}
+	// A proxy for the agent API that is expose to the bootstrap
+	runner.APIProxy = NewAPIProxy(r.Endpoint, r.Agent.AccessToken)
 
 	// Create our header times struct
 	runner.headerTimesStreamer = &HeaderTimesStreamer{UploadCallback: r.onUploadHeaderTime}

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/api"
+	"github.com/buildkite/agent/experiments"
 	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/process"
 	"github.com/buildkite/agent/retry"
@@ -21,6 +22,9 @@ type JobRunner struct {
 
 	// The APIClient that will be used when updating the job
 	APIClient *api.Client
+
+	// The APIProxy that will be exposed to the job bootstrap
+	APIProxy *APIProxy
 
 	// The endpoint that should be used when communicating with the API
 	Endpoint string
@@ -60,12 +64,22 @@ func (r JobRunner) Create() (runner *JobRunner, err error) {
 	// Our own APIClient using the endpoint and the agents access token
 	runner.APIClient = APIClient{Endpoint: r.Endpoint, Token: r.Agent.AccessToken}.Create()
 
-	// // Create our header times struct
+	// A proxy for our APIClient that is expose to the bootstrap
+	runner.APIProxy = &APIProxy{UpstreamEndpoint: r.Endpoint, UpstreamToken: r.Agent.AccessToken}
+
+	// Create our header times struct
 	runner.headerTimesStreamer = &HeaderTimesStreamer{UploadCallback: r.onUploadHeaderTime}
 
 	// The log streamer that will take the output chunks, and send them to
 	// the Buildkite Agent API
 	runner.logStreamer = LogStreamer{MaxChunkSizeBytes: r.Job.ChunksMaxSizeBytes, Callback: r.onUploadChunk}.New()
+
+	// Start a proxy to give to the job for api operations
+	if experiments.IsEnabled("agent-socket") {
+		if err := r.APIProxy.Listen(); err != nil {
+			return nil, err
+		}
+	}
 
 	// Prepare a file to recieve the given job environment
 	if file, err := ioutil.TempFile("", fmt.Sprintf("job-env-%s", runner.Job.ID)); err != nil {
@@ -163,6 +177,13 @@ func (r *JobRunner) Run() error {
 		logger.Debug("[JobRunner] Deleted env file: %s", r.envFile.Name())
 	}
 
+	// Destroy the proxy
+	if experiments.IsEnabled("agent-socket") {
+		if err := r.APIProxy.Close(); err != nil {
+			logger.Warn("[JobRunner] Failed to close API proxy: %v", err)
+		}
+	}
+
 	logger.Info("Finished job %s", r.Job.ID)
 
 	return nil
@@ -212,9 +233,15 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 		env["BUILDKITE_ENV_FILE"] = r.envFile.Name()
 	}
 
+	if experiments.IsEnabled("agent-socket") {
+		env["BUILDKITE_AGENT_ENDPOINT"] = r.APIProxy.Endpoint()
+		env["BUILDKITE_AGENT_ACCESS_TOKEN"] = r.APIProxy.AccessToken()
+	} else {
+		env["BUILDKITE_AGENT_ENDPOINT"] = r.Endpoint
+		env["BUILDKITE_AGENT_ACCESS_TOKEN"] = r.Agent.AccessToken
+	}
+
 	// Add agent environment variables
-	env["BUILDKITE_AGENT_ENDPOINT"] = r.Endpoint
-	env["BUILDKITE_AGENT_ACCESS_TOKEN"] = r.Agent.AccessToken
 	env["BUILDKITE_AGENT_DEBUG"] = fmt.Sprintf("%t", logger.GetLevel() == logger.DEBUG)
 	env["BUILDKITE_AGENT_PID"] = fmt.Sprintf("%d", os.Getpid())
 

--- a/api/auth.go
+++ b/api/auth.go
@@ -31,11 +31,6 @@ func (t AuthenticatedTransport) RoundTrip(req *http.Request) (*http.Response, er
 	return t.transport().RoundTrip(req)
 }
 
-// Client builds a new http client.
-func (t *AuthenticatedTransport) Client() *http.Client {
-	return &http.Client{Transport: t}
-}
-
 // CancelRequest cancels an in-flight request by closing its connection.
 func (t *AuthenticatedTransport) CancelRequest(req *http.Request) {
 	cancelableTransport := t.Transport.(canceler)


### PR DESCRIPTION
Currently we pass jobs `BUILDKITE_AGENT_ACCESS_TOKEN`, which is a per-agent-connection session token that is derived from the Agent Registration Token. This token is then used by agent commands that run within jobs, like `buildkite-agent pipeline upload` and the `artifact` and `meta-data` sub-commands. 

The downside with this approach is that the access token can be easily stolen by untrusted jobs (see https://github.com/buildkite/feedback/issues/360). 

This PR implements a proxy that listens on a unix socket or a localhost http port and proxies through to the upstream https://agent.buildkite.com. This should radically improve the security profile, as if it's a unix socket then it's not possible to access externally, or exfiltrate. If it's http based, you need access to whatever it's bound to (localhost) and even then, it only lasts for the duration of the job. 