### PR TITLE
use deploytools to publish to s3

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -7,6 +7,13 @@ steps:
       CODENAME: "experimental"
     agents:
       queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v3.5.0:
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          propagate-environment: true
 
   - name: ":redhat: publish rpms"
     command: ".buildkite/steps/publish-rpm-package.sh"

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -12,6 +12,13 @@ steps:
       CODENAME: "stable"
     agents:
       queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v3.5.0:
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          propagate-environment: true
 
   - name: ":octocat: :rocket:"
     command: ".buildkite/steps/github-release.sh"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -12,6 +12,13 @@ steps:
       CODENAME: "unstable"
     agents:
       queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v3.5.0:
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          propagate-environment: true
 
   - name: ":octocat: :rocket:"
     command: ".buildkite/steps/github-release.sh"

--- a/.buildkite/steps/publish-to-s3.sh
+++ b/.buildkite/steps/publish-to-s3.sh
@@ -43,13 +43,7 @@ done
 
 echo "--- :s3: Copying /$version to /latest"
 
-# write all versions to a tmp file
-aws s3 ls --region "us-east-1" "$s3_base_url/" | grep PRE | awk '{print $2}' | awk -F '/' '{print $1}' > ../.versions
-
-# use ruby to determine the latest version
-../scripts/ruby-env bash -c "cat .versions | ./scripts/latest_version.rb > .latest_version"
-
-latest_version=$(cat ../.latest_version | tr -d "\n")
+latest_version=$(aws s3 ls --region "us-east-1" "$s3_base_url/" | grep PRE | awk '{print $2}' | awk -F '/' '{print $1}' | ruby ../scripts/latest_version.rb)
 latest_version_s3_url="$s3_base_url/$latest_version/"
 latest_s3_url="$s3_base_url/latest/"
 


### PR DESCRIPTION
In PR #1170 (and then c6de240) I jumped through some hoops to get the publishing to S3 to work without the "deploy-legacy" queue.

It worked, but the result was pretty messy.

This changes that step to launch within a docker container with all the tools we need, so the scripts can assume the tools are on the path.