### PR TITLE
output-redactor: redact shell logger, including changed env vars

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -335,7 +335,7 @@ func (b *Bootstrap) executeHook(ctx context.Context, scope string, name string, 
 
 	b.shell.Headerf("Running %s hook", name)
 
-	redactors := b.setupRedactor()
+	redactors := b.setupRedactors()
 	defer redactors.Flush()
 
 	// We need a script to wrap the hook script so that we can snaffle the changed
@@ -1670,7 +1670,7 @@ func (b *Bootstrap) defaultCommandPhase(ctx context.Context) error {
 		cmdToExec = fmt.Sprintf(`trap 'kill -- $$' INT TERM QUIT; %s`, cmdToExec)
 	}
 
-	redactors := b.setupRedactor()
+	redactors := b.setupRedactors()
 	defer redactors.Flush()
 
 	var cmd []string
@@ -1796,11 +1796,11 @@ func (b *Bootstrap) ignoredEnv() []string {
 	return ignored
 }
 
-// setupRedactor wraps shell output and logging in Redactor if any redaction
+// setupRedactors wraps shell output and logging in Redactor if any redaction
 // is necessary based on RedactedVars configuration and the existence of
 // matching environment vars.
 // RedactorMux (possibly empty) is returned so the caller can `defer redactor.Flush()`
-func (b *Bootstrap) setupRedactor() RedactorMux {
+func (b *Bootstrap) setupRedactors() RedactorMux {
 	if experiments.IsEnabled("output-redactor") {
 		b.shell.Commentf("Using output-redactor experiment 🧪")
 	} else {
@@ -1847,7 +1847,7 @@ func (b *Bootstrap) setupRedactor() RedactorMux {
 }
 
 // Given a redaction config string and an environment map, return the list of values to be redacted.
-// Lifted out of Bootstrap.setupRedactor to facilitate testing
+// Lifted out of Bootstrap.setupRedactors to facilitate testing
 func getValuesToRedact(logger shell.Logger, patterns []string, environment map[string]string) []string {
 	var valuesToRedact []string
 

--- a/bootstrap/redactor_test.go
+++ b/bootstrap/redactor_test.go
@@ -45,3 +45,23 @@ func TestRedactorWriteBoundaries(t *testing.T) {
 		t.Errorf("Redaction failed: %s", buf.String())
 	}
 }
+
+func TestRedactorResetMidStream(t *testing.T) {
+	var buf bytes.Buffer
+	redactor := NewRedactor(&buf, "[REDACTED]", []string{"secret1111"})
+
+	// start writing to the stream (no trailing newline, to be extra tricky)
+	redactor.Write([]byte("redact secret1111 but don't redact secret2222 until"))
+
+	// update the redactor with a new secret
+	redactor.Flush() // manual flush is necessary before Reset
+	redactor.Reset([]string{"secret1111", "secret2222"})
+
+	// finish writing
+	redactor.Write([]byte(" after secret2222 is added\n"))
+	redactor.Flush()
+
+	if buf.String() != "redact [REDACTED] but don't redact secret2222 until after [REDACTED] is added\n" {
+		t.Errorf("Redaction failed: %s", buf.String())
+	}
+}


### PR DESCRIPTION
Currently the `output-redactor` only applies to `Shell.Writer`, so the output of programs run via the shell are redacted. However `Shell` also has a `Logger` which is used to show the command being run, and — importantly — to show environment variable changes after hooks run. Those environment variable changes may contain secrets, e.g. if `BUILDKITE_REPO` is changed by a hook to include a secret token in the URL.

This PR applies the redactor to `Shell.Logger` too (assuming it's a `shell.WriterLogger`, which is true except in tests). This actually requires setting up a second redactor instance, because shell's default logger outputs separately to `os.Stderr`. To manage two redactors instead of one, a `type RedactorMux []*Redactor` is introduced to multiplex `Flush()` and `Reset()` commands to both. As a bonus, this obviates some `nil` checks, because a zero-length `RedactorMux` can have methods called.

This PR also resets the redactors when environment variables change, so that new potentially-secret values are added as strings to redact.

There's non test coverage for the complete integration, but a new `TestRedactorResetMidStream` demonstrates that a redactor can indeed be flushed and reset with new strings during output streaming.

Thanks @JuanitoFatas for the concept in #1399

Here's a before/after of the bootstrap output:

![image-3](https://user-images.githubusercontent.com/15759/111606546-700fff80-882b-11eb-937f-80e9db023cc0.png)
