### PR TITLE
Deprecate disconnect-after-job-timeout

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -23,7 +23,6 @@ type AgentConfiguration struct {
 	RunInPty                   bool
 	TimestampLines             bool
 	DisconnectAfterJob         bool
-	DisconnectAfterJobTimeout  int
 	DisconnectAfterIdleTimeout int
 	CancelGracePeriod          int
 	Shell                      string

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -148,7 +148,8 @@ func (l *Loader) Load() (warnings []string, err error) {
 			// If the deprecated field's value isn't empty, then we
 			// return the deprecation error message.
 			if !l.fieldValueIsEmpty(fieldName) {
-				return warnings, fmt.Errorf(deprecationError)
+				warnings = append(warnings,
+					fmt.Sprintf("The config option `%s` has been deprecated: %s", cliName, deprecationError))
 			}
 		}
 
@@ -309,6 +310,8 @@ func (l Loader) fieldValueIsEmpty(fieldName string) bool {
 		return v.Len() == 0
 	} else if fieldKind == reflect.Bool {
 		return value == false
+	} else if fieldKind == reflect.Int {
+		return value == 0
 	} else {
 		panic(fmt.Sprintf("Can't determine empty-ness for field type %s", fieldKind))
 	}


### PR DESCRIPTION
Originally the agent had two disconnect settings: `disconnect-after-job`, which caused the agent to disconnect after a job, and `disconnect-after-job-timeout` which was a timeout prior to receiving a job that if no job was received by would cause the agent to disconnect. 

We subsequently added `disconnect-after-idle-timeout` which disconnects the agent after it's been idle at any time, either before or after a job. 

This PR deprecates `disconnect-after-job-timeout` and suggests using `disconnect-after-idle-timeout` instead, as it simplifies a lot of code paths. Functionally, they are very similar. 