### PR TITLE
env: Disallow variables starting with =

### DIFF
--- a/env/environment.go
+++ b/env/environment.go
@@ -15,21 +15,15 @@ func New() Environment {
 }
 
 // Split splits an environment variable (in the form "name=value") into the name
-// and value substrings. Names starting with a single '=' are allowed but a
-// second '=' is required later in the string.
-// If there is no '=', or the only '=' is at the start, it returns
-// `"", "", false`.
+// and value substrings. If there is no '=', or the first '=' is at the start,
+// it returns `"", "", false`.
 func Split(l string) (name, value string, ok bool) {
 	// Variable names should not contain '=' on any platform...and yet Windows
 	// creates environment variables beginning with '=' in some circumstances.
 	// See https://github.com/golang/go/issues/49886.
-	// Values can contain '=' anywhere, so a variant of strings.Cut that
-	// uses strings.LastIndex is not enough.
+	// Dropping them matches the previous behaviour on Windows, which used SET
+	// to obtain the state of environment variables.
 	i := strings.IndexRune(l, '=')
-	if i == 0 {
-		// l began with '=', so split on the next '='.
-		i = strings.IndexRune(l[1:], '=') + 1
-	}
 	// Either there is no '=', or it is at the start of the string.
 	// Both are disallowed.
 	if i <= 0 {

--- a/env/environment_test.go
+++ b/env/environment_test.go
@@ -219,8 +219,8 @@ func TestSplit(t *testing.T) {
 	}{
 		{"key=value", "key", "value", true},
 		{"equalsign==", "equalsign", "=", true},
-		{"=Windows=Nonsense", "=Windows", "Nonsense", true},
-		{"=Bonus=Windows=Nonsense", "=Bonus", "Windows=Nonsense", true},
+		{"=Windows=Nonsense", "", "", false},
+		{"=Bonus=Windows=Nonsense", "", "", false},
 		{"no_value=", "no_value", "", true},
 		{"NotValid", "", "", false},
 		{"=AlsoInvalid", "", "", false},


### PR DESCRIPTION
To maintain the same behaviour as before, we've instead decided to drop them instead of preserve them. 

This changes the outcome for #1804, but #1804 remains fixed.