### PR TITLE
shutdown hook on Windows supports Batch & PowerShell

### DIFF
--- a/agent/job_runner_test.go
+++ b/agent/job_runner_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestTruncateEnv(t *testing.T) {
-	l := &logger.Buffer{}
+	l := logger.NewBuffer()
 	env := map[string]string{"FOO": strings.Repeat("a", 100)}
 	err := truncateEnv(l, env, "FOO", 64)
 	require.NoError(t, err)

--- a/logger/buffer.go
+++ b/logger/buffer.go
@@ -10,6 +10,15 @@ type Buffer struct {
 	Messages []string
 }
 
+// NewBuffer creates a new Buffer with Messages slice initialized.
+// This makes it simpler to assert empty []string when no log messages
+// have been sent; otherwise Messages would be nil.
+func NewBuffer() *Buffer {
+	return &Buffer{
+		Messages: make([]string, 0),
+	}
+}
+
 func (b *Buffer) Debug(format string, v ...interface{}) {
 	b.Messages = append(b.Messages, "[debug] "+fmt.Sprintf(format, v...))
 }

--- a/logger/buffer_test.go
+++ b/logger/buffer_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBuffer(t *testing.T) {
-	l := &logger.Buffer{}
+	l := logger.NewBuffer()
 	l.Info("hello %s", "world")
 	func(x logger.Logger) {
 		x.Debug("foo bar")


### PR DESCRIPTION
## Background

#1275 introduced a `shutdown` hook, which runs as the agent is shutting down. This is the first hook we've added which doesn't run as part of the `bootstrap` process for a job.

The current implementation looks for a `$HOOKS/shutdown` file, and runs it directly as a shell command, which assumes it's a bash script due to the lack of a file extension. Windows users are more likely to specify a shutdown hook as a batch or PowerShell file.

## Solution

I've done some refactoring in #1324, #1325 and to extract some hook code from package `bootstrap` into a new package `hook`.

This pull request uses the new `hook.Find(dir, name)` function to give `shutdownHook()` the same search logic as bootstrap hooks; that means on Windows `shutdown.bat`, `shutdown.cmd` and `shutdown.ps1` files are considered.

`TestShutdownHook()` now uses `shutdown.bat` on Windows, which appears to be more likely to work than a `shutdown` bash script. The test also verifies no errors are logged — previously the test was logging failure messages on Windows but they were being ignored.

## Local verification

In my local Windows environment, this works for `shutdown.bat`:
```
> C:\buildkite-agent\hooks\shutdown.bat
C:\Users\pda\bk\agent>echo hello
hello
```

I get an error for `shutdown.ps1`, but it looks like it's being invoked fine, and my machine isn't configured to allow the script to run, so that's fine:
```
> C:\buildkite-agent\hooks\shutdown.ps1
File C:\buildkite-agent\hooks\shutdown.ps1 cannot be loaded because running scripts is disabled on this system. For
more information, see about_Execution_Policies at https:/go.microsoft.com/fwlink/?LinkID=135170.
    + CategoryInfo          : SecurityError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : UnauthorizedAccess
2020-10-12 21:25:42 ERROR  Shutdown hook error: exit status 1 hook=shutdown
```

### Caveat

I still get an error during shutdown when specifying a `shutdown` bash hook:
```
/bin/bash: C:/buildkite-agent/hooks/shutdown: No such file or directory
2020-10-12 21:16:39 ERROR  Shutdown hook error: exit status 127
```
I'm not sure why that's not working, or how/whether Windows bash scripts work in our existing bootstrap hooks. I think we can figure that out in a future pull request — it's not a regression in this pull request.