### PR TITLE
Update the README now that we're not vendoring dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ go run *.go start --debug --build-path=/tmp/buildkite-builds --token "abc"
 
 ### Dependency management
 
-We're using Go 1.13+ and [Go Modules](https://github.com/golang/go/wiki/Modules) to manage our Go dependencies. We are keeping the dependencies vendored to remain backwards compatible with older go versions.
+We're using Go 1.13+ and [Go Modules](https://github.com/golang/go/wiki/Modules) to manage our Go dependencies.
 
 If you are using Go 1.11+ and have the agent in your `GOPATH`, you will need to enable modules via the environment variable:
 
@@ -71,17 +71,7 @@ If you are using Go 1.11+ and have the agent in your `GOPATH`, you will need to 
 export GO111MODULE=on
 ```
 
-If you introduce a new package:
-
-```bash
-go get github.com/my/new/package
-```
-
-Then you can write that package to the `vendor/` with:
-
-```bash
-go mod vendor
-```
+Dependencies are no longer committed to the repository, so compiling on Go <= 1.10 is not supported.
 
 ## Contributing
 


### PR DESCRIPTION
Since #1117 merged, compilation is only possible on Go 1.11+