### PR TITLE
Use a bufio.Scanner for parsing git -G output

### DIFF
--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -1,6 +1,8 @@
 package bootstrap
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"net/url"
 	"path/filepath"
@@ -157,12 +159,14 @@ func resolveGitHost(sh *shell.Shell, host string) string {
 	output, err := sh.RunAndCapture("ssh", "-G", host)
 
 	// if we got no error, let's process the output
-	if (err == nil) {
-		// split up the ssh -G output
-		lines := strings.Split(output, "\n")
+	if err == nil {
+		// split up the ssh -G output by lines
+		scanner := bufio.NewScanner(bytes.NewBufferString(output))
 
-		// search the ssh -G output for "hostname" and "port" lines
-		for _, line := range lines {
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			// search the ssh -G output for "hostname" and "port" lines
 			tokens := strings.SplitN(line, " ", 2)
 
 			// skip any line which isn't a key-value pair


### PR DESCRIPTION
Use a Scanner vs splitting on `\n` for line parsing in `resolveGitHost()`. This should better deal with different line ending types.

I'm hoping this fixes https://github.com/buildkite/agent/issues/925, I wasn't able to reproduce the issue locally, but I have seen it before. 