### PR TITLE
Make secret value rejection on pipeline upload optional

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -57,6 +57,7 @@ type PipelineUploadConfig struct {
 	DryRun          bool     `cli:"dry-run"`
 	NoInterpolation bool     `cli:"no-interpolation"`
 	RedactedVars    []string `cli:"redacted-vars" normalize:"list"`
+	RejectSecrets   bool     `cli:"reject-secrets"`
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
@@ -73,7 +74,7 @@ type PipelineUploadConfig struct {
 
 var PipelineUploadCommand = cli.Command{
 	Name:        "upload",
-	Usage:       "Uploads a description of a build pipeline adds it to the currently running build after the current job.",
+	Usage:       "Uploads a description of a build pipeline adds it to the currently running build after the current job",
 	Description: PipelineUploadHelpDescription,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
@@ -96,6 +97,11 @@ var PipelineUploadCommand = cli.Command{
 			Name:   "no-interpolation",
 			Usage:  "Skip variable interpolation the pipeline when uploaded",
 			EnvVar: "BUILDKITE_PIPELINE_NO_INTERPOLATION",
+		},
+		cli.BoolFlag{
+			Name:   "reject-secrets",
+			Usage:  "When true, fail the pipeline upload early if the the pipeline contains secrets",
+			EnvVar: "BUILDKITE_AGENT_PIPELINE_UPLOAD_REJECT_SECRETS",
 		},
 
 		// API Flags
@@ -227,6 +233,34 @@ var PipelineUploadCommand = cli.Command{
 			l.Fatal("Pipeline parsing of \"%s\" failed (%s)", src, err)
 		}
 
+		if len(cfg.RedactedVars) > 0 {
+			needles := redaction.GetKeyValuesToRedact(shell.StderrLogger, cfg.RedactedVars, env.FromSlice(os.Environ()).ToMap())
+			serialisedPipeline, err := result.MarshalJSON()
+
+			if err != nil {
+				l.Fatal("Couldn’t scan the %q pipeline for redacted variables. This parsed pipeline could not be serialized, ensure the pipeline YAML is valid, or ignore interpolated secrets for this upload by passing --redacted-vars=''. (%s)", src, err)
+			}
+
+			stringifiedserialisedPipeline := string(serialisedPipeline)
+
+			secretsFound := make([]string, 0, len(needles))
+			for needleKey, needle := range needles {
+				if strings.Contains(stringifiedserialisedPipeline, needle) {
+					secretsFound = append(secretsFound, needleKey)
+				}
+			}
+
+			if len(secretsFound) > 0 {
+				if cfg.RejectSecrets {
+					l.Fatal("Pipeline %q contains values interpolated from the following secret environment variables: %v, and cannot be uploaded to Buildkite", src, secretsFound)
+				} else {
+					l.Warn("Pipeline %q contains values interpolated from the following secret environment variables: %v, which could leak sensitive information into the Buildkite UI.", src, secretsFound)
+					l.Warn("This pipeline will still be uploaded, but if you'd like to to prevent this from happening, you can use the `--reject-secrets` cli flag, or the `BUILDKITE_AGENT_PIPELINE_UPLOAD_REJECT_SECRETS` environment variable, which will make the `buildkite-agent pipeline upload` command fail if it finds secrets in the pipeline.")
+					l.Warn("The behaviour in the above flags will become default in Buildkite Agent v4")
+				}
+			}
+		}
+
 		// In dry-run mode we just output the generated pipeline to stdout
 		if cfg.DryRun {
 			enc := json.NewEncoder(os.Stdout)
@@ -239,23 +273,6 @@ var PipelineUploadCommand = cli.Command{
 			}
 
 			return
-		}
-
-		if len(cfg.RedactedVars) > 0 {
-			needles := redaction.GetKeyValuesToRedact(shell.StderrLogger, cfg.RedactedVars, env.FromSlice(os.Environ()).ToMap())
-			serialisedPipeline, err := result.MarshalJSON()
-
-			if err != nil {
-				l.Fatal("Couldn’t scan the %q pipeline for redacted variables. This parsed pipeline could not be serialized, ensure the pipeline YAML is valid, or ignore interpolated secrets for this upload by passing --redacted-vars=''. (%s)", src, err)
-			}
-
-			stringifiedserialisedPipeline := string(serialisedPipeline)
-
-			for needleKey, needle := range needles {
-				if strings.Contains(stringifiedserialisedPipeline, needle) {
-					l.Fatal("Couldn’t upload the %q pipeline. Refusing to upload pipeline containing the value interpolated from the %q environment variable. Ensure your pipeline does not include secret values or interpolated secret values.", src, needleKey)
-				}
-			}
 		}
 
 		// Check we have a job id set if not in dry run

--- a/redaction/redactor.go
+++ b/redaction/redactor.go
@@ -321,7 +321,7 @@ func GetKeyValuesToRedact(logger shell.Logger, patterns []string, environment ma
 
 			if matched {
 				if len(varValue) < RedactLengthMin {
-					logger.Warningf("Value of %s below minimum length and will not be redacted", varName)
+					logger.Warningf("Value of %s below minimum length (%d bytes) and will not be redacted", varName, RedactLengthMin)
 				} else {
 					valuesToRedact[varName] = varValue
 				}


### PR DESCRIPTION
**🤔 Problem:** In https://github.com/buildkite/agent/pull/1523, we made it so that the `buildkite-agent pipeline upload` command would reject any pipeline yaml that had sensitive values in it. We shipped this as part of [v3.34](https://github.com/buildkite/agent/releases/tag/v3.34.0). This is an awesome security feature, and prevents a bunch of footguns, but unfortunately it's a breaking change, and we accidentally shipped it as part of a minor release.

**✅ Solution:** This PR reverts default redaction behaviour to how it was previously, with some slight changes:
- The newer behaviour (rejecting a pipeline upload if there's juicy secrets in it) is available with the `--reject-secrets` flag
- Even when the `--reject-secrets` flag isn't used, the command issues a warning that:
  - There are unredacted secrets in the pipeline
  - and that default behaviour in agent v4 will be to reject these pipeline uploads

Slightly related, it makes the `--dry-run` flag for the pipeline upload command work with redaction.

**Screenshots:**
Without `--reject-secrets`:

<img width="1511" alt="Screen Shot 2022-03-22 at 2 59 50 PM" src="https://user-images.githubusercontent.com/15753101/159392235-d7444aa4-44d6-4696-926f-18e572b9dbff.png">

With `--reject-secrets`:

<img width="1506" alt="Screen Shot 2022-03-22 at 3 00 10 PM" src="https://user-images.githubusercontent.com/15753101/159392313-131266a0-7e68-4d98-9d01-91df6707ca2f.png">


These are from my local machine using the `--dry-run` flag, using this pipeline:
```yaml
steps:
  - label: ":hammer: Example Script"
    command: "echo $COOL_PASSWORD"
    artifact_paths: "artifacts/*"
    agents:
      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
```

Closes #1578 
Closes PIP-309