### PR TITLE
report OS versions when running on AIX and Solaris

### DIFF
--- a/system/version_dump.go
+++ b/system/version_dump.go
@@ -16,8 +16,10 @@ func VersionDump(l logger.Logger) (string, error) {
 		return process.Run(l, "sw_vers")
 	case "linux":
 		return process.Cat("/etc/*-release")
-	case "freebsd", "openbsd", "netbsd", "dragonfly":
+	case "freebsd", "openbsd", "netbsd", "dragonfly", "solaris":
 		return process.Run(l, "uname", "-sr")
+	case "aix":
+		return process.Run(l, "oslevel", "-s")
 	default:
 		return "", nil
 	}


### PR DESCRIPTION
I noticed we have a few agents connected from aix/ppc64. That's not a GOOS/GOARCH we compile for, but it's a platform supported by go and I assume an enterprising customer has built it themselves.

For our own metrics, it'd be nice to have some visibility into the AIX version when customers run the agent, similar to what we get from Windows, Linux and the BSDs. I don't have an AIX system handy to test on, but multiple sites I found via google suggest `oslevel -s` is where it's at.

While I was editing this file I checked the [full list of GOOS values support in go 1.17](https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63). We cover all the important ones, and a few have no evidence of ever being used by our customers (like android, ios and js). Solaris is interesting though - no customers use it at the moment, but it feels plausible that some might. I also have no solaris system to test on, but the Internet tells me `uname -sr` will work.