### PR TITLE
switch to golang 1.16 for running tests and compiling binaries

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -2,20 +2,7 @@ version: '3.5'
 
 services:
   agent:
-    image: golang:1.15@sha256:1ba0da74b20aad52b091877b0e0ece503c563f39e37aa6b0e46777c4d820a2ae
-    volumes:
-      - ../:/work:cached
-    working_dir: /work
-    environment:
-      - BUILDKITE_BUILD_NUMBER
-      - BUILDKITE_JOB_ID
-      - "BUILDKITE_AGENT_TAGS=queue=default"
-      - "BUILDKITE_BUILD_PATH=/buildkite"
-
-  # a temporary service for building a mac+arm binary. We can drop this once the above service
-  # is using 1.16+
-  agent1-16:
-    image: golang:1.16rc1-buster@sha256:924e207d894369efb63d996a9fcf430b2a452c38bd1227d0cf20c0cf55f32f19
+    image: golang:1.16@sha256:f3f90f4d30866c1bdae90012b506bd5e557ce27ccd2510ed30a011c44c1affc8
     volumes:
       - ../:/work:cached
     working_dir: /work

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -134,7 +134,7 @@ steps:
     plugins:
       docker-compose#v3.0.0:
         config: .buildkite/docker-compose.yml
-        run: agent1-16
+        run: agent
 
   - name: ":freebsd: amd64"
     command: ".buildkite/steps/build-binary.sh freebsd amd64"


### PR DESCRIPTION
1.16.0 was released today. It includes official support for cross compiling for macos m1 systems, so we can remove the special case that built that particular binary using a pre-release of go.

I used [dfresh](https://github.com/realestate-com-au/dfresh) to get the correct image sha:

```
$ dfresh resolve golang:1.16
golang:1.16@sha256:f3f90f4d30866c1bdae90012b506bd5e557ce27ccd2510ed30a011c44c1affc8
``` 