### PR TITLE
Accept `--experiment` flags in all buildkite-agent subcommands

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -408,9 +408,9 @@ var AgentStartCommand = cli.Command{
 		DebugHTTPFlag,
 
 		// Global flags
-		ExperimentsFlag,
 		NoColorFlag,
 		DebugFlag,
+		ExperimentsFlag,
 		ProfileFlag,
 
 		// Deprecated flags which will be removed in v4

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -55,9 +55,10 @@ type AnnotateConfig struct {
 	Job     string `cli:"job" validate:"required"`
 
 	// Global flags
-	Debug   bool   `cli:"debug"`
-	NoColor bool   `cli:"no-color"`
-	Profile string `cli:"profile"`
+	Debug   bool         `cli:"debug"`
+	NoColor bool         `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile string       `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -102,6 +103,7 @@ var AnnotateCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ExperimentsFlag,
 		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -42,9 +42,10 @@ type ArtifactDownloadConfig struct {
 	IncludeRetriedJobs bool   `cli:"include-retried-jobs"`
 
 	// Global flags
-	Debug   bool   `cli:"debug"`
-	NoColor bool   `cli:"no-color"`
-	Profile string `cli:"profile"`
+	Debug   bool         `cli:"debug"`
+	NoColor bool         `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile string       `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -84,6 +85,7 @@ var ArtifactDownloadCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ExperimentsFlag,
 		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -43,9 +43,10 @@ type ArtifactShasumConfig struct {
 	IncludeRetriedJobs bool   `cli:"include-retried-jobs"`
 
 	// Global flags
-	Debug   bool   `cli:"debug"`
-	NoColor bool   `cli:"no-color"`
-	Profile string `cli:"profile"`
+	Debug   bool         `cli:"debug"`
+	NoColor bool         `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile string       `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -85,6 +86,7 @@ var ArtifactShasumCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ExperimentsFlag,
 		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -56,9 +56,10 @@ type ArtifactUploadConfig struct {
 	ContentType string `cli:"content-type"`
 
 	// Global flags
-	Debug   bool   `cli:"debug"`
-	NoColor bool   `cli:"no-color"`
-	Profile string `cli:"profile"`
+	Debug   bool         `cli:"debug"`
+	NoColor bool         `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile string       `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -94,6 +95,7 @@ var ArtifactUploadCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ExperimentsFlag,
 		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -28,9 +28,10 @@ type MetaDataExistsConfig struct {
 	Job string `cli:"job" validate:"required"`
 
 	// Global flags
-	Debug   bool   `cli:"debug"`
-	NoColor bool   `cli:"no-color"`
-	Profile string `cli:"profile"`
+	Debug   bool         `cli:"debug"`
+	NoColor bool         `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile string       `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -60,6 +61,7 @@ var MetaDataExistsCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ExperimentsFlag,
 		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -28,9 +28,10 @@ type MetaDataGetConfig struct {
 	Job     string `cli:"job" validate:"required"`
 
 	// Global flags
-	Debug   bool   `cli:"debug"`
-	NoColor bool   `cli:"no-color"`
-	Profile string `cli:"profile"`
+	Debug   bool         `cli:"debug"`
+	NoColor bool         `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile string       `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -65,6 +66,7 @@ var MetaDataGetCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ExperimentsFlag,
 		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {

--- a/clicommand/meta_data_keys.go
+++ b/clicommand/meta_data_keys.go
@@ -27,9 +27,10 @@ type MetaDataKeysConfig struct {
 	Job string `cli:"job" validate:"required"`
 
 	// Global flags
-	Debug   bool   `cli:"debug"`
-	NoColor bool   `cli:"no-color"`
-	Profile string `cli:"profile"`
+	Debug   bool         `cli:"debug"`
+	NoColor bool         `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile string       `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -59,6 +60,7 @@ var MetaDataKeysCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ExperimentsFlag,
 		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -34,9 +34,10 @@ type MetaDataSetConfig struct {
 	Job   string `cli:"job" validate:"required"`
 
 	// Global flags
-	Debug   bool   `cli:"debug"`
-	NoColor bool   `cli:"no-color"`
-	Profile string `cli:"profile"`
+	Debug   bool         `cli:"debug"`
+	NoColor bool         `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile string       `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -66,6 +67,7 @@ var MetaDataSetCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ExperimentsFlag,
 		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -56,13 +56,14 @@ type PipelineUploadConfig struct {
 	NoInterpolation bool   `cli:"no-interpolation"`
 
 	// Global flags
-	Debug   bool   `cli:"debug"`
-	NoColor bool   `cli:"no-color"`
-	Profile string `cli:"profile"`
+	Debug   bool         `cli:"debug"`
+	NoColor bool         `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile string       `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
-	AgentAccessToken string `cli:"agent-access-token"`
+	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
 	Endpoint         string `cli:"endpoint" validate:"required"`
 	NoHTTP2          bool   `cli:"no-http2"`
 }
@@ -103,6 +104,7 @@ var PipelineUploadCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ExperimentsFlag,
 		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {

--- a/clicommand/step_get.go
+++ b/clicommand/step_get.go
@@ -37,9 +37,10 @@ type StepGetConfig struct {
 	Format    string `cli:"format"`
 
 	// Global flags
-	Debug   bool   `cli:"debug"`
-	NoColor bool   `cli:"no-color"`
-	Profile string `cli:"profile"`
+	Debug   bool         `cli:"debug"`
+	NoColor bool         `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile string       `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -81,6 +82,7 @@ var StepGetCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ExperimentsFlag,
 		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -34,9 +34,10 @@ type StepUpdateConfig struct {
 	Build     string `cli:"build"`
 
 	// Global flags
-	Debug   bool   `cli:"debug"`
-	NoColor bool   `cli:"no-color"`
-	Profile string `cli:"profile"`
+	Debug   bool         `cli:"debug"`
+	NoColor bool         `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile string       `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -77,6 +78,7 @@ var StepUpdateCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		ExperimentsFlag,
 		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {


### PR DESCRIPTION
While the upload path normalisation logic added in #1211 worked in unit tests, it turns out the subcommand wasn't actually accepting the experiment flag, only `buildkite-agent start` was.

This updates all other subcommands to read the experiment values, even if they don't themselves currently implement an experiment. This permits experiments such as that added in #1211 to exist within in-job commands such as `artifact upload`.

Given that there currently are no end-to-end tests of the subcommand mechanism, should some be added? What shape would that take?

Tested by looking at the output of this (fake, expected to error out) command:

```bash
BUILDKITE_AGENT_ACCESS_TOKEN=fake \
BUILDKITE_JOB_ID=fake-uuid \
BUILDKITE_AGENT_EXPERIMENT=nomalise-upload-paths \
  buildkite-agent artifact upload \
    --debug ./install.sh
```

Output should contain "DEBUG  Enabled experiment `nomalise-upload-paths`,” but without this patch it does not.