### PR TITLE
Support plugin SHA-1 digests

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -19,6 +19,7 @@ type AgentConfiguration struct {
 	CommandEval                bool
 	PluginsEnabled             bool
 	PluginValidation           bool
+	RequirePluginDigests       bool
 	LocalHooksEnabled          bool
 	RunInPty                   bool
 	TimestampLines             bool

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -33,8 +33,7 @@ type Plugin struct {
 }
 
 var (
-	locationSchemeRegex = regexp.MustCompile(`^[a-z\+]+://`)
-	vendoredRegex       = regexp.MustCompile(`^\.`)
+	vendoredRegex = regexp.MustCompile(`^\.`)
 )
 
 func CreatePlugin(location string, config map[string]interface{}) (*Plugin, error) {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -723,14 +723,14 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	headCommit, err := gitRevParseInWorkingDirectory(b.shell, directory, "HEAD")
 
 	// Verify plugin digest
-	if p.Digest != "" {
-		if headCommit != p.Digest {
+	if p.DigestType == "git-sha1" {
+		if headCommit != p.DigestValue {
 			if p.Version != "" {
-				return nil, fmt.Errorf("Plugin digest mismatch. Expected git tag %s to have SHA1 of %s, found %s", p.Version, p.Digest, headCommit)
+				return nil, fmt.Errorf("Plugin digest mismatch. Expected git tag %s to have SHA1 of %s, found %s", p.Version, p.DigestValue, headCommit)
 			}
-			return nil, fmt.Errorf("Plugin digest mismatch. Expected git SHA1 of %s, found %s", p.Digest, headCommit)
+			return nil, fmt.Errorf("Plugin digest mismatch. Expected git SHA1 of %s, found %s", p.DigestValue, headCommit)
 		}
-		b.shell.Commentf("Plugin digest matches %s", p.Digest)
+		b.shell.Commentf("Plugin digest matches %s", p.DigestValue)
 	}
 
 	// Has it already been checked out?

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -722,6 +722,10 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	// let's figure that out.
 	headCommit, err := gitRevParseInWorkingDirectory(b.shell, directory, "HEAD")
 
+	if b.RequirePluginDigests && (p.DigestType == "" || p.DigestValue == "") {
+		return nil, fmt.Errorf("Agent configuration requires plugin digests, but no digest found for %s", p.Name())
+	}
+
 	// Verify plugin digest
 	if p.DigestType == "git-sha1" {
 		if headCommit != p.DigestValue {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -724,15 +724,14 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 
 	// Verify plugin digest
 	if p.Digest != "" {
-		b.shell.Commentf("Verifying plugin digest equals %s", p.Digest)
 		if headCommit != p.Digest {
 			if p.Version != "" {
 				return nil, fmt.Errorf("Plugin digest mismatch. Expected git tag %s to have SHA1 of %s, found %s", p.Version, p.Digest, headCommit)
-			} else {
-				return nil, fmt.Errorf("Plugin digest mismatch. Expected git SHA1 of %s, found %s", p.Digest, headCommit)
-			}		
+			}
+			return nil, fmt.Errorf("Plugin digest mismatch. Expected git SHA1 of %s, found %s", p.Digest, headCommit)
 		}
-	}	
+		b.shell.Commentf("Plugin digest matches %s", p.Digest)
+	}
 
 	// Has it already been checked out?
 	if fileExists(pluginGitDirectory) {

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -85,6 +85,9 @@ type Config struct {
 	// Whether to validate plugin configuration
 	PluginValidation bool
 
+	// Whether there must be a valid digest to use a plugin
+	RequirePluginDigests bool
+
 	// Are local hooks enabled?
 	LocalHooksEnabled bool
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -75,6 +75,7 @@ type AgentStartConfig struct {
 	NoPlugins                  bool     `cli:"no-plugins"`
 	NoPluginValidation         bool     `cli:"no-plugin-validation"`
 	NoPTY                      bool     `cli:"no-pty"`
+	RequirePluginDigests       bool     `cli:"require-plugin-digests"`
 	TimestampLines             bool     `cli:"timestamp-lines"`
 	MetricsDatadog             bool     `cli:"metrics-datadog"`
 	MetricsDatadogHost         string   `cli:"metrics-datadog-host"`
@@ -330,6 +331,11 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_NO_GIT_SUBMODULES,BUILDKITE_DISABLE_GIT_SUBMODULES",
 		},
 		cli.BoolFlag{
+			Name:   "require-plugin-digests",
+			Usage:  "Require all plugins to be pinned to a version and digest",
+			EnvVar: "BUILDKITE_REQUIRE_PLUGIN_DIGESTS",
+		},
+		cli.BoolFlag{
 			Name:   "metrics-datadog",
 			Usage:  "Send metrics to DogStatsD for Datadog",
 			EnvVar: "BUILDKITE_METRICS_DATADOG",
@@ -518,6 +524,7 @@ var AgentStartCommand = cli.Command{
 			CommandEval:                !cfg.NoCommandEval,
 			PluginsEnabled:             !cfg.NoPlugins,
 			PluginValidation:           !cfg.NoPluginValidation,
+			RequirePluginDigests:       cfg.RequirePluginDigests,
 			LocalHooksEnabled:          !cfg.NoLocalHooks,
 			RunInPty:                   !cfg.NoPTY,
 			TimestampLines:             cfg.TimestampLines,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -73,6 +73,7 @@ type BootstrapConfig struct {
 	CommandEval                  bool     `cli:"command-eval"`
 	PluginsEnabled               bool     `cli:"plugins-enabled"`
 	PluginValidation             bool     `cli:"plugin-validation"`
+	RequirePluginDigests         bool     `cli:"require-plugin-digests"`
 	LocalHooksEnabled            bool     `cli:"local-hooks-enabled"`
 	PTY                          bool     `cli:"pty"`
 	Debug                        bool     `cli:"debug"`
@@ -256,6 +257,11 @@ var BootstrapCommand = cli.Command{
 			Usage:  "Validate plugin configuration",
 			EnvVar: "BUILDKITE_PLUGIN_VALIDATION",
 		},
+		cli.BoolFlag{
+			Name:   "require-plugin-digests",
+			Usage:  "Require all plugins to be pinned to a version and digest",
+			EnvVar: "BUILDKITE_REQUIRE_PLUGIN_DIGESTS",
+		},
 		cli.BoolTFlag{
 			Name:   "local-hooks-enabled",
 			Usage:  "Allow local hooks to be run",
@@ -357,6 +363,7 @@ var BootstrapCommand = cli.Command{
 			HooksPath:                    cfg.HooksPath,
 			PluginsPath:                  cfg.PluginsPath,
 			PluginValidation:             cfg.PluginValidation,
+			RequirePluginDigests:         cfg.RequirePluginDigests,
 			Debug:                        cfg.Debug,
 			RunInPty:                     runInPty,
 			CommandEval:                  cfg.CommandEval,


### PR DESCRIPTION
This adds the ability to specify a plugin git commit SHA-1 (ala `git show-ref` / `git rev-parse`), preventing any modification to the plugin after it has been added to the pipeline.yml file:

```yml
steps:
  - command: |
      node -e 'console.log("Hello world")'
    plugins:
      docker#v3.2.0@git-sha1:f199bc812a7d7c770139fe8f67203010e103d0f8:
        image: node
```

If the digest matches then this is the output, and everything continues hunky dory:

<img width="756" alt="image" src="https://user-images.githubusercontent.com/153/59159769-da055c00-8b11-11e9-90ab-c20153389755.png">

If the SHA-1 of the plugin checkout doesn't match the SHA-1 specified in the pipeline.yml, you get

<img width="862" alt="image" src="https://user-images.githubusercontent.com/153/59159774-ed182c00-8b11-11e9-8f33-77cad9285bba.png">

Some design notes:

* The intention is that this is the new default for how people specify plugins in their pipeline.yml files. Digests should be baked into the default usage for everyone, helping increase the security of the entire ecosystem, just like it is bundler/npm/yarn/etc. Rather than something that can be specified for those who are worried.
* I can easily add support for the commit SHA updating into https://github.com/toolmantim/boomper, which we're using to help keep the plugin readme version numbers up-to-date. This means we retain the same API for usage (copying+pasting from readme markdown file examples), and no extra maintenance burden for plugin authoring.
* The `git-sha1` syntax was chosen over just specifying the SHA1, so we're explicitly stating what/where the SHA1 comes from. i.e. `docker#v3.2.0@git-sha1:f199bc812a7d7c770139fe8f67203010e103d0f8` is assumed to be clearer, and more self-documenting, than `docker#v3.2.0@f199bc812a7d7c770139fe8f67203010e103d0f8`
* There's nothing to change on the backend side, it just passes the plugin string all the way back through to the agent to handle. I've given it a test, and works well.
* Running this new digest plugin step on an older agent will fail (e.g. `error: pathspec 'v3.2.0@git-sha1:f199fc812a7d7c770139fe8f67203010e103d0f8' did not match any file(s) known to git.`). I believe this behaviour is okay (even desired) because if you're specifying digests then you want to make sure they're being enforced and not just ignored. (We can auto-detect the error in the build output, same as we do SSH key problems).
* Providing a digest here should avoid the need to vendor plugins for the sake of ensuring they're not tampered with (e.g. a tag is force-pushed, or the repo taken over)

- [x] Works on backend (no changes needed)
- [x] Initial implementation
- [x] Feedback on overall design
- [x] Error on incorrect digest format (e.g. `docker#v3.2.0@invalid:f199bc812a7d7c770139fe8f67203010e103d0f8:`). At the moment invalidly formatted digests are silently ignored, which is bad because they might appear correct to the eye but are silently ignored.
- [ ] Tests
- [ ] Code review