### PR TITLE
add s390x as a target architecture

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -126,6 +126,16 @@ steps:
         config: .buildkite/docker-compose.yml
         run: agent
 
+  - name: ":linux: s390x"
+    command: ".buildkite/steps/build-binary.sh linux s390x"
+    key: build-binary-linux-s390x
+    depends_on: test-linux # don't wait for slower windows tests
+    artifact_paths: "pkg/*"
+    plugins:
+      docker-compose#v3.0.0:
+        config: .buildkite/docker-compose.yml
+        run: agent
+
   - name: ":mac: amd64"
     command: ".buildkite/steps/build-binary.sh darwin amd64"
     key: build-binary-darwin-amd64
@@ -276,6 +286,7 @@ steps:
       - build-binary-linux-arm64
       - build-binary-linux-ppc64le
       - build-binary-linux-mips64le
+      - build-binary-linux-s390x
       - build-binary-darwin-amd64
       - build-binary-darwin-arm64
       - build-binary-freebsd-amd64

--- a/install.sh
+++ b/install.sh
@@ -64,6 +64,7 @@ else
     *ppc64le*) ARCH="ppc64le" ;;
     *aarch64*) ARCH="arm64"   ;;
     *mips64*) ARCH="mips64le" ;;
+    *s390x*)   ARCH="s390x"   ;;
     *)
       ARCH="386"
       echo -e "\n\033[36mWe don't recognise the $MACHINE architecture; falling back to $ARCH\033[0m"


### PR DESCRIPTION
A customer is keen to run the agent on IBM Z systems. It's an officially supported architecture for go, so in theory this should just work. Only one way to find out!