### PR TITLE
Use non-conflicting docker networks

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -28,3 +28,7 @@ services:
 
 volumes:
   ruby-2-6-agent-gem-cache: ~
+
+networks:
+  default:
+    name: buildkite-agent-${RAND}

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -28,7 +28,3 @@ services:
 
 volumes:
   ruby-2-6-agent-gem-cache: ~
-
-networks:
-  default:
-    name: buildkite-agent-${RAND}

--- a/scripts/ruby-env
+++ b/scripts/ruby-env
@@ -3,7 +3,9 @@ set -euo pipefail
 
 # start a docker container with the ruby environment we need in some build steps
 
-compose_file="$(dirname $0)/../.buildkite/docker-compose.yml"
+compose_file="$(dirname "$0")/../.buildkite/docker-compose.yml"
+
+RAND=$(random)
+export RAND
 
 docker-compose -f "$compose_file" run --rm ruby "${@-bash}"
-

--- a/scripts/ruby-env
+++ b/scripts/ruby-env
@@ -5,7 +5,6 @@ set -euo pipefail
 
 compose_file="$(dirname "$0")/../.buildkite/docker-compose.yml"
 
-RAND=$(random)
-export RAND
+export COMPOSE_PROJECT_NAME="buildkite${BUILDKITE_JOB_ID//-}"
 
 docker-compose -f "$compose_file" run --rm ruby "${@-bash}"


### PR DESCRIPTION
When running multiple jobs on the same machine, they use the same docker network by default, which means that the two running jobs can run into a race condition where they both create a docker network with the same name, leading to a build failure (see https://buildkite.com/buildkite/agent/builds/4420#0181ba48-c82c-4b92-bac9-5bff1743a373).

~~This PR adjusts the build script to add a random number to the end of the docker network name, meaning that we have a 32767x lower chance of a network name collision~~

This PR uses the COMPOSE_PROJECT_NAME environment variable set to the job ID of the build we're running to avoid network name collisions