### PR TITLE
Reject pipeline uploads containing redacted vars

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -21,6 +21,7 @@ import (
 	"github.com/buildkite/agent/v3/experiments"
 	"github.com/buildkite/agent/v3/hook"
 	"github.com/buildkite/agent/v3/process"
+	"github.com/buildkite/agent/v3/redaction"
 	"github.com/buildkite/agent/v3/retry"
 	"github.com/buildkite/agent/v3/tracetools"
 	"github.com/buildkite/agent/v3/utils"
@@ -32,13 +33,6 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
-
-// RedactLengthMin is the shortest string length that will be considered a
-// potential secret by the environment redactor. e.g. if the redactor is
-// configured to filter out environment variables matching *_TOKEN, and
-// API_TOKEN is set to "none", this minimum length will prevent the word "none"
-// from being redacted from useful log output.
-const RedactLengthMin = 6
 
 // Bootstrap represents the phases of execution in a Buildkite Job. It's run
 // as a sub-process of the buildkite-agent and finishes at the conclusion of a job.
@@ -432,7 +426,7 @@ func (b *Bootstrap) executeHook(ctx context.Context, scope string, name string, 
 	return nil
 }
 
-func (b *Bootstrap) applyEnvironmentChanges(changes hook.HookScriptChanges, redactors RedactorMux) {
+func (b *Bootstrap) applyEnvironmentChanges(changes hook.HookScriptChanges, redactors redaction.RedactorMux) {
 	if afterWd, err := changes.GetAfterWd(); err == nil {
 		if afterWd != b.shell.Getwd() {
 			_ = b.shell.Chdir(afterWd)
@@ -1846,8 +1840,8 @@ func (b *Bootstrap) ignoredEnv() []string {
 // setupRedactors wraps shell output and logging in Redactor if any redaction
 // is necessary based on RedactedVars configuration and the existence of
 // matching environment vars.
-// RedactorMux (possibly empty) is returned so the caller can `defer redactor.Flush()`
-func (b *Bootstrap) setupRedactors() RedactorMux {
+// redaction.RedactorMux (possibly empty) is returned so the caller can `defer redactor.Flush()`
+func (b *Bootstrap) setupRedactors() redaction.RedactorMux {
 	valuesToRedact := getValuesToRedact(b.shell, b.Config.RedactedVars, b.shell.Env.ToMap())
 	if len(valuesToRedact) == 0 {
 		return nil
@@ -1857,16 +1851,16 @@ func (b *Bootstrap) setupRedactors() RedactorMux {
 		b.shell.Commentf("Enabling output redaction for values from environment variables matching: %v", b.Config.RedactedVars)
 	}
 
-	var mux RedactorMux
+	var mux redaction.RedactorMux
 
 	// If the shell Writer is already a Redactor, reset the values to redact.
-	if redactor, ok := b.shell.Writer.(*Redactor); ok {
+	if redactor, ok := b.shell.Writer.(*redaction.Redactor); ok {
 		redactor.Reset(valuesToRedact)
 		mux = append(mux, redactor)
 	} else if len(valuesToRedact) == 0 {
 		// skip
 	} else {
-		redactor := NewRedactor(b.shell.Writer, "[REDACTED]", valuesToRedact)
+		redactor := redaction.NewRedactor(b.shell.Writer, "[REDACTED]", valuesToRedact)
 		b.shell.Writer = redactor
 		mux = append(mux, redactor)
 	}
@@ -1875,10 +1869,10 @@ func (b *Bootstrap) setupRedactors() RedactorMux {
 	// (maybe there's a better way to do two levels of type assertion? ...
 	// shell.Logger may be a WriterLogger, and its Writer may be a Redactor)
 	var shellWriterLogger *shell.WriterLogger
-	var shellLoggerRedactor *Redactor
+	var shellLoggerRedactor *redaction.Redactor
 	if logger, ok := b.shell.Logger.(*shell.WriterLogger); ok {
 		shellWriterLogger = logger
-		if redactor, ok := logger.Writer.(*Redactor); ok {
+		if redactor, ok := logger.Writer.(*redaction.Redactor); ok {
 			shellLoggerRedactor = redactor
 		}
 	}
@@ -1888,7 +1882,7 @@ func (b *Bootstrap) setupRedactors() RedactorMux {
 	} else if len(valuesToRedact) == 0 {
 		// skip
 	} else if shellWriterLogger != nil {
-		redactor := NewRedactor(b.shell.Writer, "[REDACTED]", valuesToRedact)
+		redactor := redaction.NewRedactor(b.shell.Writer, "[REDACTED]", valuesToRedact)
 		shellWriterLogger.Writer = redactor
 		mux = append(mux, redactor)
 	}
@@ -1911,7 +1905,7 @@ func getValuesToRedact(logger shell.Logger, patterns []string, environment map[s
 			}
 
 			if matched {
-				if len(varValue) < RedactLengthMin {
+				if len(varValue) < redaction.RedactLengthMin {
 					logger.Warningf("Value of %s below minimum length and will not be redacted", varName)
 				} else {
 					valuesToRedact = append(valuesToRedact, varValue)

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/agent/v3/bootstrap/shell"
+	"github.com/buildkite/agent/v3/redaction"
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"
@@ -40,7 +41,7 @@ func TestGetValuesToRedact(t *testing.T) {
 		"DATABASE_PASSWORD":  "hunter2",
 	}
 
-	valuesToRedact := getValuesToRedact(shell.DiscardLogger, redactConfig, environment)
+	valuesToRedact := redaction.GetValuesToRedact(shell.DiscardLogger, redactConfig, environment)
 
 	assert.Equal(t, []string{"hunter2"}, valuesToRedact)
 }
@@ -54,7 +55,7 @@ func TestGetValuesToRedactEmpty(t *testing.T) {
 		"BUILDKITE_PIPELINE": "unit-test",
 	}
 
-	valuesToRedact := getValuesToRedact(shell.DiscardLogger, redactConfig, environment)
+	valuesToRedact := redaction.GetValuesToRedact(shell.DiscardLogger, redactConfig, environment)
 
 	var expected []string
 	assert.Equal(t, expected, valuesToRedact)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -435,12 +435,6 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_CANCEL_SIGNAL",
 			Value:  "SIGTERM",
 		},
-		cli.StringSliceFlag{
-			Name:   "redacted-vars",
-			Usage:  "Pattern of environment variable names containing sensitive values",
-			EnvVar: "BUILDKITE_REDACTED_VARS",
-			Value:  &cli.StringSlice{"*_PASSWORD", "*_SECRET", "*_TOKEN", "*_ACCESS_KEY", "*_SECRET_KEY"},
-		},
 		cli.StringFlag{
 			Name:   "tracing-backend",
 			Usage:  "The name of the tracing backend to use.",
@@ -459,6 +453,7 @@ var AgentStartCommand = cli.Command{
 		DebugFlag,
 		ExperimentsFlag,
 		ProfileFlag,
+		RedactedVars,
 
 		// Deprecated flags which will be removed in v4
 		cli.StringSliceFlag{

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -77,6 +77,13 @@ var ExperimentsFlag = cli.StringSliceFlag{
 	EnvVar: "BUILDKITE_AGENT_EXPERIMENT",
 }
 
+var RedactedVars = cli.StringSliceFlag{
+	Name:   "redacted-vars",
+	Usage:  "Pattern of environment variable names containing sensitive values",
+	EnvVar: "BUILDKITE_REDACTED_VARS",
+	Value:  &cli.StringSlice{"*_PASSWORD", "*_SECRET", "*_TOKEN", "*_ACCESS_KEY", "*_SECRET_KEY"},
+}
+
 func CreateLogger(cfg interface{}) logger.Logger {
 	var l logger.Logger
 	logFormat := `text`

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -49,11 +49,12 @@ Example:
    $ ./script/dynamic_step_generator | buildkite-agent pipeline upload`
 
 type PipelineUploadConfig struct {
-	FilePath        string `cli:"arg:0" label:"upload paths"`
-	Replace         bool   `cli:"replace"`
-	Job             string `cli:"job"`
-	DryRun          bool   `cli:"dry-run"`
-	NoInterpolation bool   `cli:"no-interpolation"`
+	FilePath        string 	 `cli:"arg:0" label:"upload paths"`
+	Replace         bool   	 `cli:"replace"`
+	Job             string 	 `cli:"job"`
+	DryRun          bool   	 `cli:"dry-run"`
+	NoInterpolation bool   	 `cli:"no-interpolation"`
+	RedactedVars	 []string `cli:"redacted-vars" normalize:"list"`
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
@@ -106,6 +107,7 @@ var PipelineUploadCommand = cli.Command{
 		DebugFlag,
 		ExperimentsFlag,
 		ProfileFlag,
+		RedactedVars,
 	},
 	Action: func(c *cli.Context) {
 		// The configuration will be loaded into this struct

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -253,7 +253,7 @@ var PipelineUploadCommand = cli.Command{
 
 			for needleKey, needle := range needles {
 				if strings.Contains(stringifiedserialisedPipeline, needle) {
-					l.Fatal("Couldn't upload %q pipeline. Refusing to upload pipeline containing interpolated values of the %q. Ensure your pipeline does not include secret values or interpolated secret values", src, needleKey)
+					l.Fatal("Couldn’t upload the %q pipeline. Refusing to upload pipeline containing the value interpolated from the %q environment variable. Ensure your pipeline does not include secret values or interpolated secret values.", src, needleKey)
 				}
 			}
 		}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -209,6 +209,11 @@ var PipelineUploadCommand = cli.Command{
 			}
 		}
 
+		src := filename
+		if src == "" {
+			src = "(stdin)"
+		}
+
 		// Parse the pipeline
 		result, err := agent.PipelineParser{
 			Env:             environ,
@@ -217,10 +222,6 @@ var PipelineUploadCommand = cli.Command{
 			NoInterpolation: cfg.NoInterpolation,
 		}.Parse()
 		if err != nil {
-			src := filename
-			if src == "" {
-				src = "(stdin)"
-			}
 			l.Fatal("Pipeline parsing of \"%s\" failed (%s)", src, err)
 		}
 

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -246,7 +246,7 @@ var PipelineUploadCommand = cli.Command{
 			serialisedPipeline, err := result.MarshalJSON()
 
 			if err != nil {
-				l.Fatal("Pipeline serialization of \"%s\" failed (%s)", src, err)
+				l.Fatal("Couldn’t scan the %q pipeline for redacted variables. This parsed pipeline could not be serialized, ensure the pipeline YAML is valid, or ignore interpolated secrets for this upload by passing --redacted-vars=''. (%s)", src, err)
 			}
 
 			stringifiedserialisedPipeline := string(serialisedPipeline)

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -242,7 +242,7 @@ var PipelineUploadCommand = cli.Command{
 		}
 
 		if len(cfg.RedactedVars) > 0 {
-			needles := redaction.GetValuesToRedact(shell.StderrLogger, cfg.RedactedVars, env.FromSlice(os.Environ()).ToMap())
+			needles := redaction.GetKeyValuesToRedact(shell.StderrLogger, cfg.RedactedVars, env.FromSlice(os.Environ()).ToMap())
 			serialisedPipeline, err := result.MarshalJSON()
 
 			if err != nil {
@@ -251,9 +251,9 @@ var PipelineUploadCommand = cli.Command{
 
 			stringifiedserialisedPipeline := string(serialisedPipeline)
 
-			for _, needle := range needles {
+			for needleKey, needle := range needles {
 				if strings.Contains(stringifiedserialisedPipeline, needle) {
-					l.Fatal("Couldn't upload %q pipeline. Refusing to upload pipeline containing redacted vars. Ensure your pipeline does not include secret values or interpolated secret values", src)
+					l.Fatal("Couldn't upload %q pipeline. Refusing to upload pipeline containing interpolated values of the %q. Ensure your pipeline does not include secret values or interpolated secret values", src, needleKey)
 				}
 			}
 		}

--- a/redaction/redactor.go
+++ b/redaction/redactor.go
@@ -296,10 +296,19 @@ func (mux RedactorMux) Reset(needles []string) {
 	}
 }
 
-// Given a redaction config string and an environment map, return the list of values to be redacted.
-// Lifted out of Bootstrap.setupRedactors to facilitate testing
 func GetValuesToRedact(logger shell.Logger, patterns []string, environment map[string]string) []string {
 	var valuesToRedact []string
+		for _, varValue := range GetKeyValuesToRedact(logger, patterns, environment) {
+			valuesToRedact = append(valuesToRedact, varValue)
+		}
+
+		return valuesToRedact
+}
+
+// Given a redaction config string and an environment map, return the list of values to be redacted.
+// Lifted out of Bootstrap.setupRedactors to facilitate testing
+func GetKeyValuesToRedact(logger shell.Logger, patterns []string, environment map[string]string) map[string]string {
+	valuesToRedact := make(map[string]string)
 
 	for varName, varValue := range environment {
 		for _, pattern := range patterns {
@@ -314,7 +323,7 @@ func GetValuesToRedact(logger shell.Logger, patterns []string, environment map[s
 				if len(varValue) < RedactLengthMin {
 					logger.Warningf("Value of %s below minimum length and will not be redacted", varName)
 				} else {
-					valuesToRedact = append(valuesToRedact, varValue)
+					valuesToRedact[varName] = varValue
 				}
 				break // Break pattern loop, continue to next env var
 			}

--- a/redaction/redactor.go
+++ b/redaction/redactor.go
@@ -1,9 +1,16 @@
-package bootstrap
+package redaction
 
 import (
 	"bytes"
 	"io"
 )
+
+// RedactLengthMin is the shortest string length that will be considered a
+// potential secret by the environment redactor. e.g. if the redactor is
+// configured to filter out environment variables matching *_TOKEN, and
+// API_TOKEN is set to "none", this minimum length will prevent the word "none"
+// from being redacted from useful log output.
+const RedactLengthMin = 6
 
 type Redactor struct {
 	replacement []byte

--- a/redaction/redactor_test.go
+++ b/redaction/redactor_test.go
@@ -1,4 +1,4 @@
-package bootstrap
+package redaction
 
 import (
 	"bytes"


### PR DESCRIPTION
Work in progress with @eleanorakh and @pzeballos to catch and prevent pipeline uploads from including interpolated redacted vars.

Fixes #1469