### PR TITLE
Add meta-data keys command

### DIFF
--- a/api/meta_data.go
+++ b/api/meta_data.go
@@ -64,3 +64,20 @@ func (c *Client) ExistsMetaData(jobId string, key string) (*MetaDataExists, *Res
 
 	return e, resp, err
 }
+
+func (c *Client) MetaDataKeys(jobId string) ([]string, *Response, error) {
+	u := fmt.Sprintf("jobs/%s/data/keys", jobId)
+
+	req, err := c.newRequest("POST", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keys := []string{}
+	resp, err := c.doRequest(req, &keys)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return keys, resp, err
+}

--- a/clicommand/meta_data_keys.go
+++ b/clicommand/meta_data_keys.go
@@ -104,8 +104,13 @@ var MetaDataKeysCommand = cli.Command{
 			l.Fatal("Failed to find meta-data keys: %s", err)
 		}
 
-		for _, key := range keys {
-			fmt.Printf("%s%s", cfg.Delimiter, key)
+		last := len(keys) - 1
+
+		for idx, key := range keys {
+			fmt.Printf("%s", key)
+			if idx != last {
+				fmt.Printf("%s", cfg.Delimiter)
+			}
 		}
 	},
 }

--- a/clicommand/meta_data_keys.go
+++ b/clicommand/meta_data_keys.go
@@ -1,0 +1,111 @@
+package clicommand
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/buildkite/agent/api"
+	"github.com/buildkite/agent/cliconfig"
+	"github.com/buildkite/agent/retry"
+	"github.com/urfave/cli"
+)
+
+var MetaDataKeysHelpDescription = `Usage:
+
+   buildkite-agent meta-data keys [arguments...]
+
+Description:
+
+   Lists all meta-data keys that have been previously set, delimited by a newline.
+
+Example:
+
+   $ buildkite-agent meta-data keys`
+
+type MetaDataKeysConfig struct {
+	Job       string `cli:"job" validate:"required"`
+	Delimiter string `cli:"delimiter"`
+
+	// Global flags
+	Debug   bool   `cli:"debug"`
+	NoColor bool   `cli:"no-color"`
+	Profile string `cli:"profile"`
+
+	// API config
+	DebugHTTP        bool   `cli:"debug-http"`
+	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
+	Endpoint         string `cli:"endpoint" validate:"required"`
+	NoHTTP2          bool   `cli:"no-http2"`
+}
+
+var MetaDataKeysCommand = cli.Command{
+	Name:        "keys",
+	Usage:       "Lists all meta-data keys that have been previously set",
+	Description: MetaDataKeysHelpDescription,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:   "job",
+			Value:  "",
+			Usage:  "Which job should the meta-data be checked for",
+			EnvVar: "BUILDKITE_JOB_ID",
+		},
+		cli.StringFlag{
+			Name:   "delimiter",
+			Value:  "\n",
+			Usage:  "The delimiter to use between meta-data keys",
+			EnvVar: "BUILDKITE_META_DATA_KEYS_DELIMITER",
+		},
+
+		// API Flags
+		AgentAccessTokenFlag,
+		EndpointFlag,
+		NoHTTP2Flag,
+		DebugHTTPFlag,
+
+		// Global flags
+		NoColorFlag,
+		DebugFlag,
+		ProfileFlag,
+	},
+	Action: func(c *cli.Context) {
+		// The configuration will be loaded into this struct
+		cfg := MetaDataKeysConfig{}
+
+		l := CreateLogger(&cfg)
+
+		// Load the configuration
+		if err := cliconfig.Load(c, l, &cfg); err != nil {
+			l.Fatal("%s", err)
+		}
+
+		// Setup any global configuration options
+		done := HandleGlobalFlags(l, cfg)
+		defer done()
+
+		// Create the API client
+		client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))
+
+		// Find the meta data keys
+		var err error
+		var keys []string
+		var resp *api.Response
+		err = retry.Do(func(s *retry.Stats) error {
+			keys, resp, err = client.MetaDataKeys(cfg.Job)
+			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404) {
+				s.Break()
+			}
+			if err != nil {
+				l.Warn("%s (%s)", err, s)
+			}
+
+			return err
+		}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
+		if err != nil {
+			l.Fatal("Failed to find meta-data keys: %s", err)
+		}
+
+		for _, key := range keys {
+			fmt.Printf("%s%s", cfg.Delimiter, key)
+		}
+	},
+}

--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ func main() {
 				clicommand.MetaDataSetCommand,
 				clicommand.MetaDataGetCommand,
 				clicommand.MetaDataExistsCommand,
+				clicommand.MetaDataKeysCommand,
 			},
 		},
 		{


### PR DESCRIPTION
Implement a `buildkite-agent meta-data keys` command for listing meta-data keys:

E.g:

```bash
buildkite-agent meta-data keys # default delimited by newlines
buildkite-agent meta-data keys --delimiter ';'
```

You can use it to enumerate meta-data like:

```bash
#!/bin/bash
set -euo pipefail

buildkite-agent meta-data keys | while read -r key; do
  echo "$key: $(buildkite-agent meta-data get "$key")"
done
```

/cc @toolmantim 