### PR TITLE
Change git-clean-flags to cleanup submodules

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -216,7 +216,7 @@ var AgentStartCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name:   "git-clean-flags",
-			Value:  "-fxdq",
+			Value:  "-ffxdq",
 			Usage:  "Flags to pass to \"git clean\" command",
 			EnvVar: "BUILDKITE_GIT_CLEAN_FLAGS",
 		},

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -179,7 +179,7 @@ var BootstrapCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name:   "git-clean-flags",
-			Value:  "-fxdq",
+			Value:  "-ffxdq",
 			Usage:  "Flags to pass to \"git clean\" command",
 			EnvVar: "BUILDKITE_GIT_CLEAN_FLAGS",
 		},

--- a/packaging/docker/alpine-linux/buildkite-agent.cfg
+++ b/packaging/docker/alpine-linux/buildkite-agent.cfg
@@ -37,7 +37,7 @@ plugins-path="/buildkite/plugins"
 # git-clone-flags=-v
 
 # Flags to pass to the `git clean` command
-# git-clean-flags=-fxdq
+# git-clean-flags=-ffxdq
 
 # Do not run jobs within a pseudo terminal
 # no-pty=true

--- a/packaging/docker/ubuntu-linux/buildkite-agent.cfg
+++ b/packaging/docker/ubuntu-linux/buildkite-agent.cfg
@@ -37,7 +37,7 @@ plugins-path="/buildkite/plugins"
 # git-clone-flags=-v
 
 # Flags to pass to the `git clean` command
-# git-clean-flags=-fxdq
+# git-clean-flags=-ffxdq
 
 # Do not run jobs within a pseudo terminal
 # no-pty=true

--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -37,7 +37,7 @@ plugins-path="$HOME/.buildkite-agent/plugins"
 # git-clone-flags=-v
 
 # Flags to pass to the `git clean` command
-# git-clean-flags=-fxdq
+# git-clean-flags=-ffxdq
 
 # Do not run jobs within a pseudo terminal
 # no-pty=true

--- a/packaging/github/windows/buildkite-agent.cfg
+++ b/packaging/github/windows/buildkite-agent.cfg
@@ -28,7 +28,7 @@ plugins-path="C:\buildkite-agent\plugins"
 # git-clone-flags=-v
 
 # Flags to pass to the `git clean` command
-# git-clean-flags=-fxdq
+# git-clean-flags=-ffxdq
 
 # Don't automatically verify SSH fingerprints (2.2 and above with `buildkite bootstrap`)
 # no-automatic-ssh-fingerprint-verification=true

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -37,7 +37,7 @@ plugins-path="/etc/buildkite-agent/plugins"
 # git-clone-flags=-v
 
 # Flags to pass to the `git clean` command
-# git-clean-flags=-fxdq
+# git-clean-flags=-ffxdq
 
 # Do not run jobs within a pseudo terminal
 # no-pty=true


### PR DESCRIPTION
Turns out that a second -f is needed to force `git clean` to remove .git subdirectories.

From https://git-scm.com/docs/git-clean:

> Git will refuse to delete directories with .git sub directory or file unless a second -f is given.

The big question here is whether this counts as a breaking change 🤔 I am leaning towards no, as I think we thought that this was the behaviour of the existing flags, so I view this as fixing a bug. 

Closes https://github.com/buildkite/agent/issues/865.