### PR TITLE
Support log output in json

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -20,7 +20,6 @@ type AgentConfiguration struct {
 	PluginValidation           bool
 	LocalHooksEnabled          bool
 	RunInPty                   bool
-	DisableColors              bool
 	TimestampLines             bool
 	DisconnectAfterJob         bool
 	DisconnectAfterJobTimeout  int

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -1,8 +1,6 @@
 package agent
 
 import (
-	"fmt"
-	"os"
 	"sync"
 
 	"github.com/buildkite/agent/logger"
@@ -106,58 +104,4 @@ func (r *AgentPool) watchWorkers() {
 			r.logger.Debug("Ignoring signal `%s`", sig.String())
 		}
 	})
-}
-
-// ShowBanner prints a welcome banner and the configuration options
-func ShowBanner(l logger.Logger, conf AgentConfiguration) {
-	welcomeMessage :=
-		"\n" +
-			"%s  _           _ _     _ _    _ _                                _\n" +
-			" | |         (_) |   | | |  (_) |                              | |\n" +
-			" | |__  _   _ _| | __| | | ___| |_ ___    __ _  __ _  ___ _ __ | |_\n" +
-			" | '_ \\| | | | | |/ _` | |/ / | __/ _ \\  / _` |/ _` |/ _ \\ '_ \\| __|\n" +
-			" | |_) | |_| | | | (_| |   <| | ||  __/ | (_| | (_| |  __/ | | | |_\n" +
-			" |_.__/ \\__,_|_|_|\\__,_|_|\\_\\_|\\__\\___|  \\__,_|\\__, |\\___|_| |_|\\__|\n" +
-			"                                                __/ |\n" +
-			" http://buildkite.com/agent                    |___/\n%s\n"
-
-	if !conf.DisableColors {
-		fmt.Fprintf(os.Stderr, welcomeMessage, "\x1b[38;5;48m", "\x1b[0m")
-	} else {
-		fmt.Fprintf(os.Stderr, welcomeMessage, "", "")
-	}
-
-	l.Notice("Starting buildkite-agent v%s with PID: %s", Version(), fmt.Sprintf("%d", os.Getpid()))
-	l.Notice("The agent source code can be found here: https://github.com/buildkite/agent")
-	l.Notice("For questions and support, email us at: hello@buildkite.com")
-
-	if conf.ConfigPath != "" {
-		l.Info("Configuration loaded from: %s", conf.ConfigPath)
-	}
-
-	l.Debug("Bootstrap command: %s", conf.BootstrapScript)
-	l.Debug("Build path: %s", conf.BuildPath)
-	l.Debug("Hooks directory: %s", conf.HooksPath)
-	l.Debug("Plugins directory: %s", conf.PluginsPath)
-
-	if !conf.SSHKeyscan {
-		l.Info("Automatic ssh-keyscan has been disabled")
-	}
-
-	if !conf.CommandEval {
-		l.Info("Evaluating console commands has been disabled")
-	}
-
-	if !conf.PluginsEnabled {
-		l.Info("Plugins have been disabled")
-	}
-
-	if !conf.RunInPty {
-		l.Info("Running builds within a pseudoterminal (PTY) has been disabled")
-	}
-
-	if conf.DisconnectAfterJob {
-		l.Info("Agent will disconnect after a job run has completed with a timeout of %d seconds",
-			conf.DisconnectAfterJobTimeout)
-	}
 }

--- a/agent/api_client.go
+++ b/agent/api_client.go
@@ -24,11 +24,6 @@ type APIClientConfig struct {
 	DisableHTTP2 bool
 }
 
-type APIClient struct {
-	config APIClientConfig
-	logger logger.Logger
-}
-
 func APIClientEnableHTTPDebug() {
 	debugHTTP = true
 }

--- a/api/buildkite.go
+++ b/api/buildkite.go
@@ -201,7 +201,11 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 		return nil, err
 	}
 
-	c.logger.Debug("↳ %s %s (%s %s %s)", req.Method, req.URL, resp.Proto, resp.Status, time.Now().Sub(ts))
+	c.logger.WithFields(
+		logger.StringField(`proto`, resp.Proto),
+		logger.IntField(`status`, resp.StatusCode),
+		logger.DurationField(`Δ`, time.Since(ts)),
+	).Debug("↳ %s %s", req.Method, req.URL)
 
 	defer resp.Body.Close()
 	defer io.Copy(ioutil.Discard, resp.Body)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -408,17 +408,7 @@ var AgentStartCommand = cli.Command{
 			os.Exit(1)
 		}
 
-		var l logger.Logger
-
-		switch cfg.LogFormat {
-		case `text`:
-			l = logger.NewTextLogger()
-		case `json`:
-			l = logger.NewJSONLogger()
-		default:
-			fmt.Printf("Unknown log-format of %q, try text or json\n", cfg.LogFormat)
-			os.Exit(1)
-		}
+		l := CreateLogger(cfg)
 
 		// Show warnings now we have a logger
 		for _, warning := range warnings {
@@ -632,7 +622,8 @@ var AgentStartCommand = cli.Command{
 
 			// Create an agent worker to run the agent
 			workers = append(workers,
-				agent.NewAgentWorker(l.WithFields(logger.AgentNameField(ag.Name)), ag, mc, workerConf))
+				agent.NewAgentWorker(
+					l.WithFields(logger.StringField(`agent`, ag.Name)), ag, mc, workerConf))
 		}
 
 		// Setup the agent pool that spawns agent workers

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -532,8 +532,58 @@ var AgentStartCommand = cli.Command{
 			agentConf.ConfigPath = loader.File.Path
 		}
 
-		// Show the welcome banner
-		agent.ShowBanner(l, agentConf)
+		if cfg.LogFormat == `text` {
+			welcomeMessage :=
+				"\n" +
+					"%s  _           _ _     _ _    _ _                                _\n" +
+					" | |         (_) |   | | |  (_) |                              | |\n" +
+					" | |__  _   _ _| | __| | | ___| |_ ___    __ _  __ _  ___ _ __ | |_\n" +
+					" | '_ \\| | | | | |/ _` | |/ / | __/ _ \\  / _` |/ _` |/ _ \\ '_ \\| __|\n" +
+					" | |_) | |_| | | | (_| |   <| | ||  __/ | (_| | (_| |  __/ | | | |_\n" +
+					" |_.__/ \\__,_|_|_|\\__,_|_|\\_\\_|\\__\\___|  \\__,_|\\__, |\\___|_| |_|\\__|\n" +
+					"                                                __/ |\n" +
+					" http://buildkite.com/agent                    |___/\n%s\n"
+
+			if !cfg.NoColor {
+				fmt.Fprintf(os.Stderr, welcomeMessage, "\x1b[38;5;48m", "\x1b[0m")
+			} else {
+				fmt.Fprintf(os.Stderr, welcomeMessage, "", "")
+			}
+		}
+
+		l.Notice("Starting buildkite-agent v%s with PID: %s", agent.Version(), fmt.Sprintf("%d", os.Getpid()))
+		l.Notice("The agent source code can be found here: https://github.com/buildkite/agent")
+		l.Notice("For questions and support, email us at: hello@buildkite.com")
+
+		if agentConf.ConfigPath != "" {
+			l.Info("Configuration loaded from: %s", agentConf.ConfigPath)
+		}
+
+		l.Debug("Bootstrap command: %s", agentConf.BootstrapScript)
+		l.Debug("Build path: %s", agentConf.BuildPath)
+		l.Debug("Hooks directory: %s", agentConf.HooksPath)
+		l.Debug("Plugins directory: %s", agentConf.PluginsPath)
+
+		if !agentConf.SSHKeyscan {
+			l.Info("Automatic ssh-keyscan has been disabled")
+		}
+
+		if !agentConf.CommandEval {
+			l.Info("Evaluating console commands has been disabled")
+		}
+
+		if !agentConf.PluginsEnabled {
+			l.Info("Plugins have been disabled")
+		}
+
+		if !agentConf.RunInPty {
+			l.Info("Running builds within a pseudoterminal (PTY) has been disabled")
+		}
+
+		if agentConf.DisconnectAfterJob {
+			l.Info("Agent will disconnect after a job run has completed with a timeout of %d seconds",
+				agentConf.DisconnectAfterJobTimeout)
+		}
 
 		apiClientConf := loadAPIClientConfig(cfg, `Token`)
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -546,7 +546,7 @@ var AgentStartCommand = cli.Command{
 		l.Notice("For questions and support, email us at: hello@buildkite.com")
 
 		if agentConf.ConfigPath != "" {
-			l.Info("Configuration loaded from: %s", agentConf.ConfigPath)
+			l.WithFields(logger.StringField(`path`, agentConf.ConfigPath)).Info("Configuration loaded")
 		}
 
 		l.Debug("Bootstrap command: %s", agentConf.BootstrapScript)

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -10,7 +10,6 @@ import (
 	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/cliconfig"
-	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/retry"
 	"github.com/urfave/cli"
 )
@@ -105,10 +104,10 @@ var AnnotateCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewTextLogger()
-
 		// The configuration will be loaded into this struct
 		cfg := AnnotateConfig{}
+
+		l := CreateLogger(&cfg)
 
 		// Load the configuration
 		if err := cliconfig.Load(c, l, &cfg); err != nil {

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -3,7 +3,6 @@ package clicommand
 import (
 	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/cliconfig"
-	"github.com/buildkite/agent/logger"
 	"github.com/urfave/cli"
 )
 
@@ -78,10 +77,10 @@ var ArtifactDownloadCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewTextLogger()
-
 		// The configuration will be loaded into this struct
 		cfg := ArtifactDownloadConfig{}
+
+		l := CreateLogger(&cfg)
 
 		// Load the configuration
 		if err := cliconfig.Load(c, l, &cfg); err != nil {

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/cliconfig"
-	"github.com/buildkite/agent/logger"
 	"github.com/urfave/cli"
 )
 
@@ -80,10 +79,10 @@ var ArtifactShasumCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewTextLogger()
-
 		// The configuration will be loaded into this struct
 		cfg := ArtifactShasumConfig{}
+
+		l := CreateLogger(&cfg)
 
 		// Load the configuration
 		if err := cliconfig.Load(c, l, &cfg); err != nil {

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -3,7 +3,6 @@ package clicommand
 import (
 	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/cliconfig"
-	"github.com/buildkite/agent/logger"
 	"github.com/urfave/cli"
 )
 
@@ -82,10 +81,10 @@ var ArtifactUploadCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewTextLogger()
-
 		// The configuration will be loaded into this struct
 		cfg := ArtifactUploadConfig{}
+
+		l := CreateLogger(&cfg)
 
 		// Load the configuration
 		if err := cliconfig.Load(c, l, &cfg); err != nil {

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -284,10 +284,10 @@ var BootstrapCommand = cli.Command{
 		ExperimentsFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewTextLogger()
-
 		// The configuration will be loaded into this struct
 		cfg := BootstrapConfig{}
+
+		l := CreateLogger(&cfg)
 
 		// Load the configuration
 		if err := cliconfig.Load(c, l, &cfg); err != nil {

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -77,10 +77,12 @@ func HandleGlobalFlags(l logger.Logger, cfg interface{}) {
 
 	// Turn off color if a NoColor option is present
 	noColor, err := reflections.GetField(cfg, "NoColor")
-	if textLogger, ok := l.(*logger.TextLogger); ok && noColor == true && err == nil {
-		textLogger.Colors = false
-	} else {
-		textLogger.Colors = true
+	if textLogger, ok := l.(*logger.TextLogger); ok {
+		if noColor == true && err == nil {
+			textLogger.Colors = false
+		} else {
+			textLogger.Colors = true
+		}
 	}
 
 	// Enable experiments

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -162,14 +162,3 @@ func loadAPIClientConfig(cfg interface{}, tokenField string) agent.APIClientConf
 
 	return a
 }
-
-type loggerPresenter struct {
-}
-
-func (lp *loggerPresenter) IsVisible(f logger.Field) bool {
-	return true
-}
-
-func (lp *loggerPresenter) IsPrefix(f logger.Field) bool {
-	return f.Key() == `agent_name`
-}

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -79,6 +79,11 @@ func CreateLogger(cfg interface{}) logger.Logger {
 		case `text`:
 			printer := logger.NewTextPrinter(os.Stdout)
 
+			// Show agent fields as a prefix
+			printer.IsPrefixFn = func(field logger.Field) bool {
+				return field.Key() == `agent`
+			}
+
 			// Turn off color if a NoColor option is present
 			noColor, err := reflections.GetField(cfg, "NoColor")
 			if noColor == true && err == nil {

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -74,7 +74,7 @@ func CreateLogger(cfg interface{}) logger.Logger {
 	logFormat := `text`
 
 	// Check the LogFormat config field
-	if logFormatCfg, err := reflections.GetField(cfg, "LogFormat"); err != nil {
+	if logFormatCfg, err := reflections.GetField(cfg, "LogFormat"); err == nil {
 		if logFormatString, ok := logFormatCfg.(string); ok {
 			logFormat = logFormatString
 		}

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -1,6 +1,7 @@
 package clicommand
 
 import (
+	"fmt"
 	"os"
 	"reflect"
 	"strings"
@@ -68,21 +69,43 @@ var ExperimentsFlag = cli.StringSliceFlag{
 	EnvVar: "BUILDKITE_AGENT_EXPERIMENT",
 }
 
+func CreateLogger(cfg interface{}) logger.Logger {
+	var l logger.Logger
+
+	// Change the format if one is provided
+	logFormat, _ := reflections.GetField(cfg, "LogFormat")
+	if logFormat != "" {
+		switch logFormat {
+		case `text`:
+			printer := logger.NewTextPrinter(os.Stdout)
+
+			// Turn off color if a NoColor option is present
+			noColor, err := reflections.GetField(cfg, "NoColor")
+			if noColor == true && err == nil {
+				printer.Colors = false
+			} else {
+				printer.Colors = true
+			}
+
+			l = logger.NewConsoleLogger(printer, os.Exit)
+		case `json`:
+			l = logger.NewConsoleLogger(logger.NewJSONPrinter(os.Stdout), os.Exit)
+		default:
+			fmt.Printf("Unknown log-format of %q, try text or json\n", logFormat)
+			os.Exit(1)
+		}
+	}
+
+	return l
+}
+
 func HandleGlobalFlags(l logger.Logger, cfg interface{}) {
 	// Enable debugging if a Debug option is present
 	debug, _ := reflections.GetField(cfg, "Debug")
-	if debug.(bool) {
+	if debug == true {
 		l.SetLevel(logger.DEBUG)
-	}
-
-	// Turn off color if a NoColor option is present
-	noColor, err := reflections.GetField(cfg, "NoColor")
-	if textLogger, ok := l.(*logger.TextLogger); ok {
-		if noColor == true && err == nil {
-			textLogger.Colors = false
-		} else {
-			textLogger.Colors = true
-		}
+	} else {
+		l.SetLevel(logger.NOTICE)
 	}
 
 	// Enable experiments
@@ -138,4 +161,15 @@ func loadAPIClientConfig(cfg interface{}, tokenField string) agent.APIClientConf
 	}
 
 	return a
+}
+
+type loggerPresenter struct {
+}
+
+func (lp *loggerPresenter) IsVisible(f logger.Field) bool {
+	return true
+}
+
+func (lp *loggerPresenter) IsPrefix(f logger.Field) bool {
+	return f.Key() == `agent_name`
 }

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -7,7 +7,6 @@ import (
 	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/cliconfig"
-	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/retry"
 	"github.com/urfave/cli"
 )
@@ -63,10 +62,10 @@ var MetaDataExistsCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewTextLogger()
-
 		// The configuration will be loaded into this struct
 		cfg := MetaDataExistsConfig{}
+
+		l := CreateLogger(&cfg)
 
 		// Load the configuration
 		if err := cliconfig.Load(c, l, &cfg); err != nil {

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -7,7 +7,6 @@ import (
 	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/cliconfig"
-	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/retry"
 	"github.com/urfave/cli"
 )
@@ -68,10 +67,10 @@ var MetaDataGetCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewTextLogger()
-
 		// The configuration will be loaded into this struct
 		cfg := MetaDataGetConfig{}
+
+		l := CreateLogger(&cfg)
 
 		// Load the configuration
 		if err := cliconfig.Load(c, l, &cfg); err != nil {

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -8,7 +8,6 @@ import (
 	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/cliconfig"
-	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/retry"
 	"github.com/urfave/cli"
 )
@@ -69,10 +68,10 @@ var MetaDataSetCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewTextLogger()
-
 		// The configuration will be loaded into this struct
 		cfg := MetaDataSetConfig{}
+
+		l := CreateLogger(&cfg)
 
 		// Load the configuration
 		if err := cliconfig.Load(c, l, &cfg); err != nil {

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -14,7 +14,6 @@ import (
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/cliconfig"
 	"github.com/buildkite/agent/env"
-	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/retry"
 	"github.com/buildkite/agent/stdin"
 	"github.com/urfave/cli"
@@ -102,10 +101,10 @@ var PipelineUploadCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewTextLogger()
-
 		// The configuration will be loaded into this struct
 		cfg := PipelineUploadConfig{}
+
+		l := CreateLogger(&cfg)
 
 		// Load the configuration
 		if err := cliconfig.Load(c, l, &cfg); err != nil {

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -8,7 +8,6 @@ import (
 	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/api"
 	"github.com/buildkite/agent/cliconfig"
-	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/retry"
 	"github.com/urfave/cli"
 )
@@ -73,10 +72,10 @@ var StepUpdateCommand = cli.Command{
 		DebugFlag,
 	},
 	Action: func(c *cli.Context) {
-		l := logger.NewTextLogger()
-
 		// The configuration will be loaded into this struct
 		cfg := StepUpdateConfig{}
+
+		l := CreateLogger(&cfg)
 
 		// Load the configuration
 		if err := cliconfig.Load(c, l, &cfg); err != nil {

--- a/logger/field.go
+++ b/logger/field.go
@@ -1,0 +1,36 @@
+package logger
+
+type Field interface {
+	Key() string
+	Value() string
+}
+
+type Fields []Field
+
+func (f *Fields) Add(fields ...Field) {
+	*f = append(*f, fields...)
+}
+
+func (f *Fields) Get(key string) []Field {
+	fields := []Field{}
+	for _, field := range *f {
+		if field.Key() == key {
+			fields = append(fields, field)
+		}
+	}
+	return fields
+}
+
+type agentNameField string
+
+func (a agentNameField) Key() string {
+	return `agent_name`
+}
+
+func (a agentNameField) Value() string {
+	return string(a)
+}
+
+func AgentNameField(name string) Field {
+	return agentNameField(name)
+}

--- a/logger/field.go
+++ b/logger/field.go
@@ -1,8 +1,13 @@
 package logger
 
+import (
+	"fmt"
+	"time"
+)
+
 type Field interface {
 	Key() string
-	Value() string
+	String() string
 }
 
 type Fields []Field
@@ -21,16 +26,40 @@ func (f *Fields) Get(key string) []Field {
 	return fields
 }
 
-type agentNameField string
-
-func (a agentNameField) Key() string {
-	return `agent_name`
+type GenericField struct {
+	key    string
+	value  interface{}
+	format string
 }
 
-func (a agentNameField) Value() string {
-	return string(a)
+func (f GenericField) Key() string {
+	return f.key
 }
 
-func AgentNameField(name string) Field {
-	return agentNameField(name)
+func (f GenericField) String() string {
+	return fmt.Sprintf(f.format, f.value)
+}
+
+func StringField(key, value string) Field {
+	return GenericField{
+		key:    key,
+		value:  value,
+		format: "%s",
+	}
+}
+
+func IntField(key string, value int) Field {
+	return GenericField{
+		key:    key,
+		value:  value,
+		format: "%d",
+	}
+}
+
+func DurationField(key string, value time.Duration) Field {
+	return GenericField{
+		key:    key,
+		value:  value,
+		format: "%v",
+	}
 }

--- a/logger/log.go
+++ b/logger/log.go
@@ -266,6 +266,7 @@ func (l *JSONLogger) PrintLine(level Level, format string, v ...interface{}) {
 	var b strings.Builder
 
 	b.WriteString(fmt.Sprintf(`"ts":%q,`, time.Now().Format(time.RFC3339)))
+	b.WriteString(fmt.Sprintf(`"level":%q,`, level.String()))
 	b.WriteString(fmt.Sprintf(`"msg":%q,`, fmt.Sprintf(format, v...)))
 
 	for _, field := range l.Fields {

--- a/logger/log.go
+++ b/logger/log.go
@@ -141,7 +141,6 @@ func NewTextPrinter(w io.Writer) *TextPrinter {
 func (l *TextPrinter) Print(level Level, msg string, fields Fields) {
 	now := time.Now().Format(DateFormat)
 
-	var prefix string
 	var line string
 	var fieldStrs []string
 
@@ -165,24 +164,15 @@ func (l *TextPrinter) Print(level Level, msg string, fields Fields) {
 			messageColor = red
 		}
 
-		if prefix != "" {
-			line = fmt.Sprintf("\x1b[%sm%s %-6s\x1b[0m \x1b[%sm%s\x1b[0m \x1b[%sm%s\x1b[0m",
-				levelColor, now, level, lightgray, prefix, messageColor, msg)
-		} else {
-			line = fmt.Sprintf("\x1b[%sm%s %-6s\x1b[0m \x1b[%sm%s\x1b[0m",
-				fieldColor, now, level, messageColor, msg)
-		}
+		line = fmt.Sprintf("\x1b[%sm%s %-6s\x1b[0m \x1b[%sm%s\x1b[0m",
+			levelColor, now, level, messageColor, msg)
 
 		for _, field := range fields {
 			fieldStrs = append(fieldStrs, fmt.Sprintf("\x1b[%sm%s=\x1b[0m\x1b[%sm%s\x1b[0m",
-				lightgray, field.Key(), messageColor, field.String()))
+				fieldColor, field.Key(), messageColor, field.String()))
 		}
 	} else {
-		if prefix != "" {
-			line = fmt.Sprintf("%s %-6s %s %s", now, level, prefix, msg)
-		} else {
-			line = fmt.Sprintf("%s %-6s %s", now, level, msg)
-		}
+		line = fmt.Sprintf("%s %-6s %s", now, level, msg)
 
 		for _, field := range fields {
 			if field.Key() == `agent_name` {

--- a/logger/log.go
+++ b/logger/log.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,7 +18,6 @@ const (
 	red       = "31"
 	green     = "38;5;48"
 	yellow    = "33"
-	blue      = "34"
 	gray      = "38;5;251"
 	lightgray = "38;5;243"
 	cyan      = "1;36"
@@ -40,7 +40,7 @@ type Logger interface {
 	Warn(format string, v ...interface{})
 	Info(format string, v ...interface{})
 
-	WithPrefix(prefix string) Logger
+	WithFields(fields ...Field) Logger
 	SetLevel(level Level)
 	GetLevel() Level
 }
@@ -48,9 +48,9 @@ type Logger interface {
 type TextLogger struct {
 	Level  Level
 	Colors bool
-	Prefix string
 	Writer io.Writer
 	ExitFn func()
+	Fields Fields
 }
 
 func NewTextLogger() Logger {
@@ -58,6 +58,7 @@ func NewTextLogger() Logger {
 		Level:  NOTICE,
 		Colors: ColorsAvailable(),
 		Writer: os.Stderr,
+		Fields: Fields{},
 	}
 }
 
@@ -75,10 +76,10 @@ func ColorsAvailable() bool {
 	return false
 }
 
-// WithPrefix returns a copy of the logger with the provided prefix
-func (l *TextLogger) WithPrefix(prefix string) Logger {
+// WithFields returns a copy of the logger with the provided fields
+func (l *TextLogger) WithFields(fields ...Field) Logger {
 	clone := *l
-	clone.Prefix = prefix
+	clone.Fields.Add(fields...)
 	return &clone
 }
 
@@ -89,34 +90,34 @@ func (l *TextLogger) SetLevel(level Level) {
 
 func (l *TextLogger) Debug(format string, v ...interface{}) {
 	if l.Level == DEBUG {
-		l.log(DEBUG, format, v...)
+		l.PrintLine(DEBUG, format, v...)
 	}
 }
 
 func (l *TextLogger) Error(format string, v ...interface{}) {
-	l.log(ERROR, format, v...)
+	l.PrintLine(ERROR, format, v...)
 }
 
 func (l *TextLogger) Fatal(format string, v ...interface{}) {
-	l.log(FATAL, format, v...)
+	l.PrintLine(FATAL, format, v...)
 	os.Exit(1)
 }
 
 func (l *TextLogger) Notice(format string, v ...interface{}) {
 	if l.Level <= NOTICE {
-		l.log(NOTICE, format, v...)
+		l.PrintLine(NOTICE, format, v...)
 	}
 }
 
 func (l *TextLogger) Info(format string, v ...interface{}) {
 	if l.Level <= INFO {
-		l.log(INFO, format, v...)
+		l.PrintLine(INFO, format, v...)
 	}
 }
 
 func (l *TextLogger) Warn(format string, v ...interface{}) {
 	if l.Level <= WARN {
-		l.log(WARN, format, v...)
+		l.PrintLine(WARN, format, v...)
 	}
 }
 
@@ -124,10 +125,17 @@ func (l *TextLogger) GetLevel() Level {
 	return l.Level
 }
 
-func (l *TextLogger) log(level Level, format string, v ...interface{}) {
+func (l *TextLogger) PrintLine(level Level, format string, v ...interface{}) {
 	message := fmt.Sprintf(format, v...)
 	now := time.Now().Format(DateFormat)
-	line := ""
+
+	var prefix string
+	var line string
+	var fields []string
+
+	if fields := l.Fields.Get(`agent_name`); len(fields) > 0 {
+		prefix = fields[0].Value()
+	}
 
 	if l.Colors {
 		levelColor := green
@@ -148,25 +156,124 @@ func (l *TextLogger) log(level Level, format string, v ...interface{}) {
 			messageColor = red
 		}
 
-		if l.Prefix != "" {
-			line = fmt.Sprintf("\x1b[%sm%s %-6s\x1b[0m \x1b[%sm%s\x1b[0m \x1b[%sm%s\x1b[0m\n", levelColor, now, level, lightgray, l.Prefix, messageColor, message)
+		if prefix != "" {
+			line = fmt.Sprintf("\x1b[%sm%s %-6s\x1b[0m \x1b[%sm%s\x1b[0m \x1b[%sm%s\x1b[0m",
+				levelColor, now, level, lightgray, prefix, messageColor, message)
 		} else {
-			line = fmt.Sprintf("\x1b[%sm%s %-6s\x1b[0m \x1b[%sm%s\x1b[0m\n", levelColor, now, level, messageColor, message)
+			line = fmt.Sprintf("\x1b[%sm%s %-6s\x1b[0m \x1b[%sm%s\x1b[0m",
+				levelColor, now, level, messageColor, message)
+		}
+
+		for _, field := range l.Fields {
+			if field.Key() == `agent_name` {
+				continue
+			}
+			fields = append(fields, fmt.Sprintf("\x1b[%sm%s=\x1b[0m\x1b[%sm%s\x1b[0m",
+				lightgray, field.Key(), lightgray, field.Value()))
 		}
 	} else {
-		if l.Prefix != "" {
-			line = fmt.Sprintf("%s %-6s %s %s\n", now, level, l.Prefix, message)
+		if prefix != "" {
+			line = fmt.Sprintf("%s %-6s %s %s", now, level, prefix, message)
 		} else {
-			line = fmt.Sprintf("%s %-6s %s\n", now, level, message)
+			line = fmt.Sprintf("%s %-6s %s", now, level, message)
+		}
+
+		for _, field := range l.Fields {
+			if field.Key() == `agent_name` {
+				continue
+			}
+			fields = append(fields, fmt.Sprintf("%s=%s", field.Key(), field.Value()))
 		}
 	}
 
-	// Make sure we're only outputing a line one at a time
+	// Make sure we're only outputting a line one at a time
 	mutex.Lock()
 	fmt.Fprint(l.Writer, line)
+	if len(fields) > 0 {
+		fmt.Fprintf(l.Writer, " %s", strings.Join(fields, " "))
+	}
+	fmt.Fprint(l.Writer, "\n")
 	mutex.Unlock()
 }
 
 var Discard = &TextLogger{
 	Writer: ioutil.Discard,
+}
+
+type JSONLogger struct {
+	Level  Level
+	Writer io.Writer
+	ExitFn func()
+	Fields Fields
+}
+
+func NewJSONLogger() Logger {
+	return &JSONLogger{
+		Level:  DEBUG,
+		Writer: os.Stderr,
+		Fields: Fields{},
+	}
+}
+
+func (l *JSONLogger) WithFields(fields ...Field) Logger {
+	clone := *l
+	clone.Fields.Add(fields...)
+	return &clone
+}
+
+func (l *JSONLogger) SetLevel(level Level) {
+	l.Level = level
+}
+
+func (l *JSONLogger) Debug(format string, v ...interface{}) {
+	if l.Level == DEBUG {
+		l.PrintLine(DEBUG, format, v...)
+	}
+}
+
+func (l *JSONLogger) Error(format string, v ...interface{}) {
+	l.PrintLine(ERROR, format, v...)
+}
+
+func (l *JSONLogger) Fatal(format string, v ...interface{}) {
+	l.PrintLine(FATAL, format, v...)
+	os.Exit(1)
+}
+
+func (l *JSONLogger) Notice(format string, v ...interface{}) {
+	if l.Level <= NOTICE {
+		l.PrintLine(NOTICE, format, v...)
+	}
+}
+
+func (l *JSONLogger) Info(format string, v ...interface{}) {
+	if l.Level <= INFO {
+		l.PrintLine(INFO, format, v...)
+	}
+}
+
+func (l *JSONLogger) Warn(format string, v ...interface{}) {
+	if l.Level <= WARN {
+		l.PrintLine(WARN, format, v...)
+	}
+}
+
+func (l *JSONLogger) GetLevel() Level {
+	return l.Level
+}
+
+func (l *JSONLogger) PrintLine(level Level, format string, v ...interface{}) {
+	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf(`"ts":%q,`, time.Now().Format(time.RFC3339)))
+	b.WriteString(fmt.Sprintf(`"msg":%q,`, fmt.Sprintf(format, v...)))
+
+	for _, field := range l.Fields {
+		b.WriteString(fmt.Sprintf(`%q:%q,`, field.Key(), field.Value()))
+	}
+
+	// Make sure we're only outputting a line one at a time
+	mutex.Lock()
+	fmt.Fprintf(l.Writer, "{%s}\n", strings.TrimSuffix(b.String(), ","))
+	mutex.Unlock()
 }

--- a/logger/log.go
+++ b/logger/log.go
@@ -19,6 +19,7 @@ const (
 	green     = "38;5;48"
 	yellow    = "33"
 	gray      = "38;5;251"
+	graybold  = "1;38;5;251"
 	lightgray = "38;5;243"
 	cyan      = "1;36"
 )
@@ -42,104 +43,112 @@ type Logger interface {
 
 	WithFields(fields ...Field) Logger
 	SetLevel(level Level)
-	GetLevel() Level
+	Level() Level
 }
 
-type TextLogger struct {
-	Level  Level
-	Colors bool
-	Writer io.Writer
-	ExitFn func()
-	Fields Fields
+type ConsoleLogger struct {
+	level   Level
+	exitFn  func(int)
+	fields  Fields
+	printer Printer
 }
 
-func NewTextLogger() Logger {
-	return &TextLogger{
-		Level:  NOTICE,
-		Colors: ColorsAvailable(),
-		Writer: os.Stderr,
-		Fields: Fields{},
+func NewConsoleLogger(printer Printer, exitFn func(int)) Logger {
+	return &ConsoleLogger{
+		level:   DEBUG,
+		fields:  Fields{},
+		printer: printer,
+		exitFn:  exitFn,
 	}
-}
-
-func ColorsAvailable() bool {
-	// Color support for windows is set in init
-	if runtime.GOOS == "windows" && !windowsColors {
-		return false
-	}
-
-	// Colors can only be shown if STDOUT is a terminal
-	if terminal.IsTerminal(int(os.Stdout.Fd())) {
-		return true
-	}
-
-	return false
 }
 
 // WithFields returns a copy of the logger with the provided fields
-func (l *TextLogger) WithFields(fields ...Field) Logger {
+func (l *ConsoleLogger) WithFields(fields ...Field) Logger {
 	clone := *l
-	clone.Fields.Add(fields...)
+	clone.fields.Add(fields...)
 	return &clone
 }
 
 // SetLevel sets the level for the logger
-func (l *TextLogger) SetLevel(level Level) {
-	l.Level = level
+func (l *ConsoleLogger) SetLevel(level Level) {
+	l.level = level
 }
 
-func (l *TextLogger) Debug(format string, v ...interface{}) {
-	if l.Level == DEBUG {
-		l.PrintLine(DEBUG, format, v...)
+func (l *ConsoleLogger) Debug(format string, v ...interface{}) {
+	if l.level == DEBUG {
+		l.printer.Print(DEBUG, fmt.Sprintf(format, v...), l.fields)
 	}
 }
 
-func (l *TextLogger) Error(format string, v ...interface{}) {
-	l.PrintLine(ERROR, format, v...)
+func (l *ConsoleLogger) Error(format string, v ...interface{}) {
+	l.printer.Print(ERROR, fmt.Sprintf(format, v...), l.fields)
 }
 
-func (l *TextLogger) Fatal(format string, v ...interface{}) {
-	l.PrintLine(FATAL, format, v...)
-	os.Exit(1)
+func (l *ConsoleLogger) Fatal(format string, v ...interface{}) {
+	l.printer.Print(FATAL, fmt.Sprintf(format, v...), l.fields)
+	l.exitFn(1)
 }
 
-func (l *TextLogger) Notice(format string, v ...interface{}) {
-	if l.Level <= NOTICE {
-		l.PrintLine(NOTICE, format, v...)
+func (l *ConsoleLogger) Notice(format string, v ...interface{}) {
+	if l.level <= NOTICE {
+		l.printer.Print(NOTICE, fmt.Sprintf(format, v...), l.fields)
 	}
 }
 
-func (l *TextLogger) Info(format string, v ...interface{}) {
-	if l.Level <= INFO {
-		l.PrintLine(INFO, format, v...)
+func (l *ConsoleLogger) Info(format string, v ...interface{}) {
+	if l.level <= INFO {
+		l.printer.Print(INFO, fmt.Sprintf(format, v...), l.fields)
 	}
 }
 
-func (l *TextLogger) Warn(format string, v ...interface{}) {
-	if l.Level <= WARN {
-		l.PrintLine(WARN, format, v...)
+func (l *ConsoleLogger) Warn(format string, v ...interface{}) {
+	if l.level <= WARN {
+		l.printer.Print(WARN, fmt.Sprintf(format, v...), l.fields)
 	}
 }
 
-func (l *TextLogger) GetLevel() Level {
-	return l.Level
+func (l *ConsoleLogger) Level() Level {
+	return l.level
 }
 
-func (l *TextLogger) PrintLine(level Level, format string, v ...interface{}) {
-	message := fmt.Sprintf(format, v...)
+type Presenter interface {
+	IsVisible(f Field) bool
+	IsPrefix(f Field) bool
+}
+
+type DefaultPresenter struct{}
+
+func (p *DefaultPresenter) IsVisible(f Field) bool { return true }
+func (p *DefaultPresenter) IsPrefix(f Field) bool  { return true }
+
+type Printer interface {
+	Print(level Level, msg string, fields Fields)
+}
+
+type TextPrinter struct {
+	Colors    bool
+	Writer    io.Writer
+	Presenter Presenter
+}
+
+func NewTextPrinter(w io.Writer) *TextPrinter {
+	return &TextPrinter{
+		Writer: w,
+		Colors: ColorsSupported(),
+	}
+}
+
+func (l *TextPrinter) Print(level Level, msg string, fields Fields) {
 	now := time.Now().Format(DateFormat)
 
 	var prefix string
 	var line string
-	var fields []string
-
-	if fields := l.Fields.Get(`agent_name`); len(fields) > 0 {
-		prefix = fields[0].Value()
-	}
+	var fieldStrs []string
 
 	if l.Colors {
 		levelColor := green
 		messageColor := nocolor
+		fieldColor := graybold
 
 		switch level {
 		case DEBUG:
@@ -158,31 +167,28 @@ func (l *TextLogger) PrintLine(level Level, format string, v ...interface{}) {
 
 		if prefix != "" {
 			line = fmt.Sprintf("\x1b[%sm%s %-6s\x1b[0m \x1b[%sm%s\x1b[0m \x1b[%sm%s\x1b[0m",
-				levelColor, now, level, lightgray, prefix, messageColor, message)
+				levelColor, now, level, lightgray, prefix, messageColor, msg)
 		} else {
 			line = fmt.Sprintf("\x1b[%sm%s %-6s\x1b[0m \x1b[%sm%s\x1b[0m",
-				levelColor, now, level, messageColor, message)
+				fieldColor, now, level, messageColor, msg)
 		}
 
-		for _, field := range l.Fields {
-			if field.Key() == `agent_name` {
-				continue
-			}
-			fields = append(fields, fmt.Sprintf("\x1b[%sm%s=\x1b[0m\x1b[%sm%s\x1b[0m",
-				lightgray, field.Key(), lightgray, field.Value()))
+		for _, field := range fields {
+			fieldStrs = append(fieldStrs, fmt.Sprintf("\x1b[%sm%s=\x1b[0m\x1b[%sm%s\x1b[0m",
+				lightgray, field.Key(), messageColor, field.String()))
 		}
 	} else {
 		if prefix != "" {
-			line = fmt.Sprintf("%s %-6s %s %s", now, level, prefix, message)
+			line = fmt.Sprintf("%s %-6s %s %s", now, level, prefix, msg)
 		} else {
-			line = fmt.Sprintf("%s %-6s %s", now, level, message)
+			line = fmt.Sprintf("%s %-6s %s", now, level, msg)
 		}
 
-		for _, field := range l.Fields {
+		for _, field := range fields {
 			if field.Key() == `agent_name` {
 				continue
 			}
-			fields = append(fields, fmt.Sprintf("%s=%s", field.Key(), field.Value()))
+			fieldStrs = append(fieldStrs, fmt.Sprintf("%s=%s", field.Key(), field.String()))
 		}
 	}
 
@@ -190,91 +196,56 @@ func (l *TextLogger) PrintLine(level Level, format string, v ...interface{}) {
 	mutex.Lock()
 	fmt.Fprint(l.Writer, line)
 	if len(fields) > 0 {
-		fmt.Fprintf(l.Writer, " %s", strings.Join(fields, " "))
+		fmt.Fprintf(l.Writer, " %s", strings.Join(fieldStrs, " "))
 	}
 	fmt.Fprint(l.Writer, "\n")
 	mutex.Unlock()
 }
 
-var Discard = &TextLogger{
-	Writer: ioutil.Discard,
+func ColorsSupported() bool {
+	// Color support for windows is set in init
+	if runtime.GOOS == "windows" && !windowsColors {
+		return false
+	}
+
+	// Colors can only be shown if STDOUT is a terminal
+	if terminal.IsTerminal(int(os.Stdout.Fd())) {
+		return true
+	}
+
+	return false
 }
 
-type JSONLogger struct {
-	Level  Level
-	Writer io.Writer
-	ExitFn func()
-	Fields Fields
+type JSONPrinter struct {
+	Writer    io.Writer
+	Presenter Presenter
 }
 
-func NewJSONLogger() Logger {
-	return &JSONLogger{
-		Level:  DEBUG,
-		Writer: os.Stderr,
-		Fields: Fields{},
+func NewJSONPrinter(w io.Writer) *JSONPrinter {
+	return &JSONPrinter{
+		Writer: w,
 	}
 }
 
-func (l *JSONLogger) WithFields(fields ...Field) Logger {
-	clone := *l
-	clone.Fields.Add(fields...)
-	return &clone
-}
-
-func (l *JSONLogger) SetLevel(level Level) {
-	l.Level = level
-}
-
-func (l *JSONLogger) Debug(format string, v ...interface{}) {
-	if l.Level == DEBUG {
-		l.PrintLine(DEBUG, format, v...)
-	}
-}
-
-func (l *JSONLogger) Error(format string, v ...interface{}) {
-	l.PrintLine(ERROR, format, v...)
-}
-
-func (l *JSONLogger) Fatal(format string, v ...interface{}) {
-	l.PrintLine(FATAL, format, v...)
-	os.Exit(1)
-}
-
-func (l *JSONLogger) Notice(format string, v ...interface{}) {
-	if l.Level <= NOTICE {
-		l.PrintLine(NOTICE, format, v...)
-	}
-}
-
-func (l *JSONLogger) Info(format string, v ...interface{}) {
-	if l.Level <= INFO {
-		l.PrintLine(INFO, format, v...)
-	}
-}
-
-func (l *JSONLogger) Warn(format string, v ...interface{}) {
-	if l.Level <= WARN {
-		l.PrintLine(WARN, format, v...)
-	}
-}
-
-func (l *JSONLogger) GetLevel() Level {
-	return l.Level
-}
-
-func (l *JSONLogger) PrintLine(level Level, format string, v ...interface{}) {
+func (p *JSONPrinter) Print(level Level, msg string, fields Fields) {
 	var b strings.Builder
 
 	b.WriteString(fmt.Sprintf(`"ts":%q,`, time.Now().Format(time.RFC3339)))
 	b.WriteString(fmt.Sprintf(`"level":%q,`, level.String()))
-	b.WriteString(fmt.Sprintf(`"msg":%q,`, fmt.Sprintf(format, v...)))
+	b.WriteString(fmt.Sprintf(`"msg":%q,`, msg))
 
-	for _, field := range l.Fields {
-		b.WriteString(fmt.Sprintf(`%q:%q,`, field.Key(), field.Value()))
+	for _, field := range fields {
+		b.WriteString(fmt.Sprintf(`%q:%q,`, field.Key(), field.String()))
 	}
 
 	// Make sure we're only outputting a line one at a time
 	mutex.Lock()
-	fmt.Fprintf(l.Writer, "{%s}\n", strings.TrimSuffix(b.String(), ","))
+	fmt.Fprintf(p.Writer, "{%s}\n", strings.TrimSuffix(b.String(), ","))
 	mutex.Unlock()
+}
+
+var Discard = &ConsoleLogger{
+	printer: &TextPrinter{
+		Writer: ioutil.Discard,
+	},
 }

--- a/logger/log.go
+++ b/logger/log.go
@@ -111,24 +111,13 @@ func (l *ConsoleLogger) Level() Level {
 	return l.level
 }
 
-type Presenter interface {
-	IsVisible(f Field) bool
-	IsPrefix(f Field) bool
-}
-
-type DefaultPresenter struct{}
-
-func (p *DefaultPresenter) IsVisible(f Field) bool { return true }
-func (p *DefaultPresenter) IsPrefix(f Field) bool  { return true }
-
 type Printer interface {
 	Print(level Level, msg string, fields Fields)
 }
 
 type TextPrinter struct {
-	Colors    bool
-	Writer    io.Writer
-	Presenter Presenter
+	Colors bool
+	Writer io.Writer
 }
 
 func NewTextPrinter(w io.Writer) *TextPrinter {
@@ -207,8 +196,7 @@ func ColorsSupported() bool {
 }
 
 type JSONPrinter struct {
-	Writer    io.Writer
-	Presenter Presenter
+	Writer io.Writer
 }
 
 func NewJSONPrinter(w io.Writer) *JSONPrinter {

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -1,26 +1,35 @@
-package logger
+package logger_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/buildkite/agent/logger"
 )
 
-func TestTextLogger(t *testing.T) {
+func TestConsoleLogger(t *testing.T) {
 	b := &bytes.Buffer{}
-	l := NewTextLogger().(*TextLogger)
-	l.Level = INFO
-	l.Colors = false
-	l.Writer = b
+	exitCode := 0
+
+	printer := logger.NewTextPrinter(b)
+	printer.Colors = false
+
+	l := logger.NewConsoleLogger(printer, func(c int) {
+		exitCode = c
+	})
+	l.SetLevel(logger.INFO)
 
 	l.Debug("Debug %q", "llamas")
 	l.Info("Info %q", "llamas")
 	l.Warn("Warn %q", "llamas")
 	l.Error("Error %q", "llamas")
+	l.Fatal("Fatal %q", "llamas")
 
 	lines := strings.Split(strings.TrimRight(b.String(), "\n"), "\n")
 
-	if len(lines) != 3 {
+	if len(lines) != 4 {
 		t.Fatalf("bad number of lines, got %d", len(lines))
 	}
 
@@ -33,6 +42,56 @@ func TestTextLogger(t *testing.T) {
 	}
 
 	if !strings.HasSuffix(lines[2], `Error "llamas"`) {
-		t.Fatalf("line 0 bad, got %q", lines[2])
+		t.Fatalf("line 2 bad, got %q", lines[2])
+	}
+
+	if !strings.HasSuffix(lines[3], `Fatal "llamas"`) {
+		t.Fatalf("line 3 bad, got %q", lines[3])
+	}
+
+	if exitCode != 1 {
+		t.Fatalf("exit code bad, got %d", exitCode)
+	}
+}
+
+func TestTextPrinter(t *testing.T) {
+	b := &bytes.Buffer{}
+
+	printer := logger.NewTextPrinter(b)
+	printer.Colors = false
+
+	printer.Print(logger.INFO, "llamas rock", logger.Fields{logger.StringField(`key`, `val`)})
+
+	if msg := b.String(); !strings.HasSuffix(msg, "llamas rock key=val\n") {
+		t.Fatalf("bad message, got %q", msg)
+	}
+}
+
+func TestJSONPrinter(t *testing.T) {
+	b := &bytes.Buffer{}
+
+	printer := logger.NewJSONPrinter(b)
+	printer.Print(logger.INFO, "llamas rock", logger.Fields{logger.StringField(`key`, `val`)})
+
+	var results map[string]interface{}
+	err := json.Unmarshal(b.Bytes(), &results)
+	if err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+
+	if val, ok := results[`key`]; !ok || val != `val` {
+		t.Fatalf("bad key, got %v", val)
+	}
+
+	if val, ok := results[`msg`]; !ok || val != `llamas rock` {
+		t.Fatalf("bad msg, got %v", val)
+	}
+
+	if val, ok := results[`ts`]; !ok || val == `` {
+		t.Fatalf("bad ts, got %v", val)
+	}
+
+	if val, ok := results[`level`]; !ok || val != `INFO` {
+		t.Fatalf("bad level, got %v", val)
 	}
 }


### PR DESCRIPTION
This adds a `--log-format` option to `buildkite-agent start` that allows for `json` output for better integration with structured logging systems.

```bash
$ buildkite-agent start --debug --log-format=json
{"ts":"2019-03-31T22:51:28+11:00","level":"NOTICE","msg":"Starting buildkite-agent v3.10.2 with PID: 3282"}
{"ts":"2019-03-31T22:51:28+11:00","level":"NOTICE","msg":"The agent source code can be found here: https://github.com/buildkite/agent"}
{"ts":"2019-03-31T22:51:28+11:00","level":"NOTICE","msg":"For questions and support, email us at: hello@buildkite.com"}
{"ts":"2019-03-31T22:51:28+11:00","level":"INFO","msg":"Configuration loaded from: /usr/local/etc/buildkite-agent/buildkite-agent.cfg"}
{"ts":"2019-03-31T22:51:28+11:00","level":"DEBUG","msg":"Bootstrap command: buildkite-agent bootstrap"}
{"ts":"2019-03-31T22:51:28+11:00","level":"DEBUG","msg":"Build path: /usr/local/var/buildkite-agent/builds"}
{"ts":"2019-03-31T22:51:28+11:00","level":"DEBUG","msg":"Hooks directory: /usr/local/etc/buildkite-agent/hooks"}
{"ts":"2019-03-31T22:51:28+11:00","level":"DEBUG","msg":"Plugins directory: /usr/local/var/buildkite-agent/plugins"}
{"ts":"2019-03-31T22:51:28+11:00","level":"INFO","msg":"Registering agent with Buildkite..."}
{"ts":"2019-03-31T22:51:28+11:00","level":"DEBUG","msg":"POST https://agent.buildkite.com/v3/register"}
```

This lays the groundwork for structured field logging too, although the only field currently implemented is the agent name. 