### PR TITLE
update path parsing to support windows

### DIFF
--- a/agent/arty_uploader.go
+++ b/agent/arty_uploader.go
@@ -87,7 +87,7 @@ func (u *ArtifactoryUploader) URL(artifact *api.Artifact) string {
 	// ensure proper URL formatting for upload
 	url.Path = strings.Join([]string{
 		strings.Trim(url.Path, "/"),
-		u.artifactPath(artifact),
+		strings.Replace(u.artifactPath(artifact), "\\", "/", -1),
 	}, "/")
 	return url.String()
 }

--- a/agent/arty_uploader.go
+++ b/agent/arty_uploader.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/buildkite/agent/api"
@@ -85,10 +87,10 @@ func ParseArtifactoryDestination(destination string) (repo string, path string) 
 func (u *ArtifactoryUploader) URL(artifact *api.Artifact) string {
 	url := *u.iURL
 	// ensure proper URL formatting for upload
-	url.Path = strings.Join([]string{
-		strings.Trim(url.Path, "/"),
-		strings.Replace(u.artifactPath(artifact), "\\", "/", -1),
-	}, "/")
+	url.Path = path.Join(
+		url.Path,
+		filepath.ToSlash(u.artifactPath(artifact)),
+	)
 	return url.String()
 }
 


### PR DESCRIPTION
Path parsing for any Windows path was resulting in a %20 being injected into the URL, and would fail to upload in some cases to Artifactory. 