### PR TITLE
Discover artifact bucket region using S3 manager API

### DIFF
--- a/agent/s3.go
+++ b/agent/s3.go
@@ -130,7 +130,7 @@ func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 		return nil, err
 	}
 
-	l.Debug("Testing AWS S3 credentials for bucket %q in region %q...", bucket, sess.Config.Region)
+	l.Debug("Testing AWS S3 credentials for bucket %q in region %q...", bucket, *sess.Config.Region)
 
 	s3client := s3.New(sess)
 
@@ -152,7 +152,7 @@ func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 
 			return nil, fmt.Errorf("%s You can authenticate by setting Buildkite environment variables (BUILDKITE_S3_ACCESS_KEY_ID, BUILDKITE_S3_SECRET_ACCESS_KEY), AWS environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY), Web Identity environment variables (AWS_ROLE_ARN, AWS_ROLE_SESSION_NAME, AWS_WEB_IDENTITY_TOKEN_FILE), or if running on AWS EC2 ensuring network access to the EC2 Instance Metadata Service to use an instance profile’s IAM Role credentials.", errorTitle)
 		}
-		return nil, fmt.Errorf("Could not s3:ListObjects in your AWS S3 bucket %q in region %q: (%s)", bucket, sess.Config.Region, err.Error())
+		return nil, fmt.Errorf("Could not s3:ListObjects in your AWS S3 bucket %q in region %q: (%s)", bucket, *sess.Config.Region, err.Error())
 	}
 
 	return s3client, nil

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -130,7 +130,7 @@ func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 		return nil, err
 	}
 
-	l.Debug("Testing AWS S3 credentials for bucket %q in region %q...", bucket, bucketRegion)
+	l.Debug("Testing AWS S3 credentials for bucket %q in region %q...", bucket, sess.Config.Region)
 
 	s3client := s3.New(sess)
 
@@ -152,7 +152,7 @@ func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 
 			return nil, fmt.Errorf("%s You can authenticate by setting Buildkite environment variables (BUILDKITE_S3_ACCESS_KEY_ID, BUILDKITE_S3_SECRET_ACCESS_KEY), AWS environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY), Web Identity environment variables (AWS_ROLE_ARN, AWS_ROLE_SESSION_NAME, AWS_WEB_IDENTITY_TOKEN_FILE), or if running on AWS EC2 ensuring network access to the EC2 Instance Metadata Service to use an instance profile’s IAM Role credentials.", errorTitle)
 		}
-		return nil, fmt.Errorf("Could not s3:ListObjects in your AWS S3 bucket `%s` in region `%s`: (%s)", bucket, region, err.Error())
+		return nil, fmt.Errorf("Could not s3:ListObjects in your AWS S3 bucket %q in region %q: (%s)", bucket, sess.Config.Region, err.Error())
 	}
 
 	return s3client, nil

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -52,11 +52,8 @@ func (e *credentialsProvider) IsExpired() bool {
 }
 
 func awsS3RegionFromEnv() (region string, err error) {
-	regionName := "us-east-1"
-	if os.Getenv("BUILDKITE_S3_DEFAULT_REGION") != "" {
-		regionName = os.Getenv("BUILDKITE_S3_DEFAULT_REGION")
-	} else {
-		var err error
+	regionName := os.Getenv("BUILDKITE_S3_DEFAULT_REGION")
+	if regionName == "" {
 		regionName, err = awsRegion()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
Use the provided region to discover the actual region.

This handles the cross region case where a pipeline’s `AWS_DEFAULT_REGION` points somewhere other than the bucket region.

Fixes https://github.com/buildkite/agent/pull/new/keithduncan/artifact-cross-region