### PR TITLE
Use process.Process inside of the shell abstraction

### DIFF
--- a/bootstrap/hook_test.go
+++ b/bootstrap/hook_test.go
@@ -102,8 +102,13 @@ func TestRunningHookDetectsChangedWorkingDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if changes.Dir != expected {
-		t.Fatalf("Expected working dir of %q, got %q", expected, changes.Dir)
+	changesDir, err := filepath.EvalSymlinks(changes.Dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if changesDir != expected {
+		t.Fatalf("Expected working dir of %q, got %q", expected, changesDir)
 	}
 }
 

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -374,12 +374,13 @@ func (s *Shell) executeCommand(cmd *command, w io.Writer, flags executeFlags) er
 		}
 	}
 
-	p := process.NewProcess(logger.Discard, cfg)
+	p := process.New(logger.Discard, cfg)
+
 	if err := p.Run(); err != nil {
 		return errors.Wrapf(err, "Error running `%s`", cmdStr)
 	}
 
-	return nil
+	return p.WaitResult()
 }
 
 // GetExitCode extracts an exit code from an error where the platform supports it,

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/env"
+	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/process"
 	"github.com/buildkite/shellwords"
 	"github.com/nightlyone/lockfile"
@@ -24,10 +25,6 @@ import (
 
 var (
 	lockRetryDuration = time.Second
-)
-
-const (
-	termType = `xterm-256color`
 )
 
 // Shell represents a virtual shell, handles logging, executing commands and
@@ -288,31 +285,37 @@ func (s *Shell) RunScript(path string, extra *env.Environment) error {
 }
 
 type command struct {
-	*exec.Cmd
+	process.Config
 	cancel context.CancelFunc
 }
 
-// buildCommand returns a command that runs in the context of the shell
+// buildCommand returns a command that can later be executed
 func (s *Shell) buildCommand(name string, arg ...string) (*command, error) {
-	// Always use absolute path as Windows has a hard time finding executables in it's path
+	// Always use absolute path as Windows has a hard time
+	// finding executables in it's path
 	absPath, err := s.AbsolutePath(name)
 	if err != nil {
 		return nil, err
 	}
 
-	// Create a sub-context so that shell.Cancel() can interrupt a running command
-	subctx, cancel := context.WithCancel(s.ctx)
-	cmd := exec.CommandContext(subctx, absPath, arg...)
+	cfg := process.Config{
+		Path: absPath,
+		Args: arg,
+		Env:  s.Env.ToSlice(),
+		Dir:  s.wd,
+	}
 
-	cmd.Env = s.Env.ToSlice()
-	cmd.Dir = s.wd
+	// Create a sub-context so that shell.Cancel() can interrupt
+	// a running command
+	subctx, cancel := context.WithCancel(s.ctx)
+	cfg.Context = subctx
 
 	// Add env that commands expect a shell to set
-	cmd.Env = append(cmd.Env,
+	cfg.Env = append(cfg.Env,
 		`PWD=`+s.wd,
 	)
 
-	return &command{Cmd: cmd, cancel: cancel}, nil
+	return &command{Config: cfg, cancel: cancel}, nil
 }
 
 type executeFlags struct {
@@ -331,7 +334,7 @@ func (s *Shell) executeCommand(cmd *command, w io.Writer, flags executeFlags) er
 	s.cmd = cmd
 	s.cmdLock.Unlock()
 
-	cmdStr := process.FormatCommand(cmd.Path, cmd.Args[1:])
+	cmdStr := process.FormatCommand(cmd.Path, cmd.Args)
 
 	if s.Debug {
 		t := time.Now()
@@ -345,50 +348,34 @@ func (s *Shell) executeCommand(cmd *command, w io.Writer, flags executeFlags) er
 		cmd.cancel()
 	}()
 
+	cfg := cmd.Config
+
+	// Modify process config based on execution flags
 	if flags.PTY {
-		pty, err := process.StartPTY(cmd.Cmd)
-		if err != nil {
-			return errors.Wrapf(err, "Error starting PTY")
-		}
-
-		// Copy the pty to our buffer. This will block until it EOF's
-		// or something breaks.
-		_, err = io.Copy(w, pty)
-		if e, ok := err.(*os.PathError); ok && e.Err == syscall.EIO {
-			// We can safely ignore this error, because it's just the PTY telling us
-			// that it closed successfully.
-			// See https://github.com/buildkite/agent/pull/34#issuecomment-46080419
-		}
-
-		// Commands like tput expect a TERM value for a PTY
-		cmd.Env = append(cmd.Env, `TERM=`+termType)
+		cfg.PTY = true
+		cfg.Stdout = w
 	} else {
-		cmd.Stdout = nil
-		cmd.Stderr = nil
-		cmd.Stdin = nil
-
+		// Show stdout if requested or via debug
 		if flags.Stdout {
-			cmd.Stdout = w
+			cfg.Stdout = w
 		} else if s.Debug {
 			stdOutStreamer := NewLoggerStreamer(s.Logger)
 			defer stdOutStreamer.Close()
-			cmd.Stdout = stdOutStreamer
+			cfg.Stdout = stdOutStreamer
 		}
 
+		// Show stderr if requested or via debug
 		if flags.Stderr {
-			cmd.Stderr = w
+			cfg.Stderr = w
 		} else if s.Debug {
 			stdErrStreamer := NewLoggerStreamer(s.Logger)
 			defer stdErrStreamer.Close()
-			cmd.Stderr = stdErrStreamer
-		}
-
-		if err := cmd.Start(); err != nil {
-			return errors.Wrapf(err, "Error starting `%s`", cmdStr)
+			cfg.Stderr = stdErrStreamer
 		}
 	}
 
-	if err := cmd.Wait(); err != nil {
+	p := process.NewProcess(logger.Discard, cfg)
+	if err := p.Run(); err != nil {
 		return errors.Wrapf(err, "Error running `%s`", cmdStr)
 	}
 

--- a/bootstrap/shell/shell_test.go
+++ b/bootstrap/shell/shell_test.go
@@ -39,7 +39,7 @@ func TestRunAndCaptureWithTTY(t *testing.T) {
 	}
 
 	if expected := "Llama party! 🎉"; string(actual) != expected {
-		t.Fatalf("Expected %q, got %q", expected, actual)
+		t.Errorf("Expected %q, got %q", expected, actual)
 	}
 }
 

--- a/bootstrap/shell/shell_test.go
+++ b/bootstrap/shell/shell_test.go
@@ -43,6 +43,32 @@ func TestRunAndCaptureWithTTY(t *testing.T) {
 	}
 }
 
+func TestRunAndCaptureWithExitCode(t *testing.T) {
+	sshKeygen, err := bintest.CompileProxy("ssh-keygen")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sshKeygen.Close()
+
+	sh := newShellForTest(t)
+
+	go func() {
+		call := <-sshKeygen.Ch
+		fmt.Fprintln(call.Stdout, "Llama drama! 🚨")
+		call.Exit(24)
+	}()
+
+	_, err = sh.RunAndCapture(sshKeygen.Path)
+	if err == nil {
+		t.Error("Expected an error, got nil")
+	}
+
+	if exitCode := shell.GetExitCode(err); exitCode != 24 {
+		t.Fatalf("Expected %d, got %d", 24, exitCode)
+	}
+
+}
+
 func TestRun(t *testing.T) {
 	sshKeygen, err := bintest.CompileProxy("ssh-keygen")
 	if err != nil {


### PR DESCRIPTION
Following on from #919 and #920, this uses `process.Process` inside of the shell abstraction which lets us use it's superior process terminating technology rather than what is build into the golang `exec` package. 