### PR TITLE
Add agent.Registrar and a `register` command

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -1,5 +1,14 @@
 package agent
 
+import (
+	"fmt"
+	"os"
+
+	"github.com/buildkite/agent/logger"
+)
+
+// AgentConfiguration is the run-time configuration for an agent that
+// has been loaded from the config file and command-line params
 type AgentConfiguration struct {
 	ConfigPath                 string
 	BootstrapScript            string
@@ -18,10 +27,65 @@ type AgentConfiguration struct {
 	PluginValidation           bool
 	LocalHooksEnabled          bool
 	RunInPty                   bool
+	DisableColors              bool
 	TimestampLines             bool
 	DisconnectAfterJob         bool
 	DisconnectAfterJobTimeout  int
 	DisconnectAfterIdleTimeout int
 	CancelGracePeriod          int
 	Shell                      string
+}
+
+// ShowBanner prints a welcome banner and the configuration options
+func ShowBanner(l *logger.Logger, conf AgentConfiguration) {
+	welcomeMessage :=
+		"\n" +
+			"%s  _           _ _     _ _    _ _                                _\n" +
+			" | |         (_) |   | | |  (_) |                              | |\n" +
+			" | |__  _   _ _| | __| | | ___| |_ ___    __ _  __ _  ___ _ __ | |_\n" +
+			" | '_ \\| | | | | |/ _` | |/ / | __/ _ \\  / _` |/ _` |/ _ \\ '_ \\| __|\n" +
+			" | |_) | |_| | | | (_| |   <| | ||  __/ | (_| | (_| |  __/ | | | |_\n" +
+			" |_.__/ \\__,_|_|_|\\__,_|_|\\_\\_|\\__\\___|  \\__,_|\\__, |\\___|_| |_|\\__|\n" +
+			"                                                __/ |\n" +
+			" http://buildkite.com/agent                    |___/\n%s\n"
+
+	if !conf.DisableColors {
+		fmt.Fprintf(os.Stderr, welcomeMessage, "\x1b[38;5;48m", "\x1b[0m")
+	} else {
+		fmt.Fprintf(os.Stderr, welcomeMessage, "", "")
+	}
+
+	l.Notice("Starting buildkite-agent v%s with PID: %s", Version(), fmt.Sprintf("%d", os.Getpid()))
+	l.Notice("The agent source code can be found here: https://github.com/buildkite/agent")
+	l.Notice("For questions and support, email us at: hello@buildkite.com")
+
+	if conf.ConfigPath != "" {
+		l.Info("Configuration loaded from: %s", conf.ConfigPath)
+	}
+
+	l.Debug("Bootstrap command: %s", conf.BootstrapScript)
+	l.Debug("Build path: %s", conf.BuildPath)
+	l.Debug("Hooks directory: %s", conf.HooksPath)
+	l.Debug("Plugins directory: %s", conf.PluginsPath)
+
+	if !conf.SSHKeyscan {
+		l.Info("Automatic ssh-keyscan has been disabled")
+	}
+
+	if !conf.CommandEval {
+		l.Info("Evaluating console commands has been disabled")
+	}
+
+	if !conf.PluginsEnabled {
+		l.Info("Plugins have been disabled")
+	}
+
+	if !conf.RunInPty {
+		l.Info("Running builds within a pseudoterminal (PTY) has been disabled")
+	}
+
+	if conf.DisconnectAfterJob {
+		l.Info("Agent will disconnect after a job run has completed with a timeout of %d seconds",
+			conf.DisconnectAfterJobTimeout)
+	}
 }

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -1,72 +1,42 @@
 package agent
 
 import (
-	"errors"
-	"fmt"
-	"os"
-	"runtime"
-	"strings"
 	"sync"
-	"time"
 
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/logger"
-	"github.com/buildkite/agent/metrics"
-	"github.com/buildkite/agent/retry"
 	"github.com/buildkite/agent/signalwatcher"
-	"github.com/buildkite/agent/system"
-	"github.com/denisbrodbeck/machineid"
 )
 
-type AgentPoolConfig struct {
-	ConfigFilePath          string
-	Name                    string
-	Priority                string
-	Tags                    []string
-	TagsFromEC2             bool
-	TagsFromEC2Tags         bool
-	TagsFromGCP             bool
-	TagsFromGCPLabels       bool
-	TagsFromHost            bool
-	WaitForEC2TagsTimeout   time.Duration
-	WaitForGCPLabelsTimeout time.Duration
-	Debug                   bool
-	DisableColors           bool
-	Spawn                   int
-	AgentConfiguration      *AgentConfiguration
-	APIClientConfig         APIClientConfig
-}
-
+// AgentPool registers and spawns multiple parallel agent workers
+// and manages their execution lifecycles
 type AgentPool struct {
-	conf             AgentPoolConfig
-	logger           *logger.Logger
-	apiClient        *api.Client
-	metricsCollector *metrics.Collector
-	interruptCount   int
-	signalLock       sync.Mutex
+	reg            *Registrar
+	logger         *logger.Logger
+	workerFunc     func(*api.Agent) *AgentWorker
+	interruptCount int
+	signalLock     sync.Mutex
 }
 
-func NewAgentPool(l *logger.Logger, m *metrics.Collector, c AgentPoolConfig) *AgentPool {
+// NewAgentPool returns a new AgentPool
+func NewAgentPool(l *logger.Logger, r *Registrar, f func(*api.Agent) *AgentWorker) *AgentPool {
 	return &AgentPool{
-		conf:             c,
-		logger:           l,
-		metricsCollector: m,
-		apiClient:        NewAPIClient(l, c.APIClientConfig),
+		logger:     l,
+		reg:        r,
+		workerFunc: f,
 	}
 }
 
-func (r *AgentPool) Start() error {
-	// Show the welcome banner and config options used
-	r.ShowBanner()
-
+// Start kicks off the parallel registration and running of AgentWorkers
+func (r *AgentPool) Start(spawn int) error {
 	var wg sync.WaitGroup
-	var errs = make(chan error, r.conf.Spawn)
+	var errs = make(chan error, spawn)
 
-	for i := 0; i < r.conf.Spawn; i++ {
-		if r.conf.Spawn == 1 {
+	for i := 0; i < spawn; i++ {
+		if spawn == 1 {
 			r.logger.Info("Registering agent with Buildkite...")
 		} else {
-			r.logger.Info("Registering agent %d of %d with Buildkite...", i+1, r.conf.Spawn)
+			r.logger.Info("Registering agent %d of %d with Buildkite...", i+1, spawn)
 		}
 
 		wg.Add(1)
@@ -83,50 +53,24 @@ func (r *AgentPool) Start() error {
 		close(errs)
 	}()
 
-	r.logger.Info("Started %d Agent(s)", r.conf.Spawn)
+	r.logger.Info("Started %d Agent(s)", spawn)
 	r.logger.Info("You can press Ctrl-C to stop the agents")
 
 	return <-errs
 }
 
 func (r *AgentPool) startWorker() error {
-	registered, err := r.RegisterAgent(r.CreateAgentTemplate())
+	registered, err := r.reg.Register()
 	if err != nil {
 		return err
 	}
 
-	r.logger.Info("Successfully registered agent \"%s\" with tags [%s]", registered.Name,
-		strings.Join(registered.Tags, ", "))
-
-	// Create a prefixed logger for some context in concurrent output
-	l := r.logger.WithPrefix(registered.Name)
-
-	l.Debug("Ping interval: %ds", registered.PingInterval)
-	l.Debug("Job status interval: %ds", registered.JobStatusInterval)
-	l.Debug("Heartbeat interval: %ds", registered.HearbeatInterval)
-
 	// Now that we have a registered agent, we can connect it to the API,
 	// and start running jobs.
-	worker := NewAgentWorker(l, registered, r.metricsCollector, AgentWorkerConfig{
-		AgentConfiguration: r.conf.AgentConfiguration,
-		Debug:              r.conf.Debug,
-		Endpoint:           r.conf.APIClientConfig.Endpoint,
-		DisableHTTP2:       r.conf.APIClientConfig.DisableHTTP2,
-	})
+	worker := r.workerFunc(registered)
 
-	l.Info("Connecting to Buildkite...")
 	if err := worker.Connect(); err != nil {
 		return err
-	}
-
-	if r.conf.AgentConfiguration.DisconnectAfterJob {
-		l.Info("Waiting for job to be assigned...")
-		l.Info("The agent will automatically disconnect after %d seconds if no job is assigned", r.conf.AgentConfiguration.DisconnectAfterJobTimeout)
-	} else if r.conf.AgentConfiguration.DisconnectAfterIdleTimeout > 0 {
-		l.Info("Waiting for job to be assigned...")
-		l.Info("The agent will automatically disconnect after %d seconds of inactivity", r.conf.AgentConfiguration.DisconnectAfterIdleTimeout)
-	} else {
-		l.Info("Waiting for work...")
 	}
 
 	// Start a signalwatcher so we can monitor signals and handle shutdowns
@@ -135,20 +79,20 @@ func (r *AgentPool) startWorker() error {
 		defer r.signalLock.Unlock()
 
 		if sig == signalwatcher.QUIT {
-			l.Debug("Received signal `%s`", sig.String())
+			r.logger.Debug("Received signal `%s`", sig.String())
 			worker.Stop(false)
 		} else if sig == signalwatcher.TERM || sig == signalwatcher.INT {
-			l.Debug("Received signal `%s`", sig.String())
+			r.logger.Debug("Received signal `%s`", sig.String())
 			if r.interruptCount == 0 {
 				r.interruptCount++
-				l.Info("Received CTRL-C, send again to forcefully kill the agent")
+				r.logger.Info("Received CTRL-C, send again to forcefully kill the agent")
 				worker.Stop(true)
 			} else {
-				l.Info("Forcefully stopping running jobs and stopping the agent")
+				r.logger.Info("Forcefully stopping running jobs and stopping the agent")
 				worker.Stop(false)
 			}
 		} else {
-			l.Debug("Ignoring signal `%s`", sig.String())
+			r.logger.Debug("Ignoring signal `%s`", sig.String())
 		}
 	})
 
@@ -158,233 +102,9 @@ func (r *AgentPool) startWorker() error {
 	}
 
 	// Now that the agent has stopped, we can disconnect it
-	l.Info("Disconnecting %s...", worker.agent.Name)
 	if err := worker.Disconnect(); err != nil {
 		return err
 	}
 
 	return nil
-}
-
-// Takes the options passed to the CLI, and creates an api.Agent record that
-// will be sent to the Buildkite Agent API for registration.
-func (r *AgentPool) CreateAgentTemplate() *api.Agent {
-	agent := &api.Agent{
-		Name:              r.conf.Name,
-		Priority:          r.conf.Priority,
-		Tags:              r.conf.Tags,
-		ScriptEvalEnabled: r.conf.AgentConfiguration.CommandEval,
-		Version:           Version(),
-		Build:             BuildVersion(),
-		PID:               os.Getpid(),
-		Arch:              runtime.GOARCH,
-	}
-
-	// get a unique identifier for the underlying host
-	if machineID, err := machineid.ProtectedID("buildkite-agent"); err != nil {
-		r.logger.Warn("Failed to find unique machine-id: %v", err)
-	} else {
-		agent.MachineID = machineID
-	}
-
-	// Attempt to add the EC2 tags
-	if r.conf.TagsFromEC2 {
-		r.logger.Info("Fetching EC2 meta-data...")
-
-		err := retry.Do(func(s *retry.Stats) error {
-			tags, err := EC2MetaData{}.Get()
-			if err != nil {
-				r.logger.Warn("%s (%s)", err, s)
-			} else {
-				r.logger.Info("Successfully fetched EC2 meta-data")
-				for tag, value := range tags {
-					agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
-				}
-				s.Break()
-			}
-
-			return err
-		}, &retry.Config{Maximum: 5, Interval: 1 * time.Second, Jitter: true})
-
-		// Don't blow up if we can't find them, just show a nasty error.
-		if err != nil {
-			r.logger.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
-		}
-	}
-
-	// Attempt to add the EC2 tags
-	if r.conf.TagsFromEC2Tags {
-		r.logger.Info("Fetching EC2 tags...")
-		err := retry.Do(func(s *retry.Stats) error {
-			tags, err := EC2Tags{}.Get()
-			// EC2 tags are apparently "eventually consistent" and sometimes take several seconds
-			// to be applied to instances. This error will cause retries.
-			if err == nil && len(tags) == 0 {
-				err = errors.New("EC2 tags are empty")
-			}
-			if err != nil {
-				r.logger.Warn("%s (%s)", err, s)
-			} else {
-				r.logger.Info("Successfully fetched EC2 tags")
-				for tag, value := range tags {
-					agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
-				}
-				s.Break()
-			}
-			return err
-		}, &retry.Config{Maximum: 5, Interval: r.conf.WaitForEC2TagsTimeout / 5, Jitter: true})
-
-		// Don't blow up if we can't find them, just show a nasty error.
-		if err != nil {
-			r.logger.Error(fmt.Sprintf("Failed to find EC2 tags: %s", err.Error()))
-		}
-	}
-
-	// Attempt to add the Google Cloud meta-data
-	if r.conf.TagsFromGCP {
-		tags, err := GCPMetaData{}.Get()
-		if err != nil {
-			// Don't blow up if we can't find them, just show a nasty error.
-			r.logger.Error(fmt.Sprintf("Failed to fetch Google Cloud meta-data: %s", err.Error()))
-		} else {
-			for tag, value := range tags {
-				agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
-			}
-		}
-	}
-
-	// Attempt to add the Google Compute instance labels
-	if r.conf.TagsFromGCPLabels {
-		r.logger.Info("Fetching GCP instance labels...")
-		err := retry.Do(func(s *retry.Stats) error {
-			labels, err := GCPLabels{}.Get()
-			if err == nil && len(labels) == 0 {
-				err = errors.New("GCP instance labels are empty")
-			}
-			if err != nil {
-				r.logger.Warn("%s (%s)", err, s)
-			} else {
-				r.logger.Info("Successfully fetched GCP instance labels")
-				for label, value := range labels {
-					agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", label, value))
-				}
-				s.Break()
-			}
-			return err
-		}, &retry.Config{Maximum: 5, Interval: r.conf.WaitForGCPLabelsTimeout / 5, Jitter: true})
-
-		// Don't blow up if we can't find them, just show a nasty error.
-		if err != nil {
-			r.logger.Error(fmt.Sprintf("Failed to find GCP instance labels: %s", err.Error()))
-		}
-	}
-
-	var err error
-
-	// Add the hostname
-	agent.Hostname, err = os.Hostname()
-	if err != nil {
-		r.logger.Warn("Failed to find hostname: %s", err)
-	}
-
-	// Add the OS dump
-	agent.OS, err = system.VersionDump(r.logger)
-	if err != nil {
-		r.logger.Warn("Failed to find OS information: %s", err)
-	}
-
-	// Attempt to add the host tags
-	if r.conf.TagsFromHost {
-		agent.Tags = append(agent.Tags,
-			fmt.Sprintf("hostname=%s", agent.Hostname),
-			fmt.Sprintf("os=%s", runtime.GOOS),
-		)
-		if agent.MachineID != "" {
-			agent.Tags = append(agent.Tags, fmt.Sprintf("machine-id=%s", agent.MachineID))
-		}
-	}
-
-	return agent
-}
-
-// Takes the agent template and returns a registered agent. The registered
-// agent includes the Access Token used to communicate with the Buildkite Agent
-// API
-func (r *AgentPool) RegisterAgent(agent *api.Agent) (*api.Agent, error) {
-	var registered *api.Agent
-	var err error
-	var resp *api.Response
-
-	register := func(s *retry.Stats) error {
-		registered, resp, err = r.apiClient.Agents.Register(agent)
-		if err != nil {
-			if resp != nil && resp.StatusCode == 401 {
-				r.logger.Warn("Buildkite rejected the registration (%s)", err)
-				s.Break()
-			} else {
-				r.logger.Warn("%s (%s)", err, s)
-			}
-		}
-
-		return err
-	}
-
-	// Try to register, retrying every 10 seconds for a maximum of 30 attempts (5 minutes)
-	err = retry.Do(register, &retry.Config{Maximum: 30, Interval: 10 * time.Second})
-
-	return registered, err
-}
-
-// Shows the welcome banner and the configuration options used when starting
-// this agent.
-func (r *AgentPool) ShowBanner() {
-	welcomeMessage :=
-		"\n" +
-			"%s  _           _ _     _ _    _ _                                _\n" +
-			" | |         (_) |   | | |  (_) |                              | |\n" +
-			" | |__  _   _ _| | __| | | ___| |_ ___    __ _  __ _  ___ _ __ | |_\n" +
-			" | '_ \\| | | | | |/ _` | |/ / | __/ _ \\  / _` |/ _` |/ _ \\ '_ \\| __|\n" +
-			" | |_) | |_| | | | (_| |   <| | ||  __/ | (_| | (_| |  __/ | | | |_\n" +
-			" |_.__/ \\__,_|_|_|\\__,_|_|\\_\\_|\\__\\___|  \\__,_|\\__, |\\___|_| |_|\\__|\n" +
-			"                                                __/ |\n" +
-			" http://buildkite.com/agent                    |___/\n%s\n"
-
-	if !r.conf.DisableColors {
-		fmt.Fprintf(os.Stderr, welcomeMessage, "\x1b[38;5;48m", "\x1b[0m")
-	} else {
-		fmt.Fprintf(os.Stderr, welcomeMessage, "", "")
-	}
-
-	r.logger.Notice("Starting buildkite-agent v%s with PID: %s", Version(), fmt.Sprintf("%d", os.Getpid()))
-	r.logger.Notice("The agent source code can be found here: https://github.com/buildkite/agent")
-	r.logger.Notice("For questions and support, email us at: hello@buildkite.com")
-
-	if r.conf.ConfigFilePath != "" {
-		r.logger.Info("Configuration loaded from: %s", r.conf.ConfigFilePath)
-	}
-
-	r.logger.Debug("Bootstrap command: %s", r.conf.AgentConfiguration.BootstrapScript)
-	r.logger.Debug("Build path: %s", r.conf.AgentConfiguration.BuildPath)
-	r.logger.Debug("Hooks directory: %s", r.conf.AgentConfiguration.HooksPath)
-	r.logger.Debug("Plugins directory: %s", r.conf.AgentConfiguration.PluginsPath)
-
-	if !r.conf.AgentConfiguration.SSHKeyscan {
-		r.logger.Info("Automatic ssh-keyscan has been disabled")
-	}
-
-	if !r.conf.AgentConfiguration.CommandEval {
-		r.logger.Info("Evaluating console commands has been disabled")
-	}
-
-	if !r.conf.AgentConfiguration.PluginsEnabled {
-		r.logger.Info("Plugins have been disabled")
-	}
-
-	if !r.conf.AgentConfiguration.RunInPty {
-		r.logger.Info("Running builds within a pseudoterminal (PTY) has been disabled")
-	}
-
-	if r.conf.AgentConfiguration.DisconnectAfterJob {
-		r.logger.Info("Agent will disconnect after a job run has completed with a timeout of %d seconds", r.conf.AgentConfiguration.DisconnectAfterJobTimeout)
-	}
 }

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -11,7 +11,7 @@ import (
 // AgentPool registers and spawns multiple parallel agent workers
 // and manages their execution lifecycles
 type AgentPool struct {
-	reg            *Registrar
+	reg            *Registrator
 	logger         *logger.Logger
 	workerFunc     func(*api.Agent) *AgentWorker
 	interruptCount int
@@ -19,7 +19,7 @@ type AgentPool struct {
 }
 
 // NewAgentPool returns a new AgentPool
-func NewAgentPool(l *logger.Logger, r *Registrar, f func(*api.Agent) *AgentWorker) *AgentPool {
+func NewAgentPool(l *logger.Logger, r *Registrator, f func(*api.Agent) *AgentWorker) *AgentPool {
 	return &AgentPool{
 		logger:     l,
 		reg:        r,

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -25,7 +25,7 @@ type AgentWorkerConfig struct {
 	DisableHTTP2 bool
 
 	// The configuration of the agent from the CLI
-	AgentConfiguration *AgentConfiguration
+	AgentConfiguration AgentConfiguration
 }
 
 type AgentWorker struct {
@@ -42,7 +42,7 @@ type AgentWorker struct {
 	logger *logger.Logger
 
 	// The configuration of the agent from the CLI
-	agentConfiguration *AgentConfiguration
+	agentConfiguration AgentConfiguration
 
 	// The registered agent API record
 	agent *api.Agent
@@ -95,12 +95,12 @@ func NewAgentWorker(l *logger.Logger, a *api.Agent, m *metrics.Collector, c Agen
 	})
 
 	return &AgentWorker{
-		logger:             l,
-		agent:              a,
-		metricsCollector:   m,
-		apiClient:          apiClient,
-		debug:              c.Debug,
-		agentConfiguration: c.AgentConfiguration,
+		logger:           l,
+		agent:            a,
+		metricsCollector: m,
+		apiClient:        apiClient,
+		debug:            c.Debug,
+		agentConfiguration:      c.AgentConfiguration,
 	}
 }
 
@@ -172,6 +172,16 @@ func (a *AgentWorker) Start() error {
 				}
 			}
 		}()
+	}
+
+	if a.agentConfiguration.DisconnectAfterJob {
+		a.logger.Info("Waiting for job to be assigned...")
+		a.logger.Info("The agent will automatically disconnect after %d seconds if no job is assigned", a.agentConfiguration.DisconnectAfterJobTimeout)
+	} else if a.agentConfiguration.DisconnectAfterIdleTimeout > 0 {
+		a.logger.Info("Waiting for job to be assigned...")
+		a.logger.Info("The agent will automatically disconnect after %d seconds of inactivity", a.agentConfiguration.DisconnectAfterIdleTimeout)
+	} else {
+		a.logger.Info("Waiting for work...")
 	}
 
 	// Continue this loop until the the ticker is stopped, and we received
@@ -259,6 +269,8 @@ func (a *AgentWorker) stopIfIdle() {
 // Connects the agent to the Buildkite Agent API, retrying up to 30 times if it
 // fails.
 func (a *AgentWorker) Connect() error {
+	a.logger.Info("Connecting to Buildkite...")
+
 	// Update the proc title
 	a.UpdateProcTitle("connecting")
 
@@ -406,8 +418,8 @@ func (a *AgentWorker) Ping() {
 
 	// Now that the job has been accepted, we can start it.
 	a.jobRunner, err = NewJobRunner(a.logger, jobMetricsScope, a.agent, accepted, JobRunnerConfig{
-		Debug:              a.debug,
-		Endpoint:           accepted.Endpoint,
+		Debug:       a.debug,
+		Endpoint:    accepted.Endpoint,
 		AgentConfiguration: a.agentConfiguration,
 	})
 
@@ -452,6 +464,8 @@ func (a *AgentWorker) Ping() {
 // Disconnects the agent from the Buildkite Agent API, doesn't bother retrying
 // because we want to disconnect as fast as possible.
 func (a *AgentWorker) Disconnect() error {
+	a.logger.Info("Disconnecting...")
+
 	// Update the proc title
 	a.UpdateProcTitle("disconnecting")
 

--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -26,7 +26,7 @@ func TestJobRunnerPassesAccessTokenToBootstrap(t *testing.T) {
 		},
 	}
 
-	cfg := &agent.AgentConfiguration{}
+	cfg := agent.AgentConfiguration{}
 
 	runJob(t, ag, j, cfg, func(c *bintest.Call) {
 		if c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN") != `llamasrock` {
@@ -51,7 +51,7 @@ func TestJobRunnerIgnoresPipelineChangesToProtectedVars(t *testing.T) {
 		},
 	}
 
-	cfg := &agent.AgentConfiguration{
+	cfg := agent.AgentConfiguration{
 		CommandEval: true,
 	}
 
@@ -65,7 +65,7 @@ func TestJobRunnerIgnoresPipelineChangesToProtectedVars(t *testing.T) {
 
 }
 
-func runJob(t *testing.T, ag *api.Agent, j *api.Job, cfg *agent.AgentConfiguration, bootstrap func(c *bintest.Call)) {
+func runJob(t *testing.T, ag *api.Agent, j *api.Job, cfg agent.AgentConfiguration, bootstrap func(c *bintest.Call)) {
 	// create a mock agent API
 	server := createTestAgentEndpoint(t, `my-job-id`)
 	defer server.Close()
@@ -90,7 +90,7 @@ func runJob(t *testing.T, ag *api.Agent, j *api.Job, cfg *agent.AgentConfigurati
 	cfg.BootstrapScript = bs.Path
 
 	jr, err := agent.NewJobRunner(l, scope, ag, j, agent.JobRunnerConfig{
-		Endpoint:           server.URL,
+		Endpoint:    server.URL,
 		AgentConfiguration: cfg,
 	})
 	if err != nil {

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -25,7 +25,7 @@ type JobRunnerConfig struct {
 	Endpoint string
 
 	// The configuration of the agent from the CLI
-	AgentConfiguration *AgentConfiguration
+	AgentConfiguration AgentConfiguration
 
 	// Whether to set debug in the job
 	Debug bool

--- a/agent/registrar.go
+++ b/agent/registrar.go
@@ -1,0 +1,225 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/buildkite/agent/api"
+	"github.com/buildkite/agent/logger"
+	"github.com/buildkite/agent/retry"
+	"github.com/buildkite/agent/system"
+	"github.com/denisbrodbeck/machineid"
+)
+
+type RegistrarConfig struct {
+	Name                    string
+	Priority                string
+	Tags                    []string
+	TagsFromEC2             bool
+	TagsFromEC2Tags         bool
+	TagsFromGCP             bool
+	TagsFromGCPLabels       bool
+	TagsFromHost            bool
+	WaitForEC2TagsTimeout   time.Duration
+	WaitForGCPLabelsTimeout time.Duration
+	ScriptEvalEnabled       bool
+}
+
+type Registrar struct {
+	conf      RegistrarConfig
+	logger    *logger.Logger
+	apiClient *api.Client
+}
+
+func NewRegistrar(l *logger.Logger, ac *api.Client, c RegistrarConfig) *Registrar {
+	return &Registrar{
+		conf:      c,
+		logger:    l,
+		apiClient: ac,
+	}
+}
+
+func (r *Registrar) Register() (*api.Agent, error) {
+	agent := r.createAgentTemplate()
+
+	var registered *api.Agent
+	var err error
+	var resp *api.Response
+
+	register := func(s *retry.Stats) error {
+		registered, resp, err = r.apiClient.Agents.Register(agent)
+		if err != nil {
+			if resp != nil && resp.StatusCode == 401 {
+				r.logger.Warn("Buildkite rejected the registration (%s)", err)
+				s.Break()
+			} else {
+				r.logger.Warn("%s (%s)", err, s)
+			}
+		}
+
+		return err
+	}
+
+	// Try to register, retrying every 10 seconds for a maximum of 30 attempts (5 minutes)
+	err = retry.Do(register, &retry.Config{Maximum: 30, Interval: 10 * time.Second})
+
+	if err != nil {
+		r.logger.Info("Successfully registered agent \"%s\" with tags [%s]", registered.Name,
+			strings.Join(registered.Tags, ", "))
+
+		r.logger.Debug("Ping interval: %ds", registered.PingInterval)
+		r.logger.Debug("Job status interval: %ds", registered.JobStatusInterval)
+		r.logger.Debug("Heartbeat interval: %ds", registered.HearbeatInterval)
+
+		if registered.Endpoint != "" {
+			r.logger.Debug("Endpoint: %s", registered.Endpoint)
+		}
+	}
+
+	return registered, err
+}
+
+// Creates an api.Agent record that will be sent to the
+// Buildkite Agent API for registration.
+func (r *Registrar) createAgentTemplate() *api.Agent {
+	agent := &api.Agent{
+		Name:              r.conf.Name,
+		Priority:          r.conf.Priority,
+		Tags:              r.conf.Tags,
+		ScriptEvalEnabled: r.conf.ScriptEvalEnabled,
+		Version:           Version(),
+		Build:             BuildVersion(),
+		PID:               os.Getpid(),
+		Arch:              runtime.GOARCH,
+	}
+
+	// get a unique identifier for the underlying host
+	if machineID, err := machineid.ProtectedID("buildkite-agent"); err != nil {
+		r.logger.Warn("Failed to find unique machine-id: %v", err)
+	} else {
+		agent.MachineID = machineID
+	}
+
+	// Attempt to add the EC2 tags
+	if r.conf.TagsFromEC2 {
+		r.logger.Info("Fetching EC2 meta-data...")
+
+		err := retry.Do(func(s *retry.Stats) error {
+			tags, err := EC2MetaData{}.Get()
+			if err != nil {
+				r.logger.Warn("%s (%s)", err, s)
+			} else {
+				r.logger.Info("Successfully fetched EC2 meta-data")
+				for tag, value := range tags {
+					agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
+				}
+				s.Break()
+			}
+
+			return err
+		}, &retry.Config{Maximum: 5, Interval: 1 * time.Second, Jitter: true})
+
+		// Don't blow up if we can't find them, just show a nasty error.
+		if err != nil {
+			r.logger.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
+		}
+	}
+
+	// Attempt to add the EC2 tags
+	if r.conf.TagsFromEC2Tags {
+		r.logger.Info("Fetching EC2 tags...")
+		err := retry.Do(func(s *retry.Stats) error {
+			tags, err := EC2Tags{}.Get()
+			// EC2 tags are apparently "eventually consistent" and sometimes take several seconds
+			// to be applied to instances. This error will cause retries.
+			if err == nil && len(tags) == 0 {
+				err = errors.New("EC2 tags are empty")
+			}
+			if err != nil {
+				r.logger.Warn("%s (%s)", err, s)
+			} else {
+				r.logger.Info("Successfully fetched EC2 tags")
+				for tag, value := range tags {
+					agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
+				}
+				s.Break()
+			}
+			return err
+		}, &retry.Config{Maximum: 5, Interval: r.conf.WaitForEC2TagsTimeout / 5, Jitter: true})
+
+		// Don't blow up if we can't find them, just show a nasty error.
+		if err != nil {
+			r.logger.Error(fmt.Sprintf("Failed to find EC2 tags: %s", err.Error()))
+		}
+	}
+
+	// Attempt to add the Google Cloud meta-data
+	if r.conf.TagsFromGCP {
+		tags, err := GCPMetaData{}.Get()
+		if err != nil {
+			// Don't blow up if we can't find them, just show a nasty error.
+			r.logger.Error(fmt.Sprintf("Failed to fetch Google Cloud meta-data: %s", err.Error()))
+		} else {
+			for tag, value := range tags {
+				agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
+			}
+		}
+	}
+
+	// Attempt to add the Google Compute instance labels
+	if r.conf.TagsFromGCPLabels {
+		r.logger.Info("Fetching GCP instance labels...")
+		err := retry.Do(func(s *retry.Stats) error {
+			labels, err := GCPLabels{}.Get()
+			if err == nil && len(labels) == 0 {
+				err = errors.New("GCP instance labels are empty")
+			}
+			if err != nil {
+				r.logger.Warn("%s (%s)", err, s)
+			} else {
+				r.logger.Info("Successfully fetched GCP instance labels")
+				for label, value := range labels {
+					agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", label, value))
+				}
+				s.Break()
+			}
+			return err
+		}, &retry.Config{Maximum: 5, Interval: r.conf.WaitForGCPLabelsTimeout / 5, Jitter: true})
+
+		// Don't blow up if we can't find them, just show a nasty error.
+		if err != nil {
+			r.logger.Error(fmt.Sprintf("Failed to find GCP instance labels: %s", err.Error()))
+		}
+	}
+
+	var err error
+
+	// Add the hostname
+	agent.Hostname, err = os.Hostname()
+	if err != nil {
+		r.logger.Warn("Failed to find hostname: %s", err)
+	}
+
+	// Add the OS dump
+	agent.OS, err = system.VersionDump(r.logger)
+	if err != nil {
+		r.logger.Warn("Failed to find OS information: %s", err)
+	}
+
+	// Attempt to add the host tags
+	if r.conf.TagsFromHost {
+		agent.Tags = append(agent.Tags,
+			fmt.Sprintf("hostname=%s", agent.Hostname),
+			fmt.Sprintf("os=%s", runtime.GOOS),
+		)
+		if agent.MachineID != "" {
+			agent.Tags = append(agent.Tags, fmt.Sprintf("machine-id=%s", agent.MachineID))
+		}
+	}
+
+	return agent
+}

--- a/clicommand/agent_register.go
+++ b/clicommand/agent_register.go
@@ -1,0 +1,213 @@
+package clicommand
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/buildkite/agent/agent"
+	"github.com/buildkite/agent/cliconfig"
+	"github.com/buildkite/agent/logger"
+	"github.com/urfave/cli"
+)
+
+var RegisterDescription = `Usage:
+
+   buildkite-agent register [arguments...]
+
+Description:
+
+   Register an Agent with the Buildkite API for advanced usage.
+
+   The command outputs JSON to stdout that can be consumed by
+   the 'buildkite-agent start' command.
+
+Example:
+
+   $ buildkite-agent register --token xxx`
+
+type AgentRegisterConfig struct {
+	Config                  string   `cli:"config"`
+	Name                    string   `cli:"name"`
+	Priority                string   `cli:"priority"`
+	Tags                    []string `cli:"tags" normalize:"list"`
+	TagsFromEC2             bool     `cli:"tags-from-ec2"`
+	TagsFromEC2Tags         bool     `cli:"tags-from-ec2-tags"`
+	TagsFromGCP             bool     `cli:"tags-from-gcp"`
+	TagsFromGCPLabels       bool     `cli:"tags-from-gcp-labels"`
+	TagsFromHost            bool     `cli:"tags-from-host"`
+	WaitForEC2TagsTimeout   string   `cli:"wait-for-ec2-tags-timeout"`
+	WaitForGCPLabelsTimeout string   `cli:"wait-for-gcp-labels-timeout"`
+
+	// Global flags
+	Debug           bool     `cli:"debug"`
+	DebugWithoutAPI bool     `cli:"debug-without-api"`
+	NoColor         bool     `cli:"no-color"`
+	Experiments     []string `cli:"experiment" normalize:"list"`
+
+	// API config
+	DebugHTTP bool   `cli:"debug-http"`
+	Token     string `cli:"token" validate:"required"`
+	Endpoint  string `cli:"endpoint" validate:"required"`
+	NoHTTP2   bool   `cli:"no-http2"`
+
+	// Deprecated
+	NoSSHFingerprintVerification bool     `cli:"no-automatic-ssh-fingerprint-verification" deprecated-and-renamed-to:"NoSSHKeyscan"`
+	MetaData                     []string `cli:"meta-data" deprecated-and-renamed-to:"Tags"`
+	MetaDataEC2                  bool     `cli:"meta-data-ec2" deprecated-and-renamed-to:"TagsFromEC2"`
+	MetaDataEC2Tags              bool     `cli:"meta-data-ec2-tags" deprecated-and-renamed-to:"TagsFromEC2Tags"`
+	MetaDataGCP                  bool     `cli:"meta-data-gcp" deprecated-and-renamed-to:"TagsFromGCP"`
+}
+
+var AgentRegisterCommand = cli.Command{
+	Name:        "register",
+	Usage:       "Register an Agent with the Buildkite API (advanced)",
+	Description: RegisterDescription,
+	Hidden:      true,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:   "config",
+			Value:  "",
+			Usage:  "Path to a configuration file",
+			EnvVar: "BUILDKITE_AGENT_CONFIG",
+		},
+		cli.StringFlag{
+			Name:   "name",
+			Value:  "",
+			Usage:  "The name of the agent",
+			EnvVar: "BUILDKITE_AGENT_NAME",
+		},
+		cli.StringFlag{
+			Name:   "priority",
+			Value:  "",
+			Usage:  "The priority of the agent (higher priorities are assigned work first)",
+			EnvVar: "BUILDKITE_AGENT_PRIORITY",
+		},
+		cli.StringSliceFlag{
+			Name:   "tags",
+			Value:  &cli.StringSlice{},
+			Usage:  "A comma-separated list of tags for the agent (e.g. \"linux\" or \"mac,xcode=8\")",
+			EnvVar: "BUILDKITE_AGENT_TAGS",
+		},
+		cli.BoolFlag{
+			Name:   "tags-from-host",
+			Usage:  "Include tags from the host (hostname, machine-id, os)",
+			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_HOST",
+		},
+		cli.BoolFlag{
+			Name:   "tags-from-ec2",
+			Usage:  "Include the host's EC2 meta-data as tags (instance-id, instance-type, and ami-id)",
+			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_EC2",
+		},
+		cli.BoolFlag{
+			Name:   "tags-from-ec2-tags",
+			Usage:  "Include the host's EC2 tags as tags",
+			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_EC2_TAGS",
+		},
+		cli.BoolFlag{
+			Name:   "tags-from-gcp",
+			Usage:  "Include the host's Google Cloud instance meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)",
+			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_GCP",
+		},
+		cli.BoolFlag{
+			Name:   "tags-from-gcp-labels",
+			Usage:  "Include the host's Google Cloud instance labels as tags",
+			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_GCP_LABELS",
+		},
+		cli.DurationFlag{
+			Name:   "wait-for-ec2-tags-timeout",
+			Usage:  "The amount of time to wait for tags from EC2 before proceeding",
+			EnvVar: "BUILDKITE_AGENT_WAIT_FOR_EC2_TAGS_TIMEOUT",
+			Value:  time.Second * 10,
+		},
+		cli.DurationFlag{
+			Name:   "wait-for-gcp-labels-timeout",
+			Usage:  "The amount of time to wait for labels from GCP before proceeding",
+			EnvVar: "BUILDKITE_AGENT_WAIT_FOR_GCP_LABELS_TIMEOUT",
+			Value:  time.Second * 10,
+		},
+
+		// API Flags
+		AgentRegisterTokenFlag,
+		EndpointFlag,
+		NoHTTP2Flag,
+		DebugHTTPFlag,
+		DebugWithoutAPIFlag,
+
+		// Global flags
+		ExperimentsFlag,
+		NoColorFlag,
+		DebugFlag,
+	},
+	Action: func(c *cli.Context) {
+		l := logger.NewLogger()
+
+		// The configuration will be loaded into this struct
+		cfg := AgentRegisterConfig{}
+
+		// Setup the config loader. You'll see that we also path paths to
+		// potential config files. The loader will use the first one it finds.
+		loader := cliconfig.Loader{
+			CLI:                    c,
+			Config:                 &cfg,
+			DefaultConfigFilePaths: DefaultConfigFilePaths(),
+			Logger:                 l,
+		}
+
+		// Load the configuration
+		if err := loader.Load(); err != nil {
+			l.Fatal("%s", err)
+		}
+
+		// Setup the any global configuration options
+		HandleGlobalFlags(l, cfg)
+
+		var ec2TagTimeout time.Duration
+		if t := cfg.WaitForEC2TagsTimeout; t != "" {
+			var err error
+			ec2TagTimeout, err = time.ParseDuration(t)
+			if err != nil {
+				l.Fatal("Failed to parse ec2 tag timeout: %v", err)
+			}
+		}
+
+		var gcpLabelsTimeout time.Duration
+		if t := cfg.WaitForGCPLabelsTimeout; t != "" {
+			var err error
+			gcpLabelsTimeout, err = time.ParseDuration(t)
+			if err != nil {
+				l.Fatal("Failed to parse gcp labels timeout: %v", err)
+			}
+		}
+
+		// Create the API client for registering
+		client := agent.NewAPIClient(l, loadAPIClientConfig(cfg, `Token`))
+
+		// Create an agent registrar
+		reg := agent.NewRegistrar(l, client, agent.RegistrarConfig{
+			Name:                    cfg.Name,
+			Priority:                cfg.Priority,
+			Tags:                    cfg.Tags,
+			TagsFromEC2:             cfg.TagsFromEC2,
+			TagsFromEC2Tags:         cfg.TagsFromEC2Tags,
+			TagsFromGCP:             cfg.TagsFromGCP,
+			TagsFromGCPLabels:       cfg.TagsFromGCPLabels,
+			TagsFromHost:            cfg.TagsFromHost,
+			WaitForEC2TagsTimeout:   ec2TagTimeout,
+			WaitForGCPLabelsTimeout: gcpLabelsTimeout,
+		})
+
+		ag, err := reg.Register()
+		if err != nil {
+			l.Fatal("Failed to register agent: %v", err)
+		}
+
+		json, err := json.MarshalIndent(ag, "  ", "")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Println(string(json))
+	},
+}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -516,8 +516,8 @@ var AgentStartCommand = cli.Command{
 		// Create the API client
 		client := agent.NewAPIClient(l, apiClientConf)
 
-		// Create a Registrar for registering agents
-		reg := agent.NewRegistrar(l, client, agent.RegistrarConfig{
+		// Create a template for agent registration
+		agentTpl := agent.CreateAgentTemplate(l, agent.AgentTemplateConfig{
 			Name:                    cfg.Name,
 			Priority:                cfg.Priority,
 			Tags:                    cfg.Tags,
@@ -530,6 +530,9 @@ var AgentStartCommand = cli.Command{
 			WaitForGCPLabelsTimeout: gcpLabelsTimeout,
 			ScriptEvalEnabled:       !cfg.NoCommandEval,
 		})
+
+		// Create a registrator for registering agents
+		reg := agent.NewRegistrator(l, client, agentTpl)
 
 		// Setup the agent pool that spawns agent workers
 		pool := agent.NewAgentPool(l, reg, func(reg *api.Agent) *agent.AgentWorker {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/agent"
+	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/cliconfig"
 	"github.com/buildkite/agent/experiments"
 	"github.com/buildkite/agent/logger"
@@ -41,7 +42,6 @@ Example:
 
 type AgentStartConfig struct {
 	Config                     string   `cli:"config"`
-	Token                      string   `cli:"token" validate:"required"`
 	Name                       string   `cli:"name"`
 	Priority                   string   `cli:"priority"`
 	DisconnectAfterJob         bool     `cli:"disconnect-after-job"`
@@ -67,25 +67,30 @@ type AgentStartConfig struct {
 	GitMirrorsPath             string   `cli:"git-mirrors-path" normalize:"filepath"`
 	GitMirrorsLockTimeout      int      `cli:"git-mirrors-lock-timeout"`
 	NoGitSubmodules            bool     `cli:"no-git-submodules"`
-	NoColor                    bool     `cli:"no-color"`
 	NoSSHKeyscan               bool     `cli:"no-ssh-keyscan"`
 	NoCommandEval              bool     `cli:"no-command-eval"`
 	NoLocalHooks               bool     `cli:"no-local-hooks"`
 	NoPlugins                  bool     `cli:"no-plugins"`
 	NoPluginValidation         bool     `cli:"no-plugin-validation"`
 	NoPTY                      bool     `cli:"no-pty"`
-	NoHTTP2                    bool     `cli:"no-http2"`
 	TimestampLines             bool     `cli:"timestamp-lines"`
-	Endpoint                   string   `cli:"endpoint" validate:"required"`
-	Debug                      bool     `cli:"debug"`
-	DebugHTTP                  bool     `cli:"debug-http"`
-	DebugWithoutAPI            bool     `cli:"debug-without-api"`
-	Experiments                []string `cli:"experiment" normalize:"list"`
 	MetricsDatadog             bool     `cli:"metrics-datadog"`
 	MetricsDatadogHost         string   `cli:"metrics-datadog-host"`
 	Spawn                      int      `cli:"spawn"`
 
-	/* Deprecated */
+	// Global flags
+	Debug           bool     `cli:"debug"`
+	DebugWithoutAPI bool     `cli:"debug-without-api"`
+	NoColor         bool     `cli:"no-color"`
+	Experiments     []string `cli:"experiment" normalize:"list"`
+
+	// API config
+	DebugHTTP bool   `cli:"debug-http"`
+	Token     string `cli:"token" validate:"required"`
+	Endpoint  string `cli:"endpoint" validate:"required"`
+	NoHTTP2   bool   `cli:"no-http2"`
+
+	// Deprecated
 	NoSSHFingerprintVerification bool     `cli:"no-automatic-ssh-fingerprint-verification" deprecated-and-renamed-to:"NoSSHKeyscan"`
 	MetaData                     []string `cli:"meta-data" deprecated-and-renamed-to:"Tags"`
 	MetaDataEC2                  bool     `cli:"meta-data-ec2" deprecated-and-renamed-to:"TagsFromEC2"`
@@ -476,7 +481,43 @@ var AgentStartCommand = cli.Command{
 			DatadogHost: cfg.MetricsDatadogHost,
 		})
 
-		config := agent.AgentPoolConfig{
+		// AgentConfiguration is the runtime configuration for an agent
+		agentConf := agent.AgentConfiguration{
+			BootstrapScript:            cfg.BootstrapScript,
+			BuildPath:                  cfg.BuildPath,
+			GitMirrorsPath:             cfg.GitMirrorsPath,
+			GitMirrorsLockTimeout:      cfg.GitMirrorsLockTimeout,
+			HooksPath:                  cfg.HooksPath,
+			PluginsPath:                cfg.PluginsPath,
+			GitCloneFlags:              cfg.GitCloneFlags,
+			GitCloneMirrorFlags:        cfg.GitCloneMirrorFlags,
+			GitCleanFlags:              cfg.GitCleanFlags,
+			GitSubmodules:              !cfg.NoGitSubmodules,
+			SSHKeyscan:                 !cfg.NoSSHKeyscan,
+			CommandEval:                !cfg.NoCommandEval,
+			PluginsEnabled:             !cfg.NoPlugins,
+			PluginValidation:           !cfg.NoPluginValidation,
+			LocalHooksEnabled:          !cfg.NoLocalHooks,
+			RunInPty:                   !cfg.NoPTY,
+			TimestampLines:             cfg.TimestampLines,
+			DisconnectAfterJob:         cfg.DisconnectAfterJob,
+			DisconnectAfterJobTimeout:  cfg.DisconnectAfterJobTimeout,
+			DisconnectAfterIdleTimeout: cfg.DisconnectAfterIdleTimeout,
+			CancelGracePeriod:          cfg.CancelGracePeriod,
+			Shell:                      cfg.Shell,
+		}
+
+		if loader.File != nil {
+			agentConf.ConfigPath = loader.File.Path
+		}
+
+		apiClientConf := loadAPIClientConfig(cfg, `Token`)
+
+		// Create the API client
+		client := agent.NewAPIClient(l, apiClientConf)
+
+		// Create a Registrar for registering agents
+		reg := agent.NewRegistrar(l, client, agent.RegistrarConfig{
 			Name:                    cfg.Name,
 			Priority:                cfg.Priority,
 			Tags:                    cfg.Tags,
@@ -487,48 +528,26 @@ var AgentStartCommand = cli.Command{
 			TagsFromHost:            cfg.TagsFromHost,
 			WaitForEC2TagsTimeout:   ec2TagTimeout,
 			WaitForGCPLabelsTimeout: gcpLabelsTimeout,
-			Debug:                   cfg.Debug,
-			DisableColors:           cfg.NoColor,
-			Spawn:                   cfg.Spawn,
-			APIClientConfig:         loadAPIClientConfig(cfg, `Token`),
-			AgentConfiguration: &agent.AgentConfiguration{
-				BootstrapScript:            cfg.BootstrapScript,
-				BuildPath:                  cfg.BuildPath,
-				GitMirrorsPath:             cfg.GitMirrorsPath,
-				GitMirrorsLockTimeout:      cfg.GitMirrorsLockTimeout,
-				HooksPath:                  cfg.HooksPath,
-				PluginsPath:                cfg.PluginsPath,
-				GitCloneFlags:              cfg.GitCloneFlags,
-				GitCloneMirrorFlags:        cfg.GitCloneMirrorFlags,
-				GitCleanFlags:              cfg.GitCleanFlags,
-				GitSubmodules:              !cfg.NoGitSubmodules,
-				SSHKeyscan:                 !cfg.NoSSHKeyscan,
-				CommandEval:                !cfg.NoCommandEval,
-				PluginsEnabled:             !cfg.NoPlugins,
-				PluginValidation:           !cfg.NoPluginValidation,
-				LocalHooksEnabled:          !cfg.NoLocalHooks,
-				RunInPty:                   !cfg.NoPTY,
-				TimestampLines:             cfg.TimestampLines,
-				DisconnectAfterJob:         cfg.DisconnectAfterJob,
-				DisconnectAfterJobTimeout:  cfg.DisconnectAfterJobTimeout,
-				DisconnectAfterIdleTimeout: cfg.DisconnectAfterIdleTimeout,
-				CancelGracePeriod:          cfg.CancelGracePeriod,
-				Shell:                      cfg.Shell,
-			},
-		}
+			ScriptEvalEnabled:       !cfg.NoCommandEval,
+		})
 
-		// Store the loaded config file path on the pool and agent config so we can
-		// show it when the agent starts and set an env
-		if loader.File != nil {
-			config.ConfigFilePath = loader.File.Path
-			config.AgentConfiguration.ConfigPath = loader.File.Path
-		}
+		// Setup the agent pool that spawns agent workers
+		pool := agent.NewAgentPool(l, reg, func(reg *api.Agent) *agent.AgentWorker {
 
-		// Setup the agent
-		pool := agent.NewAgentPool(l, mc, config)
+			// Called after the pool registers and needs to create a worker
+			return agent.NewAgentWorker(l.WithPrefix(reg.Name), reg, mc, agent.AgentWorkerConfig{
+				AgentConfiguration: agentConf,
+				Debug:              cfg.Debug,
+				Endpoint:           apiClientConf.Endpoint,
+				DisableHTTP2:       apiClientConf.DisableHTTP2,
+			})
+		})
+
+		// Show the welcome banner
+		agent.ShowBanner(l, agentConf)
 
 		// Start the agent pool
-		if err := pool.Start(); err != nil {
+		if err := pool.Start(cfg.Spawn); err != nil {
 			l.Fatal("%s", err)
 		}
 	},

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func main() {
 	app.Version = agent.Version()
 	app.Commands = []cli.Command{
 		clicommand.AgentStartCommand,
+		clicommand.AgentRegisterCommand,
 		clicommand.AnnotateCommand,
 		{
 			Name:  "artifact",

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ var AppHelpTemplate = `Usage:
 
 Available commands are:
 
-  {{range .Commands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
+  {{range .VisibleCommands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
   {{end}}
 Use "{{.Name}} <command> --help" for more information about a command.
 
@@ -27,7 +27,7 @@ var SubcommandHelpTemplate = `Usage:
 
 Available commands are:
 
-   {{range .Commands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
+   {{range .VisibleCommands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
    {{end}}{{if .VisibleFlags}}
 Options:
 


### PR DESCRIPTION
This adds a hidden `register` command that will be used with a forthcoming `connect` command for an advanced agent flow where you want to split the register from the agent execution, for instance when using a K8S or ECS scheduler. 

This involves a pretty heavy refactor of the `AgentPool`. I split out the registration related parts into a `Registrator` which let me take a lot of complexity out of `AgentPool`. I'm pleased with the result and think it will make future custom agents much easier to assemble out of components. 

This PR is 98% about the refactor and 2% about the register command, but interested in feels on both.  