### PR TITLE
Flush output immediately if timestamp-lines not on

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -165,8 +165,8 @@ func NewJobRunner(l *logger.Logger, scope *metrics.Scope, ag *api.Agent, j *api.
 				// Send to our header streamer and determine if it's a header
 				isHeader := runner.headerTimesStreamer.Scan(line)
 
-				// Optionally prefix log lines with timestamps
-				if conf.AgentConfiguration.TimestampLines && !(isHeaderExpansion(line) || isHeader) {
+				// Prefix non-header log lines with timestamps
+				if !(isHeaderExpansion(line) || isHeader) {
 					line = fmt.Sprintf("[%s] %s", time.Now().UTC().Format(time.RFC3339), line)
 				}
 

--- a/process/scanner.go
+++ b/process/scanner.go
@@ -79,21 +79,18 @@ func (s *Scanner) ScanLines(r io.Reader, f func(line string)) error {
 	return nil
 }
 
-type LineBuffer struct {
+type Buffer struct {
 	mu  sync.RWMutex
 	buf bytes.Buffer
 }
 
-func (l *LineBuffer) WriteLine(line string) {
+func (l *Buffer) Write(b []byte) (int, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-
-	// Finally write the line to the writer
-	l.buf.Write([]byte(line + "\n"))
+	return l.buf.Write(b)
 }
 
-// Output returns the buffered output of the line processor
-func (l *LineBuffer) Output() string {
+func (l *Buffer) String() string {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	return l.buf.String()


### PR DESCRIPTION
As pointed out in #929, we are buffering line output before flushing it to log chunks. This is a regression that impacts things like rspec that output lots of dots before they output a newline.

The regression was a result of me simplifying some code so that the same codepath was used whether `--timestamp-lines` was turned on or off. 

At this stage, it's just too hard to support `--timestamp-lines` and not buffer lines (as we need to only add timestamp prefixes to non-headers), so this PR brings back the two code paths and fixes #929 at the expense of more code and being a bit gross. 