### PR TITLE
Artifact SHA-256 checksum alongside existing SHA-1

### DIFF
--- a/agent/artifact_uploader_test.go
+++ b/agent/artifact_uploader_test.go
@@ -41,6 +41,7 @@ func TestCollect(t *testing.T) {
 		GlobPath     string
 		FileSize     int
 		Sha1Sum      string
+		Sha256Sum    string
 	}{
 		{
 			Name:         "Mr Freeze.jpg",
@@ -49,6 +50,7 @@ func TestCollect(t *testing.T) {
 			GlobPath:     filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
 			FileSize:     362371,
 			Sha1Sum:      "f5bc7bc9f5f9c3e543dde0eb44876c6f9acbfb6b",
+			Sha256Sum:    "0c657a363d92093e68224e0716ed8b8b5d4bbc3dfe9b026e32b241fc9b369d47",
 		},
 		{
 			Name:         "Commando.jpg",
@@ -57,6 +59,7 @@ func TestCollect(t *testing.T) {
 			GlobPath:     filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
 			FileSize:     113000,
 			Sha1Sum:      "811d7cb0317582e22ebfeb929d601cdabea4b3c0",
+			Sha256Sum:    "fcfbe62fd7b6638165a61e8de901ac9df93fc1389906f2772bdefed5de115426",
 		},
 		{
 			Name:         "The Terminator.jpg",
@@ -65,6 +68,7 @@ func TestCollect(t *testing.T) {
 			GlobPath:     filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
 			FileSize:     47301,
 			Sha1Sum:      "ed76566ede9cb6edc975fcadca429665aad8785a",
+			Sha256Sum:    "5b4228a4bbef3d9f676e0a2e8cf6ea06759124ef0fbdb27a6c35df8759fcd39d",
 		},
 		{
 			Name:         "Smile.gif",
@@ -73,6 +77,7 @@ func TestCollect(t *testing.T) {
 			GlobPath:     filepath.Join(root, "test", "fixtures", "artifacts", "**", "*.gif"),
 			FileSize:     2038453,
 			Sha1Sum:      "bd4caf2e01e59777744ac1d52deafa01c2cb9bfd",
+			Sha256Sum:    "fc5e8608c7772e4ae834fbc47eec3d902099eb3599f5191e40d9e3d9b3764b0e",
 		},
 	}
 
@@ -132,6 +137,7 @@ func TestCollect(t *testing.T) {
 			assert.Equal(t, tc.GlobPath, a.GlobPath)
 			assert.Equal(t, tc.FileSize, int(a.FileSize))
 			assert.Equal(t, tc.Sha1Sum, a.Sha1Sum)
+			assert.Equal(t, tc.Sha256Sum, a.Sha256Sum)
 		})
 	}
 
@@ -155,6 +161,7 @@ func TestCollect(t *testing.T) {
 			assert.Equal(t, tc.GlobPath, a.GlobPath)
 			assert.Equal(t, tc.FileSize, int(a.FileSize))
 			assert.Equal(t, tc.Sha1Sum, a.Sha1Sum)
+			assert.Equal(t, tc.Sha256Sum, a.Sha256Sum)
 		})
 	}
 }

--- a/api/artifacts.go
+++ b/api/artifacts.go
@@ -23,8 +23,11 @@ type Artifact struct {
 	// The size of the file in bytes
 	FileSize int64 `json:"file_size"`
 
-	// A Sha1Sum calculation of the file
+	// A SHA-1 hash of the uploaded file
 	Sha1Sum string `json:"sha1sum"`
+
+	// A SHA-2 256-bit hash of the uploaded file, possibly empty
+	Sha256Sum string `json:"sha256sum"`
 
 	// ID of the job that created this artifact (from API)
 	JobID string `json:"job_id"`

--- a/clicommand/artifact_shasum_test.go
+++ b/clicommand/artifact_shasum_test.go
@@ -15,7 +15,7 @@ func newTestServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.RequestURI() {
 		case "/builds/buildid/artifacts/search?query=foo.%2A":
-			io.WriteString(rw, `[{"path": "foo.txt", "sha1sum": "theshastring"}]`)
+			io.WriteString(rw, `[{"path": "foo.txt", "sha1sum": "theshastring", "sha256sum": "thesha256string"}]`)
 		default:
 			t.Errorf("unexpected HTTP request: %s %v", req.Method, req.URL.RequestURI())
 		}
@@ -35,9 +35,31 @@ func TestSearchAndPrintSha1Sum(t *testing.T) {
 	l := logger.NewBuffer()
 	stdout := new(bytes.Buffer)
 
-	searchAndPrintSha1Sum(cfg, l, stdout)
+	searchAndPrintShaSum(cfg, l, stdout)
 
 	assert.Equal(t, "theshastring\n", stdout.String())
+
+	assert.Contains(t, l.Messages, `[info] Searching for artifacts: "foo.*"`)
+	assert.Contains(t, l.Messages, `[debug] Artifact "foo.txt" found`)
+}
+
+func TestSearchAndPrintSha256Sum(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+
+	cfg := ArtifactShasumConfig{
+		Query:            "foo.*",
+		Build:            "buildid",
+		Sha256:           true,
+		AgentAccessToken: "agentaccesstoken",
+		Endpoint:         server.URL,
+	}
+	l := logger.NewBuffer()
+	stdout := new(bytes.Buffer)
+
+	searchAndPrintShaSum(cfg, l, stdout)
+
+	assert.Equal(t, "thesha256string\n", stdout.String())
 
 	assert.Contains(t, l.Messages, `[info] Searching for artifacts: "foo.*"`)
 	assert.Contains(t, l.Messages, `[debug] Artifact "foo.txt" found`)


### PR DESCRIPTION
Begin to shift from SHA-1 to SHA-256 for artifact checksums.

- `buildkite-agent artifact upload` will calculate and submit both SHA-1 and SHA-256.
- `buildkite-agent artifact shasum --sha256` will print the SHA-256 hash (or error if there isn't one).

_Currently_ there's no server-side support for `sha256sum` in the API, so the uploaded SHA-256 will not be stored, and the `--sha256` option on `buildkite-agent artifact shasum` will always fail. But that support would be added if/when this PR merges.

- [ ] teach `--format` of `artifact search` to show SHA-256 (non-blocking for this PR)