### PR TITLE
add 'spawn=1' with comment + default to all .cfg templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,7 +328,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add buildkite-agent.cfg to docker images [#847](https://github.com/buildkite/agent/pull/847) (@lox)
 
 ### Added
-- Experimental `--spawn` option to spawn multiple parallel agents [#590](https://github.com/buildkite/agent/pull/590) (@lox)
+- Experimental `--spawn` option to spawn multiple parallel agents [#590](https://github.com/buildkite/agent/pull/590) (@lox) - **Update:** This feature is now super stable.
 - Add a linux/ppc64le build target [#859](https://github.com/buildkite/agent/pull/859) (@lox)
 - Basic metrics collection for Datadog [#832](https://github.com/buildkite/agent/pull/832) (@lox)
 - Added a `job update` command to make changes to a job [#833](https://github.com/buildkite/agent/pull/833) (@keithpitt)

--- a/packaging/docker/alpine-linux/buildkite-agent.cfg
+++ b/packaging/docker/alpine-linux/buildkite-agent.cfg
@@ -4,6 +4,9 @@
 # The name of the agent
 name="%hostname-%n"
 
+# The number of agents to spawn in parallel (default is "1")
+# spawn=1
+
 # The priority of the agent (higher priorities are assigned work first)
 # priority=1
 

--- a/packaging/docker/centos-linux/buildkite-agent.cfg
+++ b/packaging/docker/centos-linux/buildkite-agent.cfg
@@ -4,6 +4,9 @@
 # The name of the agent
 name="%hostname-%n"
 
+# The number of agents to spawn in parallel (default is "1")
+# spawn=1
+
 # The priority of the agent (higher priorities are assigned work first)
 # priority=1
 

--- a/packaging/docker/ubuntu-linux/buildkite-agent.cfg
+++ b/packaging/docker/ubuntu-linux/buildkite-agent.cfg
@@ -4,6 +4,9 @@
 # The name of the agent
 name="%hostname-%n"
 
+# The number of agents to spawn in parallel (default is "1")
+# spawn=1
+
 # The priority of the agent (higher priorities are assigned work first)
 # priority=1
 

--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -4,6 +4,9 @@ token="xxx"
 # The name of the agent
 name="%hostname-%n"
 
+# The number of agents to spawn in parallel (default is "1")
+# spawn=1
+
 # The priority of the agent (higher priorities are assigned work first)
 # priority=1
 

--- a/packaging/github/windows/buildkite-agent.cfg
+++ b/packaging/github/windows/buildkite-agent.cfg
@@ -4,6 +4,9 @@ token="xxx"
 # The name of the agent
 name="%hostname-%n"
 
+# The number of agents to spawn in parallel (default is "1")
+# spawn=1
+
 # The priority of the agent (higher priorities are assigned work first)
 # priority=1
 

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -4,6 +4,9 @@ token="xxx"
 # The name of the agent
 name="%hostname-%n"
 
+# The number of agents to spawn in parallel (default is "1")
+# spawn=1
+
 # The priority of the agent (higher priorities are assigned work first)
 # priority=1
 


### PR DESCRIPTION
No examples of `buildkite-agent start` nor samples of `buildkite-agent.cfg` mention the `--spawn` nor `spawn=1` options, respectively. But its so much nicer than manually curating half a dozen `buildkite-agent start` processes, their PIDs, etc. Let's advertise it some more.