### PR TITLE
Avoid os.Exit in pipeline upload command

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -227,7 +227,7 @@ var PipelineUploadCommand = cli.Command{
 				l.Fatal("%#v", err)
 			}
 
-			os.Exit(0)
+			return
 		}
 
 		// Check we have a job id set if not in dry run


### PR DESCRIPTION
Golang doesn't execute deferred calls on system exit, so this removes one found in the pipeline upload command. 

This allows `--profile` to be used with `--dry-run`. 