### PR TITLE
bootstrap: Tidy up t.Error/t.Fatal (part 3)

### DIFF
--- a/bootstrap/integration/command_integration_test.go
+++ b/bootstrap/integration/command_integration_test.go
@@ -16,7 +16,7 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 
 	tester, err := NewBootstrapTester()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -25,9 +25,8 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 
 	setup.Expect().Once()
 	build.Expect().Once().AndCallFunc(func(c *bintest.Call) {
-		llamas := c.GetEnv(`LLAMAS`)
-		if llamas != "COOL" {
-			t.Errorf("Expected LLAMAS=COOL, got %s", llamas)
+		if got, want := c.GetEnv("LLAMAS"), "COOL"; got != want {
+			t.Errorf("c.GetEnv(LLAMAS) = %q, want %q", got, want)
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -45,7 +44,7 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {
 	tester, err := NewBootstrapTester()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -56,9 +55,8 @@ func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {
 		AndExitWith(0)
 
 	preExitFunc := func(c *bintest.Call) {
-		cmdExitStatus := c.GetEnv(`BUILDKITE_COMMAND_EXIT_STATUS`)
-		if cmdExitStatus != "1" {
-			t.Errorf("Expected an exit status of 1, got %v", cmdExitStatus)
+		if got, want := c.GetEnv("BUILDKITE_COMMAND_EXIT_STATUS"), "1"; got != want {
+			t.Errorf("c.GetEnv(BUILDKITE_COMMAND_EXIT_STATUS) = %q, want %q", got, want)
 		}
 		c.Exit(0)
 	}
@@ -66,8 +64,8 @@ func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {
 	tester.ExpectGlobalHook("pre-exit").Once().AndCallFunc(preExitFunc)
 	tester.ExpectLocalHook("pre-exit").Once().AndCallFunc(preExitFunc)
 
-	if err = tester.Run(t, "BUILDKITE_COMMAND=false"); err == nil {
-		t.Fatal("Expected the bootstrap to fail")
+	if err := tester.Run(t, "BUILDKITE_COMMAND=false"); err == nil {
+		t.Fatalf("tester.Run(t, BUILDKITE_COMMAND=false) = %v, want non-nil error", err)
 	}
 
 	tester.CheckMocks(t)

--- a/bootstrap/integration/docker_integration_test.go
+++ b/bootstrap/integration/docker_integration_test.go
@@ -19,7 +19,7 @@ func argumentForCommand(cmd string) interface{} {
 func TestRunningCommandWithDocker(t *testing.T) {
 	tester, err := NewBootstrapTester()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -52,7 +52,7 @@ func TestRunningCommandWithDocker(t *testing.T) {
 func TestRunningCommandWithDockerAndCustomDockerfile(t *testing.T) {
 	tester, err := NewBootstrapTester()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -86,7 +86,7 @@ func TestRunningCommandWithDockerAndCustomDockerfile(t *testing.T) {
 func TestRunningFailingCommandWithDocker(t *testing.T) {
 	tester, err := NewBootstrapTester()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -116,7 +116,7 @@ func TestRunningFailingCommandWithDocker(t *testing.T) {
 	expectCommandHooks("1", t, tester)
 
 	if err = tester.Run(t, env...); err == nil {
-		t.Fatal("Expected bootstrap to fail")
+		t.Fatalf("tester.Run(t, %v) = %v, want non-nil error", env, err)
 	}
 
 	tester.CheckMocks(t)
@@ -125,7 +125,7 @@ func TestRunningFailingCommandWithDocker(t *testing.T) {
 func TestRunningCommandWithDockerCompose(t *testing.T) {
 	tester, err := NewBootstrapTester()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -158,7 +158,7 @@ func TestRunningCommandWithDockerCompose(t *testing.T) {
 func TestRunningFailingCommandWithDockerCompose(t *testing.T) {
 	tester, err := NewBootstrapTester()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -189,7 +189,7 @@ func TestRunningFailingCommandWithDockerCompose(t *testing.T) {
 	expectCommandHooks("1", t, tester)
 
 	if err = tester.Run(t, env...); err == nil {
-		t.Fatal("Expected bootstrap to fail")
+		t.Fatalf("tester.Run(t, %v) = %v, want non-nil error", env, err)
 	}
 
 	tester.CheckMocks(t)
@@ -198,7 +198,7 @@ func TestRunningFailingCommandWithDockerCompose(t *testing.T) {
 func TestRunningCommandWithDockerComposeAndExtraConfig(t *testing.T) {
 	tester, err := NewBootstrapTester()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -232,7 +232,7 @@ func TestRunningCommandWithDockerComposeAndExtraConfig(t *testing.T) {
 func TestRunningCommandWithDockerComposeAndBuildAll(t *testing.T) {
 	tester, err := NewBootstrapTester()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -261,9 +261,8 @@ func expectCommandHooks(exitStatus string, t *testing.T, tester *BootstrapTester
 	tester.ExpectLocalHook("post-command").Once()
 
 	preExitFunc := func(c *bintest.Call) {
-		cmdExitStatus := c.GetEnv(`BUILDKITE_COMMAND_EXIT_STATUS`)
-		if cmdExitStatus != exitStatus {
-			t.Errorf("Expected an exit status of %s, got %v", exitStatus, cmdExitStatus)
+		if got, want := c.GetEnv("BUILDKITE_COMMAND_EXIT_STATUS"), exitStatus; got != want {
+			t.Errorf("c.GetEnv(BUILDKITE_COMMAND_EXIT_STATUS) = %q, want %q", got, want)
 		}
 		c.Exit(0)
 	}

--- a/bootstrap/shell/test.go
+++ b/bootstrap/shell/test.go
@@ -13,7 +13,7 @@ import (
 func NewTestShell(t *testing.T) *Shell {
 	sh, err := New()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("shell.New() error = %v", err)
 	}
 
 	sh.Logger = DiscardLogger


### PR DESCRIPTION
This is the third chunk in a series of tidy-ups. This one focuses on
tests in the bootstrap subpackage, and applies some comments from
https://github.com/golang/go/wiki/TestComments.