### PR TITLE
Acquire a lock on checkout dir

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -886,6 +886,14 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 		return err
 	}
 
+	// Try and lock the directory in-case any processes remain using the directory
+	// from previous cancelled builds (looking at you windows)
+	checkoutLock, err := b.shell.LockFile(b.shell.Getwd(), time.Second * 20)
+	if err != nil {
+		return fmt.Errorf("Unable to acquire lock on checkout dir: %v", err)
+	}
+	defer checkoutLock.Unlock()
+
 	if b.SSHKeyscan {
 		addRepositoryHostToSSHKnownHosts(b.shell, b.Repository)
 	}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -888,7 +888,10 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 
 	// Try and lock the directory in-case any processes remain using the directory
 	// from previous cancelled builds (looking at you windows)
-	checkoutLock, err := b.shell.LockFile(b.shell.Getwd(), time.Second * 20)
+	lf := b.shell.Getwd() + `.lock`
+	b.shell.Commentf("Acquiring checkout lock on %s", lf)
+
+	checkoutLock, err := b.shell.LockFile(lf, time.Second * 20)
 	if err != nil {
 		return fmt.Errorf("Unable to acquire lock on checkout dir: %v", err)
 	}


### PR DESCRIPTION
Sometimes when we cancel jobs under windows, processes are left over that might still be accessing the checkout dir. This leads to errors when the next job runs `git clean`, as I suspect we are seeing in #866. 

This PR adds a cross-process lock to the checkout dir to avoid concurrent access. Hopefully it will make for a clearer error than we are presently seeing. 