### PR TITLE
Fix a seg-fault in the artifact uploader

### DIFF
--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -48,6 +48,7 @@ type ArtifactUploader struct {
 func NewArtifactUploader(l *logger.Logger, ac *api.Client, c ArtifactUploaderConfig) *ArtifactUploader {
 	return &ArtifactUploader{
 		logger: l,
+		apiClient: ac,
 		conf:   c,
 	}
 }


### PR DESCRIPTION
This fixes a segfault in the artifact uploader that was introduced in #894.

```
panic: runtime error: invalid memory address or nil pointer dereference
--
  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xb869ae]
  |  
  | goroutine 1 [running]:
  | github.com/buildkite/agent/agent.(*ArtifactUploader).upload(0xc0000897c0, 0xc0000821f0, 0x1, 0x1, 0x2, 0x2)
  | /code/agent/artifact_uploader.go:204 +0xade
  | github.com/buildkite/agent/agent.(*ArtifactUploader).Upload(0xc0000897c0, 0xc0000897c0, 0x1e)
  | /code/agent/artifact_uploader.go:67 +0x1ee
  | github.com/buildkite/agent/clicommand.glob..func5(0xc0000f1080)
  | /code/clicommand/artifact_upload.go:95 +0x2cc
  | github.com/urfave/cli.HandleAction(0xcbacc0, 0xef4980, 0xc0000f1080, 0x0, 0xc0000853e0)
  | /go/pkg/mod/github.com/urfave/cli@v0.0.0-20180226030253-8e01ec4cd3e2/app.go:503 +0x7c
  | github.com/urfave/cli.Command.Run(0xebad8a, 0x6, 0x0, 0x0, 0x0, 0x0, 0x0, 0xed799c, 0x23, 0x0, ...)
  | /go/pkg/mod/github.com/urfave/cli@v0.0.0-20180226030253-8e01ec4cd3e2/command.go:165 +0x459
  | github.com/urfave/cli.(*App).RunAsSubcommand(0xc0001e4380, 0xc0000f0dc0, 0x0, 0x0)
  | /go/pkg/mod/github.com/urfave/cli@v0.0.0-20180226030253-8e01ec4cd3e2/app.go:383 +0x827
  | github.com/urfave/cli.Command.startApp(0xebc658, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0xedf854, 0x2d, 0x0, ...)
  | /go/pkg/mod/github.com/urfave/cli@v0.0.0-20180226030253-8e01ec4cd3e2/command.go:330 +0x808
  | github.com/urfave/cli.Command.Run(0xebc658, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0xedf854, 0x2d, 0x0, ...)
  | /go/pkg/mod/github.com/urfave/cli@v0.0.0-20180226030253-8e01ec4cd3e2/command.go:103 +0x80f
  | github.com/urfave/cli.(*App).Run(0xc0001e41c0, 0xc000088000, 0x4, 0x4, 0x0, 0x0)
  | /go/pkg/mod/github.com/urfave/cli@v0.0.0-20180226030253-8e01ec4cd3e2/app.go:259 +0x6bb
  | main.main()
  | /code/main.go:109 +0x4ff
```