### PR TITLE
Increase golang version due to runtime panic

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   agent:
-    image: golang:1.14@sha256:d27017d27f9c9a58b361aa36126a29587ffd3b1b274af0d583fe4954365a4a59
+    image: golang:1.14@sha256:b451547e2056c6369bbbaf5a306da1327cc12c074f55c311f6afe3bfc1c286b6
     volumes:
       - ../:/work:cached
     working_dir: /work


### PR DESCRIPTION
buildkite-agent 3.21.0 was built with go 1.14, which triggers a runtime panic in some situations where an mlock fails: https://github.com/golang/go/issues/37436

This bumps the docker sha to one containing 1.14.2, which correctly doesn't panic in those situations. 

Crash log is here: https://gist.github.com/zifnab06/afe1a89992e6374b9ebc42d38e119734

Either downgrading to 3.20.0-3264 (built with 1.13) or rebuilding 3.21.0 using go 1.14.2 resolves this.

If you really want to reproduce this, we're running buildkite-agent in a 16.04 (xenial) lxc container on a 20.04 (focal) host using kernel 5.4.0-29-generic (which maps to upstream 5.4.30). 