### PR TITLE
gcp:instance-name and tweak GCP labels fetching

### DIFF
--- a/agent/gcp_labels.go
+++ b/agent/gcp_labels.go
@@ -25,17 +25,15 @@ func (e GCPLabels) Get() (map[string]string, error) {
 
 	// Grab the current instance's metadata as a convenience
 	// to obtain the projectId, zone, and instanceId.
-	metadata, err := GCPMetaData{}.Get()
+	meta, err := GCPMetaData{}.Get()
 	if err != nil {
 		return nil, err
 	}
 
-	projectID := metadata["gcp:project-id"]
-	zone := metadata["gcp:zone"]
-	instanceID := metadata["gcp:instance-id"]
-
 	instance, err := computeService.Instances.Get(
-		projectID, zone, instanceID,
+		meta["gcp:project-id"],
+		meta["gcp:zone"],
+		meta["gcp:instance-name"],
 	).Context(ctx).Do()
 
 	if err != nil {

--- a/agent/gcp_meta_data.go
+++ b/agent/gcp_meta_data.go
@@ -35,6 +35,12 @@ func (e GCPMetaData) Get() (map[string]string, error) {
 	}
 	result["gcp:instance-id"] = instanceId
 
+	instanceName, err := metadata.Get("instance/name")
+	if err != nil {
+		return result, err
+	}
+	result["gcp:instance-name"] = instanceName
+
 	machineType, err := machineType()
 	if err != nil {
 		return result, err
@@ -47,11 +53,11 @@ func (e GCPMetaData) Get() (map[string]string, error) {
 	}
 	result["gcp:preemptible"] = strings.ToLower(preemptible)
 
-	projectId, err := metadata.ProjectID()
+	projectID, err := metadata.ProjectID()
 	if err != nil {
 		return result, err
 	}
-	result["gcp:project-id"] = projectId
+	result["gcp:project-id"] = projectID
 
 	zone, err := metadata.Zone()
 	if err != nil {


### PR DESCRIPTION
Add `gcp:instance-name` tag in `--tags-from-gcp-meta-data` mode. The existing `gcp:instance-id` is numeric (e.g. `6502291863206740772`) and less friendly/useful than the name.

Also, in `--tags-from-gcp-labels` mode, fetch GCP labels by instance _name_, not instance _id_. The [`instances.get` REST API](https://cloud.google.com/compute/docs/reference/rest/v1/instances/get) specifies “Name of the instance” but appears to also accept the numeric ID. However using the name allows GCP IAM condition expressions to match against a prefix of the instance name, as demonstrated in this Terraform example:

```terraform
resource "google_project_iam_member" "compute_viewer" {
  project = var.gcp_project
  member  = "serviceAccount:${google_service_account.default.email}"
  role    = "roles/compute.viewer"

  condition {
    title       = "only_buildkite_instances"
    description = "only instances named buildkite-*"
    expression  = <<-END
      resource.type == "compute.googleapis.com/Instance" &&
      resource.name.extract("instances/{instance}").startsWith("buildkite-")
    END
  }
}
```

Sadly there's no existing tests around this, and I'm already too 🐇🕳 to add them now, but I'll verify this branch works on a GCP VM…