### PR TITLE
Update docker and compose versions.

### DIFF
--- a/packaging/docker/ubuntu-linux/Dockerfile
+++ b/packaging/docker/ubuntu-linux/Dockerfile
@@ -1,23 +1,35 @@
 FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV DOCKER_COMPOSE_VERSION=1.25.5
+ENV TINI_VERSION=v0.18.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      curl \
-      ca-certificates \
-      bash \
-      git \
-      perl \
-      rsync \
-      openssh-client \
-      curl \
-      docker.io \
-      jq \
-    && rm -rf /var/lib/apt/lists/*
+  apt-transport-https \
+  bash \
+  ca-certificates \
+  curl \
+  git \
+  gnupg-agent \
+  jq \
+  openssh-client \
+  perl \
+  rsync \
+  software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+RUN add-apt-repository \
+  "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) \
+  stable"
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  containerd.io \
+  docker-ce \
+  docker-ce-cli
+RUN rm -rf /var/lib/apt/lists/*
 
-RUN curl -Lfs -o /sbin/tini  https://github.com/krallin/tini/releases/download/v0.18.0/tini \
+RUN curl -Lfs -o /sbin/tini  https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
     && chmod +x /sbin/tini \
-    && curl -Lfs https://github.com/docker/compose/releases/download/1.24.0/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
+    && curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \


### PR DESCRIPTION
docker.io switched out for recommended installation method via new
packages

Following the updated advice by docker themselves, the docker.io package is no longer recommended as an installable binary.
https://docs.docker.com/engine/install/ubuntu/