### PR TITLE
Allow for exponential backoff between retries for artifact uploads

### DIFF
--- a/agent/artifact_batch_creator.go
+++ b/agent/artifact_batch_creator.go
@@ -17,6 +17,9 @@ type ArtifactBatchCreatorConfig struct {
 
 	// Where the artifacts are being uploaded to on the command line
 	UploadDestination string
+
+	// backoff strategy between retries
+	BackoffStrategy string
 }
 
 type ArtifactBatchCreator struct {
@@ -76,7 +79,7 @@ func (a *ArtifactBatchCreator) Create() ([]*api.Artifact, error) {
 			}
 
 			return err
-		}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
+		}, &retry.Config{Maximum: 10, Interval: 5 * time.Second, BackoffStrategy: a.conf.BackoffStrategy})
 
 		// Did the batch creation eventually fail?
 		if err != nil {

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -40,6 +40,9 @@ type ArtifactUploaderConfig struct {
 
 	// Whether to show HTTP debugging
 	DebugHTTP bool
+
+	// How to vary backoff between failed attempts
+	BackoffStrategy string
 }
 
 type ArtifactUploader struct {
@@ -344,7 +347,7 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 				}
 
 				return err
-			}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
+			}, &retry.Config{Maximum: 10, Interval: 5 * time.Second, BackoffStrategy: a.conf.BackoffStrategy})
 
 			var state string
 

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -250,6 +250,7 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 		JobID:             a.conf.JobID,
 		Artifacts:         artifacts,
 		UploadDestination: a.conf.Destination,
+		BackoffStrategy:   a.conf.BackoffStrategy,
 	})
 
 	artifacts, err = batchCreator.Create()

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -305,7 +305,7 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 					}
 
 					return err
-				}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
+				}, &retry.Config{Maximum: 10, Interval: 5 * time.Second, BackoffStrategy: a.conf.BackoffStrategy})
 
 				if err != nil {
 					a.logger.Error("Error uploading artifact states: %s", err)
@@ -339,7 +339,7 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 
 			// Upload the artifact and then set the state depending
 			// on whether or not it passed. We'll retry the upload
-			// a couple of times before giving up.
+			// upto 10 times and give up.
 			err = retry.Do(func(s *retry.Stats) error {
 				err := uploader.Upload(artifact)
 				if err != nil {

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -44,10 +44,10 @@ Example:
    $ buildkite-agent artifact upload "log/**/*.log" rt://name-of-your-artifactory-repo/$BUILDKITE_JOB_ID`
 
 type ArtifactUploadConfig struct {
-	UploadPaths   string `cli:"arg:0" label:"upload paths" validate:"required"`
-	Destination   string `cli:"arg:1" label:"destination" env:"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"`
-	Job           string `cli:"job" validate:"required"`
-	ContentType   string `cli:"content-type"`
+	UploadPaths     string `cli:"arg:0" label:"upload paths" validate:"required"`
+	Destination     string `cli:"arg:1" label:"destination" env:"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"`
+	Job             string `cli:"job" validate:"required"`
+	ContentType     string `cli:"content-type"`
 	BackoffStrategy string `cli:"backoff-strategy"`
 
 	// Global flags
@@ -79,11 +79,11 @@ var ArtifactUploadCommand = cli.Command{
 			Usage:  "A specific Content-Type to set for the artifacts (otherwise detected)",
 			EnvVar: "BUILDKITE_ARTIFACT_CONTENT_TYPE",
 		},
-		cli.StringFlag{
-			Name: "backoff-strategy",
-			Value: "linear",
-			Usage: "How to vary backoff between retries on failed attempts. "
-		}
+		cli.StringSliceFlag{
+			Name:  "backoff-strategy",
+			Value: &cli.StringSlice{"linear", "exponential-backoff"},
+			Usage: "How to vary backoff between retries on failed attempts. ",
+		},
 
 		// API Flags
 		AgentAccessTokenFlag,
@@ -116,11 +116,11 @@ var ArtifactUploadCommand = cli.Command{
 
 		// Setup the uploader
 		uploader := agent.NewArtifactUploader(l, client, agent.ArtifactUploaderConfig{
-			JobID:         cfg.Job,
-			Paths:         cfg.UploadPaths,
-			Destination:   cfg.Destination,
-			ContentType:   cfg.ContentType,
-			DebugHTTP:     cfg.DebugHTTP,
+			JobID:           cfg.Job,
+			Paths:           cfg.UploadPaths,
+			Destination:     cfg.Destination,
+			ContentType:     cfg.ContentType,
+			DebugHTTP:       cfg.DebugHTTP,
 			BackoffStrategy: cfg.BackoffStrategy,
 		})
 

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -79,9 +79,9 @@ var ArtifactUploadCommand = cli.Command{
 			Usage:  "A specific Content-Type to set for the artifacts (otherwise detected)",
 			EnvVar: "BUILDKITE_ARTIFACT_CONTENT_TYPE",
 		},
-		cli.StringSliceFlag{
+		cli.StringFlag{
 			Name:  "backoff-strategy",
-			Value: &cli.StringSlice{"linear", "exponential-backoff"},
+			Value: "linear",
 			Usage: "How to vary backoff between retries on failed attempts. ",
 		},
 

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -44,10 +44,11 @@ Example:
    $ buildkite-agent artifact upload "log/**/*.log" rt://name-of-your-artifactory-repo/$BUILDKITE_JOB_ID`
 
 type ArtifactUploadConfig struct {
-	UploadPaths string `cli:"arg:0" label:"upload paths" validate:"required"`
-	Destination string `cli:"arg:1" label:"destination" env:"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"`
-	Job         string `cli:"job" validate:"required"`
-	ContentType string `cli:"content-type"`
+	UploadPaths   string `cli:"arg:0" label:"upload paths" validate:"required"`
+	Destination   string `cli:"arg:1" label:"destination" env:"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"`
+	Job           string `cli:"job" validate:"required"`
+	ContentType   string `cli:"content-type"`
+	BackoffStrategy string `cli:"backoff-strategy"`
 
 	// Global flags
 	Debug   bool   `cli:"debug"`
@@ -78,6 +79,11 @@ var ArtifactUploadCommand = cli.Command{
 			Usage:  "A specific Content-Type to set for the artifacts (otherwise detected)",
 			EnvVar: "BUILDKITE_ARTIFACT_CONTENT_TYPE",
 		},
+		cli.StringFlag{
+			Name: "backoff-strategy",
+			Value: "linear",
+			Usage: "How to vary backoff between retries on failed attempts. "
+		}
 
 		// API Flags
 		AgentAccessTokenFlag,
@@ -110,11 +116,12 @@ var ArtifactUploadCommand = cli.Command{
 
 		// Setup the uploader
 		uploader := agent.NewArtifactUploader(l, client, agent.ArtifactUploaderConfig{
-			JobID:       cfg.Job,
-			Paths:       cfg.UploadPaths,
-			Destination: cfg.Destination,
-			ContentType: cfg.ContentType,
-			DebugHTTP:   cfg.DebugHTTP,
+			JobID:         cfg.Job,
+			Paths:         cfg.UploadPaths,
+			Destination:   cfg.Destination,
+			ContentType:   cfg.ContentType,
+			DebugHTTP:     cfg.DebugHTTP,
+			BackoffStrategy: cfg.BackoffStrategy,
 		})
 
 		// Upload the artifacts

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -80,6 +80,7 @@ func Do(callback func(*Stats) error, config *Config) error {
 		// access to it in the callback)
 		stats.Interval = config.Interval
 
+		// update interval if exponential backoff is being used
 		if config.BackoffStrategy == exponentialBackoff {
 			stats.Interval = time.Duration(math.Pow(2, float64(stats.Attempt)))
 		}

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -82,7 +82,7 @@ func Do(callback func(*Stats) error, config *Config) error {
 
 		// update interval if exponential backoff is being used
 		if config.BackoffStrategy == exponentialBackoff {
-			stats.Interval = time.Duration(math.Pow(2, float64(stats.Attempt)))
+			stats.Interval = time.Duration(1000 * 1000 * 1000 * math.Pow(2, float64(stats.Attempt)))
 		}
 
 		if config.Jitter {


### PR DESCRIPTION
We occasionally get rate-limited from GCS (where we upload artifacts to) due to high load on the bucket. The suggested retry policy in such cases is to use exponential backoff between retries. https://cloud.google.com/storage/docs/exponential-backoff. We add a cli flag to optionally specify backoff strategy.

Since the agent doesn't do this currently, we're having to workaround by using `gsutil` which already does this. However, we'd like to do this through the agent so that we can see the artifacts in UI and also allow sharing of artifacts between jobs (which we've lost with using `gsutil`). 

Tested locally as follows with dummy values:
```
C02Y231UJHD2:agent sridhar.mocherla$ buildkite-agent artifact upload --job testjob --backoff-strategy exponential --endpoint localhost test.txt
2019-08-19 23:07:47 INFO   Found 1 files that match "test.txt"
2019-08-19 23:07:47 INFO   Creating (0-1)/1 artifacts
2019-08-19 23:07:47 WARN   Post localhost/jobs/testjob/artifacts: unsupported protocol scheme "" (Attempt 1/10 Retrying in 2s)
2019-08-19 23:07:49 WARN   Post localhost/jobs/testjob/artifacts: unsupported protocol scheme "" (Attempt 2/10 Retrying in 4s)
2019-08-19 23:07:53 WARN   Post localhost/jobs/testjob/artifacts: unsupported protocol scheme "" (Attempt 3/10 Retrying in 8s)
2019-08-19 23:08:01 WARN   Post localhost/jobs/testjob/artifacts: unsupported protocol scheme "" (Attempt 4/10 Retrying in 16s)
```