### PR TITLE
Truncate BUILDKITE_MESSAGE to 64 KiB

### DIFF
--- a/agent/job_runner_test.go
+++ b/agent/job_runner_test.go
@@ -1,0 +1,20 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTruncateEnv(t *testing.T) {
+	l := &logger.Buffer{}
+	env := map[string]string{"FOO": strings.Repeat("a", 100)}
+	err := truncateEnv(l, env, "FOO", 64)
+	require.NoError(t, err)
+	assert.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaa[value truncated 100 -> 59 bytes]", env["FOO"])
+	assert.Equal(t, 64, len(fmt.Sprintf("FOO=%s\000", env["FOO"])))
+}

--- a/logger/buffer.go
+++ b/logger/buffer.go
@@ -1,0 +1,37 @@
+package logger
+
+import (
+	"fmt"
+)
+
+// Buffer is a Logger implementation intended for testing;
+// messages are stored internally.
+type Buffer struct {
+	Messages []string
+}
+
+func (b *Buffer) Debug(format string, v ...interface{}) {
+	b.Messages = append(b.Messages, "[debug] "+fmt.Sprintf(format, v...))
+}
+func (b *Buffer) Error(format string, v ...interface{}) {
+	b.Messages = append(b.Messages, "[error] "+fmt.Sprintf(format, v...))
+}
+func (b *Buffer) Fatal(format string, v ...interface{}) {
+	b.Messages = append(b.Messages, "[fatal] "+fmt.Sprintf(format, v...))
+}
+func (b *Buffer) Notice(format string, v ...interface{}) {
+	b.Messages = append(b.Messages, "[notice] "+fmt.Sprintf(format, v...))
+}
+func (b *Buffer) Warn(format string, v ...interface{}) {
+	b.Messages = append(b.Messages, "[warn] "+fmt.Sprintf(format, v...))
+}
+func (b *Buffer) Info(format string, v ...interface{}) {
+	b.Messages = append(b.Messages, "[info] "+fmt.Sprintf(format, v...))
+}
+func (b *Buffer) WithFields(fields ...Field) Logger {
+	return b
+}
+func (b *Buffer) SetLevel(level Level) {}
+func (b *Buffer) Level() Level {
+	return 0
+}

--- a/logger/buffer_test.go
+++ b/logger/buffer_test.go
@@ -1,0 +1,20 @@
+package logger_test
+
+import (
+	"testing"
+
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuffer(t *testing.T) {
+	l := &logger.Buffer{}
+	l.Info("hello %s", "world")
+	func(x logger.Logger) {
+		x.Debug("foo bar")
+	}(l)
+	assert.Equal(t, []string{
+		"[info] hello world",
+		"[debug] foo bar",
+	}, l.Messages)
+}


### PR DESCRIPTION
Truncate the `BUILDKITE_MESSAGE` commit message passed to the bootstrap process to 64 KiB so that large commit messages won't stop execution.

Follow-up to #1302, which enabled large commit messages to be pushed from the agent to Buildkite via `buildkite-agent meta-data set buildkite:git:commit`, but which uncovered this other bottleneck for message size.

The 64 KiB figure was chosen somewhat arbitrarily; but it is…
* half the per-env limit of modern linux
* quarter the shared limit of macOS
* a tiny fraction of the modern Windows limit
* double the [limit of Windows circa 2010](https://devblogs.microsoft.com/oldnewthing/20100203-00/?p=15083) (if this becomes a problem, we can reduce it for that platform)

Here's some ENV limits I've researched/discovered (see notes below):

```
// macOS 10.15:    256 KiB shared by environment & argv
// Linux 4.19:     128 KiB per k=v env
// Windows 10:  16,384 KiB shared
// POSIX:           (4 KiB minimum shared)
```

A truncation marker is added to the end of the message like this:

```
A long commit message

Lots of text here
... even more text here
... even more text here
... even mo[value truncated 131071 -> 65517 bytes]
```

And also logged to the agent:

```
2020-09-24 16:17:18 WARN   localhost BUILDKITE_MESSAGE value truncated 131071 -> 65517 bytes
```

I considered finding and re-embedding any `[skip ci]` / `[ci skip]` markers, but then realised that would be silly; they prevent the build getting this far.

---

Investigation into auto-discovering environment limit:

```
#include <stdio.h>
#include <unistd.h>
#include <limits.h>
int main(int argc, char ** argv) {
#ifdef ARG_MAX
  printf("            ARG_MAX : %d\n", ARG_MAX);
#else
  printf("            ARG_MAX : (undefined)\n");
#endif
  printf("sysconf(_SC_ARG_MAX): %ld\n", sysconf(_SC_ARG_MAX));
}
```

```
$ uname -a
Darwin paulbookpro.local 19.6.0 Darwin Kernel Version 19.6.0: Thu Jun 18 20:49:00 PDT 2020; root:xnu-6153.141.1~1/RELEASE_X86_64 x86_64

$ gcc -o testlimit testlimit.c && ./testlimit
            ARG_MAX : 262144
sysconf(_SC_ARG_MAX): 262144
```

```
$ uname -a
Linux localhost 4.4.0-173-generic #203-Ubuntu SMP Wed Jan 15 02:55:01 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

$ gcc -o testlimit testlimit.c && ./testlimit
            ARG_MAX : (undefined)
sysconf(_SC_ARG_MAX): 2097152
```

But this doesn't work for Windows.

A program to brute-force bisect to discover largest permitted env size:

```go
package main

import (
	"fmt"
	"os"
	"os/exec"
	"strconv"
	"strings"
)

const (
	min  = 1024
	max  = 640 * 1024 // 640K should be enough for anybody
	name = "X"
)

func main() {
	if len(os.Args) == 3 && os.Args[1] == "assert-size" {
		assertSize(os.Args[2])
	} else {
		fmt.Println(findEnvLimit())
	}
}

func findEnvLimit() int {
	good := min
	bad := max
	for bad-good > 1 {
		mid := good + (bad-good)/2
		if err := attempt(mid); err == nil {
			good = mid
			debugf("size=%d ok\n", mid)
		} else {
			bad = mid
			debugf("size=%d %v\n", mid, err)
		}
	}
	return good
}

func attempt(size int) error {
	return (&exec.Cmd{
		Path:   os.Args[0], // run self
		Args:   []string{os.Args[0], "assert-size", strconv.FormatInt(int64(size), 10)},
		Env:    []string{name + "=" + strings.Repeat(".", size)},
		Stdout: os.Stdout,
		Stderr: os.Stderr,
	}).Run()
}

func assertSize(arg string) {
	wantLen, err := strconv.ParseInt(arg, 10, 64)
	if err != nil {
		panic(err)
	}
	value, ok := os.LookupEnv(name)
	if !ok {
		fmt.Fprintln(os.Stderr, name, "not in environment")
		os.Exit(1)
	}
	if len(value) != int(wantLen) {
		fmt.Fprintf(os.Stderr, "expected %d bytes, got %d\n", wantLen, len(value))
		os.Exit(1)
	}
}

func debugf(format string, a ...interface{}) {
	fmt.Fprintf(os.Stderr, format, a...)
}
```

Linux:

```
root@23f42323a677:/envlimit# go build -o envlimit-linux && ./envlimit-linux
size=328192 fork/exec ./envlimit-linux: argument list too long
size=164608 fork/exec ./envlimit-linux: argument list too long
size=82816 ok
size=123712 ok
size=144160 fork/exec ./envlimit-linux: argument list too long
size=133936 fork/exec ./envlimit-linux: argument list too long
size=128824 ok
size=131380 fork/exec ./envlimit-linux: argument list too long
size=130102 ok
size=130741 ok
size=131060 ok
size=131220 fork/exec ./envlimit-linux: argument list too long
size=131140 fork/exec ./envlimit-linux: argument list too long
size=131100 fork/exec ./envlimit-linux: argument list too long
size=131080 fork/exec ./envlimit-linux: argument list too long
size=131070 fork/exec ./envlimit-linux: argument list too long
size=131065 ok
size=131067 ok
size=131068 ok
size=131069 ok
131069
```

macOS:

```
size=328192 fork/exec ./envlimit: argument list too long
size=164608 ok
size=246400 ok
size=287296 fork/exec ./envlimit: argument list too long
size=266848 fork/exec ./envlimit: argument list too long
size=256624 ok
size=261736 ok
size=264292 fork/exec ./envlimit: argument list too long
size=263014 fork/exec ./envlimit: argument list too long
size=262375 fork/exec ./envlimit: argument list too long
size=262055 ok
size=262215 fork/exec ./envlimit: argument list too long
size=262135 fork/exec ./envlimit: argument list too long
size=262095 fork/exec ./envlimit: argument list too long
size=262075 fork/exec ./envlimit: argument list too long
size=262065 fork/exec ./envlimit: argument list too long
size=262060 ok
size=262062 ok
size=262063 ok
size=262064 fork/exec ./envlimit: argument list too long
262063
```

Windows: `16,777,190` (16 MiB!)