### PR TITLE
env: handle '='-prefixed vars

### DIFF
--- a/clicommand/env.go
+++ b/clicommand/env.go
@@ -39,12 +39,9 @@ var EnvCommand = cli.Command{
 		envMap := make(map[string]string, len(envn))
 
 		for _, e := range envn {
-			k, v, ok := env.Split(e)
-			if !ok {
-				fmt.Fprintf(c.App.ErrWriter, "Invalid environment variable from os.Environ: %q\n", e)
-				os.Exit(2)
+			if k, v, ok := env.Split(e); ok {
+				envMap[k] = v
 			}
-			envMap[k] = v
 		}
 
 		enc := json.NewEncoder(c.App.Writer)

--- a/clicommand/env.go
+++ b/clicommand/env.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
+	"github.com/buildkite/agent/v3/env"
 	"github.com/urfave/cli"
 )
 
@@ -13,8 +13,9 @@ const envDescription = `Usage:
   buildkite-agent env [options]
 
 Description:
-   Prints out the environment of the current process as a JSON object, easily parsable by other programs. Used when
-   executing hooks to discover changes that hooks make to the environment.
+   Prints out the environment of the current process as a JSON object, easily
+   parsable by other programs. Used when executing hooks to discover changes
+   that hooks make to the environment.
 
 Example:
    $ buildkite-agent env
@@ -34,38 +35,27 @@ var EnvCommand = cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		env := os.Environ()
-		envMap := make(map[string]string, len(env))
+		envn := os.Environ()
+		envMap := make(map[string]string, len(envn))
 
-		for _, e := range env {
-			k, v, _ := strings.Cut(e, "=")
+		for _, e := range envn {
+			k, v, ok := env.Split(e)
+			if !ok {
+				fmt.Fprintf(c.App.ErrWriter, "Invalid environment variable from os.Environ: %q\n", e)
+				os.Exit(2)
+			}
 			envMap[k] = v
 		}
 
-		var (
-			envJSON []byte
-			err     error
-		)
-
+		enc := json.NewEncoder(c.App.Writer)
 		if c.Bool("pretty") {
-			envJSON, err = json.MarshalIndent(envMap, "", "  ")
-		} else {
-			envJSON, err = json.Marshal(envMap)
+			enc.SetIndent("", "  ")
 		}
 
-		// let's be polite to interactive shells etc.
-		envJSON = append(envJSON, '\n')
-
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error marshalling JSON: %v\n", err)
+		if err := enc.Encode(envMap); err != nil {
+			fmt.Fprintf(c.App.ErrWriter, "Error marshalling JSON: %v\n", err)
 			os.Exit(1)
 		}
-
-		if _, err := os.Stdout.Write(envJSON); err != nil {
-			fmt.Fprintf(os.Stderr, "Error writing JSON to stdout: %v\n", err)
-			os.Exit(1)
-		}
-
 		return nil
 	},
 }

--- a/env/environment_test.go
+++ b/env/environment_test.go
@@ -209,3 +209,26 @@ func TestEnvironmentApply(t *testing.T) {
 	})
 	assert.Equal(t, FromSlice([]string{}), env)
 }
+
+func TestSplit(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in          string
+		name, value string
+		ok          bool
+	}{
+		{"key=value", "key", "value", true},
+		{"equalsign==", "equalsign", "=", true},
+		{"=Windows=Nonsense", "=Windows", "Nonsense", true},
+		{"=Bonus=Windows=Nonsense", "=Bonus", "Windows=Nonsense", true},
+		{"NotValid", "", "", false},
+		{"=AlsoInvalid", "", "", false},
+	}
+
+	for _, test := range tests {
+		gotName, gotValue, gotOK := Split(test.in)
+		if gotName != test.name || gotValue != test.value || gotOK != test.ok {
+			t.Errorf("Split(%q) = (%q, %q, %t), want (%q, %q, %t)", test.in, gotName, gotValue, gotOK, test.name, test.value, test.ok)
+		}
+	}
+}

--- a/env/environment_test.go
+++ b/env/environment_test.go
@@ -221,6 +221,7 @@ func TestSplit(t *testing.T) {
 		{"equalsign==", "equalsign", "=", true},
 		{"=Windows=Nonsense", "=Windows", "Nonsense", true},
 		{"=Bonus=Windows=Nonsense", "=Bonus", "Windows=Nonsense", true},
+		{"no_value=", "no_value", "", true},
 		{"NotValid", "", "", false},
 		{"=AlsoInvalid", "", "", false},
 	}


### PR DESCRIPTION
Windows can have interestingly-named environment variables (#1804). This update changes both the env command and env subpackage to handle variables with names starting with '='.

It is debatable whether to filter out these variables or preserve them. Preserving them feels like the least surprising option to me. I did some brief experimenting on Windows and didn't uncover huge issues. But I'm willing to be convinced otherwise.

I've also taken the opportunity to slightly simplify the env command implementation. 

Fixes #1804