### PR TITLE
Don't retry deleting annotations that are already deleted

### DIFF
--- a/clicommand/annotation_remove.go
+++ b/clicommand/annotation_remove.go
@@ -98,7 +98,7 @@ var AnnotationRemoveCommand = cli.Command{
       resp, err := client.AnnotationRemove(cfg.Job, cfg.Context)
 
       // Don't bother retrying if the response was one of these statuses
-      if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 400) {
+      if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 400 || resp.StatusCode == 410) {
         s.Break()
         return err
       }


### PR DESCRIPTION
From Slack:

```
oleg avdeev Today at 11:31 AM
Is there a way to make agent CLI to not retry on API error? if I do buildkite-agent annotation remove , if there is no annotation it retries 5 times with some backoff. In my scenario I just need it to remove the annotation if it exists, so i do `buildkite-agent annotation remove || true , which works but takes ~10s due to retries
```

This adds `410 Gone` as a status to not retry any more when removing an annotation. 
