### PR TITLE
Add artifact search subcommand

### DIFF
--- a/agent/artifact_downloader.go
+++ b/agent/artifact_downloader.go
@@ -66,7 +66,7 @@ func (a *ArtifactDownloader) Download() error {
 
 	// Find the artifacts that we want to download
 	artifacts, err := NewArtifactSearcher(a.logger, a.apiClient, a.conf.BuildID).
-		Search(a.conf.Query, a.conf.Step, a.conf.IncludeRetriedJobs)
+		Search(a.conf.Query, a.conf.Step, a.conf.IncludeRetriedJobs, false)
 	if err != nil {
 		return err
 	}

--- a/agent/artifact_searcher.go
+++ b/agent/artifact_searcher.go
@@ -27,7 +27,7 @@ func NewArtifactSearcher(l logger.Logger, ac APIClient, buildID string) *Artifac
 	}
 }
 
-func (a *ArtifactSearcher) Search(query string, scope string, includeRetriedJobs bool) ([]*api.Artifact, error) {
+func (a *ArtifactSearcher) Search(query string, scope string, includeRetriedJobs bool, includeDuplicates bool) ([]*api.Artifact, error) {
 	if scope == "" {
 		a.logger.Info("Searching for artifacts: \"%s\"", query)
 	} else {
@@ -43,6 +43,7 @@ func (a *ArtifactSearcher) Search(query string, scope string, includeRetriedJobs
 			Query:              query,
 			Scope:              scope,
 			IncludeRetriedJobs: includeRetriedJobs,
+			IncludeDuplicates:  includeDuplicates,
 		})
 		return searchErr
 	}, &retry.Config{Maximum: 10, Interval: 5 * time.Second})

--- a/api/artifacts.go
+++ b/api/artifacts.go
@@ -74,6 +74,7 @@ type ArtifactSearchOptions struct {
 	Query              string `url:"query,omitempty"`
 	Scope              string `url:"scope,omitempty"`
 	IncludeRetriedJobs bool   `url:"include_retried_jobs,omitempty"`
+	IncludeDuplicates  bool   `url:"include_duplicates,omitempty"`
 }
 
 type ArtifactBatchUpdateArtifact struct {

--- a/api/artifacts.go
+++ b/api/artifacts.go
@@ -2,13 +2,14 @@ package api
 
 import (
 	"fmt"
+	"time"
 )
 
 // Artifact represents an artifact on the Buildkite Agent API
 type Artifact struct {
 	// The ID of the artifact. The ID is assigned to it after a successful
 	// batch creation
-	ID string `json:"-"`
+	ID string `json:"id"`
 
 	// The path to the artifact relative to the working directory
 	Path string `json:"path"`
@@ -24,6 +25,12 @@ type Artifact struct {
 
 	// A Sha1Sum calculation of the file
 	Sha1Sum string `json:"sha1sum"`
+
+	// ID of the job that created this artifact (from API)
+	JobID string `json:"job_id"`
+
+	// UTC timestamp this artifact was considered created
+	CreatedAt time.Time `json:"created_at"`
 
 	// The HTTP url to this artifact once it's been uploaded
 	URL string `json:"url,omitempty"`

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -42,7 +42,7 @@ Example:
 
    $ buildkite-agent artifact search "*" -printf "%p\n"
 
-   The above will return a list of filenames separated by newline. Other available options are:`
+   The above will return a list of filenames separated by newline.`
 
 type ArtifactSearchConfig struct {
 	Query              string `cli:"arg:0" label:"artifact search query" validate:"required"`
@@ -140,7 +140,7 @@ var ArtifactSearchCommand = cli.Command{
 
 		// Setup the searcher and try get the artifacts
 		searcher := agent.NewArtifactSearcher(l, client, cfg.Build)
-		artifacts, err := searcher.Search(cfg.Query, cfg.Step, cfg.IncludeRetriedJobs)
+		artifacts, err := searcher.Search(cfg.Query, cfg.Step, cfg.IncludeRetriedJobs, true)
 		if err != nil {
 			return err
 		}

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -38,9 +38,9 @@ Example:
 
    You can also use the step's job id (provided by the environment variable $BUILDKITE_JOB_ID)
 
-   Formatting output can be done somewhat like unix find's -printf option:
+   Output formatting can be altered with the -format flag as follows:
 
-   $ buildkite-agent artifact search "*" -printf "%p\n"
+   $ buildkite-agent artifact search "*" -format "%p\n"
 
    The above will return a list of filenames separated by newline.`
 
@@ -49,7 +49,7 @@ type ArtifactSearchConfig struct {
 	Step               string `cli:"step"`
 	Build              string `cli:"build" validate:"required"`
 	IncludeRetriedJobs bool   `cli:"include-retried-jobs"`
-	PrintFormat        string `cli:"printf"`
+	PrintFormat        string `cli:"format"`
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
@@ -86,7 +86,7 @@ var ArtifactSearchCommand = cli.Command{
 			Usage:   "Include artifacts from retried jobs in the search",
 		},
 		&cli.StringFlag{
-			Name:  "printf",
+			Name:  "format",
 			Value: "%j %p %c\n",
 			Usage: `Output formatting of results. Defaults to "%j %p %c\n" (Job ID, path, created at time).
 
@@ -145,10 +145,8 @@ var ArtifactSearchCommand = cli.Command{
 			return err
 		}
 
-		artifactCount := len(artifacts)
-
-		if artifactCount == 0 {
-			l.Debug("No matches found for %s", cfg.Query)
+		if len(artifacts) == 0 {
+			return cli.Exit(fmt.Sprintf("No matches found for %s", cfg.Query), 1)
 		}
 
 		for _, artifact := range artifacts {

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -1,0 +1,124 @@
+package clicommand
+
+import (
+	"github.com/buildkite/agent/v3/agent"
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/cliconfig"
+	"github.com/urfave/cli/v2"
+)
+
+var SearchHelpDescription = `Usage:
+
+   buildkite-agent artifact search [options] <query> <destination>
+
+Description:  ## TODO CHECK
+
+	 Searches for build artifacts specified by <query> on Buildkite
+
+   Note: You need to ensure that your search query is surrounded by quotes if
+   using a wild card as the built-in shell path globbing will provide files,
+   which will break the search.
+
+Example: ## TODO CHECK
+
+   $ buildkite-agent artifact search "pkg/*.tar.gz" --build xxx
+
+   This will search across all the artifacts for the build for files that match that query.
+   The first argument is the search query.
+
+   If you're trying to find a specific file, and there are multiple artifacts from different
+   jobs, you can target the particular job you want to search the artifact using --step:
+
+   $ buildkite-agent artifact search "pkg/*.tar.gz" --step "tests" --build xxx
+
+   You can also use the step's job id (provided by the environment variable $BUILDKITE_JOB_ID)`
+
+type ArtifactSearchConfig struct {
+	Query              string `cli:"arg:0" label:"artifact search query" validate:"required"`
+	Step               string `cli:"step"`
+	Build              string `cli:"build" validate:"required"`
+	IncludeRetriedJobs bool   `cli:"include-retried-jobs"`
+
+	// Global flags
+	Debug       bool     `cli:"debug"`
+	NoColor     bool     `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile     string   `cli:"profile"`
+
+	// API config
+	DebugHTTP        bool   `cli:"debug-http"`
+	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
+	Endpoint         string `cli:"endpoint" validate:"required"`
+	NoHTTP2          bool   `cli:"no-http2"`
+}
+
+var ArtifactSearchCommand = cli.Command{
+	Name:        "search",
+	Usage:       "Searches artifacts in Buildkite",
+	Description: SearchHelpDescription,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "step",
+			Value: "",
+			Usage: "Scope the search to a particular step by using either its name or job ID",
+		},
+		&cli.StringFlag{
+			Name:    "build",
+			Value:   "",
+			EnvVars: []string{"BUILDKITE_BUILD_ID"},
+			Usage:   "The build that the artifacts were uploaded to",
+		},
+		&cli.BoolFlag{
+			Name:    "include-retried-jobs",
+			EnvVars: []string{"BUILDKITE_AGENT_INCLUDE_RETRIED_JOBS"},
+			Usage:   "Include artifacts from retried jobs in the search",
+		},
+
+		// API Flags
+		AgentAccessTokenFlag,
+		EndpointFlag,
+		NoHTTP2Flag,
+		DebugHTTPFlag,
+
+		// Global flags
+		NoColorFlag,
+		DebugFlag,
+		ExperimentsFlag,
+		ProfileFlag,
+	},
+	Action: func(c *cli.Context) error {
+		// The configuration will be loaded into this struct
+		cfg := ArtifactSearchConfig{}
+
+		l := CreateLogger(&cfg)
+
+		// Load the configuration
+		if err := cliconfig.Load(c, l, &cfg); err != nil {
+			l.Fatal("%s", err)
+		}
+
+		// Setup any global configuration options
+		done := HandleGlobalFlags(l, cfg)
+		defer done()
+
+		// Create the API client
+		client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))
+
+		// Setup the downloader
+		downloader := agent.NewArtifactDownloader(l, client, agent.ArtifactDownloaderConfig{
+			Query:              cfg.Query,
+			Destination:        cfg.Destination,
+			BuildID:            cfg.Build,
+			Step:               cfg.Step,
+			IncludeRetriedJobs: cfg.IncludeRetriedJobs,
+			DebugHTTP:          cfg.DebugHTTP,
+		})
+
+		// Download the artifacts
+		if err := downloader.Download(); err != nil {
+			l.Fatal("Failed to download artifacts: %s", err)
+		}
+
+		return nil
+	},
+}

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -43,10 +43,10 @@ type ArtifactShasumConfig struct {
 	IncludeRetriedJobs bool   `cli:"include-retried-jobs"`
 
 	// Global flags
-	Debug   bool         `cli:"debug"`
-	NoColor bool         `cli:"no-color"`
+	Debug       bool     `cli:"debug"`
+	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
-	Profile string       `cli:"profile"`
+	Profile     string   `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
@@ -110,7 +110,7 @@ var ArtifactShasumCommand = cli.Command{
 		// Find the artifact we want to show the SHASUM for
 		searcher := agent.NewArtifactSearcher(l, client, cfg.Build)
 
-		artifacts, err := searcher.Search(cfg.Query, cfg.Step, cfg.IncludeRetriedJobs)
+		artifacts, err := searcher.Search(cfg.Query, cfg.Step, cfg.IncludeRetriedJobs, false)
 		if err != nil {
 			l.Fatal("Failed to find artifacts: %s", err)
 		}

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func main() {
 			Subcommands: []*cli.Command{
 				&clicommand.ArtifactUploadCommand,
 				&clicommand.ArtifactDownloadCommand,
+				&clicommand.ArtifactSearchCommand,
 				&clicommand.ArtifactShasumCommand,
 			},
 		},


### PR DESCRIPTION
Currently the `buildkite-agent artifact download` command runs an API search for artifacts on a build matching a pattern and then subsequently downloads those files. The search phase of this is useful to have and having a separate subcommand resolves a couple of CS tickets.

Additional fields have been added to the `artifact` struct to make the output from search more useful. A `search` subcommand has been added to `buildkite-agent artifact` which takes the signature:
```sh
$ buildkite-agent artifact search [options] <query>
```

The output from this command is a flexible printf statement not unlike [unix find's -printf directives](https://man7.org/linux/man-pages/man1/find.1.html). By default it lists the job ID, artifact path and timestamp of each artifact  separated by newline (aiming to be reasonably lean and easy to grok) but can be changed into a different shape e.g. if you wanted to build a csv file, or if you wanted to list a bunch of files and their download urls as part of a Buildkite annotation. 

This is a complete list of the available printf directives:
| Directive | Description |
| --- | --- |
| `%i` | UUID of the artifact |
| `%p` | Artifact path |
| `%c` | Artifact creation time (an ISO 8601 / RFC-3339 formatted UTC timestamp) |
| `%j` | UUID of the job that uploaded the artifact, helpful for subsequent artifact downloads |
| `%s` | File size of the artifact in bytes |
| `%S` | SHA1 checksum of the artifact |
| ` %u` | Download URL for the artifact, though consider using 'buildkite-agent artifact download' instead |

[Platform API changes needed for this are here and are relatively light](https://github.com/buildkite/buildkite/pull/5475)

## Example usage
I used a [variation of buildkite/bash-example](https://github.com/buildkite/bash-example/tree/test-dupe-artifacts) to upload the same artifacts multiple times. This is the output of the search command used on that step:

```sh
$ buildkite-agent artifact search "*"
2020-09-01 18:35:36 INFO   Searching for artifacts: "*"
c0ac95ee-bc19-4c5e-851a-536b97e3d608 artifacts/thumbsup.txt 2020-09-01T08:35:28Z
c0ac95ee-bc19-4c5e-851a-536b97e3d608 artifacts/image.gif 2020-09-01T08:35:28Z
ab8d85e6-9255-4eaf-8e52-283958d130cd artifacts/thumbsup.txt 2020-09-01T08:35:32Z
ab8d85e6-9255-4eaf-8e52-283958d130cd artifacts/image.gif 2020-09-01T08:35:32Z
```