### PR TITLE
Send queue metrics to Datadog when job received

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -250,6 +250,17 @@ func (r *JobRunner) Run() error {
 
 	startedAt := time.Now()
 
+	// Publish metric for how long this job was in the queue for, if we can
+	// calculate that
+	if r.job.RunnableAt != "" {
+		runnableAt, err := time.Parse(time.RFC3339Nano, r.job.RunnableAt)
+		if err != nil {
+			r.logger.Error("Metric submission failed to parse %s", r.job.RunnableAt)
+		} else {
+			r.metrics.Timing("queue.duration", startedAt.Sub(runnableAt))
+		}
+	}
+
 	// Start the build in the Buildkite Agent API. This is the first thing
 	// we do so if it fails, we don't have to worry about cleaning things
 	// up like started log streamer workers, etc.

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -16,6 +16,7 @@ type Job struct {
 	SignalReason       string            `json:"signal_reason,omitempty"`
 	StartedAt          string            `json:"started_at,omitempty"`
 	FinishedAt         string            `json:"finished_at,omitempty"`
+	RunnableAt         string            `json:"runnable_at,omitempty"`
 	ChunksFailedCount  int               `json:"chunks_failed_count,omitempty"`
 }
 


### PR DESCRIPTION
We would like to also send how long a job was queued for when a job is
acquired by the agent to Datadog. This will empower teams to validate
that their clusters are not causing jobs to queue for "too long" (for
the users definition of that) on the assumption that all jobs will
eventually execute on an agent. Note that this :see_no_evil: that jobs
get stuck indefinitely.

This is not a complete Pull Request as we are waiting for our friends in
the Buildkite team to add the actual "scheduled_at" time to the acquire
job API, which will enable this pull request to actually calculate how
long the job was sitting in the queue for.