### PR TITLE
shuffle agent targeting rules for the release pipelines

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -6,25 +6,25 @@ steps:
     env:
       CODENAME: "experimental"
     agents:
-      queue: "deploy-production"
+      queue: "deploy"
 
   - name: ":redhat: publish rpms"
     command: ".buildkite/steps/publish-rpm-package.sh"
     env:
       CODENAME: "experimental"
     agents:
-      queue: "deploy"
+      queue: "deploy-legacy"
 
   - name: ":debian: publish debs"
     command: ".buildkite/steps/publish-debian-package.sh"
     env:
       CODENAME: "experimental"
     agents:
-      queue: "deploy"
+      queue: "deploy-legacy"
 
   - name: ":docker:"
     command: ".buildkite/steps/publish-docker-images.sh"
     env:
       CODENAME: "experimental"
     agents:
-      queue: "deploy"
+      queue: "deploy-legacy"

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -11,35 +11,35 @@ steps:
     env:
       CODENAME: "stable"
     agents:
-      queue: "deploy-production"
+      queue: "deploy"
 
   - name: ":octocat: :rocket:"
     command: ".buildkite/steps/github-release.sh"
     env:
       CODENAME: "stable"
     agents:
-      queue: "deploy"
+      queue: "deploy-legacy"
 
   - name: ":redhat:"
     command: ".buildkite/steps/publish-rpm-package.sh"
     env:
       CODENAME: "stable"
     agents:
-      queue: "deploy"
+      queue: "deploy-legacy"
 
   - name: ":debian:"
     command: ".buildkite/steps/publish-debian-package.sh"
     env:
       CODENAME: "stable"
     agents:
-      queue: "deploy"
+      queue: "deploy-legacy"
 
   - name: ":docker:"
     command: ".buildkite/steps/publish-docker-images.sh"
     env:
       CODENAME: "stable"
     agents:
-      queue: "deploy"
+      queue: "deploy-legacy"
 
   - wait
 
@@ -49,5 +49,4 @@ steps:
     env:
       CODENAME: "stable"
     agents:
-      queue: "deploy"
-
+      queue: "deploy-legacy"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -11,35 +11,35 @@ steps:
     env:
       CODENAME: "unstable"
     agents:
-      queue: "deploy-production"
+      queue: "deploy"
 
   - name: ":octocat: :rocket:"
     command: ".buildkite/steps/github-release.sh"
     env:
       CODENAME: "unstable"
     agents:
-      queue: "deploy"
+      queue: "deploy-legacy"
 
   - name: ":redhat:"
     command: ".buildkite/steps/publish-rpm-package.sh"
     env:
       CODENAME: "unstable"
     agents:
-      queue: "deploy"
+      queue: "deploy-legacy"
 
   - name: ":debian:"
     command: ".buildkite/steps/publish-debian-package.sh"
     env:
       CODENAME: "unstable"
     agents:
-      queue: "deploy"
+      queue: "deploy-legacy"
 
   - name: ":docker:"
     command: ".buildkite/steps/publish-docker-images.sh"
     env:
       CODENAME: "unstable"
     agents:
-      queue: "deploy"
+      queue: "deploy-legacy"
 
   - wait
 
@@ -49,5 +49,4 @@ steps:
     env:
       CODENAME: "unstable"
     agents:
-      queue: "deploy"
-
+      queue: "deploy-legacy"


### PR DESCRIPTION
The agent that used to process the "deploy" queue is now processing the "deploy-legacy" queue. That agent is deprecated and we're working on shutting it down.

Steps that used to run via the "deploy-production" queue should now target the "deploy" queue, which is an elastic stack.

/cc @chloeruka 