### PR TITLE
Warn in bootstrap when protected env are used

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -349,16 +349,16 @@ func (b *Bootstrap) setUp() error {
 
 	b.shell.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", filepath.Join(b.BuildPath, dirForAgentName(b.AgentName), b.OrganizationSlug, b.PipelineSlug))
 
-	// The job runner rewrites any protected environment variables to a certain format
-	// This detects those environment vars and shows a warning to the user so they don't get confused
+	// The job runner sets BUILDKITE_IGNORED_ENV with any keys that were ignored
+	// or overwritten. This shows a warning to the user so they don't get confused
 	// when their environment changes don't seem to do anything
-	if ignored := b.ignoredEnv(); len(ignored) > 0 {
+	if ignored, exists := b.shell.Env.Get("BUILDKITE_IGNORED_ENV"); exists {
 		b.shell.Headerf("Detected protected environment variables")
 		b.shell.Commentf("Your pipeline environment has protected environment variables set. " +
 			"These can only be set via hooks, plugins or the agent configuration.")
 
-		for _, env := range ignored {
-			b.shell.Warningf("Ignoring %s", env)
+		for _, env := range strings.Split(ignored, ",") {
+			b.shell.Warningf("Ignored %s", env)
 		}
 
 		b.shell.Printf("^^^ +++")

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -349,6 +349,9 @@ func (b *Bootstrap) setUp() error {
 
 	b.shell.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", filepath.Join(b.BuildPath, dirForAgentName(b.AgentName), b.OrganizationSlug, b.PipelineSlug))
 
+	// The job runner rewrites any protected environment variables to a certain format
+	// This detects those environment vars and shows a warning to the user so they don't get confused
+	// when their environment changes don't seem to do anything
 	if ignored := b.ignoredEnv(); len(ignored) > 0 {
 		b.shell.Headerf("Detected protected environment variables")
 		b.shell.Commentf("Your pipeline environment has protected environment variables set. These can only be set via hooks or via the agent configuration.")

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -354,7 +354,8 @@ func (b *Bootstrap) setUp() error {
 	// when their environment changes don't seem to do anything
 	if ignored := b.ignoredEnv(); len(ignored) > 0 {
 		b.shell.Headerf("Detected protected environment variables")
-		b.shell.Commentf("Your pipeline environment has protected environment variables set. These can only be set via hooks or via the agent configuration.")
+		b.shell.Commentf("Your pipeline environment has protected environment variables set. " +
+			"These can only be set via hooks, plugins or the agent configuration.")
 
 		for _, env := range ignored {
 			b.shell.Warningf("Ignoring %s", env)


### PR DESCRIPTION
We frequently have people try and set things like `BUILDKITE_GIT_CLEAN_FLAGS` in their pipeline global environment or per-step environment and get very confused why it doesn't work.

The reason it doesn't work is that we override certain environment variables for each build in the job runner to ensure they are correct as they are security sensitive: https://github.com/buildkite/agent/blob/c9645249f076beef3cebce34dc9980fe8c54d502/agent/job_runner.go#L264-L276

We do allow certain environment variables set by hooks to override these values, but we completely ignore values from the pipeline environment. 

~~This change rewrites the original values so they are available in the bootstrap if the user wants them, for instance `BUILDKITE_GIT_CLEAN_FLAGS` becomes `BUILDKITE_X_GIT_CLEAN_FLAGS`~~. The job runner sets ignored keys via `BUILDKITE_IGNORED_ENV` and then the bootstrap then prints a warning:

<img width="1143" alt="20180717-6kpt6kf7osnyvzw" src="https://user-images.githubusercontent.com/15758/42792098-18c62206-89b7-11e8-9140-707ed66ec803.png">
