### PR TITLE
S3 uploader: load BUILDKITE_S3_SESSION_TOKEN

### DIFF
--- a/agent/s3.go
+++ b/agent/s3.go
@@ -31,6 +31,8 @@ func (e *credentialsProvider) Retrieve() (creds credentials.Value, err error) {
 		creds.SecretAccessKey = os.Getenv("BUILDKITE_S3_SECRET_KEY")
 	}
 
+	creds.SessionToken = os.Getenv("BUILDKITE_S3_SESSION_TOKEN")
+
 	if creds.AccessKeyID == "" {
 		err = errors.New("BUILDKITE_S3_ACCESS_KEY_ID or BUILDKITE_S3_ACCESS_KEY not found in environment")
 	}

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -37,6 +37,10 @@ Example:
    $ export BUILDKITE_S3_ACL=private # default is public-read
    $ buildkite-agent artifact upload "log/**/*.log" s3://name-of-your-s3-bucket/$BUILDKITE_JOB_ID
 
+   You can use Amazon IAM assumed roles by specifying the session token:
+
+   $ export BUILDKITE_S3_SESSION_TOKEN=zzz
+
    Or upload directly to Google Cloud Storage:
 
    $ export BUILDKITE_GS_ACL=private


### PR DESCRIPTION
Allows BuildKite pipelines to upload artifacts using AssumedRoles.

Closes #1357 