### PR TITLE
Fix bootstrap usage capitalization of "Buildkite"

### DIFF
--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -22,7 +22,7 @@ var BootstrapHelpDescription = `Usage:
 
 Description:
 
-   The bootstrap command executes a buildkite job locally.
+   The bootstrap command executes a Buildkite job locally.
 
    Generally the bootstrap command is run as a sub-process of the buildkite-agent to execute
    a given job sent from buildkite.com, but you can also invoke the bootstrap manually.


### PR DESCRIPTION
A recent upgrade to the documentation spellcheck picked up this error. This change upstreams the correction made in the docs repo.

https://github.com/buildkite/docs/pull/1585