### PR TITLE
Allow using the spawn index in the agent name

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -10,6 +10,8 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -730,6 +732,9 @@ var AgentStartCommand = cli.Command{
 			} else {
 				l.Info("Registering agent %d of %d with Buildkite...", i, cfg.Spawn)
 			}
+
+			// Handle per-spawn name interpolation, replacing %spawn with the spawn index
+			registerReq.Name = strings.ReplaceAll(cfg.Name, "%spawn", strconv.Itoa(i))
 
 			// Register the agent with the buildkite API
 			ag, err := agent.Register(l, client, registerReq)


### PR DESCRIPTION
This allows using the special token `%spawn` in the agent name, which will locally substitute the spawned worker index.