### PR TITLE
Artifact help doc destination tweaks

### DIFF
--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -9,11 +9,12 @@ import (
 
 var DownloadHelpDescription = `Usage:
 
-   buildkite-agent artifact download [arguments...]
+   buildkite-agent artifact download [options] <query> <destination>
 
 Description:
 
-   Downloads artifacts from Buildkite to the local machine.
+	 Downloads artifacts specified by <query> from Buildkite to <destination>
+	 directory on the local machine.
 
    Note: You need to ensure that your search query is surrounded by quotes if
    using a wild card as the built-in shell path globbing will provide files,

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -9,7 +9,7 @@ import (
 
 var UploadHelpDescription = `Usage:
 
-   buildkite-agent artifact upload <pattern> <destination> [arguments...]
+   buildkite-agent artifact upload [options] <pattern> [destination]
 
 Description:
 
@@ -18,6 +18,12 @@ Description:
    You need to ensure that the paths are surrounded by quotes otherwise the
    built-in shell path globbing will provide the files, which is currently not
    supported.
+
+   You can specify an alternate destination on Amazon S3, Google Cloud Storage
+   or Artifactory as per the examples below. This may be specified in the
+   'destination' argument, or in the 'BUILDKITE_ARTIFACT_UPLOAD_DESTINATION'
+   environment variable.  Otherwise, artifacts are uploaded to a
+   Buildkite-managed Amazon S3 bucket.
 
 Example:
 


### PR DESCRIPTION
Based on https://github.com/buildkite/docs/pull/643 we figured the usage documenation regarding artifact destination wasn't clear. This updates the `--help` text for `buildkite-agent artifact upload` and `... download`, which will also eventually end up on https://buildkite.com/docs/agent/v3/cli-artifact#uploading-artifacts

Closes #1176 