### PR TITLE
Wrap calls for GCP metadata in a retry

### DIFF
--- a/agent/tags.go
+++ b/agent/tags.go
@@ -163,7 +163,7 @@ func (t *tagFetcher) Fetch(l logger.Logger, conf FetchTagsConfig) []string {
 			gcpTags, err := t.gcpMetaDataDefault()
 			if err != nil {
 				// Don't blow up if we can't find them, just show a nasty error.
-				l.Error(fmt.Sprintf("Failed to fetch Google Cloud meta-data: %s", err.Error()))
+				l.Error(fmt.Sprintf("Failed to fetch GCP meta-data: %s", err.Error()))
 			} else {
 				for tag, value := range gcpTags {
 					tags = append(tags, fmt.Sprintf("%s=%s", tag, value))

--- a/agent/tags.go
+++ b/agent/tags.go
@@ -163,13 +163,15 @@ func (t *tagFetcher) Fetch(l logger.Logger, conf FetchTagsConfig) []string {
 			gcpTags, err := t.gcpMetaDataDefault()
 			if err != nil {
 				// Don't blow up if we can't find them, just show a nasty error.
-				l.Error(fmt.Sprintf("Failed to fetch GCP meta-data: %s", err.Error()))
-			} else {
-				for tag, value := range gcpTags {
-					tags = append(tags, fmt.Sprintf("%s=%s", tag, value))
-				}
+				l.Error(fmt.Sprintf("Failed to fetch Google Cloud meta-data: %s", err.Error()))
+				return err
 			}
-			return err
+
+			for tag, value := range gcpTags {
+				tags = append(tags, fmt.Sprintf("%s=%s", tag, value))
+			}
+
+			return nil
 		}, &retry.Config{Maximum: 5, Interval: 1 * time.Second, Jitter: true})
 
 		// Don't blow up if we can't find them, just show a nasty error.

--- a/agent/tags.go
+++ b/agent/tags.go
@@ -174,7 +174,7 @@ func (t *tagFetcher) Fetch(l logger.Logger, conf FetchTagsConfig) []string {
 
 		// Don't blow up if we can't find them, just show a nasty error.
 		if err != nil {
-			l.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
+			l.Error(fmt.Sprintf("Failed to fetch GCP meta-data: %s", err.Error()))
 		}
 	}
 


### PR DESCRIPTION
Problem:
The Buildkite agent is trying to get GCP metadata before the network is ready on the VM

Solution:
This wraps the call (TagsFromGCPMetaData) in a retry, giving it the same treatment as we do for [TagsFromEC2MetaData](https://github.com/buildkite/agent/blob/master/agent/tags.go#L87) 

Still to do:
  - Tests [ ] 