### PR TITLE
Don't trim whitespace from the annotation body

### DIFF
--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -121,9 +121,6 @@ var AnnotateCommand = cli.Command{
 			body = string(stdin[:])
 		}
 
-		// Trim any whitespace edges on the annotation body
-		body = strings.TrimSpace(body)
-
 		// Create the API client
 		client := agent.APIClient{
 			Endpoint: cfg.Endpoint,


### PR DESCRIPTION
... because this prevents bullet-lists (for example) from being created via appending annotations together.

Fixes #391