### PR TITLE
Add restrictions on possible lifetime values at the clicommand level

### DIFF
--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -58,14 +58,12 @@ var OIDCRequestTokenCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "audience",
-			Value: "",
-			Usage: "The audience that will consume the OIDC token",
+			Usage: "The audience that will consume the OIDC token. The API will supply a default audience if it is ommited.",
 		},
 		cli.IntFlag{
 			Name:  "lifetime",
 			Value: 0,
-			Usage: `The time (in seconds) the OIDC token will be valid for before expiry.
-Specfying 0 will result the in the API substituting its default value for the lifetime instead of 0.`,
+			Usage: "The time (in seconds) the OIDC token will be valid for before expiry. Must be a non-negative integer. Ommitting this flag or specifying 0 will result the in the API substituting its default value and NOT a non-expriing token.",
 		},
 		cli.StringFlag{
 			Name:   "job",

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -107,6 +107,11 @@ var OIDCRequestTokenCommand = cli.Command{
 		done := HandleGlobalFlags(l, cfg)
 		defer done()
 
+		// Note: if --lifetime is omitted, cfg.Lifetime = 0
+		if cfg.Lifetime < 0 {
+			l.Fatal("Lifetime %d must be a non-negative integer.", cfg.Lifetime)
+		}
+
 		// Create the API client
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
 

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -62,12 +62,10 @@ var OIDCRequestTokenCommand = cli.Command{
 		},
 		cli.IntFlag{
 			Name:  "lifetime",
-			Value: 0,
 			Usage: "The time (in seconds) the OIDC token will be valid for before expiry. Must be a non-negative integer. Ommitting this flag or specifying 0 will result the in the API substituting its default value and NOT a non-expriing token.",
 		},
 		cli.StringFlag{
 			Name:   "job",
-			Value:  "",
 			Usage:  "Buildkite Job Id to claim in the OIDC token",
 			EnvVar: "BUILDKITE_JOB_ID",
 		},

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -58,11 +58,11 @@ var OIDCRequestTokenCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "audience",
-			Usage: "The audience that will consume the OIDC token. The API will supply a default audience if it is ommited.",
+			Usage: "The audience that will consume the OIDC token. The API will choose a default audience if it is omitted.",
 		},
 		cli.IntFlag{
 			Name:  "lifetime",
-			Usage: "The time (in seconds) the OIDC token will be valid for before expiry. Must be a non-negative integer. Ommitting this flag or specifying 0 will result the in the API substituting its default value and NOT a non-expriing token.",
+			Usage: "The time (in seconds) the OIDC token will be valid for before expiry. Must be a non-negative integer. If the flag is omitted or set to 0, the API will choose a default finite lifetime.",
 		},
 		cli.StringFlag{
 			Name:   "job",


### PR DESCRIPTION
The API does not allow non-positive lifetimes. However, a combination of the cli framework we depend on, and the configuration parsing we have written means that there is no good way to distinguish between omitted configuration values and those that are set to the zero value for their type (e.g. 0 for integers). So we have to let the cli take a 0 valued lifetime, but that will not be passed on the API.