### PR TITLE
Add package comments and pkg.go.dev badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Buildkite Agent ![Build status](https://badge.buildkite.com/08e4e12a0a1e478f0994eb1e8d51822c5c74d395.svg?branch=main)
+# Buildkite Agent 
+
+[![Build status](https://badge.buildkite.com/08e4e12a0a1e478f0994eb1e8d51822c5c74d395.svg?branch=main)]()
+[![Go Reference](https://pkg.go.dev/badge/github.com/buildkite/agent/v3.svg)](https://pkg.go.dev/github.com/buildkite/agent/v3)
 
 _Note: This is the development branch of the buildkite-agent, and may not contain files or code in the current stable release._
 

--- a/agent/doc.go
+++ b/agent/doc.go
@@ -1,0 +1,5 @@
+// Package agent provides the key agent components - workers, worker pool, job
+// runner, log streamer, artifact up/downloaders, etc.
+//
+// It is intended for internal use of buildkite-agent only.
+package agent

--- a/api/doc.go
+++ b/api/doc.go
@@ -1,0 +1,4 @@
+// Package api provides an API client for the Buildkite Pipelines API.
+//
+// It is intended for internal use by buildkite-agent only.
+package api

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1,3 +1,7 @@
+// Package bootstrap provides management of the phases of execution of a
+// Buildkite job.
+//
+// It is intended for internal use by buildkite-agent only.
 package bootstrap
 
 import (
@@ -26,10 +30,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Bootstrap represents the phases of execution in a Buildkite Job. It's run
-// as a sub-process of the buildkite-agent and finishes at the conclusion of a job.
-// Historically (prior to v3) the bootstrap was a shell script, but was ported to
-// Golang for portability and testability
+// Bootstrap represents the phases of execution in a Buildkite Job. It's run as
+// a sub-process of the buildkite-agent and finishes at the conclusion of a job.
+//
+// Historically (prior to v3) the bootstrap was a shell script, but was ported
+// to Go for portability and testability.
 type Bootstrap struct {
 	// Config provides the bootstrap configuration
 	Config
@@ -120,7 +125,7 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 		return false
 	}
 
-	//  Execute the bootstrap phases in order
+	// Execute the bootstrap phases in order
 	var phaseErr error
 
 	if includePhase(`plugin`) {

--- a/bootstrap/integration/doc.go
+++ b/bootstrap/integration/doc.go
@@ -1,0 +1,4 @@
+// Package integration defines a series of integration tests for the bootstrap.
+//
+// It is intended for internal use by buildkite-agent only.
+package integration

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -1,3 +1,7 @@
+// Package shell provides a cross-platform virtual shell abstraction for
+// executing commands.
+//
+// It is intended for internal use by buildkite-agent only.
 package shell
 
 import (

--- a/clicommand/doc.go
+++ b/clicommand/doc.go
@@ -1,0 +1,4 @@
+// Package clicommand contains the definitions of buildkite-agent subcommands.
+//
+// It is intended for internal use by buildkite-agent only.
+package clicommand

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -1,3 +1,6 @@
+// Package cliconfig provides a configuration file loader.
+//
+// It is intended for internal use by buildkite-agent only.
 package cliconfig
 
 import (
@@ -15,7 +18,7 @@ import (
 )
 
 type Loader struct {
-	// The context that is passed when using a codegangsta/cli action
+	// The context that is passed when using a urfave/cli action
 	CLI *cli.Context
 
 	// The struct that the config values will be loaded into

--- a/env/environment.go
+++ b/env/environment.go
@@ -1,3 +1,6 @@
+// Package env provides utilities for dealing with environment variables.
+//
+// It is intended for internal use by buildkite-agent only.
 package env
 
 import (

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -1,23 +1,27 @@
+// Package experiments provides a global registry of enabled and disabled
+// experiments.
+//
+// It is intended for internal use by buildkite-agent only.
 package experiments
 
 var experiments = make(map[string]bool)
 
-// Enable a particular experiment in the agent
+// Enable a particular experiment in the agent.
 func Enable(key string) {
 	experiments[key] = true
 }
 
-// Disable a particular experiment in the agent
+// Disable a particular experiment in the agent.
 func Disable(key string) {
 	delete(experiments, key)
 }
 
-// IsEnabled returns whether the named experiment is enabled
+// IsEnabled reports whether the named experiment is enabled.
 func IsEnabled(key string) bool {
 	return experiments[key] // map[T]bool returns false for missing keys
 }
 
-// Enabled returns the keys of all the enabled experiments
+// Enabled returns the keys of all the enabled experiments.
 func Enabled() []string {
 	var keys []string
 	for key, enabled := range experiments {

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -1,3 +1,7 @@
+// Package hook provides management and execution of hook scripts, and the
+// ability to capture environment variable changes caused by scripts.
+//
+// It is intended for internal use by buildkite-agent only.
 package hook
 
 import (

--- a/logger/log.go
+++ b/logger/log.go
@@ -1,3 +1,8 @@
+// Package logger provides a logger abstraction for writing log messages in
+// configurable formats to different outputs, such as a console, plain text
+// file, or a JSON file.
+//
+// It is intended for internal use by buildkite-agent only.
 package logger
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,5 @@
+// Buildkite-agent is a small, reliable, cross-platform build runner that makes
+// it easy to run automated builds on your own infrastructure.
 package main
 
 // see https://blog.golang.org/generate

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,3 +1,6 @@
+// Package metrics provides a wrapper around Datadog metrics collection.
+//
+// It is intended for internal use by buildkite-agent only.
 package metrics
 
 import (

--- a/mime/generate.go
+++ b/mime/generate.go
@@ -1,7 +1,9 @@
 //go:build ignore
 // +build ignore
 
-// Generates the mime type mappings.
+// This is a `go generate` script generates the MIME type mappings written to
+// mime.go. Both this script and the generated output are intended for internal
+// use only.
 package main
 
 import (
@@ -30,6 +32,10 @@ var mimeFileTemplate = template.Must(template.New("").Parse(
 // using data from the following sources:
 // {{ .URLs.apache }}
 // {{ .URLs.nginx }}
+
+// Package mime provides an extended mapping of file extensions to MIME types.
+//
+// It is intended for internal use by buildkite-agent only.
 package mime
 
 import (

--- a/mime/mime.go
+++ b/mime/mime.go
@@ -4,6 +4,10 @@
 // using data from the following sources:
 // https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types
 // https://hg.nginx.org/nginx/raw-file/default/conf/mime.types
+
+// Package mime provides an extended mapping of file extensions to MIME types.
+//
+// It is intended for internal use by buildkite-agent only.
 package mime
 
 import (

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -1,3 +1,7 @@
+// Package pool provides a worker pool that enforces an upper limit on
+// concurrent workers.
+//
+// It is intended for internal use by buildkite-agent only.
 package pool
 
 import (

--- a/process/process.go
+++ b/process/process.go
@@ -1,3 +1,6 @@
+// Package process provides a helper for running and managing a subprocess.
+//
+// It is intended for internal use by buildkite-agent only.
 package process
 
 import (

--- a/race/doc.go
+++ b/race/doc.go
@@ -1,0 +1,4 @@
+// Package race can be used to tell if the race detector is enabled.
+//
+// It is intended for internal use by buildkite-agent only.
+package race

--- a/redaction/redactor.go
+++ b/redaction/redactor.go
@@ -1,3 +1,6 @@
+// Package redaction provides an efficient configurable string redactor.
+//
+// It is intended for internal use by buildkite-agent only.
 package redaction
 
 import (

--- a/stdin/stdin.go
+++ b/stdin/stdin.go
@@ -1,3 +1,7 @@
+// Package stdin provides a cross-platform method for determining if standard
+// input is readable.
+//
+// It is intended for internal use by buildkite-agent only.
 package stdin
 
 import (

--- a/system/doc.go
+++ b/system/doc.go
@@ -1,0 +1,4 @@
+// Package system provides a way to log OS-specific platform information.
+//
+// It is intended for internal use by buildkite-agent only.
+package system

--- a/tracetools/doc.go
+++ b/tracetools/doc.go
@@ -1,0 +1,5 @@
+// Package tracetools provides an abstraction across tracing systems
+// (OpenTelemetry, DataDog).
+//
+// It is intended for internal use by buildkite-agent only.
+package tracetools

--- a/utils/doc.go
+++ b/utils/doc.go
@@ -1,0 +1,5 @@
+// Package utils provides some file- and filepath-helper functions.
+//
+// It is intended for internal use by buildkite-agent only.
+// TODO: `utils` is too vague. Find a better name for this package.
+package utils

--- a/yamltojson/yaml.go
+++ b/yamltojson/yaml.go
@@ -1,3 +1,6 @@
+// Package yamltojson provides a helper for converting map slices to JSON.
+//
+// It is intended for internal use by buildkite-agent only.
 package yamltojson
 
 import (


### PR DESCRIPTION
This adds package comments, briefly explaining what each subpackage does. Where a package `foo` has a `foo.go`, the comment is added to the top of that file, otherwise I have added a new `doc.go` for the comment.

I've also added a pkg.go.dev badge. To make it look neater, I moved the build status badge out of the heading.