### PR TITLE
bump Go to 1.14 for tests and compilation

### DIFF
--- a/.buildkite/Dockerfile-windows
+++ b/.buildkite/Dockerfile-windows
@@ -12,7 +12,7 @@ RUN powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object Sys
 # Install Chocolatey packages
 RUN choco install -ry git.install -params '"/GitAndUnixToolsOnPath"' && \
   choco install -ry openssh && \
-  choco install golang --version 1.13 -mry && \
+  choco install golang --version 1.14 -mry && \
   choco install -ry mingw
 
 WORKDIR c:/Users/ContainerAdministrator/go/src/github.com/buildkite/agent

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   agent:
-    image: golang:1.13
+    image: golang:1.14.0-buster
     volumes:
       - ../:/work:cached
     working_dir: /work

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   agent:
-    image: golang:1.14.0-buster
+    image: golang:1.14@sha256:d27017d27f9c9a58b361aa36126a29587ffd3b1b274af0d583fe4954365a4a59
     volumes:
       - ../:/work:cached
     working_dir: /work

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ go run *.go start --debug --build-path=/tmp/buildkite-builds --token "abc"
 
 ### Dependency management
 
-We're using Go 1.13+ and [Go Modules](https://github.com/golang/go/wiki/Modules) to manage our Go dependencies.
+We're using Go 1.14+ and [Go Modules](https://github.com/golang/go/wiki/Modules) to manage our Go dependencies.
 
 If you are using Go 1.11+ and have the agent in your `GOPATH`, you will need to enable modules via the environment variable:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/agent/v3
 
-go 1.13
+go 1.14
 
 require (
 	cloud.google.com/go v0.0.0-20170217213217-65216237311a


### PR DESCRIPTION
1.14 was released a few weeks ago, let's see if the agent pipelines likes it