### PR TITLE
Update windows install script to detect arm64 systems [FDN-1134]

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,14 @@
 $installDir = "C:\buildkite-agent"
-$arch = "amd64"
 $beta = $env:buildkiteAgentBeta
 $token = $env:buildkiteAgentToken
 $tags = $env:buildkiteAgentTags
+
+if ($(Get-ComputerInfo -Property OsArchitecture).OsArchitecture -eq "ARM 64-bit Processor") {
+  $arch = "arm64"
+} else {
+  # The value is "64-bit" on my intel laptop with windows in a virtualbox VM
+  $arch = "amd64"
+}
 
 if ([string]::IsNullOrEmpty($token)) {
     throw "No token specified, set `$env:buildkiteAgentToken"


### PR DESCRIPTION
In #1767 we added windows/arm64 to the official build matrix for the agent. However, the recommended powershell install script in our docs looks like this:

    PS> $env:buildkiteAgentToken = "<your_token>"
    PS> Set-ExecutionPolicy Bypass -Scope Process -Force
    iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/buildkite/agent/main/install.ps1'))

.. and it always decides what binary to download by fetching this URL with a hard coded amd64 arch:

    $ curl "https://buildkite.com/agent/releases/latest?platform=windows&arch=amd64"

    version=3.39.0
    filename=buildkite-agent-windows-amd64-3.39.0.zip
    url=https://github.com/buildkite/agent/releases/download/v3.39.0/buildkite-agent-windows-amd64-3.39.0.zip

This PR updates the install.ps1 script to detect the architecture of the local machine and send it in the request to buildkite.com. Currently that returns no results:

    $ curl
    "https://buildkite.com/agent/releases/latest?platform=windows&arch=arm64"

    No release found for these parameters

However, once #1767 is shipped in an official release (presumably 3.40.0) then it should Just Work (like this):

    $ curl "https://buildkite.com/agent/releases/latest?platform=windows&arch=arm64"

    version=3.40.0
    filename=buildkite-agent-windows-arm64-3.40.0.zip
    url=https://github.com/buildkite/agent/releases/download/v3.40.0/buildkite-agent-windows-arm64-3.40.0.zip

... and powershell will automatically install a binary with the correct architecture.