### PR TITLE
Support multiple commands on Windows

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1760,7 +1760,7 @@ func (b *Bootstrap) writeBatchScript(cmd string) (string, error) {
 
 	for _, line := range strings.Split(cmd, "\n") {
 		if line != "" {
-			scriptContents += line + "\n" + "if %errorlevel% neq 0 exit /b %errorlevel%\n"
+			scriptContents += "call " + line + "\n" + "if %errorlevel% neq 0 exit /b %errorlevel%\n"
 		}
 	}
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1756,15 +1756,16 @@ func (b *Bootstrap) writeBatchScript(cmd string) (string, error) {
 	}
 	defer scriptFile.Close()
 
-	var scriptContents = "@echo off\n"
+	var scriptContents = []string{"@echo off"}
 
 	for _, line := range strings.Split(cmd, "\n") {
 		if line != "" {
-			scriptContents += "call " + line + "\n" + "if %errorlevel% neq 0 exit /b %errorlevel%\n"
+			scriptContents = append(scriptContents, "call " + line)
+			scriptContents = append(scriptContents, "if %errorlevel% neq 0 exit /b %errorlevel%")
 		}
 	}
 
-	_, err = io.WriteString(scriptFile, scriptContents)
+	_, err = io.WriteString(scriptFile, strings.Join(scriptContents, "\n"))
 	if err != nil {
 		return "", err
 	}

--- a/bootstrap/integration/bootstrap_tester.go
+++ b/bootstrap/integration/bootstrap_tester.go
@@ -303,10 +303,13 @@ func (b *BootstrapTester) ReadEnvFromOutput(key string) (string, bool) {
 
 // Run the bootstrap and then check the mocks
 func (b *BootstrapTester) RunAndCheck(t *testing.T, env ...string) {
-	if err := b.Run(t, env...); err != nil {
-		t.Logf("Bootstrap output:\n%s", b.Output)
+	err := b.Run(t, env...)
+	t.Logf("Bootstrap output:\n%s", b.Output)
+
+	if err != nil {
 		t.Fatal(err)
 	}
+
 	b.CheckMocks(t)
 }
 

--- a/bootstrap/integration/command_integration_test.go
+++ b/bootstrap/integration/command_integration_test.go
@@ -40,6 +40,8 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 	}
 
 	tester.RunAndCheck(t, env...)
+
+	t.Fatal("test")
 }
 
 func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {

--- a/bootstrap/integration/command_integration_test.go
+++ b/bootstrap/integration/command_integration_test.go
@@ -20,8 +20,8 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 	}
 	defer tester.Close()
 
-	tester.MustMock(t, "Setup.cmd")
-	tester.MustMock(t, "BuildProject.cmd")
+	tester.MustMock(t, "Setup.cmd").Expect().Once()
+	tester.MustMock(t, "BuildProject.cmd").Expect().Once()
 
 	tester.RunAndCheck(t, "BUILDKITE_COMMAND=Setup.cmd\nBuildProject.cmd")
 }

--- a/bootstrap/integration/command_integration_test.go
+++ b/bootstrap/integration/command_integration_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"fmt"
 	"runtime"
 	"testing"
 
@@ -27,7 +26,8 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 	setup.Expect().Once()
 	build.Expect().Once().AndCallFunc(func(c *bintest.Call) {
 		llamas := c.GetEnv(`LLAMAS`)
-		t.Fatal(fmt.Printf("LLAMAS was %s", llamas))
+		t.Errorf("LLAMAS was %s", llamas)
+		c.Exit(1)
 
 		if llamas != "COOL" {
 			t.Errorf("Expected LLAMAS=COOL, got %s", llamas)

--- a/bootstrap/integration/command_integration_test.go
+++ b/bootstrap/integration/command_integration_test.go
@@ -23,7 +23,7 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 	tester.MustMock(t, "Setup.cmd").Expect().Once()
 	tester.MustMock(t, "BuildProject.cmd").Expect().Once()
 
-	tester.RunAndCheck(t, "BUILDKITE_COMMAND=Setup.cmd\nBuildProject.cmd")
+	tester.RunAndCheck(t, "BUILDKITE_COMMAND=Setup.cmd\nset foo=bar\nBuildProject.cmd")
 }
 
 func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {

--- a/bootstrap/integration/command_integration_test.go
+++ b/bootstrap/integration/command_integration_test.go
@@ -26,9 +26,6 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 	setup.Expect().Once()
 	build.Expect().Once().AndCallFunc(func(c *bintest.Call) {
 		llamas := c.GetEnv(`LLAMAS`)
-		t.Errorf("LLAMAS was %s", llamas)
-		c.Exit(1)
-
 		if llamas != "COOL" {
 			t.Errorf("Expected LLAMAS=COOL, got %s", llamas)
 			c.Exit(1)
@@ -43,8 +40,6 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 	}
 
 	tester.RunAndCheck(t, env...)
-
-	t.Fatal("test")
 }
 
 func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {

--- a/bootstrap/integration/command_integration_test.go
+++ b/bootstrap/integration/command_integration_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"fmt"
 	"runtime"
 	"testing"
 
@@ -23,9 +24,11 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 	setup := tester.MustMock(t, "Setup.cmd")
 	build := tester.MustMock(t, "BuildProject.cmd")
 
-	setup.Expect().Exactly(2)
+	setup.Expect().Once()
 	build.Expect().Once().AndCallFunc(func(c *bintest.Call) {
 		llamas := c.GetEnv(`LLAMAS`)
+		t.Fatal(fmt.Printf("LLAMAS was %s", llamas))
+
 		if llamas != "COOL" {
 			t.Errorf("Expected LLAMAS=COOL, got %s", llamas)
 			c.Exit(1)

--- a/bootstrap/integration/command_integration_test.go
+++ b/bootstrap/integration/command_integration_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/buildkite/bintest/v3"
@@ -19,10 +20,7 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 	}
 	defer tester.Close()
 
-	err = tester.RunAndCheck(t, "BUILDKITE_COMMAND=Setup.cmd\nBuildProject.cmd")
-	if err != nil {
-		t.Fatalf("bootstrap failed %v", err)
-	}
+	tester.RunAndCheck(t, "BUILDKITE_COMMAND=Setup.cmd\nBuildProject.cmd")
 }
 
 func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {

--- a/bootstrap/integration/command_integration_test.go
+++ b/bootstrap/integration/command_integration_test.go
@@ -23,7 +23,7 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 	setup := tester.MustMock(t, "Setup.cmd")
 	build := tester.MustMock(t, "BuildProject.cmd")
 
-	setup.Expect().Once()
+	setup.Expect().Exactly(2)
 	build.Expect().Once().AndCallFunc(func(c *bintest.Call) {
 		llamas := c.GetEnv(`LLAMAS`)
 		if llamas != "COOL" {

--- a/bootstrap/integration/command_integration_test.go
+++ b/bootstrap/integration/command_integration_test.go
@@ -6,6 +6,25 @@ import (
 	"github.com/buildkite/bintest/v3"
 )
 
+func TestMultilineCommandRunUnderBatch(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "windows" {
+		t.Skip("batch test only applies to Windows")
+	}
+
+	tester, err := NewBootstrapTester()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tester.Close()
+
+	err = tester.RunAndCheck(t, "BUILDKITE_COMMAND=Setup.cmd\nBuildProject.cmd")
+	if err != nil {
+		t.Fatalf("bootstrap failed %v", err)
+	}
+}
+
 func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {
 	tester, err := NewBootstrapTester()
 	if err != nil {

--- a/bootstrap/integration/command_integration_test.go
+++ b/bootstrap/integration/command_integration_test.go
@@ -34,7 +34,12 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 		}
 	})
 
-	tester.RunAndCheck(t, "BUILDKITE_COMMAND=Setup.cmd\nset LLAMAS=COOL\nBuildProject.cmd")
+	env := []string{
+		"BUILDKITE_COMMAND=Setup.cmd\nset LLAMAS=COOL\nBuildProject.cmd",
+		`BUILDKITE_SHELL=C:\Windows\System32\CMD.exe /S /C`,
+	}
+
+	tester.RunAndCheck(t, env...)
 }
 
 func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {

--- a/bootstrap/integration/command_integration_test.go
+++ b/bootstrap/integration/command_integration_test.go
@@ -20,6 +20,9 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 	}
 	defer tester.Close()
 
+	tester.MustMock(t, "Setup.cmd")
+	tester.MustMock(t, "BuildProject.cmd")
+
 	tester.RunAndCheck(t, "BUILDKITE_COMMAND=Setup.cmd\nBuildProject.cmd")
 }
 


### PR DESCRIPTION
Insert a leading `'call '` for commands on Windows in the generated batch script per #1538 

I’ve also added a work in progress test for this functionality that I expect to fail pending finishing it off.

Fixes #1538 