### PR TITLE
fix: don't warn about unredacted vars if var is empty

### DIFF
--- a/redaction/redactor.go
+++ b/redaction/redactor.go
@@ -321,7 +321,9 @@ func GetKeyValuesToRedact(logger shell.Logger, patterns []string, environment ma
 
 			if matched {
 				if len(varValue) < RedactLengthMin {
-					logger.Warningf("Value of %s below minimum length (%d bytes) and will not be redacted", varName, RedactLengthMin)
+					if len(varValue) > 0 {
+						logger.Warningf("Value of %s below minimum length (%d bytes) and will not be redacted", varName, RedactLengthMin)
+					}
 				} else {
 					valuesToRedact[varName] = varValue
 				}


### PR DESCRIPTION
This change removes the warning for an unredacted variable if said variable is empty (e.g. there is nothing to be redacted anyway).

We have a few variables that can be empty; each of these produces an insane amount of warnings in each lifecycle execution:

<img width="889" alt="Infra__apply_terraform__48053" src="https://user-images.githubusercontent.com/188038/160732905-abbe6b0f-48ac-45c4-ba4b-3d4df503a5a9.png">

(^ this is only one variable and only a subset of lifecycles)

