### PR TITLE
Fix order of level names for logger.Level.String()

### DIFF
--- a/logger/level.go
+++ b/logger/level.go
@@ -20,8 +20,8 @@ var levelNames = []string{
 	"DEBUG",
 	"NOTICE",
 	"INFO",
-	"ERROR",
 	"WARN",
+	"ERROR",
 	"FATAL",
 }
 
@@ -33,10 +33,10 @@ func LevelFromString(s string) (Level, error) {
 		return NOTICE, nil
 	case "info":
 		return INFO, nil
-	case "error":
-		return ERROR, nil
 	case "warn", "warning":
 		return WARN, nil
+	case "error":
+		return ERROR, nil
 	case "fatal":
 		return FATAL, nil
 	default:


### PR DESCRIPTION
We changed the iota placement of the `logger.Level` const in #1720 to fix log levels, but in doing so forgot to chage the placement in the `levelNames` array. This means that if someone were to use `--log-level error` it would behave like error, but say it was using warning logging.

I really wish that go had real enums.