### PR TITLE
Add tests exposing a paths issue.

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -3,7 +3,7 @@
 We frequently introduce new experimental features to the agent. You can use the `--experiment` flag to opt-in to them and test them out:
 
 ```bash
-buildkite-agent start --experiment experiment1 --experiment expertiment2
+buildkite-agent start --experiment experiment1 --experiment experiment2
 ```
 
 Or you can set them in your [agent configuration file](https://buildkite.com/docs/agent/v3/configuration):

--- a/utils/path_test_windows.go
+++ b/utils/path_test_windows.go
@@ -1,0 +1,32 @@
+// +build windows
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeWindowsDriveAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	fp, err := NormalizeFilePath("C:\\programdata\\buildkite-agent")
+	assert.NoError(t, err)
+	expected := filepath.Join("C:", "programdata", "buildkite-agent")
+	assert.Equal(t, expected, fp)
+}
+
+func TestNormalizeWindowsBackslashAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	// A naked backslash on Windows resolves to root of current working directory's drive.
+	dir, err := os.Getwd()
+	assert.NoError(t, err)
+	drive := filepath.VolumeName(dir)
+	fp, err := NormalizeFilePath("\\")
+
+	assert.NoError(t, err)
+	expected := filepath.Join(drive, "programdata", "buildkite-agent")
+	assert.Equal(t, expected, fp)
+}


### PR DESCRIPTION
On windows, absolute paths start either with \ or with c: (as in, drive-letter then colon)