### PR TITLE
Allow fetching arbitrary tag=suffix pairs from GCP/EC2 meta-data

### DIFF
--- a/agent/ec2_meta_data.go
+++ b/agent/ec2_meta_data.go
@@ -5,31 +5,53 @@ import (
 )
 
 type EC2MetaData struct {
+	Client *ec2metadata.EC2Metadata
+}
+
+func NewEC2MetaData() (*EC2MetaData, error) {
+	sess, err := awsSession()
+	if err != nil {
+		return &EC2MetaData{}, err
+	}
+
+	return &EC2MetaData{
+		Client: ec2metadata.New(sess),
+	}, nil
+}
+
+// Takes a map of tags and meta-data paths to get, returns a map of tags and fetched values.
+func (e EC2MetaData) GetPaths(paths map[string]string) (map[string]string, error) {
+	result := make(map[string]string)
+
+	for key, path := range paths {
+		value, err := e.Client.GetMetadata(path)
+		if err != nil {
+			return nil, err
+		} else {
+			result[key] = value
+		}
+	}
+
+	return result, nil
 }
 
 func (e EC2MetaData) Get() (map[string]string, error) {
-	sess, err := awsSession()
-	if err != nil {
-		return nil, err
-	}
-
 	metaData := make(map[string]string)
-	ec2metadataClient := ec2metadata.New(sess)
 
-	instanceId, err := ec2metadataClient.GetMetadata("instance-id")
+	instanceId, err := e.Client.GetMetadata("instance-id")
 	if err != nil {
 		return metaData, err
 	}
 
 	metaData["aws:instance-id"] = string(instanceId)
 
-	instanceType, err := ec2metadataClient.GetMetadata("instance-type")
+	instanceType, err := e.Client.GetMetadata("instance-type")
 	if err != nil {
 		return metaData, err
 	}
 	metaData["aws:instance-type"] = string(instanceType)
 
-	amiId, err := ec2metadataClient.GetMetadata("ami-id")
+	amiId, err := e.Client.GetMetadata("ami-id")
 	if err != nil {
 		return metaData, err
 	}

--- a/agent/ec2_meta_data_test.go
+++ b/agent/ec2_meta_data_test.go
@@ -1,28 +1,8 @@
 package agent
 
 import (
-	"fmt"
-	// "github.com/stretchr/testify/assert"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	// "os"
 	"testing"
 )
 
 func TestEC2MetaDataGetSuffixes(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-
-		switch path := r.URL.EscapedPath(); path {
-		default:
-			t.Fatalf("Error %q", path)
-		}
-	}))
-	defer ts.Close()
-
-	url, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("Error %q", err)
-	}
 }

--- a/agent/ec2_meta_data_test.go
+++ b/agent/ec2_meta_data_test.go
@@ -1,0 +1,28 @@
+package agent
+
+import (
+	"fmt"
+	// "github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	// "os"
+	"testing"
+)
+
+func TestEC2MetaDataGetSuffixes(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		switch path := r.URL.EscapedPath(); path {
+		default:
+			t.Fatalf("Error %q", path)
+		}
+	}))
+	defer ts.Close()
+
+	url, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Error %q", err)
+	}
+}

--- a/agent/gcp_meta_data.go
+++ b/agent/gcp_meta_data.go
@@ -10,6 +10,27 @@ import (
 type GCPMetaData struct {
 }
 
+// Provided for consistency with the EC2 Metadata (and potential future?) implementation
+func NewGCPMetaData() (*GCPMetaData, error) {
+	return &GCPMetaData{}, nil
+}
+
+// Takes a map of tags and meta-data paths to get, returns a map of tags and fetched values.
+func (e GCPMetaData) GetPaths(paths map[string]string) (map[string]string, error) {
+	result := make(map[string]string)
+
+	for key, path := range paths {
+		value, err := metadata.Get(path)
+		if err != nil {
+			return nil, err
+		} else {
+			result[key] = value
+		}
+	}
+
+	return result, nil
+}
+
 func (e GCPMetaData) Get() (map[string]string, error) {
 	result := make(map[string]string)
 

--- a/agent/gcp_meta_data.go
+++ b/agent/gcp_meta_data.go
@@ -10,11 +10,6 @@ import (
 type GCPMetaData struct {
 }
 
-// Provided for consistency with the EC2 Metadata (and potential future?) implementation
-func NewGCPMetaData() (*GCPMetaData, error) {
-	return &GCPMetaData{}, nil
-}
-
 // Takes a map of tags and meta-data paths to get, returns a map of tags and fetched values.
 func (e GCPMetaData) GetPaths(paths map[string]string) (map[string]string, error) {
 	result := make(map[string]string)

--- a/agent/gcp_meta_data_test.go
+++ b/agent/gcp_meta_data_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestGCPMetaDataGetSuffixes(t *testing.T) {
+func TestGCPMetaDataGetPaths(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 
@@ -34,7 +34,7 @@ func TestGCPMetaDataGetSuffixes(t *testing.T) {
 	defer os.Setenv("GCE_METADATA_HOST", old)
 	os.Setenv("GCE_METADATA_HOST", url.Host)
 
-	values, err := GCPMetaData{}.GetSuffixes(map[string]string{
+	values, err := GCPMetaData{}.GetPaths(map[string]string{
 		"truth":     "value",
 		"scary":     "nested/paths/work",
 		"weird key": "value",

--- a/agent/gcp_meta_data_test.go
+++ b/agent/gcp_meta_data_test.go
@@ -1,0 +1,52 @@
+package agent
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+)
+
+func TestGCPMetaDataGetSuffixes(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		switch path := r.URL.EscapedPath(); path {
+		case "/computeMetadata/v1/value":
+			fmt.Fprintf(w, "I could live on only burritos for the rest of my life")
+		case "/computeMetadata/v1/nested/paths/work":
+			fmt.Fprintf(w, "Velociraptors are terrifying")
+		default:
+			t.Fatalf("Error %q", path)
+		}
+	}))
+	defer ts.Close()
+
+	url, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Error %q", err)
+	}
+
+	old := os.Getenv("GCE_METADATA_HOST")
+	defer os.Setenv("GCE_METADATA_HOST", old)
+	os.Setenv("GCE_METADATA_HOST", url.Host)
+
+	values, err := GCPMetaData{}.GetSuffixes(map[string]string{
+		"truth":     "value",
+		"scary":     "nested/paths/work",
+		"weird key": "value",
+	})
+
+	if err != nil {
+		t.Fatalf("Error %q", err)
+	}
+
+	assert.Equal(t, values, map[string]string{
+		"truth":     "I could live on only burritos for the rest of my life",
+		"scary":     "Velociraptors are terrifying",
+		"weird key": "I could live on only burritos for the rest of my life",
+	})
+}

--- a/agent/tags.go
+++ b/agent/tags.go
@@ -217,7 +217,6 @@ func (t *tagFetcher) Fetch(l logger.Logger, conf FetchTagsConfig) []string {
 	return tags
 }
 
-// TODO: Seems maybe el crapola, dunno will ask lox
 func parseTagValuePathPairs(paths []string) (map[string]string, error) {
 	result := make(map[string]string)
 
@@ -229,8 +228,7 @@ func parseTagValuePathPairs(paths []string) (map[string]string, error) {
 		}
 
 		x := strings.Split(pair, "=")
-		// TODO: Should we just let people have stupid keys? Probably?
-		key := strings.ToLower(strings.Trim(x[0], " "))
+		key := strings.ToLower(strings.TrimSpace(x[0]))
 
 		uri, err := url.Parse(x[1])
 		if err != nil {

--- a/agent/tags.go
+++ b/agent/tags.go
@@ -113,7 +113,6 @@ func (t *tagFetcher) Fetch(l logger.Logger, conf FetchTagsConfig) []string {
 		paths, err := parseTagValuePathPairs(conf.TagsFromEC2MetaDataPaths)
 		if err != nil {
 			l.Error(fmt.Sprintf("Error parsing meta-data tag and path pairs: %s", err.Error()))
-			return err
 		}
 
 		ec2Tags, err := t.ec2MetaDataPaths(paths)
@@ -174,7 +173,6 @@ func (t *tagFetcher) Fetch(l logger.Logger, conf FetchTagsConfig) []string {
 		paths, err := parseTagValuePathPairs(conf.TagsFromGCPMetaDataPaths)
 		if err != nil {
 			l.Error(fmt.Sprintf("Error parsing meta-data tag and path pairs: %s", err.Error()))
-			return err
 		}
 
 		gcpTags, err := t.gcpMetaDataPaths(paths)

--- a/agent/tags.go
+++ b/agent/tags.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -85,7 +84,7 @@ func (t *tagFetcher) Fetch(l logger.Logger, conf FetchTagsConfig) []string {
 	}
 
 	// Attempt to add the default EC2 meta-data tags
-	if conf.TagsFromEC2MetaData && awsSess != nil {
+	if conf.TagsFromEC2MetaData {
 		l.Info("Fetching EC2 meta-data...")
 
 		err := retry.Do(func(s *retry.Stats) error {
@@ -236,16 +235,7 @@ func parseTagValuePathPairs(paths []string) (map[string]string, error) {
 			return result, err
 		}
 
-		meta_data_path := filepath.Clean(uri.Path)
-
-		if filepath.IsAbs(meta_data_path) {
-			meta_data_path, err = filepath.Rel("/", meta_data_path)
-			if err != nil {
-				return result, err
-			}
-		}
-
-		result[key] = meta_data_path
+		result[key] = strings.TrimPrefix(uri.Path, "/")
 	}
 
 	return result, nil

--- a/agent/tags.go
+++ b/agent/tags.go
@@ -113,6 +113,7 @@ func (t *tagFetcher) Fetch(l logger.Logger, conf FetchTagsConfig) []string {
 		paths, err := parseTagValuePathPairs(conf.TagsFromEC2MetaDataPaths)
 		if err != nil {
 			l.Error(fmt.Sprintf("Error parsing meta-data tag and path pairs: %s", err.Error()))
+			return err
 		}
 
 		ec2Tags, err := t.ec2MetaDataPaths(paths)
@@ -173,6 +174,7 @@ func (t *tagFetcher) Fetch(l logger.Logger, conf FetchTagsConfig) []string {
 		paths, err := parseTagValuePathPairs(conf.TagsFromGCPMetaDataPaths)
 		if err != nil {
 			l.Error(fmt.Sprintf("Error parsing meta-data tag and path pairs: %s", err.Error()))
+			return err
 		}
 
 		gcpTags, err := t.gcpMetaDataPaths(paths)


### PR DESCRIPTION
This patch enhances the integration of the agent with EC2 and GCP meta-data endpoints by allowing for arbitrary fetching of tag name & meta-data path suffix pairs.

This new functionality is intended to be additive only and can be used via two new flags, on for AWS and one for GCP; `--tags-from-ec2-meta-data-paths`, `--tags-from-gcp-meta-data-paths`.

#### Example

```
--tags-from-ec2-meta-data-paths "omg=spot/termination-time"
```

This patch also deprecates the `--tags-from-ec2` & `--tags-from-gcp` flags in favour of `--tags-from-ec2-meta-data` && `--tags-from-gcp-meta-data` respectively for consistency. The deprecated flags are not removed yet, but would be in v4.