### PR TITLE
Fetch only branch vs remote update

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1078,8 +1078,8 @@ func (b *Bootstrap) updateGitMirror() (string, error) {
 		return "", err
 	}
 
-	// Update our mirror
-	if err := b.shell.Run("git", "--git-dir", mirrorDir, "remote", "update", "--prune"); err != nil {
+	// Fetch the build branch from the upstream repository into the mirror.
+	if err := b.shell.Run("git", "--git-dir", mirrorDir, "fetch", "origin", b.Branch); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
This changes the default for the `git-mirrors` experiment to fetch only the branch vs a full `git remote update`. As reported in #1100, this can be a hugely expensive operation in large repositories.

---

_@pda update:_ Closes #1100 — this is the same idea, but without being user configurable.