### PR TITLE
Resolve the absolute path to the buildkite-agent binary for bootstrap

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -546,7 +546,14 @@ var AgentStartCommand = cli.Command{
 
 		// Set a useful default for the bootstrap script
 		if cfg.BootstrapScript == "" {
-			cfg.BootstrapScript = fmt.Sprintf("%s bootstrap", shellwords.Quote(os.Args[0]))
+			pathToBinary, err := filepath.Abs(os.Args[0])
+			if err != nil {
+				// This error *likely* means the working directory got deleted,
+				// which is possible, but given this runs at startup, unlikely
+				// https://github.com/golang/go/blob/6c1c055d1ea417d050503efe92c1eead0da68cef/src/path/filepath/path.go#L238-L256
+				l.Fatal("Could not determine absolute path to buildkite-agent binary")
+			}
+			cfg.BootstrapScript = fmt.Sprintf("%s bootstrap", shellwords.Quote(pathToBinary))
 		}
 
 		// Show a warning if plugins are enabled by no-command-eval or no-local-hooks is set


### PR DESCRIPTION
Previously, the built-in bootstrap subcommand was called using the raw value of `os.Args[0]`, which meant it could fail if the path was relative to the current working directory, as jobs run in a build-specific directory.

This patch updates it to use `filepath.Abs` to resolve an absolute version of that path, so, for example, calling `.buildkite-agent/bin/buildkite-agent` from the user's home directory would no longer fail to run jobs.

It also treats an error resolving this path as fatal, though looking at the code for it this should only really happen if the current working directory is deleted, but given this happens at agent start that is extremely unlikely.

Fixes #1439