### PR TITLE
Proposal for --default-timeout-in-minutes flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+[Full Changelog](https://github.com/buildkite/agent/compare/v3.2.0...master)
+
+### Changed
+
+### Fixed
+
 ## [v3.2.0](https://github.com/buildkite/agent/tree/v3.2.0) (2018-05-25)
 [Full Changelog](https://github.com/buildkite/agent/compare/v3.1.2...v3.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [Full Changelog](https://github.com/buildkite/agent/compare/v3.2.0...master)
 
 ### Changed
+- Add `--default-timeout-in-minutes` flag to `buildkite-agent start` command [(discussion)](https://github.com/buildkite/feedback/issues/170#issuecomment-400535789) (@pda)
 
 ### Fixed
 

--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -18,4 +18,5 @@ type AgentConfiguration struct {
 	DisconnectAfterJob        bool
 	DisconnectAfterJobTimeout int
 	Shell                     string
+	DefaultTimeoutInMinutes   int
 }

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -127,6 +127,7 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 		Build:             BuildVersion(),
 		PID:               os.Getpid(),
 		Arch:              runtime.GOARCH,
+		DefaultTimeoutInMinutes: r.AgentConfiguration.DefaultTimeoutInMinutes,
 	}
 
 	// Attempt to add the EC2 tags

--- a/api/agents.go
+++ b/api/agents.go
@@ -14,21 +14,22 @@ type AgentsService struct {
 
 // Agent represents an agent on the Buildkite Agent API
 type Agent struct {
-	Name              string   `json:"name" msgpack:"name"`
-	AccessToken       string   `json:"access_token" msgpack:"access_token"`
-	Hostname          string   `json:"hostname" msgpack:"hostname"`
-	Endpoint          string   `json:"endpoint" msgpack:"endpoint"`
-	PingInterval      int      `json:"ping_interval" msgpack:"ping_interval"`
-	JobStatusInterval int      `json:"job_status_interval" msgpack:"job_status_interval"`
-	HearbeatInterval  int      `json:"heartbeat_interval" msgpack:"heartbeat_interval"`
-	OS                string   `json:"os" msgpack:"os"`
-	Arch              string   `json:"arch" msgpack:"arch"`
-	ScriptEvalEnabled bool     `json:"script_eval_enabled" msgpack:"script_eval_enabled"`
-	Priority          string   `json:"priority,omitempty" msgpack:"priority,omitempty"`
-	Version           string   `json:"version" msgpack:"version"`
-	Build             string   `json:"build" msgpack:"build"`
-	Tags              []string `json:"meta_data" msgpack:"meta_data"`
-	PID               int      `json:"pid,omitempty" msgpack:"pid,omitempty"`
+	Name                    string   `json:"name" msgpack:"name"`
+	AccessToken             string   `json:"access_token" msgpack:"access_token"`
+	Hostname                string   `json:"hostname" msgpack:"hostname"`
+	Endpoint                string   `json:"endpoint" msgpack:"endpoint"`
+	PingInterval            int      `json:"ping_interval" msgpack:"ping_interval"`
+	JobStatusInterval       int      `json:"job_status_interval" msgpack:"job_status_interval"`
+	HearbeatInterval        int      `json:"heartbeat_interval" msgpack:"heartbeat_interval"`
+	OS                      string   `json:"os" msgpack:"os"`
+	Arch                    string   `json:"arch" msgpack:"arch"`
+	ScriptEvalEnabled       bool     `json:"script_eval_enabled" msgpack:"script_eval_enabled"`
+	Priority                string   `json:"priority,omitempty" msgpack:"priority,omitempty"`
+	Version                 string   `json:"version" msgpack:"version"`
+	Build                   string   `json:"build" msgpack:"build"`
+	Tags                    []string `json:"meta_data" msgpack:"meta_data"`
+	PID                     int      `json:"pid,omitempty" msgpack:"pid,omitempty"`
+	DefaultTimeoutInMinutes int      `json:"default_timeout_in_minutes,omitempty" msgpack:"default_timeout_in_minutes,omitempty"`
 }
 
 // Registers the agent against the Buildktie Agent API. The client for this

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -68,6 +68,7 @@ type AgentStartConfig struct {
 	Debug                     bool     `cli:"debug"`
 	DebugHTTP                 bool     `cli:"debug-http"`
 	Experiments               []string `cli:"experiment" normalize:"list"`
+	DefaultTimeoutInMinutes   int      `cli:"default-timeout-in-minutes"`
 
 	/* Deprecated */
 	NoSSHFingerprintVerification bool     `cli:"no-automatic-ssh-fingerprint-verification" deprecated-and-renamed-to:"NoSSHKeyscan"`
@@ -264,6 +265,11 @@ var AgentStartCommand = cli.Command{
 		NoColorFlag,
 		DebugFlag,
 		DebugHTTPFlag,
+		cli.IntFlag{
+			Name:   "default-timeout-in-minutes",
+			Usage:  "Timeout for jobs without an explicit timeout_in_minutes",
+			EnvVar: "BUILDKITE_DEFAULT_TIMEOUT_IN_MINUTES",
+		},
 		/* Deprecated flags which will be removed in v4 */
 		cli.StringSliceFlag{
 			Name:   "meta-data",
@@ -374,6 +380,7 @@ var AgentStartCommand = cli.Command{
 				DisconnectAfterJob:        cfg.DisconnectAfterJob,
 				DisconnectAfterJobTimeout: cfg.DisconnectAfterJobTimeout,
 				Shell: cfg.Shell,
+				DefaultTimeoutInMinutes: cfg.DefaultTimeoutInMinutes,
 			},
 		}
 


### PR DESCRIPTION
Introduces `--default-timeout-in-minutes` flag (or `BUILDKITE_DEFAULT_TIMEOUT_IN_MINUTES` environment) to `buildkite-agent start`, which is passed to the Register Agent API via an as-yet unsupported `default_timeout_in_minutes` attribute.

For this PR to be useful, Buildkite backend would need to support this new agent attribute. When a job is assigned to an agent and that job does not have a `timeout_in_minutes` attribute but the agent does have a `default_timeout_in_minutes`, the latter value would be used as the timeout.

This would allow a timeout to be specified at the agent level, where an agent may be handling jobs from a diverse range of codebases and pipelines that cannot be expected to always specify a `timeout_in_minutes` on every command step. This option will make agents more resilient to frozen/stalled jobs, increasing agent availability, decreasing wait times, and allowing https://github.com/buildkite/elastic-ci-stack-for-aws to scale down after a job freezes.

Some more context / discussion in https://github.com/buildkite/feedback/issues/170#issuecomment-400535789

- [x] Flag in buildkite-agent
- [ ] Support in Buildkite agent API / backend.