### PR TITLE
bump alpine docker image from alpine 3.8 to 3.12

### DIFF
--- a/packaging/docker/alpine-linux/Dockerfile
+++ b/packaging/docker/alpine-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.12
 
 RUN apk add --no-cache \
       bash \
@@ -8,16 +8,14 @@ RUN apk add --no-cache \
       openssh-client \
       curl \
       docker \
+      docker-compose \
       jq \
       su-exec \
       py-pip \
       libc6-compat \
       run-parts \
       tini \
-      tzdata \
-    && \
-    pip install --upgrade pip && \
-    pip install --quiet docker-compose~=1.23.0
+      tzdata
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg
 

--- a/packaging/docker/sidecar/Dockerfile
+++ b/packaging/docker/sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.12
 
 RUN mkdir /buildkite \
           /buildkite/builds \


### PR DESCRIPTION
Alpine 3.8 was released in June 2018 and last updated in December 2018. Bumping to 3.12 means we'll get newer versions of supporting libraries and programs like jq, tzdata, docker client, bash, git and ca-certificates.

We can also switch to installing docker-compose from a package - alpine 3.12 ships with docker-compose 1.25.4.

I've also bumped the alpine version we use while building the sidecar docker image, although it's only a stage on the way to the final image and should have no user visible impact.

Like the similar ubuntu bump in #1312, this has the potential to surprise some users when  they get newer tools versions at the same time as upgrading to a new agent version though. However, with our current docker tagging strategy that's unavoidable and it's probably better for us to bump the base image semi-regularly before our customer agent fleets get so used to the tool versions in alpine 3.8 that we're unable to change it.

Users that need the tool versions in alpine 3.8 can change to the `buildkite/agent:3.25.0` tag - the last official release shipped on alpine 3.8.