### PR TITLE
Early exit when annotation exceeds max body size

### DIFF
--- a/clicommand/annotate_test.go
+++ b/clicommand/annotate_test.go
@@ -1,0 +1,53 @@
+package clicommand
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func newAnnotateTestServer(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.RequestURI() {
+		case "/jobs/jobid/annotations":
+			io.WriteString(rw, `{"context":"", style:"", body:"abc"}`)
+		default:
+			t.Errorf("unexpected HTTP request: %s %v", req.Method, req.URL.RequestURI())
+		}
+	}))
+}
+
+func TestAnnotate(t *testing.T) {
+	server := newAnnotateTestServer(t)
+	defer server.Close()
+
+	ctx := context.Background()
+	cfg := AnnotateConfig{
+		Body:             "abc",
+		Job:              "jobid",
+		AgentAccessToken: "agentaccesstoken",
+		Endpoint:         server.URL,
+	}
+	l := logger.NewBuffer()
+
+	err := annotate(ctx, cfg, l)
+	assert.NoError(t, err)
+	assert.Contains(t, l.Messages, `[debug] Successfully annotated build`)
+}
+
+func TestAnnotateMaxBodySize(t *testing.T) {
+	ctx := context.Background()
+	cfg := AnnotateConfig{
+		Body: strings.Repeat("a", 1048577),
+	}
+	l := logger.NewBuffer()
+
+	err := annotate(ctx, cfg, l)
+	assert.Error(t, err, "Annotation body size (1048577) exceeds maximum (1048576)")
+}

--- a/clicommand/artifact_shasum_test.go
+++ b/clicommand/artifact_shasum_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newTestServer(t *testing.T) *httptest.Server {
+func newArtifactTestServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.RequestURI() {
 		case "/builds/buildid/artifacts/search?query=foo.%2A&state=finished":
@@ -24,7 +24,7 @@ func newTestServer(t *testing.T) *httptest.Server {
 }
 
 func TestSearchAndPrintSha1Sum(t *testing.T) {
-	server := newTestServer(t)
+	server := newArtifactTestServer(t)
 	defer server.Close()
 
 	ctx := context.Background()
@@ -47,7 +47,7 @@ func TestSearchAndPrintSha1Sum(t *testing.T) {
 }
 
 func TestSearchAndPrintSha256Sum(t *testing.T) {
-	server := newTestServer(t)
+	server := newArtifactTestServer(t)
 	defer server.Close()
 
 	ctx := context.Background()


### PR DESCRIPTION
Buildkite imposes a maximum body size of 1MiB. Return a fatal error early instead of waiting for a round-trip API request.

I borrowed the `annotate` function and tests pattern from `ArtifactShasumCommand`.

(The diff is easier to see with [whitespace changes turned off](https://github.com/buildkite/agent/pull/1844/files?diff=unified&w=1))