### PR TITLE
install: use the arm64 binary for aarch64 machines

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,6 +77,7 @@ else
     *armv6*)   ARCH="armhf"   ;;
     *arm*)     ARCH="arm"     ;;
     *ppc64le*) ARCH="ppc64le" ;;
+    *aarch64*) ARCH="arm64"   ;;
     *)
       ARCH="386"
       echo -e "\n\033[36mWe don't recognise the $MACHINE architecture; falling back to $ARCH\033[0m"


### PR DESCRIPTION
Enable the install script to use the arm64 binary when uname reports that the machine is aarch64.