### PR TITLE
Use a win32 Job Object to manage job termination on windows

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -204,8 +204,7 @@ func (p *Process) Run() error {
 		if err != nil {
 			return err
 		}
-		err = p.postStart()
-		if err != nil {
+		if err := p.postStart(); err != nil {
 			p.logger.Error("[Process] postStart failed: %v", err)
 		}
 		p.pid = p.command.Process.Pid

--- a/process/process.go
+++ b/process/process.go
@@ -82,6 +82,8 @@ type Process struct {
 	command       *exec.Cmd
 	mu            sync.Mutex
 	started, done chan struct{}
+
+	winJobHandle uintptr
 }
 
 // New returns a new instance of Process
@@ -202,7 +204,10 @@ func (p *Process) Run() error {
 		if err != nil {
 			return err
 		}
-
+		err = p.postStart()
+		if err != nil {
+			p.logger.Error("[Process] postStart failed: %v", err)
+		}
 		p.pid = p.command.Process.Pid
 
 		// Signal waiting consumers in Started() by closing the started channel

--- a/process/signal.go
+++ b/process/signal.go
@@ -19,6 +19,11 @@ func (p *Process) setupProcessGroup() {
 	}
 }
 
+func (p *Process) postStart() error {
+	// a no-op on non-windows
+	return nil
+}
+
 func (p *Process) terminateProcessGroup() error {
 	p.logger.Debug("[Process] Sending signal SIGKILL to PGID: %d", p.pid)
 	return syscall.Kill(-p.pid, syscall.SIGKILL)

--- a/process/signal_test.go
+++ b/process/signal_test.go
@@ -1,9 +1,9 @@
 package process_test
 
 import (
+	"runtime"
 	"syscall"
 	"testing"
-	"runtime"
 
 	"github.com/buildkite/agent/v3/process"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
Imagine a windows process tree like this:

    1000 buildkite-agent.exe start
    └─ 1001 buildkite-agent.exe bootstrap
      └─ 1002 cmd.exe
        └─ 1003 python.exe
          └─ 1004 python.exe

It's reasonably common in windows for a process to end and orphan its children, leaving a tree like this:

    1000 buildkite-agent.exe start
    └─ 1001 buildkite-agent.exe bootstrap
      └─ 1002 cmd.exe
    └─ 1004 python.exe

Then the bootstrap might end, leaving the orphan process hanging around after the job has completed. Oops.

On UNIX systems we avoid this by creating a progress group, so any process that starts during job execution is tidied up when the bootstrap process finishes.

Here I've introduced win32 Job Object to achieve a similar effect on Windows. This has two noteworthy impacts:

1. The bootstrap process created to run a Buildkite Job is added to a new win32 Job Object. Any child process started by descendant processes will be added to the same Job Object, and they'll be automatically terminated when the bootstrap process finishes
2. A request to hard terminate a running Buildkite Job now does so by terminating the win32 Job (which in turn terminates all processes within it). This should be more reliable than TASKKILL.EXE, which was unable to find and destroy orphans and would error completely if the bootstrap process had completed

HT to [this gist](https://gist.github.com/hallazzang/76f3970bfc949831808bbebc8ca15209#gistcomment-2948162) that pointed me in the right direction [1]. The [MSDN docs on Job Objects](https://docs.microsoft.com/en-us/windows/win32/procthread/job-objects?redirectedfrom=MSDN) were reasonably useful too.

Fixes #1292