### PR TITLE
avoid passing nils to Printf() during HTTP Debug mode

### DIFF
--- a/agent/download.go
+++ b/agent/download.go
@@ -114,7 +114,11 @@ func (d Download) try() error {
 	if response.StatusCode/100 != 2 && response.StatusCode/100 != 3 {
 		if d.conf.DebugHTTP {
 			responseDump, err := httputil.DumpResponse(response, true)
-			d.logger.Debug("\nERR: %s\n%s", err, string(responseDump))
+			if err != nil {
+				d.logger.Debug("\nERR: %s\n%s", err, string(responseDump))
+			}  else {
+				d.logger.Debug("\n%s", string(responseDump))
+			}
 		}
 
 		return &downloadError{response.Status}

--- a/agent/form_uploader.go
+++ b/agent/form_uploader.go
@@ -67,7 +67,11 @@ func (u *FormUploader) Upload(artifact *api.Artifact) error {
 			requestDump, err = httputil.DumpRequestOut(request, true)
 		}
 
-		u.logger.Debug("\nERR: %s\n%s", err, string(requestDump))
+		if err != nil {
+			u.logger.Debug("\nERR: %s\n%s", err, string(requestDump))
+		} else {
+			u.logger.Debug("\n%s", string(requestDump))
+		}
 	}
 
 	// Create the client
@@ -87,7 +91,11 @@ func (u *FormUploader) Upload(artifact *api.Artifact) error {
 
 		if u.conf.DebugHTTP {
 			responseDump, err := httputil.DumpResponse(response, true)
-			u.logger.Debug("\nERR: %s\n%s", err, string(responseDump))
+			if err != nil {
+				u.logger.Debug("\nERR: %s\n%s", err, string(responseDump))
+			} else {
+				u.logger.Debug("\n%s", string(responseDump))
+			}
 		}
 
 		if response.StatusCode/100 != 2 {

--- a/api/client.go
+++ b/api/client.go
@@ -220,7 +220,11 @@ func (c *Client) doRequest(req *http.Request, v interface{}) (*Response, error) 
 			requestDump, err = httputil.DumpRequestOut(req, true)
 		}
 
-		c.logger.Debug("ERR: %s\n%s", err, string(requestDump))
+		if err != nil {
+			c.logger.Debug("ERR: %s\n%s", err, string(requestDump))
+		} else {
+			c.logger.Debug("%s", string(requestDump))
+		}
 	}
 
 	ts := time.Now()
@@ -245,7 +249,11 @@ func (c *Client) doRequest(req *http.Request, v interface{}) (*Response, error) 
 
 	if c.conf.DebugHTTP {
 		responseDump, err := httputil.DumpResponse(resp, true)
-		c.logger.Debug("\nERR: %s\n%s", err, string(responseDump))
+		if err != nil {
+			c.logger.Debug("\nERR: %s\n%s", err, string(responseDump))
+		} else {
+			c.logger.Debug("\n%s", string(responseDump))
+		}
 	}
 
 	err = checkResponse(resp)


### PR DESCRIPTION
I've been staring at logs from the agent in HTTP Debug mode a whole bunch recently. I noticed the request logs always started like this:

    2020-07-20 21:05:15 DEBUG  ERR: %!s(<nil>)
    POST /v3/jobs/3a242e02-9ff7-4a2e-8e80-939bc30231c8/artifacts HTTP/1.1
    Host: agent.buildkite.com
    User-Agent: buildkite-agent/3.23-beta.1.x (linux; amd64)

.... and the response logs started like this...

    2020-07-20 21:05:16 DEBUG
    ERR: %!s(<nil>)
    HTTP/1.1 201 Created
    Transfer-Encoding: chunked
    Cache-Control: max-age=0, private, must-revalidate

The potential error that we're trying to log is almost always going to be nil. Serialising the request/response into bytes will almost never fail.

I was unreasonably irritated by the little `%!s(<nil>)` for every request, so I've added some conditionals to make the log output warning-free.