### PR TITLE
Fix build script

### DIFF
--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -40,7 +40,7 @@ fi
 export CGO_ENABLED=0
 
 mkdir -p $BUILD_PATH
-go build -v -ldflags "-X github.com/buildkite/agent/agent.buildVersion=$BUILD_VERSION" -o $BUILD_PATH/$BINARY_FILENAME *.go
+go build -v -ldflags "-X github.com/buildkite/agent/v3/agent.buildVersion=$BUILD_VERSION" -o $BUILD_PATH/$BINARY_FILENAME *.go
 
 chmod +x $BUILD_PATH/$BINARY_FILENAME
 


### PR DESCRIPTION
The `BUILD_VERSION` arg was not being properly set because the
package/import path changed with the v3 agent.

Without:

```
scripts/build-binary.sh linux amd64 1
pkg/buildkite-agent-linux-amd64 --version
buildkite-agent version 3.23.1, build x
```

With:

```
scripts/build-binary.sh linux amd64 1
pkg/buildkite-agent-linux-amd64 --version
buildkite-agent version 3.23.1, build 1
```