### PR TITLE
OpenTelemetry Polishing

### DIFF
--- a/bootstrap/tracing.go
+++ b/bootstrap/tracing.go
@@ -220,6 +220,16 @@ func GenericTracingExtras(b *Bootstrap, env env.Environment) map[string]any {
 		triggeredFromID = "n/a"
 	}
 
+	jobLabel, has := env.Get("BUILDKITE_LABEL")
+	if !has || jobLabel == "" {
+		jobLabel = "n/a"
+	}
+
+	jobKey, has := env.Get("BUILDKITE_STEP_KEY")
+	if !has || jobKey == "" {
+		jobKey = "n/a"
+	}
+
 	return map[string]any{
 		"buildkite.agent":             b.AgentName,
 		"buildkite.version":           agent.Version(),
@@ -227,6 +237,8 @@ func GenericTracingExtras(b *Bootstrap, env env.Environment) map[string]any {
 		"buildkite.org":               b.OrganizationSlug,
 		"buildkite.pipeline":          b.PipelineSlug,
 		"buildkite.branch":            b.Branch,
+		"buildkite.job_label":         jobLabel,
+		"buildkite.job_key":           jobKey,
 		"buildkite.job_id":            b.JobID,
 		"buildkite.job_url":           jobURL,
 		"buildkite.build_id":          buildID,


### PR DESCRIPTION
**This PR:** Takes a couple of the things we've learned from tracing our own agent builds and implements them in the opentelemetry-tracing experiment. We've:
- Added a Deployment Environment attribute, `ci`.
- Renamed the root span for each build from `job.run` (which doesn't say a whole lot about what's happening!) to something dynamic per job, in the format `<buildkite org>/<pipeline slug>/<job key or label>`. For example, this might end up as `buildkite/agent/go-fmt` or `rails/rails/rspec`.
- Added job label and key attributes to all spans generated by the agent, making them easier to group
