### PR TITLE
No fake exits

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -18,6 +18,12 @@ If an experiment doesn't exist, no error will be raised.
 
 ## Available Experiments
 
+### `no-fake-exits`
+
+Avoid returning `-1` exit codes from processes which were killed. This value comes from Go's process management code, rather than the system, which can cause confusion. In concert with reporting the signal which terminated a process, this gives you a complete and accurate picture of the POSIX exit state of processes run in the agent.
+
+**Status**: correcting a historical bug, but holding back for a major release to avoid breaking peoples' workflows. We'd like this to be the standard behaviour in 4.0. 👍👍
+
 ### `git-mirrors`
 
 Maintain a single bare git mirror for each repository on a host that is shared amongst multiple agents and pipelines. Checkouts reference the git mirror using `git clone --reference`, as do submodules.

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -281,9 +281,13 @@ func (r *JobRunner) Run() error {
 		r.logger.Debug("[JobRunner] Deleted env file: %s", r.envFile.Name())
 	}
 
-	exitStatus := fmt.Sprintf("%d", r.process.WaitStatus().ExitStatus())
+	ws := r.process.WaitStatus()
+	exitStatus := ""
 	signal := ""
-	if ws := r.process.WaitStatus(); ws.Signaled() {
+	if !experiments.IsEnabled(`no-fake-exits`) || ws.Exited() {
+		exitStatus = fmt.Sprintf("%d", r.process.WaitStatus().ExitStatus())
+	}
+	if ws.Signaled() {
 		signal = process.SignalString(ws.Signal())
 	}
 

--- a/process/process.go
+++ b/process/process.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/buildkite/agent/v3/experiments"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/pkg/errors"
 )

--- a/process/process.go
+++ b/process/process.go
@@ -249,12 +249,18 @@ func (p *Process) Run() error {
 	}
 
 	// Find the exit status or terminating signal of the script
+	exitStatus := "nil"
 	exitSignal := "nil"
+
+	if !experiments.IsEnabled(`no-fake-exits`) || p.status.Exited() {
+		exitStatus = fmt.Sprintf("%d", p.status.ExitStatus())
+	}
+
 	if p.status.Signaled() {
 		exitSignal = SignalString(p.status.Signal())
 	}
-	p.logger.Info("Process with PID: %d finished with Exit Status: %d, Signal: %s",
-		p.pid, p.status.ExitStatus(), exitSignal)
+
+	p.logger.Info("Process with PID: %d finished with Exit Status: %s, Signal: %s", p.pid, exitStatus, exitSignal)
 
 	// Sometimes (in docker containers) io.Copy never seems to finish. This is a mega
 	// hack around it. If it doesn't finish after 1 second, just continue.


### PR DESCRIPTION
follows on from #899 to add a feature where the golang implementation detail-derived `-1` exit status is never passed to Buildkite, meaning that it will henceforth only be returned from Buildkite itself, and thus have a single meaning

please see EXPERIMENTS.md where I’ve put together a description of what this aims to achieve