### PR TITLE
Use new client-side %spawn not server-side %n in default configs

### DIFF
--- a/packaging/docker/alpine-linux/buildkite-agent.cfg
+++ b/packaging/docker/alpine-linux/buildkite-agent.cfg
@@ -2,7 +2,7 @@
 #token="xxx"
 
 # The name of the agent
-name="%hostname-%n"
+name="%hostname-%spawn"
 
 # The number of agents to spawn in parallel (default is "1")
 # spawn=1

--- a/packaging/docker/centos-linux/buildkite-agent.cfg
+++ b/packaging/docker/centos-linux/buildkite-agent.cfg
@@ -2,7 +2,7 @@
 #token="xxx"
 
 # The name of the agent
-name="%hostname-%n"
+name="%hostname-%spawn"
 
 # The number of agents to spawn in parallel (default is "1")
 # spawn=1

--- a/packaging/docker/sidecar/buildkite-agent.cfg
+++ b/packaging/docker/sidecar/buildkite-agent.cfg
@@ -2,7 +2,7 @@
 #token="xxx"
 
 # The name of the agent
-name="%hostname-%n"
+name="%hostname-%spawn"
 
 # The number of agents to spawn in parallel (default is "1")
 # spawn=1

--- a/packaging/docker/ubuntu-linux/buildkite-agent.cfg
+++ b/packaging/docker/ubuntu-linux/buildkite-agent.cfg
@@ -2,7 +2,7 @@
 #token="xxx"
 
 # The name of the agent
-name="%hostname-%n"
+name="%hostname-%spawn"
 
 # The number of agents to spawn in parallel (default is "1")
 # spawn=1

--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -2,7 +2,7 @@
 token="xxx"
 
 # The name of the agent
-name="%hostname-%n"
+name="%hostname-%spawn"
 
 # The number of agents to spawn in parallel (default is "1")
 # spawn=1

--- a/packaging/github/windows/buildkite-agent.cfg
+++ b/packaging/github/windows/buildkite-agent.cfg
@@ -2,7 +2,7 @@
 token="xxx"
 
 # The name of the agent
-name="%hostname-%n"
+name="%hostname-%spawn"
 
 # The number of agents to spawn in parallel (default is "1")
 # spawn=1

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -2,7 +2,7 @@
 token="xxx"
 
 # The name of the agent
-name="%hostname-%n"
+name="%hostname-%spawn"
 
 # The number of agents to spawn in parallel (default is "1")
 # spawn=1


### PR DESCRIPTION
`%spawn` was introduced in 8f6ee24646d4e1f028845fab6fa987d4cebdc68e / https://github.com/buildkite/agent/pull/1377 and is resolved client-side via `buildkite-agent start --spawn <n>`. 

`%n` is resolved server-side and is considered soft-deprecated.

This PR changes the default configuration files to use `%spawn` rather than `%n`.

This has some potential for mischief if people are running multiple agents with the same name as separate processes, rather than using `--spawn`. For example `name=%hostname-%spawn` with multiple agent processes per machine. Or, if `%hostname` is replaced with a fixed value like `name=acme-%spawn` across multiple machines. In those cases, `%n` would resolve to a different number for each process, while `%spawn` would resolve to `1` in each process.

In the case of multiple agent processes named `%hostname-%spawn` running on a single host as the same user, there's potential for the different agent processes to compete for a checkout directory, overwriting files out from under each other. This is not a recommended configuration, and we believe most/all existing installs will not pick up these new configuration files anyway.

With those risks in mind, this PR is a proposal / discussion, which I'm happy to close without merging if that's the outcome.