### PR TITLE
Add an agent-wide shutdown hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Added support for a shutdown hook that runs during shutdown. Once per agent regardless of the number of workers it spawns.
+
 ## [v3.23.1](https://github.com/buildkite/agent/compare/v3.23.0...v3.23.1) (2020-09-09)
 
 ### Fixed

--- a/clicommand/agent_start_test.go
+++ b/clicommand/agent_start_test.go
@@ -1,0 +1,53 @@
+package clicommand
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func setupHooksPath() (string, func(), error) {
+	hooksPath, err := ioutil.TempDir("", "")
+	if err != nil {
+		return "", nil, err
+	}
+	return hooksPath, func() { os.RemoveAll(hooksPath) }, nil
+}
+
+// Since the hook doesn't really return anything, we can't really test stuff but at
+// least make sure the code doesn't explode.
+func TestShutdownHook(t *testing.T) {
+	log := CreateLogger(&AgentStartConfig{})
+
+	t.Run("with shutdown hook", func(t *testing.T) {
+		hooksPath, closer, err := setupHooksPath()
+		if err != nil {
+			assert.FailNow(t, "failed to create temp file: %v", err)
+		}
+		defer closer()
+
+		err = ioutil.WriteFile(filepath.Join(hooksPath, "shutdown"), []byte("echo hello"), 0755)
+		if err != nil {
+			assert.FailNow(t, "failed to write shutdown hook: %v", err)
+		}
+
+		shutdownHook(log, hooksPath)
+	})
+
+	t.Run("with no shutdown hook", func(t *testing.T) {
+		hooksPath, closer, err := setupHooksPath()
+		if err != nil {
+			assert.FailNow(t, "failed to create temp file: %v", err)
+		}
+		defer closer()
+
+		shutdownHook(log, hooksPath)
+	})
+
+	t.Run("with bad hooks path", func(t *testing.T) {
+		shutdownHook(log, "zxczxczxc")
+	})
+}


### PR DESCRIPTION
This will be useful for ensuring graceful shutdowns and cleanup when the
agent is integrated with other systems, like k8s.

This only runs once per agent, regardless of the number of workers. It looks for a `shutdown` script in the hooks directory on the agent.

Question:
- Does anything special need to be done for Windows?