### PR TITLE
enable dependabot for go.mod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/.buildkite"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
It would be nice to slowly bump the various dependencies we have, to avoid situations like #1573 where a key dependency is nearly 2 years out of date.

On the other hand, we don't want to be overwhelmed by tiny bumps all the time.

Here's one way we could walk that path. Allow dependabot to open PRs with updates, but not more than 2 per week. I'm not wedded to these values, but I thought I'd start with a strawman.

The dependabot [config options are documented here](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#open-pull-requests-limit).

/cc @pda @moskyb 