### PR TITLE
run-parts on CentOS does not have --exit-on-error

### DIFF
--- a/packaging/docker/centos-linux/entrypoint.sh
+++ b/packaging/docker/centos-linux/entrypoint.sh
@@ -5,7 +5,7 @@ DIR=/docker-entrypoint.d
 
 if [[ -d "$DIR" ]] ; then
   echo "Executing scripts in $DIR"
-  /bin/run-parts --exit-on-error "$DIR"
+  /bin/run-parts "$DIR"
 fi
 
 exec /sbin/tini -g -- ssh-env-config.sh /usr/local/bin/buildkite-agent "$@"


### PR DESCRIPTION
On Debian, `run-parts` is an actual program. On RHEL and derivatives, it's an assimilation of the same implemented in Bash.

```sh
$> /bin/run-parts --exit-on-error /somedir
Not a directory: --exit-on-error
```