### PR TITLE
Update Ubuntu docker image to docker-compose 1.24

### DIFF
--- a/packaging/docker/ubuntu-linux/Dockerfile
+++ b/packaging/docker/ubuntu-linux/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN curl -Lfs -o /sbin/tini  https://github.com/krallin/tini/releases/download/v0.18.0/tini \
     && chmod +x /sbin/tini \
-    && curl -Lfs https://github.com/docker/compose/releases/download/1.21.0/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
+    && curl -Lfs https://github.com/docker/compose/releases/download/1.24.0/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \


### PR DESCRIPTION
## Why
`docker-compose#1.21` binary seems to have issues with the `COPY` command doing docker builds.

```
❯ /tmp/dc-bad build fakeapp
Building fakeapp
Step 1/10 : FROM openjdk:8-jre-slim
 ---> 87285d0871fd
[...]
Step 7/10 : COPY target/scala-*/*-assembly-*.jar ./fakeapp.jar
ERROR: Service 'fakeapp' failed to build: COPY failed: no source files were specified
```
I tried both the `docker-compose` from `pip` and from the GH releases page and they behave differently,  the `pip` one does not have this issue.


## What
Use `docker-compose#1.24` which does not seem to have the issue
```
❯ /tmp/dc build fakeapp       
Building fakeapp
Step 1/10 : FROM openjdk:8-jre-slim
[...]
Step 7/10 : COPY target/scala-*/*-assembly-*.jar ./fakeapp.jar
 ---> fafdb06a39b4
[...]
Successfully built ce7218161c4b
Successfully tagged fakeapp:local
```


## Steps to reproduce
Create `Dockerfile`
```
FROM openjdk:8-jre-slim
COPY target/scala-*/*-assembly-*.jar ./fakeapp.jar
```

Create `.dockerignore`
```
# Ignore all except scala artifact
**/*
!target/scala*
```

Create `docker-compose.yml`
```
version: '3.3'
services:
  fakeapp:
    image: ${REPO:-fakeapp}:${CI_COMMIT:-local}
    build: .
    ports:
      - 3000

```

Create fake folder and file
```
❯ mkdir -p target/scala-2.12/
❯ touch target/scala-2.12/fakeapp-assembly-0.0.1.jar
```

Try to build (assuming your system allows exec from `/tmp`)
```
❯ curl -Lf https://github.com/docker/compose/releases/download/1.21.0/docker-compose-Linux-x86_64 -o /tmp/dc-bad
❯ chmod +x /tmp/dc-bad
❯ /tmp/dc-and build fakeapp
```