### PR TITLE
Respect pre-set BUILDKITE_BUILD_CHECKOUT_PATH

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -368,6 +368,9 @@ func (b *Bootstrap) setUp() error {
 	// Set a BUILDKITE_BUILD_CHECKOUT_PATH unless one exists already. We do this here
 	// so that the environment will have a checkout path to work with
 	if _, exists := b.shell.Env.Get("BUILDKITE_BUILD_CHECKOUT_PATH"); !exists {
+		if b.BuildPath == "" {
+			return fmt.Errorf("Must set either a BUILDKITE_BUILD_PATH or a BUILDKITE_BUILD_CHECKOUT_PATH")
+		}
 		b.shell.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH",
 			filepath.Join(b.BuildPath, dirForAgentName(b.AgentName), b.OrganizationSlug, b.PipelineSlug))
 	}
@@ -708,9 +711,6 @@ func (b *Bootstrap) CheckoutPhase() error {
 			return err
 		}
 	}
-
-	// After this point, artifacts will be uploaded on failure
-	b.hasCheckout = true
 
 	// Store the current value of BUILDKITE_BUILD_CHECKOUT_PATH, so we can detect if
 	// one of the post-checkout hooks changed it.

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -58,7 +58,7 @@ type BootstrapConfig struct {
 	GitCloneFlags                string   `cli:"git-clone-flags"`
 	GitCleanFlags                string   `cli:"git-clean-flags"`
 	BinPath                      string   `cli:"bin-path" normalize:"filepath"`
-	BuildPath                    string   `cli:"build-path" normalize:"filepath" validate:"required"`
+	BuildPath                    string   `cli:"build-path" normalize:"filepath"`
 	HooksPath                    string   `cli:"hooks-path" normalize:"filepath"`
 	PluginsPath                  string   `cli:"plugins-path" normalize:"filepath"`
 	CommandEval                  bool     `cli:"command-eval"`


### PR DESCRIPTION
When running a bootstrap manually with just the checkout phase you need to be able to pass in the `BUILDKITE_BUILD_CHECKOUT_PATH` of where you have checked code out. This allows that, and also ensures that directory has been changed to at the start of the command phase. 

It also only uploads artifacts after the command phase, it doesn't make much sense to upload artifacts in bootstrap invocations where there is only a checkout phase.