### PR TITLE
Trim trailing slash from the bucketPath

### DIFF
--- a/agent/s3_uploader.go
+++ b/agent/s3_uploader.go
@@ -58,7 +58,9 @@ func NewS3Uploader(l logger.Logger, c S3UploaderConfig) (*S3Uploader, error) {
 }
 
 func ParseS3Destination(destination string) (name string, path string) {
-	parts := strings.Split(strings.TrimPrefix(string(destination), "s3://"), "/")
+	destinationWithNoTrailingSlash := strings.TrimSuffix(string(destination), "/")
+	destinationWithNoProtocol := strings.TrimPrefix(destinationWithNoTrailingSlash, "s3://")
+	parts := strings.Split(destinationWithNoProtocol, "/")
 	path = strings.Join(parts[1:len(parts)], "/")
 	name = parts[0]
 	return

--- a/agent/s3_uploader_test.go
+++ b/agent/s3_uploader_test.go
@@ -13,6 +13,7 @@ func TestParseS3DestinationBucketPath(t *testing.T) {
 	}{
 		{"s3://my-bucket-name/foo/bar", "foo/bar"},
 		{"s3://starts-with-an-s/and-this-is-its/folder", "and-this-is-its/folder"},
+		{"s3://custom-s3-domain/folder/ends-with-a-slash/", "folder/ends-with-a-slash"},
 	} {
 		_, path := ParseS3Destination(tc.Destination)
 		if path != tc.Path {


### PR DESCRIPTION
If a user passes a destination with a trailing slash, the artifact url ends up with a double slash in it (between the bucketPath and artifact path).

This trims the trailing slash before setting the bucketPath, so the rest of the code doesn't have to account for whether it has a trailing slash or not.

See also: https://github.com/buildkite/agent/issues/1145