### PR TITLE
Allow --no-plugins=false to force plugins on

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -325,7 +325,8 @@ var AgentStartCommand = cli.Command{
 		// Show a warning if plugins are enabled by no-command-eval or no-local-hooks is set
 		if c.IsSet("no-plugins") && cfg.NoPlugins == false {
 			msg := `Plugins have been specifically enabled, despite %s being enabled. ` +
-				`Plugins can execute arbitrary hooks and commands, make sure you are whitelisting your plugins in ` +
+				`Plugins can execute arbitrary hooks and commands, make sure you are ` +
+				`whitelisting your plugins in ` +
 				`your environment hook.`
 
 			switch {
@@ -336,8 +337,8 @@ var AgentStartCommand = cli.Command{
 			}
 		}
 
-		// Turning off command eval or local hooks will also turn off plugins unless "--no-plugins=false"
-		// is provided specifically
+		// Turning off command eval or local hooks will also turn off plugins unless
+		// `--no-plugins=false` is provided specifically
 		if (cfg.NoCommandEval || cfg.NoLocalHooks) && !c.IsSet("no-plugins") {
 			cfg.NoPlugins = true
 		}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -322,8 +322,23 @@ var AgentStartCommand = cli.Command{
 			cfg.BootstrapScript = fmt.Sprintf("%s bootstrap", shellwords.Quote(os.Args[0]))
 		}
 
-		// Turning off command eval or local hooks will also turn off plugins.
-		if cfg.NoCommandEval || cfg.NoLocalHooks {
+		// Show a warning if plugins are enabled by no-command-eval or no-local-hooks is set
+		if c.IsSet("no-plugins") && cfg.NoPlugins == false {
+			msg := `Plugins have been specifically enabled, despite %s being enabled. ` +
+				`Plugins can execute arbitrary hooks and commands, make sure you are whitelisting your plugins in ` +
+				`your environment hook.`
+
+			switch {
+			case cfg.NoCommandEval:
+				logger.Warn(msg, `no-command-eval`)
+			case cfg.NoLocalHooks:
+				logger.Warn(msg, `no-local-hooks`)
+			}
+		}
+
+		// Turning off command eval or local hooks will also turn off plugins unless "--no-plugins=false"
+		// is provided specifically
+		if (cfg.NoCommandEval || cfg.NoLocalHooks) && !c.IsSet("no-plugins") {
 			cfg.NoPlugins = true
 		}
 


### PR DESCRIPTION
By default plugins are disabled when no-command-eval or no-local-hooks is set. This allows a way around that.

I kind of hate the syntax of `--no-plugins=true`, and I hate even more the ternary nature of this, in that we only look at the `false` value if it's specifically set vs just the default value. Suggestions welcomed. 