### PR TITLE
Fix unowned plugin reference

### DIFF
--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -63,9 +63,9 @@ func TestCreateFromJSON(t *testing.T) {
 			}},
 		},
 		{
-			`["github.com/buildkite-unofficial/ping#master"]`,
 			[]*Plugin{&Plugin{
-				Location:      `github.com/buildkite-unofficial/ping`,
+			`["github.com/buildkite-plugins/fake-plugin#master"]`,
+				Location:      `github.com/buildkite-plugins/fake-plugin`,
 				Version:       `master`,
 				Scheme:        ``,
 				Configuration: map[string]interface{}{},

--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -18,7 +18,7 @@ func TestCreateFromJSON(t *testing.T) {
 	}{
 		{
 			`[{"https://github.com/buildkite-plugins/docker-compose#a34fa34":{"container":"app"}}]`,
-			[]*Plugin{&Plugin{
+			[]*Plugin{{
 				Location:      `github.com/buildkite-plugins/docker-compose`,
 				Version:       `a34fa34`,
 				Scheme:        `https`,
@@ -27,7 +27,7 @@ func TestCreateFromJSON(t *testing.T) {
 		},
 		{
 			`[{"github.com/buildkite-plugins/docker-compose#a34fa34":{}}]`,
-			[]*Plugin{&Plugin{
+			[]*Plugin{{
 				Location:      `github.com/buildkite-plugins/docker-compose`,
 				Version:       `a34fa34`,
 				Scheme:        ``,
@@ -36,7 +36,7 @@ func TestCreateFromJSON(t *testing.T) {
 		},
 		{
 			`[{"http://github.com/buildkite-plugins/docker-compose#a34fa34":{}}]`,
-			[]*Plugin{&Plugin{
+			[]*Plugin{{
 				Location:      `github.com/buildkite-plugins/docker-compose`,
 				Version:       `a34fa34`,
 				Scheme:        `http`,
@@ -45,7 +45,7 @@ func TestCreateFromJSON(t *testing.T) {
 		},
 		{
 			`["ssh://git:foo@github.com/buildkite-plugins/docker-compose#a34fa34"]`,
-			[]*Plugin{&Plugin{
+			[]*Plugin{{
 				Location:       `github.com/buildkite-plugins/docker-compose`,
 				Version:        `a34fa34`,
 				Scheme:         `ssh`,
@@ -55,7 +55,7 @@ func TestCreateFromJSON(t *testing.T) {
 		},
 		{
 			`["file://github.com/buildkite-plugins/docker-compose#a34fa34"]`,
-			[]*Plugin{&Plugin{
+			[]*Plugin{{
 				Location:      `github.com/buildkite-plugins/docker-compose`,
 				Version:       `a34fa34`,
 				Scheme:        `file`,
@@ -63,8 +63,8 @@ func TestCreateFromJSON(t *testing.T) {
 			}},
 		},
 		{
-			[]*Plugin{&Plugin{
 			`["github.com/buildkite-plugins/fake-plugin#master"]`,
+			[]*Plugin{{
 				Location:      `github.com/buildkite-plugins/fake-plugin`,
 				Version:       `master`,
 				Scheme:        ``,
@@ -73,7 +73,7 @@ func TestCreateFromJSON(t *testing.T) {
 		},
 		{
 			`[{"./.buildkite/plugins/llamas":{}}]`,
-			[]*Plugin{&Plugin{
+			[]*Plugin{{
 				Location:      `./.buildkite/plugins/llamas`,
 				Scheme:        ``,
 				Vendored:      true,


### PR DESCRIPTION
We had a report on [hackerone (only available to buildkite staff unfortunately!)](https://hackerone.com/reports/1653984#), reporting that one of our plugin definitions in the plugin tests refers to a org/repo combo that doesn't belong to buildkite. 

While this **currently poses no security risk** as we don't actually clone or run the plugins as part of the tests, it's not out of the question that we might run/clone plugins as part of tests in the future, so we should change this reference to something that we own, just in case.