### PR TITLE
Increase pipeline upload retries on 5xx errors

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -247,7 +247,9 @@ var PipelineUploadCommand = cli.Command{
 			}
 
 			return err
-		}, &retry.Config{Maximum: 5, Interval: 1 * time.Second})
+			// On a server error, it means there is downtime or other problems, we
+			// need to retry. Let's retry every 5 seconds, for a total of 5 minutes.
+		}, &retry.Config{Maximum: 60, Interval: 5 * time.Second})
 		if err != nil {
 			l.Fatal("Failed to upload and process pipeline: %s", err)
 		}


### PR DESCRIPTION
In the case of server problems, we should give the Agent API a bit more time to recover, and to successfully accept a pipeline upload, before giving up and failing the pipeline upload job (and build) — which results on user intervention being required.

This increases the retry interval, and total number of retries, in the case of 5xx errors on pipeline uploads from 5 seconds to 5 minutes.

I think it's a good tradeoff to save user intervention and a failed build status, at the cost of the pipeline upload step taking much longer to run than usual in the case of server problems (such as downtime, maintenance windows, or unusually high load).

- [ ] Increase to more than 5 minutes?
- [ ] Is every 5 seconds a good number? It seems too short?
- [ ] Check the Agent API to see if there's any known 5xx responses from the backend which we'd want to fail more quickly