### PR TITLE
Fix redactor table size

### DIFF
--- a/bootstrap/redactor.go
+++ b/bootstrap/redactor.go
@@ -16,7 +16,7 @@ type Redactor struct {
 	maxlen int
 
 	// Table of Boyer-Moore skip distances, and values to redact matching this end byte
-	table [255]struct {
+	table [256]struct {
 		skip    int
 		needles [][]byte
 	}

--- a/bootstrap/redactor_test.go
+++ b/bootstrap/redactor_test.go
@@ -112,3 +112,11 @@ func TestRedactorSubsetSecrets(t *testing.T) {
 		t.Errorf("Redaction failed: %s", buf.String())
 	}
 }
+
+func TestRedactorLatin1(t *testing.T) {
+	var buf bytes.Buffer
+	redactor := NewRedactor(&buf, "[REDACTED]", []string{"ÿ"})
+
+	redactor.Write([]byte("foo"))
+	redactor.Flush()
+}


### PR DESCRIPTION
This was missed while reviewing the redactor code. I focused on the string indexing and arithmetic and completely missed that the skip table only covered bytes 0b0000_0000 through 0b1111_1110 allowing this out of range indexing.

Fixes #1478 