### PR TITLE
WIP: Self-execute the same path

### DIFF
--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/internal/self"
 	"github.com/buildkite/bintest/v3"
 	"gotest.tools/v3/assert"
 )
@@ -83,11 +84,9 @@ func TestPreBootstrapHookScripts(t *testing.T) {
 			t.Cleanup(func() { _ = os.RemoveAll(hooksDir) })
 
 			hookPath := filepath.Join(hooksDir, "pre-bootstrap"+tc.ext)
-			testMainPath, err := os.Executable()
-			assert.NilError(t, err)
 
 			// Write pre-bootstrap hook in a subprocess to avoid intermittent ETXTBSY errors on Linux
-			cmd := exec.Command(testMainPath, "write-exec", hookPath)
+			cmd := exec.Command(self.Path(ctx), "write-exec", hookPath)
 			cmd.Stdin = strings.NewReader(tc.contents)
 			err = cmd.Run()
 			assert.NilError(t, err)

--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -77,7 +77,11 @@ func TestPreBootstrapHookScripts(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+
+			testMainPath, err := os.Executable()
+			assert.NilError(t, err)
+
+			ctx := self.OverridePath(context.Background(), testMainPath)
 
 			hooksDir, err := os.MkdirTemp("", "bootstrap-hooks")
 			assert.NilError(t, err, "making bootstrap-hooks directory: %v", err)

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildkite/agent/v3/core"
 	"github.com/buildkite/agent/v3/env"
 	"github.com/buildkite/agent/v3/internal/experiments"
+	"github.com/buildkite/agent/v3/internal/self"
 	"github.com/buildkite/agent/v3/internal/shell"
 	"github.com/buildkite/agent/v3/kubernetes"
 	"github.com/buildkite/agent/v3/logger"
@@ -527,11 +528,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	// We know the BUILDKITE_BIN_PATH dir, because it's the path to the
 	// currently running file (there is only 1 binary)
 	// Note that [os.Executable] returns an absolute path.
-	exePath, err := os.Executable()
-	if err != nil {
-		return nil, err
-	}
-	env["BUILDKITE_BIN_PATH"] = filepath.Dir(exePath)
+	env["BUILDKITE_BIN_PATH"] = filepath.Dir(self.Path(ctx))
 
 	// Add options from the agent configuration
 	env["BUILDKITE_CONFIG_PATH"] = r.conf.AgentConfiguration.ConfigPath

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -32,6 +32,7 @@ import (
 	"github.com/buildkite/agent/v3/internal/job"
 	"github.com/buildkite/agent/v3/internal/job/hook"
 	"github.com/buildkite/agent/v3/internal/osutil"
+	"github.com/buildkite/agent/v3/internal/self"
 	"github.com/buildkite/agent/v3/internal/shell"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/agent/v3/metrics"
@@ -306,13 +307,10 @@ func defaultConfigFilePaths() (paths []string) {
 
 	// Also check to see if there's a buildkite-agent.cfg in the folder
 	// that the binary is running in.
-	exePath, err := os.Executable()
+	pathToBinary, err := filepath.Abs(filepath.Dir(self.Path(context.Background())))
 	if err == nil {
-		pathToBinary, err := filepath.Abs(filepath.Dir(exePath))
-		if err == nil {
-			pathToRelativeConfig := filepath.Join(pathToBinary, "buildkite-agent.cfg")
-			paths = append([]string{pathToRelativeConfig}, paths...)
-		}
+		pathToRelativeConfig := filepath.Join(pathToBinary, "buildkite-agent.cfg")
+		paths = append([]string{pathToRelativeConfig}, paths...)
 	}
 
 	return paths
@@ -799,11 +797,7 @@ var AgentStartCommand = cli.Command{
 
 		// Set a useful default for the bootstrap script
 		if cfg.BootstrapScript == "" {
-			exePath, err := os.Executable()
-			if err != nil {
-				return errors.New("unable to find executable path for bootstrap")
-			}
-			cfg.BootstrapScript = fmt.Sprintf("%s bootstrap", shellwords.Quote(exePath))
+			cfg.BootstrapScript = fmt.Sprintf("%s bootstrap", shellwords.Quote(self.Path(ctx)))
 		}
 
 		isSetNoPlugins := c.IsSet("no-plugins")

--- a/internal/job/artifacts.go
+++ b/internal/job/artifacts.go
@@ -3,6 +3,7 @@ package job
 import (
 	"context"
 
+	"github.com/buildkite/agent/v3/internal/self"
 	"github.com/buildkite/agent/v3/tracetools"
 )
 
@@ -69,7 +70,7 @@ func (e *Executor) uploadArtifacts(ctx context.Context) error {
 		args = append(args, e.ArtifactUploadDestination)
 	}
 
-	if err = e.shell.Command("buildkite-agent", args...).Run(ctx); err != nil {
+	if err = e.shell.Command(self.Path(ctx), args...).Run(ctx); err != nil {
 		return err
 	}
 

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -483,7 +483,7 @@ func logMissingHookInfo(l shell.Logger, hookName, wrapperPath string) {
 func (e *Executor) runWrappedShellScriptHook(ctx context.Context, hookName string, hookCfg HookConfig) error {
 	defer e.redactors.Flush()
 
-	script, err := hook.NewWrapper(hook.WithPath(hookCfg.Path))
+	script, err := hook.NewWrapper(ctx, hook.WithPath(hookCfg.Path))
 	if err != nil {
 		e.shell.Errorf("Error creating hook script: %v", err)
 		return err

--- a/internal/job/hook/wrapper.go
+++ b/internal/job/hook/wrapper.go
@@ -143,7 +143,7 @@ func WithOS(o string) WrapperOpt {
 
 // NewWrapper creates and configures a hook.Wrapper.
 // Writes temporary files to the filesystem.
-func NewWrapper(opts ...WrapperOpt) (*Wrapper, error) {
+func NewWrapper(ctx context.Context, opts ...WrapperOpt) (*Wrapper, error) {
 	wrap := &Wrapper{
 		os: runtime.GOOS,
 	}
@@ -239,7 +239,7 @@ func NewWrapper(opts ...WrapperOpt) (*Wrapper, error) {
 	}
 
 	templateInput := WrapperTemplateInput{
-		AgentBinary:       self.Path(context.TODO()),
+		AgentBinary:       self.Path(ctx),
 		ShebangLine:       shebang,
 		BeforeEnvFileName: wrap.beforeEnvPath,
 		AfterEnvFileName:  wrap.afterEnvPath,

--- a/internal/job/hook/wrapper.go
+++ b/internal/job/hook/wrapper.go
@@ -1,6 +1,7 @@
 package hook
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/buildkite/agent/v3/env"
+	"github.com/buildkite/agent/v3/internal/self"
 	"github.com/buildkite/agent/v3/internal/shellscript"
 	"github.com/buildkite/agent/v3/internal/tempfile"
 )
@@ -236,13 +238,8 @@ func NewWrapper(opts ...WrapperOpt) (*Wrapper, error) {
 		return nil, fmt.Errorf("finding absolute path to %q: %w", wrap.hookPath, err)
 	}
 
-	buildkiteAgent, err := os.Executable()
-	if err != nil {
-		return nil, err
-	}
-
 	templateInput := WrapperTemplateInput{
-		AgentBinary:       buildkiteAgent,
+		AgentBinary:       self.Path(context.TODO()),
 		ShebangLine:       shebang,
 		BeforeEnvFileName: wrap.beforeEnvPath,
 		AfterEnvFileName:  wrap.afterEnvPath,

--- a/internal/job/hook/wrapper_test.go
+++ b/internal/job/hook/wrapper_test.go
@@ -73,7 +73,7 @@ echo "hello world"
 			ctx := context.Background()
 
 			hookFilename := writeTestHook(t, tc.name, tc.hook)
-			wrapper, err := hook.NewWrapper(hook.WithPath(hookFilename), hook.WithOS(tc.os))
+			wrapper, err := hook.NewWrapper(ctx, hook.WithPath(hookFilename), hook.WithOS(tc.os))
 			assert.NilError(t, err, "failed to create hook wrapper: %v", err)
 
 			sh := shell.NewTestShell(t)
@@ -166,7 +166,7 @@ echo hello world
 			ctx := context.Background()
 
 			hookFilename := writeTestHook(t, tc.name, tc.hook)
-			wrapper, err := hook.NewWrapper(hook.WithPath(hookFilename), hook.WithOS(tc.os))
+			wrapper, err := hook.NewWrapper(ctx, hook.WithPath(hookFilename), hook.WithOS(tc.os))
 			assert.NilError(t, err, "failed to create hook wrapper: %v", err)
 
 			sh := shell.NewTestShell(t)
@@ -209,7 +209,7 @@ func TestScriptWrapperFailsOnHookWithInvalidShebang(t *testing.T) {
 
 	hookFilename := writeTestHook(t, "hook", "#!/usr/bin/env ruby\nputs 'hello world'")
 
-	_, err := hook.NewWrapper(
+	_, err := hook.NewWrapper(context.Background(),
 		hook.WithPath(hookFilename),
 		hook.WithOS("linux"),
 	)

--- a/internal/job/integration/artifact_integration_test.go
+++ b/internal/job/integration/artifact_integration_test.go
@@ -27,7 +27,7 @@ func TestArtifactsUploadAfterCommand(t *testing.T) {
 	})
 
 	// Mock out the artifact calls
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
@@ -35,7 +35,7 @@ func TestArtifactsUploadAfterCommand(t *testing.T) {
 		Expect("artifact", "upload", "llamas.txt").
 		AndExitWith(0)
 
-	tester.RunAndCheck(t, "BUILDKITE_ARTIFACT_PATHS=llamas.txt")
+	tester.RunAndCheck(ctx, t, "BUILDKITE_ARTIFACT_PATHS=llamas.txt")
 }
 
 func TestArtifactsUploadAfterCommandFails(t *testing.T) {
@@ -56,7 +56,7 @@ func TestArtifactsUploadAfterCommandFails(t *testing.T) {
 	})
 
 	// Mock out the artifact calls
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
@@ -64,7 +64,7 @@ func TestArtifactsUploadAfterCommandFails(t *testing.T) {
 		Expect("artifact", "upload", "llamas.txt").
 		AndExitWith(0)
 
-	err = tester.Run(t, "BUILDKITE_ARTIFACT_PATHS=llamas.txt", "BUILDKITE_COMMAND=my-command")
+	err = tester.Run(ctx, t, "BUILDKITE_ARTIFACT_PATHS=llamas.txt", "BUILDKITE_COMMAND=my-command")
 	if err == nil {
 		t.Fatalf("Expected command to fail")
 	}
@@ -91,7 +91,7 @@ func TestArtifactsUploadAfterCommandHookFails(t *testing.T) {
 	})
 
 	// Mock out the artifact calls
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
@@ -99,7 +99,7 @@ func TestArtifactsUploadAfterCommandHookFails(t *testing.T) {
 		Expect("artifact", "upload", "llamas.txt").
 		AndExitWith(0)
 
-	if err := tester.Run(t, "BUILDKITE_ARTIFACT_PATHS=llamas.txt"); err == nil {
+	if err := tester.Run(ctx, t, "BUILDKITE_ARTIFACT_PATHS=llamas.txt"); err == nil {
 		t.Fatalf("tester.Run(BUILDKITE_ARTIFACT_PATHS=llamas.txt) = %v, want non-nil error", err)
 	}
 

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -52,11 +52,11 @@ func TestCheckingOutGitHubPullRequests_WithGitMirrors(t *testing.T) {
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestWithResolvingCommitExperiment_WithGitMirrors(t *testing.T) {
@@ -96,7 +96,7 @@ func TestWithResolvingCommitExperiment_WithGitMirrors(t *testing.T) {
 		{"rev-parse", "HEAD"},
 	})
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestCheckingOutLocalGitProject_WithGitMirrors(t *testing.T) {
@@ -136,11 +136,11 @@ func TestCheckingOutLocalGitProject_WithGitMirrors(t *testing.T) {
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestCheckingOutLocalGitProjectWithSubmodules_WithGitMirrors(t *testing.T) {
@@ -208,11 +208,11 @@ func TestCheckingOutLocalGitProjectWithSubmodules_WithGitMirrors(t *testing.T) {
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestCheckingOutLocalGitProjectWithSubmodulesDisabled_WithGitMirrors(t *testing.T) {
@@ -274,11 +274,11 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled_WithGitMirrors(t *test
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestCheckingOutShallowCloneOfLocalGitProject_WithGitMirrors(t *testing.T) {
@@ -318,11 +318,11 @@ func TestCheckingOutShallowCloneOfLocalGitProject_WithGitMirrors(t *testing.T) {
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite_WithGitMirrors(t *testing.T) {
@@ -338,11 +338,11 @@ func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite_WithGitMirrors(t
 		t.Fatalf("EnableGitMirrors() error = %v", err)
 	}
 
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(ctx, t)
 }
 
 func TestCheckingOutWithSSHKeyscan_WithGitMirrors(t *testing.T) {
@@ -374,7 +374,7 @@ func TestCheckingOutWithSSHKeyscan_WithGitMirrors(t *testing.T) {
 		"BUILDKITE_SSH_KEYSCAN=true",
 	}
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 }
 
 func TestCheckingOutWithoutSSHKeyscan_WithGitMirrors(t *testing.T) {
@@ -399,7 +399,7 @@ func TestCheckingOutWithoutSSHKeyscan_WithGitMirrors(t *testing.T) {
 		"BUILDKITE_SSH_KEYSCAN=false",
 	}
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 }
 
 func TestCheckingOutWithSSHKeyscanAndUnscannableRepo_WithGitMirrors(t *testing.T) {
@@ -430,7 +430,7 @@ func TestCheckingOutWithSSHKeyscanAndUnscannableRepo_WithGitMirrors(t *testing.T
 		"BUILDKITE_SSH_KEYSCAN=true",
 	}
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 }
 
 func TestCleaningAnExistingCheckout_WithGitMirrors(t *testing.T) {
@@ -459,12 +459,12 @@ func TestCleaningAnExistingCheckout_WithGitMirrors(t *testing.T) {
 	}
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(ctx, t)
 
 	// This used to check if os.IsExist(err) == true.
 	// Unfortunately, os.IsExist(err) is not the same as !os.IsNotExist(err)
@@ -489,12 +489,12 @@ func TestForcingACleanCheckout_WithGitMirrors(t *testing.T) {
 	}
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
-	tester.RunAndCheck(t, "BUILDKITE_CLEAN_CHECKOUT=true")
+	tester.RunAndCheck(ctx, t, "BUILDKITE_CLEAN_CHECKOUT=true")
 
 	if !strings.Contains(tester.Output, "Cleaning pipeline checkout") {
 		t.Fatal(`tester.Output does not contain "Cleaning pipeline checkout"`)
@@ -524,12 +524,12 @@ func TestCheckoutOnAnExistingRepositoryWithoutAGitFolder_WithGitMirrors(t *testi
 		t.Fatalf("os.RemoveAll(.git/refs) = %v", err)
 	}
 
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(ctx, t)
 }
 
 func TestCheckoutRetriesOnCleanFailure_WithGitMirrors(t *testing.T) {
@@ -561,7 +561,7 @@ func TestCheckoutRetriesOnCleanFailure_WithGitMirrors(t *testing.T) {
 	})
 
 	git.Expect().AtLeastOnce().WithAnyArguments()
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(mainCtx, t)
 }
 
 func TestCheckoutRetriesOnCloneFailure_WithGitMirrors(t *testing.T) {
@@ -591,7 +591,7 @@ func TestCheckoutRetriesOnCloneFailure_WithGitMirrors(t *testing.T) {
 	})
 
 	git.Expect().AtLeastOnce().WithAnyArguments()
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(mainCtx, t)
 }
 
 func TestCheckoutDoesNotRetryOnHookFailure_WithGitMirrors(t *testing.T) {
@@ -620,7 +620,7 @@ func TestCheckoutDoesNotRetryOnHookFailure_WithGitMirrors(t *testing.T) {
 		}
 	})
 
-	if err := tester.Run(t); err == nil {
+	if err := tester.Run(mainCtx, t); err == nil {
 		t.Fatalf("tester.Run(t) = %v, want non-nil error", err)
 	}
 
@@ -661,7 +661,7 @@ func TestRepositorylessCheckout_WithGitMirrors(t *testing.T) {
 	tester.ExpectGlobalHook("post-command").Once()
 	tester.ExpectGlobalHook("pre-exit").Once()
 
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(mainCtx, t)
 }
 
 func TestGitMirrorEnv(t *testing.T) {
@@ -708,11 +708,11 @@ func TestGitMirrorEnv(t *testing.T) {
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 
 	if !strings.HasPrefix(gitMirrorPath, tester.GitMirrorsDir) {
 		t.Errorf("gitMirrorPath = %q, want prefix %q", gitMirrorPath, tester.GitMirrorsDir)

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -62,7 +62,7 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 		{"rev-parse", "HEAD"},
 	})
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestCheckingOutLocalGitProject(t *testing.T) {
@@ -97,11 +97,11 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
@@ -163,11 +163,11 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
@@ -224,11 +224,11 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
@@ -263,11 +263,11 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestCheckingOutLocalGitProjectWithShortCommitHash(t *testing.T) {
@@ -278,7 +278,7 @@ func TestCheckingOutLocalGitProjectWithShortCommitHash(t *testing.T) {
 	defer tester.Close()
 
 	// Do one checkout
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(mainCtx, t)
 
 	// Create another commit on the same branch in the remote repo
 	err = tester.Repo.ExecuteAll([][]string{
@@ -308,14 +308,14 @@ func TestCheckingOutLocalGitProjectWithShortCommitHash(t *testing.T) {
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	env := []string{
 		fmt.Sprintf("BUILDKITE_COMMIT=%s", shortCommitHash),
 	}
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 
 	// Check state of the checkout directory
 	checkoutRepo := &gitRepository{Path: tester.CheckoutDir()}
@@ -345,7 +345,7 @@ func TestCheckingOutGitHubPullRequestWithCommitHash(t *testing.T) {
 		fmt.Sprintf("BUILDKITE_COMMIT=%s", strings.TrimSpace(commitHash)),
 	}
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 
 	// Check state of the checkout directory
 	checkoutRepo := &gitRepository{Path: tester.CheckoutDir()}
@@ -375,7 +375,7 @@ func TestCheckingOutGitHubPullRequestAndCustomRefmap(t *testing.T) {
 		fmt.Sprintf("BUILDKITE_COMMIT=%s", strings.TrimSpace(commitHash)),
 	}
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 
 	// Check state of the checkout directory
 	checkoutRepo := &gitRepository{Path: tester.CheckoutDir()}
@@ -429,7 +429,7 @@ func TestCheckingOutGitHubPullRequestWithCommitHashAfterForcePush(t *testing.T) 
 	_, err = tester.Repo.Execute("update-ref", "refs/pull/123/head", "HEAD")
 	assert.NilError(t, err)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 
 	// Check state of the checkout directory
 	checkoutRepo := &gitRepository{Path: tester.CheckoutDir()}
@@ -459,7 +459,7 @@ func TestCheckingOutGitHubPullRequestWithShortCommitHash(t *testing.T) {
 		fmt.Sprintf("BUILDKITE_COMMIT=%s", shortCommitHash),
 	}
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 
 	// Check state of the checkout directory
 	checkoutRepo := &gitRepository{Path: tester.CheckoutDir()}
@@ -488,7 +488,7 @@ func TestCheckingOutGitHubPullRequestAtHead(t *testing.T) {
 		"BUILDKITE_COMMIT=HEAD",
 	}
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 
 	// Check state of the checkout directory
 	checkoutRepo := &gitRepository{Path: tester.CheckoutDir()}
@@ -521,7 +521,7 @@ func TestCheckingOutGitHubPullRequestAtHeadFromFork(t *testing.T) {
 		"BUILDKITE_COMMIT=HEAD",
 	}
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 
 	// Check state of the checkout directory
 	checkoutRepo := &gitRepository{Path: tester.CheckoutDir()}
@@ -586,11 +586,11 @@ func TestCheckoutErrorIsRetried(t *testing.T) {
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestFetchErrorIsRetried(t *testing.T) {
@@ -648,11 +648,11 @@ func TestFetchErrorIsRetried(t *testing.T) {
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite(t *testing.T) {
@@ -664,11 +664,11 @@ func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite(t *testing.T) {
 	}
 	defer tester.Close()
 
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(ctx, t)
 }
 
 func TestCheckingOutWithSSHKeyscan(t *testing.T) {
@@ -696,7 +696,7 @@ func TestCheckingOutWithSSHKeyscan(t *testing.T) {
 		"BUILDKITE_SSH_KEYSCAN=true",
 	}
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 }
 
 func TestCheckingOutWithoutSSHKeyscan(t *testing.T) {
@@ -717,7 +717,7 @@ func TestCheckingOutWithoutSSHKeyscan(t *testing.T) {
 		"BUILDKITE_SSH_KEYSCAN=false",
 	}
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 }
 
 func TestCheckingOutWithSSHKeyscanAndUnscannableRepo(t *testing.T) {
@@ -744,7 +744,7 @@ func TestCheckingOutWithSSHKeyscanAndUnscannableRepo(t *testing.T) {
 		"BUILDKITE_SSH_KEYSCAN=true",
 	}
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 }
 
 func TestCleaningAnExistingCheckout(t *testing.T) {
@@ -769,12 +769,12 @@ func TestCleaningAnExistingCheckout(t *testing.T) {
 	}
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(ctx, t)
 
 	// This used to check if os.IsExist(err) == true.
 	// Unfortunately, os.IsExist(err) is not the same as !os.IsNotExist(err)
@@ -795,12 +795,12 @@ func TestForcingACleanCheckout(t *testing.T) {
 	defer tester.Close()
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
-	tester.RunAndCheck(t, "BUILDKITE_CLEAN_CHECKOUT=true")
+	tester.RunAndCheck(ctx, t, "BUILDKITE_CLEAN_CHECKOUT=true")
 
 	if !strings.Contains(tester.Output, "Cleaning pipeline checkout") {
 		t.Fatal(`tester.Output does not contain "Cleaning pipeline checkout"`)
@@ -826,12 +826,12 @@ func TestCheckoutOnAnExistingRepositoryWithoutAGitFolder(t *testing.T) {
 		t.Fatalf("os.RemoveAll(.git/refs) = %v", err)
 	}
 
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(ctx, t)
 }
 
 func TestCheckoutRetriesOnCleanFailure(t *testing.T) {
@@ -859,7 +859,7 @@ func TestCheckoutRetriesOnCleanFailure(t *testing.T) {
 	})
 
 	git.Expect().AtLeastOnce().WithAnyArguments()
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(mainCtx, t)
 }
 
 func TestCheckoutRetriesOnCloneFailure(t *testing.T) {
@@ -885,7 +885,7 @@ func TestCheckoutRetriesOnCloneFailure(t *testing.T) {
 	})
 
 	git.Expect().AtLeastOnce().WithAnyArguments()
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(mainCtx, t)
 }
 
 func TestCheckoutDoesNotRetryOnHookFailure(t *testing.T) {
@@ -910,7 +910,7 @@ func TestCheckoutDoesNotRetryOnHookFailure(t *testing.T) {
 		}
 	})
 
-	if err := tester.Run(t); err == nil {
+	if err := tester.Run(mainCtx, t); err == nil {
 		t.Fatalf("tester.Run(t) = %v, want non-nil error", err)
 	}
 
@@ -947,7 +947,7 @@ func TestRepositorylessCheckout(t *testing.T) {
 	tester.ExpectGlobalHook("post-command").Once()
 	tester.ExpectGlobalHook("pre-exit").Once()
 
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(mainCtx, t)
 }
 
 func TestGitCheckoutWithCommitResolved(t *testing.T) {
@@ -971,10 +971,10 @@ func TestGitCheckoutWithCommitResolved(t *testing.T) {
 		{"clean", "-ffxdq"},
 	})
 
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).Exactly(0)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestGitCheckoutWithoutCommitResolved(t *testing.T) {
@@ -998,10 +998,10 @@ func TestGitCheckoutWithoutCommitResolved(t *testing.T) {
 		{"clean", "-ffxdq"},
 	})
 
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(0).Exactly(1)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestGitCheckoutWithoutCommitResolvedAndNoMetaData(t *testing.T) {
@@ -1026,11 +1026,11 @@ func TestGitCheckoutWithoutCommitResolvedAndNoMetaData(t *testing.T) {
 		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
 
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1).Exactly(1)
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 type subDirMatcher struct {

--- a/internal/job/integration/command_integration_test.go
+++ b/internal/job/integration/command_integration_test.go
@@ -39,7 +39,7 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 		`BUILDKITE_SHELL=C:\Windows\System32\CMD.exe /S /C`,
 	}
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 }
 
 func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {
@@ -52,7 +52,7 @@ func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {
 	defer tester.Close()
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
@@ -67,7 +67,7 @@ func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {
 	tester.ExpectGlobalHook("pre-exit").Once().AndCallFunc(preExitFunc)
 	tester.ExpectLocalHook("pre-exit").Once().AndCallFunc(preExitFunc)
 
-	if err := tester.Run(t, "BUILDKITE_COMMAND=false"); err == nil {
+	if err := tester.Run(ctx, t, "BUILDKITE_COMMAND=false"); err == nil {
 		t.Fatalf("tester.Run(t, BUILDKITE_COMMAND=false) = %v, want non-nil error", err)
 	}
 

--- a/internal/job/integration/docker_integration_test.go
+++ b/internal/job/integration/docker_integration_test.go
@@ -25,7 +25,7 @@ func TestRunningCommandWithDocker(t *testing.T) {
 	defer tester.Close()
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
@@ -47,7 +47,7 @@ func TestRunningCommandWithDocker(t *testing.T) {
 
 	expectCommandHooks("0", t, tester)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestRunningCommandWithDockerAndCustomDockerfile(t *testing.T) {
@@ -58,7 +58,7 @@ func TestRunningCommandWithDockerAndCustomDockerfile(t *testing.T) {
 	defer tester.Close()
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
@@ -81,7 +81,7 @@ func TestRunningCommandWithDockerAndCustomDockerfile(t *testing.T) {
 
 	expectCommandHooks("0", t, tester)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestRunningFailingCommandWithDocker(t *testing.T) {
@@ -92,7 +92,7 @@ func TestRunningFailingCommandWithDocker(t *testing.T) {
 	defer tester.Close()
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
@@ -116,7 +116,7 @@ func TestRunningFailingCommandWithDocker(t *testing.T) {
 
 	expectCommandHooks("1", t, tester)
 
-	if err = tester.Run(t, env...); err == nil {
+	if err = tester.Run(ctx, t, env...); err == nil {
 		t.Fatalf("tester.Run(t, %v) = %v, want non-nil error", env, err)
 	}
 
@@ -131,7 +131,7 @@ func TestRunningCommandWithDockerCompose(t *testing.T) {
 	defer tester.Close()
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
@@ -153,7 +153,7 @@ func TestRunningCommandWithDockerCompose(t *testing.T) {
 
 	expectCommandHooks("0", t, tester)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestRunningFailingCommandWithDockerCompose(t *testing.T) {
@@ -164,7 +164,7 @@ func TestRunningFailingCommandWithDockerCompose(t *testing.T) {
 	defer tester.Close()
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
@@ -189,7 +189,7 @@ func TestRunningFailingCommandWithDockerCompose(t *testing.T) {
 
 	expectCommandHooks("1", t, tester)
 
-	if err = tester.Run(t, env...); err == nil {
+	if err = tester.Run(ctx, t, env...); err == nil {
 		t.Fatalf("tester.Run(t, %v) = %v, want non-nil error", env, err)
 	}
 
@@ -204,7 +204,7 @@ func TestRunningCommandWithDockerComposeAndExtraConfig(t *testing.T) {
 	defer tester.Close()
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
@@ -227,7 +227,7 @@ func TestRunningCommandWithDockerComposeAndExtraConfig(t *testing.T) {
 
 	expectCommandHooks("0", t, tester)
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func TestRunningCommandWithDockerComposeAndBuildAll(t *testing.T) {
@@ -238,7 +238,7 @@ func TestRunningCommandWithDockerComposeAndBuildAll(t *testing.T) {
 	defer tester.Close()
 
 	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
+	ctx, agent := tester.MockAgent(mainCtx, t)
 	agent.
 		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
@@ -252,7 +252,7 @@ func TestRunningCommandWithDockerComposeAndBuildAll(t *testing.T) {
 	dockerCompose.IgnoreUnexpectedInvocations()
 	dockerCompose.Expect("-f", "docker-compose.yml", "-p", "buildkite1111111111111111", "--verbose", "build", "--pull").Once()
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 }
 
 func expectCommandHooks(exitStatus string, t *testing.T, tester *ExecutorTester) {

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -57,7 +57,7 @@ func TestEnvironmentVariablesPassBetweenHooks(t *testing.T) {
 		}
 	})
 
-	tester.RunAndCheck(t, "MY_CUSTOM_ENV=1")
+	tester.RunAndCheck(mainCtx, t, "MY_CUSTOM_ENV=1")
 }
 
 func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
@@ -117,7 +117,7 @@ func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
 		}
 	})
 
-	tester.RunAndCheck(t, "MY_CUSTOM_ENV=1")
+	tester.RunAndCheck(mainCtx, t, "MY_CUSTOM_ENV=1")
 }
 
 func TestDirectoryPassesBetweenHooks(t *testing.T) {
@@ -153,7 +153,7 @@ func TestDirectoryPassesBetweenHooks(t *testing.T) {
 		}
 	})
 
-	tester.RunAndCheck(t, "MY_CUSTOM_ENV=1")
+	tester.RunAndCheck(mainCtx, t, "MY_CUSTOM_ENV=1")
 }
 
 func TestDirectoryPassesBetweenHooksIgnoredUnderExit(t *testing.T) {
@@ -188,7 +188,7 @@ func TestDirectoryPassesBetweenHooksIgnoredUnderExit(t *testing.T) {
 		}
 	})
 
-	tester.RunAndCheck(t, "MY_CUSTOM_ENV=1")
+	tester.RunAndCheck(mainCtx, t, "MY_CUSTOM_ENV=1")
 }
 
 func TestCheckingOutFiresCorrectHooks(t *testing.T) {
@@ -218,7 +218,7 @@ func TestCheckingOutFiresCorrectHooks(t *testing.T) {
 	tester.ExpectGlobalHook("pre-exit").Once()
 	tester.ExpectLocalHook("pre-exit").Once()
 
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(mainCtx, t)
 }
 
 func TestReplacingCheckoutHook(t *testing.T) {
@@ -247,7 +247,7 @@ func TestReplacingCheckoutHook(t *testing.T) {
 	tester.ExpectGlobalHook("pre-exit").Once()
 	tester.ExpectLocalHook("pre-exit").Once()
 
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(mainCtx, t)
 }
 
 func TestReplacingGlobalCommandHook(t *testing.T) {
@@ -272,7 +272,7 @@ func TestReplacingGlobalCommandHook(t *testing.T) {
 	tester.ExpectGlobalHook("pre-exit").Once()
 	tester.ExpectLocalHook("pre-exit").Once()
 
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(mainCtx, t)
 }
 
 func TestReplacingLocalCommandHook(t *testing.T) {
@@ -298,7 +298,7 @@ func TestReplacingLocalCommandHook(t *testing.T) {
 	tester.ExpectGlobalHook("pre-exit").Once()
 	tester.ExpectLocalHook("pre-exit").Once()
 
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(mainCtx, t)
 }
 
 func TestPreExitHooksFireAfterCommandFailures(t *testing.T) {
@@ -313,7 +313,7 @@ func TestPreExitHooksFireAfterCommandFailures(t *testing.T) {
 	tester.ExpectGlobalHook("pre-exit").Once()
 	tester.ExpectLocalHook("pre-exit").Once()
 
-	if err := tester.Run(t, "BUILDKITE_COMMAND=false"); err == nil {
+	if err := tester.Run(mainCtx, t, "BUILDKITE_COMMAND=false"); err == nil {
 		t.Fatalf("tester.Run(t, BUILDKITE_COMMAND=false) = %v, want non-nil error", err)
 	}
 
@@ -332,7 +332,7 @@ func TestPreExitHooksDoesNotFireWithoutCommandPhase(t *testing.T) {
 	tester.ExpectGlobalHook("pre-exit").NotCalled()
 	tester.ExpectLocalHook("pre-exit").NotCalled()
 
-	tester.RunAndCheck(t, "BUILDKITE_BOOTSTRAP_PHASES=plugin,checkout")
+	tester.RunAndCheck(mainCtx, t, "BUILDKITE_BOOTSTRAP_PHASES=plugin,checkout")
 }
 
 func TestPreExitHooksFireAfterHookFailures(t *testing.T) {
@@ -422,7 +422,7 @@ func TestPreExitHooksFireAfterHookFailures(t *testing.T) {
 			}
 			defer tester.Close()
 
-			agent := tester.MockAgent(t)
+			ctx, agent := tester.MockAgent(ctx, t)
 
 			tester.ExpectGlobalHook(tc.failingHook).
 				Once().
@@ -454,7 +454,7 @@ func TestPreExitHooksFireAfterHookFailures(t *testing.T) {
 					AndExitWith(0)
 			}
 
-			if err := tester.Run(t, "BUILDKITE_ARTIFACT_PATHS=test.txt"); err == nil {
+			if err := tester.Run(ctx, t, "BUILDKITE_ARTIFACT_PATHS=test.txt"); err == nil {
 				t.Fatalf("tester.Run(t, BUILDKITE_ARTIFACT_PATHS=test.txt) = %v, want non-nil error", err)
 			}
 
@@ -477,7 +477,7 @@ func TestNoLocalHooksCalledWhenConfigSet(t *testing.T) {
 	tester.ExpectGlobalHook("pre-command").Once()
 	tester.ExpectLocalHook("pre-command").NotCalled()
 
-	if err = tester.Run(t, "BUILDKITE_COMMAND=true"); err == nil {
+	if err = tester.Run(mainCtx, t, "BUILDKITE_COMMAND=true"); err == nil {
 		t.Fatalf("tester.Run(t, BUILDKITE_COMMAND=true) = %v, want non-nil error", err)
 	}
 
@@ -510,7 +510,7 @@ func TestExitCodesPropagateOutFromGlobalHooks(t *testing.T) {
 
 			tester.ExpectGlobalHook(hook).Once().AndExitWith(5)
 
-			err = tester.Run(t)
+			err = tester.Run(ctx, t)
 
 			if err == nil {
 				t.Fatalf("tester.Run(t) = %v, want non-nil error", err)
@@ -546,7 +546,7 @@ func TestPreExitHooksFireAfterCancel(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		if err := tester.Run(t, "BUILDKITE_COMMAND=sleep 5"); err == nil {
+		if err := tester.Run(mainCtx, t, "BUILDKITE_COMMAND=sleep 5"); err == nil {
 			t.Errorf(`tester.Run(t, "BUILDKITE_COMMAND=sleep 5") = %v, want non-nil error`, err)
 		}
 		t.Logf("Command finished")
@@ -595,7 +595,7 @@ func TestPolyglotScriptHooksCanBeRun(t *testing.T) {
 		t.Fatalf("os.WriteFile(%q, script, 0o755) = %v", filename, err)
 	}
 
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(ctx, t)
 
 	if !strings.Contains(tester.Output, "ohai, it's ruby!") {
 		t.Fatalf("tester.Output %q does not contain expected output: %q", tester.Output, "ohai, it's ruby!")
@@ -639,7 +639,7 @@ func TestPolyglotBinaryHooksCanBeRun(t *testing.T) {
 		}
 	})
 
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(ctx, t)
 
 	if !strings.Contains(tester.Output, "hi there from golang 🌊") {
 		t.Fatalf("tester.Output %s does not contain expected output: %q", tester.Output, "hi there from golang 🌊")

--- a/internal/job/integration/job_api_integration_test.go
+++ b/internal/job/integration/job_api_integration_test.go
@@ -142,5 +142,5 @@ func TestBootstrapRunsJobAPI(t *testing.T) {
 		}
 	})
 
-	tester.RunAndCheck(t)
+	tester.RunAndCheck(mainCtx, t)
 }

--- a/internal/job/integration/plugin_integration_test.go
+++ b/internal/job/integration/plugin_integration_test.go
@@ -73,7 +73,7 @@ func TestRunningPlugins(t *testing.T) {
 		}
 	})
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 }
 
 func TestExitCodesPropagateOutFromPlugins(t *testing.T) {
@@ -111,7 +111,7 @@ func TestExitCodesPropagateOutFromPlugins(t *testing.T) {
 		"BUILDKITE_PLUGINS=" + json,
 	}
 
-	err = tester.Run(t, env...)
+	err = tester.Run(mainCtx, t, env...)
 
 	if err == nil {
 		t.Fatalf("tester.Run(t, %v) = %v, want non-nil error", env, err)
@@ -136,7 +136,7 @@ func TestMalformedPluginNamesDontCrashBootstrap(t *testing.T) {
 		`BUILDKITE_PLUGINS=["sdgmdgn.@$!sdf,asdf#llamas"]`,
 	}
 
-	if err := tester.Run(t, env...); err == nil {
+	if err := tester.Run(mainCtx, t, env...); err == nil {
 		t.Fatalf("tester.Run(t, %v) = %v, want non-nil error", env, err)
 	}
 
@@ -204,7 +204,7 @@ func TestOverlappingPluginHooks(t *testing.T) {
 		"BUILDKITE_PLUGINS=" + string(pluginsJSON),
 	}
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 }
 
 func TestPluginCloneRetried(t *testing.T) {
@@ -267,7 +267,7 @@ func TestPluginCloneRetried(t *testing.T) {
 		"BUILDKITE_PLUGINS=" + json,
 	}
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(mainCtx, t, env...)
 }
 
 // We want to support the situation where a user wants a plugin from a particular Git branch, e.g.,
@@ -347,7 +347,7 @@ func TestModifiedPluginNoForcePull(t *testing.T) {
 		}
 	})
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 
 	// Now, we want to "repeat" the test build, having modified the plugin's contents.
 	tester2, err := NewExecutorTester(ctx)
@@ -385,7 +385,7 @@ func TestModifiedPluginNoForcePull(t *testing.T) {
 		}
 	})
 
-	tester2.RunAndCheck(t, env...)
+	tester2.RunAndCheck(ctx, t, env...)
 }
 
 // As described above the previous integration test, this time we want to run the build both before
@@ -451,7 +451,7 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 		}
 	})
 
-	tester.RunAndCheck(t, env...)
+	tester.RunAndCheck(ctx, t, env...)
 
 	tester2, err := NewExecutorTester(ctx)
 	if err != nil {
@@ -492,7 +492,7 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 		}
 	})
 
-	tester2.RunAndCheck(t, env...)
+	tester2.RunAndCheck(ctx, t, env...)
 }
 
 type testPlugin struct {

--- a/internal/job/integration/redaction_integration_test.go
+++ b/internal/job/integration/redaction_integration_test.go
@@ -24,7 +24,7 @@ func TestRedactorRedactsAgentToken(t *testing.T) {
 		c.Exit(0)
 	})
 
-	err = tester.Run(t)
+	err = tester.Run(mainCtx, t)
 	if err != nil {
 		t.Fatalf("running executor tester: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestRedactorDoesNotRedactAgentToken_WhenNotInRedactedVars(t *testing.T) {
 		c.Exit(0)
 	})
 
-	err = tester.Run(t, `BUILDKITE_REDACTED_VARS=""`)
+	err = tester.Run(mainCtx, t, `BUILDKITE_REDACTED_VARS=""`)
 	if err != nil {
 		t.Fatalf("running executor tester: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestRedactorAdd_RedactsVarsAfterUse(t *testing.T) {
 	secret := "hunter2"
 	tester.ExpectGlobalHook("command").AndCallFunc(redactionTestCommandHook(t, secret))
 
-	err = tester.Run(t)
+	err = tester.Run(mainCtx, t)
 	if err != nil {
 		t.Fatalf("running executor tester: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestRegression_TestRedactorAdd_StillWorksWhenNoInitialRedactedVarsAreProvid
 	secret := "hunter2"
 	tester.ExpectGlobalHook("command").AndCallFunc(redactionTestCommandHook(t, secret))
 
-	err = tester.Run(t, `BUILDKITE_REDACTED_VARS=""`)
+	err = tester.Run(mainCtx, t, `BUILDKITE_REDACTED_VARS=""`)
 	if err != nil {
 		t.Fatalf("running executor tester: %v", err)
 	}

--- a/internal/self/self.go
+++ b/internal/self/self.go
@@ -1,0 +1,37 @@
+// Package self implements helpers for self-interaction.
+package self
+
+import (
+	"context"
+	"os"
+)
+
+// Overwritten by init.
+var pathToSelf = "buildkite-agent"
+
+func init() {
+	p, err := os.Executable()
+	if err != nil {
+		return
+	}
+	pathToSelf = p
+}
+
+type ctxKey struct{}
+
+// Path returns an absolute file path to buildkite-agent. If an absolute
+// path cannot be found, it defaults to "buildkite-agent" on the assumption it
+// is in $PATH. Self-executing with this path can still fail if someone is
+// playing games (e.g. unlinking the binary after starting it).
+func Path(ctx context.Context) string {
+	if val := ctx.Value(ctxKey{}); val != nil {
+		return val.(string)
+	}
+	return pathToSelf
+}
+
+// OverridePath changes the self-path used within a context. This is usually
+// only used for testing purposes (creating a mock of buildkite-agent.)
+func OverridePath(parent context.Context, path string) context.Context {
+	return context.WithValue(parent, ctxKey{}, path)
+}

--- a/version/version.go
+++ b/version/version.go
@@ -38,10 +38,6 @@ func BuildNumber() string {
 	return buildNumber
 }
 
-func IsDevelopmentBuild() bool {
-	return buildNumber == "x"
-}
-
 // commitInfo returns a string consisting of the commit hash and whether the the build was made in a
 // `dirty` working directory or not. A dirty working directory is one that has uncommitted changes
 // to files that git would track.


### PR DESCRIPTION
The README suggests an alternative way to run the agent from source is to use `go run`. Because the agent executes itself, using `go run main.go start` without an existing `buildkite-agent` in `$PATH` means it fails to run any jobs, and (perhaps more confusingly) if it does find a `buildkite-agent` it is unlikely to have the changes being tested. This applies to any system with more than one `buildkite-agent` on `$PATH`.