### PR TITLE
migrate publishing of rpm packages to the new "deploy" queue

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -19,8 +19,18 @@ steps:
     command: ".buildkite/steps/publish-rpm-package.sh"
     env:
       CODENAME: "experimental"
+      RPM_S3_BUCKET: "yum.buildkite.com"
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v3.5.0:
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          propagate-environment: true
+          volumes:
+            - "/yum.buildkite.com"
 
   - name: ":debian: publish debs"
     command: ".buildkite/steps/publish-debian-package.sh"

--- a/.buildkite/steps/publish-rpm-package.sh
+++ b/.buildkite/steps/publish-rpm-package.sh
@@ -27,7 +27,7 @@ echo '--- Installing dependencies'
 apk --no-cache add createrepo_c --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 # createrepo_c requires some exotic flags on the cp, which aren't available on the busybox version
-apk add coreutils
+apk --no-cache add coreutils
 
 # Make sure we have a local copy of the yum repo
 echo "--- Syncing s3://$RPM_S3_BUCKET to `hostname`"

--- a/.buildkite/steps/publish-rpm-package.sh
+++ b/.buildkite/steps/publish-rpm-package.sh
@@ -24,12 +24,15 @@ mkdir -p rpm
 buildkite-agent artifact download --build "$artifacts_build" "rpm/*.rpm" rpm/
 
 echo '--- Installing dependencies'
-bundle
+apk --no-cache add createrepo_c --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
+
+# createrepo_c requires some exotic flags on the cp, which aren't available on the busybox version
+apk add coreutils
 
 # Make sure we have a local copy of the yum repo
 echo "--- Syncing s3://$RPM_S3_BUCKET to `hostname`"
 mkdir -p $YUM_PATH
-aws --region us-east-1 s3 sync --delete "s3://$RPM_S3_BUCKET" "$YUM_PATH"
+aws --region us-east-1 s3 sync --delete --only-show-errors "s3://$RPM_S3_BUCKET" "$YUM_PATH"
 
 # Add the rpms and update meta-data
 for ARCH in "x86_64" "i386"; do


### PR DESCRIPTION
The "deploy-legacy" queue is deprecated, and we're slowly moving steps off it.

The new "deploy" queue is processed by agents in an elastic stack, which means most of the tools we need (like createrepo_c) aren't available by default. We can use a docker container with the tools we need.

Some highlights to call out here:

1. createrepo_c is available in the alpine package repositories (lucky!), so we install it each time
2. createrepo_c requires a full local copy of the rpm repository. The elastic stack agents processing the "deploy" queue don't have persistent local disk, so each time this step runs we have to re-download the full archive. It's currently ~9Gb and takes ~90 seconds to download. It's inefficient, but the time is probably tolerable given this doesn't run *that* often
3. Downloading the full archive for (2) outputs a lot to stdout, so I added the --only-show-errors switch
4. The existing script was running bundler to download gems, however we weren't using them
5. The agents processing the "deploy-legacy" queue have createrepo_c v0.10, but the new agents will have v0.15.6