### PR TITLE
update artifatory uploader to use the right PUT url

### DIFF
--- a/agent/arty_uploader.go
+++ b/agent/arty_uploader.go
@@ -112,7 +112,7 @@ func (u *ArtifactoryUploader) Upload(artifact *api.Artifact) error {
 	// Upload the file to Artifactory.
 	u.logger.Debug("Uploading \"%s\" to `%s`", artifact.Path, u.Repository)
 
-	req, err := http.NewRequest("PUT", u.iURL.String(), f)
+	req, err := http.NewRequest("PUT", u.URL(artifact), f)
 	req.SetBasicAuth(u.user, u.password)
 	if err != nil {
 		return err


### PR DESCRIPTION
side-effect we found from the previous patch update : the artifact uploader was using the wrong URL to PUT to, this PR is to use the proper URL for uploading 😅 