### PR TITLE
Okay, I give up, everything has 777 permissions again.

### DIFF
--- a/agent/download.go
+++ b/agent/download.go
@@ -133,6 +133,7 @@ func (d Download) try() error {
 	}
 
 	// Now make the folder for our file
+	// Actual file permissions will be reduced by umask, and won't be 0777 unless the user has manually changed the umask to 000
 	err = os.MkdirAll(targetDirectory, 0777)
 	if err != nil {
 		return fmt.Errorf("Failed to create folder for %s (%T: %v)", targetFile, err, err)

--- a/agent/download.go
+++ b/agent/download.go
@@ -133,7 +133,7 @@ func (d Download) try() error {
 	}
 
 	// Now make the folder for our file
-	err = os.MkdirAll(targetDirectory, 0775)
+	err = os.MkdirAll(targetDirectory, 0777)
 	if err != nil {
 		return fmt.Errorf("Failed to create folder for %s (%T: %v)", targetFile, err, err)
 	}

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -133,6 +133,7 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 	// TempDir is not guaranteed to exist
 	tempDir := os.TempDir()
 	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
+		// Actual file permissions will be reduced by umask, and won't be 0777 unless the user has manually changed the umask to 000
 		if err = os.MkdirAll(tempDir, 0777); err != nil {
 			return nil, err
 		}

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -133,7 +133,7 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 	// TempDir is not guaranteed to exist
 	tempDir := os.TempDir()
 	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
-		if err = os.MkdirAll(tempDir, 0775); err != nil {
+		if err = os.MkdirAll(tempDir, 0777); err != nil {
 			return nil, err
 		}
 	}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -766,7 +766,7 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	}
 
 	// Ensure the plugin directory exists, otherwise we can't create the lock
-	err = os.MkdirAll(b.PluginsPath, 0775)
+	err = os.MkdirAll(b.PluginsPath, 0777)
 	if err != nil {
 		return nil, err
 	}
@@ -907,7 +907,7 @@ func (b *Bootstrap) createCheckoutDir() error {
 
 	if !utils.FileExists(checkoutPath) {
 		b.shell.Commentf("Creating \"%s\"", checkoutPath)
-		if err := os.MkdirAll(checkoutPath, 0775); err != nil {
+		if err := os.MkdirAll(checkoutPath, 0777); err != nil {
 			return err
 		}
 	}
@@ -1096,7 +1096,7 @@ func (b *Bootstrap) updateGitMirror() (string, error) {
 	// Create the mirrors path if it doesn't exist
 	if baseDir := filepath.Dir(mirrorDir); !utils.FileExists(baseDir) {
 		b.shell.Commentf("Creating \"%s\"", baseDir)
-		if err := os.MkdirAll(baseDir, 0775); err != nil {
+		if err := os.MkdirAll(baseDir, 0777); err != nil {
 			return "", err
 		}
 	}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -766,6 +766,7 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	}
 
 	// Ensure the plugin directory exists, otherwise we can't create the lock
+	// Actual file permissions will be reduced by umask, and won't be 0777 unless the user has manually changed the umask to 000
 	err = os.MkdirAll(b.PluginsPath, 0777)
 	if err != nil {
 		return nil, err
@@ -907,6 +908,7 @@ func (b *Bootstrap) createCheckoutDir() error {
 
 	if !utils.FileExists(checkoutPath) {
 		b.shell.Commentf("Creating \"%s\"", checkoutPath)
+		// Actual file permissions will be reduced by umask, and won't be 0777 unless the user has manually changed the umask to 000
 		if err := os.MkdirAll(checkoutPath, 0777); err != nil {
 			return err
 		}
@@ -1096,6 +1098,7 @@ func (b *Bootstrap) updateGitMirror() (string, error) {
 	// Create the mirrors path if it doesn't exist
 	if baseDir := filepath.Dir(mirrorDir); !utils.FileExists(baseDir) {
 		b.shell.Commentf("Creating \"%s\"", baseDir)
+		// Actual file permissions will be reduced by umask, and won't be 0777 unless the user has manually changed the umask to 000
 		if err := os.MkdirAll(baseDir, 0777); err != nil {
 			return "", err
 		}

--- a/bootstrap/shell/tempfile.go
+++ b/bootstrap/shell/tempfile.go
@@ -16,6 +16,7 @@ func TempFileWithExtension(filename string) (*os.File, error) {
 	// TempDir is not guaranteed to exist
 	tempDir := os.TempDir()
 	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
+		// Actual file permissions will be reduced by umask, and won't be 0777 unless the user has manually changed the umask to 000
 		if err = os.MkdirAll(tempDir, 0777); err != nil {
 			return nil, err
 		}

--- a/bootstrap/shell/tempfile.go
+++ b/bootstrap/shell/tempfile.go
@@ -16,7 +16,7 @@ func TempFileWithExtension(filename string) (*os.File, error) {
 	// TempDir is not guaranteed to exist
 	tempDir := os.TempDir()
 	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
-		if err = os.MkdirAll(tempDir, 0775); err != nil {
+		if err = os.MkdirAll(tempDir, 0777); err != nil {
 			return nil, err
 		}
 	}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -747,6 +747,7 @@ var AgentStartCommand = cli.Command{
 		// so we may as well check that'll work now and fail early if it's a problem
 		if !utils.FileExists(agentConf.BuildPath) {
 			l.Info("Build Path doesn't exist, creating it (%s)", agentConf.BuildPath)
+			// Actual file permissions will be reduced by umask, and won't be 0777 unless the user has manually changed the umask to 000
 			if err := os.MkdirAll(agentConf.BuildPath, 0777); err != nil {
 				l.Fatal("Failed to create builds path: %v", err)
 			}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -747,7 +747,7 @@ var AgentStartCommand = cli.Command{
 		// so we may as well check that'll work now and fail early if it's a problem
 		if !utils.FileExists(agentConf.BuildPath) {
 			l.Info("Build Path doesn't exist, creating it (%s)", agentConf.BuildPath)
-			if err := os.MkdirAll(agentConf.BuildPath, 0775); err != nil {
+			if err := os.MkdirAll(agentConf.BuildPath, 0777); err != nil {
 				l.Fatal("Failed to create builds path: %v", err)
 			}
 		}


### PR DESCRIPTION
We've tried [a bunch](https://github.com/buildkite/agent/pull/1580) of [solutions](https://github.com/buildkite/agent/pull/1616) to make file permissions for directories created by the agent a bit more restrictive, so that other processes can't subtly change what the agent is doing, but every time we've tried, it's broken docker workflows for our customers because of docker namespace remapping, and the fact that docker (rightly!) recommends that users don't use the root user inside containers.

This PR reverts all changes to directory permissions, and goes back to letting the umask dictate what permissions files get. This means that in most cases, things will get assigned 0755 perms, but this can be overridden by the user.