### PR TITLE
Propagate --no-pty to the bootstrap --pty flag

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -514,6 +514,12 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 		env["BUILDKITE_AGENT_PROFILE"] = r.conf.AgentConfiguration.Profile
 	}
 
+	// PTY-mode is enabled by default in `start` and `bootstrap`, so we only need
+	// to propagate it if it's explicitly disabled.
+	if r.conf.AgentConfiguration.RunInPty == false {
+		env["BUILDKITE_PTY"] = "false"
+	}
+
 	enablePluginValidation := r.conf.AgentConfiguration.PluginValidation
 	// Allow BUILDKITE_PLUGIN_VALIDATION to be enabled from env for easier
 	// per-pipeline testing


### PR DESCRIPTION
`buildkite-agent start` has a `--no-pty` flag which prevents the bootstrap from being run as a PTY process.

![image](https://user-images.githubusercontent.com/15759/111265307-0520c600-867d-11eb-8b8f-ba2e80a3cf02.png)

Seperately, `buildkite-agent bootstrap` has a default-true `--pty` flag which determines whether commands run _within_ the bootstrap are run as PTY processes.

Presumably, `buildkite-agent start --no-pty` should propagate to `buildkite-agent bootstrap --pty=false`, but that was not happening. That meant that builds running under `buildkite-agent start --no-pty` invoked a bootstrap as a non-PTY process, but the bootstrap invoked commands in PTY mode. On systems with no PTY capability (e.g. AWS Lambda) that was causing severe errors:

![image](https://user-images.githubusercontent.com/15759/111265574-6b0d4d80-867d-11eb-8e79-96eebd4398ed.png)

This pull request propagates the flag into the bootstrap via the internal `BUILDKITE_PTY` environment variable.

Here's that previously failing build step:

![image](https://user-images.githubusercontent.com/15759/111265824-ce977b00-867d-11eb-9f1b-340a54285942.png)
