### PR TITLE
Add support for new config field: tag-from-gcp-labels

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -274,8 +274,6 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 		if err != nil {
 			r.logger.Error(fmt.Sprintf("Failed to find GCP instance labels: %s", err.Error()))
 		}
-	} else {
-		r.logger.Info("TagsFromGCPLabels was FALSE, so skipping the new code")
 	}
 
 	var err error

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -19,29 +19,31 @@ import (
 )
 
 type AgentPoolConfig struct {
-	ConfigFilePath        string
-	Name                  string
-	Priority              string
-	Tags                  []string
-	TagsFromEC2           bool
-	TagsFromEC2Tags       bool
-	TagsFromGCP           bool
-	TagsFromHost          bool
-	WaitForEC2TagsTimeout time.Duration
-	Debug                 bool
-	DisableColors         bool
-	Spawn                 int
-	AgentConfiguration    *AgentConfiguration
-	APIClientConfig       APIClientConfig
+	ConfigFilePath          string
+	Name                    string
+	Priority                string
+	Tags                    []string
+	TagsFromEC2             bool
+	TagsFromEC2Tags         bool
+	TagsFromGCP             bool
+	TagsFromGCPLabels       bool
+	TagsFromHost            bool
+	WaitForEC2TagsTimeout   time.Duration
+	WaitForGCPLabelsTimeout time.Duration
+	Debug                   bool
+	DisableColors           bool
+	Spawn                   int
+	AgentConfiguration      *AgentConfiguration
+	APIClientConfig         APIClientConfig
 }
 
 type AgentPool struct {
-	conf                  AgentPoolConfig
-	logger                *logger.Logger
-	apiClient             *api.Client
-	metricsCollector      *metrics.Collector
-	interruptCount        int
-	signalLock            sync.Mutex
+	conf             AgentPoolConfig
+	logger           *logger.Logger
+	apiClient        *api.Client
+	metricsCollector *metrics.Collector
+	interruptCount   int
+	signalLock       sync.Mutex
 }
 
 func NewAgentPool(l *logger.Logger, m *metrics.Collector, c AgentPoolConfig) *AgentPool {
@@ -71,7 +73,7 @@ func (r *AgentPool) Start() error {
 		go func() {
 			defer wg.Done()
 			if err := r.startWorker(); err != nil {
-				errs<-err
+				errs <- err
 			}
 		}()
 	}
@@ -246,6 +248,34 @@ func (r *AgentPool) CreateAgentTemplate() *api.Agent {
 				agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
 			}
 		}
+	}
+
+	// Attempt to add the Google Compute instance labels
+	if r.conf.TagsFromGCPLabels {
+		r.logger.Info("Fetching GCP instance labels...")
+		err := retry.Do(func(s *retry.Stats) error {
+			labels, err := GCPLabels{}.Get()
+			if err == nil && len(labels) == 0 {
+				err = errors.New("GCP instance labels are empty")
+			}
+			if err != nil {
+				r.logger.Warn("%s (%s)", err, s)
+			} else {
+				r.logger.Info("Successfully fetched GCP instance labels")
+				for label, value := range labels {
+					agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", label, value))
+				}
+				s.Break()
+			}
+			return err
+		}, &retry.Config{Maximum: 5, Interval: r.conf.WaitForGCPLabelsTimeout / 5, Jitter: true})
+
+		// Don't blow up if we can't find them, just show a nasty error.
+		if err != nil {
+			r.logger.Error(fmt.Sprintf("Failed to find GCP instance labels: %s", err.Error()))
+		}
+	} else {
+		r.logger.Info("TagsFromGCPLabels was FALSE, so skipping the new code")
 	}
 
 	var err error

--- a/agent/gcp_labels.go
+++ b/agent/gcp_labels.go
@@ -1,0 +1,46 @@
+package agent
+
+import (
+	"context"
+
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/compute/v1"
+)
+
+type GCPLabels struct {
+}
+
+func (e GCPLabels) Get() (map[string]string, error) {
+
+	ctx := context.Background()
+	client, err := google.DefaultClient(ctx, compute.CloudPlatformScope)
+	if err != nil {
+		return nil, err
+	}
+
+	computeService, err := compute.New(client)
+	if err != nil {
+		return nil, err
+	}
+
+	// Grab the current instance's metadata as a convenience
+	// to obtain the projectId, zone, and instanceId.
+	metadata, err := GCPMetaData{}.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	projectID := metadata["gcp:project-id"]
+	zone := metadata["gcp:zone"]
+	instanceID := metadata["gcp:instance-id"]
+
+	instance, err := computeService.Instances.Get(
+		projectID, zone, instanceID,
+	).Context(ctx).Do()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return instance.Labels, nil
+}

--- a/packaging/docker/alpine-linux/buildkite-agent.cfg
+++ b/packaging/docker/alpine-linux/buildkite-agent.cfg
@@ -16,8 +16,11 @@ name="%hostname-%n"
 # Include the host's EC2 tags as tags
 # tags-from-ec2-tags=true
 
-# Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
+# Include the host's Google Cloud instance meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
 # tags-from-gcp=true
+
+# Include the host's Google Cloud instance labels as tags
+# tags-from-gcp-labels=true
 
 # Path to a custom bootstrap command to run. By default this is `buildkite-agent bootstrap`.
 # This allows you to override the entire execution of a job. Generally you should use hooks instead!

--- a/packaging/docker/ubuntu-linux/buildkite-agent.cfg
+++ b/packaging/docker/ubuntu-linux/buildkite-agent.cfg
@@ -16,8 +16,11 @@ name="%hostname-%n"
 # Include the host's EC2 tags as tags
 # tags-from-ec2-tags=true
 
-# Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
+# Include the host's Google Cloud instance meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
 # tags-from-gcp=true
+
+# Include the host's Google Cloud instance labels as tags
+# tags-from-gcp-labels=true
 
 # Path to a custom bootstrap command to run. By default this is `buildkite-agent bootstrap`.
 # This allows you to override the entire execution of a job. Generally you should use hooks instead!

--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -16,8 +16,11 @@ name="%hostname-%n"
 # Include the host's EC2 tags as tags
 # tags-from-ec2-tags=true
 
-# Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
+# Include the host's Google Cloud instance meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
 # tags-from-gcp=true
+
+# Include the host's Google Cloud instance labels as tags
+# tags-from-gcp-labels=true
 
 # Path to a custom bootstrap command to run. By default this is `buildkite-agent bootstrap`.
 # This allows you to override the entire execution of a job. Generally you should use hooks instead!

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -16,8 +16,11 @@ name="%hostname-%n"
 # Include the host's EC2 tags as tags
 # tags-from-ec2-tags=true
 
-# Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
+# Include the host's Google Cloud instance meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
 # tags-from-gcp=true
+
+# Include the host's Google Cloud instance labels as tags
+# tags-from-gcp-labels=true
 
 # Path to a custom bootstrap command to run. By default this is `buildkite-agent bootstrap`.
 # This allows you to override the entire execution of a job. Generally you should use hooks instead!


### PR DESCRIPTION
Adds support for a new configuration field `tags-from-gcp-labels` that pulls the GCP instance labels and turns them into agent tags. This is the same functionality as `tags-from-ec2-tags` in AWS.

I tested this manually and seems to work fine. However, this is my first time updating the agent, so please shout if there are additional tests that need writing, docs that need updating, etc. I am happy to update.