### PR TITLE
bootstrap/integration `git show` mock args updated.

### DIFF
--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -45,7 +45,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 			{"fetch", "-v", "origin", "master"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color"},
+			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
 		})
 	} else {
 		git.ExpectAll([][]interface{}{
@@ -54,7 +54,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 			{"fetch", "-v", "origin", "master"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color"},
+			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
 		})
 	}
 
@@ -126,7 +126,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 			{"submodule", "foreach", "--recursive", "git reset --hard"},
 			{"clean", "-fdq"},
 			{"submodule", "foreach", "--recursive", "git clean -fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color"},
+			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
 		})
 	} else {
 		git.ExpectAll([][]interface{}{
@@ -141,7 +141,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 			{"submodule", "foreach", "--recursive", "git reset --hard"},
 			{"clean", "-fdq"},
 			{"submodule", "foreach", "--recursive", "git clean -fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color"},
+			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
 		})
 	}
 
@@ -209,7 +209,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 			{"fetch", "-v", "origin", "master"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color"},
+			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
 		})
 	} else {
 		git.ExpectAll([][]interface{}{
@@ -219,7 +219,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 			{"fetch", "-v", "origin", "master"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color"},
+			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
 		})
 	}
 
@@ -265,7 +265,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 			{"fetch", "--depth=1", "origin", "master"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color"},
+			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
 		})
 	} else {
 		git.ExpectAll([][]interface{}{
@@ -274,7 +274,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 			{"fetch", "--depth=1", "origin", "master"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color"},
+			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
 		})
 	}
 


### PR DESCRIPTION
Updates `git show HEAD` mock arguments to match changes from #1223 (70001925411ad1c459c47b00b217aba5027e126b, merged as f6d8056c6cdc6c2c82e5064013dd98067354185c) which introduced a trailing `--` to disambiguiate HEAD ref from HEAD file.