### PR TITLE
[build] Add `ppc64le` packaging to Debian repository

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -278,6 +278,7 @@ steps:
       - build-binary-linux-arm
       - build-binary-linux-armhf
       - build-binary-linux-arm64
+      - build-binary-linux-ppc64le
       - set-metadata
     command: ".buildkite/steps/build-debian-packages.sh"
     artifact_paths: "deb/**/*"

--- a/.buildkite/steps/build-debian-packages.sh
+++ b/.buildkite/steps/build-debian-packages.sh
@@ -24,7 +24,7 @@ rm -rf deb
 
 # Build the packages into deb/
 PLATFORM="linux"
-for ARCH in "amd64" "386" "arm" "armhf" "arm64"; do
+for ARCH in "amd64" "386" "arm" "armhf" "arm64" "ppc64le"; do
   echo "--- Building debian package ${PLATFORM}/${ARCH}"
 
   BINARY="pkg/buildkite-agent-${PLATFORM}-${ARCH}"

--- a/scripts/build-debian-package.sh
+++ b/scripts/build-debian-package.sh
@@ -32,6 +32,8 @@ elif [ "$BUILD_ARCH" == "armhf" ]; then
   ARCH="armhf"
 elif [ "$BUILD_ARCH" == "arm64" ]; then
   ARCH="arm64"
+elif [ "$BUILD_ARCH" == "ppc64le" ]; then
+  ARCH="ppc64el"
 else
   echo "Unknown architecture: $BUILD_ARCH"
   exit 1


### PR DESCRIPTION
The debian repository was missing some connections to properly package
up the `ppc64le` binary and deploy it to the apt repository.  This adds
the necessary pipes to get the bits flowing.

Closes #1472