### PR TITLE
Fix empty command hook afterEnv breaking redactors

### DIFF
--- a/bootstrap/redactor.go
+++ b/bootstrap/redactor.go
@@ -105,6 +105,11 @@ func (redactor *Redactor) Reset(needles []string) {
 }
 
 func (redactor *Redactor) Write(input []byte) (int, error) {
+	// This is the no needles case e.g. Reset([]string{})
+	if redactor.minlen == 0 && redactor.maxlen == 0 {
+		return redactor.output.Write(input)
+	}
+
 	if len(input) == 0 {
 		return 0, nil
 	}

--- a/bootstrap/redactor_test.go
+++ b/bootstrap/redactor_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestRedactorEmpty(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	redactor := NewRedactor(&buf, "[REDACTED]", []string{})
@@ -20,6 +22,8 @@ func TestRedactorEmpty(t *testing.T) {
 }
 
 func TestRedactorSingle(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	redactor := NewRedactor(&buf, "[REDACTED]", []string{"ipsum"})
@@ -33,6 +37,8 @@ func TestRedactorSingle(t *testing.T) {
 }
 
 func TestRedactorMulti(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	redactor := NewRedactor(&buf, "[REDACTED]", []string{"ipsum", "amet"})
@@ -46,6 +52,8 @@ func TestRedactorMulti(t *testing.T) {
 }
 
 func TestRedactorWriteBoundaries(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	redactor := NewRedactor(&buf, "[REDACTED]", []string{"ipsum"})
@@ -60,6 +68,8 @@ func TestRedactorWriteBoundaries(t *testing.T) {
 }
 
 func TestRedactorResetMidStream(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 	redactor := NewRedactor(&buf, "[REDACTED]", []string{"secret1111"})
 
@@ -80,6 +90,8 @@ func TestRedactorResetMidStream(t *testing.T) {
 }
 
 func TestRedactorSlowLoris(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 	redactor := NewRedactor(&buf, "[REDACTED]", []string{"secret1111"})
 
@@ -101,6 +113,8 @@ func TestRedactorSlowLoris(t *testing.T) {
 }
 
 func TestRedactorSubsetSecrets(t *testing.T) {
+	t.Parallel()
+
 	/*
 		This probably isn't a desired behaviour but I wanted to document it.
 
@@ -127,6 +141,8 @@ func TestRedactorSubsetSecrets(t *testing.T) {
 }
 
 func TestRedactorLatin1(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 	redactor := NewRedactor(&buf, "[REDACTED]", []string{"ÿ"})
 

--- a/bootstrap/redactor_test.go
+++ b/bootstrap/redactor_test.go
@@ -4,7 +4,20 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func TestRedactorEmpty(t *testing.T) {
+	var buf bytes.Buffer
+
+	redactor := NewRedactor(&buf, "[REDACTED]", []string{})
+
+	fmt.Fprint(redactor, "Lorem ipsum dolor sit amet")
+	redactor.Flush()
+
+	assert.Equal(t, "Lorem ipsum dolor sit amet", buf.String())
+}
 
 func TestRedactorSingle(t *testing.T) {
 	var buf bytes.Buffer

--- a/hook/scriptwrapper.go
+++ b/hook/scriptwrapper.go
@@ -170,7 +170,16 @@ func (wrap *ScriptWrapper) Changes() (HookScriptChanges, error) {
 	}
 
 	beforeEnv := env.FromExport(string(beforeEnvContents))
+
 	afterEnv := env.FromExport(string(afterEnvContents))
+	if afterEnv.Length() == 0 {
+		// If the after env is completely empty it is likely because the hook
+		// ran exit(). Instead of falling over and breaking any subsequent
+		// commands, lets fall back to the original before env since we can’t
+		// extract a meaningful diff.
+		afterEnv = beforeEnv
+	}
+
 	diff := afterEnv.Diff(beforeEnv)
 
 	wd := wrap.getAfterWd(diff)


### PR DESCRIPTION
This shook out from the docker-compose plug-in which exposes a command hook but also [exits](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/blob/6d94eaa362963f93c908560f27e254444625a4a4/hooks/commands/run.sh#L147), naughty. The combination of supporting [removed](https://github.com/buildkite/agent/pull/1488) environment variables, and a bug in the redactor produced a panic.

The redactor did not support being passed an empty list of needles, something we handled at [set up time](https://github.com/buildkite/agent/blob/61a06503fe330d93f00415c99d841215d82f8b4f/bootstrap/bootstrap.go#L1836-L1839) but missed at [reset time](https://github.com/buildkite/agent/blob/61a06503fe330d93f00415c99d841215d82f8b4f/bootstrap/bootstrap.go#L436). This is tested for in https://github.com/buildkite/agent/commit/7df3134d7311b8fb4451ba407f866a1177a566f5 and handled in https://github.com/buildkite/agent/commit/ac69745326dcf3a7d9699d221a693b1a15091476.

Then to fix the environment from blowing up after a command hook exits, I decided to [use the value of the `beforeEnv`](https://github.com/buildkite/agent/commit/93c8326b5c9a95a5f7e44e328815849e5415bd85). This is somewhat consistent, because in the different [command cases](https://github.com/buildkite/agent/blob/61a06503fe330d93f00415c99d841215d82f8b4f/bootstrap/bootstrap.go#L1502-L1519) the non-hook exec variant does not support changing the environment, while the hook variants _do_. I think the :ship: to apply any consistency to that has long sailed so this is the next best option, make it look like the exec'd command case.