### PR TITLE
upgrade from golang 1.14 to 1.15

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   agent:
-    image: golang:1.14@sha256:174e1be71bd2aa8c65d6c17be0e5c0f8bc4e4ec03e82a5f57aad0b8acf22ef7f
+    image: golang:1.15@sha256:1ba0da74b20aad52b091877b0e0ece503c563f39e37aa6b0e46777c4d820a2ae
     volumes:
       - ../:/work:cached
     working_dir: /work


### PR DESCRIPTION
There's no driving reason to upgrade, but 1.15 has been out for a couple of months and has a few bugfix releases. Maybe it's ready for us to try?