### PR TITLE
Let the agent serve a status page via HTTP.

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -22,6 +22,7 @@ type AgentConfiguration struct {
 	LocalHooksEnabled          bool
 	RunInPty                   bool
 	TimestampLines             bool
+	HealthCheckAddr            string
 	DisconnectAfterJob         bool
 	DisconnectAfterIdleTimeout int
 	CancelGracePeriod          int

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -3,9 +3,10 @@ package agent
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/buildkite/agent/api"
@@ -23,16 +24,25 @@ type AgentWorkerConfig struct {
 	// What signal to use for worker cancellation
 	CancelSignal process.Signal
 
+	// The index of this agent worker
+	SpawnIndex int
+
 	// The configuration of the agent from the CLI
 	AgentConfiguration AgentConfiguration
 }
 
-type AgentWorker struct {
+type agentStats struct {
+	sync.Mutex
+
 	// Tracks the last successful heartbeat and ping
-	// NOTE: to avoid alignment issues on ARM architectures when
-	// using atomic.StoreInt64 we need to keep this at the beginning
-	// of the struct
-	lastPing, lastHeartbeat int64
+	lastPing, lastHeartbeat time.Time
+
+	// The last error that occurred during heartbeat, or nil if it was successful
+	lastHeartbeatError error
+}
+
+type AgentWorker struct {
+	stats agentStats
 
 	// The API Client used when this agent is communicating with the API
 	apiClient APIClient
@@ -63,6 +73,9 @@ type AgentWorker struct {
 	stopping  bool
 	stopMutex sync.Mutex
 
+	// The index of this agent worker
+	spawnIndex int
+
 	// When this worker runs a job, we'll store an instance of the
 	// JobRunner here
 	jobRunner *JobRunner
@@ -79,6 +92,7 @@ func NewAgentWorker(l logger.Logger, a *api.AgentRegisterResponse, m *metrics.Co
 		agentConfiguration: c.AgentConfiguration,
 		stop:               make(chan struct{}),
 		cancelSig:          c.CancelSignal,
+		spawnIndex:         c.SpawnIndex,
 	}
 }
 
@@ -106,6 +120,23 @@ func (a *AgentWorker) Start(idleMonitor *IdleMonitor) error {
 	heartbeatCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Register our worker specific health check handler
+	http.HandleFunc("/agent/"+strconv.Itoa(a.spawnIndex), func(w http.ResponseWriter, r *http.Request) {
+		a.stats.Lock()
+		defer a.stats.Unlock()
+
+		if a.stats.lastHeartbeatError != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "ERROR: last heartbeat failed: %v. last successful was %v ago", a.stats.lastHeartbeatError, time.Since(a.stats.lastHeartbeat))
+		} else {
+			if a.stats.lastHeartbeat.IsZero() {
+				fmt.Fprintf(w, "OK: no heartbeat yet")
+			} else {
+				fmt.Fprintf(w, "OK: last heartbeat successful %v ago", time.Since(a.stats.lastHeartbeat))
+			}
+		}
+	})
+
 	// Setup and start the heartbeater
 	go func() {
 		for {
@@ -114,10 +145,10 @@ func (a *AgentWorker) Start(idleMonitor *IdleMonitor) error {
 				err := a.Heartbeat()
 				if err != nil {
 					// Get the last heartbeat time to the nearest microsecond
-					lastHeartbeat := time.Unix(atomic.LoadInt64(&a.lastHeartbeat), 0)
-
+					a.stats.Lock()
 					a.logger.Error("Failed to heartbeat %s. Will try again in %s. (Last successful was %v ago)",
-						err, heartbeatInterval, time.Now().Sub(lastHeartbeat))
+						err, heartbeatInterval, time.Now().Sub(a.stats.lastHeartbeat))
+					a.stats.Unlock()
 				}
 
 			case <-heartbeatCtx.Done():
@@ -268,12 +299,17 @@ func (a *AgentWorker) Heartbeat() error {
 		return err
 	}, &retry.Config{Maximum: 5, Interval: 5 * time.Second})
 
+	a.stats.Lock()
+	defer a.stats.Unlock()
+
+	a.stats.lastHeartbeatError = err
+
 	if err != nil {
 		return err
 	}
 
 	// Track a timestamp for the successful heartbeat for better errors
-	atomic.StoreInt64(&a.lastHeartbeat, time.Now().Unix())
+	a.stats.lastHeartbeat = time.Now()
 
 	a.logger.Debug("Heartbeat sent at %s and received at %s", beat.SentAt, beat.ReceivedAt)
 	return nil
@@ -288,15 +324,18 @@ func (a *AgentWorker) Ping() (*api.Job, error) {
 	ping, _, err := a.apiClient.Ping()
 	if err != nil {
 		// Get the last ping time to the nearest microsecond
-		lastPing := time.Unix(atomic.LoadInt64(&a.lastPing), 0)
+		a.stats.Lock()
+		defer a.stats.Unlock()
 
 		// If a ping fails, we don't really care, because it'll
 		// ping again after the interval.
-		return nil, fmt.Errorf("Failed to ping: %v (Last successful was %v ago)", err, time.Now().Sub(lastPing))
+		return nil, fmt.Errorf("Failed to ping: %v (Last successful was %v ago)", err, a.stats.lastPing)
 	}
 
 	// Track a timestamp for the successful ping for better errors
-	atomic.StoreInt64(&a.lastPing, time.Now().Unix())
+	a.stats.Lock()
+	a.stats.lastPing = time.Now()
+	a.stats.Unlock()
 
 	// Should we switch endpoints?
 	if ping.Endpoint != "" && ping.Endpoint != a.agent.Endpoint {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -2,6 +2,7 @@ package clicommand
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -77,6 +78,7 @@ type AgentStartConfig struct {
 	NoPluginValidation         bool     `cli:"no-plugin-validation"`
 	NoPTY                      bool     `cli:"no-pty"`
 	TimestampLines             bool     `cli:"timestamp-lines"`
+	HealthCheckAddr            string   `cli:"health-check-addr"`
 	MetricsDatadog             bool     `cli:"metrics-datadog"`
 	MetricsDatadogHost         string   `cli:"metrics-datadog-host"`
 	Spawn                      int      `cli:"spawn"`
@@ -296,6 +298,11 @@ var AgentStartCommand = cli.Command{
 			Name:   "timestamp-lines",
 			Usage:  "Prepend timestamps on each line of output.",
 			EnvVar: "BUILDKITE_TIMESTAMP_LINES",
+		},
+		cli.StringFlag{
+			Name:   "health-check-addr",
+			Usage:  "Start an HTTP server on this addr:port that returns whether the agent is healthy, disabled by default",
+			EnvVar: "BUILDKITE_AGENT_HEALTH_CHECK_ADDR",
 		},
 		cli.BoolFlag{
 			Name:   "no-pty",
@@ -645,6 +652,7 @@ var AgentStartCommand = cli.Command{
 						AgentConfiguration: agentConf,
 						CancelSignal:       cancelSig,
 						Debug:              cfg.Debug,
+						SpawnIndex:         i,
 					}))
 		}
 
@@ -657,6 +665,25 @@ var AgentStartCommand = cli.Command{
 
 		l.Info("Starting %d Agent(s)", cfg.Spawn)
 		l.Info("You can press Ctrl-C to stop the agents")
+
+		// Determine the health check listening address and port for this agent
+		if cfg.HealthCheckAddr != "" {
+			http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/" {
+					http.NotFound(w, r)
+				} else {
+					fmt.Fprintf(w, "OK: Buildkite agent is running")
+				}
+			})
+
+			go func() {
+				l.Notice("Starting HTTP health check server on %v", cfg.HealthCheckAddr)
+				err := http.ListenAndServe(cfg.HealthCheckAddr, nil)
+				if err != nil {
+					l.Error("Could not start health check server: %v", err)
+				}
+			}()
+		}
 
 		// Start the agent pool
 		if err := pool.Start(); err != nil {


### PR DESCRIPTION
This feature can optionally be enabled via the `--health-check-addr addr:port` flag or the equivalent `BUILDKITE_HEALTH_CHECK_ADDR` environment variable.

When enabled, the agent starts an HTTP server on the given `addr:port` that can be used for pull-based health checks, like [Google Cloud's instance group autohealing](https://cloud.google.com/compute/docs/instance-groups/creating-groups-of-managed-instances#monitoring_groups). This allows the instance group to automatically detect when a VM isn't running a healthy Buildkite agent and recreate it.

It exports two endpoints:
- `/`: This is an overall status page for the agent itself.
- `/agent/<spawn_id>`: This is the status page of the agent worker with the numeric index `spawn_id`, starting from 1. If you use `--spawn=N`, there will be one status page for each running agent. This one actually takes the last heartbeat into account and if the heartbeat fails, this will return a failed HTTP response, signaling that the agent isn't healthy.

I'll still do some polish and testing of this, but am sending it already for review to get your feedback on this idea. :)