### PR TITLE
require tests to pass on windows before we trigger an edge release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -278,4 +278,5 @@ steps:
       - build-docker-ubuntu
       - build-docker-centos
       - build-github-release
+      - test-windows
     command: ".buildkite/steps/upload-release-steps.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -272,11 +272,12 @@ steps:
   - name: ":pipeline:"
     key: upload-release-steps
     depends_on:
+      - test-windows
+      - test-bk-cli
       - build-rpm-packages
       - build-debian-packages
       - build-docker-alpine
       - build-docker-ubuntu
       - build-docker-centos
       - build-github-release
-      - test-windows
     command: ".buildkite/steps/upload-release-steps.sh"


### PR DESCRIPTION
At the moment, we can trigger an edge release even if the tests fail on windows.

Here's what the agent pipeline looked like pre-DAG:

![Screenshot from 2020-02-14 12-09-09](https://user-images.githubusercontent.com/8132/74492394-d8065f00-4f22-11ea-8796-50f6069ba354.png)

It may have been intentional to move the windows tests off the critical path,so opening this for discussion