### PR TITLE
allow gs_downloader to use GS_APPLICATION_CREDENTIALS

### DIFF
--- a/agent/gs_downloader.go
+++ b/agent/gs_downloader.go
@@ -1,13 +1,11 @@
 package agent
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/buildkite/agent/logger"
-	"golang.org/x/oauth2/google"
 	storage "google.golang.org/api/storage/v1"
 )
 
@@ -45,7 +43,7 @@ func NewGSDownloader(l logger.Logger, c GSDownloaderConfig) *GSDownloader {
 }
 
 func (d GSDownloader) Start() error {
-	client, err := google.DefaultClient(context.Background(), storage.DevstorageReadOnlyScope)
+	client, err := newGoogleClient(storage.DevstorageReadOnlyScope)
 	if err != nil {
 		return errors.New(fmt.Sprintf("Error creating Google Cloud Storage client: %v", err))
 	}


### PR DESCRIPTION
Behind our firewall, the default google client will explode when performing some operations. This PR is to address that issue by allow us to authenticate during the download process with the client. By not using the default client, we're able to download protected artifacts and bypass the firewall restriction.

Let me know if we have any problems/questions, and thanks!