### PR TITLE
Replace deprecated ioutil calls with equivalents

### DIFF
--- a/agent/artifactory_uploader.go
+++ b/agent/artifactory_uploader.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -208,7 +207,7 @@ func checkResponse(r *http.Response) error {
 		return nil
 	}
 	errorResponse := &errorResponse{Response: r}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err == nil && data != nil {
 		err := json.Unmarshal(data, errorResponse)
 		if err != nil {

--- a/agent/form_uploader_test.go
+++ b/agent/form_uploader_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -70,7 +69,7 @@ func TestFormUploading(t *testing.T) {
 	}))
 	defer server.Close()
 
-	temp, err := ioutil.TempDir("", "agent")
+	temp, err := os.MkdirTemp("", "agent")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +84,7 @@ func TestFormUploading(t *testing.T) {
 
 	runtest := func(wd string) {
 		abspath := filepath.Join(wd, "llamas.txt")
-		err = ioutil.WriteFile(abspath, []byte("llamas"), 0700)
+		err = os.WriteFile(abspath, []byte("llamas"), 0700)
 		defer os.Remove(abspath)
 
 		uploader := NewFormUploader(logger.Discard, FormUploaderConfig{})
@@ -129,7 +128,7 @@ func TestFormUploadFileMissing(t *testing.T) {
 	}))
 	defer server.Close()
 
-	temp, err := ioutil.TempDir("", "agent")
+	temp, err := os.MkdirTemp("", "agent")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agent/gs_uploader.go
+++ b/agent/gs_uploader.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -84,7 +83,7 @@ func newGoogleClient(scope string) (*http.Client, error) {
 		data := []byte(os.Getenv("BUILDKITE_GS_APPLICATION_CREDENTIALS_JSON"))
 		return clientFromJSON(data, scope)
 	} else if os.Getenv("BUILDKITE_GS_APPLICATION_CREDENTIALS") != "" {
-		data, err := ioutil.ReadFile(os.Getenv("BUILDKITE_GS_APPLICATION_CREDENTIALS"))
+		data, err := os.ReadFile(os.Getenv("BUILDKITE_GS_APPLICATION_CREDENTIALS"))
 		if err != nil {
 			return nil, err
 		}

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -148,7 +147,7 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 	}
 
 	// Prepare a file to recieve the given job environment
-	if file, err := ioutil.TempFile(tempDir, fmt.Sprintf("job-env-%s", job.ID)); err != nil {
+	if file, err := os.CreateTemp(tempDir, fmt.Sprintf("job-env-%s", job.ID)); err != nil {
 		return runner, err
 	} else {
 		l.Debug("[JobRunner] Created env file: %s", file.Name())
@@ -224,7 +223,7 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 	// BUILDKITE_JOB_LOG_TMPFILE is an environment variable that contains the path to this temporary file.
 	var tmpFile *os.File
 	if conf.AgentConfiguration.EnableJobLogTmpfile {
-		tmpFile, err = ioutil.TempFile("", "buildkite_job_log")
+		tmpFile, err = os.CreateTemp("", "buildkite_job_log")
 		if err != nil {
 			return nil, err
 		}

--- a/agent/plugin/definition.go
+++ b/agent/plugin/definition.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -54,7 +53,7 @@ func LoadDefinitionFromDir(dir string) (*Definition, error) {
 		return nil, err
 	}
 
-	b, err := ioutil.ReadFile(f)
+	b, err := os.ReadFile(f)
 	if err != nil {
 		return nil, err
 	}

--- a/api/client.go
+++ b/api/client.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -243,7 +242,7 @@ func (c *Client) doRequest(req *http.Request, v interface{}) (*Response, error) 
 	).Debug("↳ %s %s", req.Method, req.URL)
 
 	defer resp.Body.Close()
-	defer io.Copy(ioutil.Discard, resp.Body)
+	defer io.Copy(io.Discard, resp.Body)
 
 	response := newResponse(resp)
 
@@ -302,7 +301,7 @@ func checkResponse(r *http.Response) error {
 	}
 
 	errorResponse := &ErrorResponse{Response: r}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err == nil && data != nil {
 		json.Unmarshal(data, errorResponse)
 	}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -888,7 +887,7 @@ func (b *Bootstrap) checkoutPlugin(p *plugin.Plugin) (*pluginCheckout, error) {
 	}
 
 	// Make the directory
-	tempDir, err := ioutil.TempDir(b.PluginsPath, id)
+	tempDir, err := os.MkdirTemp(b.PluginsPath, id)
 	if err != nil {
 		return nil, err
 	}
@@ -1002,7 +1001,7 @@ func (b *Bootstrap) CheckoutPhase(ctx context.Context) error {
 	// If we have a blank repository then use a temp dir for builds
 	if b.Config.Repository == "" {
 		var buildDir string
-		buildDir, err = ioutil.TempDir("", "buildkite-job-"+b.Config.JobID)
+		buildDir, err = os.MkdirTemp("", "buildkite-job-"+b.Config.JobID)
 		if err != nil {
 			return err
 		}
@@ -1638,7 +1637,7 @@ func (b *Bootstrap) defaultCommandPhase(ctx context.Context) error {
 
 		b.shell.Headerf("Running batch script")
 		if b.Debug {
-			contents, err := ioutil.ReadFile(batchScript)
+			contents, err := os.ReadFile(batchScript)
 			if err != nil {
 				return err
 			}

--- a/bootstrap/integration/artifact_integration_test.go
+++ b/bootstrap/integration/artifact_integration_test.go
@@ -1,7 +1,7 @@
 package integration
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -19,7 +19,7 @@ func TestArtifactsUploadAfterCommand(t *testing.T) {
 
 	// Write a file in the command hook
 	tester.ExpectGlobalHook("command").Once().AndCallFunc(func(c *bintest.Call) {
-		err := ioutil.WriteFile(filepath.Join(c.Dir, "test.txt"), []byte("llamas"), 0700)
+		err := os.WriteFile(filepath.Join(c.Dir, "test.txt"), []byte("llamas"), 0700)
 		if err != nil {
 			t.Fatalf("Write failed with %v", err)
 		}
@@ -48,7 +48,7 @@ func TestArtifactsUploadAfterCommandFails(t *testing.T) {
 	defer tester.Close()
 
 	tester.MustMock(t, "my-command").Expect().AndCallFunc(func(c *bintest.Call) {
-		err := ioutil.WriteFile(filepath.Join(c.Dir, "test.txt"), []byte("llamas"), 0700)
+		err := os.WriteFile(filepath.Join(c.Dir, "test.txt"), []byte("llamas"), 0700)
 		if err != nil {
 			t.Fatalf("Write failed with %v", err)
 		}
@@ -83,7 +83,7 @@ func TestArtifactsUploadAfterCommandHookFails(t *testing.T) {
 
 	// Write a file in the command hook
 	tester.ExpectGlobalHook("command").Once().AndCallFunc(func(c *bintest.Call) {
-		err := ioutil.WriteFile(filepath.Join(c.Dir, "test.txt"), []byte("llamas"), 0700)
+		err := os.WriteFile(filepath.Join(c.Dir, "test.txt"), []byte("llamas"), 0700)
 		if err != nil {
 			t.Fatalf("Write failed with %v", err)
 		}

--- a/bootstrap/integration/bootstrap_tester.go
+++ b/bootstrap/integration/bootstrap_tester.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -44,27 +43,27 @@ type BootstrapTester struct {
 }
 
 func NewBootstrapTester() (*BootstrapTester, error) {
-	homeDir, err := ioutil.TempDir("", "home")
+	homeDir, err := os.MkdirTemp("", "home")
 	if err != nil {
 		return nil, err
 	}
 
-	pathDir, err := ioutil.TempDir("", "bootstrap-path")
+	pathDir, err := os.MkdirTemp("", "bootstrap-path")
 	if err != nil {
 		return nil, err
 	}
 
-	buildDir, err := ioutil.TempDir("", "bootstrap-builds")
+	buildDir, err := os.MkdirTemp("", "bootstrap-builds")
 	if err != nil {
 		return nil, err
 	}
 
-	hooksDir, err := ioutil.TempDir("", "bootstrap-hooks")
+	hooksDir, err := os.MkdirTemp("", "bootstrap-hooks")
 	if err != nil {
 		return nil, err
 	}
 
-	pluginsDir, err := ioutil.TempDir("", "bootstrap-plugins")
+	pluginsDir, err := os.MkdirTemp("", "bootstrap-plugins")
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +109,7 @@ func NewBootstrapTester() (*BootstrapTester, error) {
 		bt.Env = append(bt.Env, `BUILDKITE_AGENT_EXPERIMENT=`+strings.Join(exp, ","))
 
 		if experiments.IsEnabled(`git-mirrors`) {
-			gitMirrorsDir, err := ioutil.TempDir("", "bootstrap-git-mirrors")
+			gitMirrorsDir, err := os.MkdirTemp("", "bootstrap-git-mirrors")
 			if err != nil {
 				return nil, err
 			}
@@ -204,7 +203,7 @@ func (b *BootstrapTester) writeHookScript(m *bintest.Mock, name string, dir stri
 		return "", err
 	}
 
-	return hookScript, ioutil.WriteFile(hookScript, []byte(body), 0600)
+	return hookScript, os.WriteFile(hookScript, []byte(body), 0600)
 }
 
 // ExpectLocalHook creates a mock object and a script in the git repository's buildkite hooks dir

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -508,7 +507,7 @@ func TestCleaningAnExistingCheckout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Clone failed with %s", out)
 	}
-	err = ioutil.WriteFile(filepath.Join(tester.CheckoutDir(), "test.txt"), []byte("llamas"), 0700)
+	err = os.WriteFile(filepath.Join(tester.CheckoutDir(), "test.txt"), []byte("llamas"), 0700)
 	if err != nil {
 		t.Fatalf("Write failed with %s", out)
 	}
@@ -667,7 +666,7 @@ func TestRepositorylessCheckout(t *testing.T) {
 		"export BUILDKITE_REPO=",
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "environment"),
+	if err := os.WriteFile(filepath.Join(tester.HooksDir, "environment"),
 		[]byte(strings.Join(script, "\n")), 0700); err != nil {
 		t.Fatal(err)
 	}

--- a/bootstrap/integration/git.go
+++ b/bootstrap/integration/git.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,7 +17,7 @@ func createTestGitRespository() (*gitRepository, error) {
 		return nil, err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(repo.Path, "test.txt"), []byte("This is a test"), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(repo.Path, "test.txt"), []byte("This is a test"), 0600); err != nil {
 		return nil, err
 	}
 
@@ -34,7 +33,7 @@ func createTestGitRespository() (*gitRepository, error) {
 		return nil, err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(repo.Path, "test.txt"), []byte("This is a test pull request"), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(repo.Path, "test.txt"), []byte("This is a test pull request"), 0600); err != nil {
 		return nil, err
 	}
 
@@ -62,7 +61,7 @@ type gitRepository struct {
 }
 
 func newGitRepository() (*gitRepository, error) {
-	tempDirRaw, err := ioutil.TempDir("", "git-repo")
+	tempDirRaw, err := os.MkdirTemp("", "git-repo")
 	if err != nil {
 		return nil, fmt.Errorf("Error creating temp dir: %v", err)
 	}

--- a/bootstrap/integration/hooks_integration_test.go
+++ b/bootstrap/integration/hooks_integration_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -29,7 +29,7 @@ func TestEnvironmentVariablesPassBetweenHooks(t *testing.T) {
 			"export LLAMAS_ROCK=absolutely",
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "environment"),
+		if err := os.WriteFile(filepath.Join(tester.HooksDir, "environment"),
 			[]byte(strings.Join(script, "\n")), 0700); err != nil {
 			t.Fatal(err)
 		}
@@ -39,7 +39,7 @@ func TestEnvironmentVariablesPassBetweenHooks(t *testing.T) {
 			"set LLAMAS_ROCK=absolutely",
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "environment.bat"),
+		if err := os.WriteFile(filepath.Join(tester.HooksDir, "environment.bat"),
 			[]byte(strings.Join(script, "\r\n")), 0700); err != nil {
 			t.Fatal(err)
 		}
@@ -80,7 +80,7 @@ func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
 			"@echo off",
 			"set LLAMAS_ROCK=absolutely",
 		}
-		if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "pre-command.bat"),
+		if err := os.WriteFile(filepath.Join(tester.HooksDir, "pre-command.bat"),
 			[]byte(strings.Join(preCommand, "\r\n")), 0700); err != nil {
 			t.Fatal(err)
 		}
@@ -89,7 +89,7 @@ func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
 			"@echo off",
 			"set LLAMAS_ROCK=",
 		}
-		if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "post-command.bat"),
+		if err := os.WriteFile(filepath.Join(tester.HooksDir, "post-command.bat"),
 			[]byte(strings.Join(postCommand, "\n")), 0700); err != nil {
 			t.Fatal(err)
 		}
@@ -98,7 +98,7 @@ func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
 			"#!/bin/bash",
 			"export LLAMAS_ROCK=absolutely",
 		}
-		if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "pre-command"),
+		if err := os.WriteFile(filepath.Join(tester.HooksDir, "pre-command"),
 			[]byte(strings.Join(preCommand, "\n")), 0700); err != nil {
 			t.Fatal(err)
 		}
@@ -107,7 +107,7 @@ func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
 			"#!/bin/bash",
 			"unset LLAMAS_ROCK",
 		}
-		if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "post-command"),
+		if err := os.WriteFile(filepath.Join(tester.HooksDir, "post-command"),
 			[]byte(strings.Join(postCommand, "\n")), 0700); err != nil {
 			t.Fatal(err)
 		}
@@ -154,7 +154,7 @@ func TestDirectoryPassesBetweenHooks(t *testing.T) {
 		"cd ./mysubdir",
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "pre-command"), []byte(strings.Join(script, "\n")), 0700); err != nil {
+	if err := os.WriteFile(filepath.Join(tester.HooksDir, "pre-command"), []byte(strings.Join(script, "\n")), 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -189,7 +189,7 @@ func TestDirectoryPassesBetweenHooksIgnoredUnderExit(t *testing.T) {
 		"exit 0",
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(tester.HooksDir, "pre-command"), []byte(strings.Join(script, "\n")), 0700); err != nil {
+	if err := os.WriteFile(filepath.Join(tester.HooksDir, "pre-command"), []byte(strings.Join(script, "\n")), 0700); err != nil {
 		t.Fatal(err)
 	}
 

--- a/bootstrap/integration/plugin_integration_test.go
+++ b/bootstrap/integration/plugin_integration_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -292,7 +291,7 @@ func TestModifiedPluginNoForcePull(t *testing.T) {
 	// Let's set a fixed location for plugins, otherwise NewBootstrapTester() gives us a random new
 	// tempdir every time, which defeats our test.  Later we'll use this pluginsDir for the second
 	// test run, too.
-	pluginsDir, err := ioutil.TempDir("", "bootstrap-plugins")
+	pluginsDir, err := os.MkdirTemp("", "bootstrap-plugins")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -399,7 +398,7 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 
 	// Let's set a fixed location for plugins, otherwise it'll be a random new tempdir every time
 	// which defeats our test.
-	pluginsDir, err := ioutil.TempDir("", "bootstrap-plugins")
+	pluginsDir, err := os.MkdirTemp("", "bootstrap-plugins")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -510,7 +509,7 @@ func createTestPlugin(t *testing.T, hooks map[string][]string) *testPlugin {
 
 	for hook, lines := range hooks {
 		data := []byte(strings.Join(lines, "\n"))
-		if err := ioutil.WriteFile(filepath.Join(repo.Path, "hooks", hook), data, 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(repo.Path, "hooks", hook), data, 0600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -537,7 +536,7 @@ func modifyTestPlugin(t *testing.T, hooks map[string][]string, testPlugin *testP
 
 	for hook, lines := range hooks {
 		data := []byte(strings.Join(lines, "\n"))
-		if err := ioutil.WriteFile(filepath.Join(repo.Path, "hooks", hook), data, 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(repo.Path, "hooks", hook), data, 0600); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/bootstrap/knownhosts_test.go
+++ b/bootstrap/knownhosts_test.go
@@ -2,7 +2,6 @@ package bootstrap
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -52,7 +51,7 @@ usage: ssh [-1246AaCfgKkMNnqsTtVvXxYy] [-b bind_address] [-c cipher_spec]
            [-w local_tun[:remote_tun]] [user@]hostname [command]`).
 				AndExitWith(255)
 
-			f, err := ioutil.TempFile("", "known-hosts")
+			f, err := os.CreateTemp("", "known-hosts")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/bootstrap/shell/logger.go
+++ b/bootstrap/shell/logger.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"runtime"
@@ -42,7 +41,7 @@ var StderrLogger = &WriterLogger{
 
 // DiscardLogger discards all log messages
 var DiscardLogger = &WriterLogger{
-	Writer: ioutil.Discard,
+	Writer: io.Discard,
 }
 
 // WriterLogger provides a logger that writes to an io.Writer

--- a/bootstrap/shell/tempfile.go
+++ b/bootstrap/shell/tempfile.go
@@ -2,7 +2,6 @@ package shell
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,7 +22,7 @@ func TempFileWithExtension(filename string) (*os.File, error) {
 	}
 
 	// Create the file
-	tempFile, err := ioutil.TempFile(tempDir, basename+"-")
+	tempFile, err := os.CreateTemp(tempDir, basename+"-")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create temporary file \"%s\" (%s)", filename, err)
 	}

--- a/bootstrap/shell/test.go
+++ b/bootstrap/shell/test.go
@@ -1,7 +1,7 @@
 package shell
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"runtime"
 	"testing"
@@ -17,7 +17,7 @@ func NewTestShell(t *testing.T) *Shell {
 	}
 
 	sh.Logger = DiscardLogger
-	sh.Writer = ioutil.Discard
+	sh.Writer = io.Discard
 
 	if os.Getenv(`DEBUG_SHELL`) == "1" {
 		sh.Logger = TestingLogger{T: t}

--- a/clicommand/agent_start_test.go
+++ b/clicommand/agent_start_test.go
@@ -1,7 +1,6 @@
 package clicommand
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -12,7 +11,7 @@ import (
 )
 
 func setupHooksPath(t *testing.T) (string, func()) {
-	hooksPath, err := ioutil.TempDir("", "")
+	hooksPath, err := os.MkdirTemp("", "")
 	if err != nil {
 		assert.FailNow(t, "failed to create temp file: %v", err)
 	}
@@ -29,7 +28,7 @@ func writeAgentShutdownHook(t *testing.T, dir string) string {
 		script = "echo hello world"
 	}
 	filepath := filepath.Join(dir, filename)
-	if err := ioutil.WriteFile(filepath, []byte(script), 0755); err != nil {
+	if err := os.WriteFile(filepath, []byte(script), 0755); err != nil {
 		assert.FailNow(t, "failed to write agent-shutdown hook: %v", err)
 	}
 	return filepath

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -2,7 +2,7 @@ package clicommand
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -139,7 +139,7 @@ var AnnotateCommand = cli.Command{
 			l.Info("Reading annotation body from STDIN")
 
 			// Actually read the file from STDIN
-			stdin, err := ioutil.ReadAll(os.Stdin)
+			stdin, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				l.Fatal("Failed to read from STDIN: %s", err)
 			}

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -2,7 +2,7 @@ package clicommand
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -99,7 +99,7 @@ var MetaDataSetCommand = cli.Command{
 		if len(c.Args()) < 2 {
 			l.Info("Reading meta-data value from STDIN")
 
-			input, err := ioutil.ReadAll(os.Stdin)
+			input, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				l.Fatal("Failed to read from STDIN: %s", err)
 			}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -3,7 +3,7 @@ package clicommand
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -151,7 +151,7 @@ var PipelineUploadCommand = cli.Command{
 			l.Info("Reading pipeline config from \"%s\"", cfg.FilePath)
 
 			filename = filepath.Base(cfg.FilePath)
-			input, err = ioutil.ReadFile(cfg.FilePath)
+			input, err = os.ReadFile(cfg.FilePath)
 			if err != nil {
 				l.Fatal("Failed to read file: %s", err)
 			}
@@ -159,7 +159,7 @@ var PipelineUploadCommand = cli.Command{
 			l.Info("Reading pipeline config from STDIN")
 
 			// Actually read the file from STDIN
-			input, err = ioutil.ReadAll(os.Stdin)
+			input, err = io.ReadAll(os.Stdin)
 			if err != nil {
 				l.Fatal("Failed to read from STDIN: %s", err)
 			}
@@ -200,7 +200,7 @@ var PipelineUploadCommand = cli.Command{
 
 			// Read the default file
 			filename = path.Base(found)
-			input, err = ioutil.ReadFile(found)
+			input, err = os.ReadFile(found)
 			if err != nil {
 				l.Fatal("Failed to read file \"%s\" (%s)", found, err)
 			}

--- a/clicommand/profiler.go
+++ b/clicommand/profiler.go
@@ -1,7 +1,6 @@
 package clicommand
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -60,7 +59,7 @@ func (p *profiler) Stop() {
 
 // Start starts a new profiling session.
 func (p *profiler) Start() {
-	path, err := ioutil.TempDir("", "profile")
+	path, err := os.MkdirTemp("", "profile")
 	if err != nil {
 		p.logger.Fatal("Could not create initial output directory: %v", err)
 	}

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -2,7 +2,7 @@ package clicommand
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -120,7 +120,7 @@ var StepUpdateCommand = cli.Command{
 		if len(c.Args()) < 2 {
 			l.Info("Reading value from STDIN")
 
-			input, err := ioutil.ReadAll(os.Stdin)
+			input, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				l.Fatal("Failed to read from STDIN: %s", err)
 			}

--- a/hook/scriptwrapper_test.go
+++ b/hook/scriptwrapper_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -190,7 +190,7 @@ func TestRunningHookDetectsChangedWorkingDirectory(t *testing.T) {
 		defer cleanup()
 	}
 
-	tempDir, err := ioutil.TempDir("", "hookwrapperdir")
+	tempDir, err := os.MkdirTemp("", "hookwrapperdir")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +285,7 @@ func assertScriptLike(t *testing.T, scriptTemplate, hookFileName string, wrapper
 
 	defer file.Close()
 
-	wrapperScriptContents, err := ioutil.ReadAll(file)
+	wrapperScriptContents, err := io.ReadAll(file)
 	assert.NoError(t, err)
 
 	expected := fmt.Sprintf(scriptTemplate, wrapper.beforeEnvFile.Name(), hookFileName, wrapper.afterEnvFile.Name())

--- a/logger/log.go
+++ b/logger/log.go
@@ -3,7 +3,6 @@ package logger
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -259,6 +258,6 @@ func (p *JSONPrinter) Print(level Level, msg string, fields Fields) {
 
 var Discard = &ConsoleLogger{
 	printer: &TextPrinter{
-		Writer: ioutil.Discard,
+		Writer: io.Discard,
 	},
 }

--- a/process/cat.go
+++ b/process/cat.go
@@ -3,7 +3,7 @@ package process
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -18,7 +18,7 @@ func Cat(path string) (string, error) {
 	var buffer bytes.Buffer
 
 	for _, file := range files {
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		if err != nil {
 			return "", fmt.Errorf("Could not read file: %s (%T: %v)", file, err, err)
 		}

--- a/stdin/main_test.go
+++ b/stdin/main_test.go
@@ -2,7 +2,6 @@ package stdin_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -66,7 +65,7 @@ func TestIsStdinIsReadableWithAPipe(t *testing.T) {
 }
 
 func TestIsStdinIsReadableWithOutputRedirection(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "output-redirect")
+	tmpfile, err := os.CreateTemp("", "output-redirect")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
io/ioutil was deprecated as of Go 1.16. Equivalent functionality is now in the io or os packages. 

Do this cleanup in one go so I stop doing it piece-by-piece.