### PR TITLE
Building a CentOS 7.x Docker image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -180,6 +180,9 @@ steps:
   - name: ":docker: ubuntu build"
     command: ".buildkite/steps/build-docker-image.sh ubuntu"
 
+  - name: ":docker: centos build"
+    command: ".buildkite/steps/build-docker-image.sh centos"
+
   - name: ":debian: build"
     command: ".buildkite/steps/build-debian-packages.sh"
     artifact_paths: "deb/**/*"

--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ## This script can be run locally like this:
 ##
-## .buildkite/steps/build-docker-image.sh (alpine|ubuntu) (image tag) (codename) (version)
+## .buildkite/steps/build-docker-image.sh (alpine|ubuntu|centos) (image tag) (codename) (version)
 ## e.g: .buildkite/steps/build-docker-image.sh alpine buildkiteci/agent:lox-manual-build stable 3.1.1
 ##
 ## You can then publish that image with
@@ -54,7 +54,7 @@ codename="${3:-}"
 version="${4:-}"
 push="${PUSH_IMAGE:-true}"
 
-if [[ ! "$variant" =~ ^(alpine|ubuntu)$ ]] ; then
+if [[ ! "$variant" =~ ^(alpine|ubuntu|centos)$ ]] ; then
   echo "Unknown docker variant $variant"
   exit 1
 fi
@@ -88,6 +88,9 @@ alpine)
   ;;
 ubuntu)
   build_docker_image "$image_tag" "packaging/docker/ubuntu-linux"
+  ;;
+centos)
+  build_docker_image "$image_tag" "packaging/docker/centos-linux"
   ;;
 *)
   echo "Unknown variant $variant"

--- a/.buildkite/steps/extract-agent-version-metadata.sh
+++ b/.buildkite/steps/extract-agent-version-metadata.sh
@@ -8,6 +8,7 @@ full_agent_version="buildkite-agent version ${agent_version}, build ${build_vers
 # docker variants
 docker_alpine_image_tag="buildkiteci/agent:alpine-build-${BUILDKITE_BUILD_NUMBER}"
 docker_ubuntu_image_tag="buildkiteci/agent:ubuntu-build-${BUILDKITE_BUILD_NUMBER}"
+docker_centos_image_tag="buildkiteci/agent:centos-build-${BUILDKITE_BUILD_NUMBER}"
 
 is_prerelease=0
 if [[ "$agent_version" =~ (alpha|beta|rc) ]] ; then
@@ -19,6 +20,7 @@ echo "Agent version: $agent_version"
 echo "Build version: $build_version"
 echo "Docker Alpine Image Tag: $docker_alpine_image_tag"
 echo "Docker Ubuntu Image Tag: $docker_ubuntu_image_tag"
+echo "Docker CentOS Image Tag: $docker_centos_image_tag"
 echo "Is prerelease? $is_prerelease"
 
 buildkite-agent meta-data set "agent-version" "$agent_version"
@@ -26,4 +28,5 @@ buildkite-agent meta-data set "agent-version-full" "$full_agent_version"
 buildkite-agent meta-data set "agent-version-build" "$build_version"
 buildkite-agent meta-data set "agent-docker-image-alpine" "$docker_alpine_image_tag"
 buildkite-agent meta-data set "agent-docker-image-ubuntu" "$docker_ubuntu_image_tag"
+buildkite-agent meta-data set "agent-docker-image-centos" "$docker_centos_image_tag"
 buildkite-agent meta-data set "agent-is-prerelease" "$is_prerelease"

--- a/.buildkite/steps/publish-docker-image.sh
+++ b/.buildkite/steps/publish-docker-image.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ## This script can be run locally like this:
 ##
-## .buildkite/steps/publish-docker-image.sh (alpine|ubuntu) imagename (stable|experimental|unstable) <version> <build>
+## .buildkite/steps/publish-docker-image.sh (alpine|ubuntu|centos) imagename (stable|experimental|unstable) <version> <build>
 ## .buildkite/steps/publish-docker-image.sh alpine buildkiteci/agent:lox-manual-build stable 3.1.1
 
 dry_run() {

--- a/.buildkite/steps/publish-docker-images.sh
+++ b/.buildkite/steps/publish-docker-images.sh
@@ -17,7 +17,7 @@ fi
 version=$(buildkite-agent meta-data get "agent-version")
 build=$(buildkite-agent meta-data get "agent-version-build")
 
-for variant in "alpine" "ubuntu" ; do
+for variant in "alpine" "ubuntu" "centos" ; do
   echo "--- Getting docker image tag for $variant from build meta data"
   source_image=$(buildkite-agent meta-data get "agent-docker-image-$variant")
   echo "Docker Image Tag for $variant: $source_image"

--- a/.buildkite/steps/upload-release-steps.sh
+++ b/.buildkite/steps/upload-release-steps.sh
@@ -29,6 +29,7 @@ trigger_step() {
         agent-version-full:  "${full_agent_version}"
         agent-docker-image-alpine: "${agent_docker_image_alpine}"
         agent-docker-image-ubuntu: "${agent_docker_image_ubuntu}"
+        agent-docker-image-centos: "${agent_docker_image_centos}"
         agent-is-prerelease: "${agent_is_prerelease}"
       env:
         DRY_RUN: "${DRY_RUN:-false}"
@@ -75,6 +76,7 @@ build_version=$(buildkite-agent meta-data get "agent-version-build")
 full_agent_version=$(buildkite-agent meta-data get "agent-version-full")
 agent_docker_image_alpine=$(buildkite-agent meta-data get "agent-docker-image-alpine")
 agent_docker_image_ubuntu=$(buildkite-agent meta-data get "agent-docker-image-ubuntu")
+agent_docker_image_centos=$(buildkite-agent meta-data get "agent-docker-image-centos")
 agent_is_prerelease=$(buildkite-agent meta-data get "agent-is-prerelease")
 
 # If there is already a release (which means a tag), we want to avoid trying to create

--- a/packaging/docker/centos-linux/Dockerfile
+++ b/packaging/docker/centos-linux/Dockerfile
@@ -1,0 +1,37 @@
+FROM centos:7.7.1908
+
+RUN yum -y install \
+      curl \
+      ca-certificates \
+      bash \
+      git \
+      perl \
+      rsync \
+      openssh-clients \
+      curl \
+      crontabs \
+      epel-release \
+    && yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo \
+    && yum -y install docker-ce jq \
+    && yum clean all \
+    && rm -rf /var/cache/yum*
+
+RUN curl -Lfs -o /sbin/tini  https://github.com/krallin/tini/releases/download/v0.18.0/tini \
+    && chmod +x /sbin/tini \
+    && curl -Lfs https://github.com/docker/compose/releases/download/1.24.0/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/docker-compose
+
+ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \
+    PATH="/usr/local/bin:${PATH}"
+
+RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
+    && curl -Lfs -o /usr/local/bin/ssh-env-config.sh https://raw.githubusercontent.com/buildkite/docker-ssh-env-config/master/ssh-env-config.sh \
+    && chmod +x /usr/local/bin/ssh-env-config.sh
+
+COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
+COPY ./buildkite-agent /usr/local/bin/buildkite-agent
+COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
+
+VOLUME /buildkite
+ENTRYPOINT ["buildkite-agent-entrypoint"]
+CMD ["start"]

--- a/packaging/docker/centos-linux/buildkite-agent.cfg
+++ b/packaging/docker/centos-linux/buildkite-agent.cfg
@@ -1,0 +1,61 @@
+# The token from your Buildkite "Agents" page
+#token="xxx"
+
+# The name of the agent
+name="%hostname-%n"
+
+# The priority of the agent (higher priorities are assigned work first)
+# priority=1
+
+# Tags for the agent (default is "queue=default")
+# tags="key1=val2,key2=val2"
+
+# Include the host's EC2 meta-data as tags (instance-id, instance-type, and ami-id)
+# tags-from-ec2=true
+
+# Include the host's EC2 tags as tags
+# tags-from-ec2-tags=true
+
+# Include the host's Google Cloud instance meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
+# tags-from-gcp=true
+
+# Include the host's Google Cloud instance labels as tags
+# tags-from-gcp-labels=true
+
+# Path to a custom bootstrap command to run. By default this is `buildkite-agent bootstrap`.
+# This allows you to override the entire execution of a job. Generally you should use hooks instead!
+# See https://buildkite.com/docs/agent/hooks
+# bootstrap-script=""
+
+# Path to where the builds will run from
+build-path="/buildkite/builds"
+
+# Directory where the hook scripts are found
+hooks-path="/buildkite/hooks"
+
+# Directory where plugins will be installed
+plugins-path="/buildkite/plugins"
+
+# Flags to pass to the `git clone` command
+# git-clone-flags=-v
+
+# Flags to pass to the `git clean` command
+# git-clean-flags=-ffxdq
+
+# Do not run jobs within a pseudo terminal
+# no-pty=true
+
+# Don't automatically verify SSH fingerprints
+# no-automatic-ssh-fingerprint-verification=true
+
+# Don't allow this agent to run arbitrary console commands
+# no-command-eval=true
+
+# Don't allow this agent to run plugins
+# no-plugins=true
+
+# Enable debug mode
+# debug=true
+
+# Don't show colors in logging
+# no-color=true

--- a/packaging/docker/centos-linux/entrypoint.sh
+++ b/packaging/docker/centos-linux/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+DIR=/docker-entrypoint.d
+
+if [[ -d "$DIR" ]] ; then
+  echo "Executing scripts in $DIR"
+  /bin/run-parts --exit-on-error "$DIR"
+fi
+
+exec /sbin/tini -g -- ssh-env-config.sh /usr/local/bin/buildkite-agent "$@"


### PR DESCRIPTION
Creates a `buildkite/agent` docker image based on `centos:7.7.1908`.

Sadly, image size came out to be 757MB, compared to 466MB for the current `3.16.0-ubuntu` image. Suggestions for further size reduction welcome.

A couple of notes:

- `openssh-client` is `openssh-clients` on CentOS
- `crontabs` package is what provides `/bin/run-parts` used in the entrypoint
- CentOS does not provide `jq`, but EPEL does
- Both CentOS and EPEL have rather old docker versions, installing from `docker-ce` directly