### PR TITLE
pipeline_parser_test decouple from environment

### DIFF
--- a/agent/pipeline_parser.go
+++ b/agent/pipeline_parser.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 
@@ -25,7 +24,7 @@ type PipelineParser struct {
 
 func (p PipelineParser) Parse() (*PipelineParserResult, error) {
 	if p.Env == nil {
-		p.Env = env.FromSlice(os.Environ())
+		p.Env = env.New()
 	}
 
 	var errPrefix string


### PR DESCRIPTION
`PipelineParser` no longer loads system env by default. There is no non-test code relying on the default.

The only real caller of `PipelineParser` is `clicommand/pipeline_upload.go`, which manually passes a (potentially modified) system environment.

The only other caller is `agent/pipeline_parser_test.go`, and defaulting to system environment in tests makes them fragile. Currently they're breaking due to `BUILDKITE_TRACE_CONTEXT` leaking in from outside.

So, this PR defaults `PipelineParser` to an empty environment, and adjusts the tests accordingly. It also normalises PipelineParser syntax/whitespace in the tests, which accounts for many lines of code — I recommend viewing 347ae27fcafca2910b72ab1064634789c92a8bfd separately.

Before:

```
pda@paulbookpro ~/bk/agent $ BUILDKITE_TRACE_CONTEXT=foo go test ./agent -run TestPipelineParserSupportsYamlMergesAndAnchors -count 1
--- FAIL: TestPipelineParserSupportsYamlMergesAndAnchors (0.00s)
    pipeline_parser_test.go:61:
                Error Trace:    pipeline_parser_test.go:61
                Error:          Not equal:
                                expected: "{\"base_step\":{\"type\":\"script\",\"agent_query_rules\":[\"queue=default\"]},\"steps\":[{\"type\":\"script\",\"agent_query_rules\":[\"queue=default\"],\"name\":\":docker: building image\",\"command\":\"docker build .\",\"agents\":{\"queue\":\"default\"}}]}"
                                actual  : "{\"base_step\":{\"type\":\"script\",\"agent_query_rules\":[\"queue=default\"]},\"steps\":[{\"type\":\"script\",\"agent_query_rules\":[\"queue=default\"],\"name\":\":docker: building image\",\"command\":\"docker build .\",\"agents\":{\"queue\":\"default\"}}],\"env\":{\"BUILDKITE_TRACE_CONTEXT\":\"foo\"}}"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -{"base_step":{"type":"script","agent_query_rules":["queue=default"]},"steps":[{"type":"script","agent_query_rules":["queue=default"],"name":":docker: building image","command":"docker build .","agents":{"queue":"default"}}]}
                                +{"base_step":{"type":"script","agent_query_rules":["queue=default"]},"steps":[{"type":"script","agent_query_rules":["queue=default"],"name":":docker: building image","command":"docker build .","agents":{"queue":"default"}}],"env":{"BUILDKITE_TRACE_CONTEXT":"foo"}}
                Test:           TestPipelineParserSupportsYamlMergesAndAnchors
FAIL
FAIL    github.com/buildkite/agent/v3/agent     0.177s
FAIL
```

After:

```
pda@paulbookpro ~/bk/agent $ BUILDKITE_TRACE_CONTEXT=foo go test ./agent -run TestPipelineParserSupportsYamlMergesAndAnchors -count 1
ok      github.com/buildkite/agent/v3/agent     0.173s
```