### PR TITLE
Fix bug where host tags overwrite other tags

### DIFF
--- a/agent/tags.go
+++ b/agent/tags.go
@@ -29,8 +29,6 @@ func FetchTags(l logger.Logger, conf FetchTagsConfig) []string {
 
 	// Load tags from host
 	if conf.TagsFromHost {
-		var tags []string
-
 		hostname, err := os.Hostname()
 		if err != nil {
 			l.Warn("Failed to find hostname: %v", err)

--- a/agent/tags_test.go
+++ b/agent/tags_test.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"os"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/buildkite/agent/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchingTags(t *testing.T) {
+	l := logger.NewTextLogger()
+
+	tags := FetchTags(l, FetchTagsConfig{
+		Tags: []string{"llamas", "rock"},
+	})
+
+	if !reflect.DeepEqual(tags, []string{"llamas", "rock"}) {
+		t.Fatalf("bad tags: %#v", tags)
+	}
+
+	t.Logf("Tags: %#v", tags)
+}
+
+func TestFetchingTagsWithHostTags(t *testing.T) {
+	l := logger.NewTextLogger()
+
+	tags := FetchTags(l, FetchTagsConfig{
+		Tags:         []string{"llamas", "rock"},
+		TagsFromHost: true,
+	})
+
+	assert.Contains(t, tags, "llamas")
+	assert.Contains(t, tags, "rock")
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Contains(t, tags, "hostname="+hostname)
+	assert.Contains(t, tags, "os="+runtime.GOOS)
+}
+
+func TestFetchingTagsWithEC2Metadata(t *testing.T) {
+	l := logger.NewTextLogger()
+
+	tags := FetchTags(l, FetchTagsConfig{
+		Tags:        []string{"llamas", "rock"},
+		TagsFromEC2: true,
+	})
+
+	assert.Contains(t, tags, "llamas")
+	assert.Contains(t, tags, "rock")
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Contains(t, tags, "hostname="+hostname)
+	assert.Contains(t, tags, "os="+runtime.GOOS)
+}

--- a/agent/tags_test.go
+++ b/agent/tags_test.go
@@ -11,9 +11,7 @@ import (
 )
 
 func TestFetchingTags(t *testing.T) {
-	l := logger.NewTextLogger()
-
-	tags := FetchTags(l, FetchTagsConfig{
+	tags := FetchTags(logger.Discard, FetchTagsConfig{
 		Tags: []string{"llamas", "rock"},
 	})
 
@@ -25,31 +23,9 @@ func TestFetchingTags(t *testing.T) {
 }
 
 func TestFetchingTagsWithHostTags(t *testing.T) {
-	l := logger.NewTextLogger()
-
-	tags := FetchTags(l, FetchTagsConfig{
+	tags := FetchTags(logger.Discard, FetchTagsConfig{
 		Tags:         []string{"llamas", "rock"},
 		TagsFromHost: true,
-	})
-
-	assert.Contains(t, tags, "llamas")
-	assert.Contains(t, tags, "rock")
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Contains(t, tags, "hostname="+hostname)
-	assert.Contains(t, tags, "os="+runtime.GOOS)
-}
-
-func TestFetchingTagsWithEC2Metadata(t *testing.T) {
-	l := logger.NewTextLogger()
-
-	tags := FetchTags(l, FetchTagsConfig{
-		Tags:        []string{"llamas", "rock"},
-		TagsFromEC2: true,
 	})
 
 	assert.Contains(t, tags, "llamas")


### PR DESCRIPTION
Looks like we introduced a bug in https://github.com/buildkite/agent/pull/956 where we extracted tag collection into `agent.TagFetcher`. 

This fixes the issue and adds a minimal test. I'm going to follow up with some more extensive tests on the tags collection, as part of the intention behind the extraction was to make it more testable 😓

Closes #967.