### PR TITLE
Allow more time for systemd graceful stop

### DIFF
--- a/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent.service
+++ b/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent.service
@@ -11,7 +11,9 @@ Environment=HOME=/var/lib/buildkite-agent
 ExecStart=/usr/bin/buildkite-agent start
 RestartSec=5
 Restart=on-failure
-TimeoutSec=10
+TimeoutStartSec=10
+TimeoutStopSec=5min
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent@.service
+++ b/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent@.service
@@ -11,7 +11,9 @@ Environment=HOME=/var/lib/buildkite-agent
 ExecStart=/usr/bin/buildkite-agent start
 RestartSec=5
 Restart=on-failure
-TimeoutSec=10
+TimeoutStartSec=10
+TimeoutStopSec=5min
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Prompted by https://github.com/buildkite/agent/issues/476#issuecomment-417940614, this makes two changes:

* Increase `TimeoutStopSec` to 5mins from 10secs. This is the time between the initial `SIGTERM` and the final fatal `SIGKILL`. This gives the agent time to finish it's job.
* Set `KillMode` to `mixed`, vs the default of `control-group`. This means that the initial `SIGTERM` is sent to `buildkite-agent` directly, but the final `SIGKILL` to the control group. The agent [already sends shutdown signals to it's control group](https://github.com/buildkite/agent/blob/master/bootstrap/shell/signal.go#L19), so it can handle it. 