### PR TITLE
Resolve ssh hostname aliases before running ssh-keyscan

### DIFF
--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -149,7 +149,7 @@ func parseGittableURL(ref string) (*url.URL, error) {
 // https://buildkite.com/docs/agent/ssh-keys#creating-multiple-ssh-keys
 var gitHostAliasRegexp = regexp.MustCompile(`-[a-z0-9\-]+$`)
 
-func resolveGitHost(host string) string {
+func resolveGitHost(sh *shell.Shell, host string) string {
 	// ask SSH to print its configuration for this host, honouring .ssh/config
 	output, err := sh.RunAndCapture("ssh", "-G", host)
 

--- a/bootstrap/git_test.go
+++ b/bootstrap/git_test.go
@@ -64,9 +64,9 @@ func TestParsingGittableRepositoryFromSSHURLsWithPorts(t *testing.T) {
 	assert.Equal(t, `git.host.de:4019`, u.Host)
 }
 
-func TestStrippingGitHostAliases(t *testing.T) {
+func TestResolvingGitHostAliases(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "github.com", stripAliasesFromGitHost("github.com-alias1"))
-	assert.Equal(t, "blargh-no-alias.com", stripAliasesFromGitHost("blargh-no-alias.com"))
+	assert.Equal(t, "github.com", resolveGitHost("github.com-alias1"))
+	assert.Equal(t, "blargh-no-alias.com", resolveGitHost("blargh-no-alias.com"))
 }

--- a/bootstrap/git_test.go
+++ b/bootstrap/git_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"testing"
 
+	"github.com/buildkite/agent/bootstrap/shell"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -67,6 +68,13 @@ func TestParsingGittableRepositoryFromSSHURLsWithPorts(t *testing.T) {
 func TestResolvingGitHostAliases(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "github.com", resolveGitHost("github.com-alias1"))
-	assert.Equal(t, "blargh-no-alias.com", resolveGitHost("blargh-no-alias.com"))
+	sh, err := shell.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sh.Logger = shell.TestingLogger{t}
+
+	assert.Equal(t, "github.com", resolveGitHost(sh, "github.com-alias1"))
+	assert.Equal(t, "blargh-no-alias.com", resolveGitHost(sh, "blargh-no-alias.com"))
 }

--- a/bootstrap/git_test.go
+++ b/bootstrap/git_test.go
@@ -81,28 +81,30 @@ func TestResolvingGitHostAliasesWithoutFlagSupport(t *testing.T) {
 
 	ssh.
 		Expect("-G", "github.com-alias1").
-		AndWriteToStderr(`ssh: illegal option -- G
-usage: ssh [-46AaCfGgKkMNnqsTtVvXxYy] [-B bind_interface]
-           [-b bind_address] [-c cipher_spec] [-D [bind_address:]port]
-           [-E log_file] [-e escape_char] [-F configfile] [-I pkcs11]
-           [-i identity_file] [-J [user@]host[:port]] [-L address]
-           [-l login_name] [-m mac_spec] [-O ctl_cmd] [-o option] [-p port]
-           [-Q query_option] [-R address] [-S ctl_path] [-W host:port]
-           [-w local_tun[:remote_tun]] destination [command]`).
+		AndWriteToStderr(`unknown option -- G
+usage: ssh [-1246AaCfgKkMNnqsTtVvXxYy] [-b bind_address] [-c cipher_spec]
+           [-D [bind_address:]port] [-E log_file] [-e escape_char]
+           [-F configfile] [-I pkcs11] [-i identity_file]
+           [-L [bind_address:]port:host:hostport] [-l login_name] [-m mac_spec]
+           [-O ctl_cmd] [-o option] [-p port]
+           [-Q cipher | cipher-auth | mac | kex | key]
+           [-R [bind_address:]port:host:hostport] [-S ctl_path] [-W host:port]
+           [-w local_tun[:remote_tun]] [user@]hostname [command]`).
 		AndExitWith(255)
 
 	assert.Equal(t, "github.com", resolveGitHost(sh, "github.com-alias1"))
 
 	ssh.
 		Expect("-G", "blargh-no-alias.com").
-		AndWriteToStderr(`ssh: illegal option -- G
-usage: ssh [-46AaCfGgKkMNnqsTtVvXxYy] [-B bind_interface]
-           [-b bind_address] [-c cipher_spec] [-D [bind_address:]port]
-           [-E log_file] [-e escape_char] [-F configfile] [-I pkcs11]
-           [-i identity_file] [-J [user@]host[:port]] [-L address]
-           [-l login_name] [-m mac_spec] [-O ctl_cmd] [-o option] [-p port]
-           [-Q query_option] [-R address] [-S ctl_path] [-W host:port]
-           [-w local_tun[:remote_tun]] destination [command]`).
+		AndWriteToStderr(`unknown option -- G
+usage: ssh [-1246AaCfgKkMNnqsTtVvXxYy] [-b bind_address] [-c cipher_spec]
+           [-D [bind_address:]port] [-E log_file] [-e escape_char]
+           [-F configfile] [-I pkcs11] [-i identity_file]
+           [-L [bind_address:]port:host:hostport] [-l login_name] [-m mac_spec]
+           [-O ctl_cmd] [-o option] [-p port]
+           [-Q cipher | cipher-auth | mac | kex | key]
+           [-R [bind_address:]port:host:hostport] [-S ctl_path] [-W host:port]
+           [-w local_tun[:remote_tun]] [user@]hostname [command]`).
 		AndExitWith(255)
 
 	assert.Equal(t, "blargh-no-alias.com", resolveGitHost(sh, "blargh-no-alias.com"))

--- a/bootstrap/git_test.go
+++ b/bootstrap/git_test.go
@@ -226,6 +226,80 @@ syslogfacility USER`).
 		AndExitWith(0)
 
 	assert.Equal(t, "blargh-no-alias.com", resolveGitHost(sh, "blargh-no-alias.com"))
+
+	ssh.
+		Expect("-G", "cool-alias").
+		AndWriteToStdout(`user cool-admin
+hostname rad-git-host.com
+port 443
+addkeystoagent false
+addressfamily any
+batchmode no
+canonicalizefallbacklocal yes
+canonicalizehostname false
+challengeresponseauthentication yes
+checkhostip yes
+compression no
+controlmaster false
+enablesshkeysign no
+clearallforwardings no
+exitonforwardfailure no
+fingerprinthash SHA256
+forwardagent no
+forwardx11 no
+forwardx11trusted no
+gatewayports no
+gssapiauthentication no
+gssapidelegatecredentials no
+hashknownhosts no
+hostbasedauthentication no
+identitiesonly no
+kbdinteractiveauthentication yes
+nohostauthenticationforlocalhost no
+passwordauthentication yes
+permitlocalcommand no
+proxyusefdpass no
+pubkeyauthentication yes
+requesttty auto
+streamlocalbindunlink no
+stricthostkeychecking ask
+tcpkeepalive yes
+tunnel false
+verifyhostkeydns false
+visualhostkey no
+updatehostkeys false
+canonicalizemaxdots 1
+connectionattempts 1
+forwardx11timeout 1200
+numberofpasswordprompts 3
+serveralivecountmax 3
+serveraliveinterval 0
+ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
+hostkeyalgorithms ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+hostbasedkeytypes ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+kexalgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1
+casignaturealgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+loglevel INFO
+macs umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1
+pubkeyacceptedkeytypes ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+xauthlocation xauth
+identityfile ~/.ssh/github_rsa
+canonicaldomains
+globalknownhostsfile /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2
+userknownhostsfile ~/.ssh/known_hosts ~/.ssh/known_hosts2
+sendenv LANG
+sendenv LC_*
+connecttimeout none
+tunneldevice any:any
+controlpersist no
+escapechar ~
+ipqos af21 cs1
+rekeylimit 0 0
+streamlocalbindmask 0177
+syslogfacility USER`).
+		AndExitWith(0)
+
+	assert.Equal(t, "rad-git-host.com:443", resolveGitHost(sh, "cool-alias"))
 }
 
 func TestResolvingGitHostAliasesWithoutFlagSupport(t *testing.T) {

--- a/bootstrap/git_test.go
+++ b/bootstrap/git_test.go
@@ -66,6 +66,168 @@ func TestParsingGittableRepositoryFromSSHURLsWithPorts(t *testing.T) {
 	assert.Equal(t, `git.host.de:4019`, u.Host)
 }
 
+func TestResolvingGitHostAliasesWithFlagSupport(t *testing.T) {
+	t.Parallel()
+
+	sh := newTestShell(t)
+
+	ssh, err := bintest.NewMock("ssh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ssh.CheckAndClose(t)
+
+	sh.Env.Set("PATH", filepath.Dir(ssh.Path))
+
+	ssh.
+		Expect("-G", "github.com-alias1").
+		AndWriteToStdout(`user buildkite
+hostname github.com
+port 22
+addkeystoagent false
+addressfamily any
+batchmode no
+canonicalizefallbacklocal yes
+canonicalizehostname false
+challengeresponseauthentication yes
+checkhostip yes
+compression no
+controlmaster false
+enablesshkeysign no
+clearallforwardings no
+exitonforwardfailure no
+fingerprinthash SHA256
+forwardagent no
+forwardx11 no
+forwardx11trusted no
+gatewayports no
+gssapiauthentication no
+gssapidelegatecredentials no
+hashknownhosts no
+hostbasedauthentication no
+identitiesonly no
+kbdinteractiveauthentication yes
+nohostauthenticationforlocalhost no
+passwordauthentication yes
+permitlocalcommand no
+proxyusefdpass no
+pubkeyauthentication yes
+requesttty auto
+streamlocalbindunlink no
+stricthostkeychecking ask
+tcpkeepalive yes
+tunnel false
+verifyhostkeydns false
+visualhostkey no
+updatehostkeys false
+canonicalizemaxdots 1
+connectionattempts 1
+forwardx11timeout 1200
+numberofpasswordprompts 3
+serveralivecountmax 3
+serveraliveinterval 0
+ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
+hostkeyalgorithms ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+hostbasedkeytypes ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+kexalgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1
+casignaturealgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+loglevel INFO
+macs umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1
+pubkeyacceptedkeytypes ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+xauthlocation xauth
+identityfile ~/.ssh/github_rsa
+canonicaldomains
+globalknownhostsfile /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2
+userknownhostsfile ~/.ssh/known_hosts ~/.ssh/known_hosts2
+sendenv LANG
+sendenv LC_*
+connecttimeout none
+tunneldevice any:any
+controlpersist no
+escapechar ~
+ipqos af21 cs1
+rekeylimit 0 0
+streamlocalbindmask 0177
+syslogfacility USER`).
+		AndExitWith(0)
+
+	assert.Equal(t, "github.com", resolveGitHost(sh, "github.com-alias1"))
+
+	ssh.
+		Expect("-G", "blargh-no-alias.com").
+		AndWriteToStdout(`user buildkite
+hostname blargh-no-alias.com
+port 22
+addkeystoagent false
+addressfamily any
+batchmode no
+canonicalizefallbacklocal yes
+canonicalizehostname false
+challengeresponseauthentication yes
+checkhostip yes
+compression no
+controlmaster false
+enablesshkeysign no
+clearallforwardings no
+exitonforwardfailure no
+fingerprinthash SHA256
+forwardagent no
+forwardx11 no
+forwardx11trusted no
+gatewayports no
+gssapiauthentication no
+gssapidelegatecredentials no
+hashknownhosts no
+hostbasedauthentication no
+identitiesonly no
+kbdinteractiveauthentication yes
+nohostauthenticationforlocalhost no
+passwordauthentication yes
+permitlocalcommand no
+proxyusefdpass no
+pubkeyauthentication yes
+requesttty auto
+streamlocalbindunlink no
+stricthostkeychecking ask
+tcpkeepalive yes
+tunnel false
+verifyhostkeydns false
+visualhostkey no
+updatehostkeys false
+canonicalizemaxdots 1
+connectionattempts 1
+forwardx11timeout 1200
+numberofpasswordprompts 3
+serveralivecountmax 3
+serveraliveinterval 0
+ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
+hostkeyalgorithms ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+hostbasedkeytypes ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+kexalgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1
+casignaturealgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+loglevel INFO
+macs umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1
+pubkeyacceptedkeytypes ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+xauthlocation xauth
+identityfile ~/.ssh/github_rsa
+canonicaldomains
+globalknownhostsfile /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2
+userknownhostsfile ~/.ssh/known_hosts ~/.ssh/known_hosts2
+sendenv LANG
+sendenv LC_*
+connecttimeout none
+tunneldevice any:any
+controlpersist no
+escapechar ~
+ipqos af21 cs1
+rekeylimit 0 0
+streamlocalbindmask 0177
+syslogfacility USER`).
+		AndExitWith(0)
+
+	assert.Equal(t, "blargh-no-alias.com", resolveGitHost(sh, "blargh-no-alias.com"))
+}
+
 func TestResolvingGitHostAliasesWithoutFlagSupport(t *testing.T) {
 	t.Parallel()
 

--- a/bootstrap/knownhosts.go
+++ b/bootstrap/knownhosts.go
@@ -142,7 +142,7 @@ func (kh *knownHosts) AddFromRepository(repository string) error {
 		return nil
 	}
 
-	host := stripAliasesFromGitHost(u.Host)
+	host := resolveGitHost(u.Host)
 
 	if err = kh.Add(host); err != nil {
 		return errors.Wrapf(err, "Failed to add `%s` to known_hosts file `%s`", host, u)

--- a/bootstrap/knownhosts.go
+++ b/bootstrap/knownhosts.go
@@ -142,7 +142,7 @@ func (kh *knownHosts) AddFromRepository(repository string) error {
 		return nil
 	}
 
-	host := resolveGitHost(u.Host)
+	host := resolveGitHost(kh.Shell, u.Host)
 
 	if err = kh.Add(host); err != nil {
 		return errors.Wrapf(err, "Failed to add `%s` to known_hosts file `%s`", host, u)


### PR DESCRIPTION
This is a PoC to improve compatibility with ssh aliases which don’t conform to our special-casing behaviour.

For any incoming ssh host, this asks `ssh` for what host it will connect to. This allows `ssh-keyscan` to connect to that host, rather than whatever the alias name is, which may or may not match.

It also supersedes the older behaviour wherein our special-case aliases were stripped, and on agents which are already correctly configured, should work the same.

~I haven’t been able to get the test suite working to confirm this works, but I figured putting the sketch up would be better than doing nothing! 😃~

I’ve updated this to pass, and add new, tests, and it’s looking good!

For reference, `ssh -G` appears to have been added in OpenSSH in 6.0 (released April 22, 2012, sadly no source link as this took gripping multiple tgz files to bisect), but it appears to be turned off in some OS’ distributions of 6.x (one of our virtual servers is running a version from 2014, but it’s missing) so the existence of the fallback remains potentially important.