### PR TITLE
Use .gitmodules for determining what hosts to keyscan

### DIFF
--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -93,7 +93,7 @@ func gitEnumerateSubmoduleURLs(sh *shell.Shell) ([]string, error) {
 	// submodule.github-git-docker-example.url\ngit@github.com:buildkite/docker-example.git\0
 	// submodule.github-https-docker-example.url\nhttps://github.com/buildkite/docker-example.git\0
 	output, err := sh.RunAndCapture(
-		"git", "config", "--file", ".gitmodules", "--null", "--get-regexp", "url")
+		"git", "config", "--file", ".gitmodules", "--null", "--get-regexp", "submodule\\..+\\.url")
 	if err != nil {
 		return nil, err
 	}

--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -105,7 +105,7 @@ func gitEnumerateSubmoduleURLs(sh *shell.Shell) ([]string, error) {
 	for _, line := range lines {
 		tokens := strings.SplitN(line, "\n", 2)
 		if len(tokens) != 2 {
-			return nil, fmt.Errorf("Failed to parse .gitmodule line %q", line)
+			return nil, fmt.Errorf("Failed to parse .gitmodules line %q", line)
 		}
 		urls = append(urls, tokens[1])
 	}

--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -88,10 +88,10 @@ func gitEnumerateSubmoduleURLs(sh *shell.Shell) ([]string, error) {
 	urls := []string{}
 
 	// The output of this command looks like:
-	//submodule.bitbucket-git-docker-example.url\ngit@bitbucket.org:lox24/docker-example.git\0
-	//submodule.bitbucket-https-docker-example.url\nhttps://lox24@bitbucket.org/lox24/docker-example.git\0
-	//submodule.github-git-docker-example.url\ngit@github.com:buildkite/docker-example.git\0
-	//submodule.github-https-docker-example.url\nhttps://github.com/buildkite/docker-example.git\0
+	// submodule.bitbucket-git-docker-example.url\ngit@bitbucket.org:lox24/docker-example.git\0
+	// submodule.bitbucket-https-docker-example.url\nhttps://lox24@bitbucket.org/lox24/docker-example.git\0
+	// submodule.github-git-docker-example.url\ngit@github.com:buildkite/docker-example.git\0
+	// submodule.github-https-docker-example.url\nhttps://github.com/buildkite/docker-example.git\0
 	output, err := sh.RunAndCapture(
 		"git", "config", "--file", ".gitmodules", "--null", "--get-regexp", "url")
 	if err != nil {

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -102,12 +102,12 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 		{"submodule", "foreach", "--recursive", "git", "clean", "-fdq"},
 		{"fetch", "-v", "--prune", "origin", "master"},
 		{"checkout", "-f", "FETCH_HEAD"},
+		{"config", "--file", ".gitmodules", "--null", "--get-regexp", "url"},
 		{"submodule", "sync", "--recursive"},
 		{"submodule", "update", "--init", "--recursive", "--force"},
 		{"submodule", "foreach", "--recursive", "git", "reset", "--hard"},
 		{"clean", "-fdq"},
 		{"submodule", "foreach", "--recursive", "git", "clean", "-fdq"},
-		{"submodule", "foreach", "--recursive", "git", "ls-remote", "--get-url"},
 		{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color"},
 	})
 

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -102,7 +102,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 		{"submodule", "foreach", "--recursive", "git", "clean", "-fdq"},
 		{"fetch", "-v", "--prune", "origin", "master"},
 		{"checkout", "-f", "FETCH_HEAD"},
-		{"config", "--file", ".gitmodules", "--null", "--get-regexp", "url"},
+		{"config", "--file", ".gitmodules", "--null", "--get-regexp", "submodule\\..+\\.url"},
 		{"submodule", "sync", "--recursive"},
 		{"submodule", "update", "--init", "--recursive", "--force"},
 		{"submodule", "foreach", "--recursive", "git", "reset", "--hard"},

--- a/bootstrap/knownhosts.go
+++ b/bootstrap/knownhosts.go
@@ -113,6 +113,8 @@ func (kh *knownHosts) Add(host string) error {
 		return errors.Wrap(err, "Could not perform `ssh-keyscan`")
 	}
 
+	kh.Shell.Commentf("Added host %q to known hosts at \"%s\"", host, kh.Path)
+
 	// Try and open the existing hostfile in (append_only) mode
 	f, err := os.OpenFile(kh.Path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0700)
 	if err != nil {


### PR DESCRIPTION
Currently we use a git submodule foreach to try and get the url of all our submodules so that we can figure out if any need ssh keyscanning. This is unfortunately completely flawed as none of them exist until after we call git submodule update.

This uses the git config command to parse the .gitmodule file instead.

Closes https://github.com/buildkite/agent/issues/825. 