### PR TITLE
clicommand/annotate: demote success log from Info to Debug

### DIFF
--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -171,6 +171,6 @@ var AnnotateCommand = cli.Command{
 			l.Fatal("Failed to annotate build: %s", err)
 		}
 
-		l.Info("Successfully annotated build")
+		l.Debug("Successfully annotated build")
 	},
 }


### PR DESCRIPTION
Change the "Successfully annotated build" log level from Info to Debug on the `buildkite-agent annotate ...` command.

In this context, a successful exit status and the absence of error messages should be enough to indicate that "it worked". This improves the signal to noise ratio of build logs.

This log message was added during initial implementation, so I don't think there's any historic need/request that we'd be breaking.