### PR TITLE
Add profile option to all cli commands

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -26,4 +26,5 @@ type AgentConfiguration struct {
 	DisconnectAfterIdleTimeout int
 	CancelGracePeriod          int
 	Shell                      string
+	Profile                    string
 }

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -429,6 +429,11 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	env["BUILDKITE_SHELL"] = r.conf.AgentConfiguration.Shell
 	env["BUILDKITE_AGENT_EXPERIMENT"] = strings.Join(experiments.Enabled(), ",")
 
+	// Whether to enable profiling in the bootstrap
+	if r.conf.AgentConfiguration.Profile != "" {
+		env["BUILDKITE_AGENT_PROFILE"] = r.conf.AgentConfiguration.Profile
+	}
+
 	enablePluginValidation := r.conf.AgentConfiguration.PluginValidation
 
 	// Allow BUILDKITE_PLUGIN_VALIDATION to be enabled from env for easier

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -85,6 +85,7 @@ type AgentStartConfig struct {
 	Debug       bool     `cli:"debug"`
 	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile     string   `cli:"profile"`
 
 	// API config
 	DebugHTTP bool   `cli:"debug-http"`
@@ -363,6 +364,7 @@ var AgentStartCommand = cli.Command{
 		ExperimentsFlag,
 		NoColorFlag,
 		DebugFlag,
+		ProfileFlag,
 
 		// Deprecated flags which will be removed in v4
 		cli.StringSliceFlag{
@@ -424,8 +426,9 @@ var AgentStartCommand = cli.Command{
 			l.Warn("%s", warning)
 		}
 
-		// Setup the any global configuration options
-		HandleGlobalFlags(l, cfg)
+		// Setup any global configuration options
+		done := HandleGlobalFlags(l, cfg)
+		defer done()
 
 		// Remove any config env from the environment to prevent them propagating to bootstrap
 		UnsetConfigFromEnvironment(c)

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -55,8 +55,9 @@ type AnnotateConfig struct {
 	Job     string `cli:"job" validate:"required"`
 
 	// Global flags
-	Debug   bool `cli:"debug"`
-	NoColor bool `cli:"no-color"`
+	Debug   bool   `cli:"debug"`
+	NoColor bool   `cli:"no-color"`
+	Profile string `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -101,6 +102,7 @@ var AnnotateCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {
 		// The configuration will be loaded into this struct
@@ -113,8 +115,9 @@ var AnnotateCommand = cli.Command{
 			l.Fatal("%s", err)
 		}
 
-		// Setup the any global configuration options
-		HandleGlobalFlags(l, cfg)
+		// Setup any global configuration options
+		done := HandleGlobalFlags(l, cfg)
+		defer done()
 
 		var body string
 		var err error

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -40,8 +40,9 @@ type ArtifactDownloadConfig struct {
 	Build       string `cli:"build" validate:"required"`
 
 	// Global flags
-	Debug   bool `cli:"debug"`
-	NoColor bool `cli:"no-color"`
+	Debug   bool   `cli:"debug"`
+	NoColor bool   `cli:"no-color"`
+	Profile string `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -76,6 +77,7 @@ var ArtifactDownloadCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {
 		// The configuration will be loaded into this struct
@@ -88,8 +90,9 @@ var ArtifactDownloadCommand = cli.Command{
 			l.Fatal("%s", err)
 		}
 
-		// Setup the any global configuration options
-		HandleGlobalFlags(l, cfg)
+		// Setup any global configuration options
+		done := HandleGlobalFlags(l, cfg)
+		defer done()
 
 		// Create the API client
 		client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -42,8 +42,9 @@ type ArtifactShasumConfig struct {
 	Build string `cli:"build" validate:"required"`
 
 	// Global flags
-	Debug   bool `cli:"debug"`
-	NoColor bool `cli:"no-color"`
+	Debug   bool   `cli:"debug"`
+	NoColor bool   `cli:"no-color"`
+	Profile string `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -78,6 +79,7 @@ var ArtifactShasumCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {
 		// The configuration will be loaded into this struct
@@ -90,8 +92,9 @@ var ArtifactShasumCommand = cli.Command{
 			l.Fatal("%s", err)
 		}
 
-		// Setup the any global configuration options
-		HandleGlobalFlags(l, cfg)
+		// Setup any global configuration options
+		done := HandleGlobalFlags(l, cfg)
+		defer done()
 
 		// Create the API client
 		client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -43,8 +43,9 @@ type ArtifactUploadConfig struct {
 	ContentType string `cli:"content-type"`
 
 	// Global flags
-	Debug   bool `cli:"debug"`
-	NoColor bool `cli:"no-color"`
+	Debug   bool   `cli:"debug"`
+	NoColor bool   `cli:"no-color"`
+	Profile string `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -80,6 +81,7 @@ var ArtifactUploadCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {
 		// The configuration will be loaded into this struct
@@ -92,8 +94,9 @@ var ArtifactUploadCommand = cli.Command{
 			l.Fatal("%s", err)
 		}
 
-		// Setup the any global configuration options
-		HandleGlobalFlags(l, cfg)
+		// Setup any global configuration options
+		done := HandleGlobalFlags(l, cfg)
+		defer done()
 
 		// Create the API client
 		client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -79,6 +79,7 @@ type BootstrapConfig struct {
 	Shell                        string   `cli:"shell"`
 	Experiments                  []string `cli:"experiment" normalize:"list"`
 	Phases                       []string `cli:"phases" normalize:"list"`
+	Profile                      string   `cli:"profile"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -289,6 +290,7 @@ var BootstrapCommand = cli.Command{
 		},
 		DebugFlag,
 		ExperimentsFlag,
+		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {
 		// The configuration will be loaded into this struct
@@ -310,6 +312,10 @@ var BootstrapCommand = cli.Command{
 		if cfg.Debug {
 			l.SetLevel(logger.DEBUG)
 		}
+
+		// Handle profiling flag
+		done := HandleProfileFlag(l, cfg)
+		defer done()
 
 		// Turn of PTY support if we're on Windows
 		runInPty := cfg.PTY

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -28,8 +28,9 @@ type MetaDataExistsConfig struct {
 	Job string `cli:"job" validate:"required"`
 
 	// Global flags
-	Debug   bool `cli:"debug"`
-	NoColor bool `cli:"no-color"`
+	Debug   bool   `cli:"debug"`
+	NoColor bool   `cli:"no-color"`
+	Profile string `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -59,6 +60,7 @@ var MetaDataExistsCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {
 		// The configuration will be loaded into this struct
@@ -71,8 +73,9 @@ var MetaDataExistsCommand = cli.Command{
 			l.Fatal("%s", err)
 		}
 
-		// Setup the any global configuration options
-		HandleGlobalFlags(l, cfg)
+		// Setup any global configuration options
+		done := HandleGlobalFlags(l, cfg)
+		defer done()
 
 		// Create the API client
 		client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -28,8 +28,9 @@ type MetaDataGetConfig struct {
 	Job     string `cli:"job" validate:"required"`
 
 	// Global flags
-	Debug   bool `cli:"debug"`
-	NoColor bool `cli:"no-color"`
+	Debug   bool   `cli:"debug"`
+	NoColor bool   `cli:"no-color"`
+	Profile string `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -64,6 +65,7 @@ var MetaDataGetCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {
 		// The configuration will be loaded into this struct
@@ -76,8 +78,9 @@ var MetaDataGetCommand = cli.Command{
 			l.Fatal("%s", err)
 		}
 
-		// Setup the any global configuration options
-		HandleGlobalFlags(l, cfg)
+		// Setup any global configuration options
+		done := HandleGlobalFlags(l, cfg)
+		defer done()
 
 		// Create the API client
 		client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -34,8 +34,9 @@ type MetaDataSetConfig struct {
 	Job   string `cli:"job" validate:"required"`
 
 	// Global flags
-	Debug   bool `cli:"debug"`
-	NoColor bool `cli:"no-color"`
+	Debug   bool   `cli:"debug"`
+	NoColor bool   `cli:"no-color"`
+	Profile string `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -65,6 +66,7 @@ var MetaDataSetCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {
 		// The configuration will be loaded into this struct
@@ -77,8 +79,9 @@ var MetaDataSetCommand = cli.Command{
 			l.Fatal("%s", err)
 		}
 
-		// Setup the any global configuration options
-		HandleGlobalFlags(l, cfg)
+		// Setup any global configuration options
+		done := HandleGlobalFlags(l, cfg)
+		defer done()
 
 		// Read the value from STDIN if argument omitted entirely
 		if len(c.Args()) < 2 {

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -53,8 +53,9 @@ type PipelineUploadConfig struct {
 	NoInterpolation bool   `cli:"no-interpolation"`
 
 	// Global flags
-	Debug   bool `cli:"debug"`
-	NoColor bool `cli:"no-color"`
+	Debug   bool   `cli:"debug"`
+	NoColor bool   `cli:"no-color"`
+	Profile string `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -99,6 +100,7 @@ var PipelineUploadCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {
 		// The configuration will be loaded into this struct
@@ -111,8 +113,9 @@ var PipelineUploadCommand = cli.Command{
 			l.Fatal("%s", err)
 		}
 
-		// Setup the any global configuration options
-		HandleGlobalFlags(l, cfg)
+		// Setup any global configuration options
+		done := HandleGlobalFlags(l, cfg)
+		defer done()
 
 		// Find the pipeline file either from STDIN or the first
 		// argument

--- a/clicommand/profiler.go
+++ b/clicommand/profiler.go
@@ -1,0 +1,144 @@
+package clicommand
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
+
+	"github.com/buildkite/agent/logger"
+)
+
+type profilerMode string
+
+const (
+	cpuMode          profilerMode = `cpu`
+	memMode          profilerMode = `mem`
+	mutexMode        profilerMode = `mutex`
+	blockMode        profilerMode = `block`
+	traceMode        profilerMode = `trace`
+	threadCreateMode profilerMode = `thread`
+)
+
+type profiler struct {
+	logger logger.Logger
+	mode   profilerMode
+	closer func()
+}
+
+// Profile starts a profiling session
+func Profile(l logger.Logger, mode string) func() {
+	p := profiler{logger: l}
+
+	switch mode {
+	case `cpu`:
+		p.mode = cpuMode
+	case `mem`, `memory`:
+		p.mode = memMode
+	case `mutex`:
+		p.mode = mutexMode
+	case `block`:
+		p.mode = blockMode
+	case `thread`:
+		p.mode = threadCreateMode
+	case `trace`:
+		p.mode = traceMode
+	default:
+		p.logger.Fatal("Unknown profile mode %q", mode)
+	}
+
+	p.Start()
+	return p.Stop
+}
+
+// Stop stops the profile and flushes any unwritten data.
+func (p *profiler) Stop() {
+	p.closer()
+}
+
+// Start starts a new profiling session.
+func (p *profiler) Start() {
+	path, err := ioutil.TempDir("", "profile")
+	if err != nil {
+		p.logger.Fatal("Could not create initial output directory: %v", err)
+	}
+
+	// create a pprof file for the mode
+	fn := filepath.Join(path, string(p.mode)+".pprof")
+	f, err := os.Create(fn)
+	if err != nil {
+		p.logger.Fatal("Could not create %s profile %q: %v", p.mode, fn, err)
+	}
+
+	// called after mode specific closers
+	closer := func() {
+		if err := f.Close(); err != nil {
+			p.logger.Fatal("Failed to close %s: %v", fn, err)
+		}
+		p.logger.Info("Finished %s profiling finished, %s", p.mode, fn)
+	}
+
+	must := func(err error) {
+		if err != nil {
+			p.logger.Fatal("Profiler mode %s failed: %v", p.mode, err)
+		}
+	}
+
+	switch p.mode {
+	case cpuMode:
+		p.logger.Info("CPU profiling enabled, %s", fn)
+		must(pprof.StartCPUProfile(f))
+		p.closer = func() {
+			pprof.StopCPUProfile()
+			closer()
+		}
+
+	case memMode:
+		p.logger.Info("Memory profiling enabled, %s", fn)
+		p.closer = func() {
+			must(pprof.WriteHeapProfile(f))
+			closer()
+		}
+
+	case mutexMode:
+		runtime.SetMutexProfileFraction(1)
+		p.logger.Info("Mutex profiling enabled, %s", fn)
+		p.closer = func() {
+			if mp := pprof.Lookup("mutex"); mp != nil {
+				must(mp.WriteTo(f, 0))
+			}
+			runtime.SetMutexProfileFraction(0)
+			closer()
+		}
+
+	case blockMode:
+		runtime.SetBlockProfileRate(1)
+		p.logger.Info("Block profiling enabled, %s", fn)
+		p.closer = func() {
+			must(pprof.Lookup("block").WriteTo(f, 0))
+			runtime.SetBlockProfileRate(0)
+			closer()
+		}
+
+	case threadCreateMode:
+		p.logger.Info("Thread creation profiling enabled, %s", fn)
+		p.closer = func() {
+			if mp := pprof.Lookup("threadcreate"); mp != nil {
+				must(mp.WriteTo(f, 0))
+			}
+			closer()
+		}
+
+	case traceMode:
+		if err := trace.Start(f); err != nil {
+			p.logger.Fatal("Could not start profiling trace: %v", err)
+		}
+		p.logger.Info("Trace enabled, %s", fn)
+		p.closer = func() {
+			trace.Stop()
+			closer()
+		}
+	}
+}

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -33,8 +33,9 @@ type StepUpdateConfig struct {
 	Job       string `cli:"job" validate:"required"`
 
 	// Global flags
-	Debug   bool `cli:"debug"`
-	NoColor bool `cli:"no-color"`
+	Debug   bool   `cli:"debug"`
+	NoColor bool   `cli:"no-color"`
+	Profile string `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -69,6 +70,7 @@ var StepUpdateCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {
 		// The configuration will be loaded into this struct
@@ -81,8 +83,9 @@ var StepUpdateCommand = cli.Command{
 			l.Fatal("%s", err)
 		}
 
-		// Setup the any global configuration options
-		HandleGlobalFlags(l, cfg)
+		// Setup any global configuration options
+		done := HandleGlobalFlags(l, cfg)
+		defer done()
 
 		// Read the value from STDIN if argument omitted entirely
 		if len(c.Args()) < 2 {


### PR DESCRIPTION
This makes it easy to get profiling traces for different agent commands. 

```bash
buildkite-agent start --profile memory
go tool pprof /var/folders/kk/2wmv_tq14m907m49pr66t1hh0000gn/T/profile511809002/mem.pprof
top5
```