### PR TITLE
Configure dependabot to propose update to the golang version we build with

### DIFF
--- a/.buildkite/Dockerfile-compile
+++ b/.buildkite/Dockerfile-compile
@@ -1,0 +1,1 @@
+FROM golang:1.16@sha256:f3f90f4d30866c1bdae90012b506bd5e557ce27ccd2510ed30a011c44c1affc8

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3.5'
 
 services:
   agent:
-    image: golang:1.16@sha256:f3f90f4d30866c1bdae90012b506bd5e557ce27ccd2510ed30a011c44c1affc8
+    build:
+      context: .
+      dockerfile: Dockerfile-compile
     volumes:
       - ../:/work:cached
     working_dir: /work

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/.buildkite"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This configures dependabot to propose updates to the golang version we use, but at most once per week.

The nice thing about this is we can continue to provide precise docker image digests so builds are deterministic (no failures when a docker tag is mutated with an unexpected change), but we'll also be prompted to start using golang security updates.

Unfortunately dependabot doesn't support docker compose files, so I had to add some indirection and move the base image details into a Dockerfile.