### PR TITLE
shutdown hook: pipe output lines to main logger

### DIFF
--- a/clicommand/agent_start_test.go
+++ b/clicommand/agent_start_test.go
@@ -22,7 +22,12 @@ func setupHooksPath() (string, func(), error) {
 // Since the hook doesn't really return anything, we can't really test stuff but at
 // least make sure the code doesn't explode.
 func TestShutdownHook(t *testing.T) {
-
+	cfg := func(hooksPath string) AgentStartConfig {
+		return AgentStartConfig{
+			HooksPath: hooksPath,
+			NoColor:   true,
+		}
+	}
 	t.Run("with shutdown hook", func(t *testing.T) {
 		hooksPath, closer, err := setupHooksPath()
 		if err != nil {
@@ -34,16 +39,19 @@ func TestShutdownHook(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			filename = "shutdown.bat"
 		}
-		err = ioutil.WriteFile(filepath.Join(hooksPath, filename), []byte("echo hello"), 0755)
+		filepath := filepath.Join(hooksPath, filename)
+		err = ioutil.WriteFile(filepath, []byte("echo hello"), 0755)
 		if err != nil {
 			assert.FailNow(t, "failed to write shutdown hook: %v", err)
 		}
 
 		log := logger.NewBuffer()
-		shutdownHook(log, hooksPath)
-		assert.Equal(t, []string{}, log.Messages)
+		shutdownHook(log, cfg(hooksPath))
+		assert.Equal(t, []string{
+			"[info] $ " + filepath, // prompt
+			"[info] hello",         // output
+		}, log.Messages)
 	})
-
 	t.Run("with no shutdown hook", func(t *testing.T) {
 		hooksPath, closer, err := setupHooksPath()
 		if err != nil {
@@ -52,13 +60,12 @@ func TestShutdownHook(t *testing.T) {
 		defer closer()
 
 		log := logger.NewBuffer()
-		shutdownHook(log, hooksPath)
+		shutdownHook(log, cfg(hooksPath))
 		assert.Equal(t, []string{}, log.Messages)
 	})
-
 	t.Run("with bad hooks path", func(t *testing.T) {
 		log := logger.NewBuffer()
-		shutdownHook(log, "zxczxczxc")
+		shutdownHook(log, cfg("zxczxczxc"))
 		assert.Equal(t, []string{}, log.Messages)
 	})
 }

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -95,7 +95,12 @@ func CreateLogger(cfg interface{}) logger.Logger {
 
 		// Show agent fields as a prefix
 		printer.IsPrefixFn = func(field logger.Field) bool {
-			return field.Key() == `agent`
+			switch field.Key() {
+			case "agent", "hook":
+				return true
+			default:
+				return false
+			}
 		}
 
 		// Turn off color if a NoColor option is present


### PR DESCRIPTION
This pull request pipes the output of the new shutdown script (#1275) into the main logger.

## Before

The shutdown hook output is written directly to `os.Stdout`:

![image](https://user-images.githubusercontent.com/15759/95818779-606a2780-0d70-11eb-8632-fda60b0af02a.png)

(The :skull: is my shell warning that the program terminated without a trailing newline)

## After

The shutdown hook output is pipes to the logger, with a prefix of `shutdown` to identify where it came from:

![image](https://user-images.githubusercontent.com/15759/95818707-37e22d80-0d70-11eb-8bbc-d879a989629b.png)

## And with `--no-color`

I had some issues with color creeping in despite `--no-color` being passed. All fixed:

![image](https://user-images.githubusercontent.com/15759/95818725-42042c00-0d70-11eb-8f0e-de07c08328d7.png)

## Test hook

Here's the `shutdown` hook I was using:

```
$ cat tmp/hooks/shutdown
#!/bin/bash

echo "hello stdout from shutdown hook"
echo >&2 "hello stderr from shutdown hook"
echo -n "no line ending here"
```

## Notes

It would be nice to refactor the `io.Writer`→`logger.Logger` pipe gear out of `shutdownHook()` so it can be used elsewhere. That'll need a bit of finesse to decouple it without concurrency issues, so I figure we can do it later when there's a second use-case.