### PR TITLE
Don't blow up when a hook exports an array

### DIFF
--- a/env/export.go
+++ b/env/export.go
@@ -96,31 +96,31 @@ func FromExport(body string) Environment {
 			//     2. `FOO="open quote for new lines`
 			//     3. `FOO`
 			//
-			parts := strings.SplitN(line, "=\"", 2)
-			if len(parts) == 2 {
+			key, val, ok := strings.Cut(line, `="`)
+			if ok {
 				// If the value ends with an unescaped quote,
 				// then we know it's a single line environment
 				// variable (see example 1)
-				if endsWithUnescapedQuoteRegex.MatchString(parts[1]) {
+				if endsWithUnescapedQuoteRegex.MatchString(val) {
 					// Remove the `"` at the end
-					singleLineValueWithQuoteRemoved := strings.TrimSuffix(parts[1], `"`)
+					singleLineValueWithQuoteRemoved := strings.TrimSuffix(val, `"`)
 
 					// Set the single line env var
-					env.Set(parts[0], unquoteShell(singleLineValueWithQuoteRemoved))
+					env.Set(key, unquoteShell(singleLineValueWithQuoteRemoved))
 				} else {
 					// We're in an example 2 situation,
 					// where we need to keep keep the
 					// environment variable open until we
 					// encounter a line that ends with an
 					// unescaped quote
-					openKeyName = parts[0]
-					openKeyValue = []string{parts[1]}
+					openKeyName = key
+					openKeyValue = []string{val}
 				}
 			} else {
 				// Since there wasn't an `=` sign, we assume
 				// it's just an environment variable without a
 				// value (see example 3)
-				env.Set(parts[0], "")
+				env.Set(key, "")
 			}
 		}
 

--- a/env/export_test.go
+++ b/env/export_test.go
@@ -29,15 +29,17 @@ func TestFromExportHandlesNewlines(t *testing.T) {
 
 	env := FromExport(strings.Join(lines, "\n"))
 
-	assertEqualEnv(t, `SOMETHING`, `0`, env)
-	assertEqualEnv(t, `USER`, `keithpitt`, env)
-	assertEqualEnv(t, `VAR1`, "boom\\nboom\\nshake\\nthe\\nroom", env)
-	assertEqualEnv(t, `VAR2`, "hello\nfriends", env)
-	assertEqualEnv(t, `VAR3`, "hello\nfriends\nOMG=foo\ntest", env)
-	assertEqualEnv(t, `VAR4`, `ends with a space `, env)
-	assertEqualEnv(t, `VAR5`, "ends with\nanother space ", env)
-	assertEqualEnv(t, `VAR6`, "ends with a quote \"\nand a new line \"", env)
-	assertEqualEnv(t, `_`, `/usr/local/bin/watch`, env)
+	assert.Equal(t, Environment{
+		"SOMETHING": `0`,
+		"USER":      `keithpitt`,
+		"VAR1":      "boom\\nboom\\nshake\\nthe\\nroom",
+		"VAR2":      "hello\nfriends",
+		"VAR3":      "hello\nfriends\nOMG=foo\ntest",
+		"VAR4":      `ends with a space `,
+		"VAR5":      "ends with\nanother space ",
+		"VAR6":      "ends with a quote \"\nand a new line \"",
+		"_":         `/usr/local/bin/watch`,
+	}, env)
 }
 
 func TestFromExportHandlesEscapedCharacters(t *testing.T) {
@@ -51,11 +53,13 @@ func TestFromExportHandlesEscapedCharacters(t *testing.T) {
 
 	env := FromExport(strings.Join(lines, "\n"))
 
-	assertEqualEnv(t, `DOLLARS`, `i love $money`, env)
-	assertEqualEnv(t, `WITH_NEW_LINE`, `i have a \n new line`, env)
-	assertEqualEnv(t, `CARRIAGE_RETURN`, `i have a \r carriage`, env)
-	assertEqualEnv(t, `TOTES`, `with a " quote`, env)
-	assertEqualEnv(t, `COOL_BACKTICK`, "look at this -----> ` <----- cool backtick", env)
+	assert.Equal(t, Environment{
+		"DOLLARS":         `i love $money`,
+		"WITH_NEW_LINE":   `i have a \n new line`,
+		"CARRIAGE_RETURN": `i have a \r carriage`,
+		"TOTES":           `with a " quote`,
+		"COOL_BACKTICK":   "look at this -----> ` <----- cool backtick",
+	}, env)
 }
 
 func TestFromExport_IgnoresArrays_Links_Refs_AndIntegers(t *testing.T) {
@@ -113,16 +117,20 @@ func TestFromExportWithVariablesWithoutEquals(t *testing.T) {
 
 	env := FromExport(strings.Join(lines, "\n"))
 
-	assertEqualEnv(t, "LANG", "en_US.UTF-8", env)
-	assertEqualEnv(t, "LOGNAME", `buildkite-agent`, env)
-	assertEqualEnv(t, "SOME_VALUE", `this is my value`, env)
-	assertEqualEnv(t, "OLDPWD", ``, env)
-	assertEqualEnv(t, "SOME_OTHER_VALUE", "this is my value across\nnew\nlines", env)
-	assertEqualEnv(t, "OLDPWD2", ``, env)
-	assertEqualEnv(t, "SPACES", `this   one has      a bunch of spaces      in it`, env)
-	assertEqualEnv(t, "GONNA_TRICK_YOU", "the next line is a string\ndeclare -x WITH_A_STRING=\"I'm a string!!\n", env)
-	assertEqualEnv(t, "PATH", `/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`, env)
-	assertEqualEnv(t, "PWD", `/`, env)
+	assert.Equal(t, Environment{
+		"THING_TOTES":      "",
+		"HTTP_PROXY":       "http://proxy.example.com:1234/",
+		"LANG":             "en_US.UTF-8",
+		"LOGNAME":          `buildkite-agent`,
+		"SOME_VALUE":       `this is my value`,
+		"OLDPWD":           ``,
+		"SOME_OTHER_VALUE": "this is my value across\nnew\nlines",
+		"SPACES":           `this   one has      a bunch of spaces      in it`,
+		"OLDPWD2":          ``,
+		"GONNA_TRICK_YOU":  "the next line is a string\ndeclare -x WITH_A_STRING=\"I'm a string!!\n",
+		"PATH":             `/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`,
+		"PWD":              `/`,
+	}, env)
 }
 
 func TestFromExportWithLeadingAndTrailingWhitespace(t *testing.T) {
@@ -145,10 +153,12 @@ func TestFromExportWithLeadingAndTrailingWhitespace(t *testing.T) {
 		t.Fatalf("Expected length of 4, got %d", env.Length())
 	}
 
-	assertEqualEnv(t, `DOLLARS`, "i love $money", env)
-	assertEqualEnv(t, `WITH_NEW_LINE`, `i have a \n new line`, env)
-	assertEqualEnv(t, `CARRIAGE_RETURN`, `i have a \r carriage`, env)
-	assertEqualEnv(t, `TOTES`, `with a " quote`, env)
+	assert.Equal(t, Environment{
+		"DOLLARS":         "i love $money",
+		"WITH_NEW_LINE":   `i have a \n new line`,
+		"CARRIAGE_RETURN": `i have a \r carriage`,
+		"TOTES":           `with a " quote`,
+	}, env)
 }
 
 func TestFromExportJSONInside(t *testing.T) {
@@ -176,7 +186,7 @@ func TestFromExportJSONInside(t *testing.T) {
 
 	env := FromExport(strings.Join(lines, "\n"))
 
-	assertEqualEnv(t, `FOO`, strings.Join(expected, "\n"), env)
+	assert.Equal(t, Environment{"FOO": strings.Join(expected, "\n")}, env)
 }
 
 func TestFromExportFromWindows(t *testing.T) {
@@ -191,16 +201,12 @@ func TestFromExportFromWindows(t *testing.T) {
 
 	env := FromExport(strings.Join(lines, "\r\n"))
 
-	if !assert.Equal(t, env.Length(), 6) {
-		t.FailNow()
-	}
-
-	assertEqualEnv(t, `SESSIONNAME`, "Console", env)
-	assertEqualEnv(t, `SystemDrive`, "C:", env)
-	assertEqualEnv(t, `SystemRoot`, "C:\\Windows", env)
-	assertEqualEnv(t, `TEMP`, "C:\\Users\\IEUser\\AppData\\Local\\Temp", env)
-	assertEqualEnv(t, `TMP`, "C:\\Users\\IEUser\\AppData\\Local\\Temp", env)
-	assertEqualEnv(t, `USERDOMAIN`, "IE11WIN10", env)
+	assertEnvHas(t, env, "SESSIONNAME", "Console")
+	assertEnvHas(t, env, "SystemDrive", "C:")
+	assertEnvHas(t, env, "SystemRoot", `C:\Windows`)
+	assertEnvHas(t, env, "TEMP", `C:\Users\IEUser\AppData\Local\Temp`)
+	assertEnvHas(t, env, "TMP", `C:\Users\IEUser\AppData\Local\Temp`)
+	assertEnvHas(t, env, "USERDOMAIN", "IE11WIN10")
 }
 
 func TestFromExportFromWindowsWithLeadingAndTrailingSpaces(t *testing.T) {
@@ -221,22 +227,19 @@ func TestFromExportFromWindowsWithLeadingAndTrailingSpaces(t *testing.T) {
 
 	env := FromExport(strings.Join(lines, "\r\n"))
 
-	if !assert.Equal(t, env.Length(), 6) {
-		t.FailNow()
-	}
-
-	assertEqualEnv(t, `SESSIONNAME`, "Console", env)
-	assertEqualEnv(t, `SystemDrive`, "C:", env)
-	assertEqualEnv(t, `SystemRoot`, "C:\\Windows", env)
-	assertEqualEnv(t, `TEMP`, "C:\\Users\\IEUser\\AppData\\Local\\Temp", env)
-	assertEqualEnv(t, `TMP`, "C:\\Users\\IEUser\\AppData\\Local\\Temp", env)
-	assertEqualEnv(t, `USERDOMAIN`, "IE11WIN10", env)
+	assertEnvHas(t, env, "SESSIONNAME", "Console")
+	assertEnvHas(t, env, "SystemDrive", "C:")
+	assertEnvHas(t, env, "SystemRoot", `C:\Windows`)
+	assertEnvHas(t, env, "TEMP", `C:\Users\IEUser\AppData\Local\Temp`)
+	assertEnvHas(t, env, "TMP", `C:\Users\IEUser\AppData\Local\Temp`)
+	assertEnvHas(t, env, "USERDOMAIN", "IE11WIN10")
 }
 
-func assertEqualEnv(t *testing.T, key string, expected string, env Environment) {
+// How we case the environment is different per platform - on linux we leave it alone, on windows we upcase it
+// So when we're testing windowsy env vars (ie, ones that might be not all uppercase), test using env.Get(), which
+// normalises everything for us
+func assertEnvHas(t *testing.T, env Environment, key string, expectedVal string) {
 	t.Helper()
 	v, _ := env.Get(key)
-	if !assert.Equal(t, expected, v) {
-		t.FailNow()
-	}
+	assert.Equal(t, expectedVal, v)
 }

--- a/env/export_test.go
+++ b/env/export_test.go
@@ -45,7 +45,7 @@ func TestFromExportHandlesEscapedCharacters(t *testing.T) {
 		`declare -x WITH_NEW_LINE="i have a \\n new line"`,
 		`declare -x CARRIAGE_RETURN="i have a \\r carriage"`,
 		`declare -x TOTES="with a \" quote"`,
-		"declare -x ESCAPED_BACKTICK=\"escaped -----> \\` <----- backtick\"",
+		"declare -x COOL_BACKTICK=\"look at this -----> \\` <----- cool backtick\"",
 	}
 
 	env := FromExport(strings.Join(lines, "\n"))
@@ -54,7 +54,7 @@ func TestFromExportHandlesEscapedCharacters(t *testing.T) {
 	assertEqualEnv(t, `WITH_NEW_LINE`, `i have a \n new line`, env)
 	assertEqualEnv(t, `CARRIAGE_RETURN`, `i have a \r carriage`, env)
 	assertEqualEnv(t, `TOTES`, `with a " quote`, env)
-	assertEqualEnv(t, `ESCAPED_BACKTICK`, "escaped -----> ` <----- backtick", env)
+	assertEqualEnv(t, `COOL_BACKTICK`, "look at this -----> ` <----- cool backtick", env)
 }
 
 func TestFromExportWithVariablesWithoutEquals(t *testing.T) {


### PR DESCRIPTION
Previously, if a line in the output of `export -p` contained multiple options on the `declare` call (eg, there was an array in there - `declare -ax ARRAY=("red", "green", "blue")`), env.FromExport() would have some very weird behaviour - it could eat variables entirely, leading to them being unset in the build that the agent ran - more context for buildkite staff [here](https://3.basecamp.com/3453178/buckets/23112918/messages/5089354108#__recording_5089608441), but the TL;DR is that a hook was exporting an array variable, and it was causing other variables - important ones like `PATH` and `PWD` - to go missing.

**This PR:** Teaches env.FromExport to be able to introspect the args passed to each `declare` call, and allows it to ignore anything that it won't be able to parse. At the moment, it ignores indexed arrays (`declare -a`), associative arrays (`declare -A`), integers (`declare -i`) and links (`declare -n`)