### PR TITLE
Run docker builds on the elastic-builders buildkite queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -117,6 +117,8 @@ steps:
     steps:
       - name: ":docker: {{matrix}} build"
         key: build-docker
+        agents:
+          queue: elastic-builders
         depends_on:
           - build-binary
           - set-metadata

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,53 +46,55 @@ steps:
       - junit-annotate#v1.6.0:
           artifacts: junit-*.xml
 
-  - name: ":{{matrix.os}}: {{matrix.arch}}"
-    command: ".buildkite/steps/build-binary.sh {{matrix.os}} {{matrix.arch}}"
-    key: build-binary
-    depends_on:
-      # don't wait for slower windows tests
-      - test-linux-amd64
-      - test-linux-arm64
-    artifact_paths: "pkg/*"
-    plugins:
-      docker-compose#v3.0.0:
-        config: .buildkite/docker-compose.yml
-        run: agent
-    matrix:
-      setup:
-        os:
-          - darwin
-          - freebsd
-          - linux
-          - openbsd
-          - windows
-        arch:
-          - "386"
-          - amd64
-          - arm64
-      adjustments:
-        - with: { os: darwin, arch: "386" }
-          skip: "macOS no longer supports x86 binaries"
+  - group: "Binary builds"
+    steps:
+    - name: ":{{matrix.os}}: {{matrix.arch}}"
+      command: ".buildkite/steps/build-binary.sh {{matrix.os}} {{matrix.arch}}"
+      key: build-binary
+      depends_on:
+        # don't wait for slower windows tests
+        - test-linux-amd64
+        - test-linux-arm64
+      artifact_paths: "pkg/*"
+      plugins:
+        docker-compose#v3.0.0:
+          config: .buildkite/docker-compose.yml
+          run: agent
+      matrix:
+        setup:
+          os:
+            - darwin
+            - freebsd
+            - linux
+            - openbsd
+            - windows
+          arch:
+            - "386"
+            - amd64
+            - arm64
+        adjustments:
+          - with: { os: darwin, arch: "386" }
+            skip: "macOS no longer supports x86 binaries"
 
-        - with: { os: dragonflybsd, arch: amd64 }
+          - with: { os: dragonflybsd, arch: amd64 }
 
-        - with: { os: freebsd, arch: arm64 }
-          skip: "arm64 FreeBSD is not currently supported"
+          - with: { os: freebsd, arch: arm64 }
+            skip: "arm64 FreeBSD is not currently supported"
 
-        - with: { os: linux, arch: arm }
-        - with: { os: linux, arch: armhf }
-        - with: { os: linux, arch: ppc64 }
-        - with: { os: linux, arch: ppc64le }
-        - with: { os: linux, arch: mips64le }
-        - with: { os: linux, arch: s390x }
+          - with: { os: linux, arch: arm }
+          - with: { os: linux, arch: armhf }
+          - with: { os: linux, arch: ppc64 }
+          - with: { os: linux, arch: ppc64le }
+          - with: { os: linux, arch: mips64le }
+          - with: { os: linux, arch: s390x }
 
-        - with: { os: netbsd, arch: amd64 }
+          - with: { os: netbsd, arch: amd64 }
 
-        - with: { os: openbsd, arch: arm64 }
-          skip: "arm64 OpenBSD is not currently supported"
+          - with: { os: openbsd, arch: arm64 }
+            skip: "arm64 OpenBSD is not currently supported"
 
-        - with: { os: windows, arch: arm64 }
-          skip: "arm64 Windows is not currently supported"
+          - with: { os: windows, arch: arm64 }
+            skip: "arm64 Windows is not currently supported"
 
   - name: ":hammer: bk cli & agent cli"
     key: test-bk-cli


### PR DESCRIPTION
**🤔 Problem:** A recent change to buildkite's buildkite setup changed it so that only a subset of buildkite agent queues have access to ECR. this is a useful security change, but unfortunately, the docker builds for the agent run on the default queue

**✅ Solution:** Move our docker builds to the `elastic-builders` queue, which has access to ECR.