### PR TITLE
Add back windows docker things in .buildkite/

### DIFF
--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -1,0 +1,30 @@
+## Development docker image for buildkite-agent on windows
+FROM microsoft/windowsservercore:latest
+
+ENV ChocolateyUseWindowsCompression false
+
+# Set your PowerShell execution policy
+RUN powershell Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force
+
+# Install Chocolatey
+RUN powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
+
+# Install Chocolatey packages
+RUN choco install -y git.install -params '"/GitAndUnixToolsOnPath"' && \
+  choco install -y openssh && \
+  choco install -y golang
+
+# Hack for mounting in code later (Use G:)
+# See https://github.com/moby/moby/issues/27537#issuecomment-271546031
+VOLUME c:/data
+RUN powershell set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'G:' -Value '\??\C:\data' -Type String
+
+# Copy across the agent source
+ENV GOPATH=c:/gopath
+WORKDIR c:/gopath/src/github.com/buildkite/agent
+COPY . .
+
+# Build agent and put binary in a dir in the PATH (remarkably hard to add to path)
+RUN go build -i -o .\buildkite-agent.exe
+
+CMD ["./buildkite-agent.exe", "start"]

--- a/.buildkite/docker-compose.windows.yml
+++ b/.buildkite/docker-compose.windows.yml
@@ -1,0 +1,18 @@
+version: "3.2"
+
+# This is a docker-compose file designed to be called in macOS and translate through to windows
+
+services:
+  agent:
+    build:
+      dockerfile: Dockerfile-windows
+      context: ../
+    working_dir: C:/gopath/src/github.com/buildkite/agent
+    environment:
+      - BUILDKITE_BUILD_NUMBER
+      - "BUILDKITE_BUILD_PATH=c:\\buildkite\\builds"
+
+networks:
+  default:
+    external:
+      name: nat


### PR DESCRIPTION
I was a bit heavy handed in https://github.com/buildkite/agent/pull/843. This adds back the parts needed to run our windows tests.