### PR TITLE
Refactor handling pings into main agent worker run loop

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -57,9 +57,6 @@ type AgentWorker struct {
 	// Whether to enable debug
 	debug bool
 
-	// Whether or not the agent is running
-	running bool
-
 	// Used by the Start call to control the looping of the pings
 	ticker *time.Ticker
 
@@ -118,9 +115,6 @@ func (a *AgentWorker) Start(idle *IdleMonitor) error {
 		return err
 	}
 	defer a.metricsCollector.Stop()
-
-	// Mark the agent as running
-	a.running = true
 
 	// Create the intervals we'll be using
 	pingInterval := time.Second * time.Duration(a.agent.PingInterval)
@@ -254,10 +248,6 @@ func (a *AgentWorker) Start(idle *IdleMonitor) error {
 			continue
 		case <-a.stop:
 			a.ticker.Stop()
-
-			// Mark the agent as not running anymore
-			a.running = false
-
 			return nil
 		}
 	}


### PR DESCRIPTION
Currently the `AgentWorker.Ping()` method also handles the ping results and runs a job if one is included. This makes it hard to do things like add locking around ping, or even just find where the code is that runs a job. 

This PR makes the `Ping()` method simply return an `api.Ping`, which is then processed in the main loop in `AgentWorker.Start()`. 