### PR TITLE
Fetch git tags by default

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -310,7 +310,7 @@ var AgentStartCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name:   "git-fetch-flags",
-			Value:  "-v --prune",
+			Value:  "-v --prune --tags",
 			Usage:  "Flags to pass to \"git fetch\" command",
 			EnvVar: "BUILDKITE_GIT_FETCH_FLAGS",
 		},


### PR DESCRIPTION
Historically this wasn't added due to --tags not being supported in earlier git versions (#338), but that was 2016. By now it's well supported and optimized so it's quite fast.

I'd advocate for this change being the least surprising, and adding it to defaults shouldn't break any existing configurations.