### PR TITLE
bump build environment from go 1.14.4 to 1.14.7

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   agent:
-    image: golang:1.14@sha256:d31a307a7e42116adb00d8d70971dbf228460904dd9b6217e911d088aa4b650c
+    image: golang:1.14@sha256:174e1be71bd2aa8c65d6c17be0e5c0f8bc4e4ec03e82a5f57aad0b8acf22ef7f
     volumes:
       - ../:/work:cached
     working_dir: /work


### PR DESCRIPTION
There's a few security and bug fixes. I'm not sure any of them impact us, but there's no harm in using the latest point release.

I noticed the bump was available because 1.14.7 fixes CVE-2020-16845, an [interesting sounding DOS vulnerability](https://groups.google.com/forum/m/#!msg/golang-announce/NyPIaucMgXo/GdsyQP6QAAAJ).

    $ docker run -it golang:1.14@sha256:d31a307a7e42116adb00d8d70971dbf228460904dd9b6217e911d088aa4b650c
    root@6fd0b4080736:/go# go version
    go version go1.14.4 linux/amd64

    $ docker run -it golang:1.14@sha256:174e1be71bd2aa8c65d6c17be0e5c0f8bc4e4ec03e82a5f57aad0b8acf22ef7f
    root@45cef25b927c:/go# go version
    go version go1.14.7 linux/amd64