### PR TITLE
Skip pre-exit on cancel test on darwin

### DIFF
--- a/bootstrap/integration/hooks_integration_test.go
+++ b/bootstrap/integration/hooks_integration_test.go
@@ -470,7 +470,7 @@ func TestExitCodesPropagateOutFromGlobalHooks(t *testing.T) {
 }
 
 func TestPreExitHooksFireAfterCancel(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
 		t.Skip()
 	}
 


### PR DESCRIPTION
It doesn't work, and hasn't for ages :/