### PR TITLE
Use new Windows Server 2019 docker images

### DIFF
--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -1,5 +1,5 @@
 ## Development docker image for buildkite-agent on windows
-FROM microsoft/windowsservercore:latest
+FROM mcr.microsoft.com/windows/servercore:1809
 
 ENV ChocolateyUseWindowsCompression false
 
@@ -23,6 +23,3 @@ RUN go mod download
 
 # Copy the rest of the code
 COPY . c:/code/
-
-# Run things in bash
-ENTRYPOINT ["BASH.EXE"]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,9 +10,9 @@ steps:
         run: agent
 
   - name: ":hammer: :windows:"
-    command: ".buildkite/steps/tests.sh"
+    command: ".buildkite\\steps\\tests.sh"
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#6568f6d:
         config: .buildkite/docker-compose.windows.yml
         run: agent
         tty: false

--- a/bootstrap/hook_test.go
+++ b/bootstrap/hook_test.go
@@ -130,6 +130,7 @@ func newTestShell(t *testing.T) *shell.Shell {
 			"PATHEXT=" + os.Getenv("PATHEXT"),
 			"TMP=" + os.Getenv("TMP"),
 			"TEMP=" + os.Getenv("TEMP"),
+			"ProgramData=" + os.Getenv("ProgramData"),
 		})
 	} else {
 		sh.Env = env.New()


### PR DESCRIPTION
The new Windows Server 2019 docker images are smaller and more capable. I've updated our agents to use them, so this matches that. 