### PR TITLE
git-mirrors promoted from experiment, enabled by git-mirrors-path

### DIFF
--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -5,6 +5,3 @@ GO111MODULE=off go get gotest.tools/gotestsum
 
 echo '+++ Running tests'
 gotestsum --junitfile "junit-${OSTYPE}.xml" -- -count=1 -failfast ./...
-
-echo '+++ Running integration tests for git-mirrors experiment'
-TEST_EXPERIMENT=git-mirrors gotestsum --junitfile "junit-${OSTYPE}-git-mirrors.xml" -- -count=1 -failfast ./bootstrap/integration

--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -18,14 +18,6 @@ If an experiment doesn't exist, no error will be raised.
 
 ## Available Experiments
 
-### `git-mirrors`
-
-Maintain a single bare git mirror for each repository on a host that is shared amongst multiple agents and pipelines. Checkouts reference the git mirror using `git clone --reference`, as do submodules.
-
-You must set a `git-mirrors-path` in your config for this to work.
-
-**Status**: broadly useful, we'd like this to be the standard behaviour in 4.0. 👍👍
-
 ### `ansi-timestamps`
 
 Outputs inline ANSI timestamps for each line of log output which enables toggle-able timestamps in the Buildkite UI.

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1100,9 +1100,8 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 	var mirrorDir string
 
 	// If we can, get a mirror of the git repository to use for reference later
-	if experiments.IsEnabled(`git-mirrors`) && b.Config.GitMirrorsPath != "" && b.Config.Repository != "" {
-		b.shell.Commentf("Using git-mirrors experiment 🧪")
-
+	if b.Config.GitMirrorsPath != "" && b.Config.Repository != "" {
+		b.shell.Commentf("Using git-mirrors")
 		var err error
 		mirrorDir, err = b.updateGitMirror()
 		if err != nil {

--- a/bootstrap/integration/bootstrap_tester.go
+++ b/bootstrap/integration/bootstrap_tester.go
@@ -107,16 +107,6 @@ func NewBootstrapTester() (*BootstrapTester, error) {
 	// Support testing experiments
 	if exp := experiments.Enabled(); len(exp) > 0 {
 		bt.Env = append(bt.Env, `BUILDKITE_AGENT_EXPERIMENT=`+strings.Join(exp, ","))
-
-		if experiments.IsEnabled(`git-mirrors`) {
-			gitMirrorsDir, err := ioutil.TempDir("", "bootstrap-git-mirrors")
-			if err != nil {
-				return nil, err
-			}
-
-			bt.GitMirrorsDir = gitMirrorsDir
-			bt.Env = append(bt.Env, "BUILDKITE_GIT_MIRRORS_PATH="+gitMirrorsDir)
-		}
 	}
 
 	// Windows requires certain env variables to be present

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -50,28 +50,15 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 		PassthroughToLocalCommand()
 
 	// But assert which ones are called
-	if experiments.IsEnabled(`git-mirrors`) {
-		git.ExpectAll([][]interface{}{
-			{"clone", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
-			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
-			{"clean", "-fdq"},
-			{"fetch", "-v", "origin", "master"},
-			{"checkout", "-f", "FETCH_HEAD"},
-			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
-			{"rev-parse", "HEAD"},
-		})
-	} else {
-		git.ExpectAll([][]interface{}{
-			{"clone", "-v", "--", tester.Repo.Path, "."},
-			{"clean", "-fdq"},
-			{"fetch", "-v", "origin", "master"},
-			{"checkout", "-f", "FETCH_HEAD"},
-			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
-			{"rev-parse", "HEAD"},
-		})
-	}
+	git.ExpectAll([][]interface{}{
+		{"clone", "-v", "--", tester.Repo.Path, "."},
+		{"clean", "-fdq"},
+		{"fetch", "-v", "origin", "master"},
+		{"checkout", "-f", "FETCH_HEAD"},
+		{"clean", "-fdq"},
+		{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+		{"rev-parse", "HEAD"},
+	})
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MustMock(t, "buildkite-agent")
@@ -102,26 +89,14 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 		PassthroughToLocalCommand()
 
 	// But assert which ones are called
-	if experiments.IsEnabled(`git-mirrors`) {
-		git.ExpectAll([][]interface{}{
-			{"clone", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
-			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
-			{"clean", "-fdq"},
-			{"fetch", "-v", "origin", "master"},
-			{"checkout", "-f", "FETCH_HEAD"},
-			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
-		})
-	} else {
-		git.ExpectAll([][]interface{}{
-			{"clone", "-v", "--", tester.Repo.Path, "."},
-			{"clean", "-fdq"},
-			{"fetch", "-v", "origin", "master"},
-			{"checkout", "-f", "FETCH_HEAD"},
-			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
-		})
-	}
+	git.ExpectAll([][]interface{}{
+		{"clone", "-v", "--", tester.Repo.Path, "."},
+		{"clean", "-fdq"},
+		{"fetch", "-v", "origin", "master"},
+		{"checkout", "-f", "FETCH_HEAD"},
+		{"clean", "-fdq"},
+		{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+	})
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MustMock(t, "buildkite-agent")
@@ -177,38 +152,20 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 		PassthroughToLocalCommand()
 
 	// But assert which ones are called
-	if experiments.IsEnabled(`git-mirrors`) {
-		git.ExpectAll([][]interface{}{
-			{"clone", "-v", "--mirror", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
-			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
-			{"clean", "-fdq"},
-			{"submodule", "foreach", "--recursive", "git clean -fdq"},
-			{"fetch", "-v", "origin", "master"},
-			{"checkout", "-f", "FETCH_HEAD"},
-			{"submodule", "sync", "--recursive"},
-			{"config", "--file", ".gitmodules", "--null", "--get-regexp", "submodule\\..+\\.url"},
-			{"submodule", "update", "--init", "--recursive", "--force"},
-			{"submodule", "foreach", "--recursive", "git reset --hard"},
-			{"clean", "-fdq"},
-			{"submodule", "foreach", "--recursive", "git clean -fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
-		})
-	} else {
-		git.ExpectAll([][]interface{}{
-			{"clone", "-v", "--", tester.Repo.Path, "."},
-			{"clean", "-fdq"},
-			{"submodule", "foreach", "--recursive", "git clean -fdq"},
-			{"fetch", "-v", "origin", "master"},
-			{"checkout", "-f", "FETCH_HEAD"},
-			{"submodule", "sync", "--recursive"},
-			{"config", "--file", ".gitmodules", "--null", "--get-regexp", "submodule\\..+\\.url"},
-			{"submodule", "update", "--init", "--recursive", "--force"},
-			{"submodule", "foreach", "--recursive", "git reset --hard"},
-			{"clean", "-fdq"},
-			{"submodule", "foreach", "--recursive", "git clean -fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
-		})
-	}
+	git.ExpectAll([][]interface{}{
+		{"clone", "-v", "--", tester.Repo.Path, "."},
+		{"clean", "-fdq"},
+		{"submodule", "foreach", "--recursive", "git clean -fdq"},
+		{"fetch", "-v", "origin", "master"},
+		{"checkout", "-f", "FETCH_HEAD"},
+		{"submodule", "sync", "--recursive"},
+		{"config", "--file", ".gitmodules", "--null", "--get-regexp", "submodule\\..+\\.url"},
+		{"submodule", "update", "--init", "--recursive", "--force"},
+		{"submodule", "foreach", "--recursive", "git reset --hard"},
+		{"clean", "-fdq"},
+		{"submodule", "foreach", "--recursive", "git clean -fdq"},
+		{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+	})
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MustMock(t, "buildkite-agent")
@@ -264,29 +221,16 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 		MustMock(t, "git").
 		PassthroughToLocalCommand()
 
-	// But assert which ones are called
-	if experiments.IsEnabled(`git-mirrors`) {
-		git.ExpectAll([][]interface{}{
-			{"clone", "-v", "--mirror", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
-			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
-			{"clean", "-fdq"},
-			{"submodule", "foreach", "--recursive", "git clean -fdq"},
-			{"fetch", "-v", "origin", "master"},
-			{"checkout", "-f", "FETCH_HEAD"},
-			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
-		})
-	} else {
-		git.ExpectAll([][]interface{}{
-			{"clone", "-v", "--", tester.Repo.Path, "."},
-			{"clean", "-fdq"},
-			{"submodule", "foreach", "--recursive", "git clean -fdq"},
-			{"fetch", "-v", "origin", "master"},
-			{"checkout", "-f", "FETCH_HEAD"},
-			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
-		})
-	}
+		// But assert which ones are called
+	git.ExpectAll([][]interface{}{
+		{"clone", "-v", "--", tester.Repo.Path, "."},
+		{"clean", "-fdq"},
+		{"submodule", "foreach", "--recursive", "git clean -fdq"},
+		{"fetch", "-v", "origin", "master"},
+		{"checkout", "-f", "FETCH_HEAD"},
+		{"clean", "-fdq"},
+		{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+	})
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MustMock(t, "buildkite-agent")
@@ -321,27 +265,15 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 		MustMock(t, "git").
 		PassthroughToLocalCommand()
 
-	// But assert which ones are called
-	if experiments.IsEnabled(`git-mirrors`) {
-		git.ExpectAll([][]interface{}{
-			{"clone", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
-			{"clone", "--depth=1", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
-			{"clean", "-fdq"},
-			{"fetch", "--depth=1", "origin", "master"},
-			{"checkout", "-f", "FETCH_HEAD"},
-			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
-		})
-	} else {
-		git.ExpectAll([][]interface{}{
-			{"clone", "--depth=1", "--", tester.Repo.Path, "."},
-			{"clean", "-fdq"},
-			{"fetch", "--depth=1", "origin", "master"},
-			{"checkout", "-f", "FETCH_HEAD"},
-			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
-		})
-	}
+		// But assert which ones are called
+	git.ExpectAll([][]interface{}{
+		{"clone", "--depth=1", "--", tester.Repo.Path, "."},
+		{"clean", "-fdq"},
+		{"fetch", "--depth=1", "origin", "master"},
+		{"checkout", "-f", "FETCH_HEAD"},
+		{"clean", "-fdq"},
+		{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+	})
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MustMock(t, "buildkite-agent")
@@ -394,13 +326,8 @@ func TestCheckingOutWithSSHKeyscan(t *testing.T) {
 	git := tester.MustMock(t, "git")
 	git.IgnoreUnexpectedInvocations()
 
-	if experiments.IsEnabled(`git-mirrors`) {
-		git.Expect("clone", "-v", "--mirror", "--", "git@github.com:buildkite/agent.git", bintest.MatchAny()).
-			AndExitWith(0)
-	} else {
-		git.Expect("clone", "-v", "--", "git@github.com:buildkite/agent.git", ".").
-			AndExitWith(0)
-	}
+	git.Expect("clone", "-v", "--", "git@github.com:buildkite/agent.git", ".").
+		AndExitWith(0)
 
 	env := []string{
 		`BUILDKITE_REPO=git@github.com:buildkite/agent.git`,
@@ -447,13 +374,8 @@ func TestCheckingOutWithSSHKeyscanAndUnscannableRepo(t *testing.T) {
 	git := tester.MustMock(t, "git")
 	git.IgnoreUnexpectedInvocations()
 
-	if experiments.IsEnabled(`git-mirrors`) {
-		git.Expect("clone", "-v", "--mirror", "--", "https://github.com/buildkite/bash-example.git", bintest.MatchAny()).
-			AndExitWith(0)
-	} else {
-		git.Expect("clone", "-v", "--", "https://github.com/buildkite/bash-example.git", ".").
-			AndExitWith(0)
-	}
+	git.Expect("clone", "-v", "--", "https://github.com/buildkite/bash-example.git", ".").
+		AndExitWith(0)
 
 	env := []string{
 		`BUILDKITE_REPO=https://github.com/buildkite/bash-example.git`,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -13,7 +13,6 @@ import (
 	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/cliconfig"
-	"github.com/buildkite/agent/v3/experiments"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/agent/v3/metrics"
 	"github.com/buildkite/agent/v3/process"
@@ -493,13 +492,6 @@ var AgentStartCommand = cli.Command{
 		if err != nil {
 			fmt.Printf("%s", err)
 			os.Exit(1)
-		}
-
-		// Check if git-mirrors are enabled
-		if experiments.IsEnabled(`git-mirrors`) {
-			if cfg.GitMirrorsPath == `` {
-				l.Fatal("Must provide a git-mirrors-path in your configuration for git-mirrors experiment")
-			}
 		}
 
 		// Force some settings if on Windows (these aren't supported yet)


### PR DESCRIPTION
This _draft_ pull request promotes the `git-mirrors` functionality from experiment to standard.
It still requires `git-mirrors-path` to be configured, otherwise it remains disabled. This makes it pretty safe to promote from experiment status, with a few caveats below.

## elastic-ci-stack-for-aws consideration

Note that elastic-ci-stack-for-aws prior to https://github.com/buildkite/elastic-ci-stack-for-aws/pull/698 does provide a `git-mirrors-path` even when the stack chooses not to enable the experiment. That means shipping this PR could result in surprising/disruptive behaviour if it's used in an elastic-stack prior to that PR merged.

## test coverage

This PR regrettably removes test coverage for `git-mirrors`, because that coverage was being driven externally via `TEST_EXPERIMENTS`:
https://github.com/buildkite/agent/blob/f119ac1494f1c10ae5811c84f58a0c47a932ee89/bootstrap/integration/main_test.go#L38

… as well as special handling in BootstrapTester:
https://github.com/buildkite/agent/blob/f119ac1494f1c10ae5811c84f58a0c47a932ee89/bootstrap/integration/bootstrap_tester.go#L111-L119

… and a special CI test entrypoint:
https://github.com/buildkite/agent/blob/f119ac1494f1c10ae5811c84f58a0c47a932ee89/.buildkite/steps/tests.sh#L9-L10

I think this PR should add some test coverage back in, but via a dedicated test which sets up a `git-mirror-path` at at least traverses the happy path of the code.