### PR TITLE
Ensure TempDir exists

### DIFF
--- a/agent/api_proxy.go
+++ b/agent/api_proxy.go
@@ -90,7 +90,15 @@ func (p *APIProxy) Listen() error {
 }
 
 func (p *APIProxy) listenOnUnixSocket() (net.Listener, *os.File, error) {
-	socket, err := ioutil.TempFile("", "agent-socket")
+	// TempDir is not guaranteed to exist
+	tempDir := os.TempDir()
+	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
+		if err = os.MkdirAll(tempDir, 0777); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	socket, err := ioutil.TempFile(tempDir, "agent-socket")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/bootstrap/knownhosts_test.go
+++ b/bootstrap/knownhosts_test.go
@@ -2,9 +2,9 @@ package bootstrap
 
 import (
 	"fmt"
-	"path/filepath"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/buildkite/bintest"

--- a/bootstrap/shell/tempfile.go
+++ b/bootstrap/shell/tempfile.go
@@ -13,8 +13,16 @@ func TempFileWithExtension(filename string) (*os.File, error) {
 	extension := filepath.Ext(filename)
 	basename := strings.TrimSuffix(filename, extension)
 
+	// TempDir is not guaranteed to exist
+	tempDir := os.TempDir()
+	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
+		if err = os.MkdirAll(tempDir, 0777); err != nil {
+			return nil, err
+		}
+	}
+
 	// Create the file
-	tempFile, err := ioutil.TempFile("", basename+"-")
+	tempFile, err := ioutil.TempFile(tempDir, basename+"-")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create temporary file \"%s\" (%s)", filename, err)
 	}


### PR DESCRIPTION
Well, TIL that it's possible for golang's `os.TempDir` to not exists. Our windows agents are failing to create temp files. 

See https://golang.org/pkg/os/#TempDir and then the [actual implementation](https://golang.org/src/io/ioutil/tempfile.go) of `io.TempFile`.