### PR TITLE
Fix checkout when there is a file called HEAD in the repository root

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1269,7 +1269,7 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 	if err := b.shell.Run("buildkite-agent", "meta-data", "exists", "buildkite:git:commit"); err != nil {
 		b.shell.Commentf("Sending Git commit information back to Buildkite")
 
-		gitCommitOutput, err := b.shell.RunAndCapture("git", "--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color")
+		gitCommitOutput, err := b.shell.RunAndCapture("git", "--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Problem: `git show HEAD` fails when there is a file called 'HEAD' in the
repository root, complaining about ambiguous reference

Solution: call `git show` without 'HEAD' argument, which will always show
the HEAD commit