### PR TITLE
CI: fix createrepo_c / libcrypto3 Alpine/APK edge breakage

### DIFF
--- a/.buildkite/steps/publish-rpm-package.sh
+++ b/.buildkite/steps/publish-rpm-package.sh
@@ -24,7 +24,17 @@ mkdir -p rpm
 buildkite-agent artifact download --build "$artifacts_build" "rpm/*.rpm" rpm/
 
 echo '--- Installing dependencies'
-apk --no-cache add createrepo_c --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
+# currently, the libcrypto3-3.0.5-r0 in the alpine/v3.16/main repo isn't compatible with createrepo_c:
+#     ERROR: unable to select packages:
+#       so:libcrypto.so.3 (no such package):
+#         required by: createrepo_c-libs-0.17.1-r2[so:libcrypto.so.3]
+# So, we add alpine/edge/main for libcrypto3 and alpine/edge/testing for createrepo_c.
+# In future we can probably remove the explicit libcrypto3 install, and the alpine/edge/main repo.
+apk add \
+  --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+  --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+  'libcrypto3>=3.0.5-r2' \
+  createrepo_c
 
 # createrepo_c requires some exotic flags on the cp, which aren't available on the busybox version
 apk --no-cache add coreutils


### PR DESCRIPTION
Specify `libcrypto3>=3.0.5-r2` from `https://dl-cdn.alpinelinux.org/alpine/edge/main` so that `createrepo_c` from `https://dl-cdn.alpinelinux.org/alpine/edge/testing` installs without “so:libcrypto.so.3 (no such package)” error.

Currently this release step is broken:
https://buildkite.com/buildkite/agent-release-edge/builds/449#0182ae98-d45d-44fd-b71c-bd90f2085f37