### PR TITLE
Stop building i386 for darwin after 14 years of amd64 Mac hardware

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -112,16 +112,6 @@ steps:
         config: .buildkite/docker-compose.yml
         run: agent
 
-  - name: ":mac: 386"
-    command: ".buildkite/steps/build-binary.sh darwin 386"
-    key: build-binary-darwin-386
-    depends_on: test-linux # don't wait for slower windows tests
-    artifact_paths: "pkg/*"
-    plugins:
-      docker-compose#v3.0.0:
-        config: .buildkite/docker-compose.yml
-        run: agent
-
   - name: ":mac: amd64"
     command: ".buildkite/steps/build-binary.sh darwin amd64"
     key: build-binary-darwin-amd64
@@ -254,7 +244,6 @@ steps:
       - build-binary-linux-armhf
       - build-binary-linux-arm64
       - build-binary-linux-ppc64le
-      - build-binary-darwin-386
       - build-binary-darwin-amd64
       - build-binary-freebsd-amd64
       - build-binary-freebsd-386


### PR DESCRIPTION
Apple switched from Intel Core Duo (32-bit) to Core 2 Duo (64-bit) around 2006. Nothing running darwin since then needs a 32-bit i386 build. Our usage stats show that nobody is using darwin-386 builds of buildkite-agent v3.x. AFAIK the latest macOS (10.15 Catalina) won't run 32-bit binaries at all. And upcoming Macs are shifting to arm64.

There's no big gain from dropping this, but no real reason to keep it either.