### PR TITLE
bump version to 3.30.0-beta.1

### DIFF
--- a/agent/version.go
+++ b/agent/version.go
@@ -10,7 +10,7 @@ import "runtime"
 //
 // Pre-release builds' versions must be in the format `x.y-beta`, `x.y-beta.z` or `x.y-beta.z.a`
 
-var baseVersion string = "3.29.0"
+var baseVersion string = "3.30.0-beta.1"
 var buildVersion string = ""
 
 func Version() string {


### PR DESCRIPTION
The build pipeline will recognise this as a pre-release version and start publishing it through our experimental channels (apt, yum,
binaries on s3).

I've carefully confirmed this version format matches the requirements!