### PR TITLE
Centralize api and global cli flags

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -144,12 +144,6 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_AGENT_CONFIG",
 		},
 		cli.StringFlag{
-			Name:   "token",
-			Value:  "",
-			Usage:  "Your account agent token",
-			EnvVar: "BUILDKITE_AGENT_TOKEN",
-		},
-		cli.StringFlag{
 			Name:   "name",
 			Value:  "",
 			Usage:  "The name of the agent",
@@ -328,11 +322,6 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_NO_GIT_SUBMODULES,BUILDKITE_DISABLE_GIT_SUBMODULES",
 		},
 		cli.BoolFlag{
-			Name:   "no-http2",
-			Usage:  "Disable HTTP2 when communicating with the Agent API.",
-			EnvVar: "BUILDKITE_NO_HTTP2",
-		},
-		cli.BoolFlag{
 			Name:   "metrics-datadog",
 			Usage:  "Send metrics to DogStatsD for Datadog",
 			EnvVar: "BUILDKITE_METRICS_DATADOG",
@@ -349,13 +338,20 @@ var AgentStartCommand = cli.Command{
 			Value:  1,
 			EnvVar: "BUILDKITE_AGENT_SPAWN",
 		},
-		ExperimentsFlag,
+
+		// API Flags
+		AgentRegisterTokenFlag,
 		EndpointFlag,
-		NoColorFlag,
-		DebugFlag,
+		NoHTTP2Flag,
 		DebugHTTPFlag,
 		DebugWithoutAPIFlag,
-		/* Deprecated flags which will be removed in v4 */
+
+		// Global flags
+		ExperimentsFlag,
+		NoColorFlag,
+		DebugFlag,
+
+		// Deprecated flags which will be removed in v4
 		cli.StringSliceFlag{
 			Name:   "meta-data",
 			Value:  &cli.StringSlice{},
@@ -494,11 +490,7 @@ var AgentStartCommand = cli.Command{
 			Debug:                   cfg.Debug,
 			DisableColors:           cfg.NoColor,
 			Spawn:                   cfg.Spawn,
-			APIClientConfig: agent.APIClientConfig{
-				Token:        cfg.Token,
-				Endpoint:     cfg.Endpoint,
-				DisableHTTP2: cfg.NoHTTP2,
-			},
+			APIClientConfig:         loadAPIClientConfig(cfg, `Token`),
 			AgentConfiguration: &agent.AgentConfiguration{
 				BootstrapScript:            cfg.BootstrapScript,
 				BuildPath:                  cfg.BuildPath,

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -34,15 +34,20 @@ Example:
    You can also use the step's jobs id (provided by the environment variable $BUILDKITE_JOB_ID)`
 
 type ArtifactDownloadConfig struct {
-	Query            string `cli:"arg:0" label:"artifact search query" validate:"required"`
-	Destination      string `cli:"arg:1" label:"artifact download path" validate:"required"`
-	Step             string `cli:"step"`
-	Build            string `cli:"build" validate:"required"`
+	Query       string `cli:"arg:0" label:"artifact search query" validate:"required"`
+	Destination string `cli:"arg:1" label:"artifact download path" validate:"required"`
+	Step        string `cli:"step"`
+	Build       string `cli:"build" validate:"required"`
+
+	// Global flags
+	Debug   bool `cli:"debug"`
+	NoColor bool `cli:"no-color"`
+
+	// API config
+	DebugHTTP        bool   `cli:"debug-http"`
 	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
 	Endpoint         string `cli:"endpoint" validate:"required"`
-	NoColor          bool   `cli:"no-color"`
-	Debug            bool   `cli:"debug"`
-	DebugHTTP        bool   `cli:"debug-http"`
+	NoHTTP2          bool   `cli:"no-http2"`
 }
 
 var ArtifactDownloadCommand = cli.Command{
@@ -61,11 +66,16 @@ var ArtifactDownloadCommand = cli.Command{
 			EnvVar: "BUILDKITE_BUILD_ID",
 			Usage:  "The build that the artifacts were uploaded to",
 		},
+
+		// API Flags
 		AgentAccessTokenFlag,
 		EndpointFlag,
+		NoHTTP2Flag,
+		DebugHTTPFlag,
+
+		// Global flags
 		NoColorFlag,
 		DebugFlag,
-		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
 		l := logger.NewLogger()
@@ -82,10 +92,7 @@ var ArtifactDownloadCommand = cli.Command{
 		HandleGlobalFlags(l, cfg)
 
 		// Create the API client
-		client := agent.NewAPIClient(l, agent.APIClientConfig{
-			Endpoint: cfg.Endpoint,
-			Token:    cfg.AgentAccessToken,
-		})
+		client := agent.NewAPIClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))
 
 		// Setup the downloader
 		downloader := agent.NewArtifactDownloader(l, client, agent.ArtifactDownloaderConfig{

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -23,11 +23,24 @@ var AgentAccessTokenFlag = cli.StringFlag{
 	EnvVar: "BUILDKITE_AGENT_ACCESS_TOKEN",
 }
 
+var AgentRegisterTokenFlag = cli.StringFlag{
+	Name:   "token",
+	Value:  "",
+	Usage:  "Your account agent token",
+	EnvVar: "BUILDKITE_AGENT_TOKEN",
+}
+
 var EndpointFlag = cli.StringFlag{
 	Name:   "endpoint",
 	Value:  DefaultEndpoint,
 	Usage:  "The Agent API endpoint",
 	EnvVar: "BUILDKITE_AGENT_ENDPOINT",
+}
+
+var NoHTTP2Flag = cli.BoolFlag{
+	Name:   "no-http2",
+	Usage:  "Disable HTTP2 when communicating with the Agent API.",
+	EnvVar: "BUILDKITE_NO_HTTP2",
 }
 
 var DebugFlag = cli.BoolFlag{
@@ -74,12 +87,6 @@ func HandleGlobalFlags(l *logger.Logger, cfg interface{}) {
 		l.Level = logger.INFO
 	}
 
-	// Enable HTTP debugging
-	debugHTTP, err := reflections.GetField(cfg, "DebugHTTP")
-	if debugHTTP == true && err == nil {
-		agent.APIClientEnableHTTPDebug()
-	}
-
 	// Turn off color if a NoColor option is present
 	noColor, err := reflections.GetField(cfg, "NoColor")
 	if noColor == true && err == nil {
@@ -114,4 +121,31 @@ func UnsetConfigFromEnvironment(c *cli.Context) {
 			}
 		}
 	}
+}
+
+func loadAPIClientConfig(cfg interface{}, tokenField string) agent.APIClientConfig {
+	// Enable HTTP debugging
+	debugHTTP, err := reflections.GetField(cfg, "DebugHTTP")
+	if debugHTTP == true && err == nil {
+		agent.APIClientEnableHTTPDebug()
+	}
+
+	var a agent.APIClientConfig
+
+	endpoint, err := reflections.GetField(cfg, "Endpoint")
+	if endpoint != "" && err == nil {
+		a.Endpoint = endpoint.(string)
+	}
+
+	token, err := reflections.GetField(cfg, tokenField)
+	if token != "" && err == nil {
+		a.Token = token.(string)
+	}
+
+	noHTTP2, err := reflections.GetField(cfg, "NoHTTP2")
+	if err == nil {
+		a.DisableHTTP2 = noHTTP2.(bool)
+	}
+
+	return a
 }

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -13,10 +13,10 @@ import (
 	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/cliconfig"
+	"github.com/buildkite/agent/env"
 	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/retry"
 	"github.com/buildkite/agent/stdin"
-	"github.com/buildkite/agent/env"
 	"github.com/urfave/cli"
 )
 
@@ -47,16 +47,21 @@ Example:
    $ ./script/dynamic_step_generator | buildkite-agent pipeline upload`
 
 type PipelineUploadConfig struct {
-	FilePath         string `cli:"arg:0" label:"upload paths"`
-	Replace          bool   `cli:"replace"`
-	Job              string `cli:"job"`
+	FilePath        string `cli:"arg:0" label:"upload paths"`
+	Replace         bool   `cli:"replace"`
+	Job             string `cli:"job"`
+	DryRun          bool   `cli:"dry-run"`
+	NoInterpolation bool   `cli:"no-interpolation"`
+
+	// Global flags
+	Debug   bool `cli:"debug"`
+	NoColor bool `cli:"no-color"`
+
+	// API config
+	DebugHTTP        bool   `cli:"debug-http"`
 	AgentAccessToken string `cli:"agent-access-token"`
 	Endpoint         string `cli:"endpoint" validate:"required"`
-	DryRun           bool   `cli:"dry-run"`
-	NoColor          bool   `cli:"no-color"`
-	NoInterpolation  bool   `cli:"no-interpolation"`
-	Debug            bool   `cli:"debug"`
-	DebugHTTP        bool   `cli:"debug-http"`
+	NoHTTP2          bool   `cli:"no-http2"`
 }
 
 var PipelineUploadCommand = cli.Command{
@@ -85,11 +90,16 @@ var PipelineUploadCommand = cli.Command{
 			Usage:  "Skip variable interpolation the pipeline when uploaded",
 			EnvVar: "BUILDKITE_PIPELINE_NO_INTERPOLATION",
 		},
+
+		// API Flags
 		AgentAccessTokenFlag,
 		EndpointFlag,
+		NoHTTP2Flag,
+		DebugHTTPFlag,
+
+		// Global flags
 		NoColorFlag,
 		DebugFlag,
-		DebugHTTPFlag,
 	},
 	Action: func(c *cli.Context) {
 		l := logger.NewLogger()
@@ -223,10 +233,7 @@ var PipelineUploadCommand = cli.Command{
 		}
 
 		// Create the API client
-		client := agent.NewAPIClient(l, agent.APIClientConfig{
-			Endpoint: cfg.Endpoint,
-			Token:    cfg.AgentAccessToken,
-		})
+		client := agent.NewAPIClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))
 
 		// Generate a UUID that will identifiy this pipeline change. We
 		// do this outside of the retry loop because we want this UUID


### PR DESCRIPTION
All the CLI commands each had their own selection of the global and api flags. This unifies how they are processed and handled. 