### PR TITLE
redaction: treat needles as byte slices

### DIFF
--- a/redaction/redactor.go
+++ b/redaction/redactor.go
@@ -97,7 +97,7 @@ func (redactor *Redactor) Reset(needles []string) {
 	}
 
 	for _, needle := range needles {
-		for i, ch := range needle {
+		for i, ch := range []byte(needle) {
 			// For bytes that do exist in search strings, find the shortest distance
 			// between that byte appearing to the end of the same search string
 			skip := len(needle) - i - 1

--- a/redaction/redactor_test.go
+++ b/redaction/redactor_test.go
@@ -140,12 +140,16 @@ func TestRedactorSubsetSecrets(t *testing.T) {
 	}
 }
 
-func TestRedactorLatin1(t *testing.T) {
+func TestRedactorMultibyte(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
 	redactor := NewRedactor(&buf, "[REDACTED]", []string{"ÿ"})
 
-	redactor.Write([]byte("foo"))
+	redactor.Write([]byte("fooÿbar"))
 	redactor.Flush()
+
+	if got, want := buf.Bytes(), []byte("foo[REDACTED]bar"); !bytes.Equal(got, want) {
+		t.Errorf("post-redaction buf.Bytes() = %q, want %q", got, want)
+	}
 }


### PR DESCRIPTION
redactor.go:100 ranges over a string (needle), and in Go, ranging over a string iterates each _rune_ each of which can be a single or multibyte code point. But the rest of the redactor deals in bytes, particularly the table array.

This also updates the misleadingly-named test to (a) a better name and (b) actually look at the redacted output.