### PR TITLE
Filter env used for command config out of environment

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -362,6 +362,9 @@ var AgentStartCommand = cli.Command{
 		// Setup the any global configuration options
 		HandleGlobalFlags(l, cfg)
 
+		// Remove any config env from the environment to prevent them propagating to bootstrap
+		UnsetConfigFromEnvironment(c)
+
 		// Force some settings if on Windows (these aren't supported yet)
 		if runtime.GOOS == "windows" {
 			cfg.NoPTY = true
@@ -430,9 +433,9 @@ var AgentStartCommand = cli.Command{
 			DisableColors:         cfg.NoColor,
 			Spawn:                 cfg.Spawn,
 			APIClientConfig: agent.APIClientConfig{
-				Token:                 cfg.Token,
-				Endpoint:              cfg.Endpoint,
-				DisableHTTP2:          cfg.NoHTTP2,
+				Token:        cfg.Token,
+				Endpoint:     cfg.Endpoint,
+				DisableHTTP2: cfg.NoHTTP2,
 			},
 			AgentConfiguration: &agent.AgentConfiguration{
 				BootstrapScript:           cfg.BootstrapScript,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -270,9 +270,6 @@ var BootstrapCommand = cli.Command{
 			l.Fatal("%s", err)
 		}
 
-		// Remove any config env from the environment to prevent them propagating to bootstrap
-		UnsetConfigFromEnvironment(c)
-
 		// Enable debug if set
 		if cfg.Debug {
 			l.Level = logger.DEBUG

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -270,6 +270,9 @@ var BootstrapCommand = cli.Command{
 			l.Fatal("%s", err)
 		}
 
+		// Remove any config env from the environment to prevent them propagating to bootstrap
+		UnsetConfigFromEnvironment(c)
+
 		// Enable debug if set
 		if cfg.Debug {
 			l.Level = logger.DEBUG

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -1,6 +1,10 @@
 package clicommand
 
 import (
+	"os"
+	"reflect"
+	"strings"
+
 	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/experiments"
 	"github.com/buildkite/agent/logger"
@@ -80,6 +84,21 @@ func HandleGlobalFlags(l *logger.Logger, cfg interface{}) {
 			for _, name := range experimentNamesSlice {
 				experiments.Enable(name)
 				l.Debug("Enabled experiment `%s`", name)
+			}
+		}
+	}
+}
+
+func UnsetConfigFromEnvironment(c *cli.Context) {
+	flags := append(c.App.Flags, c.Command.Flags...)
+	for _, fl := range flags {
+		// use golang reflection to find EnvVar values on flags
+		r := reflect.ValueOf(fl)
+		f := reflect.Indirect(r).FieldByName(`EnvVar`)
+		// split comma delimited env
+		if envVars := f.String(); envVars != `` {
+			for _, env := range strings.Split(envVars, ",") {
+				os.Unsetenv(env)
 			}
 		}
 	}


### PR DESCRIPTION
We follow a linux process model where any environment that is available to `buildkite-agent start` gets passed down to `buildkite-agent bootstrap` and then onto the actual job environment.

This includes env used for configuring those commands, for instance things like `BUILDKITE_AGENT_TOKEN` and other more minor things like `BUILDKITE_AGENT_TAGS`. These filter down to the execution environment for jobs, which creates a really wide API that is hard to keep up to date in docs. 

This change filters out any environment used for command config. They are unset, which means they need to be explicitly set by the job runner that creates the environment for the job.

Note that things other than env used for config are still passed down from the parent environment. 