### PR TITLE
collect instance-life-cycle as a default tag on EC2 instances

### DIFF
--- a/agent/ec2_meta_data.go
+++ b/agent/ec2_meta_data.go
@@ -40,7 +40,6 @@ func (e EC2MetaData) Get() (map[string]string, error) {
 	if err != nil {
 		return metaData, err
 	}
-
 	metaData["aws:instance-id"] = string(instanceId)
 
 	instanceType, err := c.GetMetadata("instance-type")
@@ -54,6 +53,11 @@ func (e EC2MetaData) Get() (map[string]string, error) {
 		return metaData, err
 	}
 	metaData["aws:ami-id"] = string(amiId)
+
+	instanceLifeCycle, err := c.GetMetadata("instance-life-cycle")
+	if err == nil {
+		metaData["aws:instance-life-cycle"] = string(instanceLifeCycle)
+	}
 
 	return metaData, nil
 }

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -239,7 +239,7 @@ var AgentStartCommand = cli.Command{
 		cli.StringSliceFlag{
 			Name:   "tags-from-ec2-meta-data",
 			Value:  &cli.StringSlice{},
-			Usage:  "Include the default set of host EC2 meta-data as tags (instance-id, instance-type, and ami-id)",
+			Usage:  "Include the default set of host EC2 meta-data as tags (instance-id, instance-type, ami-id, and instance-life-cycle)",
 			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_EC2_META_DATA",
 		},
 		cli.StringSliceFlag{


### PR DESCRIPTION
When the agent is started with the --tags-from-ec2-meta-data flag it collects a default set of agent tags by querying the instance metadata service.

This adds a new tag to the default set - aws:instance-life-cycle. The tag value will be either "on-demand" or "spot", which can be useful to debugging."on-demand" or "spot", which can be useful to debugging.

The instance-life-cycle metadata key was [added in IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html). I'm not 100% sure what will happen if the agent runs on an instance with only IMDSv1. I added the new code at the end of the method, so I suspect the new tag will just be missing on those agents.

Here's the output starting an agent built with this branch:

    $ ./buildkite-agent start --build-path=~/foo --token=xxx --tags-from-ec2-meta-data=true

       _           _ _     _ _    _ _                                _
      | |         (_) |   | | |  (_) |                              | |
      | |__  _   _ _| | __| | | ___| |_ ___    __ _  __ _  ___ _ __ | |_
      | '_ \| | | | | |/ _` | |/ / | __/ _ \  / _` |/ _` |/ _ \ '_ \| __|
      | |_) | |_| | | | (_| |   <| | ||  __/ | (_| | (_| |  __/ | | | |_
      |_.__/ \__,_|_|_|\__,_|_|\_\_|\__\___|  \__,_|\__, |\___|_| |_|\__|
                                                     __/ |
     https://buildkite.com/agent                    |___/

    2021-02-03 11:57:51 NOTICE Starting buildkite-agent v3.27.0 with PID: 2175
    2021-02-03 11:57:51 NOTICE The agent source code can be found here: https://github.com/buildkite/agent/v3
    2021-02-03 11:57:51 NOTICE For questions and support, email us at: hello@buildkite.com
    2021-02-03 11:57:51 INFO   Fetching EC2 meta-data...
    2021-02-03 11:57:51 INFO   Successfully fetched EC2 meta-data
    2021-02-03 11:57:51 INFO   Registering agent with Buildkite...
    2021-02-03 11:57:52 INFO   Successfully registered agent "ip-172-31-87-129" with tags [aws:instance-type=t3.medium, aws:ami-id=ami-0885b1f6bd170450c, aws:instance-life-cycle=on-demand, aws:instance-id=i-0d55d5962c54f30b3]
    2021-02-03 11:57:52 INFO   Starting 1 Agent(s)
    2021-02-03 11:57:52 INFO   You can press Ctrl-C to stop the agents
    2021-02-03 11:57:52 INFO   ip-172-31-87-129 Connecting to Buildkite...
    2021-02-03 11:57:52 INFO   ip-172-31-87-129 Waiting for work...