### PR TITLE
Fix unsetting of agent config env to work with ufave/cli/v2

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -489,7 +489,11 @@ var AgentStartCommand = cli.Command{
 		defer done()
 
 		// Remove any config env from the environment to prevent them propagating to bootstrap
-		UnsetConfigFromEnvironment(c)
+		err = UnsetConfigFromEnvironment(c)
+		if err != nil {
+			fmt.Printf("%s", err)
+			os.Exit(1)
+		}
 
 		// Check if git-mirrors are enabled
 		if experiments.IsEnabled(`git-mirrors`) {

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -1,6 +1,7 @@
 package clicommand
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -150,12 +151,15 @@ func HandleGlobalFlags(l logger.Logger, cfg interface{}) func() {
 	return HandleProfileFlag(l, cfg)
 }
 
-func UnsetConfigFromEnvironment(c *cli.Context) {
+func UnsetConfigFromEnvironment(c *cli.Context) error {
 	flags := append(c.App.Flags, c.Command.Flags...)
 	for _, fl := range flags {
 		// use golang reflection to find EnvVar values on flags
 		r := reflect.ValueOf(fl)
 		f := reflect.Indirect(r).FieldByName(`EnvVar`)
+		if !f.IsValid() {
+			return errors.New("EnvVar field not found on flag")
+		}
 		// split comma delimited env
 		if envVars := f.String(); envVars != `` {
 			for _, env := range strings.Split(envVars, ",") {
@@ -163,6 +167,7 @@ func UnsetConfigFromEnvironment(c *cli.Context) {
 			}
 		}
 	}
+	return nil
 }
 
 func loadAPIClientConfig(cfg interface{}, tokenField string) api.Config {


### PR DESCRIPTION
This method dynamically fetches a list of all the environment variables that can be used to configure the agent, and removes them from the environment so they're not passed down to child processes (like the bootstrap used to run a job).

It's implemented using reflection on the flag structs from the `ufave/cli` package we use for CLI structure. It checks the EnvVar field on the flag struct, which works just fine with `ufave/cli/v1`. However, that field doesn't exist any more in `ufave/cli/v2` and this method has started silently failing since we upgraded to v2 in #1233.

In commit 1, I changed the method to fail loudly if the flag structs don't have the EnvVar field we expect. This would've made the issue obvious when #1233 was first proposed.

In commit 2, I update the method to work with `ufave/cli/v2`. In `ufave/cli/v1` each flag supported a single environment variable key, stored in the EnvVar field. In `ufave/cli/v2` each flag can have multiple environment variable keys and they're stored in a slice of Strings called EnvVars (note the `S`).

I've also added some safety checks that will fail loudly if `ufave/cli/v3` decides to change/rename things again.