### PR TITLE
Fix bug where ec2 tags arent added correctly

### DIFF
--- a/agent/tags.go
+++ b/agent/tags.go
@@ -29,8 +29,6 @@ func FetchTags(l logger.Logger, conf FetchTagsConfig) []string {
 
 	// Load tags from host
 	if conf.TagsFromHost {
-		var tags []string
-
 		hostname, err := os.Hostname()
 		if err != nil {
 			l.Warn("Failed to find hostname: %v", err)

--- a/agent/tags_test.go
+++ b/agent/tags_test.go
@@ -11,19 +11,17 @@ import (
 )
 
 func TestFetchingTags(t *testing.T) {
-	tags := FetchTags(logger.Discard, FetchTagsConfig{
+	tags := (&tagFetcher{}).Fetch(logger.Discard, FetchTagsConfig{
 		Tags: []string{"llamas", "rock"},
 	})
 
 	if !reflect.DeepEqual(tags, []string{"llamas", "rock"}) {
 		t.Fatalf("bad tags: %#v", tags)
 	}
-
-	t.Logf("Tags: %#v", tags)
 }
 
 func TestFetchingTagsWithHostTags(t *testing.T) {
-	tags := FetchTags(logger.Discard, FetchTagsConfig{
+	tags := (&tagFetcher{}).Fetch(logger.Discard, FetchTagsConfig{
 		Tags:         []string{"llamas", "rock"},
 		TagsFromHost: true,
 	})
@@ -38,4 +36,56 @@ func TestFetchingTagsWithHostTags(t *testing.T) {
 
 	assert.Contains(t, tags, "hostname="+hostname)
 	assert.Contains(t, tags, "os="+runtime.GOOS)
+}
+
+func TestFetchingTagsFromEC2(t *testing.T) {
+	fetcher := &tagFetcher{
+		ec2Metadata: func() (map[string]string, error) {
+			return map[string]string{
+				`aws:instance-id`:   "i-blahblah",
+				`aws:instance-type`: "t2.small",
+			}, nil
+		},
+		ec2Tags: func() (map[string]string, error) {
+			return map[string]string{
+				`custom_tag`: "true",
+			}, nil
+		},
+	}
+
+	tags := fetcher.Fetch(logger.Discard, FetchTagsConfig{
+		Tags:            []string{"llamas", "rock"},
+		TagsFromEC2:     true,
+		TagsFromEC2Tags: true,
+	})
+
+	if !reflect.DeepEqual(tags, []string{"llamas", "rock", "aws:instance-id=i-blahblah", "aws:instance-type=t2.small", "custom_tag=true"}) {
+		t.Fatalf("bad tags: %#v", tags)
+	}
+}
+
+func TestFetchingTagsFromGCP(t *testing.T) {
+	fetcher := &tagFetcher{
+		gcpMetadata: func() (map[string]string, error) {
+			return map[string]string{
+				`gcp:instance-id`: "my-instance",
+				`gcp:zone`:        "blah",
+			}, nil
+		},
+		gcpLabels: func() (map[string]string, error) {
+			return map[string]string{
+				`custom_tag`: "true",
+			}, nil
+		},
+	}
+
+	tags := fetcher.Fetch(logger.Discard, FetchTagsConfig{
+		Tags:              []string{"llamas", "rock"},
+		TagsFromGCP:       true,
+		TagsFromGCPLabels: true,
+	})
+
+	if !reflect.DeepEqual(tags, []string{"llamas", "rock", "gcp:instance-id=my-instance", "gcp:zone=blah", "custom_tag=true"}) {
+		t.Fatalf("bad tags: %#v", tags)
+	}
 }

--- a/agent/tags_test.go
+++ b/agent/tags_test.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"os"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/buildkite/agent/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchingTags(t *testing.T) {
+	l := logger.NewTextLogger()
+
+	tags := FetchTags(l, FetchTagsConfig{
+		Tags: []string{"llamas", "rock"},
+	})
+
+	if !reflect.DeepEqual(tags, []string{"llamas", "rock"}) {
+		t.Fatalf("bad tags: %#v", tags)
+	}
+
+	t.Logf("Tags: %#v", tags)
+}
+
+func TestFetchingTagsWithHostTags(t *testing.T) {
+	l := logger.NewTextLogger()
+
+	tags := FetchTags(l, FetchTagsConfig{
+		Tags:         []string{"llamas", "rock"},
+		TagsFromHost: true,
+	})
+
+	assert.Contains(t, tags, "llamas")
+	assert.Contains(t, tags, "rock")
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Contains(t, tags, "hostname="+hostname)
+	assert.Contains(t, tags, "os="+runtime.GOOS)
+}
+
+func TestFetchingTagsWithEC2Metadata(t *testing.T) {
+	l := logger.NewTextLogger()
+
+	tags := FetchTags(l, FetchTagsConfig{
+		Tags:        []string{"llamas", "rock"},
+		TagsFromEC2: true,
+	})
+
+	assert.Contains(t, tags, "llamas")
+	assert.Contains(t, tags, "rock")
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Contains(t, tags, "hostname="+hostname)
+	assert.Contains(t, tags, "os="+runtime.GOOS)
+}

--- a/agent/tags_test.go
+++ b/agent/tags_test.go
@@ -11,9 +11,7 @@ import (
 )
 
 func TestFetchingTags(t *testing.T) {
-	l := logger.NewTextLogger()
-
-	tags := FetchTags(l, FetchTagsConfig{
+	tags := FetchTags(logger.Discard, FetchTagsConfig{
 		Tags: []string{"llamas", "rock"},
 	})
 
@@ -25,31 +23,9 @@ func TestFetchingTags(t *testing.T) {
 }
 
 func TestFetchingTagsWithHostTags(t *testing.T) {
-	l := logger.NewTextLogger()
-
-	tags := FetchTags(l, FetchTagsConfig{
+	tags := FetchTags(logger.Discard, FetchTagsConfig{
 		Tags:         []string{"llamas", "rock"},
 		TagsFromHost: true,
-	})
-
-	assert.Contains(t, tags, "llamas")
-	assert.Contains(t, tags, "rock")
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Contains(t, tags, "hostname="+hostname)
-	assert.Contains(t, tags, "os="+runtime.GOOS)
-}
-
-func TestFetchingTagsWithEC2Metadata(t *testing.T) {
-	l := logger.NewTextLogger()
-
-	tags := FetchTags(l, FetchTagsConfig{
-		Tags:        []string{"llamas", "rock"},
-		TagsFromEC2: true,
 	})
 
 	assert.Contains(t, tags, "llamas")


### PR DESCRIPTION
In a similar vein to #969, this was a bug introduced in #956. 

This fixes an issues where tags weren't correctly being loaded from ec2 tags and metadata and adds tests around it. 

Closes #968.