### PR TITLE
Move graceful kill behaviour out of process.Process

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -193,7 +193,7 @@ func (a *AgentWorker) Stop(graceful bool) {
 			// Kill the current job. Doesn't do anything if the job
 			// is already being killed, so it's safe to call
 			// multiple times.
-			a.jobRunner.Kill()
+			a.jobRunner.Cancel()
 		} else {
 			logger.Info("Forcefully stopping agent. Since there is no job running, the agent will disconnect immediately")
 		}

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -79,7 +79,7 @@ func TestProcessCapturesOutputLineByLine(t *testing.T) {
 	}
 }
 
-func TestProcessIsKilledGracefully(t *testing.T) {
+func TestProcessInterrupts(t *testing.T) {
 	var lines []string
 	var mu sync.Mutex
 
@@ -99,7 +99,7 @@ func TestProcessIsKilledGracefully(t *testing.T) {
 		// give the signal handler some time to install
 		time.Sleep(time.Millisecond * 50)
 
-		p.Kill(time.Millisecond * 20)
+		p.Interrupt()
 	}()
 
 	if err := p.Start(); err != nil {
@@ -131,8 +131,7 @@ func TestMain(m *testing.M) {
 			syscall.SIGTERM,
 			syscall.SIGINT,
 		)
-		sig := <-signals
-		fmt.Printf("SIG %v", sig)
+		fmt.Printf("SIG %v", <-signals)
 		os.Exit(0)
 
 	default:

--- a/process/utils.go
+++ b/process/utils.go
@@ -26,5 +26,7 @@ func terminateProcess(p *os.Process) error {
 
 func interruptProcess(p *os.Process) error {
 	logger.Debug("[Process] Sending signal SIGTERM to PID: %d", p.Pid)
+
+	// TODO: this should be SIGINT, but will be a breaking change
 	return p.Signal(syscall.SIGTERM)
 }

--- a/process/utils.go
+++ b/process/utils.go
@@ -5,10 +5,26 @@ package process
 import (
 	"os"
 	"os/exec"
+	"syscall"
 
+	"github.com/buildkite/agent/logger"
 	"github.com/kr/pty"
 )
 
 func StartPTY(c *exec.Cmd) (*os.File, error) {
 	return pty.Start(c)
+}
+
+func createCommand(name string, arg ...string) *exec.Cmd {
+	return exec.Command(name, arg...)
+}
+
+func terminateProcess(p *os.Process) error {
+	logger.Debug("[Process] Sending signal SIGKILL to PID: %d", p.Pid)
+	return p.Signal(syscall.SIGKILL)
+}
+
+func interruptProcess(p *os.Process) error {
+	logger.Debug("[Process] Sending signal SIGTERM to PID: %d", p.Pid)
+	return p.Signal(syscall.SIGTERM)
 }

--- a/process/utils_windows.go
+++ b/process/utils_windows.go
@@ -9,6 +9,15 @@ import (
 	"github.com/buildkite/agent/logger"
 )
 
+// Windows signal handling isn't a thing unfortunately, so we are limited in what we
+// can do with gracefully terminating. Windows also doesn't have process hierarchies
+// in the same way that unix does, so killing a process doesn't have any effect on
+// the processes it spawned. We use TASKKILL.EXE with the /T flag to traverse processes
+// that have a matching ParentProcessID, but even then if a process in the middle
+// of the chain has died, we leave a heap of processes hanging around. Future improvements
+// might include using terminal groups or job groups, which are a modern windows thing
+// that might work for us.
+
 func StartPTY(c *exec.Cmd) (*os.File, error) {
 	return nil, errors.New("PTY is not supported on Windows")
 }
@@ -19,10 +28,16 @@ func createCommand(name string, arg ...string) *exec.Cmd {
 
 func terminateProcess(p *os.Process) error {
 	logger.Debug("[Process] Terminating process tree with TASKKILL.EXE PID: %d", p.Pid)
+
+	// taskkill.exe with /F will call TerminateProcess and hard-kill the process and
+	// anything in it's process tree.
 	return exec.Command("CMD", "/C", "TASKKILL.EXE", "/F", "/T", "/PID", strconv.Itoa(p.Pid)).Run()
 }
 
 func interruptProcess(p *os.Process) error {
 	logger.Debug("[Process] Interrupting process tree with TASKKILL.EXE PID: %d", p.Pid)
+
+	// taskkill.exe without the /F will use window signalling (WM_STOP, WM_QUIT) to kind
+	// of gracefull shutdown windows things that support it.
 	return exec.Command("CMD", "/C", "TASKKILL.EXE", "/T", "/PID", strconv.Itoa(p.Pid)).Run()
 }

--- a/process/utils_windows.go
+++ b/process/utils_windows.go
@@ -18,13 +18,11 @@ func createCommand(name string, arg ...string) *exec.Cmd {
 }
 
 func terminateProcess(p *os.Process) error {
-	logger.Debug("[Process] Killing process with PID: %d", p.Pid)
-	return p.Kill()
+	logger.Debug("[Process] Terminating process tree with TASKKILL.EXE PID: %d", p.Pid)
+	return exec.Command("CMD", "/C", "TASKKILL.EXE", "/F", "/T", "/PID", strconv.Itoa(p.Pid)).Run()
 }
 
 func interruptProcess(p *os.Process) error {
-	logger.Debug("[Process] Killing process tree with TASKKILL.EXE PID: %d", p.Pid)
-	// Sending Interrupt on Windows is not implemented.
-	// https://golang.org/src/os/exec.go?s=3842:3884#L110
-	return exec.Command("CMD", "/C", "TASKKILL", "/F", "/T", "/PID", strconv.Itoa(p.Pid)).Run()
+	logger.Debug("[Process] Interrupting process tree with TASKKILL.EXE PID: %d", p.Pid)
+	return exec.Command("CMD", "/C", "TASKKILL.EXE", "/T", "/PID", strconv.Itoa(p.Pid)).Run()
 }

--- a/process/utils_windows.go
+++ b/process/utils_windows.go
@@ -4,8 +4,27 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strconv"
+
+	"github.com/buildkite/agent/logger"
 )
 
 func StartPTY(c *exec.Cmd) (*os.File, error) {
 	return nil, errors.New("PTY is not supported on Windows")
+}
+
+func createCommand(name string, arg ...string) *exec.Cmd {
+	return exec.Command(name, arg...)
+}
+
+func terminateProcess(p *os.Process) error {
+	logger.Debug("[Process] Killing process with PID: %d", p.Pid)
+	return p.Kill()
+}
+
+func interruptProcess(p *os.Process) error {
+	logger.Debug("[Process] Killing process tree with TASKKILL.EXE PID: %d", p.Pid)
+	// Sending Interrupt on Windows is not implemented.
+	// https://golang.org/src/os/exec.go?s=3842:3884#L110
+	return exec.Command("CMD", "/C", "TASKKILL", "/F", "/T", "/PID", strconv.Itoa(p.Pid)).Run()
 }


### PR DESCRIPTION
Previously `process.Process.Kill()` handled our graceful shutdown behaviour, e.g first interrupt the sub-process, wait 10 seconds and then kill it. 

It turns out that windows support is a lot more complicated, so this moves that functionality to `agent.JobRunner.Cancel()`, which delegates to `process.Process.Interrupt()` and then `process.Process.Terminate()`.

This should be functionally identical to the current behaviour, just with some code moved around to better support future changes like #879.