### PR TITLE
bump agent version to include -pre

### DIFF
--- a/agent/version.go
+++ b/agent/version.go
@@ -8,7 +8,7 @@ import "runtime"
 //
 // On CI, the binaries are always build with the buildVersion variable set.
 
-var baseVersion string = "3.27.0"
+var baseVersion string = "3.28.0.pre"
 var buildVersion string = ""
 
 func Version() string {


### PR DESCRIPTION
Bumping this to be higher than the current released version will mean our build/release pipeline starts releasing each main build as an experimental release that's available to customers.