### PR TITLE
Ensure pipeline parser maintains map order in output

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -133,7 +133,7 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 
 	// get a unique identifier for the underlying host
 	if machineID, err := machineid.ProtectedID("buildkite-agent"); err != nil {
-		logger.Warn("Failed to find unique machine-id", err)
+		logger.Warn("Failed to find unique machine-id: %v", err)
 	} else {
 		agent.MachineID = machineID
 	}

--- a/agent/pipeline_parser_test.go
+++ b/agent/pipeline_parser_test.go
@@ -126,14 +126,14 @@ func TestPipelineParserPreservesFloats(t *testing.T) {
 	result, err := PipelineParser{Pipeline: []byte("steps:\n  - trigger: hello\n    llamas: 3.142")}.Parse()
 	assert.Nil(t, err)
 	j, err := json.Marshal(result)
-	assert.Equal(t, `{"steps":[{"llamas":3.142,"trigger":"hello"}]}`, string(j))
+	assert.Equal(t, `{"steps":[{"trigger":"hello","llamas":3.142}]}`, string(j))
 }
 
 func TestPipelineParserHandlesDates(t *testing.T) {
 	result, err := PipelineParser{Pipeline: []byte("steps:\n  - trigger: hello\n    llamas: 2002-08-15T17:18:23.18-06:00")}.Parse()
 	assert.Nil(t, err)
 	j, err := json.Marshal(result)
-	assert.Equal(t, `{"steps":[{"llamas":"2002-08-15T17:18:23.18-06:00","trigger":"hello"}]}`, string(j))
+	assert.Equal(t, `{"steps":[{"trigger":"hello","llamas":"2002-08-15T17:18:23.18-06:00"}]}`, string(j))
 }
 
 func TestPipelineParserInterpolatesKeysAsWellAsValues(t *testing.T) {

--- a/agent/pipeline_parser_test.go
+++ b/agent/pipeline_parser_test.go
@@ -1,9 +1,11 @@
 package agent
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/buildkite/agent/env"
@@ -55,7 +57,7 @@ steps:
 
 	assert.NoError(t, err)
 	j, err := json.Marshal(result)
-	assert.Equal(t, `{"base_step":{"agent_query_rules":["queue=default"],"type":"script"},"steps":[{"agent_query_rules":["queue=default"],"agents":{"queue":"default"},"command":"docker build .","name":":docker: building image","type":"script"}]}`, string(j))
+	assert.Equal(t, `{"base_step":{"type":"script","agent_query_rules":["queue=default"]},"steps":[{"type":"script","agent_query_rules":["queue=default"],"name":":docker: building image","command":"docker build .","agents":{"queue":"default"}}]}`, string(j))
 }
 
 func TestPipelineParserReturnsYamlParsingErrors(t *testing.T) {
@@ -96,14 +98,14 @@ func TestPipelineParserParsesJsonArrays(t *testing.T) {
 	result, err := PipelineParser{Pipeline: []byte("\n\n     \n  [ { \"foo\": \"bye ${ENV_VAR_FRIEND}\" } ]\n"), Env: environ}.Parse()
 	assert.NoError(t, err)
 	j, err := json.Marshal(result)
-	assert.Equal(t, `[{"foo":"bye \"friend\""}]`, string(j))
+	assert.Equal(t, `{"steps":[{"foo":"bye \"friend\""}]}`, string(j))
 }
 
 func TestPipelineParserPreservesBools(t *testing.T) {
 	result, err := PipelineParser{Pipeline: []byte("steps:\n  - trigger: hello\n    async: true")}.Parse()
 	assert.Nil(t, err)
 	j, err := json.Marshal(result)
-	assert.Equal(t, `{"steps":[{"async":true,"trigger":"hello"}]}`, string(j))
+	assert.Equal(t, `{"steps":[{"trigger":"hello","async":true}]}`, string(j))
 }
 
 func TestPipelineParserPreservesInts(t *testing.T) {
@@ -240,4 +242,41 @@ func TestPipelineParserLoadsSystemEnvironment(t *testing.T) {
 	if decoded.Steps[0].Command != "echo absolutely" {
 		t.Fatalf("Unexpected: %q", decoded.Steps[0].Command)
 	}
+}
+
+func TestPipelineParserPreservesOrderOfPlugins(t *testing.T) {
+	var pipeline = `---
+steps:
+  - name: ":s3: xxx"
+    command: "script/buildkite/xxx.sh"
+    plugins:
+      xxx/aws-assume-role#v0.1.0:
+        role: arn:aws:iam::xxx:role/xxx
+      ecr#v1.1.4:
+        login: true
+        account_ids: xxx
+        registry_region: us-east-1
+      docker-compose#v2.5.1:
+        run: xxx
+        config: .buildkite/docker/docker-compose.yml
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+    agents:
+      queue: xxx`
+
+	result, err := PipelineParser{Pipeline: []byte(pipeline), Env: nil}.Parse()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := &bytes.Buffer{}
+	err = json.NewEncoder(buf).Encode(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `{"steps":[{"name":":s3: xxx","command":"script/buildkite/xxx.sh","plugins":{"xxx/aws-assume-role#v0.1.0":{"role":"arn:aws:iam::xxx:role/xxx"},"ecr#v1.1.4":{"login":true,"account_ids":"xxx","registry_region":"us-east-1"},"docker-compose#v2.5.1":{"run":"xxx","config":".buildkite/docker/docker-compose.yml","env":["AWS_ACCESS_KEY_ID","AWS_SECRET_ACCESS_KEY","AWS_SESSION_TOKEN"]}},"agents":{"queue":"xxx"}}]}`
+	assert.Equal(t, expected, strings.TrimSpace(buf.String()))
 }

--- a/agent/plugin/definition.go
+++ b/agent/plugin/definition.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/buildkite/agent/yamltojson"
+	"github.com/buildkite/yaml"
 	"github.com/qri-io/jsonschema"
 )
 
@@ -25,25 +26,15 @@ type Definition struct {
 
 // ParseDefinition parses either yaml or json bytes into a Definition
 func ParseDefinition(b []byte) (*Definition, error) {
-	var parsed interface{}
+	var parsed yaml.MapSlice
 
-	// Parse the definition as a json compatible string map, the plain yaml
-	// Unmarshal returns a structure that has map[interface{}]interface{}
-	// which causes anything that expects map[string]interface{} to break
-	if err := yamltojson.UnmarshalAsStringMap(b, &parsed); err != nil {
+	if err := yaml.Unmarshal(b, &parsed); err != nil {
 		return nil, err
-	}
-
-	// Check we've got a map, vs a list or something else, this lets us
-	// give a useful error message
-	parsedMap, ok := parsed.(map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("Failed to convert %T to map[string]interface{}", parsed)
 	}
 
 	// Marshal the whole lot back into json which will let the jsonschema library
 	// parse the schema into and object tree 💃🏼
-	jsonBytes, err := json.Marshal(parsedMap)
+	jsonBytes, err := yamltojson.MarshalMapSliceJSON(parsed)
 	if err != nil {
 		return nil, err
 	}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -169,10 +169,8 @@ var PipelineUploadCommand = cli.Command{
 			logger.Fatal("Config file is empty")
 		}
 
-		var parsed interface{}
-
 		// Parse the pipeline
-		parsed, err = agent.PipelineParser{
+		result, err := agent.PipelineParser{
 			Filename:        filename,
 			Pipeline:        input,
 			NoInterpolation: cfg.NoInterpolation,
@@ -188,7 +186,7 @@ var PipelineUploadCommand = cli.Command{
 
 			// Dump json indented to stdout. All logging happens to stderr
 			// this can be used with other tools to get interpolated json
-			if err := enc.Encode(parsed); err != nil {
+			if err := enc.Encode(result); err != nil {
 				logger.Fatal("%#v", err)
 			}
 
@@ -218,7 +216,7 @@ var PipelineUploadCommand = cli.Command{
 
 		// Retry the pipeline upload a few times before giving up
 		err = retry.Do(func(s *retry.Stats) error {
-			_, err = client.Pipelines.Upload(cfg.Job, &api.Pipeline{UUID: uuid, Pipeline: parsed, Replace: cfg.Replace})
+			_, err = client.Pipelines.Upload(cfg.Job, &api.Pipeline{UUID: uuid, Pipeline: result, Replace: cfg.Replace})
 			if err != nil {
 				logger.Warn("%s (%s)", err, s)
 

--- a/yamltojson/yaml.go
+++ b/yamltojson/yaml.go
@@ -1,51 +1,71 @@
 package yamltojson
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 
 	// This is a fork of gopkg.in/yaml.v2 that fixes anchors with MapSlice
 	"github.com/buildkite/yaml"
 )
 
-// Unmarshal YAML to map[string]interface{} instead of map[interface{}]interface{}, such that
-// we can Marshal cleanly into JSON
-// Via https://github.com/go-yaml/yaml/issues/139#issuecomment-220072190
-func UnmarshalAsStringMap(in []byte, out interface{}) error {
-	var res interface{}
+func MarshalMapSliceJSON(m yaml.MapSlice) ([]byte, error) {
+	buffer := bytes.NewBufferString("{")
+	length := len(m)
+	count := 0
 
-	if err := yaml.Unmarshal(in, &res); err != nil {
-		return err
+	for _, item := range m {
+		jsonValue, err := marshalInterfaceJSON(item.Value)
+		if err != nil {
+			return nil, err
+		}
+		buffer.WriteString(fmt.Sprintf("%q:%s", item.Key, string(jsonValue)))
+		count++
+		if count < length {
+			buffer.WriteString(",")
+		}
 	}
-	*out.(*interface{}) = cleanupMapValue(res)
 
-	return nil
+	buffer.WriteString("}")
+	return buffer.Bytes(), nil
 }
 
-func cleanupInterfaceArray(in []interface{}) []interface{} {
-	res := make([]interface{}, len(in))
-	for i, v := range in {
-		res[i] = cleanupMapValue(v)
+func marshalSliceJSON(m []interface{}) ([]byte, error) {
+	buffer := bytes.NewBufferString("[")
+	length := len(m)
+	count := 0
+
+	for _, item := range m {
+		jsonValue, err := marshalInterfaceJSON(item)
+		if err != nil {
+			return nil, err
+		}
+		buffer.WriteString(fmt.Sprintf("%s", string(jsonValue)))
+		count++
+		if count < length {
+			buffer.WriteString(",")
+		}
 	}
-	return res
+
+	buffer.WriteString("]")
+	return buffer.Bytes(), nil
 }
 
-func cleanupInterfaceMap(in map[interface{}]interface{}) map[string]interface{} {
-	res := make(map[string]interface{})
-	for k, v := range in {
-		res[fmt.Sprintf("%v", k)] = cleanupMapValue(v)
-	}
-	return res
-}
-
-func cleanupMapValue(v interface{}) interface{} {
-	switch v := v.(type) {
+func marshalInterfaceJSON(i interface{}) ([]byte, error) {
+	switch t := i.(type) {
+	case yaml.MapItem:
+		return marshalInterfaceJSON(t.Value)
+	case yaml.MapSlice:
+		return MarshalMapSliceJSON(t)
+	case []yaml.MapItem:
+		var s []interface{}
+		for _, mi := range t {
+			s = append(s, mi.Value)
+		}
+		return marshalSliceJSON(s)
 	case []interface{}:
-		return cleanupInterfaceArray(v)
-	case map[interface{}]interface{}:
-		return cleanupInterfaceMap(v)
-	case nil, bool, string, int, float64:
-		return v
+		return marshalSliceJSON(t)
 	default:
-		panic("Unhandled map type " + fmt.Sprintf("%T", v))
+		return json.Marshal(i)
 	}
 }


### PR DESCRIPTION
As reported in #728, the order of plugins in a pipeline don't respect source order in some cases. What was happening here was that the order was getting lost when converting to JSON. 

This PR implements a custom JSON serializer that reads the ordered YAML parse tree. It ends up being radically simpler and the code reads a bit better I think. 

Closes #728. 