### PR TITLE
Don't force set the executable bit on scripts to be set

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1370,10 +1370,12 @@ func (b *Bootstrap) defaultCommandPhase() error {
 
 		cmdToExec = batchScript
 	} else if commandIsScript {
-		// Make script executable
-		if err = addExecutePermissionToFile(pathToCommand); err != nil {
-			b.shell.Warningf("Error marking script %q as executable: %v", pathToCommand, err)
-			return err
+		if b.Config.CommandEval {
+			// Make script executable
+			if err = addExecutePermissionToFile(pathToCommand); err != nil {
+				b.shell.Warningf("Error marking script %q as executable: %v", pathToCommand, err)
+				return err
+			}
 		}
 
 		// Make the path relative to the shell working dir


### PR DESCRIPTION
At present, buildkite sets the executable bit on any script it attempts to
execute as part of a job.

This is actually quite hazardous as there may be files that are valid
interpreter scripts, but are dangerous to run -- by having this behaviour, it
actually subverts any good that no-command-eval can achieve by leaving another
potentially gaping hole which we can't turn off!

It's also relatively unnecessary - git, by default, tries to store the state of
the execute bit into the repo.  We should not subvert this if the user doesn't
want us to.

This patch adds a flag that can disable this behaviour, so, if you're security
minded, and you really need to be able to ensure that arbitrary files in your
repo cannot be invoked, without use of a whitelist, you have the ability to do
so!