### PR TITLE
Log error messages when canceling a running job fails

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -268,7 +268,10 @@ func (a *AgentWorker) Stop(graceful bool) {
 			// Kill the current job. Doesn't do anything if the job
 			// is already being killed, so it's safe to call
 			// multiple times.
-			a.jobRunner.CancelAndStop()
+			err := a.jobRunner.CancelAndStop()
+			if err != nil {
+				a.logger.Error("Unexpected error canceling job (err: %s)", err)
+			}
 		} else {
 			a.logger.Info("Forcefully stopping agent. Since there is no job running, the agent will disconnect immediately")
 		}

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -667,7 +667,10 @@ func (r *JobRunner) onProcessStartCallback() {
 				// try again soon anyway
 				r.logger.Warn("Problem with getting job state %s (%s)", r.job.ID, err)
 			} else if jobState.State == "canceling" || jobState.State == "canceled" {
-				r.Cancel()
+				err = r.Cancel()
+				if err != nil {
+					r.logger.Error("Unexpected error canceling process as requested by server (job: %s) (err: %s)", r.job.ID, err)
+				}
 			}
 
 			// Sleep for a bit, or until the job is finished


### PR DESCRIPTION
I noticed a log like the following agent output. A user clicked cancel on buildkite.com, the agent detected the request and attempted to stop the job process, but then continued to believe the job was still running for days (until the server was stopped):

> 2020-09-29 17:13:51 DEBUG  GET https://agent.buildkite.com/v3/jobs/fc8a2db9-c642-44f6-8d1f-61ece6b37b1f
> 2020-09-29 17:13:51 DEBUG  ↳ GET https://agent.buildkite.com/v3/jobs/fc8a2db9-c642-44f6-8d1f-61ece6b37b1f proto=HTTP/1.1 status=200 Δ=203.896ms
> 2020-09-29 17:13:51 INFO   myagent-1 Canceling job fc8a2db9-c642-44f6-8d1f-61ece6b37b1f with a grace period of 10s
> 2020-09-29 17:14:01 INFO   myagent-1 Job fc8a2db9-c642-44f6-8d1f-61ece6b37b1f hasn't stopped in time, terminating
> 2020-09-29 17:14:01 DEBUG  myagent-1 [Process] Terminating process tree with TASKKILL.EXE PID: 11412
> 2020-09-29 17:14:06 DEBUG  GET https://agent.buildkite.com/v3/jobs/fc8a2db9-c642-44f6-8d1f-61ece6b37b1f
> 2020-09-29 17:14:06 DEBUG  ↳ GET https://agent.buildkite.com/v3/jobs/fc8a2db9-c642-44f6-8d1f-61ece6b37b1f proto=HTTP/1.1 status=200 Δ=220.211ms
> 2020-09-29 17:14:10 DEBUG  POST https://agent.buildkite.com/v3/heartbeat
> 2020-09-29 17:14:10 DEBUG  ↳ POST https://agent.buildkite.com/v3/heartbeat proto=HTTP/1.1 status=200 Δ=206.0859ms
> 2020-09-29 17:14:10 DEBUG  myagent-1 Heartbeat sent at 2020-09-29T17:14:10.2852043+13:00 and received at 2020-09-29T04:14:10.636+00:00
> 2020-09-29 17:14:11 DEBUG  GET https://agent.buildkite.com/v3/jobs/fc8a2db9-c642-44f6-8d1f-61ece6b37b1f
> 2020-09-29 17:14:12 DEBUG  ↳ GET https://agent.buildkite.com/v3/jobs/fc8a2db9-c642-44f6-8d1f-61ece6b37b1f proto=HTTP/1.1 status=200 Δ=214.8323ms
> 2020-09-29 17:14:17 DEBUG  GET https://agent.buildkite.com/v3/jobs/fc8a2db9-c642-44f6-8d1f-61ece6b37b1f
> 2020-09-29 17:14:17 DEBUG  ↳ GET https://agent.buildkite.com/v3/jobs/fc8a2db9-c642-44f6-8d1f-61ece6b37b1f proto=HTTP/1.1 status=200 Δ=206.5778ms
> 2020-09-29 17:14:22 DEBUG  GET https://agent.buildkite.com/v3/jobs/fc8a2db9-c642-44f6-8d1f-61ece6b37b1f
> 2020-09-29 17:14:22 DEBUG  ↳ GET https://agent.buildkite.com/v3/jobs/fc8a2db9-c642-44f6-8d1f-61ece6b37b1f proto=HTTP/1.1 status=200 Δ=221.8024ms
> 2020-09-29 17:14:27 DEBUG  GET https://agent.buildkite.com/v3/jobs/fc8a2db9-c642-44f6-8d1f-61ece6b37b1f

This particular agent was running on windows and it seems plausible that we have a process handling bug.

I noticed that JobRunner.Cancel can return an error, and we don't handle it in two places:

1. while canceling a running job following a cancelation request from buildkite.com
2. while canceling a job during a graceful shutdown of the agent

The errors ultimately come from process/signal.go and the windows-specific version in process/signal_windows.go. Given the
scenario I saw was on windows, I'm wondering if there's some cases where the windows-specific code doesn't do what we think.

This change doesn't really improve the situation. The errors remain unhandled, but at least they're logged. Hopefully if I see the same situation in the future, we'll have extra clues pointing to why the job cancelation failed.