### PR TITLE
Add line break in env command usage

### DIFF
--- a/clicommand/env.go
+++ b/clicommand/env.go
@@ -10,6 +10,7 @@ import (
 )
 
 const envDescription = `Usage:
+
   buildkite-agent env [options]
 
 Description:


### PR DESCRIPTION
This has consequences for the generated docs. I'm not going to dig too
deeply in to why, but without the right whitespace in the help
text, the docs don't escape the command usage as code.

Before:
```
buildkite-agent env [options]
``
```
After:
```
`buildkite-agent env [options]`
```

But furthermore, this is consistent with the situation for other sub commands.
```
Usage:

  buildkite-agent meta-data <command> [options...]

Available commands are:

   set     Set data on a build
   get     Get data from a build
   exists  Check to see if the meta data key exists for a build
   keys    Lists all meta-data keys that have been previously set
   help    Shows a list of commands or help for one command

Options:

   --help, -h  show help
```

Before:
```
Usage:
  buildkite-agent env [options]

Description:
   Prints out the environment of the current process as a JSON object, easily parsable by other programs. Used when
   executing hooks to discover changes that hooks make to the environment.

Example:
   $ buildkite-agent env

   Prints the environment passed into the process


Options:

   --pretty  Pretty print the JSON output [$BUILDKITE_AGENT_ENV_PRETTY]

```
After:
```
Usage:

  buildkite-agent env [options]

Description:
   Prints out the environment of the current process as a JSON object, easily parsable by other programs. Used when
   executing hooks to discover changes that hooks make to the environment.

Example:
   $ buildkite-agent env

   Prints the environment passed into the process


Options:

   --pretty  Pretty print the JSON output [$BUILDKITE_AGENT_ENV_PRETTY]

```