### PR TITLE
Install docker compose plugin in agent alpine docker images

### DIFF
--- a/packaging/docker/alpine-linux-k8s/Dockerfile
+++ b/packaging/docker/alpine-linux-k8s/Dockerfile
@@ -4,6 +4,7 @@ RUN apk update && apk add --no-cache \
     bash \
     curl \
     docker-cli \
+    docker-cli-compose \
     docker-compose \
     git \
     jq \

--- a/packaging/docker/alpine-linux/Dockerfile
+++ b/packaging/docker/alpine-linux/Dockerfile
@@ -4,6 +4,7 @@ RUN apk add --no-cache \
     bash \
     curl \
     docker-cli \
+    docker-cli-compose \
     docker-compose \
     git \
     jq \


### PR DESCRIPTION
The `docker-compose` alpine package contains docker compose v1 as a standalone tool.
The `docker-cli-compose` alpine package contains docker compose v2 as a docker plugin.

Not having `docker-cli-compose` in the agent docker image causes it to fail with the docker compose buildkite plugin when using `cli-version: 2`.