### PR TITLE
Fix issue where top level steps failed to parse

### DIFF
--- a/agent/pipeline_parser.go
+++ b/agent/pipeline_parser.go
@@ -34,22 +34,24 @@ func (p PipelineParser) Parse() (*PipelineParserResult, error) {
 		errPrefix = fmt.Sprintf("Failed to parse %s", p.Filename)
 	}
 
-	var pipelineAsSlice []yaml.MapSlice
+	var pipelineAsSlice []topLevelStep
 	var pipeline yaml.MapSlice
 
 	// We support top-level arrays of steps, so try that first
 	if err := yaml.Unmarshal(p.Pipeline, &pipelineAsSlice); err == nil {
 		var steps []interface{}
+
+		// Unwrap our custom topLevelStep types for marshaling later
 		for _, step := range pipelineAsSlice {
-			steps = append(steps, step)
+			if step.MapSlice != nil {
+				steps = append(steps, step.MapSlice)
+			} else {
+				steps = append(steps, step.Body)
+			}
 		}
 
-		// Reformat as a map with steps
 		pipeline = yaml.MapSlice{
-			yaml.MapItem{
-				Key:   "steps",
-				Value: steps,
-			},
+			{Key: "steps", Value: steps},
 		}
 	} else if err := yaml.Unmarshal(p.Pipeline, &pipeline); err != nil {
 		return nil, fmt.Errorf("%s: %v", errPrefix, formatYAMLError(err))
@@ -251,4 +253,20 @@ type PipelineParserResult struct {
 
 func (p *PipelineParserResult) MarshalJSON() ([]byte, error) {
 	return yamltojson.MarshalMapSliceJSON(p.pipeline)
+}
+
+// topLevelStep is a custom type to support "step or string" which works around
+// an issue where ordered parsing of yaml doesn't work with a top-level slice
+type topLevelStep struct {
+	yaml.MapSlice
+	Body string
+}
+
+func (s *topLevelStep) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// Some steps are plain old strings like "wait". To avoid unmarshaling errors
+	// we check for plain old strings
+	if err := unmarshal(&s.Body); err == nil {
+		return nil
+	}
+	return unmarshal(&s.MapSlice)
 }

--- a/agent/pipeline_parser_test.go
+++ b/agent/pipeline_parser_test.go
@@ -102,10 +102,10 @@ func TestPipelineParserParsesJsonArrays(t *testing.T) {
 }
 
 func TestPipelineParserParsesTopLevelSteps(t *testing.T) {
-	result, err := PipelineParser{Pipeline: []byte("---\n- name: Build\n  command: echo hello world"), Env: nil}.Parse()
+	result, err := PipelineParser{Pipeline: []byte("---\n- name: Build\n  command: echo hello world\n- wait\n"), Env: nil}.Parse()
 	assert.NoError(t, err)
 	j, err := json.Marshal(result)
-	assert.Equal(t, `{"steps":[{"name":"Build","command":"echo hello world"}]}`, string(j))
+	assert.Equal(t, `{"steps":[{"name":"Build","command":"echo hello world"},"wait"]}`, string(j))
 }
 
 func TestPipelineParserPreservesBools(t *testing.T) {

--- a/agent/pipeline_parser_test.go
+++ b/agent/pipeline_parser_test.go
@@ -101,6 +101,13 @@ func TestPipelineParserParsesJsonArrays(t *testing.T) {
 	assert.Equal(t, `{"steps":[{"foo":"bye \"friend\""}]}`, string(j))
 }
 
+func TestPipelineParserParsesTopLevelSteps(t *testing.T) {
+	result, err := PipelineParser{Pipeline: []byte("---\n- name: Build\n  command: echo hello world"), Env: nil}.Parse()
+	assert.NoError(t, err)
+	j, err := json.Marshal(result)
+	assert.Equal(t, `{"steps":[{"name":"Build","command":"echo hello world"}]}`, string(j))
+}
+
 func TestPipelineParserPreservesBools(t *testing.T) {
 	result, err := PipelineParser{Pipeline: []byte("steps:\n  - trigger: hello\n    async: true")}.Parse()
 	assert.Nil(t, err)


### PR DESCRIPTION
As part of #824 we accidentally introduced #829 due to a simplified heuristic around detecting pipeline.yml files with top-level arrays of steps.

This fixes that issues and adds some tests to prevent a recurrence. 

Closes #829.