### PR TITLE
Add a flag to disable http2 in the start command

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -26,6 +26,9 @@ type AgentWorker struct {
 	// The endpoint that should be used when communicating with the API
 	Endpoint string
 
+	// Whether to disable http for the API
+	DisableHTTP2 bool
+
 	// The registred agent API record
 	Agent *api.Agent
 
@@ -60,7 +63,11 @@ func (a AgentWorker) Create() AgentWorker {
 		endpoint = a.Endpoint
 	}
 
-	a.APIClient = APIClient{Endpoint: endpoint, Token: a.Agent.AccessToken}.Create()
+	a.APIClient = APIClient{
+		Endpoint:     endpoint,
+		Token:        a.Agent.AccessToken,
+		DisableHTTP2: a.DisableHTTP2,
+	}.Create()
 
 	return a
 }

--- a/agent/api_client.go
+++ b/agent/api_client.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bufio"
+	"crypto/tls"
 	"errors"
 	"net"
 	"net/http"
@@ -16,8 +17,9 @@ import (
 var debug = false
 
 type APIClient struct {
-	Endpoint string
-	Token    string
+	Endpoint     string
+	Token        string
+	DisableHTTP2 bool
 }
 
 func APIClientEnableHTTPDebug() {
@@ -45,6 +47,10 @@ func (a APIClient) Create() *api.Client {
 		MaxIdleConns:        100,
 		IdleConnTimeout:     90 * time.Second,
 		TLSHandshakeTimeout: 30 * time.Second,
+	}
+
+	if a.DisableHTTP2 {
+		httpTransport.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
 	}
 
 	// Configure the HTTP client

--- a/api/buildkite.go
+++ b/api/buildkite.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/buildkite/agent/logger"
 	"github.com/google/go-querystring/query"
-	"gopkg.in/vmihailenco/msgpack.v2"
+	msgpack "gopkg.in/vmihailenco/msgpack.v2"
 )
 
 const (
@@ -197,7 +197,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 		return nil, err
 	}
 
-	logger.Debug("↳ %s %s (%s %s)", req.Method, req.URL, resp.Status, time.Now().Sub(ts))
+	logger.Debug("↳ %s %s (%s %s %s)", req.Method, req.URL, resp.Proto, resp.Status, time.Now().Sub(ts))
 
 	defer resp.Body.Close()
 	defer io.Copy(ioutil.Discard, resp.Body)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -65,6 +65,7 @@ type AgentStartConfig struct {
 	NoPlugins                 bool     `cli:"no-plugins"`
 	NoPluginValidation        bool     `cli:"no-plugin-validation"`
 	NoPTY                     bool     `cli:"no-pty"`
+	NoHTTP2                   bool     `cli:"no-http2"`
 	TimestampLines            bool     `cli:"timestamp-lines"`
 	Endpoint                  string   `cli:"endpoint" validate:"required"`
 	Debug                     bool     `cli:"debug"`
@@ -271,6 +272,11 @@ var AgentStartCommand = cli.Command{
 			Usage:  "Don't automatically checkout git submodules",
 			EnvVar: "BUILDKITE_NO_GIT_SUBMODULES,BUILDKITE_DISABLE_GIT_SUBMODULES",
 		},
+		cli.BoolFlag{
+			Name:   "no-http2",
+			Usage:  "Disable HTTP2 when communicating with the Agent API.",
+			EnvVar: "BUILDKITE_NO_HTTP2",
+		},
 		ExperimentsFlag,
 		EndpointFlag,
 		NoColorFlag,
@@ -386,6 +392,7 @@ var AgentStartCommand = cli.Command{
 			TagsFromHost:          cfg.TagsFromHost,
 			WaitForEC2TagsTimeout: ec2TagTimeout,
 			Endpoint:              cfg.Endpoint,
+			DisableHTTP2:          cfg.NoHTTP2,
 			AgentConfiguration: &agent.AgentConfiguration{
 				BootstrapScript:           cfg.BootstrapScript,
 				BuildPath:                 cfg.BuildPath,
@@ -403,7 +410,7 @@ var AgentStartCommand = cli.Command{
 				TimestampLines:            cfg.TimestampLines,
 				DisconnectAfterJob:        cfg.DisconnectAfterJob,
 				DisconnectAfterJobTimeout: cfg.DisconnectAfterJobTimeout,
-				Shell: cfg.Shell,
+				Shell:                     cfg.Shell,
 			},
 		}
 


### PR DESCRIPTION
This adds a flag that lets us optionally disable http2 for communicating with the Agent API. This is useful for proxies that don't support http2. 