### PR TITLE
Use a channel to monitor whether process is killed

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -60,6 +60,8 @@ func (p *Process) Start() error {
 
 	p.command = exec.Command(p.Script[0], p.Script[1:]...)
 
+	// Create a channel that we use for signaling when the process is
+	// done for Done()
 	p.mu.Lock()
 	if p.done == nil {
 		p.done = make(chan struct{})
@@ -244,6 +246,8 @@ func (p *Process) Start() error {
 
 	// The process is no longer running at this point
 	p.setRunning(false)
+
+	// Signal waiting consumers in Done() by closing the done channel
 	close(p.done)
 
 	// Find the exit status of the script
@@ -271,6 +275,7 @@ func (p *Process) Output() string {
 // Done returns a channel that is closed when the process finishes
 func (p *Process) Done() <-chan struct{} {
 	p.mu.Lock()
+	// We create this here in case this is called before Start()
 	if p.done == nil {
 		p.done = make(chan struct{})
 	}

--- a/process/process.go
+++ b/process/process.go
@@ -275,6 +275,8 @@ func (p *Process) Done() <-chan struct{} {
 	return d
 }
 
+// Kill terminates the process gracefully. Initially a SIGTERM is sent, and
+// then 10 seconds later a SIGTERM is sent.
 func (p *Process) Kill() error {
 	var err error
 	if runtime.GOOS == "windows" {
@@ -324,7 +326,7 @@ func (p *Process) signal(sig os.Signal) error {
 }
 
 // Returns whether or not the process is running
-// Deprecated: use Wait() instead
+// Deprecated: use Done() instead
 func (p *Process) IsRunning() bool {
 	return atomic.LoadInt32(&p.running) != 0
 }


### PR DESCRIPTION
Chatting with @sj26, we sometimes miss out on exit signals for killed processes because we call `wait()` in the start loop but also in the kill loop to monitor if the kill worked. 

This ditches that and just uses a channel internally to monitor of the process has exited or not. 

Future work would be to replace `IsRunning()` which is a busy-wait with a blocking call to `Done()`. 