### PR TITLE
Allow buildkite agent to finish jobs before being killed

### DIFF
--- a/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent@.service
+++ b/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent@.service
@@ -13,7 +13,7 @@ RestartSec=5
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE
 TimeoutStartSec=10
-TimeoutStopSec=0
+TimeoutStopSec=infinity
 KillMode=process
 
 [Install]


### PR DESCRIPTION
Set TimeoutStopSec to "infinity" per the systemd documentation
I am assuming when someone set this to 0, they were thinking that 0 meant disable/infinity so that the agent would have chance to finish running any current builds

See:
https://www.freedesktop.org/software/systemd/man/systemd.service.html#TimeoutStopSec=

Same for man systemd.service:

```
       TimeoutStopSec=
           This option serves two purposes. First, it configures the time to wait for each
           ExecStop= command. If any of them times out, subsequent ExecStop= commands are skipped
           and the service will be terminated by SIGTERM. If no ExecStop= commands are specified,
           the service gets the SIGTERM immediately. Second, it configures the time to wait for
           the service itself to stop. If it doesn't terminate in the specified time, it will be
           forcibly terminated by SIGKILL (see KillMode= in systemd.kill(5)). Takes a unit-less
           value in seconds, or a time span value such as "5min 20s". Pass "infinity" to disable
           the timeout logic. Defaults to DefaultTimeoutStopSec= from the manager configuration
           file (see systemd-system.conf(5)).
```