### PR TITLE
Ensure plugin directory exists, otherwise checkout lock thrashes

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -547,6 +547,12 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 		return nil, err
 	}
 
+	// Ensure the plugin directory exists, otherwise we can't create the lock
+	err = os.MkdirAll(b.PluginsPath, 0777)
+	if err != nil {
+		return nil, err
+	}
+
 	// Try and lock this particular plugin while we check it out (we create
 	// the file outside of the plugin directory so git clone doesn't have
 	// a cry about the directory not being empty)


### PR DESCRIPTION
It appears that with #827 we've introduced a bug where if the plugin directory doesn't exist the agent will never be able to acquire the checkout lock. The result is races with output like:

```
# Could not acquire lock on "/usr/local/var/buildkite-agent/plugins/github-com-buildkite-plugins-docker-buildkite-plugin-v1-4-0.lock" (open /usr/local/var/buildkite-agent/plugins/953740525: no such file or directory)
--
  | # Trying again in 1s...
  | # Could not acquire lock on "/usr/local/var/buildkite-agent/plugins/github-com-buildkite-plugins-docker-buildkite-plugin-v1-4-0.lock" (open /usr/local/var/buildkite-agent/plugins/969463144: no such file or directory)
  | # Trying again in 1s...
  | # Could not acquire lock on "/usr/local/var/buildkite-agent/plugins/github-com-buildkite-plugins-docker-buildkite-plugin-v1-4-0.lock" (open /usr/local/var/buildkite-agent/plugins/800153511: no such file or directory)
```

This PR fixes the issue by ensuring that the `PluginsPath` exists prior to acquiring the lock. 
