### PR TITLE
systemctl disable via template and symlinks

### DIFF
--- a/packaging/linux/scripts/before-remove.sh
+++ b/packaging/linux/scripts/before-remove.sh
@@ -17,7 +17,7 @@ if command -v systemctl > /dev/null; then
   systemctl --no-reload disable buildkite-agent || :
   systemctl stop buildkite-agent || :
 
-  systemctl --no-reload disable "buildkite-agent@*" || :
+  systemctl --no-reload disable "buildkite-agent@" || :
   systemctl stop "buildkite-agent@*" || :
 elif [ $BK_UPSTART_EXISTS -eq 0 ] && [ $BK_UPSTART_TOO_OLD -eq 0 ]; then
   echo "Stopping buildkite-agent upstart service"


### PR DESCRIPTION
`systemctl disable` doesn't accept wildcards (unlike start/stop/etc) but:

> Note that this removes all symlinks to matching unit files, including manually created symlinks, and not just those actually created by enable or link.

https://www.freedesktop.org/software/systemd/man/systemctl.html#disable%20UNIT…

so we can disable the template and that should remove all symlinked instances.

Fixes #1370.