### PR TITLE
Alter debian package build step to work on agents without ruby

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -13,3 +13,18 @@ services:
       - BUILDKITE_JOB_ID
       - "BUILDKITE_AGENT_TAGS=queue=default"
       - "BUILDKITE_BUILD_PATH=/buildkite"
+
+  ruby:
+    image: ruby:2.6
+    volumes:
+      - ..:/work
+      - ruby-2-6-agent-gem-cache:/usr/local/bundle
+    working_dir: /work
+    command: /bin/bash
+    environment:
+      - FULL_AGENT_VERSION
+      - AGENT_VERSION
+      - BUILD_VERSION
+
+volumes:
+  ruby-2-6-agent-gem-cache: ~

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -233,8 +233,6 @@ steps:
       - set-metadata
     command: ".buildkite/steps/build-debian-packages.sh"
     artifact_paths: "deb/**/*"
-    agents:
-      queue: "deploy"
 
   - name: ":redhat: build"
     key: build-rpm-packages

--- a/.buildkite/steps/build-debian-packages.sh
+++ b/.buildkite/steps/build-debian-packages.sh
@@ -19,9 +19,6 @@ dry_run() {
   fi
 }
 
-echo "--- Installing dependencies"
-bundle
-
 # Make sure we have a clean deb folder
 rm -rf deb
 
@@ -39,5 +36,5 @@ for ARCH in "amd64" "386" "arm" "armhf" "arm64"; do
   chmod +x "$BINARY"
 
   # Build the debian package using the architectre and binary, they are saved to deb/
-  ./scripts/build-debian-package.sh "$ARCH" "$BINARY" "$AGENT_VERSION" "$BUILD_VERSION"
+  .buildkite/steps/ruby-env ./scripts/build-debian-package.sh "$ARCH" "$BINARY" "$AGENT_VERSION" "$BUILD_VERSION"
 done

--- a/.buildkite/steps/ruby-env
+++ b/.buildkite/steps/ruby-env
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+# start a docker container with the ruby environment we need in some build steps
+
+compose_file="$(dirname $0)/../docker-compose.yml"
+
+echo "+++ :docker::ruby: execute deploy"
+docker-compose -f "$compose_file" run --rm ruby "${@-bash}"
+

--- a/scripts/build-debian-package.sh
+++ b/scripts/build-debian-package.sh
@@ -44,6 +44,10 @@ PACKAGE_PATH="${DESTINATION_PATH}/${PACKAGE_NAME}"
 
 mkdir -p "$DESTINATION_PATH"
 
+info "Installing dependencies"
+
+bundle check || bundle
+
 info "Building debian package $PACKAGE_NAME to $DESTINATION_PATH"
 
 bundle exec fpm -s "dir" \


### PR DESCRIPTION
This step requires an environment with ruby (to use the fpm gem). Historically we've used the "queue=deploy" targeting to ensure it runs on an agent that happens to have ruby.

However, we'd like to be able to run this step on a standard elastic stack environment, which only has the bk agent binary, awscli, and docker.

This changes the step to launch a docker container with ruby for
the parts that need it.

I considered using the docker-compose plugin for the whole step like other parts of the pipeline, however there's a reasonable amount of existing shell code used here and I wasn't sure how it would interact with the plugin. In the end, I optimised for the least disruption to what was already there.