### PR TITLE
If BUILDKITE_REPO is empty, skip checkout

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -791,17 +791,17 @@ func (b *Bootstrap) createCheckoutDir() error {
 // CheckoutPhase creates the build directory and makes sure we're running the
 // build at the right commit.
 func (b *Bootstrap) CheckoutPhase() error {
-	if b.Config.Repository == "" {
-		b.shell.Headerf("Skipping checkout phase")
-		return nil
-	}
-
 	if err := b.executeGlobalHook("pre-checkout"); err != nil {
 		return err
 	}
 
 	if err := b.executePluginHook("pre-checkout", b.pluginCheckouts); err != nil {
 		return err
+	}
+
+	if b.Config.Repository == "" {
+		b.shell.Headerf("Skipping checkout phase")
+		return nil
 	}
 
 	// Remove the checkout directory if BUILDKITE_CLEAN_CHECKOUT is present

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -791,6 +791,11 @@ func (b *Bootstrap) createCheckoutDir() error {
 // CheckoutPhase creates the build directory and makes sure we're running the
 // build at the right commit.
 func (b *Bootstrap) CheckoutPhase() error {
+	if b.Config.Repository == "" {
+		b.shell.Headerf("Skipping checkout phase")
+		return nil
+	}
+
 	if err := b.executeGlobalHook("pre-checkout"); err != nil {
 		return err
 	}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -820,7 +820,7 @@ func (b *Bootstrap) CheckoutPhase() error {
 
 	// If we have a blank repository then use a temp dir for builds
 	if b.Config.Repository == "" {
-		buildDir, err := ioutil.TempDir("", "bootstrap-builds")
+		buildDir, err := ioutil.TempDir("", "buildkite-job-"+b.Config.JobID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This allows hooks to unset or empty `BUILDKITE_REPO` to conditionally skip checkout entirely. 