### PR TITLE
Pin docker-compose to 1.23 to avoid extra deps

### DIFF
--- a/packaging/docker/alpine-linux/Dockerfile
+++ b/packaging/docker/alpine-linux/Dockerfile
@@ -17,7 +17,7 @@ RUN apk add --no-cache \
       tzdata \
     && \
     pip install --upgrade pip && \
-    pip install docker-compose
+    pip install --quiet docker-compose~=1.23.0
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg
 


### PR DESCRIPTION
The new docker-compose version introduces a dependency on gcc when installing. To avoid this, we'll pin to the previous version for now.

https://github.com/docker/compose/issues/6617