### PR TITLE
Use base64+json for trace context encoding

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -36,4 +36,5 @@ type AgentConfiguration struct {
 	AcquireJob                 string
 	TracingBackend             string
 	TracingServiceName         string
+	UseJsonTraceContext        bool
 }

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -658,7 +658,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	}
 
 	if r.conf.AgentConfiguration.UseJsonTraceContext {
-		env["BUILDKITE_USE_JSON_TRACING_CONTEXT"] = "true"
+		env["BUILDKITE_USE_JSON_TRACE_CONTEXT"] = "true"
 	}
 
 	// see documentation for BuildkiteMessageMax

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -657,6 +657,10 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 		env["BUILDKITE_TRACING_SERVICE_NAME"] = r.conf.AgentConfiguration.TracingServiceName
 	}
 
+	if r.conf.AgentConfiguration.UseJsonTraceContext {
+		env["BUILDKITE_USE_JSON_TRACING_CONTEXT"] = "true"
+	}
+
 	// see documentation for BuildkiteMessageMax
 	if err := truncateEnv(r.logger, env, BuildkiteMessageName, BuildkiteMessageMax); err != nil {
 		r.logger.Warn("failed to truncate %s: %v", BuildkiteMessageName, err)

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -79,6 +79,7 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 		b.shell.PTY = b.Config.RunInPty
 		b.shell.Debug = b.Config.Debug
 		b.shell.InterruptSignal = b.Config.CancelSignal
+		b.shell.UseJsonTraceContext = b.Config.UseJsonTraceContext
 	}
 	if experiments.IsEnabled("kubernetes-exec") {
 		kubernetesClient := &kubernetes.Client{}

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -157,6 +157,9 @@ type Config struct {
 
 	// Service name to use when reporting traces.
 	TracingServiceName string
+
+	// When true, base64-JSON encoding is used for trace context propagation. Else, base64-golang-binary.
+	UseJsonTraceContext bool
 }
 
 // ReadFromEnvironment reads configuration from the Environment, returns a map

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -71,6 +71,10 @@ type Shell struct {
 
 	// The signal to use to interrupt the command
 	InterruptSignal process.Signal
+
+	// Whether to use a base-64 JSON encoding when propagating trace contexts.
+	// If false, uses gob (golang-binary).
+	UseJsonTraceContext bool
 }
 
 // New returns a new Shell
@@ -333,7 +337,7 @@ func (s *Shell) injectTraceCtx(ctx context.Context, env *env.Environment) {
 	if span == nil {
 		return
 	}
-	if err := tracetools.EncodeTraceContext(span, env.Dump()); err != nil {
+	if err := tracetools.EncodeTraceContext(span, env.Dump(), s.UseJsonTraceContext); err != nil {
 		if s.Debug {
 			s.Logger.Warningf("Failed to encode trace context: %v", err)
 		}

--- a/bootstrap/tracing.go
+++ b/bootstrap/tracing.go
@@ -100,7 +100,7 @@ func (b *Bootstrap) startTracingDatadog(ctx context.Context) (tracetools.Span, c
 // extractTraceCtx pulls encoded distributed tracing information from the env vars.
 // Note: This should match the injectTraceCtx code in shell.
 func (b *Bootstrap) extractDDTraceCtx() opentracing.SpanContext {
-	sctx, err := tracetools.DecodeTraceContext(b.shell.Env.Dump())
+	sctx, err := tracetools.DecodeTraceContext(b.shell.Env.Dump(), b.shell.UseJsonTraceContext)
 	if err != nil {
 		// Return nil so a new span will be created
 		return nil

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -551,7 +551,7 @@ var AgentStartCommand = cli.Command{
 		cli.BoolFlag{
 			Name:   "use-json-trace-context",
 			Usage:  "Uses base-64 JSON encoding when propagating traces through environment variables. When false, base64 golang-binary encoding will be used.",
-			EnvVar: "BUILDKITE_USE_JSON_TRACING_CONTEXT",
+			EnvVar: "BUILDKITE_USE_JSON_TRACE_CONTEXT",
 		},
 
 		// API Flags

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -109,6 +109,7 @@ type AgentStartConfig struct {
 	MetricsDatadogDistributions bool     `cli:"metrics-datadog-distributions"`
 	TracingBackend              string   `cli:"tracing-backend"`
 	TracingServiceName          string   `cli:"tracing-service-name"`
+	UseJsonTraceContext         bool     `cli:"use-json-trace-context"`
 	Spawn                       int      `cli:"spawn"`
 	SpawnWithPriority           bool     `cli:"spawn-with-priority"`
 	LogFormat                   string   `cli:"log-format"`
@@ -547,6 +548,11 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_TRACING_SERVICE_NAME",
 			Value:  "buildkite-agent",
 		},
+		cli.BoolFlag{
+			Name:   "use-json-tracing-context",
+			Usage:  "Uses base-64 JSON encoding when propagating traces through environment variables. When false, base64 golang-binary encoding will be used.",
+			EnvVar: "BUILDKITE_USE_JSON_TRACING_CONTEXT",
+		},
 
 		// API Flags
 		AgentRegisterTokenFlag,
@@ -783,6 +789,7 @@ var AgentStartCommand = cli.Command{
 			AcquireJob:                 cfg.AcquireJob,
 			TracingBackend:             cfg.TracingBackend,
 			TracingServiceName:         cfg.TracingServiceName,
+			UseJsonTraceContext:        cfg.UseJsonTraceContext,
 		}
 
 		if loader.File != nil {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -549,7 +549,7 @@ var AgentStartCommand = cli.Command{
 			Value:  "buildkite-agent",
 		},
 		cli.BoolFlag{
-			Name:   "use-json-tracing-context",
+			Name:   "use-json-trace-context",
 			Usage:  "Uses base-64 JSON encoding when propagating traces through environment variables. When false, base64 golang-binary encoding will be used.",
 			EnvVar: "BUILDKITE_USE_JSON_TRACING_CONTEXT",
 		},

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -92,6 +92,7 @@ type BootstrapConfig struct {
 	RedactedVars                 []string `cli:"redacted-vars" normalize:"list"`
 	TracingBackend               string   `cli:"tracing-backend"`
 	TracingServiceName           string   `cli:"tracing-service-name"`
+	UseJsonTraceContext          bool     `cli:"use-json-trace-context"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -357,6 +358,11 @@ var BootstrapCommand = cli.Command{
 			EnvVar: "BUILDKITE_TRACING_SERVICE_NAME",
 			Value:  "buildkite-agent",
 		},
+		cli.BoolFlag{
+			Name:   "use-json-tracing-context",
+			Usage:  "Uses base-64 JSON encoding when propagating traces through environment variables. When false, base64 golang-binary encoding will be used.",
+			EnvVar: "BUILDKITE_USE_JSON_TRACING_CONTEXT",
+		},
 		DebugFlag,
 		LogLevelFlag,
 		ExperimentsFlag,
@@ -458,6 +464,7 @@ var BootstrapCommand = cli.Command{
 			Tag:                          cfg.Tag,
 			TracingBackend:               cfg.TracingBackend,
 			TracingServiceName:           cfg.TracingServiceName,
+			UseJsonTraceContext:          cfg.UseJsonTraceContext,
 		})
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -359,7 +359,7 @@ var BootstrapCommand = cli.Command{
 			Value:  "buildkite-agent",
 		},
 		cli.BoolFlag{
-			Name:   "use-json-tracing-context",
+			Name:   "use-json-trace-context",
 			Usage:  "Uses base-64 JSON encoding when propagating traces through environment variables. When false, base64 golang-binary encoding will be used.",
 			EnvVar: "BUILDKITE_USE_JSON_TRACING_CONTEXT",
 		},

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -361,7 +361,7 @@ var BootstrapCommand = cli.Command{
 		cli.BoolFlag{
 			Name:   "use-json-trace-context",
 			Usage:  "Uses base-64 JSON encoding when propagating traces through environment variables. When false, base64 golang-binary encoding will be used.",
-			EnvVar: "BUILDKITE_USE_JSON_TRACING_CONTEXT",
+			EnvVar: "BUILDKITE_USE_JSON_TRACE_CONTEXT",
 		},
 		DebugFlag,
 		LogLevelFlag,

--- a/tracetools/propagate_example_test.go
+++ b/tracetools/propagate_example_test.go
@@ -35,7 +35,7 @@ func ExampleEncodeTraceContext() {
 
 		// Now say we want to launch a child process.
 		// Prepare it's env vars. This will be the carrier for the tracing data.
-		if err := EncodeTraceContext(span, childEnv); err != nil {
+		if err := EncodeTraceContext(span, childEnv, true); err != nil {
 			fmt.Println("oops an error for parent process trace injection")
 		}
 		// Now childEnv will contain the encoded data set with the env var key.
@@ -58,7 +58,7 @@ func ExampleEncodeTraceContext() {
 		// Make sure tracing is setup the same way (same env var key)
 		// Normally you'd use os.Environ or similar here (the list of strings is
 		// supported). We're just reusing childEnv for test simplicity.
-		sctx, err := DecodeTraceContext(childEnv)
+		sctx, err := DecodeTraceContext(childEnv, true)
 		if err != nil {
 			fmt.Println("oops an error for child process trace extraction")
 		} else {

--- a/tracetools/propagate_test.go
+++ b/tracetools/propagate_test.go
@@ -2,11 +2,15 @@ package tracetools
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/gob"
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,17 +19,84 @@ type nullLogger struct{}
 
 func (n nullLogger) Log(_ string) {}
 
+func stubGlobalTracer() func() {
+	oriTracer := opentracing.GlobalTracer()
+	opentracing.SetGlobalTracer(mocktracer.New())
+	return func() {
+		opentracing.SetGlobalTracer(oriTracer)
+	}
+}
+
+func TestEncodeTraceContext(t *testing.T) {
+	cleanup := stubGlobalTracer()
+	defer cleanup()
+
+	testCases := []struct {
+		useJson  bool
+		name     string
+		decoder  func(*bytes.Buffer, *opentracing.TextMapCarrier) error
+		expected opentracing.TextMapCarrier
+	}{
+		{
+			true,
+			"with json encoder",
+			func(b *bytes.Buffer, m *opentracing.TextMapCarrier) error { return json.NewDecoder(b).Decode(m) },
+			opentracing.TextMapCarrier{"mockpfx-ids-sampled": "true", "mockpfx-ids-spanid": "46", "mockpfx-ids-traceid": "43"},
+		},
+		{
+			false,
+			"with gob encoder",
+			func(b *bytes.Buffer, m *opentracing.TextMapCarrier) error { return gob.NewDecoder(b).Decode(m) },
+			opentracing.TextMapCarrier{"mockpfx-ids-sampled": "true", "mockpfx-ids-spanid": "50", "mockpfx-ids-traceid": "47"},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(fmt.Sprintf("Encodes %s", test.name), func(t *testing.T) {
+			ctx := context.Background()
+			parent := opentracing.StartSpan("job.parent")
+			ctx = opentracing.ContextWithSpan(ctx, parent)
+
+			span, ctx := opentracing.StartSpanFromContext(ctx, "job.run")
+			env := map[string]string{}
+			err := EncodeTraceContext(span, env, test.useJson)
+			if err != nil {
+				assert.FailNow(t, "unexpected encode error: %v", err)
+			}
+			assert.Contains(t, env, EnvVarTraceContextKey)
+			assert.NotNil(t, env[EnvVarTraceContextKey])
+
+			contextBytes, err := base64.URLEncoding.DecodeString(env[EnvVarTraceContextKey])
+			if err != nil {
+				assert.FailNow(t, "unexpected base64 decode error: %v", err)
+			}
+
+			buf := bytes.NewBuffer(contextBytes)
+			textmap := opentracing.TextMapCarrier{}
+			if err := test.decoder(buf, &textmap); err != nil {
+				assert.FailNow(t, "unexpected encode error: %v", err)
+			}
+			// The content of the trace context will vary based on the tracer used. Not sure if hardcoding the stuff
+			// from the MockTracer would be stable.
+			assert.NotEmpty(t, textmap)
+			assert.Equal(t, test.expected, textmap)
+		})
+	}
+}
+
 func TestDecodeTraceContext(t *testing.T) {
+	cleanup := stubGlobalTracer()
+	defer cleanup()
+
 	t.Run("No context info", func(t *testing.T) {
-		sctx, err := DecodeTraceContext(map[string]string{})
+		sctx, err := DecodeTraceContext(map[string]string{}, true)
 		assert.Nil(t, sctx)
 		assert.Equal(t, opentracing.ErrSpanContextNotFound, err)
 	})
 
-	t.Run("Invalid bsae64 context string", func(t *testing.T) {
+	t.Run("Invalid base64 context string", func(t *testing.T) {
 		sctx, err := DecodeTraceContext(map[string]string{
 			EnvVarTraceContextKey: "asd",
-		})
+		}, true)
 		assert.Nil(t, sctx)
 		assert.Equal(t, base64.CorruptInputError(0), err)
 	})
@@ -39,8 +110,32 @@ func TestDecodeTraceContext(t *testing.T) {
 		s := base64.URLEncoding.EncodeToString(buf.Bytes())
 		sctx, err := DecodeTraceContext(map[string]string{
 			EnvVarTraceContextKey: s,
-		})
+		}, true)
 		assert.Nil(t, sctx)
 		assert.Error(t, err)
 	})
+
+	testCases := []struct {
+		useJson bool
+		name    string
+	}{
+		{true, "with json encoder"},
+		{false, "with gob encoder"},
+	}
+	for _, test := range testCases {
+		t.Run(fmt.Sprintf("Encode-decode flows %s", test.name), func(t *testing.T) {
+			span := opentracing.StartSpan("job.run")
+			env := map[string]string{}
+			err := EncodeTraceContext(span, env, test.useJson)
+			if err != nil {
+				assert.FailNow(t, "unexpected encode error: %v", err)
+			}
+
+			sctx, err := DecodeTraceContext(env, test.useJson)
+			if err != nil {
+				assert.FailNow(t, "unexpected decode error: %v", err)
+			}
+			assert.NotNil(t, sctx)
+		})
+	}
 }


### PR DESCRIPTION
Back when I added trace propagation to the agent, I was short-sighted and used the golang-binary format. Since the trace context was meant to be propagated between builds of a pipeline, it was safe to assume the consumers would always be able to decode golang-binary formats.

But now I want to trace additional spans within non-Golang code and link it to the parent trace of the pipeline build. This will let me gather hollistic metrics about specific failure modes and performance of various commands/tooling running in my repos.

So I picked JSON, since it's a format all modern languages can easily parse without the need for a special library.

TODOs
- [x] Tests
- [x] Test a build and verify traces go through and trace context is properly passed to subprocesses