### PR TITLE
Fix two more instances of os.Args[0]

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -498,7 +498,14 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 
 	// We know the BUILDKITE_BIN_PATH dir, because it's the path to the
 	// currently running file (there is only 1 binary)
-	dir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
+	exePath, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+	dir, err := filepath.Abs(filepath.Dir(exePath))
+	if err != nil {
+		return nil, err
+	}
 	env["BUILDKITE_BIN_PATH"] = dir
 
 	// Add options from the agent configuration

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -161,10 +161,13 @@ func DefaultConfigFilePaths() (paths []string) {
 
 	// Also check to see if there's a buildkite-agent.cfg in the folder
 	// that the binary is running in.
-	pathToBinary, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	exePath, err := os.Executable()
 	if err == nil {
-		pathToRelativeConfig := filepath.Join(pathToBinary, "buildkite-agent.cfg")
-		paths = append([]string{pathToRelativeConfig}, paths...)
+		pathToBinary, err := filepath.Abs(filepath.Dir(exePath))
+		if err == nil {
+			pathToRelativeConfig := filepath.Join(pathToBinary, "buildkite-agent.cfg")
+			paths = append([]string{pathToRelativeConfig}, paths...)
+		}
 	}
 
 	return


### PR DESCRIPTION
Swap two more instances of `os.Args[0]` with `os.Executable()` for a more reliable way to locate the binary.

Follow up to https://github.com/buildkite/agent/pull/1444