### PR TITLE
Test & error message re. dollar sign escaping in pipeline conditional regexp

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -213,7 +213,11 @@ var PipelineUploadCommand = cli.Command{
 			NoInterpolation: cfg.NoInterpolation,
 		}.Parse()
 		if err != nil {
-			l.Fatal("Pipeline parsing of \"%s\" failed (%s)", filename, err)
+			src := filename
+			if src == "" {
+				src = "(stdin)"
+			}
+			l.Fatal("Pipeline parsing of \"%s\" failed (%s)", src, err)
 		}
 
 		// In dry-run mode we just output the generated pipeline to stdout


### PR DESCRIPTION
There was a report of pipeline statement `if: build.env("ACCOUNT") =~ /^(foo|bar)$/` resulted in error `Pipeline parsing of "" failed (Expected identifier to start with a letter, got /)`.

It turns out the `$` in the regexp is actually being interpreted as invalid [Environment Variable Substitution](https://buildkite.com/docs/agent/v3/cli-pipeline#environment-variable-substitution).

This PR;
(a) makes the error less mysterious; `parsing of "(stdin)" failed` rather than `parsing of "" failed` 
(b) adds a test demonstrating this case with and without env substitution enabled. 

I'm not actually sure the test is valuable, but it runs in 68 microseconds on my machine, so maybe not a burden to keep around.