### PR TITLE
Explicitly set a working directory when we start the bootstrap

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -219,6 +219,7 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 	runner.process = process.New(l, process.Config{
 		Path:            cmd[0],
 		Args:            cmd[1:],
+		Dir:             conf.AgentConfiguration.BuildPath,
 		Env:             processEnv,
 		PTY:             conf.AgentConfiguration.RunInPty,
 		Stdout:          processWriter,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -25,6 +25,7 @@ import (
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/agent/v3/metrics"
 	"github.com/buildkite/agent/v3/process"
+	"github.com/buildkite/agent/v3/utils"
 	"github.com/buildkite/shellwords"
 	"github.com/urfave/cli"
 )
@@ -690,6 +691,15 @@ var AgentStartCommand = cli.Command{
 		cancelSig, err := process.ParseSignal(cfg.CancelSignal)
 		if err != nil {
 			l.Fatal("Failed to parse cancel-signal: %v", err)
+		}
+
+		// confirm the BuildPath is exists. The bootstrap is going to write to it when a job executes,
+		// so we may as well check that'll work now and fail early if it's a problem
+		if !utils.FileExists(agentConf.BuildPath) {
+			l.Info("Build Path doesn't exist, creating it (%s)", agentConf.BuildPath)
+			if err := os.MkdirAll(agentConf.BuildPath, 0777); err != nil {
+				l.Fatal("Failed to create builds path: %v", err)
+			}
 		}
 
 		// Create the API client


### PR DESCRIPTION
Currently we start the bootstrap process without an explicit working directory. Presumably the operating system assigns it one, maybe the same as the main agent process?

We've seen an example of a customer build where the default working directory for the bootstrap didn't exist. This results in a fatal exception and the job fails to run: https://github.com/buildkite/agent/blob/bed05dda2d7bfb888d80c621af827ee2bce39144/bootstrap/shell/shell.go#L62-L65

Our process abstraction supports setting an explicit working directory for the child process, so we may as well use it: https://github.com/buildkite/agent/blob/bed05dda2d7bfb888d80c621af827ee2bce39144/process/process.go#L127-L132

I've opted to use the agent build path, which should be a directory that exists. There's no real reason for the bootstrap process to start with that as the working directory, other than the fact that it should exist.

Not long after it starts, the bootstrap process will find or create the full checkout path where the source code will be cloned to, and then change its own working directory to that: https://github.com/buildkite/agent/blob/bed05dda2d7bfb888d80c621af827ee2bce39144/bootstrap/bootstrap.go#L842-L846


Our process abstraction wraps [cmd.Exec](https://golang.org/pkg/os/exec/#Cmd), which has this so say about setting the working directory:

```go
// Dir specifies the working directory of the command.
// If Dir is the empty string, Run runs the command in the
// calling process's current directory.
```