### PR TITLE
Retry forever to upload job chunks

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -560,7 +560,7 @@ func (r *JobRunner) onUploadChunk(chunk *LogStreamerChunk) error {
 	// from Buildkite that it's considered the chunk (a 422 will be
 	// returned if the chunk is invalid, and we shouldn't retry on that)
 	return retry.Do(func(s *retry.Stats) error {
-		_, err := r.apiClient.Chunks.Upload(r.job.ID, &api.Chunk{
+		response, err := r.apiClient.Chunks.Upload(r.job.ID, &api.Chunk{
 			Data:     chunk.Data,
 			Sequence: chunk.Order,
 			Offset:   chunk.Offset,

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -557,7 +557,7 @@ func (r *JobRunner) onUploadChunk(chunk *LogStreamerChunk) error {
 	// hold onto chunks until it's back online to upload them.
 	//
 	// This code will retry forever until we get back a successful response
-	// from Buildkite that it's considered the chunk (a 422 will be
+	// from Buildkite that it's considered the chunk (a 4xx will be
 	// returned if the chunk is invalid, and we shouldn't retry on that)
 	return retry.Do(func(s *retry.Stats) error {
 		response, err := r.apiClient.Chunks.Upload(r.job.ID, &api.Chunk{
@@ -567,7 +567,7 @@ func (r *JobRunner) onUploadChunk(chunk *LogStreamerChunk) error {
 			Size:     chunk.Size,
 		})
 		if err != nil {
-			if response != nil && response.StatusCode == 422 {
+			if response != nil && (response.StatusCode >= 400 && response.StatusCode <= 499) {
 				r.logger.Warn("Buildkite rejected the chunk upload (%s)", err)
 				s.Break()
 			} else {


### PR DESCRIPTION
Currently we wait a max of 50 seconds on each chunk before trying to upload it. If chunks are failing to upload, the main reason would be a problem with Buildkite. Presumably if they're failing to upload, finishing a job and starting a new one will also have the same problem (at which point we're just throwing chunk data away, to get more, and probably throw them away too).

This change tweaks the retry rules so we don't give up on chunks. It does handle cases that BK returns a 422, which "is" a successful chunk upload (whether or not we actually stored it is another thing), but a 422 does mean communications were successful, and Buildkite did "the right thing"