### PR TITLE
Correct tests introduced in #881

### DIFF
--- a/utils/path_windows_test.go
+++ b/utils/path_windows_test.go
@@ -13,10 +13,9 @@ import (
 func TestNormalizeWindowsDriveAbsolutePath(t *testing.T) {
 	t.Parallel()
 
-	fp, err := NormalizeFilePath("C:\\programdata\\buildkite-agent")
+	fp, err := NormalizeFilePath(`C:\programdata\buildkite-agent`)
 	assert.NoError(t, err)
-	expected := filepath.Join("C:", "programdata", "buildkite-agent")
-	assert.Equal(t, expected, fp)
+	assert.Equal(t, `C:\programdata\buildkite-agent`, fp)
 }
 
 func TestNormalizeWindowsBackslashAbsolutePath(t *testing.T) {
@@ -26,9 +25,8 @@ func TestNormalizeWindowsBackslashAbsolutePath(t *testing.T) {
 	dir, err := os.Getwd()
 	assert.NoError(t, err)
 	drive := filepath.VolumeName(dir)
-	fp, err := NormalizeFilePath("\\")
+	fp, err := NormalizeFilePath(`\`)
 
 	assert.NoError(t, err)
-	expected := filepath.Join(drive, "programdata", "buildkite-agent")
-	assert.Equal(t, expected, fp)
+	assert.Equal(t, drive+`\`, fp)
 }


### PR DESCRIPTION
@petemounce I renamed the test so that it would run as a test.

I wasn't sure what you intended with the `filepath.Join`, are you saying that `C:\programdata\buildkite-agent` should normalize to `C:programdata\buildkite-agent`? I know either works in windows, but I wasn't aware of a reason the latter should be preferred. 

See https://github.com/golang/go/issues/11551 for some context on the weird ways that golang handles file paths. 