### PR TITLE
Fix race condition in bootstrap.go

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,6 +19,19 @@ steps:
         config: .buildkite/docker-compose.yml
         run: agent
 
+  - name: ":hammer: :oncoming_automobile: :linux: arm64"
+    key: test-race-linux-arm64
+    command: ".buildkite/steps/tests.sh -race"
+    artifact_paths: junit-*.xml
+    soft_fail:
+      - exit_status: "*"
+    agents:
+      queue: elastic-runners-arm64
+    plugins:
+      docker-compose#v3.0.0:
+        config: .buildkite/docker-compose.yml
+        run: agent
+
   - name: ":hammer: :linux: arm64"
     key: test-linux-arm64
     command: ".buildkite/steps/tests.sh"

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -7,7 +7,7 @@ echo arch is "$(uname -m)"
 GO111MODULE=off go get gotest.tools/gotestsum
 
 echo '+++ Running tests'
-gotestsum --junitfile "junit-${OSTYPE}.xml" -- -count=1 -failfast ./...
+gotestsum --junitfile "junit-${OSTYPE}.xml" -- -count=1 -failfast "$@" ./...
 
 echo '+++ Running integration tests for git-mirrors experiment'
-TEST_EXPERIMENT=git-mirrors gotestsum --junitfile "junit-${OSTYPE}-git-mirrors.xml" -- -count=1 -failfast ./bootstrap/integration
+TEST_EXPERIMENT=git-mirrors gotestsum --junitfile "junit-${OSTYPE}-git-mirrors.xml" -- -count=1 -failfast "$@" ./bootstrap/integration

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -81,6 +81,11 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 		b.shell.InterruptSignal = b.Config.CancelSignal
 	}
 
+	span, ctx, stopper := b.startTracing(ctx)
+	defer stopper()
+	var err error
+	defer func() { tracetools.FinishWithError(span, err) }()
+
 	// Listen for cancellation
 	go func() {
 		select {
@@ -92,11 +97,6 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 			b.shell.Interrupt()
 		}
 	}()
-
-	span, ctx, stopper := b.startTracing(ctx)
-	defer stopper()
-	var err error
-	defer func() { tracetools.FinishWithError(span, err) }()
 
 	// Tear down the environment (and fire pre-exit hook) before we exit
 	defer func() {


### PR DESCRIPTION
**🤔 Problem:** In bootstrap.go, we were accessing a variable `ctx` in a goroutine, but further down in the function, the `ctx` variable was being wrapped with a different context and rebound to the wrapped context, so the goroutine was referring to a variable that didn't exist anymore.

It's worth noting that this race condition has been rearing its head more often recently, and i'm not entirely sure why - the code causing the race has been in place for almost 2 years, so i can only think that until recently we weren't often calling `ctx.Done()` on the bootstrap process? but that also doesn't make much sense, because that context should have `Done()` called on it every time the bootstrap exits successfully.

So, in short, i'm not 100% sure what's going on, but this change should hopefully fix the issue, or at the very least not make it any worse.

**✅ Solution:** Only start the goroutine listening on the context's done channel after the context has been wrapped.

Additionally, when running tests in CI, run them in race detector mode. This should catch most (but not necessarily all) data races within the agent's codebase, provided that they're covered by tests.

Note that we're adding the race detector tests as a soft-fail step in CI - there's a race condition in `bintest` that we're hitting in one of our tests that i don't want to fail the build, but we should also probably get around to fixing that at some point. 

Fixes PIP-381