### PR TITLE
Add a fetch-only option for the git mirror experiment

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -9,6 +9,7 @@ type AgentConfiguration struct {
 	HooksPath                  string
 	GitMirrorsPath             string
 	GitMirrorsLockTimeout      int
+	GitMirrorsFetchOnly        bool
 	PluginsPath                string
 	GitCloneFlags              string
 	GitCloneMirrorFlags        string

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1045,8 +1045,15 @@ func (b *Bootstrap) updateGitMirror() (string, error) {
 	}
 
 	// Update our mirror
-	if err := b.shell.Run("git", "--git-dir", mirrorDir, "remote", "update", "--prune"); err != nil {
-		return "", err
+	if b.GitMirrorsFetchOnly {
+		gitFetchFlags := fmt.Sprintf("--git-dir '%s' %s", mirrorDir, b.GitFetchFlags)
+		if err := gitFetch(b.shell, gitFetchFlags, "origin", b.Branch); err != nil {
+			return "", err
+		}
+	} else {
+		if err := b.shell.Run("git", "--git-dir", mirrorDir, "remote", "update", "--prune"); err != nil {
+			return "", err
+		}
 	}
 
 	return mirrorDir, nil

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -70,6 +70,9 @@ type Config struct {
 	// Flags to pass to "git clone" command for mirroring
 	GitCloneMirrorFlags string
 
+	// Use "git fetch" rather than "git remote update" -- wise if you have a large number of branches
+	GitMirrorsFetchOnly bool
+
 	// Flags to pass to "git clean" command
 	GitCleanFlags string `env:"BUILDKITE_GIT_CLEAN_FLAGS"`
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -70,6 +70,7 @@ type AgentStartConfig struct {
 	GitFetchFlags              string   `cli:"git-fetch-flags"`
 	GitMirrorsPath             string   `cli:"git-mirrors-path" normalize:"filepath"`
 	GitMirrorsLockTimeout      int      `cli:"git-mirrors-lock-timeout"`
+	GitMirrorsFetchOnly        bool     `cli:"git-mirrors-fetch-only"`
 	NoGitSubmodules            bool     `cli:"no-git-submodules"`
 	NoSSHKeyscan               bool     `cli:"no-ssh-keyscan"`
 	NoCommandEval              bool     `cli:"no-command-eval"`
@@ -525,6 +526,7 @@ var AgentStartCommand = cli.Command{
 			BuildPath:                  cfg.BuildPath,
 			GitMirrorsPath:             cfg.GitMirrorsPath,
 			GitMirrorsLockTimeout:      cfg.GitMirrorsLockTimeout,
+			GitMirrorsFetchOnly:        cfg.GitMirrorsFetchOnly,
 			HooksPath:                  cfg.HooksPath,
 			PluginsPath:                cfg.PluginsPath,
 			GitCloneFlags:              cfg.GitCloneFlags,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -66,6 +66,7 @@ type BootstrapConfig struct {
 	GitCleanFlags                string   `cli:"git-clean-flags"`
 	GitMirrorsPath               string   `cli:"git-mirrors-path" normalize:"filepath"`
 	GitMirrorsLockTimeout        int      `cli:"git-mirrors-lock-timeout"`
+	GitMirrorsFetchOnly          bool     `cli:"git-mirrors-fetch-only"`
 	BinPath                      string   `cli:"bin-path" normalize:"filepath"`
 	BuildPath                    string   `cli:"build-path" normalize:"filepath"`
 	HooksPath                    string   `cli:"hooks-path" normalize:"filepath"`
@@ -359,6 +360,7 @@ var BootstrapCommand = cli.Command{
 			BuildPath:                    cfg.BuildPath,
 			GitMirrorsPath:               cfg.GitMirrorsPath,
 			GitMirrorsLockTimeout:        cfg.GitMirrorsLockTimeout,
+			GitMirrorsFetchOnly:          cfg.GitMirrorsFetchOnly,
 			BinPath:                      cfg.BinPath,
 			HooksPath:                    cfg.HooksPath,
 			PluginsPath:                  cfg.PluginsPath,


### PR DESCRIPTION
The git mirror experiment currently calls `git remote update` as the primary update command. When the repository has a large number of branches (n > 10,000) this operation significantly slows down the server (especially with many parallel builds).

This PR adds an option which will optionally (must opt-in) call `git fetch origin refspec` instead of `git remote update`. This is essentially the same call except that `git fetch` only operates on one branch. This makes much less work for the server in the case of many branches.

And in case anyone asks, yes this is actually a concern for my team on the project we work with. We're running in to these limitations daily.