### PR TITLE
stage docker images in ECR rather than docker hub

### DIFF
--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -45,7 +45,7 @@ test_docker_image() {
 push_docker_image() {
   local image_tag="$1"
   echo "--- Pushing :docker: image to $image_tag"
-  dry_run docker push "$image_tag"
+  docker push "$image_tag"
 }
 
 variant="${1:-}"

--- a/.buildkite/steps/extract-agent-version-metadata.sh
+++ b/.buildkite/steps/extract-agent-version-metadata.sh
@@ -6,9 +6,9 @@ build_version=${BUILDKITE_BUILD_NUMBER:-1}
 full_agent_version="buildkite-agent version ${agent_version}, build ${build_version}"
 
 # docker variants
-docker_alpine_image_tag="buildkiteci/agent:alpine-build-${BUILDKITE_BUILD_NUMBER}"
-docker_ubuntu_image_tag="buildkiteci/agent:ubuntu-build-${BUILDKITE_BUILD_NUMBER}"
-docker_centos_image_tag="buildkiteci/agent:centos-build-${BUILDKITE_BUILD_NUMBER}"
+docker_alpine_image_tag="445615400570.dkr.ecr.us-east-1.amazonaws.com/agent:alpine-build-${BUILDKITE_BUILD_NUMBER}"
+docker_ubuntu_image_tag="445615400570.dkr.ecr.us-east-1.amazonaws.com/agent:ubuntu-build-${BUILDKITE_BUILD_NUMBER}"
+docker_centos_image_tag="445615400570.dkr.ecr.us-east-1.amazonaws.com/agent:centos-build-${BUILDKITE_BUILD_NUMBER}"
 
 is_prerelease=0
 if [[ "$agent_version" =~ (alpha|beta|rc) ]] ; then

--- a/.buildkite/steps/publish-docker-images.sh
+++ b/.buildkite/steps/publish-docker-images.sh
@@ -26,7 +26,7 @@ for variant in "alpine" "ubuntu" "centos" ; do
   echo "Docker Image Tag for $variant: $source_image"
 
   echo "--- :docker: Pulling prebuilt image"
-  dry_run docker pull "$source_image"
+  docker pull "$source_image"
 
   echo "--- :docker: Publishing images for $variant"
   .buildkite/steps/publish-docker-image.sh "$variant" "$source_image" "$CODENAME" "$version" "$build"

--- a/.buildkite/steps/publish-docker-images.sh
+++ b/.buildkite/steps/publish-docker-images.sh
@@ -14,6 +14,9 @@ if [[ "$CODENAME" == "" ]]; then
   exit 1
 fi
 
+# login to ECR in the buildkite-dev AWS account, where the docker images have been staged privately
+eval "$(aws ecr get-login --no-include-email --registry-ids=445615400570)"
+
 version=$(buildkite-agent meta-data get "agent-version")
 build=$(buildkite-agent meta-data get "agent-version-build")
 


### PR DESCRIPTION
Historically, we've used a private docker hub area to hold images that may eventually be released as public images on https://hub.docker.com/r/buildkite/agent.

These days we're using ECR a lot more though, and managing authentication for that is much easier. It's one less secret for us to handle.

The agents that currently run this step don't auto-login to ECR, so we need to do so manually.
