### PR TITLE
Added feature to enable encryption at rest for artifacts in S3.

### DIFF
--- a/agent/s3_uploader.go
+++ b/agent/s3_uploader.go
@@ -133,7 +133,7 @@ func (u *S3Uploader) resolvePermission() (string, error) {
 	case "private", "public-read", "public-read-write", "authenticated-read", "bucket-owner-read", "bucket-owner-full-control":
 		return permission, nil
 	default:
-		return permission, fmt.Errorf("Invalid S3 ACL value: `%s`", permission)
+		return "", fmt.Errorf("Invalid S3 ACL value: `%s`", permission)
 	}
 }
 

--- a/agent/s3_uploader.go
+++ b/agent/s3_uploader.go
@@ -79,21 +79,10 @@ func (u *S3Uploader) URL(artifact *api.Artifact) string {
 }
 
 func (u *S3Uploader) Upload(artifact *api.Artifact) error {
-	permission := "public-read"
-	if os.Getenv("BUILDKITE_S3_ACL") != "" {
-		permission = os.Getenv("BUILDKITE_S3_ACL")
-	} else if os.Getenv("AWS_S3_ACL") != "" {
-		permission = os.Getenv("AWS_S3_ACL")
-	}
 
-	// The dirtiest validation method ever...
-	if permission != "private" &&
-		permission != "public-read" &&
-		permission != "public-read-write" &&
-		permission != "authenticated-read" &&
-		permission != "bucket-owner-read" &&
-		permission != "bucket-owner-full-control" {
-		return fmt.Errorf("Invalid S3 ACL `%s`", permission)
+	permission, err := u.resolvePermission()
+	if err != nil {
+		return err
 	}
 
 	// Create an uploader with the session and default options
@@ -108,13 +97,20 @@ func (u *S3Uploader) Upload(artifact *api.Artifact) error {
 
 	// Upload the file to S3.
 	u.logger.Debug("Uploading \"%s\" to bucket with permission `%s`", u.artifactPath(artifact), permission)
-	_, err = uploader.Upload(&s3manager.UploadInput{
+
+	params := &s3manager.UploadInput{
 		Bucket:      aws.String(u.BucketName),
 		Key:         aws.String(u.artifactPath(artifact)),
 		ContentType: aws.String(artifact.ContentType),
 		ACL:         aws.String(permission),
 		Body:        f,
-	})
+	}
+	// if enabled we assign the sse configuration
+	if u.serverSideEncryptionEnabled() {
+		params.ServerSideEncryption = aws.String("AES256")
+	}
+
+	_, err = uploader.Upload(params)
 
 	return err
 }
@@ -123,4 +119,31 @@ func (u *S3Uploader) artifactPath(artifact *api.Artifact) string {
 	parts := []string{u.BucketPath, artifact.Path}
 
 	return strings.Join(parts, "/")
+}
+
+func (u *S3Uploader) resolvePermission() (string, error) {
+	permission := "public-read"
+	if os.Getenv("BUILDKITE_S3_ACL") != "" {
+		permission = os.Getenv("BUILDKITE_S3_ACL")
+	} else if os.Getenv("AWS_S3_ACL") != "" {
+		permission = os.Getenv("AWS_S3_ACL")
+	}
+
+	switch permission {
+	case "private", "public-read", "public-read-write", "authenticated-read", "bucket-owner-read", "bucket-owner-full-control":
+		return permission, nil
+	default:
+		return permission, fmt.Errorf("Invalid S3 ACL value: `%s`", permission)
+	}
+}
+
+// is encryption at rest enabled for artifacts to satisfy basic security requirements
+func (u *S3Uploader) serverSideEncryptionEnabled() bool {
+	sse := os.Getenv("BUILDKITE_S3_SSE_ENABLED")
+	switch {
+	case strings.ToLower(sse) == "true":
+		return true
+	default:
+		return false
+	}
 }

--- a/agent/s3_uploader_test.go
+++ b/agent/s3_uploader_test.go
@@ -1,7 +1,10 @@
 package agent
 
 import (
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseS3DestinationBucketPath(t *testing.T) {
@@ -29,5 +32,60 @@ func TestParseS3DestinationBucketName(t *testing.T) {
 		if bucket != tc.Bucket {
 			t.Fatalf("Expected %q, got %q", tc.Bucket, bucket)
 		}
+	}
+}
+
+func TestResolveServerSideEncryptionConfig(t *testing.T) {
+
+	assert := require.New(t)
+
+	for _, tc := range []struct {
+		ServerSideEncryptionConfig string
+		ExpectedResult             bool
+	}{
+		{"True", true},
+		{"falsE", false},
+		{"lol", false},
+	} {
+		uploader := &S3Uploader{}
+		os.Setenv("BUILDKITE_S3_SSE_ENABLED", tc.ServerSideEncryptionConfig)
+		config := uploader.serverSideEncryptionEnabled()
+
+		assert.Equal(tc.ExpectedResult, config)
+
+		os.Unsetenv("BUILDKITE_S3_SSE_ENABLED")
+	}
+}
+
+func TestResolvePermission(t *testing.T) {
+
+	assert := require.New(t)
+	for _, tc := range []struct {
+		Permission     string
+		ExpectedResult string
+		ShouldErr      bool
+	}{
+		{"", "public-read", false},
+		{"private", "private", false},
+		{"public-read", "public-read", false},
+		{"public-read-write", "public-read-write", false},
+		{"authenticated-read", "authenticated-read", false},
+		{"bucket-owner-read", "bucket-owner-read", false},
+		{"bucket-owner-full-control", "bucket-owner-full-control", false},
+		{"foo", "", true},
+	} {
+		uploader := &S3Uploader{}
+		os.Setenv("BUILDKITE_S3_ACL", tc.Permission)
+		config, err := uploader.resolvePermission()
+
+		// if it should error we just look at the error
+		if tc.ShouldErr {
+			assert.Error(err)
+		} else {
+			assert.Nil(err)
+			assert.Equal(tc.ExpectedResult, config)
+		}
+
+		os.Unsetenv("BUILDKITE_S3_ACL")
 	}
 }


### PR DESCRIPTION
This uses a new ENV variable BUILDKITE_S3_SSE_ENABLED in line with the
existing enviroment variables.

Currently validate of this value is optimised for feedback, being limited
to covering the case of encryption at rest. If this accepted the full
range of options supported by S3 it would be difficult to validate
as it requires a how load of KMS infrastructure and permissions.

Also extracted the existing flag and wrote some tests for it and the new
option.