### PR TITLE
Add some extra debug logging during artifact uploads

### DIFF
--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -380,8 +380,12 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 		})
 	}
 
+	a.logger.Debug("Waiting for uploads to complete...")
+
 	// Wait for the pool to finish
 	p.Wait()
+
+	a.logger.Debug("Uploads complete, waiting for upload status to be sent to buildkite...")
 
 	// Wait for the statuses to finish uploading
 	stateUploaderWaitGroup.Wait()
@@ -389,6 +393,8 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 	if len(errors) > 0 {
 		return fmt.Errorf("There were errors with uploading some of the artifacts")
 	}
+
+	a.logger.Info("Artifact uploads completed succesfully")
 
 	return nil
 }


### PR DESCRIPTION
The current non-debug output during artifact uploads looks like this:

    --- Uploading artifacts
    $ buildkite-agent artifact upload log/*.log
    2020-06-23 17:46:52 INFO   Found 1 files that match "log/*.log"
    2020-06-23 17:46:52 INFO   Creating (0-1)/1 artifacts
    2020-06-23 17:46:52 INFO   Uploading artifact 4941dcd3-665d-445b-86b0-8d552b86dd53 log/foo.log (2275 bytes)

Without debug logging, there's no output once the uploads start, and if the upload process hangs for any reason it can be hard to see (based on log output only) where things have become stuck.

This adds a single Info-level log line when all artifacts have successfully been uploaded, so it's obvious when that process has
completed. Any stalled builds after that point will be easier to attribute to a non-artifact uploading issue.

I also added a couple of extra Debug-level logs at points where the agent is waiting for asynchronous network IO to complete. Just in case we want to see where things are at for customers in the future.