### PR TITLE
Allow signal agent sends to bootstrap on cancel to be customized

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -24,6 +24,9 @@ type JobRunnerConfig struct {
 	// The configuration of the agent from the CLI
 	AgentConfiguration AgentConfiguration
 
+	// What signal to use for worker cancellation
+	CancelSignal process.Signal
+
 	// Whether to set debug in the job
 	Debug bool
 }
@@ -181,12 +184,13 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 
 	// The process that will run the bootstrap script
 	runner.process = process.New(l, process.Config{
-		Path:   cmd[0],
-		Args:   cmd[1:],
-		Env:    processEnv,
-		PTY:    conf.AgentConfiguration.RunInPty,
-		Stdout: processWriter,
-		Stderr: processWriter,
+		Path:            cmd[0],
+		Args:            cmd[1:],
+		Env:             processEnv,
+		PTY:             conf.AgentConfiguration.RunInPty,
+		Stdout:          processWriter,
+		Stderr:          processWriter,
+		InterruptSignal: conf.CancelSignal,
 	})
 
 	// Kick off our callback when the process starts

--- a/process/signal_windows.go
+++ b/process/signal_windows.go
@@ -2,12 +2,9 @@ package process
 
 import (
 	"errors"
-	"os"
 	"os/exec"
 	"strconv"
 	"syscall"
-
-	"github.com/buildkite/agent/logger"
 )
 
 // Windows has no concept of parent/child processes or signals. The best we can do
@@ -26,24 +23,24 @@ const (
 	createNewProcessGroupFlag = 0x00000200
 )
 
-func setupProcessGroup(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{
+func (p *Process) setupProcessGroup() {
+	p.command.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: syscall.CREATE_UNICODE_ENVIRONMENT | createNewProcessGroupFlag,
 	}
 }
 
-func terminateProcessGroup(p *os.Process, l logger.Logger) error {
-	l.Debug("[Process] Terminating process tree with TASKKILL.EXE PID: %d", p.Pid)
+func (p *Process) terminateProcessGroup() error {
+	p.logger.Debug("[Process] Terminating process tree with TASKKILL.EXE PID: %d", p.Pid)
 
 	// taskkill.exe with /F will call TerminateProcess and hard-kill the process and
 	// anything left in it's process tree.
-	return exec.Command("CMD", "/C", "TASKKILL.EXE", "/F", "/T", "/PID", strconv.Itoa(p.Pid)).Run()
+	return exec.Command("CMD", "/C", "TASKKILL.EXE", "/F", "/T", "/PID", strconv.Itoa(p.pid)).Run()
 }
 
-func interruptProcessGroup(p *os.Process, l logger.Logger) error {
+func (p *Process) interruptProcessGroup() error {
 	// Sends a CTRL-BREAK signal to the process group id, which is the same as the process PID
 	// For some reason I cannot fathom, this returns "Incorrect function" in docker for windows
-	r1, _, err := procGenerateConsoleCtrlEvent.Call(syscall.CTRL_BREAK_EVENT, uintptr(p.Pid))
+	r1, _, err := procGenerateConsoleCtrlEvent.Call(syscall.CTRL_BREAK_EVENT, uintptr(p.pid))
 	if r1 == 0 {
 		return err
 	}

--- a/process/signal_windows.go
+++ b/process/signal_windows.go
@@ -26,13 +26,13 @@ const (
 	createNewProcessGroupFlag = 0x00000200
 )
 
-func SetupProcessGroup(cmd *exec.Cmd) {
+func setupProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: syscall.CREATE_UNICODE_ENVIRONMENT | createNewProcessGroupFlag,
 	}
 }
 
-func TerminateProcessGroup(p *os.Process, l logger.Logger) error {
+func terminateProcessGroup(p *os.Process, l logger.Logger) error {
 	l.Debug("[Process] Terminating process tree with TASKKILL.EXE PID: %d", p.Pid)
 
 	// taskkill.exe with /F will call TerminateProcess and hard-kill the process and
@@ -40,7 +40,7 @@ func TerminateProcessGroup(p *os.Process, l logger.Logger) error {
 	return exec.Command("CMD", "/C", "TASKKILL.EXE", "/F", "/T", "/PID", strconv.Itoa(p.Pid)).Run()
 }
 
-func InterruptProcessGroup(p *os.Process, l logger.Logger) error {
+func interruptProcessGroup(p *os.Process, l logger.Logger) error {
 	// Sends a CTRL-BREAK signal to the process group id, which is the same as the process PID
 	// For some reason I cannot fathom, this returns "Incorrect function" in docker for windows
 	r1, _, err := procGenerateConsoleCtrlEvent.Call(syscall.CTRL_BREAK_EVENT, uintptr(p.Pid))


### PR DESCRIPTION
Currently the agent sends a `SIGTERM` to the bootstrap on user cancellation of a job. 

This adds `cancel-signal` which accepts signals in the form of `SIGTERM`, `SIGHUP`, etc.

The default will remain `SIGTERM` until the next major version and then it will be `SIGINT`. 

/cc @DazWorrall 