### PR TITLE
buildkite:git:commit meta-data via stdin; avoid Argument List Too Long

### DIFF
--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/agent/v3/metrics"
-	"github.com/buildkite/bintest"
+	"github.com/buildkite/bintest/v3"
 )
 
 func TestJobRunnerPassesAccessTokenToBootstrap(t *testing.T) {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1278,13 +1278,12 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 	b.shell.Commentf("Checking to see if Git data needs to be sent to Buildkite")
 	if err := b.shell.Run("buildkite-agent", "meta-data", "exists", "buildkite:git:commit"); err != nil {
 		b.shell.Commentf("Sending Git commit information back to Buildkite")
-
-		gitCommitOutput, err := b.shell.RunAndCapture("git", "--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--")
+		out, err := b.shell.RunAndCapture("git", "--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--")
 		if err != nil {
 			return err
 		}
-
-		if err = b.shell.Run("buildkite-agent", "meta-data", "set", "buildkite:git:commit", gitCommitOutput); err != nil {
+		stdin := strings.NewReader(out)
+		if err := b.shell.WithStdin(stdin).Run("buildkite-agent", "meta-data", "set", "buildkite:git:commit"); err != nil {
 			return err
 		}
 	}

--- a/bootstrap/git_test.go
+++ b/bootstrap/git_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/buildkite/bintest"
+	"github.com/buildkite/bintest/v3"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/bootstrap/integration/artifact_integration_test.go
+++ b/bootstrap/integration/artifact_integration_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/buildkite/bintest"
+	"github.com/buildkite/bintest/v3"
 )
 
 func TestArtifactsUploadAfterCommand(t *testing.T) {

--- a/bootstrap/integration/bootstrap_tester.go
+++ b/bootstrap/integration/bootstrap_tester.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/buildkite/agent/v3/experiments"
 
-	"github.com/buildkite/bintest"
+	"github.com/buildkite/bintest/v3"
 )
 
 // BootstrapTester invokes a buildkite-agent bootstrap script with a temporary environment

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -12,8 +12,19 @@ import (
 	"testing"
 
 	"github.com/buildkite/agent/v3/experiments"
-	"github.com/buildkite/bintest"
+	"github.com/buildkite/bintest/v3"
 )
+
+// Example commit info:
+//
+// commit 65e2f46931cf9fe1ba9e445d92d213cfa3be5312
+// Author:     Example Human <legit@example.com>
+// AuthorDate: Thu Jan 15 11:05:16 2015 +0800
+// Commit:     Example Human <legit@example.com>
+// CommitDate: Thu Jan 15 11:05:16 2015 +0800
+//
+//     hello world
+var commitPattern = bintest.MatchPattern(`(?ms)\Acommit [0-9a-f]+\n.*^Author:`)
 
 // Enable an experiment, returning a function to restore the previous state.
 // Usage: defer experimentWithUndo("foo")()
@@ -76,10 +87,11 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MustMock(t, "buildkite-agent")
 	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit", bintest.MatchPattern(`^commit`)).AndExitWith(0)
+	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
+
 func TestCheckingOutLocalGitProject(t *testing.T) {
 	t.Parallel()
 
@@ -125,12 +137,8 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MustMock(t, "buildkite-agent")
-	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
-		AndExitWith(1)
-	agent.
-		Expect("meta-data", "set", "buildkite:git:commit", bintest.MatchAny()).
-		AndExitWith(0)
+	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
+	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -212,12 +220,8 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MustMock(t, "buildkite-agent")
-	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
-		AndExitWith(1)
-	agent.
-		Expect("meta-data", "set", "buildkite:git:commit", bintest.MatchAny()).
-		AndExitWith(0)
+	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
+	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -290,12 +294,8 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MustMock(t, "buildkite-agent")
-	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
-		AndExitWith(1)
-	agent.
-		Expect("meta-data", "set", "buildkite:git:commit", bintest.MatchAny()).
-		AndExitWith(0)
+	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
+	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -345,12 +345,8 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MustMock(t, "buildkite-agent")
-	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
-		AndExitWith(1)
-	agent.
-		Expect("meta-data", "set", "buildkite:git:commit", bintest.MatchAny()).
-		AndExitWith(0)
+	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
+	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -365,14 +361,8 @@ func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite(t *testing.T) {
 	defer tester.Close()
 
 	agent := tester.MustMock(t, "buildkite-agent")
-	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
-		AndExitWith(1)
-
-	agent.
-		Expect("meta-data", "set", "buildkite:git:commit",
-			bintest.MatchPattern(`^commit`)).
-		AndExitWith(0)
+	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
+	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
 
 	tester.RunAndCheck(t)
 }

--- a/bootstrap/integration/command_integration_test.go
+++ b/bootstrap/integration/command_integration_test.go
@@ -3,7 +3,7 @@ package integration
 import (
 	"testing"
 
-	"github.com/buildkite/bintest"
+	"github.com/buildkite/bintest/v3"
 )
 
 func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {

--- a/bootstrap/integration/docker_integration_test.go
+++ b/bootstrap/integration/docker_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/buildkite/bintest"
+	"github.com/buildkite/bintest/v3"
 )
 
 func argumentForCommand(cmd string) interface{} {

--- a/bootstrap/integration/hooks_integration_test.go
+++ b/bootstrap/integration/hooks_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/v3/bootstrap/shell"
-	"github.com/buildkite/bintest"
+	"github.com/buildkite/bintest/v3"
 )
 
 func TestEnvironmentVariablesPassBetweenHooks(t *testing.T) {

--- a/bootstrap/integration/main_test.go
+++ b/bootstrap/integration/main_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/clicommand"
 	"github.com/buildkite/agent/v3/experiments"
-	"github.com/buildkite/bintest"
+	"github.com/buildkite/bintest/v3"
 	"github.com/urfave/cli"
 )
 

--- a/bootstrap/integration/plugin_integration_test.go
+++ b/bootstrap/integration/plugin_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/agent/v3/bootstrap/shell"
-	"github.com/buildkite/bintest"
+	"github.com/buildkite/bintest/v3"
 )
 
 func TestRunningPlugins(t *testing.T) {

--- a/bootstrap/knownhosts_test.go
+++ b/bootstrap/knownhosts_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/buildkite/bintest"
+	"github.com/buildkite/bintest/v3"
 )
 
 func TestAddingToKnownHosts(t *testing.T) {

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -216,7 +216,13 @@ func (s *Shell) LockFile(path string, timeout time.Duration) (LockFile, error) {
 // Run runs a command, write stdout and stderr to the logger and return an error
 // if it fails
 func (s *Shell) Run(command string, arg ...string) error {
-	s.Promptf("%s", process.FormatCommand(command, arg))
+	formatted := process.FormatCommand(command, arg)
+	if s.stdin == nil {
+		s.Promptf("%s", formatted)
+	} else {
+		// bash-syntax-compatible indication that input is coming from somewhere
+		s.Promptf("%s < /dev/stdin", formatted)
+	}
 
 	return s.RunWithoutPrompt(command, arg...)
 }

--- a/bootstrap/shell/shell_test.go
+++ b/bootstrap/shell/shell_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -101,6 +102,20 @@ func TestRun(t *testing.T) {
 
 	if expected := promptPrefix + " " + sshKeygen.Path + " -f my_hosts -F llamas.com\nLlama party! 🎉\n"; actual != expected {
 		t.Fatalf("Expected %q, got %q", expected, actual)
+	}
+}
+
+func TestRunWithStdin(t *testing.T) {
+	out := &bytes.Buffer{}
+	sh := newShellForTest(t)
+	sh.Writer = out
+
+	err := sh.WithStdin(strings.NewReader("hello stdin")).Run("tr", "hs", "HS")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expected, actual := "Hello Stdin", out.String(); expected != actual {
+		t.Errorf("expected %q, got %q", expected, actual)
 	}
 }
 

--- a/bootstrap/shell/shell_test.go
+++ b/bootstrap/shell/shell_test.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/v3/bootstrap/shell"
-	"github.com/buildkite/bintest"
+	"github.com/buildkite/bintest/v3"
 )
 
 func TestRunAndCaptureWithTTY(t *testing.T) {

--- a/bootstrap/ssh_test.go
+++ b/bootstrap/ssh_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/v3/bootstrap/shell"
-	"github.com/buildkite/bintest"
+	"github.com/buildkite/bintest/v3"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.0.0-20170217213217-65216237311a
 	github.com/DataDog/datadog-go v0.0.0-20180822151419-281ae9f2d895
 	github.com/aws/aws-sdk-go v1.32.10
-	github.com/buildkite/bintest v0.0.0-20190227031731-820c89d3b3a0
+	github.com/buildkite/bintest/v3 v3.1.0
 	github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/aws/aws-sdk-go v1.32.10 h1:cEJTxGcBGlsM2tN36MZQKhlK93O9HrnaRs+lq2f0zN
 github.com/aws/aws-sdk-go v1.32.10/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/buildkite/bintest v0.0.0-20190227031731-820c89d3b3a0 h1:UYcAVM2IdwHl3wTyyB2HfZc2MEVQrUqw/OkbwHlsy30=
 github.com/buildkite/bintest v0.0.0-20190227031731-820c89d3b3a0/go.mod h1:nElEwZWoSPGIBD8VvYabl9t5KNi7v430iDC0/gQRsYk=
+github.com/buildkite/bintest/v3 v3.1.0 h1:auJ22sFpyy7t6xR7p5FcqAwpNgkP0AyVhEMSRErFmk0=
+github.com/buildkite/bintest/v3 v3.1.0/go.mod h1:T3Et1VwEizryWfwLLruFqExHsEU+wjkxOlL54283ccc=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000 h1:hiVSLk7s3yFKFOHF/huoShLqrj13RMguWX2yzfvy7es=
@@ -23,6 +25,7 @@ github.com/denisbrodbeck/machineid v1.0.0 h1:6tMg1EaB3r/EfIqKS0on/pvkRBZJAXH3fmS
 github.com/denisbrodbeck/machineid v1.0.0/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/fortytw2/leaktest v0.0.0-20170715211739-3b724c3d7b87 h1:vC7ihXqN2fougprHfqpv7GyEd7tUgZfmHZ5bXPiSKgE=
 github.com/fortytw2/leaktest v0.0.0-20170715211739-3b724c3d7b87/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/process/process.go
+++ b/process/process.go
@@ -64,6 +64,7 @@ type Config struct {
 	Path            string
 	Args            []string
 	Env             []string
+	Stdin           io.Reader
 	Stdout          io.Writer
 	Stderr          io.Writer
 	Dir             string
@@ -193,9 +194,9 @@ func (p *Process) Run() error {
 			waitGroup.Done()
 		}()
 	} else {
+		p.command.Stdin = p.conf.Stdin
 		p.command.Stdout = p.conf.Stdout
 		p.command.Stderr = p.conf.Stderr
-		p.command.Stdin = nil
 
 		err := p.command.Start()
 		if err != nil {

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -72,6 +72,25 @@ func TestProcessOutputPTY(t *testing.T) {
 	assertProcessDoesntExist(t, p)
 }
 
+func TestProcessInput(t *testing.T) {
+	stdout := &bytes.Buffer{}
+
+	p := process.New(logger.Discard, process.Config{
+		Path:   "tr",
+		Args:   []string{"hw", "HW"},
+		Stdin:  strings.NewReader("hello world"),
+		Stdout: stdout,
+	})
+	// wait for the process to finish
+	if err := p.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if expected, actual := "Hello World", stdout.String(); expected != actual {
+		t.Errorf("stdout expected %q, got %q", expected, actual)
+	}
+	assertProcessDoesntExist(t, p)
+}
+
 func TestProcessRunsAndSignalsStartedAndStopped(t *testing.T) {
 	var started int32
 	var done int32


### PR DESCRIPTION
This builds on @sj26's [great investigation](https://github.com/buildkite/agent/pull/1270) identifying that `buildkite-agent meta-data set buildkite:git:commit` should take the commit message via stdin, not argv. Otherwise a very large commit message may exceed the system argv limit,
resulting in: `fork/exec /usr/local/bin/buildkite-agent: argument list too long`.

The key to this approach is `func (s *Shell) WithStdin(r io.Reader) *Shell` — it avoids threading our new `stdin` through multiple layers and variants of `Run()` etc.

The initial “package process supports Stdin” and “bootstrap/shell.Shell.WithStdin() to pass stdin to commands.” commits in this PR are self-contained with a test each, which I think demonstrates there's no blocking/closing issue with passing the `io.Reader` to our `process` package.

I haven't tested this on a real build yet, and there's heaps of bintest mock expectations in other tests that this breaks.

Closes #1270