### PR TITLE
Cache S3 clients between artifact downloads

### DIFF
--- a/agent/artifact_downloader.go
+++ b/agent/artifact_downloader.go
@@ -123,7 +123,7 @@ func (a *ArtifactDownloader) Download() error {
 				}
 
 				err = NewS3Downloader(a.logger, S3DownloaderConfig{
-					S3Client:    s3Clients[artifact.UploadDestination],
+					S3Client:    s3Clients[bucketName],
 					Path:        path,
 					S3Path:      artifact.UploadDestination,
 					Destination: downloadDestination,

--- a/agent/artifact_downloader.go
+++ b/agent/artifact_downloader.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/agent/v3/pool"
 )
@@ -83,7 +84,10 @@ func (a *ArtifactDownloader) Download() error {
 
 	p := pool.New(pool.MaxConcurrencyLimit)
 	errors := []error{}
-	s3Clients := map[string]*s3.S3{}
+	s3Clients, err := a.generateS3Clients(artifacts)
+	if err != nil {
+		return fmt.Errorf("failed to generate S3 clients for artifact upload: %w", err)
+	}
 
 	for _, artifact := range artifacts {
 		// Create new instance of the artifact for the goroutine
@@ -91,37 +95,18 @@ func (a *ArtifactDownloader) Download() error {
 		artifact := artifact
 
 		p.Spawn(func() {
-			var err error
-			var path string = artifact.Path
-
 			// Convert windows paths to slashes, otherwise we get a literal
 			// download of "dir/dir/file" vs sub-directories on non-windows agents
+			path := artifact.Path
 			if runtime.GOOS != `windows` {
 				path = strings.Replace(path, `\`, `/`, -1)
 			}
 
 			// Handle downloading from S3, GS, or RT
-			if strings.HasPrefix(artifact.UploadDestination, "s3://") {
-				// We want to have as few S3 clients as possible, as creating them is kind of an expensive operation
-				// But it's also theoretically possible that we'll have multiple artifacts with different S3 buckets, and each
-				// S3Client only applies to one bucket, so we need to store the S3 clients in a map, one for each bucket
+			var err error
+			switch {
+			case strings.HasPrefix(artifact.UploadDestination, "s3://"):
 				bucketName, _ := ParseS3Destination(artifact.UploadDestination)
-				if _, has := s3Clients[bucketName]; !has {
-					p.Lock()
-					client, err := NewS3Client(a.logger, bucketName)
-					if err != nil {
-						err = fmt.Errorf("Failed to create S3 client for bucket %s: %w", bucketName, err)
-						a.logger.Error("%v", err)
-
-						errors = append(errors, err)
-						p.Unlock()
-						return
-					}
-
-					s3Clients[bucketName] = client
-					p.Unlock()
-				}
-
 				err = NewS3Downloader(a.logger, S3DownloaderConfig{
 					S3Client:    s3Clients[bucketName],
 					Path:        path,
@@ -130,7 +115,7 @@ func (a *ArtifactDownloader) Download() error {
 					Retries:     5,
 					DebugHTTP:   a.conf.DebugHTTP,
 				}).Start()
-			} else if strings.HasPrefix(artifact.UploadDestination, "gs://") {
+			case strings.HasPrefix(artifact.UploadDestination, "gs://"):
 				err = NewGSDownloader(a.logger, GSDownloaderConfig{
 					Path:        path,
 					Bucket:      artifact.UploadDestination,
@@ -138,7 +123,7 @@ func (a *ArtifactDownloader) Download() error {
 					Retries:     5,
 					DebugHTTP:   a.conf.DebugHTTP,
 				}).Start()
-			} else if strings.HasPrefix(artifact.UploadDestination, "rt://") {
+			case strings.HasPrefix(artifact.UploadDestination, "rt://"):
 				err = NewArtifactoryDownloader(a.logger, ArtifactoryDownloaderConfig{
 					Path:        path,
 					Repository:  artifact.UploadDestination,
@@ -146,7 +131,7 @@ func (a *ArtifactDownloader) Download() error {
 					Retries:     5,
 					DebugHTTP:   a.conf.DebugHTTP,
 				}).Start()
-			} else {
+			default:
 				err = NewDownload(a.logger, http.DefaultClient, DownloadConfig{
 					URL:         artifact.URL,
 					Path:        path,
@@ -167,13 +152,38 @@ func (a *ArtifactDownloader) Download() error {
 				p.Unlock()
 			}
 		})
+	}
 
-		p.Wait()
+	p.Wait()
 
-		if len(errors) > 0 {
-			return fmt.Errorf("There were errors with downloading some of the artifacts")
-		}
+	if len(errors) > 0 {
+		return fmt.Errorf("There were errors with downloading some of the artifacts")
 	}
 
 	return nil
+}
+
+// We want to have as few S3 clients as possible, as creating them is kind of an expensive operation
+// But it's also theoretically possible that we'll have multiple artifacts with different S3 buckets, and each
+// S3Client only applies to one bucket, so we need to store the S3 clients in a map, one for each bucket
+func (a *ArtifactDownloader) generateS3Clients(artifacts []*api.Artifact) (map[string]*s3.S3, error) {
+	s3Clients := map[string]*s3.S3{}
+
+	for _, artifact := range artifacts {
+		if !strings.HasPrefix(artifact.UploadDestination, "s3://") {
+			continue
+		}
+
+		bucketName, _ := ParseS3Destination(artifact.UploadDestination)
+		if _, has := s3Clients[bucketName]; !has {
+			client, err := NewS3Client(a.logger, bucketName)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create S3 client for bucket %s: %w", bucketName, err)
+			}
+
+			s3Clients[bucketName] = client
+		}
+	}
+
+	return s3Clients, nil
 }

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -19,11 +19,13 @@ import (
 
 const regionHintEnvVar = "BUILDKITE_S3_DEFAULT_REGION"
 
-type credentialsProvider struct {
+type buildkiteEnvProvider struct {
 	retrieved bool
 }
 
-func (e *credentialsProvider) Retrieve() (creds credentials.Value, err error) {
+func (e *buildkiteEnvProvider) Retrieve() (credentials.Value, error) {
+	creds := credentials.Value{}
+
 	e.retrieved = false
 
 	creds.AccessKeyID = os.Getenv("BUILDKITE_S3_ACCESS_KEY_ID")
@@ -39,17 +41,18 @@ func (e *credentialsProvider) Retrieve() (creds credentials.Value, err error) {
 	creds.SessionToken = os.Getenv("BUILDKITE_S3_SESSION_TOKEN")
 
 	if creds.AccessKeyID == "" {
-		err = errors.New("BUILDKITE_S3_ACCESS_KEY_ID or BUILDKITE_S3_ACCESS_KEY not found in environment")
+		return credentials.Value{}, errors.New("BUILDKITE_S3_ACCESS_KEY_ID or BUILDKITE_S3_ACCESS_KEY not found in environment")
 	}
+
 	if creds.SecretAccessKey == "" {
-		err = errors.New("BUILDKITE_S3_SECRET_ACCESS_KEY or BUILDKITE_S3_SECRET_KEY not found in environment")
+		return credentials.Value{}, errors.New("BUILDKITE_S3_SECRET_ACCESS_KEY or BUILDKITE_S3_SECRET_KEY not found in environment")
 	}
 
 	e.retrieved = true
-	return
+	return creds, nil
 }
 
-func (e *credentialsProvider) IsExpired() bool {
+func (e *buildkiteEnvProvider) IsExpired() bool {
 	return !e.retrieved
 }
 
@@ -64,7 +67,7 @@ func awsS3Session(region string) (*session.Session, error) {
 
 	sess.Config.Credentials = credentials.NewChainCredentials(
 		[]credentials.Provider{
-			&credentialsProvider{},
+			&buildkiteEnvProvider{},
 			&credentials.EnvProvider{},
 			webIdentityRoleProvider(sess),
 			// EC2 and ECS meta-data providers

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -83,7 +83,7 @@ func webIdentityRoleProvider(sess *session.Session) *stscreds.WebIdentityRolePro
 	)
 }
 
-func newS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
+func NewS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 	var sess *session.Session
 
 	regionHint := os.Getenv(regionHintEnvVar)

--- a/agent/s3_downloader.go
+++ b/agent/s3_downloader.go
@@ -12,8 +12,11 @@ import (
 )
 
 type S3DownloaderConfig struct {
+	//
+	S3Client *s3.S3
+
 	// The S3 bucket name and the path, for example, s3://my-bucket-name/foo/bar
-	Bucket string
+	S3Path string
 
 	// The root directory of the download
 	Destination string
@@ -88,7 +91,7 @@ func (d S3Downloader) BucketName() string {
 }
 
 func (d S3Downloader) destinationParts() []string {
-	trimmed := strings.TrimPrefix(d.conf.Bucket, "s3://")
+	trimmed := strings.TrimPrefix(d.conf.S3Path, "s3://")
 
 	return strings.Split(trimmed, "/")
 }

--- a/agent/s3_downloader.go
+++ b/agent/s3_downloader.go
@@ -49,7 +49,7 @@ func NewS3Downloader(l logger.Logger, c S3DownloaderConfig) *S3Downloader {
 
 func (d S3Downloader) Start() error {
 	// Initialize the s3 client, and authenticate it
-	s3Client, err := newS3Client(d.logger, d.BucketName())
+	s3Client, err := NewS3Client(d.logger, d.BucketName())
 	if err != nil {
 		return err
 	}

--- a/agent/s3_downloader.go
+++ b/agent/s3_downloader.go
@@ -48,13 +48,11 @@ func NewS3Downloader(l logger.Logger, c S3DownloaderConfig) *S3Downloader {
 }
 
 func (d S3Downloader) Start() error {
-	// Initialize the s3 client, and authenticate it
-	s3Client, err := NewS3Client(d.logger, d.BucketName())
-	if err != nil {
-		return err
+	if d.conf.S3Client == nil {
+		return fmt.Errorf("S3Downloader for %s: S3Client is nil", d.conf.S3Path)
 	}
 
-	req, _ := s3Client.GetObjectRequest(&s3.GetObjectInput{
+	req, _ := d.conf.S3Client.GetObjectRequest(&s3.GetObjectInput{
 		Bucket: aws.String(d.BucketName()),
 		Key:    aws.String(d.BucketFileLocation()),
 	})

--- a/agent/s3_downloader.go
+++ b/agent/s3_downloader.go
@@ -12,7 +12,7 @@ import (
 )
 
 type S3DownloaderConfig struct {
-	//
+	// The client for interacting with S3
 	S3Client *s3.S3
 
 	// The S3 bucket name and the path, for example, s3://my-bucket-name/foo/bar

--- a/agent/s3_downloader_test.go
+++ b/agent/s3_downloader_test.go
@@ -11,12 +11,12 @@ func TestS3DowloaderBucketPath(t *testing.T) {
 	t.Parallel()
 
 	s3Uploader := NewS3Downloader(logger.Discard, S3DownloaderConfig{
-		Bucket: "s3://my-bucket-name/foo/bar",
+		S3Path: "s3://my-bucket-name/foo/bar",
 	})
 	assert.Equal(t, s3Uploader.BucketPath(), "foo/bar")
 
 	s3Uploader = NewS3Downloader(logger.Discard, S3DownloaderConfig{
-		Bucket: "s3://starts-with-an-s/and-this-is-its/folder",
+		S3Path: "s3://starts-with-an-s/and-this-is-its/folder",
 	})
 	assert.Equal(t, s3Uploader.BucketPath(), "and-this-is-its/folder")
 }
@@ -25,12 +25,12 @@ func TestS3DowloaderBucketName(t *testing.T) {
 	t.Parallel()
 
 	s3Uploader := NewS3Downloader(logger.Discard, S3DownloaderConfig{
-		Bucket: "s3://my-bucket-name/foo/bar",
+		S3Path: "s3://my-bucket-name/foo/bar",
 	})
 	assert.Equal(t, s3Uploader.BucketName(), "my-bucket-name")
 
 	s3Uploader = NewS3Downloader(logger.Discard, S3DownloaderConfig{
-		Bucket: "s3://starts-with-an-s",
+		S3Path: "s3://starts-with-an-s",
 	})
 	assert.Equal(t, s3Uploader.BucketName(), "starts-with-an-s")
 }
@@ -39,13 +39,13 @@ func TestS3DowloaderBucketFileLocation(t *testing.T) {
 	t.Parallel()
 
 	s3Uploader := NewS3Downloader(logger.Discard, S3DownloaderConfig{
-		Bucket: "s3://my-bucket-name/s3/folder",
+		S3Path: "s3://my-bucket-name/s3/folder",
 		Path:   "here/please/right/now/",
 	})
 	assert.Equal(t, s3Uploader.BucketFileLocation(), "s3/folder/here/please/right/now/")
 
 	s3Uploader = NewS3Downloader(logger.Discard, S3DownloaderConfig{
-		Bucket: "s3://my-bucket-name/s3/folder",
+		S3Path: "s3://my-bucket-name/s3/folder",
 		Path:   "",
 	})
 	assert.Equal(t, s3Uploader.BucketFileLocation(), "s3/folder/")

--- a/agent/s3_downloader_test.go
+++ b/agent/s3_downloader_test.go
@@ -10,43 +10,43 @@ import (
 func TestS3DowloaderBucketPath(t *testing.T) {
 	t.Parallel()
 
-	s3Uploader := NewS3Downloader(logger.Discard, S3DownloaderConfig{
+	s3Downloader := NewS3Downloader(logger.Discard, S3DownloaderConfig{
 		S3Path: "s3://my-bucket-name/foo/bar",
 	})
-	assert.Equal(t, s3Uploader.BucketPath(), "foo/bar")
+	assert.Equal(t, s3Downloader.BucketPath(), "foo/bar")
 
-	s3Uploader = NewS3Downloader(logger.Discard, S3DownloaderConfig{
+	s3Downloader = NewS3Downloader(logger.Discard, S3DownloaderConfig{
 		S3Path: "s3://starts-with-an-s/and-this-is-its/folder",
 	})
-	assert.Equal(t, s3Uploader.BucketPath(), "and-this-is-its/folder")
+	assert.Equal(t, s3Downloader.BucketPath(), "and-this-is-its/folder")
 }
 
 func TestS3DowloaderBucketName(t *testing.T) {
 	t.Parallel()
 
-	s3Uploader := NewS3Downloader(logger.Discard, S3DownloaderConfig{
+	s3Downloader := NewS3Downloader(logger.Discard, S3DownloaderConfig{
 		S3Path: "s3://my-bucket-name/foo/bar",
 	})
-	assert.Equal(t, s3Uploader.BucketName(), "my-bucket-name")
+	assert.Equal(t, s3Downloader.BucketName(), "my-bucket-name")
 
-	s3Uploader = NewS3Downloader(logger.Discard, S3DownloaderConfig{
+	s3Downloader = NewS3Downloader(logger.Discard, S3DownloaderConfig{
 		S3Path: "s3://starts-with-an-s",
 	})
-	assert.Equal(t, s3Uploader.BucketName(), "starts-with-an-s")
+	assert.Equal(t, s3Downloader.BucketName(), "starts-with-an-s")
 }
 
 func TestS3DowloaderBucketFileLocation(t *testing.T) {
 	t.Parallel()
 
-	s3Uploader := NewS3Downloader(logger.Discard, S3DownloaderConfig{
+	s3Downloader := NewS3Downloader(logger.Discard, S3DownloaderConfig{
 		S3Path: "s3://my-bucket-name/s3/folder",
 		Path:   "here/please/right/now/",
 	})
-	assert.Equal(t, s3Uploader.BucketFileLocation(), "s3/folder/here/please/right/now/")
+	assert.Equal(t, s3Downloader.BucketFileLocation(), "s3/folder/here/please/right/now/")
 
-	s3Uploader = NewS3Downloader(logger.Discard, S3DownloaderConfig{
+	s3Downloader = NewS3Downloader(logger.Discard, S3DownloaderConfig{
 		S3Path: "s3://my-bucket-name/s3/folder",
 		Path:   "",
 	})
-	assert.Equal(t, s3Uploader.BucketFileLocation(), "s3/folder/")
+	assert.Equal(t, s3Downloader.BucketFileLocation(), "s3/folder/")
 }

--- a/agent/s3_uploader.go
+++ b/agent/s3_uploader.go
@@ -43,7 +43,7 @@ func NewS3Uploader(l logger.Logger, c S3UploaderConfig) (*S3Uploader, error) {
 	bucketName, bucketPath := ParseS3Destination(c.Destination)
 
 	// Initialize the s3 client, and authenticate it
-	s3Client, err := newS3Client(l, bucketName)
+	s3Client, err := NewS3Client(l, bucketName)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func ParseS3Destination(destination string) (name string, path string) {
 	destinationWithNoTrailingSlash := strings.TrimSuffix(string(destination), "/")
 	destinationWithNoProtocol := strings.TrimPrefix(destinationWithNoTrailingSlash, "s3://")
 	parts := strings.Split(destinationWithNoProtocol, "/")
-	path = strings.Join(parts[1:len(parts)], "/")
+	path = strings.Join(parts[1:], "/")
 	name = parts[0]
 	return
 }

--- a/agent/s3_uploader.go
+++ b/agent/s3_uploader.go
@@ -57,13 +57,13 @@ func NewS3Uploader(l logger.Logger, c S3UploaderConfig) (*S3Uploader, error) {
 	}, nil
 }
 
-func ParseS3Destination(destination string) (name string, path string) {
-	destinationWithNoTrailingSlash := strings.TrimSuffix(string(destination), "/")
+func ParseS3Destination(destination string) (string, string) {
+	destinationWithNoTrailingSlash := strings.TrimSuffix(destination, "/")
 	destinationWithNoProtocol := strings.TrimPrefix(destinationWithNoTrailingSlash, "s3://")
 	parts := strings.Split(destinationWithNoProtocol, "/")
-	path = strings.Join(parts[1:], "/")
-	name = parts[0]
-	return
+	path := strings.Join(parts[1:], "/")
+	bucket := parts[0]
+	return bucket, path
 }
 
 func (u *S3Uploader) URL(artifact *api.Artifact) string {

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -17,7 +17,10 @@ const (
 
 func New(concurrencyLimit int) *Pool {
 	if concurrencyLimit == MaxConcurrencyLimit {
-		concurrencyLimit = runtime.NumCPU()
+		// Completely arbitrary. Most of the time we could probably have unbounded concurrency, but the situations where we use
+		// this pool is basically just S3 uploading and downloading, so this number is kind of a proxy for "What won't rate limit us"
+		// TODO: Make artifact uploads and downloads gracefully handle rate limiting, remove this pool entirely, and use unbounded concurrency via a WaitGroup
+		concurrencyLimit = runtime.NumCPU() * 10
 	}
 
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
**🤔 Problem:** Currently, when downloading multiple artifacts in the agent, we initialise an S3 client for each artifact that we're downloading. This is problematic for a couple of reasons, first of which is that the credential initialisation actually [involves a call to S3](https://github.com/buildkite/agent/blob/main/agent/s3.go#L132-L135), so if there's a lot of artifacts to download, the the `ListObjects` calls made by each credential initialisation will contribute to our rate limits.

The other issue is that we don't need to create an S3 client per call, and it actually hurts us in a couple of ways; first and foremost, as reported by a customer, each client initialisation first has to authenticate with AWS. We've seen evidence that when a lot of artifacts are being uploaded, this authentication process being performed more often than necessary leads to the AWS EC2 Instance Metadata Service rate-limiting the instance asking for creds, leading to some artifacts not being uploaded.

There are other less-important issues with using an S3 client per artifact upload, mostly that it's just kinda wasteful and takes up more memory than necessary.

**✅ Solution:** When uploading multiple artifacts to S3, share an instance of the S3 client between calls. 

There's also a "while i'm here" or two hanging around in this PR, namely:
- Increase the artifact up/download concurrency limit from the completely arbitrary "the number of CPUs on this machine" to the still arbitrary but much higher "CPUs*10". I'm not sure why the limit was set to the number of CPUs, it seems to ignore what goroutines are best at, but 🤷. We considered letting artifact up/downloads have unbounded concurrency, as this would make them waaaaaaaay faster, but rate limiting on S3 is a thing, and it's probably best to keep these things bounded for now
- Rename our Buildkite-specific AWS credentials provider from `credentialsProvider` to `buildkiteCredentialsProvider`. 

**This PR is best reviewed commit-by-commit, and "Hide Whitespace" on (i dedented a block and it makes the diff confusing)**

![CleanShot 2022-08-01 at 10 28 07@2x](https://user-images.githubusercontent.com/15753101/182047810-04b4837d-af83-48dd-9142-e8ec97b0612c.png)
 