### PR TITLE
Apply `gofmt -s` simplifications

### DIFF
--- a/agent/gs_uploader.go
+++ b/agent/gs_uploader.go
@@ -66,7 +66,7 @@ func NewGSUploader(l logger.Logger, c GSUploaderConfig) (*GSUploader, error) {
 
 func ParseGSDestination(destination string) (name string, path string) {
 	parts := strings.Split(strings.TrimPrefix(string(destination), "gs://"), "/")
-	path = strings.Join(parts[1:len(parts)], "/")
+	path = strings.Join(parts[1:], "/")
 	name = parts[0]
 	return
 }

--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -44,7 +44,7 @@ func TestCreateFromJSON(t *testing.T) {
 			}},
 		},
 		{`[{"https://gitlab.example.com/path/to/repo#main":{}}]`,
-			[]*Plugin{&Plugin{
+			[]*Plugin{{
 				Location:      `gitlab.example.com/path/to/repo`,
 				Version:       `main`,
 				Scheme:        `https`,
@@ -52,7 +52,7 @@ func TestCreateFromJSON(t *testing.T) {
 			}},
 		},
 		{`[{"https://gitlab.com/group/team/path/to/repo#main":{}}]`,
-			[]*Plugin{&Plugin{
+			[]*Plugin{{
 				Location:      `gitlab.com/group/team/path/to/repo`,
 				Version:       `main`,
 				Scheme:        `https`,

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1740,10 +1740,10 @@ func isPosixShell(shell []string) bool {
 }
 
 /*
-	If line is another batch script, it should be prefixed with `call ` so that
-	the second batch script doesn’t early exit our calling script.
+If line is another batch script, it should be prefixed with `call ` so that
+the second batch script doesn’t early exit our calling script.
 
-	See https://www.robvanderwoude.com/call.php
+See https://www.robvanderwoude.com/call.php
 */
 func shouldCallBatchLine(line string) bool {
 	// "  	gubiwargiub.bat /S  /e -e foo"

--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -252,19 +252,19 @@ func resolveGitHost(sh *shell.Shell, host string) string {
 // gitCheckRefFormatDenyRegexp is a pattern used by gitCheckRefFormat().
 // Numbered rules are from git 2.28.0's `git help check-ref-format`.
 // Not covered by this implementation:
-//   1. They can include slash / for hierarchical (directory) grouping, but
-//   no slash-separated component can begin with a dot .  or end with the
-//   sequence .lock
-//   2. They must contain at least one /. This enforces the presence of a
-//   category like heads/, tags/, and so on, but the actual names are not
-//   restricted. If the --allow-onelevel option is used, this rule is waived
-//   5. They cannot have question-mark ?, asterisk *, or open bracket [
-//   anywhere. See the --refspec-pattern option below for an exception to
-//   this rule
-//   6. They cannot begin or end with a slash / or contain multiple
-//   consecutive slashes (see the --normalize option below for an exception
-//   to this rule)
-//   8. They cannot contain a sequence @{.
+//  1. They can include slash / for hierarchical (directory) grouping, but
+//     no slash-separated component can begin with a dot .  or end with the
+//     sequence .lock
+//  2. They must contain at least one /. This enforces the presence of a
+//     category like heads/, tags/, and so on, but the actual names are not
+//     restricted. If the --allow-onelevel option is used, this rule is waived
+//  5. They cannot have question-mark ?, asterisk *, or open bracket [
+//     anywhere. See the --refspec-pattern option below for an exception to
+//     this rule
+//  6. They cannot begin or end with a slash / or contain multiple
+//     consecutive slashes (see the --normalize option below for an exception
+//     to this rule)
+//  8. They cannot contain a sequence @{.
 var gitCheckRefFormatDenyRegexp = regexp.MustCompile(strings.Join([]string{
 	`\.\.`,        //  3. cannot have two consecutive dots .. anywhere
 	`[[:cntrl:]]`, //  4. cannot have ASCII control characters (In other words, bytes whose values are lower than \040, or \177 DEL) ...

--- a/env/environment.go
+++ b/env/environment.go
@@ -167,12 +167,12 @@ func (e Environment) ToSlice() []string {
 // Environment variables on Windows are case-insensitive. When you run `SET`
 // within a Windows command prompt, you'll see variables like this:
 //
-//     ...
-//     Path=C:\Program Files (x86)\Parallels\Parallels Tools\Applications;...
-//     PROCESSOR_IDENTIFIER=Intel64 Family 6 Model 94 Stepping 3, GenuineIntel
-//     SystemDrive=C:
-//     SystemRoot=C:\Windows
-//     ...
+//	...
+//	Path=C:\Program Files (x86)\Parallels\Parallels Tools\Applications;...
+//	PROCESSOR_IDENTIFIER=Intel64 Family 6 Model 94 Stepping 3, GenuineIntel
+//	SystemDrive=C:
+//	SystemRoot=C:\Windows
+//	...
 //
 // There's a mix of both CamelCase and UPPERCASE, but the can all be accessed
 // regardless of the case you use. So PATH is the same as Path, PAth, pATH,
@@ -181,7 +181,7 @@ func (e Environment) ToSlice() []string {
 // os.Environ() in Golang returns key/values in the original casing, so it
 // returns a slice like this:
 //
-//     { "Path=...", "PROCESSOR_IDENTIFIER=...", "SystemRoot=..." }
+//	{ "Path=...", "PROCESSOR_IDENTIFIER=...", "SystemRoot=..." }
 //
 // Users of env.Environment shouldn't need to care about this.
 // env.Get("PATH") should "just work" on Windows. This means on Windows

--- a/env/environment_test.go
+++ b/env/environment_test.go
@@ -103,14 +103,14 @@ func TestEnvironmentDiff(t *testing.T) {
 	assert.Equal(t, Diff{
 		Added: map[string]string{},
 		Changed: map[string]DiffPair{
-			"B": DiffPair{
+			"B": {
 				Old: "there",
 				New: "world",
 			},
 		},
 		Removed: map[string]struct{}{
-			"C": struct{}{},
-			"D": struct{}{},
+			"C": {},
+			"D": {},
 		},
 	}, ab)
 
@@ -121,7 +121,7 @@ func TestEnvironmentDiff(t *testing.T) {
 			"D": "",
 		},
 		Changed: map[string]DiffPair{
-			"B": DiffPair{
+			"B": {
 				Old: "world",
 				New: "there",
 			},
@@ -138,13 +138,13 @@ func TestEnvironmentDiffRemove(t *testing.T) {
 			"A": "new",
 		},
 		Changed: map[string]DiffPair{
-			"B": DiffPair{
+			"B": {
 				Old: "old",
 				New: "new",
 			},
 		},
 		Removed: map[string]struct{}{
-			"C": struct{}{},
+			"C": {},
 		},
 	}
 
@@ -187,7 +187,7 @@ func TestEnvironmentApply(t *testing.T) {
 			"ALPACAS_ENABLED": "1",
 		},
 		Changed: map[string]DiffPair{
-			"LLAMAS_ENABLED": DiffPair{
+			"LLAMAS_ENABLED": {
 				Old: "1",
 				New: "0",
 			},
@@ -203,8 +203,8 @@ func TestEnvironmentApply(t *testing.T) {
 		Added:   map[string]string{},
 		Changed: map[string]DiffPair{},
 		Removed: map[string]struct{}{
-			"LLAMAS_ENABLED":  struct{}{},
-			"ALPACAS_ENABLED": struct{}{},
+			"LLAMAS_ENABLED":  {},
+			"ALPACAS_ENABLED": {},
 		},
 	})
 	assert.Equal(t, FromSlice([]string{}), env)

--- a/env/export.go
+++ b/env/export.go
@@ -25,30 +25,29 @@ var (
 // FromExport parses environment variables from a shell export of environment variables. On
 // *nix it looks like this:
 //
-//     $ export -p
-//     declare -x USER="keithpitt"
-//     declare -x VAR1="boom\\nboom\\nshake\\nthe\\nroom"
-//     declare -x VAR2="hello
-//     friends"
-//     declare -x VAR3="hello
-//     friends
-//     OMG=foo
-//     test"
-//     declare -x VAR4="great
-//     typeset -x TOTES=''
-//     lollies"
-//     declare -x XPC_FLAGS="0x0"
+//	$ export -p
+//	declare -x USER="keithpitt"
+//	declare -x VAR1="boom\\nboom\\nshake\\nthe\\nroom"
+//	declare -x VAR2="hello
+//	friends"
+//	declare -x VAR3="hello
+//	friends
+//	OMG=foo
+//	test"
+//	declare -x VAR4="great
+//	typeset -x TOTES=''
+//	lollies"
+//	declare -x XPC_FLAGS="0x0"
 //
 // And on Windowws...
 //
-//     $ SET
-//     SESSIONNAME=Console
-//     SystemDrive=C:
-//     SystemRoot=C:\Windows
-//     TEMP=C:\Users\IEUser\AppData\Local\Temp
-//     TMP=C:\Users\IEUser\AppData\Local\Temp
-//     USERDOMAIN=IE11WIN10
-//
+//	$ SET
+//	SESSIONNAME=Console
+//	SystemDrive=C:
+//	SystemRoot=C:\Windows
+//	TEMP=C:\Users\IEUser\AppData\Local\Temp
+//	TMP=C:\Users\IEUser\AppData\Local\Temp
+//	USERDOMAIN=IE11WIN10
 func FromExport(body string) Environment {
 	// Create the environment that we'll load values into
 	env := Environment{}


### PR DESCRIPTION
Beyond the usual formatting of `gofmt`, the `-s` flag applies some straightforward simplifications, such as removing redundant types. While useful from time to time, it is usually unnecessary to enforce it on every change, so I left the gofmt test alone.