### PR TITLE
Thread GitCloneMirrorFlags through from env vars

### DIFF
--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -68,7 +68,7 @@ type Config struct {
 	GitFetchFlags string `env:"BUILDKITE_GIT_FETCH_FLAGS"`
 
 	// Flags to pass to "git clone" command for mirroring
-	GitCloneMirrorFlags string
+	GitCloneMirrorFlags string  `env:"BUILDKITE_GIT_CLONE_MIRROR_FLAGS"`
 
 	// Flags to pass to "git clean" command
 	GitCleanFlags string `env:"BUILDKITE_GIT_CLEAN_FLAGS"`


### PR DESCRIPTION
We would like to be able to specify custom mirror flags as environment variables. This currently works for the other fetch and clone flags, but does not yet work for mirror flags.