### PR TITLE
Simplify agent-socket implementation

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -283,8 +283,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	}
 
 	if experiments.IsEnabled("agent-socket") {
-		env["BUILDKITE_AGENT_ENDPOINT"] = r.APIProxy.Endpoint()
-		env["BUILDKITE_AGENT_ACCESS_TOKEN"] = r.APIProxy.AccessToken()
+		env["BUILDKITE_AGENT_SOCKET"] = r.APIProxy.Endpoint()
 	} else {
 		env["BUILDKITE_AGENT_ENDPOINT"] = r.Endpoint
 		env["BUILDKITE_AGENT_ACCESS_TOKEN"] = r.Agent.AccessToken

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -901,8 +901,7 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 		}
 	}
 
-	if _, hasToken := b.shell.Env.Get("BUILDKITE_AGENT_ACCESS_TOKEN"); !hasToken {
-		b.shell.Warningf("Skipping sending Git information to Buildkite as $BUILDKITE_AGENT_ACCESS_TOKEN is missing")
+	if !b.Config.SendGitCommitMetadata {
 		return nil
 	}
 

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -105,6 +105,9 @@ type Config struct {
 
 	// The shell used to execute commands
 	Shell string
+
+	// Whether to send buildkite:git:commit metadata
+	SendGitCommitMetadata bool
 }
 
 // ReadFromEnvironment reads configuration from the Environment, returns a map

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/buildkite/agent/stdin"
 
-	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/cliconfig"
 	"github.com/buildkite/agent/logger"
@@ -52,8 +51,9 @@ type AnnotateConfig struct {
 	Context          string `cli:"context"`
 	Append           bool   `cli:"append"`
 	Job              string `cli:"job" validate:"required"`
-	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
-	Endpoint         string `cli:"endpoint" validate:"required"`
+	AgentAccessToken string `cli:"agent-access-token"`
+	AgentSocket      string `cli:"agent-socket"`
+	Endpoint         string `cli:"endpoint"`
 	NoColor          bool   `cli:"no-color"`
 	Debug            bool   `cli:"debug"`
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -86,6 +86,7 @@ var AnnotateCommand = cli.Command{
 			EnvVar: "BUILDKITE_JOB_ID",
 		},
 		AgentAccessTokenFlag,
+		AgentSocketFlag,
 		EndpointFlag,
 		NoColorFlag,
 		DebugFlag,
@@ -122,10 +123,7 @@ var AnnotateCommand = cli.Command{
 		}
 
 		// Create the API client
-		client := agent.APIClient{
-			Endpoint: cfg.Endpoint,
-			Token:    cfg.AgentAccessToken,
-		}.Create()
+		client := CreateAPIClientFromConfig(cfg)
 
 		// Create the annotation we'll send to the Buildkite API
 		annotation := &api.Annotation{

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -39,6 +39,7 @@ type ArtifactDownloadConfig struct {
 	Step             string `cli:"step"`
 	Build            string `cli:"build" validate:"required"`
 	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
+	AgentSocket      string `cli:"agent-socket"`
 	Endpoint         string `cli:"endpoint" validate:"required"`
 	NoColor          bool   `cli:"no-color"`
 	Debug            bool   `cli:"debug"`
@@ -63,6 +64,7 @@ var ArtifactDownloadCommand = cli.Command{
 		},
 		AgentAccessTokenFlag,
 		EndpointFlag,
+		AgentSocketFlag,
 		NoColorFlag,
 		DebugFlag,
 		DebugHTTPFlag,
@@ -81,10 +83,7 @@ var ArtifactDownloadCommand = cli.Command{
 
 		// Setup the downloader
 		downloader := agent.ArtifactDownloader{
-			APIClient: agent.APIClient{
-				Endpoint: cfg.Endpoint,
-				Token:    cfg.AgentAccessToken,
-			}.Create(),
+			APIClient:   CreateAPIClientFromConfig(cfg),
 			Query:       cfg.Query,
 			Destination: cfg.Destination,
 			BuildID:     cfg.Build,

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -41,6 +41,7 @@ type ArtifactShasumConfig struct {
 	Step             string `cli:"step"`
 	Build            string `cli:"build" validate:"required"`
 	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
+	AgentSocket      string `cli:"agent-socket"`
 	Endpoint         string `cli:"endpoint" validate:"required"`
 	NoColor          bool   `cli:"no-color"`
 	Debug            bool   `cli:"debug"`
@@ -64,6 +65,7 @@ var ArtifactShasumCommand = cli.Command{
 			Usage:  "The build that the artifacts were uploaded to",
 		},
 		AgentAccessTokenFlag,
+		AgentSocketFlag,
 		EndpointFlag,
 		NoColorFlag,
 		DebugFlag,
@@ -83,11 +85,8 @@ var ArtifactShasumCommand = cli.Command{
 
 		// Find the artifact we want to show the SHASUM for
 		searcher := agent.ArtifactSearcher{
-			APIClient: agent.APIClient{
-				Endpoint: cfg.Endpoint,
-				Token:    cfg.AgentAccessToken,
-			}.Create(),
-			BuildID: cfg.Build,
+			APIClient: CreateAPIClientFromConfig(cfg),
+			BuildID:   cfg.Build,
 		}
 
 		artifacts, err := searcher.Search(cfg.Query, cfg.Step)

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -40,8 +40,9 @@ type ArtifactUploadConfig struct {
 	UploadPaths      string `cli:"arg:0" label:"upload paths" validate:"required"`
 	Destination      string `cli:"arg:1" label:"destination" env:"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"`
 	Job              string `cli:"job" validate:"required"`
-	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
-	Endpoint         string `cli:"endpoint" validate:"required"`
+	AgentAccessToken string `cli:"agent-access-token"`
+	AgentSocket      string `cli:"agent-socket"`
+	Endpoint         string `cli:"endpoint"`
 	NoColor          bool   `cli:"no-color"`
 	Debug            bool   `cli:"debug"`
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -59,6 +60,7 @@ var ArtifactUploadCommand = cli.Command{
 			EnvVar: "BUILDKITE_JOB_ID",
 		},
 		AgentAccessTokenFlag,
+		AgentSocketFlag,
 		EndpointFlag,
 		NoColorFlag,
 		DebugFlag,
@@ -78,10 +80,7 @@ var ArtifactUploadCommand = cli.Command{
 
 		// Setup the uploader
 		uploader := agent.ArtifactUploader{
-			APIClient: agent.APIClient{
-				Endpoint: cfg.Endpoint,
-				Token:    cfg.AgentAccessToken,
-			}.Create(),
+			APIClient:   CreateAPIClientFromConfig(cfg),
 			JobID:       cfg.Job,
 			Paths:       cfg.UploadPaths,
 			Destination: cfg.Destination,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -280,6 +280,14 @@ var BootstrapCommand = cli.Command{
 			}
 		}
 
+		// Send git commit metadata as part of bootstrap
+		// only if we have a token or a socket
+		var sendGitCommitMetadata bool
+		if os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN") != "" ||
+			os.Getenv("BUILDKITE_AGENT_SOCKET") != "" {
+			sendGitCommitMetadata = true
+		}
+
 		// Configure the bootstraper
 		bootstrap := &bootstrap.Bootstrap{
 			Phases: cfg.Phases,
@@ -315,6 +323,7 @@ var BootstrapCommand = cli.Command{
 				LocalHooksEnabled:            cfg.LocalHooksEnabled,
 				SSHKeyscan:                   cfg.SSHKeyscan,
 				Shell:                        cfg.Shell,
+				SendGitCommitMetadata: sendGitCommitMetadata,
 			},
 		}
 

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/cliconfig"
 	"github.com/buildkite/agent/logger"
@@ -28,8 +27,9 @@ Example:
 type MetaDataExistsConfig struct {
 	Key              string `cli:"arg:0" label:"meta-data key" validate:"required"`
 	Job              string `cli:"job" validate:"required"`
-	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
-	Endpoint         string `cli:"endpoint" validate:"required"`
+	AgentAccessToken string `cli:"agent-access-token"`
+	AgentSocket      string `cli:"agent-socket"`
+	Endpoint         string `cli:"endpoint"`
 	NoColor          bool   `cli:"no-color"`
 	Debug            bool   `cli:"debug"`
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -47,6 +47,7 @@ var MetaDataExistsCommand = cli.Command{
 			EnvVar: "BUILDKITE_JOB_ID",
 		},
 		AgentAccessTokenFlag,
+		AgentSocketFlag,
 		EndpointFlag,
 		NoColorFlag,
 		DebugFlag,
@@ -65,10 +66,7 @@ var MetaDataExistsCommand = cli.Command{
 		HandleGlobalFlags(cfg)
 
 		// Create the API client
-		client := agent.APIClient{
-			Endpoint: cfg.Endpoint,
-			Token:    cfg.AgentAccessToken,
-		}.Create()
+		client := CreateAPIClientFromConfig(cfg)
 
 		// Find the meta data value
 		var err error

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/cliconfig"
 	"github.com/buildkite/agent/logger"
@@ -28,8 +27,9 @@ type MetaDataGetConfig struct {
 	Key              string `cli:"arg:0" label:"meta-data key" validate:"required"`
 	Default          string `cli:"default"`
 	Job              string `cli:"job" validate:"required"`
-	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
-	Endpoint         string `cli:"endpoint" validate:"required"`
+	AgentAccessToken string `cli:"agent-access-token"`
+	AgentSocket      string `cli:"agent-socket"`
+	Endpoint         string `cli:"endpoint"`
 	NoColor          bool   `cli:"no-color"`
 	Debug            bool   `cli:"debug"`
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -53,6 +53,7 @@ var MetaDataGetCommand = cli.Command{
 		},
 		AgentAccessTokenFlag,
 		EndpointFlag,
+		AgentSocketFlag,
 		NoColorFlag,
 		DebugFlag,
 		DebugHTTPFlag,
@@ -70,10 +71,7 @@ var MetaDataGetCommand = cli.Command{
 		HandleGlobalFlags(cfg)
 
 		// Create the API client
-		client := agent.APIClient{
-			Endpoint: cfg.Endpoint,
-			Token:    cfg.AgentAccessToken,
-		}.Create()
+		client := CreateAPIClientFromConfig(cfg)
 
 		// Find the meta data value
 		var metaData *api.MetaData

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/cliconfig"
 	"github.com/buildkite/agent/logger"
@@ -34,8 +33,9 @@ type MetaDataSetConfig struct {
 	Key              string `cli:"arg:0" label:"meta-data key" validate:"required"`
 	Value            string `cli:"arg:1" label:"meta-data value"`
 	Job              string `cli:"job" validate:"required"`
-	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
-	Endpoint         string `cli:"endpoint" validate:"required"`
+	AgentAccessToken string `cli:"agent-access-token"`
+	AgentSocket      string `cli:"agent-socket"`
+	Endpoint         string `cli:"endpoint"`
 	NoColor          bool   `cli:"no-color"`
 	Debug            bool   `cli:"debug"`
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -53,6 +53,7 @@ var MetaDataSetCommand = cli.Command{
 			EnvVar: "BUILDKITE_JOB_ID",
 		},
 		AgentAccessTokenFlag,
+		AgentSocketFlag,
 		EndpointFlag,
 		NoColorFlag,
 		DebugFlag,
@@ -82,10 +83,7 @@ var MetaDataSetCommand = cli.Command{
 		}
 
 		// Create the API client
-		client := agent.APIClient{
-			Endpoint: cfg.Endpoint,
-			Token:    cfg.AgentAccessToken,
-		}.Create()
+		client := CreateAPIClientFromConfig(cfg)
 
 		// Create the meta data to set
 		metaData := &api.MetaData{

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -49,7 +49,8 @@ type PipelineUploadConfig struct {
 	Replace          bool   `cli:"replace"`
 	Job              string `cli:"job"`
 	AgentAccessToken string `cli:"agent-access-token"`
-	Endpoint         string `cli:"endpoint" validate:"required"`
+	AgentSocket      string `cli:"agent-socket"`
+	Endpoint         string `cli:"endpoint"`
 	DryRun           bool   `cli:"dry-run"`
 	NoColor          bool   `cli:"no-color"`
 	NoInterpolation  bool   `cli:"no-interpolation"`
@@ -84,6 +85,7 @@ var PipelineUploadCommand = cli.Command{
 			EnvVar: "BUILDKITE_PIPELINE_NO_INTERPOLATION",
 		},
 		AgentAccessTokenFlag,
+		AgentSocketFlag,
 		EndpointFlag,
 		NoColorFlag,
 		DebugFlag,
@@ -200,16 +202,8 @@ var PipelineUploadCommand = cli.Command{
 			logger.Fatal("Missing job parameter. Usually this is set in the environment for a Buildkite job via BUILDKITE_JOB_ID.")
 		}
 
-		// Check we have an agent access token if not in dry run
-		if cfg.AgentAccessToken == "" {
-			logger.Fatal("Missing agent-access-token parameter. Usually this is set in the environment for a Buildkite job via BUILDKITE_AGENT_ACCESS_TOKEN.")
-		}
-
 		// Create the API client
-		client := agent.APIClient{
-			Endpoint: cfg.Endpoint,
-			Token:    cfg.AgentAccessToken,
-		}.Create()
+		client := CreateAPIClientFromConfig(cfg)
 
 		// Generate a UUID that will identifiy this pipeline change. We
 		// do this outside of the retry loop because we want this UUID


### PR DESCRIPTION
Previously with the `agent-socket` experiment introduced an API proxy that was exposed to the bootstrap via setting a socket into `BUILDKITE_AGENT_ENDPOINT` and a randomly generated secret for `BUILDKITE_AGENT_ACCESS_TOKEN` that was used to authenticate to the proxy. 

I re-used the existing `BUILDKITE_AGENT_ENDPOINT` be cause it made it easy to implement, but after trying to integrate it into existing things like docker and docker-compose setups, it became apparent that it was confusing and difficult as you need to mount in the socket as a file to the docker container, but `BUILDKITE_AGENT_ENDPOINT` contained a `unix://` style path. 

This new implementation introduces a new env `BUILDKITE_AGENT_SOCKET`, which is exactly like `ssh-agent`'s `SSH_AUTH_SOCK`. It's a path to the socket. This means that all the existing commands need to be taught to either look for that env or use the old `BUILDKITE_AGENT_ENDPOINT` gear. 

I think the end result is more code, but should be easier to reason about. It does ditch the password authentication for the local socket, but given it's an ephemeral socket for the life of the job, I think it's fine and a good tradeoff for less things to break. 

### Todo

* [ ] Handle windows (no unix sockets)
* [ ] Update experiment docs

Follow on to https://github.com/buildkite/agent/pull/759