### PR TITLE
Fix bug where disconnect-after-idle stopped working

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -485,7 +485,7 @@ func (a *AgentWorker) Ping() {
 	if a.agentConfiguration.DisconnectAfterIdleTimeout > 0 {
 		a.logger.Info("Job finished. Resetting idle timer...")
 		a.idleTimer.Reset(time.Second * time.Duration(a.agentConfiguration.DisconnectAfterIdleTimeout))
-		a.idleMonitor.MarkBusy(a.agent.Name)
+		a.idleMonitor.MarkBusy(a.agent.UUID)
 	}
 }
 

--- a/api/agents.go
+++ b/api/agents.go
@@ -29,7 +29,7 @@ type AgentRegisterRequest struct {
 
 // AgentRegisterResponse is the response from the Buildkite Agent API
 type AgentRegisterResponse struct {
-	UUID              string   `json:"uuid" msgpack:"uuid"`
+	UUID              string   `json:"id" msgpack:"id"`
 	Name              string   `json:"name" msgpack:"name"`
 	AccessToken       string   `json:"access_token" msgpack:"access_token"`
 	Endpoint          string   `json:"endpoint" msgpack:"endpoint"`


### PR DESCRIPTION
We introduced a bug in #985 where the wrong return param from the register API was checked and the idle monitor never detected all the agents idle.

Closes #1003.