### PR TITLE
Update kill timeout comment to 10 seconds

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -307,7 +307,7 @@ func (p *Process) Kill() error {
 		c <- 1
 	}()
 
-	// Timeout this process after 3 seconds
+	// Timeout this process after 10 seconds
 	select {
 	case _ = <-c:
 		// Was successfully terminated


### PR DESCRIPTION
The comment was always "3 seconds" in e73bcb9f6
The timeout was bumped from 5 to 10 in 231c783a1