### PR TITLE
Expose metrics via expvar interface

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"errors"
+	"expvar"
 	"fmt"
 	"os"
 	"runtime"
@@ -61,6 +62,11 @@ func (r *AgentPool) Start() error {
 	logger.Debug("Ping interval: %ds", registered.PingInterval)
 	logger.Debug("Job status interval: %ds", registered.JobStatusInterval)
 	logger.Debug("Heartbeat interval: %ds", registered.HearbeatInterval)
+
+	var start = time.Now()
+	expvar.Publish("uptime", expvar.Func(func() interface{} {
+		return int64(time.Since(start) / time.Second)
+	}))
 
 	// Now that we have a registered agent, we can connect it to the API,
 	// and start running jobs.

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"expvar"
 	"fmt"
 	"strings"
 	"sync"
@@ -46,6 +47,9 @@ type AgentWorker struct {
 
 	// Tracks the last successful heartbeat and ping
 	lastPing, lastHeartbeat int64
+
+	// Metrics that the worker exposes
+	heartbeatMetrics, pingMetrics *expvar.Map
 }
 
 // Creates the agent worker and initializes it's API Client
@@ -58,6 +62,10 @@ func (a AgentWorker) Create() AgentWorker {
 	}
 
 	a.APIClient = APIClient{Endpoint: endpoint, Token: a.Agent.AccessToken}.Create()
+
+	// create counters for metrics
+	a.heartbeatMetrics = expvar.NewMap("heartbeats")
+	a.pingMetrics = expvar.NewMap("pings")
 
 	return a
 }
@@ -79,6 +87,9 @@ func (a *AgentWorker) Start() error {
 			if err != nil {
 				// Get the last heartbeat time to the nearest microsecond
 				lastHeartbeat := time.Unix(atomic.LoadInt64(&a.lastPing), 0)
+
+				// Track metrics
+				a.heartbeatMetrics.Add("Fail", 1)
 
 				logger.Error("Failed to heartbeat %s. Will try again in %s. (Last successful was %v ago)",
 					err, heartbeatInterval, time.Now().Sub(lastHeartbeat))
@@ -227,6 +238,10 @@ func (a *AgentWorker) Heartbeat() error {
 	// Track a timestamp for the successful heartbeat for better errors
 	atomic.StoreInt64(&a.lastHeartbeat, time.Now().Unix())
 
+	// Track metrics
+	a.heartbeatMetrics.Add("Total", 1)
+	a.heartbeatMetrics.Add("Success", 1)
+
 	logger.Debug("Heartbeat sent at %s and received at %s", beat.SentAt, beat.ReceivedAt)
 	return nil
 }
@@ -255,10 +270,17 @@ func (a *AgentWorker) Ping() {
 			logger.Debug("[DisconnectionTimer] Reset back to %d seconds because of ping failure...", a.AgentConfiguration.DisconnectAfterJobTimeout)
 		}
 
+		// Track metrics
+		a.pingMetrics.Add("Fail", 1)
+
 		return
 	} else {
 		// Track a timestamp for the successful ping for better errors
 		atomic.StoreInt64(&a.lastPing, time.Now().Unix())
+
+		// Track metrics
+		a.pingMetrics.Add("Total", 1)
+		a.pingMetrics.Add("Success", 1)
 	}
 
 	// Should we switch endpoints?


### PR DESCRIPTION
After talking a bit with @toolmantim about what metrics we could expose, I did some investigating. Turns out golang has a nice and minimal interface for exposing metrics. I prototyped it out and it works pretty well. 

To activate, you set `--metrics` on `buildkite-agent start` or set `metrics=true` in the config, which starts up a webserver as part of the buildkite-agent that you can view on the standard url `https://localhost:8080/debug/vars`.

See http://www.mikeperham.com/2014/12/17/expvar-metrics-for-golang/ for more details and details of how the datadog agent consumes these metrics at https://www.datadoghq.com/blog/instrument-go-apps-expvar-datadog/

The metrics I'm tracking initially are:

* [x] `uptime`
* [x] `heartbeats.Total`
* [x] `heartbeats.Success`
* [x] `heartbeats.Fail`
* [x] `pings.Total`
* [x] `pings.Success`
* [x] `pings.Fail`
* [ ] `jobs.Total`
* [ ] `jobs.Success`
* [ ] `jobs.Fail`

Open to suggestions!