### PR TITLE
Make `go fmt` mandatory

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,6 +2,14 @@ env:
   DRY_RUN: false # set to true to disable publishing releases
 
 steps:
+  - name: ":go: fmt"
+    key: test-go-fmt
+    command: ".buildkite/steps/test-go-fmt.sh"
+    plugins:
+      docker-compose#v3.0.0:
+        config: .buildkite/docker-compose.yml
+        run: agent
+
   - name: ":hammer: :linux: amd64"
     key: test-linux-amd64
     command: ".buildkite/steps/tests.sh"

--- a/.buildkite/steps/test-go-fmt.sh
+++ b/.buildkite/steps/test-go-fmt.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ $(gofmt -l ./ | head -c 1 | wc -c) != 0 ]]; then
+  echo "The following files haven't been formatted with \`go fmt\`:"
+  gofmt -l ./
+  echo
+  echo "Fix this by running \`go fmt ./...\` locally, and committing the result."
+  exit 1
+fi
+
+echo "Everything is formatted! 🎉"

--- a/agent/download_test.go
+++ b/agent/download_test.go
@@ -1,10 +1,11 @@
+//go:build !windows
 // +build !windows
 
 package agent
 
 import (
-	"testing"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestGetTargetPath(t *testing.T) {
@@ -36,13 +37,13 @@ func TestGetTargetPath(t *testing.T) {
 		getTargetPath(
 			"a/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/b",
 			"b/a"),
-		)
+	)
 	// Gotcha: this is not what you want.
 	assert.Equal(t, "a/lambda.zip/a/lambda.zip", getTargetPath("a/lambda.zip", "a/lambda.zip"))
 
 	// Test absolute paths
-	assert.Equal(t, "/var/logs/app/a.log", getTargetPath("app/a.log", "/var/logs")) // no match, no trailing
-	assert.Equal(t, "/var/logs/app/a.log", getTargetPath("app/a.log", "/var/logs/app")) // match, no trailing
+	assert.Equal(t, "/var/logs/app/a.log", getTargetPath("app/a.log", "/var/logs"))          // no match, no trailing
+	assert.Equal(t, "/var/logs/app/a.log", getTargetPath("app/a.log", "/var/logs/app"))      // match, no trailing
 	assert.Equal(t, "/var/logs/app/app/a.log", getTargetPath("app/a.log", "/var/logs/app/")) // match, trailing
 
 	// artifact_download documentation examples

--- a/agent/form_uploader_test.go
+++ b/agent/form_uploader_test.go
@@ -169,12 +169,12 @@ func TestFormUploadFileMissing(t *testing.T) {
 func TestFormUploadTooBig(t *testing.T) {
 	uploader := NewFormUploader(logger.Discard, FormUploaderConfig{})
 	artifact := &api.Artifact{
-		ID:           "xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx",
-		Path:         "llamas.txt",
-		AbsolutePath: "/llamas.txt",
-		GlobPath:     "llamas.txt",
-		ContentType:  "text/plain",
-		FileSize:     int64(6442450944), // 6Gb
+		ID:                 "xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx",
+		Path:               "llamas.txt",
+		AbsolutePath:       "/llamas.txt",
+		GlobPath:           "llamas.txt",
+		ContentType:        "text/plain",
+		FileSize:           int64(6442450944), // 6Gb
 		UploadInstructions: &api.ArtifactUploadInstructions{},
 	}
 

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -88,7 +88,7 @@ func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 
 	regionHint := os.Getenv(regionHintEnvVar)
 	if regionHint != "" {
-        l.Debug("Using bucket region %q from environment variable %q", regionHint, regionHintEnvVar)
+		l.Debug("Using bucket region %q from environment variable %q", regionHint, regionHintEnvVar)
 		// If there is a region hint provided, we use it unconditionally
 		session, err := awsS3Session(regionHint)
 		if err != nil {

--- a/agent/version_test.go
+++ b/agent/version_test.go
@@ -1,9 +1,9 @@
 package agent
 
 import (
-  "testing"
+	"testing"
 
-  "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVersionIsValid(t *testing.T) {

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -51,7 +51,7 @@ func TestGetValuesToRedactEmpty(t *testing.T) {
 
 	redactConfig := []string{}
 	environment := map[string]string{
-		"FOO": "BAR",
+		"FOO":                "BAR",
 		"BUILDKITE_PIPELINE": "unit-test",
 	}
 

--- a/bootstrap/integration/plugin_integration_test.go
+++ b/bootstrap/integration/plugin_integration_test.go
@@ -250,7 +250,7 @@ func TestPluginCloneRetried(t *testing.T) {
 
 	git := tester.MustMock(t, "git")
 
-	git.Expect("clone", "-v", "--", p.Path, bintest.MatchAny()).Exactly(2).AndCallFunc(func (c *bintest.Call) {
+	git.Expect("clone", "-v", "--", p.Path, bintest.MatchAny()).Exactly(2).AndCallFunc(func(c *bintest.Call) {
 		callCount = callCount + 1
 
 		if callCount == 1 {

--- a/bootstrap/shell/lookpath.go
+++ b/bootstrap/shell/lookpath.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // This file (along with its Windows counterpart) have been taken from:

--- a/bootstrap/shell/signal.go
+++ b/bootstrap/shell/signal.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package shell

--- a/clicommand/annotation_remove.go
+++ b/clicommand/annotation_remove.go
@@ -1,12 +1,12 @@
 package clicommand
 
 import (
-  "time"
+	"time"
 
-  "github.com/buildkite/agent/v3/api"
-  "github.com/buildkite/agent/v3/cliconfig"
-  "github.com/buildkite/agent/v3/retry"
-  "github.com/urfave/cli"
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/cliconfig"
+	"github.com/buildkite/agent/v3/retry"
+	"github.com/urfave/cli"
 )
 
 var AnnotationRemoveHelpDescription = `Usage:
@@ -26,96 +26,96 @@ Example:
    $ buildkite-agent annotation remove --context "remove-me"`
 
 type AnnotationRemoveConfig struct {
-  Context string `cli:"context" validate:"required"`
-  Job     string `cli:"job" validate:"required"`
+	Context string `cli:"context" validate:"required"`
+	Job     string `cli:"job" validate:"required"`
 
-  // Global flags
-  Debug   bool         `cli:"debug"`
-  NoColor bool         `cli:"no-color"`
-  Experiments []string `cli:"experiment" normalize:"list"`
-  Profile string       `cli:"profile"`
+	// Global flags
+	Debug       bool     `cli:"debug"`
+	NoColor     bool     `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile     string   `cli:"profile"`
 
-  // API config
-  DebugHTTP        bool   `cli:"debug-http"`
-  AgentAccessToken string `cli:"agent-access-token" validate:"required"`
-  Endpoint         string `cli:"endpoint" validate:"required"`
-  NoHTTP2          bool   `cli:"no-http2"`
+	// API config
+	DebugHTTP        bool   `cli:"debug-http"`
+	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
+	Endpoint         string `cli:"endpoint" validate:"required"`
+	NoHTTP2          bool   `cli:"no-http2"`
 }
 
 var AnnotationRemoveCommand = cli.Command{
-  Name:        "remove",
-  Usage:       "Remove an existing annotation from a Buildkite build",
-  Description: AnnotationRemoveHelpDescription,
-  Flags: []cli.Flag{
-    cli.StringFlag{
-      Name:   "context",
-      Value:  "default",
-      Usage:  "The context of the annotation used to differentiate this annotation from others",
-      EnvVar: "BUILDKITE_ANNOTATION_CONTEXT",
-    },
-    cli.StringFlag{
-      Name:   "job",
-      Value:  "",
-      Usage:  "Which job is removing the annotation",
-      EnvVar: "BUILDKITE_JOB_ID",
-    },
+	Name:        "remove",
+	Usage:       "Remove an existing annotation from a Buildkite build",
+	Description: AnnotationRemoveHelpDescription,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:   "context",
+			Value:  "default",
+			Usage:  "The context of the annotation used to differentiate this annotation from others",
+			EnvVar: "BUILDKITE_ANNOTATION_CONTEXT",
+		},
+		cli.StringFlag{
+			Name:   "job",
+			Value:  "",
+			Usage:  "Which job is removing the annotation",
+			EnvVar: "BUILDKITE_JOB_ID",
+		},
 
-    // API Flags
-    AgentAccessTokenFlag,
-    EndpointFlag,
-    NoHTTP2Flag,
-    DebugHTTPFlag,
+		// API Flags
+		AgentAccessTokenFlag,
+		EndpointFlag,
+		NoHTTP2Flag,
+		DebugHTTPFlag,
 
-    // Global flags
-    NoColorFlag,
-    DebugFlag,
-    ExperimentsFlag,
-    ProfileFlag,
-  },
-  Action: func(c *cli.Context) {
-    // The configuration will be loaded into this struct
-    cfg := AnnotationRemoveConfig{}
+		// Global flags
+		NoColorFlag,
+		DebugFlag,
+		ExperimentsFlag,
+		ProfileFlag,
+	},
+	Action: func(c *cli.Context) {
+		// The configuration will be loaded into this struct
+		cfg := AnnotationRemoveConfig{}
 
-    l := CreateLogger(&cfg)
+		l := CreateLogger(&cfg)
 
-    // Load the configuration
-    if err := cliconfig.Load(c, l, &cfg); err != nil {
-      l.Fatal("%s", err)
-    }
+		// Load the configuration
+		if err := cliconfig.Load(c, l, &cfg); err != nil {
+			l.Fatal("%s", err)
+		}
 
-    // Setup any global configuration options
-    done := HandleGlobalFlags(l, cfg)
-    defer done()
+		// Setup any global configuration options
+		done := HandleGlobalFlags(l, cfg)
+		defer done()
 
-    var err error
+		var err error
 
-    // Create the API client
-    client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))
+		// Create the API client
+		client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))
 
-    // Retry the removal a few times before giving up
-    err = retry.Do(func(s *retry.Stats) error {
-      // Attempt to remove the annotation
-      resp, err := client.AnnotationRemove(cfg.Job, cfg.Context)
+		// Retry the removal a few times before giving up
+		err = retry.Do(func(s *retry.Stats) error {
+			// Attempt to remove the annotation
+			resp, err := client.AnnotationRemove(cfg.Job, cfg.Context)
 
-      // Don't bother retrying if the response was one of these statuses
-      if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 400 || resp.StatusCode == 410) {
-        s.Break()
-        return err
-      }
+			// Don't bother retrying if the response was one of these statuses
+			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 400 || resp.StatusCode == 410) {
+				s.Break()
+				return err
+			}
 
-      // Show the unexpected error
-      if err != nil {
-        l.Warn("%s (%s)", err, s)
-      }
+			// Show the unexpected error
+			if err != nil {
+				l.Warn("%s (%s)", err, s)
+			}
 
-      return err
-    }, &retry.Config{Maximum: 5, Interval: 1 * time.Second, Jitter: true})
+			return err
+		}, &retry.Config{Maximum: 5, Interval: 1 * time.Second, Jitter: true})
 
-    // Show a fatal error if we gave up trying to create the annotation
-    if err != nil {
-      l.Fatal("Failed to remove annotation: %s", err)
-    }
+		// Show a fatal error if we gave up trying to create the annotation
+		if err != nil {
+			l.Fatal("Failed to remove annotation: %s", err)
+		}
 
-    l.Debug("Successfully removed annotation")
-  },
+		l.Debug("Successfully removed annotation")
+	},
 }

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -52,10 +52,10 @@ type ArtifactDownloadConfig struct {
 	IncludeRetriedJobs bool   `cli:"include-retried-jobs"`
 
 	// Global flags
-	Debug   bool         `cli:"debug"`
-	NoColor bool         `cli:"no-color"`
+	Debug       bool     `cli:"debug"`
+	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
-	Profile string       `cli:"profile"`
+	Profile     string   `cli:"profile"`
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -12,11 +12,11 @@ import (
 
 	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/bootstrap/shell"
 	"github.com/buildkite/agent/v3/cliconfig"
 	"github.com/buildkite/agent/v3/env"
 	"github.com/buildkite/agent/v3/redaction"
 	"github.com/buildkite/agent/v3/retry"
-	"github.com/buildkite/agent/v3/bootstrap/shell"
 	"github.com/buildkite/agent/v3/stdin"
 	"github.com/urfave/cli"
 )
@@ -51,12 +51,12 @@ Example:
    $ ./script/dynamic_step_generator | buildkite-agent pipeline upload`
 
 type PipelineUploadConfig struct {
-	FilePath        string 	 `cli:"arg:0" label:"upload paths"`
-	Replace         bool   	 `cli:"replace"`
-	Job             string 	 `cli:"job"`
-	DryRun          bool   	 `cli:"dry-run"`
-	NoInterpolation bool   	 `cli:"no-interpolation"`
-	RedactedVars	 []string `cli:"redacted-vars" normalize:"list"`
+	FilePath        string   `cli:"arg:0" label:"upload paths"`
+	Replace         bool     `cli:"replace"`
+	Job             string   `cli:"job"`
+	DryRun          bool     `cli:"dry-run"`
+	NoInterpolation bool     `cli:"no-interpolation"`
+	RedactedVars    []string `cli:"redacted-vars" normalize:"list"`
 
 	// Global flags
 	Debug       bool     `cli:"debug"`

--- a/env/environment.go
+++ b/env/environment.go
@@ -80,8 +80,8 @@ func (e *Environment) Length() int {
 // Diff returns a new environment with the keys and values from this
 // environment which are different in the other one.
 func (e *Environment) Diff(other *Environment) Diff {
-	diff := Diff {
-		Added: make(map[string]string),
+	diff := Diff{
+		Added:   make(map[string]string),
 		Changed: make(map[string]DiffPair),
 		Removed: make(map[string]struct{}, 0),
 	}
@@ -95,7 +95,7 @@ func (e *Environment) Diff(other *Environment) Diff {
 		}
 
 		if other != v {
-			diff.Changed[k] = DiffPair {
+			diff.Changed[k] = DiffPair{
 				Old: other,
 				New: v,
 			}
@@ -205,7 +205,7 @@ func normalizeKeyName(key string) string {
 }
 
 type Diff struct {
-	Added map[string]string
+	Added   map[string]string
 	Changed map[string]DiffPair
 	Removed map[string]struct{}
 }

--- a/env/environment_test.go
+++ b/env/environment_test.go
@@ -100,28 +100,28 @@ func TestEnvironmentDiff(t *testing.T) {
 	b := FromSlice([]string{"A=hello", "B=there", "C=new", "D="})
 
 	ab := a.Diff(b)
-	assert.Equal(t, Diff {
+	assert.Equal(t, Diff{
 		Added: map[string]string{},
 		Changed: map[string]DiffPair{
-			"B": DiffPair {
+			"B": DiffPair{
 				Old: "there",
 				New: "world",
 			},
 		},
-		Removed: map[string]struct{} {
+		Removed: map[string]struct{}{
 			"C": struct{}{},
 			"D": struct{}{},
 		},
 	}, ab)
 
 	ba := b.Diff(a)
-	assert.Equal(t, Diff {
+	assert.Equal(t, Diff{
 		Added: map[string]string{
 			"C": "new",
 			"D": "",
 		},
-		Changed: map[string]DiffPair {
-			"B": DiffPair {
+		Changed: map[string]DiffPair{
+			"B": DiffPair{
 				Old: "world",
 				New: "there",
 			},
@@ -133,17 +133,17 @@ func TestEnvironmentDiff(t *testing.T) {
 func TestEnvironmentDiffRemove(t *testing.T) {
 	t.Parallel()
 
-	diff := Diff {
-		Added: map[string]string {
+	diff := Diff{
+		Added: map[string]string{
 			"A": "new",
 		},
-		Changed: map[string]DiffPair {
-			"B": DiffPair {
+		Changed: map[string]DiffPair{
+			"B": DiffPair{
 				Old: "old",
 				New: "new",
 			},
 		},
-		Removed: map[string]struct{} {
+		Removed: map[string]struct{}{
 			"C": struct{}{},
 		},
 	}
@@ -152,9 +152,9 @@ func TestEnvironmentDiffRemove(t *testing.T) {
 	diff.Remove("B")
 	diff.Remove("C")
 
-	assert.Equal(t, Diff {
-		Added: map[string]string {},
-		Changed: map[string]DiffPair {},
+	assert.Equal(t, Diff{
+		Added:   map[string]string{},
+		Changed: map[string]DiffPair{},
 		Removed: map[string]struct{}{},
 	}, diff)
 }
@@ -171,7 +171,7 @@ func TestEnvironmentApply(t *testing.T) {
 	t.Parallel()
 
 	env := &Environment{}
-	env = env.Apply(Diff {
+	env = env.Apply(Diff{
 		Added: map[string]string{
 			"LLAMAS_ENABLED": "1",
 		},
@@ -182,12 +182,12 @@ func TestEnvironmentApply(t *testing.T) {
 		"LLAMAS_ENABLED=1",
 	}), env)
 
-	env = env.Apply(Diff {
+	env = env.Apply(Diff{
 		Added: map[string]string{
 			"ALPACAS_ENABLED": "1",
 		},
 		Changed: map[string]DiffPair{
-			"LLAMAS_ENABLED": DiffPair {
+			"LLAMAS_ENABLED": DiffPair{
 				Old: "1",
 				New: "0",
 			},
@@ -199,11 +199,11 @@ func TestEnvironmentApply(t *testing.T) {
 		"LLAMAS_ENABLED=0",
 	}), env)
 
-	env = env.Apply(Diff {
-		Added: map[string]string{},
+	env = env.Apply(Diff{
+		Added:   map[string]string{},
 		Changed: map[string]DiffPair{},
-		Removed: map[string]struct{} {
-			"LLAMAS_ENABLED": struct{}{},
+		Removed: map[string]struct{}{
+			"LLAMAS_ENABLED":  struct{}{},
 			"ALPACAS_ENABLED": struct{}{},
 		},
 	})

--- a/hook/scriptwrapper.go
+++ b/hook/scriptwrapper.go
@@ -38,7 +38,7 @@ type ScriptWrapper struct {
 }
 
 type HookScriptChanges struct {
-	Diff env.Diff
+	Diff    env.Diff
 	afterWd string
 }
 

--- a/hook/scriptwrapper_test.go
+++ b/hook/scriptwrapper_test.go
@@ -53,9 +53,9 @@ func TestRunningHookDetectsChangedEnvironment(t *testing.T) {
 	// Windows’ batch 'SET >' normalises environment variables case so we apply
 	// the 'expected' and 'actual' diffs to a blank Environment which handles
 	// case normalisation for us
-	expected := (&env.Environment{}).Apply(env.Diff {
-		Added: map[string]string {
-			"LLAMAS": "rock",
+	expected := (&env.Environment{}).Apply(env.Diff{
+		Added: map[string]string{
+			"LLAMAS":  "rock",
 			"Alpacas": "are ok",
 		},
 		Changed: map[string]env.DiffPair{},

--- a/logger/init_windows.go
+++ b/logger/init_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package logger

--- a/mime/generate.go
+++ b/mime/generate.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 // Generates the mime type mappings.

--- a/process/pty.go
+++ b/process/pty.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package process

--- a/process/signal.go
+++ b/process/signal.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package process

--- a/process/signal_windows.go
+++ b/process/signal_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package process

--- a/redaction/redactor.go
+++ b/redaction/redactor.go
@@ -298,11 +298,11 @@ func (mux RedactorMux) Reset(needles []string) {
 
 func GetValuesToRedact(logger shell.Logger, patterns []string, environment map[string]string) []string {
 	var valuesToRedact []string
-		for _, varValue := range GetKeyValuesToRedact(logger, patterns, environment) {
-			valuesToRedact = append(valuesToRedact, varValue)
-		}
+	for _, varValue := range GetKeyValuesToRedact(logger, patterns, environment) {
+		valuesToRedact = append(valuesToRedact, varValue)
+	}
 
-		return valuesToRedact
+	return valuesToRedact
 }
 
 // Given a redaction config string and an environment map, return the list of values to be redacted.

--- a/system/version_dump.go
+++ b/system/version_dump.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package system

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools

--- a/utils/path_windows_test.go
+++ b/utils/path_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package utils


### PR DESCRIPTION
**🤔 Problem:** Go fmt isn't evenly applied across this repo, leading to messy diffs when adjusting files that haven't had the formatter run across them, especially when (like me) you have format-on-save enabled.

also, code formatting is pretty uncontroversial (he says, opening a can of worms).

**✅ Solution:** 
- Add a step in CI ensuring `go fmt` has been run across all of the files in the project
- Run `go fmt` across all of the files in the project, to stop the above step from complaining