### PR TITLE
Respect color settings in logger

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -34,6 +34,7 @@ type AgentPool struct {
 	Endpoint              string
 	Debug                 bool
 	DisableHTTP2          bool
+	DisableColors         bool
 	AgentConfiguration    *AgentConfiguration
 	MetricsCollector      *metrics.Collector
 	Spawn                 int
@@ -318,8 +319,8 @@ func (r *AgentPool) ShowBanner() {
 			"                                                __/ |\n" +
 			" http://buildkite.com/agent                    |___/\n%s\n"
 
-	if logger.ColorsEnabled() {
-		fmt.Fprintf(os.Stderr, welcomeMessage, "\x1b[32m", "\x1b[0m")
+	if !r.DisableColors {
+		fmt.Fprintf(os.Stderr, welcomeMessage, "\x1b[38;5;48m", "\x1b[0m")
 	} else {
 		fmt.Fprintf(os.Stderr, welcomeMessage, "", "")
 	}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -427,6 +427,7 @@ var AgentStartCommand = cli.Command{
 			Endpoint:              cfg.Endpoint,
 			Debug:                 cfg.Debug,
 			DisableHTTP2:          cfg.NoHTTP2,
+			DisableColors:         cfg.NoColor,
 			Spawn:                 cfg.Spawn,
 			AgentConfiguration: &agent.AgentConfiguration{
 				BootstrapScript:           cfg.BootstrapScript,

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -67,7 +67,9 @@ func HandleGlobalFlags(l *logger.Logger, cfg interface{}) {
 	// Turn off color if a NoColor option is present
 	noColor, err := reflections.GetField(cfg, "NoColor")
 	if noColor == true && err == nil {
-		logger.SetColors(false)
+		l.Colors = false
+	} else {
+		l.Colors = true
 	}
 
 	// Enable experiments

--- a/logger/log.go
+++ b/logger/log.go
@@ -28,8 +28,7 @@ const (
 )
 
 var (
-	mutex  = sync.Mutex{}
-	colors bool
+	mutex = sync.Mutex{}
 )
 
 type Logger struct {
@@ -43,24 +42,20 @@ type Logger struct {
 func NewLogger() *Logger {
 	return &Logger{
 		Level:  DEBUG,
-		Colors: true,
+		Colors: ColorsAvailable(),
 		Writer: os.Stderr,
 	}
 }
 
-func SetColors(b bool) {
-	colors = b
-}
-
-func ColorsEnabled() bool {
+func ColorsAvailable() bool {
+	// Boo, no colors on Windows.
 	if runtime.GOOS == "windows" {
-		// Boo, no colors on Windows.
 		return false
 	}
 
 	// Colors can only be shown if STDOUT is a terminal
 	if terminal.IsTerminal(int(os.Stdout.Fd())) {
-		return colors
+		return true
 	}
 
 	return false


### PR DESCRIPTION
Turns out I broke `--no-color` in #880. This returns it. 