### PR TITLE
Support per-worker git-mirrors-path

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -7,6 +7,8 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -700,6 +702,9 @@ var AgentStartCommand = cli.Command{
 			if err != nil {
 				l.Fatal("%s", err)
 			}
+
+			// If user has provided a per-worker git mirror path, substitute it here
+			agentConf.GitMirrorsPath = strings.Replace(agentConf.GitMirrorsPath, "%n", strconv.Itoa(i), -1)
 
 			// Create an agent worker to run the agent
 			workers = append(workers,


### PR DESCRIPTION
Howdy,

This change adds support to interpolate the spawned worker index into
the git mirrors path, to namespace git-mirrors-path per-worker, which
should minimise lock contention for repositories used across many
tasks.

Why do this?
When running >1 agent workers on a single host, concurrent fetches for
the same repo can incur contention on git's index.lock, which will cause
fetches to stall.
`BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT` can be tuned to achieve a reasonable
timeout before failing, but some users may prefer to checkout multiple copies
of the repository instead to avoid any contention at all.

See also: https://github.com/buildkite/elastic-ci-stack-for-aws/pull/663, which adds the ability to customise this parameter when deploying an elastic stack in AWS.

Let me know if you have any questions, suggestions or concerns.

Cheers,
Denbeigh