### PR TITLE
Create all directories with 0775 permissions

### DIFF
--- a/agent/download.go
+++ b/agent/download.go
@@ -130,7 +130,7 @@ func (d Download) try() error {
 	}
 
 	// Now make the folder for our file
-	err = os.MkdirAll(targetDirectory, 0777)
+	err = os.MkdirAll(targetDirectory, 0775)
 	if err != nil {
 		return fmt.Errorf("Failed to create folder for %s (%T: %v)", targetFile, err, err)
 	}

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -133,7 +133,7 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 	// TempDir is not guaranteed to exist
 	tempDir := os.TempDir()
 	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
-		if err = os.MkdirAll(tempDir, 0777); err != nil {
+		if err = os.MkdirAll(tempDir, 0775); err != nil {
 			return nil, err
 		}
 	}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -888,7 +888,7 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	}
 
 	// Ensure the plugin directory exists, otherwise we can't create the lock
-	err = os.MkdirAll(b.PluginsPath, 0777)
+	err = os.MkdirAll(b.PluginsPath, 0775)
 	if err != nil {
 		return nil, err
 	}
@@ -1005,7 +1005,7 @@ func (b *Bootstrap) createCheckoutDir() error {
 
 	if !utils.FileExists(checkoutPath) {
 		b.shell.Commentf("Creating \"%s\"", checkoutPath)
-		if err := os.MkdirAll(checkoutPath, 0777); err != nil {
+		if err := os.MkdirAll(checkoutPath, 0775); err != nil {
 			return err
 		}
 	}
@@ -1191,7 +1191,7 @@ func (b *Bootstrap) updateGitMirror() (string, error) {
 	// Create the mirrors path if it doesn't exist
 	if baseDir := filepath.Dir(mirrorDir); !utils.FileExists(baseDir) {
 		b.shell.Commentf("Creating \"%s\"", baseDir)
-		if err := os.MkdirAll(baseDir, 0777); err != nil {
+		if err := os.MkdirAll(baseDir, 0775); err != nil {
 			return "", err
 		}
 	}

--- a/bootstrap/shell/tempfile.go
+++ b/bootstrap/shell/tempfile.go
@@ -16,7 +16,7 @@ func TempFileWithExtension(filename string) (*os.File, error) {
 	// TempDir is not guaranteed to exist
 	tempDir := os.TempDir()
 	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
-		if err = os.MkdirAll(tempDir, 0777); err != nil {
+		if err = os.MkdirAll(tempDir, 0775); err != nil {
 			return nil, err
 		}
 	}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -744,7 +744,7 @@ var AgentStartCommand = cli.Command{
 		// so we may as well check that'll work now and fail early if it's a problem
 		if !utils.FileExists(agentConf.BuildPath) {
 			l.Info("Build Path doesn't exist, creating it (%s)", agentConf.BuildPath)
-			if err := os.MkdirAll(agentConf.BuildPath, 0777); err != nil {
+			if err := os.MkdirAll(agentConf.BuildPath, 0775); err != nil {
 				l.Fatal("Failed to create builds path: %v", err)
 			}
 		}


### PR DESCRIPTION
## Prologue: A quick refresher on UNIX file permissions

> nb: i'm not a unix expert, please correct me if i'm wrong in here

In UNIX-like operating systems (for example, Linux and macOS), all files have a set of permissions, represented by 3 sets of 3 bits of data. Each set of 3 bits (called a triad, which is also the binary representation of an octal digit) represents the permission set of a class of user. Each bit in the triad represents an **operation** (read, write, execute) that can be done by a class of users. One triad each is allocated for 
- The **user** - the user who created the file, or someone who has taken ownership of it since
- The **group** - the group that created the file
- The world - everyone else who's not that user, or part of the group

Each of these permission bits with the triad allows control over the operations that the above classes can perform. A permission triad is the sum of the operations allowed, where the operations are:
- 4 - 100 - execute
- 2 - 010 - write
- 1 - 001 - read

We can add these numbers together to create a set of permissions covering multiple operations - eg, 5 (101/4 + 1) grants execute and read permissions, but not write, and 3 (011/1 + 2) grants read and write permissions, but not execute.

The full set of permissions is the three bytes appended together, often prefixed with a 0. For example, full read/write/execute permissions of everybody is 777 (or 0777).

This is all complicated by the addition of a `umask`, which is a distro-specific [0] bitmask that gets applied to the permission bits for all files when they're created. This allows users to say, for example, `umask 027`, which translates to "When a file is created, subtract 2 from the group triad and 7 from the world triad". Using this umask would mean that even if i created a file with permissions `0777` (everyone has access to everything), on creation its permission set would be `0750` (user can do everything, group can't write, world can't do anything).

[0]: distro-specific in theory, but not in practice. The default umask on almost every widely-used distro is 0022 (subtract write perms from group and world). The umask can also be modified by users if necessary.

With all that context out of the way... on to some more context.

## Chapter One: How we broke docker workflows

As part of normal operations, buildkite gets pentested regularly, and part of this assessment is a code review of the agent. As part of this review, the security contractor we hired noted that in the agent, we were creating files with an overly permissive set of permissions, `0777`. This meant that theoretically, an unprivileged user on a machine running an agent could come in and modify a file used by the agent to do nefarious things, because files we create are world writable

> note that this is an absolute worst-case scenario, and would be extremely difficult in practice. as mentioned above, almost all modern OSes (notably Amazon Linux 2, which is how we distribute the agent in most cases) use a `0022` umask, meaning that files can't be world-writable unless we really put some extra effort into it to override the default umask.

In response to this report from our security contractor, in #1580, we changed the default permission set from `0777` to `0770`, meaning that the directories that the agent created could no longer be accessed by the world.

After we released that change as part of [v3.35.0](https://github.com/buildkite/agent/releases/tag/v3.35.0), we got reports from a number of customers saying that some of docker-based workflows were no longer worked, and were running file permission denied errors. Notably, customers were only running into these issues when running containers as a non-root user.

This was occurring because non-root users within docker containers have high-numbered user ids on the host system (see: [docker user namespace remapping](https://docs.docker.com/engine/security/userns-remap/)), which aren't part of the group that owns files on the machine running the agent. This means that effectively, non-root users within docker fall under the "world" category of users, which, with the new set of permissions, was now completely unable to access directories created by the agent - notably, the git repos that the agent clones when it runs a pipeline step.

The reason that this wasn't happening for the root user in docker is that in the [elastic stack](https://github.com/buildkite/elastic-ci-stack-for-aws), we remap the root docker user to the `buildkite-agent` user outside of containerland. This means that the root user in the container (kinda, it's complicated) has the same permission set as the `buildkite-agent` user, which is the user that creates all the files in the agent codebase.

## Chapter Two, Act One: How we fixed it the first time

As part of [v3.35.1](https://github.com/buildkite/agent/releases/tag/v3.35.1), we reverted the permissioning changes, such that we were creating directories with `0777` permissions (`0755` after the umask is applied) again. Back to the status quo!

However, we're now all the way where we were back at the beginning - we're still creating files with a permission set that's possibly too broad, and the report from our security contractor still applies.

## Chapter Two, Act Two: Fixing it for realsies

What we're proposing to do, and what the actual content of this novel of a PR does, is to change the file permissions for directories created by the agent from `0777` to `0775`, meaning that by deafult, any of the directories that we create will no longer be world-writable. This has **no actual functional impact in most cases** - it only actually affects things when the machine running the agent has a broken umask, and it makes double double sure that we'll never accidentally create world writable dirs.

The other main benefit of this PR is that it not only makes the agent more secure, it also makes the agent _look_ more secure - seeing `0777` permissions in a codebase can be a bit scary, but seeing `0775` looks less scary, and hopefully implies that we've spent some time thinking about this.

Closes PIP-426