### PR TITLE
Disable HTTP2 in API client for proxies

### DIFF
--- a/agent/api_client.go
+++ b/agent/api_client.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/logger"
-	"golang.org/x/net/http2"
 )
 
 var debug = false
@@ -45,7 +44,8 @@ func (a APIClient) Create() *api.Client {
 		}).Dial,
 		TLSHandshakeTimeout: 30 * time.Second,
 	}
-	http2.ConfigureTransport(httpTransport)
+
+	// http2.ConfigureTransport(httpTransport)
 
 	// Configure the HTTP client
 	httpClient := &http.Client{Transport: &api.AuthenticatedTransport{

--- a/agent/api_client.go
+++ b/agent/api_client.go
@@ -43,6 +43,7 @@ func (a APIClient) Create() *api.Client {
 			KeepAlive: 30 * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout: 30 * time.Second,
+		TLSNextProto:        nil,
 	}
 
 	// http2.ConfigureTransport(httpTransport)


### PR DESCRIPTION
I believe that the addition of http2 in https://github.com/buildkite/agent/commit/df102d7c468561b2c1da1fc527286e3b8632a5a1#diff-98fcc19b28a4a24524a5ea0698f71589 has broken some https proxies. 

This PR disables http2 as part of a troubleshooting process with an affected customer. 

The symptom is with an https proxy, proxying https (e.g `HTTPS_PROXY=https://proxy:8000`) the agent terminates with `proxyconnect: EOF`.

