### PR TITLE
Replace all instances of `the the` with just one `the`

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1250,7 +1250,7 @@ func (b *Bootstrap) updateGitMirror() (string, error) {
 
 	b.shell.Commentf("Updating existing repository mirror to find commit %s", b.Commit)
 
-	// Update the the origin of the repository so we can gracefully handle repository renames
+	// Update the origin of the repository so we can gracefully handle repository renames
 	if err := b.shell.Run("git", "--git-dir", mirrorDir, "remote", "set-url", "origin", b.Repository); err != nil {
 		return "", err
 	}
@@ -1320,7 +1320,7 @@ func (b *Bootstrap) defaultCheckoutPhase() error {
 	// Does the git directory exist?
 	existingGitDir := filepath.Join(b.shell.Getwd(), ".git")
 	if utils.FileExists(existingGitDir) {
-		// Update the the origin of the repository so we can gracefully handle repository renames
+		// Update the origin of the repository so we can gracefully handle repository renames
 		if err := b.shell.Run("git", "remote", "set-url", "origin", b.Repository); err != nil {
 			return err
 		}

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -50,7 +50,7 @@ type Config struct {
 	// If the commit was part of a pull request, this will container the PR number
 	PullRequest string
 
-	// The provider of the the pipeline
+	// The provider of the pipeline
 	PipelineProvider string
 
 	// Slug of the current organization

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -303,7 +303,7 @@ func (s *Shell) injectTraceCtx(ctx context.Context, env *env.Environment) {
 
 // RunScript is like Run, but the target is an interpreted script which has
 // some extra checks to ensure it gets to the correct interpreter. Extra environment vars
-// can also be passed the the script
+// can also be passed the script
 func (s *Shell) RunScript(ctx context.Context, path string, extra *env.Environment) error {
 	var command string
 	var args []string

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -100,7 +100,7 @@ var PipelineUploadCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name:   "reject-secrets",
-			Usage:  "When true, fail the pipeline upload early if the the pipeline contains secrets",
+			Usage:  "When true, fail the pipeline upload early if the pipeline contains secrets",
 			EnvVar: "BUILDKITE_AGENT_PIPELINE_UPLOAD_REJECT_SECRETS",
 		},
 

--- a/packaging/linux/scripts/after-install-and-upgrade.sh
+++ b/packaging/linux/scripts/after-install-and-upgrade.sh
@@ -131,7 +131,7 @@ if [ "$OPERATION" = "upgrade" ] ; then
   done
 fi
 
-# Make sure all the the folders created are owned by the buildkite-agent user #
+# Make sure all the folders created are owned by the buildkite-agent user #
 # on install
 if [ "$OPERATION" = "install" ] ; then
   if [ "$BK_USER_EXISTS" = "true" ]; then


### PR DESCRIPTION
so this PR was originally meant to fix [this particular instance](https://github.com/buildkite/agent/commit/732dc43b2530b9d4ce2633f5243cf5d54ee42adc#diff-4cfc709d07ebef6d3ace1658e50b325bdf115a978e2b4d6e6b2b388279c453a1R103) of `the the`, but apparently it's a pretty common occurence within the agent codebase 😅

This PR takes all of the instances of `the the` in the agent repo and replaces them with just the single definite article