### PR TITLE
Dont print out REDACTED environment variable changes

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -421,7 +421,12 @@ func (b *Bootstrap) applyEnvironmentChanges(environ *env.Environment, dir string
 	// anything not controlled by us.
 	for k, v := range environ.ToMap() {
 		if _, ok := bootstrapConfigEnvChanges[k]; ok {
-			b.shell.Commentf("%s is now %q", k, v)
+			// Dont print REDACTED ENV changes
+			if b.shell.Env.Get("BUILDKITE_REDACTED_VARS").contains(k) {
+				b.shell.Commentf("%s changed", k)
+			} else {
+				b.shell.Commentf("%s is now %q", k, v)
+			}
 		} else {
 			b.shell.Commentf("%s changed", k)
 		}


### PR DESCRIPTION
We have a redact feature in #1109 to filter environment variables from job outputs, but when changing special (`BUILDKITE_*` envs) variables, the new value will still be printed out. 

This PR teaches this piece to avoid print out those changes if it is already marked as redacted.

