### PR TITLE
Update architecture and OS support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,13 @@ The agent binary is fairly portable and should run out of the box on most UNIX l
 systems.
 
 - Linux based [min version TBD]
-- macOS [min version TBD]
+- macOS
+  - 10.11
+  - 10.12
+  - 10.13
+  - 10.14
+  - 10.15
+  - 11
 - Windows Server
   - 2016
   - 2019

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ Dependencies are no longer committed to the repository, so compiling on Go <= 1.
 
 We provide support for security and bug fixes on the current major release only.
 
+Our architecture and operating system support is primarily limited to what golang
+itself [supports](https://github.com/golang/go/wiki/MinimumRequirements).
+
 ### Architecture Support
 
 We offer support for the following machine architectures (inspired by the Rust language platform

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ binary is fairly portable and should run out of the box on most UNIX like system
   - 10.15
   - 11
 - Windows Server
+  - 2012
   - 2016
   - 2019
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For example, agent version 3.30.0 is published as:
 
 #### Tier 2, guaranteed to build
 
-- Centos 8
+- CentOS 8
 
 ## Starting
 
@@ -161,7 +161,9 @@ binary is fairly portable and should run out of the box on most UNIX like system
   - 2016
   - 2019
 
-[1] See https://github.com/golang/go/issues/23011 for macOS / golang support
+[1] See https://github.com/golang/go/issues/23011 for macOS / golang support and
+[Supported macOS Versions](./docs/macos.md) for the last supported version of the
+Buildkite Agent for versions of macOS prior to those listed above.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ Inspired by the Rust language platform support guidance.
 - openbsd x84_64
 - dragonfly x86_64
 
+## Operating System Support
+
+We support the agent running on the following operating systems:
+
+- Linux based [min version TBD]
+- macOS [min version TBD]
+- Windows [min version TBD]
+
 ## Docker Support
 
 We package and publish Docker Images to Docker Hub for the following operating systems:

--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ systems.
 
 - Linux based [min version TBD]
 - macOS [min version TBD]
-- Windows [min version TBD]
+- Windows Server
+  - 2016
+  - 2019
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ support guidance):
 - linux x86
 - linux arm64
 - windows x86
-- windows arm64
 - darwin x86_64
 - darwin arm64
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ binary is fairly portable and should run out of the box on most UNIX like system
 
 - Ubuntu 18.04 and newer
 - Debian 8 and newer
-- RedHat
+- Red Hat
   - RHEL 7
   - RHEL 8
 - CentOS

--- a/README.md
+++ b/README.md
@@ -146,9 +146,7 @@ binary is fairly portable and should run out of the box on most UNIX like system
 
 - Ubuntu 18.04 and newer
 - Debian 8 and newer
-- Red Hat
-  - RHEL 7
-  - RHEL 8
+- Red Hat RHEL 7 and newer
 - CentOS
   - CentOS 7
   - CentOS 8

--- a/README.md
+++ b/README.md
@@ -150,9 +150,7 @@ binary is fairly portable and should run out of the box on most UNIX like system
 - CentOS
   - CentOS 7
   - CentOS 8
-- Amazon Linux
-  - Amazon Linux 1
-  - Amazon Linux 2
+- Amazon Linux 2
 - macOS
   - 10.11
   - 10.12

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ export GO111MODULE=on
 
 Dependencies are no longer committed to the repository, so compiling on Go <= 1.10 is not supported.
 
-## Platform Support
+## Architecture Support
 
 Inspired by the Rust language platform support guidance.
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ Inspired by the Rust language platform support guidance.
 - openbsd x84_64
 - dragonfly x86_64
 
+## Docker Support
+
+We package and publish Docker Images to Docker Hub for the following operating systems:
+
+### Tier 1, guaranteed to work
+
+- Alpine 3.12
+- Ubuntu 18.04 LTS (x86_64), supported to end of life for 18.04
+- Ubuntu 20.04 LTS (x86_64), supported to end of life for 20.04
+
+### Tier 2, guaranteed to build
+
+- Centos 8
+
 ## Contributing
 
 1. Fork it

--- a/README.md
+++ b/README.md
@@ -143,9 +143,15 @@ systems.
 
 - Ubuntu 18.04 and newer
 - Debian 8 and newer
-- RedHat [min version TBD]
-- CentOS [min version TBD]
-- Amazon Linux [min version TBD]
+- RedHat
+  - RHEL 7
+  - RHEL 8
+- CentOS
+  - CentOS 7
+  - CentOS 8
+- Amazon Linux
+  - Amazon Linux 1
+  - Amazon Linux 2
 - macOS
   - 10.11
   - 10.12

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ binary is fairly portable and should run out of the box on most UNIX like system
   - CentOS 7
   - CentOS 8
 - Amazon Linux 2
-- macOS
+- macOS [1]
   - 10.12
   - 10.13
   - 10.14
@@ -160,6 +160,8 @@ binary is fairly portable and should run out of the box on most UNIX like system
 - Windows Server
   - 2016
   - 2019
+
+[1] See https://github.com/golang/go/issues/23011 for macOS / golang support
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ We provide support for running the Buildkite Agent on the following operating sy
 The agent binary is fairly portable and should run out of the box on most UNIX like
 systems.
 
-- Linux based [min version TBD]
+- Ubuntu [min version TBD]
+- Debian [min version TBD]
+- RedHat [min version TBD]
+- Amazon Linux [min version TBD]
 - macOS
   - 10.11
   - 10.12

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ systems.
 - Ubuntu 18.04 and newer
 - Debian 8 and newer
 - RedHat [min version TBD]
+- CentOS [min version TBD]
 - Amazon Linux [min version TBD]
 - macOS
   - 10.11

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ We provide support for running the Buildkite Agent on the following operating sy
 The agent binary is fairly portable and should run out of the box on most UNIX like
 systems.
 
-- Ubuntu [min version TBD]
+- Ubuntu 18.04 and newer
 - Debian [min version TBD]
 - RedHat [min version TBD]
 - Amazon Linux [min version TBD]

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Dependencies are no longer committed to the repository, so compiling on Go <= 1.
 
 We provide support for security and bug fixes on the current major release only.
 
-Our architecture and operating system support is primarily limited to what golang
+Our architecture and operating system support is primarily limited by what golang
 itself [supports](https://github.com/golang/go/wiki/MinimumRequirements).
 
 ### Architecture Support

--- a/README.md
+++ b/README.md
@@ -34,7 +34,27 @@ The agent is fairly portable and should run out of the box on most supported pla
 
 [The agents page](https://buildkite.com/organizations/-/agents) on Buildkite has personalised instructions, or you can refer to [the Buildkite docs](https://buildkite.com/docs/agent/v3/installation). Both cover installing the agent with Ubuntu (via apt), Debian (via apt), macOS (via homebrew), Windows and Linux.
 
-You can also run the agent [via Docker](https://hub.docker.com/r/buildkite/agent).
+### Docker
+
+We also support and publish [Docker Images](https://hub.docker.com/r/buildkite/agent) for the
+following operating systems. Docker images are tagged using the agent SemVer components followed
+by the operating system.
+
+For example, agent version 3.30.0 is published as:
+
+- 3-ubuntu-20.04, tracks minor updates in version 3 installed in Ubuntu 20.04
+- 3.30-ubuntu-20.04, tracks bugfix updates in version 3.30 installed in Ubuntu 20.04
+- 3.30.0-ubuntu-20.04, tracks the exact version installed in Ubuntu 20.04
+
+#### Tier 1, guaranteed to work
+
+- Alpine 3.12
+- Ubuntu 18.04 LTS (x86_64), supported to end of life for 18.04
+- Ubuntu 20.04 LTS (x86_64), supported to end of life for 20.04
+
+#### Tier 2, guaranteed to build
+
+- Centos 8
 
 ## Starting
 
@@ -79,16 +99,21 @@ export GO111MODULE=on
 
 Dependencies are no longer committed to the repository, so compiling on Go <= 1.10 is not supported.
 
-## Architecture Support
+## Platform Support
 
-Inspired by the Rust language platform support guidance.
+We provide support for security and bug fixes on the current major release only.
 
-### Tier 1, guaranteed to work
+### Architecture Support
+
+We offer support for the following machine architectures (inspired by the Rust language platform
+support guidance):
+
+#### Tier 1, guaranteed to work
 
 - linux x86_64
 - windows x86_64
 
-### Tier 2, guaranteed to build
+#### Tier 2, guaranteed to build
 
 - linux x86
 - linux arm64
@@ -97,7 +122,7 @@ Inspired by the Rust language platform support guidance.
 - darwin x86_64
 - darwin arm64
 
-### Tier 3, community supported
+#### Tier 3, community supported
 
 - linux arm
 - linux armf
@@ -111,27 +136,15 @@ Inspired by the Rust language platform support guidance.
 - openbsd x84_64
 - dragonfly x86_64
 
-## Operating System Support
+### Operating System Support
 
-We support the agent running on the following operating systems:
+We provide support for running the Buildkite Agent on the following operating systems.
+The agent binary is fairly portable and should run out of the box on most UNIX like
+systems.
 
 - Linux based [min version TBD]
 - macOS [min version TBD]
 - Windows [min version TBD]
-
-## Docker Support
-
-We package and publish Docker Images to Docker Hub for the following operating systems:
-
-### Tier 1, guaranteed to work
-
-- Alpine 3.12
-- Ubuntu 18.04 LTS (x86_64), supported to end of life for 18.04
-- Ubuntu 20.04 LTS (x86_64), supported to end of life for 20.04
-
-### Tier 2, guaranteed to build
-
-- Centos 8
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ We provide support for security and bug fixes on the current major release only.
 ### Architecture Support
 
 We offer support for the following machine architectures (inspired by the Rust language platform
-support guidance):
+support guidance).
 
 #### Tier 1, guaranteed to work
 
@@ -137,9 +137,9 @@ support guidance):
 
 ### Operating System Support
 
-We provide support for running the Buildkite Agent on the following operating systems.
-The agent binary is fairly portable and should run out of the box on most UNIX like
-systems.
+We currently provide support for running the Buildkite Agent on the following operating
+systems. Future major releases may drop support for old operating systems. The agent
+binary is fairly portable and should run out of the box on most UNIX like systems.
 
 - Ubuntu 18.04 and newer
 - Debian 8 and newer

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ binary is fairly portable and should run out of the box on most UNIX like system
   - CentOS 8
 - Amazon Linux 2
 - macOS
-  - 10.11
   - 10.12
   - 10.13
   - 10.14

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The agent binary is fairly portable and should run out of the box on most UNIX l
 systems.
 
 - Ubuntu 18.04 and newer
-- Debian [min version TBD]
+- Debian 8 and newer
 - RedHat [min version TBD]
 - Amazon Linux [min version TBD]
 - macOS

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ by the operating system.
 
 For example, agent version 3.30.0 is published as:
 
-- 3-ubuntu-20.04, tracks minor updates in version 3 installed in Ubuntu 20.04
+- 3-ubuntu-20.04, tracks minor and bugfix updates in version 3 installed in Ubuntu 20.04
 - 3.30-ubuntu-20.04, tracks bugfix updates in version 3.30 installed in Ubuntu 20.04
 - 3.30.0-ubuntu-20.04, tracks the exact version installed in Ubuntu 20.04
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,38 @@ export GO111MODULE=on
 
 Dependencies are no longer committed to the repository, so compiling on Go <= 1.10 is not supported.
 
+## Platform Support
+
+Inspired by the Rust language platform support guidance.
+
+### Tier 1, guaranteed to work
+
+- linux x86_64
+- windows x86_64
+
+### Tier 2, guaranteed to build
+
+- linux x86
+- linux arm64
+- windows x86
+- windows arm64
+- darwin x86_64
+- darwin arm64
+
+### Tier 3, community supported
+
+- linux arm
+- linux armf
+- linux ppc64
+- linux mips64
+- linux s390x
+- netbsd x86_64
+- freebsd x86
+- freebsd x86_64
+- openbsd x86
+- openbsd x84_64
+- dragonfly x86_64
+
 ## Contributing
 
 1. Fork it

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,14 @@
+# Supported macOS versions
+
+macOS Version | Last Supported By Golang | Last Supported Agent Version
+--- | --- | ---
+10.8 | 1.10.8 | v3.5.4
+10.9 | 1.10.8 | v3.5.4
+10.10 | 1.13 | v3.20.0
+10.11 | 1.15 | v3.27.0
+10.12 | 1.16 | 
+10.13 | 1.17 TBC | 
+10.14 | | 
+10.15 | | 
+11 | | 
+12 | | 


### PR DESCRIPTION
This updates and documents our OS and architecture promises to be current in terms of end-of-lifed operating systems. It also expands on the Docker section under installing to discuss the tagging system and lists the Docker base operating systems we build on top of.