### PR TITLE
Fix plugin execution being skipped with duplicate hook warning

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -674,8 +674,10 @@ func (b *Bootstrap) executePluginHook(name string, checkouts []*pluginCheckout) 
 	for i, p := range checkouts {
 		// First we verify the plugin actually implements the hook
 		hookPath, err := b.findHookFile(p.HooksDir, name)
-		if err != nil {
+		if os.IsNotExist(err) {
 			continue
+		} else if err != nil {
+			return err
 		}
 
 		// Disallow plugins executing the command or checkout hook more than once

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -290,6 +290,8 @@ func (b *Bootstrap) findHookFile(hookDir string, name string) (string, error) {
 	if p := filepath.Join(hookDir, name); fileExists(p) {
 		return p, nil
 	}
+	// don't wrap os.ErrNotExist without checking callers handle it.
+	// e.g. os.IfNotExist(err) does not handle wrapped errors.
 	return "", os.ErrNotExist
 }
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -674,6 +674,10 @@ func (b *Bootstrap) executePluginHook(name string, checkouts []*pluginCheckout) 
 	for i, p := range checkouts {
 		// First we verify the plugin actually implements the hook
 		hookPath, err := b.findHookFile(p.HooksDir, name)
+		// os.IsNotExist() doesn't unwrap wrapped errors (as at Go 1.13).
+		// agent is still go pre-1.13 compatible (I think) so we're avoiding errors.Is().
+		// In future somebody should check if os.IsNotExist() has added support for
+		// error unwrapping, or change this code to errors.Is(err, os.ErrNotExist)
 		if os.IsNotExist(err) {
 			continue
 		} else if err != nil {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -672,6 +672,13 @@ func (b *Bootstrap) executePluginHook(name string, checkouts []*pluginCheckout) 
 	hookTypeSeen := make(map[string]bool)
 
 	for i, p := range checkouts {
+		// First we verify the plugin actually implements the hook
+		hookPath, err := b.findHookFile(p.HooksDir, name)
+		if err != nil {
+			continue
+		}
+
+		// Disallow plugins executing the command or checkout hook more than once
 		if name == "command" || name == "checkout" {
 			if hookTypeSeen[name] {
 				b.shell.Warningf("Ignoring additional %s hook (%s plugin, position %d)", name, p.Plugin.Name(), i+1)
@@ -679,11 +686,6 @@ func (b *Bootstrap) executePluginHook(name string, checkouts []*pluginCheckout) 
 			} else {
 				hookTypeSeen[name] = true
 			}
-		}
-
-		hookPath, err := b.findHookFile(p.HooksDir, name)
-		if err != nil {
-			continue
 		}
 
 		env, _ := p.ConfigurationToEnvironment()

--- a/bootstrap/integration/bootstrap_tester.go
+++ b/bootstrap/integration/bootstrap_tester.go
@@ -284,9 +284,7 @@ func (b *BootstrapTester) Cancel() error {
 
 func (b *BootstrapTester) CheckMocks(t *testing.T) {
 	for _, mock := range b.mocks {
-		if !mock.Check(t) {
-			return
-		}
+		mock.Check(t)
 	}
 }
 

--- a/bootstrap/integration/plugin_integration_test.go
+++ b/bootstrap/integration/plugin_integration_test.go
@@ -144,6 +144,74 @@ func TestMalformedPluginNamesDontCrashBootstrap(t *testing.T) {
 	tester.CheckMocks(t)
 }
 
+func TestOnceOnlyHooks(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewBootstrapTester()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tester.Close()
+
+	var testPlugins []*testPlugin
+	var pluginMocks []*bintest.Mock
+	setupMock := func(name string, hooks ...string) *bintest.Mock {
+		pluginMock := tester.MustMock(t, name)
+		fakeHooks := make(map[string][]string)
+		for _, hook := range hooks {
+			if runtime.GOOS == "windows" {
+				fakeHooks[hook+".bat"] = []string{
+					"@echo off",
+					pluginMock.Path + " " + hook,
+				}
+			} else {
+				fakeHooks[hook] = []string{
+					"#!/bin/bash",
+					pluginMock.Path + " " + hook,
+				}
+			}
+		}
+		testPlugins = append(testPlugins, createTestPlugin(t, fakeHooks))
+		pluginMocks = append(pluginMocks, pluginMock)
+		return pluginMock
+	}
+
+	mockA := setupMock("plugin-a", "environment")
+	mockA.Expect("environment").Once()
+
+	mockB := setupMock("plugin-b", "environment", "checkout")
+	mockB.Expect("environment").Once()
+	mockB.Expect("checkout").Once()
+
+	mockC := setupMock("plugin-c", "checkout", "command")
+	mockC.Expect("checkout").NotCalled() // plugin-b already ran checkout
+	mockC.Expect("command").Once()
+
+	mockD := setupMock("plugin-d", "command", "post-command")
+	mockD.Expect("command").NotCalled() // plugin-c already ran command
+	mockD.Expect("post-command").Once()
+
+	pluginsJSON, err := json.Marshal(testPlugins)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	env := []string{
+		`MY_CUSTOM_ENV=1`,
+		`BUILDKITE_PLUGINS=` + string(pluginsJSON),
+	}
+
+	tester.RunAndCheck(t, env...)
+
+	assertOutputCount := func(output, substr string, count int) {
+		if actual := strings.Count(output, substr); actual != count {
+			t.Errorf("Message: '%s' wanted count: %d, got: %d", substr, count, actual)
+		}
+	}
+	assertOutputCount(tester.Output, "Ignoring additional checkout hook", 1)
+	assertOutputCount(tester.Output, "Ignoring additional command hook", 1)
+}
+
 type testPlugin struct {
 	*gitRepository
 }
@@ -176,21 +244,34 @@ func createTestPlugin(t *testing.T, hooks map[string][]string) *testPlugin {
 	return &testPlugin{repo}
 }
 
+// ToJSON turns a single testPlugin into a single-item JSON
+// array suitable for BUILDKITE_PLUGINS
 func (tp *testPlugin) ToJSON() (string, error) {
-	commitHash, err := tp.RevParse("HEAD")
+	data, err := json.Marshal([]*testPlugin{tp})
 	if err != nil {
 		return "", err
+	}
+	return string(data), nil
+}
+
+// MarshalJSON turns a single testPlugin into a JSON object.
+// BUILDKITE_PLUGINS expects an array of these, so it would
+// generally be used on a []testPlugin slice.
+func (tp *testPlugin) MarshalJSON() ([]byte, error) {
+	commitHash, err := tp.RevParse("HEAD")
+	if err != nil {
+		return nil, err
 	}
 	normalizedPath := strings.TrimPrefix(strings.Replace(tp.Path, "\\", "/", -1), "/")
 
-	var p = []interface{}{map[string]interface{}{
+	p := map[string]interface{}{
 		fmt.Sprintf(`file:///%s#%s`, normalizedPath, strings.TrimSpace(commitHash)): map[string]string{
 			"settings": "blah",
 		},
-	}}
+	}
 	b, err := json.Marshal(&p)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return string(b), nil
+	return b, nil
 }


### PR DESCRIPTION
In #1135 (and released in v3.18.0) a bug was introduced where plugins hooks were being incorrectly skipped. This fixes the bug by ensuring that the hook exists in the plugin, before checking it for duplicate execution.

This now executes correctly and uploads the artifact:

```yml
steps:
- command: "echo 'foo' > bar.txt"
  plugins:
    - docker#v3.5.0:
        image: bash
    - artifacts#v1.2.0:
        upload: bar.txt
```

The following pipeline was also tested, and outputs the expected warning on execution of the second `docker` plugin:

```yml
steps:
- command: "echo 'foo' > bar.txt"
  plugins:
    - docker#v3.5.0:
        image: bash
    - docker#v3.5.0:
        image: bash
    - artifacts#v1.2.0:
        upload: bar.txt
```

Fixes #1152 

---

_Edit by @pda_: I didn't quite understand the bug, so I dug into the code; here's my summary:

* If any plugin for a step has a checkout hook (same applies to command hooks), only the first plugin gets the opportunity to run its checkout hook;
    * subsequent plugins show the "Ignoring ..." warning message regardless of whether they implement a checkout hook.
* But if none of the plugins implement a checkout hook, there are no warning messages.
* If the first plugin implements a checkout hook, it runs as normal. If it doesn't, nothing happens, as normal.
    * If subsequent steps implement a checkout hook, they are ignored with a warning.
    * If subsequent steps _don't_ implement a checkout hook, the warning appears anyway.
* all of this applies to command hooks as well as checkout hooks.