### PR TITLE
Use /usr/pkg/bin/bash as default shell on NetBSD

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -128,8 +128,10 @@ func DefaultShell() string {
 	switch runtime.GOOS {
 	case "windows":
 		return `C:\Windows\System32\CMD.exe /S /C`
-	case "freebsd", "openbsd", "netbsd":
+	case "freebsd", "openbsd":
 		return `/usr/local/bin/bash -e -c`
+	case "netbsd":
+		return `/usr/pkg/bin/bash -e -c`
 	default:
 		return `/bin/bash -e -c`
 	}


### PR DESCRIPTION
I'm [in the process of adding](https://github.com/creack/pty/pull/117) pty support on NetBSD to the upstream dependency - which I note has also changed location.

Meanwhile, this is a tweak to the default shell location that allows the agent to run with no configuration (other than token).