### PR TITLE
Export current plugin name and Configuration

### DIFF
--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -258,6 +258,16 @@ func (p *Plugin) ConfigurationToEnvironment() (*env.Environment, error) {
 	// Sort them into a consistent order
 	sort.Strings(envSlice)
 
+	// Append current plugin name
+	envSlice = append(envSlice, fmt.Sprintf("BUILDKITE_PLUGIN_NAME=%s", formatEnvKey(p.Name())))
+
+	// Append current plugin configuration as JSON
+	configJson, err := json.Marshal(p.Configuration)
+	if err != nil {
+		return nil, err
+	}
+	envSlice = append(envSlice, fmt.Sprintf("BUILDKITE_PLUGIN_CONFIGURATION=%s", configJson))
+
 	return env.FromSlice(envSlice), nil
 }
 

--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -286,61 +286,83 @@ func TestConfigurationToEnvironment(t *testing.T) {
 
 	envMap, err = pluginEnvFromConfig(t, `{ "config-key": 42 }`)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_KEY=42"}, envMap.ToSlice())
+	assert.Equal(t, []string{
+		"BUILDKITE_PLUGIN_CONFIGURATION={\"config-key\":42}",
+		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_KEY=42",
+		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
+	}, envMap.ToSlice())
 
 	envMap, err = pluginEnvFromConfig(t, `{ "container": "app", "some-other-setting": "else right here" }`)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{
+		"BUILDKITE_PLUGIN_CONFIGURATION={\"container\":\"app\",\"some-other-setting\":\"else right here\"}",
 		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONTAINER=app",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_SOME_OTHER_SETTING=else right here"},
-		envMap.ToSlice())
+		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_SOME_OTHER_SETTING=else right here",
+		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
+	}, envMap.ToSlice())
 
 	envMap, err = pluginEnvFromConfig(t, `{ "and _ with a    - number": 12 }`)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"BUILDKITE_PLUGIN_DOCKER_COMPOSE_AND_WITH_A_NUMBER=12"}, envMap.ToSlice())
+	assert.Equal(t, []string{
+		"BUILDKITE_PLUGIN_CONFIGURATION={\"and _ with a    - number\":12}",
+		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_AND_WITH_A_NUMBER=12",
+		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
+	}, envMap.ToSlice())
 
 	envMap, err = pluginEnvFromConfig(t, `{ "bool-true-key": true, "bool-false-key": false }`)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{
+		"BUILDKITE_PLUGIN_CONFIGURATION={\"bool-false-key\":false,\"bool-true-key\":true}",
 		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_BOOL_FALSE_KEY=false",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_BOOL_TRUE_KEY=true"},
-		envMap.ToSlice())
+		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_BOOL_TRUE_KEY=true",
+		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
+	}, envMap.ToSlice())
 
 	envMap, err = pluginEnvFromConfig(t, `{ "array-key": [ "array-val-1", "array-val-2" ] }`)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{
+		"BUILDKITE_PLUGIN_CONFIGURATION={\"array-key\":[\"array-val-1\",\"array-val-2\"]}",
 		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0=array-val-1",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_1=array-val-2"},
-		envMap.ToSlice())
+		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_1=array-val-2",
+		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
+	}, envMap.ToSlice())
 
 	envMap, err = pluginEnvFromConfig(t, `{ "array-key": [ 42, 43, 44 ] }`)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{
+		"BUILDKITE_PLUGIN_CONFIGURATION={\"array-key\":[42,43,44]}",
 		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0=42",
 		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_1=43",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_2=44"},
-		envMap.ToSlice())
+		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_2=44",
+		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
+	}, envMap.ToSlice())
 
 	envMap, err = pluginEnvFromConfig(t, `{ "array-key": [ 42, 43, "foo" ] }`)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{
+		"BUILDKITE_PLUGIN_CONFIGURATION={\"array-key\":[42,43,\"foo\"]}",
 		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0=42",
 		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_1=43",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_2=foo"},
-		envMap.ToSlice())
+		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_2=foo",
+		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
+	}, envMap.ToSlice())
 
 	envMap, err = pluginEnvFromConfig(t, `{ "array-key": [ { "subkey": "subval" } ] }`)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0_SUBKEY=subval"},
-		envMap.ToSlice())
+		"BUILDKITE_PLUGIN_CONFIGURATION={\"array-key\":[{\"subkey\":\"subval\"}]}",
+		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0_SUBKEY=subval",
+		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
+	}, envMap.ToSlice())
 
 	envMap, err = pluginEnvFromConfig(t, `{ "array-key": [ { "subkey": [1, 2, "llamas"] } ] }`)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{
+		"BUILDKITE_PLUGIN_CONFIGURATION={\"array-key\":[{\"subkey\":[1,2,\"llamas\"]}]}",
 		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0_SUBKEY_0=1",
 		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0_SUBKEY_1=2",
 		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0_SUBKEY_2=llamas",
+		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
 	}, envMap.ToSlice())
 }
 


### PR DESCRIPTION
Experimental - see https://forum.buildkite.community/t/native-support-for-golang-plugins/776/5

tl;dr:
Exposes two new environment variables to plugins:

* `BUILDKITE_PLUGIN_NAME` - The "env key compatible" version of the current plugin name - that's what's being used to construct the `BUILDKITE_PLUGIN_<name>_<param>` variables
* `BUILDKITE_PLUGIN_CONFIGURATION` - JSON string holding the current plugin's configuration (as opposed to all the plugin configs as found in `BUILDKITE_PLUGINS`