### PR TITLE
Fix nil pointer deref when using --log-format json

### DIFF
--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -127,7 +127,6 @@ func CreateLogger(cfg interface{}) logger.Logger {
 
 		l = logger.NewConsoleLogger(printer, os.Exit)
 	case `json`:
-		l.Warn("FORMAT IS JSON")
 		l = logger.NewConsoleLogger(logger.NewJSONPrinter(os.Stdout), os.Exit)
 	default:
 		fmt.Printf("Unknown log-format of %q, try text or json\n", logFormat)


### PR DESCRIPTION
A bit of code that was accidentally included in #1635 causes the agent to panic with a nil pointer dereference, because we're calling a method on a logger that doesn't exist.

This PR removes that log call. Oy vey.

Fixes #1652 