### PR TITLE
Add pre-bootstrap hook which can green light the Job env before it is loaded into a process env

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -617,9 +617,6 @@ func (r *JobRunner)executePreBootstrapHook(hook string) (bool, error) {
 		return false, err
 	}
 
-	// TODO stream logging up to buildkite?
-	// TODO if capturing and printing output of this script do we expect the redactors to run?
-
 	// TODO do we expect this script to be executed by bash, or sourced by bash
 	// - agent-shutdown is executed
 	// - all other current hooks are sourced by the hook/scriptwrapper.go
@@ -632,7 +629,7 @@ func (r *JobRunner)executePreBootstrapHook(hook string) (bool, error) {
 	sh.Env.Set("BUILDKITE_ENV_FILE", r.envFile.Name())
 
 	if output, err := sh.RunAndCapture(hook); err != nil {
-		r.logStreamer.Process(output)
+		// TODO print to agent output
 		return false, err
 	}
 

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -624,6 +624,11 @@ func (r *JobRunner)executePreBootstrapHook(hook string) (bool, error) {
 	// TODO pass line logging up to buildkite?
 	// TODO if capturing and printing output of this script do we expect the redactors to run
 
+	// TODO do we expect this script to be executed by bash, or sourced by bash
+	// - agent-shutdown is executed
+	// - all other current hooks are sourced by the hook/scriptwrapper.go
+	// - proposed hearbeat hook expects an executable https://github.com/buildkite/agent/pull/1057
+
 	sh.Promptf("%s", hook)
 
 	// This (plus inherited) is the only ENV that should be exposed

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -298,7 +298,7 @@ func (r *JobRunner) Run() error {
 			environmentCommandOkay = false
 
 			// Ensure the Job UI knows why this job resulted in failure
-			r.logStreamer.Process("pre-bootstrap hook rejected this job")
+			r.logStreamer.Process("pre-bootstrap hook rejected this job, see the buildkite-agent logs for more details")
 			// But disclose more information in the agent logs
 			r.logger.Error("pre-bootstrap hook rejected this job: %s", err)
 

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -297,8 +297,10 @@ func (r *JobRunner) Run() error {
 		if !okay {
 			environmentCommandOkay = false
 
-			// Send the error as output
-			r.logStreamer.Process(fmt.Sprintf("pre-bootstrap hook rejected the environment/command for this job: %s", err))
+			// Ensure the Job UI knows why this job resulted in failure
+			r.logStreamer.Process("pre-bootstrap hook rejected this job")
+			// But disclose more information in the agent logs
+			r.logger.Error("pre-bootstrap hook rejected this job: %s", err)
 
 			exitStatus = "-1"
 

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -290,9 +290,6 @@ func (r *JobRunner) Run() error {
 	// whether it is happy to proceed.
 	environmentCommandOkay := true
 
-	// FIXME(KD) is looking on disk suitable for this use case, do we want an
-	// agent setting where if set we _must_ execute a pre-bootstrap hook,
-	// otherwise it's a hard error?
 	if hook, _ := hook.Find(r.conf.AgentConfiguration.HooksPath, "pre-bootstrap"); hook != "" {
 		// Once we have a hook any failure to run it MUST be fatal to the job to guarantee a true
 		// positive result from the hook

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -617,11 +617,6 @@ func (r *JobRunner)executePreBootstrapHook(hook string) (bool, error) {
 		return false, err
 	}
 
-	// TODO do we expect this script to be executed by bash, or sourced by bash
-	// - agent-shutdown is executed
-	// - all other current hooks are sourced by the hook/scriptwrapper.go
-	// - proposed hearbeat hook expects an executable https://github.com/buildkite/agent/pull/1057
-
 	sh.Debug = true
 
 	// This (plus inherited) is the only ENV that should be exposed

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -301,6 +301,9 @@ func (r *JobRunner) Run() error {
 			r.logStreamer.Process(fmt.Sprintf("pre-bootstrap hook rejected the environment/command for this job: %s", err))
 
 			exitStatus = "-1"
+
+			// TODO swap the signal reason once buildkite.com supports this enum value
+			// signalReason = "agent_refused"
 			signalReason = ""
 		}
 	}

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -303,10 +303,7 @@ func (r *JobRunner) Run() error {
 			r.logger.Error("pre-bootstrap hook rejected this job: %s", err)
 
 			exitStatus = "-1"
-
-			// TODO swap the signal reason once buildkite.com supports this enum value
-			// signalReason = "agent_refused"
-			signalReason = ""
+			signalReason = "agent_refused"
 		}
 	}
 

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -626,11 +626,13 @@ func (r *JobRunner)executePreBootstrapHook(hook string) (bool, error) {
 	// to the pre-bootstrap hook.
 	sh.Env.Set("BUILDKITE_ENV_FILE", r.envFile.Name())
 
-	if output, err := sh.RunAndCapture(hook); err != nil {
-		// TODO print to agent output
+	output, err := sh.RunAndCapture(hook)
+	if err != nil {
+		r.logger.Error("pre-bootstrap hook %q rejected job: %s", hook, output)
 		return false, err
 	}
 
+	r.logger.Info("pre-bootstrap hook %q accepted job: %s", hook, output)
 	return true, nil
 }
 

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -622,6 +622,7 @@ func (r *JobRunner)executePreBootstrapHook(hook string) (bool, error) {
 	}
 
 	// TODO pass line logging up to buildkite?
+	// TODO if capturing and printing output of this script do we expect the redactors to run
 
 	sh.Promptf("%s", hook)
 

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -304,7 +304,7 @@ func (r *JobRunner) Run() error {
 			r.logStreamer.Process(fmt.Sprintf("pre-bootstrap hook rejected the environment/command for this job: %s", err))
 
 			exitStatus = "-1"
-			signalReason = "pre_bootstrap_rejection"
+			signalReason = ""
 		}
 	}
 


### PR DESCRIPTION
This provides a place to examine the proposed job environment before using as a process environment.

Notes on the todos I wrote up for this below.