### PR TITLE
Use buildx to build multi arch images

### DIFF
--- a/.buildkite/pipeline.test-image.yml
+++ b/.buildkite/pipeline.test-image.yml
@@ -1,0 +1,6 @@
+---
+steps:
+  - name: ":docker: $IMAGE $PLATFORM"
+    command: .buildkite/steps/test-image.sh $IMAGE $PLATFORM
+    agents:
+      queue: $QUEUE

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -311,7 +311,7 @@ steps:
       - build-binary-linux-armhf
       - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh alpine linux/arm/v7,linux/arm64/v8,linux/amd64"
+    command: ".buildkite/steps/build-docker-image.sh alpine linux/arm/v7,linux/arm64,linux/amd64"
 
   - name: ":docker: ubuntu 18.04 build"
     key: build-docker-ubuntu-bionic-beaver
@@ -320,7 +320,7 @@ steps:
       - build-binary-linux-armhf
       - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh ubuntu-18.04 linux/arm/v7,linux/arm64/v8,linux/amd64"
+    command: ".buildkite/steps/build-docker-image.sh ubuntu-18.04 linux/arm/v7,linux/arm64,linux/amd64"
 
   - name: ":docker: ubuntu 20.04 build"
     key: build-docker-ubuntu-focal-fossa
@@ -329,7 +329,7 @@ steps:
       - build-binary-linux-armhf
       - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh ubuntu-20.04 linux/arm/v7,linux/arm64/v8,linux/amd64"
+    command: ".buildkite/steps/build-docker-image.sh ubuntu-20.04 linux/arm/v7,linux/arm64,linux/amd64"
 
   - name: ":docker: centos build"
     key: build-docker-centos
@@ -338,7 +338,7 @@ steps:
       - build-binary-linux-armhf
       - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh centos linux/arm/v7,linux/arm64/v8,linux/amd64"
+    command: ".buildkite/steps/build-docker-image.sh centos linux/arm/v7,linux/arm64,linux/amd64"
 
   - name: ":docker: sidecar build"
     key: build-docker-sidecar
@@ -347,7 +347,7 @@ steps:
       - build-binary-linux-armhf
       - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh sidecar linux/arm/v7,linux/arm64/v8,linux/amd64"
+    command: ".buildkite/steps/build-docker-image.sh sidecar linux/arm/v7,linux/arm64,linux/amd64"
 
   - name: ":debian: build"
     key: build-debian-packages

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -239,8 +239,9 @@ steps:
     key: build-docker-alpine
     depends_on:
       - build-binary-linux-amd64
+      - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh alpine"
+    command: ".buildkite/steps/build-docker-image.sh alpine linux/arm64/v8,linux/amd64"
 
   - name: ":docker: ubuntu 18.04 build"
     key: build-docker-ubuntu-bionic-beaver

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: elastic-runners-edge
+
 env:
   DRY_RUN: false # set to true to disable publishing releases
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -247,29 +247,33 @@ steps:
     key: build-docker-ubuntu-bionic-beaver
     depends_on:
       - build-binary-linux-amd64
+      - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh ubuntu-18.04"
+    command: ".buildkite/steps/build-docker-image.sh ubuntu-18.04 linux/arm64/v8,linux/amd64"
 
   - name: ":docker: ubuntu 20.04 build"
     key: build-docker-ubuntu-focal-fossa
     depends_on:
       - build-binary-linux-amd64
+      - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh ubuntu-20.04"
+    command: ".buildkite/steps/build-docker-image.sh ubuntu-20.04 linux/arm64/v8,linux/amd64"
 
   - name: ":docker: centos build"
     key: build-docker-centos
     depends_on:
       - build-binary-linux-amd64
+      - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh centos"
+    command: ".buildkite/steps/build-docker-image.sh centos linux/arm64/v8,linux/amd64"
 
   - name: ":docker: sidecar build"
     key: build-docker-sidecar
     depends_on:
       - build-binary-linux-amd64
+      - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh sidecar"
+    command: ".buildkite/steps/build-docker-image.sh sidecar linux/arm64/v8,linux/amd64"
 
   - name: ":debian: build"
     key: build-debian-packages

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -314,7 +314,7 @@ steps:
       - build-binary-linux-armhf
       - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh alpine linux/arm/v7,linux/arm64,linux/amd64"
+    command: ".buildkite/steps/build-docker-image.sh alpine linux/arm64,linux/amd64"
 
   - name: ":docker: ubuntu 18.04 build"
     key: build-docker-ubuntu-bionic-beaver
@@ -323,7 +323,7 @@ steps:
       - build-binary-linux-armhf
       - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh ubuntu-18.04 linux/arm/v7,linux/arm64,linux/amd64"
+    command: ".buildkite/steps/build-docker-image.sh ubuntu-18.04 linux/arm64,linux/amd64"
 
   - name: ":docker: ubuntu 20.04 build"
     key: build-docker-ubuntu-focal-fossa
@@ -332,7 +332,7 @@ steps:
       - build-binary-linux-armhf
       - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh ubuntu-20.04 linux/arm/v7,linux/arm64,linux/amd64"
+    command: ".buildkite/steps/build-docker-image.sh ubuntu-20.04 linux/arm64,linux/amd64"
 
   - name: ":docker: centos build"
     key: build-docker-centos
@@ -341,7 +341,7 @@ steps:
       - build-binary-linux-armhf
       - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh centos linux/arm/v7,linux/arm64,linux/amd64"
+    command: ".buildkite/steps/build-docker-image.sh centos linux/arm64,linux/amd64"
 
   - name: ":docker: sidecar build"
     key: build-docker-sidecar

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -308,41 +308,46 @@ steps:
     key: build-docker-alpine
     depends_on:
       - build-binary-linux-amd64
+      - build-binary-linux-armhf
       - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh alpine linux/arm64/v8,linux/amd64"
+    command: ".buildkite/steps/build-docker-image.sh alpine linux/arm/v7,linux/arm64/v8,linux/amd64"
 
   - name: ":docker: ubuntu 18.04 build"
     key: build-docker-ubuntu-bionic-beaver
     depends_on:
       - build-binary-linux-amd64
+      - build-binary-linux-armhf
       - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh ubuntu-18.04 linux/arm64/v8,linux/amd64"
+    command: ".buildkite/steps/build-docker-image.sh ubuntu-18.04 linux/arm/v7,linux/arm64/v8,linux/amd64"
 
   - name: ":docker: ubuntu 20.04 build"
     key: build-docker-ubuntu-focal-fossa
     depends_on:
       - build-binary-linux-amd64
+      - build-binary-linux-armhf
       - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh ubuntu-20.04 linux/arm64/v8,linux/amd64"
+    command: ".buildkite/steps/build-docker-image.sh ubuntu-20.04 linux/arm/v7,linux/arm64/v8,linux/amd64"
 
   - name: ":docker: centos build"
     key: build-docker-centos
     depends_on:
       - build-binary-linux-amd64
+      - build-binary-linux-armhf
       - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh centos linux/arm64/v8,linux/amd64"
+    command: ".buildkite/steps/build-docker-image.sh centos linux/arm/v7,linux/arm64/v8,linux/amd64"
 
   - name: ":docker: sidecar build"
     key: build-docker-sidecar
     depends_on:
       - build-binary-linux-amd64
+      - build-binary-linux-armhf
       - build-binary-linux-arm64
       - set-metadata
-    command: ".buildkite/steps/build-docker-image.sh sidecar linux/arm64/v8,linux/amd64"
+    command: ".buildkite/steps/build-docker-image.sh sidecar linux/arm/v7,linux/arm64/v8,linux/amd64"
 
   - name: ":debian: build"
     key: build-debian-packages

--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -26,8 +26,9 @@ build_docker_image() {
   echo "--- Building :docker: $image_tag"
   cp -a packaging/linux/root/usr/share/buildkite-agent/hooks/ "${packaging_dir}/hooks/"
 
-  cp pkg/* "${packaging_dir}"
+  cp pkg/buildkite-agent-* "${packaging_dir}/"
   chmod +x ${packaging_dir}/buildkite-agent-*
+  ls -la "${packaging_dir}"
 
   docker buildx create --use
   docker buildx build --platform "$platforms" --tag "$image_tag" "${packaging_dir}"

--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -53,7 +53,7 @@ test_docker_image() {
       queue="elastic-runners-edge"
       ;;
     "linux/arm64")
-      queue="elastic-runners-arm"
+      queue="elastic-runners-arm64"
       ;;
     *)
       queue=""

--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -90,7 +90,7 @@ do
 
   # What we call it
   download_query="buildkite-agent-linux-${platform_arch}"
-  if [ "$platform_arch" = "arm" && "$platform_variant" = "v7" ]
+  if [ "$platform_arch" = "arm" -a "$platform_variant" = "v7" ]
   then
     download_query="buildkite-agent-linux-armhf"
   fi

--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -107,7 +107,11 @@ do
   fi
 
   # Move it where the platform installer will look for it
-  mv "pkg/${download_query}" "pkg/buildkite-agent-linux-${platform_arch}${platform_variant}"
+  expected="pkg/buildkite-agent-linux-${platform_arch}${platform_variant}"
+  if [ "pkg/${download_query}" != "$expected" ]
+  then
+    mv "pkg/${download_query}" "$expected"
+  fi
 done
 
 if [[ -z "$image_tag" ]] ; then

--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -51,7 +51,7 @@ test_docker_image() {
   docker run --rm -v /var/run/docker.sock:/var/run/docker.sock --entrypoint "docker" "$image_tag" version
 
   echo "--- :hammer: Testing $image_tag has docker-compose"
-  docker run --rm --entrypoint "docker-compose" "$image_tag" --version
+  docker run --rm --entrypoint "docker-compose" "$image_tag" version
 }
 
 push_docker_image() {

--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -22,6 +22,13 @@ build_docker_image() {
   local platforms="$1"
   local image_tag="$2"
   local packaging_dir="$3"
+  local push="$4"
+
+  output_type="docker"
+  if [ "$push" = "true" ]
+  then
+    output_type="registry"
+  fi
 
   echo "--- Building :docker: $image_tag"
   cp -a packaging/linux/root/usr/share/buildkite-agent/hooks/ "${packaging_dir}/hooks/"
@@ -31,7 +38,7 @@ build_docker_image() {
   ls -la "${packaging_dir}"
 
   docker buildx create --use
-  docker buildx build --platform "$platforms" --tag "$image_tag" "${packaging_dir}"
+  docker buildx build --platform "$platforms" --tag "$image_tag" "${packaging_dir}" --output="type=${output_type}"
 }
 
 test_docker_image() {
@@ -111,19 +118,19 @@ fi
 
 case $variant in
 alpine)
-  build_docker_image "$platforms" "$image_tag" "packaging/docker/alpine-linux"
+  build_docker_image "$platforms" "$image_tag" "packaging/docker/alpine-linux" "$push"
   ;;
 ubuntu-18.04)
-  build_docker_image "$platforms" "$image_tag" "packaging/docker/ubuntu-18.04-linux"
+  build_docker_image "$platforms" "$image_tag" "packaging/docker/ubuntu-18.04-linux" "$push"
   ;;
 ubuntu-20.04)
-  build_docker_image "$platforms" "$image_tag" "packaging/docker/ubuntu-20.04-linux"
+  build_docker_image "$platforms" "$image_tag" "packaging/docker/ubuntu-20.04-linux" "$push"
   ;;
 centos)
-  build_docker_image "$platforms" "$image_tag" "packaging/docker/centos-linux"
+  build_docker_image "$platforms" "$image_tag" "packaging/docker/centos-linux" "$push"
   ;;
 sidecar)
-  build_docker_image "$platforms" "$image_tag" "packaging/docker/sidecar"
+  build_docker_image "$platforms" "$image_tag" "packaging/docker/sidecar" "$push"
   ;;
 *)
   echo "Unknown variant $variant"
@@ -139,7 +146,3 @@ sidecar)
   test_docker_image "$image_tag"
   ;;
 esac
-
-if [[ $push == "true" ]] ; then
-  push_docker_image "$image_tag"
-fi

--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -44,7 +44,7 @@ build_docker_image() {
 test_docker_image() {
   local image_tag="$1"
 
-  echo "--- :hammer: Testing $image_tag can run"
+  echo "--- :hammer: Testing $image_tag can run the buildkite-agent"
   docker run --rm "$image_tag" --version
 
   echo "--- :hammer: Testing $image_tag can access docker socket"

--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -38,7 +38,7 @@ build_docker_image() {
   ls -la "${packaging_dir}"
 
   docker buildx create --use
-  docker buildx build --platform "$platforms" --tag "$image_tag" "${packaging_dir}" --output="type=${output_type}"
+  docker buildx build --platform "$platforms" --tag "$image_tag" --output="type=${output_type}" "${packaging_dir}"
 }
 
 test_docker_image() {
@@ -52,12 +52,6 @@ test_docker_image() {
 
   echo "--- :hammer: Testing $image_tag has docker-compose"
   docker run --rm --entrypoint "docker-compose" "$image_tag" version
-}
-
-push_docker_image() {
-  local image_tag="$1"
-  echo "--- Pushing :docker: image to $image_tag"
-  docker push "$image_tag"
 }
 
 variant="${1:-}"

--- a/.buildkite/steps/publish-docker-images.sh
+++ b/.buildkite/steps/publish-docker-images.sh
@@ -28,9 +28,6 @@ for variant in "alpine" "ubuntu-18.04" "ubuntu-20.04" "centos" "sidecar" ; do
   source_image=$(buildkite-agent meta-data get "agent-docker-image-$variant")
   echo "Docker Image Tag for $variant: $source_image"
 
-  echo "--- :docker: Pulling prebuilt image"
-  docker pull "$source_image"
-
   echo "--- :docker: Publishing images for $variant"
   .buildkite/steps/publish-docker-image.sh "$variant" "$source_image" "$CODENAME" "$version" "$build"
 done

--- a/.buildkite/steps/test-image.sh
+++ b/.buildkite/steps/test-image.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+image="$1"
+platform="$2"
+
+echo "--- :hammer: Testing $image $platform can run the buildkite-agent"
+docker run --rm --platform "$platform" "$image" --version
+
+echo "--- :hammer: Testing $image $platform can access docker socket"
+docker run --rm --platform "$platform" --entrypoint "docker" -v /var/run/docker.sock:/var/run/docker.sock "$image" version
+
+echo "--- :hammer: Testing $image $platform has docker-compose"
+docker run --rm --platform "$platform" --entrypoint "docker-compose" "$image" version

--- a/packaging/docker/alpine-linux/Dockerfile
+++ b/packaging/docker/alpine-linux/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.12
 
+ARG TARGETARCH
+
 RUN apk add --no-cache \
       bash \
       curl \
@@ -24,7 +26,7 @@ RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
 COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
-COPY ./buildkite-agent /usr/local/bin/buildkite-agent
+COPY ./buildkite-agent-${TARGETARCH} /usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
 
 VOLUME /buildkite

--- a/packaging/docker/alpine-linux/Dockerfile
+++ b/packaging/docker/alpine-linux/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.12
 
 ARG TARGETARCH
+ARG TARGETVARIANT
 
 RUN apk add --no-cache \
       bash \
@@ -26,7 +27,7 @@ RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
 COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
-COPY ./buildkite-agent-linux-${TARGETARCH} /usr/local/bin/buildkite-agent
+COPY ./buildkite-agent-linux-${TARGETARCH}${TARGETVARIANT} /usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
 
 VOLUME /buildkite

--- a/packaging/docker/alpine-linux/Dockerfile
+++ b/packaging/docker/alpine-linux/Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
 COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
-COPY ./buildkite-agent-${TARGETARCH} /usr/local/bin/buildkite-agent
+COPY ./buildkite-agent-linux-${TARGETARCH} /usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
 
 VOLUME /buildkite

--- a/packaging/docker/centos-linux/Dockerfile
+++ b/packaging/docker/centos-linux/Dockerfile
@@ -31,7 +31,12 @@ RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
     curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${tini_arch} \
     && chmod +x /sbin/tini
 
-RUN curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${TARGETARCH} -o /usr/local/bin/docker-compose \
+RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
+    "amd64")    docker_arch=amd64 ;; \
+    "arm64/v8") docker_arch=arm64 ;; \
+    "arm/v7")   docker_arch=armv7 ;; \
+    esac && \
+    curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${docker_arch} -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \

--- a/packaging/docker/centos-linux/Dockerfile
+++ b/packaging/docker/centos-linux/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:8.3.2011
 ARG TARGETARCH
 
 ENV DOCKER_COMPOSE_VERSION=v2.0.0-rc.3
-ENV TINI_VERSION=0.19.0
+ENV TINI_VERSION=v0.19.0
 
 RUN yum -y install \
       bash \
@@ -22,9 +22,16 @@ RUN yum -y install \
     && yum clean all \
     && rm -rf /var/cache/yum*
 
-RUN curl -Lfs -o /sbin/tini  https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
-    && chmod +x /sbin/tini \
-    && curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${TARGETARCH} -o /usr/local/bin/docker-compose \
+RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
+    "amd64/")   tini_arch=amd64 ;; \
+    "arm64/v8") tini_arch=arm64 ;; \
+    "arm/v7")   tini_arch=armhf ;; \
+    "*") echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT; exit 1 ;; \
+    esac && \
+    curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${tini_arch} \
+    && chmod +x /sbin/tini
+
+RUN curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${TARGETARCH} -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \

--- a/packaging/docker/centos-linux/Dockerfile
+++ b/packaging/docker/centos-linux/Dockerfile
@@ -1,5 +1,7 @@
 FROM centos:8.3.2011
 
+ARG TARGETARCH
+
 ENV DOCKER_COMPOSE_VERSION=1.27.4
 ENV TINI_VERSION=0.19.0
 
@@ -33,7 +35,7 @@ RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
 COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
-COPY ./buildkite-agent /usr/local/bin/buildkite-agent
+COPY ./buildkite-agent-${TARGETARCH} /usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
 
 VOLUME /buildkite

--- a/packaging/docker/centos-linux/Dockerfile
+++ b/packaging/docker/centos-linux/Dockerfile
@@ -22,7 +22,7 @@ RUN yum -y install \
     && yum clean all \
     && rm -rf /var/cache/yum*
 
-RUN curl -Lfs -o /sbin/tini  https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
+RUN curl -Lfs -o /sbin/tini  https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
     && chmod +x /sbin/tini \
     && curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose

--- a/packaging/docker/centos-linux/Dockerfile
+++ b/packaging/docker/centos-linux/Dockerfile
@@ -1,6 +1,7 @@
 FROM centos:8.3.2011
 
 ARG TARGETARCH
+ARG TARGETVARIANT
 
 ENV DOCKER_COMPOSE_VERSION=v2.0.0-rc.3
 ENV TINI_VERSION=v0.19.0
@@ -32,7 +33,7 @@ RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
     && chmod +x /sbin/tini
 
 RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
-    "amd64")    docker_arch=amd64 ;; \
+    "amd64/")   docker_arch=amd64 ;; \
     "arm64/v8") docker_arch=arm64 ;; \
     "arm/v7")   docker_arch=armv7 ;; \
     "*")        echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \

--- a/packaging/docker/centos-linux/Dockerfile
+++ b/packaging/docker/centos-linux/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:8.3.2011
 
 ARG TARGETARCH
 
-ENV DOCKER_COMPOSE_VERSION=1.27.4
+ENV DOCKER_COMPOSE_VERSION=v2.0.0-rc.3
 ENV TINI_VERSION=0.19.0
 
 RUN yum -y install \
@@ -24,7 +24,7 @@ RUN yum -y install \
 
 RUN curl -Lfs -o /sbin/tini  https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
     && chmod +x /sbin/tini \
-    && curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
+    && curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${TARGETARCH} -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \

--- a/packaging/docker/centos-linux/Dockerfile
+++ b/packaging/docker/centos-linux/Dockerfile
@@ -24,19 +24,19 @@ RUN yum -y install \
     && rm -rf /var/cache/yum*
 
 RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
-    "amd64/")   tini_arch=amd64 ;; \
-    "arm64/v8") tini_arch=arm64 ;; \
-    "arm/v7")   tini_arch=armhf ;; \
+    "amd64/") tini_arch=amd64 ;; \
+    "arm64/") tini_arch=arm64 ;; \
+    "arm/v7") tini_arch=armhf ;; \
     "*") echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \
     esac && \
     curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${tini_arch} \
     && chmod +x /sbin/tini
 
 RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
-    "amd64/")   docker_arch=amd64 ;; \
-    "arm64/v8") docker_arch=arm64 ;; \
-    "arm/v7")   docker_arch=armv7 ;; \
-    "*")        echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \
+    "amd64/") docker_arch=amd64 ;; \
+    "arm64/") docker_arch=arm64 ;; \
+    "arm/v7") docker_arch=armv7 ;; \
+    "*")      echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \
     esac && \
     curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${docker_arch} -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose

--- a/packaging/docker/centos-linux/Dockerfile
+++ b/packaging/docker/centos-linux/Dockerfile
@@ -35,7 +35,7 @@ RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
 COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
-COPY ./buildkite-agent-${TARGETARCH} /usr/local/bin/buildkite-agent
+COPY ./buildkite-agent-linux-${TARGETARCH} /usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
 
 VOLUME /buildkite

--- a/packaging/docker/centos-linux/Dockerfile
+++ b/packaging/docker/centos-linux/Dockerfile
@@ -26,7 +26,7 @@ RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
     "amd64/")   tini_arch=amd64 ;; \
     "arm64/v8") tini_arch=arm64 ;; \
     "arm/v7")   tini_arch=armhf ;; \
-    "*") echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT; exit 1 ;; \
+    "*") echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \
     esac && \
     curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${tini_arch} \
     && chmod +x /sbin/tini
@@ -35,6 +35,7 @@ RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
     "amd64")    docker_arch=amd64 ;; \
     "arm64/v8") docker_arch=arm64 ;; \
     "arm/v7")   docker_arch=armv7 ;; \
+    "*")        echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \
     esac && \
     curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${docker_arch} -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose

--- a/packaging/docker/sidecar/Dockerfile
+++ b/packaging/docker/sidecar/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.12
 
+ARG TARGETARCH
+
 RUN mkdir /buildkite \
           /buildkite/builds \
           /buildkite/hooks \
@@ -7,7 +9,7 @@ RUN mkdir /buildkite \
           /buildkite/bin
 
 COPY buildkite-agent.cfg /buildkite/
-COPY buildkite-agent /buildkite/bin/
+COPY buildkite-agent-${TARGETARCH} /buildkite/bin/
 
 FROM busybox:musl
 COPY --from=0 /buildkite /buildkite

--- a/packaging/docker/sidecar/Dockerfile
+++ b/packaging/docker/sidecar/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir /buildkite \
           /buildkite/bin
 
 COPY buildkite-agent.cfg /buildkite/
-COPY buildkite-agent-${TARGETARCH} /buildkite/bin/
+COPY buildkite-agent-linux-${TARGETARCH} /buildkite/bin/
 
 FROM busybox:musl
 COPY --from=0 /buildkite /buildkite

--- a/packaging/docker/sidecar/Dockerfile
+++ b/packaging/docker/sidecar/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.12
 
 ARG TARGETARCH
+ARG TARGETVARIANT
 
 RUN mkdir /buildkite \
           /buildkite/builds \
@@ -9,7 +10,7 @@ RUN mkdir /buildkite \
           /buildkite/bin
 
 COPY buildkite-agent.cfg /buildkite/
-COPY buildkite-agent-linux-${TARGETARCH} /buildkite/bin/
+COPY buildkite-agent-linux-${TARGETARCH}${TARGETVARIANT} /buildkite/bin/buildkite-agent
 
 FROM busybox:musl
 COPY --from=0 /buildkite /buildkite

--- a/packaging/docker/ubuntu-18.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-18.04-linux/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04
 
+ARG TARGETARCH
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DOCKER_COMPOSE_VERSION=1.27.4
 ENV TINI_VERSION=0.19.0
@@ -36,7 +38,7 @@ RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
 COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
-COPY ./buildkite-agent /usr/local/bin/buildkite-agent
+COPY ./buildkite-agent-${TARGETARCH} /usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
 
 VOLUME /buildkite

--- a/packaging/docker/ubuntu-18.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-18.04-linux/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04
 
 ARG TARGETARCH
+ARG TARGETVARIANT
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DOCKER_COMPOSE_VERSION=v2.0.0-rc.3
@@ -26,8 +27,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
-    && chmod +x /sbin/tini \
-    && curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${TARGETARCH} -o /usr/local/bin/docker-compose \
+    && chmod +x /sbin/tini
+
+RUN curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${TARGETARCH} -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \
@@ -38,7 +40,7 @@ RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
 COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
-COPY ./buildkite-agent-linux-${TARGETARCH} /usr/local/bin/buildkite-agent
+COPY ./buildkite-agent-linux-${TARGETARCH}${TARGETVARIANT} /usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
 
 VOLUME /buildkite

--- a/packaging/docker/ubuntu-18.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-18.04-linux/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETVARIANT
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DOCKER_COMPOSE_VERSION=v2.0.0-rc.3
-ENV TINI_VERSION=0.19.0
+ENV TINI_VERSION=v0.19.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       apt-transport-https \
@@ -26,7 +26,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get install -y --no-install-recommends docker-ce-cli \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
+RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
+    "amd64/")   tini_arch=amd64 ;; \
+    "arm64/v8") tini_arch=arm64 ;; \
+    "arm/v7")   tini_arch=armhf ;; \
+    "*") echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT; exit 1 ;; \
+    esac && \
+    curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${tini_arch} \
     && chmod +x /sbin/tini
 
 RUN curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${TARGETARCH} -o /usr/local/bin/docker-compose \

--- a/packaging/docker/ubuntu-18.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-18.04-linux/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV DOCKER_COMPOSE_VERSION=1.27.4
+ENV DOCKER_COMPOSE_VERSION=v2.0.0-rc.3
 ENV TINI_VERSION=0.19.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
     && chmod +x /sbin/tini \
-    && curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
+    && curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${TARGETARCH} -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \

--- a/packaging/docker/ubuntu-18.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-18.04-linux/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       software-properties-common \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
     && add-apt-repository \
-      "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+      "deb [arch=${TARGETARCH}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
     && apt-get update \
     && apt-get install -y --no-install-recommends docker-ce-cli \
     && rm -rf /var/lib/apt/lists/*

--- a/packaging/docker/ubuntu-18.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-18.04-linux/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get install -y --no-install-recommends docker-ce-cli \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
+RUN curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
     && chmod +x /sbin/tini \
     && curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose

--- a/packaging/docker/ubuntu-18.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-18.04-linux/Dockerfile
@@ -30,7 +30,7 @@ RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
     "amd64/")   tini_arch=amd64 ;; \
     "arm64/v8") tini_arch=arm64 ;; \
     "arm/v7")   tini_arch=armhf ;; \
-    "*") echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT; exit 1 ;; \
+    "*") echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \
     esac && \
     curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${tini_arch} \
     && chmod +x /sbin/tini
@@ -39,6 +39,7 @@ RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
     "amd64")    docker_arch=amd64 ;; \
     "arm64/v8") docker_arch=arm64 ;; \
     "arm/v7")   docker_arch=armv7 ;; \
+    "*")        echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \
     esac && \
     curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${docker_arch} -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose

--- a/packaging/docker/ubuntu-18.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-18.04-linux/Dockerfile
@@ -38,7 +38,7 @@ RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
 COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
-COPY ./buildkite-agent-${TARGETARCH} /usr/local/bin/buildkite-agent
+COPY ./buildkite-agent-linux-${TARGETARCH} /usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
 
 VOLUME /buildkite

--- a/packaging/docker/ubuntu-18.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-18.04-linux/Dockerfile
@@ -35,7 +35,12 @@ RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
     curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${tini_arch} \
     && chmod +x /sbin/tini
 
-RUN curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${TARGETARCH} -o /usr/local/bin/docker-compose \
+RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
+    "amd64")    docker_arch=amd64 ;; \
+    "arm64/v8") docker_arch=arm64 ;; \
+    "arm/v7")   docker_arch=armv7 ;; \
+    esac && \
+    curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${docker_arch} -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \

--- a/packaging/docker/ubuntu-18.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-18.04-linux/Dockerfile
@@ -36,7 +36,7 @@ RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
     && chmod +x /sbin/tini
 
 RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
-    "amd64")    docker_arch=amd64 ;; \
+    "amd64/")   docker_arch=amd64 ;; \
     "arm64/v8") docker_arch=arm64 ;; \
     "arm/v7")   docker_arch=armv7 ;; \
     "*")        echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \

--- a/packaging/docker/ubuntu-18.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-18.04-linux/Dockerfile
@@ -27,19 +27,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
-    "amd64/")   tini_arch=amd64 ;; \
-    "arm64/v8") tini_arch=arm64 ;; \
-    "arm/v7")   tini_arch=armhf ;; \
+    "amd64/") tini_arch=amd64 ;; \
+    "arm64/") tini_arch=arm64 ;; \
+    "arm/v7") tini_arch=armhf ;; \
     "*") echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \
     esac && \
     curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${tini_arch} \
     && chmod +x /sbin/tini
 
 RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
-    "amd64/")   docker_arch=amd64 ;; \
-    "arm64/v8") docker_arch=arm64 ;; \
-    "arm/v7")   docker_arch=armv7 ;; \
-    "*")        echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \
+    "amd64/") docker_arch=amd64 ;; \
+    "arm64/") docker_arch=arm64 ;; \
+    "arm/v7") docker_arch=armv7 ;; \
+    "*")      echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \
     esac && \
     curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${docker_arch} -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose

--- a/packaging/docker/ubuntu-20.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-20.04-linux/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV DOCKER_COMPOSE_VERSION=1.27.4
+ENV DOCKER_COMPOSE_VERSION=v2.0.0-rc.3
 ENV TINI_VERSION=0.19.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -20,14 +20,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       software-properties-common \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
     && add-apt-repository \
-      "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+      "deb [arch=${TARGETARCH}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
     && apt-get update \
     && apt-get install -y --no-install-recommends docker-ce-cli \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
     && chmod +x /sbin/tini \
-    && curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
+    && curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${TARGETARCH} -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \

--- a/packaging/docker/ubuntu-20.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-20.04-linux/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:20.04
 
+ARG TARGETARCH
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DOCKER_COMPOSE_VERSION=1.27.4
 ENV TINI_VERSION=0.19.0
@@ -36,7 +38,7 @@ RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
 COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
-COPY ./buildkite-agent /usr/local/bin/buildkite-agent
+COPY ./buildkite-agent-${TARGETARCH} /usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
 
 VOLUME /buildkite

--- a/packaging/docker/ubuntu-20.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-20.04-linux/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETVARIANT
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DOCKER_COMPOSE_VERSION=v2.0.0-rc.3
-ENV TINI_VERSION=0.19.0
+ENV TINI_VERSION=v0.19.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       apt-transport-https \
@@ -26,7 +26,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get install -y --no-install-recommends docker-ce-cli \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
+RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
+    "amd64/")   tini_arch=amd64 ;; \
+    "arm64/v8") tini_arch=arm64 ;; \
+    "arm/v7")   tini_arch=armhf ;; \
+    "*") echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT; exit 1 ;; \
+    esac && \
+    curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${tini_arch} \
     && chmod +x /sbin/tini
 
 RUN curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${TARGETARCH} -o /usr/local/bin/docker-compose \

--- a/packaging/docker/ubuntu-20.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-20.04-linux/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get install -y --no-install-recommends docker-ce-cli \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
+RUN curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
     && chmod +x /sbin/tini \
     && curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose

--- a/packaging/docker/ubuntu-20.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-20.04-linux/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:20.04
 
 ARG TARGETARCH
+ARG TARGETVARIANT
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DOCKER_COMPOSE_VERSION=v2.0.0-rc.3
@@ -26,8 +27,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
-    && chmod +x /sbin/tini \
-    && curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${TARGETARCH} -o /usr/local/bin/docker-compose \
+    && chmod +x /sbin/tini
+
+RUN curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${TARGETARCH} -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \
@@ -38,7 +40,7 @@ RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
 COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
-COPY ./buildkite-agent-linux-${TARGETARCH} /usr/local/bin/buildkite-agent
+COPY ./buildkite-agent-linux-${TARGETARCH}${TARGETVARIANT} /usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
 
 VOLUME /buildkite

--- a/packaging/docker/ubuntu-20.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-20.04-linux/Dockerfile
@@ -30,7 +30,7 @@ RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
     "amd64/")   tini_arch=amd64 ;; \
     "arm64/v8") tini_arch=arm64 ;; \
     "arm/v7")   tini_arch=armhf ;; \
-    "*") echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT; exit 1 ;; \
+    "*") echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \
     esac && \
     curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${tini_arch} \
     && chmod +x /sbin/tini
@@ -39,6 +39,7 @@ RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
     "amd64")    docker_arch=amd64 ;; \
     "arm64/v8") docker_arch=arm64 ;; \
     "arm/v7")   docker_arch=armv7 ;; \
+    "*")        echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \
     esac && \
     curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${docker_arch} -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose

--- a/packaging/docker/ubuntu-20.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-20.04-linux/Dockerfile
@@ -38,7 +38,7 @@ RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
 COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
-COPY ./buildkite-agent-${TARGETARCH} /usr/local/bin/buildkite-agent
+COPY ./buildkite-agent-linux-${TARGETARCH} /usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
 
 VOLUME /buildkite

--- a/packaging/docker/ubuntu-20.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-20.04-linux/Dockerfile
@@ -35,7 +35,12 @@ RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
     curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${tini_arch} \
     && chmod +x /sbin/tini
 
-RUN curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${TARGETARCH} -o /usr/local/bin/docker-compose \
+RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
+    "amd64")    docker_arch=amd64 ;; \
+    "arm64/v8") docker_arch=arm64 ;; \
+    "arm/v7")   docker_arch=armv7 ;; \
+    esac && \
+    curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${docker_arch} -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \

--- a/packaging/docker/ubuntu-20.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-20.04-linux/Dockerfile
@@ -36,7 +36,7 @@ RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
     && chmod +x /sbin/tini
 
 RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
-    "amd64")    docker_arch=amd64 ;; \
+    "amd64/")   docker_arch=amd64 ;; \
     "arm64/v8") docker_arch=arm64 ;; \
     "arm/v7")   docker_arch=armv7 ;; \
     "*")        echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \

--- a/packaging/docker/ubuntu-20.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-20.04-linux/Dockerfile
@@ -27,19 +27,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
-    "amd64/")   tini_arch=amd64 ;; \
-    "arm64/v8") tini_arch=arm64 ;; \
-    "arm/v7")   tini_arch=armhf ;; \
+    "amd64/") tini_arch=amd64 ;; \
+    "arm64/") tini_arch=arm64 ;; \
+    "arm/v7") tini_arch=armhf ;; \
     "*") echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \
     esac && \
     curl -Lfs -o /sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${tini_arch} \
     && chmod +x /sbin/tini
 
 RUN case "${TARGETARCH}/${TARGETVARIANT}" in \
-    "amd64/")   docker_arch=amd64 ;; \
-    "arm64/v8") docker_arch=arm64 ;; \
-    "arm/v7")   docker_arch=armv7 ;; \
-    "*")        echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \
+    "amd64/") docker_arch=amd64 ;; \
+    "arm64/") docker_arch=arm64 ;; \
+    "arm/v7") docker_arch=armv7 ;; \
+    "*")      echo "unknown target arch/variant $TARGETARCH/$TARGETVARIANT"; exit 1 ;; \
     esac && \
     curl -Lfs https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${docker_arch} -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
Depends on docker-compose v2 because they don’t build arm64 executables prior to that release. It’s in rc phase so hopefully releases soon.

TODO:

- [x] Parallelise the multi-platform `test_docker_image` step, once these per-build images are `--output="type=registry"` we can run the per-architecture tests on separate machines and aggregate the results using Buildkite. This should be much faster than waiting for the serial results of each platform arch/variant to download and run through the tests.