### PR TITLE
set DRY_RUN: false

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  DRY_RUN: true # set to true to disable publishing releases
+  DRY_RUN: false # set to true to disable publishing releases
 
 steps:
   - name: ":hammer: :linux:"


### PR DESCRIPTION
This will enable releases again. Edge releases will happen automatically, beta and stable releases still require a human to unblock.

Over the past few days a few release steps have move to new agents, so this will help confirm the release process still works on the new agents.