### PR TITLE
Fix broken docker environment for windows tests

### DIFF
--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -24,3 +24,8 @@ WORKDIR c:/code
 # Cache go modules in docker cache
 COPY go.mod go.sum c:/code/
 RUN go mod download
+
+WORKDIR 'G:\\'
+ENV GO111MODULE=on
+
+ENTRYPOINT ["CMD.EXE", "/S", "/C"]

--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -12,7 +12,8 @@ RUN powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object Sys
 # Install Chocolatey packages
 RUN choco install -y git.install -params '"/GitAndUnixToolsOnPath"' && \
   choco install -y openssh && \
-  choco install golang --version 1.11.4 -my
+  choco install golang --version 1.11.4 -my && \
+  choco install -y mingw
 
 WORKDIR c:/code
 

--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -24,6 +24,3 @@ WORKDIR c:/code
 # Cache go modules in docker cache
 COPY go.mod go.sum c:/code/
 RUN go mod download
-
-WORKDIR 'G:\\'
-ENTRYPOINT ["CMD.EXE", "/S", "/C"]

--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -14,15 +14,11 @@ RUN choco install -y git.install -params '"/GitAndUnixToolsOnPath"' && \
   choco install -y openssh && \
   choco install golang --version 1.11.4 -my
 
-# Hack for mounting in code later (Use G:)
-# See https://github.com/moby/moby/issues/27537#issuecomment-271546031
-VOLUME c:/data
-RUN powershell set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'G:' -Value '\??\C:\data' -Type String
-
 WORKDIR c:/code
 
 # Cache go modules in docker cache
 COPY go.mod go.sum c:/code/
 RUN go mod download
 
-ENTRYPOINT ["CMD.EXE", "/S", "/C"]
+# Copy the rest of the code
+COPY . c:/code/

--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -12,7 +12,7 @@ RUN powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object Sys
 # Install Chocolatey packages
 RUN choco install -y git.install -params '"/GitAndUnixToolsOnPath"' && \
   choco install -y openssh && \
-  choco install golang --version 1.11.2 -my
+  choco install golang --version 1.11.4 -my
 
 # Hack for mounting in code later (Use G:)
 # See https://github.com/moby/moby/issues/27537#issuecomment-271546031
@@ -26,6 +26,4 @@ COPY go.mod go.sum c:/code/
 RUN go mod download
 
 WORKDIR 'G:\\'
-ENV GO111MODULE=on
-
 ENTRYPOINT ["CMD.EXE", "/S", "/C"]

--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -24,3 +24,5 @@ WORKDIR c:/code
 # Cache go modules in docker cache
 COPY go.mod go.sum c:/code/
 RUN go mod download
+
+ENTRYPOINT ["CMD.EXE", "/S", "/C"]

--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -23,3 +23,6 @@ RUN go mod download
 
 # Copy the rest of the code
 COPY . c:/code/
+
+# Run things in bash
+ENTRYPOINT ["BASH.EXE"]

--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -12,19 +12,15 @@ RUN powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object Sys
 # Install Chocolatey packages
 RUN choco install -y git.install -params '"/GitAndUnixToolsOnPath"' && \
   choco install -y openssh && \
-  choco install -y golang
+  choco install golang --version 1.11.2 -my
 
 # Hack for mounting in code later (Use G:)
 # See https://github.com/moby/moby/issues/27537#issuecomment-271546031
 VOLUME c:/data
 RUN powershell set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'G:' -Value '\??\C:\data' -Type String
 
-# Copy across the agent source
-ENV GOPATH=c:/gopath
-WORKDIR c:/gopath/src/github.com/buildkite/agent
-COPY . .
+WORKDIR c:/code
 
-# Build agent and put binary in a dir in the PATH (remarkably hard to add to path)
-RUN go build -i -o .\buildkite-agent.exe
-
-CMD ["./buildkite-agent.exe", "start"]
+# Cache go modules in docker cache
+COPY go.mod go.sum c:/code/
+RUN go mod download

--- a/.buildkite/docker-compose.windows.yml
+++ b/.buildkite/docker-compose.windows.yml
@@ -9,7 +9,7 @@ services:
       context: ../
     volumes:
       - ../:c:/data
-    working_dir: g:/
+    working_dir: c:/data
     tty: false
     environment:
       - BUILDKITE_BUILD_NUMBER

--- a/.buildkite/docker-compose.windows.yml
+++ b/.buildkite/docker-compose.windows.yml
@@ -7,13 +7,11 @@ services:
     build:
       dockerfile: .buildkite/Dockerfile-windows
       context: ../
-    volumes:
-      - ../:c:/data
-    working_dir: c:/data
     tty: false
     environment:
       - BUILDKITE_BUILD_NUMBER
       - "BUILDKITE_BUILD_PATH=c:\\buildkite\\builds"
+      - GO111MODULE=on
 
 networks:
   default:

--- a/.buildkite/docker-compose.windows.yml
+++ b/.buildkite/docker-compose.windows.yml
@@ -5,9 +5,12 @@ version: "3.2"
 services:
   agent:
     build:
-      dockerfile: Dockerfile-windows
+      dockerfile: .buildkite/Dockerfile-windows
       context: ../
-    working_dir: C:/gopath/src/github.com/buildkite/agent
+    volumes:
+      - ../:c:/data
+    working_dir: g:/
+    tty: false
     environment:
       - BUILDKITE_BUILD_NUMBER
       - "BUILDKITE_BUILD_PATH=c:\\buildkite\\builds"

--- a/.buildkite/pipeline.windows.yml
+++ b/.buildkite/pipeline.windows.yml
@@ -1,7 +1,0 @@
-steps:
-  - name: ":hammer: :windows:"
-    command: 
-      - "docker-compose -f docker-compose.windows.yml build --pull agent"
-      - "docker-compose -f docker-compose.windows.yml run --rm -T agent bash.exe ./.buildkite/steps/tests.sh"
-    agents:
-      queue: "windows"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,9 +12,6 @@ steps:
   - name: ":hammer: :windows:"
     command:
       - "docker-compose -f ./.buildkite/docker-compose.windows.yml build --pull agent"
-      - "docker-compose -f ./.buildkite/docker-compose.windows.yml run -T agent cd"
-      - "docker-compose -f ./.buildkite/docker-compose.windows.yml run -T agent dir"
-      - "docker-compose -f ./.buildkite/docker-compose.windows.yml run -T agent go list ./..."
       - "docker-compose -f ./.buildkite/docker-compose.windows.yml run --rm -T agent go test -race -v ./..."
     agents:
       queue: "windows"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,14 +5,14 @@ steps:
   - name: ":hammer: :linux:"
     command: ".buildkite/steps/tests.sh"
     plugins:
-      docker-compose#v1.8.0:
+      docker-compose#v2.6.0:
         config: .buildkite/docker-compose.yml
         run: agent
 
   - name: ":hammer: :windows:"
     command: ".buildkite/steps/tests.sh"
     plugins:
-      docker-compose#v1.8.0:
+      docker-compose#v2.6.0:
         config: .buildkite/docker-compose.windows.yml
         run: agent
         tty: false
@@ -25,7 +25,7 @@ steps:
     command: ".buildkite/steps/build-binary.sh windows 386"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.8.0:
+      docker-compose#v2.6.0:
         config: .buildkite/docker-compose.yml
         run: agent
 
@@ -33,7 +33,7 @@ steps:
     command: ".buildkite/steps/build-binary.sh windows amd64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.8.0:
+      docker-compose#v2.6.0:
         config: .buildkite/docker-compose.yml
         run: agent
 
@@ -41,7 +41,7 @@ steps:
     command: ".buildkite/steps/build-binary.sh linux amd64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.8.0:
+      docker-compose#v2.6.0:
         config: .buildkite/docker-compose.yml
         run: agent
 
@@ -49,7 +49,7 @@ steps:
     command: ".buildkite/steps/build-binary.sh linux 386"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.8.0:
+      docker-compose#v2.6.0:
         config: .buildkite/docker-compose.yml
         run: agent
 
@@ -57,7 +57,7 @@ steps:
     command: ".buildkite/steps/build-binary.sh linux arm"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.8.0:
+      docker-compose#v2.6.0:
         config: .buildkite/docker-compose.yml
         run: agent
 
@@ -65,7 +65,7 @@ steps:
     command: ".buildkite/steps/build-binary.sh linux armhf"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.8.0:
+      docker-compose#v2.6.0:
         config: .buildkite/docker-compose.yml
         run: agent
 
@@ -73,7 +73,7 @@ steps:
     command: ".buildkite/steps/build-binary.sh linux arm64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.8.0:
+      docker-compose#v2.6.0:
         config: .buildkite/docker-compose.yml
         run: agent
 
@@ -81,7 +81,7 @@ steps:
     command: ".buildkite/steps/build-binary.sh linux ppc64le"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.8.0:
+      docker-compose#v2.6.0:
         config: .buildkite/docker-compose.yml
         run: agent
 
@@ -89,7 +89,7 @@ steps:
     command: ".buildkite/steps/build-binary.sh darwin 386"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.8.0:
+      docker-compose#v2.6.0:
         config: .buildkite/docker-compose.yml
         run: agent
 
@@ -97,7 +97,7 @@ steps:
     command: ".buildkite/steps/build-binary.sh darwin amd64"
     artifact_paths: "pkg/*"
     plugins:
-      docker-compose#v1.8.0:
+      docker-compose#v2.6.0:
         config: .buildkite/docker-compose.yml
         run: agent
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,9 +10,11 @@ steps:
         run: agent
 
   - name: ":hammer: :windows:"
-    command:
-      - "docker-compose -f ./.buildkite/docker-compose.windows.yml build --pull agent"
-      - "docker-compose -f ./.buildkite/docker-compose.windows.yml run --rm -T agent bash.exe .buildkite/steps/tests.sh"
+    command: ".buildkite/steps/tests.sh"
+    plugins:
+      docker-compose#v1.8.0:
+        config: .buildkite/docker-compose.yml
+        run: agent
     agents:
       queue: "windows"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@ steps:
     command: ".buildkite/steps/tests.sh"
     plugins:
       docker-compose#v1.8.0:
-        config: .buildkite/docker-compose.yml
+        config: .buildkite/docker-compose.windows.yml
         run: agent
     agents:
       queue: "windows"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,7 @@ steps:
   - name: ":hammer: :windows:"
     command:
       - "docker-compose -f ./.buildkite/docker-compose.windows.yml build --pull agent"
-      - "docker-compose -f ./.buildkite/docker-compose.windows.yml run --rm -T agent go test -race -v ./..."
+      - "docker-compose -f ./.buildkite/docker-compose.windows.yml run --rm -T agent bash.exe .buildkite/steps/tests.sh"
     agents:
       queue: "windows"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,6 +15,7 @@ steps:
       docker-compose#v1.8.0:
         config: .buildkite/docker-compose.windows.yml
         run: agent
+        tty: false
     agents:
       queue: "windows"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,9 @@ steps:
   - name: ":hammer: :windows:"
     command:
       - "docker-compose -f ./.buildkite/docker-compose.windows.yml build --pull agent"
-      - "docker-compose -f ./.buildkite/docker-compose.windows.yml run --rm -T agent go list ./..."
+      - "docker-compose -f ./.buildkite/docker-compose.windows.yml run -T agent cd"
+      - "docker-compose -f ./.buildkite/docker-compose.windows.yml run -T agent dir"
+      - "docker-compose -f ./.buildkite/docker-compose.windows.yml run -T agent go list ./..."
       - "docker-compose -f ./.buildkite/docker-compose.windows.yml run --rm -T agent go test -race -v ./..."
     agents:
       queue: "windows"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,12 +10,12 @@ steps:
         run: agent
 
   - name: ":hammer: :windows:"
-    trigger: agent-windows
-    async: true
-    build:
-      message: "${BUILDKITE_MESSAGE}"
-      commit: "${BUILDKITE_COMMIT}"
-      branch: "${BUILDKITE_BRANCH}"
+    command:
+      - "docker-compose -f ./.buildkite/docker-compose.windows.yml build --pull agent"
+      - "docker-compose -f ./.buildkite/docker-compose.windows.yml run --rm -T agent go list ./..."
+      - "docker-compose -f ./.buildkite/docker-compose.windows.yml run --rm -T agent go test -race -v ./..."
+    agents:
+      queue: "windows"
 
   - wait
 

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -80,6 +81,10 @@ func TestProcessCapturesOutputLineByLine(t *testing.T) {
 }
 
 func TestProcessIsKilledGracefully(t *testing.T) {
+	if runtime.GOOS == `windows` {
+		t.Skip("Not supported on windows")
+	}
+
 	var lines []string
 	var mu sync.Mutex
 


### PR DESCRIPTION
For months our asynchronous windows tests have been broken. This unbreaks them, and moves them back into the main pipeline. They take 4 minutes to run, so this makes our tests slower, but it means we won't be able to break them in future. 