### PR TITLE
agent: Tidy up t.Error/t.Fatal (part 1)

### DIFF
--- a/agent/artifact_downloader_test.go
+++ b/agent/artifact_downloader_test.go
@@ -41,8 +41,7 @@ func TestArtifactDownloaderConnectsToEndpoint(t *testing.T) {
 		BuildID: "my-build",
 	})
 
-	err := d.Download()
-	if err != nil {
-		t.Fatal(err)
+	if err := d.Download(); err != nil {
+		t.Errorf("d.Download() = %v", err)
 	}
 }

--- a/agent/artifact_searcher_test.go
+++ b/agent/artifact_searcher_test.go
@@ -41,7 +41,7 @@ func TestArtifactSearcherConnectsToEndpoint(t *testing.T) {
 
 	artifacts, err := s.Search("llamas.txt", "my-build", false, false)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf(`s.Search("llamas.txt", "my-build", false, false) error = %v`, err)
 	}
 
 	assert.Equal(t, []*api.Artifact{{

--- a/agent/artifact_uploader_test.go
+++ b/agent/artifact_uploader_test.go
@@ -112,14 +112,14 @@ func TestCollect(t *testing.T) {
 	experiments.Disable(`normalised-upload-paths`)
 	artifactsWithoutExperimentEnabled, err := uploader.Collect()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("[normalised-upload-paths disabled] uploader.Collect() error = %v", err)
 	}
 	assert.Equal(t, 5, len(artifactsWithoutExperimentEnabled))
 
 	experiments.Enable(`normalised-upload-paths`)
 	artifactsWithExperimentEnabled, err := uploader.Collect()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("[normalised-upload-paths enabled] uploader.Collect() error = %v", err)
 	}
 	assert.Equal(t, 5, len(artifactsWithExperimentEnabled))
 
@@ -129,7 +129,7 @@ func TestCollect(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			a := findArtifact(artifactsWithoutExperimentEnabled, tc.Name)
 			if a == nil {
-				t.Fatalf("Failed to find artifact %q", tc.Name)
+				t.Fatalf("findArtifact(%q) == nil", tc.Name)
 			}
 
 			assert.Equal(t, filepath.Join(tc.Path...), a.Path)
@@ -147,7 +147,7 @@ func TestCollect(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			a := findArtifact(artifactsWithExperimentEnabled, tc.Name)
 			if a == nil {
-				t.Fatalf("Failed to find artifact %q", tc.Name)
+				t.Fatalf("findArtifact(%q) == nil", tc.Name)
 			}
 
 			// Note that the rootWithoutVolume component of some tc.Path values
@@ -183,7 +183,7 @@ func TestCollectThatDoesntMatchAnyFiles(t *testing.T) {
 
 	artifacts, err := uploader.Collect()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("uploader.Collect() error = %v", err)
 	}
 
 	assert.Equal(t, len(artifacts), 0)
@@ -205,13 +205,12 @@ func TestCollectWithSomeGlobsThatDontMatchAnything(t *testing.T) {
 
 	artifacts, err := uploader.Collect()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("uploader.Collect() error = %v", err)
 	}
 
 	if len(artifacts) != 4 {
-		t.Fatalf("Expected to match 4 artifacts, found %d", len(artifacts))
+		t.Errorf("len(artifacts) = %d, want 4", len(artifacts))
 	}
-
 }
 
 func TestCollectWithSomeGlobsThatDontMatchAnythingFollowingSymlinks(t *testing.T) {
@@ -232,11 +231,11 @@ func TestCollectWithSomeGlobsThatDontMatchAnythingFollowingSymlinks(t *testing.T
 
 	artifacts, err := uploader.Collect()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("uploader.Collect() error = %v", err)
 	}
 
 	if len(artifacts) != 5 {
-		t.Fatalf("Expected to match 5 artifacts, found %d", len(artifacts))
+		t.Errorf("len(artifacts) = %d, want 5", len(artifacts))
 	}
 }
 
@@ -255,7 +254,7 @@ func TestCollectWithDuplicateMatches(t *testing.T) {
 
 	artifacts, err := uploader.Collect()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("uploader.Collect() error = %v", err)
 	}
 
 	paths := []string{}
@@ -290,7 +289,7 @@ func TestCollectWithDuplicateMatchesFollowingSymlinks(t *testing.T) {
 
 	artifacts, err := uploader.Collect()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("uploader.Collect() error = %v", err)
 	}
 
 	paths := []string{}

--- a/agent/artifactory_uploader_test.go
+++ b/agent/artifactory_uploader_test.go
@@ -4,30 +4,25 @@ import (
 	"testing"
 )
 
-func TestParseArtifactoryDestinationBucketPath(t *testing.T) {
-	for _, tc := range []struct {
-		Destination, Path string
+func TestParseArtifactoryDestination(t *testing.T) {
+	tests := []struct {
+		dest, bucket, path string
 	}{
-		{"rt://my-bucket-name/foo/bar", "foo/bar"},
-		{"rt://stats-with-an-s/and-this-is-its/folder", "and-this-is-its/folder"},
-	} {
-		_, path := ParseArtifactoryDestination(tc.Destination)
-		if path != tc.Path {
-			t.Fatalf("Expected %q, got %q", tc.Path, path)
-		}
+		{
+			dest:   "rt://my-bucket-name/foo/bar",
+			bucket: "my-bucket-name",
+			path:   "foo/bar",
+		},
+		{
+			dest:   "rt://starts-with-an-s/and-this-is-its/folder",
+			bucket: "starts-with-an-s",
+			path:   "and-this-is-its/folder",
+		},
 	}
-}
-
-func TestParseArtifactoryDestinationBucketName(t *testing.T) {
-	for _, tc := range []struct {
-		Destination, Bucket string
-	}{
-		{"rt://my-bucket-name/foo/bar", "my-bucket-name"},
-		{"rt://starts-with-an-s", "starts-with-an-s"},
-	} {
-		bucket, _ := ParseArtifactoryDestination(tc.Destination)
-		if bucket != tc.Bucket {
-			t.Fatalf("Expected %q, got %q", tc.Bucket, bucket)
+	for _, tc := range tests {
+		bucket, path := ParseArtifactoryDestination(tc.dest)
+		if bucket != tc.bucket || path != tc.path {
+			t.Errorf("ParseArtifactoryDestination(%q) = (%q, %q), want (%q, %q)", tc.dest, bucket, path, tc.bucket, tc.path)
 		}
 	}
 }

--- a/agent/form_uploader.go
+++ b/agent/form_uploader.go
@@ -54,7 +54,7 @@ func (u *FormUploader) URL(artifact *api.Artifact) string {
 
 func (u *FormUploader) Upload(artifact *api.Artifact) error {
 	if artifact.FileSize > maxFormUploadedArtifactSize {
-		return errors.New(fmt.Sprintf("File size (%d bytes) exceeds the maximum supported by Buildkite's default artifact storage (5Gb). Alternative artifact storage options may support larger files.", artifact.FileSize))
+		return errArtifactTooLarge{Size: artifact.FileSize}
 	}
 
 	// Create a HTTP request for uploading the file
@@ -258,4 +258,14 @@ type multipartReadCloser struct {
 
 func (mrc *multipartReadCloser) Close() error {
 	return mrc.fh.Close()
+}
+
+type errArtifactTooLarge struct {
+	Size int64
+}
+
+func (e errArtifactTooLarge) Error() string {
+	// TODO: Clean up error strings
+	// https://github.com/golang/go/wiki/CodeReviewComments#error-strings
+	return fmt.Sprintf("File size (%d bytes) exceeds the maximum supported by Buildkite's default artifact storage (5Gb). Alternative artifact storage options may support larger files.", e.Size)
 }

--- a/agent/form_uploader_test.go
+++ b/agent/form_uploader_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,71 +18,64 @@ import (
 func TestFormUploading(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
-		case `/buildkiteartifacts.com`:
+		case "/buildkiteartifacts.com":
 			if req.ContentLength <= 0 {
-				t.Error("Expected a Content-Length header")
-				http.Error(rw, "Bad requests", http.StatusBadRequest)
+				http.Error(rw, "zero or unknown Content-Length", http.StatusBadRequest)
 				return
 			}
 
-			err := req.ParseMultipartForm(5 * 1024 * 1024)
-			if err != nil {
-				t.Error(err)
-				http.Error(rw, err.Error(), http.StatusInternalServerError)
+			if err := req.ParseMultipartForm(5 * 1024 * 1024); err != nil {
+				http.Error(rw, fmt.Sprintf("req.ParseMultipartForm() = %v", err), http.StatusBadRequest)
 				return
 			}
 
 			// Check the ${artifact:path} interpolation is working
 			path := req.FormValue("path")
-			if path != "llamas.txt" {
-				t.Errorf("Bad path content %q", path)
-				http.Error(rw, "Bad path content", http.StatusInternalServerError)
+			if got, want := path, "llamas.txt"; got != want {
+				http.Error(rw, fmt.Sprintf("path = %q, want %q", got, want), http.StatusBadRequest)
 				return
 			}
 
 			file, fh, err := req.FormFile("file")
 			if err != nil {
-				t.Error(err)
-				http.Error(rw, err.Error(), http.StatusInternalServerError)
+				http.Error(rw, fmt.Sprintf(`req.FormFile("file") error = %v`, err), http.StatusBadRequest)
 				return
 			}
 			defer file.Close()
 
 			b := &bytes.Buffer{}
-			_, _ = io.Copy(b, file)
-
-			// Check the file is attached correctly
-			if b.String() != "llamas" {
-				t.Errorf("Bad file content %q", b.String())
-				http.Error(rw, "Bad file content", http.StatusInternalServerError)
+			if _, err := io.Copy(b, file); err != nil {
+				http.Error(rw, fmt.Sprintf("io.Copy() error = %v", err), http.StatusInternalServerError)
 				return
 			}
 
-			if fh.Filename != "llamas.txt" {
-				t.Errorf("Bad filename content %q", fh.Filename)
-				http.Error(rw, "Bad filename content", http.StatusInternalServerError)
+			// Check the file is attached correctly
+			if got, want := b.String(), "llamas"; got != want {
+				http.Error(rw, fmt.Sprintf("uploaded file content = %q, want %q", got, want), http.StatusBadRequest)
+				return
+			}
+
+			if got, want := fh.Filename, "llamas.txt"; got != want {
+				http.Error(rw, fmt.Sprintf("uploaded file name = %q, want %q", got, want), http.StatusInternalServerError)
 				return
 			}
 
 		default:
-			t.Errorf("Unknown path %s %s", req.Method, req.URL.Path)
-			http.Error(rw, "Not found", http.StatusNotFound)
+			http.Error(rw, fmt.Sprintf("not found; method = %q, path = %q", req.Method, req.URL.Path), http.StatusNotFound)
 		}
 	}))
 	defer server.Close()
 
 	temp, err := os.MkdirTemp("", "agent")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf(`os.MkdirTemp("", "agent") error = %v`, err)
 	}
 	defer os.Remove(temp)
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("os.Getwd() error = %v", err)
 	}
-
-	tc := []string{temp, cwd}
 
 	runtest := func(wd string) {
 		abspath := filepath.Join(wd, "llamas.txt")
@@ -112,25 +107,24 @@ func TestFormUploading(t *testing.T) {
 		}
 
 		if err := uploader.Upload(artifact); err != nil {
-			t.Fatal(err)
+			t.Errorf("uploader.Upload(artifact) = %v", err)
 		}
 	}
 
-	for _, wd := range tc {
+	for _, wd := range []string{temp, cwd} {
 		runtest(wd)
 	}
 }
 
 func TestFormUploadFileMissing(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		t.Errorf("Unknown path %s %s", req.Method, req.URL.Path)
 		http.Error(rw, "Not found", http.StatusNotFound)
 	}))
 	defer server.Close()
 
 	temp, err := os.MkdirTemp("", "agent")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf(`os.MkdirTemp("", "agent") error = %v`, err)
 	}
 	defer os.Remove(temp)
 
@@ -161,27 +155,24 @@ func TestFormUploadFileMissing(t *testing.T) {
 	}
 
 	if err := uploader.Upload(artifact); !os.IsNotExist(err) {
-		t.Errorf("Expected error no such file or directory, got %q", err)
+		t.Errorf("uploader.Upload(artifact) = %v, want os.ErrNotExist", err)
 	}
 }
 
 func TestFormUploadTooBig(t *testing.T) {
 	uploader := NewFormUploader(logger.Discard, FormUploaderConfig{})
+	const size = int64(6442450944) // 6Gb
 	artifact := &api.Artifact{
 		ID:                 "xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx",
 		Path:               "llamas.txt",
 		AbsolutePath:       "/llamas.txt",
 		GlobPath:           "llamas.txt",
 		ContentType:        "text/plain",
-		FileSize:           int64(6442450944), // 6Gb
+		FileSize:           size,
 		UploadInstructions: &api.ArtifactUploadInstructions{},
 	}
 
-	err := uploader.Upload(artifact)
-	if err == nil {
-		t.Errorf("Expected error when uploading a file over 5Gb")
-	}
-	if err.Error() != "File size (6442450944 bytes) exceeds the maximum supported by Buildkite's default artifact storage (5Gb). Alternative artifact storage options may support larger files." {
-		t.Errorf("Expected polite error message when uploading a file over 5Gb")
+	if err := uploader.Upload(artifact); !errors.Is(err, errArtifactTooLarge{Size: size}) {
+		t.Errorf("uploader.Upload(artifact) = %v, want errArtifactTooLarge", err)
 	}
 }

--- a/agent/gs_uploader_test.go
+++ b/agent/gs_uploader_test.go
@@ -4,30 +4,25 @@ import (
 	"testing"
 )
 
-func TestParseGSDestinationBucketPath(t *testing.T) {
-	for _, tc := range []struct {
-		Destination, Path string
+func TestParseGSDestination(t *testing.T) {
+	tests := []struct {
+		dest, bucket, path string
 	}{
-		{"gs://my-bucket-name/foo/bar", "foo/bar"},
-		{"gs://starts-with-an-s/and-this-is-its/folder", "and-this-is-its/folder"},
-	} {
-		_, path := ParseGSDestination(tc.Destination)
-		if path != tc.Path {
-			t.Fatalf("Expected %q, got %q", tc.Path, path)
-		}
+		{
+			dest:   "gs://my-bucket-name/foo/bar",
+			bucket: "my-bucket-name",
+			path:   "foo/bar",
+		},
+		{
+			dest:   "gs://starts-with-an-s/and-this-is-its/folder",
+			bucket: "starts-with-an-s",
+			path:   "and-this-is-its/folder",
+		},
 	}
-}
-
-func TestParseGSDestinationBucketName(t *testing.T) {
-	for _, tc := range []struct {
-		Destination, Bucket string
-	}{
-		{"gs://my-bucket-name/foo/bar", "my-bucket-name"},
-		{"gs://starts-with-an-s", "starts-with-an-s"},
-	} {
-		bucket, _ := ParseGSDestination(tc.Destination)
-		if bucket != tc.Bucket {
-			t.Fatalf("Expected %q, got %q", tc.Bucket, bucket)
+	for _, tc := range tests {
+		bucket, path := ParseGSDestination(tc.dest)
+		if bucket != tc.bucket || path != tc.path {
+			t.Errorf("ParseGSDestination(%q) = (%q, %q), want (%q, %q)", tc.dest, bucket, path, tc.bucket, tc.path)
 		}
 	}
 }

--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -33,9 +33,8 @@ func TestJobRunner_WhenJobHasToken_ItOverridesAccessToken(t *testing.T) {
 	cfg := agent.AgentConfiguration{}
 
 	runJob(t, ag, j, cfg, func(c *bintest.Call) {
-		if c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN") != jobToken {
-			t.Errorf("Expected access token to be %q, got %q\n",
-				jobToken, c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN"))
+		if got, want := c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN"), jobToken; got != want {
+			t.Errorf("c.GetEnv(BUILDKITE_AGENT_ACCESS_TOKEN) = %q, want %q", got, want)
 		}
 		c.Exit(0)
 	})
@@ -57,9 +56,8 @@ func TestJobRunnerPassesAccessTokenToBootstrap(t *testing.T) {
 	cfg := agent.AgentConfiguration{}
 
 	runJob(t, ag, j, cfg, func(c *bintest.Call) {
-		if c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN") != `llamasrock` {
-			t.Errorf("Expected access token to be %q, got %q\n",
-				`llamasrock`, c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN"))
+		if got, want := c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN"), "llamasrock"; got != want {
+			t.Errorf("c.GetEnv(BUILDKITE_AGENT_ACCESS_TOKEN) = %q, want %q", got, want)
 		}
 		c.Exit(0)
 	})
@@ -84,9 +82,8 @@ func TestJobRunnerIgnoresPipelineChangesToProtectedVars(t *testing.T) {
 	}
 
 	runJob(t, ag, j, cfg, func(c *bintest.Call) {
-		if c.GetEnv("BUILDKITE_COMMAND_EVAL") != `true` {
-			t.Errorf("Expected BUILDKITE_COMMAND_EVAL to be %q, got %q\n",
-				`true`, c.GetEnv("BUILDKITE_COMMAND_EVAL"))
+		if got, want := c.GetEnv("BUILDKITE_COMMAND_EVAL"), "true"; got != want {
+			t.Errorf("c.GetEnv(BUILDKITE_COMMAND_EVAL) = %q, want %q", got, want)
 		}
 		c.Exit(0)
 	})
@@ -101,7 +98,7 @@ func runJob(t *testing.T, ag *api.AgentRegisterResponse, j *api.Job, cfg agent.A
 	// set up a mock bootstrap that the runner will call
 	bs, err := bintest.NewMock("buildkite-agent-bootstrap")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("bintest.NewMock() error = %v", err)
 	}
 	defer bs.CheckAndClose(t)
 
@@ -126,11 +123,11 @@ func runJob(t *testing.T, ag *api.AgentRegisterResponse, j *api.Job, cfg agent.A
 		AgentConfiguration: cfg,
 	})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("agent.NewJobRunner() error = %v", err)
 	}
 
-	if err = jr.Run(); err != nil {
-		t.Fatal(err)
+	if err := jr.Run(); err != nil {
+		t.Errorf("jr.Run() = %v", err)
 	}
 }
 
@@ -147,8 +144,7 @@ func createTestAgentEndpoint(t *testing.T, jobID string) *httptest.Server {
 		case `/jobs/` + jobID + `/finish`:
 			rw.WriteHeader(http.StatusOK)
 		default:
-			t.Errorf("Unknown endpoint %s %s", req.Method, req.URL.Path)
-			http.Error(rw, "Not found", http.StatusNotFound)
+			http.Error(rw, fmt.Sprintf("not found; method = %q, path = %q", req.Method, req.URL.Path), http.StatusNotFound)
 		}
 	}))
 }

--- a/agent/pipeline_parser_test.go
+++ b/agent/pipeline_parser_test.go
@@ -21,6 +21,9 @@ func TestPipelineParserParsesYaml(t *testing.T) {
 
 	assert.NoError(t, err)
 	j, err := json.Marshal(result)
+	if err != nil {
+		t.Errorf("json.Marshal(result) error = %v", err)
+	}
 	assert.Equal(t, `{"steps":[{"label":"hello \"friend\""}]}`, string(j))
 }
 
@@ -33,6 +36,9 @@ func TestPipelineParserParsesYamlWithNoInterpolation(t *testing.T) {
 
 	assert.NoError(t, err)
 	j, err := json.Marshal(result)
+	if err != nil {
+		t.Errorf("json.Marshal(result) error = %v", err)
+	}
 	assert.Equal(t, `{"steps":[{"label":"hello ${ENV_VAR_FRIEND}"}]}`, string(j))
 }
 
@@ -57,6 +63,9 @@ steps:
 
 	assert.NoError(t, err)
 	j, err := json.Marshal(result)
+	if err != nil {
+		t.Errorf("json.Marshal(result) error = %v", err)
+	}
 	assert.Equal(t, `{"base_step":{"type":"script","agent_query_rules":["queue=default"]},"steps":[{"type":"script","agent_query_rules":["queue=default"],"name":":docker: building image","command":"docker build .","agents":{"queue":"default"}}]}`, string(j))
 }
 
@@ -87,6 +96,9 @@ func TestPipelineParserParsesJson(t *testing.T) {
 
 	assert.NoError(t, err)
 	j, err := json.Marshal(result)
+	if err != nil {
+		t.Errorf("json.Marshal(result) error = %v", err)
+	}
 	assert.Equal(t, `{"foo":"bye \"friend\""}`, string(j))
 }
 
@@ -98,6 +110,9 @@ func TestPipelineParserParsesJsonObjects(t *testing.T) {
 
 	assert.NoError(t, err)
 	j, err := json.Marshal(result)
+	if err != nil {
+		t.Errorf("json.Marshal(result) error = %v", err)
+	}
 	assert.Equal(t, `{"foo":"bye \"friend\""}`, string(j))
 }
 
@@ -109,6 +124,9 @@ func TestPipelineParserParsesJsonArrays(t *testing.T) {
 
 	assert.NoError(t, err)
 	j, err := json.Marshal(result)
+	if err != nil {
+		t.Errorf("json.Marshal(result) error = %v", err)
+	}
 	assert.Equal(t, `{"steps":[{"foo":"bye \"friend\""}]}`, string(j))
 }
 
@@ -119,6 +137,9 @@ func TestPipelineParserParsesTopLevelSteps(t *testing.T) {
 
 	assert.NoError(t, err)
 	j, err := json.Marshal(result)
+	if err != nil {
+		t.Errorf("json.Marshal(result) error = %v", err)
+	}
 	assert.Equal(t, `{"steps":[{"name":"Build","command":"echo hello world"},"wait"]}`, string(j))
 }
 
@@ -129,6 +150,9 @@ func TestPipelineParserPreservesBools(t *testing.T) {
 
 	assert.Nil(t, err)
 	j, err := json.Marshal(result)
+	if err != nil {
+		t.Errorf("json.Marshal(result) error = %v", err)
+	}
 	assert.Equal(t, `{"steps":[{"trigger":"hello","async":true}]}`, string(j))
 }
 
@@ -139,6 +163,9 @@ func TestPipelineParserPreservesInts(t *testing.T) {
 
 	assert.Nil(t, err)
 	j, err := json.Marshal(result)
+	if err != nil {
+		t.Errorf("json.Marshal(result) error = %v", err)
+	}
 	assert.Equal(t, `{"steps":[{"label":"hello","parallelism":10}]}`, string(j))
 }
 
@@ -149,6 +176,9 @@ func TestPipelineParserPreservesNull(t *testing.T) {
 
 	assert.Nil(t, err)
 	j, err := json.Marshal(result)
+	if err != nil {
+		t.Errorf("json.Marshal(result) error = %v", err)
+	}
 	assert.Equal(t, `{"steps":[{"wait":null}]}`, string(j))
 }
 
@@ -159,6 +189,9 @@ func TestPipelineParserPreservesFloats(t *testing.T) {
 
 	assert.Nil(t, err)
 	j, err := json.Marshal(result)
+	if err != nil {
+		t.Errorf("json.Marshal(result) error = %v", err)
+	}
 	assert.Equal(t, `{"steps":[{"trigger":"hello","llamas":3.142}]}`, string(j))
 }
 
@@ -169,6 +202,9 @@ func TestPipelineParserHandlesDates(t *testing.T) {
 
 	assert.Nil(t, err)
 	j, err := json.Marshal(result)
+	if err != nil {
+		t.Errorf("json.Marshal(result) error = %v", err)
+	}
 	assert.Equal(t, `{"steps":[{"trigger":"hello","llamas":"2002-08-15T17:18:23.18-06:00"}]}`, string(j))
 }
 
@@ -190,11 +226,10 @@ func TestPipelineParserInterpolatesKeysAsWellAsValues(t *testing.T) {
 	}.Parse()
 
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("PipelineParser{}.Parse() error = %v", err)
 	}
-	err = decodeIntoStruct(&decoded, result)
-	if err != nil {
-		t.Fatal(err)
+	if err := decodeIntoStruct(&decoded, result); err != nil {
+		t.Fatalf("decodeIntoStruct(&decoded, result) error = %v", err)
 	}
 	assert.Equal(t, `MyTest`, decoded.Env["llamasTEST1"])
 	assert.Equal(t, `llamas`, decoded.Env["TEST2"])
@@ -225,11 +260,10 @@ func TestPipelineParserLoadsGlobalEnvBlockFirst(t *testing.T) {
 	}.Parse()
 
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("PipelineParser{}.Parse() error = %v", err)
 	}
-	err = decodeIntoStruct(&decoded, result)
-	if err != nil {
-		t.Fatal(err)
+	if err := decodeIntoStruct(&decoded, result); err != nil {
+		t.Fatalf("decodeIntoStruct(&decoded, result) error = %v", err)
 	}
 	assert.Equal(t, `England`, decoded.Env["TEAM1"])
 	assert.Equal(t, `England smashes Australia to win the ashes in 1912!!`, decoded.Env["HEADLINE"])
@@ -268,13 +302,12 @@ steps:
 
 	result, err := PipelineParser{Pipeline: []byte(pipeline), Env: nil}.Parse()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("PipelineParser{}.Parse() error = %v", err)
 	}
 
 	buf := &bytes.Buffer{}
-	err = json.NewEncoder(buf).Encode(result)
-	if err != nil {
-		t.Fatal(err)
+	if err := json.NewEncoder(buf).Encode(result); err != nil {
+		t.Fatalf("json.NewEncoder(buf).Encode(result) = %v", err)
 	}
 
 	expected := `{"steps":[{"name":":s3: xxx","command":"script/buildkite/xxx.sh","plugins":{"xxx/aws-assume-role#v0.1.0":{"role":"arn:aws:iam::xxx:role/xxx"},"ecr#v1.1.4":{"login":true,"account_ids":"xxx","registry_region":"us-east-1"},"docker-compose#v2.5.1":{"run":"xxx","config":".buildkite/docker/docker-compose.yml","env":["AWS_ACCESS_KEY_ID","AWS_SECRET_ACCESS_KEY","AWS_SESSION_TOKEN"]}},"agents":{"queue":"xxx"}}]}`

--- a/agent/s3_uploader_test.go
+++ b/agent/s3_uploader_test.go
@@ -7,31 +7,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseS3DestinationBucketPath(t *testing.T) {
+func TestParseS3Destination(t *testing.T) {
 	for _, tc := range []struct {
-		Destination, Path string
+		dest, bucket, path string
 	}{
-		{"s3://my-bucket-name/foo/bar", "foo/bar"},
-		{"s3://starts-with-an-s/and-this-is-its/folder", "and-this-is-its/folder"},
-		{"s3://custom-s3-domain/folder/ends-with-a-slash/", "folder/ends-with-a-slash"},
+		{
+			dest:   "s3://my-bucket-name/foo/bar",
+			bucket: "my-bucket-name",
+			path:   "foo/bar",
+		},
+		{
+			dest:   "s3://starts-with-an-s/and-this-is-its/folder",
+			bucket: "starts-with-an-s",
+			path:   "and-this-is-its/folder",
+		},
+		{
+			dest:   "s3://custom-s3-domain/folder/ends-with-a-slash/",
+			bucket: "custom-s3-domain",
+			path:   "folder/ends-with-a-slash",
+		},
 	} {
-		_, path := ParseS3Destination(tc.Destination)
-		if path != tc.Path {
-			t.Fatalf("Expected %q, got %q", tc.Path, path)
-		}
-	}
-}
-
-func TestParseS3DestinationBucketName(t *testing.T) {
-	for _, tc := range []struct {
-		Destination, Bucket string
-	}{
-		{"s3://my-bucket-name/foo/bar", "my-bucket-name"},
-		{"s3://starts-with-an-s", "starts-with-an-s"},
-	} {
-		bucket, _ := ParseS3Destination(tc.Destination)
-		if bucket != tc.Bucket {
-			t.Fatalf("Expected %q, got %q", tc.Bucket, bucket)
+		bucket, path := ParseS3Destination(tc.dest)
+		if bucket != tc.bucket || path != tc.path {
+			t.Errorf("ParseS3Destination(%q) = (%q, %q), want (%q, %q)", tc.dest, bucket, path, tc.bucket, tc.path)
 		}
 	}
 }

--- a/agent/tags_test.go
+++ b/agent/tags_test.go
@@ -3,11 +3,11 @@ package agent
 import (
 	"errors"
 	"os"
-	"reflect"
 	"runtime"
 	"testing"
 
 	"github.com/buildkite/agent/v3/logger"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,8 +16,8 @@ func TestFetchingTags(t *testing.T) {
 		Tags: []string{"llamas", "rock"},
 	})
 
-	if !reflect.DeepEqual(tags, []string{"llamas", "rock"}) {
-		t.Fatalf("bad tags: %#v", tags)
+	if diff := cmp.Diff(tags, []string{"llamas", "rock"}); diff != "" {
+		t.Errorf("(*tagFetcher).Fetch() diff (-got +want):\n%v", diff)
 	}
 }
 
@@ -32,7 +32,7 @@ func TestFetchingTagsWithHostTags(t *testing.T) {
 
 	hostname, err := os.Hostname()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("os.Hostname() error = %v", err)
 	}
 
 	assert.Contains(t, tags, "hostname="+hostname)
@@ -150,7 +150,7 @@ func TestFetchingTagsFromAllSources(t *testing.T) {
 
 	hostname, err := os.Hostname()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("os.Hostname() error = %v", err)
 	}
 
 	assert.Contains(t, tags, "llamas")

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 require (
 	cloud.google.com/go/compute v1.9.0
 	github.com/buildkite/roko v1.0.1
+	github.com/google/go-cmp v0.5.9
 	go.opentelemetry.io/contrib/propagators/aws v1.11.1
 	go.opentelemetry.io/contrib/propagators/b3 v1.11.0
 	go.opentelemetry.io/contrib/propagators/jaeger v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,7 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135 h1:zLTLjkaOFEFIOxY5BWLFLwh+cL8vOBW4XJ2aqLE/Tf0=
 github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=


### PR DESCRIPTION
This is the first chunk in a series of tidy-ups. This one focuses
on tests in the agent subpackage and applying comments from
https://github.com/golang/go/wiki/TestComments
(excluding the comment about assert libraries).