### PR TITLE
Log levels

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -108,6 +108,7 @@ type AgentStartConfig struct {
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
 	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
 	Profile     string   `cli:"profile"`
@@ -463,6 +464,7 @@ var AgentStartCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
 		RedactedVars,

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -56,6 +56,7 @@ type AnnotateConfig struct {
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
 	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
 	Profile     string   `cli:"profile"`
@@ -103,6 +104,7 @@ var AnnotateCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
 	},

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -1,6 +1,7 @@
 package clicommand
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"time"
@@ -112,11 +113,18 @@ var AnnotateCommand = cli.Command{
 		// The configuration will be loaded into this struct
 		cfg := AnnotateConfig{}
 
+		loader := cliconfig.Loader{CLI: c, Config: &cfg}
+		warnings, err := loader.Load()
+		if err != nil {
+			fmt.Printf("%s", err)
+			os.Exit(1)
+		}
+
 		l := CreateLogger(&cfg)
 
-		// Load the configuration
-		if err := cliconfig.Load(c, l, &cfg); err != nil {
-			l.Fatal("%s", err)
+		// Now that we have a logger, log out the warnings that loading config generated
+		for _, warning := range warnings {
+			l.Warn("%s", warning)
 		}
 
 		// Setup any global configuration options
@@ -124,7 +132,6 @@ var AnnotateCommand = cli.Command{
 		defer done()
 
 		var body string
-		var err error
 
 		if cfg.Body != "" {
 			body = cfg.Body

--- a/clicommand/annotation_remove.go
+++ b/clicommand/annotation_remove.go
@@ -31,6 +31,7 @@ type AnnotationRemoveConfig struct {
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
 	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
 	Profile     string   `cli:"profile"`
@@ -69,6 +70,7 @@ var AnnotationRemoveCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
 	},

--- a/clicommand/annotation_remove.go
+++ b/clicommand/annotation_remove.go
@@ -1,6 +1,8 @@
 package clicommand
 
 import (
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/buildkite/agent/v3/api"
@@ -78,18 +80,23 @@ var AnnotationRemoveCommand = cli.Command{
 		// The configuration will be loaded into this struct
 		cfg := AnnotationRemoveConfig{}
 
+		loader := cliconfig.Loader{CLI: c, Config: &cfg}
+		warnings, err := loader.Load()
+		if err != nil {
+			fmt.Printf("%s", err)
+			os.Exit(1)
+		}
+
 		l := CreateLogger(&cfg)
 
-		// Load the configuration
-		if err := cliconfig.Load(c, l, &cfg); err != nil {
-			l.Fatal("%s", err)
+		// Now that we have a logger, log out the warnings that loading config generated
+		for _, warning := range warnings {
+			l.Warn("%s", warning)
 		}
 
 		// Setup any global configuration options
 		done := HandleGlobalFlags(l, cfg)
 		defer done()
-
-		var err error
 
 		// Create the API client
 		client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -53,6 +53,7 @@ type ArtifactDownloadConfig struct {
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
 	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
 	Profile     string   `cli:"profile"`
@@ -95,6 +96,7 @@ var ArtifactDownloadCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
 	},

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -1,6 +1,9 @@
 package clicommand
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/cliconfig"
@@ -104,11 +107,18 @@ var ArtifactDownloadCommand = cli.Command{
 		// The configuration will be loaded into this struct
 		cfg := ArtifactDownloadConfig{}
 
+		loader := cliconfig.Loader{CLI: c, Config: &cfg}
+		warnings, err := loader.Load()
+		if err != nil {
+			fmt.Printf("%s", err)
+			os.Exit(1)
+		}
+
 		l := CreateLogger(&cfg)
 
-		// Load the configuration
-		if err := cliconfig.Load(c, l, &cfg); err != nil {
-			l.Fatal("%s", err)
+		// Now that we have a logger, log out the warnings that loading config generated
+		for _, warning := range warnings {
+			l.Warn("%s", warning)
 		}
 
 		// Setup any global configuration options

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -53,6 +53,7 @@ type ArtifactSearchConfig struct {
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
 	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
 	Profile     string   `cli:"profile"`
@@ -123,6 +124,7 @@ Format specifiers:
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
 	},

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -2,6 +2,7 @@ package clicommand
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -132,11 +133,18 @@ Format specifiers:
 		// The configuration will be loaded into this struct
 		cfg := ArtifactSearchConfig{}
 
+		loader := cliconfig.Loader{CLI: c, Config: &cfg}
+		warnings, err := loader.Load()
+		if err != nil {
+			fmt.Printf("%s", err)
+			os.Exit(1)
+		}
+
 		l := CreateLogger(&cfg)
 
-		// Load the configuration
-		if err := cliconfig.Load(c, l, &cfg); err != nil {
-			l.Fatal("%s", err)
+		// Now that we have a logger, log out the warnings that loading config generated
+		for _, warning := range warnings {
+			l.Warn("%s", warning)
 		}
 
 		// Setup any global configuration options

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -58,6 +58,7 @@ type ArtifactShasumConfig struct {
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
 	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
 	Profile     string   `cli:"profile"`
@@ -104,6 +105,7 @@ var ArtifactShasumCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
 	},

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -113,11 +113,18 @@ var ArtifactShasumCommand = cli.Command{
 		// The configuration will be loaded into this struct
 		cfg := ArtifactShasumConfig{}
 
+		loader := cliconfig.Loader{CLI: c, Config: &cfg}
+		warnings, err := loader.Load()
+		if err != nil {
+			fmt.Printf("%s", err)
+			os.Exit(1)
+		}
+
 		l := CreateLogger(&cfg)
 
-		// Load the configuration
-		if err := cliconfig.Load(c, l, &cfg); err != nil {
-			l.Fatal("%s", err)
+		// Now that we have a logger, log out the warnings that loading config generated
+		for _, warning := range warnings {
+			l.Warn("%s", warning)
 		}
 
 		// Setup any global configuration options

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -67,6 +67,7 @@ type ArtifactUploadConfig struct {
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
 	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
 	Profile     string   `cli:"profile"`
@@ -108,6 +109,7 @@ var ArtifactUploadCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
 		FollowSymlinksFlag,

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -1,6 +1,9 @@
 package clicommand
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/cliconfig"
@@ -118,11 +121,18 @@ var ArtifactUploadCommand = cli.Command{
 		// The configuration will be loaded into this struct
 		cfg := ArtifactUploadConfig{}
 
+		loader := cliconfig.Loader{CLI: c, Config: &cfg}
+		warnings, err := loader.Load()
+		if err != nil {
+			fmt.Printf("%s", err)
+			os.Exit(1)
+		}
+
 		l := CreateLogger(&cfg)
 
-		// Load the configuration
-		if err := cliconfig.Load(c, l, &cfg); err != nil {
-			l.Fatal("%s", err)
+		// Now that we have a logger, log out the warnings that loading config generated
+		for _, warning := range warnings {
+			l.Warn("%s", warning)
 		}
 
 		// Setup any global configuration options

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -56,7 +56,7 @@ var LogLevelFlag = cli.StringFlag{
 	Name:   "log-level",
 	Value:  "notice",
 	Usage:  "Set the log level for the agent, making logging more or less verbose. Defaults to notice",
-	EnvVar: "BUILDKITE_LOG_LEVEL",
+	EnvVar: "BUILDKITE_AGENT_LOG_LEVEL",
 }
 
 var ProfileFlag = cli.StringFlag{

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -127,6 +127,7 @@ func CreateLogger(cfg interface{}) logger.Logger {
 
 		l = logger.NewConsoleLogger(printer, os.Exit)
 	case `json`:
+		l.Warn("FORMAT IS JSON")
 		l = logger.NewConsoleLogger(logger.NewJSONPrinter(os.Stdout), os.Exit)
 	default:
 		fmt.Printf("Unknown log-format of %q, try text or json\n", logFormat)

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -29,6 +29,7 @@ type MetaDataExistsConfig struct {
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
 	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
 	Profile     string   `cli:"profile"`
@@ -61,6 +62,7 @@ var MetaDataExistsCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
 	},

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -1,6 +1,7 @@
 package clicommand
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -70,11 +71,18 @@ var MetaDataExistsCommand = cli.Command{
 		// The configuration will be loaded into this struct
 		cfg := MetaDataExistsConfig{}
 
+		loader := cliconfig.Loader{CLI: c, Config: &cfg}
+		warnings, err := loader.Load()
+		if err != nil {
+			fmt.Printf("%s", err)
+			os.Exit(1)
+		}
+
 		l := CreateLogger(&cfg)
 
-		// Load the configuration
-		if err := cliconfig.Load(c, l, &cfg); err != nil {
-			l.Fatal("%s", err)
+		// Now that we have a logger, log out the warnings that loading config generated
+		for _, warning := range warnings {
+			l.Warn("%s", warning)
 		}
 
 		// Setup any global configuration options
@@ -85,7 +93,6 @@ var MetaDataExistsCommand = cli.Command{
 		client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))
 
 		// Find the meta data value
-		var err error
 		var exists *api.MetaDataExists
 		var resp *api.Response
 

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -29,6 +29,7 @@ type MetaDataGetConfig struct {
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
 	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
 	Profile     string   `cli:"profile"`
@@ -66,6 +67,7 @@ var MetaDataGetCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
 	},

--- a/clicommand/meta_data_keys.go
+++ b/clicommand/meta_data_keys.go
@@ -28,6 +28,7 @@ type MetaDataKeysConfig struct {
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
 	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
 	Profile     string   `cli:"profile"`
@@ -60,6 +61,7 @@ var MetaDataKeysCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
 	},

--- a/clicommand/meta_data_keys.go
+++ b/clicommand/meta_data_keys.go
@@ -2,6 +2,7 @@ package clicommand
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/buildkite/agent/v3/api"
@@ -69,11 +70,18 @@ var MetaDataKeysCommand = cli.Command{
 		// The configuration will be loaded into this struct
 		cfg := MetaDataKeysConfig{}
 
+		loader := cliconfig.Loader{CLI: c, Config: &cfg}
+		warnings, err := loader.Load()
+		if err != nil {
+			fmt.Printf("%s", err)
+			os.Exit(1)
+		}
+
 		l := CreateLogger(&cfg)
 
-		// Load the configuration
-		if err := cliconfig.Load(c, l, &cfg); err != nil {
-			l.Fatal("%s", err)
+		// Now that we have a logger, log out the warnings that loading config generated
+		for _, warning := range warnings {
+			l.Warn("%s", warning)
 		}
 
 		// Setup any global configuration options
@@ -84,7 +92,6 @@ var MetaDataKeysCommand = cli.Command{
 		client := api.NewClient(l, loadAPIClientConfig(cfg, `AgentAccessToken`))
 
 		// Find the meta data keys
-		var err error
 		var keys []string
 		var resp *api.Response
 

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -35,6 +35,7 @@ type MetaDataSetConfig struct {
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
 	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
 	Profile     string   `cli:"profile"`
@@ -67,6 +68,7 @@ var MetaDataSetCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
 	},

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -1,6 +1,7 @@
 package clicommand
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"time"
@@ -76,11 +77,18 @@ var MetaDataSetCommand = cli.Command{
 		// The configuration will be loaded into this struct
 		cfg := MetaDataSetConfig{}
 
+		loader := cliconfig.Loader{CLI: c, Config: &cfg}
+		warnings, err := loader.Load()
+		if err != nil {
+			fmt.Printf("%s", err)
+			os.Exit(1)
+		}
+
 		l := CreateLogger(&cfg)
 
-		// Load the configuration
-		if err := cliconfig.Load(c, l, &cfg); err != nil {
-			l.Fatal("%s", err)
+		// Now that we have a logger, log out the warnings that loading config generated
+		for _, warning := range warnings {
+			l.Warn("%s", warning)
 		}
 
 		// Setup any global configuration options
@@ -108,7 +116,7 @@ var MetaDataSetCommand = cli.Command{
 		}
 
 		// Set the meta data
-		err := retry.NewRetrier(
+		err = retry.NewRetrier(
 			retry.WithMaxAttempts(10),
 			retry.WithStrategy(retry.Constant(5*time.Second)),
 		).Do(func(r *retry.Retrier) error {

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -61,6 +61,7 @@ type PipelineUploadConfig struct {
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
 	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
 	Profile     string   `cli:"profile"`
@@ -113,6 +114,7 @@ var PipelineUploadCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
 		RedactedVars,

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -2,6 +2,7 @@ package clicommand
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -123,11 +124,18 @@ var PipelineUploadCommand = cli.Command{
 		// The configuration will be loaded into this struct
 		cfg := PipelineUploadConfig{}
 
+		loader := cliconfig.Loader{CLI: c, Config: &cfg}
+		warnings, err := loader.Load()
+		if err != nil {
+			fmt.Printf("%s", err)
+			os.Exit(1)
+		}
+
 		l := CreateLogger(&cfg)
 
-		// Load the configuration
-		if err := cliconfig.Load(c, l, &cfg); err != nil {
-			l.Fatal("%s", err)
+		// Now that we have a logger, log out the warnings that loading config generated
+		for _, warning := range warnings {
+			l.Warn("%s", warning)
 		}
 
 		// Setup any global configuration options
@@ -137,7 +145,6 @@ var PipelineUploadCommand = cli.Command{
 		// Find the pipeline file either from STDIN or the first
 		// argument
 		var input []byte
-		var err error
 		var filename string
 
 		if cfg.FilePath != "" {

--- a/clicommand/step_get.go
+++ b/clicommand/step_get.go
@@ -38,6 +38,7 @@ type StepGetConfig struct {
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
 	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
 	Profile     string   `cli:"profile"`
@@ -82,6 +83,7 @@ var StepGetCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
 	},

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -35,6 +35,7 @@ type StepUpdateConfig struct {
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
 	NoColor     bool     `cli:"no-color"`
 	Experiments []string `cli:"experiment" normalize:"list"`
 	Profile     string   `cli:"profile"`
@@ -78,6 +79,7 @@ var StepUpdateCommand = cli.Command{
 		// Global flags
 		NoColorFlag,
 		DebugFlag,
+		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
 	},

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -1,6 +1,7 @@
 package clicommand
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"time"
@@ -87,11 +88,18 @@ var StepUpdateCommand = cli.Command{
 		// The configuration will be loaded into this struct
 		cfg := StepUpdateConfig{}
 
+		loader := cliconfig.Loader{CLI: c, Config: &cfg}
+		warnings, err := loader.Load()
+		if err != nil {
+			fmt.Printf("%s", err)
+			os.Exit(1)
+		}
+
 		l := CreateLogger(&cfg)
 
-		// Load the configuration
-		if err := cliconfig.Load(c, l, &cfg); err != nil {
-			l.Fatal("%s", err)
+		// Now that we have a logger, log out the warnings that loading config generated
+		for _, warning := range warnings {
+			l.Warn("%s", warning)
 		}
 
 		// Setup any global configuration options
@@ -127,7 +135,7 @@ var StepUpdateCommand = cli.Command{
 		}
 
 		// Post the change
-		err := retry.NewRetrier(
+		err = retry.NewRetrier(
 			retry.WithMaxAttempts(10),
 			retry.WithStrategy(retry.Constant(5*time.Second)),
 		).Do(func(r *retry.Retrier) error {

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -33,19 +33,6 @@ type Loader struct {
 
 var argCliNameRegexp = regexp.MustCompile(`arg:(\d+)`)
 
-// A shortcut for loading a config from the CLI
-func Load(c *cli.Context, l logger.Logger, cfg interface{}) error {
-	loader := Loader{CLI: c, Config: cfg}
-	warnings, err := loader.Load()
-	if err != nil {
-		return err
-	}
-	for _, warning := range warnings {
-		l.Warn("%s", warning)
-	}
-	return nil
-}
-
 // Loads the config from the CLI and config files that are present and returns
 // any warnings or errors
 func (l *Loader) Load() (warnings []string, err error) {

--- a/logger/level.go
+++ b/logger/level.go
@@ -1,5 +1,10 @@
 package logger
 
+import (
+	"fmt"
+	"strings"
+)
+
 type Level int
 
 const (
@@ -18,6 +23,25 @@ var levelNames = []string{
 	"ERROR",
 	"WARN",
 	"FATAL",
+}
+
+func LevelFromString(s string) (Level, error) {
+	switch strings.ToLower(s) {
+	case "debug":
+		return DEBUG, nil
+	case "notice":
+		return NOTICE, nil
+	case "info":
+		return INFO, nil
+	case "error":
+		return ERROR, nil
+	case "warn", "warning":
+		return WARN, nil
+	case "fatal":
+		return FATAL, nil
+	default:
+		return -1, fmt.Errorf("invalid log level: %s. Valid levels are: %v", s, levelNames)
+	}
 }
 
 // String returns the string representation of a logging level.


### PR DESCRIPTION
**🤔 Problem:** Some of the time, users of the buildkite-agent might not necessarily want or need all of the logs we're spitting out, either for cost reasons (storing logs can get pricy) or for readability reasons (i don't necessarily care about everything the agent is doing all the time.

**✅ Solution:** Add a cli flag, `--log-level` and an accompanying envar `BUILDKITE_AGENT_LOG_LEVEL`, to set the level of the logger on the agent. Now, if I set `--log-level error`, the buildkite agent logger will only output logs of level error or higher. This flag is enabled for all CLI commands, except `bootstrap`.

This PR is best read commit-by-commit.