### PR TITLE
Updated github.com/kr/pty for OpenBSD support.

### DIFF
--- a/vendor/github.com/kr/pty/mktypes.bash
+++ b/vendor/github.com/kr/pty/mktypes.bash
@@ -13,7 +13,7 @@ GODEFS="go tool cgo -godefs"
 $GODEFS types.go |gofmt > ztypes_$GOARCH.go
 
 case $GOOS in
-freebsd|dragonfly)
+freebsd|dragonfly|openbsd)
 	$GODEFS types_$GOOS.go |gofmt > ztypes_$GOOSARCH.go
 	;;
 esac

--- a/vendor/github.com/kr/pty/pty_darwin.go
+++ b/vendor/github.com/kr/pty/pty_darwin.go
@@ -13,19 +13,23 @@ func open() (pty, tty *os.File, err error) {
 		return nil, nil, err
 	}
 	p := os.NewFile(uintptr(pFD), "/dev/ptmx")
+	// In case of error after this point, make sure we close the ptmx fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
 
 	sname, err := ptsname(p)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	err = grantpt(p)
-	if err != nil {
+	if err := grantpt(p); err != nil {
 		return nil, nil, err
 	}
 
-	err = unlockpt(p)
-	if err != nil {
+	if err := unlockpt(p); err != nil {
 		return nil, nil, err
 	}
 

--- a/vendor/github.com/kr/pty/pty_dragonfly.go
+++ b/vendor/github.com/kr/pty/pty_dragonfly.go
@@ -14,19 +14,23 @@ func open() (pty, tty *os.File, err error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	// In case of error after this point, make sure we close the ptmx fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
 
 	sname, err := ptsname(p)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	err = grantpt(p)
-	if err != nil {
+	if err := grantpt(p); err != nil {
 		return nil, nil, err
 	}
 
-	err = unlockpt(p)
-	if err != nil {
+	if err := unlockpt(p); err != nil {
 		return nil, nil, err
 	}
 

--- a/vendor/github.com/kr/pty/pty_freebsd.go
+++ b/vendor/github.com/kr/pty/pty_freebsd.go
@@ -7,22 +7,28 @@ import (
 	"unsafe"
 )
 
-func posix_openpt(oflag int) (fd int, err error) {
+func posixOpenpt(oflag int) (fd int, err error) {
 	r0, _, e1 := syscall.Syscall(syscall.SYS_POSIX_OPENPT, uintptr(oflag), 0, 0)
 	fd = int(r0)
 	if e1 != 0 {
 		err = e1
 	}
-	return
+	return fd, err
 }
 
 func open() (pty, tty *os.File, err error) {
-	fd, err := posix_openpt(syscall.O_RDWR | syscall.O_CLOEXEC)
+	fd, err := posixOpenpt(syscall.O_RDWR | syscall.O_CLOEXEC)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	p := os.NewFile(uintptr(fd), "/dev/pts")
+	// In case of error after this point, make sure we close the pts fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
+
 	sname, err := ptsname(p)
 	if err != nil {
 		return nil, nil, err
@@ -42,7 +48,7 @@ func isptmaster(fd uintptr) (bool, error) {
 
 var (
 	emptyFiodgnameArg fiodgnameArg
-	ioctl_FIODGNAME   = _IOW('f', 120, unsafe.Sizeof(emptyFiodgnameArg))
+	ioctlFIODGNAME    = _IOW('f', 120, unsafe.Sizeof(emptyFiodgnameArg))
 )
 
 func ptsname(f *os.File) (string, error) {
@@ -59,8 +65,7 @@ func ptsname(f *os.File) (string, error) {
 		buf = make([]byte, n)
 		arg = fiodgnameArg{Len: n, Buf: (*byte)(unsafe.Pointer(&buf[0]))}
 	)
-	err = ioctl(f.Fd(), ioctl_FIODGNAME, uintptr(unsafe.Pointer(&arg)))
-	if err != nil {
+	if err := ioctl(f.Fd(), ioctlFIODGNAME, uintptr(unsafe.Pointer(&arg))); err != nil {
 		return "", err
 	}
 

--- a/vendor/github.com/kr/pty/pty_linux.go
+++ b/vendor/github.com/kr/pty/pty_linux.go
@@ -12,14 +12,19 @@ func open() (pty, tty *os.File, err error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	// In case of error after this point, make sure we close the ptmx fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
 
 	sname, err := ptsname(p)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	err = unlockpt(p)
-	if err != nil {
+	if err := unlockpt(p); err != nil {
 		return nil, nil, err
 	}
 

--- a/vendor/github.com/kr/pty/pty_openbsd.go
+++ b/vendor/github.com/kr/pty/pty_openbsd.go
@@ -1,0 +1,33 @@
+package pty
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func open() (pty, tty *os.File, err error) {
+	/*
+	 * from ptm(4):
+	 * The PTMGET command allocates a free pseudo terminal, changes its
+	 * ownership to the caller, revokes the access privileges for all previous
+	 * users, opens the file descriptors for the master and slave devices and
+	 * returns them to the caller in struct ptmget.
+	 */
+
+	p, err := os.OpenFile("/dev/ptm", os.O_RDWR|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer p.Close()
+
+	var ptm ptmget
+	if err := ioctl(p.Fd(), uintptr(ioctl_PTMGET), uintptr(unsafe.Pointer(&ptm))); err != nil {
+		return nil, nil, err
+	}
+
+	pty = os.NewFile(uintptr(ptm.Cfd), "/dev/ptm")
+	tty = os.NewFile(uintptr(ptm.Sfd), "/dev/ptm")
+
+	return pty, tty, nil
+}

--- a/vendor/github.com/kr/pty/pty_unsupported.go
+++ b/vendor/github.com/kr/pty/pty_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!darwin,!freebsd,!dragonfly
+// +build !linux,!darwin,!freebsd,!dragonfly,!openbsd
 
 package pty
 

--- a/vendor/github.com/kr/pty/ztypes_openbsd_amd64.go
+++ b/vendor/github.com/kr/pty/ztypes_openbsd_amd64.go
@@ -1,0 +1,13 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_openbsd.go
+
+package pty
+
+type ptmget struct {
+	Cfd int32
+	Sfd int32
+	Cn  [16]int8
+	Sn  [16]int8
+}
+
+var ioctl_PTMGET = 0x40287401

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -75,10 +75,10 @@
 			"revisionTime": "2017-05-10T13:15:34Z"
 		},
 		{
-			"checksumSHA1": "RRbuqW6/i6m9ChhQDTVU7A2F9E8=",
+			"checksumSHA1": "ym3Koe72EEWlnhyjCmuC0FSlDyw=",
 			"path": "github.com/kr/pty",
-			"revision": "1278f20d9cf7455f0465f3bf74a73d1eeb555c0f",
-			"revisionTime": "2018-01-06T19:11:30Z"
+			"revision": "282ce0e5322c82529687d609ee670fac7c7d917c",
+			"revisionTime": "2018-01-13T18:08:13Z"
 		},
 		{
 			"checksumSHA1": "vtvVqCnKI84k5jo9sfuGsNlFUKM=",


### PR DESCRIPTION
This corrects "unsupported" on OpenBSD.  Hasn't been tested for regression, although the diff between vendor hashes includes only a fix for leaky file descriptors, and OpenBSD support:

https://github.com/kr/pty/pull/57
https://github.com/kr/pty/pull/58
