### PR TITLE
Remove the checkout dir when git clean fails

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -710,11 +710,15 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 	// Git clean prior to checkout
 	if hasGitSubmodules(b.shell) {
 		if err := gitCleanSubmodules(b.shell, b.GitCleanFlags); err != nil {
+			// Remove the checkout as often this is due to a corrupt git submodules
+			_ = b.removeCheckoutDir()
 			return err
 		}
 	}
 
 	if err := gitClean(b.shell, b.GitCleanFlags); err != nil {
+		// Remove the checkout as often this is due to a corrupt git submodules
+		_ = b.removeCheckoutDir()
 		return err
 	}
 


### PR DESCRIPTION
We previously removed the checkout dir when `git remote set-url` fails or when `git clone` fails, but we don't on `git clean`. If there are corrupted submodules, then `git clean` will fail, leaving a corrupted working dir. 

This adds the `remote checkout dir on error` behaviour to `git clean` as well.