### PR TITLE
Add repository consolidation

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -30,4 +30,5 @@ type AgentConfiguration struct {
 	Profile                    string
 	RedactedVars               []string
 	AcquireJob                 string
+	ShouldConsolidateRepos     bool
 }

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -399,6 +399,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 		`BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT`,
 		`BUILDKITE_GIT_CLEAN_FLAGS`,
 		`BUILDKITE_SHELL`,
+		`BUILDKITE_CONSOLIDATE_REPOS_INTO_BUILD_DIR`,
 	}
 
 	var ignoredEnv []string
@@ -448,6 +449,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	env["BUILDKITE_SHELL"] = r.conf.AgentConfiguration.Shell
 	env["BUILDKITE_AGENT_EXPERIMENT"] = strings.Join(experiments.Enabled(), ",")
 	env["BUILDKITE_REDACTED_VARS"] = strings.Join(r.conf.AgentConfiguration.RedactedVars, ",")
+	env["BUILDKITE_CONSOLIDATE_REPOS_INTO_BUILD_DIR"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.ShouldConsolidateRepos)
 
 	// Whether to enable profiling in the bootstrap
 	if r.conf.AgentConfiguration.Profile != "" {

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -448,6 +448,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	env["BUILDKITE_SHELL"] = r.conf.AgentConfiguration.Shell
 	env["BUILDKITE_AGENT_EXPERIMENT"] = strings.Join(experiments.Enabled(), ",")
 	env["BUILDKITE_REDACTED_VARS"] = strings.Join(r.conf.AgentConfiguration.RedactedVars, ",")
+	env["BUILDKITE_CONSOLIDATE_REPOS_INTO_BUILD_DIR"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.ShouldConsolidateRepos)
 
 	// Whether to enable profiling in the bootstrap
 	if r.conf.AgentConfiguration.Profile != "" {

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -448,7 +448,6 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	env["BUILDKITE_SHELL"] = r.conf.AgentConfiguration.Shell
 	env["BUILDKITE_AGENT_EXPERIMENT"] = strings.Join(experiments.Enabled(), ",")
 	env["BUILDKITE_REDACTED_VARS"] = strings.Join(r.conf.AgentConfiguration.RedactedVars, ",")
-	env["BUILDKITE_CONSOLIDATE_REPOS_INTO_BUILD_DIR"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.ShouldConsolidateRepos)
 
 	// Whether to enable profiling in the bootstrap
 	if r.conf.AgentConfiguration.Profile != "" {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -836,7 +836,18 @@ func (b *Bootstrap) removeCheckoutDir() error {
 }
 
 func (b *Bootstrap) createCheckoutDir() error {
-	checkoutPath, _ := b.shell.Env.Get("BUILDKITE_BUILD_CHECKOUT_PATH")
+
+	var checkoutPath string
+
+	if b.ShouldConsolidateRepos && b.Config.Repository != "" {
+		checkoutPath = b.Config.Repository
+	} else {
+		checkoutPath, _ = b.shell.Env.Get("BUILDKITE_BUILD_CHECKOUT_PATH")
+	}
+
+	if b.Debug {
+		b.shell.Commentf("Using %s as the checkout path", checkoutPath)
+	}
 
 	if !fileExists(checkoutPath) {
 		b.shell.Commentf("Creating \"%s\"", checkoutPath)

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -153,6 +153,6 @@ func (c *Config) ReadFromEnvironment(environ *env.Environment) map[string]string
 			}
 		}
 	}
-	
+
 	return changed
 }

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -123,6 +123,9 @@ type Config struct {
 
 	// List of environment variable globs to redact from job output
 	RedactedVars []string
+
+	// Whether or not to consolidate identical repositories into single build directory
+	ShouldConsolidateRepos bool
 }
 
 // ReadFromEnvironment reads configuration from the Environment, returns a map

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -125,7 +125,7 @@ type Config struct {
 	RedactedVars []string
 
 	// Whether or not to consolidate identical repositories into single build directory
-	ShouldConsolidateRepos bool `env:"BUILDKITE_CONSOLIDATE_REPOS_INTO_BUILD_DIR"`
+	ShouldConsolidateRepos bool
 }
 
 // ReadFromEnvironment reads configuration from the Environment, returns a map
@@ -153,6 +153,7 @@ func (c *Config) ReadFromEnvironment(environ *env.Environment) map[string]string
 			}
 		}
 	}
+	
 
 	return changed
 }

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -154,6 +154,5 @@ func (c *Config) ReadFromEnvironment(environ *env.Environment) map[string]string
 		}
 	}
 	
-
 	return changed
 }

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -125,7 +125,7 @@ type Config struct {
 	RedactedVars []string
 
 	// Whether or not to consolidate identical repositories into single build directory
-	ShouldConsolidateRepos bool
+	ShouldConsolidateRepos bool `env:"BUILDKITE_CONSOLIDATE_REPOS_INTO_BUILD_DIR"`
 }
 
 // ReadFromEnvironment reads configuration from the Environment, returns a map

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -631,7 +631,6 @@ var AgentStartCommand = cli.Command{
 		l.Debug("Build path: %s", agentConf.BuildPath)
 		l.Debug("Hooks directory: %s", agentConf.HooksPath)
 		l.Debug("Plugins directory: %s", agentConf.PluginsPath)
-		l.Debug("Value of consolidate: %t", agentConf.ShouldConsolidateRepos)
 
 		if !agentConf.SSHKeyscan {
 			l.Info("Automatic ssh-keyscan has been disabled")

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -656,6 +656,10 @@ var AgentStartCommand = cli.Command{
 			l.Info("Agents will disconnect after %d seconds of inactivity", agentConf.DisconnectAfterIdleTimeout)
 		}
 
+		if agentConf.ShouldConsolidateRepos {
+			l.Info("Agent will use hashed name of repository for the build dir of all jobs using identical repositories")
+		}
+
 		cancelSig, err := process.ParseSignal(cfg.CancelSignal)
 		if err != nil {
 			l.Fatal("Failed to parse cancel-signal: %v", err)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -403,7 +403,7 @@ var AgentStartCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name:   "should-consolidate-repos",
-			Usage:  "Consolidate identical repositories into a single build dir",
+			Usage:  "Consolidate all builds using identical repositories into a single build directory",
 			EnvVar: "BUILDKITE_CONSOLIDATE_REPOS_INTO_BUILD_DIR",
 		},
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -88,6 +88,7 @@ type AgentStartConfig struct {
 	LogFormat                  string   `cli:"log-format"`
 	CancelSignal               string   `cli:"cancel-signal"`
 	RedactedVars               []string `cli:"redacted-vars" normalize:"list"`
+	ShouldConsolidateRepos     bool     `cli:"should-consolidate-repos"`
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
@@ -400,6 +401,11 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_REDACTED_VARS",
 			Value:  &cli.StringSlice{"*_PASSWORD", "*_SECRET", "*_TOKEN"},
 		},
+		cli.BoolFlag{
+			Name:   "should-consolidate-repos",
+			Usage:  "Consolidate identical repositories into a single build dir",
+			EnvVar: "BUILDKITE_CONSOLIDATE_REPOS_INTO_BUILD_DIR",
+		},
 
 		// API Flags
 		AgentRegisterTokenFlag,
@@ -587,6 +593,7 @@ var AgentStartCommand = cli.Command{
 			Shell:                      cfg.Shell,
 			RedactedVars:               cfg.RedactedVars,
 			AcquireJob:                 cfg.AcquireJob,
+			ShouldConsolidateRepos:     cfg.ShouldConsolidateRepos,
 		}
 
 		if loader.File != nil {
@@ -624,6 +631,7 @@ var AgentStartCommand = cli.Command{
 		l.Debug("Build path: %s", agentConf.BuildPath)
 		l.Debug("Hooks directory: %s", agentConf.HooksPath)
 		l.Debug("Plugins directory: %s", agentConf.PluginsPath)
+		l.Debug("Value of consolidate: %t", agentConf.ShouldConsolidateRepos)
 
 		if !agentConf.SSHKeyscan {
 			l.Info("Automatic ssh-keyscan has been disabled")

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -81,6 +81,7 @@ type BootstrapConfig struct {
 	Phases                       []string `cli:"phases" normalize:"list"`
 	Profile                      string   `cli:"profile"`
 	RedactedVars                 []string `cli:"redacted-vars" normalize:"list"`
+	ShouldConsolidateRepos       bool     `cli:"should-consolidate-repos"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -294,6 +295,11 @@ var BootstrapCommand = cli.Command{
 			Usage:  "Pattern of environment variable names containing sensitive values",
 			EnvVar: "BUILDKITE_REDACTED_VARS",
 		},
+		cli.BoolTFlag{
+			Name:   "should-consolidate-repos",
+			Usage:  "Consolidate identical repositories into a single build dir",
+			EnvVar: "BUILDKITE_CONSOLIDATE_REPOS_INTO_BUILD_DIR",
+		},
 		DebugFlag,
 		ExperimentsFlag,
 		ProfileFlag,
@@ -378,6 +384,7 @@ var BootstrapCommand = cli.Command{
 			Shell:                        cfg.Shell,
 			Phases:                       cfg.Phases,
 			RedactedVars:                 cfg.RedactedVars,
+			ShouldConsolidateRepos:       cfg.ShouldConsolidateRepos,
 		})
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -297,7 +297,7 @@ var BootstrapCommand = cli.Command{
 		},
 		cli.BoolTFlag{
 			Name:   "should-consolidate-repos",
-			Usage:  "Consolidate identical repositories into a single build dir",
+			Usage:  "Consolidate all builds using identical repositories into a single build directory",
 			EnvVar: "BUILDKITE_CONSOLIDATE_REPOS_INTO_BUILD_DIR",
 		},
 		DebugFlag,

--- a/packaging/docker/alpine-linux/buildkite-agent.cfg
+++ b/packaging/docker/alpine-linux/buildkite-agent.cfg
@@ -59,3 +59,6 @@ plugins-path="/buildkite/plugins"
 
 # Don't show colors in logging
 # no-color=true
+
+# Consolidate all builds using identical repositories into a single build directory
+# should-consolidate-repos=false

--- a/packaging/docker/centos-linux/buildkite-agent.cfg
+++ b/packaging/docker/centos-linux/buildkite-agent.cfg
@@ -59,3 +59,6 @@ plugins-path="/buildkite/plugins"
 
 # Don't show colors in logging
 # no-color=true
+
+# Consolidate all builds using identical repositories into a single build directory
+# should-consolidate-repos=false

--- a/packaging/docker/ubuntu-linux/buildkite-agent.cfg
+++ b/packaging/docker/ubuntu-linux/buildkite-agent.cfg
@@ -59,3 +59,6 @@ plugins-path="/buildkite/plugins"
 
 # Don't show colors in logging
 # no-color=true
+
+# Consolidate all builds using identical repositories into a single build directory
+# should-consolidate-repos=false

--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -59,3 +59,6 @@ plugins-path="$HOME/.buildkite-agent/plugins"
 
 # Don't show colors in logging
 # no-color=true
+
+# Consolidate all builds using identical repositories into a single build directory
+# should-consolidate-repos=false

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -59,3 +59,6 @@ plugins-path="/etc/buildkite-agent/plugins"
 
 # Don't show colors in logging
 # no-color=true
+
+# Consolidate all builds using identical repositories into a single build directory
+# should-consolidate-repos=false


### PR DESCRIPTION
## Consolidating jobs using the same repository into single build directory

The idea here is that with large repositories, we waste a lot of space on our nodes when we have numerous pipelines. This is because the agent creates build dirs based on the `pipeline-slug`. We could save a lot of space and not need to limit the amount of pipelines we make by having all builds of the same repo use the same build directory

This would be really helpful for our org so I imagine other teams with large repositories could benefit as well

### Things I'd like feedback on
- [ ] Language: specifically around "Consolidate all builds using identical repositories into a single build directory" being the language convention to use for this functionality
- [ ] Hashing: This approach ensures the dir is alphanumeric, but certainly obscures what the build dir is. Thoughts? If this is the right approach we could also move it into utils.
- [ ] Protected Env: I currently have this as a protected ENV variable, I think this is the right approach so it must be configured at the agent level. Open to discussion though. 

### Next steps
- If we get sign off on this, I'd of course like to add tests.