### PR TITLE
Terminate bootstrap with unhandled signal after cancel

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1,6 +1,8 @@
 package bootstrap
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -11,8 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"encoding/json"
-	"context"
 
 	"github.com/buildkite/agent/agent/plugin"
 	"github.com/buildkite/agent/bootstrap/shell"
@@ -483,7 +483,7 @@ func (b *Bootstrap) loadPlugins() ([]*plugin.Plugin, error) {
 	return b.plugins, nil
 }
 
-func (b *Bootstrap) validatePluginCheckout(checkout *pluginCheckout)  error {
+func (b *Bootstrap) validatePluginCheckout(checkout *pluginCheckout) error {
 	if !b.Config.PluginValidation {
 		return nil
 	}
@@ -601,9 +601,9 @@ func (b *Bootstrap) VendoredPluginPhase() error {
 		}
 
 		checkout := &pluginCheckout{
-			Plugin: p,
+			Plugin:      p,
 			CheckoutDir: pluginLocation,
-			HooksDir: filepath.Join(pluginLocation, "hooks"),
+			HooksDir:    filepath.Join(pluginLocation, "hooks"),
 		}
 
 		// Also make sure that plugin is withing this repository


### PR DESCRIPTION
Currently the bootstrap will exit with whatever exit code it gets from the subprocesses it kills after cancellation. Following bash's example, it now removes its signal handler and SIGTERM's itself (arguably, it should use the signal it received, but this was easier initially). This shows up as consistently as a -1 in the UI. 

<img width="505" alt="image" src="https://user-images.githubusercontent.com/15758/50957687-03926b00-1513-11e9-8e73-750346e41e65.png">