### PR TITLE
Log HTTP requests to S3 if the global DebugHTTP flag is on

### DIFF
--- a/agent/s3.go
+++ b/agent/s3.go
@@ -93,7 +93,7 @@ func awsS3Session(region string) (*session.Session, error) {
 	return sess, nil
 }
 
-func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
+func newS3Client(l logger.Logger, bucket string, debugHTTP bool) (*s3.S3, error) {
 	region, err := awsS3RegionFromEnv()
 	if err != nil {
 		return nil, err
@@ -106,7 +106,11 @@ func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 
 	l.Debug("Authorizing S3 credentials and finding bucket `%s` in region `%s`...", bucket, region)
 
-	s3client := s3.New(sess)
+	awsConfig := aws.NewConfig()
+	if debugHTTP {
+		awsConfig = awsConfig.WithLogLevel(aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
+	}
+	s3client := s3.New(sess, awsConfig)
 
 	// Test the authentication by trying to list the first 0 objects in the bucket.
 	_, err = s3client.ListObjects(&s3.ListObjectsInput{

--- a/agent/s3_downloader.go
+++ b/agent/s3_downloader.go
@@ -46,7 +46,7 @@ func NewS3Downloader(l logger.Logger, c S3DownloaderConfig) *S3Downloader {
 
 func (d S3Downloader) Start() error {
 	// Initialize the s3 client, and authenticate it
-	s3Client, err := newS3Client(d.logger, d.BucketName())
+	s3Client, err := newS3Client(d.logger, d.BucketName(), d.conf.DebugHTTP)
 	if err != nil {
 		return err
 	}

--- a/agent/s3_uploader.go
+++ b/agent/s3_uploader.go
@@ -43,7 +43,7 @@ func NewS3Uploader(l logger.Logger, c S3UploaderConfig) (*S3Uploader, error) {
 	bucketName, bucketPath := ParseS3Destination(c.Destination)
 
 	// Initialize the s3 client, and authenticate it
-	s3Client, err := newS3Client(l, bucketName)
+	s3Client, err := newS3Client(l, bucketName, c.DebugHTTP)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The DebugHTTP flag is a helpful tool for debugging what's happening when something goes wrong on customer-managed build servers.

This change ensures that flag applies to artifact uploads and downloads from S3. Hopefully this will help us understand what's happening when artifact uploads fail in interesting ways.