### PR TITLE
Agent start without registration, allows using an access token

### DIFF
--- a/api/agents.go
+++ b/api/agents.go
@@ -20,7 +20,7 @@ type Agent struct {
 	Endpoint          string   `json:"endpoint" msgpack:"endpoint"`
 	PingInterval      int      `json:"ping_interval" msgpack:"ping_interval"`
 	JobStatusInterval int      `json:"job_status_interval" msgpack:"job_status_interval"`
-	HearbeatInterval  int      `json:"heartbeat_interval" msgpack:"heartbeat_interval"`
+	HeartbeatInterval  int      `json:"heartbeat_interval" msgpack:"heartbeat_interval"`
 	OS                string   `json:"os" msgpack:"os"`
 	Arch              string   `json:"arch" msgpack:"arch"`
 	ScriptEvalEnabled bool     `json:"script_eval_enabled" msgpack:"script_eval_enabled"`


### PR DESCRIPTION
In the schedulers we've been writing for Lambda, ECS and other places, we quite often want to register an agent in one spot and then schedule a "one-shot" agent elsewhere. 

This adds two new flags to the `buildkite-agent start` command: 

* `--register-only` - Registers an agent and prints the access token and then exits
* `--access-token` - Skips registration of the agent and makes use of the provided access-token

In practice, I didn't love this implementation. The `agent.register` command returns lots of parameters for configuring the agent worker, such as the interpolated agent name, how often it should ping, etc. These needed to be have place holder values used.

Beyond that, I didn't love the duplication or the kind of confusing `AgentPool` method `StartWithoutRegister`. 

That said, this gets it done and makes it possible to register an agent in one spot and then run a once-off in another spot without potentially disclosing the agent registration token.

Interested in thoughts. 
