### PR TITLE
Restart agents on SIGPIPE from systemd

### DIFF
--- a/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent.service
+++ b/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent.service
@@ -11,9 +11,10 @@ Environment=HOME=/var/lib/buildkite-agent
 ExecStart=/usr/bin/buildkite-agent start
 RestartSec=5
 Restart=on-failure
+RestartForceExitStatus=SIGPIPE
 TimeoutStartSec=10
-TimeoutStopSec=5min
-KillMode=mixed
+TimeoutStopSec=0
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent@.service
+++ b/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent@.service
@@ -11,9 +11,10 @@ Environment=HOME=/var/lib/buildkite-agent
 ExecStart=/usr/bin/buildkite-agent start
 RestartSec=5
 Restart=on-failure
+RestartForceExitStatus=SIGPIPE
 TimeoutStartSec=10
-TimeoutStopSec=5min
-KillMode=mixed
+TimeoutStopSec=0
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This brings in recent improvements we've made to the systemd unit from the Elastic Stack.

See https://github.com/buildkite/elastic-ci-stack-for-aws/pull/545 and https://github.com/buildkite/elastic-ci-stack-for-aws/pull/521