### PR TITLE
Create directories only accessible by current user and group

### DIFF
--- a/agent/download.go
+++ b/agent/download.go
@@ -121,7 +121,7 @@ func (d Download) try() error {
 			responseDump, err := httputil.DumpResponse(response, true)
 			if err != nil {
 				d.logger.Debug("\nERR: %s\n%s", err, string(responseDump))
-			}  else {
+			} else {
 				d.logger.Debug("\n%s", string(responseDump))
 			}
 		}
@@ -130,7 +130,7 @@ func (d Download) try() error {
 	}
 
 	// Now make the folder for our file
-	err = os.MkdirAll(targetDirectory, 0777)
+	err = os.MkdirAll(targetDirectory, 0770)
 	if err != nil {
 		return fmt.Errorf("Failed to create folder for %s (%T: %v)", targetFile, err, err)
 	}

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -133,7 +133,7 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 	// TempDir is not guaranteed to exist
 	tempDir := os.TempDir()
 	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
-		if err = os.MkdirAll(tempDir, 0777); err != nil {
+		if err = os.MkdirAll(tempDir, 0770); err != nil {
 			return nil, err
 		}
 	}
@@ -629,7 +629,7 @@ func (w LogWriter) Write(bytes []byte) (int, error) {
 	return len(bytes), nil
 }
 
-func (r *JobRunner)executePreBootstrapHook(hook string) (bool, error) {
+func (r *JobRunner) executePreBootstrapHook(hook string) (bool, error) {
 	r.logger.Info("Running pre-bootstrap hook %q", hook)
 
 	sh, err := shell.New()
@@ -641,7 +641,7 @@ func (r *JobRunner)executePreBootstrapHook(hook string) (bool, error) {
 	// to the pre-bootstrap hook.
 	sh.Env.Set("BUILDKITE_ENV_FILE", r.envFile.Name())
 
-	sh.Writer = LogWriter {
+	sh.Writer = LogWriter{
 		l: r.logger,
 	}
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -888,7 +888,7 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	}
 
 	// Ensure the plugin directory exists, otherwise we can't create the lock
-	err = os.MkdirAll(b.PluginsPath, 0777)
+	err = os.MkdirAll(b.PluginsPath, 0770)
 	if err != nil {
 		return nil, err
 	}
@@ -1005,7 +1005,7 @@ func (b *Bootstrap) createCheckoutDir() error {
 
 	if !utils.FileExists(checkoutPath) {
 		b.shell.Commentf("Creating \"%s\"", checkoutPath)
-		if err := os.MkdirAll(checkoutPath, 0777); err != nil {
+		if err := os.MkdirAll(checkoutPath, 0770); err != nil {
 			return err
 		}
 	}
@@ -1191,7 +1191,7 @@ func (b *Bootstrap) updateGitMirror() (string, error) {
 	// Create the mirrors path if it doesn't exist
 	if baseDir := filepath.Dir(mirrorDir); !utils.FileExists(baseDir) {
 		b.shell.Commentf("Creating \"%s\"", baseDir)
-		if err := os.MkdirAll(baseDir, 0777); err != nil {
+		if err := os.MkdirAll(baseDir, 0770); err != nil {
 			return "", err
 		}
 	}
@@ -1791,7 +1791,7 @@ func (b *Bootstrap) writeBatchScript(cmd string) (string, error) {
 	for _, line := range strings.Split(cmd, "\n") {
 		if line != "" {
 			if shouldCallBatchLine(line) {
-				scriptContents = append(scriptContents, "call " + line)
+				scriptContents = append(scriptContents, "call "+line)
 			} else {
 				scriptContents = append(scriptContents, line)
 			}

--- a/bootstrap/shell/tempfile.go
+++ b/bootstrap/shell/tempfile.go
@@ -16,7 +16,7 @@ func TempFileWithExtension(filename string) (*os.File, error) {
 	// TempDir is not guaranteed to exist
 	tempDir := os.TempDir()
 	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
-		if err = os.MkdirAll(tempDir, 0777); err != nil {
+		if err = os.MkdirAll(tempDir, 0770); err != nil {
 			return nil, err
 		}
 	}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -730,7 +730,7 @@ var AgentStartCommand = cli.Command{
 		// so we may as well check that'll work now and fail early if it's a problem
 		if !utils.FileExists(agentConf.BuildPath) {
 			l.Info("Build Path doesn't exist, creating it (%s)", agentConf.BuildPath)
-			if err := os.MkdirAll(agentConf.BuildPath, 0777); err != nil {
+			if err := os.MkdirAll(agentConf.BuildPath, 0770); err != nil {
 				l.Fatal("Failed to create builds path: %v", err)
 			}
 		}


### PR DESCRIPTION
Buildkite Agent creates directories on the filesystem for a few reasons:

- if started with a `--build-path` that doesn't exist,
- when downloading artifacts,
- when checking out the codebase to be built,
- when checking out plugins,
- when checking out git mirrors,
- for various temporary files.

This pull request changes the mode passed to `os.MkdirAll` from `0777` to `0770`.

Note that the specified mode is masked by [umask](https://en.wikipedia.org/wiki/Umask) before the directory is created.
The default umask of most systems is `0022`, or at the very least `0002`.

    $ echo "$(uname): $(umask)"
    Darwin: 022

    $ for img in archlinux debian ubuntu centos alpine; do echo -n "$img: "; docker run --rm $img sh -c umask; done
    archlinux: 0022
    debian: 0022
    ubuntu: 0022
    centos: 0022
    alpine: 0022

Given a standard umask of `0022`:

- The previous mode of `0777` created directories as: `0755` (`drwxr-xr-x`)
- The new mode of `0770` creates directories as:      `0750` (`drwxr-x---`)

In neither case is the directory world-writable.

This patch drops the ability for _other users_ to read the directory regardless of the umask in effect during creation.

It continues to delegate _group_ access control to umask, so that system administrators can use that standard mechanism to control how different users in the same group can share resources. The standard `0022` umask provides a safe default of disallowing write access from other users in the same group.

This change is not relevant to Windows, where new directories inherits the ACL from their parent.