### PR TITLE
Removes process callbacks and moves them to job runner

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -1,18 +1,15 @@
 package process
 
 import (
-	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
-	"regexp"
 	"runtime"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -27,44 +24,29 @@ type Process struct {
 	Env        []string
 	ExitStatus string
 
-	buffer  outputBuffer
-	command *exec.Cmd
+	// Handler is called with each line of output
+	Handler func(string)
 
-	// This callback is called when the process offically starts
-	StartCallback func()
-
-	// For every line in the process output, this callback will be called
-	// with the contents of the line if its filter returns true.
-	LineCallback       func(string)
-	LinePreProcessor   func(string) string
-	LineCallbackFilter func(string) bool
-
-	// Running is stored as an int32 so we can use atomic operations to
-	// set/get it (it's accessed by multiple goroutines)
-	running int32
-
-	mu   sync.Mutex
-	done chan struct{}
+	command       *exec.Cmd
+	mu            sync.Mutex
+	started, done chan struct{}
 }
-
-// If you change header parsing here make sure to change it in the
-// buildkite.com frontend logic, too
-
-var headerExpansionRegex = regexp.MustCompile("^(?:\\^\\^\\^\\s+\\+\\+\\+)\\s*$")
 
 // Start executes the command and blocks until it finishes
 func (p *Process) Start() error {
-	if p.IsRunning() {
+	if p.command != nil {
 		return fmt.Errorf("Process is already running")
 	}
 
 	p.command = exec.Command(p.Script[0], p.Script[1:]...)
 
-	// Create a channel that we use for signaling when the process is
-	// done for Done()
+	// Create channels for signalling started and done
 	p.mu.Lock()
 	if p.done == nil {
 		p.done = make(chan struct{})
+	}
+	if p.started == nil {
+		p.started = make(chan struct{})
 	}
 	p.mu.Unlock()
 
@@ -79,13 +61,6 @@ func (p *Process) Start() error {
 
 	lineReaderPipe, lineWriterPipe := io.Pipe()
 
-	var multiWriter io.Writer
-	if p.Timestamp {
-		multiWriter = io.MultiWriter(lineWriterPipe)
-	} else {
-		multiWriter = io.MultiWriter(&p.buffer, lineWriterPipe)
-	}
-
 	// Toggle between running in a pty
 	if p.PTY {
 		pty, err := StartPTY(p.command)
@@ -95,7 +70,9 @@ func (p *Process) Start() error {
 		}
 
 		p.Pid = p.command.Process.Pid
-		p.setRunning(true)
+
+		// Signal waiting consumers in Started() by closing the started channel
+		close(p.started)
 
 		waitGroup.Add(1)
 
@@ -104,7 +81,7 @@ func (p *Process) Start() error {
 
 			// Copy the pty to our buffer. This will block until it
 			// EOF's or something breaks.
-			_, err = io.Copy(multiWriter, pty)
+			_, err = io.Copy(lineWriterPipe, pty)
 			if e, ok := err.(*os.PathError); ok && e.Err == syscall.EIO {
 				// We can safely ignore this error, because
 				// it's just the PTY telling us that it closed
@@ -122,8 +99,8 @@ func (p *Process) Start() error {
 			waitGroup.Done()
 		}()
 	} else {
-		p.command.Stdout = multiWriter
-		p.command.Stderr = multiWriter
+		p.command.Stdout = lineWriterPipe
+		p.command.Stderr = lineWriterPipe
 		p.command.Stdin = nil
 
 		err := p.command.Start()
@@ -133,109 +110,27 @@ func (p *Process) Start() error {
 		}
 
 		p.Pid = p.command.Process.Pid
-		p.setRunning(true)
+
+		// Signal waiting consumers in Started() by closing the started channel
+		close(p.started)
 	}
 
 	logger.Info("[Process] Process is running with PID: %d", p.Pid)
 
-	// Add the line callback routine to the waitGroup
-	waitGroup.Add(1)
+	if p.Handler != nil {
+		// Add the scanner the waitGroup
+		waitGroup.Add(1)
 
-	go func() {
-		logger.Debug("[LineScanner] Starting to read lines")
-
-		reader := bufio.NewReader(lineReaderPipe)
-
-		var appending []byte
-		var lineCallbackWaitGroup sync.WaitGroup
-
-		for {
-			line, isPrefix, err := reader.ReadLine()
-			if err != nil {
-				if err == io.EOF {
-					logger.Debug("[LineScanner] Encountered EOF")
-					break
-				}
-
-				logger.Error("[LineScanner] Failed to read: (%T: %v)", err, err)
+		// Start the Scanner
+		go func() {
+			defer waitGroup.Done()
+			if err := ScanLines(lineReaderPipe, p.Handler); err != nil {
+				logger.Error("[Process] Scanner failed with %v", err)
 			}
-
-			// If isPrefix is true, that means we've got a really
-			// long line incoming, and we'll keep appending to it
-			// until isPrefix is false (which means the long line
-			// has ended.
-			if isPrefix && appending == nil {
-				logger.Debug("[LineScanner] Line is too long to read, going to buffer it until it finishes")
-				// bufio.ReadLine returns a slice which is only valid until the next invocation
-				// since it points to its own internal buffer array. To accumulate the entire
-				// result we make a copy of the first prefix, and insure there is spare capacity
-				// for future appends to minimize the need for resizing on append.
-				appending = make([]byte, len(line), (cap(line))*2)
-				copy(appending, line)
-
-				continue
-			}
-
-			// Should we be appending?
-			if appending != nil {
-				appending = append(appending, line...)
-
-				// No more isPrefix! Line is finished!
-				if !isPrefix {
-					logger.Debug("[LineScanner] Finished buffering long line")
-					line = appending
-
-					// Reset appending back to nil
-					appending = nil
-				} else {
-					continue
-				}
-			}
-
-			// If we're timestamping this main thread will take
-			// the hit of running the regex so we can build up
-			// the timestamped buffer without breaking headers,
-			// otherwise we let the goroutines take the perf hit.
-
-			checkedForCallback := false
-			lineHasCallback := false
-			lineString := p.LinePreProcessor(string(line))
-
-			// Create the prefixed buffer
-			if p.Timestamp {
-				lineHasCallback = p.LineCallbackFilter(lineString)
-				checkedForCallback = true
-				if lineHasCallback || headerExpansionRegex.MatchString(lineString) {
-					// Don't timestamp special lines (e.g. header)
-					p.buffer.WriteString(fmt.Sprintf("%s\n", line))
-				} else {
-					currentTime := time.Now().UTC().Format(time.RFC3339)
-					p.buffer.WriteString(fmt.Sprintf("[%s] %s\n", currentTime, line))
-				}
-			}
-
-			if lineHasCallback || !checkedForCallback {
-				lineCallbackWaitGroup.Add(1)
-				go func(line string) {
-					defer lineCallbackWaitGroup.Done()
-					if (checkedForCallback && lineHasCallback) || p.LineCallbackFilter(lineString) {
-						p.LineCallback(line)
-					}
-				}(lineString)
-			}
-		}
-
-		// We need to make sure all the line callbacks have finish before
-		// finish up the process
-		logger.Debug("[LineScanner] Waiting for callbacks to finish")
-		lineCallbackWaitGroup.Wait()
-
-		logger.Debug("[LineScanner] Finished")
-		waitGroup.Done()
-	}()
-
-	// Call the StartCallback
-	go p.StartCallback()
+		}()
+	} else {
+		go io.Copy(ioutil.Discard, lineReaderPipe)
+	}
 
 	// Wait until the process has finished. The returned error is nil if the command runs,
 	// has no problems copying stdin, stdout, and stderr, and exits with a zero exit status.
@@ -243,9 +138,6 @@ func (p *Process) Start() error {
 
 	// Close the line writer pipe
 	lineWriterPipe.Close()
-
-	// The process is no longer running at this point
-	p.setRunning(false)
 
 	// Signal waiting consumers in Done() by closing the done channel
 	close(p.done)
@@ -267,11 +159,6 @@ func (p *Process) Start() error {
 	return nil
 }
 
-// Output returns the current state of the output buffer and can be called incrementally
-func (p *Process) Output() string {
-	return p.buffer.String()
-}
-
 // Done returns a channel that is closed when the process finishes
 func (p *Process) Done() <-chan struct{} {
 	p.mu.Lock()
@@ -280,6 +167,18 @@ func (p *Process) Done() <-chan struct{} {
 		p.done = make(chan struct{})
 	}
 	d := p.done
+	p.mu.Unlock()
+	return d
+}
+
+// Started returns a channel that is closed when the process is started
+func (p *Process) Started() <-chan struct{} {
+	p.mu.Lock()
+	// We create this here in case this is called before Start()
+	if p.started == nil {
+		p.started = make(chan struct{})
+	}
+	d := p.started
 	p.mu.Unlock()
 	return d
 }
@@ -334,23 +233,6 @@ func (p *Process) signal(sig os.Signal) error {
 	return nil
 }
 
-// Returns whether or not the process is running
-// Deprecated: use Done() instead
-func (p *Process) IsRunning() bool {
-	return atomic.LoadInt32(&p.running) != 0
-}
-
-// Sets the running flag of the process
-func (p *Process) setRunning(r bool) {
-	// Use the atomic package to avoid race conditions when setting the
-	// `running` value from multiple routines
-	if r {
-		atomic.StoreInt32(&p.running, 1)
-	} else {
-		atomic.StoreInt32(&p.running, 0)
-	}
-}
-
 // https://github.com/hnakamur/commango/blob/fe42b1cf82bf536ce7e24dceaef6656002e03743/os/executil/executil.go#L29
 // TODO: Can this be better?
 func getExitStatus(waitResult error) string {
@@ -389,32 +271,4 @@ func timeoutWait(waitGroup *sync.WaitGroup) error {
 	case <-time.After(10 * time.Second):
 		return errors.New("Timeout")
 	}
-}
-
-// outputBuffer is a goroutine safe bytes.Buffer
-type outputBuffer struct {
-	sync.RWMutex
-	buf bytes.Buffer
-}
-
-// Write appends the contents of p to the buffer, growing the buffer as needed. It returns
-// the number of bytes written.
-func (ob *outputBuffer) Write(p []byte) (n int, err error) {
-	ob.Lock()
-	defer ob.Unlock()
-	return ob.buf.Write(p)
-}
-
-// WriteString appends the contents of s to the buffer, growing the buffer as needed. It returns
-// the number of bytes written.
-func (ob *outputBuffer) WriteString(s string) (n int, err error) {
-	return ob.Write([]byte(s))
-}
-
-// String returns the contents of the unread portion of the buffer
-// as a string.  If the Buffer is a nil pointer, it returns "<nil>".
-func (ob *outputBuffer) String() string {
-	ob.RLock()
-	defer ob.RUnlock()
-	return ob.buf.String()
 }

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"reflect"
-	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -13,30 +11,24 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/process"
 )
 
-const longTestOutput = `+++ My header
-llamas
-and more llamas
-a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line
-and some alpacas
-`
-
-func TestProcessRunsAndCallsStartCallback(t *testing.T) {
+func TestProcessRunsAndSignalsStartedAndStopped(t *testing.T) {
 	var started int32
+	var done int32
 
 	p := process.Process{
 		Script: []string{os.Args[0]},
 		Env:    []string{"TEST_MAIN=tester"},
-		StartCallback: func() {
-			atomic.AddInt32(&started, 1)
-		},
-		LineCallback:       func(s string) {},
-		LinePreProcessor:   func(s string) string { return s },
-		LineCallbackFilter: func(s string) bool { return false },
 	}
+
+	go func() {
+		<-p.Started()
+		atomic.AddInt32(&started, 1)
+		<-p.Done()
+		atomic.AddInt32(&done, 1)
+	}()
 
 	if err := p.Start(); err != nil {
 		t.Fatal(err)
@@ -46,157 +38,49 @@ func TestProcessRunsAndCallsStartCallback(t *testing.T) {
 		t.Fatalf("Expected started to be 1, got %d", startedVal)
 	}
 
+	if doneVal := atomic.LoadInt32(&done); doneVal != 1 {
+		t.Fatalf("Expected done to be 1, got %d", doneVal)
+	}
+
 	if exitStatus := p.ExitStatus; exitStatus != "0" {
 		t.Fatalf("Expected ExitStatus of 0, got %v", exitStatus)
 	}
-
-	output := p.Output()
-	if output != string(longTestOutput) {
-		t.Fatalf("Output was unexpected:\nWanted: %q\nGot:    %q\n", longTestOutput, output)
-	}
 }
 
-func TestProcessCallsLineCallbacksForEachOutputLine(t *testing.T) {
-	var lineCounter int32
+func TestProcessIsKilledGracefully(t *testing.T) {
 	var lines []string
-	var linesLock sync.Mutex
-
-	p := process.Process{
-		Script:        []string{os.Args[0]},
-		Env:           []string{"TEST_MAIN=tester"},
-		StartCallback: func() {},
-		LineCallback: func(s string) {
-			linesLock.Lock()
-			defer linesLock.Unlock()
-			lines = append(lines, s)
-		},
-		LinePreProcessor: func(s string) string {
-			lineNumber := atomic.AddInt32(&lineCounter, 1)
-			return fmt.Sprintf("#%d: chars %d", lineNumber, len(s))
-		},
-		LineCallbackFilter: func(s string) bool {
-			return true
-		},
-	}
-
-	if err := p.Start(); err != nil {
-		t.Fatal(err)
-	}
-
-	linesLock.Lock()
-
-	var expected = []string{
-		`#1: chars 13`,
-		`#2: chars 6`,
-		`#3: chars 15`,
-		`#4: chars 237`,
-		`#5: chars 16`,
-	}
-
-	if !reflect.DeepEqual(expected, lines) {
-		t.Fatalf("Lines was unexpected:\nWanted: %v\nGot:    %v\n", expected, lines)
-	}
-}
-
-func TestProcessPrependsLinesWithTimestamps(t *testing.T) {
-	p := process.Process{
-		Script:             []string{os.Args[0]},
-		Env:                []string{"TEST_MAIN=tester"},
-		StartCallback:      func() {},
-		LineCallback:       func(s string) {},
-		LinePreProcessor:   func(s string) string { return s },
-		LineCallbackFilter: func(s string) bool { return strings.HasPrefix(s, "+++") },
-		Timestamp:          true,
-	}
-
-	if err := p.Start(); err != nil {
-		t.Fatal(err)
-	}
-
-	lines := strings.Split(strings.TrimSpace(p.Output()), "\n")
-
-	if lines[0] != `+++ My header` {
-		t.Fatalf("Expected first line to be %q, got %q", `+++ My header`, lines[0])
-	}
-
-	tsRegex := regexp.MustCompile(`^\[.+?\]`)
-
-	for _, line := range lines[1:] {
-		if !tsRegex.MatchString(line) {
-			t.Fatalf("Line doesn't start with a timestamp: %s", line)
-		}
-	}
-}
-
-func TestProcessOutputIsSafeFromRaces(t *testing.T) {
-	var counter int32
-
-	p := process.Process{
-		Script:             []string{os.Args[0]},
-		Env:                []string{"TEST_MAIN=tester"},
-		LineCallback:       func(s string) {},
-		LinePreProcessor:   func(s string) string { return s },
-		LineCallbackFilter: func(s string) bool { return false },
-	}
-
-	// the job_runner has a for loop that calls IsRunning and Output, so this checks those are safe from races
-	p.StartCallback = func() {
-		for p.IsRunning() {
-			_ = p.Output()
-			atomic.AddInt32(&counter, 1)
-			time.Sleep(time.Millisecond * 10)
-		}
-	}
-
-	if err := p.Start(); err != nil {
-		t.Fatal(err)
-	}
-
-	output := p.Output()
-	if output != string(longTestOutput) {
-		t.Fatalf("Output was unexpected:\nWanted: %q\nGot:    %q\n", longTestOutput, output)
-	}
-
-	if counterVal := atomic.LoadInt32(&counter); counterVal < 10 {
-		t.Fatalf("Expected counter to be at least 10, got %d", counterVal)
-	}
-}
-
-func TestKillingProcess(t *testing.T) {
-	logger.SetLevel(logger.DEBUG)
+	var mu sync.Mutex
 
 	p := process.Process{
 		Script: []string{os.Args[0]},
 		Env:    []string{"TEST_MAIN=tester-signal"},
-		LineCallback: func(s string) {
-			t.Logf("Line: %s", s)
+		Handler: func(s string) {
+			mu.Lock()
+			defer mu.Unlock()
+			lines = append(lines, s)
 		},
-		LinePreProcessor:   func(s string) string { return s },
-		LineCallbackFilter: func(s string) bool { return false },
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	p.StartCallback = func() {
-		go func() {
-			<-time.After(time.Millisecond * 10)
-			if err := p.Kill(); err != nil {
-				t.Error(err)
-			}
-		}()
 	}
 
 	go func() {
-		defer wg.Done()
-		if err := p.Start(); err != nil {
+		<-p.Started()
+
+		// Needs some time to install signal handler
+		<-time.After(time.Millisecond * 10)
+
+		t.Logf("Killing process")
+		if err := p.Kill(); err != nil {
 			t.Error(err)
 		}
 	}()
 
-	wg.Wait()
+	if err := p.Start(); err != nil {
+		t.Error(err)
+	}
 
-	output := p.Output()
+	mu.Lock()
+	defer mu.Unlock()
+
+	output := strings.Join(lines, "\n")
 	if output != `SIG terminated` {
 		t.Fatalf("Bad output: %q", output)
 	}

--- a/process/scanner.go
+++ b/process/scanner.go
@@ -1,0 +1,90 @@
+package process
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"sync"
+
+	"github.com/buildkite/agent/logger"
+)
+
+func ScanLines(r io.Reader, f func(line string)) error {
+	var reader = bufio.NewReader(r)
+	var appending []byte
+
+	logger.Debug("[LineScanner] Starting to read lines")
+
+	// Note that we do this manually rather than
+	// because we need to handle very long lines
+
+	for {
+		line, isPrefix, err := reader.ReadLine()
+		if err != nil {
+			if err == io.EOF {
+				logger.Debug("[LineScanner] Encountered EOF")
+				break
+			}
+			return err
+		}
+
+		// If isPrefix is true, that means we've got a really
+		// long line incoming, and we'll keep appending to it
+		// until isPrefix is false (which means the long line
+		// has ended.
+		if isPrefix && appending == nil {
+			logger.Debug("[LineScanner] Line is too long to read, going to buffer it until it finishes")
+
+			// bufio.ReadLine returns a slice which is only valid until the next invocation
+			// since it points to its own internal buffer array. To accumulate the entire
+			// result we make a copy of the first prefix, and ensure there is spare capacity
+			// for future appends to minimize the need for resizing on append.
+			appending = make([]byte, len(line), (cap(line))*2)
+			copy(appending, line)
+
+			continue
+		}
+
+		// Should we be appending?
+		if appending != nil {
+			appending = append(appending, line...)
+
+			// No more isPrefix! Line is finished!
+			if !isPrefix {
+				logger.Debug("[LineScanner] Finished buffering long line")
+				line = appending
+
+				// Reset appending back to nil
+				appending = nil
+			} else {
+				continue
+			}
+		}
+
+		// Write to the handler function
+		f(string(line))
+	}
+
+	logger.Debug("[LineScanner] Finished")
+	return nil
+}
+
+type LineBuffer struct {
+	mu  sync.RWMutex
+	buf bytes.Buffer
+}
+
+func (l *LineBuffer) WriteLine(line string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Finally write the line to the writer
+	l.buf.Write([]byte(line + "\n"))
+}
+
+// Output returns the buffered output of the line processor
+func (l *LineBuffer) Output() string {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.buf.String()
+}

--- a/process/scanner_test.go
+++ b/process/scanner_test.go
@@ -1,0 +1,56 @@
+package process_test
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent/process"
+)
+
+const longTestOutput = `+++ My header
+llamas
+and more llamas
+a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line
+and some alpacas
+`
+
+func TestScanLines(t *testing.T) {
+	var lineCounter int32
+	var lines []string
+
+	pr, pw := io.Pipe()
+
+	go func() {
+		for _, line := range strings.Split(strings.TrimSuffix(longTestOutput, "\n"), "\n") {
+			fmt.Fprintf(pw, "%s\n", line)
+			time.Sleep(time.Millisecond * 10)
+		}
+		pw.Close()
+	}()
+
+	err := process.ScanLines(pr, func(l string) {
+		lineNumber := atomic.AddInt32(&lineCounter, 1)
+		s := fmt.Sprintf("#%d: chars %d", lineNumber, len(l))
+		lines = append(lines, s)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var expected = []string{
+		`#1: chars 13`,
+		`#2: chars 6`,
+		`#3: chars 15`,
+		`#4: chars 237`,
+		`#5: chars 16`,
+	}
+
+	if !reflect.DeepEqual(expected, lines) {
+		t.Fatalf("Lines was unexpected:\nWanted: %v\nGot: %v\n", expected, lines)
+	}
+}


### PR DESCRIPTION
This follows up #855 with a further cleanup of the process package. Previously there was a complicated set of callbacks for processing log output. This replaces that with a much simpler setup that moves that logic into the `agent.JobRunner`, where I think it belongs. This leaves `process.Process` as a generic process runner with a much simpler (and goroutine-safe) API.

I also removed `Process.IsRunning` in favour of `Process.Started()` which uses that same channel closing trick as `Process.Done()`. 