### PR TITLE
retry 5xx responses when attempting to start a job

### DIFF
--- a/api/retryable.go
+++ b/api/retryable.go
@@ -3,9 +3,12 @@ package api
 import (
 	"io"
 	"net"
+	"net/http"
 	"net/url"
 	"strings"
 	"syscall"
+
+	"golang.org/x/exp/slices"
 )
 
 var retrableErrorSuffixes = []string{
@@ -16,6 +19,19 @@ var retrableErrorSuffixes = []string{
 	"remote error: handshake failure",
 	io.ErrUnexpectedEOF.Error(),
 	io.EOF.Error(),
+}
+
+var retryableStatuses = []int{
+	http.StatusTooManyRequests,     // 429
+	http.StatusInternalServerError, // 500
+	http.StatusBadGateway,          // 502
+	http.StatusServiceUnavailable,  // 503
+	http.StatusGatewayTimeout,      // 504
+}
+
+// IsRetryableStatus returns true if the response's StatusCode is one that we should retry.
+func IsRetryableStatus(r *Response) bool {
+	return slices.Contains(retryableStatuses, r.StatusCode)
 }
 
 // Looks at a bunch of connection related errors, and returns true if the error


### PR DESCRIPTION
We occasionally see 502 responses from the Agent API when starting a job:
```
Failed to run job: PUT https://agent.buildkite.com/v3/jobs/0183a95c-c17e-4b0f-8058-e405362c6dc7/start: 502
```
Since those responses likely indicate a transient issue, I think it makes sense to attempt to retry those and other 5xx responses for this call rather than failing and having the job be re-scheduled. Open to any suggestions or input y'all might have.