### PR TITLE
Move logger.Logger to an interface

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -11,12 +11,12 @@ import (
 
 // AgentPool manages multiple parallel AgentWorkers
 type AgentPool struct {
-	logger  *logger.Logger
+	logger  logger.Logger
 	workers []*AgentWorker
 }
 
 // NewAgentPool returns a new AgentPool
-func NewAgentPool(l *logger.Logger, workers []*AgentWorker) *AgentPool {
+func NewAgentPool(l logger.Logger, workers []*AgentWorker) *AgentPool {
 	return &AgentPool{
 		logger:  l,
 		workers: workers,
@@ -109,7 +109,7 @@ func (r *AgentPool) watchWorkers() {
 }
 
 // ShowBanner prints a welcome banner and the configuration options
-func ShowBanner(l *logger.Logger, conf AgentConfiguration) {
+func ShowBanner(l logger.Logger, conf AgentConfiguration) {
 	welcomeMessage :=
 		"\n" +
 			"%s  _           _ _     _ _    _ _                                _\n" +

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -39,7 +39,7 @@ type AgentWorker struct {
 	apiClient *api.Client
 
 	// The logger instance to use
-	logger *logger.Logger
+	logger logger.Logger
 
 	// The configuration of the agent from the CLI
 	agentConfiguration AgentConfiguration
@@ -79,7 +79,7 @@ type AgentWorker struct {
 }
 
 // Creates the agent worker and initializes it's API Client
-func NewAgentWorker(l *logger.Logger, a *api.AgentRegisterResponse, m *metrics.Collector, c AgentWorkerConfig) *AgentWorker {
+func NewAgentWorker(l logger.Logger, a *api.AgentRegisterResponse, m *metrics.Collector, c AgentWorkerConfig) *AgentWorker {
 	var endpoint string
 	if a.Endpoint != "" {
 		endpoint = a.Endpoint

--- a/agent/api_client.go
+++ b/agent/api_client.go
@@ -27,7 +27,7 @@ type APIClientConfig struct {
 
 type APIClient struct {
 	config APIClientConfig
-	logger *logger.Logger
+	logger logger.Logger
 }
 
 func APIClientEnableHTTPDebug() {
@@ -38,8 +38,8 @@ func APIClientDisableDebug() {
 	disableDebug = true
 }
 
-func NewAPIClient(l *logger.Logger, c APIClientConfig) *api.Client {
-	if disableDebug == true && l.Level == logger.DEBUG {
+func NewAPIClient(l logger.Logger, c APIClientConfig) *api.Client {
+	if disableDebug == true && l.GetLevel() == logger.DEBUG {
 		l = l.WithLevel(logger.INFO)
 	}
 
@@ -85,7 +85,7 @@ func NewAPIClient(l *logger.Logger, c APIClientConfig) *api.Client {
 	return client
 }
 
-func NewAPIClientFromSocket(l *logger.Logger, socket string, c APIClientConfig) *api.Client {
+func NewAPIClientFromSocket(l logger.Logger, socket string, c APIClientConfig) *api.Client {
 	httpClient := &http.Client{
 		Transport: &api.AuthenticatedTransport{
 			Token: c.Token,

--- a/agent/api_proxy.go
+++ b/agent/api_proxy.go
@@ -20,7 +20,7 @@ import (
 // APIProxy provides either a unix socket or a tcp socket listener with a proxy
 // that will authenticate to the Buildkite Agent API
 type APIProxy struct {
-	logger           *logger.Logger
+	logger           logger.Logger
 	upstreamToken    string
 	upstreamEndpoint string
 	token            string
@@ -29,7 +29,7 @@ type APIProxy struct {
 	listenerWg       *sync.WaitGroup
 }
 
-func NewAPIProxy(l *logger.Logger, endpoint string, token string) *APIProxy {
+func NewAPIProxy(l logger.Logger, endpoint string, token string) *APIProxy {
 	var wg sync.WaitGroup
 	wg.Add(1)
 

--- a/agent/artifact_batch_creator.go
+++ b/agent/artifact_batch_creator.go
@@ -24,13 +24,13 @@ type ArtifactBatchCreator struct {
 	conf ArtifactBatchCreatorConfig
 
 	// The logger instance to use
-	logger *logger.Logger
+	logger logger.Logger
 
 	// The APIClient that will be used when uploading jobs
 	apiClient *api.Client
 }
 
-func NewArtifactBatchCreator(l *logger.Logger, ac *api.Client, c ArtifactBatchCreatorConfig) *ArtifactBatchCreator {
+func NewArtifactBatchCreator(l logger.Logger, ac *api.Client, c ArtifactBatchCreatorConfig) *ArtifactBatchCreator {
 	return &ArtifactBatchCreator{
 		logger:    l,
 		conf:      c,

--- a/agent/artifact_downloader.go
+++ b/agent/artifact_downloader.go
@@ -32,13 +32,13 @@ type ArtifactDownloader struct {
 	conf ArtifactDownloaderConfig
 
 	// The logger instance to use
-	logger *logger.Logger
+	logger logger.Logger
 
 	// The *api.Client that will be used when uploading jobs
 	apiClient *api.Client
 }
 
-func NewArtifactDownloader(l *logger.Logger, ac *api.Client, c ArtifactDownloaderConfig) ArtifactDownloader {
+func NewArtifactDownloader(l logger.Logger, ac *api.Client, c ArtifactDownloaderConfig) ArtifactDownloader {
 	return ArtifactDownloader{
 		logger:    l,
 		apiClient: ac,

--- a/agent/artifact_searcher.go
+++ b/agent/artifact_searcher.go
@@ -7,7 +7,7 @@ import (
 
 type ArtifactSearcher struct {
 	// The logger instance to use
-	logger *logger.Logger
+	logger logger.Logger
 
 	// The APIClient that will be used when uploading jobs
 	apiClient *api.Client
@@ -16,7 +16,7 @@ type ArtifactSearcher struct {
 	buildID string
 }
 
-func NewArtifactSearcher(l *logger.Logger, ac *api.Client, buildID string) *ArtifactSearcher {
+func NewArtifactSearcher(l logger.Logger, ac *api.Client, buildID string) *ArtifactSearcher {
 	return &ArtifactSearcher{
 		logger:    l,
 		apiClient: ac,

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -44,13 +44,13 @@ type ArtifactUploader struct {
 	conf ArtifactUploaderConfig
 
 	// The logger instance to use
-	logger *logger.Logger
+	logger logger.Logger
 
 	// The APIClient that will be used when uploading jobs
 	apiClient *api.Client
 }
 
-func NewArtifactUploader(l *logger.Logger, ac *api.Client, c ArtifactUploaderConfig) *ArtifactUploader {
+func NewArtifactUploader(l logger.Logger, ac *api.Client, c ArtifactUploaderConfig) *ArtifactUploader {
 	return &ArtifactUploader{
 		logger:    l,
 		apiClient: ac,

--- a/agent/arty_downloader.go
+++ b/agent/arty_downloader.go
@@ -34,10 +34,10 @@ type ArtifactoryDownloader struct {
 	conf ArtifactoryDownloaderConfig
 
 	// The logger instance to use
-	logger *logger.Logger
+	logger logger.Logger
 }
 
-func NewArtifactoryDownloader(l *logger.Logger, c ArtifactoryDownloaderConfig) *ArtifactoryDownloader {
+func NewArtifactoryDownloader(l logger.Logger, c ArtifactoryDownloaderConfig) *ArtifactoryDownloader {
 	return &ArtifactoryDownloader{
 		conf:   c,
 		logger: l,

--- a/agent/arty_uploader.go
+++ b/agent/arty_uploader.go
@@ -43,7 +43,7 @@ type ArtifactoryUploader struct {
 	jobID string
 
 	// The logger instance to use
-	logger *logger.Logger
+	logger logger.Logger
 
 	// Artifactory username
 	user string
@@ -52,7 +52,7 @@ type ArtifactoryUploader struct {
 	password string
 }
 
-func NewArtifactoryUploader(l *logger.Logger, c ArtifactoryUploaderConfig) (*ArtifactoryUploader, error) {
+func NewArtifactoryUploader(l logger.Logger, c ArtifactoryUploaderConfig) (*ArtifactoryUploader, error) {
 	repo, path := ParseArtifactoryDestination(c.Destination)
 	jobID := os.Getenv("BUILDKITE_JOB_ID")
 	stringURL := os.Getenv("BUILDKITE_ARTIFACTORY_URL")

--- a/agent/download.go
+++ b/agent/download.go
@@ -39,13 +39,13 @@ type Download struct {
 	conf DownloadConfig
 
 	// The logger instance to use
-	logger *logger.Logger
+	logger logger.Logger
 
 	// The HTTP client to use for downloading
 	client *http.Client
 }
 
-func NewDownload(l *logger.Logger, client *http.Client, c DownloadConfig) *Download {
+func NewDownload(l logger.Logger, client *http.Client, c DownloadConfig) *Download {
 	return &Download{
 		logger: l,
 		client: client,

--- a/agent/form_uploader.go
+++ b/agent/form_uploader.go
@@ -31,10 +31,10 @@ type FormUploader struct {
 	conf FormUploaderConfig
 
 	// The logger instance to use
-	logger *logger.Logger
+	logger logger.Logger
 }
 
-func NewFormUploader(l *logger.Logger, c FormUploaderConfig) *FormUploader {
+func NewFormUploader(l logger.Logger, c FormUploaderConfig) *FormUploader {
 	return &FormUploader{
 		logger: l,
 		conf:   c,

--- a/agent/gs_downloader.go
+++ b/agent/gs_downloader.go
@@ -34,10 +34,10 @@ type GSDownloader struct {
 	conf GSDownloaderConfig
 
 	// The logger instance to use
-	logger *logger.Logger
+	logger logger.Logger
 }
 
-func NewGSDownloader(l *logger.Logger, c GSDownloaderConfig) *GSDownloader {
+func NewGSDownloader(l logger.Logger, c GSDownloaderConfig) *GSDownloader {
 	return &GSDownloader{
 		logger: l,
 		conf:   c,

--- a/agent/gs_uploader.go
+++ b/agent/gs_uploader.go
@@ -39,13 +39,13 @@ type GSUploader struct {
 	conf GSUploaderConfig
 
 	// The logger instance to use
-	logger *logger.Logger
+	logger logger.Logger
 
 	// The GS service
 	service *storage.Service
 }
 
-func NewGSUploader(l *logger.Logger, c GSUploaderConfig) (*GSUploader, error) {
+func NewGSUploader(l logger.Logger, c GSUploaderConfig) (*GSUploader, error) {
 	client, err := newGoogleClient(storage.DevstorageFullControlScope)
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("Error creating Google Cloud Storage client: %v", err))

--- a/agent/header_times_streamer.go
+++ b/agent/header_times_streamer.go
@@ -11,7 +11,7 @@ import (
 
 type headerTimesStreamer struct {
 	// The logger instance to use
-	logger *logger.Logger
+	logger logger.Logger
 
 	// The callback that will be called when a header time is ready for
 	// upload
@@ -39,7 +39,7 @@ type headerTimesStreamer struct {
 	cursor int
 }
 
-func newHeaderTimesStreamer(l *logger.Logger, upload func(int, int, map[string]string)) *headerTimesStreamer {
+func newHeaderTimesStreamer(l logger.Logger, upload func(int, int, map[string]string)) *headerTimesStreamer {
 	return &headerTimesStreamer{
 		logger:         l,
 		uploadCallback: upload,

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -36,7 +36,7 @@ type JobRunner struct {
 	conf JobRunnerConfig
 
 	// The logger to use
-	logger *logger.Logger
+	logger logger.Logger
 
 	// The registered agent API record running this job
 	agent *api.AgentRegisterResponse
@@ -83,7 +83,7 @@ type JobRunner struct {
 }
 
 // Initializes the job runner
-func NewJobRunner(l *logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterResponse, j *api.Job, conf JobRunnerConfig) (*JobRunner, error) {
+func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterResponse, j *api.Job, conf JobRunnerConfig) (*JobRunner, error) {
 	runner := &JobRunner{
 		agent:   ag,
 		job:     j,

--- a/agent/log_streamer.go
+++ b/agent/log_streamer.go
@@ -22,7 +22,7 @@ type LogStreamer struct {
 	conf LogStreamerConfig
 
 	// The logger instance to use
-	logger *logger.Logger
+	logger logger.Logger
 
 	// A counter of how many chunks failed to upload
 	chunksFailedCount int32
@@ -63,7 +63,7 @@ type LogStreamerChunk struct {
 }
 
 // Creates a new instance of the log streamer
-func NewLogStreamer(l *logger.Logger, cb func(chunk *LogStreamerChunk) error, c LogStreamerConfig) *LogStreamer {
+func NewLogStreamer(l logger.Logger, cb func(chunk *LogStreamerChunk) error, c LogStreamerConfig) *LogStreamer {
 	return &LogStreamer{
 		logger:   l,
 		conf:     c,

--- a/agent/register.go
+++ b/agent/register.go
@@ -23,7 +23,7 @@ var (
 
 // Register takes an api.Agent and registers it with the Buildkite API
 // and populates the result of the register call
-func Register(l *logger.Logger, ac *api.Client, req api.AgentRegisterRequest) (*api.AgentRegisterResponse, error) {
+func Register(l logger.Logger, ac *api.Client, req api.AgentRegisterRequest) (*api.AgentRegisterResponse, error) {
 	var registered *api.AgentRegisterResponse
 	var err error
 	var resp *api.Response
@@ -72,7 +72,7 @@ func Register(l *logger.Logger, ac *api.Client, req api.AgentRegisterRequest) (*
 	return registered, err
 }
 
-func cacheRegisterSystemInfo(l *logger.Logger) {
+func cacheRegisterSystemInfo(l logger.Logger) {
 	var err error
 
 	machineID, err = machineid.ProtectedID("buildkite-agent")

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -93,7 +93,7 @@ func awsS3Session(region string) (*session.Session, error) {
 	return sess, nil
 }
 
-func newS3Client(l *logger.Logger, bucket string) (*s3.S3, error) {
+func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 	region, err := awsS3RegionFromEnv()
 	if err != nil {
 		return nil, err

--- a/agent/s3_downloader.go
+++ b/agent/s3_downloader.go
@@ -34,10 +34,10 @@ type S3Downloader struct {
 	conf S3DownloaderConfig
 
 	// The logger instance to use
-	logger *logger.Logger
+	logger logger.Logger
 }
 
-func NewS3Downloader(l *logger.Logger, c S3DownloaderConfig) *S3Downloader {
+func NewS3Downloader(l logger.Logger, c S3DownloaderConfig) *S3Downloader {
 	return &S3Downloader{
 		conf:   c,
 		logger: l,

--- a/agent/s3_uploader.go
+++ b/agent/s3_uploader.go
@@ -36,10 +36,10 @@ type S3Uploader struct {
 	conf S3UploaderConfig
 
 	// The logger instance to use
-	logger *logger.Logger
+	logger logger.Logger
 }
 
-func NewS3Uploader(l *logger.Logger, c S3UploaderConfig) (*S3Uploader, error) {
+func NewS3Uploader(l logger.Logger, c S3UploaderConfig) (*S3Uploader, error) {
 	bucketName, bucketPath := ParseS3Destination(c.Destination)
 
 	// Initialize the s3 client, and authenticate it

--- a/agent/tags.go
+++ b/agent/tags.go
@@ -24,7 +24,7 @@ type FetchTagsConfig struct {
 }
 
 // FetchTags loads tags from a variety of sources
-func FetchTags(l *logger.Logger, conf FetchTagsConfig) []string {
+func FetchTags(l logger.Logger, conf FetchTagsConfig) []string {
 	tags := conf.Tags
 
 	// Load tags from host

--- a/api/buildkite.go
+++ b/api/buildkite.go
@@ -31,7 +31,7 @@ type Client struct {
 	client *http.Client
 
 	// The logger used
-	logger *logger.Logger
+	logger logger.Logger
 
 	// Base URL for API requests. Defaults to the public Buildkite Agent API.
 	// The URL should always be specified with a trailing slash.
@@ -57,7 +57,7 @@ type Client struct {
 }
 
 // NewClient returns a new Buildkite Agent API Client.
-func NewClient(httpClient *http.Client, l *logger.Logger) *Client {
+func NewClient(httpClient *http.Client, l logger.Logger) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
 
 	c := &Client{

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -385,7 +385,7 @@ var AgentStartCommand = cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLogger()
+		l := logger.NewTextLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := AgentStartConfig{}

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -105,7 +105,7 @@ var AnnotateCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLogger()
+		l := logger.NewTextLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := AnnotateConfig{}

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -78,7 +78,7 @@ var ArtifactDownloadCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLogger()
+		l := logger.NewTextLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := ArtifactDownloadConfig{}

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -80,7 +80,7 @@ var ArtifactShasumCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLogger()
+		l := logger.NewTextLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := ArtifactShasumConfig{}

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -82,7 +82,7 @@ var ArtifactUploadCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLogger()
+		l := logger.NewTextLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := ArtifactUploadConfig{}

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -284,7 +284,7 @@ var BootstrapCommand = cli.Command{
 		ExperimentsFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLogger()
+		l := logger.NewTextLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := BootstrapConfig{}
@@ -301,7 +301,7 @@ var BootstrapCommand = cli.Command{
 
 		// Enable debug if set
 		if cfg.Debug {
-			l.Level = logger.DEBUG
+			l = l.WithLevel(logger.DEBUG)
 		}
 
 		// Turn of PTY support if we're on Windows

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -74,7 +74,7 @@ var ExperimentsFlag = cli.StringSliceFlag{
 	EnvVar: "BUILDKITE_AGENT_EXPERIMENT",
 }
 
-func HandleGlobalFlags(l *logger.Logger, cfg interface{}) {
+func HandleGlobalFlags(l logger.Logger, cfg interface{}) {
 	// Enable debugging, but disable the api client
 	debugWithoutAPI, err := reflections.GetField(cfg, "DebugWithoutAPI")
 	if debugWithoutAPI == true && err == nil {
@@ -84,15 +84,15 @@ func HandleGlobalFlags(l *logger.Logger, cfg interface{}) {
 	// Enable debugging if a Debug option is present
 	debug, _ := reflections.GetField(cfg, "Debug")
 	if debug == false && debugWithoutAPI == false {
-		l.Level = logger.INFO
+		l = l.WithLevel(logger.INFO)
 	}
 
 	// Turn off color if a NoColor option is present
 	noColor, err := reflections.GetField(cfg, "NoColor")
-	if noColor == true && err == nil {
-		l.Colors = false
+	if textLogger, ok := l.(*logger.TextLogger); ok && noColor == true && err == nil {
+		textLogger.Colors = false
 	} else {
-		l.Colors = true
+		textLogger.Colors = true
 	}
 
 	// Enable experiments

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -63,7 +63,7 @@ var MetaDataExistsCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLogger()
+		l := logger.NewTextLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := MetaDataExistsConfig{}

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -68,7 +68,7 @@ var MetaDataGetCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLogger()
+		l := logger.NewTextLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := MetaDataGetConfig{}

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -69,7 +69,7 @@ var MetaDataSetCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLogger()
+		l := logger.NewTextLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := MetaDataSetConfig{}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -102,7 +102,7 @@ var PipelineUploadCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLogger()
+		l := logger.NewTextLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := PipelineUploadConfig{}

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -73,7 +73,7 @@ var StepUpdateCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewLogger()
+		l := logger.NewTextLogger()
 
 		// The configuration will be loaded into this struct
 		cfg := StepUpdateConfig{}

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -22,7 +22,7 @@ type Loader struct {
 	Config interface{}
 
 	// The logger used
-	Logger *logger.Logger
+	Logger logger.Logger
 
 	// A slice of paths to files that should be used as config files
 	DefaultConfigFilePaths []string
@@ -34,7 +34,7 @@ type Loader struct {
 var argCliNameRegexp = regexp.MustCompile(`arg:(\d+)`)
 
 // A shortcut for loading a config from the CLI
-func Load(c *cli.Context, l *logger.Logger, cfg interface{}) error {
+func Load(c *cli.Context, l logger.Logger, cfg interface{}) error {
 	loader := Loader{
 		CLI:    c,
 		Config: cfg,

--- a/logger/log.go
+++ b/logger/log.go
@@ -32,7 +32,20 @@ var (
 	windowsColors bool
 )
 
-type Logger struct {
+type Logger interface {
+	Debug(format string, v ...interface{})
+	Error(format string, v ...interface{})
+	Fatal(format string, v ...interface{})
+	Notice(format string, v ...interface{})
+	Warn(format string, v ...interface{})
+	Info(format string, v ...interface{})
+
+	WithPrefix(prefix string) Logger
+	WithLevel(level Level) Logger
+	GetLevel() Level
+}
+
+type TextLogger struct {
 	Level  Level
 	Colors bool
 	Prefix string
@@ -40,8 +53,8 @@ type Logger struct {
 	ExitFn func()
 }
 
-func NewLogger() *Logger {
-	return &Logger{
+func NewTextLogger() Logger {
+	return &TextLogger{
 		Level:  DEBUG,
 		Colors: ColorsAvailable(),
 		Writer: os.Stderr,
@@ -63,53 +76,57 @@ func ColorsAvailable() bool {
 }
 
 // WithPrefix returns a copy of the logger with the provided prefix
-func (l *Logger) WithPrefix(prefix string) *Logger {
+func (l *TextLogger) WithPrefix(prefix string) Logger {
 	clone := *l
 	clone.Prefix = prefix
 	return &clone
 }
 
 // WithLevel returns a copy of the logger with the provided level
-func (l *Logger) WithLevel(level Level) *Logger {
+func (l *TextLogger) WithLevel(level Level) Logger {
 	clone := *l
 	clone.Level = level
 	return &clone
 }
 
-func (l *Logger) Debug(format string, v ...interface{}) {
+func (l *TextLogger) Debug(format string, v ...interface{}) {
 	if l.Level == DEBUG {
 		l.log(DEBUG, format, v...)
 	}
 }
 
-func (l *Logger) Error(format string, v ...interface{}) {
+func (l *TextLogger) Error(format string, v ...interface{}) {
 	l.log(ERROR, format, v...)
 }
 
-func (l *Logger) Fatal(format string, v ...interface{}) {
+func (l *TextLogger) Fatal(format string, v ...interface{}) {
 	l.log(FATAL, format, v...)
 	os.Exit(1)
 }
 
-func (l *Logger) Notice(format string, v ...interface{}) {
+func (l *TextLogger) Notice(format string, v ...interface{}) {
 	if l.Level <= NOTICE {
 		l.log(NOTICE, format, v...)
 	}
 }
 
-func (l *Logger) Info(format string, v ...interface{}) {
+func (l *TextLogger) Info(format string, v ...interface{}) {
 	if l.Level <= INFO {
 		l.log(INFO, format, v...)
 	}
 }
 
-func (l *Logger) Warn(format string, v ...interface{}) {
+func (l *TextLogger) Warn(format string, v ...interface{}) {
 	if l.Level <= WARN {
 		l.log(WARN, format, v...)
 	}
 }
 
-func (l *Logger) log(level Level, format string, v ...interface{}) {
+func (l *TextLogger) GetLevel() Level {
+	return l.Level
+}
+
+func (l *TextLogger) log(level Level, format string, v ...interface{}) {
 	message := fmt.Sprintf(format, v...)
 	now := time.Now().Format(DateFormat)
 	line := ""
@@ -152,6 +169,6 @@ func (l *Logger) log(level Level, format string, v ...interface{}) {
 	mutex.Unlock()
 }
 
-var Discard = &Logger{
+var Discard = &TextLogger{
 	Writer: ioutil.Discard,
 }

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 )
 
-func TestLevelLogger(t *testing.T) {
+func TestTextLogger(t *testing.T) {
 	b := &bytes.Buffer{}
-	l := NewLogger()
+	l := NewTextLogger().(*TextLogger)
 	l.Level = INFO
 	l.Colors = false
 	l.Writer = b

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -21,7 +21,7 @@ const (
 
 type Collector struct {
 	config CollectorConfig
-	logger *logger.Logger
+	logger logger.Logger
 	client *statsd.Client
 }
 
@@ -30,7 +30,7 @@ type CollectorConfig struct {
 	DatadogHost string
 }
 
-func NewCollector(l *logger.Logger, c CollectorConfig) *Collector {
+func NewCollector(l logger.Logger, c CollectorConfig) *Collector {
 	return &Collector{
 		config: c,
 		logger: l,

--- a/process/process.go
+++ b/process/process.go
@@ -37,14 +37,14 @@ type Process struct {
 	status        syscall.WaitStatus
 	pid           int
 	conf          Config
-	logger        *logger.Logger
+	logger        logger.Logger
 	command       *exec.Cmd
 	mu            sync.Mutex
 	started, done chan struct{}
 }
 
 // New returns a new instance of Process
-func New(l *logger.Logger, c Config) *Process {
+func New(l logger.Logger, c Config) *Process {
 	return &Process{
 		logger: l,
 		conf:   c,

--- a/process/run.go
+++ b/process/run.go
@@ -8,7 +8,7 @@ import (
 	"github.com/buildkite/agent/logger"
 )
 
-func Run(l *logger.Logger, command string, arg ...string) (string, error) {
+func Run(l logger.Logger, command string, arg ...string) (string, error) {
 	output, err := exec.Command(command, arg...).Output()
 
 	if err != nil {

--- a/process/scanner.go
+++ b/process/scanner.go
@@ -10,10 +10,10 @@ import (
 )
 
 type Scanner struct {
-	logger *logger.Logger
+	logger logger.Logger
 }
 
-func NewScanner(l *logger.Logger) *Scanner {
+func NewScanner(l logger.Logger) *Scanner {
 	return &Scanner{
 		logger: l,
 	}

--- a/process/signal.go
+++ b/process/signal.go
@@ -17,12 +17,12 @@ func SetupProcessGroup(cmd *exec.Cmd) {
 	}
 }
 
-func TerminateProcessGroup(p *os.Process, l *logger.Logger) error {
+func TerminateProcessGroup(p *os.Process, l logger.Logger) error {
 	l.Debug("[Process] Sending signal SIGKILL to PGID: %d", p.Pid)
 	return syscall.Kill(-p.Pid, syscall.SIGKILL)
 }
 
-func InterruptProcessGroup(p *os.Process, l *logger.Logger) error {
+func InterruptProcessGroup(p *os.Process, l logger.Logger) error {
 	l.Debug("[Process] Sending signal SIGTERM to PGID: %d", p.Pid)
 
 	// TODO: this should be SIGINT, but will be a breaking change

--- a/process/signal_windows.go
+++ b/process/signal_windows.go
@@ -32,7 +32,7 @@ func SetupProcessGroup(cmd *exec.Cmd) {
 	}
 }
 
-func TerminateProcessGroup(p *os.Process, l *logger.Logger) error {
+func TerminateProcessGroup(p *os.Process, l logger.Logger) error {
 	l.Debug("[Process] Terminating process tree with TASKKILL.EXE PID: %d", p.Pid)
 
 	// taskkill.exe with /F will call TerminateProcess and hard-kill the process and
@@ -40,7 +40,7 @@ func TerminateProcessGroup(p *os.Process, l *logger.Logger) error {
 	return exec.Command("CMD", "/C", "TASKKILL.EXE", "/F", "/T", "/PID", strconv.Itoa(p.Pid)).Run()
 }
 
-func InterruptProcessGroup(p *os.Process, l *logger.Logger) error {
+func InterruptProcessGroup(p *os.Process, l logger.Logger) error {
 	// Sends a CTRL-BREAK signal to the process group id, which is the same as the process PID
 	// For some reason I cannot fathom, this returns "Incorrect function" in docker for windows
 	r1, _, err := procGenerateConsoleCtrlEvent.Call(syscall.CTRL_BREAK_EVENT, uintptr(p.Pid))

--- a/system/version_dump.go
+++ b/system/version_dump.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Returns a dump of the raw operating system information
-func VersionDump(l *logger.Logger) (string, error) {
+func VersionDump(l logger.Logger) (string, error) {
 	if runtime.GOOS == "darwin" {
 		return process.Run(l, "sw_vers")
 	} else if runtime.GOOS == "linux" {

--- a/system/version_dump_windows.go
+++ b/system/version_dump_windows.go
@@ -7,7 +7,7 @@ import (
 	"github.com/buildkite/agent/logger"
 )
 
-func VersionDump(_ *logger.Logger) (string, error) {
+func VersionDump(_ logger.Logger) (string, error) {
 	dll := syscall.MustLoadDLL("kernel32.dll")
 	p := dll.MustFindProc("GetVersion")
 	v, _, _ := p.Call()


### PR DESCRIPTION
This moves the `logger.Logger` struct to an interface with a concrete implementation in `logger.TextLogger`. 

This prepares things for splitting out a json-based logger, or other logger implementations. 