### PR TITLE
Change the environment diff algorithm to support removed keys

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -404,7 +404,7 @@ func (b *Bootstrap) applyEnvironmentChanges(changes hook.HookScriptChanges, reda
 		return
 	}
 
-	mergedEnv := b.shell.Env.Merge(changes.Diff)
+	mergedEnv := b.shell.Env.Apply(changes.Diff)
 
 	// reset output redactors based on new environment variable values
 	redactors.Flush()

--- a/env/environment.go
+++ b/env/environment.go
@@ -147,6 +147,22 @@ func (e *Environment) Merge(other *Environment) *Environment {
 	return c
 }
 
+func (e *Environment) Apply(diff Diff) *Environment {
+	c := e.Copy()
+
+	for k, v := range diff.Added {
+		c.env[k] = v
+	}
+	for k, v := range diff.Changed {
+		c.env[k] = v.New
+	}
+	for k, _ := range diff.Removed {
+		delete(c.env, k)
+	}
+
+	return c
+}
+
 // Copy returns a copy of the env
 func (e *Environment) Copy() *Environment {
 	c := make(map[string]string)

--- a/env/environment.go
+++ b/env/environment.go
@@ -20,7 +20,7 @@ type Pair struct {
 type Diff struct {
 	Added map[string]string
 	Changed map[string]Pair
-	Removed []string
+	Removed map[string]struct{}
 }
 
 func New() *Environment {
@@ -94,7 +94,7 @@ func (e *Environment) Diff(other *Environment) Diff {
 	diff := Diff{
 		Added: make(map[string]string),
 		Changed: make(map[string]Pair),
-		Removed: make([]string, 0),
+		Removed: make(map[string]struct{}, 0),
 	}
 
 	for k, v := range e.env {
@@ -115,7 +115,7 @@ func (e *Environment) Diff(other *Environment) Diff {
 
 	for k, _ := range other.env {
 		if _, ok := e.Get(k); !ok {
-			diff.Removed = append(diff.Removed, k)
+			diff.Removed[k] = struct{}{}
 		}
 	}
 

--- a/env/environment.go
+++ b/env/environment.go
@@ -151,10 +151,10 @@ func (e *Environment) Apply(diff Diff) *Environment {
 	c := e.Copy()
 
 	for k, v := range diff.Added {
-		c.env[k] = v
+		c.Set(k, v)
 	}
 	for k, v := range diff.Changed {
-		c.env[k] = v.New
+		c.Set(k, v.New)
 	}
 	for k, _ := range diff.Removed {
 		delete(c.env, k)

--- a/env/environment.go
+++ b/env/environment.go
@@ -29,6 +29,10 @@ func (diff *Diff) Remove(key string) {
 	delete(diff.Removed, key)
 }
 
+func (diff *Diff) Empty() bool {
+	return len(diff.Added) == 0 && len(diff.Changed) == 0 && len(diff.Removed) == 0
+}
+
 func New() *Environment {
 	return &Environment{env: map[string]string{}}
 }

--- a/env/environment.go
+++ b/env/environment.go
@@ -23,6 +23,12 @@ type Diff struct {
 	Removed map[string]struct{}
 }
 
+func (diff *Diff) Remove(key string) {
+	delete(diff.Added, key)
+	delete(diff.Changed, key)
+	delete(diff.Removed, key)
+}
+
 func New() *Environment {
 	return &Environment{env: map[string]string{}}
 }

--- a/env/environment.go
+++ b/env/environment.go
@@ -12,27 +12,6 @@ type Environment struct {
 	env map[string]string
 }
 
-type Pair struct {
-	Old string
-	New string
-}
-
-type Diff struct {
-	Added map[string]string
-	Changed map[string]Pair
-	Removed map[string]struct{}
-}
-
-func (diff *Diff) Remove(key string) {
-	delete(diff.Added, key)
-	delete(diff.Changed, key)
-	delete(diff.Removed, key)
-}
-
-func (diff *Diff) Empty() bool {
-	return len(diff.Added) == 0 && len(diff.Changed) == 0 && len(diff.Removed) == 0
-}
-
 func New() *Environment {
 	return &Environment{env: map[string]string{}}
 }
@@ -101,9 +80,9 @@ func (e *Environment) Length() int {
 // Diff returns a new environment with the keys and values from this
 // environment which are different in the other one.
 func (e *Environment) Diff(other *Environment) Diff {
-	diff := Diff{
+	diff := Diff {
 		Added: make(map[string]string),
-		Changed: make(map[string]Pair),
+		Changed: make(map[string]DiffPair),
 		Removed: make(map[string]struct{}, 0),
 	}
 
@@ -116,7 +95,7 @@ func (e *Environment) Diff(other *Environment) Diff {
 		}
 
 		if other != v {
-			diff.Changed[k] = Pair {
+			diff.Changed[k] = DiffPair {
 				Old: other,
 				New: v,
 			}
@@ -223,4 +202,25 @@ func normalizeKeyName(key string) string {
 	} else {
 		return key
 	}
+}
+
+type Diff struct {
+	Added map[string]string
+	Changed map[string]DiffPair
+	Removed map[string]struct{}
+}
+
+type DiffPair struct {
+	Old string
+	New string
+}
+
+func (diff *Diff) Remove(key string) {
+	delete(diff.Added, key)
+	delete(diff.Changed, key)
+	delete(diff.Removed, key)
+}
+
+func (diff *Diff) Empty() bool {
+	return len(diff.Added) == 0 && len(diff.Changed) == 0 && len(diff.Removed) == 0
 }

--- a/env/environment_test.go
+++ b/env/environment_test.go
@@ -166,3 +166,46 @@ func TestEmptyDiff(t *testing.T) {
 
 	assert.Equal(t, true, empty.Empty())
 }
+
+func TestEnvironmentApply(t *testing.T) {
+	t.Parallel()
+
+	env := &Environment{}
+	env = env.Apply(Diff {
+		Added: map[string]string{
+			"LLAMAS_ENABLED": "1",
+		},
+		Changed: map[string]Pair{},
+		Removed: map[string]struct{}{},
+	})
+	assert.Equal(t, FromSlice([]string{
+		"LLAMAS_ENABLED=1",
+	}), env)
+
+	env = env.Apply(Diff {
+		Added: map[string]string{
+			"ALPACAS_ENABLED": "1",
+		},
+		Changed: map[string]Pair{
+			"LLAMAS_ENABLED": Pair {
+				Old: "1",
+				New: "0",
+			},
+		},
+		Removed: map[string]struct{}{},
+	})
+	assert.Equal(t, FromSlice([]string{
+		"ALPACAS_ENABLED=1",
+		"LLAMAS_ENABLED=0",
+	}), env)
+
+	env = env.Apply(Diff {
+		Added: map[string]string{},
+		Changed: map[string]Pair{},
+		Removed: map[string]struct{} {
+			"LLAMAS_ENABLED": struct{}{},
+			"ALPACAS_ENABLED": struct{}{},
+		},
+	})
+	assert.Equal(t, FromSlice([]string{}), env)
+}

--- a/env/environment_test.go
+++ b/env/environment_test.go
@@ -102,8 +102,8 @@ func TestEnvironmentDiff(t *testing.T) {
 	ab := a.Diff(b)
 	assert.Equal(t, Diff {
 		Added: map[string]string{},
-		Changed: map[string]Pair{
-			"B": Pair {
+		Changed: map[string]DiffPair{
+			"B": DiffPair {
 				Old: "there",
 				New: "world",
 			},
@@ -120,8 +120,8 @@ func TestEnvironmentDiff(t *testing.T) {
 			"C": "new",
 			"D": "",
 		},
-		Changed: map[string]Pair {
-			"B": Pair {
+		Changed: map[string]DiffPair {
+			"B": DiffPair {
 				Old: "world",
 				New: "there",
 			},
@@ -137,8 +137,8 @@ func TestEnvironmentDiffRemove(t *testing.T) {
 		Added: map[string]string {
 			"A": "new",
 		},
-		Changed: map[string]Pair {
-			"B": Pair {
+		Changed: map[string]DiffPair {
+			"B": DiffPair {
 				Old: "old",
 				New: "new",
 			},
@@ -154,7 +154,7 @@ func TestEnvironmentDiffRemove(t *testing.T) {
 
 	assert.Equal(t, Diff {
 		Added: map[string]string {},
-		Changed: map[string]Pair {},
+		Changed: map[string]DiffPair {},
 		Removed: map[string]struct{}{},
 	}, diff)
 }
@@ -175,7 +175,7 @@ func TestEnvironmentApply(t *testing.T) {
 		Added: map[string]string{
 			"LLAMAS_ENABLED": "1",
 		},
-		Changed: map[string]Pair{},
+		Changed: map[string]DiffPair{},
 		Removed: map[string]struct{}{},
 	})
 	assert.Equal(t, FromSlice([]string{
@@ -186,8 +186,8 @@ func TestEnvironmentApply(t *testing.T) {
 		Added: map[string]string{
 			"ALPACAS_ENABLED": "1",
 		},
-		Changed: map[string]Pair{
-			"LLAMAS_ENABLED": Pair {
+		Changed: map[string]DiffPair{
+			"LLAMAS_ENABLED": DiffPair {
 				Old: "1",
 				New: "0",
 			},
@@ -201,7 +201,7 @@ func TestEnvironmentApply(t *testing.T) {
 
 	env = env.Apply(Diff {
 		Added: map[string]string{},
-		Changed: map[string]Pair{},
+		Changed: map[string]DiffPair{},
 		Removed: map[string]struct{} {
 			"LLAMAS_ENABLED": struct{}{},
 			"ALPACAS_ENABLED": struct{}{},

--- a/env/environment_test.go
+++ b/env/environment_test.go
@@ -98,12 +98,34 @@ func TestEnvironmentDiff(t *testing.T) {
 	t.Parallel()
 	a := FromSlice([]string{"A=hello", "B=world"})
 	b := FromSlice([]string{"A=hello", "B=there", "C=new", "D="})
-	ab := a.Diff(b).ToMap()
-	ba := b.Diff(a).ToMap()
 
-	// a.Diff(b) gives us the key:values from a that are different in b
-	assert.Equal(t, map[string]string{"B": "world"}, ab)
+	ab := a.Diff(b)
+	assert.Equal(t, Diff {
+		Added: map[string]string{},
+		Changed: map[string]Pair{
+			"B": Pair {
+				Old: "there",
+				New: "world",
+			},
+		},
+		Removed: []string{
+			"C",
+			"D",
+		},
+	}, ab)
 
-	// b.Diff(a) gives us the key:values from b that are different in a
-	assert.Equal(t, map[string]string{"B": "there", "C": "new", "D": ""}, ba)
+	ba := b.Diff(a)
+	assert.Equal(t, Diff {
+		Added: map[string]string{
+			"C": "new",
+			"D": "",
+		},
+		Changed: map[string]Pair {
+			"B": Pair {
+				Old: "world",
+				New: "there",
+			},
+		},
+		Removed: []string{},
+	}, ba)
 }

--- a/env/environment_test.go
+++ b/env/environment_test.go
@@ -129,3 +129,32 @@ func TestEnvironmentDiff(t *testing.T) {
 		Removed: map[string]struct{}{},
 	}, ba)
 }
+
+func TestEnvironmentDiffRemove(t *testing.T) {
+	t.Parallel()
+
+	diff := Diff {
+		Added: map[string]string {
+			"A": "new",
+		},
+		Changed: map[string]Pair {
+			"B": Pair {
+				Old: "old",
+				New: "new",
+			},
+		},
+		Removed: map[string]struct{} {
+			"C": struct{}{},
+		},
+	}
+
+	diff.Remove("A")
+	diff.Remove("B")
+	diff.Remove("C")
+
+	assert.Equal(t, Diff {
+		Added: map[string]string {},
+		Changed: map[string]Pair {},
+		Removed: map[string]struct{}{},
+	}, diff)
+}

--- a/env/environment_test.go
+++ b/env/environment_test.go
@@ -108,9 +108,9 @@ func TestEnvironmentDiff(t *testing.T) {
 				New: "world",
 			},
 		},
-		Removed: []string{
-			"C",
-			"D",
+		Removed: map[string]struct{} {
+			"C": struct{}{},
+			"D": struct{}{},
 		},
 	}, ab)
 
@@ -126,6 +126,6 @@ func TestEnvironmentDiff(t *testing.T) {
 				New: "there",
 			},
 		},
-		Removed: []string{},
+		Removed: map[string]struct{}{},
 	}, ba)
 }

--- a/env/environment_test.go
+++ b/env/environment_test.go
@@ -158,3 +158,11 @@ func TestEnvironmentDiffRemove(t *testing.T) {
 		Removed: map[string]struct{}{},
 	}, diff)
 }
+
+func TestEmptyDiff(t *testing.T) {
+	t.Parallel()
+
+	empty := Diff{}
+
+	assert.Equal(t, true, empty.Empty())
+}

--- a/hook/scriptwrapper.go
+++ b/hook/scriptwrapper.go
@@ -178,6 +178,9 @@ func (wrap *ScriptWrapper) Changes() (hookScriptChanges, error) {
 	diff.Remove(hookExitStatusEnv)
 	diff.Remove(hookWorkingDirEnv)
 
+	// Bash sets this, but we don't care about it
+	diff.Remove("_")
+
 	return hookScriptChanges{Diff: diff, Dir: wd}, nil
 }
 

--- a/hook/scriptwrapper.go
+++ b/hook/scriptwrapper.go
@@ -38,7 +38,7 @@ type ScriptWrapper struct {
 	beforeWd      string
 }
 
-type hookScriptChanges struct {
+type HookScriptChanges struct {
 	Diff env.Diff
 	Dir string
 }
@@ -158,15 +158,15 @@ func (wrap *ScriptWrapper) Close() {
 }
 
 // Changes returns the changes in the environment and working dir after the hook script runs
-func (wrap *ScriptWrapper) Changes() (hookScriptChanges, error) {
+func (wrap *ScriptWrapper) Changes() (HookScriptChanges, error) {
 	beforeEnvContents, err := ioutil.ReadFile(wrap.beforeEnvFile.Name())
 	if err != nil {
-		return hookScriptChanges{}, fmt.Errorf("Failed to read \"%s\" (%s)", wrap.beforeEnvFile.Name(), err)
+		return HookScriptChanges{}, fmt.Errorf("Failed to read \"%s\" (%s)", wrap.beforeEnvFile.Name(), err)
 	}
 
 	afterEnvContents, err := ioutil.ReadFile(wrap.afterEnvFile.Name())
 	if err != nil {
-		return hookScriptChanges{}, fmt.Errorf("Failed to read \"%s\" (%s)", wrap.afterEnvFile.Name(), err)
+		return HookScriptChanges{}, fmt.Errorf("Failed to read \"%s\" (%s)", wrap.afterEnvFile.Name(), err)
 	}
 
 	beforeEnv := env.FromExport(string(beforeEnvContents))
@@ -181,7 +181,7 @@ func (wrap *ScriptWrapper) Changes() (hookScriptChanges, error) {
 	// Bash sets this, but we don't care about it
 	diff.Remove("_")
 
-	return hookScriptChanges{Diff: diff, Dir: wd}, nil
+	return HookScriptChanges{Diff: diff, Dir: wd}, nil
 }
 
 func (wrap *ScriptWrapper) getAfterWd(diff env.Diff) string {

--- a/hook/scriptwrapper_test.go
+++ b/hook/scriptwrapper_test.go
@@ -50,17 +50,24 @@ func TestRunningHookDetectsChangedEnvironment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The strict equals check here also ensures we aren't bubbling up the
-	// internal BUILDKITE_HOOK_EXIT_STATUS and BUILDKITE_HOOK_WORKING_DIR
-	// environment variables
-	assert.Equal(t, env.Diff {
+	// Windows’ batch 'SET >' normalises environment variables case so we apply
+	// the 'expected' and 'actual' diffs to a blank Environment which handles
+	// case normalisation for us
+	expected := (&env.Environment{}).Apply(env.Diff {
 		Added: map[string]string {
 			"LLAMAS": "rock",
 			"Alpacas": "are ok",
 		},
 		Changed: map[string]env.Pair{},
 		Removed: map[string]struct{}{},
-	}, changes.Diff)
+	})
+
+	actual := (&env.Environment{}).Apply(changes.Diff)
+
+	// The strict equals check here also ensures we aren't bubbling up the
+	// internal BUILDKITE_HOOK_EXIT_STATUS and BUILDKITE_HOOK_WORKING_DIR
+	// environment variables
+	assert.Equal(t, expected, actual)
 }
 
 func TestRunningHookDetectsChangedWorkingDirectory(t *testing.T) {

--- a/hook/scriptwrapper_test.go
+++ b/hook/scriptwrapper_test.go
@@ -58,7 +58,7 @@ func TestRunningHookDetectsChangedEnvironment(t *testing.T) {
 			"LLAMAS": "rock",
 			"Alpacas": "are ok",
 		},
-		Changed: map[string]env.Pair{},
+		Changed: map[string]env.DiffPair{},
 		Removed: map[string]struct{}{},
 	})
 

--- a/hook/scriptwrapper_test.go
+++ b/hook/scriptwrapper_test.go
@@ -6,12 +6,12 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"testing"
 
 	"github.com/buildkite/agent/v3/bootstrap/shell"
 	"github.com/buildkite/agent/v3/env"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRunningHookDetectsChangedEnvironment(t *testing.T) {
@@ -50,9 +50,14 @@ func TestRunningHookDetectsChangedEnvironment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(changes.Env, env.FromSlice([]string{"LLAMAS=rock", "Alpacas=are ok"})) {
-		t.Fatalf("Unexpected env in %#v", changes.Env)
-	}
+	assert.Equal(t, env.Diff {
+		Added: map[string]string {
+			"LLAMAS": "rock",
+			"Alpacas": "are ok",
+		},
+		Changed: map[string]env.Pair{},
+		Removed: map[string]struct{}{},
+	}, changes.Diff)
 }
 
 func TestRunningHookDetectsChangedWorkingDirectory(t *testing.T) {

--- a/hook/scriptwrapper_test.go
+++ b/hook/scriptwrapper_test.go
@@ -50,6 +50,9 @@ func TestRunningHookDetectsChangedEnvironment(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// The strict equals check here also ensures we aren't bubbling up the
+	// internal BUILDKITE_HOOK_EXIT_STATUS and BUILDKITE_HOOK_WORKING_DIR
+	// environment variables
 	assert.Equal(t, env.Diff {
 		Added: map[string]string {
 			"LLAMAS": "rock",


### PR DESCRIPTION
A work in progress to support `unset` in hooks and propagate those to subsequent hooks and phases. The primary use case for this being AWS credentials stored in environment variables.

Fixes #1471