### PR TITLE
When homebrew releases fail, print the body of the API call that failed

### DIFF
--- a/.buildkite/steps/release-homebrew.sh
+++ b/.buildkite/steps/release-homebrew.sh
@@ -131,7 +131,7 @@ if [[ "${DRY_RUN:-}" == "false" ]] ; then
       -H "Authorization: token ${GITHUB_RELEASE_ACCESS_TOKEN}" \
       -H "Content-Type: application/json" \
       --data-binary "@pkg/github_post_data.json" \
-      --fail
+      --fail-with-body
 else
   echo "Dry Run Mode: skipping commit on github"
 fi


### PR DESCRIPTION
Our homebrew release step wasn't working for a little while, because we'd misconfigured the branch protection settings on the homebrew-buildkite repo. The failure only printed out the status code (409? why?), which made it harder to diagnose the issue.

This PR replaces the curl `--fail` flag with `--fail-with-body`, which does the same thing, but means that it'll print the response when the command fails, making issues with this process easier to diagnose in the future.