### PR TITLE
Add buildkite-agent.cfg to docker images

### DIFF
--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -23,6 +23,7 @@ build_docker_image() {
   local packaging_dir="$2"
 
   echo "--- Building :docker: $image_tag"
+  cp -a packaging/linux/root/usr/share/buildkite-agent/hooks/ "${packaging_dir}/hooks/"
   cp pkg/buildkite-agent-linux-amd64 "${packaging_dir}/buildkite-agent"
   chmod +x "${packaging_dir}/buildkite-agent"
   docker build --tag "$image_tag" "${packaging_dir}"

--- a/packaging/docker/alpine-linux/Dockerfile
+++ b/packaging/docker/alpine-linux/Dockerfile
@@ -19,15 +19,13 @@ RUN apk add --no-cache \
     pip install --upgrade pip && \
     pip install docker-compose
 
-ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \
-    BUILDKITE_BUILD_PATH=/buildkite/builds \
-    BUILDKITE_HOOKS_PATH=/buildkite/hooks \
-    BUILDKITE_PLUGINS_PATH=/buildkite/plugins
+ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg
 
 RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && curl -Lfs -o /usr/local/bin/ssh-env-config.sh https://raw.githubusercontent.com/buildkite/docker-ssh-env-config/master/ssh-env-config.sh \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
+COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
 COPY ./buildkite-agent /usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
 

--- a/packaging/docker/alpine-linux/buildkite-agent.cfg
+++ b/packaging/docker/alpine-linux/buildkite-agent.cfg
@@ -1,0 +1,58 @@
+# The token from your Buildkite "Agents" page
+#token="xxx"
+
+# The name of the agent
+name="%hostname-%n"
+
+# The priority of the agent (higher priorities are assigned work first)
+# priority=1
+
+# Tags for the agent (default is "queue=default")
+# tags="key1=val2,key2=val2"
+
+# Include the host's EC2 meta-data as tags (instance-id, instance-type, and ami-id)
+# tags-from-ec2=true
+
+# Include the host's EC2 tags as tags
+# tags-from-ec2-tags=true
+
+# Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
+# tags-from-gcp=true
+
+# Path to a custom bootstrap command to run. By default this is `buildkite-agent bootstrap`.
+# This allows you to override the entire execution of a job. Generally you should use hooks instead!
+# See https://buildkite.com/docs/agent/hooks
+# bootstrap-script=""
+
+# Path to where the builds will run from
+build-path="/buildkite/builds"
+
+# Directory where the hook scripts are found
+hooks-path="/buildkite/hooks"
+
+# Directory where plugins will be installed
+plugins-path="/buildkite/plugins"
+
+# Flags to pass to the `git clone` command
+# git-clone-flags=-v
+
+# Flags to pass to the `git clean` command
+# git-clean-flags=-fxdq
+
+# Do not run jobs within a pseudo terminal
+# no-pty=true
+
+# Don't automatically verify SSH fingerprints
+# no-automatic-ssh-fingerprint-verification=true
+
+# Don't allow this agent to run arbitrary console commands
+# no-command-eval=true
+
+# Don't allow this agent to run plugins
+# no-plugins=true
+
+# Enable debug mode
+# debug=true
+
+# Don't show colors in logging
+# no-color=true

--- a/packaging/docker/ubuntu-linux/Dockerfile
+++ b/packaging/docker/ubuntu-linux/Dockerfile
@@ -21,15 +21,13 @@ RUN curl -Lfs -o /sbin/tini  https://github.com/krallin/tini/releases/download/v
     && chmod +x /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \
-    BUILDKITE_BUILD_PATH=/buildkite/builds \
-    BUILDKITE_HOOKS_PATH=/buildkite/hooks \
-    BUILDKITE_PLUGINS_PATH=/buildkite/plugins \
     PATH="/usr/local/bin:${PATH}"
 
 RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && curl -Lfs -o /usr/local/bin/ssh-env-config.sh https://raw.githubusercontent.com/buildkite/docker-ssh-env-config/master/ssh-env-config.sh \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
+COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
 COPY ./buildkite-agent /usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
 

--- a/packaging/docker/ubuntu-linux/buildkite-agent.cfg
+++ b/packaging/docker/ubuntu-linux/buildkite-agent.cfg
@@ -1,0 +1,58 @@
+# The token from your Buildkite "Agents" page
+#token="xxx"
+
+# The name of the agent
+name="%hostname-%n"
+
+# The priority of the agent (higher priorities are assigned work first)
+# priority=1
+
+# Tags for the agent (default is "queue=default")
+# tags="key1=val2,key2=val2"
+
+# Include the host's EC2 meta-data as tags (instance-id, instance-type, and ami-id)
+# tags-from-ec2=true
+
+# Include the host's EC2 tags as tags
+# tags-from-ec2-tags=true
+
+# Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
+# tags-from-gcp=true
+
+# Path to a custom bootstrap command to run. By default this is `buildkite-agent bootstrap`.
+# This allows you to override the entire execution of a job. Generally you should use hooks instead!
+# See https://buildkite.com/docs/agent/hooks
+# bootstrap-script=""
+
+# Path to where the builds will run from
+build-path="/buildkite/builds"
+
+# Directory where the hook scripts are found
+hooks-path="/buildkite/hooks"
+
+# Directory where plugins will be installed
+plugins-path="/buildkite/plugins"
+
+# Flags to pass to the `git clone` command
+# git-clone-flags=-v
+
+# Flags to pass to the `git clean` command
+# git-clean-flags=-fxdq
+
+# Do not run jobs within a pseudo terminal
+# no-pty=true
+
+# Don't automatically verify SSH fingerprints
+# no-automatic-ssh-fingerprint-verification=true
+
+# Don't allow this agent to run arbitrary console commands
+# no-command-eval=true
+
+# Don't allow this agent to run plugins
+# no-plugins=true
+
+# Enable debug mode
+# debug=true
+
+# Don't show colors in logging
+# no-color=true


### PR DESCRIPTION
This adds `/buildkite/buildkite-agent.cfg` to our docker images, and also example hooks.

Closes https://github.com/buildkite/agent/issues/846.