### PR TITLE
run "publish to s3" steps on the new deploy-production agents

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -6,7 +6,7 @@ steps:
     env:
       CODENAME: "experimental"
     agents:
-      queue: "deploy"
+      queue: "deploy-production"
 
   - name: ":redhat: publish rpms"
     command: ".buildkite/steps/publish-rpm-package.sh"

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -11,7 +11,7 @@ steps:
     env:
       CODENAME: "stable"
     agents:
-      queue: "deploy"
+      queue: "deploy-production"
 
   - name: ":octocat: :rocket:"
     command: ".buildkite/steps/github-release.sh"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -11,7 +11,7 @@ steps:
     env:
       CODENAME: "unstable"
     agents:
-      queue: "deploy"
+      queue: "deploy-production"
 
   - name: ":octocat: :rocket:"
     command: ".buildkite/steps/github-release.sh"


### PR DESCRIPTION
The "deploy" queue currently runs on the bastion, and we're trying to move things off that so it can be shut down.

publishing to s3 requires the buildkite-agent (to fetch metadata) and awscli (to push to s3), both of which are available on the elastic stack agents that process the "deploy-production" queue.

There's a good chance the agents won't have IAM permissions for pushing to the bucket, but we can address that if it happens.