### PR TITLE
bootstrap/shell: re-enable TestInterrupt under -race

### DIFF
--- a/bootstrap/shell/shell_test.go
+++ b/bootstrap/shell/shell_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -17,7 +16,6 @@ import (
 
 	"github.com/buildkite/agent/v3/bootstrap/shell"
 	"github.com/buildkite/agent/v3/experiments"
-	"github.com/buildkite/agent/v3/race"
 	"github.com/buildkite/bintest/v3"
 	"github.com/stretchr/testify/assert"
 )
@@ -163,10 +161,6 @@ func TestInterrupt(t *testing.T) {
 		t.Skip("Not supported in windows")
 	}
 
-	if race.Enabled {
-		t.Skip("Bintest has a race condition that we run into here, we should fix it, but it only shows up in tests")
-	}
-
 	sleepCmd, err := bintest.CompileProxy("sleep")
 	if err != nil {
 		t.Fatal(err)
@@ -214,7 +208,7 @@ func TestDefaultWorkingDirFromSystem(t *testing.T) {
 }
 
 func TestWorkingDir(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "shelltest")
+	tempDir, err := os.MkdirTemp("", "shelltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +276,7 @@ func TestLockFileRetriesAndTimesOut(t *testing.T) {
 		t.Skip("Flakey on windows")
 	}
 
-	dir, err := ioutil.TempDir("", "shelltest")
+	dir, err := os.MkdirTemp("", "shelltest")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/aws/aws-sdk-go v1.44.66
-	github.com/buildkite/bintest/v3 v3.1.0
+	github.com/buildkite/bintest/v3 v3.1.1
 	github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/buildkite/yaml v0.0.0-20210326113714-4a3f40911396

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
-github.com/buildkite/bintest/v3 v3.1.0 h1:auJ22sFpyy7t6xR7p5FcqAwpNgkP0AyVhEMSRErFmk0=
-github.com/buildkite/bintest/v3 v3.1.0/go.mod h1:T3Et1VwEizryWfwLLruFqExHsEU+wjkxOlL54283ccc=
+github.com/buildkite/bintest/v3 v3.1.1 h1:bS924OU8Ljm46DesONXzxxTBMjbliQRnPB+H4DOeUDE=
+github.com/buildkite/bintest/v3 v3.1.1/go.mod h1:T3Et1VwEizryWfwLLruFqExHsEU+wjkxOlL54283ccc=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/buildkite/roko v1.0.1 h1:J9dNjn4FBHJ0EoT3qySHeh8CK0Uaqf5Ve0mstmi3OmM=


### PR DESCRIPTION
The race in bintest that causes TestInterrupt to fail should now be fixed.

While I'm here, replace uses of io/ioutil (deprecated).