### PR TITLE
Update log-level description

### DIFF
--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -55,7 +55,7 @@ var DebugFlag = cli.BoolFlag{
 var LogLevelFlag = cli.StringFlag{
 	Name:   "log-level",
 	Value:  "notice",
-	Usage:  "Set the log level for the agent, making logging more or less verbose. Defaults to notice. Other values: debug, info, error, warn, fatal",
+	Usage:  "Set the log level for the agent, making logging more or less verbose. Defaults to notice. Allowed values are: debug, info, error, warn, fatal",
 	EnvVar: "BUILDKITE_AGENT_LOG_LEVEL",
 }
 

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -55,7 +55,7 @@ var DebugFlag = cli.BoolFlag{
 var LogLevelFlag = cli.StringFlag{
 	Name:   "log-level",
 	Value:  "notice",
-	Usage:  "Set the log level for the agent, making logging more or less verbose. Defaults to notice",
+	Usage:  "Set the log level for the agent, making logging more or less verbose. Defaults to notice. Other values: debug, info, error, warn, fatal",
 	EnvVar: "BUILDKITE_AGENT_LOG_LEVEL",
 }
 


### PR DESCRIPTION
The description from the docs around the the `-log-level` option doesn't include the rest of the possibles values: https://buildkite.com/docs/agent/v3/cli-pipeline#options
This was raised by a customer.

That doc section gets automatically generated from this code.
I'm adding the rest of the possibles values according to https://github.com/buildkite/agent/blob/main/logger/level.go#L19