### PR TITLE
Revert "bump to servercore 1909"

### DIFF
--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -1,5 +1,5 @@
 ## Development docker image for buildkite-agent on windows
-FROM mcr.microsoft.com/windows/servercore:1909
+FROM mcr.microsoft.com/windows/servercore:1809
 
 ENV ChocolateyUseWindowsCompression false
 


### PR DESCRIPTION
This reverts commit 77e0ecad3bfa816118b9f28c8f1793a9ce2c99af.

It broke our CI environment which is Windows Server 2019. 