### PR TITLE
The great "it's" purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -765,7 +765,7 @@ No changes
 
 ## 3.0-beta.19 - 2017-03-29
 ### Added
-- `buildkite-agent start --disconnect-after-job` will run the agent, and automatically disconnect after running it's first job. This has sometimes been referred to as "one shot" mode and is useful when you spin up an environment per-job and want the agent to automatically disconnect once it's finished it's job
+- `buildkite-agent start --disconnect-after-job` will run the agent, and automatically disconnect after running its first job. This has sometimes been referred to as "one shot" mode and is useful when you spin up an environment per-job and want the agent to automatically disconnect once its finished its job
 - `buildkite-agent start --disconnect-after-job-timeout` is the time in seconds the agent will wait for that first job to be assigned. The default value is 120 seconds (2 minutes). If a job isn't assigned to the agent after this time, it will automatically disconnect and the agent process will stop.
 
 ## 3.0-beta.18 - 2017-03-27
@@ -820,7 +820,7 @@ No changes
 
 ## 3.0-beta.15 - 2016-11-16
 ### Changed
-- The agent now receives it's "job status interval" from the Agent API (the number of seconds between checking if it's current job has been remotely canceled)
+- The agent now receives its "job status interval" from the Agent API (the number of seconds between checking if its current job has been remotely canceled)
 
 ## 3.0-beta.14 - 2016-11-11
 ### Fixed
@@ -1072,7 +1072,7 @@ No changes
 - Debian packages now include the debian_version property 📦
 - Artifacts are uploaded faster! We've optimised our Agent API payloads to have a smaller footprint meaning you can uploading more artifacts faster! 🚗💨
 - You can now download artifacts from private S3 buckets using buildkite-artifact download ☁️
-- The agent will now change it's process title on linux/amd64 machines to report it's current status: `buildkite-agent v2.1 (my-agent-name) [job a4f-a4fa4-af4a34f-af4]`
+- The agent will now change its process title on linux/amd64 machines to report its current status: `buildkite-agent v2.1 (my-agent-name) [job a4f-a4fa4-af4a34f-af4]`
 
 ## 2.1-beta - 2015-07-3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -765,7 +765,7 @@ No changes
 
 ## 3.0-beta.19 - 2017-03-29
 ### Added
-- `buildkite-agent start --disconnect-after-job` will run the agent, and automatically disconnect after running its first job. This has sometimes been referred to as "one shot" mode and is useful when you spin up an environment per-job and want the agent to automatically disconnect once its finished its job
+- `buildkite-agent start --disconnect-after-job` will run the agent, and automatically disconnect after running its first job. This has sometimes been referred to as "one shot" mode and is useful when you spin up an environment per-job and want the agent to automatically disconnect once it's finished its job
 - `buildkite-agent start --disconnect-after-job-timeout` is the time in seconds the agent will wait for that first job to be assigned. The default value is 120 seconds (2 minutes). If a job isn't assigned to the agent after this time, it will automatically disconnect and the agent process will stop.
 
 ## 3.0-beta.18 - 2017-03-27

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -79,7 +79,7 @@ type AgentWorker struct {
 	jobRunner *JobRunner
 }
 
-// Creates the agent worker and initializes it's API Client
+// Creates the agent worker and initializes its API Client
 func NewAgentWorker(l logger.Logger, a *api.AgentRegisterResponse, m *metrics.Collector, apiClient APIClient, c AgentWorkerConfig) *AgentWorker {
 	return &AgentWorker{
 		logger:             l,

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -159,14 +159,14 @@ func (a *ArtifactUploader) Collect() (artifacts []*api.Artifact, err error) {
 }
 
 func (a *ArtifactUploader) build(path string, absolutePath string, globPath string) (*api.Artifact, error) {
-	// Temporarily open the file to get it's size
+	// Temporarily open the file to get its size
 	file, err := os.Open(absolutePath)
 	if err != nil {
 		return nil, err
 	}
 	defer file.Close()
 
-	// Grab it's file info (which includes it's file size)
+	// Grab its file info (which includes its file size)
 	fileInfo, err := file.Stat()
 	if err != nil {
 		return nil, err

--- a/agent/arty_downloader.go
+++ b/agent/arty_downloader.go
@@ -21,7 +21,7 @@ type ArtifactoryDownloaderConfig struct {
 	Destination string
 
 	// The relative path that should be preserved in the download folder,
-	// also it's location in the repo
+	// also its location in the repo
 	Path string
 
 	// How many times should it retry the download before giving up

--- a/agent/gs_downloader.go
+++ b/agent/gs_downloader.go
@@ -17,7 +17,7 @@ type GSDownloaderConfig struct {
 	Destination string
 
 	// The relative path that should be preserved in the download folder,
-	// also it's location in the bucket
+	// also its location in the bucket
 	Path string
 
 	// How many times should it retry the download before giving up

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -572,8 +572,7 @@ func (r *JobRunner) onProcessStartCallback() {
 			r.logger.Debug("[JobRunner] Routine that refreshes the job has finished")
 		}()
 		for {
-			// Re-get the job and check its status to see if its been
-			// cancelled
+			// Re-get the job and check its status to see if it's been cancelled
 			jobState, _, err := r.apiClient.GetJobState(r.job.ID)
 			if err != nil {
 				// We don't really care if it fails, we'll just

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -572,7 +572,7 @@ func (r *JobRunner) onProcessStartCallback() {
 			r.logger.Debug("[JobRunner] Routine that refreshes the job has finished")
 		}()
 		for {
-			// Re-get the job and check it's status to see if it's been
+			// Re-get the job and check its status to see if its been
 			// cancelled
 			jobState, _, err := r.apiClient.GetJobState(r.job.ID)
 			if err != nil {

--- a/agent/s3_downloader.go
+++ b/agent/s3_downloader.go
@@ -19,7 +19,7 @@ type S3DownloaderConfig struct {
 	Destination string
 
 	// The relative path that should be preserved in the download folder,
-	// also it's location in the bucket
+	// also its location in the bucket
 	Path string
 
 	// How many times should it retry the download before giving up

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -49,7 +49,7 @@ func (c *Client) GetJobState(id string) (*JobState, *Response, error) {
 	return s, resp, err
 }
 
-// Acquires a job using it's ID
+// Acquires a job using its ID
 func (c *Client) AcquireJob(id string) (*Job, *Response, error) {
 	u := fmt.Sprintf("jobs/%s/acquire", id)
 
@@ -67,7 +67,7 @@ func (c *Client) AcquireJob(id string) (*Job, *Response, error) {
 	return j, resp, err
 }
 
-// AcceptJob accepts the passed in job. Returns the job with it's finalized set of
+// AcceptJob accepts the passed in job. Returns the job with its finalized set of
 // environment variables (when a job is accepted, the agents environment is
 // applied to the job)
 func (c *Client) AcceptJob(job *Job) (*Job, *Response, error) {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1416,7 +1416,7 @@ func (b *Bootstrap) defaultCommandPhase() error {
 		//
 		// Such undesired payloads could be delivered by hiding that payload in
 		// non-executable objects in the repo (such as through partial shell
-		// fragments, or other material not intended to be run on it's own),
+		// fragments, or other material not intended to be run on its own),
 		// or by obfuscating binary executable code into other types of binaries.
 		//
 		// This also closes the risk factor with agents where you

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1421,7 +1421,7 @@ func (b *Bootstrap) defaultCommandPhase() error {
 		//
 		// This also closes the risk factor with agents where you
 		// may have a dangerous script committed, but not executable (maybe
-		// because its part of a deployment process), but you don't want that
+		// because it's part of a deployment process), but you don't want that
 		// script to ever be executed on the buildkite agent itself!  With
 		// command-eval agents, such risks are everpresent since the master
 		// can tell the agent to do anything anyway, but no-command-eval agents

--- a/bootstrap/shell/lookpath.go
+++ b/bootstrap/shell/lookpath.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-// This file (along with it's Windows counterpart) have been taken from:
+// This file (along with its Windows counterpart) have been taken from:
 //
 // https://github.com/golang/go/blob/master/src/os/exec/lp.go
 //

--- a/bootstrap/shell/lookpath_windows.go
+++ b/bootstrap/shell/lookpath_windows.go
@@ -1,4 +1,4 @@
-// This file (along with it's *nix counterpart) have been taken from:
+// This file (along with its *nix counterpart) have been taken from:
 //
 // https://github.com/golang/go/blob/master/src/os/exec/lp_windows.go
 //

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -312,7 +312,7 @@ type command struct {
 // buildCommand returns a command that can later be executed
 func (s *Shell) buildCommand(name string, arg ...string) (*command, error) {
 	// Always use absolute path as Windows has a hard time
-	// finding executables in it's path
+	// finding executables in its path
 	absPath, err := s.AbsolutePath(name)
 	if err != nil {
 		return nil, err

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -60,7 +60,7 @@ var ArtifactDownloadCommand = cli.Command{
 		cli.StringFlag{
 			Name:  "step",
 			Value: "",
-			Usage: "Scope the search to a particular step by using either it's name or job ID",
+			Usage: "Scope the search to a particular step by using either its name or job ID",
 		},
 		cli.StringFlag{
 			Name:   "build",

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -62,7 +62,7 @@ var ArtifactShasumCommand = cli.Command{
 		cli.StringFlag{
 			Name:  "step",
 			Value: "",
-			Usage: "Scope the search to a particular step by using either it's name of job ID",
+			Usage: "Scope the search to a particular step by using either its name of job ID",
 		},
 		cli.StringFlag{
 			Name:   "build",

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -27,7 +27,7 @@ Example:
    $ buildkite-agent artifact shasum "pkg/release.tar.gz" --build xxx
 
    This will search for all the files in the build with the path "pkg/release.tar.gz" and will
-   print to STDOUT it's SHA-1 checksum.
+   print to STDOUT its SHA-1 checksum.
 
    If you would like to target artifacts from a specific build step, you can do
    so by using the --step argument.

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -80,7 +80,7 @@ var PipelineUploadCommand = cli.Command{
 		cli.StringFlag{
 			Name:   "job",
 			Value:  "",
-			Usage:  "The job that is making the changes to it's build",
+			Usage:  "The job that is making the changes to its build",
 			EnvVar: "BUILDKITE_JOB_ID",
 		},
 		cli.BoolFlag{

--- a/clicommand/step_get.go
+++ b/clicommand/step_get.go
@@ -56,13 +56,13 @@ var StepGetCommand = cli.Command{
 		cli.StringFlag{
 			Name:   "step",
 			Value:  "",
-			Usage:  "The step to get. Can be either it's ID (BUILDKITE_STEP_ID) or key (BUILDKITE_STEP_KEY)",
+			Usage:  "The step to get. Can be either its ID (BUILDKITE_STEP_ID) or key (BUILDKITE_STEP_KEY)",
 			EnvVar: "BUILDKITE_STEP_ID",
 		},
 		cli.StringFlag{
 			Name:   "build",
 			Value:  "",
-			Usage:  "The build to look for the step in. Only required when targeting a step using it's key (BUILDKITE_STEP_KEY)",
+			Usage:  "The build to look for the step in. Only required when targeting a step using its key (BUILDKITE_STEP_KEY)",
 			EnvVar: "BUILDKITE_BUILD_ID",
 		},
 		cli.StringFlag{

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -53,13 +53,13 @@ var StepUpdateCommand = cli.Command{
 		cli.StringFlag{
 			Name:   "step",
 			Value:  "",
-			Usage:  "The step to update. Can be either it's ID (BUILDKITE_STEP_ID) or key (BUILDKITE_STEP_KEY)",
+			Usage:  "The step to update. Can be either its ID (BUILDKITE_STEP_ID) or key (BUILDKITE_STEP_KEY)",
 			EnvVar: "BUILDKITE_STEP_ID",
 		},
 		cli.StringFlag{
 			Name:   "build",
 			Value:  "",
-			Usage:  "The build to look for the step in. Only required when targeting a step using it's key (BUILDKITE_STEP_KEY)",
+			Usage:  "The build to look for the step in. Only required when targeting a step using its key (BUILDKITE_STEP_KEY)",
 			EnvVar: "BUILDKITE_BUILD_ID",
 		},
 		cli.BoolFlag{

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -169,7 +169,7 @@ func (l *Loader) Load() (warnings []string, err error) {
 				}
 			}
 
-			// Validate the fieid, and if it fails, return it's
+			// Validate the fieid, and if it fails, return its
 			// error.
 			err := l.validateField(fieldName, label, validationRules)
 			if err != nil {
@@ -225,7 +225,7 @@ func (l Loader) setFieldValueFromCLI(fieldName string, cliName string) error {
 		// by the configuration file
 		if l.File != nil {
 			if configFileValue, ok := l.File.Config[cliName]; ok {
-				// Convert the config file value to it's correct type
+				// Convert the config file value to its correct type
 				if fieldKind == reflect.String {
 					value = configFileValue
 				} else if fieldKind == reflect.Slice {

--- a/env/environment.go
+++ b/env/environment.go
@@ -63,7 +63,7 @@ func (e *Environment) Set(key string, value string) string {
 	return value
 }
 
-// Remove a key from the Environment and return it's value
+// Remove a key from the Environment and return its value
 func (e *Environment) Remove(key string) string {
 	value, ok := e.Get(key)
 	if ok {

--- a/packaging/linux/scripts/after-install-and-upgrade.sh
+++ b/packaging/linux/scripts/after-install-and-upgrade.sh
@@ -15,14 +15,14 @@ fi
 # Add the buildkite user if it doesn't exist on installation
 if [ "$OPERATION" = "install" ] ; then
   if [ "$BK_USER_EXISTS" = "false" ]; then
-    # Create the buildkite system user and set it's home to /var/lib/buildkite
+    # Create the buildkite system user and set its home to /var/lib/buildkite
     useradd --system --no-create-home -d /var/lib/buildkite-agent buildkite-agent
 
     # The user exists now!
     BK_USER_EXISTS=true
   fi
 
-  # We create it's home folder in a seperate command so it doesn't blow up if
+  # We create its home folder in a seperate command so it doesn't blow up if
   # the folder already exists
   mkdir -p /var/lib/buildkite-agent
 fi

--- a/process/signal_windows.go
+++ b/process/signal_windows.go
@@ -33,7 +33,7 @@ func (p *Process) terminateProcessGroup() error {
 	p.logger.Debug("[Process] Terminating process tree with TASKKILL.EXE PID: %d", p.pid)
 
 	// taskkill.exe with /F will call TerminateProcess and hard-kill the process and
-	// anything left in it's process tree.
+	// anything left in its process tree.
 	return exec.Command("CMD", "/C", "TASKKILL.EXE", "/F", "/T", "/PID", strconv.Itoa(p.pid)).Run()
 }
 

--- a/scripts/latest_version.rb
+++ b/scripts/latest_version.rb
@@ -15,7 +15,7 @@ def parse(version_string)
     (\.(?<tiny>\d+))?
     # Pre is a string like alpha, beta, etc
     (\-(?<prerelease>[a-z]+))?
-    # The rest are numbers, and we dont care if its dashes or dots
+    # The rest are numbers, and we dont care if they use dashes or dots
     ([\-\.](?<prerelease_major>\d+))?
     ([\-\.](?<prerelease_minor>\d+))?
     ([\-\.](?<prerelease_patch>\d+))?

--- a/utils/path.go
+++ b/utils/path.go
@@ -30,7 +30,7 @@ func NormalizeCommand(commandPath string) (string, error) {
 
 	// if the file exists, absolute it
 	if _, err := os.Stat(commandPath); err == nil {
-		// make sure its absolute
+		// make sure it's absolute
 		absoluteCommandPath, err := filepath.Abs(commandPath)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
Fix "it's" that should be "its", and a few "its" that should be "it's", plus one that should be neither.

These were mostly in internal code comments, but also some user-facing docs (CHANGELOG and CLI usage output).

FYI the low-tech way I did this:

```
rg --glob '!vendor' "it's" -l | xargs sed -i '' -e "s/it's/its/g"
git add -p     # manually decide
git restore .  # restore the ones I chose not to add
```