### PR TITLE
Support --command-only and --checkout-only in bootstrap

### DIFF
--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -56,6 +56,8 @@ type BootstrapConfig struct {
 	PTY                          bool   `cli:"pty"`
 	Debug                        bool   `cli:"debug"`
 	Shell                        string `cli:"shell"`
+	CheckoutOnly                 bool   `cli:"checkout-only"`
+	CommandOnly                  bool   `cli:"command-only"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -230,6 +232,16 @@ var BootstrapCommand = cli.Command{
 			EnvVar: "BUILDKITE_SHELL",
 			Value:  DefaultShell(),
 		},
+		cli.BoolFlag{
+			Name:   "checkout-only",
+			Usage:  "Only execute the checkout phase",
+			EnvVar: "BUILDKITE_CHECKOUT_ONLY",
+		},
+		cli.BoolFlag{
+			Name:   "command-only",
+			Usage:  "Only execute the command phase",
+			EnvVar: "BUILDKITE_COMMAND_ONLY",
+		},
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
@@ -247,8 +259,14 @@ var BootstrapCommand = cli.Command{
 			runInPty = false
 		}
 
+		if cfg.CheckoutOnly && cfg.CommandOnly {
+			logger.Fatal("Only one of checkout-only and command-only can be set")
+		}
+
 		// Configure the bootstraper
 		bootstrap := &bootstrap.Bootstrap{
+			CheckoutOnly: cfg.CheckoutOnly,
+			CommandOnly:  cfg.CommandOnly,
 			Config: bootstrap.Config{
 				Command:                      cfg.Command,
 				JobID:                        cfg.JobID,


### PR DESCRIPTION
This allows for only running the command or checkout phase of the bootstrap. This allows for things like https://github.com/wolfeidau/buildkite-serverless-agent to run checkout and command phases independently.

The neat thing about this split is that generally you need to expose ssh key material to the checkout phase, where as you don't want to expose it to the command phase. Suspect this will end up being useful for Public Build isolation in several ways. 

```bash
$ buildkite-agent bootstrap \
  --job "llamas" \
  --repository "$PWD" \
  --commit "HEAD" \
  --branch "master" \
  --agent "my-agent" \
  --organization "buildkite" \
  --pipeline "agent" \
  --pipeline-provider git \
  --build-path /usr/local/var/buildkite-agent/builds \
  --command-only 
  --command "echo hello world"

~~~ Running commands
$ echo hello world
hello world
```