### PR TITLE
Bump version and CHANGELOG for v3.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v3.40.0](https://github.com/buildkite/agent/tree/v3.40.0) (2022-10-14)
+[Full Changelog](https://github.com/buildkite/agent/compare/v3.39.0...v3.40.0)
+
+### Added
+- Create an alpine k8s image [#1771](https://github.com/buildkite/agent/pull/1771) (@dabarrell)
+- Build agent binaries for windows/arm64 [#1767](https://github.com/buildkite/agent/pull/1767) (@yob)
+
+### Changed
+- Retry 5xx responses when attempting to start a job [#1777](https://github.com/buildkite/agent/pull/1777) (@jonahbull)
+
+### Security
+- Replace use of export -p with a dedicated agent command for printing environment [#1781](https://github.com/buildkite/agent/pull/1781) (@moskyb)
+
+
 ## [v3.39.0](https://github.com/buildkite/agent/tree/v3.39.0) (2022-09-08)
 [Full Changelog](https://github.com/buildkite/agent/compare/v3.38.0...v3.39.0)
 

--- a/agent/version.go
+++ b/agent/version.go
@@ -10,8 +10,10 @@ import "runtime"
 //
 // Pre-release builds' versions must be in the format `x.y-beta`, `x.y-beta.z` or `x.y-beta.z.a`
 
-var baseVersion string = "3.39.0"
-var buildVersion string = ""
+var (
+	baseVersion  string = "3.40.0"
+	buildVersion string = ""
+)
 
 func Version() string {
 	return baseVersion


### PR DESCRIPTION
## [v3.40.0](https://github.com/buildkite/agent/tree/v3.40.0) (2022-10-14)
[Full Changelog](https://github.com/buildkite/agent/compare/v3.39.0...v3.40.0)

### Added
- Create an alpine k8s image [#1771](https://github.com/buildkite/agent/pull/1771) (@dabarrell)
- Build agent binaries for windows/arm64 [#1767](https://github.com/buildkite/agent/pull/1767) (@yob)

### Changed
- Retry 5xx responses when attempting to start a job [#1777](https://github.com/buildkite/agent/pull/1777) (@jonahbull)

### Security
- Replace use of export -p with a dedicated agent command for printing environment [#1781](https://github.com/buildkite/agent/pull/1781) (@moskyb)