### PR TITLE
Add ansi timestamp output experiment

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -25,3 +25,9 @@ Maintain a single bare git mirror with for each repository on a host that is sha
 You must set a `git-mirrors-path` in your config for this to work.
 
 **Status**: broadly useful, we'd like this to be the standard behaviour in 4.0. 👍👍
+
+### `ansi-timestamps`
+
+Outputs inline ANSI timestamps for each line of log output which enables toggle-able timestamps in the Buildkite UI.
+
+**Status**: broadly useful, we'd like this to be the standard behaviour in 4.0. 👍👍

--- a/go.mod
+++ b/go.mod
@@ -39,3 +39,5 @@ require (
 	google.golang.org/grpc v0.0.0-20170216003643-d0c32ee6a441 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )
+
+go 1.13

--- a/process/prefixer.go
+++ b/process/prefixer.go
@@ -1,0 +1,56 @@
+package process
+
+import (
+	"bytes"
+	"io"
+)
+
+type Prefixer struct {
+	w       io.Writer
+	f       func() string
+	initial bool
+}
+
+func NewPrefixer(w io.Writer, f func() string) *Prefixer {
+	return &Prefixer{
+		w:       w,
+		f:       f,
+		initial: true,
+	}
+}
+
+func (p *Prefixer) Write(data []byte) (n int, err error) {
+	// if not already written, write the initial prefix
+	if p.initial {
+		n, err := p.w.Write([]byte(p.f()))
+		if err != nil {
+			return n, err
+		}
+		p.initial = false
+	}
+
+	offset := 0
+	out := make([]byte, 0, len(data))
+
+	// loop through newlines
+	for offset < len(data) {
+		next := bytes.IndexRune(data[offset:], '\n')
+		if next == -1 {
+			break
+		}
+		out = append(out, data[offset:offset+next+1]...)
+		out = append(out, []byte(p.f())...)
+		offset = offset + next + 1
+	}
+
+	// add any left overs
+	if offset < len(data) {
+		out = append(out, data[offset:]...)
+	}
+
+	if _, err := p.w.Write(out); err != nil {
+		return 0, err
+	}
+
+	return len(data), nil
+}

--- a/process/prefixer_test.go
+++ b/process/prefixer_test.go
@@ -1,0 +1,46 @@
+package process_test
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/buildkite/agent/process"
+)
+
+func TestPrefixer(t *testing.T) {
+	var lineCounter int32
+	var input string = "blah\nblergh\n\nnope\n"
+	var out = &bytes.Buffer{}
+
+	pw := process.NewPrefixer(out, func() string {
+		lineNumber := atomic.AddInt32(&lineCounter, 1)
+		return fmt.Sprintf("#%d: ", lineNumber)
+	})
+
+	n, err := pw.Write([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expected := len(input); n != expected {
+		t.Fatalf("Short write: %d vs expected %d", n, expected)
+	}
+
+	lines := strings.Split(out.String(), "\n")
+
+	var expected = []string{
+		`#1: blah`,
+		`#2: blergh`,
+		`#3: `,
+		`#4: nope`,
+		`#5: `,
+	}
+
+	if !reflect.DeepEqual(expected, lines) {
+		t.Fatalf("Lines was unexpected:\nWanted: %v\nGot: %v\n", expected, lines)
+	}
+}


### PR DESCRIPTION
Currently, we calculate timing information in the Buildkite UI by sending a stream of timestamps from when headers are output. This can lead to some weird bugs with time skew and at best shows time elapsed between headers.

This change uses invisible ANSI control codes at the start of every line to send more granular timing information to Buildkite, which allows for magically toggling in the UI:

![](https://user-images.githubusercontent.com/25882/66519126-66f90a00-eb32-11e9-9f9c-2a2533530efa.gif)

This also disables sending header timing information. 

The aim is for this to be the default in 4.0.