### PR TITLE
Retry Disconnect API calls

### DIFF
--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
+	"time"
 
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/logger"
@@ -37,10 +39,65 @@ func TestDisconnect(t *testing.T) {
 		agent:              nil,
 		apiClient:          client,
 		agentConfiguration: AgentConfiguration{},
+		retrySleepFunc: func(time.Duration) {
+			t.Error("unexpected retrier sleep")
+		},
 	}
 
 	err := worker.Disconnect()
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"[info] Disconnecting..."}, l.Messages)
+	assert.Equal(t, []string{"[info] Disconnecting...", "[info] Disconnected"}, l.Messages)
+}
+
+func TestDisconnectRetry(t *testing.T) {
+	tries := 0
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/disconnect":
+			if tries < 2 { // three failures before success
+				rw.WriteHeader(http.StatusInternalServerError)
+				tries++
+			} else {
+				rw.WriteHeader(http.StatusOK)
+				fmt.Fprintf(rw, `{"id": "fakeuuid", "connection_state": "disconnected"}`)
+			}
+		default:
+			t.Errorf("Unknown endpoint %s %s", req.Method, req.URL.Path)
+			http.Error(rw, "Not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := api.NewClient(logger.Discard, api.Config{
+		Endpoint: server.URL,
+		Token:    "llamas",
+	})
+
+	l := logger.NewBuffer()
+
+	retrySleeps := make([]time.Duration, 0)
+	retrySleepFunc := func(d time.Duration) {
+		retrySleeps = append(retrySleeps, d)
+	}
+
+	worker := &AgentWorker{
+		logger:             l,
+		agent:              nil,
+		apiClient:          client,
+		agentConfiguration: AgentConfiguration{},
+		retrySleepFunc:     retrySleepFunc,
+	}
+
+	err := worker.Disconnect()
+	assert.NoError(t, err)
+
+	// 2 failed attempts sleep 1 second each
+	assert.Equal(t, []time.Duration{1 * time.Second, 1 * time.Second}, retrySleeps)
+
+	require.Equal(t, 4, len(l.Messages))
+	assert.Equal(t, "[info] Disconnecting...", l.Messages[0])
+	assert.Regexp(t, regexp.MustCompile(`\[warn\] POST http.*/disconnect: 500 \(Attempt 0/4`), l.Messages[1])
+	assert.Regexp(t, regexp.MustCompile(`\[warn\] POST http.*/disconnect: 500 \(Attempt 1/4`), l.Messages[2])
+	assert.Equal(t, "[info] Disconnected", l.Messages[3])
 }

--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -1,0 +1,46 @@
+package agent
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisconnect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/disconnect":
+			rw.WriteHeader(http.StatusOK)
+			fmt.Fprintf(rw, `{"id": "fakeuuid", "connection_state": "disconnected"}`)
+		default:
+			t.Errorf("Unknown endpoint %s %s", req.Method, req.URL.Path)
+			http.Error(rw, "Not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := api.NewClient(logger.Discard, api.Config{
+		Endpoint: server.URL,
+		Token:    "llamas",
+	})
+
+	l := logger.NewBuffer()
+
+	worker := &AgentWorker{
+		logger:             l,
+		agent:              nil,
+		apiClient:          client,
+		agentConfiguration: AgentConfiguration{},
+	}
+
+	err := worker.Disconnect()
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"[info] Disconnecting..."}, l.Messages)
+}


### PR DESCRIPTION
We've had some situations where the Agent Disconnect API call fails (e.g. HTTP 500 or 502), which leaves the agent in a connected state on the server side; this is normally cleared within 5 minutes, but in some situations could take longer. During that time, jobs may be assigned to the “ghost” agent, preventing them actually running on another connected agent.

This pull request retries the Disconnect API call up to 4 times, with a constant 1 second delay between tries. This keeps the total duration under 4-5 seconds; disconnection should remain fast as part of agent shutdown, even if the API fails.

This PR also introduces test coverage for `AgentWorker.Disconnect`, both without and with failure retries.

Alongside this, I've opened an issue at https://github.com/buildkite/roko/issues/2 so that roko's sleep function can be set globally during tests, without threading it through the code under test.