### PR TITLE
Test `buildkite artifact shasum`, refactor for testability.

### DIFF
--- a/agent/artifact_uploader_test.go
+++ b/agent/artifact_uploader_test.go
@@ -41,6 +41,7 @@ func TestCollect(t *testing.T) {
 		GlobPath     string
 		FileSize     int
 		Sha1Sum      string
+		Sha256Sum    string
 	}{
 		{
 			Name:         "Mr Freeze.jpg",
@@ -49,6 +50,7 @@ func TestCollect(t *testing.T) {
 			GlobPath:     filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
 			FileSize:     362371,
 			Sha1Sum:      "f5bc7bc9f5f9c3e543dde0eb44876c6f9acbfb6b",
+			Sha256Sum:    "0c657a363d92093e68224e0716ed8b8b5d4bbc3dfe9b026e32b241fc9b369d47",
 		},
 		{
 			Name:         "Commando.jpg",
@@ -57,6 +59,7 @@ func TestCollect(t *testing.T) {
 			GlobPath:     filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
 			FileSize:     113000,
 			Sha1Sum:      "811d7cb0317582e22ebfeb929d601cdabea4b3c0",
+			Sha256Sum:    "fcfbe62fd7b6638165a61e8de901ac9df93fc1389906f2772bdefed5de115426",
 		},
 		{
 			Name:         "The Terminator.jpg",
@@ -65,6 +68,7 @@ func TestCollect(t *testing.T) {
 			GlobPath:     filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
 			FileSize:     47301,
 			Sha1Sum:      "ed76566ede9cb6edc975fcadca429665aad8785a",
+			Sha256Sum:    "5b4228a4bbef3d9f676e0a2e8cf6ea06759124ef0fbdb27a6c35df8759fcd39d",
 		},
 		{
 			Name:         "Smile.gif",
@@ -73,6 +77,7 @@ func TestCollect(t *testing.T) {
 			GlobPath:     filepath.Join(root, "test", "fixtures", "artifacts", "**", "*.gif"),
 			FileSize:     2038453,
 			Sha1Sum:      "bd4caf2e01e59777744ac1d52deafa01c2cb9bfd",
+			Sha256Sum:    "fc5e8608c7772e4ae834fbc47eec3d902099eb3599f5191e40d9e3d9b3764b0e",
 		},
 	}
 
@@ -132,6 +137,7 @@ func TestCollect(t *testing.T) {
 			assert.Equal(t, tc.GlobPath, a.GlobPath)
 			assert.Equal(t, tc.FileSize, int(a.FileSize))
 			assert.Equal(t, tc.Sha1Sum, a.Sha1Sum)
+			assert.Equal(t, tc.Sha256Sum, a.Sha256Sum)
 		})
 	}
 
@@ -155,6 +161,7 @@ func TestCollect(t *testing.T) {
 			assert.Equal(t, tc.GlobPath, a.GlobPath)
 			assert.Equal(t, tc.FileSize, int(a.FileSize))
 			assert.Equal(t, tc.Sha1Sum, a.Sha1Sum)
+			assert.Equal(t, tc.Sha256Sum, a.Sha256Sum)
 		})
 	}
 }

--- a/api/artifacts.go
+++ b/api/artifacts.go
@@ -23,8 +23,11 @@ type Artifact struct {
 	// The size of the file in bytes
 	FileSize int64 `json:"file_size"`
 
-	// A Sha1Sum calculation of the file
+	// A SHA-1 hash of the uploaded file
 	Sha1Sum string `json:"sha1sum"`
+
+	// A SHA-2 256-bit hash of the uploaded file, possibly empty
+	Sha256Sum string `json:"sha256sum"`
 
 	// ID of the job that created this artifact (from API)
 	JobID string `json:"job_id"`

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -2,10 +2,13 @@ package clicommand
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/cliconfig"
+	"github.com/buildkite/agent/v3/logger"
 	"github.com/urfave/cli"
 )
 
@@ -109,27 +112,34 @@ var ArtifactShasumCommand = cli.Command{
 		done := HandleGlobalFlags(l, cfg)
 		defer done()
 
-		// Create the API client
-		client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))
-
-		// Find the artifact we want to show the SHASUM for
-		searcher := agent.NewArtifactSearcher(l, client, cfg.Build)
-		state := "finished"
-		artifacts, err := searcher.Search(cfg.Query, cfg.Step, state, cfg.IncludeRetriedJobs, false)
-		if err != nil {
-			l.Fatal("Error searching for artifacts: %s", err)
-		}
-
-		artifactsFoundLength := len(artifacts)
-
-		if artifactsFoundLength == 0 {
-			l.Fatal("No artifacts matched the search query")
-		} else if artifactsFoundLength > 1 {
-			l.Fatal("Multiple artifacts were found. Try being more specific with the search or scope by step")
-		} else {
-			l.Debug("Artifact \"%s\" found", artifacts[0].Path)
-
-			fmt.Printf("%s\n", artifacts[0].Sha1Sum)
+		if err := searchAndPrintSha1Sum(cfg, l, os.Stdout); err != nil {
+			l.Fatal(err.Error())
 		}
 	},
+}
+
+func searchAndPrintSha1Sum(cfg ArtifactShasumConfig, l logger.Logger, stdout io.Writer) error {
+	// Create the API client
+	client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))
+
+	// Find the artifact we want to show the SHASUM for
+	searcher := agent.NewArtifactSearcher(l, client, cfg.Build)
+	state := "finished"
+	artifacts, err := searcher.Search(cfg.Query, cfg.Step, state, cfg.IncludeRetriedJobs, false)
+	if err != nil {
+		return fmt.Errorf("Error searching for artifacts: %s", err)
+	}
+
+	artifactsFoundLength := len(artifacts)
+
+	if artifactsFoundLength == 0 {
+		return fmt.Errorf("No artifacts matched the search query")
+	} else if artifactsFoundLength > 1 {
+		return fmt.Errorf("Multiple artifacts were found. Try being more specific with the search or scope by step")
+	} else {
+		l.Debug("Artifact \"%s\" found", artifacts[0].Path)
+
+		fmt.Fprintln(stdout, artifacts[0].Sha1Sum)
+	}
+	return nil
 }

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -18,10 +18,11 @@ var ShasumHelpDescription = `Usage:
 
 Description:
 
-   Prints the SHA-1 hash for the single artifact specified by a search query.
+   Prints the SHA-1 or SHA-256 hash for the single artifact specified by a
+   search query.
 
-   The SHA-1 hash is fetched from Buildkite's API, having been generated
-   client-side by the agent during artifact upload.
+   The hash is fetched from Buildkite's API, having been generated client-side
+   by the agent during artifact upload.
 
    A search query that does not match exactly one artifact results in an error.
 
@@ -42,10 +43,15 @@ Example:
 
    $ buildkite-agent artifact shasum "pkg/release.tar.gz" --step "release" --build xxx
 
-   You can also use the step's job ID (provided by the environment variable $BUILDKITE_JOB_ID)`
+   You can also use the step's job ID (provided by the environment variable $BUILDKITE_JOB_ID)
+
+   The --sha256 argument requests SHA-256 instead of SHA-1; this is only
+   available for artifacts uploaded since SHA-256 support was added to the
+   agent.`
 
 type ArtifactShasumConfig struct {
 	Query              string `cli:"arg:0" label:"artifact search query" validate:"required"`
+	Sha256             bool   `cli:"sha256"`
 	Step               string `cli:"step"`
 	Build              string `cli:"build" validate:"required"`
 	IncludeRetriedJobs bool   `cli:"include-retried-jobs"`
@@ -68,6 +74,10 @@ var ArtifactShasumCommand = cli.Command{
 	Usage:       "Prints the SHA-1 hash for a single artifact specified by a search query",
 	Description: ShasumHelpDescription,
 	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "sha256",
+			Usage: "Request SHA-256 instead of SHA-1, errors if SHA-256 not available",
+		},
 		cli.StringFlag{
 			Name:  "step",
 			Value: "",
@@ -112,13 +122,13 @@ var ArtifactShasumCommand = cli.Command{
 		done := HandleGlobalFlags(l, cfg)
 		defer done()
 
-		if err := searchAndPrintSha1Sum(cfg, l, os.Stdout); err != nil {
+		if err := searchAndPrintShaSum(cfg, l, os.Stdout); err != nil {
 			l.Fatal(err.Error())
 		}
 	},
 }
 
-func searchAndPrintSha1Sum(cfg ArtifactShasumConfig, l logger.Logger, stdout io.Writer) error {
+func searchAndPrintShaSum(cfg ArtifactShasumConfig, l logger.Logger, stdout io.Writer) error {
 	// Create the API client
 	client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))
 
@@ -137,9 +147,19 @@ func searchAndPrintSha1Sum(cfg ArtifactShasumConfig, l logger.Logger, stdout io.
 	} else if artifactsFoundLength > 1 {
 		return fmt.Errorf("Multiple artifacts were found. Try being more specific with the search or scope by step")
 	} else {
-		l.Debug("Artifact \"%s\" found", artifacts[0].Path)
+		a := artifacts[0]
+		l.Debug("Artifact \"%s\" found", a.Path)
 
-		fmt.Fprintln(stdout, artifacts[0].Sha1Sum)
+		var sha string
+		if cfg.Sha256 {
+			if a.Sha256Sum == "" {
+				return fmt.Errorf("SHA-256 requested but was not generated at upload time")
+			}
+			sha = a.Sha256Sum
+		} else {
+			sha = a.Sha1Sum
+		}
+		fmt.Fprintln(stdout, sha)
 	}
 	return nil
 }

--- a/clicommand/artifact_shasum_test.go
+++ b/clicommand/artifact_shasum_test.go
@@ -1,0 +1,44 @@
+package clicommand
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestServer(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.RequestURI() {
+		case "/builds/buildid/artifacts/search?query=foo.%2A&state=finished":
+			io.WriteString(rw, `[{"path": "foo.txt", "sha1sum": "theshastring"}]`)
+		default:
+			t.Errorf("unexpected HTTP request: %s %v", req.Method, req.URL.RequestURI())
+		}
+	}))
+}
+
+func TestSearchAndPrintSha1Sum(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+
+	cfg := ArtifactShasumConfig{
+		Query:            "foo.*",
+		Build:            "buildid",
+		AgentAccessToken: "agentaccesstoken",
+		Endpoint:         server.URL,
+	}
+	l := logger.NewBuffer()
+	stdout := new(bytes.Buffer)
+
+	searchAndPrintSha1Sum(cfg, l, stdout)
+
+	assert.Equal(t, "theshastring\n", stdout.String())
+
+	assert.Contains(t, l.Messages, `[info] Searching for artifacts: "foo.*"`)
+	assert.Contains(t, l.Messages, `[debug] Artifact "foo.txt" found`)
+}


### PR DESCRIPTION
Basic test coverage for the `buildkite artifact shasum` command.

We don't have an established way to test our CLI invocations, and I think the way we wire up `github.com/urfave/cli` would need substantial refactoring to make it possible.

So instead, this pull request extracts a ` func searchAndPrintSha1Sum(…)` from the CLI action and tests that. The main API interaction, output and logging is covered by the test.

I'm interested in shifting from SHA-1 to SHA-256, so some coverage would be valuable.