### PR TITLE
Fix assumption that custom GCS hosts use the same path format as GCS.

### DIFF
--- a/agent/gs_uploader.go
+++ b/agent/gs_uploader.go
@@ -88,14 +88,18 @@ func newGoogleClient(scope string) (*http.Client, error) {
 
 func (u *GSUploader) URL(artifact *api.Artifact) string {
 	host := "storage.googleapis.com"
+	path := fmt.Sprintf("%s/%s", u.BucketName, u.artifactPath(artifact))
+
+	// When overriding the default GCS host to go through a proxy, we should use the path passed in directly - it's not safe to assume that a proxy's URL path follows the same path format as GCS.
 	if os.Getenv("BUILDKITE_GCS_ACCESS_HOST") != "" {
 		host = os.Getenv("BUILDKITE_GCS_ACCESS_HOST")
+		path = u.artifactPath(artifact)
 	}
 
 	var artifactURL = &url.URL{
 		Scheme: "https",
 		Host:   host,
-		Path:   u.BucketName + "/" + u.artifactPath(artifact),
+		Path:   path,
 	}
 	return artifactURL.String()
 }


### PR DESCRIPTION
We store our BK-generated artifacts in a private GCS bucket, but want to expose those artifacts to internal users via HTTPS.  For this we use a GCS->HTTPS proxy that sits in the middle, checking user authorization, and only allowing our users through.

However, the buildkite-agent artifact URL generation func appears to be hard-coded to insert the GCS bucket name into the path of the URL it generates.  This is necessary when talking directly to GCS, since the URLs to use look like `https://storage.googleapis.com/$BUCKET_NAME/$FILE_PATH`.

However, our proxy only talks to one bucket, and thus the URLs used to talk to it do not include the unnecessary bucket name - it generates URLs of the format `https://$ARTIFACT_PROXY_HOST/$FILE_PATH`.  Thus, this hard-coded insertion into the URL prevents our proxy from working, unless we hack our proxy to strip out the bucket name for this specific case, which is less than ideal.

This PR preserves the current behavior unless `BUILDKITE_GCS_ACCESS_HOST` has been overridden.  In that case, since we're using a custom GCS access host, it doesn't make sense to hard-code in the same path modification done for talking directly to GCS - the path of the artifact, as passed into `URL()`, should properly point at the stored artifact.

FYI @petemounce @lox 