### PR TITLE
Add note about using `--step` with parallelized steps

### DIFF
--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -76,7 +76,7 @@ var ArtifactDownloadCommand = cli.Command{
 		cli.StringFlag{
 			Name:  "step",
 			Value: "",
-			Usage: "Scope the search to a particular step by using either its name or job ID",
+			Usage: "Scope the search to a particular step by using either its name or job ID. See [section](/docs/agent/v3/cli-artifact#parallelized-steps) for parralelized steps.",
 		},
 		cli.StringFlag{
 			Name:   "build",

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -97,7 +97,7 @@ Format specifiers:
 		cli.StringFlag{
 			Name:  "step",
 			Value: "",
-			Usage: "Scope the search to a particular step by using either its name or job ID",
+			Usage: "Scope the search to a particular step by using either its name or job ID. See [section](/docs/agent/v3/cli-artifact#parallelized-steps) for parralelized steps.",
 		},
 		cli.StringFlag{
 			Name:   "build",


### PR DESCRIPTION
Adds note about about using the `--step` option with parallelized steps to be added in https://github.com/buildkite/docs/pull/1607.