### PR TITLE
Move AgentWorker construction and registration out of AgentPool

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -1,5 +1,7 @@
 package agent
 
+// AgentConfiguration is the run-time configuration for an agent that
+// has been loaded from the config file and command-line params
 type AgentConfiguration struct {
 	ConfigPath                 string
 	BootstrapScript            string
@@ -18,6 +20,7 @@ type AgentConfiguration struct {
 	PluginValidation           bool
 	LocalHooksEnabled          bool
 	RunInPty                   bool
+	DisableColors              bool
 	TimestampLines             bool
 	DisconnectAfterJob         bool
 	DisconnectAfterJobTimeout  int

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -1,81 +1,45 @@
 package agent
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"runtime"
-	"strings"
 	"sync"
-	"time"
 
-	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/logger"
-	"github.com/buildkite/agent/metrics"
-	"github.com/buildkite/agent/retry"
 	"github.com/buildkite/agent/signalwatcher"
-	"github.com/buildkite/agent/system"
-	"github.com/denisbrodbeck/machineid"
 )
 
-type AgentPoolConfig struct {
-	ConfigFilePath          string
-	Name                    string
-	Priority                string
-	Tags                    []string
-	TagsFromEC2             bool
-	TagsFromEC2Tags         bool
-	TagsFromGCP             bool
-	TagsFromGCPLabels       bool
-	TagsFromHost            bool
-	WaitForEC2TagsTimeout   time.Duration
-	WaitForGCPLabelsTimeout time.Duration
-	Debug                   bool
-	DisableColors           bool
-	Spawn                   int
-	AgentConfiguration      *AgentConfiguration
-	APIClientConfig         APIClientConfig
-}
-
+// AgentPool manages multiple parallel AgentWorkers
 type AgentPool struct {
-	conf             AgentPoolConfig
-	logger           *logger.Logger
-	apiClient        *api.Client
-	metricsCollector *metrics.Collector
-	interruptCount   int
-	signalLock       sync.Mutex
+	logger  *logger.Logger
+	workers []*AgentWorker
 }
 
-func NewAgentPool(l *logger.Logger, m *metrics.Collector, c AgentPoolConfig) *AgentPool {
+// NewAgentPool returns a new AgentPool
+func NewAgentPool(l *logger.Logger, workers []*AgentWorker) *AgentPool {
 	return &AgentPool{
-		conf:             c,
-		logger:           l,
-		metricsCollector: m,
-		apiClient:        NewAPIClient(l, c.APIClientConfig),
+		logger:  l,
+		workers: workers,
 	}
 }
 
+// Start kicks off the parallel AgentWorkers and waits for them to finish
 func (r *AgentPool) Start() error {
-	// Show the welcome banner and config options used
-	r.ShowBanner()
-
 	var wg sync.WaitGroup
-	var errs = make(chan error, r.conf.Spawn)
+	var spawn int = len(r.workers)
+	var errs = make(chan error, spawn)
 
-	for i := 0; i < r.conf.Spawn; i++ {
-		if r.conf.Spawn == 1 {
-			r.logger.Info("Registering agent with Buildkite...")
-		} else {
-			r.logger.Info("Registering agent %d of %d with Buildkite...", i+1, r.conf.Spawn)
-		}
-
+	// Spawn goroutines for each parallel worker
+	for _, worker := range r.workers {
 		wg.Add(1)
-		go func() {
+
+		go func(worker *AgentWorker) {
 			defer wg.Done()
-			if err := r.startWorker(); err != nil {
+
+			if err := r.runWorker(worker); err != nil {
 				errs <- err
 			}
-		}()
+		}(worker)
 	}
 
 	go func() {
@@ -83,82 +47,27 @@ func (r *AgentPool) Start() error {
 		close(errs)
 	}()
 
-	r.logger.Info("Started %d Agent(s)", r.conf.Spawn)
+	// Listen for process signals
+	r.watchWorkers()
+
+	r.logger.Info("Started %d Agent(s)", spawn)
 	r.logger.Info("You can press Ctrl-C to stop the agents")
 
 	return <-errs
 }
 
-func (r *AgentPool) startWorker() error {
-	registered, err := r.RegisterAgent(r.CreateAgentTemplate())
-	if err != nil {
-		return err
-	}
-
-	r.logger.Info("Successfully registered agent \"%s\" with tags [%s]", registered.Name,
-		strings.Join(registered.Tags, ", "))
-
-	// Create a prefixed logger for some context in concurrent output
-	l := r.logger.WithPrefix(registered.Name)
-
-	l.Debug("Ping interval: %ds", registered.PingInterval)
-	l.Debug("Job status interval: %ds", registered.JobStatusInterval)
-	l.Debug("Heartbeat interval: %ds", registered.HearbeatInterval)
-
-	// Now that we have a registered agent, we can connect it to the API,
-	// and start running jobs.
-	worker := NewAgentWorker(l, registered, r.metricsCollector, AgentWorkerConfig{
-		AgentConfiguration: r.conf.AgentConfiguration,
-		Debug:              r.conf.Debug,
-		Endpoint:           r.conf.APIClientConfig.Endpoint,
-		DisableHTTP2:       r.conf.APIClientConfig.DisableHTTP2,
-	})
-
-	l.Info("Connecting to Buildkite...")
+func (r *AgentPool) runWorker(worker *AgentWorker) error {
+	// Connect the worker to the API
 	if err := worker.Connect(); err != nil {
 		return err
 	}
 
-	if r.conf.AgentConfiguration.DisconnectAfterJob {
-		l.Info("Waiting for job to be assigned...")
-		l.Info("The agent will automatically disconnect after %d seconds if no job is assigned", r.conf.AgentConfiguration.DisconnectAfterJobTimeout)
-	} else if r.conf.AgentConfiguration.DisconnectAfterIdleTimeout > 0 {
-		l.Info("Waiting for job to be assigned...")
-		l.Info("The agent will automatically disconnect after %d seconds of inactivity", r.conf.AgentConfiguration.DisconnectAfterIdleTimeout)
-	} else {
-		l.Info("Waiting for work...")
-	}
-
-	// Start a signalwatcher so we can monitor signals and handle shutdowns
-	signalwatcher.Watch(func(sig signalwatcher.Signal) {
-		r.signalLock.Lock()
-		defer r.signalLock.Unlock()
-
-		if sig == signalwatcher.QUIT {
-			l.Debug("Received signal `%s`", sig.String())
-			worker.Stop(false)
-		} else if sig == signalwatcher.TERM || sig == signalwatcher.INT {
-			l.Debug("Received signal `%s`", sig.String())
-			if r.interruptCount == 0 {
-				r.interruptCount++
-				l.Info("Received CTRL-C, send again to forcefully kill the agent")
-				worker.Stop(true)
-			} else {
-				l.Info("Forcefully stopping running jobs and stopping the agent")
-				worker.Stop(false)
-			}
-		} else {
-			l.Debug("Ignoring signal `%s`", sig.String())
-		}
-	})
-
-	// Starts the agent worker.
+	// Starts the agent worker and wait for it to finish
 	if err := worker.Start(); err != nil {
 		return err
 	}
 
 	// Now that the agent has stopped, we can disconnect it
-	l.Info("Disconnecting %s...", worker.agent.Name)
 	if err := worker.Disconnect(); err != nil {
 		return err
 	}
@@ -166,178 +75,41 @@ func (r *AgentPool) startWorker() error {
 	return nil
 }
 
-// Takes the options passed to the CLI, and creates an api.Agent record that
-// will be sent to the Buildkite Agent API for registration.
-func (r *AgentPool) CreateAgentTemplate() *api.Agent {
-	agent := &api.Agent{
-		Name:              r.conf.Name,
-		Priority:          r.conf.Priority,
-		Tags:              r.conf.Tags,
-		ScriptEvalEnabled: r.conf.AgentConfiguration.CommandEval,
-		Version:           Version(),
-		Build:             BuildVersion(),
-		PID:               os.Getpid(),
-		Arch:              runtime.GOARCH,
-	}
+func (r *AgentPool) watchWorkers() {
+	var signalLock sync.Mutex
+	var interruptCount int
 
-	// get a unique identifier for the underlying host
-	if machineID, err := machineid.ProtectedID("buildkite-agent"); err != nil {
-		r.logger.Warn("Failed to find unique machine-id: %v", err)
-	} else {
-		agent.MachineID = machineID
-	}
+	signalwatcher.Watch(func(sig signalwatcher.Signal) {
+		signalLock.Lock()
+		defer signalLock.Unlock()
 
-	// Attempt to add the EC2 tags
-	if r.conf.TagsFromEC2 {
-		r.logger.Info("Fetching EC2 meta-data...")
-
-		err := retry.Do(func(s *retry.Stats) error {
-			tags, err := EC2MetaData{}.Get()
-			if err != nil {
-				r.logger.Warn("%s (%s)", err, s)
-			} else {
-				r.logger.Info("Successfully fetched EC2 meta-data")
-				for tag, value := range tags {
-					agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
+		if sig == signalwatcher.QUIT {
+			r.logger.Debug("Received signal `%s`", sig.String())
+			for _, worker := range r.workers {
+				worker.Stop(false)
+			}
+		} else if sig == signalwatcher.TERM || sig == signalwatcher.INT {
+			r.logger.Debug("Received signal `%s`", sig.String())
+			if interruptCount == 0 {
+				interruptCount++
+				r.logger.Info("Received CTRL-C, send again to forcefully kill the agent(s)")
+				for _, worker := range r.workers {
+					worker.Stop(true)
 				}
-				s.Break()
-			}
-
-			return err
-		}, &retry.Config{Maximum: 5, Interval: 1 * time.Second, Jitter: true})
-
-		// Don't blow up if we can't find them, just show a nasty error.
-		if err != nil {
-			r.logger.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
-		}
-	}
-
-	// Attempt to add the EC2 tags
-	if r.conf.TagsFromEC2Tags {
-		r.logger.Info("Fetching EC2 tags...")
-		err := retry.Do(func(s *retry.Stats) error {
-			tags, err := EC2Tags{}.Get()
-			// EC2 tags are apparently "eventually consistent" and sometimes take several seconds
-			// to be applied to instances. This error will cause retries.
-			if err == nil && len(tags) == 0 {
-				err = errors.New("EC2 tags are empty")
-			}
-			if err != nil {
-				r.logger.Warn("%s (%s)", err, s)
 			} else {
-				r.logger.Info("Successfully fetched EC2 tags")
-				for tag, value := range tags {
-					agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
+				r.logger.Info("Forcefully stopping running jobs and stopping the agent(s)")
+				for _, worker := range r.workers {
+					worker.Stop(false)
 				}
-				s.Break()
 			}
-			return err
-		}, &retry.Config{Maximum: 5, Interval: r.conf.WaitForEC2TagsTimeout / 5, Jitter: true})
-
-		// Don't blow up if we can't find them, just show a nasty error.
-		if err != nil {
-			r.logger.Error(fmt.Sprintf("Failed to find EC2 tags: %s", err.Error()))
-		}
-	}
-
-	// Attempt to add the Google Cloud meta-data
-	if r.conf.TagsFromGCP {
-		tags, err := GCPMetaData{}.Get()
-		if err != nil {
-			// Don't blow up if we can't find them, just show a nasty error.
-			r.logger.Error(fmt.Sprintf("Failed to fetch Google Cloud meta-data: %s", err.Error()))
 		} else {
-			for tag, value := range tags {
-				agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", tag, value))
-			}
+			r.logger.Debug("Ignoring signal `%s`", sig.String())
 		}
-	}
-
-	// Attempt to add the Google Compute instance labels
-	if r.conf.TagsFromGCPLabels {
-		r.logger.Info("Fetching GCP instance labels...")
-		err := retry.Do(func(s *retry.Stats) error {
-			labels, err := GCPLabels{}.Get()
-			if err == nil && len(labels) == 0 {
-				err = errors.New("GCP instance labels are empty")
-			}
-			if err != nil {
-				r.logger.Warn("%s (%s)", err, s)
-			} else {
-				r.logger.Info("Successfully fetched GCP instance labels")
-				for label, value := range labels {
-					agent.Tags = append(agent.Tags, fmt.Sprintf("%s=%s", label, value))
-				}
-				s.Break()
-			}
-			return err
-		}, &retry.Config{Maximum: 5, Interval: r.conf.WaitForGCPLabelsTimeout / 5, Jitter: true})
-
-		// Don't blow up if we can't find them, just show a nasty error.
-		if err != nil {
-			r.logger.Error(fmt.Sprintf("Failed to find GCP instance labels: %s", err.Error()))
-		}
-	}
-
-	var err error
-
-	// Add the hostname
-	agent.Hostname, err = os.Hostname()
-	if err != nil {
-		r.logger.Warn("Failed to find hostname: %s", err)
-	}
-
-	// Add the OS dump
-	agent.OS, err = system.VersionDump(r.logger)
-	if err != nil {
-		r.logger.Warn("Failed to find OS information: %s", err)
-	}
-
-	// Attempt to add the host tags
-	if r.conf.TagsFromHost {
-		agent.Tags = append(agent.Tags,
-			fmt.Sprintf("hostname=%s", agent.Hostname),
-			fmt.Sprintf("os=%s", runtime.GOOS),
-		)
-		if agent.MachineID != "" {
-			agent.Tags = append(agent.Tags, fmt.Sprintf("machine-id=%s", agent.MachineID))
-		}
-	}
-
-	return agent
+	})
 }
 
-// Takes the agent template and returns a registered agent. The registered
-// agent includes the Access Token used to communicate with the Buildkite Agent
-// API
-func (r *AgentPool) RegisterAgent(agent *api.Agent) (*api.Agent, error) {
-	var registered *api.Agent
-	var err error
-	var resp *api.Response
-
-	register := func(s *retry.Stats) error {
-		registered, resp, err = r.apiClient.Agents.Register(agent)
-		if err != nil {
-			if resp != nil && resp.StatusCode == 401 {
-				r.logger.Warn("Buildkite rejected the registration (%s)", err)
-				s.Break()
-			} else {
-				r.logger.Warn("%s (%s)", err, s)
-			}
-		}
-
-		return err
-	}
-
-	// Try to register, retrying every 10 seconds for a maximum of 30 attempts (5 minutes)
-	err = retry.Do(register, &retry.Config{Maximum: 30, Interval: 10 * time.Second})
-
-	return registered, err
-}
-
-// Shows the welcome banner and the configuration options used when starting
-// this agent.
-func (r *AgentPool) ShowBanner() {
+// ShowBanner prints a welcome banner and the configuration options
+func ShowBanner(l *logger.Logger, conf AgentConfiguration) {
 	welcomeMessage :=
 		"\n" +
 			"%s  _           _ _     _ _    _ _                                _\n" +
@@ -349,42 +121,43 @@ func (r *AgentPool) ShowBanner() {
 			"                                                __/ |\n" +
 			" http://buildkite.com/agent                    |___/\n%s\n"
 
-	if !r.conf.DisableColors {
+	if !conf.DisableColors {
 		fmt.Fprintf(os.Stderr, welcomeMessage, "\x1b[38;5;48m", "\x1b[0m")
 	} else {
 		fmt.Fprintf(os.Stderr, welcomeMessage, "", "")
 	}
 
-	r.logger.Notice("Starting buildkite-agent v%s with PID: %s", Version(), fmt.Sprintf("%d", os.Getpid()))
-	r.logger.Notice("The agent source code can be found here: https://github.com/buildkite/agent")
-	r.logger.Notice("For questions and support, email us at: hello@buildkite.com")
+	l.Notice("Starting buildkite-agent v%s with PID: %s", Version(), fmt.Sprintf("%d", os.Getpid()))
+	l.Notice("The agent source code can be found here: https://github.com/buildkite/agent")
+	l.Notice("For questions and support, email us at: hello@buildkite.com")
 
-	if r.conf.ConfigFilePath != "" {
-		r.logger.Info("Configuration loaded from: %s", r.conf.ConfigFilePath)
+	if conf.ConfigPath != "" {
+		l.Info("Configuration loaded from: %s", conf.ConfigPath)
 	}
 
-	r.logger.Debug("Bootstrap command: %s", r.conf.AgentConfiguration.BootstrapScript)
-	r.logger.Debug("Build path: %s", r.conf.AgentConfiguration.BuildPath)
-	r.logger.Debug("Hooks directory: %s", r.conf.AgentConfiguration.HooksPath)
-	r.logger.Debug("Plugins directory: %s", r.conf.AgentConfiguration.PluginsPath)
+	l.Debug("Bootstrap command: %s", conf.BootstrapScript)
+	l.Debug("Build path: %s", conf.BuildPath)
+	l.Debug("Hooks directory: %s", conf.HooksPath)
+	l.Debug("Plugins directory: %s", conf.PluginsPath)
 
-	if !r.conf.AgentConfiguration.SSHKeyscan {
-		r.logger.Info("Automatic ssh-keyscan has been disabled")
+	if !conf.SSHKeyscan {
+		l.Info("Automatic ssh-keyscan has been disabled")
 	}
 
-	if !r.conf.AgentConfiguration.CommandEval {
-		r.logger.Info("Evaluating console commands has been disabled")
+	if !conf.CommandEval {
+		l.Info("Evaluating console commands has been disabled")
 	}
 
-	if !r.conf.AgentConfiguration.PluginsEnabled {
-		r.logger.Info("Plugins have been disabled")
+	if !conf.PluginsEnabled {
+		l.Info("Plugins have been disabled")
 	}
 
-	if !r.conf.AgentConfiguration.RunInPty {
-		r.logger.Info("Running builds within a pseudoterminal (PTY) has been disabled")
+	if !conf.RunInPty {
+		l.Info("Running builds within a pseudoterminal (PTY) has been disabled")
 	}
 
-	if r.conf.AgentConfiguration.DisconnectAfterJob {
-		r.logger.Info("Agent will disconnect after a job run has completed with a timeout of %d seconds", r.conf.AgentConfiguration.DisconnectAfterJobTimeout)
+	if conf.DisconnectAfterJob {
+		l.Info("Agent will disconnect after a job run has completed with a timeout of %d seconds",
+			conf.DisconnectAfterJobTimeout)
 	}
 }

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -45,7 +45,7 @@ type AgentWorker struct {
 	agentConfiguration AgentConfiguration
 
 	// The registered agent API record
-	agent *api.Agent
+	agent *api.AgentRegisterResponse
 
 	// Metric collection for the agent
 	metricsCollector *metrics.Collector
@@ -79,7 +79,7 @@ type AgentWorker struct {
 }
 
 // Creates the agent worker and initializes it's API Client
-func NewAgentWorker(l *logger.Logger, a *api.Agent, m *metrics.Collector, c AgentWorkerConfig) *AgentWorker {
+func NewAgentWorker(l *logger.Logger, a *api.AgentRegisterResponse, m *metrics.Collector, c AgentWorkerConfig) *AgentWorker {
 	var endpoint string
 	if a.Endpoint != "" {
 		endpoint = a.Endpoint
@@ -121,7 +121,7 @@ func (a *AgentWorker) Start() error {
 
 	// Create the intervals we'll be using
 	pingInterval := time.Second * time.Duration(a.agent.PingInterval)
-	heartbeatInterval := time.Second * time.Duration(a.agent.HearbeatInterval)
+	heartbeatInterval := time.Second * time.Duration(a.agent.HeartbeatInterval)
 
 	// Setup and start the heartbeater
 	go func() {

--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestJobRunnerPassesAccessTokenToBootstrap(t *testing.T) {
-	ag := &api.Agent{
+	ag := &api.AgentRegisterResponse{
 		AccessToken: "llamasrock",
 	}
 
@@ -38,7 +38,7 @@ func TestJobRunnerPassesAccessTokenToBootstrap(t *testing.T) {
 }
 
 func TestJobRunnerIgnoresPipelineChangesToProtectedVars(t *testing.T) {
-	ag := &api.Agent{
+	ag := &api.AgentRegisterResponse{
 		AccessToken: "llamasrock",
 	}
 
@@ -65,7 +65,7 @@ func TestJobRunnerIgnoresPipelineChangesToProtectedVars(t *testing.T) {
 
 }
 
-func runJob(t *testing.T, ag *api.Agent, j *api.Job, cfg agent.AgentConfiguration, bootstrap func(c *bintest.Call)) {
+func runJob(t *testing.T, ag *api.AgentRegisterResponse, j *api.Job, cfg agent.AgentConfiguration, bootstrap func(c *bintest.Call)) {
 	// create a mock agent API
 	server := createTestAgentEndpoint(t, `my-job-id`)
 	defer server.Close()
@@ -90,7 +90,7 @@ func runJob(t *testing.T, ag *api.Agent, j *api.Job, cfg agent.AgentConfiguratio
 	cfg.BootstrapScript = bs.Path
 
 	jr, err := agent.NewJobRunner(l, scope, ag, j, agent.JobRunnerConfig{
-		Endpoint:    server.URL,
+		Endpoint:           server.URL,
 		AgentConfiguration: cfg,
 	})
 	if err != nil {

--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -26,7 +26,7 @@ func TestJobRunnerPassesAccessTokenToBootstrap(t *testing.T) {
 		},
 	}
 
-	cfg := &agent.AgentConfiguration{}
+	cfg := agent.AgentConfiguration{}
 
 	runJob(t, ag, j, cfg, func(c *bintest.Call) {
 		if c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN") != `llamasrock` {
@@ -51,7 +51,7 @@ func TestJobRunnerIgnoresPipelineChangesToProtectedVars(t *testing.T) {
 		},
 	}
 
-	cfg := &agent.AgentConfiguration{
+	cfg := agent.AgentConfiguration{
 		CommandEval: true,
 	}
 
@@ -65,7 +65,7 @@ func TestJobRunnerIgnoresPipelineChangesToProtectedVars(t *testing.T) {
 
 }
 
-func runJob(t *testing.T, ag *api.Agent, j *api.Job, cfg *agent.AgentConfiguration, bootstrap func(c *bintest.Call)) {
+func runJob(t *testing.T, ag *api.Agent, j *api.Job, cfg agent.AgentConfiguration, bootstrap func(c *bintest.Call)) {
 	// create a mock agent API
 	server := createTestAgentEndpoint(t, `my-job-id`)
 	defer server.Close()
@@ -90,7 +90,7 @@ func runJob(t *testing.T, ag *api.Agent, j *api.Job, cfg *agent.AgentConfigurati
 	cfg.BootstrapScript = bs.Path
 
 	jr, err := agent.NewJobRunner(l, scope, ag, j, agent.JobRunnerConfig{
-		Endpoint:           server.URL,
+		Endpoint:    server.URL,
 		AgentConfiguration: cfg,
 	})
 	if err != nil {

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -39,7 +39,7 @@ type JobRunner struct {
 	logger *logger.Logger
 
 	// The registered agent API record running this job
-	agent *api.Agent
+	agent *api.AgentRegisterResponse
 
 	// The job being run
 	job *api.Job
@@ -83,7 +83,7 @@ type JobRunner struct {
 }
 
 // Initializes the job runner
-func NewJobRunner(l *logger.Logger, scope *metrics.Scope, ag *api.Agent, j *api.Job, conf JobRunnerConfig) (*JobRunner, error) {
+func NewJobRunner(l *logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterResponse, j *api.Job, conf JobRunnerConfig) (*JobRunner, error) {
 	runner := &JobRunner{
 		agent:   ag,
 		job:     j,

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -25,7 +25,7 @@ type JobRunnerConfig struct {
 	Endpoint string
 
 	// The configuration of the agent from the CLI
-	AgentConfiguration *AgentConfiguration
+	AgentConfiguration AgentConfiguration
 
 	// Whether to set debug in the job
 	Debug bool

--- a/agent/register.go
+++ b/agent/register.go
@@ -1,0 +1,101 @@
+package agent
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/buildkite/agent/api"
+	"github.com/buildkite/agent/logger"
+	"github.com/buildkite/agent/retry"
+	"github.com/buildkite/agent/system"
+	"github.com/denisbrodbeck/machineid"
+)
+
+// AgentTemplate represents an Agent to be registered
+type AgentTemplate struct {
+	Name              string
+	Priority          string
+	Tags              []string
+	ScriptEvalEnabled bool
+}
+
+// Build an api.Agent out of the Template populated with system info
+func (a AgentTemplate) Build(l *logger.Logger) *api.Agent {
+	agent := &api.Agent{
+		Name:              a.Name,
+		Priority:          a.Priority,
+		Tags:              a.Tags,
+		ScriptEvalEnabled: a.ScriptEvalEnabled,
+		Version:           Version(),
+		Build:             BuildVersion(),
+		PID:               os.Getpid(),
+		Arch:              runtime.GOARCH,
+	}
+
+	// get a unique identifier for the underlying host
+	machineID, err := machineid.ProtectedID("buildkite-agent")
+	if err != nil {
+		l.Warn("Failed to find unique machine-id: %v", err)
+	} else {
+		agent.MachineID = machineID
+	}
+
+	// Add the hostname
+	agent.Hostname, err = os.Hostname()
+	if err != nil {
+		l.Warn("Failed to find hostname: %s", err)
+	}
+
+	// Add the OS dump
+	agent.OS, err = system.VersionDump(l)
+	if err != nil {
+		l.Warn("Failed to find OS information: %s", err)
+	}
+
+	return agent
+}
+
+// Register takes an AgentTemplate and registers it with the Buildkite API
+func Register(l *logger.Logger, ac *api.Client, tpl AgentTemplate) (*api.Agent, error) {
+	var registered *api.Agent
+	var err error
+	var resp *api.Response
+
+	// Build the template into an Agent record that is filled out in the register call
+	agent := tpl.Build(l)
+
+	l.Info("Registering agent with Buildkite...")
+
+	register := func(s *retry.Stats) error {
+		registered, resp, err = ac.Agents.Register(agent)
+		if err != nil {
+			if resp != nil && resp.StatusCode == 401 {
+				l.Warn("Buildkite rejected the registration (%s)", err)
+				s.Break()
+			} else {
+				l.Warn("%s (%s)", err, s)
+			}
+		}
+
+		return err
+	}
+
+	// Try to register, retrying every 10 seconds for a maximum of 30 attempts (5 minutes)
+	err = retry.Do(register, &retry.Config{Maximum: 30, Interval: 10 * time.Second})
+	if err != nil {
+		l.Info("Successfully registered agent \"%s\" with tags [%s]", registered.Name,
+			strings.Join(registered.Tags, ", "))
+
+		l.Debug("Ping interval: %ds", registered.PingInterval)
+		l.Debug("Job status interval: %ds", registered.JobStatusInterval)
+		l.Debug("Heartbeat interval: %ds", registered.HearbeatInterval)
+
+		if registered.Endpoint != "" {
+			l.Debug("Endpoint: %s", registered.Endpoint)
+		}
+	}
+
+	return registered, err
+}

--- a/agent/tags.go
+++ b/agent/tags.go
@@ -1,0 +1,145 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/buildkite/agent/logger"
+	"github.com/buildkite/agent/retry"
+	"github.com/denisbrodbeck/machineid"
+)
+
+type FetchTagsConfig struct {
+	Tags                    []string
+	TagsFromEC2             bool
+	TagsFromEC2Tags         bool
+	TagsFromGCP             bool
+	TagsFromGCPLabels       bool
+	TagsFromHost            bool
+	WaitForEC2TagsTimeout   time.Duration
+	WaitForGCPLabelsTimeout time.Duration
+}
+
+// FetchTags loads tags from a variety of sources
+func FetchTags(l *logger.Logger, conf FetchTagsConfig) []string {
+	tags := conf.Tags
+
+	// Load tags from host
+	if conf.TagsFromHost {
+		var tags []string
+
+		hostname, err := os.Hostname()
+		if err != nil {
+			l.Warn("Failed to find hostname: %v", err)
+		}
+
+		tags = append(tags,
+			fmt.Sprintf("hostname=%s", hostname),
+			fmt.Sprintf("os=%s", runtime.GOOS),
+		)
+
+		machineID, _ := machineid.ProtectedID("buildkite-agent")
+		if machineID != "" {
+			tags = append(tags, fmt.Sprintf("machine-id=%s", machineID))
+		}
+
+		return tags
+	}
+
+	// Attempt to add the EC2 tags
+	if conf.TagsFromEC2 && awsSess != nil {
+		l.Info("Fetching EC2 meta-data...")
+
+		err := retry.Do(func(s *retry.Stats) error {
+			ec2Tags, err := EC2MetaData{}.Get()
+			if err != nil {
+				l.Warn("%s (%s)", err, s)
+			} else {
+				l.Info("Successfully fetched EC2 meta-data")
+				for tag, value := range ec2Tags {
+					tags = append(tags, fmt.Sprintf("%s=%s", tag, value))
+				}
+				s.Break()
+			}
+
+			return err
+		}, &retry.Config{Maximum: 5, Interval: 1 * time.Second, Jitter: true})
+
+		// Don't blow up if we can't find them, just show a nasty error.
+		if err != nil {
+			l.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
+		}
+	}
+
+	// Attempt to add the EC2 tags
+	if conf.TagsFromEC2Tags && awsSess != nil {
+		l.Info("Fetching EC2 tags...")
+		err := retry.Do(func(s *retry.Stats) error {
+			ec2Tags, err := EC2Tags{}.Get()
+			// EC2 tags are apparently "eventually consistent" and sometimes take several seconds
+			// to be applied to instances. This error will cause retries.
+			if err == nil && len(tags) == 0 {
+				err = errors.New("EC2 tags are empty")
+			}
+			if err != nil {
+				l.Warn("%s (%s)", err, s)
+			} else {
+				l.Info("Successfully fetched EC2 tags")
+				for tag, value := range ec2Tags {
+					tags = append(tags, fmt.Sprintf("%s=%s", tag, value))
+				}
+				s.Break()
+			}
+			return err
+		}, &retry.Config{Maximum: 5, Interval: conf.WaitForEC2TagsTimeout / 5, Jitter: true})
+
+		// Don't blow up if we can't find them, just show a nasty error.
+		if err != nil {
+			l.Error(fmt.Sprintf("Failed to find EC2 tags: %s", err.Error()))
+		}
+	}
+
+	// Attempt to add the Google Cloud meta-data
+	if conf.TagsFromGCP {
+		gcpTags, err := GCPMetaData{}.Get()
+		if err != nil {
+			// Don't blow up if we can't find them, just show a nasty error.
+			l.Error(fmt.Sprintf("Failed to fetch Google Cloud meta-data: %s", err.Error()))
+		} else {
+			for tag, value := range gcpTags {
+				tags = append(tags, fmt.Sprintf("%s=%s", tag, value))
+			}
+		}
+	}
+
+	// Attempt to add the Google Compute instance labels
+	if conf.TagsFromGCPLabels {
+		l.Info("Fetching GCP instance labels...")
+		err := retry.Do(func(s *retry.Stats) error {
+			labels, err := GCPLabels{}.Get()
+			if err == nil && len(labels) == 0 {
+				err = errors.New("GCP instance labels are empty")
+			}
+			if err != nil {
+				l.Warn("%s (%s)", err, s)
+			} else {
+				l.Info("Successfully fetched GCP instance labels")
+				for label, value := range labels {
+					tags = append(tags, fmt.Sprintf("%s=%s", label, value))
+				}
+				s.Break()
+			}
+			return err
+		}, &retry.Config{Maximum: 5, Interval: conf.WaitForGCPLabelsTimeout / 5, Jitter: true})
+
+		// Don't blow up if we can't find them, just show a nasty error.
+		if err != nil {
+			l.Error(fmt.Sprintf("Failed to find GCP instance labels: %s", err.Error()))
+		}
+	}
+
+	return tags
+}

--- a/api/agents.go
+++ b/api/agents.go
@@ -12,15 +12,10 @@ type AgentsService struct {
 	client *Client
 }
 
-// Agent represents an agent on the Buildkite Agent API
-type Agent struct {
+// AgentRegisterRequest is a call to register on the Buildkite Agent API
+type AgentRegisterRequest struct {
 	Name              string   `json:"name" msgpack:"name"`
-	AccessToken       string   `json:"access_token" msgpack:"access_token"`
 	Hostname          string   `json:"hostname" msgpack:"hostname"`
-	Endpoint          string   `json:"endpoint" msgpack:"endpoint"`
-	PingInterval      int      `json:"ping_interval" msgpack:"ping_interval"`
-	JobStatusInterval int      `json:"job_status_interval" msgpack:"job_status_interval"`
-	HearbeatInterval  int      `json:"heartbeat_interval" msgpack:"heartbeat_interval"`
 	OS                string   `json:"os" msgpack:"os"`
 	Arch              string   `json:"arch" msgpack:"arch"`
 	ScriptEvalEnabled bool     `json:"script_eval_enabled" msgpack:"script_eval_enabled"`
@@ -32,22 +27,34 @@ type Agent struct {
 	MachineID         string   `json:"machine_id,omitempty" msgpack:"machine_id,omitempty"`
 }
 
-// Registers the agent against the Buildktie Agent API. The client for this
+// AgentRegisterResponse is the response from the Buildkite Agent API
+type AgentRegisterResponse struct {
+	UUID              string   `json:"uuid" msgpack:"uuid"`
+	Name              string   `json:"name" msgpack:"name"`
+	AccessToken       string   `json:"access_token" msgpack:"access_token"`
+	Endpoint          string   `json:"endpoint" msgpack:"endpoint"`
+	PingInterval      int      `json:"ping_interval" msgpack:"ping_interval"`
+	JobStatusInterval int      `json:"job_status_interval" msgpack:"job_status_interval"`
+	HeartbeatInterval int      `json:"heartbeat_interval" msgpack:"heartbeat_interval"`
+	Tags              []string `json:"meta_data" msgpack:"meta_data"`
+}
+
+// Registers the agent against the Buildkite Agent API. The client for this
 // call must be authenticated using an Agent Registration Token
-func (as *AgentsService) Register(agent *Agent) (*Agent, *Response, error) {
+func (as *AgentsService) Register(regReq *AgentRegisterRequest) (*AgentRegisterResponse, *Response, error) {
 	var req *http.Request
 	var err error
 	if experiments.IsEnabled("msgpack") {
-		req, err = as.client.NewRequestWithMessagePack("POST", "register", agent)
+		req, err = as.client.NewRequestWithMessagePack("POST", "register", regReq)
 	} else {
-		req, err = as.client.NewRequest("POST", "register", agent)
+		req, err = as.client.NewRequest("POST", "register", regReq)
 	}
 
 	if err != nil {
 		return nil, nil, err
 	}
 
-	a := new(Agent)
+	a := new(AgentRegisterResponse)
 	resp, err := as.client.Do(req, a)
 	if err != nil {
 		return nil, resp, err

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -41,7 +41,6 @@ Example:
 
 type AgentStartConfig struct {
 	Config                     string   `cli:"config"`
-	Token                      string   `cli:"token" validate:"required"`
 	Name                       string   `cli:"name"`
 	Priority                   string   `cli:"priority"`
 	DisconnectAfterJob         bool     `cli:"disconnect-after-job"`
@@ -67,25 +66,30 @@ type AgentStartConfig struct {
 	GitMirrorsPath             string   `cli:"git-mirrors-path" normalize:"filepath"`
 	GitMirrorsLockTimeout      int      `cli:"git-mirrors-lock-timeout"`
 	NoGitSubmodules            bool     `cli:"no-git-submodules"`
-	NoColor                    bool     `cli:"no-color"`
 	NoSSHKeyscan               bool     `cli:"no-ssh-keyscan"`
 	NoCommandEval              bool     `cli:"no-command-eval"`
 	NoLocalHooks               bool     `cli:"no-local-hooks"`
 	NoPlugins                  bool     `cli:"no-plugins"`
 	NoPluginValidation         bool     `cli:"no-plugin-validation"`
 	NoPTY                      bool     `cli:"no-pty"`
-	NoHTTP2                    bool     `cli:"no-http2"`
 	TimestampLines             bool     `cli:"timestamp-lines"`
-	Endpoint                   string   `cli:"endpoint" validate:"required"`
-	Debug                      bool     `cli:"debug"`
-	DebugHTTP                  bool     `cli:"debug-http"`
-	DebugWithoutAPI            bool     `cli:"debug-without-api"`
-	Experiments                []string `cli:"experiment" normalize:"list"`
 	MetricsDatadog             bool     `cli:"metrics-datadog"`
 	MetricsDatadogHost         string   `cli:"metrics-datadog-host"`
 	Spawn                      int      `cli:"spawn"`
 
-	/* Deprecated */
+	// Global flags
+	Debug           bool     `cli:"debug"`
+	DebugWithoutAPI bool     `cli:"debug-without-api"`
+	NoColor         bool     `cli:"no-color"`
+	Experiments     []string `cli:"experiment" normalize:"list"`
+
+	// API config
+	DebugHTTP bool   `cli:"debug-http"`
+	Token     string `cli:"token" validate:"required"`
+	Endpoint  string `cli:"endpoint" validate:"required"`
+	NoHTTP2   bool   `cli:"no-http2"`
+
+	// Deprecated
 	NoSSHFingerprintVerification bool     `cli:"no-automatic-ssh-fingerprint-verification" deprecated-and-renamed-to:"NoSSHKeyscan"`
 	MetaData                     []string `cli:"meta-data" deprecated-and-renamed-to:"Tags"`
 	MetaDataEC2                  bool     `cli:"meta-data-ec2" deprecated-and-renamed-to:"TagsFromEC2"`
@@ -476,9 +480,46 @@ var AgentStartCommand = cli.Command{
 			DatadogHost: cfg.MetricsDatadogHost,
 		})
 
-		config := agent.AgentPoolConfig{
-			Name:                    cfg.Name,
-			Priority:                cfg.Priority,
+		// AgentConfiguration is the runtime configuration for an agent
+		agentConf := agent.AgentConfiguration{
+			BootstrapScript:            cfg.BootstrapScript,
+			BuildPath:                  cfg.BuildPath,
+			GitMirrorsPath:             cfg.GitMirrorsPath,
+			GitMirrorsLockTimeout:      cfg.GitMirrorsLockTimeout,
+			HooksPath:                  cfg.HooksPath,
+			PluginsPath:                cfg.PluginsPath,
+			GitCloneFlags:              cfg.GitCloneFlags,
+			GitCloneMirrorFlags:        cfg.GitCloneMirrorFlags,
+			GitCleanFlags:              cfg.GitCleanFlags,
+			GitSubmodules:              !cfg.NoGitSubmodules,
+			SSHKeyscan:                 !cfg.NoSSHKeyscan,
+			CommandEval:                !cfg.NoCommandEval,
+			PluginsEnabled:             !cfg.NoPlugins,
+			PluginValidation:           !cfg.NoPluginValidation,
+			LocalHooksEnabled:          !cfg.NoLocalHooks,
+			RunInPty:                   !cfg.NoPTY,
+			TimestampLines:             cfg.TimestampLines,
+			DisconnectAfterJob:         cfg.DisconnectAfterJob,
+			DisconnectAfterJobTimeout:  cfg.DisconnectAfterJobTimeout,
+			DisconnectAfterIdleTimeout: cfg.DisconnectAfterIdleTimeout,
+			CancelGracePeriod:          cfg.CancelGracePeriod,
+			Shell:                      cfg.Shell,
+		}
+
+		if loader.File != nil {
+			agentConf.ConfigPath = loader.File.Path
+		}
+
+		// Show the welcome banner
+		agent.ShowBanner(l, agentConf)
+
+		apiClientConf := loadAPIClientConfig(cfg, `Token`)
+
+		// Create the API client
+		client := agent.NewAPIClient(l, apiClientConf)
+
+		// Fetch the tags for the agent
+		tags := agent.FetchTags(l, agent.FetchTagsConfig{
 			Tags:                    cfg.Tags,
 			TagsFromEC2:             cfg.TagsFromEC2,
 			TagsFromEC2Tags:         cfg.TagsFromEC2Tags,
@@ -487,45 +528,41 @@ var AgentStartCommand = cli.Command{
 			TagsFromHost:            cfg.TagsFromHost,
 			WaitForEC2TagsTimeout:   ec2TagTimeout,
 			WaitForGCPLabelsTimeout: gcpLabelsTimeout,
-			Debug:                   cfg.Debug,
-			DisableColors:           cfg.NoColor,
-			Spawn:                   cfg.Spawn,
-			APIClientConfig:         loadAPIClientConfig(cfg, `Token`),
-			AgentConfiguration: &agent.AgentConfiguration{
-				BootstrapScript:            cfg.BootstrapScript,
-				BuildPath:                  cfg.BuildPath,
-				GitMirrorsPath:             cfg.GitMirrorsPath,
-				GitMirrorsLockTimeout:      cfg.GitMirrorsLockTimeout,
-				HooksPath:                  cfg.HooksPath,
-				PluginsPath:                cfg.PluginsPath,
-				GitCloneFlags:              cfg.GitCloneFlags,
-				GitCloneMirrorFlags:        cfg.GitCloneMirrorFlags,
-				GitCleanFlags:              cfg.GitCleanFlags,
-				GitSubmodules:              !cfg.NoGitSubmodules,
-				SSHKeyscan:                 !cfg.NoSSHKeyscan,
-				CommandEval:                !cfg.NoCommandEval,
-				PluginsEnabled:             !cfg.NoPlugins,
-				PluginValidation:           !cfg.NoPluginValidation,
-				LocalHooksEnabled:          !cfg.NoLocalHooks,
-				RunInPty:                   !cfg.NoPTY,
-				TimestampLines:             cfg.TimestampLines,
-				DisconnectAfterJob:         cfg.DisconnectAfterJob,
-				DisconnectAfterJobTimeout:  cfg.DisconnectAfterJobTimeout,
-				DisconnectAfterIdleTimeout: cfg.DisconnectAfterIdleTimeout,
-				CancelGracePeriod:          cfg.CancelGracePeriod,
-				Shell:                      cfg.Shell,
-			},
+		})
+
+		var workers []*agent.AgentWorker
+
+		for i := 1; i <= cfg.Spawn; i++ {
+			if cfg.Spawn == 1 {
+				l.Info("Registering agent with Buildkite...")
+			} else {
+				l.Info("Registering agent %d of %d with Buildkite...", i, cfg.Spawn)
+			}
+
+			// Register the agent with the buildkite API
+			ag, err := agent.Register(l, client, agent.AgentTemplate{
+				Name:              cfg.Name,
+				Priority:          cfg.Priority,
+				Tags:              tags,
+				ScriptEvalEnabled: !cfg.NoCommandEval,
+			})
+			if err != nil {
+				l.Fatal("%s", err)
+			}
+
+			// Create an agent worker to run the agent
+			worker := agent.NewAgentWorker(l.WithPrefix(ag.Name), ag, mc, agent.AgentWorkerConfig{
+				AgentConfiguration: agentConf,
+				Debug:              cfg.Debug,
+				Endpoint:           apiClientConf.Endpoint,
+				DisableHTTP2:       apiClientConf.DisableHTTP2,
+			})
+
+			workers = append(workers, worker)
 		}
 
-		// Store the loaded config file path on the pool and agent config so we can
-		// show it when the agent starts and set an env
-		if loader.File != nil {
-			config.ConfigFilePath = loader.File.Path
-			config.AgentConfiguration.ConfigPath = loader.File.Path
-		}
-
-		// Setup the agent
-		pool := agent.NewAgentPool(l, mc, config)
+		// Setup the agent pool that spawns agent workers
+		pool := agent.NewAgentPool(l, workers)
 
 		// Start the agent pool
 		if err := pool.Start(); err != nil {


### PR DESCRIPTION
This is another take on #954 that reduces the diff somewhat. 

The aim here is to decouple the AgentPool from the creation of AgentWorkers and registration. This allows better composition and pushes the construction of dependencies up to the caller, which is the cli command level.

The only practical difference in how things work here is that there is a single signal handler for the whole AgentPool vs one for each AgentWorker. This shouldn't have anything other than aesthetic difference.

Registration and fetching of tags are now different things too, and the results are passed into things that need them.