### PR TITLE
unstable and stable rpm publishing should run on the deploy queue

### DIFF
--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -32,7 +32,16 @@ steps:
     env:
       CODENAME: "stable"
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v3.5.0:
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          propagate-environment: true
+          volumes:
+            - "/yum.buildkite.com"
 
   - name: ":debian:"
     command: ".buildkite/steps/publish-debian-package.sh"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -32,7 +32,16 @@ steps:
     env:
       CODENAME: "unstable"
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v3.5.0:
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          propagate-environment: true
+          volumes:
+            - "/yum.buildkite.com"
 
   - name: ":debian:"
     command: ".buildkite/steps/publish-debian-package.sh"


### PR DESCRIPTION
In PR #1180 we moved rpm publishing to the deploy queue for experimental releases. That's working well, so this makes the same change for unstable (beta) and stable releases.