### PR TITLE
Update bundler version to be compatible with Ruby 2.7.6 alpine image

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -15,10 +15,10 @@ services:
       - "BUILDKITE_BUILD_PATH=/buildkite"
 
   ruby:
-    image: ruby:2.6
+    image: ruby:2.7.6
     volumes:
       - ..:/work
-      - ruby-2-6-agent-gem-cache:/usr/local/bundle
+      - ruby-2-7-6-agent-gem-cache:/usr/local/bundle
     working_dir: /work
     command: /bin/bash
     environment:
@@ -27,4 +27,4 @@ services:
       - BUILD_VERSION
 
 volumes:
-  ruby-2-6-agent-gem-cache: ~
+  ruby-2-7-6-agent-gem-cache: ~

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,4 +54,4 @@ DEPENDENCIES
   fpm
 
 BUNDLED WITH
-   1.16.5
+   2.3.14

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    arr-pm (0.0.10)
+    arr-pm (0.0.11)
       cabin (> 0)
     aws-sdk (2.11.152)
       aws-sdk-resources (= 2.11.152)
@@ -11,42 +11,38 @@ GEM
     aws-sdk-resources (2.11.152)
       aws-sdk-core (= 2.11.152)
     aws-sigv4 (1.0.3)
-    backports (3.11.4)
+    backports (3.23.0)
     cabin (0.9.0)
-    childprocess (0.9.0)
-      ffi (~> 1.0, >= 1.0.11)
     clamp (1.0.1)
     deb-s3 (0.10.0)
       aws-sdk (~> 2)
       thor (~> 0.19.0)
-    dotenv (2.5.0)
-    ffi (1.9.25)
-    fpm (1.10.2)
-      arr-pm (~> 0.0.10)
+    dotenv (2.7.6)
+    fpm (1.14.2)
+      arr-pm (~> 0.0.11)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
-      childprocess
       clamp (~> 1.0.0)
-      ffi
-      json (>= 1.7.7, < 2.0)
+      git (>= 1.3.0, < 2.0)
+      json (>= 1.7.7, < 3.0)
       pleaserun (~> 0.0.29)
-      ruby-xz (~> 0.2.3)
+      rexml
       stud
+    git (1.11.0)
+      rchardet (~> 1.8)
     insist (1.0.0)
-    io-like (0.3.0)
     jmespath (1.4.0)
-    json (1.8.6)
+    json (2.6.2)
     mustache (0.99.8)
-    pleaserun (0.0.30)
+    pleaserun (0.0.32)
       cabin (> 0)
       clamp
       dotenv
       insist
       mustache (= 0.99.8)
       stud
-    ruby-xz (0.2.3)
-      ffi (~> 1.9)
-      io-like (~> 0.3)
+    rchardet (1.8.0)
+    rexml (3.2.5)
     stud (0.0.23)
     thor (0.19.4)
 


### PR DESCRIPTION
For some reason, after [updating our deployer image](https://github.com/buildkite/agent/pull/1716), debian releases are now failing, as it appears that bundler has gone away as part of that process.

This PR runs `gem install bundler` before running `bundle install` in the debian deploy process.

It'd be nice to get rid of the gemfile completely - this is a go project after all, but that's a problem for tomorrow.