### PR TITLE
Experimental: Build RPM package for ARM64 architecture (aarch64)

### DIFF
--- a/.buildkite/steps/build-rpm-packages.sh
+++ b/.buildkite/steps/build-rpm-packages.sh
@@ -24,7 +24,7 @@ rm -rf rpm
 
 # Build the packages into rpm/
 PLATFORM="linux"
-for ARCH in "amd64" "386"; do
+for ARCH in "amd64" "386" "arm64"; do
   echo "--- Building rpm package ${PLATFORM}/${ARCH}"
 
   BINARY="pkg/buildkite-agent-${PLATFORM}-${ARCH}"

--- a/scripts/build-rpm-package.sh
+++ b/scripts/build-rpm-package.sh
@@ -26,6 +26,8 @@ if [ "$BUILD_ARCH" == "amd64" ]; then
   ARCH="x86_64"
 elif [ "$BUILD_ARCH" == "386" ]; then
   ARCH="i386"
+elif [ "$BUILD_ARCH" == "arm64" ]; then
+  ARCH="aarch64"
 else
   echo "Unknown architecture: $BUILD_ARCH"
   exit 1


### PR DESCRIPTION
To address #1162 I'm tossing together a naive package builder codepath for RPM using our linux `arm64` binary to upload with the architecture `aarch64`. From googling, this appears to be the canonical architecture nomenclature for Red Hat based systems to refer to modern ARM processors. 

Please let me know if there's more that might need to be done, of particular concern is `scripts/build-rpm-package.sh` which possibly might need other adjustments to support ARM directly. I'd like to merge this ASAP to test it on an agent. I also think @jnewbigin has offered to do some testing if they see this 😄 