### PR TITLE
Release Agent Edge any time a main build completes

### DIFF
--- a/.buildkite/steps/upload-release-steps.sh
+++ b/.buildkite/steps/upload-release-steps.sh
@@ -45,13 +45,15 @@ block_step() {
 YAML
 }
 
-output_steps_yaml() {
+edge_steps_yaml() {
   echo "steps:"
 
   trigger_step \
     "edge ${agent_version}.${build_version}" \
     "agent-release-edge"
+}
 
+output_steps_yaml() {
   block_step "beta?"
 
   trigger_step \
@@ -80,6 +82,8 @@ agent_docker_image_ubuntu_bionic=$(buildkite-agent meta-data get "agent-docker-i
 agent_docker_image_ubuntu_focal=$(buildkite-agent meta-data get "agent-docker-image-ubuntu-20.04")
 agent_docker_image_sidecar=$(buildkite-agent meta-data get "agent-docker-image-sidecar")
 agent_is_prerelease=$(buildkite-agent meta-data get "agent-is-prerelease")
+
+edge_steps_yaml | buildkite-agent pipeline upload
 
 # If there is already a release (which means a tag), we want to avoid trying to create
 # another one, as this will fail and cause partial broken releases


### PR DESCRIPTION
Currently, we don't do any real pre-releasing for the agent. We have three release "streams", `edge`, `beta`, and `stable`, but we only really ever use them when making a stable release, which is underutilising them, IMO.

This PR repurposes the `edge` release stream, and makes it so that whenever we successfully merge to main, we'll publish the `edge` release stream with whatever's in main at that time. The main benefit of this is that it makes it easier for customers to get at new features prior to their full release, whether that's because they like to live dangerously, or if they're acceptance testing something for us.

To use this release stream, customers can use the plug `edge` into the `BuildkiteAgentRelease` parameter in the elastic stack. I would argue that all of our agent builds should run on the latest version of the agent, but actually making that happen is out of scope for this PR.

Many thanks to @toothbrush for their inspiration on this!