### PR TITLE
Updates to `step update` and added `step get`

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -98,23 +98,3 @@ func (c *Client) FinishJob(job *Job) (*Response, error) {
 
 	return c.doRequest(req, nil)
 }
-
-// StepUpdate represents a change request to a step
-type StepUpdate struct {
-	UUID      string `json:"uuid,omitempty"`
-	Attribute string `json:"attribute,omitempty"`
-	Value     string `json:"value,omitempty"`
-	Append    bool   `json:"append,omitempty"`
-}
-
-// StepUpdate updates a step
-func (c *Client) StepUpdate(jobId string, stepUpdate *StepUpdate) (*Response, error) {
-	u := fmt.Sprintf("jobs/%s/step_update", jobId)
-
-	req, err := c.newRequest("PUT", u, stepUpdate)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.doRequest(req, nil)
-}

--- a/api/steps.go
+++ b/api/steps.go
@@ -4,6 +4,35 @@ import (
 	"fmt"
 )
 
+// StepGetRequest represents a request for information about a step
+type StepGetRequest struct {
+	Attribute string `json:"attribute,omitempty"`
+	Build     string `json:"build_id,omitempty"`
+	Format    string `json:"format,omitempty"`
+}
+
+type StepGetResponse struct {
+	Value string `json:"value"`
+}
+
+// StepGet gets an attribute from step
+func (c *Client) StepGet(stepIdOrKey string, stepGetRequest *StepGetRequest) (*StepGetResponse, *Response, error) {
+	u := fmt.Sprintf("steps/%s/get", stepIdOrKey)
+
+	req, err := c.newRequest("POST", u, stepGetRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r := new(StepGetResponse)
+	resp, err := c.doRequest(req, r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r, resp, err
+}
+
 // StepUpdate represents a change request to a step
 type StepUpdate struct {
 	IdempotencyUUID string `json:"idempotency_uuid,omitempty"`

--- a/api/steps.go
+++ b/api/steps.go
@@ -4,27 +4,27 @@ import (
 	"fmt"
 )
 
-// StepGetRequest represents a request for information about a step
-type StepGetRequest struct {
+// StepExportRequest represents a request for information about a step
+type StepExportRequest struct {
 	Attribute string `json:"attribute,omitempty"`
 	Build     string `json:"build_id,omitempty"`
 	Format    string `json:"format,omitempty"`
 }
 
-type StepGetResponse struct {
-	Value string `json:"value"`
+type StepExportResponse struct {
+	Output string `json:"output"`
 }
 
-// StepGet gets an attribute from step
-func (c *Client) StepGet(stepIdOrKey string, stepGetRequest *StepGetRequest) (*StepGetResponse, *Response, error) {
-	u := fmt.Sprintf("steps/%s/get", stepIdOrKey)
+// StepExport gets an attribute from step
+func (c *Client) StepExport(stepIdOrKey string, stepGetRequest *StepExportRequest) (*StepExportResponse, *Response, error) {
+	u := fmt.Sprintf("steps/%s/export", stepIdOrKey)
 
 	req, err := c.newRequest("POST", u, stepGetRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	r := new(StepGetResponse)
+	r := new(StepExportResponse)
 	resp, err := c.doRequest(req, r)
 	if err != nil {
 		return nil, resp, err

--- a/api/steps.go
+++ b/api/steps.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"fmt"
+)
+
+// StepUpdate represents a change request to a step
+type StepUpdate struct {
+	IdempotencyUUID string `json:"idempotency_uuid,omitempty"`
+	Build           string `json:"build_id,omitempty"`
+	Attribute       string `json:"attribute,omitempty"`
+	Value           string `json:"value,omitempty"`
+	Append          bool   `json:"append,omitempty"`
+}
+
+// StepUpdate updates a step
+func (c *Client) StepUpdate(stepIdOrKey string, stepUpdate *StepUpdate) (*Response, error) {
+	u := fmt.Sprintf("steps/%s", stepIdOrKey)
+
+	req, err := c.newRequest("PUT", u, stepUpdate)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.doRequest(req, nil)
+}

--- a/clicommand/step_get.go
+++ b/clicommand/step_get.go
@@ -1,0 +1,137 @@
+package clicommand
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/buildkite/agent/api"
+	"github.com/buildkite/agent/cliconfig"
+	"github.com/buildkite/agent/retry"
+	"github.com/urfave/cli"
+)
+
+var StepGetHelpDescription = `Usage:
+
+   buildkite-agent step get <attribute> [arguments...]
+
+Description:
+
+   Retrieve the value of an attribute in a step. If no attribute is passed, the
+   entire step will be returned.
+
+   In the event a complex object is returned (i.e. an object or an array),
+   you'll need to supply the --format option to tell the agent how it should
+   output the data (currently only JSON is supported).
+
+Example:
+
+   $ buildkite-agent step get "label"
+   $ buildkite-agent step get --format json
+   $ buildkite-agent step get "retry" --format json
+   $ buildkite-agent step get "state" --step "my-other-step"`
+
+type StepGetConfig struct {
+	Attribute string `cli:"arg:0" label:"step attribute"`
+	StepOrKey string `cli:"step" validate:"required"`
+	Build     string `cli:"build"`
+	Format    string `cli:"format"`
+
+	// Global flags
+	Debug   bool   `cli:"debug"`
+	NoColor bool   `cli:"no-color"`
+	Profile string `cli:"profile"`
+
+	// API config
+	DebugHTTP        bool   `cli:"debug-http"`
+	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
+	Endpoint         string `cli:"endpoint" validate:"required"`
+	NoHTTP2          bool   `cli:"no-http2"`
+}
+
+var StepGetCommand = cli.Command{
+	Name:        "get",
+	Usage:       "Get the value of an attribute",
+	Description: StepGetHelpDescription,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:   "step",
+			Value:  "",
+			Usage:  "The step to get. Can be either it's ID (BUILDKITE_STEP_ID) or key (BUILDKITE_STEP_KEY)",
+			EnvVar: "BUILDKITE_STEP_ID",
+		},
+		cli.StringFlag{
+			Name:   "build",
+			Value:  "",
+			Usage:  "The build to look for the step in. Only required when targeting a step using it's key (BUILDKITE_STEP_KEY)",
+			EnvVar: "BUILDKITE_BUILD_ID",
+		},
+		cli.StringFlag{
+			Name:   "format",
+			Value:  "",
+			Usage:  "The format to output the attribute value in (currently only json is supported)",
+			EnvVar: "BUILDKITE_STEP_GET_FORMAT",
+		},
+
+		// API Flags
+		AgentAccessTokenFlag,
+		EndpointFlag,
+		NoHTTP2Flag,
+		DebugHTTPFlag,
+
+		// Global flags
+		NoColorFlag,
+		DebugFlag,
+		ProfileFlag,
+	},
+	Action: func(c *cli.Context) {
+		// The configuration will be loaded into this struct
+		cfg := StepGetConfig{}
+
+		l := CreateLogger(&cfg)
+
+		// Load the configuration
+		if err := cliconfig.Load(c, l, &cfg); err != nil {
+			l.Fatal("%s", err)
+		}
+
+		// Setup any global configuration options
+		done := HandleGlobalFlags(l, cfg)
+		defer done()
+
+		// Create the API client
+		client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))
+
+		// Create the request
+		stepGetRequest := &api.StepGetRequest{
+			Build:     cfg.Build,
+			Attribute: cfg.Attribute,
+			Format:    cfg.Format,
+		}
+
+		// Find the step attribute
+		var err error
+		var resp *api.Response
+		var stepGetResponse *api.StepGetResponse
+		err = retry.Do(func(s *retry.Stats) error {
+			stepGetResponse, resp, err = client.StepGet(cfg.StepOrKey, stepGetRequest)
+			// Don't bother retrying if the response was one of these statuses
+			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 400) {
+				s.Break()
+				return err
+			}
+			if err != nil {
+				l.Warn("%s (%s)", err, s)
+			}
+
+			return err
+		}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})
+
+		// Deal with the error if we got one
+		if err != nil {
+			l.Fatal("Failed to get step: %s", err)
+		}
+
+		// Output the value to STDOUT
+		fmt.Print(stepGetResponse.Value)
+	},
+}

--- a/clicommand/step_get.go
+++ b/clicommand/step_get.go
@@ -68,7 +68,7 @@ var StepGetCommand = cli.Command{
 		cli.StringFlag{
 			Name:   "format",
 			Value:  "",
-			Usage:  "The format to output the attribute value in (currently only json is supported)",
+			Usage:  "The format to output the attribute value in (currently only JSON is supported)",
 			EnvVar: "BUILDKITE_STEP_GET_FORMAT",
 		},
 
@@ -102,7 +102,7 @@ var StepGetCommand = cli.Command{
 		client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))
 
 		// Create the request
-		stepGetRequest := &api.StepGetRequest{
+		stepExportRequest := &api.StepExportRequest{
 			Build:     cfg.Build,
 			Attribute: cfg.Attribute,
 			Format:    cfg.Format,
@@ -111,9 +111,9 @@ var StepGetCommand = cli.Command{
 		// Find the step attribute
 		var err error
 		var resp *api.Response
-		var stepGetResponse *api.StepGetResponse
+		var stepExportResponse *api.StepExportResponse
 		err = retry.Do(func(s *retry.Stats) error {
-			stepGetResponse, resp, err = client.StepGet(cfg.StepOrKey, stepGetRequest)
+			stepExportResponse, resp, err = client.StepExport(cfg.StepOrKey, stepExportRequest)
 			// Don't bother retrying if the response was one of these statuses
 			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 400) {
 				s.Break()
@@ -132,6 +132,6 @@ var StepGetCommand = cli.Command{
 		}
 
 		// Output the value to STDOUT
-		fmt.Print(stepGetResponse.Value)
+		fmt.Print(stepExportResponse.Output)
 	},
 }

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -17,7 +17,7 @@ var StepUpdateHelpDescription = `Usage:
 
 Description:
 
-   Update an attribute of a step associated with a job
+   Update an attribute of a step in the build
 
 Example:
 
@@ -30,7 +30,8 @@ type StepUpdateConfig struct {
 	Attribute string `cli:"arg:0" label:"attribute" validate:"required"`
 	Value     string `cli:"arg:1" label:"value"`
 	Append    bool   `cli:"append"`
-	Job       string `cli:"job" validate:"required"`
+	StepOrKey string `cli:"step" validate:"required"`
+	Build     string `cli:"build"`
 
 	// Global flags
 	Debug   bool   `cli:"debug"`
@@ -50,10 +51,16 @@ var StepUpdateCommand = cli.Command{
 	Description: StepUpdateHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{
-			Name:   "job",
+			Name:   "step",
 			Value:  "",
-			Usage:  "Target the step of a specific job in the build",
-			EnvVar: "BUILDKITE_JOB_ID",
+			Usage:  "The step to update. Can be either it's ID (BUILDKITE_STEP_ID) or key (BUILDKITE_STEP_KEY)",
+			EnvVar: "BUILDKITE_STEP_ID",
+		},
+		cli.StringFlag{
+			Name:   "build",
+			Value:  "",
+			Usage:  "The build to look for the step in. Only required when targeting a step using it's key (BUILDKITE_STEP_KEY)",
+			EnvVar: "BUILDKITE_BUILD_ID",
 		},
 		cli.BoolFlag{
 			Name:   "append",
@@ -104,19 +111,20 @@ var StepUpdateCommand = cli.Command{
 		// Generate a UUID that will identifiy this change. We do this
 		// outside of the retry loop because we want this UUID to be
 		// the same for each attempt at updating the step.
-		uuid := api.NewUUID()
+		idempotencyUUID := api.NewUUID()
 
 		// Create the value to update
 		update := &api.StepUpdate{
-			UUID:      uuid,
-			Attribute: cfg.Attribute,
-			Value:     cfg.Value,
-			Append:    cfg.Append,
+			IdempotencyUUID: idempotencyUUID,
+			Build:           cfg.Build,
+			Attribute:       cfg.Attribute,
+			Value:           cfg.Value,
+			Append:          cfg.Append,
 		}
 
 		// Post the change
 		err := retry.Do(func(s *retry.Stats) error {
-			resp, err := client.StepUpdate(cfg.Job, update)
+			resp, err := client.StepUpdate(cfg.StepOrKey, update)
 			if resp != nil && (resp.StatusCode == 400 || resp.StatusCode == 401 || resp.StatusCode == 404) {
 				s.Break()
 			}

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -47,7 +47,7 @@ type StepUpdateConfig struct {
 
 var StepUpdateCommand = cli.Command{
 	Name:        "update",
-	Usage:       "Change an attribute on a step",
+	Usage:       "Change the value of an attribute",
 	Description: StepUpdateHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{

--- a/main.go
+++ b/main.go
@@ -91,8 +91,9 @@ func main() {
 		},
 		{
 			Name:  "step",
-			Usage: "Make changes to a step (this includes any jobs that were created from the step)",
+			Usage: "Get or update an attribute of a build step",
 			Subcommands: []cli.Command{
+				clicommand.StepGetCommand,
 				clicommand.StepUpdateCommand,
 			},
 		},


### PR DESCRIPTION
Currently `step update` works by updating a step associated with a job. This means you can't update steps that aren't commands (blocks, waits, etc).

This change switches the arguments for `step update` from `--job` to `--step`. `BUILDKITE_STEP_ID` is the value it uses as a default.

As a bonus, you can now pass in `--step key` (instead of an ID), since it's a bit of a pain to figure out the ID of another step in the pipeline.