### PR TITLE
Alter rpm package build step to work on agents without ruby

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -242,8 +242,6 @@ steps:
       - set-metadata
     command: ".buildkite/steps/build-rpm-packages.sh"
     artifact_paths: "rpm/**/*"
-    agents:
-      queue: "deploy"
 
   - name: ":github: :hammer:"
     key: build-github-release

--- a/.buildkite/steps/build-rpm-packages.sh
+++ b/.buildkite/steps/build-rpm-packages.sh
@@ -19,9 +19,6 @@ dry_run() {
   fi
 }
 
-echo "--- Installing dependencies"
-bundle
-
 # Make sure we have a clean rpm folder
 rm -rf rpm
 
@@ -39,5 +36,5 @@ for ARCH in "amd64" "386"; do
   chmod +x "$BINARY"
 
   # Build the rpm package using the architecture and binary, they are saved to rpm/
-  ./scripts/build-rpm-package.sh "$ARCH" "$BINARY" "$AGENT_VERSION" "$BUILD_VERSION"
+  .buildkite/steps/ruby-env ./scripts/build-rpm-package.sh "$ARCH" "$BINARY" "$AGENT_VERSION" "$BUILD_VERSION"
 done

--- a/scripts/build-rpm-package.sh
+++ b/scripts/build-rpm-package.sh
@@ -38,6 +38,11 @@ PACKAGE_PATH="${DESTINATION_PATH}/${PACKAGE_NAME}"
 
 mkdir -p "$DESTINATION_PATH"
 
+info "Installing dependencies"
+
+bundle check || bundle
+which rpmbuild || (apt update && apt install -y rpm)
+
 info "Building rpm package $PACKAGE_NAME to $DESTINATION_PATH"
 
 bundle exec fpm -s "dir" \


### PR DESCRIPTION
This step requires an environment with ruby (to use the fpm gem). Historically we've used the "queue=deploy" targeting to ensure it runs on an agent that happens to have ruby.

However, we'd like to be able to run this step on a standard elastic stack environment, which only has the bk agent binary, awscli, and docker.

This changes the step to launch a docker container with ruby for the parts that need it.

I considered using the docker-compose plugin for the whole step like other parts of the pipeline, however there's a reasonable amount of existing shell code used here and I wasn't sure how it would interact with the plugin. In the end, I optimised for the least disruption to what was already there.

PR #1165 is a matching change for building debian packages.