### PR TITLE
Job Acquisition Technology™️

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -29,4 +29,5 @@ type AgentConfiguration struct {
 	Shell                      string
 	Profile                    string
 	RedactedVars               []string
+	AcquireJob                 string
 }

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -156,7 +156,7 @@ func (a *AgentWorker) Start(idleMonitor *IdleMonitor) error {
 		// there's really no point in letting the idle monitor know
 		// we're busy, but it's probably a good thing to do for good
 		// measure.
-		//idleMonitor.MarkBusy(a.agent.UUID)
+		idleMonitor.MarkBusy(a.agent.UUID)
 
 		return a.AcquireAndRunJob(a.agentConfiguration.AcquireJob)
 	} else {

--- a/agent/api.go
+++ b/agent/api.go
@@ -9,6 +9,7 @@ import (
 // APIClient is an interface generated for "github.com/buildkite/agent/v3/api.Client".
 type APIClient interface {
 	AcceptJob(*api.Job) (*api.Job, *api.Response, error)
+	AcquireJob(string) (*api.Job, *api.Response, error)
 	Annotate(string, *api.Annotation) (*api.Response, error)
 	Config() api.Config
 	Connect() (*api.Response, error)

--- a/api/agents.go
+++ b/api/agents.go
@@ -2,17 +2,18 @@ package api
 
 // AgentRegisterRequest is a call to register on the Buildkite Agent API
 type AgentRegisterRequest struct {
-	Name              string   `json:"name"`
-	Hostname          string   `json:"hostname"`
-	OS                string   `json:"os"`
-	Arch              string   `json:"arch"`
-	ScriptEvalEnabled bool     `json:"script_eval_enabled"`
-	Priority          string   `json:"priority,omitempty"`
-	Version           string   `json:"version"`
-	Build             string   `json:"build"`
-	Tags              []string `json:"meta_data"`
-	PID               int      `json:"pid,omitempty"`
-	MachineID         string   `json:"machine_id,omitempty"`
+	Name               string   `json:"name"`
+	Hostname           string   `json:"hostname"`
+	OS                 string   `json:"os"`
+	Arch               string   `json:"arch"`
+	ScriptEvalEnabled  bool     `json:"script_eval_enabled"`
+	IgnoreInDispatches bool     `json:"ignore_in_dispatches"`
+	Priority           string   `json:"priority,omitempty"`
+	Version            string   `json:"version"`
+	Build              string   `json:"build"`
+	Tags               []string `json:"meta_data"`
+	PID                int      `json:"pid,omitempty"`
+	MachineID          string   `json:"machine_id,omitempty"`
 }
 
 // AgentRegisterResponse is the response from the Buildkite Agent API

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -49,6 +49,24 @@ func (c *Client) GetJobState(id string) (*JobState, *Response, error) {
 	return s, resp, err
 }
 
+// Acquires a job using it's ID
+func (c *Client) AcquireJob(id string) (*Job, *Response, error) {
+	u := fmt.Sprintf("jobs/%s/acquire", id)
+
+	req, err := c.newRequest("PUT", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	j := new(Job)
+	resp, err := c.doRequest(req, j)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return j, resp, err
+}
+
 // AcceptJob accepts the passed in job. Returns the job with it's finalized set of
 // environment variables (when a job is accepted, the agents environment is
 // applied to the job)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25882/70512751-300f9680-1b6b-11ea-92d4-f9b344f8202c.png)

This change adds a new `--acquire-job` option to `buildkite-agent start`. You use it like this:

```sh
buildkite-agent start --token "xx" --acquire-job "f6f1a0c9-3431-451d-942d-846dfd1fb623"
```

When the agent boots, instead of doing the normal "ping until you find work" routine, it'll specifically ask Buildkite if it can acquire the job provided (acquire is the word we use to describe an agent self-assigning and accepting a job). Once the job has been acquired, it'll run the job and exit when it's finished.

If it fails to acquire the job, it'll just bail:

![image](https://user-images.githubusercontent.com/25882/70512933-92689700-1b6b-11ea-9232-3de542117ef8.png)

In an original cut of this code I just had it as `buildkite-agent start --job`, but I didn't really mean much in context of other stuff. For example, we've got `disconnect-after-job` which is a verbose argument, so I figured `--acquire-job` is pretty clear as it what it's doing.
