### PR TITLE
Linux arm64 moving up in the world

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,12 @@ support guidance).
 #### Tier 1, guaranteed to work
 
 - linux x86_64
+- linux arm64
 - windows x86_64
 
 #### Tier 2, guaranteed to build
 
 - linux x86
-- linux arm64
 - windows x86
 - darwin x86_64
 - darwin arm64


### PR DESCRIPTION
With the [addition](https://github.com/buildkite/agent/pull/1501) of the Linux arm64 tests to our pipeline we can now commit Linux arm64 to "guaranteed to work".