### PR TITLE
More architecture packaging

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -289,6 +289,7 @@ steps:
     depends_on:
       - build-binary-linux-amd64
       - build-binary-linux-386
+      - build-binary-linux-arm64
       - set-metadata
     command: ".buildkite/steps/build-rpm-packages.sh"
     artifact_paths: "rpm/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -278,6 +278,7 @@ steps:
       - build-binary-linux-arm
       - build-binary-linux-armhf
       - build-binary-linux-arm64
+      - build-binary-linux-ppc64
       - build-binary-linux-ppc64le
       - set-metadata
     command: ".buildkite/steps/build-debian-packages.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -290,6 +290,8 @@ steps:
       - build-binary-linux-amd64
       - build-binary-linux-386
       - build-binary-linux-arm64
+      - build-binary-linux-ppc64
+      - build-binary-linux-ppc64le
       - set-metadata
     command: ".buildkite/steps/build-rpm-packages.sh"
     artifact_paths: "rpm/**/*"

--- a/.buildkite/steps/build-debian-packages.sh
+++ b/.buildkite/steps/build-debian-packages.sh
@@ -24,7 +24,7 @@ rm -rf deb
 
 # Build the packages into deb/
 PLATFORM="linux"
-for ARCH in "amd64" "386" "arm" "armhf" "arm64" "ppc64le"; do
+for ARCH in "amd64" "386" "arm" "armhf" "arm64" "ppc64" "ppc64le"; do
   echo "--- Building debian package ${PLATFORM}/${ARCH}"
 
   BINARY="pkg/buildkite-agent-${PLATFORM}-${ARCH}"

--- a/.buildkite/steps/build-rpm-packages.sh
+++ b/.buildkite/steps/build-rpm-packages.sh
@@ -24,7 +24,7 @@ rm -rf rpm
 
 # Build the packages into rpm/
 PLATFORM="linux"
-for ARCH in "amd64" "386" "arm64"; do
+for ARCH in "amd64" "386" "arm64" "ppc64" "ppc64le"; do
   echo "--- Building rpm package ${PLATFORM}/${ARCH}"
 
   BINARY="pkg/buildkite-agent-${PLATFORM}-${ARCH}"

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ support guidance).
 - linux arm
 - linux armf
 - linux ppc64
+- linux ppc64le
 - linux mips64
 - linux s390x
 - netbsd x86_64

--- a/scripts/build-debian-package.sh
+++ b/scripts/build-debian-package.sh
@@ -32,6 +32,8 @@ elif [ "$BUILD_ARCH" == "armhf" ]; then
   ARCH="armhf"
 elif [ "$BUILD_ARCH" == "arm64" ]; then
   ARCH="arm64"
+elif [ "$BUILD_ARCH" == "ppc64" ]; then
+  ARCH="ppc64"
 elif [ "$BUILD_ARCH" == "ppc64le" ]; then
   ARCH="ppc64el"
 else

--- a/scripts/build-rpm-package.sh
+++ b/scripts/build-rpm-package.sh
@@ -28,6 +28,10 @@ elif [ "$BUILD_ARCH" == "386" ]; then
   ARCH="i386"
 elif [ "$BUILD_ARCH" == "arm64" ]; then
   ARCH="aarch64"
+elif [ "$BUILD_ARCH" == "ppc64" ]; then
+  ARCH="ppc64"
+elif [ "$BUILD_ARCH" == "ppc64le" ]; then
+  ARCH="ppc64le"
 else
   echo "Unknown architecture: $BUILD_ARCH"
   exit 1


### PR DESCRIPTION
Update DEB and RPM packaging to include ppc64(le). These architectures are community supported but we already build them so including them in our packaging is an easy win.

Fixes #1393 