### PR TITLE
support mips64le architecture target.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -116,6 +116,16 @@ steps:
         config: .buildkite/docker-compose.yml
         run: agent
 
+  - name: ":linux: mips64le"
+    command: ".buildkite/steps/build-binary.sh linux mips64le"
+    key: build-binary-linux-mips64le
+    depends_on: test-linux # don't wait for slower windows tests
+    artifact_paths: "pkg/*"
+    plugins:
+      docker-compose#v3.0.0:
+        config: .buildkite/docker-compose.yml
+        run: agent
+
   - name: ":mac: amd64"
     command: ".buildkite/steps/build-binary.sh darwin amd64"
     key: build-binary-darwin-amd64
@@ -265,6 +275,7 @@ steps:
       - build-binary-linux-armhf
       - build-binary-linux-arm64
       - build-binary-linux-ppc64le
+      - build-binary-linux-mips64le
       - build-binary-darwin-amd64
       - build-binary-darwin-arm64
       - build-binary-freebsd-amd64

--- a/install.sh
+++ b/install.sh
@@ -63,6 +63,7 @@ else
     *arm*)     ARCH="arm"     ;;
     *ppc64le*) ARCH="ppc64le" ;;
     *aarch64*) ARCH="arm64"   ;;
+    *mips64*) ARCH="mips64le" ;;
     *)
       ARCH="386"
       echo -e "\n\033[36mWe don't recognise the $MACHINE architecture; falling back to $ARCH\033[0m"


### PR DESCRIPTION
I am going to submit mips64le architecture，The main reasons are:
1、The mips64le architecture is also the mainstream cpu architecture (amd64, arm64), which is used by many users;
2、Golang supports cross compilation, and mips64le is officially supported;
Therefore, I hope that the release package also supports the mips64le architecture, which is convenient for more users.
Build result：
![buildkit-agent](https://user-images.githubusercontent.com/60801291/107099750-7b940200-684d-11eb-999f-7288c55ec5c5.png)


Signed-off-by: houfangdong houfangdong@loongson.com