### PR TITLE
Give all the things a logger instance

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -19,7 +19,7 @@ import (
 )
 
 type AgentPool struct {
-	Logger                logger.Logger
+	Logger                *logger.Logger
 	APIClient             *api.Client
 	Token                 string
 	ConfigFilePath        string

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -21,6 +21,12 @@ type AgentWorker struct {
 	// of the struct
 	lastPing, lastHeartbeat int64
 
+	// The logger instance to use
+	Logger logger.Logger
+
+	// Whether to set debug in the job
+	Debug bool
+
 	// The API Client used when this agent is communicating with the API
 	APIClient *api.Client
 
@@ -71,6 +77,7 @@ func (a AgentWorker) Create() AgentWorker {
 	}
 
 	a.APIClient = APIClient{
+		Logger:       a.Logger,
 		Endpoint:     endpoint,
 		Token:        a.Agent.AccessToken,
 		DisableHTTP2: a.DisableHTTP2,
@@ -107,7 +114,7 @@ func (a *AgentWorker) Start() error {
 				// Get the last heartbeat time to the nearest microsecond
 				lastHeartbeat := time.Unix(atomic.LoadInt64(&a.lastPing), 0)
 
-				logger.Error("Failed to heartbeat %s. Will try again in %s. (Last successful was %v ago)",
+				a.Logger.Error("Failed to heartbeat %s. Will try again in %s. (Last successful was %v ago)",
 					err, heartbeatInterval, time.Now().Sub(lastHeartbeat))
 			}
 
@@ -124,7 +131,7 @@ func (a *AgentWorker) Start() error {
 		a.disconnectTimeoutTimer = time.NewTimer(time.Second * time.Duration(a.AgentConfiguration.DisconnectAfterJobTimeout))
 		go func() {
 			<-a.disconnectTimeoutTimer.C
-			logger.Debug("[DisconnectionTimer] Reached %d seconds...", a.AgentConfiguration.DisconnectAfterJobTimeout)
+			a.Logger.Debug("[DisconnectionTimer] Reached %d seconds...", a.AgentConfiguration.DisconnectAfterJobTimeout)
 
 			// Just double check that the agent isn't running a
 			// job. The timer is stopped just after this is
@@ -132,14 +139,14 @@ func (a *AgentWorker) Start() error {
 			// where in between accepting the job, and creating the
 			// `jobRunner`, the timer pops.
 			if a.jobRunner == nil && !a.stopping {
-				logger.Debug("[DisconnectionTimer] The agent isn't running a job, going to signal a stop")
+				a.Logger.Debug("[DisconnectionTimer] The agent isn't running a job, going to signal a stop")
 				a.Stop(true)
 			} else {
-				logger.Debug("[DisconnectionTimer] Agent is running a job, going to just ignore and let it finish it's work")
+				a.Logger.Debug("[DisconnectionTimer] Agent is running a job, going to just ignore and let it finish it's work")
 			}
 		}()
 
-		logger.Debug("[DisconnectionTimer] Started for %d seconds...", a.AgentConfiguration.DisconnectAfterJobTimeout)
+		a.Logger.Debug("[DisconnectionTimer] Started for %d seconds...", a.AgentConfiguration.DisconnectAfterJobTimeout)
 	}
 
 	// Continue this loop until the the ticker is stopped, and we received
@@ -175,27 +182,27 @@ func (a *AgentWorker) Stop(graceful bool) {
 
 	if graceful {
 		if a.stopping {
-			logger.Warn("Agent is already gracefully stopping...")
+			a.Logger.Warn("Agent is already gracefully stopping...")
 		} else {
 			// If we have a job, tell the user that we'll wait for
 			// it to finish before disconnecting
 			if a.jobRunner != nil {
-				logger.Info("Gracefully stopping agent. Waiting for current job to finish before disconnecting...")
+				a.Logger.Info("Gracefully stopping agent. Waiting for current job to finish before disconnecting...")
 			} else {
-				logger.Info("Gracefully stopping agent. Since there is no job running, the agent will disconnect immediately")
+				a.Logger.Info("Gracefully stopping agent. Since there is no job running, the agent will disconnect immediately")
 			}
 		}
 	} else {
 		// If there's a job running, kill it, then disconnect
 		if a.jobRunner != nil {
-			logger.Info("Forcefully stopping agent. The current job will be canceled before disconnecting...")
+			a.Logger.Info("Forcefully stopping agent. The current job will be canceled before disconnecting...")
 
 			// Kill the current job. Doesn't do anything if the job
 			// is already being killed, so it's safe to call
 			// multiple times.
 			a.jobRunner.Cancel()
 		} else {
-			logger.Info("Forcefully stopping agent. Since there is no job running, the agent will disconnect immediately")
+			a.Logger.Info("Forcefully stopping agent. Since there is no job running, the agent will disconnect immediately")
 		}
 	}
 
@@ -227,7 +234,7 @@ func (a *AgentWorker) Connect() error {
 	return retry.Do(func(s *retry.Stats) error {
 		_, err := a.APIClient.Agents.Connect()
 		if err != nil {
-			logger.Warn("%s (%s)", err, s)
+			a.Logger.Warn("%s (%s)", err, s)
 		}
 
 		return err
@@ -243,7 +250,7 @@ func (a *AgentWorker) Heartbeat() error {
 	err = retry.Do(func(s *retry.Stats) error {
 		beat, _, err = a.APIClient.Heartbeats.Beat()
 		if err != nil {
-			logger.Warn("%s (%s)", err, s)
+			a.Logger.Warn("%s (%s)", err, s)
 		}
 		return err
 	}, &retry.Config{Maximum: 5, Interval: 5 * time.Second})
@@ -255,7 +262,7 @@ func (a *AgentWorker) Heartbeat() error {
 	// Track a timestamp for the successful heartbeat for better errors
 	atomic.StoreInt64(&a.lastHeartbeat, time.Now().Unix())
 
-	logger.Debug("Heartbeat sent at %s and received at %s", beat.SentAt, beat.ReceivedAt)
+	a.Logger.Debug("Heartbeat sent at %s and received at %s", beat.SentAt, beat.ReceivedAt)
 	return nil
 }
 
@@ -271,7 +278,7 @@ func (a *AgentWorker) Ping() {
 
 		// If a ping fails, we don't really care, because it'll
 		// ping again after the interval.
-		logger.Warn("Failed to ping: %s (Last successful was %v ago)", err, time.Now().Sub(lastPing))
+		a.Logger.Warn("Failed to ping: %s (Last successful was %v ago)", err, time.Now().Sub(lastPing))
 
 		// When the ping fails, we wan't to reset our disconnection
 		// timer. It wouldnt' be very nice if we just killed the agent
@@ -280,7 +287,7 @@ func (a *AgentWorker) Ping() {
 			jobTimeoutSeconds := time.Second * time.Duration(a.AgentConfiguration.DisconnectAfterJobTimeout)
 			a.disconnectTimeoutTimer.Reset(jobTimeoutSeconds)
 
-			logger.Debug("[DisconnectionTimer] Reset back to %d seconds because of ping failure...", a.AgentConfiguration.DisconnectAfterJobTimeout)
+			a.Logger.Debug("[DisconnectionTimer] Reset back to %d seconds because of ping failure...", a.AgentConfiguration.DisconnectAfterJobTimeout)
 		}
 
 		return
@@ -294,10 +301,15 @@ func (a *AgentWorker) Ping() {
 		// Before switching to the new one, do a ping test to make sure it's
 		// valid. If it is, switch and carry on, otherwise ignore the switch
 		// for now.
-		newAPIClient := APIClient{Endpoint: ping.Endpoint, Token: a.Agent.AccessToken}.Create()
+		newAPIClient := APIClient{
+			Logger:   a.Logger,
+			Endpoint: ping.Endpoint,
+			Token:    a.Agent.AccessToken,
+		}.Create()
+
 		newPing, _, err := newAPIClient.Pings.Get()
 		if err != nil {
-			logger.Warn("Failed to ping the new endpoint %s - ignoring switch for now (%s)", ping.Endpoint, err)
+			a.Logger.Warn("Failed to ping the new endpoint %s - ignoring switch for now (%s)", ping.Endpoint, err)
 		} else {
 			// Replace the APIClient and process the new ping
 			a.APIClient = newAPIClient
@@ -308,7 +320,7 @@ func (a *AgentWorker) Ping() {
 
 	// Is there a message that should be shown in the logs?
 	if ping.Message != "" {
-		logger.Info(ping.Message)
+		a.Logger.Info(ping.Message)
 	}
 
 	// Should the agent disconnect?
@@ -328,7 +340,7 @@ func (a *AgentWorker) Ping() {
 	// Update the proc title
 	a.UpdateProcTitle(fmt.Sprintf("job %s", strings.Split(ping.Job.ID, "-")[0]))
 
-	logger.Info("Assigned job %s. Accepting...", ping.Job.ID)
+	a.Logger.Info("Assigned job %s. Accepting...", ping.Job.ID)
 
 	// Accept the job. We'll retry on connection related issues, but if
 	// Buildkite returns a 422 or 500 for example, we'll just bail out,
@@ -339,9 +351,9 @@ func (a *AgentWorker) Ping() {
 
 		if err != nil {
 			if api.IsRetryableError(err) {
-				logger.Warn("%s (%s)", err, s)
+				a.Logger.Warn("%s (%s)", err, s)
 			} else {
-				logger.Warn("Buildkite rejected the call to accept the job (%s)", err)
+				a.Logger.Warn("Buildkite rejected the call to accept the job (%s)", err)
 				s.Break()
 			}
 		}
@@ -351,7 +363,7 @@ func (a *AgentWorker) Ping() {
 
 	// If `accepted` is nil, then the job was never accepted
 	if accepted == nil {
-		logger.Error("Failed to accept job")
+		a.Logger.Error("Failed to accept job")
 		return
 	}
 
@@ -364,6 +376,8 @@ func (a *AgentWorker) Ping() {
 
 	// Now that the job has been accepted, we can start it.
 	a.jobRunner, err = JobRunner{
+		Logger:             a.Logger,
+		Debug:              a.Debug,
 		Endpoint:           accepted.Endpoint,
 		Agent:              a.Agent,
 		AgentConfiguration: a.AgentConfiguration,
@@ -373,26 +387,26 @@ func (a *AgentWorker) Ping() {
 
 	// Woo! We've got a job, and successfully accepted it, let's kill our auto-disconnect timer
 	if a.disconnectTimeoutTimer != nil {
-		logger.Debug("[DisconnectionTimer] A job was assigned and accepted, stopping timer...")
+		a.Logger.Debug("[DisconnectionTimer] A job was assigned and accepted, stopping timer...")
 		a.disconnectTimeoutTimer.Stop()
 	}
 
 	// Was there an error creating the job runner?
 	if err != nil {
-		logger.Error("Failed to initialize job: %s", err)
+		a.Logger.Error("Failed to initialize job: %s", err)
 		return
 	}
 
 	// Start running the job
 	if err = a.jobRunner.Run(); err != nil {
-		logger.Error("Failed to run job: %s", err)
+		a.Logger.Error("Failed to run job: %s", err)
 	}
 
 	// No more job, no more runner.
 	a.jobRunner = nil
 
 	if a.AgentConfiguration.DisconnectAfterJob {
-		logger.Info("Job finished. Disconnecting...")
+		a.Logger.Info("Job finished. Disconnecting...")
 
 		// We can just kill this timer now as well
 		if a.disconnectTimeoutTimer != nil {
@@ -412,7 +426,7 @@ func (a *AgentWorker) Disconnect() error {
 
 	_, err := a.APIClient.Agents.Disconnect()
 	if err != nil {
-		logger.Warn("There was an error sending the disconnect API call to Buildkite. If this agent still appears online, you may have to manually stop it (%s)", err)
+		a.Logger.Warn("There was an error sending the disconnect API call to Buildkite. If this agent still appears online, you may have to manually stop it (%s)", err)
 	}
 
 	return err

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -22,7 +22,7 @@ type AgentWorker struct {
 	lastPing, lastHeartbeat int64
 
 	// The logger instance to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	// Whether to set debug in the job
 	Debug bool

--- a/agent/api_client.go
+++ b/agent/api_client.go
@@ -17,7 +17,7 @@ import (
 var debug = false
 
 type APIClient struct {
-	Logger       logger.Logger
+	Logger       *logger.Logger
 	Endpoint     string
 	Token        string
 	DisableHTTP2 bool

--- a/agent/api_client.go
+++ b/agent/api_client.go
@@ -17,6 +17,7 @@ import (
 var debug = false
 
 type APIClient struct {
+	Logger       logger.Logger
 	Endpoint     string
 	Token        string
 	DisableHTTP2 bool
@@ -29,7 +30,7 @@ func APIClientEnableHTTPDebug() {
 func (a APIClient) Create() *api.Client {
 	u, err := url.Parse(a.Endpoint)
 	if err != nil {
-		logger.Warn("Failed to parse %q: %v", a.Endpoint, err)
+		a.Logger.Warn("Failed to parse %q: %v", a.Endpoint, err)
 	}
 
 	if u != nil && u.Scheme == `unix` {
@@ -61,7 +62,7 @@ func (a APIClient) Create() *api.Client {
 	httpClient.Timeout = 60 * time.Second
 
 	// Create the Buildkite Agent API Client
-	client := api.NewClient(httpClient)
+	client := api.NewClient(httpClient, a.Logger)
 	client.BaseURL, _ = url.Parse(a.Endpoint)
 	client.UserAgent = a.UserAgent()
 	client.DebugHTTP = debug
@@ -81,7 +82,7 @@ func (a APIClient) createFromSocket(socket string) *api.Client {
 	}
 
 	// Create the Buildkite Agent API Client
-	client := api.NewClient(httpClient)
+	client := api.NewClient(httpClient, a.Logger)
 	client.BaseURL, _ = url.Parse(`http+unix://buildkite-agent`)
 	client.UserAgent = a.UserAgent()
 	client.DebugHTTP = debug

--- a/agent/api_proxy.go
+++ b/agent/api_proxy.go
@@ -21,7 +21,7 @@ import (
 // that will authenticate to the Buildkite Agent API
 type APIProxy struct {
 	// The logger instance to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	upstreamToken    string
 	upstreamEndpoint string
@@ -36,7 +36,7 @@ func NewAPIProxy(endpoint string, token string) *APIProxy {
 	wg.Add(1)
 
 	return &APIProxy{
-		Logger:           logger.DiscardLogger,
+		Logger:           logger.Discard,
 		upstreamToken:    token,
 		upstreamEndpoint: endpoint,
 		token:            fmt.Sprintf("%x", sha256.Sum256([]byte(string(time.Now().UnixNano())))),

--- a/agent/api_proxy.go
+++ b/agent/api_proxy.go
@@ -20,6 +20,9 @@ import (
 // APIProxy provides either a unix socket or a tcp socket listener with a proxy
 // that will authenticate to the Buildkite Agent API
 type APIProxy struct {
+	// The logger instance to use
+	Logger logger.Logger
+
 	upstreamToken    string
 	upstreamEndpoint string
 	token            string
@@ -33,6 +36,7 @@ func NewAPIProxy(endpoint string, token string) *APIProxy {
 	wg.Add(1)
 
 	return &APIProxy{
+		Logger:           logger.DiscardLogger,
 		upstreamToken:    token,
 		upstreamEndpoint: endpoint,
 		token:            fmt.Sprintf("%x", sha256.Sum256([]byte(string(time.Now().UnixNano())))),
@@ -97,7 +101,7 @@ func (p *APIProxy) listenOnUnixSocket() (net.Listener, *os.File, error) {
 	// https://troydhanson.github.io/network/Unix_domain_sockets.html
 	_ = os.Remove(socket.Name())
 
-	logger.Debug("[APIProxy] Listening on unix socket %s", socket.Name())
+	p.Logger.Debug("[APIProxy] Listening on unix socket %s", socket.Name())
 
 	// create a unix socket to do the listening
 	l, err := net.Listen("unix", socket.Name())
@@ -120,7 +124,7 @@ func (p *APIProxy) listenOnTCPSocket() (net.Listener, error) {
 		return nil, err
 	}
 
-	logger.Debug("[APIProxy] Listening on tcp socket %s", l.Addr().String())
+	p.Logger.Debug("[APIProxy] Listening on tcp socket %s", l.Addr().String())
 	return l, nil
 }
 

--- a/agent/api_proxy_test.go
+++ b/agent/api_proxy_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/buildkite/agent/logger"
 )
 
 func TestAPIProxy(t *testing.T) {
@@ -25,6 +27,7 @@ func TestAPIProxy(t *testing.T) {
 
 	// create a client to talk to our proxy api
 	client := APIClient{
+		Logger:   logger.DiscardLogger,
 		Endpoint: proxy.Endpoint(),
 		Token:    proxy.AccessToken(),
 	}.Create()
@@ -58,6 +61,7 @@ func TestAPIProxyFailsWithoutAccessToken(t *testing.T) {
 
 	// create a client to talk to our proxy api, but with incorrect access token
 	client := APIClient{
+		Logger:   logger.DiscardLogger,
 		Endpoint: proxy.Endpoint(),
 		Token:    `xxx`,
 	}.Create()

--- a/agent/api_proxy_test.go
+++ b/agent/api_proxy_test.go
@@ -27,7 +27,7 @@ func TestAPIProxy(t *testing.T) {
 
 	// create a client to talk to our proxy api
 	client := APIClient{
-		Logger:   logger.DiscardLogger,
+		Logger:   logger.Discard,
 		Endpoint: proxy.Endpoint(),
 		Token:    proxy.AccessToken(),
 	}.Create()
@@ -61,7 +61,7 @@ func TestAPIProxyFailsWithoutAccessToken(t *testing.T) {
 
 	// create a client to talk to our proxy api, but with incorrect access token
 	client := APIClient{
-		Logger:   logger.DiscardLogger,
+		Logger:   logger.Discard,
 		Endpoint: proxy.Endpoint(),
 		Token:    `xxx`,
 	}.Create()

--- a/agent/artifact_batch_creator.go
+++ b/agent/artifact_batch_creator.go
@@ -10,7 +10,7 @@ import (
 
 type ArtifactBatchCreator struct {
 	// The logger instance to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	// The APIClient that will be used when uploading jobs
 	APIClient *api.Client

--- a/agent/artifact_batch_creator.go
+++ b/agent/artifact_batch_creator.go
@@ -9,6 +9,9 @@ import (
 )
 
 type ArtifactBatchCreator struct {
+	// The logger instance to use
+	Logger logger.Logger
+
 	// The APIClient that will be used when uploading jobs
 	APIClient *api.Client
 
@@ -43,7 +46,7 @@ func (a *ArtifactBatchCreator) Create() ([]*api.Artifact, error) {
 		// upload)
 		batch := &api.ArtifactBatch{api.NewUUID(), theseArtiacts, a.UploadDestination}
 
-		logger.Info("Creating (%d-%d)/%d artifacts", i, j, length)
+		a.Logger.Info("Creating (%d-%d)/%d artifacts", i, j, length)
 
 		var creation *api.ArtifactBatchCreateResponse
 		var resp *api.Response
@@ -56,7 +59,7 @@ func (a *ArtifactBatchCreator) Create() ([]*api.Artifact, error) {
 				s.Break()
 			}
 			if err != nil {
-				logger.Warn("%s (%s)", err, s)
+				a.Logger.Warn("%s (%s)", err, s)
 			}
 
 			return err

--- a/agent/artifact_downloader.go
+++ b/agent/artifact_downloader.go
@@ -14,7 +14,7 @@ import (
 
 type ArtifactDownloader struct {
 	// The logger instance to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	// The APIClient that will be used when uploading jobs
 	APIClient *api.Client

--- a/agent/artifact_searcher.go
+++ b/agent/artifact_searcher.go
@@ -6,6 +6,9 @@ import (
 )
 
 type ArtifactSearcher struct {
+	// The logger instance to use
+	Logger logger.Logger
+
 	// The APIClient that will be used when uploading jobs
 	APIClient *api.Client
 
@@ -15,9 +18,9 @@ type ArtifactSearcher struct {
 
 func (a *ArtifactSearcher) Search(query string, scope string) ([]*api.Artifact, error) {
 	if scope == "" {
-		logger.Info("Searching for artifacts: \"%s\"", query)
+		a.Logger.Info("Searching for artifacts: \"%s\"", query)
 	} else {
-		logger.Info("Searching for artifacts: \"%s\" within step: \"%s\"", query, scope)
+		a.Logger.Info("Searching for artifacts: \"%s\" within step: \"%s\"", query, scope)
 	}
 
 	options := &api.ArtifactSearchOptions{Query: query, Scope: scope}

--- a/agent/artifact_searcher.go
+++ b/agent/artifact_searcher.go
@@ -7,7 +7,7 @@ import (
 
 type ArtifactSearcher struct {
 	// The logger instance to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	// The APIClient that will be used when uploading jobs
 	APIClient *api.Client

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -25,7 +25,7 @@ const (
 
 type ArtifactUploader struct {
 	// The logger instance to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	// The APIClient that will be used when uploading jobs
 	APIClient *api.Client

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -24,6 +24,9 @@ const (
 )
 
 type ArtifactUploader struct {
+	// The logger instance to use
+	Logger logger.Logger
+
 	// The APIClient that will be used when uploading jobs
 	APIClient *api.Client
 
@@ -45,9 +48,9 @@ func (a *ArtifactUploader) Upload() error {
 	}
 
 	if len(artifacts) == 0 {
-		logger.Info("No files matched paths: %s", a.Paths)
+		a.Logger.Info("No files matched paths: %s", a.Paths)
 	} else {
-		logger.Info("Found %d files that match \"%s\"", len(artifacts), a.Paths)
+		a.Logger.Info("Found %d files that match \"%s\"", len(artifacts), a.Paths)
 
 		err := a.upload(artifacts)
 		if err != nil {
@@ -78,13 +81,13 @@ func (a *ArtifactUploader) Collect() (artifacts []*api.Artifact, err error) {
 			continue
 		}
 
-		logger.Debug("Searching for %s", globPath)
+		a.Logger.Debug("Searching for %s", globPath)
 
 		// Resolve the globs (with * and ** in them), if it's a non-globbed path and doesn't exists
 		// then we will get the ErrNotExist that is handled below
 		files, err := zglob.Glob(globPath)
 		if err == os.ErrNotExist {
-			logger.Info("File not found: %s", globPath)
+			a.Logger.Info("File not found: %s", globPath)
 			continue
 		} else if err != nil {
 			return nil, err
@@ -99,7 +102,7 @@ func (a *ArtifactUploader) Collect() (artifacts []*api.Artifact, err error) {
 
 			// Ignore directories, we only want files
 			if isDir(absolutePath) {
-				logger.Debug("Skipping directory %s", file)
+				a.Logger.Debug("Skipping directory %s", file)
 				continue
 			}
 
@@ -171,14 +174,20 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 	// Determine what uploader to use
 	if a.Destination != "" {
 		if strings.HasPrefix(a.Destination, "s3://") {
-			uploader = new(S3Uploader)
+			uploader = &S3Uploader{
+				Logger: a.Logger,
+			}
 		} else if strings.HasPrefix(a.Destination, "gs://") {
-			uploader = new(GSUploader)
+			uploader = &GSUploader{
+				Logger: a.Logger,
+			}
 		} else {
 			return errors.New(fmt.Sprintf("Invalid upload destination: '%v'. Only s3:// and gs:// upload destinations are allowed. Did you forget to surround your artifact upload pattern in double quotes?", a.Destination))
 		}
 	} else {
-		uploader = new(FormUploader)
+		uploader = &FormUploader{
+			Logger: a.Logger,
+		}
 	}
 
 	// Setup the uploader
@@ -241,21 +250,21 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 			if len(statesToUpload) > 0 {
 				artifactStatesUploaded += len(statesToUpload)
 				for id, state := range statesToUpload {
-					logger.Debug("Artifact `%s` has state `%s`", id, state)
+					a.Logger.Debug("Artifact `%s` has state `%s`", id, state)
 				}
 
 				// Update the states of the artifacts in bulk.
 				err = retry.Do(func(s *retry.Stats) error {
 					_, err = a.APIClient.Artifacts.Update(a.JobID, statesToUpload)
 					if err != nil {
-						logger.Warn("%s (%s)", err, s)
+						a.Logger.Warn("%s (%s)", err, s)
 					}
 
 					return err
 				}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
 
 				if err != nil {
-					logger.Error("Error uploading artifact states: %s", err)
+					a.Logger.Error("Error uploading artifact states: %s", err)
 
 					// Track the error that was raised. We need to
 					// aquire a lock since we mutate the errors
@@ -265,7 +274,7 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 					errorsMutex.Unlock()
 				}
 
-				logger.Debug("Uploaded %d artfact states (%d/%d)", len(statesToUpload), artifactStatesUploaded, len(artifacts))
+				a.Logger.Debug("Uploaded %d artfact states (%d/%d)", len(statesToUpload), artifactStatesUploaded, len(artifacts))
 			}
 
 			// Check again for states to upload in a few seconds
@@ -282,7 +291,7 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 
 		p.Spawn(func() {
 			// Show a nice message that we're starting to upload the file
-			logger.Info("Uploading artifact %s %s (%d bytes)", artifact.ID, artifact.Path, artifact.FileSize)
+			a.Logger.Info("Uploading artifact %s %s (%d bytes)", artifact.ID, artifact.Path, artifact.FileSize)
 
 			// Upload the artifact and then set the state depending
 			// on whether or not it passed. We'll retry the upload
@@ -290,7 +299,7 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 			err = retry.Do(func(s *retry.Stats) error {
 				err := uploader.Upload(artifact)
 				if err != nil {
-					logger.Warn("%s (%s)", err, s)
+					a.Logger.Warn("%s (%s)", err, s)
 				}
 
 				return err
@@ -300,7 +309,7 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 
 			// Did the upload eventually fail?
 			if err != nil {
-				logger.Error("Error uploading artifact \"%s\": %s", artifact.Path, err)
+				a.Logger.Error("Error uploading artifact \"%s\": %s", artifact.Path, err)
 
 				// Track the error that was raised. We need to
 				// aquire a lock since we mutate the errors
@@ -330,7 +339,7 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 	stateUploaderWaitGroup.Wait()
 
 	if len(errors) > 0 {
-		logger.Fatal("There were errors with uploading some of the artifacts")
+		return fmt.Errorf("There were errors with uploading some of the artifacts")
 	}
 
 	return nil

--- a/agent/artifact_uploader_test.go
+++ b/agent/artifact_uploader_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/agent/api"
+	"github.com/buildkite/agent/logger"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,6 +38,7 @@ func TestCollect(t *testing.T) {
 			filepath.Join("test", "fixtures", "artifacts", "**/*.jpg"),
 			filepath.Join(root, "test", "fixtures", "artifacts", "**/*.gif"),
 		),
+		Logger: logger.Discard,
 	}
 
 	artifacts, err := uploader.Collect()
@@ -110,12 +112,15 @@ func TestCollectThatDoesntMatchAnyFiles(t *testing.T) {
 	os.Chdir(root)
 	defer os.Chdir(wd)
 
-	uploader := ArtifactUploader{Paths: strings.Join([]string{
-		filepath.Join("log", "*"),
-		filepath.Join("tmp", "capybara", "**", "*"),
-		filepath.Join("mkmf.log"),
-		filepath.Join("log", "mkmf.log"),
-	}, ";")}
+	uploader := ArtifactUploader{
+		Logger: logger.Discard,
+		Paths: strings.Join([]string{
+			filepath.Join("log", "*"),
+			filepath.Join("tmp", "capybara", "**", "*"),
+			filepath.Join("mkmf.log"),
+			filepath.Join("log", "mkmf.log"),
+		}, ";"),
+	}
 
 	artifacts, err := uploader.Collect()
 	if err != nil {
@@ -131,11 +136,14 @@ func TestCollectWithSomeGlobsThatDontMatchAnything(t *testing.T) {
 	os.Chdir(root)
 	defer os.Chdir(wd)
 
-	uploader := ArtifactUploader{Paths: strings.Join([]string{
-		filepath.Join("dontmatchanything", "*"),
-		filepath.Join("dontmatchanything.zip"),
-		filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
-	}, ";")}
+	uploader := ArtifactUploader{
+		Logger: logger.Discard,
+		Paths: strings.Join([]string{
+			filepath.Join("dontmatchanything", "*"),
+			filepath.Join("dontmatchanything.zip"),
+			filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
+		}, ";"),
+	}
 
 	artifacts, err := uploader.Collect()
 	if err != nil {

--- a/agent/aws.go
+++ b/agent/aws.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/buildkite/agent/logger"
 )
 
 var awsSess *session.Session
@@ -33,11 +32,7 @@ func awsRegion() (string, error) {
 
 	meta := ec2metadata.New(sess)
 	if meta.Available() {
-		region, err := meta.Region()
-		if err == nil {
-			logger.Debug("Detected AWS region %s", region)
-		}
-		return region, err
+		return meta.Region()
 	}
 
 	return "", aws.ErrMissingRegion

--- a/agent/download.go
+++ b/agent/download.go
@@ -15,6 +15,9 @@ import (
 )
 
 type Download struct {
+	// The logger instance to use
+	Logger logger.Logger
+
 	// The HTTP client to use for downloading
 	Client http.Client
 
@@ -38,7 +41,7 @@ func (d Download) Start() error {
 	return retry.Do(func(s *retry.Stats) error {
 		err := d.try()
 		if err != nil {
-			logger.Warn("Error trying to download %s (%s) %s", d.URL, err, s)
+			d.Logger.Warn("Error trying to download %s (%s) %s", d.URL, err, s)
 		}
 		return err
 	}, &retry.Config{Maximum: d.Retries, Interval: 5 * time.Second})
@@ -74,7 +77,7 @@ func (d Download) try() error {
 	targetDirectory, _ := filepath.Split(targetFile)
 
 	// Show a nice message that we're starting to download the file
-	logger.Debug("Downloading %s to %s", d.URL, targetFile)
+	d.Logger.Debug("Downloading %s to %s", d.URL, targetFile)
 
 	// Start by downloading the file
 	response, err := d.Client.Get(d.URL)
@@ -87,7 +90,7 @@ func (d Download) try() error {
 	if response.StatusCode/100 != 2 && response.StatusCode/100 != 3 {
 		if d.DebugHTTP {
 			responseDump, err := httputil.DumpResponse(response, true)
-			logger.Debug("\nERR: %s\n%s", err, string(responseDump))
+			d.Logger.Debug("\nERR: %s\n%s", err, string(responseDump))
 		}
 
 		return &downloadError{response.Status}
@@ -112,7 +115,7 @@ func (d Download) try() error {
 		return fmt.Errorf("Error when copying data %s (%T: %v)", d.URL, err, err)
 	}
 
-	logger.Info("Successfully downloaded \"%s\" %d bytes", d.Path, bytes)
+	d.Logger.Info("Successfully downloaded \"%s\" %d bytes", d.Path, bytes)
 
 	return nil
 }

--- a/agent/download.go
+++ b/agent/download.go
@@ -16,7 +16,7 @@ import (
 
 type Download struct {
 	// The logger instance to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	// The HTTP client to use for downloading
 	Client http.Client

--- a/agent/form_uploader.go
+++ b/agent/form_uploader.go
@@ -23,7 +23,7 @@ var ArtifactPathVariableRegex = regexp.MustCompile("\\$\\{artifact\\:path\\}")
 
 type FormUploader struct {
 	// The logger instance to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	// Whether or not HTTP calls shoud be debugged
 	DebugHTTP bool

--- a/agent/form_uploader.go
+++ b/agent/form_uploader.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"regexp"
+
 	// "net/http/httputil"
 	"errors"
 	"net/url"
@@ -21,6 +22,9 @@ import (
 var ArtifactPathVariableRegex = regexp.MustCompile("\\$\\{artifact\\:path\\}")
 
 type FormUploader struct {
+	// The logger instance to use
+	Logger logger.Logger
+
 	// Whether or not HTTP calls shoud be debugged
 	DebugHTTP bool
 }
@@ -48,7 +52,7 @@ func (u *FormUploader) Upload(artifact *api.Artifact) error {
 	client := &http.Client{}
 
 	// Perform the request
-	logger.Debug("%s %s", request.Method, request.URL)
+	u.Logger.Debug("%s %s", request.Method, request.URL)
 	response, err := client.Do(request)
 
 	// Check for errors
@@ -61,7 +65,7 @@ func (u *FormUploader) Upload(artifact *api.Artifact) error {
 
 		if u.DebugHTTP {
 			responseDump, err := httputil.DumpResponse(response, true)
-			logger.Debug("\nERR: %s\n%s", err, string(responseDump))
+			u.Logger.Debug("\nERR: %s\n%s", err, string(responseDump))
 		}
 
 		if response.StatusCode/100 != 2 {

--- a/agent/gs_downloader.go
+++ b/agent/gs_downloader.go
@@ -6,11 +6,15 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/buildkite/agent/logger"
 	"golang.org/x/oauth2/google"
 	storage "google.golang.org/api/storage/v1"
 )
 
 type GSDownloader struct {
+	// The logger instance to use
+	Logger logger.Logger
+
 	// The name of the bucket
 	Bucket string
 
@@ -38,6 +42,7 @@ func (d GSDownloader) Start() error {
 
 	// We can now cheat and pass the URL onto our regular downloader
 	return Download{
+		Logger:      d.Logger,
 		Client:      *client,
 		URL:         url,
 		Path:        d.Path,

--- a/agent/gs_downloader.go
+++ b/agent/gs_downloader.go
@@ -13,7 +13,7 @@ import (
 
 type GSDownloader struct {
 	// The logger instance to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	// The name of the bucket
 	Bucket string

--- a/agent/gs_uploader.go
+++ b/agent/gs_uploader.go
@@ -22,7 +22,7 @@ import (
 
 type GSUploader struct {
 	// The logger instance to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	// The destination which includes the GS bucket name and the path.
 	// gs://my-bucket-name/foo/bar

--- a/agent/header_times_streamer.go
+++ b/agent/header_times_streamer.go
@@ -11,7 +11,7 @@ import (
 
 type HeaderTimesStreamer struct {
 	// The logger instance to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	// The callback that will be called when a header time is ready for
 	// upload

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -21,7 +21,7 @@ import (
 
 type JobRunner struct {
 	// The logger to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	// The job being run
 	Job *api.Job

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -269,11 +269,11 @@ func (r *JobRunner) Cancel() error {
 	}
 
 	if r.process == nil {
-		logger.Error("No process to kill")
+		r.Logger.Error("No process to kill")
 		return nil
 	}
 
-	logger.Info("Canceling job %s with a grace period of %ds",
+	r.Logger.Info("Canceling job %s with a grace period of %ds",
 		r.Job.ID, r.AgentConfiguration.CancelGracePeriod)
 
 	// First we interrupt the process (ctrl-c or SIGINT)
@@ -284,7 +284,7 @@ func (r *JobRunner) Cancel() error {
 	select {
 	// Grace period for cancelling
 	case <-time.After(time.Second * time.Duration(r.AgentConfiguration.CancelGracePeriod)):
-		logger.Info("Job %s hasn't stopped in time, terminating", r.Job.ID)
+		r.Logger.Info("Job %s hasn't stopped in time, terminating", r.Job.ID)
 
 		// Terminate the process as we've exceeded our context
 		if err := r.process.Terminate(); err != nil {

--- a/agent/log_streamer.go
+++ b/agent/log_streamer.go
@@ -10,6 +10,9 @@ import (
 )
 
 type LogStreamer struct {
+	// The logger instance to use
+	Logger logger.Logger
+
 	// How many log streamer workers are running at any one time
 	Concurrency int
 
@@ -116,7 +119,7 @@ func (ls *LogStreamer) Process(output string) error {
 			}
 
 			ls.queue <- &chunk
-			
+
 			// Save the new amount of bytes
 			ls.bytes += len(partialChunk)
 		}
@@ -129,11 +132,11 @@ func (ls *LogStreamer) Process(output string) error {
 
 // Waits for all the chunks to be uploaded, then shuts down all the workers
 func (ls *LogStreamer) Stop() error {
-	logger.Debug("[LogStreamer] Waiting for all the chunks to be uploaded")
+	ls.Logger.Debug("[LogStreamer] Waiting for all the chunks to be uploaded")
 
 	ls.chunkWaitGroup.Wait()
 
-	logger.Debug("[LogStreamer] Shutting down all workers")
+	ls.Logger.Debug("[LogStreamer] Shutting down all workers")
 
 	for n := 0; n < ls.Concurrency; n++ {
 		ls.queue <- nil
@@ -144,7 +147,7 @@ func (ls *LogStreamer) Stop() error {
 
 // The actual log streamer worker
 func Worker(id int, ls *LogStreamer) {
-	logger.Debug("[LogStreamer/Worker#%d] Worker is starting...", id)
+	ls.Logger.Debug("[LogStreamer/Worker#%d] Worker is starting...", id)
 
 	var chunk *LogStreamerChunk
 	for {
@@ -162,12 +165,12 @@ func Worker(id int, ls *LogStreamer) {
 		if err != nil {
 			atomic.AddInt32(&ls.ChunksFailedCount, 1)
 
-			logger.Error("Giving up on uploading chunk %d, this will result in only a partial build log on Buildkite", chunk.Order)
+			ls.Logger.Error("Giving up on uploading chunk %d, this will result in only a partial build log on Buildkite", chunk.Order)
 		}
 
 		// Signal to the chunkWaitGroup that this one is done
 		ls.chunkWaitGroup.Done()
 	}
 
-	logger.Debug("[LogStreamer/Worker#%d] Worker has shutdown", id)
+	ls.Logger.Debug("[LogStreamer/Worker#%d] Worker has shutdown", id)
 }

--- a/agent/log_streamer.go
+++ b/agent/log_streamer.go
@@ -11,7 +11,7 @@ import (
 
 type LogStreamer struct {
 	// The logger instance to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	// How many log streamer workers are running at any one time
 	Concurrency int

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -93,7 +93,7 @@ func awsS3Session(region string) (*session.Session, error) {
 	return sess, nil
 }
 
-func newS3Client(bucket string) (*s3.S3, error) {
+func newS3Client(logger logger.Logger, bucket string) (*s3.S3, error) {
 	region, err := awsS3RegionFromEnv()
 	if err != nil {
 		return nil, err

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -93,7 +93,7 @@ func awsS3Session(region string) (*session.Session, error) {
 	return sess, nil
 }
 
-func newS3Client(logger logger.Logger, bucket string) (*s3.S3, error) {
+func newS3Client(l *logger.Logger, bucket string) (*s3.S3, error) {
 	region, err := awsS3RegionFromEnv()
 	if err != nil {
 		return nil, err
@@ -104,7 +104,7 @@ func newS3Client(logger logger.Logger, bucket string) (*s3.S3, error) {
 		return nil, err
 	}
 
-	logger.Debug("Authorizing S3 credentials and finding bucket `%s` in region `%s`...", bucket, region)
+	l.Debug("Authorizing S3 credentials and finding bucket `%s` in region `%s`...", bucket, region)
 
 	s3client := s3.New(sess)
 

--- a/agent/s3_downloader.go
+++ b/agent/s3_downloader.go
@@ -13,7 +13,7 @@ import (
 
 type S3Downloader struct {
 	// The logger instance to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	// The S3 bucket name and the path, e.g s3://my-bucket-name/foo/bar
 	Bucket string

--- a/agent/s3_downloader.go
+++ b/agent/s3_downloader.go
@@ -8,9 +8,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/buildkite/agent/logger"
 )
 
 type S3Downloader struct {
+	// The logger instance to use
+	Logger logger.Logger
+
 	// The S3 bucket name and the path, e.g s3://my-bucket-name/foo/bar
 	Bucket string
 
@@ -30,7 +34,7 @@ type S3Downloader struct {
 
 func (d S3Downloader) Start() error {
 	// Initialize the s3 client, and authenticate it
-	s3Client, err := newS3Client(d.BucketName())
+	s3Client, err := newS3Client(d.Logger, d.BucketName())
 	if err != nil {
 		return err
 	}
@@ -47,6 +51,7 @@ func (d S3Downloader) Start() error {
 
 	// We can now cheat and pass the URL onto our regular downloader
 	return Download{
+		Logger:      d.Logger,
 		Client:      *http.DefaultClient,
 		URL:         signedURL,
 		Path:        d.Path,

--- a/agent/s3_uploader.go
+++ b/agent/s3_uploader.go
@@ -17,7 +17,7 @@ import (
 
 type S3Uploader struct {
 	// The logger instance to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	// The destination which includes the S3 bucket name and the path.
 	// e.g s3://my-bucket-name/foo/bar

--- a/api/buildkite.go
+++ b/api/buildkite.go
@@ -31,7 +31,7 @@ type Client struct {
 	client *http.Client
 
 	// The logger used
-	logger logger.Logger
+	logger *logger.Logger
 
 	// Base URL for API requests. Defaults to the public Buildkite Agent API.
 	// The URL should always be specified with a trailing slash.
@@ -57,7 +57,7 @@ type Client struct {
 }
 
 // NewClient returns a new Buildkite Agent API Client.
-func NewClient(httpClient *http.Client, l logger.Logger) *Client {
+func NewClient(httpClient *http.Client, l *logger.Logger) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
 
 	c := &Client{

--- a/api/buildkite.go
+++ b/api/buildkite.go
@@ -30,6 +30,9 @@ type Client struct {
 	// HTTP client used to communicate with the API.
 	client *http.Client
 
+	// The logger used
+	logger logger.Logger
+
 	// Base URL for API requests. Defaults to the public Buildkite Agent API.
 	// The URL should always be specified with a trailing slash.
 	BaseURL *url.URL
@@ -54,10 +57,11 @@ type Client struct {
 }
 
 // NewClient returns a new Buildkite Agent API Client.
-func NewClient(httpClient *http.Client) *Client {
+func NewClient(httpClient *http.Client, l logger.Logger) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
 
 	c := &Client{
+		logger:    l,
 		client:    httpClient,
 		BaseURL:   baseURL,
 		UserAgent: defaultUserAgent,
@@ -185,19 +189,19 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 			requestDump, err = httputil.DumpRequestOut(req, true)
 		}
 
-		logger.Debug("ERR: %s\n%s", err, string(requestDump))
+		c.logger.Debug("ERR: %s\n%s", err, string(requestDump))
 	}
 
 	ts := time.Now()
 
-	logger.Debug("%s %s", req.Method, req.URL)
+	c.logger.Debug("%s %s", req.Method, req.URL)
 
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 
-	logger.Debug("↳ %s %s (%s %s %s)", req.Method, req.URL, resp.Proto, resp.Status, time.Now().Sub(ts))
+	c.logger.Debug("↳ %s %s (%s %s %s)", req.Method, req.URL, resp.Proto, resp.Status, time.Now().Sub(ts))
 
 	defer resp.Body.Close()
 	defer io.Copy(ioutil.Discard, resp.Body)
@@ -206,7 +210,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 
 	if c.DebugHTTP {
 		responseDump, err := httputil.DumpResponse(resp, true)
-		logger.Debug("\nERR: %s\n%s", err, string(responseDump))
+		c.logger.Debug("\nERR: %s\n%s", err, string(responseDump))
 	}
 
 	err = checkResponse(resp)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -340,7 +340,7 @@ var AgentStartCommand = cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLevelLogger(logger.INFO)
+		l := logger.NewLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := AgentStartConfig{}

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -95,17 +95,18 @@ var AnnotateCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
+		l := logger.NewLevelLogger(logger.INFO)
+
 		// The configuration will be loaded into this struct
 		cfg := AnnotateConfig{}
 
 		// Load the configuration
-		loader := cliconfig.Loader{CLI: c, Config: &cfg}
-		if err := loader.Load(); err != nil {
-			logger.Fatal("%s", err)
+		if err := cliconfig.Load(c, l, &cfg); err != nil {
+			l.Fatal("%s", err)
 		}
 
 		// Setup the any global configuration options
-		HandleGlobalFlags(cfg)
+		HandleGlobalFlags(l, cfg)
 
 		var body string
 		var err error
@@ -113,12 +114,12 @@ var AnnotateCommand = cli.Command{
 		if cfg.Body != "" {
 			body = cfg.Body
 		} else if stdin.IsReadable() {
-			logger.Info("Reading annotation body from STDIN")
+			l.Info("Reading annotation body from STDIN")
 
 			// Actually read the file from STDIN
 			stdin, err := ioutil.ReadAll(os.Stdin)
 			if err != nil {
-				logger.Fatal("Failed to read from STDIN: %s", err)
+				l.Fatal("Failed to read from STDIN: %s", err)
 			}
 
 			body = string(stdin[:])
@@ -126,6 +127,7 @@ var AnnotateCommand = cli.Command{
 
 		// Create the API client
 		client := agent.APIClient{
+			Logger: l,
 			Endpoint: cfg.Endpoint,
 			Token:    cfg.AgentAccessToken,
 		}.Create()
@@ -151,7 +153,7 @@ var AnnotateCommand = cli.Command{
 
 			// Show the unexpected error
 			if err != nil {
-				logger.Warn("%s (%s)", err, s)
+				l.Warn("%s (%s)", err, s)
 			}
 
 			return err
@@ -159,9 +161,9 @@ var AnnotateCommand = cli.Command{
 
 		// Show a fatal error if we gave up trying to create the annotation
 		if err != nil {
-			logger.Fatal("Failed to annotate build: %s", err)
+			l.Fatal("Failed to annotate build: %s", err)
 		}
 
-		logger.Info("Successfully annotated build")
+		l.Info("Successfully annotated build")
 	},
 }

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -95,7 +95,7 @@ var AnnotateCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLevelLogger(logger.INFO)
+		l := logger.NewLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := AnnotateConfig{}

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -68,7 +68,7 @@ var ArtifactDownloadCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLevelLogger(logger.INFO)
+		l := logger.NewLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := ArtifactDownloadConfig{}

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -68,20 +68,24 @@ var ArtifactDownloadCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
+		l := logger.NewLevelLogger(logger.INFO)
+
 		// The configuration will be loaded into this struct
 		cfg := ArtifactDownloadConfig{}
 
 		// Load the configuration
-		if err := cliconfig.Load(c, &cfg); err != nil {
-			logger.Fatal("%s", err)
+		if err := cliconfig.Load(c, l, &cfg); err != nil {
+			l.Fatal("%s", err)
 		}
 
 		// Setup the any global configuration options
-		HandleGlobalFlags(cfg)
+		HandleGlobalFlags(l, cfg)
 
 		// Setup the downloader
 		downloader := agent.ArtifactDownloader{
+			Logger: l,
 			APIClient: agent.APIClient{
+				Logger:   l,
 				Endpoint: cfg.Endpoint,
 				Token:    cfg.AgentAccessToken,
 			}.Create(),
@@ -93,7 +97,7 @@ var ArtifactDownloadCommand = cli.Command{
 
 		// Download the artifacts
 		if err := downloader.Download(); err != nil {
-			logger.Fatal("Failed to download artifacts: %s", err)
+			l.Fatal("Failed to download artifacts: %s", err)
 		}
 	},
 }

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -70,7 +70,7 @@ var ArtifactShasumCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLevelLogger(logger.INFO)
+		l := logger.NewLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := ArtifactShasumConfig{}

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -65,7 +65,7 @@ var ArtifactUploadCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLevelLogger(logger.INFO)
+		l := logger.NewLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := ArtifactUploadConfig{}

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -65,20 +65,24 @@ var ArtifactUploadCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
+		l := logger.NewLevelLogger(logger.INFO)
+
 		// The configuration will be loaded into this struct
 		cfg := ArtifactUploadConfig{}
 
 		// Load the configuration
-		if err := cliconfig.Load(c, &cfg); err != nil {
-			logger.Fatal("%s", err)
+		if err := cliconfig.Load(c, l, &cfg); err != nil {
+			l.Fatal("%s", err)
 		}
 
 		// Setup the any global configuration options
-		HandleGlobalFlags(cfg)
+		HandleGlobalFlags(l, cfg)
 
 		// Setup the uploader
 		uploader := agent.ArtifactUploader{
+			Logger: l,
 			APIClient: agent.APIClient{
+				Logger:   l,
 				Endpoint: cfg.Endpoint,
 				Token:    cfg.AgentAccessToken,
 			}.Create(),
@@ -89,7 +93,7 @@ var ArtifactUploadCommand = cli.Command{
 
 		// Upload the artifacts
 		if err := uploader.Upload(); err != nil {
-			logger.Fatal("Failed to upload artifacts: %s", err)
+			l.Fatal("Failed to upload artifacts: %s", err)
 		}
 	},
 }

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -256,7 +256,7 @@ var BootstrapCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLevelLogger(logger.INFO)
+		l := logger.NewLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := BootstrapConfig{}
@@ -268,7 +268,7 @@ var BootstrapCommand = cli.Command{
 
 		// Enable debug if set
 		if cfg.Debug {
-			l = logger.NewLevelLogger(logger.DEBUG)
+			l.Level = logger.DEBUG
 		}
 
 		// Turn of PTY support if we're on Windows

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -256,12 +256,19 @@ var BootstrapCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
+		l := logger.NewLevelLogger(logger.INFO)
+
 		// The configuration will be loaded into this struct
 		cfg := BootstrapConfig{}
 
 		// Load the configuration
-		if err := cliconfig.Load(c, &cfg); err != nil {
-			logger.Fatal("%s", err)
+		if err := cliconfig.Load(c, l, &cfg); err != nil {
+			l.Fatal("%s", err)
+		}
+
+		// Enable debug if set
+		if cfg.Debug {
+			l = logger.NewLevelLogger(logger.DEBUG)
 		}
 
 		// Turn of PTY support if we're on Windows
@@ -276,7 +283,7 @@ var BootstrapCommand = cli.Command{
 			case "plugin", "checkout", "command":
 				// Valid phase
 			default:
-				logger.Fatal("Invalid phase %q", phase)
+				l.Fatal("Invalid phase %q", phase)
 			}
 		}
 

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -51,11 +51,13 @@ var ExperimentsFlag = cli.StringSliceFlag{
 	EnvVar: "BUILDKITE_AGENT_EXPERIMENT",
 }
 
-func HandleGlobalFlags(cfg interface{}) {
+func HandleGlobalFlags(l logger.Logger, cfg interface{}) {
 	// Enable debugging if a Debug option is present
-	debug, err := reflections.GetField(cfg, "Debug")
-	if debug == true && err == nil {
-		logger.SetLevel(logger.DEBUG)
+	if levelLogger, ok := l.(*logger.LevelLogger); ok {
+		debug, err := reflections.GetField(cfg, "Debug")
+		if debug == true && err == nil {
+			levelLogger.SetLevel(logger.DEBUG)
+		}
 	}
 
 	// Enable HTTP debugging
@@ -77,6 +79,7 @@ func HandleGlobalFlags(cfg interface{}) {
 		if ok {
 			for _, name := range experimentNamesSlice {
 				experiments.Enable(name)
+				l.Debug("Enabled experiment `%s`", name)
 			}
 		}
 	}

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -51,13 +51,11 @@ var ExperimentsFlag = cli.StringSliceFlag{
 	EnvVar: "BUILDKITE_AGENT_EXPERIMENT",
 }
 
-func HandleGlobalFlags(l logger.Logger, cfg interface{}) {
+func HandleGlobalFlags(l *logger.Logger, cfg interface{}) {
 	// Enable debugging if a Debug option is present
-	if levelLogger, ok := l.(*logger.LevelLogger); ok {
-		debug, err := reflections.GetField(cfg, "Debug")
-		if debug == true && err == nil {
-			levelLogger.SetLevel(logger.DEBUG)
-		}
+	debug, err := reflections.GetField(cfg, "Debug")
+	if debug == false && err == nil {
+		l.Level = logger.INFO
 	}
 
 	// Enable HTTP debugging

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -53,19 +53,22 @@ var MetaDataExistsCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
+		l := logger.NewLevelLogger(logger.INFO)
+
 		// The configuration will be loaded into this struct
 		cfg := MetaDataExistsConfig{}
 
 		// Load the configuration
-		if err := cliconfig.Load(c, &cfg); err != nil {
-			logger.Fatal("%s", err)
+		if err := cliconfig.Load(c, l, &cfg); err != nil {
+			l.Fatal("%s", err)
 		}
 
 		// Setup the any global configuration options
-		HandleGlobalFlags(cfg)
+		HandleGlobalFlags(l, cfg)
 
 		// Create the API client
 		client := agent.APIClient{
+			Logger: l,
 			Endpoint: cfg.Endpoint,
 			Token:    cfg.AgentAccessToken,
 		}.Create()
@@ -80,13 +83,13 @@ var MetaDataExistsCommand = cli.Command{
 				s.Break()
 			}
 			if err != nil {
-				logger.Warn("%s (%s)", err, s)
+				l.Warn("%s (%s)", err, s)
 			}
 
 			return err
 		}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
 		if err != nil {
-			logger.Fatal("Failed to see if meta-data exists: %s", err)
+			l.Fatal("Failed to see if meta-data exists: %s", err)
 		}
 
 		// If the meta data didn't exist, exit with an error.

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -53,7 +53,7 @@ var MetaDataExistsCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLevelLogger(logger.INFO)
+		l := logger.NewLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := MetaDataExistsConfig{}

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -58,19 +58,22 @@ var MetaDataGetCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
+		l := logger.NewLevelLogger(logger.INFO)
+
 		// The configuration will be loaded into this struct
 		cfg := MetaDataGetConfig{}
 
 		// Load the configuration
-		if err := cliconfig.Load(c, &cfg); err != nil {
-			logger.Fatal("%s", err)
+		if err := cliconfig.Load(c, l, &cfg); err != nil {
+			l.Fatal("%s", err)
 		}
 
 		// Setup the any global configuration options
-		HandleGlobalFlags(cfg)
+		HandleGlobalFlags(l, cfg)
 
 		// Create the API client
 		client := agent.APIClient{
+			Logger: l,
 			Endpoint: cfg.Endpoint,
 			Token:    cfg.AgentAccessToken,
 		}.Create()
@@ -87,7 +90,7 @@ var MetaDataGetCommand = cli.Command{
 				return err
 			}
 			if err != nil {
-				logger.Warn("%s (%s)", err, s)
+				l.Warn("%s (%s)", err, s)
 			}
 
 			return err
@@ -102,12 +105,12 @@ var MetaDataGetCommand = cli.Command{
 			// We also use `IsSet` instead of `cfg.Default != ""`
 			// to allow people to use a default of a blank string.
 			if resp.StatusCode == 404 && c.IsSet("default") {
-				logger.Warn("No meta-data value exists with key `%s`, returning the supplied default \"%s\"", cfg.Key, cfg.Default)
+				l.Warn("No meta-data value exists with key `%s`, returning the supplied default \"%s\"", cfg.Key, cfg.Default)
 
 				fmt.Print(cfg.Default)
 				return
 			} else {
-				logger.Fatal("Failed to get meta-data: %s", err)
+				l.Fatal("Failed to get meta-data: %s", err)
 			}
 		}
 

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -58,7 +58,7 @@ var MetaDataGetCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLevelLogger(logger.INFO)
+		l := logger.NewLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := MetaDataGetConfig{}

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -59,7 +59,7 @@ var MetaDataSetCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLevelLogger(logger.INFO)
+		l := logger.NewLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := MetaDataSetConfig{}

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -59,30 +59,33 @@ var MetaDataSetCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
+		l := logger.NewLevelLogger(logger.INFO)
+
 		// The configuration will be loaded into this struct
 		cfg := MetaDataSetConfig{}
 
 		// Load the configuration
-		if err := cliconfig.Load(c, &cfg); err != nil {
-			logger.Fatal("%s", err)
+		if err := cliconfig.Load(c, l, &cfg); err != nil {
+			l.Fatal("%s", err)
 		}
 
 		// Setup the any global configuration options
-		HandleGlobalFlags(cfg)
+		HandleGlobalFlags(l, cfg)
 
 		// Read the value from STDIN if argument omitted entirely
 		if len(c.Args()) < 2 {
-			logger.Info("Reading meta-data value from STDIN")
+			l.Info("Reading meta-data value from STDIN")
 
 			input, err := ioutil.ReadAll(os.Stdin)
 			if err != nil {
-				logger.Fatal("Failed to read from STDIN: %s", err)
+				l.Fatal("Failed to read from STDIN: %s", err)
 			}
 			cfg.Value = string(input)
 		}
 
 		// Create the API client
 		client := agent.APIClient{
+			Logger: l,
 			Endpoint: cfg.Endpoint,
 			Token:    cfg.AgentAccessToken,
 		}.Create()
@@ -100,13 +103,13 @@ var MetaDataSetCommand = cli.Command{
 				s.Break()
 			}
 			if err != nil {
-				logger.Warn("%s (%s)", err, s)
+				l.Warn("%s (%s)", err, s)
 			}
 
 			return err
 		}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
 		if err != nil {
-			logger.Fatal("Failed to set meta-data: %s", err)
+			l.Fatal("Failed to set meta-data: %s", err)
 		}
 	},
 }

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -92,17 +92,18 @@ var PipelineUploadCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
+		l := logger.NewLevelLogger(logger.INFO)
+
 		// The configuration will be loaded into this struct
 		cfg := PipelineUploadConfig{}
 
 		// Load the configuration
-		loader := cliconfig.Loader{CLI: c, Config: &cfg}
-		if err := loader.Load(); err != nil {
-			logger.Fatal("%s", err)
+		if err := cliconfig.Load(c, l, &cfg); err != nil {
+			l.Fatal("%s", err)
 		}
 
 		// Setup the any global configuration options
-		HandleGlobalFlags(cfg)
+		HandleGlobalFlags(l, cfg)
 
 		// Find the pipeline file either from STDIN or the first
 		// argument
@@ -111,23 +112,23 @@ var PipelineUploadCommand = cli.Command{
 		var filename string
 
 		if cfg.FilePath != "" {
-			logger.Info("Reading pipeline config from \"%s\"", cfg.FilePath)
+			l.Info("Reading pipeline config from \"%s\"", cfg.FilePath)
 
 			filename = filepath.Base(cfg.FilePath)
 			input, err = ioutil.ReadFile(cfg.FilePath)
 			if err != nil {
-				logger.Fatal("Failed to read file: %s", err)
+				l.Fatal("Failed to read file: %s", err)
 			}
 		} else if stdin.IsReadable() {
-			logger.Info("Reading pipeline config from STDIN")
+			l.Info("Reading pipeline config from STDIN")
 
 			// Actually read the file from STDIN
 			input, err = ioutil.ReadAll(os.Stdin)
 			if err != nil {
-				logger.Fatal("Failed to read from STDIN: %s", err)
+				l.Fatal("Failed to read from STDIN: %s", err)
 			}
 		} else {
-			logger.Info("Searching for pipeline config...")
+			l.Info("Searching for pipeline config...")
 
 			paths := []string{
 				"buildkite.yml",
@@ -149,26 +150,26 @@ var PipelineUploadCommand = cli.Command{
 			// If more than 1 of the config files exist, throw an
 			// error. There can only be one!!
 			if len(exists) > 1 {
-				logger.Fatal("Found multiple configuration files: %s. Please only have 1 configuration file present.", strings.Join(exists, ", "))
+				l.Fatal("Found multiple configuration files: %s. Please only have 1 configuration file present.", strings.Join(exists, ", "))
 			} else if len(exists) == 0 {
-				logger.Fatal("Could not find a default pipeline configuration file. See `buildkite-agent pipeline upload --help` for more information.")
+				l.Fatal("Could not find a default pipeline configuration file. See `buildkite-agent pipeline upload --help` for more information.")
 			}
 
 			found := exists[0]
 
-			logger.Info("Found config file \"%s\"", found)
+			l.Info("Found config file \"%s\"", found)
 
 			// Read the default file
 			filename = path.Base(found)
 			input, err = ioutil.ReadFile(found)
 			if err != nil {
-				logger.Fatal("Failed to read file \"%s\" (%s)", found, err)
+				l.Fatal("Failed to read file \"%s\" (%s)", found, err)
 			}
 		}
 
 		// Make sure the file actually has something in it
 		if len(input) == 0 {
-			logger.Fatal("Config file is empty")
+			l.Fatal("Config file is empty")
 		}
 
 		// Load environment to pass into parser
@@ -178,10 +179,10 @@ var PipelineUploadCommand = cli.Command{
 		if commitRef, ok := environ.Get(`BUILDKITE_COMMIT`); ok {
 			cmdOut, err := exec.Command(`git`, `rev-parse`, commitRef).Output()
 			if err != nil {
-				logger.Warn("Error running git rev-parse %q: %v", commitRef, err)
+				l.Warn("Error running git rev-parse %q: %v", commitRef, err)
 			} else {
 				trimmedCmdOut := strings.TrimSpace(string(cmdOut))
-				logger.Info("Updating BUILDKITE_COMMIT to %q", trimmedCmdOut)
+				l.Info("Updating BUILDKITE_COMMIT to %q", trimmedCmdOut)
 				environ.Set(`BUILDKITE_COMMIT`, trimmedCmdOut)
 			}
 		}
@@ -194,7 +195,7 @@ var PipelineUploadCommand = cli.Command{
 			NoInterpolation: cfg.NoInterpolation,
 		}.Parse()
 		if err != nil {
-			logger.Fatal("Pipeline parsing of \"%s\" failed (%s)", filename, err)
+			l.Fatal("Pipeline parsing of \"%s\" failed (%s)", filename, err)
 		}
 
 		// In dry-run mode we just output the generated pipeline to stdout
@@ -205,7 +206,7 @@ var PipelineUploadCommand = cli.Command{
 			// Dump json indented to stdout. All logging happens to stderr
 			// this can be used with other tools to get interpolated json
 			if err := enc.Encode(result); err != nil {
-				logger.Fatal("%#v", err)
+				l.Fatal("%#v", err)
 			}
 
 			os.Exit(0)
@@ -213,16 +214,17 @@ var PipelineUploadCommand = cli.Command{
 
 		// Check we have a job id set if not in dry run
 		if cfg.Job == "" {
-			logger.Fatal("Missing job parameter. Usually this is set in the environment for a Buildkite job via BUILDKITE_JOB_ID.")
+			l.Fatal("Missing job parameter. Usually this is set in the environment for a Buildkite job via BUILDKITE_JOB_ID.")
 		}
 
 		// Check we have an agent access token if not in dry run
 		if cfg.AgentAccessToken == "" {
-			logger.Fatal("Missing agent-access-token parameter. Usually this is set in the environment for a Buildkite job via BUILDKITE_AGENT_ACCESS_TOKEN.")
+			l.Fatal("Missing agent-access-token parameter. Usually this is set in the environment for a Buildkite job via BUILDKITE_AGENT_ACCESS_TOKEN.")
 		}
 
 		// Create the API client
 		client := agent.APIClient{
+			Logger: l,
 			Endpoint: cfg.Endpoint,
 			Token:    cfg.AgentAccessToken,
 		}.Create()
@@ -236,11 +238,11 @@ var PipelineUploadCommand = cli.Command{
 		err = retry.Do(func(s *retry.Stats) error {
 			_, err = client.Pipelines.Upload(cfg.Job, &api.Pipeline{UUID: uuid, Pipeline: result, Replace: cfg.Replace})
 			if err != nil {
-				logger.Warn("%s (%s)", err, s)
+				l.Warn("%s (%s)", err, s)
 
 				// 422 responses will always fail no need to retry
 				if apierr, ok := err.(*api.ErrorResponse); ok && apierr.Response.StatusCode == 422 {
-					logger.Error("Unrecoverable error, skipping retries")
+					l.Error("Unrecoverable error, skipping retries")
 					s.Break()
 				}
 			}
@@ -248,9 +250,9 @@ var PipelineUploadCommand = cli.Command{
 			return err
 		}, &retry.Config{Maximum: 5, Interval: 1 * time.Second})
 		if err != nil {
-			logger.Fatal("Failed to upload and process pipeline: %s", err)
+			l.Fatal("Failed to upload and process pipeline: %s", err)
 		}
 
-		logger.Info("Successfully uploaded and parsed pipeline config")
+		l.Info("Successfully uploaded and parsed pipeline config")
 	},
 }

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -92,7 +92,7 @@ var PipelineUploadCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLevelLogger(logger.INFO)
+		l := logger.NewLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := PipelineUploadConfig{}

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -63,30 +63,33 @@ var StepUpdateCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
+		l := logger.NewLevelLogger(logger.INFO)
+
 		// The configuration will be loaded into this struct
 		cfg := StepUpdateConfig{}
 
 		// Load the configuration
-		if err := cliconfig.Load(c, &cfg); err != nil {
-			logger.Fatal("%s", err)
+		if err := cliconfig.Load(c, l, &cfg); err != nil {
+			l.Fatal("%s", err)
 		}
 
 		// Setup the any global configuration options
-		HandleGlobalFlags(cfg)
+		HandleGlobalFlags(l, cfg)
 
 		// Read the value from STDIN if argument omitted entirely
 		if len(c.Args()) < 2 {
-			logger.Info("Reading value from STDIN")
+			l.Info("Reading value from STDIN")
 
 			input, err := ioutil.ReadAll(os.Stdin)
 			if err != nil {
-				logger.Fatal("Failed to read from STDIN: %s", err)
+				l.Fatal("Failed to read from STDIN: %s", err)
 			}
 			cfg.Value = string(input)
 		}
 
 		// Create the API client
 		client := agent.APIClient{
+			Logger: l,
 			Endpoint: cfg.Endpoint,
 			Token:    cfg.AgentAccessToken,
 		}.Create()
@@ -111,13 +114,13 @@ var StepUpdateCommand = cli.Command{
 				s.Break()
 			}
 			if err != nil {
-				logger.Warn("%s (%s)", err, s)
+				l.Warn("%s (%s)", err, s)
 			}
 
 			return err
 		}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
 		if err != nil {
-			logger.Fatal("Failed to change step: %s", err)
+			l.Fatal("Failed to change step: %s", err)
 		}
 	},
 }

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -63,7 +63,7 @@ var StepUpdateCommand = cli.Command{
 		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLevelLogger(logger.INFO)
+		l := logger.NewLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := StepUpdateConfig{}

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -22,7 +22,7 @@ type Loader struct {
 	Config interface{}
 
 	// The logger used
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	// A slice of paths to files that should be used as config files
 	DefaultConfigFilePaths []string
@@ -34,7 +34,7 @@ type Loader struct {
 var argCliNameRegexp = regexp.MustCompile(`arg:(\d+)`)
 
 // A shortcut for loading a config from the CLI
-func Load(c *cli.Context, l logger.Logger, cfg interface{}) error {
+func Load(c *cli.Context, l*logger.Logger, cfg interface{}) error {
 	loader := Loader{
 		CLI:    c,
 		Config: cfg,

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -21,6 +21,9 @@ type Loader struct {
 	// The struct that the config values will be loaded into
 	Config interface{}
 
+	// The logger used
+	Logger logger.Logger
+
 	// A slice of paths to files that should be used as config files
 	DefaultConfigFilePaths []string
 
@@ -31,10 +34,13 @@ type Loader struct {
 var argCliNameRegexp = regexp.MustCompile(`arg:(\d+)`)
 
 // A shortcut for loading a config from the CLI
-func Load(c *cli.Context, cfg interface{}) error {
-	l := Loader{CLI: c, Config: cfg}
-
-	return l.Load()
+func Load(c *cli.Context, l logger.Logger, cfg interface{}) error {
+	loader := Loader{
+		CLI:    c,
+		Config: cfg,
+		Logger: l,
+	}
+	return loader.Load()
 }
 
 // Loads the config from the CLI and config files that are present.
@@ -110,7 +116,7 @@ func (l *Loader) Load() error {
 			if !l.fieldValueIsEmpty(fieldName) {
 				renamedFieldCliName, _ := reflections.GetFieldTag(l.Config, renamedToFieldName, "cli")
 				if renamedFieldCliName != "" {
-					logger.Warn("The config option `%s` has been renamed to `%s`. Please update your configuration.", cliName, renamedFieldCliName)
+					l.Logger.Warn("The config option `%s` has been renamed to `%s`. Please update your configuration.", cliName, renamedFieldCliName)
 				}
 
 				value, _ := reflections.GetField(l.Config, fieldName)

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -1,15 +1,10 @@
 package experiments
 
-import (
-	"github.com/buildkite/agent/logger"
-)
-
 var experiments = make(map[string]bool)
 
 // Enable a paticular experiment in the agent
 func Enable(experiment string) {
 	experiments[experiment] = true
-	logger.Debug("Enabled experiment `%s`", experiment)
 }
 
 // Check if an experiment has been enabled

--- a/logger/level.go
+++ b/logger/level.go
@@ -3,18 +3,18 @@ package logger
 type Level int
 
 const (
-	INFO Level = iota
+	DEBUG Level = iota
 	NOTICE
-	DEBUG
+	INFO
 	ERROR
 	WARN
 	FATAL
 )
 
 var levelNames = []string{
-	"INFO",
-	"NOTICE",
 	"DEBUG",
+	"NOTICE",
+	"INFO",
 	"ERROR",
 	"WARN",
 	"FATAL",

--- a/logger/log.go
+++ b/logger/log.go
@@ -31,48 +31,21 @@ var (
 	colors bool
 )
 
-type Logger interface {
-	Debug(format string, v ...interface{})
-	Notice(format string, v ...interface{})
-	Info(format string, v ...interface{})
-	Warn(format string, v ...interface{})
-	Error(format string, v ...interface{})
-	Fatal(format string, v ...interface{})
-}
-
-type Tag struct {
-	Key   string
-	Value interface{}
-}
-
-type LevelLogger struct {
+type Logger struct {
 	Level  Level
 	Colors bool
+	Prefix string
 	Writer io.Writer
-	Tags   []Tag
 	ExitFn func()
 }
 
-func NewLevelLogger(l Level, tags ...Tag) *LevelLogger {
-	return &LevelLogger{
-		Level:  l,
+func NewLogger() *Logger {
+	return &Logger{
+		Level:  DEBUG,
 		Colors: true,
 		Writer: os.Stderr,
-		Tags:   []Tag{},
 	}
 }
-
-// func LevelledLogger GetLevel() Level {
-// 	return level
-// }
-
-// func SetLevel(l Level) {
-// 	level = l
-
-// 	if level == DEBUG {
-// 		Debug("Debug mode enabled")
-// 	}
-// }
 
 func SetColors(b bool) {
 	colors = b
@@ -96,40 +69,40 @@ func (l *LevelLogger) SetLevel(v Level) {
 	l.Level = v
 }
 
-func (l *LevelLogger) Debug(format string, v ...interface{}) {
+func (l *Logger) Debug(format string, v ...interface{}) {
 	if l.Level == DEBUG {
 		l.log(DEBUG, format, v...)
 	}
 }
 
-func (l *LevelLogger) Error(format string, v ...interface{}) {
+func (l *Logger) Error(format string, v ...interface{}) {
 	l.log(ERROR, format, v...)
 }
 
-func (l *LevelLogger) Fatal(format string, v ...interface{}) {
+func (l *Logger) Fatal(format string, v ...interface{}) {
 	l.log(FATAL, format, v...)
 	os.Exit(1)
 }
 
-func (l *LevelLogger) Notice(format string, v ...interface{}) {
+func (l *Logger) Notice(format string, v ...interface{}) {
 	if l.Level <= NOTICE {
 		l.log(NOTICE, format, v...)
 	}
 }
 
-func (l *LevelLogger) Info(format string, v ...interface{}) {
+func (l *Logger) Info(format string, v ...interface{}) {
 	if l.Level <= INFO {
 		l.log(INFO, format, v...)
 	}
 }
 
-func (l *LevelLogger) Warn(format string, v ...interface{}) {
+func (l *Logger) Warn(format string, v ...interface{}) {
 	if l.Level <= WARN {
 		l.log(WARN, format, v...)
 	}
 }
 
-func (l *LevelLogger) log(level Level, format string, v ...interface{}) {
+func (l *Logger) log(level Level, format string, v ...interface{}) {
 	message := fmt.Sprintf(format, v...)
 	now := time.Now().Format(DateFormat)
 	line := ""
@@ -164,6 +137,6 @@ func (l *LevelLogger) log(level Level, format string, v ...interface{}) {
 	mutex.Unlock()
 }
 
-var DiscardLogger = &LevelLogger{
+var Discard = &Logger{
 	Writer: ioutil.Discard,
 }

--- a/logger/log.go
+++ b/logger/log.go
@@ -13,13 +13,14 @@ import (
 )
 
 const (
-	nocolor = "0"
-	red     = "31"
-	green   = "1;32"
-	yellow  = "33"
-	blue    = "34"
-	gray    = "1;30"
-	cyan    = "1;36"
+	nocolor   = "0"
+	red       = "31"
+	green     = "38;5;48"
+	yellow    = "33"
+	blue      = "34"
+	gray      = "38;5;251"
+	lightgray = "38;5;243"
+	cyan      = "1;36"
 )
 
 const (
@@ -55,18 +56,21 @@ func ColorsEnabled() bool {
 	if runtime.GOOS == "windows" {
 		// Boo, no colors on Windows.
 		return false
-	} else {
-		// Colors can only be shown if STDOUT is a terminal
-		if terminal.IsTerminal(int(os.Stdout.Fd())) {
-			return colors
-		} else {
-			return false
-		}
 	}
+
+	// Colors can only be shown if STDOUT is a terminal
+	if terminal.IsTerminal(int(os.Stdout.Fd())) {
+		return colors
+	}
+
+	return false
 }
 
-func (l *LevelLogger) SetLevel(v Level) {
-	l.Level = v
+// WithPrefix returns a copy of the logger with the provided prefix
+func (l *Logger) WithPrefix(prefix string) *Logger {
+	clone := *l
+	clone.Prefix = prefix
+	return &clone
 }
 
 func (l *Logger) Debug(format string, v ...interface{}) {
@@ -108,27 +112,35 @@ func (l *Logger) log(level Level, format string, v ...interface{}) {
 	line := ""
 
 	if l.Colors {
-		prefixColor := green
+		levelColor := green
 		messageColor := nocolor
 
 		switch level {
 		case DEBUG:
-			prefixColor = gray
+			levelColor = gray
 			messageColor = gray
 		case NOTICE:
-			prefixColor = cyan
+			levelColor = cyan
 		case WARN:
-			prefixColor = yellow
+			levelColor = yellow
 		case ERROR:
-			prefixColor = red
+			levelColor = red
 		case FATAL:
-			prefixColor = red
+			levelColor = red
 			messageColor = red
 		}
 
-		line = fmt.Sprintf("\x1b[%sm%s %-6s\x1b[0m \x1b[%sm%s\x1b[0m\n", prefixColor, now, level, messageColor, message)
+		if l.Prefix != "" {
+			line = fmt.Sprintf("\x1b[%sm%s %-6s\x1b[0m \x1b[%sm%s\x1b[0m \x1b[%sm%s\x1b[0m\n", levelColor, now, level, lightgray, l.Prefix, messageColor, message)
+		} else {
+			line = fmt.Sprintf("\x1b[%sm%s %-6s\x1b[0m \x1b[%sm%s\x1b[0m\n", levelColor, now, level, messageColor, message)
+		}
 	} else {
-		line = fmt.Sprintf("%s %-6s %s\n", now, level, message)
+		if l.Prefix != "" {
+			line = fmt.Sprintf("%s %-6s %s %s\n", now, level, l.Prefix, message)
+		} else {
+			line = fmt.Sprintf("%s %-6s %s\n", now, level, message)
+		}
 	}
 
 	// Make sure we're only outputing a line one at a time

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -8,12 +8,12 @@ import (
 
 func TestLevelLogger(t *testing.T) {
 	b := &bytes.Buffer{}
-	l := NewLevelLogger(INFO)
+	l := NewLogger()
+	l.Level = INFO
 	l.Colors = false
 	l.Writer = b
 
 	l.Debug("Debug %q", "llamas")
-	l.Notice("Notice %q", "llamas")
 	l.Info("Info %q", "llamas")
 	l.Warn("Warn %q", "llamas")
 	l.Error("Error %q", "llamas")

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -1,0 +1,38 @@
+package logger
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestLevelLogger(t *testing.T) {
+	b := &bytes.Buffer{}
+	l := NewLevelLogger(INFO)
+	l.Colors = false
+	l.Writer = b
+
+	l.Debug("Debug %q", "llamas")
+	l.Notice("Notice %q", "llamas")
+	l.Info("Info %q", "llamas")
+	l.Warn("Warn %q", "llamas")
+	l.Error("Error %q", "llamas")
+
+	lines := strings.Split(strings.TrimRight(b.String(), "\n"), "\n")
+
+	if len(lines) != 3 {
+		t.Fatalf("bad number of lines, got %d", len(lines))
+	}
+
+	if !strings.HasSuffix(lines[0], `Info "llamas"`) {
+		t.Fatalf("line 0 bad, got %q", lines[0])
+	}
+
+	if !strings.HasSuffix(lines[1], `Warn "llamas"`) {
+		t.Fatalf("line 1 bad, got %q", lines[1])
+	}
+
+	if !strings.HasSuffix(lines[2], `Error "llamas"`) {
+		t.Fatalf("line 0 bad, got %q", lines[2])
+	}
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -24,7 +24,7 @@ type Collector struct {
 	DatadogHost string
 
 	// The logger to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	client *statsd.Client
 }

--- a/process/cat.go
+++ b/process/cat.go
@@ -2,34 +2,29 @@ package process
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
-
-	"github.com/buildkite/agent/logger"
 )
 
 // Replicates how the command line tool `cat` works, but is more verbose about
 // what it does
-func Cat(path string) string {
+func Cat(path string) (string, error) {
 	files, err := filepath.Glob(path)
-
 	if err != nil {
-		logger.Debug("Failed to get list of files: %s", path)
+		return "", fmt.Errorf("Failed to get a list of files: %v", err)
+	}
 
-		return ""
-	} else {
-		var buffer bytes.Buffer
+	var buffer bytes.Buffer
 
-		for _, file := range files {
-			data, err := ioutil.ReadFile(file)
-
-			if err != nil {
-				logger.Debug("Could not read file: %s (%T: %v)", file, err, err)
-			} else {
-				buffer.WriteString(string(data))
-			}
+	for _, file := range files {
+		data, err := ioutil.ReadFile(file)
+		if err != nil {
+			return "", fmt.Errorf("Could not read file: %s (%T: %v)", file, err, err)
 		}
 
-		return buffer.String()
+		buffer.WriteString(string(data))
 	}
+
+	return buffer.String(), nil
 }

--- a/process/process.go
+++ b/process/process.go
@@ -200,11 +200,11 @@ func (p *Process) Interrupt() error {
 	}
 
 	// interrupt the process (ctrl-c or SIGINT)
-	if err := interruptProcess(p.command.Process); err != nil {
+	if err := interruptProcess(p.command.Process, p.Logger); err != nil {
 		p.Logger.Error("[Process] Failed to interrupt process %d: %v", p.Pid, err)
 
 		// Fallback to terminating if we get an error
-		if termErr := terminateProcess(p.command.Process); termErr != nil {
+		if termErr := terminateProcess(p.command.Process, p.Logger); termErr != nil {
 			return termErr
 		}
 	}
@@ -222,7 +222,7 @@ func (p *Process) Terminate() error {
 		return nil
 	}
 
-	return terminateProcess(p.command.Process)
+	return terminateProcess(p.command.Process, p.Logger)
 }
 
 // https://github.com/hnakamur/commango/blob/fe42b1cf82bf536ce7e24dceaef6656002e03743/os/executil/executil.go#L29

--- a/process/process.go
+++ b/process/process.go
@@ -27,6 +27,9 @@ type Process struct {
 	// Handler is called with each line of output
 	Handler func(string)
 
+	// The logger to use
+	Logger logger.Logger
+
 	command       *exec.Cmd
 	mu            sync.Mutex
 	started, done chan struct{}
@@ -78,7 +81,7 @@ func (p *Process) Start() error {
 		waitGroup.Add(1)
 
 		go func() {
-			logger.Debug("[Process] Starting to copy PTY to the buffer")
+			p.Logger.Debug("[Process] Starting to copy PTY to the buffer")
 
 			// Copy the pty to our buffer. This will block until it
 			// EOF's or something breaks.
@@ -92,9 +95,9 @@ func (p *Process) Start() error {
 			}
 
 			if err != nil {
-				logger.Error("[Process] PTY output copy failed with error: %T: %v", err, err)
+				p.Logger.Error("[Process] PTY output copy failed with error: %T: %v", err, err)
 			} else {
-				logger.Debug("[Process] PTY has finished being copied to the buffer")
+				p.Logger.Debug("[Process] PTY has finished being copied to the buffer")
 			}
 
 			waitGroup.Done()
@@ -116,17 +119,19 @@ func (p *Process) Start() error {
 		close(p.started)
 	}
 
-	logger.Info("[Process] Process is running with PID: %d", p.Pid)
+	p.Logger.Info("[Process] Process is running with PID: %d", p.Pid)
 
 	if p.Handler != nil {
 		// Add the scanner the waitGroup
 		waitGroup.Add(1)
 
+		scanner := &Scanner{Logger: p.Logger}
+
 		// Start the Scanner
 		go func() {
 			defer waitGroup.Done()
-			if err := ScanLines(lineReaderPipe, p.Handler); err != nil {
-				logger.Error("[Process] Scanner failed with %v", err)
+			if err := scanner.ScanLines(lineReaderPipe, p.Handler); err != nil {
+				p.Logger.Error("[Process] Scanner failed with %v", err)
 			}
 		}()
 	} else {
@@ -144,16 +149,16 @@ func (p *Process) Start() error {
 	close(p.done)
 
 	// Find the exit status of the script
-	p.ExitStatus = getExitStatus(waitResult)
+	p.ExitStatus = p.getExitStatus(waitResult)
 
-	logger.Info("Process with PID: %d finished with Exit Status: %s", p.Pid, p.ExitStatus)
+	p.Logger.Info("Process with PID: %d finished with Exit Status: %s", p.Pid, p.ExitStatus)
 
 	// Sometimes (in docker containers) io.Copy never seems to finish. This is a mega
 	// hack around it. If it doesn't finish after 1 second, just continue.
-	logger.Debug("[Process] Waiting for routines to finish")
+	p.Logger.Debug("[Process] Waiting for routines to finish")
 	err := timeoutWait(&waitGroup)
 	if err != nil {
-		logger.Debug("[Process] Timed out waiting for wait group: (%T: %v)", err, err)
+		p.Logger.Debug("[Process] Timed out waiting for wait group: (%T: %v)", err, err)
 	}
 
 	// No error occurred so we can return nil
@@ -190,13 +195,13 @@ func (p *Process) Interrupt() error {
 	defer p.mu.Unlock()
 
 	if p.command == nil || p.command.Process == nil {
-		logger.Debug("[Process] No process to interrupt yet")
+		p.Logger.Debug("[Process] No process to interrupt yet")
 		return nil
 	}
 
 	// interrupt the process (ctrl-c or SIGINT)
 	if err := interruptProcess(p.command.Process); err != nil {
-		logger.Error("[Process] Failed to interrupt process %d: %v", p.Pid, err)
+		p.Logger.Error("[Process] Failed to interrupt process %d: %v", p.Pid, err)
 
 		// Fallback to terminating if we get an error
 		if termErr := terminateProcess(p.command.Process); termErr != nil {
@@ -213,7 +218,7 @@ func (p *Process) Terminate() error {
 	defer p.mu.Unlock()
 
 	if p.command == nil || p.command.Process == nil {
-		logger.Debug("[Process] No process to terminate yet")
+		p.Logger.Debug("[Process] No process to terminate yet")
 		return nil
 	}
 
@@ -222,7 +227,7 @@ func (p *Process) Terminate() error {
 
 // https://github.com/hnakamur/commango/blob/fe42b1cf82bf536ce7e24dceaef6656002e03743/os/executil/executil.go#L29
 // TODO: Can this be better?
-func getExitStatus(waitResult error) string {
+func (p *Process) getExitStatus(waitResult error) string {
 	exitStatus := -1
 
 	if waitResult != nil {
@@ -230,10 +235,10 @@ func getExitStatus(waitResult error) string {
 			if s, ok := err.Sys().(syscall.WaitStatus); ok {
 				exitStatus = s.ExitStatus()
 			} else {
-				logger.Error("[Process] Unimplemented for system where exec.ExitError.Sys() is not syscall.WaitStatus.")
+				p.Logger.Error("[Process] Unimplemented for system where exec.ExitError.Sys() is not syscall.WaitStatus.")
 			}
 		} else {
-			logger.Error("[Process] Unexpected error type in getExitStatus: %#v", waitResult)
+			p.Logger.Error("[Process] Unexpected error type in getExitStatus: %#v", waitResult)
 		}
 	} else {
 		exitStatus = 0

--- a/process/process.go
+++ b/process/process.go
@@ -28,7 +28,7 @@ type Process struct {
 	Handler func(string)
 
 	// The logger to use
-	Logger logger.Logger
+	Logger *logger.Logger
 
 	command       *exec.Cmd
 	mu            sync.Mutex

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/process"
 )
 
@@ -23,6 +24,7 @@ func TestProcessRunsAndSignalsStartedAndStopped(t *testing.T) {
 	p := process.Process{
 		Script: []string{os.Args[0]},
 		Env:    []string{"TEST_MAIN=tester"},
+		Logger: logger.Discard,
 	}
 
 	var wg sync.WaitGroup
@@ -65,6 +67,7 @@ func TestProcessCapturesOutputLineByLine(t *testing.T) {
 	p := process.Process{
 		Script: []string{os.Args[0]},
 		Env:    []string{"TEST_MAIN=tester"},
+		Logger: logger.Discard,
 		Handler: func(line string) {
 			mu.Lock()
 			defer mu.Unlock()
@@ -100,6 +103,7 @@ func TestProcessInterrupts(t *testing.T) {
 	p := process.Process{
 		Script: []string{os.Args[0]},
 		Env:    []string{"TEST_MAIN=tester-signal"},
+		Logger: logger.Discard,
 		Handler: func(line string) {
 			mu.Lock()
 			defer mu.Unlock()

--- a/process/run.go
+++ b/process/run.go
@@ -8,11 +8,11 @@ import (
 	"github.com/buildkite/agent/logger"
 )
 
-func Run(command string, arg ...string) (string, error) {
+func Run(l logger.Logger, command string, arg ...string) (string, error) {
 	output, err := exec.Command(command, arg...).Output()
 
 	if err != nil {
-		logger.Debug("Could not run: %s %s (returned %s) (%T: %v)", command, arg, output, err, err)
+		l.Debug("Could not run: %s %s (returned %s) (%T: %v)", command, arg, output, err, err)
 		return "", err
 	}
 

--- a/process/run.go
+++ b/process/run.go
@@ -8,7 +8,7 @@ import (
 	"github.com/buildkite/agent/logger"
 )
 
-func Run(l logger.Logger, command string, arg ...string) (string, error) {
+func Run(l *logger.Logger, command string, arg ...string) (string, error) {
 	output, err := exec.Command(command, arg...).Output()
 
 	if err != nil {

--- a/process/scanner.go
+++ b/process/scanner.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Scanner struct {
-	Logger logger.Logger
+	Logger *logger.Logger
 }
 
 func (s *Scanner) ScanLines(r io.Reader, f func(line string)) error {

--- a/process/scanner.go
+++ b/process/scanner.go
@@ -9,11 +9,15 @@ import (
 	"github.com/buildkite/agent/logger"
 )
 
-func ScanLines(r io.Reader, f func(line string)) error {
+type Scanner struct {
+	Logger logger.Logger
+}
+
+func (s *Scanner) ScanLines(r io.Reader, f func(line string)) error {
 	var reader = bufio.NewReader(r)
 	var appending []byte
 
-	logger.Debug("[LineScanner] Starting to read lines")
+	s.Logger.Debug("[LineScanner] Starting to read lines")
 
 	// Note that we do this manually rather than
 	// because we need to handle very long lines
@@ -22,7 +26,7 @@ func ScanLines(r io.Reader, f func(line string)) error {
 		line, isPrefix, err := reader.ReadLine()
 		if err != nil {
 			if err == io.EOF {
-				logger.Debug("[LineScanner] Encountered EOF")
+				s.Logger.Debug("[LineScanner] Encountered EOF")
 				break
 			}
 			return err
@@ -33,7 +37,7 @@ func ScanLines(r io.Reader, f func(line string)) error {
 		// until isPrefix is false (which means the long line
 		// has ended.
 		if isPrefix && appending == nil {
-			logger.Debug("[LineScanner] Line is too long to read, going to buffer it until it finishes")
+			s.Logger.Debug("[LineScanner] Line is too long to read, going to buffer it until it finishes")
 
 			// bufio.ReadLine returns a slice which is only valid until the next invocation
 			// since it points to its own internal buffer array. To accumulate the entire
@@ -51,7 +55,7 @@ func ScanLines(r io.Reader, f func(line string)) error {
 
 			// No more isPrefix! Line is finished!
 			if !isPrefix {
-				logger.Debug("[LineScanner] Finished buffering long line")
+				s.Logger.Debug("[LineScanner] Finished buffering long line")
 				line = appending
 
 				// Reset appending back to nil
@@ -65,7 +69,7 @@ func ScanLines(r io.Reader, f func(line string)) error {
 		f(string(line))
 	}
 
-	logger.Debug("[LineScanner] Finished")
+	s.Logger.Debug("[LineScanner] Finished")
 	return nil
 }
 

--- a/process/scanner_test.go
+++ b/process/scanner_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/process"
 )
 
@@ -33,7 +34,9 @@ func TestScanLines(t *testing.T) {
 		pw.Close()
 	}()
 
-	err := process.ScanLines(pr, func(l string) {
+	scanner := &process.Scanner{Logger: logger.DiscardLogger}
+
+	err := scanner.ScanLines(pr, func(l string) {
 		lineNumber := atomic.AddInt32(&lineCounter, 1)
 		s := fmt.Sprintf("#%d: chars %d", lineNumber, len(l))
 		lines = append(lines, s)

--- a/process/scanner_test.go
+++ b/process/scanner_test.go
@@ -34,7 +34,7 @@ func TestScanLines(t *testing.T) {
 		pw.Close()
 	}()
 
-	scanner := &process.Scanner{Logger: logger.DiscardLogger}
+	scanner := &process.Scanner{Logger: logger.Discard}
 
 	err := scanner.ScanLines(pr, func(l string) {
 		lineNumber := atomic.AddInt32(&lineCounter, 1)

--- a/process/utils.go
+++ b/process/utils.go
@@ -19,13 +19,13 @@ func createCommand(name string, arg ...string) *exec.Cmd {
 	return exec.Command(name, arg...)
 }
 
-func terminateProcess(p *os.Process) error {
-	logger.Debug("[Process] Sending signal SIGKILL to PID: %d", p.Pid)
+func terminateProcess(p *os.Process, l *logger.Logger) error {
+	l.Debug("[Process] Sending signal SIGKILL to PID: %d", p.Pid)
 	return p.Signal(syscall.SIGKILL)
 }
 
-func interruptProcess(p *os.Process) error {
-	logger.Debug("[Process] Sending signal SIGTERM to PID: %d", p.Pid)
+func interruptProcess(p *os.Process, l *logger.Logger) error {
+	l.Debug("[Process] Sending signal SIGTERM to PID: %d", p.Pid)
 
 	// TODO: this should be SIGINT, but will be a breaking change
 	return p.Signal(syscall.SIGTERM)

--- a/process/utils_windows.go
+++ b/process/utils_windows.go
@@ -26,16 +26,16 @@ func createCommand(name string, arg ...string) *exec.Cmd {
 	return exec.Command(name, arg...)
 }
 
-func terminateProcess(p *os.Process) error {
-	logger.Debug("[Process] Terminating process tree with TASKKILL.EXE PID: %d", p.Pid)
+func terminateProcess(p *os.Process, l *logger.Logger) error {
+	l.Debug("[Process] Terminating process tree with TASKKILL.EXE PID: %d", p.Pid)
 
 	// taskkill.exe with /F will call TerminateProcess and hard-kill the process and
 	// anything in it's process tree.
 	return exec.Command("CMD", "/C", "TASKKILL.EXE", "/F", "/T", "/PID", strconv.Itoa(p.Pid)).Run()
 }
 
-func interruptProcess(p *os.Process) error {
-	logger.Debug("[Process] Interrupting process tree with TASKKILL.EXE PID: %d", p.Pid)
+func interruptProcess(p *os.Process, l *logger.Logger) error {
+	l.Debug("[Process] Interrupting process tree with TASKKILL.EXE PID: %d", p.Pid)
 
 	// taskkill.exe without the /F will use window signalling (WM_STOP, WM_QUIT) to kind
 	// of gracefull shutdown windows things that support it.

--- a/system/version_dump.go
+++ b/system/version_dump.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Returns a dump of the raw operating system information
-func VersionDump(l logger.Logger) (string, error) {
+func VersionDump(l *logger.Logger) (string, error) {
 	if runtime.GOOS == "darwin" {
 		return process.Run(l, "sw_vers")
 	} else if runtime.GOOS == "linux" {

--- a/system/version_dump.go
+++ b/system/version_dump.go
@@ -5,15 +5,16 @@ package system
 import (
 	"runtime"
 
+	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/process"
 )
 
 // Returns a dump of the raw operating system information
-func VersionDump() (string, error) {
+func VersionDump(l logger.Logger) (string, error) {
 	if runtime.GOOS == "darwin" {
-		return process.Run("sw_vers")
+		return process.Run(l, "sw_vers")
 	} else if runtime.GOOS == "linux" {
-		return process.Cat("/etc/*-release"), nil
+		return process.Cat("/etc/*-release")
 	}
 
 	return "", nil

--- a/system/version_dump_windows.go
+++ b/system/version_dump_windows.go
@@ -3,9 +3,11 @@ package system
 import (
 	"fmt"
 	"syscall"
+
+	"github.com/buildkite/agent/logger"
 )
 
-func VersionDump() (string, error) {
+func VersionDump(_ *logger.Logger) (string, error) {
 	dll := syscall.MustLoadDLL("kernel32.dll")
 	p := dll.MustFindProc("GetVersion")
 	v, _, _ := p.Call()


### PR DESCRIPTION
With the rise of our new `--spawn` param, I'd really like to have a prefix in the log output for the specific agent that console output is coming from. This is really, really hard to do with the global logger.

This moves to an instance that gets passed into anything that needs a logger. It's a lot of code and opens up a lot of spots for nil pointer errors as we rarely use constructors and tend to use direct struct instantiations. 

I'd love some feels on this approach. It's been hard work and I don't super like the result, but it's probably more correct? 