### PR TITLE
Allow specifying which phases bootstrap should execute

### DIFF
--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -244,7 +244,7 @@ var BootstrapCommand = cli.Command{
 		},
 		cli.StringSliceFlag{
 			Name:   "phases",
-			Usage:  "The specific phases to execute",
+			Usage:  "The specific phases to execute. The order they're defined is is irrelevant.",
 			EnvVar: "BUILDKITE_BOOTSTRAP_PHASES",
 		},
 		DebugFlag,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -16,8 +16,19 @@ var BootstrapHelpDescription = `Usage:
 
 Description:
 
-   The bootstrap command checks out the jobs repository source code and
-   executes the commands defined in the job.
+   The bootstrap command executes a buildkite job locally.
+
+   Generally the bootstrap command is run as a sub-process of the buildkite-agent to execute
+   a given job sent from buildkite.com, but you can also invoke the bootstrap manually.
+
+   Execution is broken down into phases. By default, the bootstrap runs a plugin phase which
+   sets up any plugins specified, then a checkout phase which pulls down your code and then a
+   command phase that executes the specified command in the created environment.
+
+   You can run only specific phases with the --phases flag.
+
+   The bootstrap is also responsible for executing hooks around the phases.
+   See https://buildkite.com/docs/agent/v3/hooks for more details.
 
 Example:
 
@@ -26,36 +37,37 @@ Example:
    $ buildkite-agent bootstrap --build-path builds`
 
 type BootstrapConfig struct {
-	Command                      string `cli:"command"`
-	JobID                        string `cli:"job" validate:"required"`
-	Repository                   string `cli:"repository" validate:"required"`
-	Commit                       string `cli:"commit" validate:"required"`
-	Branch                       string `cli:"branch" validate:"required"`
-	Tag                          string `cli:"tag"`
-	RefSpec                      string `cli:"refspec"`
-	Plugins                      string `cli:"plugins"`
-	PullRequest                  string `cli:"pullrequest"`
-	GitSubmodules                bool   `cli:"git-submodules"`
-	SSHKeyscan                   bool   `cli:"ssh-keyscan"`
-	AgentName                    string `cli:"agent" validate:"required"`
-	OrganizationSlug             string `cli:"organization" validate:"required"`
-	PipelineSlug                 string `cli:"pipeline" validate:"required"`
-	PipelineProvider             string `cli:"pipeline-provider" validate:"required"`
-	AutomaticArtifactUploadPaths string `cli:"artifact-upload-paths"`
-	ArtifactUploadDestination    string `cli:"artifact-upload-destination"`
-	CleanCheckout                bool   `cli:"clean-checkout"`
-	GitCloneFlags                string `cli:"git-clone-flags"`
-	GitCleanFlags                string `cli:"git-clean-flags"`
-	BinPath                      string `cli:"bin-path" normalize:"filepath"`
-	BuildPath                    string `cli:"build-path" normalize:"filepath" validate:"required"`
-	HooksPath                    string `cli:"hooks-path" normalize:"filepath"`
-	PluginsPath                  string `cli:"plugins-path" normalize:"filepath"`
-	CommandEval                  bool   `cli:"command-eval"`
-	PluginsEnabled               bool   `cli:"plugins-enabled"`
-	LocalHooksEnabled            bool   `cli:"local-hooks-enabled"`
-	PTY                          bool   `cli:"pty"`
-	Debug                        bool   `cli:"debug"`
-	Shell                        string `cli:"shell"`
+	Command                      string   `cli:"command"`
+	JobID                        string   `cli:"job" validate:"required"`
+	Repository                   string   `cli:"repository" validate:"required"`
+	Commit                       string   `cli:"commit" validate:"required"`
+	Branch                       string   `cli:"branch" validate:"required"`
+	Tag                          string   `cli:"tag"`
+	RefSpec                      string   `cli:"refspec"`
+	Plugins                      string   `cli:"plugins"`
+	PullRequest                  string   `cli:"pullrequest"`
+	GitSubmodules                bool     `cli:"git-submodules"`
+	SSHKeyscan                   bool     `cli:"ssh-keyscan"`
+	AgentName                    string   `cli:"agent" validate:"required"`
+	OrganizationSlug             string   `cli:"organization" validate:"required"`
+	PipelineSlug                 string   `cli:"pipeline" validate:"required"`
+	PipelineProvider             string   `cli:"pipeline-provider" validate:"required"`
+	AutomaticArtifactUploadPaths string   `cli:"artifact-upload-paths"`
+	ArtifactUploadDestination    string   `cli:"artifact-upload-destination"`
+	CleanCheckout                bool     `cli:"clean-checkout"`
+	GitCloneFlags                string   `cli:"git-clone-flags"`
+	GitCleanFlags                string   `cli:"git-clean-flags"`
+	BinPath                      string   `cli:"bin-path" normalize:"filepath"`
+	BuildPath                    string   `cli:"build-path" normalize:"filepath" validate:"required"`
+	HooksPath                    string   `cli:"hooks-path" normalize:"filepath"`
+	PluginsPath                  string   `cli:"plugins-path" normalize:"filepath"`
+	CommandEval                  bool     `cli:"command-eval"`
+	PluginsEnabled               bool     `cli:"plugins-enabled"`
+	LocalHooksEnabled            bool     `cli:"local-hooks-enabled"`
+	PTY                          bool     `cli:"pty"`
+	Debug                        bool     `cli:"debug"`
+	Shell                        string   `cli:"shell"`
+	Phases                       []string `cli:"phases" normalize:"list"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -230,6 +242,11 @@ var BootstrapCommand = cli.Command{
 			EnvVar: "BUILDKITE_SHELL",
 			Value:  DefaultShell(),
 		},
+		cli.StringSliceFlag{
+			Name:   "phases",
+			Usage:  "The specific phases to execute",
+			EnvVar: "BUILDKITE_BOOTSTRAP_PHASES",
+		},
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
@@ -247,8 +264,19 @@ var BootstrapCommand = cli.Command{
 			runInPty = false
 		}
 
+		// Validate phases
+		for _, phase := range cfg.Phases {
+			switch phase {
+			case "plugin", "checkout", "command":
+				// Valid phase
+			default:
+				logger.Fatal("Invalid phase %q", phase)
+			}
+		}
+
 		// Configure the bootstraper
 		bootstrap := &bootstrap.Bootstrap{
+			Phases: cfg.Phases,
 			Config: bootstrap.Config{
 				Command:                      cfg.Command,
 				JobID:                        cfg.JobID,


### PR DESCRIPTION
Another take on #798, allows specific phases of the bootstrap to be executed.

```
$ buildkite-agent bootstrap \
  --job "llamas" \
  --repository "$PWD" \
  --commit "HEAD" \
  --branch "master" \
  --agent "my-agent" \
  --organization "buildkite" \
  --pipeline "agent" \
  --pipeline-provider git \
  --build-path /usr/local/var/buildkite-agent/builds \
  --phases "plugin,command" \
  --command "echo hello world"

~~~ Running commands
$ echo hello world
hello world
```