### PR TITLE
Fetch amd64 binaries on Apple Silicon Macs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,13 +37,23 @@ else
   case $UNAME in
     *amd64*)   ARCH="amd64"   ;;
     *x86_64*)  ARCH="amd64"   ;;
+    *arm64*)
+      ARCH="arm64"
+      if [[ "$PLATFORM" == "darwin" ]]; then
+        ARCH="amd64"
+        echo -e "\n\033[35mHi there, adventurer! \033[36mWe don't yet have a binary for macOS on Apple Silicon; relying on Rosetta 2 and using $ARCH instead!\033[0m"
+      fi
+      ;;
     *armv8*)   ARCH="arm64"   ;;
     *armv7*)   ARCH="armhf"   ;;
     *armv6l*)  ARCH="arm"     ;;
     *armv6*)   ARCH="armhf"   ;;
     *arm*)     ARCH="arm"     ;;
     *ppc64le*) ARCH="ppc64le" ;;
-    *)         ARCH="386"     ;;
+    *)
+      ARCH="386"
+      echo -e "\n\033[36mWe don't recognise the $UNAME architecture; falling back to $ARCH\033[0m"
+      ;;
   esac
 fi
 


### PR DESCRIPTION
Upcoming macOS computers [will use the `arm64` architecture](https://developer.apple.com/documentation/xcode/building_a_universal_macos_binary). On such machines, our install script will currently fall through to attempting to fetch a `darwin-arm` binary, which does not exist. This future version of macOS allows `arm64` Macs to run `amd64` binaries through an emulation layer called Rosetta 2, and thus `darwin-amd64` is the most appropriate binary type for these machines until golang supports native `darwin-arm64` (see golang/go#38485).

This updates our install script to special-case the arm64 architecture when the platform is darwin, emit a message to the user, and proceed more or less as expected.

<img width="625" alt="image" src="https://user-images.githubusercontent.com/282113/86828281-dc552500-c047-11ea-9f84-732cad7ddb1e.png">
