### PR TITLE
allow CleanCheckout to be set via hooks

### DIFF
--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -59,7 +59,7 @@ type Config struct {
 	AgentName string
 
 	// Should the bootstrap remove an existing checkout before running the job
-	CleanCheckout bool
+	CleanCheckout bool `env:"BUILDKITE_CLEAN_CHECKOUT"`
 
 	// Flags to pass to "git clone" command
 	GitCloneFlags string `env:"BUILDKITE_GIT_CLONE_FLAGS"`

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -2,6 +2,9 @@ package bootstrap
 
 import (
 	"reflect"
+	"strconv"
+
+	"log"
 
 	"github.com/buildkite/agent/v3/env"
 )
@@ -131,22 +134,38 @@ func (c *Config) ReadFromEnvironment(environ *env.Environment) map[string]string
 	changed := map[string]string{}
 
 	// Use reflection for the type and values
-	t := reflect.TypeOf(*c)
-	v := reflect.ValueOf(c).Elem()
+	fields := reflect.TypeOf(*c)
+	values := reflect.ValueOf(c).Elem()
 
 	// Iterate over all available fields and read the tag value
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
-		value := v.Field(i)
+	for i := 0; i < fields.NumField(); i++ {
+		f := fields.Field(i)
+		v := values.Field(i)
 
 		// Find struct fields with env tag
-		if tag := field.Tag.Get("env"); tag != "" && environ.Exists(tag) {
-			newValue, _ := environ.Get(tag)
+		if tag := f.Tag.Get("env"); tag != "" && environ.Exists(tag) {
+			newStr, _ := environ.Get(tag)
 
-			// We only care if the value has changed
-			if newValue != value.String() {
-				value.SetString(newValue)
-				changed[tag] = newValue
+			switch v.Kind() {
+			case reflect.String:
+				if newStr == v.String() {
+					break
+				}
+				v.SetString(newStr)
+				changed[tag] = newStr
+			case reflect.Bool:
+				newBool, err := strconv.ParseBool(newStr)
+				if err != nil {
+					log.Printf("warning: cannot parse %s=%s as bool, ignoring", tag, newStr)
+					break
+				}
+				if newBool == v.Bool() {
+					break
+				}
+				v.SetBool(newBool)
+				changed[tag] = newStr
+			default:
+				log.Printf("warning: bootstrap.Config.ReadFromEnvironment does not support %v for %s", v.Kind(), tag)
 			}
 		}
 	}

--- a/bootstrap/config_test.go
+++ b/bootstrap/config_test.go
@@ -16,6 +16,7 @@ func TestEnvVarsAreMappedToConfig(t *testing.T) {
 		GitCloneFlags:                "--prune",
 		GitCleanFlags:                "-v",
 		AgentName:                    "myAgent",
+		CleanCheckout:								false,
 	}
 
 	environ := env.FromSlice([]string{
@@ -23,6 +24,7 @@ func TestEnvVarsAreMappedToConfig(t *testing.T) {
 		"BUILDKITE_GIT_CLONE_FLAGS=-f",
 		"BUILDKITE_SOMETHING_ELSE=1",
 		"BUILDKITE_REPO=https://my.mirror/repo.git",
+		"BUILDKITE_CLEAN_CHECKOUT=true",
 	})
 
 	changes := config.ReadFromEnvironment(environ)
@@ -30,6 +32,7 @@ func TestEnvVarsAreMappedToConfig(t *testing.T) {
 		"BUILDKITE_ARTIFACT_PATHS":  "newpath",
 		"BUILDKITE_GIT_CLONE_FLAGS": "-f",
 		"BUILDKITE_REPO":            "https://my.mirror/repo.git",
+		"BUILDKITE_CLEAN_CHECKOUT": "true"
 	}
 
 	if !reflect.DeepEqual(expected, changes) {
@@ -44,5 +47,10 @@ func TestEnvVarsAreMappedToConfig(t *testing.T) {
 	if expected := "https://my.mirror/repo.git"; config.Repository != expected {
 		t.Fatalf("Expected Repository to be %v, got %v",
 			expected, config.Repository)
+	}
+
+	if expected := false; config.CleanCheckout != expected {
+		t.Fatalf("Expected CleanCheckout to be %v, got %v",
+			expected, config.CleanCheckout)
 	}
 }

--- a/bootstrap/config_test.go
+++ b/bootstrap/config_test.go
@@ -16,7 +16,7 @@ func TestEnvVarsAreMappedToConfig(t *testing.T) {
 		GitCloneFlags:                "--prune",
 		GitCleanFlags:                "-v",
 		AgentName:                    "myAgent",
-		CleanCheckout:								false,
+		CleanCheckout:                false,
 	}
 
 	environ := env.FromSlice([]string{
@@ -32,7 +32,7 @@ func TestEnvVarsAreMappedToConfig(t *testing.T) {
 		"BUILDKITE_ARTIFACT_PATHS":  "newpath",
 		"BUILDKITE_GIT_CLONE_FLAGS": "-f",
 		"BUILDKITE_REPO":            "https://my.mirror/repo.git",
-		"BUILDKITE_CLEAN_CHECKOUT": "true"
+		"BUILDKITE_CLEAN_CHECKOUT":  "true",
 	}
 
 	if !reflect.DeepEqual(expected, changes) {
@@ -49,8 +49,25 @@ func TestEnvVarsAreMappedToConfig(t *testing.T) {
 			expected, config.Repository)
 	}
 
-	if expected := false; config.CleanCheckout != expected {
-		t.Fatalf("Expected CleanCheckout to be %v, got %v",
-			expected, config.CleanCheckout)
+	if expected := true; config.CleanCheckout != expected {
+		t.Fatalf("Expected Repository to be %v, got %v",
+			expected, config.Repository)
+	}
+}
+
+func TestReadFromEnvironmentIgnoresMalformedBooleans(t *testing.T) {
+	t.Parallel()
+	config := &Config{
+		CleanCheckout: true,
+	}
+	environ := env.FromSlice([]string{
+		"BUILDKITE_CLEAN_CHECKOUT=blarg",
+	})
+	changes := config.ReadFromEnvironment(environ)
+	if len(changes) != 0 {
+		t.Fatalf("expected no changes, got %#v", changes)
+	}
+	if expected := true; config.CleanCheckout != expected {
+		t.Fatalf("Expected %v, got %v", expected, config.CleanCheckout)
 	}
 }


### PR DESCRIPTION
Add functionality to support `BUILDKITE_CLEAN_CHECKOUT` being set via hooks, and some fancy reflections to handle the conversion of the string value of this environment variable to a boolean. 