### PR TITLE
set RPM_S3_BUCKET bucket env var for unstable/stable releases

### DIFF
--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -31,6 +31,7 @@ steps:
     command: ".buildkite/steps/publish-rpm-package.sh"
     env:
       CODENAME: "stable"
+      RPM_S3_BUCKET: "yum.buildkite.com"
     agents:
       queue: "deploy"
     plugins:

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -31,6 +31,7 @@ steps:
     command: ".buildkite/steps/publish-rpm-package.sh"
     env:
       CODENAME: "unstable"
+      RPM_S3_BUCKET: "yum.buildkite.com"
     agents:
       queue: "deploy"
     plugins:


### PR DESCRIPTION
In PR #1187 I moved unstable/stable rpm publishing to a new queue. Unfortunately, I forgot to also set the ENV var that sets the target S3 bucket for the rpms.