### PR TITLE
Add optional brackets to file arg

### DIFF
--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -15,7 +15,7 @@ import (
 
 var AnnotateHelpDescription = `Usage:
 
-   buildkite-agent annotate [<body>] [arguments...]
+   buildkite-agent annotate [body] [arguments...]
 
 Description:
 

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -13,7 +13,7 @@ import (
 
 var MetaDataSetHelpDescription = `Usage:
 
-   buildkite-agent meta-data set <key> [<value>] [arguments...]
+   buildkite-agent meta-data set <key> [value] [arguments...]
 
 Description:
 

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -21,7 +21,7 @@ import (
 
 var PipelineUploadHelpDescription = `Usage:
 
-   buildkite-agent pipeline upload [<file>] [arguments...]
+   buildkite-agent pipeline upload [file] [arguments...]
 
 Description:
 

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -21,7 +21,7 @@ import (
 
 var PipelineUploadHelpDescription = `Usage:
 
-   buildkite-agent pipeline upload <file> [arguments...]
+   buildkite-agent pipeline upload [<file>] [arguments...]
 
 Description:
 


### PR DESCRIPTION
As noted in https://github.com/buildkite/docs/pull/806 - the `file` arg is optional, and so should be wrapped in square brackets in the help text. 