### PR TITLE
Revert "Refactor AgentConfiguration into JobRunnerConfig"

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -1,0 +1,30 @@
+package agent
+
+// AgentConfiguration is the run-time configuration for an agent that
+// has been loaded from the config file and command-line params
+type AgentConfiguration struct {
+	ConfigPath                 string
+	BootstrapScript            string
+	BuildPath                  string
+	HooksPath                  string
+	GitMirrorsPath             string
+	GitMirrorsLockTimeout      int
+	PluginsPath                string
+	GitCloneFlags              string
+	GitCloneMirrorFlags        string
+	GitCleanFlags              string
+	GitFetchFlags              string
+	GitSubmodules              bool
+	SSHKeyscan                 bool
+	CommandEval                bool
+	PluginsEnabled             bool
+	PluginValidation           bool
+	LocalHooksEnabled          bool
+	RunInPty                   bool
+	TimestampLines             bool
+	DisconnectAfterJob         bool
+	DisconnectAfterJobTimeout  int
+	DisconnectAfterIdleTimeout int
+	CancelGracePeriod          int
+	Shell                      string
+}

--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/buildkite/agent/agent"
 	"github.com/buildkite/agent/api"
-	"github.com/buildkite/agent/bootstrap"
 	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/metrics"
 	"github.com/buildkite/bintest"
@@ -27,7 +26,7 @@ func TestJobRunnerPassesAccessTokenToBootstrap(t *testing.T) {
 		},
 	}
 
-	cfg := agent.JobRunnerConfig{}
+	cfg := agent.AgentConfiguration{}
 
 	runJob(t, ag, j, cfg, func(c *bintest.Call) {
 		if c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN") != `llamasrock` {
@@ -52,10 +51,8 @@ func TestJobRunnerIgnoresPipelineChangesToProtectedVars(t *testing.T) {
 		},
 	}
 
-	cfg := agent.JobRunnerConfig{
-		Config: bootstrap.Config{
-			CommandEval: true,
-		},
+	cfg := agent.AgentConfiguration{
+		CommandEval: true,
 	}
 
 	runJob(t, ag, j, cfg, func(c *bintest.Call) {
@@ -68,13 +65,10 @@ func TestJobRunnerIgnoresPipelineChangesToProtectedVars(t *testing.T) {
 
 }
 
-func runJob(t *testing.T, ag *api.AgentRegisterResponse, j *api.Job, cfg agent.JobRunnerConfig, bootstrap func(c *bintest.Call)) {
+func runJob(t *testing.T, ag *api.AgentRegisterResponse, j *api.Job, cfg agent.AgentConfiguration, bootstrap func(c *bintest.Call)) {
 	// create a mock agent API
 	server := createTestAgentEndpoint(t, `my-job-id`)
 	defer server.Close()
-
-	// set the server into the register response
-	ag.Endpoint = server.URL
 
 	// set up a mock bootstrap that the runner will call
 	bs, err := bintest.NewMock("buildkite-agent-bootstrap")
@@ -95,7 +89,10 @@ func runJob(t *testing.T, ag *api.AgentRegisterResponse, j *api.Job, cfg agent.J
 	// set the bootstrap into the config
 	cfg.BootstrapScript = bs.Path
 
-	jr, err := agent.NewJobRunner(l, scope, ag, j, cfg)
+	jr, err := agent.NewJobRunner(l, scope, ag, j, agent.JobRunnerConfig{
+		Endpoint:           server.URL,
+		AgentConfiguration: cfg,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/api"
-	"github.com/buildkite/agent/bootstrap"
 	"github.com/buildkite/agent/experiments"
 	"github.com/buildkite/agent/logger"
 	"github.com/buildkite/agent/metrics"
@@ -21,25 +20,12 @@ import (
 	"github.com/buildkite/shellwords"
 )
 
-// JobRunnerConfig embeds the bootstrap.Config that is passed to the bootstrap
-// along with some extra config that is used by the runner
 type JobRunnerConfig struct {
-	bootstrap.Config
+	// The endpoint that should be used when communicating with the API
+	Endpoint string
 
-	// The path that the config file was loaded from
-	ConfigPath string
-
-	// The path to the command to execute as the bootstrap
-	BootstrapScript string
-
-	// How long to give cancellation to run before forceful termination
-	CancelGracePeriod int
-
-	// Whether to prefix output lines with a timestamp (also forces lines buffering)
-	TimestampLines bool
-
-	// The configuration to pass to the bootstrap subprocess
-	BootstrapConfig bootstrap.Config
+	// The configuration of the agent from the CLI
+	AgentConfiguration AgentConfiguration
 
 	// Whether to set debug in the job
 	Debug bool
@@ -57,9 +43,6 @@ type JobRunner struct {
 
 	// The job being run
 	job *api.Job
-
-	// The endpoint from the AgentRegisterResponse
-	endpoint string
 
 	// The APIClient that will be used when updating the job
 	apiClient *api.Client
@@ -102,24 +85,23 @@ type JobRunner struct {
 // Initializes the job runner
 func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterResponse, j *api.Job, conf JobRunnerConfig) (*JobRunner, error) {
 	runner := &JobRunner{
-		agent:    ag,
-		job:      j,
-		logger:   l,
-		conf:     conf,
-		metrics:  scope,
-		endpoint: ag.Endpoint,
+		agent:   ag,
+		job:     j,
+		logger:  l,
+		conf:    conf,
+		metrics: scope,
 	}
 
 	runner.context, runner.contextCancel = context.WithCancel(context.Background())
 
 	// Our own APIClient using the endpoint and the agents access token
 	runner.apiClient = NewAPIClient(l, APIClientConfig{
-		Endpoint: ag.Endpoint,
+		Endpoint: runner.conf.Endpoint,
 		Token:    ag.AccessToken,
 	})
 
 	// A proxy for the agent API that is expose to the bootstrap
-	runner.apiProxy = NewAPIProxy(l, ag.Endpoint, ag.AccessToken)
+	runner.apiProxy = NewAPIProxy(l, conf.Endpoint, ag.AccessToken)
 
 	// Create our header times struct
 	runner.headerTimesStreamer = newHeaderTimesStreamer(l, runner.onUploadHeaderTime)
@@ -160,10 +142,10 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 	}
 
 	// The bootstrap-script gets parsed based on the operating system
-	cmd, err := shellwords.Split(conf.BootstrapScript)
+	cmd, err := shellwords.Split(conf.AgentConfiguration.BootstrapScript)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to split bootstrap-script (%q) into tokens: %v",
-			conf.BootstrapScript, err)
+			conf.AgentConfiguration.BootstrapScript, err)
 	}
 
 	// Our log streamer works off a buffer of output
@@ -173,7 +155,7 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 	var processWriter io.Writer
 
 	// If we have timestamp lines on, we have to buffer lines before we flush them
-	if conf.TimestampLines {
+	if conf.AgentConfiguration.TimestampLines {
 		var pr *io.PipeReader
 		pr, processWriter = io.Pipe()
 
@@ -223,7 +205,7 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 		Path:   cmd[0],
 		Args:   cmd[1:],
 		Env:    processEnv,
-		PTY:    conf.RunInPty,
+		PTY:    conf.AgentConfiguration.RunInPty,
 		Stdout: processWriter,
 		Stderr: processWriter,
 	})
@@ -345,7 +327,7 @@ func (r *JobRunner) Cancel() error {
 	}
 
 	r.logger.Info("Canceling job %s with a grace period of %ds",
-		r.job.ID, r.conf.CancelGracePeriod)
+		r.job.ID, r.conf.AgentConfiguration.CancelGracePeriod)
 
 	// First we interrupt the process (ctrl-c or SIGINT)
 	if err := r.process.Interrupt(); err != nil {
@@ -354,7 +336,7 @@ func (r *JobRunner) Cancel() error {
 
 	select {
 	// Grace period for cancelling
-	case <-time.After(time.Second * time.Duration(r.conf.CancelGracePeriod)):
+	case <-time.After(time.Second * time.Duration(r.conf.AgentConfiguration.CancelGracePeriod)):
 		r.logger.Info("Job %s hasn't stopped in time, terminating", r.job.ID)
 
 		// Terminate the process as we've exceeded our context
@@ -446,7 +428,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 		env["BUILDKITE_AGENT_ENDPOINT"] = r.apiProxy.Endpoint()
 		env["BUILDKITE_AGENT_ACCESS_TOKEN"] = r.apiProxy.AccessToken()
 	} else {
-		env["BUILDKITE_AGENT_ENDPOINT"] = r.endpoint
+		env["BUILDKITE_AGENT_ENDPOINT"] = r.conf.Endpoint
 		env["BUILDKITE_AGENT_ACCESS_TOKEN"] = r.agent.AccessToken
 	}
 
@@ -460,25 +442,25 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	env["BUILDKITE_BIN_PATH"] = dir
 
 	// Add options from the agent configuration
-	env["BUILDKITE_CONFIG_PATH"] = r.conf.ConfigPath
-	env["BUILDKITE_BUILD_PATH"] = r.conf.BuildPath
-	env["BUILDKITE_GIT_MIRRORS_PATH"] = r.conf.GitMirrorsPath
-	env["BUILDKITE_HOOKS_PATH"] = r.conf.HooksPath
-	env["BUILDKITE_PLUGINS_PATH"] = r.conf.PluginsPath
-	env["BUILDKITE_SSH_KEYSCAN"] = fmt.Sprintf("%t", r.conf.SSHKeyscan)
-	env["BUILDKITE_GIT_SUBMODULES"] = fmt.Sprintf("%t", r.conf.GitSubmodules)
-	env["BUILDKITE_COMMAND_EVAL"] = fmt.Sprintf("%t", r.conf.CommandEval)
-	env["BUILDKITE_PLUGINS_ENABLED"] = fmt.Sprintf("%t", r.conf.PluginsEnabled)
-	env["BUILDKITE_LOCAL_HOOKS_ENABLED"] = fmt.Sprintf("%t", r.conf.LocalHooksEnabled)
-	env["BUILDKITE_GIT_CLONE_FLAGS"] = r.conf.GitCloneFlags
-	env["BUILDKITE_GIT_FETCH_FLAGS"] = r.conf.GitFetchFlags
-	env["BUILDKITE_GIT_CLONE_MIRROR_FLAGS"] = r.conf.GitCloneMirrorFlags
-	env["BUILDKITE_GIT_CLEAN_FLAGS"] = r.conf.GitCleanFlags
-	env["BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT"] = fmt.Sprintf("%d", r.conf.GitMirrorsLockTimeout)
-	env["BUILDKITE_SHELL"] = r.conf.Shell
+	env["BUILDKITE_CONFIG_PATH"] = r.conf.AgentConfiguration.ConfigPath
+	env["BUILDKITE_BUILD_PATH"] = r.conf.AgentConfiguration.BuildPath
+	env["BUILDKITE_GIT_MIRRORS_PATH"] = r.conf.AgentConfiguration.GitMirrorsPath
+	env["BUILDKITE_HOOKS_PATH"] = r.conf.AgentConfiguration.HooksPath
+	env["BUILDKITE_PLUGINS_PATH"] = r.conf.AgentConfiguration.PluginsPath
+	env["BUILDKITE_SSH_KEYSCAN"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.SSHKeyscan)
+	env["BUILDKITE_GIT_SUBMODULES"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.GitSubmodules)
+	env["BUILDKITE_COMMAND_EVAL"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.CommandEval)
+	env["BUILDKITE_PLUGINS_ENABLED"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.PluginsEnabled)
+	env["BUILDKITE_LOCAL_HOOKS_ENABLED"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.LocalHooksEnabled)
+	env["BUILDKITE_GIT_CLONE_FLAGS"] = r.conf.AgentConfiguration.GitCloneFlags
+	env["BUILDKITE_GIT_FETCH_FLAGS"] = r.conf.AgentConfiguration.GitFetchFlags
+	env["BUILDKITE_GIT_CLONE_MIRROR_FLAGS"] = r.conf.AgentConfiguration.GitCloneMirrorFlags
+	env["BUILDKITE_GIT_CLEAN_FLAGS"] = r.conf.AgentConfiguration.GitCleanFlags
+	env["BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT"] = fmt.Sprintf("%d", r.conf.AgentConfiguration.GitMirrorsLockTimeout)
+	env["BUILDKITE_SHELL"] = r.conf.AgentConfiguration.Shell
 	env["BUILDKITE_AGENT_EXPERIMENT"] = strings.Join(experiments.Enabled(), ",")
 
-	enablePluginValidation := r.conf.PluginValidation
+	enablePluginValidation := r.conf.AgentConfiguration.PluginValidation
 
 	// Allow BUILDKITE_PLUGIN_VALIDATION to be enabled from env for easier
 	// per-pipeline testing


### PR DESCRIPTION
This resulted in an empty agent endpoint url in v3.11.0.

Reverts buildkite/agent#987