### PR TITLE
Remove the experiment flag from output redactor

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1802,11 +1802,12 @@ func (b *Bootstrap) ignoredEnv() []string {
 // RedactorMux (possibly empty) is returned so the caller can `defer redactor.Flush()`
 func (b *Bootstrap) setupRedactors() RedactorMux {
 	valuesToRedact := getValuesToRedact(b.shell, b.Config.RedactedVars, b.shell.Env.ToMap())
-
-	if len(valuesToRedact) > 0 {
-		b.shell.Commentf("Enabling output redaction")
-	} else {
+	if len(valuesToRedact) == 0 {
 		return nil
+	}
+
+	if b.Debug {
+		b.shell.Commentf("Enabling output redaction for values from environment variables matching: %v", b.Config.RedactedVars)
 	}
 
 	var mux RedactorMux

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1801,12 +1801,14 @@ func (b *Bootstrap) ignoredEnv() []string {
 // matching environment vars.
 // RedactorMux (possibly empty) is returned so the caller can `defer redactor.Flush()`
 func (b *Bootstrap) setupRedactors() RedactorMux {
-	if experiments.IsEnabled("output-redactor") {
-		b.shell.Commentf("Using output-redactor experiment 🧪")
+	valuesToRedact := getValuesToRedact(b.shell, b.Config.RedactedVars, b.shell.Env.ToMap())
+
+	if len(valuesToRedact) > 0 {
+		b.shell.Commentf("Enabling output redaction")
 	} else {
 		return nil
 	}
-	valuesToRedact := getValuesToRedact(b.shell, b.Config.RedactedVars, b.shell.Env.ToMap())
+
 	var mux RedactorMux
 
 	// If the shell Writer is already a Redactor, reset the values to redact.

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -42,7 +42,23 @@ func TestGetValuesToRedact(t *testing.T) {
 
 	valuesToRedact := getValuesToRedact(shell.DiscardLogger, redactConfig, environment)
 
-	assert.Equal(t, valuesToRedact, []string{"hunter2"})
+	assert.Equal(t, []string{"hunter2"}, valuesToRedact)
+}
+
+func TestGetValuesToRedactEmpty(t *testing.T) {
+	t.Parallel()
+
+	redactConfig := []string{}
+	environment := map[string]string{
+		"FOO": "BAR",
+		"BUILDKITE_PIPELINE": "unit-test",
+	}
+
+	valuesToRedact := getValuesToRedact(shell.DiscardLogger, redactConfig, environment)
+
+	var expected []string
+	assert.Equal(t, expected, valuesToRedact)
+	assert.Equal(t, 0, len(valuesToRedact))
 }
 
 func TestStartTracing(t *testing.T) {

--- a/bootstrap/redactor_test.go
+++ b/bootstrap/redactor_test.go
@@ -65,3 +65,24 @@ func TestRedactorResetMidStream(t *testing.T) {
 		t.Errorf("Redaction failed: %s", buf.String())
 	}
 }
+
+func TestRedactorSlowLoris(t *testing.T) {
+	var buf bytes.Buffer
+	redactor := NewRedactor(&buf, "[REDACTED]", []string{"secret1111"})
+
+	redactor.Write([]byte("s"))
+	redactor.Write([]byte("e"))
+	redactor.Write([]byte("c"))
+	redactor.Write([]byte("r"))
+	redactor.Write([]byte("e"))
+	redactor.Write([]byte("t"))
+	redactor.Write([]byte("1"))
+	redactor.Write([]byte("1"))
+	redactor.Write([]byte("1"))
+	redactor.Write([]byte("1"))
+	redactor.Flush()
+
+	if buf.String() != "[REDACTED]" {
+		t.Errorf("Redaction failed: %s", buf.String())
+	}
+}

--- a/bootstrap/redactor_test.go
+++ b/bootstrap/redactor_test.go
@@ -86,3 +86,29 @@ func TestRedactorSlowLoris(t *testing.T) {
 		t.Errorf("Redaction failed: %s", buf.String())
 	}
 }
+
+func TestRedactorSubsetSecrets(t *testing.T) {
+	/*
+		This probably isn't a desired behaviour but I wanted to document it.
+
+		If one of the needles/secrets is a prefix subset of another, only
+		the smaller / prefix secret will be redacted.
+
+		I suspect this will not be an issue in practice due to the strings
+		we expect to redact.
+
+		If this is a critical issue, this test is NOT required to pass
+		for backwards compatibility and SHOULD be changed to test that
+		the longer secret string is redacted.
+	*/
+
+	var buf bytes.Buffer
+	redactor := NewRedactor(&buf, "[REDACTED]", []string{"secret1111", "secret"})
+
+	redactor.Write([]byte("secret1111"))
+	redactor.Flush()
+
+	if buf.String() != "[REDACTED]1111" {
+		t.Errorf("Redaction failed: %s", buf.String())
+	}
+}

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -352,7 +352,7 @@ func (l Loader) normalizeField(fieldName string, normalization string) error {
 		value, _ := reflections.GetField(l.Config, fieldName)
 		fieldKind, _ := reflections.GetFieldKind(l.Config, fieldName)
 
-		// Make sure we're normalizing a string filed
+		// Make sure we're normalizing a string field
 		if fieldKind != reflect.String {
 			return fmt.Errorf("filepath normalization only works on string fields")
 		}
@@ -372,7 +372,7 @@ func (l Loader) normalizeField(fieldName string, normalization string) error {
 		value, _ := reflections.GetField(l.Config, fieldName)
 		fieldKind, _ := reflections.GetFieldKind(l.Config, fieldName)
 
-		// Make sure we're normalizing a string filed
+		// Make sure we're normalizing a string field
 		if fieldKind != reflect.String {
 			return fmt.Errorf("commandpath normalization only works on string fields")
 		}
@@ -392,18 +392,22 @@ func (l Loader) normalizeField(fieldName string, normalization string) error {
 		value, _ := reflections.GetField(l.Config, fieldName)
 		fieldKind, _ := reflections.GetFieldKind(l.Config, fieldName)
 
-		// Make sure we're normalizing a string filed
+		// Make sure we're normalizing a string field
 		if fieldKind != reflect.Slice {
 			return fmt.Errorf("list normalization only works on slice fields")
 		}
 
-		// Normalize the field to be a command
+		// Normalize the field to be a string
 		if valueAsSlice, ok := value.([]string); ok {
 			normalizedSlice := []string{}
 
 			for _, value := range valueAsSlice {
 				// Split values with commas into fields
 				for _, normalized := range strings.Split(value, ",") {
+					if normalized == "" {
+						continue
+					}
+
 					normalizedSlice = append(normalizedSlice, normalized)
 				}
 			}


### PR DESCRIPTION
This will remove the `output-redactor` experiment flag and enable it all the time.

I have read through the redactor source code and added a couple more comments to help me understand it. It appears sound to me. I identified one issue which I added a test for to verify where if two needles share a prefix the shortest one will be redacted while the tail of the longer will be printed. This seems unlikely to occur in practice.

I have also ensured support for an empty list of redacted vars throughout so that (once the flag is changed) a lack of vars to redact will act as the switch to disable the `Redactor` being added to the log stream processing. This gives us an escape hatch should there be any issues.

Updated docs are in https://github.com/buildkite/docs/pull/1073