### PR TITLE
Set ErrWriter

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,6 +116,8 @@ func main() {
 		clicommand.BootstrapCommand,
 	}
 
+	app.ErrWriter = os.Stderr
+
 	// When no sub command is used
 	app.Action = func(c *cli.Context) {
 		cli.ShowAppHelp(c)


### PR DESCRIPTION
We have started to use the cli.Context's App.ErrWriter in some places
now, but it is created to be nil. This results in runtime panics if we
try to write to it.