### PR TITLE
Add a cache volume for go modules

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.11
+
+WORKDIR /code
+
+# cache go modules in docker cache
+COPY go.mod go.sum /code/
+RUN go mod download

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -2,10 +2,10 @@ version: '2.1'
 
 services:
   agent:
-    image: golang:1.11
-    working_dir: /code
+    build:
+      dockerfile: .buildkite/Dockerfile
+      context: ../
     volumes:
-      - module_cache:/go/pkg/mod
       - ../:/code:cached
     environment:
       - BUILDKITE_BUILD_NUMBER

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: golang:1.11
     working_dir: /code
     volumes:
+      - module_cache:/go/pkg/mod
       - ../:/code:cached
     environment:
       - BUILDKITE_BUILD_NUMBER

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ Dockerfile*
 docker-compose*
 .vagrant
 packaging
+.gomodules


### PR DESCRIPTION
This will hopefully provide at least some caching for downloading of go modules on every build. 