### PR TITLE
Add support for requesting custom lifetime to `buildkite-agent oidc request-token`

### DIFF
--- a/api/oidc.go
+++ b/api/oidc.go
@@ -11,13 +11,16 @@ type OIDCToken struct {
 type OIDCTokenRequest struct {
 	Job      string
 	Audience string
+	Lifetime int
 }
 
 func (c *Client) OIDCToken(methodReq *OIDCTokenRequest) (*OIDCToken, *Response, error) {
 	m := &struct {
 		Audience string `json:"audience,omitempty"`
+		Lifetime int    `json:"lifetime,omitempty"`
 	}{
 		Audience: methodReq.Audience,
+		Lifetime: methodReq.Lifetime,
 	}
 
 	u := fmt.Sprintf("jobs/%s/oidc/tokens", methodReq.Job)

--- a/api/oidc_test.go
+++ b/api/oidc_test.go
@@ -86,6 +86,7 @@ func TestOIDCToken(t *testing.T) {
 	const oidcToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.NHVaYe26MbtOYhSKkoKYdFVomg4i8ZJd8_-RU8VNbftc4TSMb4bXP3l3YlNWACwyXPGffz5aXHc6lty1Y2t4SWRqGteragsVdZufDn5BlnJl9pdR_kdVFUsra2rWKEofkZeIC4yWytE58sMIihvo9H1ScmmVwBcQP6XETqYd0aSHp1gOa9RdUPDvoXQ5oqygTqVtxaDr6wUFKrKItgBMzWIdNZ6y7O9E0DhEPTbE9rfBo6KTFsHAZnMg4k68CDp2woYIaXbmYTWcvbzIuHO7_37GT79XdIwkm95QJ7hYC9RiwrV7mesbY4PAahERJawntho0my942XheVLmGwLMBkQ"
 	const accessToken = "llamas"
 	const audience = "sts.amazonaws.com"
+	const lifetime = 600
 
 	tests := []struct {
 		OIDCTokenRequest *api.OIDCTokenRequest
@@ -108,6 +109,15 @@ func TestOIDCToken(t *testing.T) {
 				Audience: audience,
 			},
 			ExpectedBody: []byte(fmt.Sprintf(`{"audience":%q}`+"\n", audience)),
+			OIDCToken:    &api.OIDCToken{Token: oidcToken},
+		},
+		{
+			AccessToken: accessToken,
+			OIDCTokenRequest: &api.OIDCTokenRequest{
+				Job:      jobID,
+				Lifetime: lifetime,
+			},
+			ExpectedBody: []byte(fmt.Sprintf(`{"lifetime":%d}`+"\n", lifetime)),
 			OIDCToken:    &api.OIDCToken{Token: oidcToken},
 		},
 	}

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -14,6 +14,7 @@ import (
 
 type OIDCTokenConfig struct {
 	Audience string `cli:"audience"`
+	Lifetime int    `cli:"lifetime"`
 	Job      string `cli:"job"      validate:"required"`
 
 	// Global flags
@@ -59,6 +60,11 @@ var OIDCRequestTokenCommand = cli.Command{
 			Name:  "audience",
 			Value: "",
 			Usage: "The audience that will consume the OIDC token",
+		},
+		cli.IntFlag{
+			Name:  "lifetime",
+			Value: 0,
+			Usage: "The time (in seconds) the OIDC token will be valid for before expiry",
 		},
 		cli.StringFlag{
 			Name:   "job",
@@ -115,6 +121,7 @@ var OIDCRequestTokenCommand = cli.Command{
 			req := &api.OIDCTokenRequest{
 				Job:      cfg.Job,
 				Audience: cfg.Audience,
+				Lifetime: cfg.Lifetime,
 			}
 
 			var resp *api.Response

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -64,7 +64,8 @@ var OIDCRequestTokenCommand = cli.Command{
 		cli.IntFlag{
 			Name:  "lifetime",
 			Value: 0,
-			Usage: "The time (in seconds) the OIDC token will be valid for before expiry",
+			Usage: `The time (in seconds) the OIDC token will be valid for before expiry.
+Specfying 0 will result the in the API substituting its default value for the lifetime instead of 0.`,
 		},
 		cli.StringFlag{
 			Name:   "job",


### PR DESCRIPTION
This adds a `--lifetime` parameter to the `buidlkite-agent oidc request-token` command. This will be interpreted as an integer number of seconds. The API will add this to the current time (at the API server) and use this value for the `exp` claim in the OIDC token. Note that specifying `0` (or omitting) will result in the API's default lifetime being used instead.