### PR TITLE
Add an agent-startup hook that is fired at the same time as the agent…

### DIFF
--- a/clicommand/agent_start_test.go
+++ b/clicommand/agent_start_test.go
@@ -18,20 +18,65 @@ func setupHooksPath(t *testing.T) (string, func()) {
 	return hooksPath, func() { os.RemoveAll(hooksPath) }
 }
 
-func writeAgentShutdownHook(t *testing.T, dir string) string {
+func writeAgentHook(t *testing.T, dir, hookName string) string {
 	var filename, script string
 	if runtime.GOOS == "windows" {
-		filename = "agent-shutdown.bat"
+		filename = hookName + ".bat"
 		script = "@echo off\necho hello world"
 	} else {
-		filename = "agent-shutdown"
+		filename = hookName
 		script = "echo hello world"
 	}
 	filepath := filepath.Join(dir, filename)
 	if err := os.WriteFile(filepath, []byte(script), 0755); err != nil {
-		assert.FailNow(t, "failed to write agent-shutdown hook: %v", err)
+		assert.FailNow(t, "failed to write %q hook: %v", hookName, err)
 	}
 	return filepath
+}
+
+func TestAgentStartupHook(t *testing.T) {
+	cfg := func(hooksPath string) AgentStartConfig {
+		return AgentStartConfig{
+			HooksPath: hooksPath,
+			NoColor:   true,
+		}
+	}
+	prompt := "$"
+	if runtime.GOOS == "windows" {
+		prompt = ">"
+	}
+	t.Run("with agent-startup hook", func(t *testing.T) {
+		hooksPath, closer := setupHooksPath(t)
+		defer closer()
+		filepath := writeAgentHook(t, hooksPath, "agent-startup")
+		log := logger.NewBuffer()
+		err := agentStartupHook(log, cfg(hooksPath))
+
+		if assert.NoError(t, err, log.Messages) {
+			assert.Equal(t, []string{
+				"[info] " + prompt + " " + filepath, // prompt
+				"[info] hello world",                // output
+			}, log.Messages)
+		}
+	})
+	t.Run("with no agent-startup hook", func(t *testing.T) {
+		hooksPath, closer := setupHooksPath(t)
+		defer closer()
+
+		log := logger.NewBuffer()
+		err := agentStartupHook(log, cfg(hooksPath))
+		if assert.NoError(t, err, log.Messages) {
+			assert.Equal(t, []string{}, log.Messages)
+		}
+	})
+	t.Run("with bad hooks path", func(t *testing.T) {
+		log := logger.NewBuffer()
+		err := agentStartupHook(log, cfg("zxczxczxc"))
+
+		if assert.NoError(t, err, log.Messages) {
+			assert.Equal(t, []string{}, log.Messages)
+		}
+	})
 }
 
 func TestAgentShutdownHook(t *testing.T) {
@@ -48,7 +93,7 @@ func TestAgentShutdownHook(t *testing.T) {
 	t.Run("with agent-shutdown hook", func(t *testing.T) {
 		hooksPath, closer := setupHooksPath(t)
 		defer closer()
-		filepath := writeAgentShutdownHook(t, hooksPath)
+		filepath := writeAgentHook(t, hooksPath, "agent-shutdown")
 		log := logger.NewBuffer()
 		agentShutdownHook(log, cfg(hooksPath))
 


### PR DESCRIPTION
…-shutdown hook is registered.

Utilise the agent-shutdown hook logic for both of the "agent lifecycle" hooks, except if the hook fails shutdown the agent .

Implement the same test suite for agent startup and agent shutdown, as the same rules apply.

Closes: https://github.com/buildkite/agent/issues/1770