### PR TITLE
Update artifact upload --help description

### DIFF
--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -15,9 +15,11 @@ Description:
 
    Uploads files to a job as artifacts.
 
-   You need to ensure that the paths are surrounded by quotes otherwise the
-   built-in shell path globbing will provide the files, which is currently not
-   supported.
+   Please ensure path patterns are surrounded by quotes otherwise the built-in
+   shell path globbing will provide the files, which is currently not supported.
+
+   The destination argument is used when you are uploading artifacts to Amazon S3,
+   GCS, or Artifactory. 
 
 Example:
 


### PR DESCRIPTION
As mentioned in https://github.com/buildkite/docs/pull/643, we don't describe the `destination` argument of the `upload` command. This PR adds a line to the `--help` description about the `destination` arg. 

I also did a super quick edit on the other bits of the description too 👍🏻