### PR TITLE
Add wait ec2 metadata tag timeout config

### DIFF
--- a/agent/tags.go
+++ b/agent/tags.go
@@ -25,6 +25,7 @@ type FetchTagsConfig struct {
 	TagsFromGCPLabels        bool
 	TagsFromHost             bool
 	WaitForEC2TagsTimeout    time.Duration
+	WaitForEC2MetaDataTagsTimeout time.Duration
 	WaitForGCPLabelsTimeout  time.Duration
 }
 
@@ -100,7 +101,7 @@ func (t *tagFetcher) Fetch(l logger.Logger, conf FetchTagsConfig) []string {
 			}
 
 			return err
-		}, &retry.Config{Maximum: 5, Interval: 1 * time.Second, Jitter: true})
+		}, &retry.Config{Maximum: 5, Interval: conf.WaitForEC2MetaDataTagsTimeout / 5, Jitter: true})
 
 		// Don't blow up if we can't find them, just show a nasty error.
 		if err != nil {

--- a/agent/tags.go
+++ b/agent/tags.go
@@ -17,16 +17,16 @@ import (
 type FetchTagsConfig struct {
 	Tags []string
 
-	TagsFromEC2MetaData      bool
-	TagsFromEC2MetaDataPaths []string
-	TagsFromEC2Tags          bool
-	TagsFromGCPMetaData      bool
-	TagsFromGCPMetaDataPaths []string
-	TagsFromGCPLabels        bool
-	TagsFromHost             bool
-	WaitForEC2TagsTimeout    time.Duration
-	WaitForEC2MetaDataTagsTimeout time.Duration
-	WaitForGCPLabelsTimeout  time.Duration
+	TagsFromEC2MetaData       bool
+	TagsFromEC2MetaDataPaths  []string
+	TagsFromEC2Tags           bool
+	TagsFromGCPMetaData       bool
+	TagsFromGCPMetaDataPaths  []string
+	TagsFromGCPLabels         bool
+	TagsFromHost              bool
+	WaitForEC2TagsTimeout     time.Duration
+	WaitForEC2MetaDataTimeout time.Duration
+	WaitForGCPLabelsTimeout   time.Duration
 }
 
 // FetchTags loads tags from a variety of sources
@@ -101,7 +101,7 @@ func (t *tagFetcher) Fetch(l logger.Logger, conf FetchTagsConfig) []string {
 			}
 
 			return err
-		}, &retry.Config{Maximum: 5, Interval: conf.WaitForEC2MetaDataTagsTimeout / 5, Jitter: true})
+		}, &retry.Config{Maximum: 5, Interval: conf.WaitForEC2MetaDataTimeout / 5, Jitter: true})
 
 		// Don't blow up if we can't find them, just show a nasty error.
 		if err != nil {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -279,6 +279,12 @@ var AgentStartCommand = cli.Command{
 			Value:  time.Second * 10,
 		},
 		cli.DurationFlag{
+			Name:   "wait-for-ec2-meta-data-tags-timeout",
+			Usage:  "The amount of time to wait for meta-data tags from EC2 before proceeding",
+			EnvVar: "BUILDKITE_AGENT_WAIT_FOR_EC2_META_DATA_TAGS_TIMEOUT",
+			Value:  time.Second * 10,
+		},
+		cli.DurationFlag{
 			Name:   "wait-for-gcp-labels-timeout",
 			Usage:  "The amount of time to wait for labels from GCP before proceeding",
 			EnvVar: "BUILDKITE_AGENT_WAIT_FOR_GCP_LABELS_TIMEOUT",

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -75,7 +75,7 @@ type AgentStartConfig struct {
 	TagsFromGCPLabels          bool     `cli:"tags-from-gcp-labels"`
 	TagsFromHost               bool     `cli:"tags-from-host"`
 	WaitForEC2TagsTimeout      string   `cli:"wait-for-ec2-tags-timeout"`
-	WaitForEC2MetaDataTagsTimeout string `cli:"wait-for-ec2-meta-data-tags-timeout"`
+	WaitForEC2MetaDataTimeout  string   `cli:"wait-for-ec2-meta-data-timeout"`
 	WaitForGCPLabelsTimeout    string   `cli:"wait-for-gcp-labels-timeout"`
 	GitCloneFlags              string   `cli:"git-clone-flags"`
 	GitCloneMirrorFlags        string   `cli:"git-clone-mirror-flags"`
@@ -279,9 +279,9 @@ var AgentStartCommand = cli.Command{
 			Value:  time.Second * 10,
 		},
 		cli.DurationFlag{
-			Name:   "wait-for-ec2-meta-data-tags-timeout",
-			Usage:  "The amount of time to wait for meta-data tags from EC2 before proceeding",
-			EnvVar: "BUILDKITE_AGENT_WAIT_FOR_EC2_META_DATA_TAGS_TIMEOUT",
+			Name:   "wait-for-ec2-meta-data-timeout",
+			Usage:  "The amount of time to wait for meta-data from EC2 before proceeding",
+			EnvVar: "BUILDKITE_AGENT_WAIT_FOR_EC2_META_DATA_TIMEOUT",
 			Value:  time.Second * 10,
 		},
 		cli.DurationFlag{
@@ -587,12 +587,12 @@ var AgentStartCommand = cli.Command{
 			}
 		}
 
-		var ec2MetaDataTagTimeout time.Duration
-		if t := cfg.WaitForEC2MetaDataTagsTimeout; t != "" {
+		var ec2MetaDataTimeout time.Duration
+		if t := cfg.WaitForEC2MetaDataTimeout; t != "" {
 			var err error
-			ec2MetaDataTagTimeout, err = time.ParseDuration(t)
+			ec2MetaDataTimeout, err = time.ParseDuration(t)
 			if err != nil {
-				l.Fatal("Failed to parse ec2 meta-data tag timeout: %v", err)
+				l.Fatal("Failed to parse ec2 meta-data timeout: %v", err)
 			}
 		}
 
@@ -727,17 +727,17 @@ var AgentStartCommand = cli.Command{
 			Priority:          cfg.Priority,
 			ScriptEvalEnabled: !cfg.NoCommandEval,
 			Tags: agent.FetchTags(l, agent.FetchTagsConfig{
-				Tags:                     cfg.Tags,
-				TagsFromEC2MetaData:      (cfg.TagsFromEC2MetaData || cfg.TagsFromEC2),
-				TagsFromEC2MetaDataPaths: cfg.TagsFromEC2MetaDataPaths,
-				TagsFromEC2Tags:          cfg.TagsFromEC2Tags,
-				TagsFromGCPMetaData:      (cfg.TagsFromGCPMetaData || cfg.TagsFromGCP),
-				TagsFromGCPMetaDataPaths: cfg.TagsFromGCPMetaDataPaths,
-				TagsFromGCPLabels:        cfg.TagsFromGCPLabels,
-				TagsFromHost:             cfg.TagsFromHost,
-				WaitForEC2TagsTimeout:    ec2TagTimeout,
-				WaitForEC2MetaDataTagsTimeout: ec2MetaDataTagTimeout,
-				WaitForGCPLabelsTimeout:  gcpLabelsTimeout,
+				Tags:                      cfg.Tags,
+				TagsFromEC2MetaData:       (cfg.TagsFromEC2MetaData || cfg.TagsFromEC2),
+				TagsFromEC2MetaDataPaths:  cfg.TagsFromEC2MetaDataPaths,
+				TagsFromEC2Tags:           cfg.TagsFromEC2Tags,
+				TagsFromGCPMetaData:       (cfg.TagsFromGCPMetaData || cfg.TagsFromGCP),
+				TagsFromGCPMetaDataPaths:  cfg.TagsFromGCPMetaDataPaths,
+				TagsFromGCPLabels:         cfg.TagsFromGCPLabels,
+				TagsFromHost:              cfg.TagsFromHost,
+				WaitForEC2TagsTimeout:     ec2TagTimeout,
+				WaitForEC2MetaDataTimeout: ec2MetaDataTimeout,
+				WaitForGCPLabelsTimeout:   gcpLabelsTimeout,
 			}),
 			// We only want this agent to be ingored in Buildkite
 			// dispatches if it's being booted to acquire a

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -75,6 +75,7 @@ type AgentStartConfig struct {
 	TagsFromGCPLabels          bool     `cli:"tags-from-gcp-labels"`
 	TagsFromHost               bool     `cli:"tags-from-host"`
 	WaitForEC2TagsTimeout      string   `cli:"wait-for-ec2-tags-timeout"`
+	WaitForEC2MetaDataTagsTimeout string `cli:"wait-for-ec2-meta-data-tags-timeout"`
 	WaitForGCPLabelsTimeout    string   `cli:"wait-for-gcp-labels-timeout"`
 	GitCloneFlags              string   `cli:"git-clone-flags"`
 	GitCloneMirrorFlags        string   `cli:"git-clone-mirror-flags"`
@@ -580,6 +581,15 @@ var AgentStartCommand = cli.Command{
 			}
 		}
 
+		var ec2MetaDataTagTimeout time.Duration
+		if t := cfg.WaitForEC2MetaDataTagsTimeout; t != "" {
+			var err error
+			ec2MetaDataTagTimeout, err = time.ParseDuration(t)
+			if err != nil {
+				l.Fatal("Failed to parse ec2 meta-data tag timeout: %v", err)
+			}
+		}
+
 		var gcpLabelsTimeout time.Duration
 		if t := cfg.WaitForGCPLabelsTimeout; t != "" {
 			var err error
@@ -720,6 +730,7 @@ var AgentStartCommand = cli.Command{
 				TagsFromGCPLabels:        cfg.TagsFromGCPLabels,
 				TagsFromHost:             cfg.TagsFromHost,
 				WaitForEC2TagsTimeout:    ec2TagTimeout,
+				WaitForEC2MetaDataTagsTimeout: ec2MetaDataTagTimeout,
 				WaitForGCPLabelsTimeout:  gcpLabelsTimeout,
 			}),
 			// We only want this agent to be ingored in Buildkite


### PR DESCRIPTION
ref https://github.com/buildkite/agent/issues/1420

Currently we have `wait-for-ec2-tags-timeout` config that waits for an EC2 instance's resource tags when buildkite-agent starts, but we don't have an equivalent config that waits for EC2's meta-data tags.

Add a config `wait-for-ec2-meta-data-tags-timeout` to set timeout waiting for ec2 meta-data tags when starting agents. 