### PR TITLE
fail fast when uploading an artifact > 5Gb to the default s3 bucket

### DIFF
--- a/agent/form_uploader_test.go
+++ b/agent/form_uploader_test.go
@@ -165,3 +165,24 @@ func TestFormUploadFileMissing(t *testing.T) {
 		t.Errorf("Expected error no such file or directory, got %q", err)
 	}
 }
+
+func TestFormUploadTooBig(t *testing.T) {
+	uploader := NewFormUploader(logger.Discard, FormUploaderConfig{})
+	artifact := &api.Artifact{
+		ID:           "xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx",
+		Path:         "llamas.txt",
+		AbsolutePath: "/llamas.txt",
+		GlobPath:     "llamas.txt",
+		ContentType:  "text/plain",
+		FileSize:     int64(6442450944), // 6Gb
+		UploadInstructions: &api.ArtifactUploadInstructions{},
+	}
+
+	err := uploader.Upload(artifact)
+	if err == nil {
+		t.Errorf("Expected error when uploading a file over 5Gb")
+	}
+	if err.Error() != "File size (6442450944 bytes) exceeds the maximum supported by Buildkite's default artifact storage (5Gb). Alternative artifact storage options may support larger files." {
+		t.Errorf("Expected polite error message when uploading a file over 5Gb")
+	}
+}


### PR DESCRIPTION
Buildkite provides a default artifact storage option that happens to be stored on S3. Each artifact is uploaded as a signed POST, which has a limit of 5Gb.

At the moment, artifacts that exceed this limit are uploaded 10 times (thanks to retries). On each attempt the full file contents is uploaded, only to be rejected by S3 at the end. What a waste of bandwidth and time.

This change ensures artifacts that exceed 5Gb display an error before starting the file upload. This isn't a perfect solution, as the retry logic kicks in and there's 10 retries. They complete quickly though, and no bandwidth is wasted.

The error message is long, but I thought it might be helpful to point to the other artifact storage options we support (like customer owned S3 buckets) where artifacts > 5Gb may work fine.

Here's what this looks like in build output:

![Screenshot from 2020-08-11 23-23-40](https://user-images.githubusercontent.com/8132/89902372-b6640700-dc29-11ea-841e-17e4045a0cf9.png)

Closes #746