### PR TITLE
Track reason why bootstrap was cancelled

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -256,7 +256,7 @@ func (a *AgentWorker) Stop(graceful bool) {
 			// Kill the current job. Doesn't do anything if the job
 			// is already being killed, so it's safe to call
 			// multiple times.
-			a.jobRunner.Cancel()
+			a.jobRunner.CancelAndStop()
 		} else {
 			a.logger.Info("Forcefully stopping agent. Since there is no job running, the agent will disconnect immediately")
 		}

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -530,11 +530,11 @@ func (r *JobRunner) finishJob(finishedAt time.Time, exitStatus string, signal st
 
 	// If the agent has been stopped, send a signal reason of `agent_stop` to distinguish between
 	// user-generated cancels and those due to the agent getting an operating system signal. If
-	// the job was signalled because it exceeded the cancel grace period, then the reason is `cancel_timeout`
+	// the job was signalled because it was cancelled then the reason is `cancel`.
 	if r.stopped {
 		r.job.SignalReason = `agent_stop`
 	} else if r.cancelled {
-		r.job.SignalReason = `cancel_timeout`
+		r.job.SignalReason = `cancel`
 	}
 
 	r.logger.Debug("[JobRunner] Finishing job with exit_status=%s, signal=%s and signal_reason=%s",

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -283,16 +283,14 @@ func (r *JobRunner) Run() error {
 
 	exitStatus := fmt.Sprintf("%d", r.process.WaitStatus().ExitStatus())
 	signal := ""
-
 	if ws := r.process.WaitStatus(); ws.Signaled() {
 		signal = process.SignalString(ws.Signal())
 	}
 
+	// Write some metrics about the job run
 	jobMetrics := r.metrics.With(metrics.Tags{
 		"exit_code": exitStatus,
 	})
-
-	// Write some metrics about the job run
 	if exitStatus == "0" {
 		jobMetrics.Timing(`jobs.duration.success`, finishedAt.Sub(startedAt))
 		jobMetrics.Count(`jobs.success`, 1)
@@ -336,7 +334,6 @@ func (r *JobRunner) Cancel() error {
 	if r.stopped {
 		reason = " (agent stopping)"
 	}
-
 	r.logger.Info("Canceling job %s with a grace period of %ds%s",
 		r.job.ID, r.conf.AgentConfiguration.CancelGracePeriod, reason)
 
@@ -475,7 +472,6 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	}
 
 	enablePluginValidation := r.conf.AgentConfiguration.PluginValidation
-
 	// Allow BUILDKITE_PLUGIN_VALIDATION to be enabled from env for easier
 	// per-pipeline testing
 	if pluginValidation, ok := env["BUILDKITE_PLUGIN_VALIDATION"]; ok {
@@ -484,7 +480,6 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 			enablePluginValidation = true
 		}
 	}
-
 	env["BUILDKITE_PLUGIN_VALIDATION"] = fmt.Sprintf("%t", enablePluginValidation)
 
 	// Convert the env map into a slice (which is what the script gear

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -12,6 +12,8 @@ type Job struct {
 	Env                map[string]string `json:"env,omitempty"`
 	ChunksMaxSizeBytes int               `json:"chunks_max_size_bytes,omitempty"`
 	ExitStatus         string            `json:"exit_status,omitempty"`
+	Signal             string            `json:"signal,omitempty"`
+	SignalReason       string            `json:"signal_reason,omitempty"`
 	StartedAt          string            `json:"started_at,omitempty"`
 	FinishedAt         string            `json:"finished_at,omitempty"`
 	ChunksFailedCount  int               `json:"chunks_failed_count,omitempty"`
@@ -27,6 +29,8 @@ type jobStartRequest struct {
 
 type jobFinishRequest struct {
 	ExitStatus        string `json:"exit_status,omitempty"`
+	Signal            string `json:"signal,omitempty"`
+	SignalReason      string `json:"signal_reason,omitempty"`
 	FinishedAt        string `json:"finished_at,omitempty"`
 	ChunksFailedCount int    `json:"chunks_failed_count"`
 }
@@ -108,6 +112,8 @@ func (c *Client) FinishJob(job *Job) (*Response, error) {
 	req, err := c.newRequest("PUT", u, &jobFinishRequest{
 		FinishedAt:        job.FinishedAt,
 		ExitStatus:        job.ExitStatus,
+		Signal:            job.Signal,
+		SignalReason:      job.SignalReason,
 		ChunksFailedCount: job.ChunksFailedCount,
 	})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	golang.org/x/crypto v0.0.0-20170825220121-81e90905daef
 	golang.org/x/oauth2 v0.0.0-20181003184128-c57b0facaced
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
-	golang.org/x/sys v0.0.0-20180706062352-ce36f3865eeb
+	golang.org/x/sys v0.0.0-20200122134326-e047566fdf82
 	google.golang.org/api v0.0.0-20181016191922-cc9bd73d51b4
 	google.golang.org/appengine v1.2.0 // indirect
 	google.golang.org/grpc v0.0.0-20170216003643-d0c32ee6a441 // indirect

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6Zh
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180706062352-ce36f3865eeb h1:Ntnx7ohMHcKlljLyqoC9d2lxCD/gujksCbAfqOPXkiY=
 golang.org/x/sys v0.0.0-20180706062352-ce36f3865eeb/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
+golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/api v0.0.0-20181016191922-cc9bd73d51b4 h1:UG/pYY/NIJQts35nrjCyhIaqDFnVbUNykqHXNnCOYBs=

--- a/process/process.go
+++ b/process/process.go
@@ -248,9 +248,14 @@ func (p *Process) Run() error {
 		}
 	}
 
+	exitSignal := "nil"
+	if p.status.Signaled() {
+		exitSignal = SignalString(p.status.Signal())
+	}
+
 	// Find the exit status of the script
-	p.logger.Info("Process with PID: %d finished with Exit Status: %d",
-		p.pid, p.status.ExitStatus())
+	p.logger.Info("Process with PID: %d finished with Exit Status: %d, Signal: %s",
+		p.pid, p.status.ExitStatus(), exitSignal)
 
 	// Sometimes (in docker containers) io.Copy never seems to finish. This is a mega
 	// hack around it. If it doesn't finish after 1 second, just continue.

--- a/process/process.go
+++ b/process/process.go
@@ -248,12 +248,11 @@ func (p *Process) Run() error {
 		}
 	}
 
+	// Find the exit status or terminating signal of the script
 	exitSignal := "nil"
 	if p.status.Signaled() {
 		exitSignal = SignalString(p.status.Signal())
 	}
-
-	// Find the exit status of the script
 	p.logger.Info("Process with PID: %d finished with Exit Status: %d, Signal: %s",
 		p.pid, p.status.ExitStatus(), exitSignal)
 

--- a/process/signal.go
+++ b/process/signal.go
@@ -3,6 +3,8 @@
 package process
 
 import (
+	"fmt"
+	"os"
 	"syscall"
 )
 
@@ -35,4 +37,76 @@ func (p *Process) interruptProcessGroup() error {
 
 func GetPgid(pid int) (int, error) {
 	return syscall.Getpgid(pid)
+}
+
+func OSSignalString(s os.Signal) string {
+	return SignalString(s.(syscall.Signal))
+}
+
+func SignalString(s syscall.Signal) string {
+	switch int(s) {
+	case 1:
+		return "SIGHUP"
+	case 2:
+		return "SIGINT"
+	case 3:
+		return "SIGQUIT"
+	case 4:
+		return "SIGILL"
+	case 5:
+		return "SIGTRAP"
+	case 6:
+		return "SIGABRT"
+	case 7:
+		return "SIGEMT"
+	case 8:
+		return "SIGFPE"
+	case 9:
+		return "SIGKILL"
+	case 10:
+		return "SIGBUS"
+	case 11:
+		return "SIGSEGV"
+	case 12:
+		return "SIGSYS"
+	case 13:
+		return "SIGPIPE"
+	case 14:
+		return "SIGALRM"
+	case 15:
+		return "SIGTERM"
+	case 16:
+		return "SIGURG"
+	case 17:
+		return "SIGSTOP"
+	case 18:
+		return "SIGTSTP"
+	case 19:
+		return "SIGCONT"
+	case 20:
+		return "SIGCHLD"
+	case 21:
+		return "SIGTTIN"
+	case 22:
+		return "SIGTTOU"
+	case 23:
+		return "SIGIO"
+	case 24:
+		return "SIGXCPU"
+	case 25:
+		return "SIGXFSZ"
+	case 26:
+		return "SIGVTALRM"
+	case 27:
+		return "SIGPROF"
+	case 28:
+		return "SIGWINCH"
+	case 29:
+		return "SIGINFO"
+	case 30:
+		return "SIGUSR1"
+	case 31:
+		return "SIGUSR2"
+	}
+	return fmt.Sprintf("%d", int(s))
 }

--- a/process/signal.go
+++ b/process/signal.go
@@ -4,7 +4,6 @@ package process
 
 import (
 	"fmt"
-	"os"
 	"syscall"
 )
 
@@ -37,10 +36,6 @@ func (p *Process) interruptProcessGroup() error {
 
 func GetPgid(pid int) (int, error) {
 	return syscall.Getpgid(pid)
-}
-
-func OSSignalString(s os.Signal) string {
-	return SignalString(s.(syscall.Signal))
 }
 
 func SignalString(s syscall.Signal) string {

--- a/process/signal.go
+++ b/process/signal.go
@@ -5,6 +5,8 @@ package process
 import (
 	"fmt"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func (p *Process) setupProcessGroup() {
@@ -38,70 +40,12 @@ func GetPgid(pid int) (int, error) {
 	return syscall.Getpgid(pid)
 }
 
+// SignalString returns the name of the given signal.
+// e.g. SignalString(syscall.Signal(15)) // "SIGTERM"
 func SignalString(s syscall.Signal) string {
-	switch int(s) {
-	case 1:
-		return "SIGHUP"
-	case 2:
-		return "SIGINT"
-	case 3:
-		return "SIGQUIT"
-	case 4:
-		return "SIGILL"
-	case 5:
-		return "SIGTRAP"
-	case 6:
-		return "SIGABRT"
-	case 7:
-		return "SIGEMT"
-	case 8:
-		return "SIGFPE"
-	case 9:
-		return "SIGKILL"
-	case 10:
-		return "SIGBUS"
-	case 11:
-		return "SIGSEGV"
-	case 12:
-		return "SIGSYS"
-	case 13:
-		return "SIGPIPE"
-	case 14:
-		return "SIGALRM"
-	case 15:
-		return "SIGTERM"
-	case 16:
-		return "SIGURG"
-	case 17:
-		return "SIGSTOP"
-	case 18:
-		return "SIGTSTP"
-	case 19:
-		return "SIGCONT"
-	case 20:
-		return "SIGCHLD"
-	case 21:
-		return "SIGTTIN"
-	case 22:
-		return "SIGTTOU"
-	case 23:
-		return "SIGIO"
-	case 24:
-		return "SIGXCPU"
-	case 25:
-		return "SIGXFSZ"
-	case 26:
-		return "SIGVTALRM"
-	case 27:
-		return "SIGPROF"
-	case 28:
-		return "SIGWINCH"
-	case 29:
-		return "SIGINFO"
-	case 30:
-		return "SIGUSR1"
-	case 31:
-		return "SIGUSR2"
+	name := unix.SignalName(s)
+	if name == "" {
+		return fmt.Sprintf("%d", int(s))
 	}
-	return fmt.Sprintf("%d", int(s))
+	return name
 }

--- a/process/signal_test.go
+++ b/process/signal_test.go
@@ -3,6 +3,7 @@ package process_test
 import (
 	"syscall"
 	"testing"
+	"runtime"
 
 	"github.com/buildkite/agent/v3/process"
 	"github.com/stretchr/testify/assert"

--- a/process/signal_test.go
+++ b/process/signal_test.go
@@ -1,0 +1,23 @@
+package process_test
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/buildkite/agent/v3/process"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSignalString(t *testing.T) {
+	for _, row := range []struct {
+		n int
+		s string
+	}{
+		{2, "SIGINT"},
+		{9, "SIGKILL"},
+		{15, "SIGTERM"},
+		{100, "100"},
+	} {
+		assert.Equal(t, row.s, process.SignalString(syscall.Signal(row.n)))
+	}
+}

--- a/process/signal_test.go
+++ b/process/signal_test.go
@@ -39,7 +39,7 @@ func TestSignalStringWindows(t *testing.T) {
 		{2, "interrupt"},
 		{9, "killed"},
 		{15, "terminated"},
-		{100, "100"},
+		{100, "signal 100"},
 	} {
 		assert.Equal(t, row.s, process.SignalString(syscall.Signal(row.n)))
 	}

--- a/process/signal_test.go
+++ b/process/signal_test.go
@@ -8,7 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSignalString(t *testing.T) {
+func TestSignalStringUnix(t *testing.T) {
+	if runtime.GOOS == `windows` {
+		t.Skip("Unix signal names are not used on Windows")
+	}
+
 	for _, row := range []struct {
 		n int
 		s string
@@ -16,6 +20,24 @@ func TestSignalString(t *testing.T) {
 		{2, "SIGINT"},
 		{9, "SIGKILL"},
 		{15, "SIGTERM"},
+		{100, "100"},
+	} {
+		assert.Equal(t, row.s, process.SignalString(syscall.Signal(row.n)))
+	}
+}
+
+func TestSignalStringWindows(t *testing.T) {
+	if runtime.GOOS != `windows` {
+		t.Skip("Windows signal names are not used on Unix")
+	}
+
+	for _, row := range []struct {
+		n int
+		s string
+	}{
+		{2, "interrupt"},
+		{9, "killed"},
+		{15, "terminated"},
 		{100, "100"},
 	} {
 		assert.Equal(t, row.s, process.SignalString(syscall.Signal(row.n)))

--- a/process/signal_windows.go
+++ b/process/signal_windows.go
@@ -1,7 +1,11 @@
+// +build windows
+
 package process
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"syscall"

--- a/process/signal_windows.go
+++ b/process/signal_windows.go
@@ -4,6 +4,7 @@ package process
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
@@ -52,4 +53,8 @@ func (p *Process) interruptProcessGroup() error {
 
 func GetPgid(pid int) (int, error) {
 	return 0, errors.New("Not implemented on Windows")
+}
+
+func SignalString(s syscall.Signal) string {
+	return fmt.Sprintf("%v", s)
 }

--- a/process/signal_windows.go
+++ b/process/signal_windows.go
@@ -4,7 +4,6 @@ package process
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"strconv"

--- a/process/signal_windows.go
+++ b/process/signal_windows.go
@@ -54,6 +54,8 @@ func GetPgid(pid int) (int, error) {
 	return 0, errors.New("Not implemented on Windows")
 }
 
+// SignalString returns the name of the given signal.
+// e.g. SignalString(syscall.Signal(15)) // "terminated"
 func SignalString(s syscall.Signal) string {
 	return fmt.Sprintf("%v", s)
 }

--- a/process/signal_windows.go
+++ b/process/signal_windows.go
@@ -5,7 +5,6 @@ package process
 import (
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"strconv"
 	"syscall"


### PR DESCRIPTION
This is a follow-on to #890, and I believe the final missing piece before we have signal handling 👌🏻in the agent. 

To differentiate between the agent stopping and other types of cancellation, we now send two new parameters to `job.finish` in the agent API:

* `signal`. This tracks the operating system signal that the bootstrap was terminated with. This is useful for figuring out whether a failed command was due to it actually failing or whether it was terminated with a signal.
* `signal_reason`. This is `agent_stop` for agent stopping or `cancel` for agent cancellation.

I'd suggest that we add support for retrying on strings like `agent_lost` or `agent_stopped` as well as numeric exit codes. Given lots of previous agents erroneously returned an exit code of `255` we should probably consider that `agent_lost` for now. 

I'd also suggest that we surface the cancel reason in the UI, like we do `Exited with -1 (Agent Lost)`, we'd also see `Killed with signal SIGTERM (Agent stopping)`.