### PR TITLE
Prevent host tags from overwriting aws/gcp tags

### DIFF
--- a/agent/tags.go
+++ b/agent/tags.go
@@ -68,8 +68,6 @@ func (t *tagFetcher) Fetch(l logger.Logger, conf FetchTagsConfig) []string {
 		if machineID != "" {
 			tags = append(tags, fmt.Sprintf("machine-id=%s", machineID))
 		}
-
-		return tags
 	}
 
 	// Attempt to add the EC2 tags


### PR DESCRIPTION
Fixes a bug where specifying `--tags-from-host` and `--tags-from-gcp-labels` only returns host tags. 

Not sure how I missed this in https://github.com/buildkite/agent/pull/969.