### PR TITLE
Add sampling logger for job-related processes on windows

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -696,8 +696,12 @@ func (r *JobRunner) onProcessStartCallback() {
 				r.logger.Debug("[ProcessLogger] Routine that logs the job process tree has finished")
 			}()
 			for {
-				tree := r.process.Processtree()
-				r.logger.Warn("Bootstrap Processtree:\n%s", tree.String())
+				tree, err := r.process.Processtree()
+				if err != nil {
+					r.logger.Error("Fetching process tree failed: %v", err)
+				} else {
+					r.logger.Warn("Bootstrap Processtree:\n%s", tree.String())
+				}
 				// Sleep for a bit, or until the job is finished
 				select {
 				case <-time.After(5 * time.Second):

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/kr/pty v1.1.2
 	github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53
 	github.com/mitchellh/go-homedir v1.0.0
+	github.com/mitchellh/go-ps v1.0.0
 	github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443
 	github.com/oleiade/reflections v0.0.0-20160817071559-0e86b3c98b2f
 	github.com/pborman/uuid v0.0.0-20170112150404-1b00554d8222

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53 h1:tGfIHhDghvEnneeR
 github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443 h1:+2OJrU8cmOstEoh0uQvYemRGVH1O6xtO2oANUWHFnP0=
 github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443/go.mod h1:JbxfV1Iifij2yhRjXai0oFrbpxszXHRx1E5RuM26o4Y=
 github.com/oleiade/reflections v0.0.0-20160817071559-0e86b3c98b2f h1:I6mXuorHlvwNDFelz7a+j0HaGYSzX7+Gq60DqLVypfc=

--- a/process/process.go
+++ b/process/process.go
@@ -99,12 +99,12 @@ func (p *Process) Pid() int {
 }
 
 // Return a tree collection of process and its descendent processes in a tree structure
-func (p *Process) Processtree() ProcessTreeRoot {
+func (p *Process) Processtree() (ProcessTreeRoot, error) {
 	tree, err := p.processGroup.processTree()
 	if err != nil {
-		p.logger.Error("error fetching process tree: %v", err)
+		return tree, err
 	}
-	return tree
+	return tree, nil
 }
 
 // WaitResult returns the raw error returned by Wait()

--- a/process/process_group.go
+++ b/process/process_group.go
@@ -1,0 +1,55 @@
+// +build !windows
+
+package process
+
+import (
+	"errors"
+	"os"
+)
+
+type processGroup struct{}
+
+type ProcessTreeRoot struct {
+	Children []*ProcessTreeNode
+}
+
+func (tree *ProcessTreeRoot) AddChild(child *ProcessTreeNode) error {
+	return errors.New("Only valid on windows")
+}
+
+func (tree *ProcessTreeRoot) String() string {
+	return ""
+}
+
+type ProcessTreeNode struct {
+	Pid        int
+	PPid       int
+	Executable string
+	Children   []*ProcessTreeNode
+}
+
+func (node *ProcessTreeNode) AddChild(child *ProcessTreeNode) error {
+	return errors.New("Only valid on windows")
+}
+
+func (node *ProcessTreeNode) String(depth int) string {
+	return ""
+}
+
+func newProcessGroup() (processGroup, error) {
+	g := processGroup{}
+	return g, errors.New("Only valid on windows")
+}
+
+func (g processGroup) dispose() error {
+	return errors.New("Only valid on windows")
+}
+
+func (g processGroup) addProcess(p *os.Process) error {
+	return errors.New("Only valid on windows")
+}
+
+func (g processGroup) processTree() (ProcessTreeRoot, error) {
+	root := ProcessTreeRoot{}
+	return root, errors.New("Only valid on windows")
+}

--- a/process/process_group_windows.go
+++ b/process/process_group_windows.go
@@ -121,12 +121,12 @@ func (g processGroup) listProcesses() ([]ps.Process, error) {
 		return nil, errors.New(fmt.Sprintf("JOBOBJECT_BASIC_PROCESS_ID_LIST buffer not large enough. Got %d pids, wanted %d", list.NumberOfProcessIdsInList, list.NumberOfAssignedProcesses))
 	}
 
-	processes := make([]ps.Process, list.NumberOfProcessIdsInList)
+	processes := make([]ps.Process, 0, list.NumberOfProcessIdsInList)
 	for i := 0; i < int(list.NumberOfProcessIdsInList); i++ {
 		pid := binary.LittleEndian.Uint64(list.ProcessIdList[8*i : 8*(i+1)])
 		process, err := ps.FindProcess(int(pid))
-		if err == nil {
-			processes[i] = process
+		if process != nil && err == nil {
+			processes = append(processes, process)
 		}
 	}
 	return processes, nil

--- a/process/process_group_windows.go
+++ b/process/process_group_windows.go
@@ -1,0 +1,162 @@
+// +build windows
+
+package process
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"unsafe"
+
+	ps "github.com/mitchellh/go-ps"
+	"golang.org/x/sys/windows"
+)
+
+// We use this struct to retreive process handle(which is unexported)
+// from os.Process using unsafe operation.
+type handleRetreiver struct {
+	Pid    int
+	Handle uintptr
+}
+
+type processGroup windows.Handle
+
+type ProcessTreeRoot struct {
+	Children []*ProcessTreeNode
+}
+
+func (tree *ProcessTreeRoot) AddChild(child *ProcessTreeNode) error {
+	tree.Children = append(tree.Children, child)
+	return nil
+}
+
+func (tree *ProcessTreeRoot) String() string {
+	result := ""
+	for _, childNode := range tree.Children {
+		result += childNode.String(1)
+	}
+	return result
+}
+
+type ProcessTreeNode struct {
+	Pid        int
+	PPid       int
+	Executable string
+	Children   []*ProcessTreeNode
+}
+
+func (node *ProcessTreeNode) AddChild(child *ProcessTreeNode) error {
+	node.Children = append(node.Children, child)
+	return nil
+}
+
+func (node *ProcessTreeNode) String(depth int) string {
+	result := ""
+	result += strings.Repeat(" ", depth*2) + fmt.Sprintf("%d - %s\n", node.Pid, node.Executable)
+	for _, childNode := range node.Children {
+		result += childNode.String(depth + 1)
+	}
+	return result
+}
+
+func newProcessGroup() (processGroup, error) {
+	handle, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	// this could be neat for enforcing clean up of all processes, but for
+	// now we're only interested in improved observability
+	//info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+	//	BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+	//		LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+	//	},
+	//}
+	//if _, err := windows.SetInformationJobObject(
+	//	handle,
+	//	windows.JobObjectExtendedLimitInformation,
+	//	uintptr(unsafe.Pointer(&info)),
+	//	uint32(unsafe.Sizeof(info))); err != nil {
+	//	return 0, err
+	//}
+
+	return processGroup(handle), nil
+}
+
+func (g processGroup) dispose() error {
+	return windows.CloseHandle(windows.Handle(g))
+}
+
+func (g processGroup) addProcess(p *os.Process) error {
+	return windows.AssignProcessToJobObject(
+		windows.Handle(g),
+		windows.Handle((*handleRetreiver)(unsafe.Pointer(p)).Handle))
+}
+
+// this could be sent upstream to the windows package
+type JOBOBJECT_BASIC_PROCESS_ID_LIST struct {
+	NumberOfAssignedProcesses uint32
+	NumberOfProcessIdsInList  uint32
+	ProcessIdList             [1024]byte
+}
+
+func (g processGroup) listProcesses() ([]ps.Process, error) {
+	JobObjectBasicProcessIdList := int32(3) // TODO upstream this to the windows package
+	var list JOBOBJECT_BASIC_PROCESS_ID_LIST
+
+	err := windows.QueryInformationJobObject(
+		windows.Handle(g),
+		JobObjectBasicProcessIdList,
+		uintptr(unsafe.Pointer(&list)),
+		uint32(unsafe.Sizeof(list)),
+		nil,
+	)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("QueryInformationJobObject failed: %v", err))
+	}
+
+	if list.NumberOfProcessIdsInList < list.NumberOfAssignedProcesses {
+		return nil, errors.New(fmt.Sprintf("JOBOBJECT_BASIC_PROCESS_ID_LIST buffer not large enough. Got %d pids, wanted %d", list.NumberOfProcessIdsInList, list.NumberOfAssignedProcesses))
+	}
+
+	processes := make([]ps.Process, list.NumberOfProcessIdsInList)
+	for i := 0; i < int(list.NumberOfProcessIdsInList); i++ {
+		pid := binary.LittleEndian.Uint64(list.ProcessIdList[8*i : 8*(i+1)])
+		process, err := ps.FindProcess(int(pid))
+		if err == nil {
+			processes[i] = process
+		}
+	}
+	return processes, nil
+}
+
+func (g processGroup) processTree() (ProcessTreeRoot, error) {
+	root := ProcessTreeRoot{}
+	processMap := make(map[int]*ProcessTreeNode)
+	processes, err := g.listProcesses()
+
+	if err != nil {
+		return root, errors.New(fmt.Sprintf("error fetching process tree: %v", err))
+	}
+
+	for _, p := range processes {
+		processMap[p.Pid()] = &ProcessTreeNode{
+			Pid:        p.Pid(),
+			PPid:       p.PPid(),
+			Executable: p.Executable(),
+		}
+	}
+
+	for _, node := range processMap {
+		parentNode, parentExists := processMap[node.PPid]
+		if parentExists {
+			parentNode.AddChild(node)
+		} else {
+			root.AddChild(node)
+		}
+	}
+
+	return root, nil
+}

--- a/process/signal_test.go
+++ b/process/signal_test.go
@@ -1,9 +1,9 @@
 package process_test
 
 import (
+	"runtime"
 	"syscall"
 	"testing"
-	"runtime"
 
 	"github.com/buildkite/agent/v3/process"
 	"github.com/stretchr/testify/assert"

--- a/process/signal_windows.go
+++ b/process/signal_windows.go
@@ -23,6 +23,11 @@ func (p *Process) setupProcessGroup() {
 	p.command.SysProcAttr = &windows.SysProcAttr{
 		CreationFlags: windows.CREATE_UNICODE_ENVIRONMENT | windows.CREATE_NEW_PROCESS_GROUP,
 	}
+	processGroup, err := newProcessGroup()
+	if err != nil {
+		p.logger.Error("Error creating processGroup: %v", err)
+	}
+	p.processGroup = processGroup
 }
 
 func (p *Process) terminateProcessGroup() error {


### PR DESCRIPTION
We've had reports from multiple customers that the windows agent can sometimes get "stuck" (eg #1292)

- from the perspective of our servers the agent is running the stuck job for days
- the main agent process considers the job to still be running, so it doesn't mark the job as finished with our API
- the main agent process sees no further output from the bootstrap process, so no new log chunks are uploaded
- when the user tries to cancel the job on buildkite.com, the main agent process attempts to terminate the bootstrap process and fails

This PR doesn't attempt ro fix the issue - we're still looking for a root cause that we can reliably reproduce.

This adds a sampling logger that prints the full process tree of the bootstrap and job every 5 seconds.

I'm told that the process hierarchy in windows can't be trusted too much. Each process maintains a pointer to its parent, but it's common for the parent process to end and leave orphan processes that can't be found by walking the parent/child tree from the bootstrap.

I've attempted to mitigate that by adding the bootstrap process to a Job Object. All child processes of the bootstrap are automatically added to the same Job, and we can use the QueryInformationJobObject windows API call to retrieve all processes in the Job.

I'm interested to see how the process tree evolves over the life of one of these stuck jobs. Hopefully we can get the clue we need to reproduce the issue and come up with a reliable fix.

The result looks like this (I considered unicode box drawing characters for a better tree-look..... but it's late). 

![Screenshot from 2020-10-12 00-42-24](https://user-images.githubusercontent.com/8132/95680246-f47aa880-0c23-11eb-985e-eb06fc884810.png)


Note: this is not production ready code! I haven't put much thought into the abstractions I've modified. To enable the logging, start the agent like this:

    buidlkite-agent.exe start -token=foo -debug -experiments=debug-processes

Some useful reading on Job Objects:

1. https://docs.microsoft.com/en-us/windows/win32/procthread/job-objects?redirectedfrom=MSDN
2. https://docs.microsoft.com/en-us/windows/win32/api/jobapi2/
3. https://nikhilism.com/post/2017/windows-job-objects-process-tree-management/
4. https://gist.github.com/hallazzang/76f3970bfc949831808bbebc8ca15209

