### PR TITLE
Add a pipeline parse command

### DIFF
--- a/clicommand/pipeline_parse.go
+++ b/clicommand/pipeline_parse.go
@@ -1,0 +1,142 @@
+package clicommand
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/buildkite/agent/agent"
+	"github.com/buildkite/agent/cliconfig"
+	"github.com/buildkite/agent/logger"
+	"github.com/buildkite/agent/stdin"
+	"github.com/urfave/cli"
+)
+
+var PipelineParseHelpDescription = `Usage:
+
+   buildkite-agent pipeline parse <file> [arguments...]
+
+Description:
+
+	 Prints to STDOUT the parsed pipeline as JSON.
+
+Example:
+
+   $ buildkite-agent pipeline parse
+   $ buildkite-agent pipeline parse my-custom-pipeline.yml
+   $ ./script/dynamic_step_generator | buildkite-agent pipeline parse`
+
+type PipelineParseConfig struct {
+	FilePath         string `cli:"arg:0" label:"upload paths"`
+	NoColor          bool   `cli:"no-color"`
+	Debug            bool   `cli:"debug"`
+}
+
+var PipelineParseCommand = cli.Command{
+	Name:        "parse",
+	Usage:       "Prints to STDOUT the parsed pipeline as JSON.",
+	Description: PipelineParseHelpDescription,
+	Flags: []cli.Flag{
+		NoColorFlag,
+		DebugFlag,
+	},
+	Action: func(c *cli.Context) {
+		// The configuration will be loaded into this struct
+		cfg := PipelineParseConfig{}
+
+		// Load the configuration
+		loader := cliconfig.Loader{CLI: c, Config: &cfg}
+		if err := loader.Load(); err != nil {
+			logger.Fatal("%s", err)
+		}
+
+		// Setup the any global configuration options
+		HandleGlobalFlags(cfg)
+
+		// Find the pipeline file either from STDIN or the first
+		// argument
+		var input []byte
+		var err error
+		var filename string
+
+		if cfg.FilePath != "" {
+			logger.Info("Reading pipeline config from \"%s\"", cfg.FilePath)
+
+			filename = filepath.Base(cfg.FilePath)
+			input, err = ioutil.ReadFile(cfg.FilePath)
+			if err != nil {
+				logger.Fatal("Failed to read file: %s", err)
+			}
+		} else if stdin.IsReadable() {
+			logger.Info("Reading pipeline config from STDIN")
+
+			// Actually read the file from STDIN
+			input, err = ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				logger.Fatal("Failed to read from STDIN: %s", err)
+			}
+		} else {
+			logger.Info("Searching for pipeline config...")
+
+			paths := []string{
+				"buildkite.yml",
+				"buildkite.yaml",
+				"buildkite.json",
+				filepath.FromSlash(".buildkite/pipeline.yml"),
+				filepath.FromSlash(".buildkite/pipeline.yaml"),
+				filepath.FromSlash(".buildkite/pipeline.json"),
+			}
+
+			// Collect all the files that exist
+			exists := []string{}
+			for _, path := range paths {
+				if _, err := os.Stat(path); err == nil {
+					exists = append(exists, path)
+				}
+			}
+
+			// If more than 1 of the config files exist, throw an
+			// error. There can only be one!!
+			if len(exists) > 1 {
+				logger.Fatal("Found multiple configuration files: %s. Please only have 1 configuration file present.", strings.Join(exists, ", "))
+			} else if len(exists) == 0 {
+				logger.Fatal("Could not find a default pipeline configuration file. See `buildkite-agent pipeline upload --help` for more information.")
+			}
+
+			found := exists[0]
+
+			logger.Info("Found config file \"%s\"", found)
+
+			// Read the default file
+			filename = path.Base(found)
+			input, err = ioutil.ReadFile(found)
+			if err != nil {
+				logger.Fatal("Failed to read file \"%s\" (%s)", found, err)
+			}
+		}
+
+		// Make sure the file actually has something in it
+		if len(input) == 0 {
+			logger.Fatal("Config file is empty")
+		}
+
+		var parsed interface{}
+
+		// Parse the pipeline
+		parsed, err = agent.PipelineParser{
+			Filename:        filename,
+			Pipeline:        input,
+			NoInterpolation: false,
+		}.Parse()
+		if err != nil {
+			logger.Fatal("Pipeline parsing of \"%s\" failed (%s)", filename, err)
+		}
+
+		pipelineJson, _ := json.Marshal(parsed)
+    fmt.Println(string(pipelineJson))
+	},
+}

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func main() {
 			Name:  "pipeline",
 			Usage: "Make changes to the pipeline of the currently running build",
 			Subcommands: []cli.Command{
+				clicommand.PipelineParseCommand,
 				clicommand.PipelineUploadCommand,
 			},
 		},


### PR DESCRIPTION
For https://github.com/toolmantim/bksr I'd like to be able to support the env interpolation that the agent does, as well as inherit the pipeline config search paths, and a few other things that are built into the agent. This adds a new pipeline parse command to help other tools that might want to process pipelines:

```
$ go run main.go pipeline parse
Usage:

   buildkite-agent pipeline parse <file> [arguments...]

Description:

   Prints to STDOUT the parsed pipeline as JSON.

Example:

   $ buildkite-agent pipeline parse
   $ buildkite-agent pipeline parse my-custom-pipeline.yml
   $ ./script/dynamic_step_generator | buildkite-agent pipeline parse

Options:

   --no-color  Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
   --debug     Enable debug mode [$BUILDKITE_AGENT_DEBUG]
```

Example output, for the agent repo:

```
$ env BUILDKITE_COMMIT=commit123 BUILDKITE_BRANCH=branch123 BUILDKITE_MESSAGE=message123 go run main.go pipeline parse
2018-05-13 22:46:29 INFO   Searching for pipeline config...
2018-05-13 22:46:29 INFO   Found config file ".buildkite/pipeline.yml"
{"env":{"DRY_RUN":false},"steps":[{"command":".buildkite/steps/tests.sh","name":":hammer: :linux:","plugins":{"docker-compose#v1.8.0":{"run":"agent"}}},{"async":true,"build":{"branch":"branch123","commit":"commit123","message":"message123"},"name":":hammer: :windows:","trigger":"agent-windows"},"wait",{"artifact_paths":"pkg/*","command":".buildkite/steps/build-binary.sh windows 386","name":":windows: 386","plugins":{"docker-compose#v1.8.0":{"run":"agent"}}},{"artifact_paths":"pkg/*","command":".buildkite/steps/build-binary.sh windows amd64","name":":windows: amd64","plugins":{"docker-compose#v1.8.0":{"run":"agent"}}},{"artifact_paths":"pkg/*","command":".buildkite/steps/build-binary.sh linux amd64","name":":linux: amd64","plugins":{"docker-compose#v1.8.0":{"run":"agent"}}},{"artifact_paths":"pkg/*","command":".buildkite/steps/build-binary.sh linux 386","name":":linux: 386","plugins":{"docker-compose#v1.8.0":{"run":"agent"}}},{"artifact_paths":"pkg/*","command":".buildkite/steps/build-binary.sh linux arm","name":":linux: arm","plugins":{"docker-compose#v1.8.0":{"run":"agent"}}},{"artifact_paths":"pkg/*","command":".buildkite/steps/build-binary.sh linux armhf","name":":linux: armhf","plugins":{"docker-compose#v1.8.0":{"run":"agent"}}},{"artifact_paths":"pkg/*","command":".buildkite/steps/build-binary.sh linux arm64","name":":linux: arm64","plugins":{"docker-compose#v1.8.0":{"run":"agent"}}},{"artifact_paths":"pkg/*","command":".buildkite/steps/build-binary.sh darwin 386","name":":mac: 386","plugins":{"docker-compose#v1.8.0":{"run":"agent"}}},{"artifact_paths":"pkg/*","command":".buildkite/steps/build-binary.sh darwin amd64","name":":mac: amd64","plugins":{"docker-compose#v1.8.0":{"run":"agent"}}},{"artifact_paths":"pkg/*","command":".buildkite/steps/build-binary.sh freebsd amd64","name":":freebsd: amd64","plugins":{"docker-compose#v1.8.0":{"run":"agent"}}},{"artifact_paths":"pkg/*","command":".buildkite/steps/build-binary.sh freebsd 386","name":":freebsd: 386","plugins":{"docker-compose#v1.8.0":{"run":"agent"}}},{"artifact_paths":"pkg/*","command":".buildkite/steps/build-binary.sh openbsd amd64","name":":openbsd: amd64","plugins":{"docker-compose#v1.8.0":{"run":"agent"}}},{"artifact_paths":"pkg/*","command":".buildkite/steps/build-binary.sh openbsd 386","name":":openbsd: 386","plugins":{"docker-compose#v1.8.0":{"run":"agent"}}},{"artifact_paths":"pkg/*","command":".buildkite/steps/build-binary.sh dragonfly amd64","name":":dragonflybsd: amd64","plugins":{"docker-compose#v1.8.0":{"run":"agent"}}},"wait",{"command":".buildkite/steps/extract-agent-version-metadata.sh","name":":mag:"},"wait",{"command":".buildkite/steps/build-docker-images.sh alpine","name":":docker: alpine build"},{"command":".buildkite/steps/build-docker-images.sh ubuntu","name":":docker: ubuntu build"},{"agents":{"queue":"deploy"},"artifact_paths":"deb/**/*","command":".buildkite/steps/build-debian-packages.sh","name":":debian: build"},{"agents":{"queue":"deploy"},"artifact_paths":"rpm/**/*","command":".buildkite/steps/build-rpm-packages.sh","name":":redhat: build"},{"artifact_paths":"releases/**/*","command":".buildkite/steps/build-github-release.sh","name":":github: :hammer:","plugins":{"docker-compose#v1.8.0":{"config":"docker-compose.release.yml","run":"github-release"}}},"wait",{"command":".buildkite/steps/upload-release-steps.sh","name":":pipeline:"}]}
```

- [x] Initial spike
- [x] Feedback
- [ ] Switch to `pipeline upload --dry-run`
- [ ] Clean up code
- [ ] Tests

I'm looking for some feedback for whether we could consider adding this, and if so, some help getting it cleaned up.