### PR TITLE
Use windows console groups for process management

### DIFF
--- a/process/process_test.go
+++ b/process/process_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/signal"
 	"reflect"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -93,10 +92,6 @@ func TestProcessCapturesOutputLineByLine(t *testing.T) {
 }
 
 func TestProcessInterrupts(t *testing.T) {
-	if runtime.GOOS == `windows` {
-		t.Skip("Not supported on windows")
-	}
-  
 	var lines []string
 	var mu sync.Mutex
 

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -92,6 +93,10 @@ func TestProcessCapturesOutputLineByLine(t *testing.T) {
 }
 
 func TestProcessInterrupts(t *testing.T) {
+	if runtime.GOOS == `windows` {
+		t.Skip("Works in windows, but not in docker")
+	}
+
 	var lines []string
 	var mu sync.Mutex
 


### PR DESCRIPTION
It turns out Windows has no concept of parent/child processes, beyond storing the PID of the process that created it. This means that trying to walk a process tree to cancel a job can leave sub-processes orphaned if a subprocess in the hierarchy dies, as you can't walk that tree past the dead process. For instance in:

`bash.exe (pid 1)` -> `bash.exe (pid 2)` -> `sleep.exe (pid 3)`

If pid 2 dies, pid 3 remains, but killing pid 1 won't be able to traverse down to pid 3.  

The best we can do is create processes inside a "console group" and then send break / ctrl-c events to that group. 

Context:
https://github.com/buildkite/agent/pull/795
https://github.com/golang/dep/issues/862
https://github.com/golang/go/issues/17608
https://github.com/golang/go/issues/6720
https://docs.microsoft.com/en-us/windows/console/generateconsolectrlevent
https://github.com/nodejs/node/issues/3617