### PR TITLE
Cancellation on Windows: Pass `/T` to `taskkill`

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -260,7 +260,7 @@ func (p *Process) Kill() error {
 	if runtime.GOOS == "windows" {
 		// Sending Interrupt on Windows is not implemented.
 		// https://golang.org/src/os/exec.go?s=3842:3884#L110
-		err = exec.Command("CMD", "/C", "TASKKILL", "/F", "/PID", strconv.Itoa(p.Pid)).Run()
+		err = exec.Command("CMD", "/C", "TASKKILL", "/F", "/T", "/PID", strconv.Itoa(p.Pid)).Run()
 	} else {
 		// Send a sigterm
 		err = p.signal(syscall.SIGTERM)


### PR DESCRIPTION
`/T` will make `taskkill` kill all the child processes as well.  This should improve the cancellation behavior. (#794) 

Please let me know if I should file a separate issue.
