### PR TITLE
Lock down file permissions on windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -49,7 +49,6 @@ foreach ($line in $resp.Content.Split("`n")) {
 Write-Host "Downloading $($releaseInfo.url)"
 Invoke-WebRequest -Uri $releaseInfo.url -OutFile 'buildkite-agent.zip'
 
-Write-Host "Preparing installation directory $installDir"
 if (Test-Path -Path $installDir) {
     $permissions = (Get-Acl $installDir).Access |
         where {$_.IdentityReference -match 'BUILTIN\\Users' -and `
@@ -62,12 +61,12 @@ WARNING: Consider only allowing administrators access to this directory.
         "
     }
 } else {
+    Write-Host "Restricting installation directory access to administrators"
     New-Item -ItemType "directory" -Path $installDir | Out-Null
     $acl = Get-Acl $installDir
     # Disable ACL inheritance and remove existing inherited rules
     $acl.SetAccessRuleProtection($true,$false)
     # Allow System and Administrators full access
-    $acl.AddAccessRule($rule)
     $rule = New-Object System.Security.AccessControl.FileSystemAccessRule("NT AUTHORITY\SYSTEM","FullControl","Allow")
     $acl.AddAccessRule($rule)
     $rule = New-Object System.Security.AccessControl.FileSystemAccessRule("BUILTIN\Administrators","FullControl","Allow")

--- a/install.ps1
+++ b/install.ps1
@@ -61,7 +61,7 @@ WARNING: Consider only allowing administrators access to this directory.
         "
     }
 } else {
-    Write-Host "Restricting installation directory access to administrators"
+    Write-Host "Restricting installation directory access to Administrators: '$installDir'"
     New-Item -ItemType "directory" -Path $installDir | Out-Null
     $acl = Get-Acl $installDir
     # Disable ACL inheritance and remove existing inherited rules


### PR DESCRIPTION
Given the buildkite-agent runs arbitrary code as administrator, we should lock down access to the agent's files. I've opted to only change the acls if we're creating the installation directory for the first time and just warn if the directory already exists and is world accessible. If I was being fancy, I'd probably only warn for world write permissions (and allow read permissions) but I'm not an expert on windows acls or powershell so I'm not sure I can figure that out how to do that in a reasonable length of time.

### Testing

I have tested that a clean install with this script blocks read access from an unprivileged user but an administrator can still run the agent.

Installing with this script over the top of a previous install from `main` gives:

```
PS C:\Users\Administrator> iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/buildkite/agent/4d566ab4184e23f5850de08d9ca75b9efdcd0342/install.ps1'))

  _           _ _     _ _    _ _                                _
 | |         (_) |   | | |  (_) |                              | |
 | |__  _   _ _| | __| | | ___| |_ ___    __ _  __ _  ___ _ __ | |_
 | '_ \| | | | | |/ _\ | |/ / | __/ _ \  / _\ |/ _\ |/ _ \ '_ \| __|
 | |_) | |_| | | | (_| |   <| | ||  __/ | (_| | (_| |  __/ | | | |_
 |_.__/ \__,_|_|_|\__,_|_|\_\_|\__\___|  \__,_|\__, |\___|_| |_|\__|
                                                __/ |
                                               |___/
Finding latest release
Downloading https://github.com/buildkite/agent/releases/download/v3.33.3/buildkite-agent-windows-amd64-3.33.3.zip
Preparing installation directory C:\buildkite-agent

WARNING: All users have the following access to the installation directory 'C:\buildkite-agent':
WARNING:   ReadAndExecute, Synchronize AppendData CreateFiles
WARNING: Consider only allowing administrators access to this directory.

Expanding buildkite-agent.zip
Expanding buildkite-agent.exe into bin
Updating PATH
buildkite-agent version 3.33.3, build 4013
Updating configuration in C:\buildkite-agent\buildkite-agent.cfg
Successfully installed to C:\buildkite-agent

You can now start the agent!

  C:\buildkite-agent\bin\buildkite-agent.exe start

For docs, help and support:

  https://buildkite.com/docs/agent/v3

Happy building! <3
```

(The extra comma in the list of permissions is because "ReadAndExecute, Synchronize" is a single row in the control list.)

Installing this version of the script twice does not show the warning.