### PR TITLE
pass sidecar docker image to release pipeline

### DIFF
--- a/.buildkite/steps/upload-release-steps.sh
+++ b/.buildkite/steps/upload-release-steps.sh
@@ -30,6 +30,7 @@ trigger_step() {
         agent-docker-image-alpine: "${agent_docker_image_alpine}"
         agent-docker-image-ubuntu: "${agent_docker_image_ubuntu}"
         agent-docker-image-centos: "${agent_docker_image_centos}"
+        agent-docker-image-sidecar: "${agent_docker_image_sidecar}"
         agent-is-prerelease: "${agent_is_prerelease}"
       env:
         DRY_RUN: "${DRY_RUN:-false}"
@@ -77,6 +78,7 @@ full_agent_version=$(buildkite-agent meta-data get "agent-version-full")
 agent_docker_image_alpine=$(buildkite-agent meta-data get "agent-docker-image-alpine")
 agent_docker_image_ubuntu=$(buildkite-agent meta-data get "agent-docker-image-ubuntu")
 agent_docker_image_centos=$(buildkite-agent meta-data get "agent-docker-image-centos")
+agent_docker_image_sidecar=$(buildkite-agent meta-data get "agent-docker-image-sidecar")
 agent_is_prerelease=$(buildkite-agent meta-data get "agent-is-prerelease")
 
 # If there is already a release (which means a tag), we want to avoid trying to create


### PR DESCRIPTION
In #1218 we added a new docker image to the build and release, but we forgot to pass the meta_data through to the release pipeline. This resulted in the release pipeline failing - eg:
https://buildkite.com/buildkite/agent-release-edge/builds/294#8d50db3e-781c-4690-9378-f1ddf83988be