### PR TITLE
Refactor agent pool to externalize registration

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -1,5 +1,14 @@
 package agent
 
+import (
+	"fmt"
+	"os"
+
+	"github.com/buildkite/agent/logger"
+)
+
+// AgentConfiguration is the run-time configuration for an agent that
+// has been loaded from the config file and command-line params
 type AgentConfiguration struct {
 	ConfigPath                 string
 	BootstrapScript            string
@@ -18,10 +27,65 @@ type AgentConfiguration struct {
 	PluginValidation           bool
 	LocalHooksEnabled          bool
 	RunInPty                   bool
+	DisableColors              bool
 	TimestampLines             bool
 	DisconnectAfterJob         bool
 	DisconnectAfterJobTimeout  int
 	DisconnectAfterIdleTimeout int
 	CancelGracePeriod          int
 	Shell                      string
+}
+
+// ShowBanner prints a welcome banner and the configuration options
+func ShowBanner(l *logger.Logger, conf AgentConfiguration) {
+	welcomeMessage :=
+		"\n" +
+			"%s  _           _ _     _ _    _ _                                _\n" +
+			" | |         (_) |   | | |  (_) |                              | |\n" +
+			" | |__  _   _ _| | __| | | ___| |_ ___    __ _  __ _  ___ _ __ | |_\n" +
+			" | '_ \\| | | | | |/ _` | |/ / | __/ _ \\  / _` |/ _` |/ _ \\ '_ \\| __|\n" +
+			" | |_) | |_| | | | (_| |   <| | ||  __/ | (_| | (_| |  __/ | | | |_\n" +
+			" |_.__/ \\__,_|_|_|\\__,_|_|\\_\\_|\\__\\___|  \\__,_|\\__, |\\___|_| |_|\\__|\n" +
+			"                                                __/ |\n" +
+			" http://buildkite.com/agent                    |___/\n%s\n"
+
+	if !conf.DisableColors {
+		fmt.Fprintf(os.Stderr, welcomeMessage, "\x1b[38;5;48m", "\x1b[0m")
+	} else {
+		fmt.Fprintf(os.Stderr, welcomeMessage, "", "")
+	}
+
+	l.Notice("Starting buildkite-agent v%s with PID: %s", Version(), fmt.Sprintf("%d", os.Getpid()))
+	l.Notice("The agent source code can be found here: https://github.com/buildkite/agent")
+	l.Notice("For questions and support, email us at: hello@buildkite.com")
+
+	if conf.ConfigPath != "" {
+		l.Info("Configuration loaded from: %s", conf.ConfigPath)
+	}
+
+	l.Debug("Bootstrap command: %s", conf.BootstrapScript)
+	l.Debug("Build path: %s", conf.BuildPath)
+	l.Debug("Hooks directory: %s", conf.HooksPath)
+	l.Debug("Plugins directory: %s", conf.PluginsPath)
+
+	if !conf.SSHKeyscan {
+		l.Info("Automatic ssh-keyscan has been disabled")
+	}
+
+	if !conf.CommandEval {
+		l.Info("Evaluating console commands has been disabled")
+	}
+
+	if !conf.PluginsEnabled {
+		l.Info("Plugins have been disabled")
+	}
+
+	if !conf.RunInPty {
+		l.Info("Running builds within a pseudoterminal (PTY) has been disabled")
+	}
+
+	if conf.DisconnectAfterJob {
+		l.Info("Agent will disconnect after a job run has completed with a timeout of %d seconds",
+			conf.DisconnectAfterJobTimeout)
+	}
 }

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -1,81 +1,43 @@
 package agent
 
 import (
-	"errors"
-	"fmt"
-	"os"
-	"runtime"
-	"strings"
 	"sync"
-	"time"
 
-	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/logger"
-	"github.com/buildkite/agent/metrics"
-	"github.com/buildkite/agent/retry"
 	"github.com/buildkite/agent/signalwatcher"
-	"github.com/buildkite/agent/system"
-	"github.com/denisbrodbeck/machineid"
 )
 
-type AgentPoolConfig struct {
-	ConfigFilePath          string
-	Name                    string
-	Priority                string
-	Tags                    []string
-	TagsFromEC2             bool
-	TagsFromEC2Tags         bool
-	TagsFromGCP             bool
-	TagsFromGCPLabels       bool
-	TagsFromHost            bool
-	WaitForEC2TagsTimeout   time.Duration
-	WaitForGCPLabelsTimeout time.Duration
-	Debug                   bool
-	DisableColors           bool
-	Spawn                   int
-	AgentConfiguration      *AgentConfiguration
-	APIClientConfig         APIClientConfig
-}
-
+// AgentPool manages multiple parallel AgentWorkers
 type AgentPool struct {
-	conf             AgentPoolConfig
-	logger           *logger.Logger
-	apiClient        *api.Client
-	metricsCollector *metrics.Collector
-	interruptCount   int
-	signalLock       sync.Mutex
+	logger  *logger.Logger
+	workers []*AgentWorker
 }
 
-func NewAgentPool(l *logger.Logger, m *metrics.Collector, c AgentPoolConfig) *AgentPool {
+// NewAgentPool returns a new AgentPool
+func NewAgentPool(l *logger.Logger, workers []*AgentWorker) *AgentPool {
 	return &AgentPool{
-		conf:             c,
-		logger:           l,
-		metricsCollector: m,
-		apiClient:        NewAPIClient(l, c.APIClientConfig),
+		logger:  l,
+		workers: workers,
 	}
 }
 
+// Start kicks off the parallel AgentWorkers and waits for them to finish
 func (r *AgentPool) Start() error {
-	// Show the welcome banner and config options used
-	r.ShowBanner()
-
 	var wg sync.WaitGroup
-	var errs = make(chan error, r.conf.Spawn)
+	var spawn int = len(r.workers)
+	var errs = make(chan error, spawn)
 
-	for i := 0; i < r.conf.Spawn; i++ {
-		if r.conf.Spawn == 1 {
-			r.logger.Info("Registering agent with Buildkite...")
-		} else {
-			r.logger.Info("Registering agent %d of %d with Buildkite...", i+1, r.conf.Spawn)
-		}
-
+	// Spawn goroutines for each parallel worker
+	for _, worker := range r.workers {
 		wg.Add(1)
-		go func() {
+
+		go func(worker *AgentWorker) {
 			defer wg.Done()
-			if err := r.startWorker(); err != nil {
+
+			if err := r.runWorker(worker); err != nil {
 				errs <- err
 			}
-		}()
+		}(worker)
 	}
 
 	go func() {
@@ -83,82 +45,27 @@ func (r *AgentPool) Start() error {
 		close(errs)
 	}()
 
-	r.logger.Info("Started %d Agent(s)", r.conf.Spawn)
+	// Listen for process signals
+	r.watchWorkers()
+
+	r.logger.Info("Started %d Agent(s)", spawn)
 	r.logger.Info("You can press Ctrl-C to stop the agents")
 
 	return <-errs
 }
 
-func (r *AgentPool) startWorker() error {
-	registered, err := r.RegisterAgent(r.CreateAgentTemplate())
-	if err != nil {
-		return err
-	}
-
-	r.logger.Info("Successfully registered agent \"%s\" with tags [%s]", registered.Name,
-		strings.Join(registered.Tags, ", "))
-
-	// Create a prefixed logger for some context in concurrent output
-	l := r.logger.WithPrefix(registered.Name)
-
-	l.Debug("Ping interval: %ds", registered.PingInterval)
-	l.Debug("Job status interval: %ds", registered.JobStatusInterval)
-	l.Debug("Heartbeat interval: %ds", registered.HearbeatInterval)
-
-	// Now that we have a registered agent, we can connect it to the API,
-	// and start running jobs.
-	worker := NewAgentWorker(l, registered, r.metricsCollector, AgentWorkerConfig{
-		AgentConfiguration: r.conf.AgentConfiguration,
-		Debug:              r.conf.Debug,
-		Endpoint:           r.conf.APIClientConfig.Endpoint,
-		DisableHTTP2:       r.conf.APIClientConfig.DisableHTTP2,
-	})
-
-	l.Info("Connecting to Buildkite...")
+func (r *AgentPool) runWorker(worker *AgentWorker) error {
+	// Connect the worker to the API
 	if err := worker.Connect(); err != nil {
 		return err
 	}
 
-	if r.conf.AgentConfiguration.DisconnectAfterJob {
-		l.Info("Waiting for job to be assigned...")
-		l.Info("The agent will automatically disconnect after %d seconds if no job is assigned", r.conf.AgentConfiguration.DisconnectAfterJobTimeout)
-	} else if r.conf.AgentConfiguration.DisconnectAfterIdleTimeout > 0 {
-		l.Info("Waiting for job to be assigned...")
-		l.Info("The agent will automatically disconnect after %d seconds of inactivity", r.conf.AgentConfiguration.DisconnectAfterIdleTimeout)
-	} else {
-		l.Info("Waiting for work...")
-	}
-
-	// Start a signalwatcher so we can monitor signals and handle shutdowns
-	signalwatcher.Watch(func(sig signalwatcher.Signal) {
-		r.signalLock.Lock()
-		defer r.signalLock.Unlock()
-
-		if sig == signalwatcher.QUIT {
-			l.Debug("Received signal `%s`", sig.String())
-			worker.Stop(false)
-		} else if sig == signalwatcher.TERM || sig == signalwatcher.INT {
-			l.Debug("Received signal `%s`", sig.String())
-			if r.interruptCount == 0 {
-				r.interruptCount++
-				l.Info("Received CTRL-C, send again to forcefully kill the agent")
-				worker.Stop(true)
-			} else {
-				l.Info("Forcefully stopping running jobs and stopping the agent")
-				worker.Stop(false)
-			}
-		} else {
-			l.Debug("Ignoring signal `%s`", sig.String())
-		}
-	})
-
-	// Starts the agent worker.
+	// Starts the agent worker and wait for it to finish
 	if err := worker.Start(); err != nil {
 		return err
 	}
 
 	// Now that the agent has stopped, we can disconnect it
-	l.Info("Disconnecting %s...", worker.agent.Name)
 	if err := worker.Disconnect(); err != nil {
 		return err
 	}
@@ -166,225 +73,35 @@ func (r *AgentPool) startWorker() error {
 	return nil
 }
 
-// Takes the options passed to the CLI, and creates an api.Agent record that
-// will be sent to the Buildkite Agent API for registration.
-func (r *AgentPool) CreateAgentTemplate() *api.Agent {
-	agent := &api.Agent{
-		Name:              r.conf.Name,
-		Priority:          r.conf.Priority,
-		Tags:              r.conf.Tags,
-		ScriptEvalEnabled: r.conf.AgentConfiguration.CommandEval,
-		Version:           Version(),
-		Build:             BuildVersion(),
-		PID:               os.Getpid(),
-		Arch:              runtime.GOARCH,
-	}
+func (r *AgentPool) watchWorkers() {
+	var signalLock sync.Mutex
+	var interruptCount int
 
-	// get a unique identifier for the underlying host
-	if machineID, err := machineid.ProtectedID("buildkite-agent"); err != nil {
-		r.logger.Warn("Failed to find unique machine-id: %v", err)
-	} else {
-		agent.MachineID = machineID
-	}
+	signalwatcher.Watch(func(sig signalwatcher.Signal) {
+		signalLock.Lock()
+		defer signalLock.Unlock()
 
-	// Attempt to add the EC2 tags
-	if r.conf.TagsFromEC2 {
-		r.logger.Info("Fetching EC2 meta-data...")
-
-		err := retry.Do(func(s *retry.Stats) error {
-			tags, err := EC2MetaData{}.Get()
-			if err != nil {
-				r.logger.Warn("%s (%s)", err, s)
-			} else {
-				r.logger.Info("Successfully fetched EC2 meta-data")
-				for tag, value := range tags {
-					agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
+		if sig == signalwatcher.QUIT {
+			r.logger.Debug("Received signal `%s`", sig.String())
+			for _, worker := range r.workers {
+				worker.Stop(false)
+			}
+		} else if sig == signalwatcher.TERM || sig == signalwatcher.INT {
+			r.logger.Debug("Received signal `%s`", sig.String())
+			if interruptCount == 0 {
+				interruptCount++
+				r.logger.Info("Received CTRL-C, send again to forcefully kill the agent(s)")
+				for _, worker := range r.workers {
+					worker.Stop(true)
 				}
-				s.Break()
-			}
-
-			return err
-		}, &retry.Config{Maximum: 5, Interval: 1 * time.Second, Jitter: true})
-
-		// Don't blow up if we can't find them, just show a nasty error.
-		if err != nil {
-			r.logger.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
-		}
-	}
-
-	// Attempt to add the EC2 tags
-	if r.conf.TagsFromEC2Tags {
-		r.logger.Info("Fetching EC2 tags...")
-		err := retry.Do(func(s *retry.Stats) error {
-			tags, err := EC2Tags{}.Get()
-			// EC2 tags are apparently "eventually consistent" and sometimes take several seconds
-			// to be applied to instances. This error will cause retries.
-			if err == nil && len(tags) == 0 {
-				err = errors.New("EC2 tags are empty")
-			}
-			if err != nil {
-				r.logger.Warn("%s (%s)", err, s)
 			} else {
-				r.logger.Info("Successfully fetched EC2 tags")
-				for tag, value := range tags {
-					agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
+				r.logger.Info("Forcefully stopping running jobs and stopping the agent(s)")
+				for _, worker := range r.workers {
+					worker.Stop(false)
 				}
-				s.Break()
 			}
-			return err
-		}, &retry.Config{Maximum: 5, Interval: r.conf.WaitForEC2TagsTimeout / 5, Jitter: true})
-
-		// Don't blow up if we can't find them, just show a nasty error.
-		if err != nil {
-			r.logger.Error(fmt.Sprintf("Failed to find EC2 tags: %s", err.Error()))
-		}
-	}
-
-	// Attempt to add the Google Cloud meta-data
-	if r.conf.TagsFromGCP {
-		tags, err := GCPMetaData{}.Get()
-		if err != nil {
-			// Don't blow up if we can't find them, just show a nasty error.
-			r.logger.Error(fmt.Sprintf("Failed to fetch Google Cloud meta-data: %s", err.Error()))
 		} else {
-			for tag, value := range tags {
-				agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
-			}
+			r.logger.Debug("Ignoring signal `%s`", sig.String())
 		}
-	}
-
-	// Attempt to add the Google Compute instance labels
-	if r.conf.TagsFromGCPLabels {
-		r.logger.Info("Fetching GCP instance labels...")
-		err := retry.Do(func(s *retry.Stats) error {
-			labels, err := GCPLabels{}.Get()
-			if err == nil && len(labels) == 0 {
-				err = errors.New("GCP instance labels are empty")
-			}
-			if err != nil {
-				r.logger.Warn("%s (%s)", err, s)
-			} else {
-				r.logger.Info("Successfully fetched GCP instance labels")
-				for label, value := range labels {
-					agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", label, value))
-				}
-				s.Break()
-			}
-			return err
-		}, &retry.Config{Maximum: 5, Interval: r.conf.WaitForGCPLabelsTimeout / 5, Jitter: true})
-
-		// Don't blow up if we can't find them, just show a nasty error.
-		if err != nil {
-			r.logger.Error(fmt.Sprintf("Failed to find GCP instance labels: %s", err.Error()))
-		}
-	}
-
-	var err error
-
-	// Add the hostname
-	agent.Hostname, err = os.Hostname()
-	if err != nil {
-		r.logger.Warn("Failed to find hostname: %s", err)
-	}
-
-	// Add the OS dump
-	agent.OS, err = system.VersionDump(r.logger)
-	if err != nil {
-		r.logger.Warn("Failed to find OS information: %s", err)
-	}
-
-	// Attempt to add the host tags
-	if r.conf.TagsFromHost {
-		agent.Tags = append(agent.Tags,
-			fmt.Sprintf("hostname=%s", agent.Hostname),
-			fmt.Sprintf("os=%s", runtime.GOOS),
-		)
-		if agent.MachineID != "" {
-			agent.Tags = append(agent.Tags, fmt.Sprintf("machine-id=%s", agent.MachineID))
-		}
-	}
-
-	return agent
-}
-
-// Takes the agent template and returns a registered agent. The registered
-// agent includes the Access Token used to communicate with the Buildkite Agent
-// API
-func (r *AgentPool) RegisterAgent(agent *api.Agent) (*api.Agent, error) {
-	var registered *api.Agent
-	var err error
-	var resp *api.Response
-
-	register := func(s *retry.Stats) error {
-		registered, resp, err = r.apiClient.Agents.Register(agent)
-		if err != nil {
-			if resp != nil && resp.StatusCode == 401 {
-				r.logger.Warn("Buildkite rejected the registration (%s)", err)
-				s.Break()
-			} else {
-				r.logger.Warn("%s (%s)", err, s)
-			}
-		}
-
-		return err
-	}
-
-	// Try to register, retrying every 10 seconds for a maximum of 30 attempts (5 minutes)
-	err = retry.Do(register, &retry.Config{Maximum: 30, Interval: 10 * time.Second})
-
-	return registered, err
-}
-
-// Shows the welcome banner and the configuration options used when starting
-// this agent.
-func (r *AgentPool) ShowBanner() {
-	welcomeMessage :=
-		"\n" +
-			"%s  _           _ _     _ _    _ _                                _\n" +
-			" | |         (_) |   | | |  (_) |                              | |\n" +
-			" | |__  _   _ _| | __| | | ___| |_ ___    __ _  __ _  ___ _ __ | |_\n" +
-			" | '_ \\| | | | | |/ _` | |/ / | __/ _ \\  / _` |/ _` |/ _ \\ '_ \\| __|\n" +
-			" | |_) | |_| | | | (_| |   <| | ||  __/ | (_| | (_| |  __/ | | | |_\n" +
-			" |_.__/ \\__,_|_|_|\\__,_|_|\\_\\_|\\__\\___|  \\__,_|\\__, |\\___|_| |_|\\__|\n" +
-			"                                                __/ |\n" +
-			" http://buildkite.com/agent                    |___/\n%s\n"
-
-	if !r.conf.DisableColors {
-		fmt.Fprintf(os.Stderr, welcomeMessage, "\x1b[38;5;48m", "\x1b[0m")
-	} else {
-		fmt.Fprintf(os.Stderr, welcomeMessage, "", "")
-	}
-
-	r.logger.Notice("Starting buildkite-agent v%s with PID: %s", Version(), fmt.Sprintf("%d", os.Getpid()))
-	r.logger.Notice("The agent source code can be found here: https://github.com/buildkite/agent")
-	r.logger.Notice("For questions and support, email us at: hello@buildkite.com")
-
-	if r.conf.ConfigFilePath != "" {
-		r.logger.Info("Configuration loaded from: %s", r.conf.ConfigFilePath)
-	}
-
-	r.logger.Debug("Bootstrap command: %s", r.conf.AgentConfiguration.BootstrapScript)
-	r.logger.Debug("Build path: %s", r.conf.AgentConfiguration.BuildPath)
-	r.logger.Debug("Hooks directory: %s", r.conf.AgentConfiguration.HooksPath)
-	r.logger.Debug("Plugins directory: %s", r.conf.AgentConfiguration.PluginsPath)
-
-	if !r.conf.AgentConfiguration.SSHKeyscan {
-		r.logger.Info("Automatic ssh-keyscan has been disabled")
-	}
-
-	if !r.conf.AgentConfiguration.CommandEval {
-		r.logger.Info("Evaluating console commands has been disabled")
-	}
-
-	if !r.conf.AgentConfiguration.PluginsEnabled {
-		r.logger.Info("Plugins have been disabled")
-	}
-
-	if !r.conf.AgentConfiguration.RunInPty {
-		r.logger.Info("Running builds within a pseudoterminal (PTY) has been disabled")
-	}
-
-	if r.conf.AgentConfiguration.DisconnectAfterJob {
-		r.logger.Info("Agent will disconnect after a job run has completed with a timeout of %d seconds", r.conf.AgentConfiguration.DisconnectAfterJobTimeout)
-	}
+	})
 }

--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -26,7 +26,7 @@ func TestJobRunnerPassesAccessTokenToBootstrap(t *testing.T) {
 		},
 	}
 
-	cfg := &agent.AgentConfiguration{}
+	cfg := agent.AgentConfiguration{}
 
 	runJob(t, ag, j, cfg, func(c *bintest.Call) {
 		if c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN") != `llamasrock` {
@@ -51,7 +51,7 @@ func TestJobRunnerIgnoresPipelineChangesToProtectedVars(t *testing.T) {
 		},
 	}
 
-	cfg := &agent.AgentConfiguration{
+	cfg := agent.AgentConfiguration{
 		CommandEval: true,
 	}
 
@@ -65,7 +65,7 @@ func TestJobRunnerIgnoresPipelineChangesToProtectedVars(t *testing.T) {
 
 }
 
-func runJob(t *testing.T, ag *api.Agent, j *api.Job, cfg *agent.AgentConfiguration, bootstrap func(c *bintest.Call)) {
+func runJob(t *testing.T, ag *api.Agent, j *api.Job, cfg agent.AgentConfiguration, bootstrap func(c *bintest.Call)) {
 	// create a mock agent API
 	server := createTestAgentEndpoint(t, `my-job-id`)
 	defer server.Close()
@@ -90,7 +90,7 @@ func runJob(t *testing.T, ag *api.Agent, j *api.Job, cfg *agent.AgentConfigurati
 	cfg.BootstrapScript = bs.Path
 
 	jr, err := agent.NewJobRunner(l, scope, ag, j, agent.JobRunnerConfig{
-		Endpoint:           server.URL,
+		Endpoint:    server.URL,
 		AgentConfiguration: cfg,
 	})
 	if err != nil {

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -25,7 +25,7 @@ type JobRunnerConfig struct {
 	Endpoint string
 
 	// The configuration of the agent from the CLI
-	AgentConfiguration *AgentConfiguration
+	AgentConfiguration AgentConfiguration
 
 	// Whether to set debug in the job
 	Debug bool

--- a/agent/register.go
+++ b/agent/register.go
@@ -1,0 +1,99 @@
+package agent
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/buildkite/agent/api"
+	"github.com/buildkite/agent/logger"
+	"github.com/buildkite/agent/retry"
+	"github.com/buildkite/agent/system"
+)
+
+// AgentTemplate represents an Agent to be registered
+type AgentTemplate struct {
+	Name              string
+	Priority          string
+	Tags              []string
+	ScriptEvalEnabled bool
+}
+
+// Build an api.Agent out of the Template populated with system info
+func (a AgentTemplate) Build(l *logger.Logger) *api.Agent {
+	agent := &api.Agent{
+		Name:              a.Name,
+		Priority:          a.Priority,
+		Tags:              a.Tags,
+		ScriptEvalEnabled: a.ScriptEvalEnabled,
+		Version:           Version(),
+		Build:             BuildVersion(),
+		PID:               os.Getpid(),
+		Arch:              runtime.GOARCH,
+	}
+
+	machineID, err := system.MachineID()
+	if err != nil {
+		l.Warn("Failed to find unique machine-id: %v", err)
+	} else {
+		agent.MachineID = machineID
+	}
+
+	// Add the hostname
+	agent.Hostname, err = os.Hostname()
+	if err != nil {
+		l.Warn("Failed to find hostname: %s", err)
+	}
+
+	// Add the OS dump
+	agent.OS, err = system.VersionDump(l)
+	if err != nil {
+		l.Warn("Failed to find OS information: %s", err)
+	}
+
+	return agent
+}
+
+// Register takes an AgentTemplate and registers it with the Buildkite API
+func Register(l *logger.Logger, ac *api.Client, tpl AgentTemplate) (*api.Agent, error) {
+	var registered *api.Agent
+	var err error
+	var resp *api.Response
+
+	// Build the template into an Agent record that is filled out in the register call
+	agent := tpl.Build(l)
+
+	l.Info("Registering agent with Buildkite...")
+
+	register := func(s *retry.Stats) error {
+		registered, resp, err = ac.Agents.Register(agent)
+		if err != nil {
+			if resp != nil && resp.StatusCode == 401 {
+				l.Warn("Buildkite rejected the registration (%s)", err)
+				s.Break()
+			} else {
+				l.Warn("%s (%s)", err, s)
+			}
+		}
+
+		return err
+	}
+
+	// Try to register, retrying every 10 seconds for a maximum of 30 attempts (5 minutes)
+	err = retry.Do(register, &retry.Config{Maximum: 30, Interval: 10 * time.Second})
+	if err != nil {
+		l.Info("Successfully registered agent \"%s\" with tags [%s]", registered.Name,
+			strings.Join(registered.Tags, ", "))
+
+		l.Debug("Ping interval: %ds", registered.PingInterval)
+		l.Debug("Job status interval: %ds", registered.JobStatusInterval)
+		l.Debug("Heartbeat interval: %ds", registered.HearbeatInterval)
+
+		if registered.Endpoint != "" {
+			l.Debug("Endpoint: %s", registered.Endpoint)
+		}
+	}
+
+	return registered, err
+}

--- a/agent/tags.go
+++ b/agent/tags.go
@@ -1,0 +1,159 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/buildkite/agent/logger"
+	"github.com/buildkite/agent/retry"
+	"github.com/buildkite/agent/system"
+)
+
+type FetchTagsConfig struct {
+	Tags                    []string
+	TagsFromEC2             bool
+	TagsFromEC2Tags         bool
+	TagsFromGCP             bool
+	TagsFromGCPLabels       bool
+	TagsFromHost            bool
+	WaitForEC2TagsTimeout   time.Duration
+	WaitForGCPLabelsTimeout time.Duration
+}
+
+// FetchTags loads tags from a variety of sources
+func FetchTags(l *logger.Logger, conf FetchTagsConfig) []string {
+	tags := conf.Tags
+
+	// Load tags from host
+	if conf.TagsFromHost {
+		var tags []string
+
+		hostname, err := os.Hostname()
+		if err != nil {
+			l.Warn("Failed to find hostname: %v", err)
+		}
+
+		machineID, err := system.MachineID()
+		if err != nil {
+			l.Warn("Failed to find machine id: %v", err)
+		}
+
+		tags = append(tags,
+			fmt.Sprintf("hostname=%s", hostname),
+			fmt.Sprintf("os=%s", runtime.GOOS),
+		)
+
+		if machineID != "" {
+			tags = append(tags, fmt.Sprintf("machine-id=%s", machineID))
+		}
+
+		return tags
+	}
+
+	var awsSess *session.Session
+	if conf.TagsFromEC2 || conf.TagsFromEC2Tags {
+		var err error
+		awsSess, err = awsSession()
+		if err != nil {
+			l.Warn("Failed to get aws session: %v", err)
+		}
+	}
+
+	// Attempt to add the EC2 tags
+	if conf.TagsFromEC2 && awsSess != nil {
+		l.Info("Fetching EC2 meta-data...")
+
+		err := retry.Do(func(s *retry.Stats) error {
+			ec2Tags, err := system.EC2MetaData(awsSess)
+			if err != nil {
+				l.Warn("%s (%s)", err, s)
+			} else {
+				l.Info("Successfully fetched EC2 meta-data")
+				for tag, value := range ec2Tags {
+					tags = append(tags, fmt.Sprintf("%s=%s", tag, value))
+				}
+				s.Break()
+			}
+
+			return err
+		}, &retry.Config{Maximum: 5, Interval: 1 * time.Second, Jitter: true})
+
+		// Don't blow up if we can't find them, just show a nasty error.
+		if err != nil {
+			l.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
+		}
+	}
+
+	// Attempt to add the EC2 tags
+	if conf.TagsFromEC2Tags && awsSess != nil {
+		l.Info("Fetching EC2 tags...")
+		err := retry.Do(func(s *retry.Stats) error {
+			ec2Tags, err := system.EC2Tags(awsSess)
+			// EC2 tags are apparently "eventually consistent" and sometimes take several seconds
+			// to be applied to instances. This error will cause retries.
+			if err == nil && len(tags) == 0 {
+				err = errors.New("EC2 tags are empty")
+			}
+			if err != nil {
+				l.Warn("%s (%s)", err, s)
+			} else {
+				l.Info("Successfully fetched EC2 tags")
+				for tag, value := range ec2Tags {
+					tags = append(tags, fmt.Sprintf("%s=%s", tag, value))
+				}
+				s.Break()
+			}
+			return err
+		}, &retry.Config{Maximum: 5, Interval: conf.WaitForEC2TagsTimeout / 5, Jitter: true})
+
+		// Don't blow up if we can't find them, just show a nasty error.
+		if err != nil {
+			l.Error(fmt.Sprintf("Failed to find EC2 tags: %s", err.Error()))
+		}
+	}
+
+	// Attempt to add the Google Cloud meta-data
+	if conf.TagsFromGCP {
+		gcpTags, err := system.GCPMetaData()
+		if err != nil {
+			// Don't blow up if we can't find them, just show a nasty error.
+			l.Error(fmt.Sprintf("Failed to fetch Google Cloud meta-data: %s", err.Error()))
+		} else {
+			for tag, value := range gcpTags {
+				tags = append(tags, fmt.Sprintf("%s=%s", tag, value))
+			}
+		}
+	}
+
+	// Attempt to add the Google Compute instance labels
+	if conf.TagsFromGCPLabels {
+		l.Info("Fetching GCP instance labels...")
+		err := retry.Do(func(s *retry.Stats) error {
+			labels, err := system.GCPLabels()
+			if err == nil && len(labels) == 0 {
+				err = errors.New("GCP instance labels are empty")
+			}
+			if err != nil {
+				l.Warn("%s (%s)", err, s)
+			} else {
+				l.Info("Successfully fetched GCP instance labels")
+				for label, value := range labels {
+					tags = append(tags, fmt.Sprintf("%s=%s", label, value))
+				}
+				s.Break()
+			}
+			return err
+		}, &retry.Config{Maximum: 5, Interval: conf.WaitForGCPLabelsTimeout / 5, Jitter: true})
+
+		// Don't blow up if we can't find them, just show a nasty error.
+		if err != nil {
+			l.Error(fmt.Sprintf("Failed to find GCP instance labels: %s", err.Error()))
+		}
+	}
+
+	return tags
+}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -41,7 +41,6 @@ Example:
 
 type AgentStartConfig struct {
 	Config                     string   `cli:"config"`
-	Token                      string   `cli:"token" validate:"required"`
 	Name                       string   `cli:"name"`
 	Priority                   string   `cli:"priority"`
 	DisconnectAfterJob         bool     `cli:"disconnect-after-job"`
@@ -67,25 +66,30 @@ type AgentStartConfig struct {
 	GitMirrorsPath             string   `cli:"git-mirrors-path" normalize:"filepath"`
 	GitMirrorsLockTimeout      int      `cli:"git-mirrors-lock-timeout"`
 	NoGitSubmodules            bool     `cli:"no-git-submodules"`
-	NoColor                    bool     `cli:"no-color"`
 	NoSSHKeyscan               bool     `cli:"no-ssh-keyscan"`
 	NoCommandEval              bool     `cli:"no-command-eval"`
 	NoLocalHooks               bool     `cli:"no-local-hooks"`
 	NoPlugins                  bool     `cli:"no-plugins"`
 	NoPluginValidation         bool     `cli:"no-plugin-validation"`
 	NoPTY                      bool     `cli:"no-pty"`
-	NoHTTP2                    bool     `cli:"no-http2"`
 	TimestampLines             bool     `cli:"timestamp-lines"`
-	Endpoint                   string   `cli:"endpoint" validate:"required"`
-	Debug                      bool     `cli:"debug"`
-	DebugHTTP                  bool     `cli:"debug-http"`
-	DebugWithoutAPI            bool     `cli:"debug-without-api"`
-	Experiments                []string `cli:"experiment" normalize:"list"`
 	MetricsDatadog             bool     `cli:"metrics-datadog"`
 	MetricsDatadogHost         string   `cli:"metrics-datadog-host"`
 	Spawn                      int      `cli:"spawn"`
 
-	/* Deprecated */
+	// Global flags
+	Debug           bool     `cli:"debug"`
+	DebugWithoutAPI bool     `cli:"debug-without-api"`
+	NoColor         bool     `cli:"no-color"`
+	Experiments     []string `cli:"experiment" normalize:"list"`
+
+	// API config
+	DebugHTTP bool   `cli:"debug-http"`
+	Token     string `cli:"token" validate:"required"`
+	Endpoint  string `cli:"endpoint" validate:"required"`
+	NoHTTP2   bool   `cli:"no-http2"`
+
+	// Deprecated
 	NoSSHFingerprintVerification bool     `cli:"no-automatic-ssh-fingerprint-verification" deprecated-and-renamed-to:"NoSSHKeyscan"`
 	MetaData                     []string `cli:"meta-data" deprecated-and-renamed-to:"Tags"`
 	MetaDataEC2                  bool     `cli:"meta-data-ec2" deprecated-and-renamed-to:"TagsFromEC2"`
@@ -476,9 +480,46 @@ var AgentStartCommand = cli.Command{
 			DatadogHost: cfg.MetricsDatadogHost,
 		})
 
-		config := agent.AgentPoolConfig{
-			Name:                    cfg.Name,
-			Priority:                cfg.Priority,
+		// AgentConfiguration is the runtime configuration for an agent
+		agentConf := agent.AgentConfiguration{
+			BootstrapScript:            cfg.BootstrapScript,
+			BuildPath:                  cfg.BuildPath,
+			GitMirrorsPath:             cfg.GitMirrorsPath,
+			GitMirrorsLockTimeout:      cfg.GitMirrorsLockTimeout,
+			HooksPath:                  cfg.HooksPath,
+			PluginsPath:                cfg.PluginsPath,
+			GitCloneFlags:              cfg.GitCloneFlags,
+			GitCloneMirrorFlags:        cfg.GitCloneMirrorFlags,
+			GitCleanFlags:              cfg.GitCleanFlags,
+			GitSubmodules:              !cfg.NoGitSubmodules,
+			SSHKeyscan:                 !cfg.NoSSHKeyscan,
+			CommandEval:                !cfg.NoCommandEval,
+			PluginsEnabled:             !cfg.NoPlugins,
+			PluginValidation:           !cfg.NoPluginValidation,
+			LocalHooksEnabled:          !cfg.NoLocalHooks,
+			RunInPty:                   !cfg.NoPTY,
+			TimestampLines:             cfg.TimestampLines,
+			DisconnectAfterJob:         cfg.DisconnectAfterJob,
+			DisconnectAfterJobTimeout:  cfg.DisconnectAfterJobTimeout,
+			DisconnectAfterIdleTimeout: cfg.DisconnectAfterIdleTimeout,
+			CancelGracePeriod:          cfg.CancelGracePeriod,
+			Shell:                      cfg.Shell,
+		}
+
+		if loader.File != nil {
+			agentConf.ConfigPath = loader.File.Path
+		}
+
+		// Show the welcome banner
+		agent.ShowBanner(l, agentConf)
+
+		apiClientConf := loadAPIClientConfig(cfg, `Token`)
+
+		// Create the API client
+		client := agent.NewAPIClient(l, apiClientConf)
+
+		// Fetch the tags for the agent
+		tags := agent.FetchTags(l, agent.FetchTagsConfig{
 			Tags:                    cfg.Tags,
 			TagsFromEC2:             cfg.TagsFromEC2,
 			TagsFromEC2Tags:         cfg.TagsFromEC2Tags,
@@ -487,45 +528,41 @@ var AgentStartCommand = cli.Command{
 			TagsFromHost:            cfg.TagsFromHost,
 			WaitForEC2TagsTimeout:   ec2TagTimeout,
 			WaitForGCPLabelsTimeout: gcpLabelsTimeout,
-			Debug:                   cfg.Debug,
-			DisableColors:           cfg.NoColor,
-			Spawn:                   cfg.Spawn,
-			APIClientConfig:         loadAPIClientConfig(cfg, `Token`),
-			AgentConfiguration: &agent.AgentConfiguration{
-				BootstrapScript:            cfg.BootstrapScript,
-				BuildPath:                  cfg.BuildPath,
-				GitMirrorsPath:             cfg.GitMirrorsPath,
-				GitMirrorsLockTimeout:      cfg.GitMirrorsLockTimeout,
-				HooksPath:                  cfg.HooksPath,
-				PluginsPath:                cfg.PluginsPath,
-				GitCloneFlags:              cfg.GitCloneFlags,
-				GitCloneMirrorFlags:        cfg.GitCloneMirrorFlags,
-				GitCleanFlags:              cfg.GitCleanFlags,
-				GitSubmodules:              !cfg.NoGitSubmodules,
-				SSHKeyscan:                 !cfg.NoSSHKeyscan,
-				CommandEval:                !cfg.NoCommandEval,
-				PluginsEnabled:             !cfg.NoPlugins,
-				PluginValidation:           !cfg.NoPluginValidation,
-				LocalHooksEnabled:          !cfg.NoLocalHooks,
-				RunInPty:                   !cfg.NoPTY,
-				TimestampLines:             cfg.TimestampLines,
-				DisconnectAfterJob:         cfg.DisconnectAfterJob,
-				DisconnectAfterJobTimeout:  cfg.DisconnectAfterJobTimeout,
-				DisconnectAfterIdleTimeout: cfg.DisconnectAfterIdleTimeout,
-				CancelGracePeriod:          cfg.CancelGracePeriod,
-				Shell:                      cfg.Shell,
-			},
+		})
+
+		var workers []*agent.AgentWorker
+
+		for i := 1; i <= cfg.Spawn; i++ {
+			if cfg.Spawn == 1 {
+				l.Info("Registering agent with Buildkite...")
+			} else {
+				l.Info("Registering agent %d of %d with Buildkite...", i, cfg.Spawn)
+			}
+
+			// Register the agent with the buildkite API
+			ag, err := agent.Register(l, client, agent.AgentTemplate{
+				Name:              cfg.Name,
+				Priority:          cfg.Priority,
+				Tags:              tags,
+				ScriptEvalEnabled: !cfg.NoCommandEval,
+			})
+			if err != nil {
+				l.Fatal("%s", err)
+			}
+
+			// Create an agent worker to run the agent
+			worker := agent.NewAgentWorker(l.WithPrefix(ag.Name), ag, mc, agent.AgentWorkerConfig{
+				AgentConfiguration: agentConf,
+				Debug:              cfg.Debug,
+				Endpoint:           apiClientConf.Endpoint,
+				DisableHTTP2:       apiClientConf.DisableHTTP2,
+			})
+
+			workers = append(workers, worker)
 		}
 
-		// Store the loaded config file path on the pool and agent config so we can
-		// show it when the agent starts and set an env
-		if loader.File != nil {
-			config.ConfigFilePath = loader.File.Path
-			config.AgentConfiguration.ConfigPath = loader.File.Path
-		}
-
-		// Setup the agent
-		pool := agent.NewAgentPool(l, mc, config)
+		// Setup the agent pool that spawns agent workers
+		pool := agent.NewAgentPool(l, workers)
 
 		// Start the agent pool
 		if err := pool.Start(); err != nil {

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ var AppHelpTemplate = `Usage:
 
 Available commands are:
 
-  {{range .Commands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
+  {{range .VisibleCommands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
   {{end}}
 Use "{{.Name}} <command> --help" for more information about a command.
 
@@ -27,7 +27,7 @@ var SubcommandHelpTemplate = `Usage:
 
 Available commands are:
 
-   {{range .Commands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
+   {{range .VisibleCommands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
    {{end}}{{if .VisibleFlags}}
 Options:
 

--- a/system/ec2_meta_data.go
+++ b/system/ec2_meta_data.go
@@ -1,18 +1,11 @@
-package agent
+package system
 
 import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
-type EC2MetaData struct {
-}
-
-func (e EC2MetaData) Get() (map[string]string, error) {
-	sess, err := awsSession()
-	if err != nil {
-		return nil, err
-	}
-
+func EC2MetaData(sess *session.Session) (map[string]string, error) {
 	metaData := make(map[string]string)
 	ec2metadataClient := ec2metadata.New(sess)
 

--- a/system/ec2_tags.go
+++ b/system/ec2_tags.go
@@ -1,20 +1,13 @@
-package agent
+package system
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
-type EC2Tags struct {
-}
-
-func (e EC2Tags) Get() (map[string]string, error) {
-	sess, err := awsSession()
-	if err != nil {
-		return nil, err
-	}
-
+func EC2Tags(sess *session.Session) (map[string]string, error) {
 	tags := make(map[string]string)
 	ec2metadataClient := ec2metadata.New(sess)
 

--- a/system/gcp_labels.go
+++ b/system/gcp_labels.go
@@ -1,4 +1,4 @@
-package agent
+package system
 
 import (
 	"context"
@@ -7,11 +7,7 @@ import (
 	"google.golang.org/api/compute/v1"
 )
 
-type GCPLabels struct {
-}
-
-func (e GCPLabels) Get() (map[string]string, error) {
-
+func GCPLabels() (map[string]string, error) {
 	ctx := context.Background()
 	client, err := google.DefaultClient(ctx, compute.CloudPlatformScope)
 	if err != nil {
@@ -25,7 +21,7 @@ func (e GCPLabels) Get() (map[string]string, error) {
 
 	// Grab the current instance's metadata as a convenience
 	// to obtain the projectId, zone, and instanceId.
-	metadata, err := GCPMetaData{}.Get()
+	metadata, err := GCPMetaData()
 	if err != nil {
 		return nil, err
 	}

--- a/system/gcp_meta_data.go
+++ b/system/gcp_meta_data.go
@@ -1,4 +1,4 @@
-package agent
+package system
 
 import (
 	"errors"
@@ -7,10 +7,7 @@ import (
 	"cloud.google.com/go/compute/metadata"
 )
 
-type GCPMetaData struct {
-}
-
-func (e GCPMetaData) Get() (map[string]string, error) {
+func GCPMetaData() (map[string]string, error) {
 	result := make(map[string]string)
 
 	instanceId, err := metadata.Get("instance/id")
@@ -19,7 +16,7 @@ func (e GCPMetaData) Get() (map[string]string, error) {
 	}
 	result["gcp:instance-id"] = instanceId
 
-	machineType, err := machineType()
+	machineType, err := gcpMachineType()
 	if err != nil {
 		return result, err
 	}
@@ -43,7 +40,7 @@ func (e GCPMetaData) Get() (map[string]string, error) {
 	}
 	result["gcp:zone"] = zone
 
-	region, err := parseRegionFromZone(zone)
+	region, err := parseGCPRegionFromZone(zone)
 	if err != nil {
 		return result, err
 	}
@@ -52,7 +49,7 @@ func (e GCPMetaData) Get() (map[string]string, error) {
 	return result, nil
 }
 
-func machineType() (string, error) {
+func gcpMachineType() (string, error) {
 	machType, err := metadata.Get("instance/machine-type")
 	// machType is of the form "projects/<projNum>/machineTypes/<machType>".
 	if err != nil {
@@ -65,7 +62,7 @@ func machineType() (string, error) {
 	return machType[index+1:], nil
 }
 
-func parseRegionFromZone(zone string) (string, error) {
+func parseGCPRegionFromZone(zone string) (string, error) {
 	// zone is of the form "<region>-<letter>".
 	index := strings.LastIndex(zone, "-")
 	if index == -1 {

--- a/system/machine_id.go
+++ b/system/machine_id.go
@@ -1,0 +1,25 @@
+package system
+
+import (
+	"fmt"
+
+	"github.com/denisbrodbeck/machineid"
+)
+
+var machineID string
+
+// MachineID returns a unique string for the underlying host
+func MachineID() (string, error) {
+	if machineID != "" {
+		return machineID, nil
+	}
+
+	// get a unique identifier for the underlying host
+	var err error
+	machineID, err = machineid.ProtectedID("buildkite-agent")
+	if err != nil {
+		return "", fmt.Errorf("Failed to find unique machine id: %v", err)
+	}
+
+	return machineID, nil
+}

--- a/system/version_dump.go
+++ b/system/version_dump.go
@@ -9,7 +9,7 @@ import (
 	"github.com/buildkite/agent/process"
 )
 
-// Returns a dump of the raw operating system information
+// VersionDump returns a string representing the operating system
 func VersionDump(l *logger.Logger) (string, error) {
 	if runtime.GOOS == "darwin" {
 		return process.Run(l, "sw_vers")

--- a/system/version_dump_windows.go
+++ b/system/version_dump_windows.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package system
 
 import (
@@ -7,6 +9,7 @@ import (
 	"github.com/buildkite/agent/logger"
 )
 
+// VersionDump returns a string representing the operating system
 func VersionDump(_ *logger.Logger) (string, error) {
 	dll := syscall.MustLoadDLL("kernel32.dll")
 	p := dll.MustFindProc("GetVersion")


### PR DESCRIPTION
This pulls a whole lot of dependencies out of the AgentPool and moves them to an AgentTemplate that gets passed to an `agent.Register` command. 

This makes agent registration and spawning workers much more compose-able for future changes.

This also moves some of the labels/metadata stuff for AWS and GCP to the system package, which becomes the spot for "information about the running host".  