### PR TITLE
enable DRY_RUN in the build pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  DRY_RUN: false # set to true to disable publishing releases
+  DRY_RUN: true # set to true to disable publishing releases
 
 steps:
   - name: ":hammer: :linux:"


### PR DESCRIPTION
This will mean all release steps have no publicly visible effect. This will enable @ticky and I to confirm the proposed changes to the homebrew release script will work as we hope.

Once we've finished changing the homebrew release script, this commit can be reversed.