### PR TITLE
Fix bug where file upload hangs and add a test

### DIFF
--- a/agent/form_uploader.go
+++ b/agent/form_uploader.go
@@ -5,9 +5,11 @@ import (
 	_ "crypto/sha512" // import sha512 to make sha512 ssl certs work
 	"fmt"
 	"io"
+	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/http/httputil"
+	"path/filepath"
 	"regexp"
 
 	// "net/http/httputil"
@@ -98,54 +100,27 @@ func createUploadRequest(l logger.Logger, artifact *api.Artifact) (*http.Request
 		return nil, err
 	}
 
-	// Use a pipe for the body to avoid buffering the entire file in memory
-	// See https://blog.depado.eu/post/bufferless-multipart-post-in-go
-	pipeR, pipeW := io.Pipe()
-	writer := multipart.NewWriter(pipeW)
-	errCh := make(chan error)
+	streamer := newMultipartStreamer()
 
-	go func() {
-		defer pipeW.Close()
-		defer close(errCh)
+	// Set the post data for the request
+	for key, val := range artifact.UploadInstructions.Data {
+		// Replace the magical ${artifact:path} variable with the
+		// artifact's path
+		newVal := ArtifactPathVariableRegex.ReplaceAllLiteralString(val, artifact.Path)
 
-		// Set the post data for the request
-		for key, val := range artifact.UploadInstructions.Data {
-			// Replace the magical ${artifact:path} variable with the
-			// artifact's path
-			newVal := ArtifactPathVariableRegex.ReplaceAllLiteralString(val, artifact.Path)
-
-			// Write the new value to the form
-			err = writer.WriteField(key, newVal)
-			if err != nil {
-				errCh <- err
-				return
-			}
-		}
-		// It's important that we add the form field last because when
-		// uploading to an S3 form, they are really nit-picky about the field
-		// order, and the file needs to be the last one other it doesn't work.
-		part, err := writer.CreateFormFile(artifact.UploadInstructions.Action.FileInput, artifact.Path)
+		// Write the new value to the form
+		err = streamer.WriteField(key, newVal)
 		if err != nil {
-			return
+			return nil, err
 		}
+	}
 
-		file, err := os.Open(artifact.AbsolutePath)
-		if err != nil {
-			errCh <- err
-			return
-		}
-		defer file.Close()
-
-		if _, err = io.Copy(part, file); err != nil {
-			errCh <- err
-			return
-		}
-
-		if err := writer.Close(); err != nil {
-			errCh <- err
-			return
-		}
-	}()
+	// It's important that we add the form field last because when
+	// uploading to an S3 form, they are really nit-picky about the field
+	// order, and the file needs to be the last one other it doesn't work.
+	if err := streamer.WriteFile(artifact.UploadInstructions.Action.FileInput, artifact.Path); err != nil {
+		return nil, err
+	}
 
 	// Create the URL that we'll send data to
 	uri, err := url.Parse(artifact.UploadInstructions.Action.URL)
@@ -156,13 +131,83 @@ func createUploadRequest(l logger.Logger, artifact *api.Artifact) (*http.Request
 	uri.Path = artifact.UploadInstructions.Action.Path
 
 	// Create the request
-	req, err := http.NewRequest(artifact.UploadInstructions.Action.Method, uri.String(), pipeR)
+	req, err := http.NewRequest(artifact.UploadInstructions.Action.Method, uri.String(), streamer.Reader())
 	if err != nil {
 		return nil, err
 	}
 
-	// Finally add the multipart content type to the request
-	req.Header.Add("Content-Type", writer.FormDataContentType())
+	// Setup the content type and length that s3 requires
+	req.Header.Add("Content-Type", streamer.ContentType)
+	req.ContentLength = streamer.Len()
 
 	return req, nil
+}
+
+// A wrapper around the complexities of streaming a multipart file and fields to
+// an http endpoint that infuriatingly requires a Content-Length
+// Derived from https://github.com/technoweenie/multipartstreamer
+type multipartStreamer struct {
+	ContentType   string
+	bodyBuffer    *bytes.Buffer
+	bodyWriter    *multipart.Writer
+	closeBuffer   *bytes.Buffer
+	reader        io.Reader
+	contentLength int64
+}
+
+// newMultipartStreamer initializes a new MultipartStreamer.
+func newMultipartStreamer() *multipartStreamer {
+	m := &multipartStreamer{
+		bodyBuffer: new(bytes.Buffer),
+	}
+
+	m.bodyWriter = multipart.NewWriter(m.bodyBuffer)
+	boundary := m.bodyWriter.Boundary()
+	m.ContentType = "multipart/form-data; boundary=" + boundary
+
+	closeBoundary := fmt.Sprintf("\r\n--%s--\r\n", boundary)
+	m.closeBuffer = bytes.NewBufferString(closeBoundary)
+
+	return m
+}
+
+// WriteField writes a form field to the multipart.Writer.
+func (m *multipartStreamer) WriteField(key, value string) error {
+	return m.bodyWriter.WriteField(key, value)
+}
+
+// WriteReader adds an io.Reader to get the content of a file.  The reader is
+// not accessed until the multipart.Reader is copied to some output writer.
+func (m *multipartStreamer) WriteReader(key, filename string, size int64, reader io.Reader) (err error) {
+	m.reader = reader
+	m.contentLength = size
+
+	_, err = m.bodyWriter.CreateFormFile(key, filename)
+	return
+}
+
+// WriteFile is a shortcut for adding a local file as an io.Reader.
+func (m *multipartStreamer) WriteFile(key, filename string) error {
+	fh, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+
+	stat, err := fh.Stat()
+	if err != nil {
+		return err
+	}
+
+	return m.WriteReader(key, filepath.Base(filename), stat.Size(), fh)
+}
+
+// Len calculates the byte size of the multipart content.
+func (m *multipartStreamer) Len() int64 {
+	return m.contentLength + int64(m.bodyBuffer.Len()) + int64(m.closeBuffer.Len())
+}
+
+// Reader gets an io.ReadCloser for passing to an http.Request.
+func (m *multipartStreamer) Reader() io.ReadCloser {
+	reader := io.MultiReader(m.bodyBuffer, m.reader, m.closeBuffer)
+	return ioutil.NopCloser(reader)
 }

--- a/agent/form_uploader_test.go
+++ b/agent/form_uploader_test.go
@@ -18,6 +18,12 @@ func TestFormUploading(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
 		case `/buildkiteartifacts.com`:
+			if req.ContentLength <= 0 {
+				t.Error("Expected a Content-Length header")
+				http.Error(rw, "Bad requests", http.StatusBadRequest)
+				return
+			}
+
 			err := req.ParseMultipartForm(5 * 1024 * 1024)
 			if err != nil {
 				t.Error(err)

--- a/agent/form_uploader_test.go
+++ b/agent/form_uploader_test.go
@@ -1,0 +1,100 @@
+package agent
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildkite/agent/api"
+	"github.com/buildkite/agent/logger"
+)
+
+func TestFormUploading(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case `/buildkiteartifacts.com`:
+			err := req.ParseMultipartForm(5 * 1024 * 1024)
+			if err != nil {
+				t.Error(err)
+				http.Error(rw, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			// Check the ${artifact:path} interpolation is working
+			path := req.FormValue("path")
+			if path != "llamas.txt" {
+				t.Errorf("Bad path content %q", path)
+				http.Error(rw, "Bad path content", http.StatusInternalServerError)
+				return
+			}
+
+			file, _, err := req.FormFile("file")
+			if err != nil {
+				t.Error(err)
+				http.Error(rw, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			defer file.Close()
+
+			b := &bytes.Buffer{}
+			_, _ = io.Copy(b, file)
+
+			// Check the file is attached correctly
+			if b.String() != "llamas" {
+				t.Errorf("Bad file content %q", b.String())
+				http.Error(rw, "Bad file content", http.StatusInternalServerError)
+				return
+			}
+
+		default:
+			t.Errorf("Unknown path %s %s", req.Method, req.URL.Path)
+			http.Error(rw, "Not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ioutil.WriteFile(filepath.Join(wd, "llamas.txt"), []byte("llamas"), 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.Remove(filepath.Join(wd, "llamas.txt"))
+
+	uploader := NewFormUploader(logger.Discard, FormUploaderConfig{})
+	artifact := &api.Artifact{
+		ID:           "xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx",
+		Path:         "llamas.txt",
+		AbsolutePath: filepath.Join(wd, "llamas.txt"),
+		GlobPath:     "llamas.txt",
+		ContentType:  "text/plain",
+		UploadInstructions: &api.ArtifactUploadInstructions{
+			Data: map[string]string{
+				"path": "${artifact:path}",
+			},
+			Action: struct {
+				URL       string "json:\"url,omitempty\""
+				Method    string "json:\"method\""
+				Path      string "json:\"path\""
+				FileInput string "json:\"file_input\""
+			}{
+				URL:       server.URL,
+				Method:    "POST",
+				Path:      "buildkiteartifacts.com",
+				FileInput: "file",
+			}},
+	}
+
+	if err := uploader.Upload(artifact); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Turns out my fix in #1033 had a race condition in it where the main go routine would race to write form fields with the go routine that write the files. 

This fixes it, and adds a test like I should have done in the first place.