### PR TITLE
go back to allowing real releases

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  DRY_RUN: true # set to true to disable publishing releases
+  DRY_RUN: false # set to true to disable publishing releases
 
 steps:
   - name: ":hammer: :linux:"

--- a/agent/version.go
+++ b/agent/version.go
@@ -8,7 +8,7 @@ import "runtime"
 //
 // On CI, the binaries are always build with the buildVersion variable set.
 
-var baseVersion string = "3.26.1"
+var baseVersion string = "3.26.0"
 var buildVersion string = ""
 
 func Version() string {


### PR DESCRIPTION
We temporarily enabled DRY_RUN mode while @ticky and I prepared a change to the homebrew release script (#1346). That change has merged, so we can allow real releases again.

I've also bumped the version back down to match the current release so the CD pipeline won't try to release new experimental versions that have low value.