### PR TITLE
Use vendors and bash.exe for running windows tests

### DIFF
--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -17,9 +17,5 @@ RUN choco install -y git.install -params '"/GitAndUnixToolsOnPath"' && \
 
 WORKDIR c:/code
 
-# Cache go modules in docker cache
-COPY go.mod go.sum c:/code/
-RUN go mod download
-
 # Copy the rest of the code
 COPY . c:/code/

--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -15,7 +15,7 @@ RUN choco install -y git.install -params '"/GitAndUnixToolsOnPath"' && \
   choco install golang --version 1.11.4 -my && \
   choco install -y mingw
 
-WORKDIR c:/code
+WORKDIR c:/Users/ContainerAdministrator/go/src/github.com/buildkite/agent
 
 # Copy the rest of the code
-COPY . c:/code/
+COPY . ./

--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -12,7 +12,7 @@ RUN powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object Sys
 # Install Chocolatey packages
 RUN choco install -y git.install -params '"/GitAndUnixToolsOnPath"' && \
   choco install -y openssh && \
-  choco install golang --version 1.11.4 -my && \
+  choco install golang --version 1.12 -my && \
   choco install -y mingw
 
 WORKDIR c:/Users/ContainerAdministrator/go/src/github.com/buildkite/agent

--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -10,10 +10,10 @@ RUN powershell Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force
 RUN powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 # Install Chocolatey packages
-RUN choco install -y git.install -params '"/GitAndUnixToolsOnPath"' && \
-  choco install -y openssh && \
-  choco install golang --version 1.12 -my && \
-  choco install -y mingw
+RUN choco install -ry git.install -params '"/GitAndUnixToolsOnPath"' && \
+  choco install -ry openssh && \
+  choco install golang --version 1.12 -mry && \
+  choco install -ry mingw
 
 WORKDIR c:/Users/ContainerAdministrator/go/src/github.com/buildkite/agent
 

--- a/.buildkite/docker-compose.windows.yml
+++ b/.buildkite/docker-compose.windows.yml
@@ -7,6 +7,8 @@ services:
     build:
       dockerfile: .buildkite/Dockerfile-windows
       context: ../
+    volumes:
+      - ../:c:/Users/ContainerAdministrator/go/src/github.com/buildkite/agent
     tty: false
     environment:
       - BUILDKITE_BUILD_NUMBER

--- a/.buildkite/docker-compose.windows.yml
+++ b/.buildkite/docker-compose.windows.yml
@@ -11,7 +11,8 @@ services:
     environment:
       - BUILDKITE_BUILD_NUMBER
       - "BUILDKITE_BUILD_PATH=c:\\buildkite\\builds"
-      - GO111MODULE=on
+      - GOFLAGS=-mod=vendor
+      - GO111MODULE=off
 
 networks:
   default:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,6 +18,7 @@ steps:
         config: .buildkite/docker-compose.windows.yml
         run: agent
         tty: false
+        shell: ["bash.exe"]
     agents:
       queue: "windows"
 

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -379,32 +379,24 @@ func TestCheckoutDoesNotRetryOnHookFailure(t *testing.T) {
 func TestRepositorylessCheckout(t *testing.T) {
 	t.Parallel()
 
+	if runtime.GOOS == "windows" {
+		t.Skip("Not supported on windows")
+	} 
+
 	tester, err := NewBootstrapTester()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer tester.Close()
 
-	if runtime.GOOS != "windows" {
-		var script = []string{
-			"#!/bin/bash",
-			"export BUILDKITE_REPO=",
-		}
+	var script = []string{
+		"#!/bin/bash",
+		"export BUILDKITE_REPO=",
+	}
 
-		if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "environment"),
-			[]byte(strings.Join(script, "\n")), 0700); err != nil {
-			t.Fatal(err)
-		}
-	} else {
-		var script = []string{
-			"@echo off",
-			"set BUILDKITE_REPO=",
-		}
-
-		if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "environment.bat"),
-			[]byte(strings.Join(script, "\r\n")), 0700); err != nil {
-			t.Fatal(err)
-		}
+	if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "environment"),
+		[]byte(strings.Join(script, "\n")), 0700); err != nil {
+		t.Fatal(err)
 	}
 
 	tester.MustMock(t, "git").Expect().NotCalled()

--- a/bootstrap/shell/shell_test.go
+++ b/bootstrap/shell/shell_test.go
@@ -105,6 +105,10 @@ func TestRun(t *testing.T) {
 }
 
 func TestContextCancelTerminates(t *testing.T) {
+	if runtime.GOOS == `windows` {
+		t.Skip("Not supported in windows")
+	}
+
 	sleepCmd, err := bintest.CompileProxy("sleep")
 	if err != nil {
 		t.Fatal(err)
@@ -136,6 +140,10 @@ func TestContextCancelTerminates(t *testing.T) {
 }
 
 func TestInterrupt(t *testing.T) {
+	if runtime.GOOS == `windows` {
+		t.Skip("Not supported in windows")
+	}
+
 	sleepCmd, err := bintest.CompileProxy("sleep")
 	if err != nil {
 		t.Fatal(err)

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -47,6 +47,10 @@ func TestProcessOutput(t *testing.T) {
 }
 
 func TestProcessOutputPTY(t *testing.T) {
+	if runtime.GOOS == `windows` {
+		t.Skip("PTY not supported on windows")
+	}
+
 	stdout := &bytes.Buffer{}
 
 	p := process.New(logger.Discard, process.Config{
@@ -129,8 +133,10 @@ func TestProcessTerminatesWhenContextDoes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !p.WaitStatus().Signaled() {
-		t.Fatalf("Expected signaled")
+	if runtime.GOOS != `windows` {
+		if !p.WaitStatus().Signaled() {
+			t.Fatalf("Expected signaled")
+		}
 	}
 
 	<-p.Done()


### PR DESCRIPTION
Windows tests seem to be have not running for a while 🤔

This rolls in the vendor changes from #934 and also ensures that the correct shell is used in windows. 