### PR TITLE
Fix plugin error causing use of master branch

### DIFF
--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+go version
+
 GO111MODULE=off go get gotest.tools/gotestsum
 
 echo '+++ Running tests'

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -916,10 +916,6 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 
 	b.shell.Commentf("Plugin \"%s\" will be checked out to \"%s\"", p.Location, directory)
 
-	if b.Debug {
-		b.shell.Commentf("Checking if \"%s\" is a local repository", repo)
-	}
-
 	// Switch to the plugin directory
 	b.shell.Commentf("Switching to the plugin directory")
 	previousWd := b.shell.Getwd()

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -903,6 +903,8 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 		return checkout, nil
 	}
 
+	b.shell.Commentf("Plugin \"%s\" will be checked out to \"%s\"", p.Location, directory)
+
 	// Make the directory
 	tempDir, err = os.MkdirTemp(b.PluginsPath, id)
 	if err != nil {
@@ -913,8 +915,6 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	b.shell.Commentf("Plugin \"%s\" will be checked out to \"%s\"", p.Location, directory)
 
 	// Switch to the plugin directory
 	b.shell.Commentf("Switching to the plugin directory")

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -915,7 +915,7 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	}
 
 	// Make the directory
-	tempDir, err = os.MkdirTemp(b.PluginsPath, id)
+	tempDir, err := os.MkdirTemp(b.PluginsPath, id)
 	if err != nil {
 		return nil, err
 	}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -871,15 +871,6 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 		return nil, err
 	}
 
-	// Try and lock this particular plugin while we check it out (we create
-	// the file outside of the plugin directory so git clone doesn't have
-	// a cry about the directory not being empty)
-	pluginCheckoutHook, err := b.shell.LockFile(filepath.Join(b.PluginsPath, id+".lock"), time.Minute*5)
-	if err != nil {
-		return nil, err
-	}
-	defer pluginCheckoutHook.Unlock()
-
 	// Create a path to the plugin
 	directory := filepath.Join(b.PluginsPath, id)
 	pluginGitDirectory := filepath.Join(directory, ".git")
@@ -888,6 +879,15 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 		CheckoutDir: directory,
 		HooksDir:    filepath.Join(directory, "hooks"),
 	}
+
+	// Try and lock this particular plugin while we check it out (we create
+	// the file outside of the plugin directory so git clone doesn't have
+	// a cry about the directory not being empty)
+	pluginCheckoutHook, err := b.shell.LockFile(filepath.Join(b.PluginsPath, id+".lock"), time.Minute*5)
+	if err != nil {
+		return nil, err
+	}
+	defer pluginCheckoutHook.Unlock()
 
 	// Has it already been checked out?
 	if utils.FileExists(pluginGitDirectory) {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -921,15 +921,13 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	}
 
 	// Switch to the plugin directory
+	b.shell.Commentf("Switching to the plugin directory")
 	previousWd := b.shell.Getwd()
 	if err = b.shell.Chdir(directory); err != nil {
 		return nil, err
 	}
-
 	// Switch back to the previous working directory
 	defer b.shell.Chdir(previousWd)
-
-	b.shell.Commentf("Switching to the plugin directory")
 
 	if b.SSHKeyscan {
 		addRepositoryHostToSSHKnownHosts(b.shell, repo)

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -909,13 +909,6 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 		return nil, err
 	}
 
-	// Once we've got the lock, we need to make sure another process didn't already
-	// checkout the plugin
-	if utils.FileExists(pluginGitDirectory) {
-		b.shell.Commentf("Plugin \"%s\" already checked out", p.Label())
-		return checkout, nil
-	}
-
 	repo, err := p.Repository()
 	if err != nil {
 		return nil, err

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -915,7 +915,7 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	}
 
 	// Make the directory
-	tempDir, err := os.MkdirTemp(b.PluginsPath, id)
+	tempDir, err := ioutil.TempDir(b.PluginsPath, id)
 	if err != nil {
 		return nil, err
 	}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -904,7 +904,7 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	}
 
 	// Make the directory
-	err = os.MkdirAll(directory, 0777)
+	tempDir, err = os.MkdirTemp(b.PluginsPath, id)
 	if err != nil {
 		return nil, err
 	}
@@ -919,7 +919,7 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	// Switch to the plugin directory
 	b.shell.Commentf("Switching to the plugin directory")
 	previousWd := b.shell.Getwd()
-	if err = b.shell.Chdir(directory); err != nil {
+	if err = b.shell.Chdir(tempDir); err != nil {
 		return nil, err
 	}
 	// Switch back to the previous working directory
@@ -940,6 +940,11 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 		if err = b.shell.Run("git", "checkout", "-f", p.Version); err != nil {
 			return nil, err
 		}
+	}
+
+	err = os.Rename(tempDir, directory)
+	if err != nil {
+		return nil, err
 	}
 
 	return checkout, nil

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -921,7 +921,7 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	}
 
 	// Switch to the plugin directory
-	b.shell.Commentf("Switching to the plugin directory")
+	b.shell.Commentf("Switching to the temporary plugin directory")
 	previousWd := b.shell.Getwd()
 	if err = b.shell.Chdir(tempDir); err != nil {
 		return nil, err
@@ -942,6 +942,7 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 		}
 	}
 
+	b.shell.Commentf("Moving temporary plugin directory to final location")
 	err = os.Rename(tempDir, directory)
 	if err != nil {
 		return nil, err

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -905,13 +905,17 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 
 	b.shell.Commentf("Plugin \"%s\" will be checked out to \"%s\"", p.Location, directory)
 
-	// Make the directory
-	tempDir, err = os.MkdirTemp(b.PluginsPath, id)
+	repo, err := p.Repository()
 	if err != nil {
 		return nil, err
 	}
 
-	repo, err := p.Repository()
+	if b.SSHKeyscan {
+		addRepositoryHostToSSHKnownHosts(b.shell, repo)
+	}
+
+	// Make the directory
+	tempDir, err = os.MkdirTemp(b.PluginsPath, id)
 	if err != nil {
 		return nil, err
 	}
@@ -924,10 +928,6 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	}
 	// Switch back to the previous working directory
 	defer b.shell.Chdir(previousWd)
-
-	if b.SSHKeyscan {
-		addRepositoryHostToSSHKnownHosts(b.shell, repo)
-	}
 
 	// Plugin clones shouldn't use custom GitCloneFlags
 	if err = b.shell.Run("git", "clone", "-v", "--", repo, "."); err != nil {


### PR DESCRIPTION
The multi-step plug-in clone needs to be fail safe. If the procedure is aborted at any point, there must not be a directory visible in the file system at the expected location, otherwise clone will not be re-attempted.

Using a temporary directory in the plugins path, and renaming the temporary directory to the final location, should avoid this. This carries the hazard that a failed checkout will linger in the plug-ins directory un-removed, but I have decided that the benefit is worth this 'directory leak'. There exists a general problem of files left behind by an aborted bootstrap process. We can use fixing that as an opportunity to fix this too.

- [x] Test locally

Fixes #1193