### PR TITLE
Fix flaky tests: experiments and parallel tests don't mix

### DIFF
--- a/agent/artifact_uploader_test.go
+++ b/agent/artifact_uploader_test.go
@@ -95,6 +95,15 @@ func TestCollect(t *testing.T) {
 	// path.Join function instead (which uses Unix/URI-style path separators,
 	// regardless of platform)
 
+	experimentKey := "normalised-upload-paths"
+	experimentPrev := experiments.IsEnabled(experimentKey)
+	defer func() {
+		if experimentPrev {
+			experiments.Enable(experimentKey)
+		} else {
+			experiments.Disable(experimentKey)
+		}
+	}()
 	experiments.Disable(`normalised-upload-paths`)
 	artifactsWithoutExperimentEnabled, err := uploader.Collect()
 	if err != nil {
@@ -108,8 +117,6 @@ func TestCollect(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, 4, len(artifactsWithExperimentEnabled))
-
-	experiments.Disable(`normalised-upload-paths`)
 
 	// These test cases use filepath.Join, which uses per-OS path separators;
 	// this is the behaviour without normalised-upload-paths.

--- a/agent/artifact_uploader_test.go
+++ b/agent/artifact_uploader_test.go
@@ -24,7 +24,7 @@ func findArtifact(artifacts []*api.Artifact, search string) *api.Artifact {
 }
 
 func TestCollect(t *testing.T) {
-	t.Parallel()
+	// t.Parallel() cannot be used with experiments.Enable
 
 	wd, _ := os.Getwd()
 	root := filepath.Join(wd, "..")

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -28,7 +28,7 @@ func experimentWithUndo(name string) func() {
 }
 
 func TestWithResolvingCommitExperiment(t *testing.T) {
-	t.Parallel()
+	// t.Parallel() cannot be used with experiments.Enable()
 	defer experimentWithUndo("resolve-commit-after-checkout")()
 
 	tester, err := NewBootstrapTester()


### PR DESCRIPTION
Some tests have been mysteriously flaky (particularly on Windows, but that may be a red herring), failing without an error message. Somehow, https://github.com/buildkite/agent/pull/1294 has revealed the error messages:

```
=== Failed
  | === FAIL: bootstrap/integration TestCheckingOutLocalGitProject (7.00s)
  | mock.go:248: Unexpected call to git "rev-parse", "HEAD"
  | mock.go:255: More invocations than expected (1 vs 7)
  |  
  | === FAIL: bootstrap/integration TestCheckingOutShallowCloneOfLocalGitProject (7.69s)
  | mock.go:248: Unexpected call to git "rev-parse", "HEAD"
  | mock.go:255: More invocations than expected (1 vs 7)
```

I believe this is being caused by `TestWithResolvingCommitExperiment` in `bootstrap/integration/checkout_integration_test.go` running with `t.Parallel()` and then temporarily enabling the `resolve-commit-after-checkout` experiment. That experiment causes an extra `git rev-parse $BUILDKITE_COMMIT` command to run, which messes up the mock expectations of tests running in parallel, which are written to assume that experiment is turned off.

Also, `TestCollect` in `agent/artifact_uploader_test.go` was also enabling an experiment, but ~it was not running in parallel~, and it was disabling the experiment afterwards, so I think it was not causing any problems. But, this PR makes the experiment revert slightly more robust using `defer` and avoiding the (currently safe) assumption that the experiment should be disabled by default. _(edit: it was running in parallel. but it wasn't causing the test failures.)_