### PR TITLE
Fix a race condition in cancellation

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.12
 
 WORKDIR /code
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ go run main.go start --debug --token "abc123"
 
 ### Dependency management
 
-We're go 1.11+ and [Go Modules](https://github.com/golang/go/wiki/Modules) to manage our Go dependencies. We are keeping the dependencies vendored to remain backwards compatible with older go versions.
+We're using Go 1.12+ and [Go Modules](https://github.com/golang/go/wiki/Modules) to manage our Go dependencies. We are keeping the dependencies vendored to remain backwards compatible with older go versions.
 
-If you are using go 1.11 and have the agent in your `GOPATH`, you will need to enable modules via the environment variable:
+If you are using Go 1.11+ and have the agent in your `GOPATH`, you will need to enable modules via the environment variable:
 
 ```bash
 export GO111MODULE=on

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -105,6 +105,9 @@ type Config struct {
 
 	// The shell used to execute commands
 	Shell string
+
+	// Phases to execute, defaults to all phases
+	Phases []string
 }
 
 // ReadFromEnvironment reads configuration from the Environment, returns a map

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -385,13 +385,7 @@ func (s *Shell) executeCommand(cmd *command, w io.Writer, flags executeFlags) er
 		}
 	}
 
-	var procLogger *logger.Logger
-
-	if s.Debug {
-		procLogger = logger.NewLogger()
-	}
-
-	p := process.New(procLogger, cfg)
+	p := process.New(logger.Discard, cfg)
 
 	s.cmdLock.Lock()
 	s.cmd.proc = p

--- a/bootstrap/shell/shell_test.go
+++ b/bootstrap/shell/shell_test.go
@@ -158,13 +158,6 @@ func TestInterrupt(t *testing.T) {
 		call.Exit(0)
 	}()
 
-	// kill the process after 2 seconds
-	go func() {
-		<-time.After(time.Second * 2)
-		t.Error("Ran too long, should have terminated after 50ms")
-		cancel()
-	}()
-
 	// interrupt the process after 50ms
 	go func() {
 		<-time.After(time.Millisecond * 50)

--- a/bootstrap/shell/shell_test.go
+++ b/bootstrap/shell/shell_test.go
@@ -171,8 +171,9 @@ func TestInterrupt(t *testing.T) {
 		sh.Interrupt()
 	}()
 
-	if err = sh.Run(sleepCmd.Path); err != nil {
-		t.Fatal(err)
+	err = sh.Run(sleepCmd.Path)
+	if err == nil {
+		t.Error("Expected an error")
 	}
 }
 

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -291,47 +291,44 @@ var BootstrapCommand = cli.Command{
 			}
 		}
 
+		// Configure the bootstraper
+		bootstrap := bootstrap.New(bootstrap.Config{
+			Command:                      cfg.Command,
+			JobID:                        cfg.JobID,
+			Repository:                   cfg.Repository,
+			Commit:                       cfg.Commit,
+			Branch:                       cfg.Branch,
+			Tag:                          cfg.Tag,
+			RefSpec:                      cfg.RefSpec,
+			Plugins:                      cfg.Plugins,
+			GitSubmodules:                cfg.GitSubmodules,
+			PullRequest:                  cfg.PullRequest,
+			GitCloneFlags:                cfg.GitCloneFlags,
+			GitCleanFlags:                cfg.GitCleanFlags,
+			AgentName:                    cfg.AgentName,
+			PipelineProvider:             cfg.PipelineProvider,
+			PipelineSlug:                 cfg.PipelineSlug,
+			OrganizationSlug:             cfg.OrganizationSlug,
+			AutomaticArtifactUploadPaths: cfg.AutomaticArtifactUploadPaths,
+			ArtifactUploadDestination:    cfg.ArtifactUploadDestination,
+			CleanCheckout:                cfg.CleanCheckout,
+			BuildPath:                    cfg.BuildPath,
+			BinPath:                      cfg.BinPath,
+			HooksPath:                    cfg.HooksPath,
+			PluginsPath:                  cfg.PluginsPath,
+			PluginValidation:             cfg.PluginValidation,
+			Debug:                        cfg.Debug,
+			RunInPty:                     runInPty,
+			CommandEval:                  cfg.CommandEval,
+			PluginsEnabled:               cfg.PluginsEnabled,
+			LocalHooksEnabled:            cfg.LocalHooksEnabled,
+			SSHKeyscan:                   cfg.SSHKeyscan,
+			Shell:                        cfg.Shell,
+			Phases:                       cfg.Phases,
+		})
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
-		// Configure the bootstraper
-		bootstrap := &bootstrap.Bootstrap{
-			Context: ctx,
-			Phases:  cfg.Phases,
-			Config: bootstrap.Config{
-				Command:                      cfg.Command,
-				JobID:                        cfg.JobID,
-				Repository:                   cfg.Repository,
-				Commit:                       cfg.Commit,
-				Branch:                       cfg.Branch,
-				Tag:                          cfg.Tag,
-				RefSpec:                      cfg.RefSpec,
-				Plugins:                      cfg.Plugins,
-				GitSubmodules:                cfg.GitSubmodules,
-				PullRequest:                  cfg.PullRequest,
-				GitCloneFlags:                cfg.GitCloneFlags,
-				GitCleanFlags:                cfg.GitCleanFlags,
-				AgentName:                    cfg.AgentName,
-				PipelineProvider:             cfg.PipelineProvider,
-				PipelineSlug:                 cfg.PipelineSlug,
-				OrganizationSlug:             cfg.OrganizationSlug,
-				AutomaticArtifactUploadPaths: cfg.AutomaticArtifactUploadPaths,
-				ArtifactUploadDestination:    cfg.ArtifactUploadDestination,
-				CleanCheckout:                cfg.CleanCheckout,
-				BuildPath:                    cfg.BuildPath,
-				BinPath:                      cfg.BinPath,
-				HooksPath:                    cfg.HooksPath,
-				PluginsPath:                  cfg.PluginsPath,
-				PluginValidation:             cfg.PluginValidation,
-				Debug:                        cfg.Debug,
-				RunInPty:                     runInPty,
-				CommandEval:                  cfg.CommandEval,
-				PluginsEnabled:               cfg.PluginsEnabled,
-				LocalHooksEnabled:            cfg.LocalHooksEnabled,
-				SSHKeyscan:                   cfg.SSHKeyscan,
-				Shell:                        cfg.Shell,
-			},
-		}
 
 		signals := make(chan os.Signal, 1)
 		signal.Notify(signals, os.Interrupt,
@@ -365,7 +362,7 @@ var BootstrapCommand = cli.Command{
 		}()
 
 		// Run the bootstrap and get the exit code
-		exitCode := bootstrap.Start()
+		exitCode := bootstrap.Run(ctx)
 
 		signalMu.Lock()
 		defer signalMu.Unlock()

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,12 @@ require (
 	github.com/DataDog/datadog-go v0.0.0-20180822151419-281ae9f2d895
 	github.com/ErikDubbelboer/gspt v0.0.0-20180711091504-e39e726e09cc
 	github.com/aws/aws-sdk-go v0.0.0-20180831223016-2a4034064ca5
-	github.com/buildkite/bintest v0.0.0-20180227222132-85c293267aed
+	github.com/buildkite/bintest v0.0.0-20190227031731-820c89d3b3a0
 	github.com/buildkite/interpolate v0.0.0-20171114090218-3a807e47135c
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/denisbrodbeck/machineid v1.0.0
-	github.com/fortytw2/leaktest v1.2.0 // indirect
 	github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135
 	github.com/googleapis/gax-go v0.0.0-20161107002406-da06d194a00e // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20181004151105-1babbf986f6f // indirect
@@ -23,12 +22,10 @@ require (
 	github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443
 	github.com/oleiade/reflections v0.0.0-20160817071559-0e86b3c98b2f
 	github.com/pborman/uuid v0.0.0-20170112150404-1b00554d8222
-	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/qri-io/jsonpointer v0.0.0-20180309164927-168dd9e45cf2 // indirect
 	github.com/qri-io/jsonschema v0.0.0-20180607150648-d0d3b10ec792
-	github.com/sasha-s/go-deadlock v0.0.0-20180226215254-237a9547c8a5 // indirect
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
 	github.com/smartystreets/goconvey v0.0.0-20180222194500-ef6db91d284a // indirect
@@ -37,7 +34,7 @@ require (
 	golang.org/x/crypto v0.0.0-20170825220121-81e90905daef
 	golang.org/x/oauth2 v0.0.0-20181003184128-c57b0facaced
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
-	golang.org/x/sys v0.0.0-20180706062352-ce36f3865eeb // indirect
+	golang.org/x/sys v0.0.0-20180706062352-ce36f3865eeb
 	google.golang.org/api v0.0.0-20181016191922-cc9bd73d51b4
 	google.golang.org/appengine v1.2.0 // indirect
 	google.golang.org/grpc v0.0.0-20170216003643-d0c32ee6a441 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/ErikDubbelboer/gspt v0.0.0-20180711091504-e39e726e09cc h1:Qs3YRJ9WQ1+
 github.com/ErikDubbelboer/gspt v0.0.0-20180711091504-e39e726e09cc/go.mod h1:01yGrV5aDnYieX2hSBoKGMaRiqHvnLoUy4ngWGZ/owg=
 github.com/aws/aws-sdk-go v0.0.0-20180831223016-2a4034064ca5 h1:raOAL5Uz269DesNi7ejlUuwQY2fyvRrBYuzRWHkl+Wo=
 github.com/aws/aws-sdk-go v0.0.0-20180831223016-2a4034064ca5/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
-github.com/buildkite/bintest v0.0.0-20180227222132-85c293267aed h1:WYisDk8AcCHDRZkONjSI5cNHI/XifpHVGaTdyvZrVjw=
-github.com/buildkite/bintest v0.0.0-20180227222132-85c293267aed/go.mod h1:2lGcuzwtlesvPHkylqPgQ0ytL6C5E6gjbb8o5ph583Y=
+github.com/buildkite/bintest v0.0.0-20190227031731-820c89d3b3a0 h1:UYcAVM2IdwHl3wTyyB2HfZc2MEVQrUqw/OkbwHlsy30=
+github.com/buildkite/bintest v0.0.0-20190227031731-820c89d3b3a0/go.mod h1:nElEwZWoSPGIBD8VvYabl9t5KNi7v430iDC0/gQRsYk=
 github.com/buildkite/interpolate v0.0.0-20171114090218-3a807e47135c h1:4b/XlGFI+q7tfsB4gDvoWeTNmG31hcr4OOFMtvZ3TOQ=
 github.com/buildkite/interpolate v0.0.0-20171114090218-3a807e47135c/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000 h1:hiVSLk7s3yFKFOHF/huoShLqrj13RMguWX2yzfvy7es=
@@ -18,8 +18,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisbrodbeck/machineid v1.0.0 h1:6tMg1EaB3r/EfIqKS0on/pvkRBZJAXH3fmSLGi8SWf0=
 github.com/denisbrodbeck/machineid v1.0.0/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
-github.com/fortytw2/leaktest v1.2.0 h1:cj6GCiwJDH7l3tMHLjZDo0QqPtrXJiWSI9JgpeQKw+Q=
-github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/fortytw2/leaktest v0.0.0-20170715211739-3b724c3d7b87 h1:vC7ihXqN2fougprHfqpv7GyEd7tUgZfmHZ5bXPiSKgE=
+github.com/fortytw2/leaktest v0.0.0-20170715211739-3b724c3d7b87/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/go-ini/ini v1.25.4 h1:Mujh4R/dH6YL8bxuISne3xX2+qcQ9p0IxKAP6ExWoUo=
 github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=

--- a/vendor/github.com/buildkite/bintest/README.md
+++ b/vendor/github.com/buildkite/bintest/README.md
@@ -1,17 +1,16 @@
-Bintest
-=======
+# Bintest
+[![Documentation](https://godoc.org/github.com/buildkite/bintest?status.svg)](http://godoc.org/github.com/buildkite/bintest)
 
 A set of tools for generating fake binaries that can be used for testing. A binary is compiled and then can be orchestrated from your test suite and later checked for assertions.
 
 Mocks can communicate and respond in real-time with the tests that are calling them, which allows for testing complicated dependencies. See https://github.com/buildkite/agent/tree/master/bootstrap/integration for how we use it to test buildkite-agent's bootstrap process.
 
-Mocks
------
+## Mocks
 
 Mocks are your typical mock object, but as an executable that your code can shell out to and then later test assertions on.
 
 ```go
-agent, err := bintest.Mock("buildkite-agent")
+agent, err := bintest.NewMock("buildkite-agent")
 if err != nil {
   t.Fatal(err)
 }
@@ -26,11 +25,10 @@ agent.
   Expect("meta-data", "set", "buildkite:git:branch", mock.MatchAny()).
   AndExitWith(0)
 
-agent.AssertExpectations(t)
+agent.CheckAndClose(t)
 ```
 
-Proxies
--------
+## Proxies
 
 Proxies are what power Mocks.
 
@@ -53,7 +51,6 @@ for call := range proxy.Ch {
 // Llama party! 🎉
 ```
 
-Credit
-------
+## Credit
 
 Inspired by [bats-mock](https://github.com/jasonkarns/bats-mock) and [go-binmock](https://github.com/pivotal-cf/go-binmock).

--- a/vendor/github.com/buildkite/bintest/proxy.go
+++ b/vendor/github.com/buildkite/bintest/proxy.go
@@ -170,20 +170,16 @@ func (p *Proxy) newCall(pid int, args []string, env []string, dir string) *Call 
 }
 
 // Close the proxy and remove the temp directory
-func (p *Proxy) Close() (err error) {
-	close(p.Ch)
+func (p *Proxy) Close() error {
+	p.Server.deregisterProxy(p)
 
-	defer func() {
-		if p.tempDir != "" {
-			if removeErr := os.RemoveAll(p.tempDir); removeErr != nil {
-				err = removeErr
-			}
+	if p.tempDir != "" {
+		if removeErr := os.RemoveAll(p.tempDir); removeErr != nil {
+			return removeErr
 		}
-	}()
-	defer func() {
-		p.Server.deregisterProxy(p)
-	}()
-	return err
+	}
+
+	return nil
 }
 
 // Call is created for every call to the proxied binary

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,8 @@
 # cloud.google.com/go v0.0.0-20170217213217-65216237311a
 cloud.google.com/go/compute/metadata
 cloud.google.com/go/internal
+# github.com/DataDog/datadog-go v0.0.0-20180822151419-281ae9f2d895
+github.com/DataDog/datadog-go/statsd
 # github.com/ErikDubbelboer/gspt v0.0.0-20180711091504-e39e726e09cc
 github.com/ErikDubbelboer/gspt
 # github.com/aws/aws-sdk-go v0.0.0-20180831223016-2a4034064ca5
@@ -39,7 +41,7 @@ github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/private/protocol/query/queryutil
 github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil
 github.com/aws/aws-sdk-go/private/protocol/query
-# github.com/buildkite/bintest v0.0.0-20180227222132-85c293267aed
+# github.com/buildkite/bintest v0.0.0-20190227031731-820c89d3b3a0
 github.com/buildkite/bintest
 # github.com/buildkite/interpolate v0.0.0-20171114090218-3a807e47135c
 github.com/buildkite/interpolate
@@ -113,9 +115,9 @@ golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sys v0.0.0-20180706062352-ce36f3865eeb
+golang.org/x/sys/windows
 golang.org/x/sys/windows/registry
 golang.org/x/sys/unix
-golang.org/x/sys/windows
 # golang.org/x/text v0.3.0
 golang.org/x/text/secure/bidirule
 golang.org/x/text/unicode/bidi


### PR DESCRIPTION
This fixes a race condition that occurred when `bootstrap.Cancel()` was called.

It also brings back the behaviour mentioned in https://github.com/buildkite/agent/issues/922 of sending a `SIGTERM` to commands that the bootstrap executes vs `SIGKILL`.

Closes #922. 