### PR TITLE
fix: agent panics on arm

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -14,6 +14,12 @@ import (
 )
 
 type AgentWorker struct {
+	// Tracks the last successful heartbeat and ping
+	// NOTE: to avoid alignment issues on ARM architectures when
+	// using atomic.StoreInt64 we need to keep this at the beginning
+	// of the struct
+	lastPing, lastHeartbeat int64
+
 	// The API Client used when this agent is communicating with the API
 	APIClient *api.Client
 
@@ -43,9 +49,6 @@ type AgentWorker struct {
 	// When this worker runs a job, we'll store an instance of the
 	// JobRunner here
 	jobRunner *JobRunner
-
-	// Tracks the last successful heartbeat and ping
-	lastPing, lastHeartbeat int64
 }
 
 // Creates the agent worker and initializes it's API Client


### PR DESCRIPTION
When running the latest version on arm systems I get the following:

```
  _           _ _     _ _    _ _                                _
 | |         (_) |   | | |  (_) |                              | |
 | |__  _   _ _| | __| | | ___| |_ ___    __ _  __ _  ___ _ __ | |_
 | '_ \| | | | | |/ _` | |/ / | __/ _ \  / _` |/ _` |/ _ \ '_ \| __|
 | |_) | |_| | | | (_| |   <| | ||  __/ | (_| | (_| |  __/ | | | |_
 |_.__/ \__,_|_|_|\__,_|_|\_\_|\__\___|  \__,_|\__, |\___|_| |_|\__|
                                                __/ |
 http://buildkite.com/agent                    |___/

2018-10-09 08:29:05 NOTICE Starting buildkite-agent v3.5.2 with PID: 16
2018-10-09 08:29:05 NOTICE The agent source code can be found here: https://github.com/buildkite/agent
2018-10-09 08:29:05 NOTICE For questions and support, email us at: hello@buildkite.com
2018-10-09 08:29:05 WARN   Failed to find unique machine-id: machineid: machineid: open /etc/machine-id: no such file or directory
2018-10-09 08:29:05 INFO   Registering agent with Buildkite...
2018-10-09 08:29:07 INFO   Successfully registered agent "8217c7dc4b66" with tags [queue=armv7]
2018-10-09 08:29:07 INFO   Connecting to Buildkite...
2018-10-09 08:29:07 INFO   Agent successfully connected
2018-10-09 08:29:07 INFO   You can press Ctrl-C to stop the agent
2018-10-09 08:29:07 INFO   Waiting for work...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x4 pc=0x114fc]

goroutine 28 [running]:
sync/atomic.storeUint64(0x1144e03c, 0x5bbc66d3, 0x0)
	/usr/local/go/src/sync/atomic/64bit_arm.go:20 +0x3c
github.com/buildkite/agent/agent.(*AgentWorker).Heartbeat(0x1144e000, 0x0, 0x0)
	/go/src/github.com/buildkite/agent/agent/agent_worker.go:228 +0x108
github.com/buildkite/agent/agent.(*AgentWorker).Start.func1(0x1144e000, 0xf8475800, 0xd)
	/go/src/github.com/buildkite/agent/agent/agent_worker.go:78 +0x44
created by github.com/buildkite/agent/agent.(*AgentWorker).Start
	/go/src/github.com/buildkite/agent/agent/agent_worker.go:75 +0x68
```

We have seen this issue with other golang projects on arm in the past as well (see for example dgraph-io/badger#311). This is caused by alignment issues that panic when using atomic.StoreInt64.

I tested this fix on an ARM machine and it works fine now.