### PR TITLE
Update datadog-go to v5.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/buildkite/agent/v3
 go 1.18
 
 require (
-	github.com/DataDog/datadog-go v4.8.2+incompatible
+	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/aws/aws-sdk-go v1.44.25
 	github.com/buildkite/bintest/v3 v3.1.0
 	github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251
@@ -49,7 +49,7 @@ require (
 
 require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.0.0-20211129110424-6491aa3bf583 // indirect
-	github.com/DataDog/datadog-go/v5 v5.0.2 // indirect
+	github.com/DataDog/datadog-go v4.8.2+incompatible // indirect
 	github.com/DataDog/sketches-go v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,9 @@ github.com/DataDog/datadog-agent/pkg/obfuscate v0.0.0-20211129110424-6491aa3bf58
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.2+incompatible h1:qbcKSx29aBLD+5QLvlQZlGmRMF/FfGqFLFev/1TDzRo=
 github.com/DataDog/datadog-go v4.8.2+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/DataDog/datadog-go/v5 v5.0.2 h1:UFtEe7662/Qojxkw1d6SboAeA0CPI3naKhVASwFn+04=
 github.com/DataDog/datadog-go/v5 v5.0.2/go.mod h1:ZI9JFB4ewXbw1sBnF4sxsR2k1H3xjV+PUAOUsHvKpcU=
+github.com/DataDog/datadog-go/v5 v5.1.1 h1:JLZ6s2K1pG2h9GkvEvMdEGqMDyVLEAccdX5TltWcLMU=
+github.com/DataDog/datadog-go/v5 v5.1.1/go.mod h1:KhiYb2Badlv9/rofz+OznKoEF5XKTonWyhx5K83AP8E=
 github.com/DataDog/gostackparse v0.5.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/DataDog/sketches-go v1.0.0 h1:chm5KSXO7kO+ywGWJ0Zs6tdmWU8PBXSbywFVciL6BG4=
 github.com/DataDog/sketches-go v1.0.0/go.mod h1:O+XkJHWk9w4hDwY2ZUDU31ZC9sNYlYo8DiFsxjYeo1k=

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/buildkite/agent/v3/logger"
 )
 
@@ -50,12 +50,13 @@ func (c *Collector) Start() error {
 		c.logger.Info("Starting datadog metrics collection to %s", c.config.DatadogHost)
 
 		var err error
-		c.client, err = statsd.NewBuffered(c.config.DatadogHost, statsdBufferLen)
+		c.client, err = statsd.New(c.config.DatadogHost,
+			statsd.WithMaxMessagesPerPayload(statsdBufferLen),
+			statsd.WithNamespace("buildkite."),
+		)
 		if err != nil {
 			return err
 		}
-
-		c.client.Namespace = "buildkite."
 	}
 	return nil
 }


### PR DESCRIPTION
This PR updates our direct usage of the datadog-go library to v5.1.1. Our go.mod file still includes v4.8.2, as it's an indirect dependency (our tracing integration -> dd-trace-go -> datadog-agent/pkg/obfuscate -> datadog-go v4.8.2)