### PR TITLE
add productType to the OS telemetry we send from windows

### DIFF
--- a/system/version_dump_windows.go
+++ b/system/version_dump_windows.go
@@ -6,8 +6,27 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+var (
+	VER_NT_WORKSTATION       = byte(0x0000001)
+	VER_NT_DOMAIN_CONTROLLER = byte(0x0000002)
+	VER_NT_SERVER            = byte(0x0000003)
+)
+
 func VersionDump(_ logger.Logger) (string, error) {
 	info := windows.RtlGetVersion()
 
-	return fmt.Sprintf("Windows version %d.%d (Build %d)\n", info.MajorVersion, info.MinorVersion, info.BuildNumber), nil
+	return fmt.Sprintf("Windows version %d.%d (Build %d) (ProductType %s)\n", info.MajorVersion, info.MinorVersion, info.BuildNumber, productTypeToString(info.ProductType)), nil
+}
+
+func productTypeToString(productType byte) string {
+	switch productType {
+	case VER_NT_WORKSTATION:
+		return "VER_NT_WORKSTATION"
+	case VER_NT_DOMAIN_CONTROLLER:
+		return "VER_NT_DOMAIN_CONTROLLER"
+	case VER_NT_SERVER:
+		return "VER_NT_SERVER"
+	default:
+		return "UNKNOWN"
+	}
 }


### PR DESCRIPTION
This value is required to disambiguate between desktop windows (like windows 7, 8 and 10) and server windows (like server 2012, 2016 and 2019).

Ref: https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/ns-wdm-_osversioninfoexw#remarks