### PR TITLE
Handle pull requests with git-mirrors

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1082,9 +1082,17 @@ func (b *Bootstrap) updateGitMirror() (string, error) {
 		return "", err
 	}
 
-	// Fetch the build branch from the upstream repository into the mirror.
-	if err := b.shell.Run("git", "--git-dir", mirrorDir, "fetch", "origin", b.Branch); err != nil {
-		return "", err
+	if b.PullRequest != "false" && strings.Contains(b.PipelineProvider, "github") {
+		refspec := fmt.Sprintf("refs/pull/%s/head", b.PullRequest)
+		// Fetch the PR head from the upstream repository into the mirror.
+		if err := b.shell.Run("git", "--git-dir", mirrorDir, "fetch", "origin", refspec); err != nil {
+			return "", err
+		}
+	} else {
+		// Fetch the build branch from the upstream repository into the mirror.
+		if err := b.shell.Run("git", "--git-dir", mirrorDir, "fetch", "origin", b.Branch); err != nil {
+			return "", err
+		}
 	}
 
 	return mirrorDir, nil

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1083,6 +1083,7 @@ func (b *Bootstrap) updateGitMirror() (string, error) {
 	}
 
 	if b.PullRequest != "false" && strings.Contains(b.PipelineProvider, "github") {
+		b.shell.Commentf("Fetch and mirror pull request head from GitHub")
 		refspec := fmt.Sprintf("refs/pull/%s/head", b.PullRequest)
 		// Fetch the PR head from the upstream repository into the mirror.
 		if err := b.shell.Run("git", "--git-dir", mirrorDir, "fetch", "origin", refspec); err != nil {

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -38,6 +38,47 @@ func experimentWithUndo(name string) func() {
 	}
 }
 
+func TestCheckingOutGitHubPullRequestsWithGitMirrorsExperiment(t *testing.T) {
+	// t.Parallel() cannot be used with experiments.Enable()
+	defer experimentWithUndo("git-mirrors")()
+
+	tester, err := NewBootstrapTester()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tester.Close()
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_MIRROR_FLAGS=--bare",
+		"BUILDKITE_PULL_REQUEST=123",
+		"BUILDKITE_PIPELINE_PROVIDER=github",
+	}
+
+	// Actually execute git commands, but with expectations
+	git := tester.
+		MustMock(t, "git").
+		PassthroughToLocalCommand()
+
+	// But assert which ones are called
+	git.ExpectAll([][]interface{}{
+		{"clone", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
+		{"clean", "-ffxdq"},
+		{"fetch", "origin", "refs/pull/123/head"},
+		{"rev-parse", "FETCH_HEAD"},
+		{"checkout", "-f", "FETCH_HEAD"},
+		{"clean", "-ffxdq"},
+		{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+	})
+
+	// Mock out the meta-data calls to the agent after checkout
+	agent := tester.MustMock(t, "buildkite-agent")
+	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
+	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+
+	tester.RunAndCheck(t, env...)
+}
+
 func TestWithResolvingCommitExperiment(t *testing.T) {
 	// t.Parallel() cannot be used with experiments.Enable()
 	defer experimentWithUndo("resolve-commit-after-checkout")()

--- a/bootstrap/integration/git.go
+++ b/bootstrap/integration/git.go
@@ -14,6 +14,10 @@ func createTestGitRespository() (*gitRepository, error) {
 		return nil, err
 	}
 
+	if err = repo.CreateBranch("master"); err != nil {
+		return nil, err
+	}
+
 	if err := ioutil.WriteFile(filepath.Join(repo.Path, "test.txt"), []byte("This is a test"), 0600); err != nil {
 		return nil, err
 	}
@@ -23,6 +27,30 @@ func createTestGitRespository() (*gitRepository, error) {
 	}
 
 	if err = repo.Commit("Initial Commit"); err != nil {
+		return nil, err
+	}
+
+	if err = repo.CreateBranch("update-test-txt"); err != nil {
+		return nil, err
+	}
+
+	if err := ioutil.WriteFile(filepath.Join(repo.Path, "test.txt"), []byte("This is a test pull request"), 0600); err != nil {
+		return nil, err
+	}
+
+	if err = repo.Add("test.txt"); err != nil {
+		return nil, err
+	}
+
+	if err = repo.Commit("PR Commit"); err != nil {
+		return nil, err
+	}
+
+	if _, err = repo.Execute("update-ref", "refs/pull/123/head", "HEAD"); err != nil {
+		return nil, err
+	}
+
+	if err = repo.CheckoutBranch("master"); err != nil {
 		return nil, err
 	}
 
@@ -79,6 +107,20 @@ func (gr *gitRepository) Add(path string) error {
 
 func (gr *gitRepository) Commit(message string, params ...interface{}) error {
 	if _, err := gr.Execute("commit", "-m", fmt.Sprintf(message, params...)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (gr *gitRepository) CheckoutBranch(branch string) error {
+	if _, err := gr.Execute("checkout", branch); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (gr *gitRepository) CreateBranch(branch string) error {
+	if _, err := gr.Execute("checkout", "-b", branch); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This fixes a regression that was introduced in https://github.com/buildkite/agent/pull/1112 which means git-mirrors doesn't work with PRs from forks