### PR TITLE
Halt retrying

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -693,6 +693,7 @@ func (r *JobRunner) startJob(startedAt time.Time) error {
 			} else {
 				r.logger.Warn("Buildkite rejected the call to start the job (%s)", err)
 				rtr.Break()
+				return err
 			}
 		}
 


### PR DESCRIPTION
We just updated from 3.35.2 to 3.37.0.

We have a build which is getting cancelled but all jobs are stuck in an endless loop retrying.

```
kubectl logs $AGENT_IT builder | grep "Buildkite rejected the call to start the job" | wc -l
     758
```

So there are 758 retries on this agent!

We got hundreds of these messages and the job is stuck for >1h.
```
{"ts":"2022-07-24T07:02:38Z","level":"INFO","msg":"Assigned job 01822a27-1e37-4968-8126-79aaecef5a44. Accepting...","agent":"shopify-build-docker-6fb69d7c48-mphf9"}
{"ts":"2022-07-24T07:02:38Z","level":"INFO","msg":"Starting job 01822a27-1e37-4968-8126-79aaecef5a44","agent":"shopify-build-docker-6fb69d7c48-mphf9"}
{"ts":"2022-07-24T07:02:38Z","level":"WARN","msg":"Buildkite rejected the call to start the job (PUT https://agent-shopify.buildkite.com/v3/jobs/01822a27-1e37-4968-8126-79aaecef5a44/start: 422 This job can't be started while the build is in a `canceling` state.)","agent":"shopify-build-docker-6fb69d7c48-mphf9"}
{"ts":"2022-07-24T07:02:38Z","level":"ERROR","msg":"Failed to run job: PUT https://agent-shopify.buildkite.com/v3/jobs/01822a27-1e37-4968-8126-79aaecef5a44/start: 422 This job can't be started while the build is in a `canceling` state.","agent":"shopify-build-docker-6fb69d7c48-mphf9"}
{"ts":"2022-07-24T07:02:46Z","level":"INFO","msg":"Assigned job 01822a27-1e37-4968-8126-79aaecef5a44. Accepting...","agent":"shopify-build-docker-6fb69d7c48-mphf9"}
{"ts":"2022-07-24T07:02:46Z","level":"INFO","msg":"Starting job 01822a27-1e37-4968-8126-79aaecef5a44","agent":"shopify-build-docker-6fb69d7c48-mphf9"}
{"ts":"2022-07-24T07:02:46Z","level":"WARN","msg":"Buildkite rejected the call to start the job (PUT https://agent-shopify.buildkite.com/v3/jobs/01822a27-1e37-4968-8126-79aaecef5a44/start: 422 This job can't be started while the build is in a `canceling` state.)","agent":"shopify-build-docker-6fb69d7c48-mphf9"}
{"ts":"2022-07-24T07:02:46Z","level":"ERROR","msg":"Failed to run job: PUT https://agent-shopify.buildkite.com/v3/jobs/01822a27-1e37-4968-8126-79aaecef5a44/start: 422 This job can't be started while the build is in a `canceling` state.","agent":"shopify-build-docker-6fb69d7c48-mphf9"}
```

I believe it might be related to https://github.com/buildkite/agent/pull/1675

I'm not entirely sure this will fix the error but the example in [roko says this](https://github.com/buildkite/roko)

```go
r := roko.NewRetrier(
  roko.WithMaxAttempts(3),                           // Only try 3 times, then give up
  roko.WithStrategy(roko.Constant(5 * time.Second)), // Wait 5 seconds between attempts
)

err := r.Do(func(r *roko.Retrier) error {
  err := canFail()
  if err.Is(errorUnrecoverable) {
    r.Break()  // Give up, we can't recover from this error
    return err // We still need to return from this function, Break() doesn't halt this callback
    // return nil would be appropriate too, if we don't want to handle this error further
  }
})
```





Close https://github.com/buildkite/agent/issues/1723