### PR TITLE
Revert "Replace bufio.Reader with bufio.Scanner"

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -30,22 +30,17 @@ type Process struct {
 	Env        []string
 	ExitStatus string
 
-	// StartCallback is called when the process is started
-	StartCallback func()
-
-	// LinePreProcessor is called with ever line of output and can be used to modify each line
-	// The modified value is then made available to LineCallbackFilter and LineCallback
-	LinePreProcessor func(string) string
-
-	// LineCallbackFilter will be called for every line, determines if LineCallback should be called
-	LineCallbackFilter func(string) bool
-
-	// LineCallback is an asynchronous call back that will be dispatched for every line, provided
-	// LineCallbackFilter returned true.
-	LineCallback func(string)
-
 	buffer  outputBuffer
 	command *exec.Cmd
+
+	// This callback is called when the process offically starts
+	StartCallback func()
+
+	// For every line in the process output, this callback will be called
+	// with the contents of the line if its filter returns true.
+	LineCallback       func(string)
+	LinePreProcessor   func(string) string
+	LineCallbackFilter func(string) bool
 
 	// Running is stored as an int32 so we can use atomic operations to
 	// set/get it (it's accessed by multiple goroutines)
@@ -71,6 +66,13 @@ func (p *Process) Start() error {
 
 	lineReaderPipe, lineWriterPipe := io.Pipe()
 
+	var multiWriter io.Writer
+	if p.Timestamp {
+		multiWriter = io.MultiWriter(lineWriterPipe)
+	} else {
+		multiWriter = io.MultiWriter(&p.buffer, lineWriterPipe)
+	}
+
 	// Toggle between running in a pty
 	if p.PTY {
 		pty, err := StartPTY(p.command)
@@ -89,7 +91,7 @@ func (p *Process) Start() error {
 
 			// Copy the pty to our buffer. This will block until it
 			// EOF's or something breaks.
-			_, err = io.Copy(lineWriterPipe, pty)
+			_, err = io.Copy(multiWriter, pty)
 			if e, ok := err.(*os.PathError); ok && e.Err == syscall.EIO {
 				// We can safely ignore this error, because
 				// it's just the PTY telling us that it closed
@@ -107,8 +109,8 @@ func (p *Process) Start() error {
 			waitGroup.Done()
 		}()
 	} else {
-		p.command.Stdout = lineWriterPipe
-		p.command.Stderr = lineWriterPipe
+		p.command.Stdout = multiWriter
+		p.command.Stderr = multiWriter
 		p.command.Stdin = nil
 
 		err := p.command.Start()
@@ -123,44 +125,82 @@ func (p *Process) Start() error {
 
 	logger.Info("[Process] Process is running with PID: %d", p.Pid)
 
-	scanner := bufio.NewScanner(lineReaderPipe)
-
-	var lineCallbackWaitGroup sync.WaitGroup
-
 	// Add the line callback routine to the waitGroup
 	waitGroup.Add(1)
 
 	go func() {
-		defer waitGroup.Done()
-
-		// We scan line by line so that we can run our various processors, currently this buffers the entire
-		// output in memory and then an asynchronous process reads it in chunks
 		logger.Debug("[LineScanner] Starting to read lines")
-		for scanner.Scan() {
-			line := scanner.Text()
+
+		reader := bufio.NewReader(lineReaderPipe)
+
+		var appending []byte
+		var lineCallbackWaitGroup sync.WaitGroup
+
+		for {
+			line, isPrefix, err := reader.ReadLine()
+			if err != nil {
+				if err == io.EOF {
+					logger.Debug("[LineScanner] Encountered EOF")
+					break
+				}
+
+				logger.Error("[LineScanner] Failed to read: (%T: %v)", err, err)
+			}
+
+			// If isPrefix is true, that means we've got a really
+			// long line incoming, and we'll keep appending to it
+			// until isPrefix is false (which means the long line
+			// has ended.
+			if isPrefix && appending == nil {
+				logger.Debug("[LineScanner] Line is too long to read, going to buffer it until it finishes")
+				// bufio.ReadLine returns a slice which is only valid until the next invocation
+				// since it points to its own internal buffer array. To accumulate the entire
+				// result we make a copy of the first prefix, and insure there is spare capacity
+				// for future appends to minimize the need for resizing on append.
+				appending = make([]byte, len(line), (cap(line))*2)
+				copy(appending, line)
+
+				continue
+			}
+
+			// Should we be appending?
+			if appending != nil {
+				appending = append(appending, line...)
+
+				// No more isPrefix! Line is finished!
+				if !isPrefix {
+					logger.Debug("[LineScanner] Finished buffering long line")
+					line = appending
+
+					// Reset appending back to nil
+					appending = nil
+				} else {
+					continue
+				}
+			}
+
+			// If we're timestamping this main thread will take
+			// the hit of running the regex so we can build up
+			// the timestamped buffer without breaking headers,
+			// otherwise we let the goroutines take the perf hit.
 
 			checkedForCallback := false
 			lineHasCallback := false
-			lineString := p.LinePreProcessor(line)
+			lineString := p.LinePreProcessor(string(line))
 
-			// Optionally prefix lines with timestamps
+			// Create the prefixed buffer
 			if p.Timestamp {
 				lineHasCallback = p.LineCallbackFilter(lineString)
 				checkedForCallback = true
-
-				// Don't timestamp special lines (e.g. header)
-				// FIXME: this should be moved to agent/job_runner.go
 				if lineHasCallback || headerExpansionRegex.MatchString(lineString) {
-					_, _ = p.buffer.WriteString(fmt.Sprintf("%s\n", line))
+					// Don't timestamp special lines (e.g. header)
+					p.buffer.WriteString(fmt.Sprintf("%s\n", line))
 				} else {
 					currentTime := time.Now().UTC().Format(time.RFC3339)
-					_, _ = p.buffer.WriteString(fmt.Sprintf("[%s] %s\n", currentTime, line))
+					p.buffer.WriteString(fmt.Sprintf("[%s] %s\n", currentTime, line))
 				}
-			} else {
-				_, _ = p.buffer.WriteString(line + "\n")
 			}
 
-			// A callback is an async function that is triggered by a line
 			if lineHasCallback || !checkedForCallback {
 				lineCallbackWaitGroup.Add(1)
 				go func(line string) {
@@ -172,16 +212,13 @@ func (p *Process) Start() error {
 			}
 		}
 
-		if err := scanner.Err(); err != nil {
-			logger.Debug("[LineScanner] Error from scanner: %v", err)
-		}
-
 		// We need to make sure all the line callbacks have finish before
 		// finish up the process
 		logger.Debug("[LineScanner] Waiting for callbacks to finish")
 		lineCallbackWaitGroup.Wait()
 
 		logger.Debug("[LineScanner] Finished")
+		waitGroup.Done()
 	}()
 
 	// Call the StartCallback
@@ -192,7 +229,7 @@ func (p *Process) Start() error {
 	waitResult := p.command.Wait()
 
 	// Close the line writer pipe
-	_ = lineWriterPipe.Close()
+	lineWriterPipe.Close()
 
 	// The process is no longer running at this point
 	p.setRunning(false)


### PR DESCRIPTION
It turns out that the bufio.Scanner doesn't handle really long tokens, so we need to do it ourselves.

@keithpitt, yes I know, you told me so.

Closes #775.