### PR TITLE
gitCheckout() validates branch, plus unit tests

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1195,11 +1195,11 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 	}
 
 	if b.Commit == "HEAD" {
-		if err := gitCheckout(b.shell, `-f`, `FETCH_HEAD`); err != nil {
+		if err := gitCheckout(b.shell, "-f", "FETCH_HEAD"); err != nil {
 			return err
 		}
 	} else {
-		if err := gitCheckout(b.shell, `-f`, b.Commit); err != nil {
+		if err := gitCheckout(b.shell, "-f", b.Commit); err != nil {
 			return err
 		}
 	}

--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -54,7 +54,7 @@ func gitCheckout(sh shellRunner, gitCheckoutFlags, reference string) error {
 	return nil
 }
 
-func gitClone(sh *shell.Shell, gitCloneFlags, repository, dir string) error {
+func gitClone(sh shellRunner, gitCloneFlags, repository, dir string) error {
 	individualCloneFlags, err := shellwords.Split(gitCloneFlags)
 	if err != nil {
 		return err

--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -103,7 +103,7 @@ func gitCleanSubmodules(sh shellRunner, gitCleanFlags string) error {
 	return nil
 }
 
-func gitFetch(sh *shell.Shell, gitFetchFlags, repository string, refSpec ...string) error {
+func gitFetch(sh shellRunner, gitFetchFlags, repository string, refSpec ...string) error {
 	individualFetchFlags, err := shellwords.Split(gitFetchFlags)
 	if err != nil {
 		return err

--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -71,7 +71,7 @@ func gitClone(sh shellRunner, gitCloneFlags, repository, dir string) error {
 	return nil
 }
 
-func gitClean(sh *shell.Shell, gitCleanFlags string) error {
+func gitClean(sh shellRunner, gitCleanFlags string) error {
 	individualCleanFlags, err := shellwords.Split(gitCleanFlags)
 	if err != nil {
 		return err

--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -87,7 +87,7 @@ func gitClean(sh shellRunner, gitCleanFlags string) error {
 	return nil
 }
 
-func gitCleanSubmodules(sh *shell.Shell, gitCleanFlags string) error {
+func gitCleanSubmodules(sh shellRunner, gitCleanFlags string) error {
 	individualCleanFlags, err := shellwords.Split(gitCleanFlags)
 	if err != nil {
 		return err

--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/buildkite/agent/v3/bootstrap/shell"
 	"github.com/buildkite/shellwords"
@@ -248,9 +249,63 @@ func resolveGitHost(sh *shell.Shell, host string) string {
 	return gitHostAliasRegexp.ReplaceAllString(host, "")
 }
 
-// gitCheckRefFormat is a simplified version of `git check-ref-format`
+// gitCheckRefFormat is a simplified version of `git check-ref-format`.
+// It mostly assumes --allow-onelevel i.e. no need for refs/heads/… prefix.
+// It is more permissive than the canonical implementation.
 // https://git-scm.com/docs/git-check-ref-format
-// Perhaps one day it should shell out to that command instead.
 func gitCheckRefFormat(ref string) bool {
-	return ref[0] != '-' // prevent args that git could interpret as options.
+	// Numbered rules are from git 2.28.0's `git help check-ref-format`.
+	// Not covered by this implementation:
+	//   1. They can include slash / for hierarchical (directory) grouping, but
+	//   no slash-separated component can begin with a dot .  or end with the
+	//   sequence .lock
+	//   2. They must contain at least one /. This enforces the presence of a
+	//   category like heads/, tags/ etc. but the actual names are not
+	//   restricted. If the --allow-onelevel option is used, this rule is waived
+	//   5. They cannot have question-mark ?, asterisk *, or open bracket [
+	//   anywhere. See the --refspec-pattern option below for an exception to
+	//   this rule
+	//   6. They cannot begin or end with a slash / or contain multiple
+	//   consecutive slashes (see the --normalize option below for an exception
+	//   to this rule)
+	//   8. They cannot contain a sequence @{.
+
+	// 3. They cannot have two consecutive dots .. anywhere
+	if strings.Contains(ref, "..") {
+		return false
+	}
+	// 9. They cannot be the single character @.
+	if ref == "@" {
+		return false
+	}
+	for i, c := range ref {
+		//  4. They cannot have ASCII control characters (i.e. bytes whose values are lower than \040, or \177 DEL) ...
+		if unicode.IsControl(c) {
+			return false
+		}
+		// 4. They cannot have ... space, tilde ~, caret ^, or colon : anywhere
+		// 10. They cannot contain a \.
+		for _, deny := range ` ~^:\` {
+			if c == deny {
+				return false
+			}
+		}
+		if i == 0 {
+			// (disallow refs that would be interpreted as command options/flags)
+			for _, deny := range `-` {
+				if c == deny {
+					return false
+				}
+			}
+		}
+		if i == len(ref)-1 {
+			// 7. They cannot end with a dot .
+			for _, deny := range `.` {
+				if c == deny {
+					return false
+				}
+			}
+		}
+	}
+	return true
 }

--- a/bootstrap/git_test.go
+++ b/bootstrap/git_test.go
@@ -390,6 +390,13 @@ func TestGitClean(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestGitCleanSubmodules(t *testing.T) {
+	sh := (&mockShellRunner{}).Expect("git", "submodule", "foreach", "--recursive", "git clean --foo --bar")
+	defer sh.Check(t)
+	err := gitCleanSubmodules(sh, "--foo --bar")
+	require.NoError(t, err)
+}
+
 // mockShellRunner implements shellRunner for testing expected calls.
 type mockShellRunner struct {
 	expect [][]string

--- a/bootstrap/git_test.go
+++ b/bootstrap/git_test.go
@@ -370,38 +370,42 @@ func TestGitCheckoutValidatesRef(t *testing.T) {
 }
 
 func TestGitCheckoutSomething(t *testing.T) {
-	sh := (&mockShellRunner{}).Expect("git", "checkout", "-f", "-q", "main")
+	sh := mockRunner().Expect("git", "checkout", "-f", "-q", "main")
 	defer sh.Check(t)
 	err := gitCheckout(sh, "-f -q", "main")
 	require.NoError(t, err)
 }
 
 func TestGitClone(t *testing.T) {
-	sh := (&mockShellRunner{}).Expect("git", "clone", "-v", "--references", "url", "--", "repo", "dir")
+	sh := mockRunner().Expect("git", "clone", "-v", "--references", "url", "--", "repo", "dir")
 	defer sh.Check(t)
 	err := gitClone(sh, "-v --references url", "repo", "dir")
 	require.NoError(t, err)
 }
 
 func TestGitClean(t *testing.T) {
-	sh := (&mockShellRunner{}).Expect("git", "clean", "--foo", "--bar")
+	sh := mockRunner().Expect("git", "clean", "--foo", "--bar")
 	defer sh.Check(t)
 	err := gitClean(sh, "--foo --bar")
 	require.NoError(t, err)
 }
 
 func TestGitCleanSubmodules(t *testing.T) {
-	sh := (&mockShellRunner{}).Expect("git", "submodule", "foreach", "--recursive", "git clean --foo --bar")
+	sh := mockRunner().Expect("git", "submodule", "foreach", "--recursive", "git clean --foo --bar")
 	defer sh.Check(t)
 	err := gitCleanSubmodules(sh, "--foo --bar")
 	require.NoError(t, err)
 }
 
 func TestGitFetch(t *testing.T) {
-	sh := (&mockShellRunner{}).Expect("git", "fetch", "--foo", "--bar", "--", "repo", "ref1", "ref2")
+	sh := mockRunner().Expect("git", "fetch", "--foo", "--bar", "--", "repo", "ref1", "ref2")
 	defer sh.Check(t)
 	err := gitFetch(sh, "--foo --bar", "repo", "ref1", "ref2")
 	require.NoError(t, err)
+}
+
+func mockRunner() *mockShellRunner {
+	return &mockShellRunner{}
 }
 
 // mockShellRunner implements shellRunner for testing expected calls.
@@ -421,13 +425,7 @@ func (r *mockShellRunner) Run(cmd string, args ...string) error {
 }
 
 func (r *mockShellRunner) Check(t *testing.T) {
-	if r.calls == nil {
-		r.calls = [][]string{{}}
-	}
-	if r.expect == nil {
-		r.expect = [][]string{{}}
-	}
 	if !reflect.DeepEqual(r.calls, r.expect) {
-		t.Errorf("\nexpected: %#v\n     got: %#v\n", r.expect, r.calls)
+		t.Errorf("\nexpected: %q\n     got: %q\n", r.expect, r.calls)
 	}
 }

--- a/bootstrap/git_test.go
+++ b/bootstrap/git_test.go
@@ -397,6 +397,13 @@ func TestGitCleanSubmodules(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestGitFetch(t *testing.T) {
+	sh := (&mockShellRunner{}).Expect("git", "fetch", "--foo", "--bar", "--", "repo", "ref1", "ref2")
+	defer sh.Check(t)
+	err := gitFetch(sh, "--foo --bar", "repo", "ref1", "ref2")
+	require.NoError(t, err)
+}
+
 // mockShellRunner implements shellRunner for testing expected calls.
 type mockShellRunner struct {
 	expect [][]string

--- a/bootstrap/git_test.go
+++ b/bootstrap/git_test.go
@@ -383,6 +383,13 @@ func TestGitClone(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestGitClean(t *testing.T) {
+	sh := (&mockShellRunner{}).Expect("git", "clean", "--foo", "--bar")
+	defer sh.Check(t)
+	err := gitClean(sh, "--foo --bar")
+	require.NoError(t, err)
+}
+
 // mockShellRunner implements shellRunner for testing expected calls.
 type mockShellRunner struct {
 	expect [][]string

--- a/bootstrap/git_test.go
+++ b/bootstrap/git_test.go
@@ -352,6 +352,7 @@ usage: ssh [-1246AaCfgKkMNnqsTtVvXxYy] [-b bind_address] [-c cipher_spec]
 func TestGitCheckRefFormat(t *testing.T) {
 	for ref, expect := range map[string]bool{
 		"hello":          true,
+		"hello-world":    true,
 		"hello/world":    true,
 		"--option":       false,
 		" leadingspace":  false,
@@ -359,10 +360,12 @@ func TestGitCheckRefFormat(t *testing.T) {
 		"has~tilde":      false,
 		"has^caret":      false,
 		"has:colon":      false,
-		"has\007special": false,
+		"has\007control": false,
+		"has\177del":     false,
 		"endswithdot.":   false,
 		"two..dots":      false,
 		"@":              false,
+		"back\\slash":    false,
 	} {
 		t.Run(ref, func(t *testing.T) {
 			if gitCheckRefFormat(ref) != expect {


### PR DESCRIPTION
When constructing the `git checkout` command, the sometimes-user-specified branch name should never be considered flags/options by `git`. It's not possible to terminate arg parsing with `--` because that has special meaning to `git checkout` — it indicates the following names are files, not refs. So, the ref must be validated. There's a [`git check-ref-format`](https://git-scm.com/docs/git-check-ref-format) subcommand which roughly does that. Rather than shelling out to git, this patch introduces a simple `gitCheckRefFormat(ref)` implementation to verify the ref doesn't start with a hyphen. This could be replaced with shell-out or a more thorough implementation if that feels worth doing.

With branch set to `--foo`…
* Before: `git checkout -f --foo` → `error: unknown option 'foo'`.
* After: `git checkout -f -- --foo` → `error: pathspec '--foo' did not match any file(s) known to git`

Related: #1314

---

This pull request also introduces unit tests (with a `mockShellRunner`) for `gitCheckout()`, `gitClone()`, `gitClean()`, `gitCleanSubmodules()` and `gitFetch()`.

```
$ go test ./bootstrap -run TestGit -v
=== RUN   TestGitCheckRefFormat
=== RUN   TestGitCheckRefFormat/hello
=== RUN   TestGitCheckRefFormat/--world
--- PASS: TestGitCheckRefFormat (0.00s)
    --- PASS: TestGitCheckRefFormat/hello (0.00s)
    --- PASS: TestGitCheckRefFormat/--world (0.00s)
=== RUN   TestGitCheckoutValidatesRef
--- PASS: TestGitCheckoutValidatesRef (0.00s)
=== RUN   TestGitCheckoutSomething
--- PASS: TestGitCheckoutSomething (0.00s)
=== RUN   TestGitClone
--- PASS: TestGitClone (0.00s)
=== RUN   TestGitClean
--- PASS: TestGitClean (0.00s)
=== RUN   TestGitCleanSubmodules
--- PASS: TestGitCleanSubmodules (0.00s)
=== RUN   TestGitFetch
--- PASS: TestGitFetch (0.00s)
PASS
```