### PR TITLE
Support vendored plugins

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -36,6 +36,9 @@ type Bootstrap struct {
 	// Shell is the shell environment for the bootstrap
 	shell *shell.Shell
 
+	// Plugins to use
+	plugins []*plugin.Plugin
+
 	// Plugin checkouts from the plugin phases
 	pluginCheckouts []*pluginCheckout
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1,7 +1,6 @@
 package bootstrap
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -12,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"encoding/json"
 
 	"github.com/buildkite/agent/agent/plugin"
 	"github.com/buildkite/agent/bootstrap/shell"
@@ -36,8 +36,11 @@ type Bootstrap struct {
 	// Shell is the shell environment for the bootstrap
 	shell *shell.Shell
 
-	// Plugins are checkout out in the PluginPhase
-	plugins []*pluginCheckout
+	// Plugins to run from the plugin phase
+	plugins []*plugin.Plugin
+
+	// Plugin checkouts from the plugin phases
+	pluginCheckouts []*pluginCheckout
 
 	// Whether the checkout dir was created as part of checkout
 	createdCheckoutDir bool
@@ -100,6 +103,10 @@ func (b *Bootstrap) Start() (exitCode int) {
 		if exists {
 			_ = b.shell.Chdir(checkoutDir)
 		}
+	}
+
+	if includePhase(`plugin`) || includePhase(`vendored-plugin`) {
+		phaseErr = b.VendoredPluginPhase()
 	}
 
 	if phaseErr == nil && includePhase(`command`) {
@@ -420,7 +427,7 @@ func (b *Bootstrap) tearDown() error {
 		return err
 	}
 
-	if err := b.executePluginHook("pre-exit"); err != nil {
+	if err := b.executePluginHook("pre-exit", b.pluginCheckouts); err != nil {
 		return err
 	}
 
@@ -432,97 +439,190 @@ func (b *Bootstrap) tearDown() error {
 	return nil
 }
 
+func (b *Bootstrap) hasPlugins() bool {
+	if b.Config.Plugins == "" {
+		return false
+	}
+
+	return true
+}
+
+func (b *Bootstrap) loadPlugins() ([]*plugin.Plugin, error) {
+	if b.plugins != nil {
+		return b.plugins, nil
+	}
+
+	// Check if we can run plugins (disabled via --no-plugins)
+	if !b.Config.PluginsEnabled {
+		if !b.Config.LocalHooksEnabled {
+			return nil, fmt.Errorf("Plugins have been disabled on this agent with `--no-local-hooks`")
+		} else if !b.Config.CommandEval {
+			return nil, fmt.Errorf("Plugins have been disabled on this agent with `--no-command-eval`")
+		} else {
+			return nil, fmt.Errorf("Plugins have been disabled on this agent with `--no-plugins`")
+		}
+	}
+
+	var err error
+	b.plugins, err = plugin.CreateFromJSON(b.Config.Plugins)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to parse a plugin definition")
+	}
+
+	return b.plugins, nil
+}
+
+func (b *Bootstrap) validatePluginCheckout(checkout *pluginCheckout)  error {
+	if b.Config.PluginValidation {
+		return nil
+	}
+
+	if checkout.Definition == nil {
+		if b.Debug {
+			b.shell.Commentf("Parsing plugin definition for %s from %s", checkout.Plugin.Name(), checkout.CheckoutDir)
+		}
+		// parse the plugin definition from the plugin checkout dir
+		var err error
+		checkout.Definition, err = plugin.LoadDefinitionFromDir(checkout.CheckoutDir)
+		if err == plugin.ErrDefinitionNotFound {
+			b.shell.Warningf("Failed to find plugin definition for plugin %s", checkout.Plugin.Name())
+		} else if err != nil {
+			return err
+		}
+	}
+
+	val := &plugin.Validator{}
+	result := val.Validate(checkout.Definition, checkout.Plugin.Configuration)
+
+	if !result.Valid() {
+		b.shell.Headerf("Plugin validation failed for %q", checkout.Plugin.Name())
+		json, _ := json.Marshal(checkout.Plugin.Configuration)
+		b.shell.Commentf("Plugin configuration JSON is %s", json)
+		return result
+	}
+
+	b.shell.Commentf("Valid plugin configuration for %q", checkout.Plugin.Name())
+	return nil
+}
+
 // PluginPhase is where plugins that weren't filtered in the Environment phase are
 // checked out and made available to later phases
 func (b *Bootstrap) PluginPhase() error {
-	if b.Plugins == "" {
+	if !b.hasPlugins() {
 		return nil
 	}
 
 	b.shell.Headerf("Setting up plugins")
 
-	// Make sure we have a plugin path before trying to do anything
-	if b.PluginsPath == "" {
-		return fmt.Errorf("Can't checkout plugins without a `plugins-path`")
-	}
-
 	if b.Debug {
 		b.shell.Commentf("Plugin JSON is %s", b.Plugins)
 	}
 
-	// Check if we can run plugins (disabled via --no-plugins)
-	if b.Plugins != "" && !b.Config.PluginsEnabled {
-		if !b.Config.LocalHooksEnabled {
-			return fmt.Errorf("Plugins have been disabled on this agent with `--no-local-hooks`")
-		} else if !b.Config.CommandEval {
-			return fmt.Errorf("Plugins have been disabled on this agent with `--no-command-eval`")
-		} else {
-			return fmt.Errorf("Plugins have been disabled on this agent with `--no-plugins`")
-		}
-	}
-
-	plugins, err := plugin.CreateFromJSON(b.Plugins)
+	plugins, err := b.loadPlugins()
 	if err != nil {
-		return errors.Wrap(err, "Failed to parse plugin definition")
+		return err
 	}
 
-	b.plugins = []*pluginCheckout{}
+	checkouts := []*pluginCheckout{}
 
+	// Checkout and validate plugins that aren't vendored
 	for _, p := range plugins {
+		if p.Vendored {
+			if b.Debug {
+				b.shell.Commentf("Skipping vendored plugin %s", p.Name())
+			}
+			continue
+		}
+
 		checkout, err := b.checkoutPlugin(p)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to checkout plugin %s", p.Name())
 		}
-		if b.Config.PluginValidation {
-			if b.Debug {
-				b.shell.Commentf("Parsing plugin definition for %s from %s", p.Name(), checkout.CheckoutDir)
-			}
-			// parse the plugin definition from the plugin checkout dir
-			checkout.Definition, err = plugin.LoadDefinitionFromDir(checkout.CheckoutDir)
-			if err == plugin.ErrDefinitionNotFound {
-				b.shell.Warningf("Failed to find plugin definition for plugin %s", p.Name())
-			} else if err != nil {
-				return err
-			}
+
+		err = b.validatePluginCheckout(checkout)
+		if err != nil {
+			return err
 		}
-		b.plugins = append(b.plugins, checkout)
+
+		checkouts = append(checkouts, checkout)
 	}
 
-	if b.Config.PluginValidation {
-		for _, checkout := range b.plugins {
-			// This is nil if the definition failed to parse or is missing
-			if checkout.Definition == nil {
-				continue
-			}
-
-			val := &plugin.Validator{}
-			result := val.Validate(checkout.Definition, checkout.Plugin.Configuration)
-
-			if !result.Valid() {
-				b.shell.Headerf("Plugin validation failed for %q", checkout.Plugin.Name())
-				json, _ := json.Marshal(checkout.Plugin.Configuration)
-				b.shell.Commentf("Plugin configuration JSON is %s", json)
-				return result
-			} else {
-				b.shell.Commentf("Valid plugin configuration for %q", checkout.Plugin.Name())
-			}
-		}
-	}
+	// Store the checkouts for future use
+	b.pluginCheckouts = checkouts
 
 	// Now we can run plugin environment hooks too
-	return b.executePluginHook("environment")
+	return b.executePluginHook("environment", checkouts)
 }
 
-// Executes a named hook on all plugins that have it
-func (b *Bootstrap) executePluginHook(name string) error {
-	for _, p := range b.plugins {
+// VendoredPluginPhase is where plugins that are included in the checked out code are added
+func (b *Bootstrap) VendoredPluginPhase() error {
+	if !b.hasPlugins() {
+		return nil
+	}
+
+	b.shell.Headerf("Setting up vendored plugins")
+
+	plugins, err := b.loadPlugins()
+	if err != nil {
+		return err
+	}
+
+	vendoredCheckouts := []*pluginCheckout{}
+
+	// Validate vendored plugins
+	for _, p := range plugins {
+		if !p.Vendored {
+			continue
+		}
+
+		checkoutPath, _ := b.shell.Env.Get("BUILDKITE_BUILD_CHECKOUT_PATH")
+
+		pluginLocation, err := filepath.Abs(filepath.Join(checkoutPath, p.Location))
+		if err != nil {
+			return errors.Wrapf(err, "Failed to resolve vendored plugin path for plugin %s", p.Name())
+		}
+
+		if !fileExists(pluginLocation) {
+			return fmt.Errorf("Vendored plugin path %s doesn't exist", p.Location)
+		}
+
+		checkout := &pluginCheckout{
+			Plugin: p,
+			CheckoutDir: pluginLocation,
+			HooksDir: filepath.Join(pluginLocation, "hooks"),
+		}
+
+		// Also make sure that plugin is withing this repository
+		// checkout and isn't elsewhere on the system.
+		if !strings.HasPrefix(pluginLocation, checkoutPath+string(os.PathSeparator)) {
+			return fmt.Errorf("Vendored plugin paths must be within the checked-out repository")
+		}
+
+		err = b.validatePluginCheckout(checkout)
+		if err != nil {
+			return err
+		}
+
+		vendoredCheckouts = append(vendoredCheckouts, checkout)
+	}
+
+	// Finally append our vendored checkouts to the rest for subsequent hooks
+	b.pluginCheckouts = append(b.pluginCheckouts, vendoredCheckouts...)
+
+	// Now we can run plugin environment hooks too
+	return b.executePluginHook("environment", vendoredCheckouts)
+}
+
+// Executes a named hook on plugins that have it
+func (b *Bootstrap) executePluginHook(name string, checkouts []*pluginCheckout) error {
+	for _, p := range checkouts {
 		hookPath, err := b.findHookFile(p.HooksDir, name)
 		if err != nil {
 			continue
 		}
 
 		env, _ := p.ConfigurationToEnvironment()
-		if err := b.executeHook("plugin "+p.Label()+" "+name, hookPath, env); err != nil {
+		if err := b.executeHook("plugin "+p.Plugin.Name()+" "+name, hookPath, env); err != nil {
 			return err
 		}
 	}
@@ -531,7 +631,7 @@ func (b *Bootstrap) executePluginHook(name string) error {
 
 // If any plugin has a hook by this name
 func (b *Bootstrap) hasPluginHook(name string) bool {
-	for _, p := range b.plugins {
+	for _, p := range b.pluginCheckouts {
 		if _, err := b.findHookFile(p.HooksDir, name); err == nil {
 			return true
 		}
@@ -541,6 +641,11 @@ func (b *Bootstrap) hasPluginHook(name string) bool {
 
 // Checkout a given plugin to the plugins directory and return that directory
 func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
+	// Make sure we have a plugin path before trying to do anything
+	if b.PluginsPath == "" {
+		return nil, fmt.Errorf("Can't checkout plugin without a `plugins-path`")
+	}
+
 	// Get the identifer for the plugin
 	id, err := p.Identifier()
 	if err != nil {
@@ -676,7 +781,7 @@ func (b *Bootstrap) CheckoutPhase() error {
 		return err
 	}
 
-	if err := b.executePluginHook("pre-checkout"); err != nil {
+	if err := b.executePluginHook("pre-checkout", b.pluginCheckouts); err != nil {
 		return err
 	}
 
@@ -698,7 +803,7 @@ func (b *Bootstrap) CheckoutPhase() error {
 	// There can only be one checkout hook, either plugin or global, in that order
 	switch {
 	case b.hasPluginHook("checkout"):
-		if err := b.executePluginHook("checkout"); err != nil {
+		if err := b.executePluginHook("checkout", b.pluginCheckouts); err != nil {
 			return err
 		}
 	case b.hasGlobalHook("checkout"):
@@ -747,7 +852,7 @@ func (b *Bootstrap) CheckoutPhase() error {
 		return err
 	}
 
-	if err := b.executePluginHook("post-checkout"); err != nil {
+	if err := b.executePluginHook("post-checkout", b.pluginCheckouts); err != nil {
 		return err
 	}
 
@@ -959,7 +1064,7 @@ func (b *Bootstrap) CommandPhase() error {
 		return err
 	}
 
-	if err := b.executePluginHook("pre-command"); err != nil {
+	if err := b.executePluginHook("pre-command", b.pluginCheckouts); err != nil {
 		return err
 	}
 
@@ -968,7 +1073,7 @@ func (b *Bootstrap) CommandPhase() error {
 	// There can only be one command hook, so we check them in order of plugin, local
 	switch {
 	case b.hasPluginHook("command"):
-		commandExitError = b.executePluginHook("command")
+		commandExitError = b.executePluginHook("command", b.pluginCheckouts)
 	case b.hasLocalHook("command"):
 		commandExitError = b.executeLocalHook("command")
 	case b.hasGlobalHook("command"):
@@ -1004,7 +1109,7 @@ func (b *Bootstrap) CommandPhase() error {
 		return err
 	}
 
-	if err := b.executePluginHook("post-command"); err != nil {
+	if err := b.executePluginHook("post-command", b.pluginCheckouts); err != nil {
 		return err
 	}
 
@@ -1149,7 +1254,7 @@ func (b *Bootstrap) uploadArtifacts() error {
 		return err
 	}
 
-	if err := b.executePluginHook("pre-artifact"); err != nil {
+	if err := b.executePluginHook("pre-artifact", b.pluginCheckouts); err != nil {
 		return err
 	}
 
@@ -1176,7 +1281,7 @@ func (b *Bootstrap) uploadArtifacts() error {
 		return err
 	}
 
-	if err := b.executePluginHook("post-artifact"); err != nil {
+	if err := b.executePluginHook("post-artifact", b.pluginCheckouts); err != nil {
 		return err
 	}
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -105,7 +105,7 @@ func (b *Bootstrap) Start() (exitCode int) {
 		}
 	}
 
-	if includePhase(`plugin`) {
+	if phaseErr == nil && includePhase(`plugin`) {
 		phaseErr = b.VendoredPluginPhase()
 	}
 


### PR DESCRIPTION
This change allows plugin paths to be relative to the checkout, so you can commit plugins along side code. The thinking is this provides a straight-forward way to lock-down what plugins are used and it has the nice upside of making it easier to iterate on plugins and code that are evolving. 

```yaml
steps:
  - label: "Test with vendored docker plugin"
    plugins:
      - "./.buildkite/plugins/docker":
          image: "hello-world"
```

Some more context on the background is at https://forum.buildkite.community/t/verifying-the-integrity-of-third-party-plugins/158/18. 

In terms of implementation, this adds an additional phase `vendored-plugin` that occurs in the bootstrap after `checkout`. This means that vendored plugins can't have `pre-checkout` or `checkout` hooks and that vendored plugins `environment` hook is called after checkout. I'm pretty ok with those constraints.

Future work could be a way to only allow vendored plugins (as a compromise on the stricter `--no-plugins`) setting we recommend. 🤔 


