### PR TITLE
docs: artifact-upload-destination takes S3 prefix too

### DIFF
--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -185,7 +185,7 @@ var BootstrapCommand = cli.Command{
 		cli.StringFlag{
 			Name:   "artifact-upload-destination",
 			Value:  "",
-			Usage:  "A custom location to upload artifact paths to (i.e. s3://my-custom-bucket)",
+			Usage:  "A custom location to upload artifact paths to (e.g. s3://my-custom-bucket/and/prefix)",
 			EnvVar: "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION",
 		},
 		cli.BoolFlag{


### PR DESCRIPTION
Make it clearer that `BUILDKITE_ARTIFACT_UPLOAD_DESTINATION` accepts a prefix as well as a bucket.

This is a trivial documentation improvement originally made as part of https://github.com/buildkite/docs/pull/1168 but which needs to be updated here as well / instead.

(Also sneaks in a `s/i.e./e.g./` as per https://github.com/buildkite/docs/pull/1169)