### PR TITLE
Don’t override the command exit code when artifact_paths also fails

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -187,7 +187,16 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 		// Only upload artifacts as part of the command phase
 		if err = b.uploadArtifacts(ctx); err != nil {
 			b.shell.Errorf("%v", err)
-			return shell.GetExitCode(err)
+
+			if commandErr != nil {
+				// Both command, and upload have errored.
+				//
+				// Ignore the agent upload error, rely on the phase and command
+				// error reporting below.
+			} else {
+				// Only upload has errored, report its error.
+				return shell.GetExitCode(err)
+			}
 		}
 	}
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -160,6 +160,22 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 	if phaseErr == nil && includePhase(`command`) {
 		var commandErr error
 		phaseErr, commandErr = b.CommandPhase(ctx)
+		/*
+			Five possible states at this point:
+
+			Pre-command failed
+			Pre-command succeeded, command failed, post-command succeeded
+			Pre-command succeeded, command failed, post-command failed
+			Pre-command succeeded, command succeeded, post-command succeeded
+			Pre-command succeeded, command succeeded, post-command failed
+
+			All states should attempt an artifact upload, to change this would
+			not be backwards compatible.
+
+			At this point, if commandErr != nil, BUILDKITE_COMMAND_EXIT_STATUS
+			has been set.
+		*/
+
 		// Add command exit error info. This is distinct from a phaseErr, which is
 		// an error from the hook/job logic. These are both good to report but
 		// shouldn't override each other in reporting.


### PR DESCRIPTION
Whether the command errors or not, we always attempt to upload the artifact paths indicated in the `artifact_paths` command step property.

While we discussed only attempting an upload following a successful command (and phase) execution, changing this would be a backwards incompatible change. Instead, we decided to bypass the artifact exit code reporting when _both_ command and artifact upload errored. We still eventually exit with a non-zero code, but we preserve the command’s exit code so that any automatic retry attributes are applied.

Fixes #1099