### PR TITLE
Continue heartbeat after stop signal

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -141,6 +141,11 @@ func (a *AgentWorker) Start() error {
 		for {
 			select {
 			case <-time.After(heartbeatInterval):
+				if !a.running {
+					a.logger.Debug("Stopping heartbeats")
+					return
+				}
+
 				err := a.Heartbeat()
 				if err != nil {
 					// Get the last heartbeat time to the nearest microsecond
@@ -149,10 +154,6 @@ func (a *AgentWorker) Start() error {
 					a.logger.Error("Failed to heartbeat %s. Will try again in %s. (Last successful was %v ago)",
 						err, heartbeatInterval, time.Now().Sub(lastHeartbeat))
 				}
-
-			case <-a.stop:
-				a.logger.Debug("Stopping heartbeats")
-				return
 			}
 		}
 	}()


### PR DESCRIPTION
This addresses a regression that was added in #971.

Heartbeats were no longer sent after a SIGTERM or SIGINT was received, which interferes with the graceful shutdown. While the buildkite-agent shuts down gracefully, buildkite.com will display `"Exited with status -1 (agent lost)"` after ~5 minutes. This limits the graceful shutdown feature to a duration of only 5 minutes.

I understand the previous change addressed a race condition, so please double check that I haven't accidentally reintroduced that issue.