### PR TITLE
README briefer/clearer re. Tier 3 platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,18 +120,7 @@ support guidance).
 
 #### Tier 3, community supported
 
-- linux arm
-- linux armf
-- linux ppc64
-- linux ppc64le
-- linux mips64
-- linux s390x
-- netbsd x86_64
-- freebsd x86
-- freebsd x86_64
-- openbsd x86
-- openbsd x84_64
-- dragonfly x86_64
+We release binaries for various other platforms, and it should be possible to build it anywhere Go compiles, but official support is not provided for these Tier 3 platforms.
 
 ### Operating System Support
 


### PR DESCRIPTION
Listing the OS/arch that we don't fully support probably takes more space than it's worth.
And, add some clarity that we don't offer official support for these Tier 3 targets.