### PR TITLE
publish images to docker hub using the deploy queue

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -34,4 +34,8 @@ steps:
     env:
       CODENAME: "experimental"
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "445615400570"

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -46,7 +46,11 @@ steps:
     env:
       CODENAME: "stable"
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "445615400570"
 
   - wait
 

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -46,7 +46,11 @@ steps:
     env:
       CODENAME: "unstable"
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "445615400570"
 
   - wait
 

--- a/.buildkite/steps/publish-docker-images.sh
+++ b/.buildkite/steps/publish-docker-images.sh
@@ -14,8 +14,11 @@ if [[ "$CODENAME" == "" ]]; then
   exit 1
 fi
 
-# login to ECR in the buildkite-dev AWS account, where the docker images have been staged privately
-eval "$(aws ecr get-login --no-include-email --registry-ids=445615400570 --region us-east-1)"
+echo "--- Logging in to Docker Hub"
+
+dockerhub_user="$(aws ssm get-parameter --name /pipelines/agent/DOCKER_HUB_USER --with-decryption --output text --query Parameter.Value --region us-east-1)"
+
+aws ssm get-parameter --name /pipelines/agent/DOCKER_HUB_PASSWORD --with-decryption --output text --query Parameter.Value --region us-east-1 | docker login --username="${dockerhub_user}" --password-stdin
 
 version=$(buildkite-agent meta-data get "agent-version")
 build=$(buildkite-agent meta-data get "agent-version-build")


### PR DESCRIPTION
The `deploy-legacy` queue is deprecated, and we're slowly moving steps off it.

There's two parts to publishing:

1. pulling the staged images from ECR
2. pushing the images to docker hub

For (1), the agents processing the new deploy queue are an elastic stack, and the instance roles in use have permission to pull from ECR. They also can use plugins, so we can use the ECR plugin to handle logins for us.

For (2), we need to manually pull the credentials from SSM and call "docker login". The agent that previously ran this step had a hook that handled docker hub authentication, but that's not our preferred approach any more.