### PR TITLE
Correctly log last successful heartbeat time.

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -114,7 +114,7 @@ func (a *AgentWorker) Start(idleMonitor *IdleMonitor) error {
 				err := a.Heartbeat()
 				if err != nil {
 					// Get the last heartbeat time to the nearest microsecond
-					lastHeartbeat := time.Unix(atomic.LoadInt64(&a.lastPing), 0)
+					lastHeartbeat := time.Unix(atomic.LoadInt64(&a.lastHeartbeat), 0)
 
 					a.logger.Error("Failed to heartbeat %s. Will try again in %s. (Last successful was %v ago)",
 						err, heartbeatInterval, time.Now().Sub(lastHeartbeat))


### PR DESCRIPTION
The agent mistakenly logged the last successful ping time instead, when an error occurred.