### PR TITLE
Metrics collection for Datadog

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"errors"
-	"expvar"
 	"fmt"
 	"os"
 	"runtime"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/logger"
+	"github.com/buildkite/agent/metrics"
 	"github.com/buildkite/agent/retry"
 	"github.com/buildkite/agent/signalwatcher"
 	"github.com/buildkite/agent/system"
@@ -33,6 +33,7 @@ type AgentPool struct {
 	Endpoint              string
 	DisableHTTP2          bool
 	AgentConfiguration    *AgentConfiguration
+	MetricsCollector      *metrics.Collector
 
 	interruptCount int
 	signalLock     sync.Mutex
@@ -68,11 +69,6 @@ func (r *AgentPool) Start() error {
 	logger.Debug("Job status interval: %ds", registered.JobStatusInterval)
 	logger.Debug("Heartbeat interval: %ds", registered.HearbeatInterval)
 
-	var start = time.Now()
-	expvar.Publish("uptime", expvar.Func(func() interface{} {
-		return int64(time.Since(start) / time.Second)
-	}))
-
 	// Now that we have a registered agent, we can connect it to the API,
 	// and start running jobs.
 	worker := AgentWorker{
@@ -80,6 +76,7 @@ func (r *AgentPool) Start() error {
 		AgentConfiguration: r.AgentConfiguration,
 		Endpoint:           r.Endpoint,
 		DisableHTTP2:       r.DisableHTTP2,
+		MetricsCollector:   r.MetricsCollector,
 	}.Create()
 
 	logger.Info("Connecting to Buildkite...")

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"errors"
+	"expvar"
 	"fmt"
 	"os"
 	"runtime"
@@ -66,6 +67,11 @@ func (r *AgentPool) Start() error {
 	logger.Debug("Ping interval: %ds", registered.PingInterval)
 	logger.Debug("Job status interval: %ds", registered.JobStatusInterval)
 	logger.Debug("Heartbeat interval: %ds", registered.HearbeatInterval)
+
+	var start = time.Now()
+	expvar.Publish("uptime", expvar.Func(func() interface{} {
+		return int64(time.Since(start) / time.Second)
+	}))
 
 	// Now that we have a registered agent, we can connect it to the API,
 	// and start running jobs.

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -70,20 +70,12 @@ func (a AgentWorker) Create() AgentWorker {
 		endpoint = a.Endpoint
 	}
 
-<<<<<<< HEAD
 	a.APIClient = APIClient{
 		Endpoint:     endpoint,
 		Token:        a.Agent.AccessToken,
 		DisableHTTP2: a.DisableHTTP2,
 	}.Create()
 
-	// create counters for metrics
-	a.heartbeatMetrics = expvar.NewMap("heartbeats")
-	a.pingMetrics = expvar.NewMap("pings")
-
-=======
-	a.APIClient = APIClient{Endpoint: endpoint, Token: a.Agent.AccessToken}.Create()
->>>>>>> Initial implementation of datadog metrics
 	return a
 }
 

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -90,7 +90,6 @@ func (a AgentWorker) Create() AgentWorker {
 // Starts the agent worker
 func (a *AgentWorker) Start() error {
 	a.metrics = a.MetricsCollector.Scope(metrics.Tags{
-		"hostname":   a.Agent.Hostname,
 		"agent_name": a.Agent.Name,
 	})
 

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -364,13 +364,10 @@ func (r *JobRunner) startJob(startedAt time.Time) error {
 		if err != nil {
 			if api.IsRetryableError(err) {
 				logger.Warn("%s (%s)", err, s)
-				r.Metrics.Count(`job.start.error`, 1)
 			} else {
 				logger.Warn("Buildkite rejected the call to start the job (%s)", err)
 				s.Break()
 			}
-		} else {
-			r.Metrics.Count(`job.start.success`, 1)
 		}
 
 		return err

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -196,13 +196,17 @@ func (r *JobRunner) Run() error {
 		}
 	}
 
+	jobMetrics := r.Metrics.With(metrics.Tags{
+		"exit_code": r.process.ExitStatus,
+	})
+
 	// Write some metrics about the job run
 	if r.process.ExitStatus == "0" {
-		r.Metrics.Timing(`jobs.duration.success`, finishedAt.Sub(startedAt))
-		r.Metrics.Count(`jobs.success`, 1)
+		jobMetrics.Timing(`jobs.duration.success`, finishedAt.Sub(startedAt))
+		jobMetrics.Count(`jobs.success`, 1)
 	} else {
-		r.Metrics.Timing(`jobs.duration.error`, finishedAt.Sub(startedAt))
-		r.Metrics.Count(`jobs.failed`, 1)
+		jobMetrics.Timing(`jobs.duration.error`, finishedAt.Sub(startedAt))
+		jobMetrics.Count(`jobs.failed`, 1)
 	}
 
 	// Finish the build in the Buildkite Agent API

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -287,7 +287,7 @@ var AgentStartCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name:   "metrics-datadog-host",
-			Usage:  "The host to send metrics to",
+			Usage:  "The dogstatsd instance to send metrics to via udp",
 			EnvVar: "BUILDKITE_METRICS_DATADOG_HOST",
 			Value:  "127.0.0.1:8125",
 		},

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/buildkite/agent
 
 require (
 	cloud.google.com/go v0.0.0-20170217213217-65216237311a
+	github.com/DataDog/datadog-go v0.0.0-20180822151419-281ae9f2d895
 	github.com/ErikDubbelboer/gspt v0.0.0-20180711091504-e39e726e09cc
 	github.com/aws/aws-sdk-go v0.0.0-20180831223016-2a4034064ca5
 	github.com/buildkite/bintest v0.0.0-20180227222132-85c293267aed

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.0.0-20170217213217-65216237311a h1:jCsBzsjojdK5UhWQfZurxl0ZyWZbvvX9QS5/4rFKGDs=
 cloud.google.com/go v0.0.0-20170217213217-65216237311a/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/DataDog/datadog-go v0.0.0-20180822151419-281ae9f2d895 h1:dmc/C8bpE5VkQn65PNbbyACDC8xw8Hpp/NEurdPmQDQ=
+github.com/DataDog/datadog-go v0.0.0-20180822151419-281ae9f2d895/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/ErikDubbelboer/gspt v0.0.0-20180711091504-e39e726e09cc h1:Qs3YRJ9WQ1+Et+uoXBVfKUBzdn9FGJiH98UgfBIiqzk=
 github.com/ErikDubbelboer/gspt v0.0.0-20180711091504-e39e726e09cc/go.mod h1:01yGrV5aDnYieX2hSBoKGMaRiqHvnLoUy4ngWGZ/owg=
 github.com/aws/aws-sdk-go v0.0.0-20180831223016-2a4034064ca5 h1:raOAL5Uz269DesNi7ejlUuwQY2fyvRrBYuzRWHkl+Wo=

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,101 @@
+package metrics
+
+import (
+	"regexp"
+	"sort"
+	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/buildkite/agent/logger"
+)
+
+type Collector struct {
+	Datadog     bool
+	DatadogHost string
+
+	client *statsd.Client
+}
+
+func (c *Collector) Start() error {
+	logger.Info("Starting metrics collection to %s", c.DatadogHost)
+
+	var err error
+	c.client, err = statsd.New(c.DatadogHost)
+	if err != nil {
+		return err
+	}
+
+	c.client.Namespace = "buildkite."
+	return nil
+}
+
+func (c *Collector) Stop() error {
+	logger.Info("Stopping metrics collection")
+	return c.client.Close()
+}
+
+func (c *Collector) Scope(tags Tags) *Scope {
+	return &Scope{
+		Tags: tags,
+		c:    c,
+	}
+}
+
+type Scope struct {
+	Tags Tags
+	c    *Collector
+}
+
+// Timing sends timing information in milliseconds.
+func (s *Scope) Timing(name string, value time.Duration, tags ...Tags) {
+	mergedTags := s.mergeTags(tags...).StringSlice()
+	logger.Debug("Metrics timing %s=%v %v", name, value, mergedTags)
+
+	if err := s.c.client.Timing(name, value, mergedTags, 1); err != nil {
+		logger.Error("Metrics timing failed: %v", err)
+	}
+}
+
+// Count tracks how many times something happened per second.
+func (s *Scope) Count(name string, value int64, tags ...Tags) {
+	mergedTags := s.mergeTags(tags...).StringSlice()
+	logger.Debug("Metrics count %s=%v %v", name, value, mergedTags)
+
+	if err := s.c.client.Count(name, value, mergedTags, 1); err != nil {
+		logger.Error("Metrics count failed: %v", err)
+	}
+}
+
+func (s *Scope) mergeTags(tagsSlice ...Tags) Tags {
+	merged := Tags{}
+	for k, v := range s.Tags {
+		merged[formatName(k)] = formatName(v)
+	}
+	for _, tags := range tagsSlice {
+		for k, v := range tags {
+			merged[formatName(k)] = formatName(v)
+		}
+	}
+	return merged
+}
+
+type Tags map[string]string
+
+func (tags Tags) StringSlice() []string {
+	var stringSlice []string
+	for k, v := range tags {
+		if k != "" && v != "" {
+			stringSlice = append(stringSlice, formatName(k)+":"+formatName(v))
+		}
+	}
+	sort.Strings(stringSlice)
+	return stringSlice
+}
+
+// Datadog allows '.', '_' and alphas only.
+// If we don't validate this here then the datadog error logs can fill up disk really quickly
+var nameRegex = regexp.MustCompile(`[^\._a-zA-Z0-9]+`)
+
+func formatName(name string) string {
+	return nameRegex.ReplaceAllString(name, "_")
+}

--- a/vendor/github.com/DataDog/datadog-go/LICENSE.txt
+++ b/vendor/github.com/DataDog/datadog-go/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2015 Datadog, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/DataDog/datadog-go/statsd/README.md
+++ b/vendor/github.com/DataDog/datadog-go/statsd/README.md
@@ -1,0 +1,64 @@
+## Overview
+
+Package `statsd` provides a Go [dogstatsd](http://docs.datadoghq.com/guides/dogstatsd/) client.  Dogstatsd extends Statsd, adding tags
+and histograms.
+
+## Get the code
+
+    $ go get github.com/DataDog/datadog-go/statsd
+
+## Usage
+
+```go
+// Create the client
+c, err := statsd.New("127.0.0.1:8125")
+if err != nil {
+    log.Fatal(err)
+}
+// Prefix every metric with the app name
+c.Namespace = "flubber."
+// Send the EC2 availability zone as a tag with every metric
+c.Tags = append(c.Tags, "us-east-1a")
+
+// Do some metrics!
+err = c.Gauge("request.queue_depth", 12, nil, 1)
+err = c.Timing("request.duration", duration, nil, 1) // Uses a time.Duration!
+err = c.TimeInMilliseconds("request", 12, nil, 1)
+err = c.Incr("request.count_total", nil, 1)
+err = c.Decr("request.count_total", nil, 1)
+err = c.Count("request.count_total", 2, nil, 1)
+```
+
+## Buffering Client
+
+DogStatsD accepts packets with multiple statsd payloads in them.  Using the BufferingClient via `NewBufferingClient` will buffer up commands and send them when the buffer is reached or after 100msec.
+
+## Unix Domain Sockets Client
+
+DogStatsD version 6 accepts packets through a Unix Socket datagram connection. You can use this protocol by giving a
+`unix:///path/to/dsd.socket` addr argument to the `New` or `NewBufferingClient`.
+
+With this protocol, writes can become blocking if the server's receiving buffer is full. Our default behaviour is to
+timeout and drop the packet after 1 ms. You can set a custom timeout duration via the `SetWriteTimeout` method.
+
+The default mode is to pass write errors from the socket to the caller. This includes write errors the library will
+automatically recover from (DogStatsD server not ready yet or is restarting). You can drop these errors and emulate
+the UDP behaviour by setting the `SkipErrors` property to `true`. Please note that packets will be dropped in both modes.
+
+## Development
+
+Run the tests with:
+
+    $ go test
+
+## Documentation
+
+Please see: http://godoc.org/github.com/DataDog/datadog-go/statsd
+
+## License
+
+go-dogstatsd is released under the [MIT license](http://www.opensource.org/licenses/mit-license.php).
+
+## Credits
+
+Original code by [ooyala](https://github.com/ooyala/go-dogstatsd).

--- a/vendor/github.com/DataDog/datadog-go/statsd/statsd.go
+++ b/vendor/github.com/DataDog/datadog-go/statsd/statsd.go
@@ -1,0 +1,719 @@
+// Copyright 2013 Ooyala, Inc.
+
+/*
+Package statsd provides a Go dogstatsd client. Dogstatsd extends the popular statsd,
+adding tags and histograms and pushing upstream to Datadog.
+
+Refer to http://docs.datadoghq.com/guides/dogstatsd/ for information about DogStatsD.
+
+Example Usage:
+
+    // Create the client
+    c, err := statsd.New("127.0.0.1:8125")
+    if err != nil {
+        log.Fatal(err)
+    }
+    // Prefix every metric with the app name
+    c.Namespace = "flubber."
+    // Send the EC2 availability zone as a tag with every metric
+    c.Tags = append(c.Tags, "us-east-1a")
+    err = c.Gauge("request.duration", 1.2, nil, 1)
+
+statsd is based on go-statsd-client.
+*/
+package statsd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+/*
+OptimalPayloadSize defines the optimal payload size for a UDP datagram, 1432 bytes
+is optimal for regular networks with an MTU of 1500 so datagrams don't get
+fragmented. It's generally recommended not to fragment UDP datagrams as losing
+a single fragment will cause the entire datagram to be lost.
+
+This can be increased if your network has a greater MTU or you don't mind UDP
+datagrams getting fragmented. The practical limit is MaxUDPPayloadSize
+*/
+const OptimalPayloadSize = 1432
+
+/*
+MaxUDPPayloadSize defines the maximum payload size for a UDP datagram.
+Its value comes from the calculation: 65535 bytes Max UDP datagram size -
+8byte UDP header - 60byte max IP headers
+any number greater than that will see frames being cut out.
+*/
+const MaxUDPPayloadSize = 65467
+
+/*
+UnixAddressPrefix holds the prefix to use to enable Unix Domain Socket
+traffic instead of UDP.
+*/
+const UnixAddressPrefix = "unix://"
+
+/*
+Stat suffixes
+*/
+var (
+	gaugeSuffix        = []byte("|g")
+	countSuffix        = []byte("|c")
+	histogramSuffix    = []byte("|h")
+	distributionSuffix = []byte("|d")
+	decrSuffix         = []byte("-1|c")
+	incrSuffix         = []byte("1|c")
+	setSuffix          = []byte("|s")
+	timingSuffix       = []byte("|ms")
+)
+
+// A statsdWriter offers a standard interface regardless of the underlying
+// protocol. For now UDS and UPD writers are available.
+type statsdWriter interface {
+	Write(data []byte) (n int, err error)
+	SetWriteTimeout(time.Duration) error
+	Close() error
+}
+
+// A Client is a handle for sending messages to dogstatsd.  It is safe to
+// use one Client from multiple goroutines simultaneously.
+type Client struct {
+	// Writer handles the underlying networking protocol
+	writer statsdWriter
+	// Namespace to prepend to all statsd calls
+	Namespace string
+	// Tags are global tags to be added to every statsd call
+	Tags []string
+	// skipErrors turns off error passing and allows UDS to emulate UDP behaviour
+	SkipErrors bool
+	// BufferLength is the length of the buffer in commands.
+	bufferLength int
+	flushTime    time.Duration
+	commands     [][]byte
+	buffer       bytes.Buffer
+	stop         chan struct{}
+	sync.Mutex
+}
+
+// New returns a pointer to a new Client given an addr in the format "hostname:port" or
+// "unix:///path/to/socket".
+func New(addr string) (*Client, error) {
+	if strings.HasPrefix(addr, UnixAddressPrefix) {
+		w, err := newUdsWriter(addr[len(UnixAddressPrefix)-1:])
+		if err != nil {
+			return nil, err
+		}
+		return NewWithWriter(w)
+	}
+	w, err := newUDPWriter(addr)
+	if err != nil {
+		return nil, err
+	}
+	return NewWithWriter(w)
+}
+
+// NewWithWriter creates a new Client with given writer. Writer is a
+// io.WriteCloser + SetWriteTimeout(time.Duration) error
+func NewWithWriter(w statsdWriter) (*Client, error) {
+	client := &Client{writer: w, SkipErrors: false}
+	return client, nil
+}
+
+// NewBuffered returns a Client that buffers its output and sends it in chunks.
+// Buflen is the length of the buffer in number of commands.
+func NewBuffered(addr string, buflen int) (*Client, error) {
+	client, err := New(addr)
+	if err != nil {
+		return nil, err
+	}
+	client.bufferLength = buflen
+	client.commands = make([][]byte, 0, buflen)
+	client.flushTime = time.Millisecond * 100
+	client.stop = make(chan struct{}, 1)
+	go client.watch()
+	return client, nil
+}
+
+// format a message from its name, value, tags and rate.  Also adds global
+// namespace and tags.
+func (c *Client) format(name string, value interface{}, suffix []byte, tags []string, rate float64) []byte {
+	// preallocated buffer, stack allocated as long as it doesn't escape
+	buf := make([]byte, 0, 200)
+
+	if c.Namespace != "" {
+		buf = append(buf, c.Namespace...)
+	}
+	buf = append(buf, name...)
+	buf = append(buf, ':')
+
+	switch val := value.(type) {
+	case float64:
+		buf = strconv.AppendFloat(buf, val, 'f', 6, 64)
+
+	case int64:
+		buf = strconv.AppendInt(buf, val, 10)
+
+	case string:
+		buf = append(buf, val...)
+
+	default:
+		// do nothing
+	}
+	buf = append(buf, suffix...)
+
+	if rate < 1 {
+		buf = append(buf, "|@"...)
+		buf = strconv.AppendFloat(buf, rate, 'f', -1, 64)
+	}
+
+	buf = appendTagString(buf, c.Tags, tags)
+
+	// non-zeroing copy to avoid referencing a larger than necessary underlying array
+	return append([]byte(nil), buf...)
+}
+
+// SetWriteTimeout allows the user to set a custom UDS write timeout. Not supported for UDP.
+func (c *Client) SetWriteTimeout(d time.Duration) error {
+	if c == nil {
+		return nil
+	}
+	return c.writer.SetWriteTimeout(d)
+}
+
+func (c *Client) watch() {
+	ticker := time.NewTicker(c.flushTime)
+
+	for {
+		select {
+		case <-ticker.C:
+			c.Lock()
+			if len(c.commands) > 0 {
+				// FIXME: eating error here
+				c.flushLocked()
+			}
+			c.Unlock()
+		case <-c.stop:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+func (c *Client) append(cmd []byte) error {
+	c.Lock()
+	defer c.Unlock()
+	c.commands = append(c.commands, cmd)
+	// if we should flush, lets do it
+	if len(c.commands) == c.bufferLength {
+		if err := c.flushLocked(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Client) joinMaxSize(cmds [][]byte, sep string, maxSize int) ([][]byte, []int) {
+	c.buffer.Reset() //clear buffer
+
+	var frames [][]byte
+	var ncmds []int
+	sepBytes := []byte(sep)
+	sepLen := len(sep)
+
+	elem := 0
+	for _, cmd := range cmds {
+		needed := len(cmd)
+
+		if elem != 0 {
+			needed = needed + sepLen
+		}
+
+		if c.buffer.Len()+needed <= maxSize {
+			if elem != 0 {
+				c.buffer.Write(sepBytes)
+			}
+			c.buffer.Write(cmd)
+			elem++
+		} else {
+			frames = append(frames, copyAndResetBuffer(&c.buffer))
+			ncmds = append(ncmds, elem)
+			// if cmd is bigger than maxSize it will get flushed on next loop
+			c.buffer.Write(cmd)
+			elem = 1
+		}
+	}
+
+	//add whatever is left! if there's actually something
+	if c.buffer.Len() > 0 {
+		frames = append(frames, copyAndResetBuffer(&c.buffer))
+		ncmds = append(ncmds, elem)
+	}
+
+	return frames, ncmds
+}
+
+func copyAndResetBuffer(buf *bytes.Buffer) []byte {
+	tmpBuf := make([]byte, buf.Len())
+	copy(tmpBuf, buf.Bytes())
+	buf.Reset()
+	return tmpBuf
+}
+
+// Flush forces a flush of the pending commands in the buffer
+func (c *Client) Flush() error {
+	if c == nil {
+		return nil
+	}
+	c.Lock()
+	defer c.Unlock()
+	return c.flushLocked()
+}
+
+// flush the commands in the buffer.  Lock must be held by caller.
+func (c *Client) flushLocked() error {
+	frames, flushable := c.joinMaxSize(c.commands, "\n", OptimalPayloadSize)
+	var err error
+	cmdsFlushed := 0
+	for i, data := range frames {
+		_, e := c.writer.Write(data)
+		if e != nil {
+			err = e
+			break
+		}
+		cmdsFlushed += flushable[i]
+	}
+
+	// clear the slice with a slice op, doesn't realloc
+	if cmdsFlushed == len(c.commands) {
+		c.commands = c.commands[:0]
+	} else {
+		//this case will cause a future realloc...
+		// drop problematic command though (sorry).
+		c.commands = c.commands[cmdsFlushed+1:]
+	}
+	return err
+}
+
+func (c *Client) sendMsg(msg []byte) error {
+	// return an error if message is bigger than MaxUDPPayloadSize
+	if len(msg) > MaxUDPPayloadSize {
+		return errors.New("message size exceeds MaxUDPPayloadSize")
+	}
+
+	// if this client is buffered, then we'll just append this
+	if c.bufferLength > 0 {
+		return c.append(msg)
+	}
+
+	_, err := c.writer.Write(msg)
+
+	if c.SkipErrors {
+		return nil
+	}
+	return err
+}
+
+// send handles sampling and sends the message over UDP. It also adds global namespace prefixes and tags.
+func (c *Client) send(name string, value interface{}, suffix []byte, tags []string, rate float64) error {
+	if c == nil {
+		return nil
+	}
+	if rate < 1 && rand.Float64() > rate {
+		return nil
+	}
+	data := c.format(name, value, suffix, tags, rate)
+	return c.sendMsg(data)
+}
+
+// Gauge measures the value of a metric at a particular time.
+func (c *Client) Gauge(name string, value float64, tags []string, rate float64) error {
+	return c.send(name, value, gaugeSuffix, tags, rate)
+}
+
+// Count tracks how many times something happened per second.
+func (c *Client) Count(name string, value int64, tags []string, rate float64) error {
+	return c.send(name, value, countSuffix, tags, rate)
+}
+
+// Histogram tracks the statistical distribution of a set of values on each host.
+func (c *Client) Histogram(name string, value float64, tags []string, rate float64) error {
+	return c.send(name, value, histogramSuffix, tags, rate)
+}
+
+// Distribution tracks the statistical distribution of a set of values across your infrastructure.
+func (c *Client) Distribution(name string, value float64, tags []string, rate float64) error {
+	return c.send(name, value, distributionSuffix, tags, rate)
+}
+
+// Decr is just Count of -1
+func (c *Client) Decr(name string, tags []string, rate float64) error {
+	return c.send(name, nil, decrSuffix, tags, rate)
+}
+
+// Incr is just Count of 1
+func (c *Client) Incr(name string, tags []string, rate float64) error {
+	return c.send(name, nil, incrSuffix, tags, rate)
+}
+
+// Set counts the number of unique elements in a group.
+func (c *Client) Set(name string, value string, tags []string, rate float64) error {
+	return c.send(name, value, setSuffix, tags, rate)
+}
+
+// Timing sends timing information, it is an alias for TimeInMilliseconds
+func (c *Client) Timing(name string, value time.Duration, tags []string, rate float64) error {
+	return c.TimeInMilliseconds(name, value.Seconds()*1000, tags, rate)
+}
+
+// TimeInMilliseconds sends timing information in milliseconds.
+// It is flushed by statsd with percentiles, mean and other info (https://github.com/etsy/statsd/blob/master/docs/metric_types.md#timing)
+func (c *Client) TimeInMilliseconds(name string, value float64, tags []string, rate float64) error {
+	return c.send(name, value, timingSuffix, tags, rate)
+}
+
+// Event sends the provided Event.
+func (c *Client) Event(e *Event) error {
+	if c == nil {
+		return nil
+	}
+	stat, err := e.Encode(c.Tags...)
+	if err != nil {
+		return err
+	}
+	return c.sendMsg([]byte(stat))
+}
+
+// SimpleEvent sends an event with the provided title and text.
+func (c *Client) SimpleEvent(title, text string) error {
+	e := NewEvent(title, text)
+	return c.Event(e)
+}
+
+// ServiceCheck sends the provided ServiceCheck.
+func (c *Client) ServiceCheck(sc *ServiceCheck) error {
+	if c == nil {
+		return nil
+	}
+	stat, err := sc.Encode(c.Tags...)
+	if err != nil {
+		return err
+	}
+	return c.sendMsg([]byte(stat))
+}
+
+// SimpleServiceCheck sends an serviceCheck with the provided name and status.
+func (c *Client) SimpleServiceCheck(name string, status ServiceCheckStatus) error {
+	sc := NewServiceCheck(name, status)
+	return c.ServiceCheck(sc)
+}
+
+// Close the client connection.
+func (c *Client) Close() error {
+	if c == nil {
+		return nil
+	}
+	select {
+	case c.stop <- struct{}{}:
+	default:
+	}
+
+	// if this client is buffered, flush before closing the writer
+	if c.bufferLength > 0 {
+		if err := c.Flush(); err != nil {
+			return err
+		}
+	}
+
+	return c.writer.Close()
+}
+
+// Events support
+// EventAlertType and EventAlertPriority became exported types after this issue was submitted: https://github.com/DataDog/datadog-go/issues/41
+// The reason why they got exported is so that client code can directly use the types.
+
+// EventAlertType is the alert type for events
+type EventAlertType string
+
+const (
+	// Info is the "info" AlertType for events
+	Info EventAlertType = "info"
+	// Error is the "error" AlertType for events
+	Error EventAlertType = "error"
+	// Warning is the "warning" AlertType for events
+	Warning EventAlertType = "warning"
+	// Success is the "success" AlertType for events
+	Success EventAlertType = "success"
+)
+
+// EventPriority is the event priority for events
+type EventPriority string
+
+const (
+	// Normal is the "normal" Priority for events
+	Normal EventPriority = "normal"
+	// Low is the "low" Priority for events
+	Low EventPriority = "low"
+)
+
+// An Event is an object that can be posted to your DataDog event stream.
+type Event struct {
+	// Title of the event.  Required.
+	Title string
+	// Text is the description of the event.  Required.
+	Text string
+	// Timestamp is a timestamp for the event.  If not provided, the dogstatsd
+	// server will set this to the current time.
+	Timestamp time.Time
+	// Hostname for the event.
+	Hostname string
+	// AggregationKey groups this event with others of the same key.
+	AggregationKey string
+	// Priority of the event.  Can be statsd.Low or statsd.Normal.
+	Priority EventPriority
+	// SourceTypeName is a source type for the event.
+	SourceTypeName string
+	// AlertType can be statsd.Info, statsd.Error, statsd.Warning, or statsd.Success.
+	// If absent, the default value applied by the dogstatsd server is Info.
+	AlertType EventAlertType
+	// Tags for the event.
+	Tags []string
+}
+
+// NewEvent creates a new event with the given title and text.  Error checking
+// against these values is done at send-time, or upon running e.Check.
+func NewEvent(title, text string) *Event {
+	return &Event{
+		Title: title,
+		Text:  text,
+	}
+}
+
+// Check verifies that an event is valid.
+func (e Event) Check() error {
+	if len(e.Title) == 0 {
+		return fmt.Errorf("statsd.Event title is required")
+	}
+	if len(e.Text) == 0 {
+		return fmt.Errorf("statsd.Event text is required")
+	}
+	return nil
+}
+
+// Encode returns the dogstatsd wire protocol representation for an event.
+// Tags may be passed which will be added to the encoded output but not to
+// the Event's list of tags, eg. for default tags.
+func (e Event) Encode(tags ...string) (string, error) {
+	err := e.Check()
+	if err != nil {
+		return "", err
+	}
+	text := e.escapedText()
+
+	var buffer bytes.Buffer
+	buffer.WriteString("_e{")
+	buffer.WriteString(strconv.FormatInt(int64(len(e.Title)), 10))
+	buffer.WriteRune(',')
+	buffer.WriteString(strconv.FormatInt(int64(len(text)), 10))
+	buffer.WriteString("}:")
+	buffer.WriteString(e.Title)
+	buffer.WriteRune('|')
+	buffer.WriteString(text)
+
+	if !e.Timestamp.IsZero() {
+		buffer.WriteString("|d:")
+		buffer.WriteString(strconv.FormatInt(int64(e.Timestamp.Unix()), 10))
+	}
+
+	if len(e.Hostname) != 0 {
+		buffer.WriteString("|h:")
+		buffer.WriteString(e.Hostname)
+	}
+
+	if len(e.AggregationKey) != 0 {
+		buffer.WriteString("|k:")
+		buffer.WriteString(e.AggregationKey)
+
+	}
+
+	if len(e.Priority) != 0 {
+		buffer.WriteString("|p:")
+		buffer.WriteString(string(e.Priority))
+	}
+
+	if len(e.SourceTypeName) != 0 {
+		buffer.WriteString("|s:")
+		buffer.WriteString(e.SourceTypeName)
+	}
+
+	if len(e.AlertType) != 0 {
+		buffer.WriteString("|t:")
+		buffer.WriteString(string(e.AlertType))
+	}
+
+	writeTagString(&buffer, tags, e.Tags)
+
+	return buffer.String(), nil
+}
+
+// ServiceCheckStatus support
+type ServiceCheckStatus byte
+
+const (
+	// Ok is the "ok" ServiceCheck status
+	Ok ServiceCheckStatus = 0
+	// Warn is the "warning" ServiceCheck status
+	Warn ServiceCheckStatus = 1
+	// Critical is the "critical" ServiceCheck status
+	Critical ServiceCheckStatus = 2
+	// Unknown is the "unknown" ServiceCheck status
+	Unknown ServiceCheckStatus = 3
+)
+
+// An ServiceCheck is an object that contains status of DataDog service check.
+type ServiceCheck struct {
+	// Name of the service check.  Required.
+	Name string
+	// Status of service check.  Required.
+	Status ServiceCheckStatus
+	// Timestamp is a timestamp for the serviceCheck.  If not provided, the dogstatsd
+	// server will set this to the current time.
+	Timestamp time.Time
+	// Hostname for the serviceCheck.
+	Hostname string
+	// A message describing the current state of the serviceCheck.
+	Message string
+	// Tags for the serviceCheck.
+	Tags []string
+}
+
+// NewServiceCheck creates a new serviceCheck with the given name and status.  Error checking
+// against these values is done at send-time, or upon running sc.Check.
+func NewServiceCheck(name string, status ServiceCheckStatus) *ServiceCheck {
+	return &ServiceCheck{
+		Name:   name,
+		Status: status,
+	}
+}
+
+// Check verifies that an event is valid.
+func (sc ServiceCheck) Check() error {
+	if len(sc.Name) == 0 {
+		return fmt.Errorf("statsd.ServiceCheck name is required")
+	}
+	if byte(sc.Status) < 0 || byte(sc.Status) > 3 {
+		return fmt.Errorf("statsd.ServiceCheck status has invalid value")
+	}
+	return nil
+}
+
+// Encode returns the dogstatsd wire protocol representation for an serviceCheck.
+// Tags may be passed which will be added to the encoded output but not to
+// the Event's list of tags, eg. for default tags.
+func (sc ServiceCheck) Encode(tags ...string) (string, error) {
+	err := sc.Check()
+	if err != nil {
+		return "", err
+	}
+	message := sc.escapedMessage()
+
+	var buffer bytes.Buffer
+	buffer.WriteString("_sc|")
+	buffer.WriteString(sc.Name)
+	buffer.WriteRune('|')
+	buffer.WriteString(strconv.FormatInt(int64(sc.Status), 10))
+
+	if !sc.Timestamp.IsZero() {
+		buffer.WriteString("|d:")
+		buffer.WriteString(strconv.FormatInt(int64(sc.Timestamp.Unix()), 10))
+	}
+
+	if len(sc.Hostname) != 0 {
+		buffer.WriteString("|h:")
+		buffer.WriteString(sc.Hostname)
+	}
+
+	writeTagString(&buffer, tags, sc.Tags)
+
+	if len(message) != 0 {
+		buffer.WriteString("|m:")
+		buffer.WriteString(message)
+	}
+
+	return buffer.String(), nil
+}
+
+func (e Event) escapedText() string {
+	return strings.Replace(e.Text, "\n", "\\n", -1)
+}
+
+func (sc ServiceCheck) escapedMessage() string {
+	msg := strings.Replace(sc.Message, "\n", "\\n", -1)
+	return strings.Replace(msg, "m:", `m\:`, -1)
+}
+
+func removeNewlines(str string) string {
+	return strings.Replace(str, "\n", "", -1)
+}
+
+func writeTagString(w io.Writer, tagList1, tagList2 []string) {
+	// the tag lists may be shared with other callers, so we cannot modify
+	// them in any way (which means we cannot append to them either)
+	// therefore we must make an entirely separate copy just for this call
+	totalLen := len(tagList1) + len(tagList2)
+	if totalLen == 0 {
+		return
+	}
+	tags := make([]string, 0, totalLen)
+	tags = append(tags, tagList1...)
+	tags = append(tags, tagList2...)
+
+	io.WriteString(w, "|#")
+	io.WriteString(w, removeNewlines(tags[0]))
+	for _, tag := range tags[1:] {
+		io.WriteString(w, ",")
+		io.WriteString(w, removeNewlines(tag))
+	}
+}
+
+func appendTagString(buf []byte, tagList1, tagList2 []string) []byte {
+	if len(tagList1) == 0 {
+		if len(tagList2) == 0 {
+			return buf
+		}
+		tagList1 = tagList2
+		tagList2 = nil
+	}
+
+	buf = append(buf, "|#"...)
+	buf = appendWithoutNewlines(buf, tagList1[0])
+	for _, tag := range tagList1[1:] {
+		buf = append(buf, ',')
+		buf = appendWithoutNewlines(buf, tag)
+	}
+	for _, tag := range tagList2 {
+		buf = append(buf, ',')
+		buf = appendWithoutNewlines(buf, tag)
+	}
+	return buf
+}
+
+func appendWithoutNewlines(buf []byte, s string) []byte {
+	// fastpath for strings without newlines
+	if strings.IndexByte(s, '\n') == -1 {
+		return append(buf, s...)
+	}
+
+	for _, b := range []byte(s) {
+		if b != '\n' {
+			buf = append(buf, b)
+		}
+	}
+	return buf
+}

--- a/vendor/github.com/DataDog/datadog-go/statsd/udp.go
+++ b/vendor/github.com/DataDog/datadog-go/statsd/udp.go
@@ -1,0 +1,40 @@
+package statsd
+
+import (
+	"errors"
+	"net"
+	"time"
+)
+
+// udpWriter is an internal class wrapping around management of UDP connection
+type udpWriter struct {
+	conn net.Conn
+}
+
+// New returns a pointer to a new udpWriter given an addr in the format "hostname:port".
+func newUDPWriter(addr string) (*udpWriter, error) {
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := net.DialUDP("udp", nil, udpAddr)
+	if err != nil {
+		return nil, err
+	}
+	writer := &udpWriter{conn: conn}
+	return writer, nil
+}
+
+// SetWriteTimeout is not needed for UDP, returns error
+func (w *udpWriter) SetWriteTimeout(d time.Duration) error {
+	return errors.New("SetWriteTimeout: not supported for UDP connections")
+}
+
+// Write data to the UDP connection with no error handling
+func (w *udpWriter) Write(data []byte) (int, error) {
+	return w.conn.Write(data)
+}
+
+func (w *udpWriter) Close() error {
+	return w.conn.Close()
+}

--- a/vendor/github.com/DataDog/datadog-go/statsd/uds.go
+++ b/vendor/github.com/DataDog/datadog-go/statsd/uds.go
@@ -1,0 +1,71 @@
+package statsd
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+/*
+UDSTimeout holds the default timeout for UDS socket writes, as they can get
+blocking when the receiving buffer is full.
+*/
+const defaultUDSTimeout = 1 * time.Millisecond
+
+// udsWriter is an internal class wrapping around management of UDS connection
+type udsWriter struct {
+	// Address to send metrics to, needed to allow reconnection on error
+	addr net.Addr
+	// Established connection object, or nil if not connected yet
+	conn net.Conn
+	// write timeout
+	writeTimeout time.Duration
+	sync.Mutex   // used to lock conn / writer can replace it
+}
+
+// New returns a pointer to a new udsWriter given a socket file path as addr.
+func newUdsWriter(addr string) (*udsWriter, error) {
+	udsAddr, err := net.ResolveUnixAddr("unixgram", addr)
+	if err != nil {
+		return nil, err
+	}
+	// Defer connection to first Write
+	writer := &udsWriter{addr: udsAddr, conn: nil, writeTimeout: defaultUDSTimeout}
+	return writer, nil
+}
+
+// SetWriteTimeout allows the user to set a custom write timeout
+func (w *udsWriter) SetWriteTimeout(d time.Duration) error {
+	w.writeTimeout = d
+	return nil
+}
+
+// Write data to the UDS connection with write timeout and minimal error handling:
+// create the connection if nil, and destroy it if the statsd server has disconnected
+func (w *udsWriter) Write(data []byte) (int, error) {
+	w.Lock()
+	defer w.Unlock()
+	// Try connecting (first packet or connection lost)
+	if w.conn == nil {
+		conn, err := net.Dial(w.addr.Network(), w.addr.String())
+		if err != nil {
+			return 0, err
+		}
+		w.conn = conn
+	}
+	w.conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
+	n, e := w.conn.Write(data)
+	if e != nil {
+		// Statsd server disconnected, retry connecting at next packet
+		w.conn = nil
+		return 0, e
+	}
+	return n, e
+}
+
+func (w *udsWriter) Close() error {
+	if w.conn != nil {
+		return w.conn.Close()
+	}
+	return nil
+}


### PR DESCRIPTION
This adds a very minimal implementation of metrics collection for the Datadog agent. 

It's controlled by two config entries:

```
metrics-datadog = true|false
metrics-datadog-host = localhost:8125
```

Currently it streams metrics in real-time as they are collected. The following metrics are collected, in the format of `[metric type], [name], [tags]`:

* [x] TIMING `buildkite.jobs.duration.success` `[agent_name, org, pipeline, branch, exit_code]`
* [x] TIMING `buildkite.jobs.duration.failure` `[agent_name, org, pipeline, branch, exit_code]`
* [x] COUNT `buildkite.jobs.success` `[agent_name, org, pipeline, branch, exit_code]`
* [x] COUNT `buildkite.jobs.failure` `[agent_name, org, pipeline, branch, exit_code]`

Batch is done, we batch 10 metrics commands presently before sending them. 

I'd love feedback on what metrics to collect and how I'm collecting them!
