### PR TITLE
Don't propagate HookExitErrors to tracing

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -323,7 +323,7 @@ func (b *Bootstrap) executeHook(ctx context.Context, hookCfg HookConfig) error {
 		case *hook.HookExitError:
 			// ...because the hook called exit(), tsk we ignore any changes
 			// since we can't discern them but continue on with the job
-			break
+			err = nil // set err to nil, otherwise the HookExitError will be captured by tracing
 		default:
 			// ...because something else happened, report it and stop the job
 			return errors.Wrapf(err, "Failed to get environment")


### PR DESCRIPTION
At current, when tracing a job using opentel, if that job uses the docker plugin (amongst some others), the trace always reports an error, even if the buildkite job passed:
<img width="1056" alt="CleanShot 2022-07-18 at 16 08 06@2x" src="https://user-images.githubusercontent.com/15753101/179444074-333959e8-1f4d-4b3a-858e-71c0acbe80d8.png">

When these errors happen as part of the bootstrap process, we ignore them, but because the `err` variable is getting set, it gets captured by tracing.

**This PR:** Updates the code to set `err = nil` if we run across a `HookExitError`, which stops these errors from being captured by tracing.
