### PR TITLE
Add a script to check the agent docs are up to date

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,6 +19,9 @@ steps:
     agents:
       queue: "windows"
 
+  - name: ":book:"
+    command: ".buildkite/steps/check-agent-docs.sh"
+
   - wait
 
   - name: ":windows: 386"

--- a/.buildkite/steps/check-agent-docs.sh
+++ b/.buildkite/steps/check-agent-docs.sh
@@ -40,7 +40,7 @@ if [ ${#undocumented[@]} -eq 0 ] ; then
 else
   for env in "${undocumented[@]}" ; do
     echo "+++ 🚨 $env isn't documented"
-    git grep "$env"
+    git --no-pager grep -n "$env"
     echo
   done
 fi

--- a/.buildkite/steps/check-agent-docs.sh
+++ b/.buildkite/steps/check-agent-docs.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+get_agent_env_vars() {
+  grep -ohr -e 'BUILDKITE_[a-zA-Z0-9_\-]*[a-zA-Z0-9]*' \
+    --include '*.go' --exclude "clicommand/bootstrap.go" \
+    --exclude '*_test.go' . \
+    | grep -v BUILDKITE_X_ | sort | uniq
+}
+
+get_docs_env_vars() {
+  grep -ohr -e 'BUILDKITE_[a-zA-Z0-9_\-]*[a-zA-Z0-9]' . \
+    | sort | uniq
+}
+
+get_agent_env_vars > agent_env_vars.txt
+
+(
+  [ -d docs ] || git clone https://github.com/buildkite/docs.git
+  cd docs
+  get_docs_env_vars > ../docs_env_vars.txt
+)
+
+undocumented=()
+echo "--- 📖 🔍 Checking env in agent are documented"
+
+while read -r env ; do
+  echo -n "Checking $env: "
+
+  if grep -q "$env" docs_env_vars.txt ; then
+    echo "✅"
+  else
+    echo "🚨"
+    undocumented+=("$env")
+  fi
+done < agent_env_vars.txt
+
+if [ ${#undocumented[@]} -eq 0 ] ; then
+  echo "+++ All documentation up to date! 💃"
+else
+  for env in "${undocumented[@]}" ; do
+    echo "+++ 🚨 $env isn't documented"
+    git grep "$env"
+    echo
+  done
+fi


### PR DESCRIPTION
This is to spawn some discussion on ways that we could check our docs were up to date in an automated way. 

The problem with actually failing builds is that often the docs come after a release, and it probably doesn't make sense to require them before. 

Thoughts @toolmantim and @harrietgrace? 