### PR TITLE
Less hideous script wrapper

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -270,7 +270,7 @@ func (b *Bootstrap) executeHook(ctx context.Context, hookCfg HookConfig) error {
 
 	// We need a script to wrap the hook script so that we can snaffle the changed
 	// environment variables
-	script, err := hook.CreateScriptWrapper(hookCfg.Path)
+	script, err := hook.NewScriptWrapper(hook.WithHookPath(hookCfg.Path))
 	if err != nil {
 		b.shell.Errorf("Error creating hook script: %v", err)
 		return err

--- a/hook/scriptwrapper.go
+++ b/hook/scriptwrapper.go
@@ -13,29 +13,10 @@ import (
 )
 
 const (
-	hookExitStatusEnv = `BUILDKITE_HOOK_EXIT_STATUS`
-	hookWorkingDirEnv = `BUILDKITE_HOOK_WORKING_DIR`
+	hookExitStatusEnv = "BUILDKITE_HOOK_EXIT_STATUS"
+	hookWorkingDirEnv = "BUILDKITE_HOOK_WORKING_DIR"
+
 )
-
-// Hooks get "sourced" into the bootstrap in the sense that they get the
-// environment set for them and then we capture any extra environment variables
-// that are exported in the script.
-
-// The tricky thing is that it's impossible to grab the ENV of a child process
-// before it finishes, so we've got an awesome (ugly) hack to get around this.
-// We write the ENV to file, run the hook and then write the ENV back to another file.
-// Then we can use the diff of the two to figure out what changes to make to the
-// bootstrap. Horrible, but effective.
-
-// ScriptWrapper wraps a hook script with env collection and then provides
-// a way to get the difference between the environment before the hook is run and
-// after it
-type ScriptWrapper struct {
-	hookPath      string
-	scriptFile    *os.File
-	beforeEnvFile *os.File
-	afterEnvFile  *os.File
-}
 
 type HookScriptChanges struct {
 	Diff    env.Diff
@@ -58,25 +39,69 @@ func (e *HookExitError) Error() string {
 	return fmt.Sprintf("Hook %q early exited, could not record after environment or working directory", e.hookPath)
 }
 
-// CreateScriptWrapper creates and configures a ScriptWrapper.
+type scriptWrapperOpt func(*ScriptWrapper)
+
+// Hooks get "sourced" into the bootstrap in the sense that they get the
+// environment set for them and then we capture any extra environment variables
+// that are exported in the script.
+
+// The tricky thing is that it's impossible to grab the ENV of a child process
+// before it finishes, so we've got an awesome (ugly) hack to get around this.
+// We write the ENV to file, run the hook and then write the ENV back to another file.
+// Then we can use the diff of the two to figure out what changes to make to the
+// bootstrap. Horrible, but effective.
+
+// ScriptWrapper wraps a hook script with env collection and then provides
+// a way to get the difference between the environment before the hook is run and
+// after it
+type ScriptWrapper struct {
+	hookPath      string
+	os            string
+	scriptFile    *os.File
+	beforeEnvFile *os.File
+	afterEnvFile  *os.File
+}
+
+func WithHookPath(path string) scriptWrapperOpt {
+	return func(wrap *ScriptWrapper) {
+		wrap.hookPath = path
+	}
+}
+
+func WithOS(os string) scriptWrapperOpt {
+	return func(wrap *ScriptWrapper) {
+		wrap.os = os
+	}
+}
+
+// NewScriptWrapper creates and configures a ScriptWrapper.
 // Writes temporary files to the filesystem.
-func CreateScriptWrapper(hookPath string) (*ScriptWrapper, error) {
-	var wrap = &ScriptWrapper{
-		hookPath: hookPath,
+func NewScriptWrapper(opts ...scriptWrapperOpt) (*ScriptWrapper, error) {
+	wrap := &ScriptWrapper{
+		os: runtime.GOOS,
+	}
+
+	for _, o := range opts {
+		o(wrap)
+	}
+
+	if wrap.hookPath == "" {
+		return nil, fmt.Errorf("Hook path was not provided")
 	}
 
 	var err error
-	var scriptFileName string = `buildkite-agent-bootstrap-hook-runner`
 	var isBashHook bool
 	var isPwshHook bool
-	var isWindows = runtime.GOOS == "windows"
+
+	scriptFileName := `buildkite-agent-bootstrap-hook-runner`
+	isWindows := wrap.os == "windows"
 
 	// we use bash hooks for scripts with no extension, otherwise on windows
 	// we probably need a .bat extension
-	if filepath.Ext(hookPath) == ".ps1" {
+	if filepath.Ext(wrap.hookPath) == ".ps1" {
 		isPwshHook = true
 		scriptFileName += ".ps1"
-	} else if filepath.Ext(hookPath) == "" {
+	} else if filepath.Ext(wrap.hookPath) == "" {
 		isBashHook = true
 	} else if isWindows {
 		scriptFileName += ".bat"

--- a/hook/scriptwrapper_test.go
+++ b/hook/scriptwrapper_test.go
@@ -70,6 +70,98 @@ func TestRunningHookDetectsChangedEnvironment(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestHookScriptsAreGeneratedCorrectlyOnWindowsBatch(t *testing.T) {
+	t.Parallel()
+
+	hookFile, err := shell.TempFileWithExtension("hookName.bat")
+	assert.NoError(t, err)
+
+	_, err = fmt.Fprintln(hookFile, `echo Hello There!`)
+	assert.NoError(t, err)
+
+	hookFile.Close()
+
+	wrapper, err := NewScriptWrapper(
+		WithHookPath(hookFile.Name()),
+		WithOS("windows"),
+	)
+	assert.NoError(t, err)
+
+	defer wrapper.Close()
+
+	// The double percent signs %% are sprintf-escaped literal percent signs. Escaping hell is impossible to get out of.
+	// See: https://pkg.go.dev/fmt > ctrl-f for "%%"
+	scriptTemplate := `@echo off
+SETLOCAL ENABLEDELAYEDEXPANSION
+SET > "%s"
+CALL "%s"
+SET BUILDKITE_HOOK_EXIT_STATUS=!ERRORLEVEL!
+SET BUILDKITE_HOOK_WORKING_DIR=%%CD%%
+SET > "%s"
+EXIT %%BUILDKITE_HOOK_EXIT_STATUS%%`
+
+	assertScriptLike(t, scriptTemplate, hookFile.Name(), wrapper)
+}
+
+func TestHookScriptsAreGeneratedCorrectlyOnWindowsPowershell(t *testing.T) {
+	t.Parallel()
+
+	hookFile, err := shell.TempFileWithExtension("hookName.ps1")
+	assert.NoError(t, err)
+
+	_, err = fmt.Fprintln(hookFile, `Write-Output "Hello There!"`)
+	assert.NoError(t, err)
+
+	hookFile.Close()
+
+	wrapper, err := NewScriptWrapper(
+		WithHookPath(hookFile.Name()),
+		WithOS("windows"),
+	)
+	assert.NoError(t, err)
+
+	defer wrapper.Close()
+
+	scriptTemplate := `$ErrorActionPreference = "STOP"
+Get-ChildItem Env: | Foreach-Object {"$($_.Name)=$($_.Value)"} | Set-Content "%s"
+%s
+if ($LASTEXITCODE -eq $null) {$Env:BUILDKITE_HOOK_EXIT_STATUS = 0} else {$Env:BUILDKITE_HOOK_EXIT_STATUS = $LASTEXITCODE}
+$Env:BUILDKITE_HOOK_WORKING_DIR = $PWD | Select-Object -ExpandProperty Path
+Get-ChildItem Env: | Foreach-Object {"$($_.Name)=$($_.Value)"} | Set-Content "%s"
+exit $Env:BUILDKITE_HOOK_EXIT_STATUS`
+
+	assertScriptLike(t, scriptTemplate, hookFile.Name(), wrapper)
+}
+
+func TestHookScriptsAreGeneratedCorrectlyOnUnix(t *testing.T) {
+	t.Parallel()
+
+	hookFile, err := shell.TempFileWithExtension("hookName")
+	assert.NoError(t, err)
+
+	_, err = fmt.Fprintln(hookFile, `echo "Hello There!"`)
+	assert.NoError(t, err)
+
+	hookFile.Close()
+
+	wrapper, err := NewScriptWrapper(
+		WithHookPath(hookFile.Name()),
+		WithOS("linux"),
+	)
+	assert.NoError(t, err)
+
+	defer wrapper.Close()
+
+	scriptTemplate := `export -p > "%s"
+. "%s"
+export BUILDKITE_HOOK_EXIT_STATUS=$?
+export BUILDKITE_HOOK_WORKING_DIR=$PWD
+export -p > "%s"
+exit $BUILDKITE_HOOK_EXIT_STATUS`
+
+	assertScriptLike(t, scriptTemplate, hookFile.Name(), wrapper)
+}
+
 func TestRunningHookDetectsChangedWorkingDirectory(t *testing.T) {
 	t.Parallel()
 
@@ -142,22 +234,31 @@ func newTestScriptWrapper(t *testing.T, script []string) *ScriptWrapper {
 	}
 
 	hookFile, err := shell.TempFileWithExtension(hookName)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	for _, line := range script {
-		if _, err = fmt.Fprintln(hookFile, line); err != nil {
-			t.Fatal(err)
-		}
+		_, err = fmt.Fprintln(hookFile, line)
+		assert.NoError(t, err)
 	}
 
 	hookFile.Close()
 
 	wrapper, err := NewScriptWrapper(WithHookPath(hookFile.Name()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	return wrapper
+}
+
+func assertScriptLike(t *testing.T, scriptTemplate, hookFileName string, wrapper *ScriptWrapper) {
+	file, err := os.Open(wrapper.scriptFile.Name())
+	assert.NoError(t, err)
+
+	defer file.Close()
+
+	wrapperScriptContents, err := ioutil.ReadAll(file)
+	assert.NoError(t, err)
+
+	expected := fmt.Sprintf(scriptTemplate, wrapper.beforeEnvFile.Name(), hookFileName, wrapper.afterEnvFile.Name())
+
+	assert.Equal(t, expected, string(wrapperScriptContents))
 }

--- a/hook/scriptwrapper_test.go
+++ b/hook/scriptwrapper_test.go
@@ -154,7 +154,7 @@ func newTestScriptWrapper(t *testing.T, script []string) *ScriptWrapper {
 
 	hookFile.Close()
 
-	wrapper, err := CreateScriptWrapper(hookFile.Name())
+	wrapper, err := NewScriptWrapper(WithHookPath(hookFile.Name()))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The ScriptWrapper part of the bootstrap is really hard to understand, but honestly, a large part of that is because the scripts themselves are really hard to read. At current, they use string concatenation nonsense that's just really difficult to decipher.

This PR takes the string concatenation nonsense and replaces it with Go Templates, as well as adding tests to catch regressions in script generation