### PR TITLE
Otel polishing 2: Electric Boogaloo

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1446,7 +1446,8 @@ func (b *Bootstrap) resolveCommit() {
 
 // runPreCommandHooks runs the pre-command hooks and adds tracing spans.
 func (b *Bootstrap) runPreCommandHooks(ctx context.Context) error {
-	span, ctx := tracetools.StartSpanFromContext(ctx, "pre-command hooks", b.Config.TracingBackend)
+	spanName := b.implementationSpecificSpanName("pre-command", "pre-command hooks")
+	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, b.Config.TracingBackend)
 	var err error
 	defer func() { span.FinishWithError(err) }()
 
@@ -1484,7 +1485,8 @@ func (b *Bootstrap) runCommand(ctx context.Context) error {
 
 // runPostCommandHooks runs the post-command hooks and adds tracing spans.
 func (b *Bootstrap) runPostCommandHooks(ctx context.Context) error {
-	span, ctx := tracetools.StartSpanFromContext(ctx, "post-command hooks", b.Config.TracingBackend)
+	spanName := b.implementationSpecificSpanName("post-command", "post-command hooks")
+	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, b.Config.TracingBackend)
 	var err error
 	defer func() { span.FinishWithError(err) }()
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1805,7 +1805,7 @@ func (b *Bootstrap) artifactPhase(ctx context.Context) error {
 		return nil
 	}
 
-	spanName := b.implementationSpecificSpanName("artifact", "artifact upload")
+	spanName := b.implementationSpecificSpanName("artifacts", "artifact upload")
 	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, b.Config.TracingBackend)
 	var err error
 	defer func() { span.FinishWithError(err) }()

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -472,7 +472,8 @@ func addRepositoryHostToSSHKnownHosts(sh *shell.Shell, repository string) {
 // setUp is run before all the phases run. It's responsible for initializing the
 // bootstrap environment
 func (b *Bootstrap) setUp(ctx context.Context) error {
-	span, ctx := tracetools.StartSpanFromContext(ctx, "environment", b.Config.TracingBackend)
+	spanName := b.implementationSpecificSpanName("phase/environment", "environment")
+	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, b.Config.TracingBackend)
 	var err error
 	defer func() { span.FinishWithError(err) }()
 
@@ -952,7 +953,8 @@ func (b *Bootstrap) createCheckoutDir() error {
 // CheckoutPhase creates the build directory and makes sure we're running the
 // build at the right commit.
 func (b *Bootstrap) CheckoutPhase(ctx context.Context) error {
-	span, ctx := tracetools.StartSpanFromContext(ctx, "checkout", b.Config.TracingBackend)
+	spanName := b.implementationSpecificSpanName("phase/checkout", "checkout")
+	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, b.Config.TracingBackend)
 	var err error
 	defer func() { span.FinishWithError(err) }()
 
@@ -1504,6 +1506,9 @@ func (b *Bootstrap) runPostCommandHooks(ctx context.Context) error {
 
 // CommandPhase determines how to run the build, and then runs it
 func (b *Bootstrap) CommandPhase(ctx context.Context) (error, error) {
+	span, ctx := tracetools.StartSpanFromContext(ctx, "phase/command", b.Config.TracingBackend)
+	var err error
+	defer func() { span.FinishWithError(err) }()
 	// Run pre-command hooks
 	if err := b.runPreCommandHooks(ctx); err != nil {
 		return err, nil
@@ -1771,7 +1776,7 @@ func (b *Bootstrap) artifactPhase(ctx context.Context) error {
 		return nil
 	}
 
-	spanName := b.implementationSpecificSpanName("artifact", "artifact upload")
+	spanName := b.implementationSpecificSpanName("phase/artifact", "artifact upload")
 	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, b.Config.TracingBackend)
 	var err error
 	defer func() { span.FinishWithError(err) }()

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -210,10 +210,11 @@ func (b *Bootstrap) Cancel() error {
 }
 
 type HookConfig struct {
-	Name  string
-	Scope string
-	Path  string
-	Env   env.Environment
+	Name           string
+	Scope          string
+	Path           string
+	Env            env.Environment
+	SpanAttributes map[string]string
 }
 
 // executeHook runs a hook script with the hookRunner
@@ -227,6 +228,7 @@ func (b *Bootstrap) executeHook(ctx context.Context, hookCfg HookConfig) error {
 		"hook.name":    hookCfg.Name,
 		"hook.command": hookCfg.Path,
 	})
+	span.AddAttributes(hookCfg.SpanAttributes)
 
 	hookName := hookCfg.Scope + " " + hookCfg.Name
 
@@ -751,6 +753,12 @@ func (b *Bootstrap) executePluginHook(ctx context.Context, name string, checkout
 			Name:  p.Plugin.Name() + " " + name,
 			Path:  hookPath,
 			Env:   env,
+			SpanAttributes: map[string]string{
+				"plugin.name":        p.Plugin.Name(),
+				"plugin.version":     p.Plugin.Version,
+				"plugin.location":    p.Plugin.Location,
+				"plugin.is_vendored": strconv.FormatBool(p.Vendored),
+			},
 		})
 		if err != nil {
 			return err

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1499,11 +1499,7 @@ func (b *Bootstrap) runPreCommandHooks(ctx context.Context) error {
 
 // runCommand runs the command and adds tracing spans.
 func (b *Bootstrap) runCommand(ctx context.Context) error {
-	spanName := b.implementationSpecificSpanName("command-exec", "command")
-	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, b.Config.TracingBackend)
 	var err error
-	defer func() { span.FinishWithError(err) }()
-
 	// There can only be one command hook, so we check them in order of plugin, local
 	switch {
 	case b.hasPluginHook("command"):

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -472,8 +472,7 @@ func addRepositoryHostToSSHKnownHosts(sh *shell.Shell, repository string) {
 // setUp is run before all the phases run. It's responsible for initializing the
 // bootstrap environment
 func (b *Bootstrap) setUp(ctx context.Context) error {
-	spanName := b.implementationSpecificSpanName("phase/environment", "environment")
-	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, b.Config.TracingBackend)
+	span, ctx := tracetools.StartSpanFromContext(ctx, "environment", b.Config.TracingBackend)
 	var err error
 	defer func() { span.FinishWithError(err) }()
 
@@ -953,8 +952,7 @@ func (b *Bootstrap) createCheckoutDir() error {
 // CheckoutPhase creates the build directory and makes sure we're running the
 // build at the right commit.
 func (b *Bootstrap) CheckoutPhase(ctx context.Context) error {
-	spanName := b.implementationSpecificSpanName("phase/checkout", "checkout")
-	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, b.Config.TracingBackend)
+	span, ctx := tracetools.StartSpanFromContext(ctx, "checkout", b.Config.TracingBackend)
 	var err error
 	defer func() { span.FinishWithError(err) }()
 
@@ -1476,7 +1474,8 @@ func (b *Bootstrap) runPreCommandHooks(ctx context.Context) error {
 
 // runCommand runs the command and adds tracing spans.
 func (b *Bootstrap) runCommand(ctx context.Context) error {
-	span, ctx := tracetools.StartSpanFromContext(ctx, "command", b.Config.TracingBackend)
+	spanName := b.implementationSpecificSpanName("command-exec", "command")
+	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, b.Config.TracingBackend)
 	var err error
 	defer func() { span.FinishWithError(err) }()
 
@@ -1515,7 +1514,7 @@ func (b *Bootstrap) runPostCommandHooks(ctx context.Context) error {
 
 // CommandPhase determines how to run the build, and then runs it
 func (b *Bootstrap) CommandPhase(ctx context.Context) (error, error) {
-	span, ctx := tracetools.StartSpanFromContext(ctx, "phase/command", b.Config.TracingBackend)
+	span, ctx := tracetools.StartSpanFromContext(ctx, "command", b.Config.TracingBackend)
 	var err error
 	defer func() { span.FinishWithError(err) }()
 	// Run pre-command hooks
@@ -1785,7 +1784,7 @@ func (b *Bootstrap) artifactPhase(ctx context.Context) error {
 		return nil
 	}
 
-	spanName := b.implementationSpecificSpanName("phase/artifact", "artifact upload")
+	spanName := b.implementationSpecificSpanName("artifact", "artifact upload")
 	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, b.Config.TracingBackend)
 	var err error
 	defer func() { span.FinishWithError(err) }()

--- a/bootstrap/tracing.go
+++ b/bootstrap/tracing.go
@@ -286,3 +286,14 @@ func toOpenTelemetryAttributes(extras map[string]any) ([]attribute.KeyValue, map
 
 	return attrs, unknownAttrTypes
 }
+
+func (b *Bootstrap) implementationSpecificSpanName(otelName, ddName string) string {
+	switch b.TracingBackend {
+	case tracetools.BackendDatadog:
+		return ddName
+	case tracetools.BackendOpenTelemetry:
+		fallthrough
+	default:
+		return otelName
+	}
+}

--- a/bootstrap/tracing.go
+++ b/bootstrap/tracing.go
@@ -132,7 +132,7 @@ func (b *Bootstrap) startTracingOpenTelemetry(ctx context.Context) (tracetools.S
 	}
 
 	attributes := []attribute.KeyValue{
-		semconv.ServiceNameKey.String("buildkite_agent"),
+		semconv.ServiceNameKey.String("buildkite-agent"),
 		semconv.ServiceVersionKey.String(agent.Version()),
 		semconv.DeploymentEnvironmentKey.String("ci"),
 	}
@@ -162,7 +162,7 @@ func (b *Bootstrap) startTracingOpenTelemetry(ctx context.Context) (tracetools.S
 	))
 
 	tracer := tracerProvider.Tracer(
-		"buildkite_agent",
+		"buildkite-agent",
 		trace.WithInstrumentationVersion(agent.Version()),
 		trace.WithSchemaURL(semconv.SchemaURL),
 	)

--- a/bootstrap/tracing.go
+++ b/bootstrap/tracing.go
@@ -73,7 +73,7 @@ func (b *Bootstrap) ddResourceName() string {
 // abstraction so the agent can support multiple libraries if needbe.
 func (b *Bootstrap) startTracingDatadog(ctx context.Context) (tracetools.Span, context.Context, stopper) {
 	opts := []tracer.StartOption{
-		tracer.WithServiceName("buildkite_agent"),
+		tracer.WithServiceName("buildkite-agent"),
 		tracer.WithSampler(tracer.NewAllSampler()),
 		tracer.WithAnalytics(true),
 	}

--- a/tracetools/span.go
+++ b/tracetools/span.go
@@ -35,7 +35,7 @@ func StartSpanFromContext(ctx context.Context, operation string, tracingBackend 
 		return NewOpenTracingSpan(span), ctx
 
 	case BackendOpenTelemetry:
-		ctx, span := otel.Tracer("buildkite_agent").Start(ctx, operation)
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, operation)
 		span.SetAttributes(attribute.String("analytics.event", "true"))
 		return &OpenTelemetrySpan{Span: span}, ctx
 


### PR DESCRIPTION
**This PR:** Makes a bunch more changes to the OpenTelemetry implementation (a few of which get backported to the datadog tracing implementation too!). Technically, we [de-experimented opentelemetry](https://github.com/buildkite/agent/pull/1702) a couple of days ago, so _technically_ we shouldn't make any breaking changes, but the de-experimentation hasn't been shipped yet so 🤷

These changes mostly only affect the opentel integration; those that also affect the datadog implementation will be noted in the diff. There shouldn't be any backwards incompatible changes.

The changes we've made are:
- Rename the tracing service name from `buildkite_agent` to `buildkite-agent`
- Trace each part of the artifact upload phase individually - previously we had one chonky span for the whole step, now we have individual spans for pre-upload, upload, and post-upload
before:
<img width="357" alt="CleanShot 2022-07-14 at 15 16 33@2x" src="https://user-images.githubusercontent.com/15753101/178890846-b8b539c5-4aec-485d-b36c-6105ef3a32f8.png">


after:
<img width="760" alt="CleanShot 2022-07-14 at 15 15 50@2x" src="https://user-images.githubusercontent.com/15753101/178890563-b270fddd-a513-422b-a247-667ac517ced5.png">

- Rename hook spans from `hook.execute` for every hook to `hook.$SCOPE.$NAME`
before: 
<img width="853" alt="image" src="https://user-images.githubusercontent.com/15753101/178891140-fceab04d-4677-41cd-8284-53531f35efdd.png">

after: 
<img width="854" alt="image" src="https://user-images.githubusercontent.com/15753101/178891267-9aa63967-2532-49b6-88f6-f5a4638be73c.png">

- For hooks where the scope is `plugin`, add plugin attributes to their hook span:
<img width="569" alt="CleanShot 2022-07-14 at 15 27 59@2x" src="https://user-images.githubusercontent.com/15753101/178891781-6a38b303-fd32-45c0-b587-bd744f8355ce.png">

- For all "phases" of the bootstrap (environment, checkout, command, artifact), either create a phase-level span or rename the existing phase-level span to be called `phase/$phase_name`. This has the effect of grouping spans in the phase together - ie `pre-command`, `command` and `post-command` all get grouped under one parent span. This is what it looked like before:
<img width="462" alt="CleanShot 2022-07-14 at 15 34 35@2x" src="https://user-images.githubusercontent.com/15753101/178892818-49a1c215-fddb-4b21-a2f3-e6ea55a99dd6.png">

and after: 
<img width="493" alt="CleanShot 2022-07-14 at 15 37 49@2x" src="https://user-images.githubusercontent.com/15753101/178892913-ed022839-91bc-44c5-8476-5f225f1fb4b2.png">

The phase thing is a little bit confusing, and i'm happy to revert that to the existing behaviour - the change makes trace easier to parse IMO, but the change itself is a bit confusing.

**This PR will be most easily reviewed commit-by-commit**
