### PR TITLE
Combine --spawn and --priority flags

### DIFF
--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
-
+set -x
 ## This script can be run locally like this:
 ##
 ## .buildkite/steps/build-docker-image.sh (alpine|ubuntu|centos) (image tag) (codename) (version)

--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
-set -x
+
 ## This script can be run locally like this:
 ##
 ## .buildkite/steps/build-docker-image.sh (alpine|ubuntu|centos) (image tag) (codename) (version)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -97,7 +97,7 @@ type AgentStartConfig struct {
 	MetricsDatadogDistributions bool     `cli:"metrics-datadog-distributions"`
 	TracingBackend              string   `cli:"tracing-backend"`
 	Spawn                       int      `cli:"spawn"`
-	SpawnSplayPriority          bool     `cli:"spawn-splay-priority"`
+	SpawnWithPriority           bool     `cli:"spawn-with-priority"`
 	LogFormat                   string   `cli:"log-format"`
 	CancelSignal                string   `cli:"cancel-signal"`
 	RedactedVars                []string `cli:"redacted-vars" normalize:"list"`
@@ -431,9 +431,9 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_AGENT_SPAWN",
 		},
 		cli.BoolFlag{
-			Name:   "spawn-splay-priority",
+			Name:   "spawn-with-priority",
 			Usage:  "Assign priorities to every spawned agent (when using --spawn) equal to the agent's index",
-			EnvVar: "BUILDKITE_AGENT_SPAWN_SPLAY_PRIORITY",
+			EnvVar: "BUILDKITE_AGENT_SPAWN_WITH_PRIORITY",
 		},
 		cli.StringFlag{
 			Name:   "cancel-signal",
@@ -785,7 +785,7 @@ var AgentStartCommand = cli.Command{
 			// Handle per-spawn name interpolation, replacing %spawn with the spawn index
 			registerReq.Name = strings.ReplaceAll(cfg.Name, "%spawn", strconv.Itoa(i))
 
-			if cfg.SpawnSplayPriority {
+			if cfg.SpawnWithPriority {
 				l.Info("Assigning priority %s for agent %d", strconv.Itoa(i), i)
 				registerReq.Priority = strconv.Itoa(i)
 			}


### PR DESCRIPTION
When running multiple agents on the same host, it is recommended to use the --priority flag if you want to force load to be balanced evenly across the hosts (https://buildkite.com/docs/agent/v3/prioritization).

The --spawn flag allows for easily registering multiple agents on the same host, greatly simplifying the operational overhead of running multiple agents.

However, --spawn and --priority can't be mixed.

This pull request proposes a general approach to combine the two flags to allow for the ease-of-use of --spawn and also solve the load balancing problem for which --priority is being suggested for. The solution is to automatically assign a --priority to each spawned agent based on the internal agent index.

I'm happy to contribute further to this (tests, etc.) as soon as there is a general agreement on the direction. 