### PR TITLE
Refactor experiments local var naming

### DIFF
--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -3,27 +3,27 @@ package experiments
 var experiments = make(map[string]bool)
 
 // Enable a particular experiment in the agent
-func Enable(experiment string) {
-	experiments[experiment] = true
+func Enable(key string) {
+	experiments[key] = true
 }
 
 // Disable a particular experiment in the agent
-func Disable(experiment string) {
-	delete(experiments, experiment)
+func Disable(key string) {
+	delete(experiments, key)
 }
 
 // IsEnabled returns whether the named experiment is enabled
-func IsEnabled(experiment string) bool {
-	return experiments[experiment] // map[T]bool returns false for missing keys
+func IsEnabled(key string) bool {
+	return experiments[key] // map[T]bool returns false for missing keys
 }
 
 // Enabled returns the keys of all the enabled experiments
 func Enabled() []string {
-	var enabled []string
-	for exp, ok := range experiments {
-		if ok {
-			enabled = append(enabled, exp)
+	var keys []string
+	for key, enabled := range experiments {
+		if enabled {
+			keys = append(keys, key)
 		}
 	}
-	return enabled
+	return keys
 }

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -12,13 +12,9 @@ func Disable(experiment string) {
 	delete(experiments, experiment)
 }
 
-// Check if an experiment has been enabled
+// IsEnabled returns whether the named experiment is enabled
 func IsEnabled(experiment string) bool {
-	if val, ok := experiments[experiment]; ok {
-		return val
-	} else {
-		return false
-	}
+	return experiments[experiment] // map[T]bool returns false for missing keys
 }
 
 // Enabled returns the keys of all the enabled experiments


### PR DESCRIPTION
Two parts, both rather superficial…

----

Simplify the implementation of `experiments.IsEnabled()`. Go's `map` type returns the zero-value of its value type for missing keys; so `map[string]bool` returns `false` for missing keys.

That means we don't need any extra logic to check for the existence of the key.

----

The rest of the PR is mostly var renaming to make the implementation of Enabled() clearer.

Idiomatic Go uses `ok` to indicate whether a key _existed_ in a map, e.g. `value, ok := experiments["foo"]`.
Whereas we were using it to refer to the boolean _value_ of the `map[string]bool` in the context of a range,
i.e. `for key, ok := range experiments`.

And `var enabled []string` as the accumulator list of enabled experiments is problematic because `enabled` isn't exclusively plural; the same `enabled` name could also refer to a boolean value in the experiments `map[string]bool`. So this patch renames the list to `keys`, and also uses `key` instead of `experiment` everywhere to refer to experiment keys.

With the name `enabled` no longer being used for a list of enabled keys, this patch uses `enabled` instead of `ok`, resulting in a clearer `if enabled { ... }`.
