### PR TITLE
add powershell support for hooks

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -282,7 +282,7 @@ func (b *Bootstrap) applyEnvironmentChanges(environ *env.Environment, dir string
 func (b *Bootstrap) findHookFile(hookDir string, name string) (string, error) {
 	if runtime.GOOS == "windows" {
 		// check for windows types first
-		if p, err := shell.LookPath(name, hookDir, ".BAT;.CMD"); err == nil {
+		if p, err := shell.LookPath(name, hookDir, ".BAT;.CMD;.PS1"); err == nil {
 			return p, nil
 		}
 	}

--- a/bootstrap/hook.go
+++ b/bootstrap/hook.go
@@ -51,6 +51,7 @@ func newHookScriptWrapper(hookPath string) (*hookScriptWrapper, error) {
 	var scriptFileName string = `buildkite-agent-bootstrap-hook-runner`
 	var isBashHook bool
 	var isPwshHook bool
+	var isWindows = runtime.GOOS == "windows"
 
 	// we use bash hooks for scripts with no extension, otherwise on windows
 	// we probably need a .bat extension
@@ -100,7 +101,7 @@ func newHookScriptWrapper(hookPath string) (*hookScriptWrapper, error) {
 
 	// Create the hook runner code
 	var script string
-	if runtime.GOOS == "windows" && !isBashHook && !isPwshHook {
+	if isWindows && !isBashHook && !isPwshHook {
 		script = "@echo off\n" +
 			"SETLOCAL ENABLEDELAYEDEXPANSION\n" +
 			"SET > \"" + h.beforeEnvFile.Name() + "\"\n" +
@@ -109,14 +110,14 @@ func newHookScriptWrapper(hookPath string) (*hookScriptWrapper, error) {
 			"SET " + hookWorkingDirEnv + "=%CD%\n" +
 			"SET > \"" + h.afterEnvFile.Name() + "\"\n" +
 			"EXIT %" + hookExitStatusEnv + "%"
-	} else if runtime.GOOS == "windows" && isPwshHook {
-		script = "$ErrorActionPreference = \"STOP\"\n" +
-			"Get-ChildItem Env: | Foreach-Object {\"$($_.Name)=$($_.Value)\"} | Set-Content \"" + h.beforeEnvFile.Name() + "\"\n" +
-			absolutePathToHook + "\n" +
-			"if ($LASTEXITCODE -eq $null) {$Env:" + hookExitStatusEnv + " = 0} else {$Env:" + hookExitStatusEnv + " = $LASTEXITCODE}\n" +
-			"$Env:" + hookWorkingDirEnv + " = $PWD | Select-Object -ExpandProperty Path\n" +
-			"Get-ChildItem Env: | Foreach-Object {\"$($_.Name)=$($_.Value)\"} | Set-Content \"" + h.afterEnvFile.Name() + "\"\n" +
-			"exit $Env:" + hookExitStatusEnv
+	} else if isWindows && isPwshHook {
+		script = `$ErrorActionPreference = "STOP"\n` +
+			`Get-ChildItem Env: | Foreach-Object {$($_.Name)=$($_.Value)"} | Set-Content "` + h.beforeEnvFile.Name() + `\n` +
+			absolutePathToHook + `\n` +
+			`if ($LASTEXITCODE -eq $null) {$Env:` + hookExitStatusEnv + ` = 0} else {$Env:` + hookExitStatusEnv + ` = $LASTEXITCODE}\n` +
+			`$Env:` + hookWorkingDirEnv + ` = $PWD | Select-Object -ExpandProperty Path\n` +
+			`Get-ChildItem Env: | Foreach-Object {"$($_.Name)=$($_.Value)"} | Set-Content "` + h.afterEnvFile.Name() + `"\n` +
+			`exit $Env:` + hookExitStatusEnv
 	} else {
 		script = "export -p > \"" + filepath.ToSlash(h.beforeEnvFile.Name()) + "\"\n" +
 			". \"" + filepath.ToSlash(absolutePathToHook) + "\"\n" +

--- a/bootstrap/hook.go
+++ b/bootstrap/hook.go
@@ -110,7 +110,7 @@ func newHookScriptWrapper(hookPath string) (*hookScriptWrapper, error) {
 			"SET > \"" + h.afterEnvFile.Name() + "\"\n" +
 			"EXIT %" + hookExitStatusEnv + "%"
 	} else if runtime.GOOS == "windows" && isPwshHook {
-		script = "$ErrorActionPreference = \"STOP\"" +
+		script = "$ErrorActionPreference = \"STOP\"\n" +
 			"Get-ChildItem Env: | Foreach-Object {\"$($_.Name)=$($_.Value)\"} | Set-Content \"" + h.beforeEnvFile.Name() + "\"\n" +
 			absolutePathToHook + "\n" +
 			"if ($LASTEXITCODE -eq $null) {$Env:" + hookExitStatusEnv + " = 0} else {$Env:" + hookExitStatusEnv + " = $LASTEXITCODE}\n" +

--- a/bootstrap/hook.go
+++ b/bootstrap/hook.go
@@ -60,7 +60,7 @@ func newHookScriptWrapper(hookPath string) (*hookScriptWrapper, error) {
 		scriptFileName += ".ps1"
 	} else if filepath.Ext(hookPath) == "" {
 		isBashHook = true
-	} else if runtime.GOOS == "windows" {
+	} else if isWindows {
 		scriptFileName += ".bat"
 	}
 

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -252,6 +252,7 @@ func (s *Shell) RunScript(path string, extra *env.Environment) error {
 
 	var isBash = filepath.Ext(path) == "" || filepath.Ext(path) == ".sh"
 	var isWindows = runtime.GOOS == "windows"
+	var isPwsh = filepath.Ext(path) == ".ps1"
 
 	switch {
 	case isWindows && isBash:
@@ -267,9 +268,18 @@ func (s *Shell) RunScript(path string, extra *env.Environment) error {
 		command = bashPath
 		args = []string{"-c", filepath.ToSlash(path)}
 
+	case isWindows && isPwsh:
+		if s.Debug {
+			s.Commentf("Attempting to run %s with Powershell", path)
+		}
+		command = "powershell.exe"
+		args = []string{"-file", path}
+
+
 	case !isWindows && isBash:
 		command = "/bin/bash"
 		args = []string{"-c", path}
+
 
 	default:
 		command = path

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -280,7 +280,6 @@ func (s *Shell) RunScript(path string, extra *env.Environment) error {
 		command = "/bin/bash"
 		args = []string{"-c", path}
 
-
 	default:
 		command = path
 		args = []string{}


### PR DESCRIPTION
This adds the ability to write native powershell hooks for windows pipelines so that executing a batch file to call a powershell script is unnecessary.  The hook still creates a batch file to handle any new environment variables and pass the exit status properly.