### PR TITLE
Support disconnecting agent after it's been idle for a certain time period

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -1,23 +1,24 @@
 package agent
 
 type AgentConfiguration struct {
-	ConfigPath                string
-	BootstrapScript           string
-	BuildPath                 string
-	HooksPath                 string
-	PluginsPath               string
-	GitCloneFlags             string
-	GitCleanFlags             string
-	GitSubmodules             bool
-	SSHKeyscan                bool
-	CommandEval               bool
-	PluginsEnabled            bool
-	PluginValidation          bool
-	LocalHooksEnabled         bool
-	RunInPty                  bool
-	TimestampLines            bool
-	DisconnectAfterJob        bool
-	DisconnectAfterJobTimeout int
-	CancelGracePeriod         int
-	Shell                     string
+	ConfigPath                 string
+	BootstrapScript            string
+	BuildPath                  string
+	HooksPath                  string
+	PluginsPath                string
+	GitCloneFlags              string
+	GitCleanFlags              string
+	GitSubmodules              bool
+	SSHKeyscan                 bool
+	CommandEval                bool
+	PluginsEnabled             bool
+	PluginValidation           bool
+	LocalHooksEnabled          bool
+	RunInPty                   bool
+	TimestampLines             bool
+	DisconnectAfterJob         bool
+	DisconnectAfterJobTimeout  int
+	DisconnectAfterIdleTimeout int
+	CancelGracePeriod          int
+	Shell                      string
 }

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -122,6 +122,9 @@ func (r *AgentPool) startWorker() error {
 	if r.conf.AgentConfiguration.DisconnectAfterJob {
 		l.Info("Waiting for job to be assigned...")
 		l.Info("The agent will automatically disconnect after %d seconds if no job is assigned", r.conf.AgentConfiguration.DisconnectAfterJobTimeout)
+	} else if r.conf.AgentConfiguration.DisconnectAfterIdleTimeout > 0 {
+		l.Info("Waiting for job to be assigned...")
+		l.Info("The agent will automatically disconnect after %d seconds of inactivity", r.conf.AgentConfiguration.DisconnectAfterIdleTimeout)
 	} else {
 		l.Info("Waiting for work...")
 	}

--- a/agent/api_client.go
+++ b/agent/api_client.go
@@ -14,7 +14,10 @@ import (
 	"github.com/buildkite/agent/logger"
 )
 
-var debug = false
+var (
+	debugHTTP    = false
+	disableDebug = false
+)
 
 type APIClientConfig struct {
 	Endpoint     string
@@ -28,10 +31,18 @@ type APIClient struct {
 }
 
 func APIClientEnableHTTPDebug() {
-	debug = true
+	debugHTTP = true
+}
+
+func APIClientDisableDebug() {
+	disableDebug = true
 }
 
 func NewAPIClient(l *logger.Logger, c APIClientConfig) *api.Client {
+	if disableDebug == true && l.Level == logger.DEBUG {
+		l = l.WithLevel(logger.INFO)
+	}
+
 	u, err := url.Parse(c.Endpoint)
 	if err != nil {
 		l.Warn("Failed to parse %q: %v", c.Endpoint, err)
@@ -69,7 +80,7 @@ func NewAPIClient(l *logger.Logger, c APIClientConfig) *api.Client {
 	client := api.NewClient(httpClient, l)
 	client.BaseURL, _ = url.Parse(c.Endpoint)
 	client.UserAgent = userAgent()
-	client.DebugHTTP = debug
+	client.DebugHTTP = debugHTTP
 
 	return client
 }
@@ -89,7 +100,7 @@ func NewAPIClientFromSocket(l *logger.Logger, socket string, c APIClientConfig) 
 	client := api.NewClient(httpClient, l)
 	client.BaseURL, _ = url.Parse(`http+unix://buildkite-agent`)
 	client.UserAgent = userAgent()
-	client.DebugHTTP = debug
+	client.DebugHTTP = debugHTTP
 
 	return client
 }

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -324,6 +324,7 @@ var AgentStartCommand = cli.Command{
 		NoColorFlag,
 		DebugFlag,
 		DebugHTTPFlag,
+		DebugWithoutAPIFlag,
 		/* Deprecated flags which will be removed in v4 */
 		cli.StringSliceFlag{
 			Name:   "meta-data",

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -42,6 +42,12 @@ var DebugHTTPFlag = cli.BoolFlag{
 	EnvVar: "BUILDKITE_AGENT_DEBUG_HTTP",
 }
 
+var DebugWithoutAPIFlag = cli.BoolFlag{
+	Name:   "debug-without-api",
+	Usage:  "Enable debug mode, except for the API client",
+	Hidden: true,
+}
+
 var NoColorFlag = cli.BoolFlag{
 	Name:   "no-color",
 	Usage:  "Don't show colors in logging",
@@ -56,9 +62,15 @@ var ExperimentsFlag = cli.StringSliceFlag{
 }
 
 func HandleGlobalFlags(l *logger.Logger, cfg interface{}) {
+	// Enable debugging, but disable the api client
+	debugWithoutAPI, err := reflections.GetField(cfg, "DebugWithoutAPI")
+	if debugWithoutAPI == true && err == nil {
+		agent.APIClientDisableDebug()
+	}
+
 	// Enable debugging if a Debug option is present
-	debug, err := reflections.GetField(cfg, "Debug")
-	if debug == false && err == nil {
+	debug, _ := reflections.GetField(cfg, "Debug")
+	if debug == false && debugWithoutAPI == false {
 		l.Level = logger.INFO
 	}
 

--- a/logger/log.go
+++ b/logger/log.go
@@ -69,6 +69,13 @@ func (l *Logger) WithPrefix(prefix string) *Logger {
 	return &clone
 }
 
+// WithLevel returns a copy of the logger with the provided level
+func (l *Logger) WithLevel(level Level) *Logger {
+	clone := *l
+	clone.Level = level
+	return &clone
+}
+
 func (l *Logger) Debug(format string, v ...interface{}) {
 	if l.Level == DEBUG {
 		l.log(DEBUG, format, v...)


### PR DESCRIPTION
This adds `--disconnect-after-idle-timeout=<seconds>` to the `start` command. The idea is to have a a script that runs on agent shutdown that scales in the host. 