### PR TITLE
Reverse error checking logic to make sure lock errors are logged

### DIFF
--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -235,10 +235,10 @@ func (s *Shell) flock(path string, timeout time.Duration) (LockFile, error) {
 	for {
 		// Keep trying the lock until we get it
 		if gotLock, err := lock.TryLock(); !gotLock || err != nil {
-			if !gotLock {
-				s.Commentf("Could not acquire lock on \"%s\" (Locked by other process)", absolutePathToLock)
-			} else {
+			if err != nil {
 				s.Commentf("Could not acquire lock on \"%s\" (%s)", absolutePathToLock, err)
+			} else {
+				s.Commentf("Could not acquire lock on \"%s\" (Locked by other process)", absolutePathToLock)
 			}
 			s.Commentf("Trying again in %s...", lockRetryDuration)
 			time.Sleep(lockRetryDuration)


### PR DESCRIPTION
Noticed this potential issue while reading through this code. Due to how the flock library will set always return (false, err) this code wouldn't print other lock errors since it would always hit the first branch. This flips the logic to make sure the err is checked first then falls through when the more typical case of the lock being held by someone else most of the time. gofrs/flock will never return (true, err): https://github.com/gofrs/flock/blob/master/flock_unix.go#L158 