### PR TITLE
Retry 500 responses when batch creating artifacts

### DIFF
--- a/agent/artifact_batch_creator.go
+++ b/agent/artifact_batch_creator.go
@@ -72,7 +72,7 @@ func (a *ArtifactBatchCreator) Create() ([]*api.Artifact, error) {
 		// Retry the batch upload a couple of times
 		err = retry.Do(func(s *retry.Stats) error {
 			creation, resp, err = a.apiClient.CreateArtifacts(a.conf.JobID, batch)
-			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 500) {
+			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404) {
 				s.Break()
 			}
 			if err != nil {


### PR DESCRIPTION
Previously, when attempting to batch-create artifacts, if the agent API returned a 500 error, we would just sorta say 'okay' and never try again, emitting a somewhat confusing log message of:

```
POST https://agent.buildkite.com/v3/jobs/<some job id>/artifacts: 500 (Attempt 1/10 retrying in 10s)
``` 
... and then a failure message with no retries.

This PR makes it so that when we run across a 500 when trying to batch-create some artifacts, we retry the operation, as the logs imply we should. also, 500s can be (though are not always) transient, so retrying them is a good idea regardless.

Closes #1565
Closes PIP-219