### PR TITLE
Include a list of enabled features in the register request

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Buildkite Agent for versions of macOS prior to those listed above.
 
 ## Contributors
 
-Many thanks to our fine contributors! @adill, @airhorns, @alexjurkiewicz, @bendrucker, @bradfeehan, @byroot, @cab, @caiofbpa, @colinrymer, @cysp, @daveoflynn, @daveoxley, @daveslutzkin, @davidk-zenefits, @DazWorrall, @dch, @deoxxa, @dgoodlad, @donpinkster, @essen, @grosskur, @jgavris, @joelmoss, @jules2689, @julianwa, @kouky, @marius92mc, @mirdhyn, @mousavian, @nikyoudale, @pda, @rprieto, @samritchie, @silarsis, @skevy, @stefanmb, @tekacs, @theojulienne, @tommeier, @underscorediscovery, and @wolfeidau.
+Many thanks to our fine contributors! A full list can be found [here](https://github.com/buildkite/agent/graphs/contributors), but you're all amazing, and we greatly appreciate your input ❤️
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ To start an agent all you need is your agent token, which you can find on your A
 buildkite-agent start --token
 ```
 
+### Telemetry
+
+By default, the agent sends some information back to the Buildkite mothership on what features are in use on that agent. Nothing sensitive or identifying is sent back to Buildkite, but if you want, you can disable this telemetry by adding the `--no-telemetry` flag to your `buildkite-agent start` call. A full list of the features that we track can be found [here](https://github.com/buildkite/agent/blob/main/clicommand/agent_start.go#L768=).
+
 ## Development
 
 These instructions assume you are running a recent macOS, but could easily be adapted to Linux and Windows.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ buildkite-agent start --token
 
 ### Telemetry
 
-By default, the agent sends some information back to the Buildkite mothership on what features are in use on that agent. Nothing sensitive or identifying is sent back to Buildkite, but if you want, you can disable this telemetry by adding the `--no-telemetry` flag to your `buildkite-agent start` call. A full list of the features that we track can be found [here](https://github.com/buildkite/agent/blob/main/clicommand/agent_start.go#L768=).
+By default, the agent sends some information back to the Buildkite mothership on what features are in use on that agent. Nothing sensitive or identifying is sent back to Buildkite, but if you want, you can disable this feature reporting by adding the `--no-feature-reporting` flag to your `buildkite-agent start` call. A full list of the features that we track can be found [here](https://github.com/buildkite/agent/blob/main/clicommand/agent_start.go#L808=).
 
 ## Development
 

--- a/api/agents.go
+++ b/api/agents.go
@@ -2,29 +2,19 @@ package api
 
 // AgentRegisterRequest is a call to register on the Buildkite Agent API
 type AgentRegisterRequest struct {
-	Name               string        `json:"name"`
-	Hostname           string        `json:"hostname"`
-	OS                 string        `json:"os"`
-	Arch               string        `json:"arch"`
-	ScriptEvalEnabled  bool          `json:"script_eval_enabled"`
-	IgnoreInDispatches bool          `json:"ignore_in_dispatches"`
-	Priority           string        `json:"priority,omitempty"`
-	Version            string        `json:"version"`
-	Build              string        `json:"build"`
-	Tags               []string      `json:"meta_data"`
-	PID                int           `json:"pid,omitempty"`
-	MachineID          string        `json:"machine_id,omitempty"`
-	FeatureUsage       *FeatureUsage `json:"feature_usage,omitempty"`
-}
-
-type FeatureUsage struct {
-	TracingBackend             string   `json:"tracing_backend"`
-	Experiments                []string `json:"experiments"`
-	DisconnectAfterJobEnabled  bool     `json:"disconnect_after_job_enabled"`
-	DisconnectAfterIdleEnabled bool     `json:"disconnect_after_idle_timeout_enabled"`
-	Shell                      string   `json:"shell"`
-	PluginsEnabled             bool     `json:"plugins_enabled"`
-	AcquireJobEnabled          bool     `json:"acquire_job_enabled"`
+	Name               string   `json:"name"`
+	Hostname           string   `json:"hostname"`
+	OS                 string   `json:"os"`
+	Arch               string   `json:"arch"`
+	ScriptEvalEnabled  bool     `json:"script_eval_enabled"`
+	IgnoreInDispatches bool     `json:"ignore_in_dispatches"`
+	Priority           string   `json:"priority,omitempty"`
+	Version            string   `json:"version"`
+	Build              string   `json:"build"`
+	Tags               []string `json:"meta_data"`
+	PID                int      `json:"pid,omitempty"`
+	MachineID          string   `json:"machine_id,omitempty"`
+	Features           []string `json:"features"`
 }
 
 // AgentRegisterResponse is the response from the Buildkite Agent API

--- a/api/agents.go
+++ b/api/agents.go
@@ -14,7 +14,7 @@ type AgentRegisterRequest struct {
 	Tags               []string      `json:"meta_data"`
 	PID                int           `json:"pid,omitempty"`
 	MachineID          string        `json:"machine_id,omitempty"`
-	FeatureUsage       *FeatureUsage `json:"feature_usage"`
+	FeatureUsage       *FeatureUsage `json:"feature_usage,omitempty"`
 }
 
 type FeatureUsage struct {

--- a/api/agents.go
+++ b/api/agents.go
@@ -2,18 +2,29 @@ package api
 
 // AgentRegisterRequest is a call to register on the Buildkite Agent API
 type AgentRegisterRequest struct {
-	Name               string   `json:"name"`
-	Hostname           string   `json:"hostname"`
-	OS                 string   `json:"os"`
-	Arch               string   `json:"arch"`
-	ScriptEvalEnabled  bool     `json:"script_eval_enabled"`
-	IgnoreInDispatches bool     `json:"ignore_in_dispatches"`
-	Priority           string   `json:"priority,omitempty"`
-	Version            string   `json:"version"`
-	Build              string   `json:"build"`
-	Tags               []string `json:"meta_data"`
-	PID                int      `json:"pid,omitempty"`
-	MachineID          string   `json:"machine_id,omitempty"`
+	Name               string        `json:"name"`
+	Hostname           string        `json:"hostname"`
+	OS                 string        `json:"os"`
+	Arch               string        `json:"arch"`
+	ScriptEvalEnabled  bool          `json:"script_eval_enabled"`
+	IgnoreInDispatches bool          `json:"ignore_in_dispatches"`
+	Priority           string        `json:"priority,omitempty"`
+	Version            string        `json:"version"`
+	Build              string        `json:"build"`
+	Tags               []string      `json:"meta_data"`
+	PID                int           `json:"pid,omitempty"`
+	MachineID          string        `json:"machine_id,omitempty"`
+	FeatureUsage       *FeatureUsage `json:"feature_usage"`
+}
+
+type FeatureUsage struct {
+	TracingBackend             string   `json:"tracing_backend"`
+	Experiments                []string `json:"experiments"`
+	DisconnectAfterJobEnabled  bool     `json:"disconnect_after_job_enabled"`
+	DisconnectAfterIdleEnabled bool     `json:"disconnect_after_idle_timeout_enabled"`
+	Shell                      string   `json:"shell"`
+	PluginsEnabled             bool     `json:"plugins_enabled"`
+	AcquireJobEnabled          bool     `json:"acquire_job_enabled"`
 }
 
 // AgentRegisterResponse is the response from the Buildkite Agent API


### PR DESCRIPTION
**This PR:** Adds a smallish list of feature enabled to the agent register request, allowing us at buildkite a bit more visibility into what features of the agent our users actually used. This telemetry is on by default, but doesn't collect any sensitive info, and can be disabled using the `--no-telemetry` flag.