### PR TITLE
Hooks can introduce empty environment variables

### DIFF
--- a/env/environment.go
+++ b/env/environment.go
@@ -81,13 +81,11 @@ func (e *Environment) Length() int {
 // environment which are different in the other one.
 func (e *Environment) Diff(other *Environment) *Environment {
 	diff := &Environment{env: make(map[string]string)}
-
 	for k, v := range e.env {
-		if other, _ := other.Get(k); other != v {
+		if other, ok := other.Get(k); !ok || other != v {
 			diff.Set(k, v)
 		}
 	}
-
 	return diff
 }
 

--- a/env/environment.go
+++ b/env/environment.go
@@ -77,7 +77,8 @@ func (e *Environment) Length() int {
 	return len(e.env)
 }
 
-// Diff returns a new environment with all the variables that have changed
+// Diff returns a new environment with the keys and values from this
+// environment which are different in the other one.
 func (e *Environment) Diff(other *Environment) *Environment {
 	diff := &Environment{env: make(map[string]string)}
 

--- a/env/environment_test.go
+++ b/env/environment_test.go
@@ -93,3 +93,17 @@ func TestEnvironmentToSlice(t *testing.T) {
 
 	assert.Equal(t, []string{"THIS_IS_GREAT=totes", "ZOMG=greatness"}, env.ToSlice())
 }
+
+func TestEnvironmentDiff(t *testing.T) {
+	t.Parallel()
+	a := FromSlice([]string{"A=hello", "B=world"})
+	b := FromSlice([]string{"A=hello", "B=there", "C=new", "D="})
+	ab := a.Diff(b).ToMap()
+	ba := b.Diff(a).ToMap()
+
+	// a.Diff(b) gives us the key:values from a that are different in b
+	assert.Equal(t, map[string]string{"B": "world"}, ab)
+
+	// b.Diff(a) gives us the key:values from b that are different in a
+	assert.Equal(t, map[string]string{"B": "there", "C": "new"}, ba)
+}

--- a/env/environment_test.go
+++ b/env/environment_test.go
@@ -105,5 +105,5 @@ func TestEnvironmentDiff(t *testing.T) {
 	assert.Equal(t, map[string]string{"B": "world"}, ab)
 
 	// b.Diff(a) gives us the key:values from b that are different in a
-	assert.Equal(t, map[string]string{"B": "there", "C": "new"}, ba)
+	assert.Equal(t, map[string]string{"B": "there", "C": "new", "D": ""}, ba)
 }


### PR DESCRIPTION
### Background

The environment is captured before and after each hook runs; changes are detected and propagated to the rest of the build.

### Problem

The current implementation does not detect newly introduced environment variables with an empty value.

This is due to the way Go's `map` type works; the key and value are statically typed, and accessing a key that does not exist returns the zero-value of the value type. That means for a `map[string]string` accessing a string key that doesn't exist returns `""`; the zero-value of `string` is an empty string.

When a newly introduced `FOO=""` environment is detected, it's empty-string value is compared to the pre-hook `env["FOO"]` which returns the empty string; this appears unchanged, so it's not included in the diff.

This is a problem if a hook attempts to declare a variable and a subsequent script running in `set -u` mode (crash on unbound variable access) tries to access it.

### Solution

Go's `map` also returns a `bool` flag indicating whether the value was present.  We were ignoring it, but now we're not.

Now, when a newly introduced empty environment variable is checked, its absence in the pre-hook environment causes it to be included in the diff.

### Verification

`env.Environment.Diff()` unit test coverage has been added.

I've run a sample build where an agent `environment` hook sets an empty var; prior to this patch it did not propagate to the build step command, now it does.