### PR TITLE
updating uploader to NOT write a mega-long url into the artifact

### DIFF
--- a/agent/arty_uploader.go
+++ b/agent/arty_uploader.go
@@ -92,7 +92,7 @@ func ParseArtifactoryDestination(destination string) (repo string, path string) 
 }
 
 func (u *ArtifactoryUploader) URL(artifact *api.Artifact) string {
-	url := u.iURL
+	url := *u.iURL
 	// ensure proper URL formatting for upload
 	url.Path = strings.Join([]string{
 		strings.Trim(url.Path, "/"),


### PR DESCRIPTION
without the de-reference to the base u.iURL, any long list of uploads will be uploaded as something like:

```
https://artifactory.com/artifactory/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/1.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/2.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/3.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/4.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/5.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/6.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/7.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/8.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/9.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/10.html: 403 [{Status:403 Message:Not enough permissions to overwrite artifact 'buildkite-artifacts:ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/1.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/2.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/3.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/4.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/5.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/6.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/7.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/8.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/9.html/buildkite-artifacts/ca88d9b6-62e9-4393-acf1-99940d150f1b/cov5/10.html
```