### PR TITLE
Fix broken list parsing in cli arguments --tags and --experiments

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -52,7 +53,8 @@ func (r *AgentPool) Start() error {
 		logger.Fatal("%s", err)
 	}
 
-	logger.Info("Successfully registered agent \"%s\" with tags %s", registered.Name, registered.Tags)
+	logger.Info("Successfully registered agent \"%s\" with tags [%s]", registered.Name,
+		strings.Join(registered.Tags, ", "))
 
 	logger.Debug("Ping interval: %ds", registered.PingInterval)
 	logger.Debug("Job status interval: %ds", registered.JobStatusInterval)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -49,7 +49,7 @@ type AgentStartConfig struct {
 	HooksPath                 string   `cli:"hooks-path" normalize:"filepath"`
 	PluginsPath               string   `cli:"plugins-path" normalize:"filepath"`
 	Shell                     string   `cli:"shell"`
-	Tags                      []string `cli:"tags"`
+	Tags                      []string `cli:"tags" normalize:"list"`
 	TagsFromEC2               bool     `cli:"tags-from-ec2"`
 	TagsFromEC2Tags           bool     `cli:"tags-from-ec2-tags"`
 	TagsFromGCP               bool     `cli:"tags-from-gcp"`
@@ -67,7 +67,7 @@ type AgentStartConfig struct {
 	Endpoint                  string   `cli:"endpoint" validate:"required"`
 	Debug                     bool     `cli:"debug"`
 	DebugHTTP                 bool     `cli:"debug-http"`
-	Experiments               []string `cli:"experiment"`
+	Experiments               []string `cli:"experiment" normalize:"list"`
 
 	/* Deprecated */
 	NoSSHFingerprintVerification bool     `cli:"no-automatic-ssh-fingerprint-verification" deprecated-and-renamed-to:"NoSSHKeyscan"`

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -374,6 +374,31 @@ func (l Loader) normalizeField(fieldName string, normalization string) error {
 				return err
 			}
 		}
+	} else if normalization == "list" {
+		value, _ := reflections.GetField(l.Config, fieldName)
+		fieldKind, _ := reflections.GetFieldKind(l.Config, fieldName)
+
+		// Make sure we're normalizing a string filed
+		if fieldKind != reflect.Slice {
+			return fmt.Errorf("list normalization only works on slice fields")
+		}
+
+		// Normalize the field to be a command
+		if valueAsSlice, ok := value.([]string); ok {
+			normalizedSlice := []string{}
+
+			for _, value := range valueAsSlice {
+				// Split values with commas into fields
+				for _, normalized := range strings.Split(value, ",") {
+					normalizedSlice = append(normalizedSlice, normalized)
+				}
+			}
+
+			if err := reflections.SetField(l.Config, fieldName, normalizedSlice); err != nil {
+				return err
+			}
+		}
+
 	} else {
 		return fmt.Errorf("Unknown normalization `%s`", normalization)
 	}

--- a/vendor/github.com/urfave/cli/CODE_OF_CONDUCT.md
+++ b/vendor/github.com/urfave/cli/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting Dan Buch at dan@meatballhat.com. All complaints will be
+reviewed and investigated and will result in a response that is deemed necessary
+and appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident.  Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+

--- a/vendor/github.com/urfave/cli/CONTRIBUTING.md
+++ b/vendor/github.com/urfave/cli/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+## Contributing
+
+**NOTE**: the primary maintainer(s) may be found in
+[./MAINTAINERS.md](./MAINTAINERS.md).
+
+Feel free to put up a pull request to fix a bug or maybe add a feature. I will
+give it a code review and make sure that it does not break backwards
+compatibility. If I or any other collaborators agree that it is in line with
+the vision of the project, we will work with you to get the code into
+a mergeable state and merge it into the master branch.
+
+If you have contributed something significant to the project, we will most
+likely add you as a collaborator. As a collaborator you are given the ability
+to merge others pull requests. It is very important that new code does not
+break existing code, so be careful about what code you do choose to merge.
+
+If you feel like you have contributed to the project but have not yet been added
+as a collaborator, we probably forgot to add you :sweat_smile:.  Please open an
+issue!

--- a/vendor/github.com/urfave/cli/MAINTAINERS.md
+++ b/vendor/github.com/urfave/cli/MAINTAINERS.md
@@ -1,0 +1,1 @@
+- @meatballhat

--- a/vendor/github.com/urfave/cli/README.md
+++ b/vendor/github.com/urfave/cli/README.md
@@ -9,9 +9,9 @@ cli
 [![top level coverage](https://gocover.io/_badge/github.com/urfave/cli?0 "top level coverage")](http://gocover.io/github.com/urfave/cli) /
 [![altsrc coverage](https://gocover.io/_badge/github.com/urfave/cli/altsrc?0 "altsrc coverage")](http://gocover.io/github.com/urfave/cli/altsrc)
 
-**Notice:** This is the library formerly known as
-`github.com/codegangsta/cli` -- Github will automatically redirect requests
-to this repository, but we recommend updating your references for clarity.
+This is the library formerly known as `github.com/codegangsta/cli` -- Github
+will automatically redirect requests to this repository, but we recommend
+updating your references for clarity.
 
 cli is a simple, fast, and fun package for building command line apps in Go. The
 goal is to enable developers to write fast and distributable command line
@@ -47,6 +47,7 @@ applications in an expressive way.
   * [Version Flag](#version-flag)
     + [Customization](#customization-2)
     + [Full API Example](#full-api-example)
+  * [Combining short Bool options](#combining-short-bool-options)
 - [Contribution Guidelines](#contribution-guidelines)
 
 <!-- tocstop -->
@@ -140,13 +141,17 @@ discovery. So a cli app can be as little as one line of code in `main()`.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
 )
 
 func main() {
-  cli.NewApp().Run(os.Args)
+  err := cli.NewApp().Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -161,6 +166,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -175,7 +181,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -199,6 +208,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -213,7 +223,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -262,6 +275,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -275,7 +289,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -291,6 +308,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -320,7 +338,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -334,6 +355,7 @@ scanned.
 package main
 
 import (
+  "log"
   "os"
   "fmt"
 
@@ -367,7 +389,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -388,6 +413,7 @@ For example this:
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -403,7 +429,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -429,6 +458,7 @@ list for the `Name`. e.g.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -445,7 +475,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -469,6 +502,7 @@ For example this:
 package main
 
 import (
+  "log"
   "os"
   "sort"
 
@@ -512,7 +546,10 @@ func main() {
   sort.Sort(cli.FlagsByName(app.Flags))
   sort.Sort(cli.CommandsByName(app.Commands))
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -535,6 +572,7 @@ You can also have the default value set from the environment via `EnvVar`.  e.g.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -552,7 +590,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -567,6 +608,7 @@ environment variable that resolves is used as the default.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -584,7 +626,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -600,6 +645,7 @@ You can also have the default value set from file via `FilePath`.  e.g.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -616,7 +662,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -652,9 +701,9 @@ the yaml input source for any flags that are defined on that command.  As a note
 the "load" flag used would also have to be defined on the command flags in order
 for this code snipped to work.
 
-Currently only the aboved specified formats are supported but developers can
-add support for other input sources by implementing the
-altsrc.InputSourceContext for their given sources.
+Currently only YAML and JSON files are supported but developers can add support
+for other input sources by implementing the altsrc.InputSourceContext for their
+given sources.
 
 Here is a more complete sample of a command using YAML support:
 
@@ -667,6 +716,7 @@ package notmain
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -689,7 +739,10 @@ func main() {
   app.Before = altsrc.InitInputSourceWithContext(flags, altsrc.NewYamlSourceFromFlagFunc("load"))
   app.Flags = flags
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -715,6 +768,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -767,7 +821,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -783,6 +840,7 @@ E.g.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -805,7 +863,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -831,6 +892,7 @@ may be set by returning a non-nil error that fulfills `cli.ExitCoder`, *or* a
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -851,7 +913,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -871,6 +936,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -902,7 +968,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -942,6 +1011,7 @@ The default bash completion flag (`--generate-bash-completion`) is defined as
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -960,7 +1030,10 @@ func main() {
       Name: "wat",
     },
   }
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -986,6 +1059,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "io"
   "os"
 
@@ -1029,7 +1103,10 @@ VERSION:
     fmt.Println("Ha HA.  I pwnd the help!!1")
   }
 
-  cli.NewApp().Run(os.Args)
+  err := cli.NewApp().Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -1044,6 +1121,7 @@ setting `cli.HelpFlag`, e.g.:
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -1056,7 +1134,10 @@ func main() {
     EnvVar: "SHOW_HALP,HALPPLZ",
   }
 
-  cli.NewApp().Run(os.Args)
+  err := cli.NewApp().Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -1079,6 +1160,7 @@ setting `cli.VersionFlag`, e.g.:
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -1093,7 +1175,10 @@ func main() {
   app := cli.NewApp()
   app.Name = "partay"
   app.Version = "19.99.0"
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -1108,6 +1193,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -1125,7 +1211,10 @@ func main() {
   app := cli.NewApp()
   app.Name = "partay"
   app.Version = "19.99.0"
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -1387,7 +1476,7 @@ func main() {
     ec := cli.NewExitError("ohwell", 86)
     fmt.Fprintf(c.App.Writer, "%d", ec.ExitCode())
     fmt.Printf("made it!\n")
-    return ec
+    return nil
   }
 
   if os.Getenv("HEXY") != "" {
@@ -1401,7 +1490,9 @@ func main() {
     "whatever-values": 19.99,
   }
 
-  app.Run(os.Args)
+
+  // ignore error so we don't exit non-zero and break gfmrun README example tests
+  _ = app.Run(os.Args)
 }
 
 func wopAction(c *cli.Context) error {
@@ -1410,18 +1501,26 @@ func wopAction(c *cli.Context) error {
 }
 ```
 
+### Combining short Bool options
+
+Traditional use of boolean options using their shortnames look like this:
+```
+# cmd foobar -s -o
+```
+
+Suppose you want users to be able to combine your bool options with their shortname.  This
+can be done using the **UseShortOptionHandling** bool in your commands.  Suppose your program
+has a two bool flags such as *serve* and *option* with the short options of *-o* and
+*-s* respectively. With **UseShortOptionHandling** set to *true*, a user can use a syntax
+like:
+```
+# cmd foobar -so
+```
+
+If you enable the **UseShortOptionHandling*, then you must not use any flags that have a single
+leading *-* or this will result in failures.  For example, **-option** can no longer be used.  Flags
+with two leading dashes (such as **--options**) are still valid.
+
 ## Contribution Guidelines
 
-Feel free to put up a pull request to fix a bug or maybe add a feature. I will
-give it a code review and make sure that it does not break backwards
-compatibility. If I or any other collaborators agree that it is in line with
-the vision of the project, we will work with you to get the code into
-a mergeable state and merge it into the master branch.
-
-If you have contributed something significant to the project, we will most
-likely add you as a collaborator. As a collaborator you are given the ability
-to merge others pull requests. It is very important that new code does not
-break existing code, so be careful about what code you do choose to merge.
-
-If you feel like you have contributed to the project but have not yet been
-added as a collaborator, we probably forgot to add you, please open an issue.
+See [./CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/vendor/github.com/urfave/cli/app.go
+++ b/vendor/github.com/urfave/cli/app.go
@@ -453,7 +453,6 @@ func (a *App) hasFlag(flag Flag) bool {
 }
 
 func (a *App) errWriter() io.Writer {
-
 	// When the app ErrWriter is nil use the package level one.
 	if a.ErrWriter == nil {
 		return ErrWriter

--- a/vendor/github.com/urfave/cli/command.go
+++ b/vendor/github.com/urfave/cli/command.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"sort"
@@ -55,6 +56,10 @@ type Command struct {
 	HideHelp bool
 	// Boolean to hide this command from help or completion
 	Hidden bool
+	// Boolean to enable short-option handling so user can combine several
+	// single-character bool arguements into one
+	// i.e. foobar -o -v -> foobar -ov
+	UseShortOptionHandling bool
 
 	// Full name of command for help, defaults to full command name, including parent commands.
 	HelpName        string
@@ -106,57 +111,7 @@ func (c Command) Run(ctx *Context) (err error) {
 		)
 	}
 
-	set, err := flagSet(c.Name, c.Flags)
-	if err != nil {
-		return err
-	}
-	set.SetOutput(ioutil.Discard)
-
-	if c.SkipFlagParsing {
-		err = set.Parse(append([]string{"--"}, ctx.Args().Tail()...))
-	} else if !c.SkipArgReorder {
-		firstFlagIndex := -1
-		terminatorIndex := -1
-		for index, arg := range ctx.Args() {
-			if arg == "--" {
-				terminatorIndex = index
-				break
-			} else if arg == "-" {
-				// Do nothing. A dash alone is not really a flag.
-				continue
-			} else if strings.HasPrefix(arg, "-") && firstFlagIndex == -1 {
-				firstFlagIndex = index
-			}
-		}
-
-		if firstFlagIndex > -1 {
-			args := ctx.Args()
-			regularArgs := make([]string, len(args[1:firstFlagIndex]))
-			copy(regularArgs, args[1:firstFlagIndex])
-
-			var flagArgs []string
-			if terminatorIndex > -1 {
-				flagArgs = args[firstFlagIndex:terminatorIndex]
-				regularArgs = append(regularArgs, args[terminatorIndex:]...)
-			} else {
-				flagArgs = args[firstFlagIndex:]
-			}
-
-			err = set.Parse(append(flagArgs, regularArgs...))
-		} else {
-			err = set.Parse(ctx.Args().Tail())
-		}
-	} else {
-		err = set.Parse(ctx.Args().Tail())
-	}
-
-	nerr := normalizeFlags(c.Flags, set)
-	if nerr != nil {
-		fmt.Fprintln(ctx.App.Writer, nerr)
-		fmt.Fprintln(ctx.App.Writer)
-		ShowCommandHelp(ctx, c.Name)
-		return nerr
-	}
+	set, err := c.parseFlags(ctx.Args().Tail())
 
 	context := NewContext(ctx.App, set, ctx)
 	context.Command = c
@@ -213,6 +168,83 @@ func (c Command) Run(ctx *Context) (err error) {
 		context.App.handleExitCoder(context, err)
 	}
 	return err
+}
+
+func (c *Command) parseFlags(args Args) (*flag.FlagSet, error) {
+	set, err := flagSet(c.Name, c.Flags)
+	if err != nil {
+		return nil, err
+	}
+	set.SetOutput(ioutil.Discard)
+
+	if c.SkipFlagParsing {
+		return set, set.Parse(append([]string{"--"}, args...))
+	}
+
+	if c.UseShortOptionHandling {
+		args = translateShortOptions(args)
+	}
+
+	if !c.SkipArgReorder {
+		args = reorderArgs(args)
+	}
+
+	err = set.Parse(args)
+	if err != nil {
+		return nil, err
+	}
+
+	err = normalizeFlags(c.Flags, set)
+	if err != nil {
+		return nil, err
+	}
+
+	return set, nil
+}
+
+// reorderArgs moves all flags before arguments as this is what flag expects
+func reorderArgs(args []string) []string {
+	var nonflags, flags []string
+
+	readFlagValue := false
+	for i, arg := range args {
+		if arg == "--" {
+			nonflags = append(nonflags, args[i:]...)
+			break
+		}
+
+		if readFlagValue && !strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") {
+			readFlagValue = false
+			flags = append(flags, arg)
+			continue
+		}
+		readFlagValue = false
+
+		if arg != "-" && strings.HasPrefix(arg, "-") {
+			flags = append(flags, arg)
+
+			readFlagValue = !strings.Contains(arg, "=")
+		} else {
+			nonflags = append(nonflags, arg)
+		}
+	}
+
+	return append(flags, nonflags...)
+}
+
+func translateShortOptions(flagArgs Args) []string {
+	// separate combined flags
+	var flagArgsSeparated []string
+	for _, flagArg := range flagArgs {
+		if strings.HasPrefix(flagArg, "-") && strings.HasPrefix(flagArg, "--") == false && len(flagArg) > 2 {
+			for _, flagChar := range flagArg[1:] {
+				flagArgsSeparated = append(flagArgsSeparated, "-"+string(flagChar))
+			}
+		} else {
+			flagArgsSeparated = append(flagArgsSeparated, flagArg)
+		}
+	}
+	return flagArgsSeparated
 }
 
 // Names returns the names including short names and aliases.

--- a/vendor/github.com/urfave/cli/flag.go
+++ b/vendor/github.com/urfave/cli/flag.go
@@ -178,7 +178,11 @@ func (f StringSliceFlag) ApplyWithError(set *flag.FlagSet) error {
 				return fmt.Errorf("could not parse %s as string value for flag %s: %s", envVal, f.Name, err)
 			}
 		}
-		f.Value = newVal
+		if f.Value == nil {
+			f.Value = newVal
+		} else {
+			*f.Value = *newVal
+		}
 	}
 
 	eachName(f.Name, func(name string) {
@@ -235,7 +239,11 @@ func (f IntSliceFlag) ApplyWithError(set *flag.FlagSet) error {
 				return fmt.Errorf("could not parse %s as int slice value for flag %s: %s", envVal, f.Name, err)
 			}
 		}
-		f.Value = newVal
+		if f.Value == nil {
+			f.Value = newVal
+		} else {
+			*f.Value = *newVal
+		}
 	}
 
 	eachName(f.Name, func(name string) {
@@ -292,7 +300,11 @@ func (f Int64SliceFlag) ApplyWithError(set *flag.FlagSet) error {
 				return fmt.Errorf("could not parse %s as int64 slice value for flag %s: %s", envVal, f.Name, err)
 			}
 		}
-		f.Value = newVal
+		if f.Value == nil {
+			f.Value = newVal
+		} else {
+			*f.Value = *newVal
+		}
 	}
 
 	eachName(f.Name, func(name string) {
@@ -624,7 +636,7 @@ func withEnvHint(envVar, str string) string {
 			suffix = "%"
 			sep = "%, %"
 		}
-		envText = fmt.Sprintf(" [%s%s%s]", prefix, strings.Join(strings.Split(envVar, ","), sep), suffix)
+		envText = " [" + prefix + strings.Join(strings.Split(envVar, ","), sep) + suffix + "]"
 	}
 	return str + envText
 }
@@ -697,13 +709,13 @@ func stringifyFlag(f Flag) string {
 		placeholder = defaultPlaceholder
 	}
 
-	usageWithDefault := strings.TrimSpace(fmt.Sprintf("%s%s", usage, defaultValueString))
+	usageWithDefault := strings.TrimSpace(usage + defaultValueString)
 
 	return FlagFileHinter(
 		fv.FieldByName("FilePath").String(),
 		FlagEnvHinter(
 			fv.FieldByName("EnvVar").String(),
-			fmt.Sprintf("%s\t%s", FlagNamePrefixer(fv.FieldByName("Name").String(), placeholder), usageWithDefault),
+			FlagNamePrefixer(fv.FieldByName("Name").String(), placeholder)+"\t"+usageWithDefault,
 		),
 	)
 }
@@ -712,7 +724,7 @@ func stringifyIntSliceFlag(f IntSliceFlag) string {
 	defaultVals := []string{}
 	if f.Value != nil && len(f.Value.Value()) > 0 {
 		for _, i := range f.Value.Value() {
-			defaultVals = append(defaultVals, fmt.Sprintf("%d", i))
+			defaultVals = append(defaultVals, strconv.Itoa(i))
 		}
 	}
 
@@ -723,7 +735,7 @@ func stringifyInt64SliceFlag(f Int64SliceFlag) string {
 	defaultVals := []string{}
 	if f.Value != nil && len(f.Value.Value()) > 0 {
 		for _, i := range f.Value.Value() {
-			defaultVals = append(defaultVals, fmt.Sprintf("%d", i))
+			defaultVals = append(defaultVals, strconv.FormatInt(i, 10))
 		}
 	}
 
@@ -735,7 +747,7 @@ func stringifyStringSliceFlag(f StringSliceFlag) string {
 	if f.Value != nil && len(f.Value.Value()) > 0 {
 		for _, s := range f.Value.Value() {
 			if len(s) > 0 {
-				defaultVals = append(defaultVals, fmt.Sprintf("%q", s))
+				defaultVals = append(defaultVals, strconv.Quote(s))
 			}
 		}
 	}
@@ -754,8 +766,8 @@ func stringifySliceFlag(usage, name string, defaultVals []string) string {
 		defaultVal = fmt.Sprintf(" (default: %s)", strings.Join(defaultVals, ", "))
 	}
 
-	usageWithDefault := strings.TrimSpace(fmt.Sprintf("%s%s", usage, defaultVal))
-	return fmt.Sprintf("%s\t%s", FlagNamePrefixer(name, placeholder), usageWithDefault)
+	usageWithDefault := strings.TrimSpace(usage + defaultVal)
+	return FlagNamePrefixer(name, placeholder) + "\t" + usageWithDefault
 }
 
 func flagFromFileEnv(filePath, envName string) (val string, ok bool) {

--- a/vendor/github.com/urfave/cli/help.go
+++ b/vendor/github.com/urfave/cli/help.go
@@ -158,8 +158,14 @@ func DefaultAppComplete(c *Context) {
 		if command.Hidden {
 			continue
 		}
-		for _, name := range command.Names() {
-			fmt.Fprintln(c.App.Writer, name)
+		if os.Getenv("_CLI_ZSH_AUTOCOMPLETE_HACK") == "1" {
+			for _, name := range command.Names() {
+				fmt.Fprintf(c.App.Writer, "%s:%s\n", name, command.Usage)
+			}
+		} else {
+			for _, name := range command.Names() {
+				fmt.Fprintf(c.App.Writer, "%s\n", name)
+			}
 		}
 	}
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -123,10 +123,10 @@
 			"revisionTime": "2017-01-30T11:31:45Z"
 		},
 		{
-			"checksumSHA1": "NJXzp9B6k1R3G4QrrWm/3wF9kc8=",
+			"checksumSHA1": "9/2qvuFPQxW7ZXzQSOYwqZb5cNg=",
 			"path": "github.com/urfave/cli",
-			"revision": "44cb242eeb4d76cc813fdc69ba5c4b224677e799",
-			"revisionTime": "2017-11-04T02:35:40Z"
+			"revision": "8e01ec4cd3e2d84ab2fe90d8210528ffbb06d8ff",
+			"revisionTime": "2018-02-26T03:02:53Z"
 		},
 		{
 			"checksumSHA1": "MlEHIE/60sB86Lmf0MPTIXHzKzE=",


### PR DESCRIPTION
Currently, `buildkite-agent start --tags "a=1,b=2"` sets a single tag of `a=1,b=2`. This is a shortcoming of the upstream urfave.cli library (see https://github.com/urfave/cli/issues/62) which expects `--tags "a=1" --tags "a=2"`.

This adds a normalization for --tags and --experiments that makes them behave as expected.