### PR TITLE
buildkite-agent env has --from-env-file and --print flags

### DIFF
--- a/clicommand/env.go
+++ b/clicommand/env.go
@@ -1,9 +1,11 @@
 package clicommand
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/urfave/cli"
@@ -32,14 +34,33 @@ var EnvCommand = cli.Command{
 			Usage:  "Pretty print the JSON output",
 			EnvVar: "BUILDKITE_AGENT_ENV_PRETTY",
 		},
+		cli.BoolFlag{
+			Name:  "from-env-file",
+			Usage: "Source environment from file described by $BUILDKITE_ENV_FILE",
+		},
+		cli.StringFlag{
+			Name:  "print",
+			Usage: "Print a single environment variable by `NAME` as raw text followed by a newline",
+		},
 	},
 	Action: func(c *cli.Context) error {
-		env := os.Environ()
-		envMap := make(map[string]string, len(env))
+		var envMap map[string]string
 
-		for _, e := range env {
-			k, v, _ := strings.Cut(e, "=")
-			envMap[k] = v
+		if c.Bool("from-env-file") {
+			envMap = mustLoadEnvFile(os.Getenv("BUILDKITE_ENV_FILE"))
+		} else {
+			env := os.Environ()
+			envMap = make(map[string]string, len(env))
+
+			for _, e := range env {
+				k, v, _ := strings.Cut(e, "=")
+				envMap[k] = v
+			}
+		}
+
+		if name := c.String("print"); name != "" {
+			fmt.Println(envMap[name])
+			return nil
 		}
 
 		var (
@@ -68,4 +89,44 @@ var EnvCommand = cli.Command{
 
 		return nil
 	},
+}
+
+func mustLoadEnvFile(path string) map[string]string {
+	envMap := make(map[string]string)
+
+	if path == "" {
+		fmt.Fprintln(os.Stderr, "BUILDKITE_ENV_FILE not set")
+		os.Exit(1)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not open BUILDKITE_ENV_FILE: %v\n", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(f)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		name, quotedValue, ok := strings.Cut(line, "=")
+		if !ok {
+			fmt.Fprintf(os.Stderr, "Unexpected format in BUILDKITE_ENV_FILE %s\n", path)
+			os.Exit(1)
+		}
+
+		value, err := strconv.Unquote(quotedValue)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error unquoting value: %v\n", err)
+			os.Exit(1)
+		}
+
+		envMap[name] = value
+	}
+
+	return envMap
 }

--- a/clicommand/env_test.go
+++ b/clicommand/env_test.go
@@ -1,0 +1,27 @@
+package clicommand
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMustLoadEnvFile(t *testing.T) {
+	f, err := os.CreateTemp("", t.Name())
+	if err != nil {
+		t.Error(err)
+	}
+	data := map[string]string{
+		"HELLO": "world",
+		"FOO":   "bar\n\"bar\"\n`black hat`\r\n$(have you any root)",
+	}
+	for name, value := range data {
+		fmt.Fprintf(f, "%s=%q\n", name, value)
+	}
+
+	result := mustLoadEnvFile(f.Name())
+
+	assert.Equal(t, data, result, "data should round-trip via env file")
+}


### PR DESCRIPTION
Adds two flags to the `buildkite-agent env` command introduced in #1781.

By default, `buildkite-agent env` loads `os.Environ()` and prints it as a JSON object; it's mainly intended for internal use to capture a snapshot of environment before a hook runs, and detect changes afterwards.

The new `--from-env-file` boolean flag sources the environment from the file named by `$BUILDKITE_ENV_FILE` instead of from `os.Environ()`, using `bufio.Scanner` and `strconv.Unquote()` to safely and correctly parse the quoting/escaping done by `%q` when the file was written:
https://github.com/buildkite/agent/blob/2aaefb699828b512ad62cd7791104b47bad46b96/agent/job_runner.go#L490

The new `--print NAME` flag causes a single environment value to be printed in its raw unescaped form followed by a newline, instead of printing all vars as a JSON object.

Combined, this solves the problem of safely parsing `BUILDKITE_ENV_FILE` (which cannot be safely evaluated in a shell if it may contain untrusted user input) to access a single variable, and allows for usage like this in a pre-command hook or similar:

```bash
if [[ $(buildkite-agent env --from-env-file --print BUILDKITE_BRANCH) != "main" ]]; then
  echo "This agent only builds branch 'main'"
  exit 42
fi
```