### PR TITLE
Add a virtual provides to the RPM package in the 2.6 stable branch

### DIFF
--- a/scripts/utils/build-linux-package.sh
+++ b/scripts/utils/build-linux-package.sh
@@ -74,6 +74,7 @@ bundle exec fpm -s "dir" \
   --after-upgrade "packaging/linux/scripts/after-install-and-upgrade.sh" \
   -p "$PACKAGE_PATH" \
   -v "$VERSION" \
+  --provides "$NAME-${VERSION%%.*}" \
   --iteration "$REVISION" \
   "./$BUILD_BINARY_PATH=/usr/bin/buildkite-agent" \
   "templates/bootstrap.sh=/usr/share/buildkite-agent/bootstrap.sh" \


### PR DESCRIPTION
Allow package to be matched as 'buildkite-agent-2' in RPM packages.