### PR TITLE
Install docker-compose with curl vs pip

### DIFF
--- a/packaging/docker/alpine-linux/Dockerfile
+++ b/packaging/docker/alpine-linux/Dockerfile
@@ -10,14 +10,12 @@ RUN apk add --no-cache \
       docker \
       jq \
       su-exec \
-      py-pip \
       libc6-compat \
       run-parts \
       tini \
       tzdata \
-    && \
-    pip install --upgrade pip && \
-    pip install docker-compose
+    && curl -Lfs https://github.com/docker/compose/releases/download/1.21.0/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg
 


### PR DESCRIPTION
Seeing random failures related to `python2` and `pip` in the Alpine docker build. This removes that dependency entirely. 