### PR TITLE
Fix multiple-nested plugin repos on gitlab

### DIFF
--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -279,7 +279,6 @@ func (p *Plugin) Label() string {
 		return p.Location
 	}
 }
-
 func (p *Plugin) constructRepositoryHost() (string, error) {
 	if p.Location == "" {
 		return "", fmt.Errorf("Missing plugin location")
@@ -289,16 +288,18 @@ func (p *Plugin) constructRepositoryHost() (string, error) {
 	if len(parts) < 2 {
 		return "", fmt.Errorf("Incomplete plugin path \"%s\"", p.Location)
 	}
-
-	var s string
-
-	if parts[0] == "github.com" || parts[0] == "bitbucket.org" || parts[0] == "gitlab.com" {
+	switch parts[0] {
+	case "github.com", "bitbucket.org":
 		if len(parts) < 3 {
-			return "", fmt.Errorf("Incomplete %s path \"%s\"", parts[0], p.Location)
+			return "", fmt.Errorf("Incomplete plugin path \"%s\"", p.Location)
 		}
-
-		s = strings.Join(parts[:3], "/")
-	} else {
+		return strings.Join(parts[:3], "/"), nil
+	case "gitlab.com":
+		if len(parts) < 3 {
+			return "", fmt.Errorf("Incomplete plugin path \"%s\"", p.Location)
+		}
+		return strings.Join(parts, "/"), nil
+	default:
 		repo := []string{}
 
 		for _, p := range parts {
@@ -309,8 +310,6 @@ func (p *Plugin) constructRepositoryHost() (string, error) {
 			}
 		}
 
-		s = strings.Join(repo, "/")
+		return strings.Join(repo, "/"), nil
 	}
-
-	return s, nil
 }

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -286,17 +286,17 @@ func (p *Plugin) constructRepositoryHost() (string, error) {
 
 	parts := strings.Split(p.Location, "/")
 	if len(parts) < 2 {
-		return "", fmt.Errorf("Incomplete plugin path \"%s\"", p.Location)
+		return "", fmt.Errorf("Incomplete plugin path %q", p.Location)
 	}
 	switch parts[0] {
 	case "github.com", "bitbucket.org":
 		if len(parts) < 3 {
-			return "", fmt.Errorf("Incomplete plugin path \"%s\"", p.Location)
+			return "", fmt.Errorf("Incomplete plugin path %q", p.Location)
 		}
 		return strings.Join(parts[:3], "/"), nil
 	case "gitlab.com":
 		if len(parts) < 3 {
-			return "", fmt.Errorf("Incomplete plugin path \"%s\"", p.Location)
+			return "", fmt.Errorf("Incomplete plugin path %q", p.Location)
 		}
 		return strings.Join(parts, "/"), nil
 	default:

--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -43,6 +43,22 @@ func TestCreateFromJSON(t *testing.T) {
 				Configuration: map[string]interface{}{},
 			}},
 		},
+		{`[{"https://gitlab.example.com/path/to/repo#main":{}}]`,
+			[]*Plugin{&Plugin{
+				Location:      `gitlab.example.com/path/to/repo`,
+				Version:       `main`,
+				Scheme:        `https`,
+				Configuration: map[string]interface{}{},
+			}},
+		},
+		{`[{"https://gitlab.com/group/team/path/to/repo#main":{}}]`,
+			[]*Plugin{&Plugin{
+				Location:      `gitlab.com/group/team/path/to/repo`,
+				Version:       `main`,
+				Scheme:        `https`,
+				Configuration: map[string]interface{}{},
+			}},
+		},
 		{
 			`["ssh://git:foo@github.com/buildkite-plugins/docker-compose#a34fa34"]`,
 			[]*Plugin{{
@@ -215,21 +231,21 @@ func TestRepositoryAndSubdirectory(t *testing.T) {
 	repo, err = plugin.Repository()
 	assert.Equal(t, repo, "")
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), `Incomplete github.com path "github.com/buildkite"`)
+	assert.Equal(t, err.Error(), `Incomplete plugin path "github.com/buildkite"`)
 	sub, err = plugin.RepositorySubdirectory()
 	assert.Equal(t, sub, "")
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), `Incomplete github.com path "github.com/buildkite"`)
+	assert.Equal(t, err.Error(), `Incomplete plugin path "github.com/buildkite"`)
 
 	plugin = &Plugin{Location: "bitbucket.org/buildkite"}
 	repo, err = plugin.Repository()
 	assert.Equal(t, repo, "")
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), `Incomplete bitbucket.org path "bitbucket.org/buildkite"`)
+	assert.Equal(t, err.Error(), `Incomplete plugin path "bitbucket.org/buildkite"`)
 	sub, err = plugin.RepositorySubdirectory()
 	assert.Equal(t, sub, "")
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), `Incomplete bitbucket.org path "bitbucket.org/buildkite"`)
+	assert.Equal(t, err.Error(), `Incomplete plugin path "bitbucket.org/buildkite"`)
 
 	plugin = &Plugin{Location: "bitbucket.org/user/project/sub/directory"}
 	repo, err = plugin.Repository()


### PR DESCRIPTION
**Context:** https://github.com/buildkite/agent/pull/1641, https://github.com/buildkite/agent/pull/1744

**🤔 Problem:** Currently, when cloning plugins from Gitlab, we assume that the repo path structure is the same as github (that is, `org/repo`), and consider anything not matching that path to be an invalid plugin reference. The trouble is, in Gitlab, there can be multiple levels of nesting in a repo path, with the pattern `some-org/some/hierarchy/of/teams/repo` - for example `https://gitlab.com/example-corp/devops/aws/lambda/example-buildkite-plugin`. If one of these multi-nested repos is used as a BK plugin reference, we'll erroneously say that it's an invalid plugin path, and fail the pipeline.

**✅ Solution:** This PR adds an additional branch to our plugin reference checking gear, allowing any level of nesting if the plugin URL starts with `gitlab.com`.

Note that this issue doesn't affect privately-hosted gitlab instances, which weren't affected by the buggy behaviour. These already worked, and should still work.

Many thanks to @brianbentson for writing the actual code in this PR! There were some git shenanigans that required me to pull it into a non-forked branch, but this is entirely their work.