### PR TITLE
Use Alpine 3.15.4 in agent release images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: "docker"
+    directory: "/packaging/docker"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
     directory: "/.buildkite"
     schedule:
       interval: "monthly"

--- a/packaging/docker/alpine-linux/Dockerfile
+++ b/packaging/docker/alpine-linux/Dockerfile
@@ -1,21 +1,21 @@
-FROM alpine:3.12
+FROM alpine:3.15.4
 
 RUN apk add --no-cache \
-      bash \
-      curl \
-      docker-cli \
-      docker-compose \
-      git \
-      jq \
-      libc6-compat \
-      openssh-client \
-      perl \
-      py-pip \
-      rsync \
-      run-parts \
-      su-exec \
-      tini \
-      tzdata
+    bash \
+    curl \
+    docker-cli \
+    docker-compose \
+    git \
+    jq \
+    libc6-compat \
+    openssh-client \
+    perl \
+    py-pip \
+    rsync \
+    run-parts \
+    su-exec \
+    tini \
+    tzdata
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg
 

--- a/packaging/docker/sidecar/Dockerfile
+++ b/packaging/docker/sidecar/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.12
+FROM alpine:3.15.4
 
 RUN mkdir /buildkite \
-          /buildkite/builds \
-          /buildkite/hooks \
-          /buildkite/plugins \
-          /buildkite/bin
+  /buildkite/builds \
+  /buildkite/hooks \
+  /buildkite/plugins \
+  /buildkite/bin
 
 COPY buildkite-agent.cfg /buildkite/
 COPY buildkite-agent /buildkite/bin/

--- a/packaging/docker/ubuntu-18.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-18.04-linux/Dockerfile
@@ -5,20 +5,20 @@ ENV DOCKER_COMPOSE_VERSION=1.27.4
 ENV TINI_VERSION=0.19.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      apt-transport-https \
-      curl \
-      ca-certificates \
-      bash \
-      git \
-      gnupg-agent \
-      jq \
-      openssh-client \
-      perl \
-      rsync \
-      software-properties-common \
+    apt-transport-https \
+    curl \
+    ca-certificates \
+    bash \
+    git \
+    gnupg-agent \
+    jq \
+    openssh-client \
+    perl \
+    rsync \
+    software-properties-common \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
     && add-apt-repository \
-      "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
     && apt-get update \
     && apt-get install -y --no-install-recommends docker-ce-cli \
     && rm -rf /var/lib/apt/lists/*

--- a/packaging/docker/ubuntu-20.04-linux/Dockerfile
+++ b/packaging/docker/ubuntu-20.04-linux/Dockerfile
@@ -5,20 +5,20 @@ ENV DOCKER_COMPOSE_VERSION=1.27.4
 ENV TINI_VERSION=0.19.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      apt-transport-https \
-      curl \
-      ca-certificates \
-      bash \
-      git \
-      gnupg-agent \
-      jq \
-      openssh-client \
-      perl \
-      rsync \
-      software-properties-common \
+    apt-transport-https \
+    curl \
+    ca-certificates \
+    bash \
+    git \
+    gnupg-agent \
+    jq \
+    openssh-client \
+    perl \
+    rsync \
+    software-properties-common \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
     && add-apt-repository \
-      "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
     && apt-get update \
     && apt-get install -y --no-install-recommends docker-ce-cli \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
We currently use Alpine 3.12 in our Alpine release images (which are the defaults, ie if you run `docker pull buildkite/agent`, it'll give you an image based on alpine). 3.12 is [EOL as of yesterday](https://alpinelinux.org/releases/), and is also different to the alpine that we use in the build process, so we should try to keep these in line.

This PR:
- Updates the version of Alpine we use from 3.12 to 3.15.4, the latest available
- Formats all of the dockerfiles in `packaging/docker` (my editor autoformatted the two i changed, so i figured it was best to do them all)
- Adds the `packaging/docker` dir to the list of things that dependabot should check for updates for - this means that hopefully this won't happen again :)