### PR TITLE
Lock our windows builds to a specific image digest

### DIFF
--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -1,5 +1,5 @@
 ## Development docker image for buildkite-agent on windows
-FROM mcr.microsoft.com/windows/servercore:1809
+FROM mcr.microsoft.com/windows/servercore:1809@sha256:23e7bb473261f12307e82d0cd52a1bcbad4bc64c00e889cee344401d0c3de3d3
 
 ENV ChocolateyUseWindowsCompression false
 


### PR DESCRIPTION
Windows builds of the agent have started failing, and all the failed jobs use the following digest of the windows/servercore image:

    sha256:47bb7fe42f88823f3e54c03cefa2f20e3d7cff8a1a051878af2f45f6b6afef65

The last green windows build used this digest:

    sha256:23e7bb473261f12307e82d0cd52a1bcbad4bc64c00e889cee344401d0c3de3d3

According to [docker hub](https://hub.docker.com/_/microsoft-windows-servercore), microsoft updated this image at:

    02/11/2020 18:12:05

The timezone of that stamp is unclear but it's with 24 hours of when our builds started failing. Maybe locking us back to the older digest will help?