### PR TITLE
Fold all api services down into the one client

### DIFF
--- a/agent/api_client.go
+++ b/agent/api_client.go
@@ -28,7 +28,7 @@ func APIClientEnableHTTPDebug() {
 	debugHTTP = true
 }
 
-func NewAPIClient(l logger.Logger, c APIClientConfig) *api.Client {
+func NewAPIClient(l logger.Logger, c APIClientConfig) APIClient {
 	u, err := url.Parse(c.Endpoint)
 	if err != nil {
 		l.Warn("Failed to parse %q: %v", c.Endpoint, err)
@@ -62,16 +62,19 @@ func NewAPIClient(l logger.Logger, c APIClientConfig) *api.Client {
 	}}
 	httpClient.Timeout = 60 * time.Second
 
+	baseURL, _ := url.Parse(c.Endpoint)
+
 	// Create the Buildkite Agent API Client
-	client := api.NewClient(httpClient, l)
-	client.BaseURL, _ = url.Parse(c.Endpoint)
-	client.UserAgent = userAgent()
-	client.DebugHTTP = debugHTTP
+	client := api.NewClient(httpClient, l, api.ClientConfig{
+		BaseURL:   baseURL,
+		UserAgent: userAgent(),
+		DebugHTTP: debugHTTP,
+	})
 
 	return client
 }
 
-func NewAPIClientFromSocket(l logger.Logger, socket string, c APIClientConfig) *api.Client {
+func NewAPIClientFromSocket(l logger.Logger, socket string, c APIClientConfig) APIClient {
 	httpClient := &http.Client{
 		Transport: &api.AuthenticatedTransport{
 			Token: c.Token,
@@ -82,11 +85,14 @@ func NewAPIClientFromSocket(l logger.Logger, socket string, c APIClientConfig) *
 		},
 	}
 
+	baseURL, _ := url.Parse(`http+unix://buildkite-agent`)
+
 	// Create the Buildkite Agent API Client
-	client := api.NewClient(httpClient, l)
-	client.BaseURL, _ = url.Parse(`http+unix://buildkite-agent`)
-	client.UserAgent = userAgent()
-	client.DebugHTTP = debugHTTP
+	client := api.NewClient(httpClient, l, api.ClientConfig{
+		BaseURL:   baseURL,
+		UserAgent: userAgent(),
+		DebugHTTP: debugHTTP,
+	})
 
 	return client
 }

--- a/agent/api_iface.go
+++ b/agent/api_iface.go
@@ -1,0 +1,31 @@
+// Created by interfacer; DO NOT EDIT
+
+package agent
+
+import (
+	"github.com/buildkite/agent/api"
+)
+
+// APIClient is an interface generated for "github.com/buildkite/agent/api.Client".
+type APIClient interface {
+	AcceptJob(*api.Job) (*api.Job, *api.Response, error)
+	Annotate(string, *api.Annotation) (*api.Response, error)
+	Connect() (*api.Response, error)
+	CreateArtifacts(string, *api.ArtifactBatch) (*api.ArtifactBatchCreateResponse, *api.Response, error)
+	Disconnect() (*api.Response, error)
+	ExistsMetaData(string, string) (*api.MetaDataExists, *api.Response, error)
+	FinishJob(*api.Job) (*api.Response, error)
+	GetJobState(string) (*api.JobState, *api.Response, error)
+	GetMetaData(string, string) (*api.MetaData, *api.Response, error)
+	Heartbeat() (*api.Heartbeat, *api.Response, error)
+	Ping() (*api.Ping, *api.Response, error)
+	Register(*api.AgentRegisterRequest) (*api.AgentRegisterResponse, *api.Response, error)
+	SaveHeaderTimes(string, *api.HeaderTimes) (*api.Response, error)
+	SearchArtifacts(string, *api.ArtifactSearchOptions) ([]*api.Artifact, *api.Response, error)
+	SetMetaData(string, *api.MetaData) (*api.Response, error)
+	StartJob(*api.Job) (*api.Response, error)
+	StepUpdate(string, *api.StepUpdate) (*api.Response, error)
+	UpdateArtifacts(string, map[string]string) (*api.Response, error)
+	UploadChunk(string, *api.Chunk) (*api.Response, error)
+	UploadPipeline(string, *api.Pipeline) (*api.Response, error)
+}

--- a/agent/api_proxy_test.go
+++ b/agent/api_proxy_test.go
@@ -32,7 +32,7 @@ func TestAPIProxy(t *testing.T) {
 	})
 
 	// fire a ping via the proxy
-	p, _, err := client.Pings.Get()
+	p, _, err := client.Ping()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestAPIProxyFailsWithoutAccessToken(t *testing.T) {
 	})
 
 	// fire a ping via the proxy
-	_, _, err := client.Pings.Get()
+	_, _, err := client.Ping()
 	if err == nil {
 		t.Fatalf("Expected an error without an access token")
 	}

--- a/agent/artifact_batch_creator.go
+++ b/agent/artifact_batch_creator.go
@@ -27,10 +27,10 @@ type ArtifactBatchCreator struct {
 	logger logger.Logger
 
 	// The APIClient that will be used when uploading jobs
-	apiClient *api.Client
+	apiClient APIClient
 }
 
-func NewArtifactBatchCreator(l logger.Logger, ac *api.Client, c ArtifactBatchCreatorConfig) *ArtifactBatchCreator {
+func NewArtifactBatchCreator(l logger.Logger, ac APIClient, c ArtifactBatchCreatorConfig) *ArtifactBatchCreator {
 	return &ArtifactBatchCreator{
 		logger:    l,
 		conf:      c,
@@ -67,7 +67,7 @@ func (a *ArtifactBatchCreator) Create() ([]*api.Artifact, error) {
 
 		// Retry the batch upload a couple of times
 		err = retry.Do(func(s *retry.Stats) error {
-			creation, resp, err = a.apiClient.Artifacts.Create(a.conf.JobID, batch)
+			creation, resp, err = a.apiClient.CreateArtifacts(a.conf.JobID, batch)
 			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 500) {
 				s.Break()
 			}

--- a/agent/artifact_searcher.go
+++ b/agent/artifact_searcher.go
@@ -10,13 +10,13 @@ type ArtifactSearcher struct {
 	logger logger.Logger
 
 	// The APIClient that will be used when uploading jobs
-	apiClient *api.Client
+	apiClient APIClient
 
 	// The ID of the Build that these artifacts belong to
 	buildID string
 }
 
-func NewArtifactSearcher(l logger.Logger, ac *api.Client, buildID string) *ArtifactSearcher {
+func NewArtifactSearcher(l logger.Logger, ac APIClient, buildID string) *ArtifactSearcher {
 	return &ArtifactSearcher{
 		logger:    l,
 		apiClient: ac,
@@ -31,7 +31,7 @@ func (a *ArtifactSearcher) Search(query string, scope string) ([]*api.Artifact, 
 		a.logger.Info("Searching for artifacts: \"%s\" within step: \"%s\"", query, scope)
 	}
 
-	artifacts, _, err := a.apiClient.Artifacts.Search(a.buildID, &api.ArtifactSearchOptions{
+	artifacts, _, err := a.apiClient.SearchArtifacts(a.buildID, &api.ArtifactSearchOptions{
 		Query: query,
 		Scope: scope,
 	})

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -45,7 +45,7 @@ type JobRunner struct {
 	job *api.Job
 
 	// The APIClient that will be used when updating the job
-	apiClient *api.Client
+	apiClient APIClient
 
 	// The APIProxy that will be exposed to the job bootstrap
 	apiProxy *APIProxy
@@ -491,7 +491,7 @@ func (r *JobRunner) startJob(startedAt time.Time) error {
 	r.job.StartedAt = startedAt.UTC().Format(time.RFC3339Nano)
 
 	return retry.Do(func(s *retry.Stats) error {
-		_, err := r.apiClient.Jobs.Start(r.job)
+		_, err := r.apiClient.StartJob(r.job)
 
 		if err != nil {
 			if api.IsRetryableError(err) {
@@ -514,7 +514,7 @@ func (r *JobRunner) finishJob(finishedAt time.Time, exitStatus string, failedChu
 	r.job.ChunksFailedCount = failedChunkCount
 
 	return retry.Do(func(s *retry.Stats) error {
-		response, err := r.apiClient.Jobs.Finish(r.job)
+		response, err := r.apiClient.FinishJob(r.job)
 		if err != nil {
 			// If the API returns with a 422, that means that we
 			// succesfully tried to finish the job, but Buildkite
@@ -580,7 +580,7 @@ func (r *JobRunner) onProcessStartCallback() {
 		for {
 			// Re-get the job and check it's status to see if it's been
 			// cancelled
-			jobState, _, err := r.apiClient.Jobs.GetState(r.job.ID)
+			jobState, _, err := r.apiClient.GetJobState(r.job.ID)
 			if err != nil {
 				// We don't really care if it fails, we'll just
 				// try again soon anyway
@@ -603,7 +603,7 @@ func (r *JobRunner) onProcessStartCallback() {
 
 func (r *JobRunner) onUploadHeaderTime(cursor int, total int, times map[string]string) {
 	retry.Do(func(s *retry.Stats) error {
-		response, err := r.apiClient.HeaderTimes.Save(r.job.ID, &api.HeaderTimes{Times: times})
+		response, err := r.apiClient.SaveHeaderTimes(r.job.ID, &api.HeaderTimes{Times: times})
 		if err != nil {
 			if response != nil && (response.StatusCode >= 400 && response.StatusCode <= 499) {
 				r.logger.Warn("Buildkite rejected the header times (%s)", err)
@@ -628,7 +628,7 @@ func (r *JobRunner) onUploadChunk(chunk *LogStreamerChunk) error {
 	// from Buildkite that it's considered the chunk (a 4xx will be
 	// returned if the chunk is invalid, and we shouldn't retry on that)
 	return retry.Do(func(s *retry.Stats) error {
-		response, err := r.apiClient.Chunks.Upload(r.job.ID, &api.Chunk{
+		response, err := r.apiClient.UploadChunk(r.job.ID, &api.Chunk{
 			Data:     chunk.Data,
 			Sequence: chunk.Order,
 			Offset:   chunk.Offset,

--- a/agent/register.go
+++ b/agent/register.go
@@ -23,7 +23,7 @@ var (
 
 // Register takes an api.Agent and registers it with the Buildkite API
 // and populates the result of the register call
-func Register(l logger.Logger, ac *api.Client, req api.AgentRegisterRequest) (*api.AgentRegisterResponse, error) {
+func Register(l logger.Logger, ac APIClient, req api.AgentRegisterRequest) (*api.AgentRegisterResponse, error) {
 	var registered *api.AgentRegisterResponse
 	var err error
 	var resp *api.Response
@@ -41,7 +41,7 @@ func Register(l logger.Logger, ac *api.Client, req api.AgentRegisterRequest) (*a
 	req.OS = osVersionDump
 
 	register := func(s *retry.Stats) error {
-		registered, resp, err = ac.Agents.Register(&req)
+		registered, resp, err = ac.Register(&req)
 		if err != nil {
 			if resp != nil && resp.StatusCode == 401 {
 				l.Warn("Buildkite rejected the registration (%s)", err)

--- a/api/agents.go
+++ b/api/agents.go
@@ -1,11 +1,5 @@
 package api
 
-// AgentsService handles communication with the agent related methods of the
-// Buildkite Agent API.
-type AgentsService struct {
-	client *Client
-}
-
 // AgentRegisterRequest is a call to register on the Buildkite Agent API
 type AgentRegisterRequest struct {
 	Name              string   `json:"name"`
@@ -35,14 +29,14 @@ type AgentRegisterResponse struct {
 
 // Registers the agent against the Buildkite Agent API. The client for this
 // call must be authenticated using an Agent Registration Token
-func (as *AgentsService) Register(regReq *AgentRegisterRequest) (*AgentRegisterResponse, *Response, error) {
-	req, err := as.client.NewRequest("POST", "register", regReq)
+func (c *Client) Register(regReq *AgentRegisterRequest) (*AgentRegisterResponse, *Response, error) {
+	req, err := c.newRequest("POST", "register", regReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	a := new(AgentRegisterResponse)
-	resp, err := as.client.Do(req, a)
+	resp, err := c.doRequest(req, a)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -51,21 +45,21 @@ func (as *AgentsService) Register(regReq *AgentRegisterRequest) (*AgentRegisterR
 }
 
 // Connects the agent to the Buildkite Agent API
-func (as *AgentsService) Connect() (*Response, error) {
-	req, err := as.client.NewRequest("POST", "connect", nil)
+func (c *Client) Connect() (*Response, error) {
+	req, err := c.newRequest("POST", "connect", nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return as.client.Do(req, nil)
+	return c.doRequest(req, nil)
 }
 
 // Disconnects the agent to the Buildkite Agent API
-func (as *AgentsService) Disconnect() (*Response, error) {
-	req, err := as.client.NewRequest("POST", "disconnect", nil)
+func (c *Client) Disconnect() (*Response, error) {
+	req, err := c.newRequest("POST", "disconnect", nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return as.client.Do(req, nil)
+	return c.doRequest(req, nil)
 }

--- a/api/annotations.go
+++ b/api/annotations.go
@@ -2,12 +2,6 @@ package api
 
 import "fmt"
 
-// AnnotationsService handles communication with the annotation related methods of the
-// Buildkite Agent API.
-type AnnotationsService struct {
-	client *Client
-}
-
 // Annotation represents a Buildkite Agent API Annotation
 type Annotation struct {
 	Body    string `json:"body,omitempty"`
@@ -16,14 +10,14 @@ type Annotation struct {
 	Append  bool   `json:"append,omitempty"`
 }
 
-// Annotates a build in the Buildkite UI
-func (cs *AnnotationsService) Create(jobId string, annotation *Annotation) (*Response, error) {
+// Annotate a build in the Buildkite UI
+func (c *Client) Annotate(jobId string, annotation *Annotation) (*Response, error) {
 	u := fmt.Sprintf("jobs/%s/annotations", jobId)
 
-	req, err := cs.client.NewRequest("POST", u, annotation)
+	req, err := c.newRequest("POST", u, annotation)
 	if err != nil {
 		return nil, err
 	}
 
-	return cs.client.Do(req, nil)
+	return c.doRequest(req, nil)
 }

--- a/api/artifacts.go
+++ b/api/artifacts.go
@@ -4,12 +4,6 @@ import (
 	"fmt"
 )
 
-// ArtifactsService handles communication with the artifact related methods of
-// the Buildkite Artifact API.
-type ArtifactsService struct {
-	client *Client
-}
-
 // Artifact represents an artifact on the Buildkite Agent API
 type Artifact struct {
 	// The ID of the artifact. The ID is assigned to it after a successful
@@ -83,17 +77,17 @@ type ArtifactBatchUpdateRequest struct {
 	Artifacts []*ArtifactBatchUpdateArtifact `json:"artifacts"`
 }
 
-// Accepts a slice of artifacts, and creates them on Buildkite as a batch.
-func (as *ArtifactsService) Create(jobId string, batch *ArtifactBatch) (*ArtifactBatchCreateResponse, *Response, error) {
+// CreateArtifacts takes a slice of artifacts, and creates them on Buildkite as a batch.
+func (c *Client) CreateArtifacts(jobId string, batch *ArtifactBatch) (*ArtifactBatchCreateResponse, *Response, error) {
 	u := fmt.Sprintf("jobs/%s/artifacts", jobId)
 
-	req, err := as.client.NewRequest("POST", u, batch)
+	req, err := c.newRequest("POST", u, batch)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	createResponse := new(ArtifactBatchCreateResponse)
-	resp, err := as.client.Do(req, createResponse)
+	resp, err := c.doRequest(req, createResponse)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -101,8 +95,8 @@ func (as *ArtifactsService) Create(jobId string, batch *ArtifactBatch) (*Artifac
 	return createResponse, resp, err
 }
 
-// Updates a paticular artifact
-func (as *ArtifactsService) Update(jobId string, artifactStates map[string]string) (*Response, error) {
+// Updates a particular artifact
+func (c *Client) UpdateArtifacts(jobId string, artifactStates map[string]string) (*Response, error) {
 	u := fmt.Sprintf("jobs/%s/artifacts", jobId)
 	payload := ArtifactBatchUpdateRequest{}
 
@@ -110,12 +104,12 @@ func (as *ArtifactsService) Update(jobId string, artifactStates map[string]strin
 		payload.Artifacts = append(payload.Artifacts, &ArtifactBatchUpdateArtifact{id, state})
 	}
 
-	req, err := as.client.NewRequest("PUT", u, payload)
+	req, err := c.newRequest("PUT", u, payload)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := as.client.Do(req, nil)
+	resp, err := c.doRequest(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -123,21 +117,21 @@ func (as *ArtifactsService) Update(jobId string, artifactStates map[string]strin
 	return resp, err
 }
 
-// Searches Buildkite for a set of artifacts
-func (as *ArtifactsService) Search(buildId string, opt *ArtifactSearchOptions) ([]*Artifact, *Response, error) {
+// SearchArtifacts searches Buildkite for a set of artifacts
+func (c *Client) SearchArtifacts(buildId string, opt *ArtifactSearchOptions) ([]*Artifact, *Response, error) {
 	u := fmt.Sprintf("builds/%s/artifacts/search", buildId)
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := as.client.NewRequest("GET", u, nil)
+	req, err := c.newRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	a := []*Artifact{}
-	resp, err := as.client.Do(req, &a)
+	resp, err := c.doRequest(req, &a)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/api/chunks.go
+++ b/api/chunks.go
@@ -16,7 +16,7 @@ type Chunk struct {
 
 // Uploads the chunk to the Buildkite Agent API. This request sends the
 // compressed log directly as a request body.
-func (c *Client) UploadChunks(jobId string, chunk *Chunk) (*Response, error) {
+func (c *Client) UploadChunk(jobId string, chunk *Chunk) (*Response, error) {
 	// Create a compressed buffer of the log content
 	body := &bytes.Buffer{}
 	gzipper := gzip.NewWriter(body)

--- a/api/chunks.go
+++ b/api/chunks.go
@@ -6,12 +6,6 @@ import (
 	"fmt"
 )
 
-// ChunksService handles communication with the chunk related methods of the
-// Buildkite Agent API.
-type ChunksService struct {
-	client *Client
-}
-
 // Chunk represents a Buildkite Agent API Chunk
 type Chunk struct {
 	Data     string
@@ -22,7 +16,7 @@ type Chunk struct {
 
 // Uploads the chunk to the Buildkite Agent API. This request sends the
 // compressed log directly as a request body.
-func (cs *ChunksService) Upload(jobId string, chunk *Chunk) (*Response, error) {
+func (c *Client) UploadChunks(jobId string, chunk *Chunk) (*Response, error) {
 	// Create a compressed buffer of the log content
 	body := &bytes.Buffer{}
 	gzipper := gzip.NewWriter(body)
@@ -33,7 +27,7 @@ func (cs *ChunksService) Upload(jobId string, chunk *Chunk) (*Response, error) {
 
 	// Pass most params as query
 	u := fmt.Sprintf("jobs/%s/chunks?sequence=%d&offset=%d&size=%d", jobId, chunk.Sequence, chunk.Offset, chunk.Size)
-	req, err := cs.client.NewFormRequest("POST", u, body)
+	req, err := c.newFormRequest("POST", u, body)
 	if err != nil {
 		return nil, err
 	}
@@ -42,5 +36,5 @@ func (cs *ChunksService) Upload(jobId string, chunk *Chunk) (*Response, error) {
 	req.Header.Add("Content-Type", "text/plain")
 	req.Header.Add("Content-Encoding", "gzip")
 
-	return cs.client.Do(req, nil)
+	return c.doRequest(req, nil)
 }

--- a/api/client.go
+++ b/api/client.go
@@ -1,5 +1,7 @@
 package api
 
+//go:generate interfacer -for github.com/buildkite/agent/api.Client -as agent.APIClient -o ../agent/api_iface.go
+
 import (
 	"bytes"
 	"encoding/json"

--- a/api/client.go
+++ b/api/client.go
@@ -7,10 +7,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"mime/multipart"
 	"net/http"
 	"net/http/httputil"
-	"net/textproto"
 	"net/url"
 	"reflect"
 	"strings"
@@ -25,14 +23,8 @@ const (
 	defaultUserAgent = "buildkite-agent/api"
 )
 
-// A Client manages communication with the Buildkite Agent API.
-type Client struct {
-	// HTTP client used to communicate with the API.
-	client *http.Client
-
-	// The logger used
-	logger logger.Logger
-
+// ClientConfig is configuration for Client
+type ClientConfig struct {
 	// Base URL for API requests. Defaults to the public Buildkite Agent API.
 	// The URL should always be specified with a trailing slash.
 	BaseURL *url.URL
@@ -42,43 +34,35 @@ type Client struct {
 
 	// If true, requests and responses will be dumped and set to the logger
 	DebugHTTP bool
+}
 
-	// Services used for talking to different parts of the Buildkite Agent API.
-	Agents      *AgentsService
-	Pings       *PingsService
-	Jobs        *JobsService
-	Chunks      *ChunksService
-	MetaData    *MetaDataService
-	HeaderTimes *HeaderTimesService
-	Artifacts   *ArtifactsService
-	Pipelines   *PipelinesService
-	Heartbeats  *HeartbeatsService
-	Annotations *AnnotationsService
+// A Client manages communication with the Buildkite Agent API.
+type Client struct {
+	// The client configuration
+	conf ClientConfig
+
+	// HTTP client used to communicate with the API.
+	client *http.Client
+
+	// The logger used
+	logger logger.Logger
 }
 
 // NewClient returns a new Buildkite Agent API Client.
-func NewClient(httpClient *http.Client, l logger.Logger) *Client {
-	baseURL, _ := url.Parse(defaultBaseURL)
-
-	c := &Client{
-		logger:    l,
-		client:    httpClient,
-		BaseURL:   baseURL,
-		UserAgent: defaultUserAgent,
+func NewClient(httpClient *http.Client, l logger.Logger, conf ClientConfig) *Client {
+	if conf.BaseURL == nil {
+		conf.BaseURL, _ = url.Parse(defaultBaseURL)
 	}
 
-	c.Agents = &AgentsService{c}
-	c.Pings = &PingsService{c}
-	c.Jobs = &JobsService{c}
-	c.Chunks = &ChunksService{c}
-	c.MetaData = &MetaDataService{c}
-	c.HeaderTimes = &HeaderTimesService{c}
-	c.Artifacts = &ArtifactsService{c}
-	c.Pipelines = &PipelinesService{c}
-	c.Heartbeats = &HeartbeatsService{c}
-	c.Annotations = &AnnotationsService{c}
+	if conf.UserAgent == "" {
+		conf.UserAgent = defaultUserAgent
+	}
 
-	return c
+	return &Client{
+		logger: l,
+		client: httpClient,
+		conf:   conf,
+	}
 }
 
 // NewRequest creates an API request. A relative URL can be provided in urlStr,
@@ -86,8 +70,8 @@ func NewClient(httpClient *http.Client, l logger.Logger) *Client {
 // Relative URLs should always be specified without a preceding slash. If
 // specified, the value pointed to by body is JSON encoded and included as the
 // request body.
-func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Request, error) {
-	u := joinURL(c.BaseURL.String(), urlStr)
+func (c *Client) newRequest(method, urlStr string, body interface{}) (*http.Request, error) {
+	u := joinURL(c.conf.BaseURL.String(), urlStr)
 
 	buf := new(bytes.Buffer)
 	if body != nil {
@@ -102,7 +86,7 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 		return nil, err
 	}
 
-	req.Header.Add("User-Agent", c.UserAgent)
+	req.Header.Add("User-Agent", c.conf.UserAgent)
 
 	if body != nil {
 		req.Header.Add("Content-Type", "application/json")
@@ -115,16 +99,16 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 // provided in urlStr, in which case it is resolved relative to the UploadURL
 // of the Client. Relative URLs should always be specified without a preceding
 // slash.
-func (c *Client) NewFormRequest(method, urlStr string, body *bytes.Buffer) (*http.Request, error) {
-	u := joinURL(c.BaseURL.String(), urlStr)
+func (c *Client) newFormRequest(method, urlStr string, body *bytes.Buffer) (*http.Request, error) {
+	u := joinURL(c.conf.BaseURL.String(), urlStr)
 
 	req, err := http.NewRequest(method, u, body)
 	if err != nil {
 		return nil, err
 	}
 
-	if c.UserAgent != "" {
-		req.Header.Add("User-Agent", c.UserAgent)
+	if c.conf.UserAgent != "" {
+		req.Header.Add("User-Agent", c.conf.UserAgent)
 	}
 
 	return req, nil
@@ -147,10 +131,10 @@ func newResponse(r *http.Response) *Response {
 // error if an API error has occurred.  If v implements the io.Writer
 // interface, the raw response body will be written to v, without attempting to
 // first decode it.
-func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
+func (c *Client) doRequest(req *http.Request, v interface{}) (*Response, error) {
 	var err error
 
-	if c.DebugHTTP {
+	if c.conf.DebugHTTP {
 		// If the request is a multi-part form, then it's probably a
 		// file upload, in which case we don't want to spewing out the
 		// file contents into the debug log (especially if it's been
@@ -185,7 +169,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 
 	response := newResponse(resp)
 
-	if c.DebugHTTP {
+	if c.conf.DebugHTTP {
 		responseDump, err := httputil.DumpResponse(resp, true)
 		c.logger.Debug("\nERR: %s\n%s", err, string(responseDump))
 	}
@@ -264,24 +248,6 @@ func addOptions(s string, opt interface{}) (string, error) {
 
 	u.RawQuery = qs.Encode()
 	return u.String(), nil
-}
-
-// Copied from http://golang.org/src/mime/multipart/writer.go
-var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
-
-func escapeQuotes(s string) string {
-	return quoteEscaper.Replace(s)
-}
-
-// createFormFileWithContentType is a copy of the CreateFormFile method, except
-// you can change the content type it uses (by default you can't)
-func createFormFileWithContentType(w *multipart.Writer, fieldname, filename, contentType string) (io.Writer, error) {
-	h := make(textproto.MIMEHeader)
-	h.Set("Content-Disposition",
-		fmt.Sprintf(`form-data; name="%s"; filename="%s"`,
-			escapeQuotes(fieldname), escapeQuotes(filename)))
-	h.Set("Content-Type", contentType)
-	return w.CreatePart(h)
 }
 
 func joinURL(endpoint string, path string) string {

--- a/api/header_times.go
+++ b/api/header_times.go
@@ -4,28 +4,22 @@ import (
 	"fmt"
 )
 
-// HeaderTimesService handles communication with the meta data related methods
-// of the Buildkite Agent API.
-type HeaderTimesService struct {
-	client *Client
-}
-
 // HeaderTimes represents a set of header times that are associated with a job
 // log.
 type HeaderTimes struct {
 	Times map[string]string `json:"header_times"`
 }
 
-// Saves the header times to the job
-func (hs *HeaderTimesService) Save(jobId string, headerTimes *HeaderTimes) (*Response, error) {
+// SaveHeaderTimes saves the header times to the job
+func (c *Client) SaveHeaderTimes(jobId string, headerTimes *HeaderTimes) (*Response, error) {
 	u := fmt.Sprintf("jobs/%s/header_times", jobId)
 
-	req, err := hs.client.NewRequest("POST", u, headerTimes)
+	req, err := c.newRequest("POST", u, headerTimes)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := hs.client.Do(req, nil)
+	resp, err := c.doRequest(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/api/heartbeats.go
+++ b/api/heartbeats.go
@@ -2,30 +2,24 @@ package api
 
 import "time"
 
-// HeartbeatsService handles communication with the ping related methods of the
-// Buildkite Agent API.
-type HeartbeatsService struct {
-	client *Client
-}
-
 // Heartbeat represents a Buildkite Agent API Heartbeat
 type Heartbeat struct {
 	SentAt     string `json:"sent_at"`
 	ReceivedAt string `json:"received_at,omitempty"`
 }
 
-// Heartbeats the API which keeps the agent connected to Buildkite
-func (hs *HeartbeatsService) Beat() (*Heartbeat, *Response, error) {
+// Heartbeat notifies Buildkite that an agent is still connected
+func (c *Client) Heartbeat() (*Heartbeat, *Response, error) {
 	// Include the current time in the heartbeat, and include the operating
 	// systems timezone.
 	heartbeat := &Heartbeat{SentAt: time.Now().Format(time.RFC3339Nano)}
 
-	req, err := hs.client.NewRequest("POST", "heartbeat", &heartbeat)
+	req, err := c.newRequest("POST", "heartbeat", &heartbeat)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	resp, err := hs.client.Do(req, heartbeat)
+	resp, err := c.doRequest(req, heartbeat)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -4,12 +4,6 @@ import (
 	"fmt"
 )
 
-// JobsService handles communication with the job related methods of the
-// Buildkite Agent API.
-type JobsService struct {
-	client *Client
-}
-
 // Job represents a Buildkite Agent API Job
 type Job struct {
 	ID                 string            `json:"id,omitempty"`
@@ -37,17 +31,17 @@ type jobFinishRequest struct {
 	ChunksFailedCount int    `json:"chunks_failed_count"`
 }
 
-// Fetches a job
-func (js *JobsService) GetState(id string) (*JobState, *Response, error) {
+// GetJobState returns the state of a given job
+func (c *Client) GetJobState(id string) (*JobState, *Response, error) {
 	u := fmt.Sprintf("jobs/%s", id)
 
-	req, err := js.client.NewRequest("GET", u, nil)
+	req, err := c.newRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	s := new(JobState)
-	resp, err := js.client.Do(req, s)
+	resp, err := c.doRequest(req, s)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -55,19 +49,19 @@ func (js *JobsService) GetState(id string) (*JobState, *Response, error) {
 	return s, resp, err
 }
 
-// Accepts the passed in job. Returns the job with it's finalized set of
+// AcceptJob accepts the passed in job. Returns the job with it's finalized set of
 // environment variables (when a job is accepted, the agents environment is
 // applied to the job)
-func (js *JobsService) Accept(job *Job) (*Job, *Response, error) {
+func (c *Client) AcceptJob(job *Job) (*Job, *Response, error) {
 	u := fmt.Sprintf("jobs/%s/accept", job.ID)
 
-	req, err := js.client.NewRequest("PUT", u, nil)
+	req, err := c.newRequest("PUT", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	j := new(Job)
-	resp, err := js.client.Do(req, j)
+	resp, err := c.doRequest(req, j)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -75,25 +69,25 @@ func (js *JobsService) Accept(job *Job) (*Job, *Response, error) {
 	return j, resp, err
 }
 
-// Starts the passed in job
-func (js *JobsService) Start(job *Job) (*Response, error) {
+// StartJob starts the passed in job
+func (c *Client) StartJob(job *Job) (*Response, error) {
 	u := fmt.Sprintf("jobs/%s/start", job.ID)
 
-	req, err := js.client.NewRequest("PUT", u, &jobStartRequest{
+	req, err := c.newRequest("PUT", u, &jobStartRequest{
 		StartedAt: job.StartedAt,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return js.client.Do(req, nil)
+	return c.doRequest(req, nil)
 }
 
-// Finishes the passed in job
-func (js *JobsService) Finish(job *Job) (*Response, error) {
+// FinishJob finishes the passed in job
+func (c *Client) FinishJob(job *Job) (*Response, error) {
 	u := fmt.Sprintf("jobs/%s/finish", job.ID)
 
-	req, err := js.client.NewRequest("PUT", u, &jobFinishRequest{
+	req, err := c.newRequest("PUT", u, &jobFinishRequest{
 		FinishedAt:        job.FinishedAt,
 		ExitStatus:        job.ExitStatus,
 		ChunksFailedCount: job.ChunksFailedCount,
@@ -102,17 +96,25 @@ func (js *JobsService) Finish(job *Job) (*Response, error) {
 		return nil, err
 	}
 
-	return js.client.Do(req, nil)
+	return c.doRequest(req, nil)
 }
 
-// Updates a step
-func (js *JobsService) StepUpdate(jobId string, stepUpdate *StepUpdate) (*Response, error) {
+// StepUpdate represents a change request to a step
+type StepUpdate struct {
+	UUID      string `json:"uuid,omitempty"`
+	Attribute string `json:"attribute,omitempty"`
+	Value     string `json:"value,omitempty"`
+	Append    bool   `json:"append,omitempty"`
+}
+
+// StepUpdate updates a step
+func (c *Client) StepUpdate(jobId string, stepUpdate *StepUpdate) (*Response, error) {
 	u := fmt.Sprintf("jobs/%s/step_update", jobId)
 
-	req, err := js.client.NewRequest("PUT", u, stepUpdate)
+	req, err := c.newRequest("PUT", u, stepUpdate)
 	if err != nil {
 		return nil, err
 	}
 
-	return js.client.Do(req, nil)
+	return c.doRequest(req, nil)
 }

--- a/api/meta_data.go
+++ b/api/meta_data.go
@@ -4,12 +4,6 @@ import (
 	"fmt"
 )
 
-// MetaDataService handles communication with the meta data related methods of
-// the Buildkite Agent API.
-type MetaDataService struct {
-	client *Client
-}
-
 // MetaData represents a Buildkite Agent API MetaData
 type MetaData struct {
 	Key   string `json:"key,omitempty"`
@@ -23,28 +17,28 @@ type MetaDataExists struct {
 }
 
 // Sets the meta data value
-func (ps *MetaDataService) Set(jobId string, metaData *MetaData) (*Response, error) {
+func (c *Client) SetMetaData(jobId string, metaData *MetaData) (*Response, error) {
 	u := fmt.Sprintf("jobs/%s/data/set", jobId)
 
-	req, err := ps.client.NewRequest("POST", u, metaData)
+	req, err := c.newRequest("POST", u, metaData)
 	if err != nil {
 		return nil, err
 	}
 
-	return ps.client.Do(req, nil)
+	return c.doRequest(req, nil)
 }
 
 // Gets the meta data value
-func (ps *MetaDataService) Get(jobId string, key string) (*MetaData, *Response, error) {
+func (c *Client) GetMetaData(jobId string, key string) (*MetaData, *Response, error) {
 	u := fmt.Sprintf("jobs/%s/data/get", jobId)
 	m := &MetaData{Key: key}
 
-	req, err := ps.client.NewRequest("POST", u, m)
+	req, err := c.newRequest("POST", u, m)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	resp, err := ps.client.Do(req, m)
+	resp, err := c.doRequest(req, m)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -53,17 +47,17 @@ func (ps *MetaDataService) Get(jobId string, key string) (*MetaData, *Response, 
 }
 
 // Returns true if the meta data key has been set, false if it hasn't.
-func (ps *MetaDataService) Exists(jobId string, key string) (*MetaDataExists, *Response, error) {
+func (c *Client) ExistsMetaData(jobId string, key string) (*MetaDataExists, *Response, error) {
 	u := fmt.Sprintf("jobs/%s/data/exists", jobId)
 	m := &MetaData{Key: key}
 
-	req, err := ps.client.NewRequest("POST", u, m)
+	req, err := c.newRequest("POST", u, m)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	e := new(MetaDataExists)
-	resp, err := ps.client.Do(req, e)
+	resp, err := c.doRequest(req, e)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/api/pings.go
+++ b/api/pings.go
@@ -1,11 +1,5 @@
 package api
 
-// PingsService handles communication with the ping related methods of the
-// Buildkite Agent API.
-type PingsService struct {
-	client *Client
-}
-
 // Ping represents a Buildkite Agent API Ping
 type Ping struct {
 	Action   string `json:"action,omitempty"`
@@ -15,14 +9,14 @@ type Ping struct {
 }
 
 // Pings the API and returns any work the client needs to perform
-func (ps *PingsService) Get() (*Ping, *Response, error) {
-	req, err := ps.client.NewRequest("GET", "ping", nil)
+func (c *Client) Ping() (*Ping, *Response, error) {
+	req, err := c.newRequest("GET", "ping", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	ping := new(Ping)
-	resp, err := ps.client.Do(req, ping)
+	resp, err := c.doRequest(req, ping)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/api/pipelines.go
+++ b/api/pipelines.go
@@ -2,12 +2,6 @@ package api
 
 import "fmt"
 
-// PipelinesService handles communication with the pipeline related methods of the
-// Buildkite Agent API.
-type PipelinesService struct {
-	client *Client
-}
-
 // Pipeline represents a Buildkite Agent API Pipeline
 type Pipeline struct {
 	UUID     string      `json:"uuid"`
@@ -17,13 +11,13 @@ type Pipeline struct {
 
 // Uploads the pipeline to the Buildkite Agent API. This request doesn't use JSON,
 // but a multi-part HTTP form upload
-func (cs *PipelinesService) Upload(jobId string, pipeline *Pipeline) (*Response, error) {
+func (c *Client) UploadPipeline(jobId string, pipeline *Pipeline) (*Response, error) {
 	u := fmt.Sprintf("jobs/%s/pipelines", jobId)
 
-	req, err := cs.client.NewRequest("POST", u, pipeline)
+	req, err := c.newRequest("POST", u, pipeline)
 	if err != nil {
 		return nil, err
 	}
 
-	return cs.client.Do(req, nil)
+	return c.doRequest(req, nil)
 }

--- a/api/steps.go
+++ b/api/steps.go
@@ -1,9 +1,0 @@
-package api
-
-// StepUpdate represents a change request to a step
-type StepUpdate struct {
-	UUID      string `json:"uuid,omitempty"`
-	Attribute string `json:"attribute,omitempty"`
-	Value     string `json:"value,omitempty"`
-	Append    bool   `json:"append,omitempty"`
-}

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -147,8 +147,8 @@ var AnnotateCommand = cli.Command{
 
 		// Retry the annotation a few times before giving up
 		err = retry.Do(func(s *retry.Stats) error {
-			// Attempt ot create the annotation
-			resp, err := client.Annotations.Create(cfg.Job, annotation)
+			// Attempt to create the annotation
+			resp, err := client.Annotate(cfg.Job, annotation)
 
 			// Don't bother retrying if the response was one of these statuses
 			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 400) {

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -99,6 +99,7 @@ var ArtifactDownloadCommand = cli.Command{
 			Destination: cfg.Destination,
 			BuildID:     cfg.Build,
 			Step:        cfg.Step,
+			DebugHTTP:   cfg.DebugHTTP,
 		})
 
 		// Download the artifacts

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -103,6 +103,7 @@ var ArtifactUploadCommand = cli.Command{
 			Paths:       cfg.UploadPaths,
 			Destination: cfg.Destination,
 			ContentType: cfg.ContentType,
+			DebugHTTP:   cfg.DebugHTTP,
 		})
 
 		// Upload the artifacts

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -83,7 +83,7 @@ var MetaDataExistsCommand = cli.Command{
 		var exists *api.MetaDataExists
 		var resp *api.Response
 		err = retry.Do(func(s *retry.Stats) error {
-			exists, resp, err = client.MetaData.Exists(cfg.Job, cfg.Key)
+			exists, resp, err = client.ExistsMetaData(cfg.Job, cfg.Key)
 			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404) {
 				s.Break()
 			}

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -88,7 +88,7 @@ var MetaDataGetCommand = cli.Command{
 		var err error
 		var resp *api.Response
 		err = retry.Do(func(s *retry.Stats) error {
-			metaData, resp, err = client.MetaData.Get(cfg.Job, cfg.Key)
+			metaData, resp, err = client.GetMetaData(cfg.Job, cfg.Key)
 			// Don't bother retrying if the response was one of these statuses
 			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 400) {
 				s.Break()

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -103,7 +103,7 @@ var MetaDataSetCommand = cli.Command{
 
 		// Set the meta data
 		err := retry.Do(func(s *retry.Stats) error {
-			resp, err := client.MetaData.Set(cfg.Job, metaData)
+			resp, err := client.SetMetaData(cfg.Job, metaData)
 			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404) {
 				s.Break()
 			}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -241,7 +241,7 @@ var PipelineUploadCommand = cli.Command{
 
 		// Retry the pipeline upload a few times before giving up
 		err = retry.Do(func(s *retry.Stats) error {
-			_, err = client.Pipelines.Upload(cfg.Job, &api.Pipeline{UUID: uuid, Pipeline: result, Replace: cfg.Replace})
+			_, err = client.UploadPipeline(cfg.Job, &api.Pipeline{UUID: uuid, Pipeline: result, Replace: cfg.Replace})
 			if err != nil {
 				l.Warn("%s (%s)", err, s)
 

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -114,7 +114,7 @@ var StepUpdateCommand = cli.Command{
 
 		// Post the change
 		err := retry.Do(func(s *retry.Stats) error {
-			resp, err := client.Jobs.StepUpdate(cfg.Job, update)
+			resp, err := client.StepUpdate(cfg.Job, update)
 			if resp != nil && (resp.StatusCode == 400 || resp.StatusCode == 401 || resp.StatusCode == 404) {
 				s.Break()
 			}


### PR DESCRIPTION
This folds the various API service structs into the one `api.Client` to make it more easily mockable. 