### PR TITLE
Create github and homebrew releases using the deploy queue 

### DIFF
--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -80,4 +80,11 @@ steps:
     env:
       CODENAME: "stable"
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v3.5.0:
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          propagate-environment: true

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -25,7 +25,14 @@ steps:
     env:
       CODENAME: "stable"
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v3.5.0:
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          propagate-environment: true
 
   - name: ":redhat:"
     command: ".buildkite/steps/publish-rpm-package.sh"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -25,7 +25,14 @@ steps:
     env:
       CODENAME: "unstable"
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v3.5.0:
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          propagate-environment: true
 
   - name: ":redhat:"
     command: ".buildkite/steps/publish-rpm-package.sh"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -80,4 +80,11 @@ steps:
     env:
       CODENAME: "unstable"
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v3.5.0:
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          propagate-environment: true

--- a/.buildkite/steps/check-changelog.sh
+++ b/.buildkite/steps/check-changelog.sh
@@ -6,5 +6,10 @@ VERSION=$(buildkite-agent meta-data get "agent-version")
 
 if ! grep --quiet "$VERSION" CHANGELOG.md; then
   echo "The CHANGELOG.md is missing an entry for version ${VERSION}"
-  exit 1
+
+  if [[ "${DRY_RUN:-}" == "false" ]] ; then
+    exit 1
+  else
+    echo "Dry Run Mode enabled, so allowing the build to continue"
+  fi
 fi

--- a/.buildkite/steps/github-release.sh
+++ b/.buildkite/steps/github-release.sh
@@ -9,6 +9,9 @@ dry_run() {
   fi
 }
 
+echo '--- Getting credentials from SSM'
+export GITHUB_RELEASE_ACCESS_TOKEN=$(aws ssm get-parameter --name /pipelines/agent/GITHUB_RELEASE_ACCESS_TOKEN --with-decryption --output text --query Parameter.Value --region us-east-1)
+
 if [[ "$GITHUB_RELEASE_ACCESS_TOKEN" == "" ]]; then
   echo "Error: Missing \$GITHUB_RELEASE_ACCESS_TOKEN"
   exit 1

--- a/.buildkite/steps/release-homebrew.sh
+++ b/.buildkite/steps/release-homebrew.sh
@@ -111,4 +111,6 @@ if [[ "${DRY_RUN:-}" == "false" ]] ; then
       -H "Content-Type: application/json" \
       --data-binary "@pkg/github_post_data.json" \
       --fail
+else
+  echo "Dry Run Mode: skipping commit on github"
 fi

--- a/.buildkite/steps/release-homebrew.sh
+++ b/.buildkite/steps/release-homebrew.sh
@@ -71,7 +71,7 @@ echo "Release SHA256: $RELEASE_SHA256"
 
 echo "--- :octocat: Fetching current homebrew formula from Github Contents API"
 
-CONTENTS_API_RESPONSE="$(curl "https://api.github.com/repos/buildkite/homebrew-buildkite/contents/buildkite-agent.rb?access_token=$GITHUB_RELEASE_ACCESS_TOKEN")"
+CONTENTS_API_RESPONSE="$(curl "https://api.github.com/repos/buildkite/homebrew-buildkite/contents/buildkite-agent.rb" -H "Authorization: token ${GITHUB_RELEASE_ACCESS_TOKEN}")"
 
 echo "Base64 decoding Github response into $FORMULA_FILE"
 
@@ -106,7 +106,8 @@ JSON
 
 if [[ "${DRY_RUN:-}" == "false" ]] ; then
   echo "Posting JSON to Github Contents API"
-  curl -X PUT "https://api.github.com/repos/buildkite/homebrew-buildkite/contents/buildkite-agent.rb?access_token=$GITHUB_RELEASE_ACCESS_TOKEN" \
+  curl -X PUT "https://api.github.com/repos/buildkite/homebrew-buildkite/contents/buildkite-agent.rb" \
+      -H "Authorization: token ${GITHUB_RELEASE_ACCESS_TOKEN}" \
       -H "Content-Type: application/json" \
       --data-binary "@pkg/github_post_data.json" \
       --fail

--- a/.buildkite/steps/release-homebrew.sh
+++ b/.buildkite/steps/release-homebrew.sh
@@ -41,6 +41,7 @@ fi
 
 GITHUB_RELEASE_VERSION=$(buildkite-agent meta-data get github_release_version)
 GITHUB_RELEASE_TYPE=$(buildkite-agent meta-data get github_release_type)
+GITHUB_RELEASE_ACCESS_TOKEN=$(aws ssm get-parameter --name /pipelines/agent/GITHUB_RELEASE_ACCESS_TOKEN --with-decryption --output text --query Parameter.Value --region us-east-1)
 
 if [[ "$GITHUB_RELEASE_TYPE" != "stable" ]]; then
   BREW_RELEASE_TYPE="devel"


### PR DESCRIPTION
The `deploy-legacy` queue is deprecated, and we're slowly moving steps off it.

This moves the final two release steps off the `deploy-legacy`:

1. creating a release on github, using our [github-release binary](https://github.com/buildkite/github-release)
2. updating https://github.com/buildkite/homebrew-buildkite with the new version

Both steps are relatively straight-forward. All the required tools are in the deploytools image and they both require the same credential (a github API  token), so I've migrated them at the same time.

I've tested them both in dry-run mode and I'm fairly confident they'll run successfully on the new agents. However, it's hard to be 100% sure until we're ready for a real release.

