### PR TITLE
Use core.symlinks to attempt symlink testing on Windows

### DIFF
--- a/.buildkite/image-builder/bootstrap.ps1
+++ b/.buildkite/image-builder/bootstrap.ps1
@@ -10,7 +10,8 @@ $Env:Path = "C:\GoPath\bin;" + $Env:Path
 [Environment]::SetEnvironmentVariable('GOPATH', $Env:GOPATH, [EnvironmentVariableTarget]::Machine)
 [Environment]::SetEnvironmentVariable('Path', $env:PATH, [EnvironmentVariableTarget]::Machine)
 
-git config --global core.symlinks true
+Write-Output "Configuring core.symlinks = true"
+git config --system core.symlinks true
 
 Write-Output "github.com/buildkite/agent: cloning into git-mirrors"
 git clone -v --mirror -- `

--- a/.buildkite/image-builder/bootstrap.ps1
+++ b/.buildkite/image-builder/bootstrap.ps1
@@ -10,6 +10,8 @@ $Env:Path = "C:\GoPath\bin;" + $Env:Path
 [Environment]::SetEnvironmentVariable('GOPATH', $Env:GOPATH, [EnvironmentVariableTarget]::Machine)
 [Environment]::SetEnvironmentVariable('Path', $env:PATH, [EnvironmentVariableTarget]::Machine)
 
+git config --global core.symlinks true
+
 Write-Output "github.com/buildkite/agent: cloning into git-mirrors"
 git clone -v --mirror -- `
   "git://github.com/buildkite/agent.git" `


### PR DESCRIPTION
_This is not a code change since this bootstrapper is managed manually (for now)._ 

The build is currently broken because (my hypothesis) the symlink changes introduced in 029676f131e776a2f580d38cd6ccf94a815067c8 were expected to work on Windows. We need to enable `core.symlinks` to correctly checkout the symlinks on the Windows platform ([here's a StackOverflow](https://stackoverflow.com/questions/5917249/git-symlinks-in-windows/59761201), here be dragons). This _does_ expect that Windows checkouts are run as Administrator, _unless_ [developer mode](https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/) is already activated on Windows Server Core AMIs (probably not?)