### PR TITLE
Add option to set the service name for tracing

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -33,4 +33,5 @@ type AgentConfiguration struct {
 	RedactedVars               []string
 	AcquireJob                 string
 	TracingBackend             string
+	TracingServiceName         string
 }

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -612,6 +612,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	if r.conf.AgentConfiguration.TracingBackend != "" {
 		env["BUILDKITE_TRACING_BACKEND"] = r.conf.AgentConfiguration.TracingBackend
 	}
+	env["BUILDKITE_TRACING_SERVICE_NAME"] = r.conf.AgentConfiguration.TracingServiceName
 
 	// see documentation for BuildkiteMessageMax
 	if err := truncateEnv(r.logger, env, BuildkiteMessageName, BuildkiteMessageMax); err != nil {

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -145,6 +145,9 @@ type Config struct {
 
 	// Backend to use for tracing. If an empty string, no tracing will occur.
 	TracingBackend string
+
+	// Service name to use when reporting traces.
+	TracingServiceName string
 }
 
 // ReadFromEnvironment reads configuration from the Environment, returns a map

--- a/bootstrap/tracing.go
+++ b/bootstrap/tracing.go
@@ -73,7 +73,7 @@ func (b *Bootstrap) ddResourceName() string {
 // abstraction so the agent can support multiple libraries if needbe.
 func (b *Bootstrap) startTracingDatadog(ctx context.Context) (tracetools.Span, context.Context, stopper) {
 	opts := []tracer.StartOption{
-		tracer.WithServiceName("buildkite-agent"),
+		tracer.WithServiceName(b.Config.TracingServiceName),
 		tracer.WithSampler(tracer.NewAllSampler()),
 		tracer.WithAnalytics(true),
 	}
@@ -132,7 +132,7 @@ func (b *Bootstrap) startTracingOpenTelemetry(ctx context.Context) (tracetools.S
 	}
 
 	attributes := []attribute.KeyValue{
-		semconv.ServiceNameKey.String("buildkite-agent"),
+		semconv.ServiceNameKey.String(b.Config.TracingServiceName),
 		semconv.ServiceVersionKey.String(agent.Version()),
 		semconv.DeploymentEnvironmentKey.String("ci"),
 	}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -101,6 +101,7 @@ type AgentStartConfig struct {
 	MetricsDatadogHost          string   `cli:"metrics-datadog-host"`
 	MetricsDatadogDistributions bool     `cli:"metrics-datadog-distributions"`
 	TracingBackend              string   `cli:"tracing-backend"`
+	TracingServiceName          string   `cli:"tracing-service-name"`
 	Spawn                       int      `cli:"spawn"`
 	SpawnWithPriority           bool     `cli:"spawn-with-priority"`
 	LogFormat                   string   `cli:"log-format"`
@@ -510,6 +511,12 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_TRACING_BACKEND",
 			Value:  "",
 		},
+		cli.StringFlag{
+			Name:   "tracing-service-name",
+			Usage:  "Service name to use when reporting traces.",
+			EnvVar: "BUILDKITE_TRACING_SERVICE_NAME",
+			Value:  "buildkite-agent",
+		},
 
 		// API Flags
 		AgentRegisterTokenFlag,
@@ -732,6 +739,7 @@ var AgentStartCommand = cli.Command{
 			RedactedVars:               cfg.RedactedVars,
 			AcquireJob:                 cfg.AcquireJob,
 			TracingBackend:             cfg.TracingBackend,
+			TracingServiceName:         cfg.TracingServiceName,
 		}
 
 		if loader.File != nil {

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -88,6 +88,7 @@ type BootstrapConfig struct {
 	CancelSignal                 string   `cli:"cancel-signal"`
 	RedactedVars                 []string `cli:"redacted-vars" normalize:"list"`
 	TracingBackend               string   `cli:"tracing-backend"`
+	TracingServiceName           string   `cli:"tracing-service-name"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -329,6 +330,12 @@ var BootstrapCommand = cli.Command{
 			EnvVar: "BUILDKITE_TRACING_BACKEND",
 			Value:  "",
 		},
+		cli.StringFlag{
+			Name:   "tracing-service-name",
+			Usage:  "Service name to use when reporting traces.",
+			EnvVar: "BUILDKITE_TRACING_SERVICE_NAME",
+			Value:  "buildkite-agent",
+		},
 		DebugFlag,
 		LogLevelFlag,
 		ExperimentsFlag,
@@ -426,6 +433,7 @@ var BootstrapCommand = cli.Command{
 			Shell:                        cfg.Shell,
 			Tag:                          cfg.Tag,
 			TracingBackend:               cfg.TracingBackend,
+			TracingServiceName:           cfg.TracingServiceName,
 		})
 
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
After the addition of OpenTelemetry, the name changed to buildkite-agent (dash instead of underscore). I'd like to keep the underscore to retain continuity with our historical data.