### PR TITLE
search the path for bash when the bootstrap wants to run a script

### DIFF
--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -337,7 +337,11 @@ func (s *Shell) RunScript(ctx context.Context, path string, extra *env.Environme
 		args = []string{"-file", path}
 
 	case !isWindows && isBash:
-		command = "/bin/bash"
+		bashPath, err := s.AbsolutePath("bash")
+		if err != nil {
+			return fmt.Errorf("Error finding bash, needed to run scripts: %v.", err)
+		}
+		command = bashPath
 		args = []string{"-c", path}
 
 	default:

--- a/bootstrap/shell/test.go
+++ b/bootstrap/shell/test.go
@@ -36,7 +36,9 @@ func NewTestShell(t *testing.T) *Shell {
 			"ProgramData=" + os.Getenv("ProgramData"),
 		})
 	} else {
-		sh.Env = env.New()
+		sh.Env = env.FromSlice([]string{
+			"PATH=" + os.Getenv("PATH"),
+		})
 	}
 
 	return sh


### PR DESCRIPTION
The bootstrap process runs a lot of shell scripts - all hooks and plugins are implemented as shell. Previously the bash path on non-windows was hard coded to /usr/bin, while on windows we search the path for it.

This unifies the behaviour and searches the path on not-windows (macos, linux, etc) as well.

This could be desirable in a number of situations, but one particular use case is on macos where the system bash (/bin/bash) is 3.x and newer versions can be installed elsewhere on the path by homebrew.

Note that the agent does have a `--shell` flag, which can also be set by `BUILDKITE_SHELL` env var. This controls the shell executable that's used to execute the command phase of a job. I considered looking for a way to use that config option in the plugin/hook execution as well. However, that would be complicated. We use some bash-isms in hook and plugin execution so we must use bash, yet the `--shell` flag is documented as being useful when the command phase might need to execute within a
different shell (zsh, busybox, etc).

Maybe one day we'd like to support any posix shell for hook/plugin execution (see #1200), but in the interim this change is a useful one to have.