### PR TITLE
artifact download (and shasum) only search for finished uploads.

### DIFF
--- a/agent/artifact_downloader.go
+++ b/agent/artifact_downloader.go
@@ -65,8 +65,9 @@ func (a *ArtifactDownloader) Download() error {
 	}
 
 	// Find the artifacts that we want to download
+	state := "finished"
 	artifacts, err := NewArtifactSearcher(a.logger, a.apiClient, a.conf.BuildID).
-		Search(a.conf.Query, a.conf.Step, a.conf.IncludeRetriedJobs, false)
+		Search(a.conf.Query, a.conf.Step, state, a.conf.IncludeRetriedJobs, false)
 	if err != nil {
 		return err
 	}

--- a/agent/artifact_downloader_test.go
+++ b/agent/artifact_downloader_test.go
@@ -15,8 +15,8 @@ func TestArtifactDownloaderConnectsToEndpoint(t *testing.T) {
 	defer os.Remove("llamas.txt")
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		switch req.URL.Path {
-		case `/builds/my-build/artifacts/search`:
+		switch req.URL.RequestURI() {
+		case `/builds/my-build/artifacts/search?state=finished`:
 			fmt.Fprintf(rw, `[{
 				"id": "4600ac5c-5a13-4e92-bb83-f86f218f7b32",
 				"file_size": 3,

--- a/agent/artifact_searcher.go
+++ b/agent/artifact_searcher.go
@@ -27,7 +27,7 @@ func NewArtifactSearcher(l logger.Logger, ac APIClient, buildID string) *Artifac
 	}
 }
 
-func (a *ArtifactSearcher) Search(query string, scope string, includeRetriedJobs bool, includeDuplicates bool) ([]*api.Artifact, error) {
+func (a *ArtifactSearcher) Search(query, scope, state string, includeRetriedJobs, includeDuplicates bool) ([]*api.Artifact, error) {
 	if scope == "" {
 		a.logger.Info("Searching for artifacts: \"%s\"", query)
 	} else {
@@ -42,6 +42,7 @@ func (a *ArtifactSearcher) Search(query string, scope string, includeRetriedJobs
 		artifacts, _, searchErr = a.apiClient.SearchArtifacts(a.buildID, &api.ArtifactSearchOptions{
 			Query:              query,
 			Scope:              scope,
+			State:              state,
 			IncludeRetriedJobs: includeRetriedJobs,
 			IncludeDuplicates:  includeDuplicates,
 		})

--- a/api/artifacts.go
+++ b/api/artifacts.go
@@ -73,6 +73,7 @@ type ArtifactBatchCreateResponse struct {
 type ArtifactSearchOptions struct {
 	Query              string `url:"query,omitempty"`
 	Scope              string `url:"scope,omitempty"`
+	State              string `url:"state,omitempty"`
 	IncludeRetriedJobs bool   `url:"include_retried_jobs,omitempty"`
 	IncludeDuplicates  bool   `url:"include_duplicates,omitempty"`
 }

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -98,15 +98,15 @@ Format specifiers:
 			Usage: "Scope the search to a particular step by using either its name or job ID",
 		},
 		cli.StringFlag{
-			Name:    "build",
-			Value:   "",
+			Name:   "build",
+			Value:  "",
 			EnvVar: "BUILDKITE_BUILD_ID",
-			Usage:   "The build that the artifacts were uploaded to",
+			Usage:  "The build that the artifacts were uploaded to",
 		},
 		cli.BoolFlag{
-			Name:    "include-retried-jobs",
-			EnvVar:  "BUILDKITE_AGENT_INCLUDE_RETRIED_JOBS",
-			Usage:   "Include artifacts from retried jobs in the search",
+			Name:   "include-retried-jobs",
+			EnvVar: "BUILDKITE_AGENT_INCLUDE_RETRIED_JOBS",
+			Usage:  "Include artifacts from retried jobs in the search",
 		},
 		cli.StringFlag{
 			Name:  "format",
@@ -146,7 +146,8 @@ Format specifiers:
 
 		// Setup the searcher and try get the artifacts
 		searcher := agent.NewArtifactSearcher(l, client, cfg.Build)
-		artifacts, err := searcher.Search(cfg.Query, cfg.Step, cfg.IncludeRetriedJobs, true)
+		state := "" // any state
+		artifacts, err := searcher.Search(cfg.Query, cfg.Step, state, cfg.IncludeRetriedJobs, true)
 		if err != nil {
 			return err
 		}

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -109,8 +109,8 @@ var ArtifactShasumCommand = cli.Command{
 
 		// Find the artifact we want to show the SHASUM for
 		searcher := agent.NewArtifactSearcher(l, client, cfg.Build)
-
-		artifacts, err := searcher.Search(cfg.Query, cfg.Step, cfg.IncludeRetriedJobs, false)
+		state := "finished"
+		artifacts, err := searcher.Search(cfg.Query, cfg.Step, state, cfg.IncludeRetriedJobs, false)
 		if err != nil {
 			l.Fatal("Failed to find artifacts: %s", err)
 		}


### PR DESCRIPTION
The Artifact Search API endpoint supports filtering the search to `finished` artifacts, so that incomplete uploads are not included.

`buildkite-agent artifact download` and `buildkite-agent artifact shasum` probably want to apply that filter, otherwise they're likely to get stuck trying to download artifacts that don't exist.

- [x] more testing and/or local validation.
- [x] sanity-check the decision to not attempt downloading unfinished artifacts.