### PR TITLE
Update buildkite agent plugin repo cloning

### DIFF
--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -288,30 +288,26 @@ func (p *Plugin) constructRepositoryHost() (string, error) {
 	if len(parts) < 2 {
 		return "", fmt.Errorf("Incomplete plugin path \"%s\"", p.Location)
 	}
-	if len(parts) < 3 {
-		return "", fmt.Errorf("Incomplete %s path \"%s\"", parts[0], p.Location)
-	}
 	
 	var s string
 	switch parts[0] {
-	case "github.com", "bitbucket.org":
-		s = strings.Join(parts[:3], "/")
-	case "gitlab.com":
-		s = strings.Join(parts, "/")
-	default:
-		repo := []string{}
+		case "github.com", "bitbucket.org":
+			s = strings.Join(parts[:3], "/")
+		case "gitlab.com":
+			s = strings.Join(parts, "/")
+		default:
+			repo := []string{}
 
-		for _, p := range parts {
-			repo = append(repo, p)
+			for _, p := range parts {
+				repo = append(repo, p)
 
-			if strings.HasSuffix(p, ".git") {
-				break
+				if strings.HasSuffix(p, ".git") {
+					break
+				}
 			}
-		}
 
-		s = strings.Join(repo, "/")
-	}
+			s = strings.Join(repo, "/")
+		}
+	
 	return s, nil
 }
-
-

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -279,7 +279,6 @@ func (p *Plugin) Label() string {
 		return p.Location
 	}
 }
-
 func (p *Plugin) constructRepositoryHost() (string, error) {
 	if p.Location == "" {
 		return "", fmt.Errorf("Missing plugin location")
@@ -289,17 +288,20 @@ func (p *Plugin) constructRepositoryHost() (string, error) {
 	if len(parts) < 2 {
 		return "", fmt.Errorf("Incomplete plugin path \"%s\"", p.Location)
 	}
-
+	if len(parts) < 3 {
+		return "", fmt.Errorf("Incomplete %s path \"%s\"", parts[0], p.Location)
+	}
+	
 	var s string
+	switch parts[0] {
+	case "github.com", "bitbucket.org":
 
-	if parts[0] == "github.com" || parts[0] == "bitbucket.org" || parts[0] == "gitlab.com" {
-		if len(parts) < 3 {
-			return "", fmt.Errorf("Incomplete %s path \"%s\"", parts[0], p.Location)
-		}
 
+		s = strings.Join(parts[:3], "/")
+	case "gitlab.com":
 		s = strings.Join(parts, "/")
-	} else {
-		repo := []string{}
+	default:
+				repo := []string{}
 
 		for _, p := range parts {
 			repo = append(repo, p)
@@ -311,6 +313,7 @@ func (p *Plugin) constructRepositoryHost() (string, error) {
 
 		s = strings.Join(repo, "/")
 	}
-
 	return s, nil
 }
+
+

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -295,13 +295,11 @@ func (p *Plugin) constructRepositoryHost() (string, error) {
 	var s string
 	switch parts[0] {
 	case "github.com", "bitbucket.org":
-
-
 		s = strings.Join(parts[:3], "/")
 	case "gitlab.com":
 		s = strings.Join(parts, "/")
 	default:
-				repo := []string{}
+		repo := []string{}
 
 		for _, p := range parts {
 			repo = append(repo, p)

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -297,7 +297,7 @@ func (p *Plugin) constructRepositoryHost() (string, error) {
 			return "", fmt.Errorf("Incomplete %s path \"%s\"", parts[0], p.Location)
 		}
 
-		s = strings.Join(parts[:3], "/")
+		s = strings.Join(parts, "/")
 	} else {
 		repo := []string{}
 

--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -44,6 +44,15 @@ func TestCreateFromJSON(t *testing.T) {
 			}},
 		},
 		{
+			`[{"https://gitlab.fipps.de/contao/contao4/isotope-colorattribute-bundle#32a1397bee5f57b332c57a9d85ccd95208dc56b5":{}}]`,
+			[]*Plugin{&Plugin{
+				Location:      `gitlab.fipps.de/contao/contao4/isotope-colorattribute-bundle`,
+				Version:       `32a1397bee5f57b332c57a9d85ccd95208dc56b5`,
+				Scheme:        `https`,
+				Configuration: map[string]interface{}{},
+			}},
+		},
+		{
 			`["ssh://git:foo@github.com/buildkite-plugins/docker-compose#a34fa34"]`,
 			[]*Plugin{&Plugin{
 				Location:       `github.com/buildkite-plugins/docker-compose`,


### PR DESCRIPTION

The buildkite agent plugin functionality only allowed urls with less than 2 "/"s to be fetched. 
So for example  `gitlab.com/devops/my-cool-plugin.git`  can be fetched but not `gitlab.com/teams/devops/my-cool-plugin.git`