### PR TITLE
Have ArtifactUploader follow symlinks

### DIFF
--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -110,7 +110,7 @@ func (a *ArtifactUploader) Collect() (artifacts []*api.Artifact, err error) {
 
 		// Resolve the globs (with * and ** in them), if it's a non-globbed path and doesn't exists
 		// then we will get the ErrNotExist that is handled below
-		files, err := zglob.Glob(globPath)
+		files, err := zglob.GlobFollowSymlinks(globPath)
 		if err == os.ErrNotExist {
 			a.logger.Info("File not found: %s", globPath)
 			continue

--- a/agent/artifact_uploader_test.go
+++ b/agent/artifact_uploader_test.go
@@ -109,14 +109,14 @@ func TestCollect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 4, len(artifactsWithoutExperimentEnabled))
+	assert.Equal(t, 6, len(artifactsWithoutExperimentEnabled))
 
 	experiments.Enable(`normalised-upload-paths`)
 	artifactsWithExperimentEnabled, err := uploader.Collect()
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 4, len(artifactsWithExperimentEnabled))
+	assert.Equal(t, 6, len(artifactsWithExperimentEnabled))
 
 	// These test cases use filepath.Join, which uses per-OS path separators;
 	// this is the behaviour without normalised-upload-paths.
@@ -201,8 +201,8 @@ func TestCollectWithSomeGlobsThatDontMatchAnything(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(artifacts) != 3 {
-		t.Fatalf("Expected to match 3 artifacts, found %d", len(artifacts))
+	if len(artifacts) != 5 {
+		t.Fatalf("Expected to match 5 artifacts, found %d", len(artifacts))
 	}
 }
 
@@ -234,6 +234,8 @@ func TestCollectWithDuplicateMatches(t *testing.T) {
 			filepath.Join("test", "fixtures", "artifacts", "Mr Freeze.jpg"),
 			filepath.Join("test", "fixtures", "artifacts", "folder", "Commando.jpg"),
 			filepath.Join("test", "fixtures", "artifacts", "this is a folder with a space", "The Terminator.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "links", "terminator", "terminator2.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "links", "folder-link", "terminator2.jpg"),
 		},
 		paths,
 	)

--- a/test/fixtures/artifacts/links/folder-link
+++ b/test/fixtures/artifacts/links/folder-link
@@ -1,0 +1,1 @@
+terminator

--- a/test/fixtures/artifacts/links/terminator/terminator2.jpg
+++ b/test/fixtures/artifacts/links/terminator/terminator2.jpg
@@ -1,0 +1,1 @@
+../../this is a folder with a space/The Terminator.jpg


### PR DESCRIPTION
Currently when specifying `artifact_paths:` in a step if the path contains a symbolic link the path pointed to by the symbolic link isn't followed and those files are excluded from the upload.

This PR updates the behavior of the artifact uploader to follow symbolic links if they are present in the glob path.