### PR TITLE
Don't retry checkout on cancel

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -708,7 +708,16 @@ func (b *Bootstrap) CheckoutPhase() error {
 	default:
 		err := retry.Do(func(s *retry.Stats) error {
 			err := b.defaultCheckoutPhase()
-			if err != nil {
+			if err == nil {
+				return nil
+			}
+
+			switch {
+			case shell.IsExitError(err) && shell.GetExitCode(err) == -1:
+				b.shell.Warningf("Checkout was interrupted by a signal")
+				s.Break()
+
+			default:
 				b.shell.Warningf("Checkout failed! %s (%s)", err, s)
 
 				// Checkout can fail because of corrupted files in the checkout


### PR DESCRIPTION
Currently our checkout retry logic will try and retry on cancellation. This prevents that happening by detecting if the reason for cancellation was that we didn't get an exitcode from the checkout process (e.g because it was sent a `SIGTERM` and lacks a signal handler). 