### PR TITLE
Fix RefSpec HEAD not picking correct branch HEAD

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1104,7 +1104,7 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 
 	// If a refspec is provided then use it instead.
 	// i.e. `refs/not/a/head`
-	if b.RefSpec != "" {
+	if b.RefSpec != "" && strings.ToLower(b.RefSpec) != "head" {
 		b.shell.Commentf("Fetch and checkout custom refspec")
 		if err := gitFetch(b.shell, gitFetchFlags, "origin", b.RefSpec); err != nil {
 			return err


### PR DESCRIPTION
**Problem statement:**
Buildkit agent is not picking the correct branch HEAD

**What steps did we do here:**
- Opened buildkite UI 
- Clicked "New build"
- We did not do anything, leaving the  "HEAD" and all as is
- Clicked build 
- Noticed the build picked completely different commit sha, not the branch head
- We noticed that the sha is the head of the previous branch ran on the same agent

**Analysis of the problem:**
When using RefSepc and triggering a manual build, specifying HEAD
and not using/doing a complete clean checkout

The build is not running for the chosen branch HEAD commit
Rather, It's picking the HEAD of the last branch that ran on the same agent before 
It did not switch to the old branch 