### PR TITLE
git-mirrors improvements

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1269,9 +1269,11 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 		var err error
 		mirrorDir, err = b.updateGitMirror()
 		if err != nil {
-			return err
+			b.shell.Errorf("Your git-mirror failed to update: %v", err)
+			mirrorDir = ""
+		} else {
+			b.shell.Env.Set("BUILDKITE_REPO_MIRROR", mirrorDir)
 		}
-		b.shell.Env.Set("BUILDKITE_REPO_MIRROR", mirrorDir)
 	}
 
 	// Make sure the build directory exists and that we change directory into it

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1185,7 +1185,6 @@ func (b *Bootstrap) updateGitMirror() (string, error) {
 	if b.Debug {
 		b.shell.Commentf("Acquiring mirror repository clone lock")
 	}
-
 	// Lock the mirror dir to prevent concurrent clones
 	mirrorCloneLock, err := b.shell.LockFile(mirrorDir+".clonelock", lockTimeout)
 	if err != nil {
@@ -1193,15 +1192,11 @@ func (b *Bootstrap) updateGitMirror() (string, error) {
 	}
 	defer mirrorCloneLock.Unlock()
 
-	// If we don't have a mirror, we need to clone it
 	if !utils.FileExists(mirrorDir) {
-		b.shell.Commentf("Cloning a mirror of the repository to %q", mirrorDir)
-		flags := "--mirror " + b.GitCloneMirrorFlags
-		if err := gitClone(b.shell, flags, b.Repository, mirrorDir); err != nil {
+		b.shell.Commentf("Creating a git-mirror at %q for %q", mirrorDir, b.Repository)
+		if err := b.shell.Run("git", "init", "--shared=group", "--bare", mirrorDir); err != nil {
 			return "", err
 		}
-
-		return mirrorDir, nil
 	}
 
 	// If it exists, immediately release the clone lock
@@ -1216,7 +1211,6 @@ func (b *Bootstrap) updateGitMirror() (string, error) {
 	if b.Debug {
 		b.shell.Commentf("Acquiring mirror repository update lock")
 	}
-
 	// Lock the mirror dir to prevent concurrent updates
 	mirrorUpdateLock, err := b.shell.LockFile(mirrorDir+".updatelock", lockTimeout)
 	if err != nil {

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -204,7 +204,7 @@ func (s *Shell) LockFile(path string, timeout time.Duration) (LockFile, error) {
 		if err := lock.TryLock(); err != nil {
 			s.Commentf("Could not acquire lock on \"%s\" (%s)", absolutePathToLock, err)
 
-			if te, ok := err.(interface{ Temporary() bool }); ok {
+			if _, ok := err.(interface{ Temporary() bool }); ok {
 				s.Commentf("Trying again in %s...", lockRetryDuration)
 				time.Sleep(lockRetryDuration)
 			} else {

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -203,8 +203,13 @@ func (s *Shell) LockFile(path string, timeout time.Duration) (LockFile, error) {
 		// Keep trying the lock until we get it
 		if err := lock.TryLock(); err != nil {
 			s.Commentf("Could not acquire lock on \"%s\" (%s)", absolutePathToLock, err)
-			s.Commentf("Trying again in %s...", lockRetryDuration)
-			time.Sleep(lockRetryDuration)
+
+			if te, ok := err.(interface{ Temporary() bool }); ok {
+				s.Commentf("Trying again in %s...", lockRetryDuration)
+				time.Sleep(lockRetryDuration)
+			} else {
+				return nil, err
+			}
 		} else {
 			break
 		}


### PR DESCRIPTION
A couple of changes to git-mirrors batched up:

- Set shared=group to allow NixOS agents to share a mirror
- Don’t retry EPERM errors on the lockfile (to be tested) because they aren’t temporary
- Replace the mirror clone with a git init (allowing shared to be set)
    - This one is fairly substantial because there is no initial clone which would pull down all refs, instead only the 'wanted' ref is pulled down via a fetch
- Make git-mirror success optional if the experiment is enabled
    - If the experiment is on but the fetch fails for any reason, continue on without it

Fixes #1481
Fixes #1480