### PR TITLE
Set BUILDKITE_AGENT_CONFIG in Docker Images

### DIFF
--- a/packaging/docker/alpine-linux/Dockerfile
+++ b/packaging/docker/alpine-linux/Dockerfile
@@ -19,7 +19,8 @@ RUN apk add --no-cache \
     pip install --upgrade pip && \
     pip install docker-compose
 
-ENV BUILDKITE_BUILD_PATH=/buildkite/builds \
+ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \
+    BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks \
     BUILDKITE_PLUGINS_PATH=/buildkite/plugins
 

--- a/packaging/docker/ubuntu-linux/Dockerfile
+++ b/packaging/docker/ubuntu-linux/Dockerfile
@@ -20,7 +20,8 @@ RUN curl -Lfs -o /sbin/tini  https://github.com/krallin/tini/releases/download/v
     && curl -Lfs https://github.com/docker/compose/releases/download/1.21.0/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
-ENV BUILDKITE_BUILD_PATH=/buildkite/builds \
+ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \
+    BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks \
     BUILDKITE_PLUGINS_PATH=/buildkite/plugins \
     PATH="/usr/local/bin:${PATH}"


### PR DESCRIPTION
The result of a discussion in [this PR](https://github.com/buildkite/docs/pull/321). This sets `BUILDKITE_AGENT_CONFIG` to `/buildkite/buildkite-agent.cfg` in the Alpine + Ubuntu images to bring the remainder of the Buildkite Agent configs into `/buildkite/`.