### PR TITLE
Propagate signals in intermediate bash shells

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1479,7 +1479,7 @@ func isPosixShell(shell []string) bool {
 	}
 
 	switch bin {
-	case `bash`, `sh`, `zsh`, `ksh`:
+	case `bash`, `sh`, `zsh`, `ksh`, `dash`:
 		return true
 	default:
 		return false

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1435,7 +1435,7 @@ func (b *Bootstrap) defaultCommandPhase() error {
 		cmdToExec = fmt.Sprintf(".%c%s", os.PathSeparator, scriptPath)
 	} else {
 		b.shell.Headerf("Running commands")
-		cmdToExec = fmt.Sprintf(`trap 'kill -- $$' INT TERM QUIT; %s`, b.Command)
+		cmdToExec = b.Command
 	}
 
 	// Support deprecated BUILDKITE_DOCKER* env vars
@@ -1444,6 +1444,11 @@ func (b *Bootstrap) defaultCommandPhase() error {
 			b.shell.Commentf("Detected deprecated docker environment variables")
 		}
 		return runDeprecatedDockerIntegration(b.shell, []string{cmdToExec})
+	} else if !commandIsScript {
+
+		// If we aren't running a script and we aren't running the command in our deprecated docker integration
+		// this adds a trap to ensure that an intermediate shell doesn't swallow signals from cancellation
+		cmdToExec = fmt.Sprintf(`trap 'kill -- $$' INT TERM QUIT; %s`, cmdToExec)
 	}
 
 	if redactor := b.setupRedactor(); redactor != nil {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1435,7 +1435,7 @@ func (b *Bootstrap) defaultCommandPhase() error {
 		cmdToExec = fmt.Sprintf(".%c%s", os.PathSeparator, scriptPath)
 	} else {
 		b.shell.Headerf("Running commands")
-		cmdToExec = b.Command
+		cmdToExec = fmt.Sprintf(`trap 'kill -- $$' INT TERM QUIT; %s`, b.Command)
 	}
 
 	// Support deprecated BUILDKITE_DOCKER* env vars


### PR DESCRIPTION
If you execute multiple commands, e.g:

```yaml
steps:
  -label: "My commands" 
   commands:
     - ./process1
     - ./process2
```

then we join them together in a single bash shell as `/bin/bash -e -c './process1\b./process2`, which has the side effect of creating an intermediate shell in between the bootstrap process and your commands. By default, most shells won't automatically propagate signals to subprocesses, so when the job is cancelled the signal gets lost in this intermediate shell. 

This could be manually fixed by adding a trap as the first command:

```yaml
steps:
  -label: "My commands" 
   commands:
     - trap "kill -- \$\$" TERM QUIT INT
     - ./process1
     - ./process2
```

That ends up kind of noisy and for those not versed in shell voodoo, confusing. 

This PR automatically adds this into non-script commands. 
