### PR TITLE
Fix for #475

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,7 @@ else
     *x86_64*)  ARCH="amd64"   ;;
     *armv8*)   ARCH="arm64"   ;;
     *armv7*)   ARCH="armhf"   ;;
+    *armv6l*)  ARCH="arm"     ;;
     *armv6*)   ARCH="armhf"   ;;
     *arm*)     ARCH="arm"     ;;
     *ppc64le*) ARCH="ppc64le" ;;


### PR DESCRIPTION
The RPi reports `uname -sm` as `Linux armv6l`, this PR adds a match for `armv6l` for checking prior to `armv6` to resolve arch to `arm` instead of `armhf` in `install.sh`.

I'm not sure this is the only way to fix it / there might be other things wrong / still needs to be tested.

Closes #475.