### PR TITLE
Migrate publishing of deb package to the new "deploy" queue

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -26,8 +26,18 @@ steps:
     command: ".buildkite/steps/publish-debian-package.sh"
     env:
       CODENAME: "experimental"
+      DEB_S3_BUCKET: "apt.buildkite.com/buildkite-agent"
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v3.5.0:
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          propagate-environment: true
+          tmpfs:
+            - "/root/.gnupg"
 
   - name: ":docker:"
     command: ".buildkite/steps/publish-docker-images.sh"

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -38,8 +38,18 @@ steps:
     command: ".buildkite/steps/publish-debian-package.sh"
     env:
       CODENAME: "stable"
+      DEB_S3_BUCKET: "apt.buildkite.com/buildkite-agent"
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v3.5.0:
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          propagate-environment: true
+          tmpfs:
+            - "/root/.gnupg"
 
   - name: ":docker:"
     command: ".buildkite/steps/publish-docker-images.sh"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -38,8 +38,18 @@ steps:
     command: ".buildkite/steps/publish-debian-package.sh"
     env:
       CODENAME: "unstable"
+      DEB_S3_BUCKET: "apt.buildkite.com/buildkite-agent"
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v3.5.0:
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          propagate-environment: true
+          tmpfs:
+            - "/root/.gnupg"
 
   - name: ":docker:"
     command: ".buildkite/steps/publish-docker-images.sh"

--- a/.buildkite/steps/publish-debian-package.sh
+++ b/.buildkite/steps/publish-debian-package.sh
@@ -1,12 +1,35 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 artifacts_build=$(buildkite-agent meta-data get "agent-artifacts-build" )
+
+# /root/,gnupg is a tmpfs volume, so we can safely store key data there and know
+# it won't be written to a disk
+secret_key_path="/root/.gnupg/gpg-secret.gpg"
+public_key_path="/root/.gnupg/gpg-public.gpg"
 
 if [[ "$CODENAME" == "" ]]; then
   echo "Error: Missing \$CODENAME (stable or unstable)"
   exit 1
 fi
+
+echo '--- Configuring gnupg'
+
+echo "fetching signing key..."
+export GPG_SIGNING_KEY=$(aws ssm get-parameter --name /pipelines/agent/GPG_SIGNING_KEY --with-decryption --output text --query Parameter.Value --region us-east-1)
+
+echo "fetching secret key..."
+aws ssm get-parameter --name /pipelines/agent/GPG_SECRET_KEY_ASCII --with-decryption --output text --query Parameter.Value --region us-east-1 > ${secret_key_path}
+ls -lh /root/.gnupg/
+gpg --import --batch ${secret_key_path}
+rm ${secret_key_path}
+
+# technically we don't need the public key for signing, but it's helpful to keep a copy
+# in the same place as the secret key so we don't lose it
+echo "fetching public key..."
+aws ssm get-parameter --name /pipelines/agent/GPG_PUBLIC_KEY_ASCII --with-decryption --output text --query Parameter.Value --region us-east-1 > ${public_key_path}
+gpg --import --batch ${public_key_path}
+rm ${public_key_path}
 
 echo '--- Downloading built debian packages'
 rm -rf deb

--- a/.buildkite/steps/publish-debian-package.sh
+++ b/.buildkite/steps/publish-debian-package.sh
@@ -3,14 +3,6 @@ set -e
 
 artifacts_build=$(buildkite-agent meta-data get "agent-artifacts-build" )
 
-dry_run() {
-  if [[ "${DRY_RUN:-}" == "false" ]] ; then
-    "$@"
-  else
-    echo "[dry-run] $*"
-  fi
-}
-
 if [[ "$CODENAME" == "" ]]; then
   echo "Error: Missing \$CODENAME (stable or unstable)"
   exit 1
@@ -27,5 +19,5 @@ bundle
 # Loop over all the .deb files and publish them
 for file in deb/*.deb; do
   echo "+++ Publishing $file"
-  dry_run ./scripts/publish-debian-package.sh "$file" "$CODENAME"
+  ./scripts/publish-debian-package.sh "$file" "$CODENAME"
 done

--- a/.buildkite/steps/publish-debian-package.sh
+++ b/.buildkite/steps/publish-debian-package.sh
@@ -15,6 +15,14 @@ fi
 
 echo '--- Configuring gnupg'
 
+echo "confirming gnupg config is stored in memory, not on disk"
+
+apk add --update findmnt
+if ! findmnt --source tmpfs --target /root/.gnupg; then
+  echo "/root/.gnupg must be mounted as tmpfs to ensure private keys aren't written to disk"
+  exit 1
+fi
+
 echo "fetching signing key..."
 export GPG_SIGNING_KEY=$(aws ssm get-parameter --name /pipelines/agent/GPG_SIGNING_KEY --with-decryption --output text --query Parameter.Value --region us-east-1)
 

--- a/scripts/publish-debian-package.sh
+++ b/scripts/publish-debian-package.sh
@@ -30,16 +30,6 @@ if [ -z "$GPG_SIGNING_KEY" ]; then
   exit 1
 fi
 
-if [ -z "$GPG_PASSPHRASE_PASSWORD" ]; then
-  echo "Error: Missing ENV variable GPG_PASSPHRASE_PASSWORD"
-  exit 1
-fi
-
-if [ -z "$GPG_PASSPHRASE_PATH" ]; then
-  echo "Error: Missing ENV variable GPG_PASSPHRASE_PATH"
-  exit 1
-fi
-
 if [ -z "$DEB_S3_BUCKET" ]; then
   echo "Error: Missing ENV variable DEB_S3_BUCKET"
   exit 1
@@ -47,13 +37,10 @@ fi
 
 info "Uploading $PACKAGE to $DEB_S3_BUCKET ($CODENAME $COMPONENT)"
 
-# Decrpyt the GPG_PASSPHRASE with our GPG_PASSPHRASE_PASSWORD
-GPG_PASSPHRASE=`openssl aes-256-cbc -k "$GPG_PASSPHRASE_PASSWORD" -in "$GPG_PASSPHRASE_PATH" -d`
-
 deb_s3_args=(
   --preserve-versions
   --sign "$GPG_SIGNING_KEY"
-  --gpg-options "\-\-digest-algo SHA512 \-\-passphrase $GPG_PASSPHRASE"
+  --gpg-options "\-\-digest-algo SHA512"
   --codename "$CODENAME"
   --component "$COMPONENT"
 )

--- a/scripts/publish-debian-package.sh
+++ b/scripts/publish-debian-package.sh
@@ -12,6 +12,14 @@ function info {
   echo -e "\033[35m$1\033[0m"
 }
 
+dry_run() {
+  if [[ "${DRY_RUN:-}" == "false" ]] ; then
+    "$@"
+  else
+    echo "[dry-run] $*"
+  fi
+}
+
 PACKAGE=${1}
 CODENAME=${2}
 COMPONENT="main"
@@ -72,7 +80,7 @@ fi
 
 # Uploads to s3 and signs with the default key on the system
 
-bundle exec deb-s3 upload "${deb_s3_args[@]}" "$PACKAGE"
+dry_run bundle exec deb-s3 upload "${deb_s3_args[@]}" "$PACKAGE"
 
 echo "✅ All done! To install this package:"
 echo ""


### PR DESCRIPTION
The `deploy-legacy` queue is deprecated, and we're slowly moving steps off it.

The new `deploy` queue is processed by agents in an elastic stack, which has a few implications:

* most of the tools we need (like gnupg and ruby) aren't available by default, so we have to use a docker container with the tools we need
* sensitive values (like gpg keys) aren't stored on the new agents, so we need to fetch them from AWS SSM

Some bonus highlights:

* I pushed the `dry_run` logic to later in the scripts, to after the point where we configure gnupg. This lets us verify the gnupg setup in dry runs
* The gnupg keys are never written to disk - they only exist in a docker tmpfs volume