### PR TITLE
Docker: run /sbin/tini without -g for graceful termination

### DIFF
--- a/packaging/docker/alpine-linux/entrypoint.sh
+++ b/packaging/docker/alpine-linux/entrypoint.sh
@@ -8,4 +8,4 @@ if [[ -d "$DIR" ]] ; then
   /bin/run-parts --exit-on-error "$DIR"
 fi
 
-exec /sbin/tini -g -- ssh-env-config.sh /usr/local/bin/buildkite-agent "$@"
+exec /sbin/tini -- ssh-env-config.sh /usr/local/bin/buildkite-agent "$@"

--- a/packaging/docker/ubuntu-18.04-linux/entrypoint.sh
+++ b/packaging/docker/ubuntu-18.04-linux/entrypoint.sh
@@ -8,4 +8,4 @@ if [[ -d "$DIR" ]] ; then
   /bin/run-parts --exit-on-error "$DIR"
 fi
 
-exec /sbin/tini -g -- ssh-env-config.sh /usr/local/bin/buildkite-agent "$@"
+exec /sbin/tini -- ssh-env-config.sh /usr/local/bin/buildkite-agent "$@"

--- a/packaging/docker/ubuntu-20.04-linux/entrypoint.sh
+++ b/packaging/docker/ubuntu-20.04-linux/entrypoint.sh
@@ -8,4 +8,4 @@ if [[ -d "$DIR" ]] ; then
   /bin/run-parts --exit-on-error "$DIR"
 fi
 
-exec /sbin/tini -g -- ssh-env-config.sh /usr/local/bin/buildkite-agent "$@"
+exec /sbin/tini -- ssh-env-config.sh /usr/local/bin/buildkite-agent "$@"


### PR DESCRIPTION
Remove the `-g` option from `/sbin/tini` in the entrypoint of the Docker images shipped with the agent.

> By default, Tini only kills its immediate child process.
> With the `-g` option, Tini kills the child process group, so that
> every process in the group gets the signal.

buildkite-agent runs as a direct subprocess of tini, and will propagate the signals appropriately to its subprocesses.

Resolves #1758 (more context in that issue), thanks @com6056!

Related:
- #1758
- #1637