### PR TITLE
Updating launchd templates to only restart on error

### DIFF
--- a/templates/launchd.plist
+++ b/templates/launchd.plist
@@ -20,7 +20,10 @@
     </array>
 
     <key>KeepAlive</key>
-    <true/>
+    <dict>
+      <key>SuccessfulExit</key>
+      <false/>
+    </dict>
 
     <key>RunAtLoad</key>
     <true/>

--- a/templates/launchd_local_with_gui.plist
+++ b/templates/launchd_local_with_gui.plist
@@ -18,7 +18,10 @@
     </array>
 
     <key>KeepAlive</key>
-    <true/>
+    <dict>
+      <key>SuccessfulExit</key>
+      <false/>
+    </dict>
 
     <key>RunAtLoad</key>
     <true/>


### PR DESCRIPTION
We references these templates at https://buildkite.com/docs/agent/v3/osx#starting-on-login, so we gotta keep em.

Also see https://github.com/buildkite/homebrew-buildkite/pull/12

Closes #802.