### PR TITLE
Fix warning log level

### DIFF
--- a/logger/level.go
+++ b/logger/level.go
@@ -11,8 +11,8 @@ const (
 	DEBUG Level = iota
 	NOTICE
 	INFO
-	ERROR
 	WARN
+	ERROR
 	FATAL
 )
 


### PR DESCRIPTION
`ERROR` should have a higher log level than `WARNING`.

Fix https://github.com/buildkite/agent/issues/1720