### PR TITLE
Job should fail when process.Run() -> err

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -349,6 +349,8 @@ func (r *JobRunner) Cancel() error {
 	r.logger.Info("Canceling job %s with a grace period of %ds%s",
 		r.job.ID, r.conf.AgentConfiguration.CancelGracePeriod, reason)
 
+	r.cancelled = true
+
 	// First we interrupt the process (ctrl-c or SIGINT)
 	if err := r.process.Interrupt(); err != nil {
 		return err


### PR DESCRIPTION
In rare cases (like a server without much memory left), it possible starting the bootstrap child process can return an error:

```go
if err := r.process.Run(); err != nil {
```

We handle the error, however we've had reports that the job may be reported as passed rather than failed. Here's two screenshots demonstrating what it can look like:

![Screenshot from 2020-08-10 10-05-45](https://user-images.githubusercontent.com/8132/89795827-375cc900-db6c-11ea-991f-92db93bf8cd4.png)

![Screenshot from 2020-08-11 11-00-24](https://user-images.githubusercontent.com/8132/89845461-e11a7500-dbc1-11ea-8b7c-2b98fb26666d.png)

This part is suspicious:

> Exited with status 0

In this failure case the process never started, so it doesn't have an exit code. This PR synthesizes a `-1` exit status to ensure the job is marked as failed.

 `-1` is an overloaded exit status though, so we also send along a "reason" string. That's not displayed in the web UI yet, but at least we have a permanent record of what causes the `-1` and job failure.