### PR TITLE
Add --mirror flag by default for mirror clones

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1001,7 +1001,11 @@ func (b *Bootstrap) updateGitMirror() (string, error) {
 	// If we don't have a mirror, we need to clone it
 	if !utils.FileExists(mirrorDir) {
 		b.shell.Commentf("Cloning a mirror of the repository to %q", mirrorDir)
-		if err := gitClone(b.shell, b.GitCloneMirrorFlags, b.Repository, mirrorDir); err != nil {
+
+		gitCloneMirrorFlags := b.GitCloneMirrorFlags
+		gitCloneMirrorFlags += "--mirror"
+
+		if err := gitClone(b.shell, gitCloneMirrorFlags, b.Repository, mirrorDir); err != nil {
 			return "", err
 		}
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1001,11 +1001,8 @@ func (b *Bootstrap) updateGitMirror() (string, error) {
 	// If we don't have a mirror, we need to clone it
 	if !utils.FileExists(mirrorDir) {
 		b.shell.Commentf("Cloning a mirror of the repository to %q", mirrorDir)
-
-		gitCloneMirrorFlags := b.GitCloneMirrorFlags
-		gitCloneMirrorFlags += "--mirror"
-
-		if err := gitClone(b.shell, gitCloneMirrorFlags, b.Repository, mirrorDir); err != nil {
+		flags := "--mirror " + b.GitCloneMirrorFlags
+		if err := gitClone(b.shell, flags, b.Repository, mirrorDir); err != nil {
 			return "", err
 		}
 

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -116,7 +116,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 	// But assert which ones are called
 	if experiments.IsEnabled(`git-mirrors`) {
 		git.ExpectAll([][]interface{}{
-			{"clone", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+			{"clone", "--bare", "--mirror", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
 			{"fetch", "-v", "--", "origin", "master"},
@@ -324,7 +324,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 	// But assert which ones are called
 	if experiments.IsEnabled(`git-mirrors`) {
 		git.ExpectAll([][]interface{}{
-			{"clone", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+			{"clone", "--bare", "--mirror", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "--depth=1", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
 			{"fetch", "--depth=1", "--", "origin", "master"},

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -116,7 +116,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 	// But assert which ones are called
 	if experiments.IsEnabled(`git-mirrors`) {
 		git.ExpectAll([][]interface{}{
-			{"clone", "--mirror", "--config pack.threads=35", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+			{"clone", "--mirror", "--config", "pack.threads=35", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
 			{"fetch", "-v", "--", "origin", "master"},
@@ -385,7 +385,7 @@ func TestCheckingOutWithSSHKeyscan(t *testing.T) {
 	git.IgnoreUnexpectedInvocations()
 
 	if experiments.IsEnabled(`git-mirrors`) {
-		git.Expect("clone", "-v", "--mirror", "--", "git@github.com:buildkite/agent.git", bintest.MatchAny()).
+		git.Expect("clone", "--mirror", "-v", "--", "git@github.com:buildkite/agent.git", bintest.MatchAny()).
 			AndExitWith(0)
 	} else {
 		git.Expect("clone", "-v", "--", "git@github.com:buildkite/agent.git", ".").
@@ -438,7 +438,7 @@ func TestCheckingOutWithSSHKeyscanAndUnscannableRepo(t *testing.T) {
 	git.IgnoreUnexpectedInvocations()
 
 	if experiments.IsEnabled(`git-mirrors`) {
-		git.Expect("clone", "-v", "--mirror", "--", "https://github.com/buildkite/bash-example.git", bintest.MatchAny()).
+		git.Expect("clone", "--mirror", "-v", "--", "https://github.com/buildkite/bash-example.git", bintest.MatchAny()).
 			AndExitWith(0)
 	} else {
 		git.Expect("clone", "-v", "--", "https://github.com/buildkite/bash-example.git", ".").

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -63,7 +63,7 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 	// But assert which ones are called
 	if experiments.IsEnabled(`git-mirrors`) {
 		git.ExpectAll([][]interface{}{
-			{"clone", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+			{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
 			{"fetch", "-v", "--", "origin", "master"},
@@ -103,7 +103,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 
 	env := []string{
 		"BUILDKITE_GIT_CLONE_FLAGS=-v",
-		"BUILDKITE_GIT_CLONE_MIRROR_FLAGS=--bare",
+		"BUILDKITE_GIT_CLONE_MIRROR_FLAGS=--config pack.threads=35",
 		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
 		"BUILDKITE_GIT_FETCH_FLAGS=-v",
 	}
@@ -116,7 +116,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 	// But assert which ones are called
 	if experiments.IsEnabled(`git-mirrors`) {
 		git.ExpectAll([][]interface{}{
-			{"clone", "--bare", "--mirror", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+			{"clone", "--mirror", "--config pack.threads=35", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
 			{"fetch", "-v", "--", "origin", "master"},
@@ -187,7 +187,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 	// But assert which ones are called
 	if experiments.IsEnabled(`git-mirrors`) {
 		git.ExpectAll([][]interface{}{
-			{"clone", "-v", "--mirror", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+			{"clone", "--mirror", "-v", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
 			{"submodule", "foreach", "--recursive", "git clean -fdq"},
@@ -271,7 +271,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 	// But assert which ones are called
 	if experiments.IsEnabled(`git-mirrors`) {
 		git.ExpectAll([][]interface{}{
-			{"clone", "-v", "--mirror", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+			{"clone", "--mirror", "-v", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
 			{"submodule", "foreach", "--recursive", "git clean -fdq"},
@@ -324,7 +324,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 	// But assert which ones are called
 	if experiments.IsEnabled(`git-mirrors`) {
 		git.ExpectAll([][]interface{}{
-			{"clone", "--bare", "--mirror", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+			{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "--depth=1", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
 			{"fetch", "--depth=1", "--", "origin", "master"},
@@ -674,7 +674,7 @@ func TestGitMirrorEnv(t *testing.T) {
 	// But assert which ones are called
 	if experiments.IsEnabled(`git-mirrors`) {
 		git.ExpectAll([][]interface{}{
-			{"clone", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+			{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
 			{"fetch", "-v", "--", "origin", "master"},

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -282,7 +282,7 @@ var AgentStartCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name:   "git-clone-mirror-flags",
-			Value:  "-v --mirror",
+			Value:  "-v",
 			Usage:  "Flags to pass to the \"git clone\" command when used for mirroring",
 			EnvVar: "BUILDKITE_GIT_CLONE_MIRROR_FLAGS",
 		},

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -191,7 +191,7 @@ var BootstrapCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name:   "git-clone-mirror-flags",
-			Value:  "-v --mirror",
+			Value:  "-v",
 			Usage:  "Flags to pass to \"git clone\" command when mirroring",
 			EnvVar: "BUILDKITE_GIT_CLONE_MIRROR_FLAGS",
 		},


### PR DESCRIPTION
The mirror clone can't operate without it as subsequent steps will fail if they are performed on a full checkout. I think I mentioned this in the original issue, but I think this is a better default.

Fixes #1319