### PR TITLE
build agent binaries for windows/arm64

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -107,9 +107,6 @@ steps:
           - with: { os: openbsd, arch: arm64 }
             skip: "arm64 OpenBSD is not currently supported"
 
-          - with: { os: windows, arch: arm64 }
-            skip: "arm64 Windows is not currently supported"
-
   - name: ":technologist: Test bk cli + Agent cli"
     key: test-bk-cli
     depends_on: build-binary


### PR DESCRIPTION
This adds arm64 windows binaries to our official build matrix. Originally requested in #1282, but at the time we were nervous about enabling because:

* none of us had access to windows/arm64 systems
* it required a golang 1.17+, and we were compiling the agent with 1.16

These days we're compiling the agent with golang 1.18 so windows/arm64 is a target that Just Works. An arm64 windows environment is also super easy to boot using parallels 18 on an Apple Silicon machine, and we have plenty of those.

I tested this by manually cross compiling compiling a windows/arm64 binary on my linux laptop and then using it inside an arm parallels VM.

Compilation on Linux:

    GOOS=windows GOARCH=arm64 go build -o buildkite-agent-win-arm64 .

On buildkite:

![2022-09-21_21-53](https://user-images.githubusercontent.com/8132/191497401-59e030f9-7487-433d-9eeb-b1160cb57e60.png)

Fixes #1282