### PR TITLE
need to put the Artifactory specific path in addition to repository

### DIFF
--- a/agent/arty_uploader.go
+++ b/agent/arty_uploader.go
@@ -121,7 +121,7 @@ func (u *ArtifactoryUploader) Upload(artifact *api.Artifact) error {
 }
 
 func (u *ArtifactoryUploader) artifactPath(artifact *api.Artifact) string {
-	parts := []string{u.Repository, artifact.Path}
+	parts := []string{u.Repository, u.Path, artifact.Path}
 
 	return strings.Join(parts, "/")
 }


### PR DESCRIPTION
It's that time of the week again!

But really, this time it's not BREAKING functionality so long as we're uploading properly, but the upload is not appending the JOB ID as we would expect in the documentation. This fix will explicitly place artifacts in the path specified through BUILDKITE_ARTIFACT_UPLOAD_DESTINATION, where now it would only respect the repository name.