### PR TITLE
bootstrap/shell: round off command durations

### DIFF
--- a/bootstrap/shell/export_test.go
+++ b/bootstrap/shell/export_test.go
@@ -1,0 +1,7 @@
+package shell
+
+import "time"
+
+func Round(d time.Duration) time.Duration {
+	return round(d)
+}

--- a/bootstrap/shell/shell_test.go
+++ b/bootstrap/shell/shell_test.go
@@ -406,3 +406,36 @@ func TestRunWithoutPromptWithContext(t *testing.T) {
 	err = sh.RunWithoutPromptWithContext(ctx, "asdasdasdasdzxczxczxzxc")
 	assert.Error(t, err)
 }
+
+var roundTests = []struct {
+	in     time.Duration
+	want   time.Duration
+	outStr string
+}{
+	{3 * time.Nanosecond, 3 * time.Nanosecond, "3ns"},
+	{32 * time.Nanosecond, 32 * time.Nanosecond, "32ns"},
+	{321 * time.Nanosecond, 321 * time.Nanosecond, "321ns"},
+	{4321 * time.Nanosecond, 4321 * time.Nanosecond, "4.321µs"},
+	{54321 * time.Nanosecond, 54321 * time.Nanosecond, "54.321µs"},
+	{654321 * time.Nanosecond, 654320 * time.Nanosecond, "654.32µs"},
+	{7654321 * time.Nanosecond, 7654300 * time.Nanosecond, "7.6543ms"},
+	{87654321 * time.Nanosecond, 87654000 * time.Nanosecond, "87.654ms"},
+	{987654321 * time.Nanosecond, 987650000 * time.Nanosecond, "987.65ms"},
+	{1987654321 * time.Nanosecond, 1987700000 * time.Nanosecond, "1.9877s"},
+	{21987654321 * time.Nanosecond, 21988000000 * time.Nanosecond, "21.988s"},
+	{321987654321 * time.Nanosecond, 321990000000 * time.Nanosecond, "5m21.99s"},
+	{4321987654321 * time.Nanosecond, 4320000000000 * time.Nanosecond, "1h12m0s"},
+	{54321987654321 * time.Nanosecond, 54320000000000 * time.Nanosecond, "15h5m20s"},
+}
+
+func TestRound(t *testing.T) {
+	for _, tt := range roundTests {
+		got := shell.Round(tt.in)
+		if got != tt.want {
+			t.Errorf("round(%v): got %v, want %v", tt.in, got, tt.want)
+		}
+		if got.String() != tt.outStr {
+			t.Errorf("round(%v): got %q, want %v", tt.in, got.String(), tt.outStr)
+		}
+	}
+}


### PR DESCRIPTION
It is unlikely that anyone will care about how much time a command
took more than about 5 significant digits:

- If you are expecting a command to take a few milliseconds, maybe you
care down to the microsecond.

- If you are expecting a command to take a few hours, maybe you care
how many minutes or seconds, but I very much doubt you care about how
many microseconds.

By default, Buildkite reports durations with extreme precision, which
can be distracting. Instead, round off durations so that at most 5
digits are present in the displayed duration.

Here's what the displayed output looks like, both before and after, for builds of different durations:

```
before: 1µs
after:  1µs

before: 10.07µs
after:  10.07µs

before: 100.47µs
after:  100.47µs

before: 1.00059ms
after:  1.0006ms

before: 10.02081ms
after:  10.021ms

before: 100.41318ms
after:  100.41ms

before: 1.00954425s
after:  1.0095s

before: 10.0612254s
after:  10.061s

before: 1m40.08240456s
after:  1m40.08s

before: 16m46.462033s
after:  16m46.5s

before: 2h46m47.60398084s
after:  2h46m50s

before: 27h57m22.63669287s
after:  27h57m20s
```