### PR TITLE
Unescape backticks when parsing env from export -p output

### DIFF
--- a/env/export.go
+++ b/env/export.go
@@ -48,7 +48,7 @@ func FromExport(body string) Environment {
 	// Split up the export into lines
 	lines := strings.Split(body, "\n")
 
-	// No lines! An empty environment it is@
+	// No lines! An empty environment it is!
 	if len(lines) == 0 {
 		return env
 	}
@@ -142,6 +142,11 @@ func unquoteShell(value string) string {
 	// They also escape double quotes when showing a value within double
 	// quotes, for example, "this is a \" quote string"
 	value = strings.Replace(value, `\"`, `"`, -1)
+
+	// Replace a literal escaped backtick (\`) with just a backtick (`)
+	// Some variables (like passwords) can contain backticks that should be interpreted as literal backticks, rather than
+	// as the beginning of a subcommand
+	value = strings.Replace(value, "\\`", "`", -1)
 
 	return value
 }

--- a/env/export_test.go
+++ b/env/export_test.go
@@ -45,6 +45,7 @@ func TestFromExportHandlesEscapedCharacters(t *testing.T) {
 		`declare -x WITH_NEW_LINE="i have a \\n new line"`,
 		`declare -x CARRIAGE_RETURN="i have a \\r carriage"`,
 		`declare -x TOTES="with a \" quote"`,
+		"declare -x ESCAPED_BACKTICK=\"escaped -----> \\` <----- backtick\"",
 	}
 
 	env := FromExport(strings.Join(lines, "\n"))
@@ -53,6 +54,7 @@ func TestFromExportHandlesEscapedCharacters(t *testing.T) {
 	assertEqualEnv(t, `WITH_NEW_LINE`, `i have a \n new line`, env)
 	assertEqualEnv(t, `CARRIAGE_RETURN`, `i have a \r carriage`, env)
 	assertEqualEnv(t, `TOTES`, `with a " quote`, env)
+	assertEqualEnv(t, `ESCAPED_BACKTICK`, "escaped -----> ` <----- backtick", env)
 }
 
 func TestFromExportWithVariablesWithoutEquals(t *testing.T) {


### PR DESCRIPTION
When we run hooks as part of a build, the agent pulls [some malarkey](https://github.com/buildkite/agent/blob/1a9c92c951fe9c962f4b0be4229f1eeeb6faf35d/hook/scriptwrapper.go) to capture the environment variables added by that hook.

As part of this process, the agent uses the bash `export -p` builtin to export the environment of the current process in a form that can be run as a script. The output looks kinda like:
```Bash
declare -x COLOUR="chartreuse"
declare -x FLAVOUR="spicy"
declare -x TEXTURE="abrasive"
# ... and so on and so forth
```

We then parse this output into our `env.Environment` type, and use that to construct a diff between what the env looked like before the hook was run, and what it looked like afterward.

The issue here was that this parsing process didn't know how to (or that it should) unescape a backtick (\`). In practice, this means that if a user exports an environment variable with a backtick in it, then the variable will come out with an extra backslash character in it.

For example, if i had an environment hook like:
```Bash
export MARKDOWN_TEXT="this should be formatted like \`code\`"
```
then i would expect to be that `echo $MARKDOWN_TEXT` to print "this should be formatted like \`code\`", but instead would print "this should be formatted like \\\`code\\`", erroneously keeping the backslashes in.

This commit teaches the environment parser to understand how to unescape backticks, fixing the issues laid out above.

Fixes #1650 