### PR TITLE
Send logging to stderr again

### DIFF
--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -83,7 +83,7 @@ func CreateLogger(cfg interface{}) logger.Logger {
 	// Create a logger based on the type
 	switch logFormat {
 	case `text`, ``:
-		printer := logger.NewTextPrinter(os.Stdout)
+		printer := logger.NewTextPrinter(os.Stderr)
 
 		// Show agent fields as a prefix
 		printer.IsPrefixFn = func(field logger.Field) bool {


### PR DESCRIPTION
We introduced a regression in #966 where logging output went to stdout. Previously it was stderr. 

This should also fix the bk cli step. 