### PR TITLE
Allow buildkite agent to finish jobs before being killed

### DIFF
--- a/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent.service
+++ b/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent.service
@@ -13,7 +13,7 @@ RestartSec=5
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE
 TimeoutStartSec=10
-TimeoutStopSec=0
+TimeoutStopSec=infinity
 KillMode=process
 
 [Install]


### PR DESCRIPTION
Set TimeoutStopSec to "infinity" per the systemd documentation
I am assuming when someone set this to 0, they were thinking that 0 meant disable/infinity so that the agent would have chance to finish running any current builds

See:
https://www.freedesktop.org/software/systemd/man/systemd.service.html#TimeoutStopSec=