### PR TITLE
Add another search path for config file on Windows

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -101,6 +101,7 @@ func DefaultConfigFilePaths() (paths []string) {
 	if runtime.GOOS == "windows" {
 		paths = []string{
 			"C:\\buildkite-agent\\buildkite-agent.cfg",
+			"$USERPROFILE\\AppData\\Local\\buildkite-agent\\buildkite-agent.cfg",
 			"$USERPROFILE\\AppData\\Local\\BuildkiteAgent\\buildkite-agent.cfg",
 		}
 	} else {


### PR DESCRIPTION
... because I'm OCD enough that `BuildkiteAgent` struck me as inconsistent with `buildkite-agent` of most other usage sites. The user is kebab-case, the other search paths on other platforms are kebab-case, I couldn't think of a reason for Windows to be snowflake.