### PR TITLE
Key JUnit files with the step ID, rather than the OS

### DIFF
--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -7,7 +7,7 @@ echo arch is "$(uname -m)"
 go install gotest.tools/gotestsum@v1.8.0
 
 echo '+++ Running tests'
-gotestsum --junitfile "junit-${OSTYPE}.xml" -- -count=1 -failfast "$@" ./...
+gotestsum --junitfile "junit-${BUILDKITE_JOB_ID}.xml" -- -count=1 -failfast "$@" ./...
 
 echo '+++ Running integration tests for git-mirrors experiment'
-TEST_EXPERIMENT=git-mirrors gotestsum --junitfile "junit-${OSTYPE}-git-mirrors.xml" -- -count=1 -failfast "$@" ./bootstrap/integration
+TEST_EXPERIMENT=git-mirrors gotestsum --junitfile "junit-${BUILDKITE_JOB_ID}-git-mirrors.xml" -- -count=1 -failfast "$@" ./bootstrap/integration


### PR DESCRIPTION
This means that every JUnit file will have a unique file name, should stop the test annotate step from failing intermittently