### PR TITLE
Refactor: extract bootstrap.findHookFile() → hook.Find()

### DIFF
--- a/hook/hook.go
+++ b/hook/hook.go
@@ -1,0 +1,28 @@
+package hook
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/buildkite/agent/v3/bootstrap/shell"
+	"github.com/buildkite/agent/v3/utils"
+)
+
+// Find returns the absolute path to the best matching hook file in a path, or
+// os.ErrNotExist if none is found
+func Find(hookDir string, name string) (string, error) {
+	if runtime.GOOS == "windows" {
+		// check for windows types first
+		if p, err := shell.LookPath(name, hookDir, ".BAT;.CMD;.PS1"); err == nil {
+			return p, nil
+		}
+	}
+	// otherwise chech for th default shell script
+	if p := filepath.Join(hookDir, name); utils.FileExists(p) {
+		return p, nil
+	}
+	// don't wrap os.ErrNotExist without checking callers handle it.
+	// e.g. os.IfNotExist(err) does not handle wrapped errors.
+	return "", os.ErrNotExist
+}

--- a/utils/file.go
+++ b/utils/file.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"os"
+)
+
+// FileExists returns whether or not a file exists on the filesystem. We
+// consider any error returned by os.Stat to indicate that the file doesn't
+// exist. We could be specific and use os.IsNotExist(err), but most other
+// errors also indicate that the file isn't there (or isn't available) so we'll
+// just catch them all.
+func FileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil
+}


### PR DESCRIPTION
_This is a refactor extracted from #1322, to reduce the size/scope of that pull request._

Introduces a new package `hook`, and extracts `bootstrap.(*Bootstrap).findHookFile()` → `hook.Find()` like so:

```diff
-// package bootstrap
-func (b *Bootstrap) findHookFile(hookDir string, name string) (string, error)
+// package hook
+func Find(hookDir string, name string) (string, error) {
```

This allows code outside package `bootstrap` to resolve hook files, including the `.BAT;.CMD;.PS1` Windows search strategy.

To support this refactor, our file-existence helper has been extracted to the existing package `utils`:

```diff
-// package bootstrap
-func fileExists(filename string) bool
+// package utils
+func FileExists(filename string) bool
```