### PR TITLE
Add --include-retried-jobs to artifact download/shasum

### DIFF
--- a/agent/artifact_downloader.go
+++ b/agent/artifact_downloader.go
@@ -22,6 +22,9 @@ type ArtifactDownloaderConfig struct {
 	// Which step should we look at for the jobs
 	Step string
 
+	// Whether to include artifacts from retried jobs in the search
+	IncludeRetriedJobs bool
+
 	// Where we'll be downloading artifacts to
 	Destination string
 
@@ -62,7 +65,7 @@ func (a *ArtifactDownloader) Download() error {
 
 	// Find the artifacts that we want to download
 	artifacts, err := NewArtifactSearcher(a.logger, a.apiClient, a.conf.BuildID).
-		Search(a.conf.Query, a.conf.Step)
+		Search(a.conf.Query, a.conf.Step, a.conf.IncludeRetriedJobs)
 	if err != nil {
 		return err
 	}

--- a/agent/artifact_searcher.go
+++ b/agent/artifact_searcher.go
@@ -24,7 +24,7 @@ func NewArtifactSearcher(l logger.Logger, ac APIClient, buildID string) *Artifac
 	}
 }
 
-func (a *ArtifactSearcher) Search(query string, scope string) ([]*api.Artifact, error) {
+func (a *ArtifactSearcher) Search(query string, scope string, includeRetriedJobs bool) ([]*api.Artifact, error) {
 	if scope == "" {
 		a.logger.Info("Searching for artifacts: \"%s\"", query)
 	} else {
@@ -32,8 +32,9 @@ func (a *ArtifactSearcher) Search(query string, scope string) ([]*api.Artifact, 
 	}
 
 	artifacts, _, err := a.apiClient.SearchArtifacts(a.buildID, &api.ArtifactSearchOptions{
-		Query: query,
-		Scope: scope,
+		Query:              query,
+		Scope:              scope,
+		IncludeRetriedJobs: includeRetriedJobs,
 	})
 
 	return artifacts, err

--- a/api/artifacts.go
+++ b/api/artifacts.go
@@ -64,8 +64,9 @@ type ArtifactBatchCreateResponse struct {
 // ArtifactSearchOptions specifies the optional parameters to the
 // ArtifactsService.Search method.
 type ArtifactSearchOptions struct {
-	Query string `url:"query,omitempty"`
-	Scope string `url:"scope,omitempty"`
+	Query              string `url:"query,omitempty"`
+	Scope              string `url:"scope,omitempty"`
+	IncludeRetriedJobs bool   `url:"include_retried_jobs,omitempty"`
 }
 
 type ArtifactBatchUpdateArtifact struct {

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -34,10 +34,11 @@ Example:
    You can also use the step's jobs id (provided by the environment variable $BUILDKITE_JOB_ID)`
 
 type ArtifactDownloadConfig struct {
-	Query       string `cli:"arg:0" label:"artifact search query" validate:"required"`
-	Destination string `cli:"arg:1" label:"artifact download path" validate:"required"`
-	Step        string `cli:"step"`
-	Build       string `cli:"build" validate:"required"`
+	Query              string `cli:"arg:0" label:"artifact search query" validate:"required"`
+	Destination        string `cli:"arg:1" label:"artifact download path" validate:"required"`
+	Step               string `cli:"step"`
+	Build              string `cli:"build" validate:"required"`
+	IncludeRetriedJobs bool   `cli:"include-retried-jobs"`
 
 	// Global flags
 	Debug   bool   `cli:"debug"`
@@ -66,6 +67,11 @@ var ArtifactDownloadCommand = cli.Command{
 			Value:  "",
 			EnvVar: "BUILDKITE_BUILD_ID",
 			Usage:  "The build that the artifacts were uploaded to",
+		},
+		cli.BoolFlag{
+			Name:   "include-retried-jobs",
+			EnvVar: "BUILDKITE_AGENT_INCLUDE_RETRIED_JOBS",
+			Usage:  "Include artifacts from retried jobs in the search",
 		},
 
 		// API Flags
@@ -99,11 +105,12 @@ var ArtifactDownloadCommand = cli.Command{
 
 		// Setup the downloader
 		downloader := agent.NewArtifactDownloader(l, client, agent.ArtifactDownloaderConfig{
-			Query:       cfg.Query,
-			Destination: cfg.Destination,
-			BuildID:     cfg.Build,
-			Step:        cfg.Step,
-			DebugHTTP:   cfg.DebugHTTP,
+			Query:              cfg.Query,
+			Destination:        cfg.Destination,
+			BuildID:            cfg.Build,
+			Step:               cfg.Step,
+			IncludeRetriedJobs: cfg.IncludeRetriedJobs,
+			DebugHTTP:          cfg.DebugHTTP,
 		})
 
 		// Download the artifacts

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -37,9 +37,10 @@ Example:
    You can also use the step's job id (provided by the environment variable $BUILDKITE_JOB_ID)`
 
 type ArtifactShasumConfig struct {
-	Query string `cli:"arg:0" label:"artifact search query" validate:"required"`
-	Step  string `cli:"step"`
-	Build string `cli:"build" validate:"required"`
+	Query              string `cli:"arg:0" label:"artifact search query" validate:"required"`
+	Step               string `cli:"step"`
+	Build              string `cli:"build" validate:"required"`
+	IncludeRetriedJobs bool   `cli:"include-retried-jobs"`
 
 	// Global flags
 	Debug   bool   `cli:"debug"`
@@ -68,6 +69,11 @@ var ArtifactShasumCommand = cli.Command{
 			Value:  "",
 			EnvVar: "BUILDKITE_BUILD_ID",
 			Usage:  "The build that the artifacts were uploaded to",
+		},
+		cli.BoolFlag{
+			Name:   "include-retried-jobs",
+			EnvVar: "BUILDKITE_AGENT_INCLUDE_RETRIED_JOBS",
+			Usage:  "Include artifacts from retried jobs in the search",
 		},
 
 		// API Flags
@@ -102,7 +108,7 @@ var ArtifactShasumCommand = cli.Command{
 		// Find the artifact we want to show the SHASUM for
 		searcher := agent.NewArtifactSearcher(l, client, cfg.Build)
 
-		artifacts, err := searcher.Search(cfg.Query, cfg.Step)
+		artifacts, err := searcher.Search(cfg.Query, cfg.Step, cfg.IncludeRetriedJobs)
 		if err != nil {
 			l.Fatal("Failed to find artifacts: %s", err)
 		}


### PR DESCRIPTION
By default, jobs that are retried are excluded from `buildkite-agent artifact download` searches. This adds support for searching retried jobs when downloading/shasumming with a new `--include-retried-jobs` CLI argument.