### PR TITLE
Show plugin validation errors as a warning

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -526,10 +526,6 @@ func (b *Bootstrap) preparePlugins() error {
 }
 
 func (b *Bootstrap) validatePluginCheckout(checkout *pluginCheckout) error {
-	if !b.Config.PluginValidation {
-		return nil
-	}
-
 	if checkout.Definition == nil {
 		if b.Debug {
 			b.shell.Commentf("Parsing plugin definition for %s from %s", checkout.Plugin.Name(), checkout.CheckoutDir)
@@ -550,14 +546,18 @@ func (b *Bootstrap) validatePluginCheckout(checkout *pluginCheckout) error {
 	val := &plugin.Validator{}
 	result := val.Validate(checkout.Definition, checkout.Plugin.Configuration)
 
-	if !result.Valid() {
-		b.shell.Headerf("Plugin validation failed for %q", checkout.Plugin.Name())
+	// For now just show warnings
+	if b.Config.PluginValidation && !result.Valid() {
+		b.shell.Headerf("⚠️ Plugin validation failed for %q", checkout.Plugin.Name())
 		json, _ := json.Marshal(checkout.Plugin.Configuration)
-		b.shell.Commentf("Plugin configuration JSON is %s", json)
-		return result
+
+		if b.Debug {
+			b.shell.Commentf("Plugin configuration JSON is %s", json)
+		}
+
+		b.shell.Errorf("%v", result)
 	}
 
-	b.shell.Commentf("Valid plugin configuration for %q", checkout.Plugin.Name())
 	return nil
 }
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -315,7 +315,7 @@ var AgentStartCommand = cli.Command{
 			Usage:  "Don't allow this agent to load plugins",
 			EnvVar: "BUILDKITE_NO_PLUGINS",
 		},
-		cli.BoolTFlag{
+		cli.BoolFlag{
 			Name:   "no-plugin-validation",
 			Usage:  "Don't validate plugin configuration and requirements",
 			EnvVar: "BUILDKITE_NO_PLUGIN_VALIDATION",


### PR DESCRIPTION
So that we can gradually transition to plugin validation warnings, this shows plugin validation errors as warnings:

<img width="1140" alt="image" src="https://user-images.githubusercontent.com/15758/61588438-d1a74300-abde-11e9-8715-933e05eefe82.png">

This can be disabled with `--no-plugin-validation` still.