### PR TITLE
bump version to 3.29.0-beta.1

### DIFF
--- a/agent/version.go
+++ b/agent/version.go
@@ -10,7 +10,7 @@ import "runtime"
 //
 // Pre-release builds' versions must be in the format `x.y-beta`, `x.y-beta.z` or `x.y-beta.z.a`
 
-var baseVersion string = "3.28.1"
+var baseVersion string = "3.29.0-beta.1"
 var buildVersion string = ""
 
 func Version() string {


### PR DESCRIPTION
We've merged a few bug fixes since 3.28.1, and I'm keen to offer a pre-release version to a few customers so they can confirm the fixes ahead of a formal 3.29.0 release.

I've carefully followed the pre-release version format we used for 3.28.1-beta.1 to avoid a repeat of the build issues I caused a few weeks ago (see PR #1385)