### PR TITLE
Tidy up context.Context

### DIFF
--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -126,7 +127,7 @@ func runJob(t *testing.T, ag *api.AgentRegisterResponse, j *api.Job, cfg agent.A
 		t.Fatalf("agent.NewJobRunner() error = %v", err)
 	}
 
-	if err := jr.Run(); err != nil {
+	if err := jr.Run(context.Background()); err != nil {
 		t.Errorf("jr.Run() = %v", err)
 	}
 }

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -86,7 +86,7 @@ func TestStartTracing_NoTracingBackend(t *testing.T) {
 	b := New(Config{})
 
 	oriCtx := context.Background()
-	b.shell, err = shell.NewWithContext(oriCtx)
+	b.shell, err = shell.New()
 	assert.NoError(t, err)
 
 	span, _, stopper := b.startTracing(oriCtx)
@@ -107,7 +107,7 @@ func TestStartTracing_Datadog(t *testing.T) {
 	b := New(cfg)
 
 	oriCtx := context.Background()
-	b.shell, err = shell.NewWithContext(oriCtx)
+	b.shell, err = shell.New()
 	assert.NoError(t, err)
 
 	span, ctx, stopper := b.startTracing(oriCtx)

--- a/bootstrap/knownhosts_test.go
+++ b/bootstrap/knownhosts_test.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -73,7 +74,7 @@ usage: ssh [-1246AaCfgKkMNnqsTtVvXxYy] [-b bind_address] [-c cipher_spec]
 				t.Errorf("kh.Contains(%q) = %t, want %t", tc.Host, got, want)
 			}
 
-			if err := kh.AddFromRepository(tc.Repository); err != nil {
+			if err := kh.AddFromRepository(context.Background(), tc.Repository); err != nil {
 				t.Errorf("kh.AddFromRespository(%q) = %v", tc.Repository, err)
 			}
 

--- a/bootstrap/ssh_test.go
+++ b/bootstrap/ssh_test.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -24,7 +25,7 @@ func TestFindingSSHTools(t *testing.T) {
 
 	sh.Logger = shell.TestingLogger{T: t}
 
-	if _, err := findPathToSSHTools(sh); err != nil {
+	if _, err := findPathToSSHTools(context.Background(), sh); err != nil {
 		t.Errorf(`findPathToSSHTools(sh) error = %v`, err)
 	}
 }
@@ -47,7 +48,7 @@ func TestSSHKeyscanReturnsOutput(t *testing.T) {
 		AndWriteToStdout("github.com ssh-rsa xxx=").
 		AndExitWith(0)
 
-	keyScanOutput, err := sshKeyScan(sh, "github.com")
+	keyScanOutput, err := sshKeyScan(context.Background(), sh, "github.com")
 
 	assert.Equal(t, keyScanOutput, "github.com ssh-rsa xxx=")
 	assert.NoError(t, err)
@@ -71,7 +72,7 @@ func TestSSHKeyscanWithHostAndPortReturnsOutput(t *testing.T) {
 		AndWriteToStdout("github.com ssh-rsa xxx=").
 		AndExitWith(0)
 
-	keyScanOutput, err := sshKeyScan(sh, "github.com:123")
+	keyScanOutput, err := sshKeyScan(context.Background(), sh, "github.com:123")
 
 	assert.Equal(t, keyScanOutput, "github.com ssh-rsa xxx=")
 	assert.NoError(t, err)
@@ -96,7 +97,7 @@ func TestSSHKeyscanRetriesOnExit1(t *testing.T) {
 		Exactly(3).
 		AndExitWith(1)
 
-	keyScanOutput, err := sshKeyScan(sh, "github.com")
+	keyScanOutput, err := sshKeyScan(context.Background(), sh, "github.com")
 
 	assert.Equal(t, keyScanOutput, "")
 	assert.EqualError(t, err, "`ssh-keyscan \"github.com\"` failed")
@@ -121,7 +122,7 @@ func TestSSHKeyscanRetriesOnBlankOutputAndExit0(t *testing.T) {
 		Exactly(3).
 		AndExitWith(0)
 
-	keyScanOutput, err := sshKeyScan(sh, "github.com")
+	keyScanOutput, err := sshKeyScan(context.Background(), sh, "github.com")
 
 	assert.Equal(t, keyScanOutput, "")
 	assert.EqualError(t, err, "`ssh-keyscan \"github.com\"` returned nothing")

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -911,7 +911,7 @@ var AgentStartCommand = cli.Command{
 		}
 
 		// Start the agent pool
-		if err := pool.Start(); err != nil {
+		if err := pool.Start(context.Background()); err != nil {
 			l.Fatal("%s", err)
 		}
 	},

--- a/process/process.go
+++ b/process/process.go
@@ -68,7 +68,6 @@ type Config struct {
 	Stdout          io.Writer
 	Stderr          io.Writer
 	Dir             string
-	Context         context.Context
 	InterruptSignal Signal
 }
 
@@ -110,7 +109,7 @@ func (p *Process) WaitStatus() syscall.WaitStatus {
 }
 
 // Run the command and block until it finishes
-func (p *Process) Run() error {
+func (p *Process) Run(ctx context.Context) error {
 	if p.command != nil {
 		return fmt.Errorf("Process is already running")
 	}
@@ -214,10 +213,10 @@ func (p *Process) Run() error {
 	}
 
 	// When the context finishes, terminate the process
-	if p.conf.Context != nil {
+	if ctx != nil {
 		go func() {
 			select {
-			case <-p.conf.Context.Done():
+			case <-ctx.Done():
 				p.logger.Debug("[Process] Context done, terminating")
 				if err := p.Terminate(); err != nil {
 					p.logger.Debug("[Process] Failed terminate: %v", err)

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -31,8 +31,8 @@ func TestProcessOutput(t *testing.T) {
 	})
 
 	// wait for the process to finish
-	if err := p.Run(); err != nil {
-		t.Fatalf("p.Run() = %v", err)
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("p.Run(ctx) = %v", err)
 	}
 
 	if got, want := stdout.String(), "llamas1llamas2"; got != want {
@@ -61,7 +61,7 @@ func TestProcessOutputPTY(t *testing.T) {
 	})
 
 	// wait for the process to finish
-	if err := p.Run(); err != nil {
+	if err := p.Run(context.Background()); err != nil {
 		t.Fatalf("p.Run() = %v", err)
 	}
 
@@ -82,7 +82,7 @@ func TestProcessInput(t *testing.T) {
 		Stdout: stdout,
 	})
 	// wait for the process to finish
-	if err := p.Run(); err != nil {
+	if err := p.Run(context.Background()); err != nil {
 		t.Fatalf("p.Run() = %v", err)
 	}
 	if got, want := stdout.String(), "Hello World"; got != want {
@@ -113,7 +113,7 @@ func TestProcessRunsAndSignalsStartedAndStopped(t *testing.T) {
 	}()
 
 	// wait for the process to finish
-	if err := p.Run(); err != nil {
+	if err := p.Run(context.Background()); err != nil {
 		t.Fatalf("p.Run() = %v", err)
 	}
 
@@ -135,9 +135,8 @@ func TestProcessTerminatesWhenContextDoes(t *testing.T) {
 	defer cancel()
 
 	p := process.New(logger.Discard, process.Config{
-		Path:    os.Args[0],
-		Env:     []string{"TEST_MAIN=tester-signal"},
-		Context: ctx,
+		Path: os.Args[0],
+		Env:  []string{"TEST_MAIN=tester-signal"},
 	})
 
 	go func() {
@@ -147,7 +146,7 @@ func TestProcessTerminatesWhenContextDoes(t *testing.T) {
 		cancel()
 	}()
 
-	if err := p.Run(); err != nil {
+	if err := p.Run(ctx); err != nil {
 		t.Fatalf("p.Run() = %v", err)
 	}
 
@@ -189,7 +188,7 @@ func TestProcessInterrupts(t *testing.T) {
 		}
 	}()
 
-	if err := p.Run(); err != nil {
+	if err := p.Run(context.Background()); err != nil {
 		t.Fatalf("p.Run() = %v", err)
 	}
 
@@ -231,7 +230,7 @@ func TestProcessInterruptsWithCustomSignal(t *testing.T) {
 		}
 	}()
 
-	if err := p.Run(); err != nil {
+	if err := p.Run(context.Background()); err != nil {
 		t.Fatalf("p.Run() = %v", err)
 	}
 
@@ -255,7 +254,7 @@ func TestProcessSetsProcessGroupID(t *testing.T) {
 		Env:  []string{"TEST_MAIN=tester-pgid"},
 	})
 
-	if err := p.Run(); err != nil {
+	if err := p.Run(context.Background()); err != nil {
 		t.Fatalf("p.Run() = %v", err)
 	}
 
@@ -280,8 +279,8 @@ func BenchmarkProcess(b *testing.B) {
 			Path: os.Args[0],
 			Env:  []string{"TEST_MAIN=output"},
 		})
-		if err := proc.Run(); err != nil {
-			b.Fatalf("p.Run() = %v", err)
+		if err := proc.Run(context.Background()); err != nil {
+			b.Fatalf("proc.Run() = %v", err)
 		}
 	}
 }


### PR DESCRIPTION
Some of the core code (shell.go, process.go) stored contexts and cancellation funcs in structs. The context package doc is clear about not doing this: https://pkg.go.dev/context. This PR removes context fields, and then makes all the consequent changes to pass context through function args instead.