### PR TITLE
Allow BUILDKITE_S3_DEFAULT_REGION to be used for unconditional bucket region

### DIFF
--- a/agent/s3.go
+++ b/agent/s3.go
@@ -103,7 +103,7 @@ func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 			region = "us-east-1"
 		}
 
-		l.Debug("Discovered current region as %q\n", region)
+		l.Debug("Discovered current region as %q", region)
 
 		// Using the guess region, construct a session and ask that region where the
 		// bucket lives
@@ -114,10 +114,10 @@ func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 
 		bucketRegion, bucketRegionErr := s3manager.GetBucketRegion(aws.BackgroundContext(), session, bucket, region)
 		if bucketRegionErr == nil && bucketRegion != "" {
-			l.Debug("Discovered %q bucket region as %q\n", bucket, bucketRegion)
+			l.Debug("Discovered %q bucket region as %q", bucket, bucketRegion)
 			session.Config.Region = &bucketRegion
 		} else {
-			l.Error("Could not discover region for bucket %q. Using the %q region as a fallback, if this is not correct configure a bucket region using the %q environment variable. (%v)\n", bucket, *sess.Config.Region, regionHintEnvVar, err)
+			l.Error("Could not discover region for bucket %q. Using the %q region as a fallback, if this is not correct configure a bucket region using the %q environment variable. (%v)", bucket, *sess.Config.Region, regionHintEnvVar, err)
 		}
 
 		sess = session

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -88,6 +88,7 @@ func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 
 	regionHint := os.Getenv(regionHintEnvVar)
 	if regionHint != "" {
+        l.Debug("Using bucket region %q from environment variable %q", regionHint, regionHintEnvVar)
 		// If there is a region hint provided, we use it unconditionally
 		session, err := awsS3Session(regionHint)
 		if err != nil {

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -17,6 +17,8 @@ import (
 	"github.com/buildkite/agent/v3/logger"
 )
 
+var regionHintEnvVar = "BUILDKITE_S3_DEFAULT_REGION"
+
 type credentialsProvider struct {
 	retrieved bool
 }
@@ -84,7 +86,7 @@ func webIdentityRoleProvider(sess *session.Session) *stscreds.WebIdentityRolePro
 func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 	var sess *session.Session
 
-	regionHint := os.Getenv("BUILDKITE_S3_DEFAULT_REGION")
+	regionHint := os.Getenv(regionHintEnvVar)
 	if regionHint != "" {
 		// If there is a region hint provided, we use it unconditionally
 		session, err := awsS3Session(regionHint)
@@ -101,21 +103,21 @@ func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 			region = "us-east-1"
 		}
 
+		l.Debug("Discovered current region as %q\n", region)
+
 		// Using the guess region, construct a session and ask that region where the
 		// bucket lives
 		session, err := awsS3Session(region)
 		if err != nil {
 			return nil, err
 		}
-		bucketRegion, err := s3manager.GetBucketRegion(aws.BackgroundContext(), sess, bucket, region)
-		if err != nil {
-			return nil, err
-		}
 
-		// Construct the final session for the bucket region
-		session, err = awsS3Session(bucketRegion)
-		if err != nil {
-			return nil, err
+		bucketRegion, bucketRegionErr := s3manager.GetBucketRegion(aws.BackgroundContext(), sess, bucket, region)
+		if bucketRegionErr == nil && bucketRegion != "" {
+			l.Debug("Discovered %q bucket region as %q\n", bucket, bucketRegion)
+			session.Config.Region = &bucketRegion
+		} else {
+			l.Error("Could not discover region for bucket %q. Using the %q region as a fallback, if this is not correct configure a bucket region using the %q environment variable. (%v)\n", bucket, *sess.Config.Region, regionHintEnvVar, err)
 		}
 
 		sess = session

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -112,7 +112,7 @@ func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 			return nil, fmt.Errorf("Could not load the AWS SDK config (%v)", err)
 		}
 
-		bucketRegion, bucketRegionErr := s3manager.GetBucketRegion(aws.BackgroundContext(), sess, bucket, region)
+		bucketRegion, bucketRegionErr := s3manager.GetBucketRegion(aws.BackgroundContext(), session, bucket, region)
 		if bucketRegionErr == nil && bucketRegion != "" {
 			l.Debug("Discovered %q bucket region as %q\n", bucket, bucketRegion)
 			session.Config.Region = &bucketRegion

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -17,7 +17,7 @@ import (
 	"github.com/buildkite/agent/v3/logger"
 )
 
-var regionHintEnvVar = "BUILDKITE_S3_DEFAULT_REGION"
+const regionHintEnvVar = "BUILDKITE_S3_DEFAULT_REGION"
 
 type credentialsProvider struct {
 	retrieved bool

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -91,7 +91,7 @@ func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 		// If there is a region hint provided, we use it unconditionally
 		session, err := awsS3Session(regionHint)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Could not load the AWS SDK config (%v)", err)
 		}
 
 		sess = session
@@ -109,7 +109,7 @@ func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 		// bucket lives
 		session, err := awsS3Session(region)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Could not load the AWS SDK config (%v)", err)
 		}
 
 		bucketRegion, bucketRegionErr := s3manager.GetBucketRegion(aws.BackgroundContext(), sess, bucket, region)


### PR DESCRIPTION
If present this environment variable is used unconditionally and must be set to the region of the S3 bucket. Dynamic region discovery is bypassed completely owing to unreliability of the API.

This matches the secrets bucket algorithm in https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/pull/54.

cc https://github.com/buildkite/elastic-ci-stack-for-aws/issues/937