### PR TITLE
Use gotip (pre 1.16) to compile a native executable for Apple Silicon

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -116,6 +116,16 @@ steps:
         config: .buildkite/docker-compose.yml
         run: agent
 
+  - name: ":mac: arm64"
+    command: ".buildkite/steps/build-apple-silicon-binary.sh darwin arm64" # this can go back to the standard build-binary.sh once go 1.16 is released
+    key: build-binary-darwin-arm64
+    depends_on: test-linux # don't wait for slower windows tests
+    artifact_paths: "pkg/*"
+    plugins:
+      docker-compose#v3.0.0:
+        config: .buildkite/docker-compose.yml
+        run: agent
+
   - name: ":freebsd: amd64"
     command: ".buildkite/steps/build-binary.sh freebsd amd64"
     key: build-binary-freebsd-amd64
@@ -246,6 +256,7 @@ steps:
       - build-binary-linux-arm64
       - build-binary-linux-ppc64le
       - build-binary-darwin-amd64
+      - build-binary-darwin-arm64
       - build-binary-freebsd-amd64
       - build-binary-freebsd-386
       - build-binary-openbsd-amd64

--- a/.buildkite/steps/build-apple-silicon-binary.sh
+++ b/.buildkite/steps/build-apple-silicon-binary.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "--- :${1}: Building ${1}/${2}"
+
+rm -rf pkg
+
+go get golang.org/dl/gotip
+
+gotip download
+
+gotip version
+
+./scripts/build-binary.sh "${1}" "${2}" "${BUILDKITE_BUILD_NUMBER}"

--- a/.buildkite/steps/build-apple-silicon-binary.sh
+++ b/.buildkite/steps/build-apple-silicon-binary.sh
@@ -8,7 +8,7 @@ rm -rf pkg
 
 go get golang.org/dl/gotip
 
-gotip download 272258
+gotip download
 
 gotip version
 

--- a/.buildkite/steps/build-apple-silicon-binary.sh
+++ b/.buildkite/steps/build-apple-silicon-binary.sh
@@ -8,7 +8,7 @@ rm -rf pkg
 
 go get golang.org/dl/gotip
 
-gotip download
+gotip download 272258
 
 gotip version
 

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -21,6 +21,13 @@ if [[ "$GOARCH" = "armhf" ]]; then
   export GOARM="7"
 fi
 
+# TODO delete this conditional once we're using go 1.16
+if [[ "$GOARCH" = "arm64" && "$GOOS" = "darwin" ]]; then
+  GO_BINARY=gotip
+else
+  GO_BINARY=go
+fi
+
 echo -e "Building $NAME with:\n"
 
 echo "GOOS=$GOOS"
@@ -40,7 +47,7 @@ fi
 export CGO_ENABLED=0
 
 mkdir -p $BUILD_PATH
-go build -v -ldflags "-X github.com/buildkite/agent/v3/agent.buildVersion=$BUILD_VERSION" -o $BUILD_PATH/$BINARY_FILENAME *.go
+$GO_BINARY build -v -ldflags "-X github.com/buildkite/agent/v3/agent.buildVersion=$BUILD_VERSION" -o $BUILD_PATH/$BINARY_FILENAME *.go
 
 chmod +x $BUILD_PATH/$BINARY_FILENAME
 


### PR DESCRIPTION
This adds a new build step that compiles a native agent for Apple Silicon. I think. I don't have one to test on.

Cross compiling for Apple Silicon requires `GOARCH=arm64` and `GOOS=darwin`, which is a valid combination on unreleased version of go and will be valid in the upcoming 1.16 release.

We currently compile using go 1.15, so this new step uses gotip to install the latest unreleased golang. That probably means the darwin-arm64 binary it spits out should be considered experimental.