### PR TITLE
Allow applying ec2 tags when config tags are empty

### DIFF
--- a/agent/tags.go
+++ b/agent/tags.go
@@ -104,7 +104,7 @@ func (t *tagFetcher) Fetch(l logger.Logger, conf FetchTagsConfig) []string {
 			ec2Tags, err := t.ec2Tags()
 			// EC2 tags are apparently "eventually consistent" and sometimes take several seconds
 			// to be applied to instances. This error will cause retries.
-			if err == nil && len(tags) == 0 {
+			if err == nil && len(ec2Tags) == 0 {
 				err = errors.New("EC2 tags are empty")
 			}
 			if err != nil {

--- a/agent/tags_test.go
+++ b/agent/tags_test.go
@@ -63,6 +63,23 @@ func TestFetchingTagsFromEC2(t *testing.T) {
 		[]string{"llamas", "rock", "aws:instance-id=i-blahblah", "aws:instance-type=t2.small", "custom_tag=true"})
 }
 
+func TestFetchingTagsFromEC2Tags(t *testing.T) {
+	fetcher := &tagFetcher{
+		ec2Tags: func() (map[string]string, error) {
+			return map[string]string{
+				`custom_tag`: "true",
+			}, nil
+		},
+	}
+
+	tags := fetcher.Fetch(logger.Discard, FetchTagsConfig{
+		TagsFromEC2Tags: true,
+	})
+
+	assert.ElementsMatch(t, tags,
+		[]string{"custom_tag=true"})
+}
+
 func TestFetchingTagsFromGCP(t *testing.T) {
 	fetcher := &tagFetcher{
 		gcpMetadata: func() (map[string]string, error) {


### PR DESCRIPTION
Looks like this might have been a bug introduced in [#970](https://github.com/buildkite/agent/pull/970/files#diff-64fc4f8002c51b533bf973bd314f0ed4R104). Not a huge deal since we can get around it by setting a custom tag in the config in the meantime.