### PR TITLE
buildkite/interpolate updated; ability to use numeric default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/DataDog/datadog-go v0.0.0-20180822151419-281ae9f2d895
 	github.com/aws/aws-sdk-go v0.0.0-20180831223016-2a4034064ca5
 	github.com/buildkite/bintest v0.0.0-20190227031731-820c89d3b3a0
-	github.com/buildkite/interpolate v0.0.0-20171114090218-3a807e47135c
+	github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/buildkite/bintest v0.0.0-20190227031731-820c89d3b3a0 h1:UYcAVM2IdwHl3
 github.com/buildkite/bintest v0.0.0-20190227031731-820c89d3b3a0/go.mod h1:nElEwZWoSPGIBD8VvYabl9t5KNi7v430iDC0/gQRsYk=
 github.com/buildkite/interpolate v0.0.0-20171114090218-3a807e47135c h1:4b/XlGFI+q7tfsB4gDvoWeTNmG31hcr4OOFMtvZ3TOQ=
 github.com/buildkite/interpolate v0.0.0-20171114090218-3a807e47135c/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
+github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
+github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000 h1:hiVSLk7s3yFKFOHF/huoShLqrj13RMguWX2yzfvy7es=
 github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000/go.mod h1:gv0DYOzHEsKgo31lTCDGauIg4DTTGn41Bzp+t3wSOlk=
 github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3 h1:q+sMKdA6L8LyGVudTkpGoC73h6ak2iWSPFiFo/pFOU8=


### PR DESCRIPTION
Update buildkite/interpolate to get https://github.com/buildkite/interpolate/pull/7 /cc @ticky 

`${VAR:-127}` will now resolve to `127` if `VAR` isn't set.

Delta commit log on buildkite/interpolate:

    *   07f35b4 Merge pull request #7 from buildkite/bash-compliant-substring-parsing Jessica Stokes 2 hours ago
    |\
    | * 24225d9 Update substring parser to comply with Bash's rules Jessica Stokes 10 days ago
    |/
    * 973457f Add an empty go.mod file Lachlan Donald 1 year, 7 months ago
    * cfbed48 Update README to reflect current code Lachlan Donald 1 year, 7 months ago
    * c1c376f Merge pull request #4 from buildkite/expose-identifiers-from-parse-tree Lachlan Donald 2 years, 3 months ago
    * ad3fc26 Add a interpolate.Identifiers() for getting identifiers from a string Lachlan Donald 2 years, 3 months ago