### PR TITLE
Provide example dogstatsd integration options

### DIFF
--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -62,3 +62,13 @@ plugins-path="/etc/buildkite-agent/plugins"
 
 # Don't show colors in logging
 # no-color=true
+
+# The next two options are relevant to the Datadog integration, available 3.7.0 and on
+# See https://forum.buildkite.community/t/about-our-datadog-integration/216 for details
+# Send metrics to DogStatsD running on metrics-datadog-host
+# metrics-datadog=true
+
+# Host to collect Buildkite metrics
+# datadog-agent will need to run DogStatsD, presumed on port 8125. 
+# Specify port below like my-host:8126 if not using 8125
+# metrics-datadog-host=127.0.0.1


### PR DESCRIPTION
Noticed as I was filling out my config file for Datadog that there descriptions with most buildkite-agent options.

Since this might be an option few know about or some people may need to use, took a swing at filling in the blanks here, and provided a link to read on.

Let me know what you think!