### PR TITLE
Fix the current beta version

### DIFF
--- a/agent/version.go
+++ b/agent/version.go
@@ -7,8 +7,10 @@ import "runtime"
 //  go run -ldflags "-X github.com/buildkite/agent/v3/agent.buildVersion abc" *.go --version
 //
 // On CI, the binaries are always build with the buildVersion variable set.
+//
+// Pre-release builds' versions must be in the format `x.y-beta`, `x.y-beta.z` or `x.y-beta.z.a`
 
-var baseVersion string = "3.28.0.pre"
+var baseVersion string = "3.28.0-beta.1"
 var buildVersion string = ""
 
 func Version() string {

--- a/agent/version_test.go
+++ b/agent/version_test.go
@@ -1,0 +1,12 @@
+package agent
+
+import (
+  "testing"
+
+  "github.com/stretchr/testify/assert"
+)
+
+func TestVersionIsValid(t *testing.T) {
+	// Making sure the version string matches `1.2.3`, `1.2.3-beta`, `1.2.3-beta.1` or `1.2-beta.1`
+	assert.Regexp(t, `\A(?:\d+\.){1,2}\d+(?:-[a-zA-Z]+(?:\.\d+)?)?\z`, Version())
+}


### PR DESCRIPTION
The current version string isn't valid and doesn't parse on the Buildkite end, so `3.28.0.pre` agents cannot register

This fixes the version string to be valid, and adds a note about valid version strings to version.go