### PR TITLE
Support for arm64 releases in release-homebrew step

### DIFF
--- a/.buildkite/steps/release-homebrew.sh
+++ b/.buildkite/steps/release-homebrew.sh
@@ -53,7 +53,7 @@ BINARY_NAME_AMD64="buildkite-agent-darwin-amd64-${AGENT_VERSION}.tar.gz"
 DOWNLOAD_URL_AMD64="https://github.com/buildkite/agent/releases/download/v$GITHUB_RELEASE_VERSION/$BINARY_NAME_AMD64"
 
 BINARY_NAME_ARM64="buildkite-agent-darwin-arm64-${AGENT_VERSION}.tar.gz"
-DOWNLOAD_URL_ARM64="https://github.com/buildkite/agent/releases/download/v$GITHUB_RELEASE_VERSION/$BINARY_NAME_AMD64"
+DOWNLOAD_URL_ARM64="https://github.com/buildkite/agent/releases/download/v$GITHUB_RELEASE_VERSION/$BINARY_NAME_ARM64"
 
 ARTIFACTS_BUILD="$(buildkite-agent meta-data get "agent-artifacts-build")"
 

--- a/.buildkite/steps/release-homebrew.sh
+++ b/.buildkite/steps/release-homebrew.sh
@@ -30,12 +30,12 @@ echo "Build version: $BUILD_VERSION"
 echo "Is prerelease?: $IS_PRERELEASE"
 
 if [[ "$CODENAME" == "unstable" && "$IS_PRERELEASE" == "0" ]] ; then
-  echo "Skipping homebrew release, will happen in stable pipeline"
+  echo "Skipping Homebrew release, will happen in stable pipeline"
   exit 0
 fi
 
 if [[ "$CODENAME" == "stable" && "$IS_PRERELEASE" == "1" ]] ; then
-  echo "Skipping homebrew release, should have happened in unstable pipeline"
+  echo "Skipping Homebrew release, should have happened in unstable pipeline"
   exit 0
 fi
 
@@ -49,32 +49,46 @@ else
   BREW_RELEASE_TYPE="stable"
 fi
 
-BINARY_ARCH="amd64"
-BINARY_NAME="buildkite-agent-darwin-${BINARY_ARCH}-${AGENT_VERSION}.tar.gz"
+BINARY_NAME_AMD64="buildkite-agent-darwin-amd64-${AGENT_VERSION}.tar.gz"
+DOWNLOAD_URL_AMD64="https://github.com/buildkite/agent/releases/download/v$GITHUB_RELEASE_VERSION/$BINARY_NAME_AMD64"
 
-DOWNLOAD_URL="https://github.com/buildkite/agent/releases/download/v$GITHUB_RELEASE_VERSION/$BINARY_NAME"
-FORMULA_FILE=./pkg/buildkite-agent.rb
-UPDATED_FORMULA_FILE=./pkg/buildkite-agent-updated.rb
+BINARY_NAME_ARM64="buildkite-agent-darwin-arm64-${AGENT_VERSION}.tar.gz"
+DOWNLOAD_URL_ARM64="https://github.com/buildkite/agent/releases/download/v$GITHUB_RELEASE_VERSION/$BINARY_NAME_AMD64"
 
 ARTIFACTS_BUILD="$(buildkite-agent meta-data get "agent-artifacts-build")"
 
-echo "--- :package: Calculating SHAs for releases/$BINARY_NAME"
+echo "--- :package: Calculating SHAs for releases/$BINARY_NAME_AMD64"
 
-buildkite-agent artifact download  --build "$ARTIFACTS_BUILD" "releases/$BINARY_NAME" .
+buildkite-agent artifact download  --build "$ARTIFACTS_BUILD" "releases/$BINARY_NAME_AMD64" .
 
 # $ openssl dgst -sha256 -hex $FILE # portable sha256 with openssl
 # SHA256($FILE)= 26ff51b51eab2bfbcb2796bc72feec366d7e37a6cf8a11686ee8a6f14a8fc92c
 # | grep -o '\S*$' # grab the last word (some openssl versions only list the hex)
 # 26ff51b51eab2bfbcb2796bc72feec366d7e37a6cf8a11686ee8a6f14a8fc92c
-RELEASE_SHA256="$(openssl dgst -sha256 -hex "releases/$BINARY_NAME" | grep -o '\S*$')"
+RELEASE_SHA256_AMD64="$(openssl dgst -sha256 -hex "releases/$BINARY_NAME_AMD64" | grep -o '\S*$')"
 
-echo "Release SHA256: $RELEASE_SHA256"
+echo "Release SHA256: $RELEASE_SHA256_AMD64"
 
-echo "--- :octocat: Fetching current homebrew formula from Github Contents API"
+echo "--- :package: Calculating SHAs for releases/$BINARY_NAME_ARM64"
+
+buildkite-agent artifact download  --build "$ARTIFACTS_BUILD" "releases/$BINARY_NAME_ARM64" .
+
+# $ openssl dgst -sha256 -hex $FILE # portable sha256 with openssl
+# SHA256($FILE)= 26ff51b51eab2bfbcb2796bc72feec366d7e37a6cf8a11686ee8a6f14a8fc92c
+# | grep -o '\S*$' # grab the last word (some openssl versions only list the hex)
+# 26ff51b51eab2bfbcb2796bc72feec366d7e37a6cf8a11686ee8a6f14a8fc92c
+RELEASE_SHA256_ARM64="$(openssl dgst -sha256 -hex "releases/$BINARY_NAME_ARM64" | grep -o '\S*$')"
+
+echo "Release SHA256: $RELEASE_SHA256_ARM64"
+
+echo "--- :octocat: Fetching current Homebrew formula from GitHub Contents API"
+
+FORMULA_FILE=./pkg/buildkite-agent.rb
+UPDATED_FORMULA_FILE=./pkg/buildkite-agent-updated.rb
 
 CONTENTS_API_RESPONSE="$(curl "https://api.github.com/repos/buildkite/homebrew-buildkite/contents/buildkite-agent.rb" -H "Authorization: token ${GITHUB_RELEASE_ACCESS_TOKEN}")"
 
-echo "Base64 decoding Github response into $FORMULA_FILE"
+echo "Base64 decoding GitHub response into $FORMULA_FILE"
 
 mkdir -p pkg
 parse_json '["content"]' <<< "$CONTENTS_API_RESPONSE" | openssl enc -base64 -d > "$FORMULA_FILE"
@@ -83,12 +97,18 @@ echo "--- :ruby: Updating formula file"
 
 echo "Homebrew release type: $BREW_RELEASE_TYPE"
 echo "Homebrew release version: $GITHUB_RELEASE_VERSION"
-echo "Homebrew release download URL: $DOWNLOAD_URL"
-echo "Homebrew release download SHA256: $RELEASE_SHA256"
+echo "Homebrew release amd64 download URL: $DOWNLOAD_URL_AMD64"
+echo "Homebrew release amd64 download SHA256: $RELEASE_SHA256_AMD64"
+echo "Homebrew release arm64 download URL: $DOWNLOAD_URL_ARM64"
+echo "Homebrew release arm64 download SHA256: $RELEASE_SHA256_ARM64"
 
-./scripts/update-homebrew-formula.rb "$BREW_RELEASE_TYPE" "$GITHUB_RELEASE_VERSION" "$DOWNLOAD_URL" "$RELEASE_SHA256" < "$FORMULA_FILE" > "$UPDATED_FORMULA_FILE"
+./scripts/update-homebrew-formula.rb \
+  "$BREW_RELEASE_TYPE" "$GITHUB_RELEASE_VERSION" \
+  "$DOWNLOAD_URL_AMD64" "$RELEASE_SHA256_AMD64" \
+  "$DOWNLOAD_URL_ARM64" "$RELEASE_SHA256_ARM64" \
+  < "$FORMULA_FILE" > "$UPDATED_FORMULA_FILE"
 
-echo "--- :rocket: Commiting new formula to master via Github Contents API"
+echo "--- :rocket: Commiting new formula to master via GitHub Contents API"
 
 UPDATED_FORMULA_BASE64="$(openssl enc -base64 -A < "$UPDATED_FORMULA_FILE")"
 MASTER_FORMULA_SHA="$(parse_json '["sha"]' <<< "$CONTENTS_API_RESPONSE")"
@@ -106,7 +126,7 @@ JSON
 
 
 if [[ "${DRY_RUN:-}" == "false" ]] ; then
-  echo "Posting JSON to Github Contents API"
+  echo "Posting JSON to GitHub Contents API"
   curl -X PUT "https://api.github.com/repos/buildkite/homebrew-buildkite/contents/buildkite-agent.rb" \
       -H "Authorization: token ${GITHUB_RELEASE_ACCESS_TOKEN}" \
       -H "Content-Type: application/json" \

--- a/scripts/update-homebrew-formula.rb
+++ b/scripts/update-homebrew-formula.rb
@@ -6,24 +6,39 @@
 #
 #   stable do
 #     version "..."
-#     url     "..."
-#     sha256  "..."
+#     if Hardware::CPU.arm?
+#       url     "..."
+#       sha256  "..."
+#     else
+#       url     "..."
+#       sha256  "..."
+#     end
 #   end
 #
 #   devel do
 #     version "..."
-#     url     "..."
-#     sha256  "..."
+#     if Hardware::CPU.arm?
+#       url     "..."
+#       sha256  "..."
+#     else
+#       url     "..."
+#       sha256  "..."
+#     end
 #   end
 
-release, version, url, sha256 = ARGV
+release, version, amd64_url, amd64_sha256, arm64_url, arm64_sha256 = ARGV
 
 print $stdin.read.sub(%r{
   (
     #{release} \s+ do      .*?
       version \s+ ").*?("  .*?
-      url     \s+ ").*?("  .*?
-      sha256  \s+ ").*?("  .*?
+      if Hardware::CPU.arm\?
+        url     \s+ ").*?("  .*?
+        sha256  \s+ ").*?("  .*?
+      else
+        url     \s+ ").*?("  .*?
+        sha256  \s+ ").*?("  .*?
+      end
     end
   )
-}xm, "\\1#{version}\\2#{url}\\3#{sha256}\\4")
+}xm, "\\1#{version}\\2#{arm64_url}\\3#{arm64_sha256}\\4#{amd64_url}\\5#{amd64_sha256}\\6")

--- a/scripts/update-homebrew-formula.rb
+++ b/scripts/update-homebrew-formula.rb
@@ -32,13 +32,13 @@ print $stdin.read.sub(%r{
   (
     #{release} \s+ do      .*?
       version \s+ ").*?("  .*?
-      if Hardware::CPU.arm\?
+      if \s+ Hardware::CPU.arm\? .*?
         url     \s+ ").*?("  .*?
         sha256  \s+ ").*?("  .*?
-      else
+      else .*?
         url     \s+ ").*?("  .*?
         sha256  \s+ ").*?("  .*?
-      end
-    end
+      end .*?
+    end .*?
   )
 }xm, "\\1#{version}\\2#{arm64_url}\\3#{arm64_sha256}\\4#{amd64_url}\\5#{amd64_sha256}\\6")


### PR DESCRIPTION
This attempts to add arm64 build support to the release-homebrew step

Depends on buildkite/homebrew-buildkite#19, and needs some testing!