### PR TITLE
Fix AgentPool to disconnect if AgentWorker.Start fails 

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -51,20 +51,11 @@ func (r *AgentPool) runWorker(worker *AgentWorker, im *IdleMonitor) error {
 	if err := worker.Connect(); err != nil {
 		return err
 	}
+	// Ensure the worker is disconnected at the end of this function.
+	defer worker.Disconnect();
 
-	// Starts the agent worker and wait for it to finish
-	err := worker.Start(im)
-
-	// Now that the agent has finished, we can disconnect it
-	disconnect := worker.Disconnect()
-
-	// If start exited due to an error return that
-	if err != nil {
-		return err
-	}
-
-	// Otherwise return the disconnect result
-	return disconnect
+	// Starts the agent worker and wait for it to finish.
+	return worker.Start(im)
 }
 
 func (r *AgentPool) Stop(graceful bool) {

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -53,16 +53,18 @@ func (r *AgentPool) runWorker(worker *AgentWorker, im *IdleMonitor) error {
 	}
 
 	// Starts the agent worker and wait for it to finish
-	if err := worker.Start(im); err != nil {
+	err := worker.Start(im)
+
+	// Now that the agent has finished, we can disconnect it
+	disconnect := worker.Disconnect()
+
+	// If start exited due to an error return that
+	if err != nil {
 		return err
 	}
 
-	// Now that the agent has stopped, we can disconnect it
-	if err := worker.Disconnect(); err != nil {
-		return err
-	}
-
-	return nil
+	// Otherwise return the disconnect result
+	return disconnect
 }
 
 func (r *AgentPool) Stop(graceful bool) {

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -412,9 +412,7 @@ func (a *AgentWorker) AcquireAndRunJob(jobId string) error {
 
 	// If `acquiredJob` is nil, then the job was never acquired
 	if acquiredJob == nil {
-		a.logger.Warn("Failed to acquire job: %v", err)
-		// Return nil so that the AgentPool disconnnects this one-shot agent
-		return nil
+		return fmt.Errorf("Failed to acquire job: %v", err)
 	}
 
 	// Now that we've acquired the job, lets' run it

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -412,7 +412,9 @@ func (a *AgentWorker) AcquireAndRunJob(jobId string) error {
 
 	// If `acquiredJob` is nil, then the job was never acquired
 	if acquiredJob == nil {
-		return fmt.Errorf("Failed to acquire job: %v", err)
+		a.logger.Warn("Failed to acquire job: %v", err)
+		// Return nil so that the AgentPool disconnnects this one-shot agent
+		return nil
 	}
 
 	// Now that we've acquired the job, lets' run it


### PR DESCRIPTION
When using `--acquire-job` to start a one-shot agent to pull a specific job, there exists a race condition when the job can be cancelled on Buildkite before the scheduled agent actually boots up. When this happens, `apiClient.AcquireJob(jobId)` returns a 422 which isn't retried, but returning an error from `AgentWorker.Start` means that `AgentPool.runWorker` skips the disconnect step.

I dug into this because I had some ghost one-shot agents that I was worried were using capacity. I checked the logs and saw that they were exiting immediately because they don’t `POST /v3/disconnect` to the Buildkite API they hang around in the agents list until they are pruned out for inactivity. I don’t think this causes any problems for scheduling because `AgentRegisterRequest.IgnoreInDispatches` is set, but it does make it appear there are more agents running than there are in practice.

@keithpitt what do you think?