### PR TITLE
add option to enable job log file

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -27,7 +27,7 @@ type AgentConfiguration struct {
 	DisconnectAfterJob         bool
 	DisconnectAfterIdleTimeout int
 	CancelGracePeriod          int
-	EnableJobLogFile           bool
+	EnableJobLogTmpfile        bool
 	Shell                      string
 	Profile                    string
 	RedactedVars               []string

--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -27,6 +27,7 @@ type AgentConfiguration struct {
 	DisconnectAfterJob         bool
 	DisconnectAfterIdleTimeout int
 	CancelGracePeriod          int
+	EnableJobLogFile           bool
 	Shell                      string
 	Profile                    string
 	RedactedVars               []string

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -212,7 +212,7 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 	}
 
 	// if agent config "EnableJobLogFile" is set, we extend the processWriter to write to a temporary file.
-	// BUILDKITE_JOB_LOGS is an environment variable that contains the path to this temporary file.
+	// BUILDKITE_JOB_LOG is an environment variable that contains the path to this temporary file.
 	var tmpFile *os.File
 	if conf.AgentConfiguration.EnableJobLogFile {
 		tmpFile, err = ioutil.TempFile("", "buildkite_job_log")

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -211,15 +211,15 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 		}()
 	}
 
-	// if agent config "EnableJobLogFile" is set, we extend the processWriter to write to a temporary file.
-	// BUILDKITE_JOB_LOG is an environment variable that contains the path to this temporary file.
+	// if agent config "EnableJobLogTmpfile" is set, we extend the processWriter to write to a temporary file.
+	// BUILDKITE_JOB_LOG_TMPFILE is an environment variable that contains the path to this temporary file.
 	var tmpFile *os.File
-	if conf.AgentConfiguration.EnableJobLogFile {
+	if conf.AgentConfiguration.EnableJobLogTmpfile {
 		tmpFile, err = ioutil.TempFile("", "buildkite_job_log")
 		if err != nil {
 			return nil, err
 		}
-		os.Setenv("BUILDKITE_JOB_LOG", tmpFile.Name())
+		os.Setenv("BUILDKITE_JOB_LOG_TMPFILE", tmpFile.Name())
 		processWriter = io.MultiWriter(processWriter, tmpFile)
 	}
 

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -211,6 +211,18 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 		}()
 	}
 
+	// if agent config "EnableJobLogFile" is set, we extend the processWriter to write to a temporary file.
+	// BUILDKITE_JOB_LOGS is an environment variable that contains the path to this temporary file.
+	var tmpFile *os.File
+	if conf.AgentConfiguration.EnableJobLogFile {
+		tmpFile, err = ioutil.TempFile("", "buildkite_job_log")
+		if err != nil {
+			return nil, err
+		}
+		os.Setenv("BUILDKITE_JOB_LOG", tmpFile.Name())
+		processWriter = io.MultiWriter(processWriter, tmpFile)
+	}
+
 	// Copy the current processes ENV and merge in the new ones. We do this
 	// so the sub process gets PATH and stuff. We merge our path in over
 	// the top of the current one so the ENV from Buildkite and the agent
@@ -234,6 +246,11 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 		<-runner.process.Done()
 		if err := pw.Close(); err != nil {
 			l.Error("%v", err)
+		}
+		if tmpFile != nil {
+			if err := os.Remove(tmpFile.Name()); err != nil {
+				l.Error("%v", err)
+			}
 		}
 	}()
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -62,6 +62,7 @@ type AgentStartConfig struct {
 	DisconnectAfterIdleTimeout  int      `cli:"disconnect-after-idle-timeout"`
 	BootstrapScript             string   `cli:"bootstrap-script" normalize:"commandpath"`
 	CancelGracePeriod           int      `cli:"cancel-grace-period"`
+	EnableJobLogFile            bool     `cli:"enable-job-log-file"`
 	BuildPath                   string   `cli:"build-path" normalize:"filepath" validate:"required"`
 	HooksPath                   string   `cli:"hooks-path" normalize:"filepath"`
 	PluginsPath                 string   `cli:"plugins-path" normalize:"filepath"`
@@ -228,6 +229,11 @@ var AgentStartCommand = cli.Command{
 			Value:  10,
 			Usage:  "The number of seconds a canceled or timed out job is given to gracefully terminate and upload its artifacts",
 			EnvVar: "BUILDKITE_CANCEL_GRACE_PERIOD",
+		},
+		cli.BoolFlag{
+			Name:   "enable-job-log-file",
+			Usage:  "Store the job logs in a temporary file `BUILDKITE_JOB_LOG_FILE` that is accessible during the job and removed at the end of the job",
+			EnvVar: "BUILDKITE_ENABLE_JOB_LOG_FILE",
 		},
 		cli.StringFlag{
 			Name:   "shell",
@@ -662,6 +668,7 @@ var AgentStartCommand = cli.Command{
 			DisconnectAfterJob:         cfg.DisconnectAfterJob,
 			DisconnectAfterIdleTimeout: cfg.DisconnectAfterIdleTimeout,
 			CancelGracePeriod:          cfg.CancelGracePeriod,
+			EnableJobLogFile:           cfg.EnableJobLogFile,
 			Shell:                      cfg.Shell,
 			RedactedVars:               cfg.RedactedVars,
 			AcquireJob:                 cfg.AcquireJob,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -62,7 +62,7 @@ type AgentStartConfig struct {
 	DisconnectAfterIdleTimeout  int      `cli:"disconnect-after-idle-timeout"`
 	BootstrapScript             string   `cli:"bootstrap-script" normalize:"commandpath"`
 	CancelGracePeriod           int      `cli:"cancel-grace-period"`
-	EnableJobLogFile            bool     `cli:"enable-job-log-file"`
+	EnableJobLogTmpfile         bool     `cli:"enable-job-log-tmpfile"`
 	BuildPath                   string   `cli:"build-path" normalize:"filepath" validate:"required"`
 	HooksPath                   string   `cli:"hooks-path" normalize:"filepath"`
 	PluginsPath                 string   `cli:"plugins-path" normalize:"filepath"`
@@ -231,9 +231,9 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_CANCEL_GRACE_PERIOD",
 		},
 		cli.BoolFlag{
-			Name:   "enable-job-log-file",
-			Usage:  "Store the job logs in a temporary file `BUILDKITE_JOB_LOG` that is accessible during the job and removed at the end of the job",
-			EnvVar: "BUILDKITE_ENABLE_JOB_LOG_FILE",
+			Name:   "enable-job-log-tmpfile",
+			Usage:  "Store the job logs in a temporary file `BUILDKITE_JOB_LOG_TMPFILE` that is accessible during the job and removed at the end of the job",
+			EnvVar: "BUILDKITE_ENABLE_JOB_LOG_TMPFILE",
 		},
 		cli.StringFlag{
 			Name:   "shell",
@@ -668,7 +668,7 @@ var AgentStartCommand = cli.Command{
 			DisconnectAfterJob:         cfg.DisconnectAfterJob,
 			DisconnectAfterIdleTimeout: cfg.DisconnectAfterIdleTimeout,
 			CancelGracePeriod:          cfg.CancelGracePeriod,
-			EnableJobLogFile:           cfg.EnableJobLogFile,
+			EnableJobLogTmpfile:        cfg.EnableJobLogTmpfile,
 			Shell:                      cfg.Shell,
 			RedactedVars:               cfg.RedactedVars,
 			AcquireJob:                 cfg.AcquireJob,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -232,7 +232,7 @@ var AgentStartCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name:   "enable-job-log-file",
-			Usage:  "Store the job logs in a temporary file `BUILDKITE_JOB_LOG_FILE` that is accessible during the job and removed at the end of the job",
+			Usage:  "Store the job logs in a temporary file `BUILDKITE_JOB_LOG` that is accessible during the job and removed at the end of the job",
 			EnvVar: "BUILDKITE_ENABLE_JOB_LOG_FILE",
 		},
 		cli.StringFlag{


### PR DESCRIPTION
Adds a new agent config option `--enable-job-log-file`.

When set, all logs for a job are written to a temporary file and exposed to the job via an environment variable `BUILDKITE_JOB_LOG`.

This log file can be used by post-command, pre-exit, and exit hooks to analyze the logs without having to fetch them via API (which is slower, and subject to race conditions). One use-case we have for this is log failure analysis of the command-step to enable dynamic retries.

This temporary file is deleted when the job finishes.