### PR TITLE
Add sidecar Dockerfile and build steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -286,5 +286,6 @@ steps:
       - build-docker-alpine
       - build-docker-ubuntu
       - build-docker-centos
+      - build-docker-sidecar
       - build-github-release
     command: ".buildkite/steps/upload-release-steps.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -222,6 +222,13 @@ steps:
       - set-metadata
     command: ".buildkite/steps/build-docker-image.sh centos"
 
+  - name: ":docker: sidecar build"
+    key: build-docker-sidecar
+    depends_on:
+      - build-binary-linux-amd64
+      - set-metadata
+    command: ".buildkite/steps/build-docker-image.sh sidecar"
+
   - name: ":debian: build"
     key: build-debian-packages
     depends_on:

--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -54,7 +54,7 @@ codename="${3:-}"
 version="${4:-}"
 push="${PUSH_IMAGE:-true}"
 
-if [[ ! "$variant" =~ ^(alpine|ubuntu|centos)$ ]] ; then
+if [[ ! "$variant" =~ ^(alpine|ubuntu|centos|sidecar)$ ]] ; then
   echo "Unknown docker variant $variant"
   exit 1
 fi
@@ -92,13 +92,23 @@ ubuntu)
 centos)
   build_docker_image "$image_tag" "packaging/docker/centos-linux"
   ;;
+sidecar)
+  build_docker_image "$image_tag" "packaging/docker/sidecar"
+  ;;
 *)
   echo "Unknown variant $variant"
   exit 1
   ;;
 esac
 
-test_docker_image "$image_tag"
+case $variant in
+sidecar)
+  echo "Skipping tests for sidecar variant"
+  ;;
+*)
+  test_docker_image "$image_tag"
+  ;;
+esac
 
 if [[ $push == "true" ]] ; then
   push_docker_image "$image_tag"

--- a/.buildkite/steps/extract-agent-version-metadata.sh
+++ b/.buildkite/steps/extract-agent-version-metadata.sh
@@ -6,9 +6,11 @@ build_version=${BUILDKITE_BUILD_NUMBER:-1}
 full_agent_version="buildkite-agent version ${agent_version}, build ${build_version}"
 
 # docker variants
-docker_alpine_image_tag="445615400570.dkr.ecr.us-east-1.amazonaws.com/agent:alpine-build-${BUILDKITE_BUILD_NUMBER}"
-docker_ubuntu_image_tag="445615400570.dkr.ecr.us-east-1.amazonaws.com/agent:ubuntu-build-${BUILDKITE_BUILD_NUMBER}"
-docker_centos_image_tag="445615400570.dkr.ecr.us-east-1.amazonaws.com/agent:centos-build-${BUILDKITE_BUILD_NUMBER}"
+registry="445615400570.dkr.ecr.us-east-1.amazonaws.com/agent"
+docker_alpine_image_tag="$registry:alpine-build-${BUILDKITE_BUILD_NUMBER}"
+docker_ubuntu_image_tag="$registry:ubuntu-build-${BUILDKITE_BUILD_NUMBER}"
+docker_centos_image_tag="$registry:centos-build-${BUILDKITE_BUILD_NUMBER}"
+docker_sidecar_image_tag="$registry:sidecar-build-${BUILDKITE_BUILD_NUMBER}"
 
 is_prerelease=0
 if [[ "$agent_version" =~ (alpha|beta|rc) ]] ; then
@@ -21,6 +23,7 @@ echo "Build version: $build_version"
 echo "Docker Alpine Image Tag: $docker_alpine_image_tag"
 echo "Docker Ubuntu Image Tag: $docker_ubuntu_image_tag"
 echo "Docker CentOS Image Tag: $docker_centos_image_tag"
+echo "Docker Sidecar Image Tag: $docker_sidecar_image_tag"
 echo "Is prerelease? $is_prerelease"
 
 buildkite-agent meta-data set "agent-version" "$agent_version"
@@ -29,4 +32,5 @@ buildkite-agent meta-data set "agent-version-build" "$build_version"
 buildkite-agent meta-data set "agent-docker-image-alpine" "$docker_alpine_image_tag"
 buildkite-agent meta-data set "agent-docker-image-ubuntu" "$docker_ubuntu_image_tag"
 buildkite-agent meta-data set "agent-docker-image-centos" "$docker_centos_image_tag"
+buildkite-agent meta-data set "agent-docker-image-sidecar" "$docker_sidecar_image_tag"
 buildkite-agent meta-data set "agent-is-prerelease" "$is_prerelease"

--- a/.buildkite/steps/publish-docker-images.sh
+++ b/.buildkite/steps/publish-docker-images.sh
@@ -23,7 +23,7 @@ aws ssm get-parameter --name /pipelines/agent/DOCKER_HUB_PASSWORD --with-decrypt
 version=$(buildkite-agent meta-data get "agent-version")
 build=$(buildkite-agent meta-data get "agent-version-build")
 
-for variant in "alpine" "ubuntu" "centos" ; do
+for variant in "alpine" "ubuntu" "centos" "sidecar" ; do
   echo "--- Getting docker image tag for $variant from build meta data"
   source_image=$(buildkite-agent meta-data get "agent-docker-image-$variant")
   echo "Docker Image Tag for $variant: $source_image"

--- a/packaging/docker/sidecar/Dockerfile
+++ b/packaging/docker/sidecar/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.8
+
+RUN mkdir /buildkite \
+          /buildkite/builds \
+          /buildkite/hooks \
+          /buildkite/plugins \
+          /buildkite/bin
+
+COPY buildkite-agent.cfg /buildkite/
+COPY buildkite-agent /buildkite/bin/
+
+FROM busybox:musl
+COPY --from=0 /buildkite /buildkite
+VOLUME /buildkite

--- a/packaging/docker/sidecar/buildkite-agent.cfg
+++ b/packaging/docker/sidecar/buildkite-agent.cfg
@@ -1,0 +1,64 @@
+# The token from your Buildkite "Agents" page
+#token="xxx"
+
+# The name of the agent
+name="%hostname-%n"
+
+# The number of agents to spawn in parallel (default is "1")
+# spawn=1
+
+# The priority of the agent (higher priorities are assigned work first)
+# priority=1
+
+# Tags for the agent (default is "queue=default")
+# tags="key1=val2,key2=val2"
+
+# Include the host's EC2 meta-data as tags (instance-id, instance-type, and ami-id)
+# tags-from-ec2=true
+
+# Include the host's EC2 tags as tags
+# tags-from-ec2-tags=true
+
+# Include the host's Google Cloud instance meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
+# tags-from-gcp=true
+
+# Include the host's Google Cloud instance labels as tags
+# tags-from-gcp-labels=true
+
+# Path to a custom bootstrap command to run. By default this is `buildkite-agent bootstrap`.
+# This allows you to override the entire execution of a job. Generally you should use hooks instead!
+# See https://buildkite.com/docs/agent/hooks
+# bootstrap-script=""
+
+# Path to where the builds will run from
+build-path="/buildkite/builds"
+
+# Directory where the hook scripts are found
+hooks-path="/buildkite/hooks"
+
+# Directory where plugins will be installed
+plugins-path="/buildkite/plugins"
+
+# Flags to pass to the `git clone` command
+# git-clone-flags=-v
+
+# Flags to pass to the `git clean` command
+# git-clean-flags=-ffxdq
+
+# Do not run jobs within a pseudo terminal
+# no-pty=true
+
+# Don't automatically verify SSH fingerprints
+# no-automatic-ssh-fingerprint-verification=true
+
+# Don't allow this agent to run arbitrary console commands
+# no-command-eval=true
+
+# Don't allow this agent to run plugins
+# no-plugins=true
+
+# Enable debug mode
+# debug=true
+
+# Don't show colors in logging
+# no-color=true


### PR DESCRIPTION
This replaces https://github.com/buildkite/buildkite-sidecar and the keithduncan/buildkite-sidecar Docker Hub repository by tagging `buildkite/agent:X-sidecar` directly at the source.

Something I haven’t yet included is the [environment hook](https://github.com/buildkite/buildkite-sidecar/blob/master/agent/hooks/environment) that I used to print `BUILDKITE_ABOUT_*` variables in the build log. I’ve found that useful for my builds but I’m not sure whether to include for all sidecars?

cc @chloeruka @pda 