### PR TITLE
Consume per-job agent tokens

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -493,12 +493,12 @@ func (a *AgentWorker) AcceptAndRunJob(job *api.Job) error {
 	return a.RunJob(accepted)
 }
 
-func (a *AgentWorker) RunJob(job *api.Job) error {
+func (a *AgentWorker) RunJob(acceptResponse *api.Job) error {
 	jobMetricsScope := a.metrics.With(metrics.Tags{
-		`pipeline`: job.Env[`BUILDKITE_PIPELINE_SLUG`],
-		`org`:      job.Env[`BUILDKITE_ORGANIZATION_SLUG`],
-		`branch`:   job.Env[`BUILDKITE_BRANCH`],
-		`source`:   job.Env[`BUILDKITE_SOURCE`],
+		`pipeline`: acceptResponse.Env[`BUILDKITE_PIPELINE_SLUG`],
+		`org`:      acceptResponse.Env[`BUILDKITE_ORGANIZATION_SLUG`],
+		`branch`:   acceptResponse.Env[`BUILDKITE_BRANCH`],
+		`source`:   acceptResponse.Env[`BUILDKITE_SOURCE`],
 	})
 
 	defer func() {
@@ -508,7 +508,7 @@ func (a *AgentWorker) RunJob(job *api.Job) error {
 
 	// Now that we've got a job to do, we can start it.
 	var err error
-	a.jobRunner, err = NewJobRunner(a.logger, jobMetricsScope, a.agent, job, a.apiClient, JobRunnerConfig{
+	a.jobRunner, err = NewJobRunner(a.logger, jobMetricsScope, a.agent, acceptResponse, a.apiClient, JobRunnerConfig{
 		Debug:              a.debug,
 		DebugHTTP:          a.debugHTTP,
 		CancelSignal:       a.cancelSig,

--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -13,6 +13,34 @@ import (
 	"github.com/buildkite/bintest/v3"
 )
 
+func TestJobRunner_WhenJobHasToken_ItOverridesAccessToken(t *testing.T) {
+	agentAccessToken := "llamasrock"
+	jobToken := "actually-llamas-are-only-okay"
+
+	ag := &api.AgentRegisterResponse{
+		AccessToken: agentAccessToken,
+	}
+
+	j := &api.Job{
+		ID:                 `my-job-id`,
+		ChunksMaxSizeBytes: 1024,
+		Token:              jobToken,
+		Env: map[string]string{
+			`BUILDKITE_COMMAND`: `echo hello world`,
+		},
+	}
+
+	cfg := agent.AgentConfiguration{}
+
+	runJob(t, ag, j, cfg, func(c *bintest.Call) {
+		if c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN") != jobToken {
+			t.Errorf("Expected access token to be %q, got %q\n",
+				jobToken, c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN"))
+		}
+		c.Exit(0)
+	})
+}
+
 func TestJobRunnerPassesAccessTokenToBootstrap(t *testing.T) {
 	ag := &api.AgentRegisterResponse{
 		AccessToken: "llamasrock",

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -11,6 +11,7 @@ type Job struct {
 	State              string            `json:"state,omitempty"`
 	Env                map[string]string `json:"env,omitempty"`
 	ChunksMaxSizeBytes int               `json:"chunks_max_size_bytes,omitempty"`
+	Token              string            `json:"token,omitempty"`
 	ExitStatus         string            `json:"exit_status,omitempty"`
 	Signal             string            `json:"signal,omitempty"`
 	SignalReason       string            `json:"signal_reason,omitempty"`


### PR DESCRIPTION
Ooooh, super spicy secret new feature!

We have a new feature in the works where agents will get assigned a buildkite agent API token for each job that they run, have that token only work on operations for that job, and make that token have a limited lifetime.

This means that if a bad actor exfiltrates a buildkite API token from a job running in your buildkite account, they won't be able to use that token to mess with stuff that's not on that job, and also the token they exfiltrate will expire.

This PR does the agent-side of this feature - consuming a token sent by the `jobs#accept` response, and using that token for operations within the job.

We're still working on the backend side of this work, and we won't merge this until that part of the work is done.