### PR TITLE
Add logging when creating artifact Uploader

### DIFF
--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -416,7 +416,7 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 		return fmt.Errorf("There were errors with uploading some of the artifacts")
 	}
 
-	a.logger.Info("Artifact uploads completed succesfully")
+	a.logger.Info("Artifact uploads completed successfully")
 
 	return nil
 }

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -250,10 +250,14 @@ func (a *ArtifactUploader) upload(artifacts []*api.Artifact) error {
 		} else {
 			return errors.New(fmt.Sprintf("Invalid upload destination: '%v'. Only s3://, gs:// or rt:// upload destinations are allowed. Did you forget to surround your artifact upload pattern in double quotes?", a.conf.Destination))
 		}
+
+		a.logger.Info("Uploading to %q, using your agent configuration", a.conf.Destination)
 	} else {
 		uploader = NewFormUploader(a.logger, FormUploaderConfig{
 			DebugHTTP: a.conf.DebugHTTP,
 		})
+
+		a.logger.Info("Uploading to default Buildkite artifact storage")
 	}
 
 	// Check if creation caused an error

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1758,7 +1758,6 @@ func (b *Bootstrap) uploadArtifacts(ctx context.Context) error {
 
 	// If blank, the upload destination is buildkite
 	if b.ArtifactUploadDestination != "" {
-		b.shell.Commentf("Using default artifact upload destination")
 		args = append(args, b.ArtifactUploadDestination)
 	}
 


### PR DESCRIPTION
To help diagnose instances where an artifact is not uploaded to customer configured storage, add logging when determining where to put the artifacts.

```
2021-08-17 09:36:42 INFO   Found 1 files that match "/etc/hosts"
2021-08-17 09:36:42 INFO   Uploading to default Buildkite artifact storage
2021-08-17 09:36:42 INFO   Creating (0-1)/1 artifacts
2021-08-17 09:36:43 INFO   Uploading artifact a9153a78-7122-41d9-9833-d627331005cc etc/hosts (750 bytes)
2021-08-17 09:36:45 INFO   Successfully uploaded artifact "etc/hosts"
2021-08-17 09:36:47 INFO   Artifact uploads completed succesfully
```

Fixes #1467