### PR TITLE
Add *_ACCESS_KEY & *_SECRET_KEY to default redactor-var

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -420,7 +420,7 @@ var AgentStartCommand = cli.Command{
 			Name:   "redacted-vars",
 			Usage:  "Pattern of environment variable names containing sensitive values",
 			EnvVar: "BUILDKITE_REDACTED_VARS",
-			Value:  &cli.StringSlice{"*_PASSWORD", "*_SECRET", "*_TOKEN"},
+			Value:  &cli.StringSlice{"*_PASSWORD", "*_SECRET", "*_TOKEN", "*_ACCESS_KEY"},
 		},
 		cli.StringFlag{
 			Name:   "tracing-backend",

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -420,7 +420,7 @@ var AgentStartCommand = cli.Command{
 			Name:   "redacted-vars",
 			Usage:  "Pattern of environment variable names containing sensitive values",
 			EnvVar: "BUILDKITE_REDACTED_VARS",
-			Value:  &cli.StringSlice{"*_PASSWORD", "*_SECRET", "*_TOKEN", "*_ACCESS_KEY"},
+			Value:  &cli.StringSlice{"*_PASSWORD", "*_SECRET", "*_TOKEN", "*_ACCESS_KEY", "*_SECRET_KEY"},
 		},
 		cli.StringFlag{
 			Name:   "tracing-backend",


### PR DESCRIPTION
`AWS_SECRET_ACCESS_KEY` is a commonly used environment variable which holds credentials that should be redacted, but wasn't matched by the existing defaults `*_PASSWORD,*_SECRET,*_TOKEN`.

Likewise, for custom S3 artifact destinations, `BUILDKITE_S3_SECRET_KEY` is used.

I don't think we should try to match everything under the sun in the default config, but AWS is a big one.