### PR TITLE
Make sure checkout dir exists after checkout failure

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -936,6 +936,14 @@ func (b *Bootstrap) CheckoutPhase() error {
 					// will be a lot slower (clone vs fetch), but hopefully will
 					// allow the agent to self-heal
 					_ = b.removeCheckoutDir()
+
+					// Now make sure the build directory exists again before we try
+					// to checkout again, or proceed and run hooks which presume the
+					// checkout dir exists
+					if err := b.createCheckoutDir(); err != nil {
+						return err
+					}
+
 				}
 
 				return err


### PR DESCRIPTION
Without a checkout dir, which is also the working directory, exec-ing hooks will fail, and hooks like pre-exit will fail to run.

This also makes sure that checkout always happens with a present checkout directory, instead of into a potentially missing directory only on subsequent retries.

Fixes #1191.

### Before

<img width="1249" alt="Checkout phase which fails to run pre-exit hook due to removed checkout directory" src="https://user-images.githubusercontent.com/14028/75733017-38c9d000-5d48-11ea-86d8-615de53d0763.png">

### After

<img width="1252" alt="Checkout phase which has symmetrical create/remove checkout directory messages, and a successful pre-exit hook" src="https://user-images.githubusercontent.com/14028/75733068-60b93380-5d48-11ea-9406-5272d463dac0.png">
