### PR TITLE
Allow signal bootstrap sends to commands on cancel to be customized

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -509,6 +509,11 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	env["BUILDKITE_AGENT_EXPERIMENT"] = strings.Join(experiments.Enabled(), ",")
 	env["BUILDKITE_REDACTED_VARS"] = strings.Join(r.conf.AgentConfiguration.RedactedVars, ",")
 
+	// propagate CancelSignal to bootstrap, unless it's the default SIGTERM
+	if r.conf.CancelSignal != process.SIGTERM {
+		env["BUILDKITE_CANCEL_SIGNAL"] = r.conf.CancelSignal.String()
+	}
+
 	// Whether to enable profiling in the bootstrap
 	if r.conf.AgentConfiguration.Profile != "" {
 		env["BUILDKITE_AGENT_PROFILE"] = r.conf.AgentConfiguration.Profile

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -85,6 +85,7 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 
 		b.shell.PTY = b.Config.RunInPty
 		b.shell.Debug = b.Config.Debug
+		b.shell.InterruptSignal = b.Config.CancelSignal
 	}
 
 	// Listen for cancellation

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -7,6 +7,7 @@ import (
 	"log"
 
 	"github.com/buildkite/agent/v3/env"
+	"github.com/buildkite/agent/v3/process"
 )
 
 // Config provides the configuration for the Bootstrap. Some of the keys are
@@ -126,6 +127,9 @@ type Config struct {
 
 	// Phases to execute, defaults to all phases
 	Phases []string
+
+	// What signal to use for command cancellation
+	CancelSignal process.Signal
 
 	// List of environment variable globs to redact from job output
 	RedactedVars []string

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -536,7 +536,11 @@ var AgentStartCommand = cli.Command{
 
 		// Set a useful default for the bootstrap script
 		if cfg.BootstrapScript == "" {
-			cfg.BootstrapScript = fmt.Sprintf("%s bootstrap", shellwords.Quote(os.Args[0]))
+			cfg.BootstrapScript = fmt.Sprintf(
+				"%s bootstrap --cancel-signal %s",
+				shellwords.Quote(os.Args[0]),
+				cfg.CancelSignal,
+			)
 		}
 
 		// Show a warning if plugins are enabled by no-command-eval or no-local-hooks is set

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -536,11 +536,7 @@ var AgentStartCommand = cli.Command{
 
 		// Set a useful default for the bootstrap script
 		if cfg.BootstrapScript == "" {
-			cfg.BootstrapScript = fmt.Sprintf(
-				"%s bootstrap --cancel-signal %s",
-				shellwords.Quote(os.Args[0]),
-				cfg.CancelSignal,
-			)
+			cfg.BootstrapScript = fmt.Sprintf("%s bootstrap", shellwords.Quote(os.Args[0]))
 		}
 
 		// Show a warning if plugins are enabled by no-command-eval or no-local-hooks is set


### PR DESCRIPTION
Currently bootstrap sends a `SIGTERM` to commands when it, itself, is interrupted.

This adds `cancel-signal` which accepts signals in the form of SIGTERM, SIGHUP, etc.

This is the same config that `start` accepts, and is based on the PR that added that feature: https://github.com/buildkite/agent/pull/1041

Finally, `start` passes its `cancel-signal` to `bootstrap`, to prevent having to customize the `bootstrap-script`.