### PR TITLE
Bump version and CHANGELOG for 3.39.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v3.39.1](https://github.com/buildkite/agent/tree/v3.39.1) (2022-10-14)
+[Full Changelog](https://github.com/buildkite/agent/compare/v3.39.0...v3.39.1)
+
+### Security
+- Replace use of export -p with a dedicated agent command for printing environment [#1781](https://github.com/buildkite/agent/pull/1781) (@moskyb)
+
 ## [v3.39.0](https://github.com/buildkite/agent/tree/v3.39.0) (2022-09-08)
 [Full Changelog](https://github.com/buildkite/agent/compare/v3.38.0...v3.39.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [Full Changelog](https://github.com/buildkite/agent/compare/v3.39.0...v3.39.1)
 
 ### Security
-- Replace use of export -p with a dedicated agent command for printing environment [#1781](https://github.com/buildkite/agent/pull/1781) (@moskyb)
+- Fix security issue where in certain situations, agents using bash v5.2 could have some environment variables leak to job logs. See the [issue](https://github.com/buildkite/agent/issues/1780) and [our security advisory](https://buildkite.com/changelog/167-security-advisory-for-buildkite-agent-and-bash-5-dot-2) for more information. [#1781](https://github.com/buildkite/agent/pull/1781) (@moskyb)
 
 ## [v3.39.0](https://github.com/buildkite/agent/tree/v3.39.0) (2022-09-08)
 [Full Changelog](https://github.com/buildkite/agent/compare/v3.38.0...v3.39.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [Full Changelog](https://github.com/buildkite/agent/compare/v3.39.0...v3.39.1)
 
 ### Security
-- Fix security issue where in certain situations, agents using bash v5.2 could have some environment variables leak to job logs. See the [issue](https://github.com/buildkite/agent/issues/1780) and [our security advisory](https://buildkite.com/changelog/167-security-advisory-for-buildkite-agent-and-bash-5-dot-2) for more information. [#1781](https://github.com/buildkite/agent/pull/1781) (@moskyb)
+- Fix security issue where in certain situations, agents using bash v5.2 could have some environment variables leak to job logs. See the [issue](https://github.com/buildkite/agent/issues/1780) and [our security advisory](https://buildkite.com/changelog/167-security-advisory-for-buildkite-agent-and-bash-5-dot-2) for more information. [#1781](https://github.com/buildkite/agent/pull/1781) (@moskyb + @triarius + @pda)
 
 ## [v3.39.0](https://github.com/buildkite/agent/tree/v3.39.0) (2022-09-08)
 [Full Changelog](https://github.com/buildkite/agent/compare/v3.38.0...v3.39.0)

--- a/agent/version.go
+++ b/agent/version.go
@@ -10,7 +10,11 @@ import "runtime"
 //
 // Pre-release builds' versions must be in the format `x.y-beta`, `x.y-beta.z` or `x.y-beta.z.a`
 
-var baseVersion string = "3.39.0"
+var baseVersion string = "3.39.1"
+
+// This comment is needed to prevent formatters from combining this `var` with the one above
+// a step in the pipeline parses this file (as text) for lines of the form `var baseVersion string = `
+// See .builkite/steps/extract-base-version-metadata.sh:4
 var buildVersion string = ""
 
 func Version() string {


### PR DESCRIPTION
## [v3.39.1](https://github.com/buildkite/agent/tree/v3.39.1) (2022-10-14)
[Full Changelog](https://github.com/buildkite/agent/compare/v3.39.0...v3.39.1)

### Security
- Fix security issue where in certain situations, agents using bash v5.2 could have some environment variables leak to job logs. See the [issue](https://github.com/buildkite/agent/issues/1780) and [our security advisory](https://buildkite.com/changelog/167-security-advisory-for-buildkite-agent-and-bash-5-dot-2) for more information. [#1781](https://github.com/buildkite/agent/pull/1781) (@moskyb + @triarius + @pda) (@moskyb)