### PR TITLE
Better race testing

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,12 +32,10 @@ steps:
         config: .buildkite/docker-compose.yml
         run: agent
 
-  - name: ":linux: Linux ARM64 Tests (with race detector)"
+  - name: ":satellite: Detect Data Races"
     key: test-race-linux-arm64
     command: ".buildkite/steps/tests.sh -race"
     artifact_paths: junit-*.xml
-    soft_fail:
-      - exit_status: "*"
     agents:
       queue: agent-runners-linux-arm64
     plugins:
@@ -45,7 +43,7 @@ steps:
         config: .buildkite/docker-compose.yml
         run: agent
 
-  - name: ":windows: Windows ARM64 Tests"
+  - name: ":windows: Windows AMD64 Tests"
     key: test-windows
     command: "bash .buildkite\\steps\\tests.sh"
     artifact_paths: junit-*.xml

--- a/bootstrap/shell/shell_test.go
+++ b/bootstrap/shell/shell_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/buildkite/agent/v3/bootstrap/shell"
 	"github.com/buildkite/agent/v3/experiments"
+	"github.com/buildkite/agent/v3/race"
 	"github.com/buildkite/bintest/v3"
 	"github.com/stretchr/testify/assert"
 )
@@ -160,6 +161,10 @@ func TestContextCancelTerminates(t *testing.T) {
 func TestInterrupt(t *testing.T) {
 	if runtime.GOOS == `windows` {
 		t.Skip("Not supported in windows")
+	}
+
+	if race.Enabled {
+		t.Skip("Bintest has a race condition that we run into here, we should fix it, but it only shows up in tests")
 	}
 
 	sleepCmd, err := bintest.CompileProxy("sleep")

--- a/race/disabled.go
+++ b/race/disabled.go
@@ -1,0 +1,9 @@
+//go:build !race
+
+package race
+
+// We can use this constant to determine whether or not the Go Race Detector is enabled. If the race detector is enabled,
+// the `race` build tag is passed, so this file won't be compiled, where the other one (./enabled.go) will be.
+// That is, if the race detector is enabled, the constant below will be false. Otherwise, it'll be true.
+// It's kinda weird, but it's also how go itself does it: https://github.com/golang/go/blob/master/src/internal/race/race.go#L15
+const Enabled = false

--- a/race/enabled.go
+++ b/race/enabled.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package race
+
+const Enabled = true


### PR DESCRIPTION
**This PR:** 
- Makes the test step with the race detector enabled hard-fail
- Skips the current failing race test - the logic here is that we don't want to add any further data races to the code. The only one that currently gets caught by the race detector is a bug in a library we use for testing, and we don't want new data races to get missed because this step is currently soft-failing