### PR TITLE
Prevent "Argument List Too Long" error

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -201,6 +201,7 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 		Args:            cmd[1:],
 		Env:             processEnv,
 		PTY:             conf.AgentConfiguration.RunInPty,
+		UseStdin:        false,
 		Stdout:          processWriter,
 		Stderr:          processWriter,
 		InterruptSignal: conf.CancelSignal,

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1278,7 +1278,7 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 			return err
 		}
 
-		if err = b.shell.Run("buildkite-agent", "meta-data", "set", "buildkite:git:commit", gitCommitOutput); err != nil {
+		if err = b.shell.RunWithInput(gitCommitOutput, "buildkite-agent", "meta-data", "set", "buildkite:git:commit"); err != nil {
 			return err
 		}
 	}

--- a/process/process.go
+++ b/process/process.go
@@ -64,6 +64,8 @@ type Config struct {
 	Path            string
 	Args            []string
 	Env             []string
+	UseStdin        bool
+	Stdin           io.Reader
 	Stdout          io.Writer
 	Stderr          io.Writer
 	Dir             string
@@ -195,7 +197,11 @@ func (p *Process) Run() error {
 	} else {
 		p.command.Stdout = p.conf.Stdout
 		p.command.Stderr = p.conf.Stderr
-		p.command.Stdin = nil
+		if p.conf.UseStdin {
+			p.command.Stdin = p.conf.Stdin
+		} else {
+			p.command.Stdin = nil
+		}
 
 		err := p.command.Start()
 		if err != nil {


### PR DESCRIPTION
If the commit info is too large then this will fail with an "argument list too long" error. We can pipe the commit in to fix this, and it makes it more reliable. But I can't figure out how to punch a hole the right size through all of these layers of abstraction.

This almost works, but it blocks forever because process.Run() blocks until the process exits, but it can't exit until we've written and closed stdin, which we can't do until we start the process in process.Run().

![image](https://user-images.githubusercontent.com/14028/90587343-7e0d8b80-e21c-11ea-97e0-7329bc81d714.png)

Fixes #1269