### PR TITLE
Make plugin parsing less verbose

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -115,7 +115,7 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 	var phaseErr error
 
 	if b.hasPlugins() && includePhase(`plugin`) {
-		phaseErr = b.parsePlugins()
+		phaseErr = b.preparePlugins()
 
 		if phaseErr == nil {
 			phaseErr = b.PluginPhase()
@@ -490,9 +490,10 @@ func (b *Bootstrap) hasPlugins() bool {
 	return true
 }
 
-func (b *Bootstrap) parsePlugins() error {
+func (b *Bootstrap) preparePlugins() error {
+	b.shell.Headerf("Preparing plugins")
+
 	if b.Debug {
-		b.shell.Headerf("Parsing plugins")
 		b.shell.Commentf("Plugin JSON is %s", b.Plugins)
 	}
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -115,7 +115,11 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 	var phaseErr error
 
 	if includePhase(`plugin`) {
-		phaseErr = b.PluginPhase()
+		phaseErr = b.parsePlugins()
+
+		if phaseErr == nil {
+			phaseErr = b.PluginPhase()
+		}
 	}
 
 	if phaseErr == nil && includePhase(`checkout`) {
@@ -486,29 +490,34 @@ func (b *Bootstrap) hasPlugins() bool {
 	return true
 }
 
-func (b *Bootstrap) loadPlugins() ([]*plugin.Plugin, error) {
-	if b.plugins != nil {
-		return b.plugins, nil
+func (b *Bootstrap) parsePlugins() error {
+	if b.Debug {
+		b.shell.Headerf("Parsing plugins")
+		b.shell.Commentf("Plugin JSON is %s", b.Plugins)
 	}
 
 	// Check if we can run plugins (disabled via --no-plugins)
 	if !b.Config.PluginsEnabled {
 		if !b.Config.LocalHooksEnabled {
-			return nil, fmt.Errorf("Plugins have been disabled on this agent with `--no-local-hooks`")
+			return fmt.Errorf("Plugins have been disabled on this agent with `--no-local-hooks`")
 		} else if !b.Config.CommandEval {
-			return nil, fmt.Errorf("Plugins have been disabled on this agent with `--no-command-eval`")
+			return fmt.Errorf("Plugins have been disabled on this agent with `--no-command-eval`")
 		} else {
-			return nil, fmt.Errorf("Plugins have been disabled on this agent with `--no-plugins`")
+			return fmt.Errorf("Plugins have been disabled on this agent with `--no-plugins`")
 		}
 	}
 
 	var err error
 	b.plugins, err = plugin.CreateFromJSON(b.Config.Plugins)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to parse a plugin definition")
+		return errors.Wrap(err, "Failed to parse a plugin definition")
 	}
 
-	return b.plugins, nil
+	if b.Debug {
+		b.shell.Commentf("Parsed %d plugins", len(b.plugins))
+	}
+
+	return nil
 }
 
 func (b *Bootstrap) validatePluginCheckout(checkout *pluginCheckout) error {
@@ -550,25 +559,17 @@ func (b *Bootstrap) validatePluginCheckout(checkout *pluginCheckout) error {
 // PluginPhase is where plugins that weren't filtered in the Environment phase are
 // checked out and made available to later phases
 func (b *Bootstrap) PluginPhase() error {
-	if !b.hasPlugins() {
+	if len(b.plugins) == 0 {
+		if b.Debug {
+			b.shell.Commentf("Skipping plugin phase")
+		}
 		return nil
-	}
-
-	b.shell.Headerf("Setting up plugins")
-
-	if b.Debug {
-		b.shell.Commentf("Plugin JSON is %s", b.Plugins)
-	}
-
-	plugins, err := b.loadPlugins()
-	if err != nil {
-		return err
 	}
 
 	checkouts := []*pluginCheckout{}
 
 	// Checkout and validate plugins that aren't vendored
-	for _, p := range plugins {
+	for _, p := range b.plugins {
 		if p.Vendored {
 			if b.Debug {
 				b.shell.Commentf("Skipping vendored plugin %s", p.Name())
@@ -596,23 +597,17 @@ func (b *Bootstrap) PluginPhase() error {
 	return b.executePluginHook("environment", checkouts)
 }
 
-// VendoredPluginPhase is where plugins that are included in the checked out code are added
+// VendoredPluginPhase is where plugins that are included in the
+// checked out code are added
 func (b *Bootstrap) VendoredPluginPhase() error {
-	if !b.hasPlugins() {
+	if len(b.plugins) == 0 {
 		return nil
-	}
-
-	b.shell.Headerf("Setting up vendored plugins")
-
-	plugins, err := b.loadPlugins()
-	if err != nil {
-		return err
 	}
 
 	vendoredCheckouts := []*pluginCheckout{}
 
 	// Validate vendored plugins
-	for _, p := range plugins {
+	for _, p := range b.plugins {
 		if !p.Vendored {
 			continue
 		}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -114,7 +114,7 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 	//  Execute the bootstrap phases in order
 	var phaseErr error
 
-	if b.hasPlugins() && includePhase(`plugin`) {
+	if includePhase(`plugin`) {
 		phaseErr = b.preparePlugins()
 
 		if phaseErr == nil {
@@ -131,7 +131,7 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 		}
 	}
 
-	if phaseErr == nil && b.hasPlugins() && includePhase(`plugin`) {
+	if phaseErr == nil && includePhase(`plugin`) {
 		phaseErr = b.VendoredPluginPhase()
 	}
 
@@ -491,6 +491,10 @@ func (b *Bootstrap) hasPlugins() bool {
 }
 
 func (b *Bootstrap) preparePlugins() error {
+	if !b.hasPlugins() {
+		return nil
+	}
+
 	b.shell.Headerf("Preparing plugins")
 
 	if b.Debug {
@@ -601,7 +605,7 @@ func (b *Bootstrap) PluginPhase() error {
 // VendoredPluginPhase is where plugins that are included in the
 // checked out code are added
 func (b *Bootstrap) VendoredPluginPhase() error {
-	if len(b.plugins) == 0 {
+	if !b.hasPlugins() {
 		return nil
 	}
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -114,7 +114,7 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 	//  Execute the bootstrap phases in order
 	var phaseErr error
 
-	if includePhase(`plugin`) {
+	if b.hasPlugins() && includePhase(`plugin`) {
 		phaseErr = b.parsePlugins()
 
 		if phaseErr == nil {
@@ -131,7 +131,7 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 		}
 	}
 
-	if phaseErr == nil && includePhase(`plugin`) {
+	if phaseErr == nil && b.hasPlugins() && includePhase(`plugin`) {
 		phaseErr = b.VendoredPluginPhase()
 	}
 


### PR DESCRIPTION
This change moves plugin parsing earlier in the bootstrap phase which means we can avoid showing lots of headers for builds that don't have plugins or vendored plugins.