### PR TITLE
Bring changelogs for 3.35.x series into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v3.35.2](https://github.com/buildkite/agent/tree/v3.35.2) (2022-04-13)
+[Full Changelog](https://github.com/buildkite/agent/compare/v3.35.1...v3.35.2)
+
+### Fixed
+- Fix race condition in bootstrap.go [#1606](https://github.com/buildkite/agent/pull/1606) (@moskyb)
+
+### Changed
+- Bump some dependency versions - thanks @dependabot!
+  - github.com/stretchr/testify: 1.5.1 -> 1.7.1 [#1608](https://github.com/buildkite/agent/pull/1608)
+  - github.com/mitchellh/go-homedir: 1.0.0 -> 1.1.0 [#1576](https://github.com/buildkite/agent/pull/1576)
+
 ## [v3.35.1](https://github.com/buildkite/agent/tree/v3.35.1) (2022-04-05)
 [Full Changelog](https://github.com/buildkite/agent/compare/v3.35.0...v3.35.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v3.35.1](https://github.com/buildkite/agent/tree/v3.35.1) (2022-04-05)
+[Full Changelog](https://github.com/buildkite/agent/compare/v3.35.0...v3.35.1)
+
+### Fixed
+
+- Revert file permission changes made in [#1580](https://github.com/buildkite/agent/pull/1580). They were creating issues with docker-based workflows [#1601](https://github.com/buildkite/agent/pull/1601) (@pda + @moskyb)
+
 ## [v3.35.0](https://github.com/buildkite/agent/tree/v3.35.0) (2022-03-23)
 [Full Changelog](https://github.com/buildkite/agent/compare/v3.34.0...v3.35.0)
 

--- a/agent/version.go
+++ b/agent/version.go
@@ -10,7 +10,7 @@ import "runtime"
 //
 // Pre-release builds' versions must be in the format `x.y-beta`, `x.y-beta.z` or `x.y-beta.z.a`
 
-var baseVersion string = "3.35.0"
+var baseVersion string = "3.35.2"
 var buildVersion string = ""
 
 func Version() string {


### PR DESCRIPTION
Due to a variety of git shenanigans, the changelog and version updates in the [`3-35-stable`](https://github.com/buildkite/agent/tree/3-35-stable) branch never came through to the main branch. This PR cherry picks those commits from the `3-35-stable` branch and adds them to the main branch (once it's merged)