### PR TITLE
Bundle update for ruby dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,25 +3,25 @@ GEM
   specs:
     arr-pm (0.0.10)
       cabin (> 0)
-    aws-sdk (2.10.117)
-      aws-sdk-resources (= 2.10.117)
-    aws-sdk-core (2.10.117)
+    aws-sdk (2.11.152)
+      aws-sdk-resources (= 2.11.152)
+    aws-sdk-core (2.11.152)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.117)
-      aws-sdk-core (= 2.10.117)
-    aws-sigv4 (1.0.2)
-    backports (3.11.0)
+    aws-sdk-resources (2.11.152)
+      aws-sdk-core (= 2.11.152)
+    aws-sigv4 (1.0.3)
+    backports (3.11.4)
     cabin (0.9.0)
-    childprocess (0.8.0)
+    childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     clamp (1.0.1)
-    deb-s3 (0.9.1)
+    deb-s3 (0.10.0)
       aws-sdk (~> 2)
       thor (~> 0.19.0)
-    dotenv (2.2.1)
-    ffi (1.9.18)
-    fpm (1.9.3)
+    dotenv (2.5.0)
+    ffi (1.9.25)
+    fpm (1.10.2)
       arr-pm (~> 0.0.10)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
@@ -30,11 +30,11 @@ GEM
       ffi
       json (>= 1.7.7, < 2.0)
       pleaserun (~> 0.0.29)
-      ruby-xz
+      ruby-xz (~> 0.2.3)
       stud
     insist (1.0.0)
     io-like (0.3.0)
-    jmespath (1.3.1)
+    jmespath (1.4.0)
     json (1.8.6)
     mustache (0.99.8)
     pleaserun (0.0.30)
@@ -58,4 +58,4 @@ DEPENDENCIES
   fpm
 
 BUNDLED WITH
-   1.15.4
+   1.16.5


### PR DESCRIPTION
This is a `bundle update` for the ruby dependencies that are causing a github security alert. 

We could probably ditch the few ruby scripts at some point. 