### PR TITLE
ArtifactDownloader: retain destination trailing slash

### DIFF
--- a/agent/artifact_downloader.go
+++ b/agent/artifact_downloader.go
@@ -57,8 +57,8 @@ func getDownloadDestination(destination string) string {
 	// trailing forward slash. We will then retain any trailing forward slash
 	// as it may indicate path merging behavior for download.getTargetPath.
 	downloadDestination, _ := filepath.Abs(destination)
-	if strings.HasSuffix(destination, "/") && len(destination) > 1 {
-		downloadDestination += "/"
+	if strings.HasSuffix(destination, string(os.PathSeparator)) && len(destination) > 1 {
+		downloadDestination += string(os.PathSeparator)
 	}
 	return downloadDestination
 }

--- a/agent/artifact_downloader.go
+++ b/agent/artifact_downloader.go
@@ -52,9 +52,20 @@ func NewArtifactDownloader(l logger.Logger, ac APIClient, c ArtifactDownloaderCo
 	}
 }
 
+func getDownloadDestination(destination string) string {
+	// Filepath.Abs calls filepath.Clean on the result, which removes any
+	// trailing forward slash. We will then retain any trailing forward slash
+	// as it may indicate path merging behavior for download.getTargetPath.
+	downloadDestination, _ := filepath.Abs(destination)
+	if strings.HasSuffix(destination, "/") && len(destination) > 1 {
+		downloadDestination += "/"
+	}
+	return downloadDestination
+}
+
 func (a *ArtifactDownloader) Download() error {
 	// Turn the download destination into an absolute path and confirm it exists
-	downloadDestination, _ := filepath.Abs(a.conf.Destination)
+	downloadDestination := getDownloadDestination(a.conf.Destination)
 	fileInfo, err := os.Stat(downloadDestination)
 	if err != nil {
 		return fmt.Errorf("Could not find information about destination: %s %v",

--- a/agent/artifact_downloader_test.go
+++ b/agent/artifact_downloader_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/logger"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestArtifactDownloaderConnectsToEndpoint(t *testing.T) {

--- a/agent/artifact_downloader_test.go
+++ b/agent/artifact_downloader_test.go
@@ -53,5 +53,9 @@ func TestGetDownloadDestination(t *testing.T) {
 	workingDirectory, _ := filepath.Abs(".")
 	assert.Equal(t, workingDirectory + string(os.PathSeparator) + "a", getDownloadDestination("a"))
 	assert.Equal(t, workingDirectory + string(os.PathSeparator) + "a" + string(os.PathSeparator), getDownloadDestination("a" + string(os.PathSeparator)))
-	assert.Equal(t, "/", getDownloadDestination("/"))
+
+	// Test that we don't get a double // on unix, must use filepath.Abs
+	// to handle the Windows case which normalises to C:\
+	root, _ := filepath.Abs("/")
+	assert.Equal(t, root, getDownloadDestination("/"))
 }

--- a/agent/artifact_downloader_test.go
+++ b/agent/artifact_downloader_test.go
@@ -2,9 +2,11 @@ package agent
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/buildkite/agent/v3/api"
@@ -45,4 +47,11 @@ func TestArtifactDownloaderConnectsToEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestGetDownloadDestination(t *testing.T) {
+	workingDirectory, _ := filepath.Abs(".")
+	assert.Equal(t, workingDirectory + "/a", getDownloadDestination("a"))
+	assert.Equal(t, workingDirectory + "/a/", getDownloadDestination("a/"))
+	assert.Equal(t, "/", getDownloadDestination("/"))
 }

--- a/agent/artifact_downloader_test.go
+++ b/agent/artifact_downloader_test.go
@@ -51,7 +51,7 @@ func TestArtifactDownloaderConnectsToEndpoint(t *testing.T) {
 
 func TestGetDownloadDestination(t *testing.T) {
 	workingDirectory, _ := filepath.Abs(".")
-	assert.Equal(t, workingDirectory + "/a", getDownloadDestination("a"))
-	assert.Equal(t, workingDirectory + "/a/", getDownloadDestination("a/"))
+	assert.Equal(t, workingDirectory + string(os.PathSeparator) + "a", getDownloadDestination("a"))
+	assert.Equal(t, workingDirectory + string(os.PathSeparator) + "a" + string(os.PathSeparator), getDownloadDestination("a" + string(os.PathSeparator)))
 	assert.Equal(t, "/", getDownloadDestination("/"))
 }


### PR DESCRIPTION
[Documentation](https://buildkite.com/docs/agent/v3/cli-artifact#downloading-artifacts-description) for `buildkite-agent artifact download` states:
> If the last path component of matches the first path component of your , the last component of is dropped from the final path. For example, a query of 'app/logs/*' with a destination of 'foo/app' will write any matched artifact files to 'foo/app/logs/', relative to the current working directory. 

> To avoid this behaviour, use a argument with a trailing slash. For example, a query of 'app/logs/*' and a destination of 'foo/app/' will write the matched artifact files to 'foo/app/app/logs/', relative to the current working directory.

`Download.getTargetPath` does behave in this way [here](https://github.com/buildkite/agent/blob/4d7e6819c11a1844283600b31fab1bca677d1073/agent/download.go#L66). However, any trailing slash provided by the user in the destination string is stripped by `filepath.Abs` in `ArtifactDownloader.Download` [here](https://github.com/buildkite/agent/blob/4d7e6819c11a1844283600b31fab1bca677d1073/agent/artifact_downloader.go#L57) prior to `Download.getTargetPath` being invoked.

I am proposing that we retain any tailing slash after calling `filepath.Abs` in `ArtifactDownloader.Download`.