### PR TITLE
Enable BUILDKITE_AGENT_DEBUG_HTTP in jobs if it's enabled in the agent process

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -19,6 +19,9 @@ type AgentWorkerConfig struct {
 	// Whether to set debug in the job
 	Debug bool
 
+	// Whether to set debugHTTP in the job
+	DebugHTTP bool
+
 	// What signal to use for worker cancellation
 	CancelSignal process.Signal
 
@@ -63,6 +66,9 @@ type AgentWorker struct {
 	// Whether to enable debug
 	debug bool
 
+	// Whether to enable debugging of HTTP requests
+	debugHTTP bool
+
 	// The signal to use for cancellation
 	cancelSig process.Signal
 
@@ -87,6 +93,7 @@ func NewAgentWorker(l logger.Logger, a *api.AgentRegisterResponse, m *metrics.Co
 		metricsCollector:   m,
 		apiClient:          apiClient.FromAgentRegisterResponse(a),
 		debug:              c.Debug,
+		debugHTTP:          c.DebugHTTP,
 		agentConfiguration: c.AgentConfiguration,
 		stop:               make(chan struct{}),
 		cancelSig:          c.CancelSignal,
@@ -477,6 +484,7 @@ func (a *AgentWorker) RunJob(job *api.Job) error {
 	var err error
 	a.jobRunner, err = NewJobRunner(a.logger, jobMetricsScope, a.agent, job, a.apiClient, JobRunnerConfig{
 		Debug:              a.debug,
+		DebugHTTP:          a.debugHTTP,
 		CancelSignal:       a.cancelSig,
 		AgentConfiguration: a.agentConfiguration,
 	})

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -29,6 +29,9 @@ type JobRunnerConfig struct {
 
 	// Whether to set debug in the job
 	Debug bool
+
+	// Whether to set debug HTTP Requests in the job
+	DebugHTTP bool
 }
 
 type JobRunner struct {
@@ -439,6 +442,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 
 	// Add agent environment variables
 	env["BUILDKITE_AGENT_DEBUG"] = fmt.Sprintf("%t", r.conf.Debug)
+	env["BUILDKITE_AGENT_DEBUG_HTTP"] = fmt.Sprintf("%t", r.conf.DebugHTTP)
 	env["BUILDKITE_AGENT_PID"] = fmt.Sprintf("%d", os.Getpid())
 
 	// We know the BUILDKITE_BIN_PATH dir, because it's the path to the

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -713,6 +713,7 @@ var AgentStartCommand = cli.Command{
 						AgentConfiguration: agentConf,
 						CancelSignal:       cancelSig,
 						Debug:              cfg.Debug,
+						DebugHTTP:          cfg.DebugHTTP,
 						SpawnIndex:         i,
 					}))
 		}


### PR DESCRIPTION
Depends on #1250.

`BUILDKITE_AGENT_DEBUG` is already passed down to the job environment, and this expands that behaviour to also include `BUILDKITE_AGENT_DEBUG_HTTP`.

This is desirable because the build-agent binary is often used with jobs (eg. for artifact uploading/downloading) and from time to time it can be helpful to see precisely what those HTTP requests look like.