### PR TITLE
Clarify step get usage

### DIFF
--- a/clicommand/step_get.go
+++ b/clicommand/step_get.go
@@ -25,7 +25,7 @@ Description:
 
 Example:
 
-   $ buildkite-agent step get "label"
+   $ buildkite-agent step get "label" --step "key"
    $ buildkite-agent step get --format json
    $ buildkite-agent step get "retry" --format json
    $ buildkite-agent step get "state" --step "my-other-step"`


### PR DESCRIPTION
Over in https://github.com/buildkite/docs/pull/989 I'm adding some clarification on getting a step outcome. I've tweaked this example to prevent people using `label` to reference the step. 

But in these examples, which step is used, the current one I think? Is this often used? Or would we be better off adding step `key` or `id` to these as well? 

```
   $ buildkite-agent step get --format json
   $ buildkite-agent step get "retry" --format json
```



