### PR TITLE
Use Docker CLI packages, update Docker Compose, and update centos to 8.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /.agent.*.conf
 /.buildkite-agent.cfg
 /.vagrant
-packaging/docker/alpine-linux/buildkite-agent
-packaging/docker/ubuntu-linux/buildkite-agent
+packaging/docker/*/buildkite-agent
+packaging/docker/*/hooks/
 
 .idea

--- a/packaging/docker/alpine-linux/Dockerfile
+++ b/packaging/docker/alpine-linux/Dockerfile
@@ -2,20 +2,20 @@ FROM alpine:3.12
 
 RUN apk add --no-cache \
       bash \
-      git \
-      perl \
-      rsync \
-      openssh-client \
       curl \
-      docker \
+      docker-cli \
       docker-compose \
+      git \
       jq \
-      su-exec \
-      py-pip \
       libc6-compat \
+      perl \
+      py-pip \
+      rsync \
       run-parts \
+      su-exec \
       tini \
-      tzdata
+      tzdata \
+      openssh-client
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg
 

--- a/packaging/docker/alpine-linux/Dockerfile
+++ b/packaging/docker/alpine-linux/Dockerfile
@@ -8,14 +8,14 @@ RUN apk add --no-cache \
       git \
       jq \
       libc6-compat \
+      openssh-client \
       perl \
       py-pip \
       rsync \
       run-parts \
       su-exec \
       tini \
-      tzdata \
-      openssh-client
+      tzdata
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg
 

--- a/packaging/docker/centos-linux/Dockerfile
+++ b/packaging/docker/centos-linux/Dockerfile
@@ -1,24 +1,28 @@
-FROM centos:7.7.1908
+FROM centos:8.3.2011
+
+ENV DOCKER_COMPOSE_VERSION=1.27.4
+ENV TINI_VERSION=0.19.0
 
 RUN yum -y install \
-      curl \
-      ca-certificates \
       bash \
+      ca-certificates \
+      crontabs \
+      curl \
+      epel-release \
       git \
+      jq \
+      openssh-clients \
       perl \
       rsync \
-      openssh-clients \
-      curl \
-      crontabs \
-      epel-release \
+      yum-utils \
     && yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo \
-    && yum -y install docker-ce jq \
+    && yum -y install docker-ce-cli \
     && yum clean all \
     && rm -rf /var/cache/yum*
 
-RUN curl -Lfs -o /sbin/tini  https://github.com/krallin/tini/releases/download/v0.18.0/tini \
+RUN curl -Lfs -o /sbin/tini  https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
     && chmod +x /sbin/tini \
-    && curl -Lfs https://github.com/docker/compose/releases/download/1.24.0/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
+    && curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \

--- a/packaging/docker/ubuntu-linux/Dockerfile
+++ b/packaging/docker/ubuntu-linux/Dockerfile
@@ -1,23 +1,31 @@
 FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV DOCKER_COMPOSE_VERSION=1.27.4
+ENV TINI_VERSION=0.19.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+      apt-transport-https \
       curl \
       ca-certificates \
       bash \
       git \
+      gnupg-agent \
+      jq \
+      openssh-client \
       perl \
       rsync \
-      openssh-client \
-      curl \
-      docker.io \
-      jq \
+      software-properties-common \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+    && add-apt-repository \
+      "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce-cli \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -Lfs -o /sbin/tini  https://github.com/krallin/tini/releases/download/v0.18.0/tini \
+RUN curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
     && chmod +x /sbin/tini \
-    && curl -Lfs https://github.com/docker/compose/releases/download/1.24.0/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
+    && curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \


### PR DESCRIPTION
This basically replaces #1214 as it seems to be abandoned and we would really like to see the Docker Compose version upgraded.

This PR upgrades de `tini` and `docker-compose` binaries to their newest versions on Ubuntu & CentOS. It also replaces the deprecated `docker.io` package with the installation method described on https://docs.docker.com/engine/install/ubuntu/ for Ubuntu.

The big difference with this PR in comparison to #1214 is the bare inclusion of Docker's CLI packages. No longer is the whole Docker engine included, as I suspect most people will just bind mount the socket inside the Docker container. Please let me know if this is undesirable somehow, then I will add the engine back.

Centos is also bumped from 7.x to 8.x, the current stable release.