### PR TITLE
Download absolute-path artifacts to correct path

### DIFF
--- a/agent/artifact_downloader_test.go
+++ b/agent/artifact_downloader_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/logger"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestArtifactDownloaderConnectsToEndpoint(t *testing.T) {
@@ -38,11 +39,51 @@ func TestArtifactDownloaderConnectsToEndpoint(t *testing.T) {
 	})
 
 	d := NewArtifactDownloader(logger.Discard, ac, ArtifactDownloaderConfig{
-		BuildID: "my-build",
+		Destination: ".",
+		BuildID:     "my-build",
 	})
 
 	err := d.Download()
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestArtifactDownloaderHandlesAbsolutePaths(t *testing.T) {
+	defer os.RemoveAll("/tmp/agent-artifact-download")
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case `/builds/my-build/artifacts/search`:
+			fmt.Fprintf(rw, `[{
+				"id": "4600ac5c-5a13-4e92-bb83-f86f218f7b32",
+				"file_size": 3,
+				"absolute_path": "/tmp/agent-artifact-download/llamas.txt",
+				"path": "/tmp/agent-artifact-download/llamas.txt",
+				"url": "http://%s/download"
+			}]`, req.Host)
+		case `/download`:
+			fmt.Fprintln(rw, "OK")
+		default:
+			http.Error(rw, "Not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	ac := api.NewClient(logger.Discard, api.Config{
+		Endpoint: server.URL,
+		Token:    `llamasforever`,
+	})
+
+	d := NewArtifactDownloader(logger.Discard, ac, ArtifactDownloaderConfig{
+		Destination: ".",
+		BuildID:     "my-build",
+	})
+
+	err := d.Download()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.FileExists(t, "/tmp/agent-artifact-download/llamas.txt")
 }

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -26,6 +26,21 @@ Example:
    This will search across all the artifacts for the build with files that match that part.
    The first argument is the search query, and the second argument is the download destination.
 
+   The exact location to which an artifact will be downloaded will be the concatenation of the
+   specified download destination and the path to the artifact when it was uploaded. Artifacts
+   uploaded with an absolute path will be downloaded to the exact same absolute path, ignoring the
+   download destination. Examples:
+
+   $ buildkite-agent artifact upload "pkg/archive.tar.gz"
+   $ buildkite-agent artifact download "pkg/*.tar.gz" "$WORKDIR"
+
+   will result in the artifact being downloaded to "$WORKDIR/pkg/archive.tar.gz".
+
+   $ buildkite-agent artifact upload "/tmp/pkg/*.tar.gz"
+   $ buildkite-agent artifact download "/tmp/pkg/*.tar.gz" "$WORKDIR"
+
+   will instead result in the artifact to be downloaded to "/tmp/pkg/archive.tar.gz".
+
    If you're trying to download a specific file, and there are multiple artifacts from different
    jobs, you can target the particular job you want to download the artifact from:
 


### PR DESCRIPTION
The handling of artifacts uploaded with absolute paths is currently
undefined and resulted in it being handled as a relative path instead.

We add explicit handling of absolute paths. The download configuration
of such artifacts still requires a download path to be specified as the
nature of paths of artifacts that will end up being downloaded can only
be determined at runtime.

We also add a new test to prevent regression of the newly implemented
behaviour as well explicit documentation in the CLI help.

Fixes #1035.