### PR TITLE
Refactor env.Environment from wrapping a map to being a map

### DIFF
--- a/agent/pipeline_parser.go
+++ b/agent/pipeline_parser.go
@@ -16,7 +16,7 @@ import (
 )
 
 type PipelineParser struct {
-	Env             *env.Environment
+	Env             env.Environment
 	Filename        string
 	Pipeline        []byte
 	NoInterpolation bool

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -244,7 +244,7 @@ func walkConfigValues(prefix string, v interface{}, into *[]string) error {
 }
 
 // Converts the plugin configuration values to environment variables
-func (p *Plugin) ConfigurationToEnvironment() (*env.Environment, error) {
+func (p *Plugin) ConfigurationToEnvironment() (env.Environment, error) {
 	envSlice := []string{}
 	envPrefix := fmt.Sprintf("BUILDKITE_PLUGIN_%s", formatEnvKey(p.Name()))
 

--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -281,7 +281,7 @@ func TestRepositoryAndSubdirectory(t *testing.T) {
 func TestConfigurationToEnvironment(t *testing.T) {
 	t.Parallel()
 
-	var envMap *env.Environment
+	var envMap env.Environment
 	var err error
 
 	envMap, err = pluginEnvFromConfig(t, `{ "config-key": 42 }`)
@@ -384,7 +384,7 @@ func TestConfigurationToEnvironment(t *testing.T) {
 	}, envMap2.ToSlice())
 }
 
-func pluginEnvFromConfig(t *testing.T, configJson string) (*env.Environment, error) {
+func pluginEnvFromConfig(t *testing.T, configJson string) (env.Environment, error) {
 	var config map[string]interface{}
 
 	json.Unmarshal([]byte(configJson), &config)

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -210,7 +210,7 @@ func (b *Bootstrap) Cancel() error {
 }
 
 // executeHook runs a hook script with the hookRunner
-func (b *Bootstrap) executeHook(ctx context.Context, scope string, name string, hookPath string, extraEnviron *env.Environment) error {
+func (b *Bootstrap) executeHook(ctx context.Context, scope string, name string, hookPath string, extraEnviron env.Environment) error {
 	span, ctx := tracetools.StartSpanFromContext(ctx, "hook.execute", b.Config.TracingBackend)
 	var err error
 	defer func() { span.FinishWithError(err) }()
@@ -319,7 +319,7 @@ func (b *Bootstrap) applyEnvironmentChanges(changes hook.HookScriptChanges, reda
 
 	// reset output redactors based on new environment variable values
 	redactors.Flush()
-	redactors.Reset(redaction.GetValuesToRedact(b.shell, b.Config.RedactedVars, mergedEnv.ToMap()))
+	redactors.Reset(redaction.GetValuesToRedact(b.shell, b.Config.RedactedVars, mergedEnv))
 
 	// First, let see any of the environment variables are supposed
 	// to change the bootstrap configuration at run time.
@@ -1780,7 +1780,7 @@ func (b *Bootstrap) ignoredEnv() []string {
 // matching environment vars.
 // redaction.RedactorMux (possibly empty) is returned so the caller can `defer redactor.Flush()`
 func (b *Bootstrap) setupRedactors() redaction.RedactorMux {
-	valuesToRedact := redaction.GetValuesToRedact(b.shell, b.Config.RedactedVars, b.shell.Env.ToMap())
+	valuesToRedact := redaction.GetValuesToRedact(b.shell, b.Config.RedactedVars, b.shell.Env)
 	if len(valuesToRedact) == 0 {
 		return nil
 	}

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -143,7 +143,7 @@ type Config struct {
 
 // ReadFromEnvironment reads configuration from the Environment, returns a map
 // of the env keys that changed and the new values
-func (c *Config) ReadFromEnvironment(environ *env.Environment) map[string]string {
+func (c *Config) ReadFromEnvironment(environ env.Environment) map[string]string {
 	changed := map[string]string{}
 
 	// Use reflection for the type and values

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -40,7 +40,7 @@ type Shell struct {
 	Logger
 
 	// The running environment for the shell
-	Env *env.Environment
+	Env env.Environment
 
 	// Whether the shell is a PTY
 	PTY bool
@@ -333,13 +333,13 @@ func (s *Shell) RunAndCapture(command string, arg ...string) (string, error) {
 
 // injectTraceCtx adds tracing information to the given env vars to support
 // distributed tracing across jobs/builds.
-func (s *Shell) injectTraceCtx(ctx context.Context, env *env.Environment) {
+func (s *Shell) injectTraceCtx(ctx context.Context, env env.Environment) {
 	span := opentracing.SpanFromContext(ctx)
 	// Not all shell runs will have tracing (nor do they really need to).
 	if span == nil {
 		return
 	}
-	if err := tracetools.EncodeTraceContext(span, env.ToMap()); err != nil {
+	if err := tracetools.EncodeTraceContext(span, env); err != nil {
 		if s.Debug {
 			s.Logger.Warningf("Failed to encode trace context: %v", err)
 		}
@@ -350,7 +350,7 @@ func (s *Shell) injectTraceCtx(ctx context.Context, env *env.Environment) {
 // RunScript is like Run, but the target is an interpreted script which has
 // some extra checks to ensure it gets to the correct interpreter. Extra environment vars
 // can also be passed the script
-func (s *Shell) RunScript(ctx context.Context, path string, extra *env.Environment) error {
+func (s *Shell) RunScript(ctx context.Context, path string, extra env.Environment) error {
 	var command string
 	var args []string
 

--- a/bootstrap/tracing.go
+++ b/bootstrap/tracing.go
@@ -85,7 +85,7 @@ func (b *Bootstrap) startTracingDatadog(ctx context.Context) (tracetools.Span, c
 		tracer.WithAnalytics(true),
 	}
 
-	tags := Merge(GenericTracingExtras(b, *b.shell.Env), DDTracingExtras())
+	tags := Merge(GenericTracingExtras(b, b.shell.Env), DDTracingExtras())
 	opts = slices.Grow(opts, len(tags))
 	for k, v := range tags {
 		opts = append(opts, tracer.WithGlobalTag(k, v))
@@ -107,7 +107,7 @@ func (b *Bootstrap) startTracingDatadog(ctx context.Context) (tracetools.Span, c
 // extractTraceCtx pulls encoded distributed tracing information from the env vars.
 // Note: This should match the injectTraceCtx code in shell.
 func (b *Bootstrap) extractDDTraceCtx() opentracing.SpanContext {
-	sctx, err := tracetools.DecodeTraceContext(b.shell.Env.ToMap())
+	sctx, err := tracetools.DecodeTraceContext(b.shell.Env)
 	if err != nil {
 		// Return nil so a new span will be created
 		return nil
@@ -128,7 +128,7 @@ func (b *Bootstrap) startTracingOpenTelemetry(ctx context.Context) (tracetools.S
 		semconv.ServiceVersionKey.String(agent.Version()),
 	}
 
-	extras, warnings := toOpenTelemetryAttributes(GenericTracingExtras(b, *b.shell.Env))
+	extras, warnings := toOpenTelemetryAttributes(GenericTracingExtras(b, b.shell.Env))
 	for k, v := range warnings {
 		b.shell.Warningf("Unknown attribute type (key: %v, value: %v (%T)) passed when initialising OpenTelemetry. This is a bug, submit this error message at https://github.com/buildkite/agent/issues", k, v, v)
 		b.shell.Warningf("OpenTelemetry will still work, but the attribute %v and its value above will not be included", v)

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -243,7 +243,7 @@ var PipelineUploadCommand = cli.Command{
 		}
 
 		if len(cfg.RedactedVars) > 0 {
-			needles := redaction.GetKeyValuesToRedact(shell.StderrLogger, cfg.RedactedVars, env.FromSlice(os.Environ()).ToMap())
+			needles := redaction.GetKeyValuesToRedact(shell.StderrLogger, cfg.RedactedVars, env.FromSlice(os.Environ()))
 			serialisedPipeline, err := result.MarshalJSON()
 
 			if err != nil {

--- a/env/environment_test.go
+++ b/env/environment_test.go
@@ -170,7 +170,7 @@ func TestEmptyDiff(t *testing.T) {
 func TestEnvironmentApply(t *testing.T) {
 	t.Parallel()
 
-	env := &Environment{}
+	env := Environment{}
 	env = env.Apply(Diff{
 		Added: map[string]string{
 			"LLAMAS_ENABLED": "1",

--- a/env/export.go
+++ b/env/export.go
@@ -35,9 +35,9 @@ var endsWithUnescapedQuoteRegex = regexp.MustCompile("([^\\\\]\"\\z|\\A\"\\z)")
 //     TMP=C:\Users\IEUser\AppData\Local\Temp
 //     USERDOMAIN=IE11WIN10
 //
-func FromExport(body string) *Environment {
+func FromExport(body string) Environment {
 	// Create the environment that we'll load values into
-	env := &Environment{env: make(map[string]string)}
+	env := Environment{}
 
 	// Remove any white space at the start and the end of the export string
 	body = strings.TrimSpace(body)

--- a/env/export_test.go
+++ b/env/export_test.go
@@ -195,7 +195,7 @@ func TestFromExportFromWindowsWithLeadingAndTrailingSpaces(t *testing.T) {
 	assertEqualEnv(t, `USERDOMAIN`, "IE11WIN10", env)
 }
 
-func assertEqualEnv(t *testing.T, key string, expected string, env *Environment) {
+func assertEqualEnv(t *testing.T, key string, expected string, env Environment) {
 	t.Helper()
 	v, _ := env.Get(key)
 	if !assert.Equal(t, expected, v) {


### PR DESCRIPTION
The main reason behind this refactor is the `*Environment.ToMap()` method. The implication behind the naming of this method is that it returns a copy of the environment in a map representation, but what it actually does is just return the underlying map that Environment is implemented on top of. This is used in a variety of ways across the codebase, and we actually reach into Environment's pockets andmodify this underlying map a fair bit. This in mind, so it makes sense (to me, anyway) to remove the confusingly-named middleman.

One possible drawback of this approach is that it makes it easier to accidentally "manually" set a k/v pair in th env, ie by calling `env["foo"] = "bar"`, buuuuuuuuuuuut it was already pretty easy by calling ToMap(), so i'm happy with this tradeoff, but I'd be very interested in review comments about this.

The impetus for this change is that I'm looking into tracing environment propagation at the moment and got confused/frustrated/sidetracked by the nature of the `*Environment.ToMap()` method. It's not strictly necessary in order to do propagation stuff - we're more than capable of implementing that without this PR - but it is a nice quality of life change regardless.