### PR TITLE
Use os.Executable() to detect path to the agents own binary

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -552,7 +552,11 @@ var AgentStartCommand = cli.Command{
 
 		// Set a useful default for the bootstrap script
 		if cfg.BootstrapScript == "" {
-			cfg.BootstrapScript = fmt.Sprintf("%s bootstrap", shellwords.Quote(os.Args[0]))
+			exePath, err := os.Executable()
+			if err != nil {
+				l.Fatal("Unable to find executable path for bootstrap")
+			}
+			cfg.BootstrapScript = fmt.Sprintf("%s bootstrap", shellwords.Quote(exePath))
 		}
 
 		// Show a warning if plugins are enabled by no-command-eval or no-local-hooks is set


### PR DESCRIPTION
We need the path to start the bootstrap as a child process. We've previously detected it using os.Args[0], however there are some edge cases where that doesn't work (eg #1439).

We think os.Executable() might be a more reliable way to detect the path.