### PR TITLE
Fix early exit hook wd change

### DIFF
--- a/bootstrap/integration/hooks_integration_test.go
+++ b/bootstrap/integration/hooks_integration_test.go
@@ -66,6 +66,74 @@ func TestEnvironmentVariablesPassBetweenHooks(t *testing.T) {
 	tester.RunAndCheck(t, "MY_CUSTOM_ENV=1")
 }
 
+func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewBootstrapTester()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tester.Close()
+
+	if runtime.GOOS == "windows" {
+		var preCommand = []string{
+			"@echo off",
+			"set LLAMAS_ROCK=absolutely",
+		}
+		if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "pre-command.bat"),
+			[]byte(strings.Join(preCommand, "\r\n")), 0700); err != nil {
+			t.Fatal(err)
+		}
+
+		var postCommand = []string{
+			"@echo off",
+			"set LLAMAS_ROCK=",
+		}
+		if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "post-command.bat"),
+			[]byte(strings.Join(postCommand, "\n")), 0700); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		var preCommand = []string{
+			"#!/bin/bash",
+			"export LLAMAS_ROCK=absolutely",
+		}
+		if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "pre-command"),
+			[]byte(strings.Join(preCommand, "\n")), 0700); err != nil {
+			t.Fatal(err)
+		}
+
+		var postCommand = []string{
+			"#!/bin/bash",
+			"unset LLAMAS_ROCK",
+		}
+		if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "post-command"),
+			[]byte(strings.Join(postCommand, "\n")), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
+		if c.GetEnv("LLAMAS_ROCK") != "absolutely" {
+			fmt.Fprintf(c.Stderr, "Expected command hook to have environment variable LLAMAS_ROCK be %q, got %q\n", "absolutely", c.GetEnv("LLAMAS_ROCK"))
+			c.Exit(1)
+		} else {
+			c.Exit(0)
+		}
+	})
+
+	tester.ExpectGlobalHook("pre-exit").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
+		if c.GetEnv("LLAMAS_ROCK") != "" {
+			fmt.Fprintf(c.Stderr, "Expected pre-exit hook to have environment variable LLAMAS_ROCK be empty, got %q\n", c.GetEnv("LLAMAS_ROCK"))
+			c.Exit(1)
+		} else {
+			c.Exit(0)
+		}
+	})
+
+	tester.RunAndCheck(t, "MY_CUSTOM_ENV=1")
+}
+
 func TestDirectoryPassesBetweenHooks(t *testing.T) {
 	t.Parallel()
 

--- a/bootstrap/integration/hooks_integration_test.go
+++ b/bootstrap/integration/hooks_integration_test.go
@@ -58,8 +58,9 @@ func TestEnvironmentVariablesPassBetweenHooks(t *testing.T) {
 		if err := bintest.ExpectEnv(t, c.Env, `MY_CUSTOM_ENV=1`, `LLAMAS_ROCK=absolutely`); err != nil {
 			fmt.Fprintf(c.Stderr, "%v\n", err)
 			c.Exit(1)
+		} else {
+			c.Exit(0)
 		}
-		c.Exit(0)
 	})
 
 	tester.RunAndCheck(t, "MY_CUSTOM_ENV=1")
@@ -93,8 +94,9 @@ func TestDirectoryPassesBetweenHooks(t *testing.T) {
 		if c.GetEnv("MY_CUSTOM_SUBDIR") != c.Dir {
 			fmt.Fprintf(c.Stderr, "Expected current dir to be %q, got %q\n", c.GetEnv("MY_CUSTOM_SUBDIR"), c.Dir)
 			c.Exit(1)
+		} else {
+			c.Exit(0)
 		}
-		c.Exit(0)
 	})
 
 	tester.RunAndCheck(t, "MY_CUSTOM_ENV=1")
@@ -145,9 +147,9 @@ func TestReplacingCheckoutHook(t *testing.T) {
 		fmt.Fprint(c.Stderr, out)
 		if err != nil {
 			c.Exit(1)
-			return
+		} else {
+			c.Exit(0)
 		}
-		c.Exit(0)
 	})
 
 	tester.ExpectGlobalHook("pre-checkout").Once()

--- a/bootstrap/integration/plugin_integration_test.go
+++ b/bootstrap/integration/plugin_integration_test.go
@@ -59,16 +59,18 @@ func TestRunningPlugins(t *testing.T) {
 		if err := bintest.ExpectEnv(t, c.Env, `MY_CUSTOM_ENV=1`, `LLAMAS_ROCK=absolutely`); err != nil {
 			fmt.Fprintf(c.Stderr, "%v\n", err)
 			c.Exit(1)
+		} else {
+			c.Exit(0)
 		}
-		c.Exit(0)
 	})
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, `MY_CUSTOM_ENV=1`, `LLAMAS_ROCK=absolutely`); err != nil {
 			fmt.Fprintf(c.Stderr, "%v\n", err)
 			c.Exit(1)
+		} else {
+			c.Exit(0)
 		}
-		c.Exit(0)
 	})
 
 	tester.RunAndCheck(t, env...)

--- a/hook/scriptwrapper.go
+++ b/hook/scriptwrapper.go
@@ -58,7 +58,7 @@ type HookExitError struct {
 }
 
 func (e *HookExitError) Error() string {
-	return fmt.Sprintf("Hook %q early exited, could not record after environment or working directory")
+	return fmt.Sprintf("Hook %q early exited, could not record after environment or working directory", e.hookPath)
 }
 
 // CreateScriptWrapper creates and configures a ScriptWrapper.

--- a/hook/scriptwrapper_test.go
+++ b/hook/scriptwrapper_test.go
@@ -120,7 +120,12 @@ func TestRunningHookDetectsChangedWorkingDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	changesDir, err := filepath.EvalSymlinks(changes.Dir)
+	afterWd, err := changes.GetAfterWd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changesDir, err := filepath.EvalSymlinks(afterWd)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
An early exit hook would revert the shell to the bootstrap’s working directory which is the `builds` dir and not the specific build being worked on. This was because the `beforeWd` didn’t hold the value of the `beforeWd` but instead `os.Getwd()`.

To handle this case I have removed that otherwise unused variable from the `ScriptWrapper` struct, and we are now detecting the hook early exit case based on an absence of an `afterEnv` and return an error. The bootstrap handles that error by continuing on.

This matches the previous behaviour where we would: get a blank afterEnv and do nothing with it (since we didn’t support propagating removed vars up into the shell env), and get an empty string for the "new" working directory which because it wasn’t absolute we [append that empty string](https://github.com/buildkite/agent/blob/c2b3d9ddb9f20829398d248282bde11a6f0977d7/bootstrap/shell/shell.go#L126-L128) to the CWD to get the exact same string back 🙈

If `Changes()` returns an error because it cannot read the afterEnv (distinct from an empty afterEnv) we return an error and the bootstrap process aborts the job, this is as before.