### PR TITLE
Add origin remote if it's not already set on the mirror repo

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1159,8 +1159,14 @@ func (b *Bootstrap) updateGitMirror() (string, error) {
 	b.shell.Commentf("Updating existing repository mirror to find commit %s", b.Commit)
 
 	// Update the origin of the repository so we can gracefully handle repository renames
-	if err := b.shell.Run("git", "--git-dir", mirrorDir, "remote", "set-url", "origin", b.Repository); err != nil {
-		return "", err
+	if err := b.shell.Run("git", "remote", "get-url", "origin"); err != nil {
+		if err := b.shell.Run("git", "--git-dir", mirrorDir, "remote", "add", "origin", b.Repository); err != nil {
+			return "", err
+		}
+	} else {
+		if err := b.shell.Run("git", "--git-dir", mirrorDir, "remote", "set-url", "origin", b.Repository); err != nil {
+			return "", err
+		}
 	}
 
 	if b.PullRequest != "false" && strings.Contains(b.PipelineProvider, "github") {


### PR DESCRIPTION
### Problem
We've hit an issue a couple times where agents with a shared git mirror repo fail when trying to set the remote url for origin. The agents sharing the repo will fail consistently but can be recovered by manually running `git --git-dir <mirrorDir> remote add origin <url>` on the host.

The root cause for the repo getting into this state isn't known yet. From scanning the logs I haven't found any errors or abnormal operation. The only thing I see is that all the agents start picking up jobs at the same time so it could be due to another git operation running without a lock somewhere else.

### Proposed Solution
This PR just checks if there's not already a url for origin and runs `git remote add` if there isn't. This code runs within the update lock so there won't be any issue with multiple agents checking and branching based on the git remote get-url result.

### Tests
There aren't any unit tests for this part of the code as far as I've seen. This doesn't reproduce often but we want to have a fix in to avoid issues in the future.