### PR TITLE
Detect ansi clear lines and add ansi timestamps

### DIFF
--- a/process/prefixer.go
+++ b/process/prefixer.go
@@ -3,6 +3,8 @@ package process
 import (
 	"bytes"
 	"io"
+	"log"
+	"unicode/utf8"
 )
 
 type Prefixer struct {
@@ -32,19 +34,40 @@ func (p *Prefixer) Write(data []byte) (n int, err error) {
 	offset := 0
 	out := make([]byte, 0, len(data))
 
-	// loop through newlines
-	for offset < len(data) {
-		next := bytes.IndexRune(data[offset:], '\n')
+	// loop through line breaks and add prefix
+	for l := len(data); offset < l; {
+		// find either a newline or an escape char
+		next := bytes.IndexAny(data[offset:], "\n\x1b")
 		if next == -1 {
 			break
 		}
-		out = append(out, data[offset:offset+next+1]...)
-		out = append(out, []byte(p.f())...)
-		offset = offset + next + 1
+
+		// decode the first rune in the string of the match
+		r, _ := utf8.DecodeRune(data[offset+next:])
+		switch r {
+		case '\n':
+			out = append(out, data[offset:offset+next+1]...)
+			out = append(out, []byte(p.f())...)
+			offset = offset + next + 1
+		case '\x1b':
+			// match a clear line escape
+			if bytes.HasPrefix(data[offset+next+1:], []byte("[K")) {
+				out = append(out, data[offset:offset+next+3]...)
+				out = append(out, []byte(p.f())...)
+				offset = offset + next + 3
+			} else {
+				out = append(out, data[offset:offset+next+1]...)
+				offset = offset + next + 1
+			}
+		default:
+			out = append(out, data[offset:offset+next+1]...)
+			offset = offset + next + 1
+		}
 	}
 
 	// add any left overs
 	if offset < len(data) {
+		log.Printf("Found leftovers %q", data[offset:])
 		out = append(out, data[offset:]...)
 	}
 

--- a/process/prefixer_test.go
+++ b/process/prefixer_test.go
@@ -16,6 +16,8 @@ func TestPrefixer(t *testing.T) {
 	}{
 		{"alpacas\nllamas\n", "#1: alpacas\n#2: llamas\n#3: "},
 		{"blah\x1b[Kbler\x1bgh", "#1: blah\x1b[K#2: bler\x1bgh"},
+		{"blah\x1b[2Kblergh", "#1: blah\x1b[2K#2: blergh"},
+		{"blah\x1b[1B\x1b[1A\x1b[2Kblergh", "#1: blah\x1b[1B\x1b[1A\x1b[2K#2: blergh"},
 	} {
 		tc := tc
 		t.Run("", func(tt *testing.T) {

--- a/process/prefixer_test.go
+++ b/process/prefixer_test.go
@@ -3,44 +3,42 @@ package process_test
 import (
 	"bytes"
 	"fmt"
-	"reflect"
-	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/buildkite/agent/v3/process"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPrefixer(t *testing.T) {
-	var lineCounter int32
-	var input string = "blah\nblergh\n\nnope\n"
-	var out = &bytes.Buffer{}
+	for _, tc := range []struct {
+		input, expected string
+	}{
+		{"alpacas\nllamas\n", "#1: alpacas\n#2: llamas\n#3: "},
+		{"blah\x1b[Kbler\x1bgh", "#1: blah\x1b[K#2: bler\x1bgh"},
+	} {
+		tc := tc
+		t.Run("", func(tt *testing.T) {
+			tt.Parallel()
 
-	pw := process.NewPrefixer(out, func() string {
-		lineNumber := atomic.AddInt32(&lineCounter, 1)
-		return fmt.Sprintf("#%d: ", lineNumber)
-	})
+			var lineCounter int32
+			var out = &bytes.Buffer{}
 
-	n, err := pw.Write([]byte(input))
-	if err != nil {
-		t.Fatal(err)
-	}
+			pw := process.NewPrefixer(out, func() string {
+				lineNumber := atomic.AddInt32(&lineCounter, 1)
+				return fmt.Sprintf("#%d: ", lineNumber)
+			})
 
-	if expected := len(input); n != expected {
-		t.Fatalf("Short write: %d vs expected %d", n, expected)
-	}
+			n, err := pw.Write([]byte(tc.input))
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	lines := strings.Split(out.String(), "\n")
+			if expected := len(tc.input); n != expected {
+				tt.Fatalf("Short write: %d vs expected %d", n, expected)
+			}
 
-	var expected = []string{
-		`#1: blah`,
-		`#2: blergh`,
-		`#3: `,
-		`#4: nope`,
-		`#5: `,
-	}
-
-	if !reflect.DeepEqual(expected, lines) {
-		t.Fatalf("Lines was unexpected:\nWanted: %v\nGot: %v\n", expected, lines)
+			assert.Equal(tt, tc.expected, out.String())
+		})
 	}
 }


### PR DESCRIPTION
Currently the ANSI timestamps don't show up certain output (like docker) that uses creative ANSI control characters for cursor movements.

This detects things like `\x1b[K` which clears the current line and includes the ANSI timestamp technology. 