### PR TITLE
git-mirrors: set BUILDKITE_REPO_MIRROR=/path/to/mirror/repo

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1102,12 +1102,12 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 	// If we can, get a mirror of the git repository to use for reference later
 	if experiments.IsEnabled(`git-mirrors`) && b.Config.GitMirrorsPath != "" && b.Config.Repository != "" {
 		b.shell.Commentf("Using git-mirrors experiment 🧪")
-
 		var err error
 		mirrorDir, err = b.updateGitMirror()
 		if err != nil {
 			return err
 		}
+		b.shell.Env.Set("BUILDKITE_REPO_MIRROR", mirrorDir)
 	}
 
 	// Make sure the build directory exists and that we change directory into it


### PR DESCRIPTION
When `git-mirrors` (currently an experiment) is enabled, export a `BUILDKITE_REPO_MIRROR=/path/to/mirror/repo` environment variable. This makes it easy to mount the mirror as a volume in docker containers, so that `git` within the container can access the git reference repository data.

The name `BUILDKITE_REPO_MIRROR` was chosen to reflect the existing `BUILDKITE_REPO` environment variable.

This environment variable enables transparent support for `git-mirrors` in our [docker plugin](https://github.com/buildkite-plugins/docker-buildkite-plugin) and our [docker-compose plugin](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin):

- https://github.com/buildkite-plugins/docker-buildkite-plugin/pull/167
- https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/pull/287