### PR TITLE
buildkite/pipeline.yaml etc in pipeline upload default search

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -35,6 +35,9 @@ Description:
    - .buildkite/pipeline.yml
    - .buildkite/pipeline.yaml
    - .buildkite/pipeline.json
+   - buildkite/pipeline.yml
+   - buildkite/pipeline.yaml
+   - buildkite/pipeline.json
 
    You can also pipe build pipelines to the command allowing you to create
    scripts that generate dynamic pipelines.
@@ -149,6 +152,9 @@ var PipelineUploadCommand = cli.Command{
 				filepath.FromSlash(".buildkite/pipeline.yml"),
 				filepath.FromSlash(".buildkite/pipeline.yaml"),
 				filepath.FromSlash(".buildkite/pipeline.json"),
+				filepath.FromSlash("buildkite/pipeline.yml"),
+				filepath.FromSlash("buildkite/pipeline.yaml"),
+				filepath.FromSlash("buildkite/pipeline.json"),
 			}
 
 			// Collect all the files that exist


### PR DESCRIPTION
Currently `buildkite-agent pipeline upload` defaults to `buildkite.yaml` in the top level of the repo, or `.buildkite/pipeline.yaml` in a hidden directory of the repo.

A lot of tooling ignores hidden directories and their contents. This makes pipelines hard to work with, easy to miss in automatic search/refactor/etc, and generally just second-class citizens. It makes me sad.

This PR adds `buildkite/pipeline.yaml` to the default search path; the non-hidden version of the current default directory, so that build pipelines can live unhidden, out in the sunlight where they belong 🌞

Thoughts? For my purposes we don't strictly need to change the default to make this move… just thought it might be useful for others too. It might benefit from some other doc changes beyond this repo, too.

I will not be offended if the PR is closed ;)