### PR TITLE
Upgrade docker ubuntu to 20.04 focal

### DIFF
--- a/packaging/docker/ubuntu-linux/Dockerfile
+++ b/packaging/docker/ubuntu-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Upgrade the ubuntu release we use when packaging the agent docker image. We're currently using the previous LTS release (18.04) and this bumps it to the latest LTS release from earlier this year (20.04).

I built and ran the image locally and it worked fine.