### PR TITLE
Allow hooks to change git repo url

### DIFF
--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	Debug bool
 
 	// The repository that needs to be cloned
-	Repository string
+	Repository string `env:"BUILDKITE_REPO"`
 
 	// The commit being built
 	Commit string

--- a/bootstrap/config_test.go
+++ b/bootstrap/config_test.go
@@ -11,6 +11,7 @@ func TestEnvVarsAreMappedToConfig(t *testing.T) {
 	t.Parallel()
 
 	config := &Config{
+		Repository:                   "https://original.host/repo.git",
 		AutomaticArtifactUploadPaths: "llamas/",
 		GitCloneFlags:                "--prune",
 		GitCleanFlags:                "-v",
@@ -21,12 +22,14 @@ func TestEnvVarsAreMappedToConfig(t *testing.T) {
 		"BUILDKITE_ARTIFACT_PATHS=newpath",
 		"BUILDKITE_GIT_CLONE_FLAGS=-f",
 		"BUILDKITE_SOMETHING_ELSE=1",
+		"BUILDKITE_REPO=https://my.mirror/repo.git",
 	})
 
 	changes := config.ReadFromEnvironment(environ)
 	expected := map[string]string{
 		"BUILDKITE_ARTIFACT_PATHS":  "newpath",
 		"BUILDKITE_GIT_CLONE_FLAGS": "-f",
+		"BUILDKITE_REPO":            "https://my.mirror/repo.git",
 	}
 
 	if !reflect.DeepEqual(expected, changes) {
@@ -36,5 +39,10 @@ func TestEnvVarsAreMappedToConfig(t *testing.T) {
 	if expected := "-v"; config.GitCleanFlags != expected {
 		t.Fatalf("Expected GitCleanFlags to be %v, got %v",
 			expected, config.GitCleanFlags)
+	}
+
+	if expected := "https://my.mirror/repo.git"; config.Repository != expected {
+		t.Fatalf("Expected Repository to be %v, got %v",
+			expected, config.Repository)
 	}
 }


### PR DESCRIPTION
Hooks should be able to export `$BUILDKITE_REPO` to change the git clone/fetch uri. The most compelling use case is for local mirrors of git repos, for caching purposes.