### PR TITLE
Clarify that metadata is always stored at the build, not the job

### DIFF
--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -47,7 +47,7 @@ var MetaDataExistsCommand = cli.Command{
 		cli.StringFlag{
 			Name:   "job",
 			Value:  "",
-			Usage:  "Which job should the meta-data be checked for",
+			Usage:  "Which job's build should the meta-data be checked for",
 			EnvVar: "BUILDKITE_JOB_ID",
 		},
 

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -52,7 +52,7 @@ var MetaDataGetCommand = cli.Command{
 		cli.StringFlag{
 			Name:   "job",
 			Value:  "",
-			Usage:  "Which job should the meta-data be retrieved from",
+			Usage:  "Which job's build should the meta-data be retrieved from",
 			EnvVar: "BUILDKITE_JOB_ID",
 		},
 

--- a/clicommand/meta_data_keys.go
+++ b/clicommand/meta_data_keys.go
@@ -46,7 +46,7 @@ var MetaDataKeysCommand = cli.Command{
 		cli.StringFlag{
 			Name:   "job",
 			Value:  "",
-			Usage:  "Which job should the meta-data be checked for",
+			Usage:  "Which job's build should the meta-data be checked for",
 			EnvVar: "BUILDKITE_JOB_ID",
 		},
 

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -53,7 +53,7 @@ var MetaDataSetCommand = cli.Command{
 		cli.StringFlag{
 			Name:   "job",
 			Value:  "",
-			Usage:  "Which job should the meta-data be set on",
+			Usage:  "Which job's build should the meta-data be set on",
 			EnvVar: "BUILDKITE_JOB_ID",
 		},
 


### PR DESCRIPTION
The agent API for working with metadata requires a job ID, but under the hood the data is stored on the build not the job.

The help text for the flags wasn't as clear on that as it could be.

Related: https://github.com/buildkite/docs/issues/631