### PR TITLE
Allow plugins to be restricted by an expression

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -19,6 +19,7 @@ type AgentConfiguration struct {
 	CommandEval                bool
 	PluginsEnabled             bool
 	PluginValidation           bool
+	PluginCondition            string
 	LocalHooksEnabled          bool
 	RunInPty                   bool
 	TimestampLines             bool

--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -19,7 +19,7 @@ type AgentConfiguration struct {
 	CommandEval                bool
 	PluginsEnabled             bool
 	PluginValidation           bool
-	PluginCondition            string
+	AllowPluginIf              string
 	LocalHooksEnabled          bool
 	RunInPty                   bool
 	TimestampLines             bool

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -439,7 +439,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	env["BUILDKITE_GIT_SUBMODULES"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.GitSubmodules)
 	env["BUILDKITE_COMMAND_EVAL"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.CommandEval)
 	env["BUILDKITE_PLUGINS_ENABLED"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.PluginsEnabled)
-	env["BUILDKITE_PLUGIN_CONDITION"] = fmt.Sprintf("%s", r.conf.AgentConfiguration.PluginCondition)
+	env["BUILDKITE_ALLOW_PLUGIN_IF"] = fmt.Sprintf("%s", r.conf.AgentConfiguration.AllowPluginIf)
 	env["BUILDKITE_LOCAL_HOOKS_ENABLED"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.LocalHooksEnabled)
 	env["BUILDKITE_GIT_CLONE_FLAGS"] = r.conf.AgentConfiguration.GitCloneFlags
 	env["BUILDKITE_GIT_FETCH_FLAGS"] = r.conf.AgentConfiguration.GitFetchFlags

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -439,6 +439,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	env["BUILDKITE_GIT_SUBMODULES"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.GitSubmodules)
 	env["BUILDKITE_COMMAND_EVAL"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.CommandEval)
 	env["BUILDKITE_PLUGINS_ENABLED"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.PluginsEnabled)
+	env["BUILDKITE_PLUGIN_CONDITION"] = fmt.Sprintf("%s", r.conf.AgentConfiguration.PluginCondition)
 	env["BUILDKITE_LOCAL_HOOKS_ENABLED"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.LocalHooksEnabled)
 	env["BUILDKITE_GIT_CLONE_FLAGS"] = r.conf.AgentConfiguration.GitCloneFlags
 	env["BUILDKITE_GIT_FETCH_FLAGS"] = r.conf.AgentConfiguration.GitFetchFlags

--- a/agent/plugin/condition.go
+++ b/agent/plugin/condition.go
@@ -1,0 +1,53 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/buildkite/conditional/ast"
+	"github.com/buildkite/conditional/evaluator"
+	"github.com/buildkite/conditional/lexer"
+	"github.com/buildkite/conditional/object"
+	"github.com/buildkite/conditional/parser"
+)
+
+type Condition struct {
+	Expression ast.Expression
+}
+
+func ParseCondition(condition string) (*Condition, error) {
+	l := lexer.New(condition)
+	p := parser.New(l)
+	expr := p.Parse()
+
+	if errs := p.Errors(); len(errs) > 0 {
+		return nil, errors.New(errs[0])
+	}
+
+	return &Condition{expr}, nil
+}
+
+func (f *Condition) Match(p *Plugin) (bool, error) {
+	scope := object.Struct{}
+
+	// convert the plugin into a scope for the conditional language
+	if err := object.Unmarshal(*p, scope); err != nil {
+		return false, err
+	}
+
+	obj := evaluator.Eval(f.Expression, object.Struct{
+		"plugin": scope,
+	})
+
+	err, ok := obj.(*object.Error)
+	if ok {
+		return false, fmt.Errorf("Failed to evaluate %v => %s", f.Expression, err.Message)
+	}
+
+	result, ok := obj.(*object.Boolean)
+	if !ok {
+		return false, fmt.Errorf("Conditional result is not Boolean. got=%T (%+v)", obj, obj)
+	}
+
+	return result.Value, nil
+}

--- a/agent/plugin/condition_test.go
+++ b/agent/plugin/condition_test.go
@@ -1,0 +1,30 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilteringPlugins(t *testing.T) {
+	t.Parallel()
+
+	plugin := &Plugin{
+		Location:      "github.com/buildkite/plugins/docker-compose",
+		Version:       "a34fa34",
+		Scheme:        "http",
+		Configuration: map[string]interface{}{"container": "app"},
+	}
+
+	condition, err := ParseCondition(`plugin.scheme == "http"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	match, err := condition.Match(plugin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.True(t, match)
+}

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -14,27 +14,26 @@ import (
 type Plugin struct {
 	// Where the plugin can be found (can either be a file system path, or
 	// a git repository)
-	Location string
+	Location string `conditional:"location"`
 
 	// The version of the plugin that should be running
-	Version string
+	Version string `conditional:"version"`
 
 	// The clone method
-	Scheme string
+	Scheme string `conditional:"scheme"`
 
 	// Any authentication attached to the repostiory
-	Authentication string
+	Authentication string `conditional:"authentication"`
 
 	// Whether the plugin refers to a vendored path
-	Vendored bool
+	Vendored bool `conditional:"vendored"`
 
 	// Configuration for the plugin
-	Configuration map[string]interface{}
+	Configuration map[string]interface{} `conditional:"config"`
 }
 
 var (
-	locationSchemeRegex = regexp.MustCompile(`^[a-z\+]+://`)
-	vendoredRegex       = regexp.MustCompile(`^\.`)
+	vendoredRegex = regexp.MustCompile(`^\.`)
 )
 
 func CreatePlugin(location string, config map[string]interface{}) (*Plugin, error) {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -522,9 +522,9 @@ func (b *Bootstrap) preparePlugins() error {
 		b.shell.Commentf("Parsed %d plugins", len(b.plugins))
 	}
 
-	if b.PluginCondition != "" {
-		b.shell.Commentf("Applying condition %q to %d plugins", b.PluginCondition, len(plugins))
-		condition, err := plugin.ParseCondition(b.PluginCondition)
+	if b.AllowPluginIf != "" {
+		b.shell.Commentf("Applying condition %q to %d plugins", b.AllowPluginIf, len(plugins))
+		condition, err := plugin.ParseCondition(b.AllowPluginIf)
 		if err != nil {
 			return err
 		}
@@ -538,7 +538,7 @@ func (b *Bootstrap) preparePlugins() error {
 			if match {
 				allowed = append(allowed, p)
 			} else {
-				return fmt.Errorf("Plugin %s doesn't match condition %q", p.Name(), b.PluginCondition)
+				return fmt.Errorf("Plugin %s doesn't match condition %q", p.Name(), b.AllowPluginIf)
 			}
 		}
 		b.plugins = allowed

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -85,8 +85,8 @@ type Config struct {
 	// Whether to validate plugin configuration
 	PluginValidation bool
 
-	// A conditional to apply to what plugins are loaded
-	PluginCondition string
+	// A conditional to apply to what plugins are allowed to be loaded
+	AllowPluginIf string
 
 	// Are local hooks enabled?
 	LocalHooksEnabled bool

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -85,6 +85,9 @@ type Config struct {
 	// Whether to validate plugin configuration
 	PluginValidation bool
 
+	// A conditional to apply to what plugins are loaded
+	PluginCondition string
+
 	// Are local hooks enabled?
 	LocalHooksEnabled bool
 

--- a/bootstrap/integration/plugin_integration_test.go
+++ b/bootstrap/integration/plugin_integration_test.go
@@ -67,6 +67,7 @@ func TestRunningPlugins(t *testing.T) {
 		if err := bintest.ExpectEnv(t, c.Env, `MY_CUSTOM_ENV=1`, `LLAMAS_ROCK=absolutely`); err != nil {
 			fmt.Fprintf(c.Stderr, "%v\n", err)
 			c.Exit(1)
+			return
 		}
 		c.Exit(0)
 	})
@@ -119,6 +120,55 @@ func TestExitCodesPropagateOutFromPlugins(t *testing.T) {
 
 	if exitCode != 5 {
 		t.Fatalf("Expected an exit code of %d, got %d", 5, exitCode)
+	}
+
+	tester.CheckMocks(t)
+}
+
+func TestPluginConditionFailsBootstrap(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewBootstrapTester()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tester.Close()
+
+	pluginMock := tester.MustMock(t, "my-plugin")
+
+	var p *testPlugin
+
+	if runtime.GOOS == "windows" {
+		p = createTestPlugin(t, map[string][]string{
+			"environment.bat": []string{
+				"@echo off",
+				pluginMock.Path + " testing",
+			},
+		})
+	} else {
+		p = createTestPlugin(t, map[string][]string{
+			"environment": []string{
+				"#!/bin/bash",
+				pluginMock.Path + " testing",
+			},
+		})
+	}
+
+	json, err := p.ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	env := []string{
+		`BUILDKITE_PLUGINS=` + json,
+		`BUILDKITE_PLUGIN_CONDITION=false`,
+	}
+
+	pluginMock.Expect("testing").NotCalled()
+
+	err = tester.Run(t, env...)
+	if err == nil {
+		t.Fatal("Expected the bootstrap to fail")
 	}
 
 	tester.CheckMocks(t)

--- a/bootstrap/integration/plugin_integration_test.go
+++ b/bootstrap/integration/plugin_integration_test.go
@@ -161,7 +161,7 @@ func TestPluginConditionFailsBootstrap(t *testing.T) {
 
 	env := []string{
 		`BUILDKITE_PLUGINS=` + json,
-		`BUILDKITE_PLUGIN_CONDITION=false`,
+		`BUILDKITE_ALLOW_PLUGIN_IF=false`,
 	}
 
 	pluginMock.Expect("testing").NotCalled()

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -77,7 +77,7 @@ type AgentStartConfig struct {
 	NoPlugins                  bool     `cli:"no-plugins"`
 	NoPluginValidation         bool     `cli:"no-plugin-validation"`
 	NoPTY                      bool     `cli:"no-pty"`
-	PluginCondition            string   `cli:"plugin-condition"`
+	AllowPluginIf              string   `cli:"allow-plugin-if"`
 	TimestampLines             bool     `cli:"timestamp-lines"`
 	HealthCheckAddr            string   `cli:"health-check-addr"`
 	MetricsDatadog             bool     `cli:"metrics-datadog"`
@@ -364,6 +364,12 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_AGENT_SPAWN",
 		},
 		cli.StringFlag{
+			Name:   "allow-plugin-if",
+			Usage:  "Apply a conditional to specify plugins that the agent can use",
+			EnvVar: "BUILDKITE_ALLOW_PLUGIN_IF",
+			Value:  "",
+		},
+		cli.StringFlag{
 			Name:   "cancel-signal",
 			Usage:  "The signal to use for cancellation",
 			EnvVar: "BUILDKITE_CANCEL_SIGNAL",
@@ -542,7 +548,7 @@ var AgentStartCommand = cli.Command{
 			SSHKeyscan:                 !cfg.NoSSHKeyscan,
 			CommandEval:                !cfg.NoCommandEval,
 			PluginsEnabled:             !cfg.NoPlugins,
-			PluginCondition:            cfg.PluginCondition,
+			AllowPluginIf:              cfg.AllowPluginIf,
 			PluginValidation:           !cfg.NoPluginValidation,
 			LocalHooksEnabled:          !cfg.NoLocalHooks,
 			RunInPty:                   !cfg.NoPTY,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -375,12 +375,6 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_CANCEL_SIGNAL",
 			Value:  "SIGTERM",
 		},
-		cli.StringFlag{
-			Name:   "plugin-condition",
-			Usage:  "Apply a conditional filter to plugins to restrict those this agent can use",
-			EnvVar: "BUILDKITE_PLUGIN_CONDITION",
-			Value:  "",
-		},
 
 		// API Flags
 		AgentRegisterTokenFlag,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -77,6 +77,7 @@ type AgentStartConfig struct {
 	NoPlugins                  bool     `cli:"no-plugins"`
 	NoPluginValidation         bool     `cli:"no-plugin-validation"`
 	NoPTY                      bool     `cli:"no-pty"`
+	PluginCondition            string   `cli:"plugin-condition"`
 	TimestampLines             bool     `cli:"timestamp-lines"`
 	HealthCheckAddr            string   `cli:"health-check-addr"`
 	MetricsDatadog             bool     `cli:"metrics-datadog"`
@@ -368,6 +369,12 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_CANCEL_SIGNAL",
 			Value:  "SIGTERM",
 		},
+		cli.StringFlag{
+			Name:   "plugin-condition",
+			Usage:  "Apply a conditional filter to plugins to restrict those this agent can use",
+			EnvVar: "BUILDKITE_PLUGIN_CONDITION",
+			Value:  "",
+		},
 
 		// API Flags
 		AgentRegisterTokenFlag,
@@ -535,6 +542,7 @@ var AgentStartCommand = cli.Command{
 			SSHKeyscan:                 !cfg.NoSSHKeyscan,
 			CommandEval:                !cfg.NoCommandEval,
 			PluginsEnabled:             !cfg.NoPlugins,
+			PluginCondition:            cfg.PluginCondition,
 			PluginValidation:           !cfg.NoPluginValidation,
 			LocalHooksEnabled:          !cfg.NoLocalHooks,
 			RunInPty:                   !cfg.NoPTY,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -73,6 +73,7 @@ type BootstrapConfig struct {
 	CommandEval                  bool     `cli:"command-eval"`
 	PluginsEnabled               bool     `cli:"plugins-enabled"`
 	PluginValidation             bool     `cli:"plugin-validation"`
+	PluginCondition              string   `cli:"plugin-condition"`
 	LocalHooksEnabled            bool     `cli:"local-hooks-enabled"`
 	PTY                          bool     `cli:"pty"`
 	Debug                        bool     `cli:"debug"`
@@ -257,6 +258,12 @@ var BootstrapCommand = cli.Command{
 			Usage:  "Validate plugin configuration",
 			EnvVar: "BUILDKITE_PLUGIN_VALIDATION",
 		},
+		cli.StringFlag{
+			Name:   "plugin-condition",
+			Usage:  "Apply a conditional filter to plugins to restrict those this agent can use",
+			EnvVar: "BUILDKITE_PLUGIN_CONDITION",
+			Value:  "",
+		},
 		cli.BoolTFlag{
 			Name:   "local-hooks-enabled",
 			Usage:  "Allow local hooks to be run",
@@ -363,6 +370,7 @@ var BootstrapCommand = cli.Command{
 			HooksPath:                    cfg.HooksPath,
 			PluginsPath:                  cfg.PluginsPath,
 			PluginValidation:             cfg.PluginValidation,
+			PluginCondition:              cfg.PluginCondition,
 			Debug:                        cfg.Debug,
 			RunInPty:                     runInPty,
 			CommandEval:                  cfg.CommandEval,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -73,7 +73,7 @@ type BootstrapConfig struct {
 	CommandEval                  bool     `cli:"command-eval"`
 	PluginsEnabled               bool     `cli:"plugins-enabled"`
 	PluginValidation             bool     `cli:"plugin-validation"`
-	PluginCondition              string   `cli:"plugin-condition"`
+	AllowPluginIf                string   `cli:"allow-plugin-if"`
 	LocalHooksEnabled            bool     `cli:"local-hooks-enabled"`
 	PTY                          bool     `cli:"pty"`
 	Debug                        bool     `cli:"debug"`
@@ -259,9 +259,9 @@ var BootstrapCommand = cli.Command{
 			EnvVar: "BUILDKITE_PLUGIN_VALIDATION",
 		},
 		cli.StringFlag{
-			Name:   "plugin-condition",
-			Usage:  "Apply a conditional filter to plugins to restrict those this agent can use",
-			EnvVar: "BUILDKITE_PLUGIN_CONDITION",
+			Name:   "allow-plugin-if",
+			Usage:  "Apply a conditional to specify plugins that the agent can use",
+			EnvVar: "BUILDKITE_ALLOW_PLUGIN_IF",
 			Value:  "",
 		},
 		cli.BoolTFlag{
@@ -370,7 +370,7 @@ var BootstrapCommand = cli.Command{
 			HooksPath:                    cfg.HooksPath,
 			PluginsPath:                  cfg.PluginsPath,
 			PluginValidation:             cfg.PluginValidation,
-			PluginCondition:              cfg.PluginCondition,
+			AllowPluginIf:                cfg.AllowPluginIf,
 			Debug:                        cfg.Debug,
 			RunInPty:                     runInPty,
 			CommandEval:                  cfg.CommandEval,

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/DataDog/datadog-go v0.0.0-20180822151419-281ae9f2d895
 	github.com/aws/aws-sdk-go v0.0.0-20180831223016-2a4034064ca5
 	github.com/buildkite/bintest v0.0.0-20190227031731-820c89d3b3a0
+	github.com/buildkite/conditional v0.0.0-20190617003428-af638d0b1550
 	github.com/buildkite/interpolate v0.0.0-20171114090218-3a807e47135c
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/aws/aws-sdk-go v0.0.0-20180831223016-2a4034064ca5 h1:raOAL5Uz269DesNi
 github.com/aws/aws-sdk-go v0.0.0-20180831223016-2a4034064ca5/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/buildkite/bintest v0.0.0-20190227031731-820c89d3b3a0 h1:UYcAVM2IdwHl3wTyyB2HfZc2MEVQrUqw/OkbwHlsy30=
 github.com/buildkite/bintest v0.0.0-20190227031731-820c89d3b3a0/go.mod h1:nElEwZWoSPGIBD8VvYabl9t5KNi7v430iDC0/gQRsYk=
+github.com/buildkite/conditional v0.0.0-20190617003428-af638d0b1550 h1:sSFAiwlKvXpHRsqbYYo/y3MXgxoLeMmGErVpmPIFXc0=
+github.com/buildkite/conditional v0.0.0-20190617003428-af638d0b1550/go.mod h1:Lf4PgCBXe72UhbYDnznCqw4iK0iAV4aK8Td9aCSmdJs=
 github.com/buildkite/interpolate v0.0.0-20171114090218-3a807e47135c h1:4b/XlGFI+q7tfsB4gDvoWeTNmG31hcr4OOFMtvZ3TOQ=
 github.com/buildkite/interpolate v0.0.0-20171114090218-3a807e47135c/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000 h1:hiVSLk7s3yFKFOHF/huoShLqrj13RMguWX2yzfvy7es=

--- a/vendor/github.com/buildkite/conditional/ast/ast.go
+++ b/vendor/github.com/buildkite/conditional/ast/ast.go
@@ -1,0 +1,164 @@
+package ast
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/buildkite/conditional/token"
+)
+
+// The base Node interface
+type Node interface {
+	TokenLiteral() string
+	String() string
+}
+
+// All expression nodes implement this
+type Expression interface {
+	Node
+	expressionNode()
+}
+
+// Expressions
+type Identifier struct {
+	Token token.Token // the token.IDENT token
+	Value string
+}
+
+func (i *Identifier) expressionNode()      {}
+func (i *Identifier) TokenLiteral() string { return i.Token.Literal }
+func (i *Identifier) String() string       { return i.Value }
+
+type Boolean struct {
+	Token token.Token
+	Value bool
+}
+
+func (b *Boolean) expressionNode()      {}
+func (b *Boolean) TokenLiteral() string { return b.Token.Literal }
+func (b *Boolean) String() string       { return b.Token.Literal }
+
+type IntegerLiteral struct {
+	Token token.Token
+	Value int64
+}
+
+func (il *IntegerLiteral) expressionNode()      {}
+func (il *IntegerLiteral) TokenLiteral() string { return il.Token.Literal }
+func (il *IntegerLiteral) String() string       { return il.Token.Literal }
+
+type StringLiteral struct {
+	Token token.Token
+	Value string
+}
+
+func (sl *StringLiteral) expressionNode()      {}
+func (sl *StringLiteral) TokenLiteral() string { return sl.Token.Literal }
+func (sl *StringLiteral) String() string {
+	return fmt.Sprintf("%q", sl.Token.Literal)
+}
+
+type Regexp struct {
+	*regexp.Regexp
+	Token token.Token
+}
+
+func (r *Regexp) expressionNode()      {}
+func (r *Regexp) TokenLiteral() string { return r.Token.Literal }
+func (r *Regexp) String() string {
+	return fmt.Sprintf("/%s/", r.Token.Literal)
+}
+
+type PrefixExpression struct {
+	Token    token.Token // The prefix token, e.g. !
+	Operator string
+	Right    Expression
+}
+
+func (pe *PrefixExpression) expressionNode()      {}
+func (pe *PrefixExpression) TokenLiteral() string { return pe.Token.Literal }
+func (pe *PrefixExpression) String() string {
+	var out bytes.Buffer
+
+	out.WriteString("(")
+	out.WriteString(pe.Operator)
+	out.WriteString(pe.Right.String())
+	out.WriteString(")")
+
+	return out.String()
+}
+
+type InfixExpression struct {
+	Token    token.Token // The operator token, e.g. +
+	Left     Expression
+	Operator string
+	Right    Expression
+}
+
+func (ie *InfixExpression) expressionNode()      {}
+func (ie *InfixExpression) TokenLiteral() string { return ie.Token.Literal }
+func (ie *InfixExpression) String() string {
+	var out bytes.Buffer
+
+	out.WriteString("(")
+	out.WriteString(ie.Left.String())
+
+	if ie.Operator == token.DOT {
+		out.WriteString(ie.Operator)
+	} else {
+		out.WriteString(" " + ie.Operator + " ")
+	}
+
+	out.WriteString(ie.Right.String())
+	out.WriteString(")")
+
+	return out.String()
+}
+
+type CallExpression struct {
+	Token     token.Token // The '(' token
+	Function  string
+	Arguments []Expression
+}
+
+func (ce *CallExpression) expressionNode()      {}
+func (ce *CallExpression) TokenLiteral() string { return ce.Token.Literal }
+func (ce *CallExpression) String() string {
+	var out bytes.Buffer
+
+	args := []string{}
+	for _, a := range ce.Arguments {
+		args = append(args, a.String())
+	}
+
+	out.WriteString(ce.Function)
+	out.WriteString("(")
+	out.WriteString(strings.Join(args, ", "))
+	out.WriteString(")")
+
+	return out.String()
+}
+
+type ArrayLiteral struct {
+	Token    token.Token // the '[' token
+	Elements []Expression
+}
+
+func (al *ArrayLiteral) expressionNode()      {}
+func (al *ArrayLiteral) TokenLiteral() string { return al.Token.Literal }
+func (al *ArrayLiteral) String() string {
+	var out bytes.Buffer
+
+	elements := []string{}
+	for _, el := range al.Elements {
+		elements = append(elements, el.String())
+	}
+
+	out.WriteString("[")
+	out.WriteString(strings.Join(elements, ", "))
+	out.WriteString("]")
+
+	return out.String()
+}

--- a/vendor/github.com/buildkite/conditional/evaluator/evaluator.go
+++ b/vendor/github.com/buildkite/conditional/evaluator/evaluator.go
@@ -1,0 +1,310 @@
+package evaluator
+
+import (
+	"fmt"
+
+	"github.com/buildkite/conditional/ast"
+	"github.com/buildkite/conditional/object"
+)
+
+var (
+	NULL  = &object.Null{}
+	TRUE  = &object.Boolean{Value: true}
+	FALSE = &object.Boolean{Value: false}
+)
+
+type Scope interface {
+	Get(key string) (object.Object, bool)
+}
+
+// Eval an ast.Node (either a literal or an expression), with a scope struct
+func Eval(node ast.Node, scope Scope) object.Object {
+	// defer untrace(trace("Eval", fmt.Sprintf("%T `%s`", node, node.String())))
+
+	switch node := node.(type) {
+
+	// Expressions
+	case *ast.IntegerLiteral:
+		return &object.Integer{Value: node.Value}
+
+	case *ast.StringLiteral:
+		return &object.String{Value: node.Value}
+
+	case *ast.Regexp:
+		return &object.Regexp{Regexp: node.Regexp}
+
+	case *ast.Boolean:
+		return nativeBoolToBooleanObject(node.Value)
+
+	case *ast.PrefixExpression:
+		right := Eval(node.Right, scope)
+		if isError(right) {
+			return right
+		}
+		return evalPrefixExpression(node.Operator, right)
+
+	case *ast.InfixExpression:
+		left := Eval(node.Left, scope)
+		if isError(left) {
+			return left
+		}
+
+		var right object.Object
+		if node.Operator == `.` {
+			ident, ok := node.Right.(*ast.Identifier)
+			if !ok {
+				return newError("dot operator must receive identifier")
+			}
+			right = &object.String{Value: ident.Value}
+		} else {
+			right = Eval(node.Right, scope)
+		}
+		if isError(right) {
+			return right
+		}
+
+		return evalInfixExpression(node.Operator, left, right)
+
+	case *ast.Identifier:
+		return evalIdentifier(node, scope)
+
+	case *ast.CallExpression:
+		args := evalExpressions(node.Arguments, scope)
+		if len(args) == 1 && isError(args[0]) {
+			return args[0]
+		}
+
+		obj, ok := scope.Get(node.Function)
+		if !ok {
+			return newError("function not defined: " + node.Function)
+		}
+
+		return applyFunction(obj, args)
+
+	case *ast.ArrayLiteral:
+		elements := evalExpressions(node.Elements, scope)
+		if len(elements) == 1 && isError(elements[0]) {
+			return elements[0]
+		}
+		return &object.Array{Elements: elements}
+
+	default:
+		return newError("unhandled type: %T", node)
+	}
+}
+
+func nativeBoolToBooleanObject(input bool) *object.Boolean {
+	if input {
+		return TRUE
+	}
+	return FALSE
+}
+
+func applyFunction(fn object.Object, args []object.Object) object.Object {
+	// defer untrace(trace("applyFunction", args))
+
+	switch fn := fn.(type) {
+	case object.Function:
+		ret := fn(args)
+		// tracePrint(fmt.Sprintf("RETURN: %+v", ret))
+		return ret
+
+	default:
+		return newError("not a function: %s", fn.Type())
+	}
+}
+
+func evalPrefixExpression(operator string, right object.Object) object.Object {
+	// defer untrace(trace("evalPrefixExpression", operator, right))
+
+	switch operator {
+	case "!":
+		return evalBangOperatorExpression(right)
+	default:
+		return newError("unknown operator: %s%s", operator, right.Type())
+	}
+}
+
+func evalInfixExpression(operator string, left, right object.Object) object.Object {
+	// defer untrace(trace("evalInfixExpression", operator, left, right))
+
+	switch {
+	case left.Type() == object.INTEGER_OBJ && right.Type() == object.INTEGER_OBJ:
+		return evalIntegerInfixExpression(operator, left, right)
+	case left.Type() == object.STRING_OBJ && right.Type() == object.STRING_OBJ:
+		return evalStringInfixExpression(operator, left, right)
+	case left.Type() == object.STRUCT_OBJ && right.Type() == object.STRING_OBJ:
+		return evalDotExpression(left, right)
+	case left.Type() == object.STRING_OBJ && right.Type() == object.REGEXP_OBJ:
+		return evalStringRegexpInfixExpression(operator, left, right)
+	case left.Type() == object.ARRAY_OBJ:
+		return evalArrayInfixExpression(operator, left, right)
+	case operator == "==":
+		return nativeBoolToBooleanObject(left == right)
+	case operator == "!=":
+		return nativeBoolToBooleanObject(left != right)
+	case left.Type() != right.Type():
+		return newError("type mismatch: %s %s %s",
+			left.Type(), operator, right.Type())
+	default:
+		return newError("unknown operator: %s %s %s",
+			left.Type(), operator, right.Type())
+	}
+}
+
+func evalBangOperatorExpression(right object.Object) object.Object {
+	// defer untrace(trace("evalBangOperatorExpression", right))
+
+	switch right {
+	case TRUE:
+		return FALSE
+	case FALSE:
+		return TRUE
+	case NULL:
+		return TRUE
+	default:
+		return FALSE
+	}
+}
+
+func evalIntegerInfixExpression(operator string, left, right object.Object) object.Object {
+	// defer untrace(trace("evalIntegerInfixExpression", operator, left, right))
+
+	leftVal := left.(*object.Integer).Value
+	rightVal := right.(*object.Integer).Value
+
+	switch operator {
+	case "==":
+		return nativeBoolToBooleanObject(leftVal == rightVal)
+	case "!=":
+		return nativeBoolToBooleanObject(leftVal != rightVal)
+	default:
+		return newError("unknown operator: %s %s %s",
+			left.Type(), operator, right.Type())
+	}
+}
+
+func evalStringInfixExpression(operator string, left, right object.Object) object.Object {
+	// defer untrace(trace("evalStringInfixExpression", operator, left, right))
+
+	leftVal := left.(*object.String).Value
+	rightVal := right.(*object.String).Value
+
+	switch operator {
+	case "==":
+		return nativeBoolToBooleanObject(leftVal == rightVal)
+	case "!=":
+		return nativeBoolToBooleanObject(leftVal != rightVal)
+	default:
+		return newError("unknown operator: %s %s %s",
+			left.Type(), operator, right.Type())
+	}
+}
+
+func evalStringRegexpInfixExpression(operator string, left, right object.Object) object.Object {
+	// defer untrace(trace("evalStringRegexpInfixExpression", operator, left, right))
+
+	leftVal := left.(*object.String).Value
+	rightVal := right.(*object.Regexp).Regexp
+
+	switch operator {
+	case "=~":
+		return nativeBoolToBooleanObject(rightVal.MatchString(leftVal))
+	case "!~":
+		return nativeBoolToBooleanObject(!rightVal.MatchString(leftVal))
+	default:
+		return newError("unknown operator: %s %s %s",
+			left.Type(), operator, right.Type())
+	}
+}
+
+func arrayContains(arr *object.Array, obj object.Object) (bool, error) {
+	// defer untrace(trace("arrayContains", arr, obj))
+
+	for idx, el := range arr.Elements {
+		if el.Type() != obj.Type() {
+			return false, fmt.Errorf("type mismatch at index %d in array: %s vs %s",
+				idx, el.Type(), obj.Type())
+		}
+		if el.Equals(obj) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func evalArrayInfixExpression(operator string, left, right object.Object) object.Object {
+	// defer untrace(trace("evalStringArrayInfixExpression", operator, left, right))
+
+	leftVal := left.(*object.Array)
+
+	switch operator {
+	case "@>":
+		contains, err := arrayContains(leftVal, right)
+		if err != nil {
+			return newError(err.Error())
+		}
+		return nativeBoolToBooleanObject(contains)
+	default:
+		return newError("unknown operator: %s %s %s",
+			left.Type(), operator, right.Type())
+	}
+}
+
+func evalDotExpression(s object.Object, prop object.Object) object.Object {
+	// defer untrace(trace("evalDotExpression", s, prop))
+
+	structVal, ok := s.(object.Struct)
+	if !ok {
+		return newError("type can't be used with the dot operator: %T", s)
+	}
+
+	propVal := prop.(*object.String).Value
+
+	val, ok := structVal.Get(propVal)
+	if !ok {
+		return newError("struct has no property %q", propVal)
+	}
+
+	return val
+
+}
+
+func evalIdentifier(node *ast.Identifier, scope Scope) object.Object {
+	// defer untrace(trace("evalIdentifier"))
+
+	val, ok := scope.Get(node.Value)
+	if !ok {
+		return newError("identifier not found: " + node.Value)
+	}
+
+	return val
+}
+
+func newError(format string, a ...interface{}) *object.Error {
+	return &object.Error{Message: fmt.Sprintf(format, a...)}
+}
+
+func isError(obj object.Object) bool {
+	if obj != nil {
+		return obj.Type() == object.ERROR_OBJ
+	}
+	return false
+}
+
+func evalExpressions(exps []ast.Expression, scope Scope) []object.Object {
+	// defer untrace(trace("evalExpressions", exps))
+
+	var result []object.Object
+
+	for _, e := range exps {
+		evaluated := Eval(e, scope)
+		if isError(evaluated) {
+			return []object.Object{evaluated}
+		}
+		result = append(result, evaluated)
+	}
+
+	return result
+}

--- a/vendor/github.com/buildkite/conditional/evaluator/tracing.go
+++ b/vendor/github.com/buildkite/conditional/evaluator/tracing.go
@@ -1,0 +1,35 @@
+package evaluator
+
+import (
+	"fmt"
+	"strings"
+)
+
+var traceLevel int = 0
+var traceEnabled bool = false
+
+const traceIdentPlaceholder string = "\t"
+
+func identLevel() string {
+	return strings.Repeat(traceIdentPlaceholder, traceLevel-1)
+}
+
+func tracePrint(fs string) {
+	if traceEnabled {
+		fmt.Printf("%s%s\n", identLevel(), fs)
+	}
+}
+
+func incIdent() { traceLevel = traceLevel + 1 }
+func decIdent() { traceLevel = traceLevel - 1 }
+
+func trace(msg string, v ...interface{}) string {
+	incIdent()
+	tracePrint(fmt.Sprintf("BEGIN %s: %+v", msg, v))
+	return msg
+}
+
+func untrace(msg string) {
+	tracePrint("END " + msg)
+	decIdent()
+}

--- a/vendor/github.com/buildkite/conditional/lexer/lexer.go
+++ b/vendor/github.com/buildkite/conditional/lexer/lexer.go
@@ -1,0 +1,215 @@
+package lexer
+
+import (
+	"github.com/buildkite/conditional/token"
+)
+
+type Lexer struct {
+	input        string
+	position     int  // current position in input (points to current char)
+	readPosition int  // current reading position in input (after current char)
+	ch           byte // current char under examination
+}
+
+func New(input string) *Lexer {
+	l := &Lexer{input: input}
+	l.readChar()
+	return l
+}
+
+func (l *Lexer) NextToken() token.Token {
+	var tok token.Token
+
+	l.skipWhitespace()
+	l.skipComment()
+
+	// log.Printf("Tok: %c %q", l.ch, l.ch)
+
+	switch l.ch {
+	case '=':
+		if l.peekChar() == '=' {
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.EQ, Literal: literal}
+		} else if l.peekChar() == '~' {
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.RE_EQ, Literal: literal}
+		} else {
+			tok = newToken(token.ILLEGAL, l.ch)
+		}
+	case '!':
+		if l.peekChar() == '=' {
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.NOT_EQ, Literal: literal}
+		} else if l.peekChar() == '~' {
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.RE_NOT_EQ, Literal: literal}
+		} else {
+			tok = newToken(token.BANG, l.ch)
+		}
+	case ',':
+		tok = newToken(token.COMMA, l.ch)
+	case '&':
+		if l.peekChar() == '&' {
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.AND, Literal: literal}
+		} else {
+			tok = newToken(token.ILLEGAL, l.ch)
+		}
+	case '|':
+		if l.peekChar() == '|' {
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.OR, Literal: literal}
+		} else {
+			tok = newToken(token.ILLEGAL, l.ch)
+		}
+	case '@':
+		if l.peekChar() == '>' {
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.CONTAINS, Literal: literal}
+		} else {
+			tok = newToken(token.ILLEGAL, l.ch)
+		}
+	case '.':
+		tok = newToken(token.DOT, l.ch)
+	case '"':
+		tok.Type = token.STRING
+		tok.Literal = l.readString('"')
+	case '\'':
+		tok.Type = token.STRING
+		tok.Literal = l.readString('\'')
+	case '/':
+		tok.Type = token.REGEXP
+		tok.Literal = l.readRegex()
+	case '(':
+		tok = newToken(token.LPAREN, l.ch)
+	case ')':
+		tok = newToken(token.RPAREN, l.ch)
+	case '[':
+		tok = newToken(token.LBRACKET, l.ch)
+	case ']':
+		tok = newToken(token.RBRACKET, l.ch)
+	case 0:
+		tok.Literal = ""
+		tok.Type = token.EOF
+	default:
+		if isLetter(l.ch) {
+			tok.Literal = l.readIdentifier()
+			tok.Type = token.LookupIdent(tok.Literal)
+			return tok
+		} else if isDigit(l.ch) {
+			tok.Type = token.INT
+			tok.Literal = l.readNumber()
+			return tok
+		} else {
+			tok = newToken(token.ILLEGAL, l.ch)
+		}
+	}
+
+	l.readChar()
+	return tok
+}
+
+func (l *Lexer) skipWhitespace() {
+	for l.ch == ' ' || l.ch == '\t' || l.ch == '\n' || l.ch == '\r' {
+		l.readChar()
+	}
+}
+
+func (l *Lexer) skipComment() {
+	if l.ch != '/' || l.peekChar() != '/' {
+		return
+	}
+	for {
+		l.readChar()
+
+		if l.ch == '\n' || l.ch == 0 {
+			l.skipWhitespace()
+			break
+		}
+	}
+
+	// keep ignoring whitespace and comments
+	l.skipComment()
+}
+
+func (l *Lexer) readChar() {
+	if l.readPosition >= len(l.input) {
+		l.ch = 0
+	} else {
+		l.ch = l.input[l.readPosition]
+	}
+	l.position = l.readPosition
+	l.readPosition += 1
+}
+
+func (l *Lexer) peekChar() byte {
+	if l.readPosition >= len(l.input) {
+		return 0
+	} else {
+		return l.input[l.readPosition]
+	}
+}
+
+func (l *Lexer) readIdentifier() string {
+	position := l.position
+	for isLetter(l.ch) {
+		l.readChar()
+	}
+	return l.input[position:l.position]
+}
+
+func (l *Lexer) readNumber() string {
+	position := l.position
+	for isDigit(l.ch) {
+		l.readChar()
+	}
+	return l.input[position:l.position]
+}
+
+func (l *Lexer) readString(quote byte) string {
+	position := l.position + 1
+	for {
+		l.readChar()
+		if l.ch == quote || l.ch == 0 {
+			break
+		}
+	}
+	return l.input[position:l.position]
+}
+
+func (l *Lexer) readRegex() string {
+	position := l.position + 1
+	for {
+		l.readChar()
+		if l.ch == '/' || l.ch == 0 {
+			break
+		}
+	}
+	return l.input[position:l.position]
+}
+
+func isLetter(ch byte) bool {
+	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_'
+}
+
+func isDigit(ch byte) bool {
+	return '0' <= ch && ch <= '9'
+}
+
+func newToken(tokenType token.TokenType, ch byte) token.Token {
+	return token.Token{Type: tokenType, Literal: string(ch)}
+}

--- a/vendor/github.com/buildkite/conditional/object/object.go
+++ b/vendor/github.com/buildkite/conditional/object/object.go
@@ -1,0 +1,132 @@
+package object
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+)
+
+type ObjectType string
+
+const (
+	NULL_OBJ  = "NULL"
+	ERROR_OBJ = "ERROR"
+
+	STRING_OBJ  = "STRING"
+	INTEGER_OBJ = "INTEGER"
+	BOOLEAN_OBJ = "BOOLEAN"
+	REGEXP_OBJ  = "REGEXP"
+
+	STRUCT_OBJ   = "STRUCT"
+	FUNCTION_OBJ = "FUNCTION"
+	ARRAY_OBJ    = "ARRAY"
+)
+
+type Object interface {
+	Type() ObjectType
+	String() string
+	Equals(o Object) bool
+}
+
+type Integer struct {
+	Value int64
+}
+
+func (i *Integer) Type() ObjectType     { return INTEGER_OBJ }
+func (i *Integer) String() string       { return fmt.Sprintf("%d", i.Value) }
+func (i *Integer) Equals(o Object) bool { return i.String() == o.String() }
+
+type Boolean struct {
+	Value bool
+}
+
+func (b *Boolean) Type() ObjectType     { return BOOLEAN_OBJ }
+func (b *Boolean) String() string       { return fmt.Sprintf("%t", b.Value) }
+func (b *Boolean) Equals(o Object) bool { return b == o }
+
+type String struct {
+	Value string
+}
+
+func (s *String) Type() ObjectType     { return STRING_OBJ }
+func (s *String) String() string       { return fmt.Sprintf("%q", s.Value) }
+func (s *String) Equals(o Object) bool { return s.String() == o.String() }
+
+type Regexp struct {
+	*regexp.Regexp
+}
+
+func (r *Regexp) Type() ObjectType     { return REGEXP_OBJ }
+func (r *Regexp) String() string       { return r.Regexp.String() }
+func (r *Regexp) Equals(o Object) bool { return r.String() == o.String() }
+
+type Null struct{}
+
+func (n *Null) Type() ObjectType { return NULL_OBJ }
+func (n *Null) String() string   { return "null" }
+func (n *Null) Equals(o Object) bool {
+	_, ok := o.(*Null)
+	return ok
+}
+
+type Function func(args []Object) Object
+
+func (f Function) Type() ObjectType     { return FUNCTION_OBJ }
+func (f Function) String() string       { return "function" }
+func (f Function) Equals(o Object) bool { return false }
+
+type Struct map[string]Object
+
+func (s Struct) Type() ObjectType { return STRUCT_OBJ }
+func (s Struct) String() string   { return "struct" }
+
+func (s Struct) Get(key string) (Object, bool) {
+	obj, ok := s[key]
+	return obj, ok
+}
+
+func (s Struct) Set(key string, obj Object) {
+	s[key] = obj
+}
+
+func (s Struct) Has(key string) bool {
+	_, ok := s[key]
+	return ok
+}
+
+func (s Struct) Equals(o Object) bool {
+	return reflect.DeepEqual(s, o)
+}
+
+type Array struct {
+	Elements []Object
+}
+
+func (ao *Array) Type() ObjectType { return ARRAY_OBJ }
+func (ao *Array) String() string {
+	var out bytes.Buffer
+
+	elements := []string{}
+	for _, e := range ao.Elements {
+		elements = append(elements, e.String())
+	}
+
+	out.WriteString("[")
+	out.WriteString(strings.Join(elements, ", "))
+	out.WriteString("]")
+
+	return out.String()
+}
+func (ao *Array) Equals(o Object) bool {
+	return reflect.DeepEqual(ao, o)
+}
+
+type Error struct {
+	Message string
+}
+
+func (e *Error) Type() ObjectType     { return ERROR_OBJ }
+func (e *Error) String() string       { return "ERROR: " + e.Message }
+func (e *Error) Equals(o Object) bool { return e == o }

--- a/vendor/github.com/buildkite/conditional/object/unmarshal.go
+++ b/vendor/github.com/buildkite/conditional/object/unmarshal.go
@@ -1,0 +1,159 @@
+package object
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+const (
+	tagName = `conditional`
+)
+
+// Unmarshal a golang objects into an Object
+func Unmarshal(data interface{}, v Object) error {
+	var handled bool
+
+	// log.Printf("Unmarshal(%v, %v)", data, v)
+
+	// handle basic types
+	switch dt := data.(type) {
+	case string:
+		vt, ok := v.(*String)
+		if ok {
+			vt.Value = dt
+			handled = true
+		}
+	case int:
+		vt, ok := v.(*Integer)
+		if ok {
+			vt.Value = int64(dt)
+			handled = true
+		}
+	case int64:
+		vt, ok := v.(*Integer)
+		if ok {
+			vt.Value = dt
+			handled = true
+		}
+	case bool:
+		vt, ok := v.(*Boolean)
+		if ok {
+			vt.Value = dt
+			handled = true
+		}
+	case map[string]interface{}:
+		vt, ok := v.(Struct)
+		if ok {
+			if err := unmarshalInterfaceMap(dt, vt); err != nil {
+				return err
+			}
+			handled = true
+		}
+	}
+
+	// handle structs
+	if isStruct(data) {
+		vt, ok := v.(Struct)
+		if ok {
+			if err := unmarshalStruct(data, vt); err != nil {
+				return err
+			}
+			handled = true
+		}
+	}
+
+	if !handled {
+		return fmt.Errorf("Unable to unmarshal %T into %T", data, v)
+	}
+
+	// log.Printf("Returning: %#v", v)
+
+	return nil
+}
+
+func unmarshalInterfaceMap(data map[string]interface{}, into Struct) error {
+	// log.Printf("unmarshalInterfaceMap: %#v", data)
+
+	for k, v := range data {
+		// log.Printf("Walking map field %s=>%v", k, v)
+
+		switch vi := v.(type) {
+		case string:
+			into.Set(k, &String{vi})
+		case int:
+			into.Set(k, &Integer{int64(vi)})
+		case int64:
+			into.Set(k, &Integer{vi})
+		case bool:
+			into.Set(k, &Boolean{vi})
+		default:
+			if isStruct(v) || isMap(v) {
+				val, exists := into[k]
+				if !exists {
+					val = Struct{}
+				}
+				if err := Unmarshal(v, val); err != nil {
+					return err
+				}
+				into[k] = val
+			} else {
+				return fmt.Errorf("Unable to unmarshal field %s of type %T", k, vi)
+			}
+		}
+	}
+	return nil
+}
+
+func isMap(i interface{}) bool {
+	return reflect.TypeOf(i).Kind() == reflect.Map
+}
+
+func isStruct(i interface{}) bool {
+	return reflect.TypeOf(i).Kind() == reflect.Struct
+}
+
+func unmarshalStruct(data interface{}, into Struct) error {
+	t := reflect.TypeOf(data)
+	v := reflect.ValueOf(data)
+
+	// Iterate over fields and use tags if we can
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get(tagName)
+
+		// Use lowercase string if no tag
+		if tag == "" {
+			tag = strings.ToLower(field.Name)
+		}
+
+		// log.Printf("Walking struct field %d %v (%v)", i, field.Name, tag)
+
+		// Handle basic types
+		switch dt := v.Field(i).Interface().(type) {
+		case string:
+			into[tag] = &String{dt}
+		case int:
+			into[tag] = &Integer{int64(dt)}
+		case int64:
+			into[tag] = &Integer{int64(dt)}
+		case bool:
+			into[tag] = &Boolean{dt}
+		default:
+			if isStruct(dt) || isMap(dt) {
+				val, exists := into[tag]
+				if !exists {
+					val = Struct{}
+				}
+				if err := Unmarshal(dt, val); err != nil {
+					return err
+				}
+				into[tag] = val
+			} else {
+				return fmt.Errorf("Unable to unmarshal field %s of type %T (%v)", field.Name, dt, reflect.TypeOf(dt).Kind())
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/buildkite/conditional/parser/parser.go
+++ b/vendor/github.com/buildkite/conditional/parser/parser.go
@@ -1,0 +1,319 @@
+package parser
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/buildkite/conditional/ast"
+	"github.com/buildkite/conditional/lexer"
+	"github.com/buildkite/conditional/token"
+)
+
+const (
+	_ int = iota
+	LOWEST
+	OR     // ||
+	AND    // &&
+	EQUALS // ==
+	PREFIX // !X
+	DOT    // foo.bar
+	CALL   // myfunction(true)
+)
+
+var precedences = map[token.TokenType]int{
+	token.EQ:        EQUALS,
+	token.NOT_EQ:    EQUALS,
+	token.RE_EQ:     EQUALS,
+	token.RE_NOT_EQ: EQUALS,
+	token.CONTAINS:  EQUALS,
+	token.AND:       AND,
+	token.OR:        OR,
+	token.LPAREN:    CALL,
+	token.DOT:       DOT,
+}
+
+type (
+	prefixParseFn func() ast.Expression
+	infixParseFn  func(ast.Expression) ast.Expression
+)
+
+type Parser struct {
+	l      *lexer.Lexer
+	errors []string
+
+	curToken  token.Token
+	peekToken token.Token
+
+	prefixParseFns map[token.TokenType]prefixParseFn
+	infixParseFns  map[token.TokenType]infixParseFn
+}
+
+func New(l *lexer.Lexer) *Parser {
+	p := &Parser{
+		l:      l,
+		errors: []string{},
+	}
+
+	p.prefixParseFns = make(map[token.TokenType]prefixParseFn)
+	p.registerPrefix(token.IDENT, p.parseIdentifier)
+	p.registerPrefix(token.INT, p.parseIntegerLiteral)
+	p.registerPrefix(token.STRING, p.parseStringLiteral)
+	p.registerPrefix(token.REGEXP, p.parseRegexp)
+	p.registerPrefix(token.BANG, p.parsePrefixExpression)
+	p.registerPrefix(token.TRUE, p.parseBoolean)
+	p.registerPrefix(token.FALSE, p.parseBoolean)
+	p.registerPrefix(token.LPAREN, p.parseGroupedExpression)
+	p.registerPrefix(token.LBRACKET, p.parseArrayLiteral)
+
+	p.infixParseFns = make(map[token.TokenType]infixParseFn)
+	p.registerInfix(token.EQ, p.parseInfixExpression)
+	p.registerInfix(token.NOT_EQ, p.parseInfixExpression)
+	p.registerInfix(token.RE_EQ, p.parseInfixExpression)
+	p.registerInfix(token.RE_NOT_EQ, p.parseInfixExpression)
+	p.registerInfix(token.CONTAINS, p.parseInfixExpression)
+	p.registerInfix(token.AND, p.parseInfixExpression)
+	p.registerInfix(token.OR, p.parseInfixExpression)
+	p.registerInfix(token.DOT, p.parseInfixExpression)
+	p.registerInfix(token.LPAREN, p.parseCallExpression)
+
+	// Read two tokens, so curToken and peekToken are both set
+	p.nextToken()
+	p.nextToken()
+
+	return p
+}
+
+func (p *Parser) nextToken() {
+	p.curToken = p.peekToken
+	p.peekToken = p.l.NextToken()
+}
+
+func (p *Parser) curTokenIs(t token.TokenType) bool {
+	return p.curToken.Type == t
+}
+
+func (p *Parser) peekTokenIs(t token.TokenType) bool {
+	return p.peekToken.Type == t
+}
+
+func (p *Parser) expectPeek(t token.TokenType) bool {
+	if p.peekTokenIs(t) {
+		p.nextToken()
+		return true
+	} else {
+		p.peekError(t)
+		return false
+	}
+}
+
+func (p *Parser) Errors() []string {
+	return p.errors
+}
+
+func (p *Parser) peekError(t token.TokenType) {
+	msg := fmt.Sprintf("expected next token to be %s, got %s instead",
+		t, p.peekToken.Type)
+	p.errors = append(p.errors, msg)
+}
+
+func (p *Parser) noPrefixParseFnError(t token.TokenType) {
+	msg := fmt.Sprintf("no prefix parse function for %s found", t)
+	p.errors = append(p.errors, msg)
+}
+
+func (p *Parser) Parse() ast.Expression {
+	// defer untrace(trace("Parse"))
+
+	if p.curToken.Type == token.EOF {
+		p.errors = append(p.errors, "empty expression")
+		return nil
+	}
+
+	return p.parseExpression(LOWEST)
+}
+
+func (p *Parser) parseExpression(precedence int) ast.Expression {
+	// defer untrace(trace("parseExpression", p.curToken))
+
+	prefix := p.prefixParseFns[p.curToken.Type]
+	if prefix == nil {
+		p.noPrefixParseFnError(p.curToken.Type)
+		return nil
+	}
+	leftExp := prefix()
+
+	for !p.peekTokenIs(token.EOF) && precedence < p.peekPrecedence() {
+		infix := p.infixParseFns[p.peekToken.Type]
+		if infix == nil {
+			return leftExp
+		}
+
+		p.nextToken()
+
+		leftExp = infix(leftExp)
+	}
+
+	return leftExp
+}
+
+func (p *Parser) peekPrecedence() int {
+	if p, ok := precedences[p.peekToken.Type]; ok {
+		return p
+	}
+
+	return LOWEST
+}
+
+func (p *Parser) curPrecedence() int {
+	if p, ok := precedences[p.curToken.Type]; ok {
+		return p
+	}
+
+	return LOWEST
+}
+
+func (p *Parser) parseIdentifier() ast.Expression {
+	// defer untrace(trace("parseIdentifier", p.curToken))
+	return &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+}
+
+func (p *Parser) parseIntegerLiteral() ast.Expression {
+	// defer untrace(trace("parseIntegerLiteral"))
+	lit := &ast.IntegerLiteral{Token: p.curToken}
+
+	value, err := strconv.ParseInt(p.curToken.Literal, 0, 64)
+	if err != nil {
+		msg := fmt.Sprintf("could not parse %q as integer", p.curToken.Literal)
+		p.errors = append(p.errors, msg)
+		return nil
+	}
+
+	lit.Value = value
+
+	return lit
+}
+
+func (p *Parser) parseStringLiteral() ast.Expression {
+	return &ast.StringLiteral{Token: p.curToken, Value: p.curToken.Literal}
+}
+
+func (p *Parser) parseRegexp() ast.Expression {
+	ar := &ast.Regexp{Token: p.curToken}
+
+	r, err := regexp.Compile(p.curToken.Literal)
+	if err != nil {
+		msg := fmt.Sprintf("could not parse regexp: %v", err)
+		p.errors = append(p.errors, msg)
+		return nil
+	}
+
+	ar.Regexp = r
+	return ar
+}
+
+func (p *Parser) parsePrefixExpression() ast.Expression {
+	// defer untrace(trace("parsePrefixExpression"))
+
+	expression := &ast.PrefixExpression{
+		Token:    p.curToken,
+		Operator: p.curToken.Literal,
+	}
+
+	p.nextToken()
+
+	expression.Right = p.parseExpression(PREFIX)
+
+	return expression
+}
+
+func (p *Parser) parseInfixExpression(left ast.Expression) ast.Expression {
+	// defer untrace(trace("parseInfixExpression"))
+
+	expression := &ast.InfixExpression{
+		Token:    p.curToken,
+		Operator: p.curToken.Literal,
+		Left:     left,
+	}
+
+	precedence := p.curPrecedence()
+	p.nextToken()
+	expression.Right = p.parseExpression(precedence)
+
+	return expression
+}
+
+func (p *Parser) parseBoolean() ast.Expression {
+	// defer untrace(trace("parseBoolean"))
+
+	return &ast.Boolean{Token: p.curToken, Value: p.curTokenIs(token.TRUE)}
+}
+
+func (p *Parser) parseGroupedExpression() ast.Expression {
+	// defer untrace(trace("parseGroupedExpression"))
+
+	p.nextToken()
+
+	exp := p.parseExpression(LOWEST)
+
+	if !p.expectPeek(token.RPAREN) {
+		return nil
+	}
+
+	return exp
+}
+
+func (p *Parser) parseCallExpression(function ast.Expression) ast.Expression {
+	defer untrace(trace("parseCallExpression"))
+
+	ident, ok := function.(*ast.Identifier)
+	if !ok {
+		msg := fmt.Sprintf("function call must be an identifier, got %v", p.curToken.Type)
+		p.errors = append(p.errors, msg)
+		return nil
+	}
+
+	exp := &ast.CallExpression{Token: p.curToken, Function: ident.Value}
+	exp.Arguments = p.parseExpressionList(token.RPAREN)
+	return exp
+}
+
+func (p *Parser) parseExpressionList(end token.TokenType) []ast.Expression {
+	list := []ast.Expression{}
+
+	if p.peekTokenIs(end) {
+		p.nextToken()
+		return list
+	}
+
+	p.nextToken()
+	list = append(list, p.parseExpression(LOWEST))
+
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		list = append(list, p.parseExpression(LOWEST))
+	}
+
+	if !p.expectPeek(end) {
+		return nil
+	}
+
+	return list
+}
+
+func (p *Parser) parseArrayLiteral() ast.Expression {
+	array := &ast.ArrayLiteral{Token: p.curToken}
+
+	array.Elements = p.parseExpressionList(token.RBRACKET)
+
+	return array
+}
+
+func (p *Parser) registerPrefix(tokenType token.TokenType, fn prefixParseFn) {
+	p.prefixParseFns[tokenType] = fn
+}
+
+func (p *Parser) registerInfix(tokenType token.TokenType, fn infixParseFn) {
+	p.infixParseFns[tokenType] = fn
+}

--- a/vendor/github.com/buildkite/conditional/parser/tracing.go
+++ b/vendor/github.com/buildkite/conditional/parser/tracing.go
@@ -1,0 +1,35 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+)
+
+var traceLevel int = 0
+var traceEnabled bool = false
+
+const traceIdentPlaceholder string = "\t"
+
+func identLevel() string {
+	return strings.Repeat(traceIdentPlaceholder, traceLevel-1)
+}
+
+func tracePrint(fs string) {
+	if traceEnabled {
+		fmt.Printf("%s%s\n", identLevel(), fs)
+	}
+}
+
+func incIdent() { traceLevel = traceLevel + 1 }
+func decIdent() { traceLevel = traceLevel - 1 }
+
+func trace(msg string, v ...interface{}) string {
+	incIdent()
+	tracePrint(fmt.Sprintf("BEGIN %s: %+v", msg, v))
+	return msg
+}
+
+func untrace(msg string) {
+	tracePrint("END " + msg)
+	decIdent()
+}

--- a/vendor/github.com/buildkite/conditional/token/token.go
+++ b/vendor/github.com/buildkite/conditional/token/token.go
@@ -1,0 +1,56 @@
+package token
+
+type TokenType string
+
+const (
+	ILLEGAL = "ILLEGAL"
+	EOF     = "EOF"
+
+	// Identifiers + literals
+	IDENT  = "IDENT"  // add, foobar, x, y, ...
+	INT    = "INT"    // 1343456
+	STRING = "STRING" // "foobar"
+	REGEXP = "REGEXP" // /^v1.0/
+
+	BANG = "!"
+	DOT  = "."
+
+	// Comparison Operators
+	EQ        = "=="
+	NOT_EQ    = "!="
+	RE_EQ     = "=~"
+	RE_NOT_EQ = "!~"
+	CONTAINS  = "@>"
+
+	// Boolean Operators
+	AND = "&&"
+	OR  = "||"
+
+	// Delimiters
+	COMMA    = ","
+	LPAREN   = "("
+	RPAREN   = ")"
+	LBRACKET = "["
+	RBRACKET = "]"
+
+	// Keywords
+	TRUE  = "TRUE"
+	FALSE = "FALSE"
+)
+
+type Token struct {
+	Type    TokenType
+	Literal string
+}
+
+var keywords = map[string]TokenType{
+	"true":  TRUE,
+	"false": FALSE,
+}
+
+func LookupIdent(ident string) TokenType {
+	if tok, ok := keywords[ident]; ok {
+		return tok
+	}
+	return IDENT
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -41,6 +41,13 @@ github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil
 github.com/aws/aws-sdk-go/private/protocol/query
 # github.com/buildkite/bintest v0.0.0-20190227031731-820c89d3b3a0
 github.com/buildkite/bintest
+# github.com/buildkite/conditional v0.0.0-20190617003428-af638d0b1550
+github.com/buildkite/conditional/ast
+github.com/buildkite/conditional/evaluator
+github.com/buildkite/conditional/lexer
+github.com/buildkite/conditional/object
+github.com/buildkite/conditional/parser
+github.com/buildkite/conditional/token
 # github.com/buildkite/interpolate v0.0.0-20171114090218-3a807e47135c
 github.com/buildkite/interpolate
 # github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000


### PR DESCRIPTION
Up until this point, we've recommended that folks concerned with security in the agent disable plugins because they could allow a variety of attacks, specifically:

* Users could reference plugins that execute arbitrary code which might by-pass the `--no-command-eval` option set on the agent
* Upstream plugin could be compromised and changed, which would result in a way to execute arbitrary code

We've recommended that people either disable them, or filter then with tools like https://github.com/buildkite/buildkite-allowed-plugins-hook-example.

This aims to use the [Conditional](http://github.com/buildkite/conditional) language to allow folks to restrict which agents an agent will allow. 

For example:

```
buildkite-agent start \
  --allow-plugin-if 'plugin.vendored == true || plugin.location == "buildkite/llamas")'
```
