### PR TITLE
Implements a basic 'step signer' that signs pipeline steps on upload

### DIFF
--- a/agent/step_signer.go
+++ b/agent/step_signer.go
@@ -1,0 +1,110 @@
+package agent
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type StepSigner struct {
+	SigningKey string
+}
+
+func (s StepSigner) SignPipeline(pipeline interface{}) (interface{}, error) {
+	original := reflect.ValueOf(pipeline)
+
+	// only process pipelines that are either a single complex step (not "wait") or a collection of steps
+	if original.Kind() != reflect.Map {
+		return pipeline, nil
+	}
+
+	copy := reflect.MakeMap(original.Type())
+
+	// Copy values to new map
+	// TODO handle pipelines of single commands (e.g. `command: foo`)
+	for _, mk := range original.MapKeys() {
+		keyName := mk.String()
+		item := original.MapIndex(mk)
+
+		// references many steps
+		if strings.EqualFold(keyName, "steps") {
+			unwrapped := item.Elem()
+			if unwrapped.Kind() == reflect.Slice {
+				var newSteps []interface{}
+				for i := 0; i < unwrapped.Len(); i += 1 {
+					stepItem := unwrapped.Index(i)
+					if stepItem.Elem().Kind() != reflect.String {
+						newSteps = append(newSteps, s.signStep(stepItem))
+					} else {
+						newSteps = append(newSteps, stepItem.Interface())
+					}
+				}
+				item = reflect.ValueOf(newSteps)
+			}
+		}
+		copy.SetMapIndex(mk, item)
+	}
+
+	return copy.Interface(), nil
+}
+
+func (s StepSigner) signStep(step reflect.Value) (interface{}) {
+	original := step.Elem()
+
+	// Check to make sure the interface isn't nil
+	if !original.IsValid() {
+		return nil
+	}
+
+	// Create a new object
+	copy := make(map[string]interface{})
+	for _, key := range original.MapKeys() {
+		copy[key.String()] = original.MapIndex(key).Interface()
+	}
+
+	rawCommand, hasCommand := copy["command"]
+	if !hasCommand {
+		// treat commands as an alias of command
+		var hasCommands bool
+		rawCommand, hasCommands = copy["commands"]
+		if !hasCommands {
+			// no commands to sign
+			return copy
+		}
+	}
+
+	commandSignature := s.signCommand(rawCommand)
+
+	env := make(map[string]interface{})
+	existingEnv, hasEnv := copy["env"]
+	if hasEnv {
+		reflectedEnv := reflect.ValueOf(existingEnv)
+		for _, key := range reflectedEnv.MapKeys() {
+			env[key.String()] = reflectedEnv.MapIndex(key).Interface()
+		}
+	}
+
+	env["BUILDKITE_STEP_SIGNATURE"] = commandSignature
+	copy["env"] = env
+
+	return copy
+}
+
+func (s StepSigner) signCommand(command interface{}) string {
+	value := reflect.ValueOf(command)
+
+	// expand into simple list of commands
+	var commandStrings []string
+	if value.Kind() == reflect.Slice {
+		for i := 0; i < value.Len(); i += 1 {
+			commandStrings = append(commandStrings, value.Index(i).Elem().String())
+		}
+	} else if value.Kind() == reflect.String {
+		commandStrings = append(commandStrings, value.String())
+	} else {
+		// BOOM
+	}
+
+	// TODO: HMAC this
+	return fmt.Sprintf("%s%s", s.SigningKey, strings.Join(commandStrings, ""))
+}

--- a/agent/step_signer_test.go
+++ b/agent/step_signer_test.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/buildkite/agent/env"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStepSignerSignPipelineIgnoresStepWithoutCommand(t *testing.T) {
+	environ := env.FromSlice([]string{`ENV_VAR_FRIEND="friend"`})
+
+	parsed, err := PipelineParser{
+		Filename: "awesome.yml",
+		Pipeline: []byte("steps:\n  - label: \"hello ${ENV_VAR_FRIEND}\""),
+		Env:	  environ}.Parse()
+
+	assert.NoError(t, err)
+
+	signed, err := StepSigner{
+		SigningKey: "secret-llama",
+	}.SignPipeline(parsed)
+
+	assert.NoError(t, err)
+
+	j, err := json.Marshal(signed)
+	assert.Equal(t, `{"steps":[{"label":"hello \"friend\""}]}`, string(j))
+}
+
+func TestStepSignerSignPipelineSignsStepWithCommand(t *testing.T) {
+	environ := env.FromSlice([]string{`YOUR_NAME="Fred"`})
+
+	parsed, err := PipelineParser{
+		Filename: "awesome.yml",
+		Pipeline: []byte("steps:\n  - command: \"echo Hello ${YOUR_NAME}\""),
+		Env:	  environ}.Parse()
+
+	assert.NoError(t, err)
+
+	signed, err := StepSigner{
+		SigningKey: "secret-llama",
+	}.SignPipeline(parsed)
+
+	assert.NoError(t, err)
+
+	j, err := json.Marshal(signed)
+	assert.Equal(t, `{"steps":[{"command":"echo Hello \"Fred\"","env":{"BUILDKITE_STEP_SIGNATURE":"secret-llamaecho Hello \"Fred\""}}]}`, string(j))
+}
+
+func TestStepSignerSignPipelineSignsStepWithCommandAndEnv(t *testing.T) {
+	environ := env.FromSlice([]string{`YOUR_NAME="Fred"`})
+
+	parsed, err := PipelineParser{
+		Filename: "awesome.yml",
+		Pipeline: []byte("steps:\n  - env:\n      EXISTING: \"existing-value\"\n    command: \"echo Hello ${YOUR_NAME}\""),
+		Env:	  environ}.Parse()
+
+	assert.NoError(t, err)
+
+	signed, err := StepSigner{
+		SigningKey: "secret-llama",
+	}.SignPipeline(parsed)
+
+	assert.NoError(t, err)
+
+	j, err := json.Marshal(signed)
+	assert.Equal(t, `{"steps":[{"command":"echo Hello \"Fred\"","env":{"BUILDKITE_STEP_SIGNATURE":"secret-llamaecho Hello \"Fred\"","EXISTING":"existing-value"}}]}`, string(j))
+}


### PR DESCRIPTION
As discussed on the community Slack channel. We're looking to ensure the commands that our agents execute came from our agents. We've explored other options, namely:

 1. `No command eval` -> But we'd like to use plugins, and the conveinence of inline commands
 2. `No command eval` with plugins forced on -> the docker command overrides the default `command` hook (https://github.com/buildkite/agent/blob/6f3b7ceb80a6df0650052224eef70b61e599acb9/bootstrap/bootstrap.go#L993) thus they don't work well together
 3. Using the Buildkite API to "check" the pipeline of the currently running job. This doesn't help much, as the uploaded pipeline is post-interpolation and asks the Buildkite master for information to verify what it sent (e.g. full-trust)
 4. Writing a separate tool to "inject" signatures into the pipeline. This approach is fine except for interpolation, which happens on pipeline upload. So this really needs to be part of the agent (as this PR adds)

This PR is a rough attempt at generating a signature for each step, the idea being you'd check the `BUILDKITE_STEP_SIGNATURE` in your environment hook against your own signature of `BUILDKITE_COMMAND` to verify the command's origin.

There's still a few things to do (empty env, pipelines that are a single step, HMAC, etc). But would love some early discussion.

TODO:
 - [ ] Handle empty `env`
 - [ ] Handle pipelines of single command `- command: echo "This is the whole pipeline"`
 - [ ] Documentation around `BUILDKITE_STEP_SIGNATURE` and how to verify it
 - [ ] Implement HMAC
 - [ ] Discuss whether signing the `command`/`commands` is enough. E.g. with the docker plugin, you can run/pull down a container without running any commands

Example input `pipeline.yml`:
```
env:
    ENV: dev
    STAGE: dev

steps:
  - label: ':docker: build'
    plugins:
      docker-compose#v2.4.1:
        build:
          - my-container

  - wait

  - label: ':hammer: info'
    commands:
        - 'scripts/size.sh'
        - 'scripts/version.sh'
    env:
        EXISTING_ENV: 'wow'
    plugins:
      docker-compose#v2.4.1:
        run: my-container

  - label: ':hammer: test'
    command: 'scripts/test.sh'
    plugins:
      docker-compose#v2.4.1:
        run: my-container

  - label: ':docker: publish container'
    plugins:
      docker-compose#v2.4.1:
        push:
          - my-container
```

`buildkite-agent pipeline upload --dry-run --step-signing-key xx` gives:
```
{
  "env": {
    "ENV": "dev",
    "STAGE": "dev"
  },
  "steps": [
    {
      "label": ":docker: build",
      "plugins": {
        "docker-compose#v2.4.1": {
          "build": [
            "my-container"
          ]
        }
      }
    },
    "wait",
    {
      "commands": [
        "scripts/size.sh",
        "scripts/version.sh"
      ],
      "env": {
        "BUILDKITE_STEP_SIGNATURE": "xxscripts/size.shscripts/version.sh",
        "EXISTING_ENV": "wow"
      },
      "label": ":hammer: info",
      "plugins": {
        "docker-compose#v2.4.1": {
          "run": "my-container"
        }
      }
    },
    {
      "command": "scripts/test.sh",
      "env": {
        "BUILDKITE_STEP_SIGNATURE": "xxscripts/test.sh"
      },
      "label": ":hammer: test",
      "plugins": {
        "docker-compose#v2.4.1": {
          "run": "my-container"
        }
      }
    },
    {
      "label": ":docker: publish container",
      "plugins": {
        "docker-compose#v2.4.1": {
          "push": [
            "my-container"
          ]
        }
      }
    }
  ]
}
```