### PR TITLE
add successful logging statement to artifact uploader

### DIFF
--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -367,6 +367,7 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 
 				state = "error"
 			} else {
+				a.logger.Info("Successfully uploaded artifact \"%s\"", artifact.Path)
 				state = "finished"
 			}
 


### PR DESCRIPTION
This adds a `Successfully uploaded "[file]"` log line to the agent output when a file has been successfully uploaded.

We would like to add this as several of our (internal) customers have misread these log lines, incorrectly assuming that the artifact was not successfully uploaded.