### PR TITLE
Code comment explaining -ffxdq flags for git clean

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -357,6 +357,10 @@ var AgentStartCommand = cli.Command{
 			Value:  "-ffxdq",
 			Usage:  "Flags to pass to \"git clean\" command",
 			EnvVar: "BUILDKITE_GIT_CLEAN_FLAGS",
+			// -ff: delete files and directories, including untracked nested git repositories
+			// -x: don't use .gitignore rules
+			// -d: recurse into untracked directories
+			// -q: quiet, only report errors
 		},
 		cli.StringFlag{
 			Name:   "git-fetch-flags",


### PR DESCRIPTION
@moskyb and I spent a few minutes reading the git manual to remember what `-ffxdq` actually tells `git clean` to do. Figured we'd add that knowledge as a code comment to help future travellers on their way.