### PR TITLE
update path parsing to support windows artifact download 

### DIFF
--- a/agent/arty_downloader.go
+++ b/agent/arty_downloader.go
@@ -6,10 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-<<<<<<< HEAD
 	"path"
-=======
->>>>>>> 45ad5d0c7b4032e08718813b97b812d1dba5b3ba
 	"path/filepath"
 	"strings"
 
@@ -83,11 +80,7 @@ func (d ArtifactoryDownloader) Start() error {
 
 func (d ArtifactoryDownloader) RepositoryFileLocation() string {
 	if d.RepositoryPath() != "" {
-<<<<<<< HEAD
 		return path.Join(strings.TrimSuffix(d.RepositoryPath(), "/"),"/" , strings.TrimPrefix(filepath.ToSlash(d.conf.Path), "/"))
-=======
-		return strings.TrimSuffix(d.RepositoryPath(), "/") + "/" + strings.TrimPrefix(filepath.ToSlash(d.conf.Path), "/")
->>>>>>> 45ad5d0c7b4032e08718813b97b812d1dba5b3ba
 	} else {
 		return d.conf.Path
 	}

--- a/agent/arty_downloader.go
+++ b/agent/arty_downloader.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/buildkite/agent/logger"
@@ -78,7 +80,7 @@ func (d ArtifactoryDownloader) Start() error {
 
 func (d ArtifactoryDownloader) RepositoryFileLocation() string {
 	if d.RepositoryPath() != "" {
-		return strings.TrimSuffix(d.RepositoryPath(), "/") + "/" + strings.TrimPrefix(d.conf.Path, "/")
+		return path.Join(strings.TrimSuffix(d.RepositoryPath(), "/"),"/" , strings.TrimPrefix(filepath.ToSlash(d.conf.Path), "/"))
 	} else {
 		return d.conf.Path
 	}

--- a/agent/arty_uploader.go
+++ b/agent/arty_uploader.go
@@ -87,7 +87,7 @@ func (u *ArtifactoryUploader) URL(artifact *api.Artifact) string {
 	// ensure proper URL formatting for upload
 	url.Path = strings.Join([]string{
 		strings.Trim(url.Path, "/"),
-		u.artifactPath(artifact),
+		strings.Replace(u.artifactPath(artifact), "\\", "/", -1),
 	}, "/")
 	return url.String()
 }

--- a/agent/arty_uploader.go
+++ b/agent/arty_uploader.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/buildkite/agent/api"
@@ -85,10 +87,10 @@ func ParseArtifactoryDestination(destination string) (repo string, path string) 
 func (u *ArtifactoryUploader) URL(artifact *api.Artifact) string {
 	url := *u.iURL
 	// ensure proper URL formatting for upload
-	url.Path = strings.Join([]string{
-		strings.Trim(url.Path, "/"),
-		strings.Replace(u.artifactPath(artifact), "\\", "/", -1),
-	}, "/")
+	url.Path = path.Join(
+		url.Path,
+		filepath.ToSlash(u.artifactPath(artifact)),
+	)
 	return url.String()
 }
 

--- a/agent/arty_uploader.go
+++ b/agent/arty_uploader.go
@@ -121,7 +121,7 @@ func (u *ArtifactoryUploader) Upload(artifact *api.Artifact) error {
 }
 
 func (u *ArtifactoryUploader) artifactPath(artifact *api.Artifact) string {
-	parts := []string{u.Repository, artifact.Path}
+	parts := []string{u.Repository, u.Path, artifact.Path}
 
 	return strings.Join(parts, "/")
 }


### PR DESCRIPTION
This compliments PR(https://github.com/buildkite/agent/pull/1013) for windows upload, both need to be merged for artifactory to work properly.
