### PR TITLE
submit basic OS info when registering from a BSD system

### DIFF
--- a/system/version_dump.go
+++ b/system/version_dump.go
@@ -15,6 +15,8 @@ func VersionDump(l logger.Logger) (string, error) {
 		return process.Run(l, "sw_vers")
 	} else if runtime.GOOS == "linux" {
 		return process.Cat("/etc/*-release")
+	} else if runtime.GOOS == "freebsd" || runtime.GOOS == "openbsd" || runtime.GOOS == "netbsd" || runtime.GOOS == "dragonfly" {
+		return process.Run(l, "uname", "-a")
 	}
 
 	return "", nil

--- a/system/version_dump.go
+++ b/system/version_dump.go
@@ -16,7 +16,7 @@ func VersionDump(l logger.Logger) (string, error) {
 	} else if runtime.GOOS == "linux" {
 		return process.Cat("/etc/*-release")
 	} else if runtime.GOOS == "freebsd" || runtime.GOOS == "openbsd" || runtime.GOOS == "netbsd" || runtime.GOOS == "dragonfly" {
-		return process.Run(l, "uname", "-a")
+		return process.Run(l, "uname", "-sr")
 	}
 
 	return "", nil

--- a/system/version_dump.go
+++ b/system/version_dump.go
@@ -11,13 +11,14 @@ import (
 
 // Returns a dump of the raw operating system information
 func VersionDump(l logger.Logger) (string, error) {
-	if runtime.GOOS == "darwin" {
+	switch runtime.GOOS {
+	case "darwin":
 		return process.Run(l, "sw_vers")
-	} else if runtime.GOOS == "linux" {
+	case "linux":
 		return process.Cat("/etc/*-release")
-	} else if runtime.GOOS == "freebsd" || runtime.GOOS == "openbsd" || runtime.GOOS == "netbsd" || runtime.GOOS == "dragonfly" {
+	case "freebsd", "openbsd", "netbsd", "dragonfly":
 		return process.Run(l, "uname", "-sr")
+	default:
+		return "", nil
 	}
-
-	return "", nil
 }


### PR DESCRIPTION
On macos, windows and linux the agent registration request includes some basic info on the operating system. Version, distribution, etc. This data is used only for metrics on what environments the agent is used in.

We publish official binaries for some BSD systems (FreeBSD, OpenBSD, NetBSD and dragonfly), however we haven't been submitting any OS versions so we have a poor understanding of how often these operating systems are used.

This change includes the output of `uname -a` in agent registration requests on those operating systems.

I checked to see if the BSDs use `/etc/os-release` or similar, but it seems there's no consensus. FreeBSD look like [they  might be adding it in the next release](https://reviews.freebsd.org/D22271), the others seem not to have it (based on googling).

We don't run tests against these GOOS so I haven't added any, but here's a screenshot of running an agent on a freebsd VM with this patch, and `--debug-http` enabled:

![Screenshot from 2020-07-09 00-53-10](https://user-images.githubusercontent.com/8132/86934487-16751280-c17f-11ea-80f7-5508894727b5.png)
 