### PR TITLE
Bump alpine to 3.8 in docker image

### DIFF
--- a/.buildkite/steps/publish-docker-image.sh
+++ b/.buildkite/steps/publish-docker-image.sh
@@ -60,8 +60,12 @@ if [[ "$codename" == "stable" ]] ; then
     release_image "${tag}${variant_suffix}"
   done
   release_image "${variant}"
-  release_image "latest"
-  release_image "stable"
+
+  # publish latest and stable only from alpine
+  if [[ "$variant" == "alpine" ]] ; then
+    release_image "latest"
+    release_image "stable"
+  fi
 fi
 
 # variants of beta/unstable - e.g 3.0-beta.16

--- a/packaging/docker/alpine-linux/Dockerfile
+++ b/packaging/docker/alpine-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
 RUN apk add --no-cache \
       bash \


### PR DESCRIPTION
Update the docker image base to `alpine:3.8` to update packages and try and clear the spurious vulnerability warning on docker hub. 

See https://github.com/buildkite/agent/issues/841 for context.