### PR TITLE
build pipeline uses step dependencies (DAG)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -275,5 +275,11 @@ steps:
 
   - name: ":pipeline:"
     key: upload-release-steps
-    depends_on: build-github-release
+    depends_on:
+      - build-rpm-packages
+      - build-debian-packages
+      - build-docker-alpine
+      - build-docker-ubuntu
+      - build-docker-centos
+      - build-github-release
     command: ".buildkite/steps/upload-release-steps.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,7 @@ env:
 
 steps:
   - name: ":hammer: :linux:"
+    key: test-linux
     command: ".buildkite/steps/tests.sh"
     artifact_paths: junit-*.xml
     plugins:
@@ -11,6 +12,7 @@ steps:
         run: agent
 
   - name: ":hammer: :windows:"
+    key: test-windows
     command: ".buildkite\\steps\\tests.sh"
     artifact_paths: junit-*.xml
     plugins:
@@ -22,18 +24,18 @@ steps:
     agents:
       queue: "windows"
 
-  - wait: ~
-    continue_on_failure: true
-
   - label: ":junit:"
+    depends_on:
+      - test-linux
+      - test-windows
     plugins:
       - junit-annotate#v1.6.0:
           artifacts: junit-*.xml
 
-  - wait
-
   - name: ":windows: 386"
     command: ".buildkite/steps/build-binary.sh windows 386"
+    key: build-binary-windows-386
+    depends_on: test-linux # don't wait for slower windows tests
     artifact_paths: "pkg/*"
     plugins:
       docker-compose#v3.0.0:
@@ -42,6 +44,8 @@ steps:
 
   - name: ":windows: amd64"
     command: ".buildkite/steps/build-binary.sh windows amd64"
+    key: build-binary-windows-amd64
+    depends_on: test-linux # don't wait for slower windows tests
     artifact_paths: "pkg/*"
     plugins:
       docker-compose#v3.0.0:
@@ -50,6 +54,8 @@ steps:
 
   - name: ":linux: amd64"
     command: ".buildkite/steps/build-binary.sh linux amd64"
+    key: build-binary-linux-amd64
+    depends_on: test-linux # don't wait for slower windows tests
     artifact_paths: "pkg/*"
     plugins:
       docker-compose#v3.0.0:
@@ -58,6 +64,8 @@ steps:
 
   - name: ":linux: 386"
     command: ".buildkite/steps/build-binary.sh linux 386"
+    key: build-binary-linux-386
+    depends_on: test-linux # don't wait for slower windows tests
     artifact_paths: "pkg/*"
     plugins:
       docker-compose#v3.0.0:
@@ -66,6 +74,8 @@ steps:
 
   - name: ":linux: arm"
     command: ".buildkite/steps/build-binary.sh linux arm"
+    key: build-binary-linux-arm
+    depends_on: test-linux # don't wait for slower windows tests
     artifact_paths: "pkg/*"
     plugins:
       docker-compose#v3.0.0:
@@ -74,6 +84,8 @@ steps:
 
   - name: ":linux: armhf"
     command: ".buildkite/steps/build-binary.sh linux armhf"
+    key: build-binary-linux-armhf
+    depends_on: test-linux # don't wait for slower windows tests
     artifact_paths: "pkg/*"
     plugins:
       docker-compose#v3.0.0:
@@ -82,6 +94,8 @@ steps:
 
   - name: ":linux: arm64"
     command: ".buildkite/steps/build-binary.sh linux arm64"
+    key: build-binary-linux-arm64
+    depends_on: test-linux # don't wait for slower windows tests
     artifact_paths: "pkg/*"
     plugins:
       docker-compose#v3.0.0:
@@ -90,6 +104,8 @@ steps:
 
   - name: ":linux: ppc64le"
     command: ".buildkite/steps/build-binary.sh linux ppc64le"
+    key: build-binary-linux-ppc64le
+    depends_on: test-linux # don't wait for slower windows tests
     artifact_paths: "pkg/*"
     plugins:
       docker-compose#v3.0.0:
@@ -98,6 +114,8 @@ steps:
 
   - name: ":mac: 386"
     command: ".buildkite/steps/build-binary.sh darwin 386"
+    key: build-binary-darwin-386
+    depends_on: test-linux # don't wait for slower windows tests
     artifact_paths: "pkg/*"
     plugins:
       docker-compose#v3.0.0:
@@ -106,6 +124,8 @@ steps:
 
   - name: ":mac: amd64"
     command: ".buildkite/steps/build-binary.sh darwin amd64"
+    key: build-binary-darwin-amd64
+    depends_on: test-linux # don't wait for slower windows tests
     artifact_paths: "pkg/*"
     plugins:
       docker-compose#v3.0.0:
@@ -114,6 +134,8 @@ steps:
 
   - name: ":freebsd: amd64"
     command: ".buildkite/steps/build-binary.sh freebsd amd64"
+    key: build-binary-freebsd-amd64
+    depends_on: test-linux # don't wait for slower windows tests
     artifact_paths: "pkg/*"
     plugins:
       docker-compose#v1.8.0:
@@ -122,6 +144,8 @@ steps:
 
   - name: ":freebsd: 386"
     command: ".buildkite/steps/build-binary.sh freebsd 386"
+    key: build-binary-freebsd-386
+    depends_on: test-linux # don't wait for slower windows tests
     artifact_paths: "pkg/*"
     plugins:
       docker-compose#v1.8.0:
@@ -130,6 +154,8 @@ steps:
 
   - name: ":openbsd: amd64"
     command: ".buildkite/steps/build-binary.sh openbsd amd64"
+    key: build-binary-openbsd-amd64
+    depends_on: test-linux # don't wait for slower windows tests
     artifact_paths: "pkg/*"
     plugins:
       docker-compose#v1.8.0:
@@ -138,6 +164,8 @@ steps:
 
   - name: ":openbsd: 386"
     command: ".buildkite/steps/build-binary.sh openbsd 386"
+    key: build-binary-openbsd-386
+    depends_on: test-linux # don't wait for slower windows tests
     artifact_paths: "pkg/*"
     plugins:
       docker-compose#v1.8.0:
@@ -146,15 +174,17 @@ steps:
 
   - name: ":dragonflybsd: amd64"
     command: ".buildkite/steps/build-binary.sh dragonfly amd64"
+    key: build-binary-dragonfly-amd64
+    depends_on: test-linux # don't wait for slower windows tests
     artifact_paths: "pkg/*"
     plugins:
       docker-compose#v1.8.0:
         config: .buildkite/docker-compose.yml
         run: agent
 
-  - wait
-
   - name: ":hammer: bk cli"
+    key: test-bk-cli
+    depends_on: build-binary-linux-amd64
     command: ".buildkite/steps/test-bk.sh"
     plugins:
       docker-compose#v3.0.0:
@@ -167,35 +197,77 @@ steps:
         volumes:
           - "/usr/bin/buildkite-agent:/usr/bin/buildkite-agent"
 
-  - wait
-
   - name: ":mag:"
+    key: set-metadata
     command: ".buildkite/steps/extract-agent-version-metadata.sh"
 
   - wait
 
   - name: ":docker: alpine build"
+    key: build-docker-alpine
+    depends_on:
+      - build-binary-linux-amd64
+      - set-metadata
     command: ".buildkite/steps/build-docker-image.sh alpine"
 
   - name: ":docker: ubuntu build"
+    key: build-docker-ubuntu
+    depends_on:
+      - build-binary-linux-amd64
+      - set-metadata
     command: ".buildkite/steps/build-docker-image.sh ubuntu"
 
   - name: ":docker: centos build"
+    key: build-docker-centos
+    depends_on:
+      - build-binary-linux-amd64
+      - set-metadata
     command: ".buildkite/steps/build-docker-image.sh centos"
 
   - name: ":debian: build"
+    key: build-debian-packages
+    depends_on:
+      - build-binary-linux-amd64
+      - build-binary-linux-386
+      - build-binary-linux-arm
+      - build-binary-linux-armhf
+      - build-binary-linux-arm64
+      - set-metadata
     command: ".buildkite/steps/build-debian-packages.sh"
     artifact_paths: "deb/**/*"
     agents:
       queue: "deploy"
 
   - name: ":redhat: build"
+    key: build-rpm-packages
+    depends_on:
+      - build-binary-linux-amd64
+      - build-binary-linux-386
+      - set-metadata
     command: ".buildkite/steps/build-rpm-packages.sh"
     artifact_paths: "rpm/**/*"
     agents:
       queue: "deploy"
 
   - name: ":github: :hammer:"
+    key: build-github-release
+    depends_on:
+      - build-binary-windows-386
+      - build-binary-windows-amd64
+      - build-binary-linux-amd64
+      - build-binary-linux-386
+      - build-binary-linux-arm
+      - build-binary-linux-armhf
+      - build-binary-linux-arm64
+      - build-binary-linux-ppc64le
+      - build-binary-darwin-386
+      - build-binary-darwin-amd64
+      - build-binary-freebsd-amd64
+      - build-binary-freebsd-386
+      - build-binary-openbsd-amd64
+      - build-binary-openbsd-386
+      - build-binary-dragonfly-amd64
+      - set-metadata
     command: ".buildkite/steps/build-github-release.sh"
     artifact_paths: "releases/**/*"
     plugins:
@@ -203,7 +275,7 @@ steps:
         config: .buildkite/docker-compose.release.yml
         run: github-release
 
-  - wait
-
   - name: ":pipeline:"
+    key: upload-release-steps
+    depends_on: build-github-release
     command: ".buildkite/steps/upload-release-steps.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -201,8 +201,6 @@ steps:
     key: set-metadata
     command: ".buildkite/steps/extract-agent-version-metadata.sh"
 
-  - wait
-
   - name: ":docker: alpine build"
     key: build-docker-alpine
     depends_on:


### PR DESCRIPTION
I'm 90% sure I have the dependencies right.
It's a shame that it adds so much noise to the pipeline YAML, but I think it's worthwhile.

Here's the non-step-dependencies DAG before:

![image](https://user-images.githubusercontent.com/15759/73409088-5de6af80-4352-11ea-9968-1f7edd735a5e.png)

and after adding step dependencies:

![image](https://user-images.githubusercontent.com/15759/73408751-625e9880-4351-11ea-9c4d-ad93036c8a4e.png)

Critically, it pushes the Windows build off the critical path, saving 5-15 minutes:

![image](https://user-images.githubusercontent.com/15759/73408823-8e7a1980-4351-11ea-832e-04bfab28292d.png)