### PR TITLE
Set default logger level to notice

### DIFF
--- a/agent/api_client.go
+++ b/agent/api_client.go
@@ -15,8 +15,7 @@ import (
 )
 
 var (
-	debugHTTP    = false
-	disableDebug = false
+	debugHTTP = false
 )
 
 type APIClientConfig struct {
@@ -34,15 +33,7 @@ func APIClientEnableHTTPDebug() {
 	debugHTTP = true
 }
 
-func APIClientDisableDebug() {
-	disableDebug = true
-}
-
 func NewAPIClient(l logger.Logger, c APIClientConfig) *api.Client {
-	if disableDebug == true && l.GetLevel() == logger.DEBUG {
-		l = l.WithLevel(logger.INFO)
-	}
-
 	u, err := url.Parse(c.Endpoint)
 	if err != nil {
 		l.Warn("Failed to parse %q: %v", c.Endpoint, err)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -79,10 +79,9 @@ type AgentStartConfig struct {
 	Spawn                      int      `cli:"spawn"`
 
 	// Global flags
-	Debug           bool     `cli:"debug"`
-	DebugWithoutAPI bool     `cli:"debug-without-api"`
-	NoColor         bool     `cli:"no-color"`
-	Experiments     []string `cli:"experiment" normalize:"list"`
+	Debug       bool     `cli:"debug"`
+	NoColor     bool     `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
 
 	// API config
 	DebugHTTP bool   `cli:"debug-http"`
@@ -349,7 +348,6 @@ var AgentStartCommand = cli.Command{
 		EndpointFlag,
 		NoHTTP2Flag,
 		DebugHTTPFlag,
-		DebugWithoutAPIFlag,
 
 		// Global flags
 		ExperimentsFlag,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -301,7 +301,7 @@ var BootstrapCommand = cli.Command{
 
 		// Enable debug if set
 		if cfg.Debug {
-			l = l.WithLevel(logger.DEBUG)
+			l.SetLevel(logger.DEBUG)
 		}
 
 		// Turn of PTY support if we're on Windows

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -55,12 +55,6 @@ var DebugHTTPFlag = cli.BoolFlag{
 	EnvVar: "BUILDKITE_AGENT_DEBUG_HTTP",
 }
 
-var DebugWithoutAPIFlag = cli.BoolFlag{
-	Name:   "debug-without-api",
-	Usage:  "Enable debug mode, except for the API client",
-	Hidden: true,
-}
-
 var NoColorFlag = cli.BoolFlag{
 	Name:   "no-color",
 	Usage:  "Don't show colors in logging",
@@ -75,15 +69,9 @@ var ExperimentsFlag = cli.StringSliceFlag{
 }
 
 func HandleGlobalFlags(l logger.Logger, cfg interface{}) {
-	// Enable debugging, but disable the api client
-	debugWithoutAPI, err := reflections.GetField(cfg, "DebugWithoutAPI")
-	if debugWithoutAPI == true && err == nil {
-		agent.APIClientDisableDebug()
-	}
-
 	// Enable debugging if a Debug option is present
 	debug, _ := reflections.GetField(cfg, "Debug")
-	if debug == false && debugWithoutAPI == false {
+	if debug == false {
 		l = l.WithLevel(logger.INFO)
 	}
 

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -71,8 +71,8 @@ var ExperimentsFlag = cli.StringSliceFlag{
 func HandleGlobalFlags(l logger.Logger, cfg interface{}) {
 	// Enable debugging if a Debug option is present
 	debug, _ := reflections.GetField(cfg, "Debug")
-	if debug == false {
-		l = l.WithLevel(logger.INFO)
+	if debug.(bool) {
+		l.SetLevel(logger.DEBUG)
 	}
 
 	// Turn off color if a NoColor option is present

--- a/logger/log.go
+++ b/logger/log.go
@@ -41,7 +41,7 @@ type Logger interface {
 	Info(format string, v ...interface{})
 
 	WithPrefix(prefix string) Logger
-	WithLevel(level Level) Logger
+	SetLevel(level Level)
 	GetLevel() Level
 }
 
@@ -55,7 +55,7 @@ type TextLogger struct {
 
 func NewTextLogger() Logger {
 	return &TextLogger{
-		Level:  DEBUG,
+		Level:  NOTICE,
 		Colors: ColorsAvailable(),
 		Writer: os.Stderr,
 	}
@@ -82,11 +82,9 @@ func (l *TextLogger) WithPrefix(prefix string) Logger {
 	return &clone
 }
 
-// WithLevel returns a copy of the logger with the provided level
-func (l *TextLogger) WithLevel(level Level) Logger {
-	clone := *l
-	clone.Level = level
-	return &clone
+// SetLevel sets the level for the logger
+func (l *TextLogger) SetLevel(level Level) {
+	l.Level = level
 }
 
 func (l *TextLogger) Debug(format string, v ...interface{}) {


### PR DESCRIPTION
Unfortunately #962 set the default log level back to `debug`. This fixes that issue, but in the course of that I came to wonder whether we should be showing `notice` level messages, especially the first few when the agent starts:

<img width="1003" alt="image" src="https://user-images.githubusercontent.com/15758/55527482-f980a280-56e4-11e9-80f9-27920e21d8a5.png">

I suspect we want a default level of `notice`, which is what this PR does.

Closes #973. 