### PR TITLE
agent/plugin: Doc comments and cleanups

### DIFF
--- a/agent/plugin/definition.go
+++ b/agent/plugin/definition.go
@@ -14,16 +14,18 @@ import (
 	"github.com/qri-io/jsonschema"
 )
 
+// ErrDefinitionNotFound is used when a plugin definition file cannot be found.
 var ErrDefinitionNotFound = errors.New("Definition file not found")
 
-// Definition defines the plugin.yml file that each plugin has
+// Definition defines the contents of the plugin.{yml,yaml,json} file that
+// each plugin has.
 type Definition struct {
 	Name          string                 `json:"name"`
 	Requirements  []string               `json:"requirements"`
 	Configuration *jsonschema.RootSchema `json:"configuration"`
 }
 
-// ParseDefinition parses either yaml or json bytes into a Definition
+// ParseDefinition parses either YAML or JSON bytes into a Definition.
 func ParseDefinition(b []byte) (*Definition, error) {
 	var parsed yaml.MapSlice
 
@@ -46,7 +48,10 @@ func ParseDefinition(b []byte) (*Definition, error) {
 	return &def, nil
 }
 
-// LoadDefinitionFromDir looks in a directory for either a plugin.json or a plugin.yml
+// LoadDefinitionFromDir looks in a directory for one of plugin.json,
+// plugin.yaml, or plugin.yml. It parses the first one it finds, and returns the
+// resulting Definition. If none of those files can be found, it returns
+// ErrDefinitionNotFound.
 func LoadDefinitionFromDir(dir string) (*Definition, error) {
 	f, err := findDefinitionFile(dir)
 	if err != nil {
@@ -61,12 +66,12 @@ func LoadDefinitionFromDir(dir string) (*Definition, error) {
 	return ParseDefinition(b)
 }
 
-// findDefinitionFile searches for known plugin definition files
+// findDefinitionFile searches for known plugin definition files.
 func findDefinitionFile(dir string) (string, error) {
-	var possibleFilenames = []string{
-		filepath.Join(dir, `plugin.json`),
-		filepath.Join(dir, `plugin.yaml`),
-		filepath.Join(dir, `plugin.yml`),
+	possibleFilenames := []string{
+		filepath.Join(dir, "plugin.json"),
+		filepath.Join(dir, "plugin.yaml"),
+		filepath.Join(dir, "plugin.yml"),
 	}
 	for _, filename := range possibleFilenames {
 		if _, err := os.Stat(filename); err == nil {
@@ -76,22 +81,23 @@ func findDefinitionFile(dir string) (string, error) {
 	return "", ErrDefinitionNotFound
 }
 
+// Validator validates plugin definitions.
 type Validator struct {
 	commandExists func(string) bool
 }
 
+// Validate checks the plugin definition for errors, including missing commands
+// from $PATH and invalid configuration under the definition's JSON Schema.
 func (v Validator) Validate(def *Definition, config map[string]interface{}) ValidateResult {
-	result := ValidateResult{
-		Errors: []string{},
-	}
+	var result ValidateResult
 
-	configAsJson, err := json.Marshal(config)
+	configJSON, err := json.Marshal(config)
 	if err != nil {
-		result.Errors = append(result.Errors, err.Error())
+		result.Errors = append(result.Errors, err)
 		return result
 	}
 
-	var commandExistsFunc = v.commandExists
+	commandExistsFunc := v.commandExists
 	if commandExistsFunc == nil {
 		commandExistsFunc = commandExists
 	}
@@ -101,20 +107,20 @@ func (v Validator) Validate(def *Definition, config map[string]interface{}) Vali
 		for _, command := range def.Requirements {
 			if !commandExistsFunc(command) {
 				result.Errors = append(result.Errors,
-					fmt.Sprintf(`Required command %q isn't in PATH`, command))
+					fmt.Errorf("Required command %q isn't in PATH", command))
 			}
 		}
 	}
 
 	// validate that the config matches the json schema we have
 	if def.Configuration != nil {
-		valErrors, err := def.Configuration.ValidateBytes(configAsJson)
+		valErrors, err := def.Configuration.ValidateBytes(configJSON)
 		if err != nil {
-			result.Errors = append(result.Errors, err.Error())
+			result.Errors = append(result.Errors, err)
 		}
 		if len(valErrors) > 0 {
 			for _, err := range valErrors {
-				result.Errors = append(result.Errors, err.Error())
+				result.Errors = append(result.Errors, err)
 			}
 		}
 	}
@@ -122,21 +128,27 @@ func (v Validator) Validate(def *Definition, config map[string]interface{}) Vali
 	return result
 }
 
+// ValidateResult contains results of a validation check.
 type ValidateResult struct {
-	Errors []string
+	Errors []error
 }
 
+// Valid reports if the result contains no errors.
 func (vr ValidateResult) Valid() bool {
 	return len(vr.Errors) == 0
 }
 
+// Error returns a single string combining all the error strings from Errors.
 func (vr ValidateResult) Error() string {
-	return strings.Join(vr.Errors, ", ")
+	s := make([]string, len(vr.Errors))
+	for i, err := range vr.Errors {
+		s[i] = err.Error()
+	}
+	return strings.Join(s, ", ")
 }
 
+// commandExists reports if the command is present somewhere in $PATH.
 func commandExists(command string) bool {
-	if _, err := exec.LookPath(command); err != nil {
-		return false
-	}
-	return true
+	_, err := exec.LookPath(command)
+	return err == nil
 }

--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/agent/v3/env"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -98,15 +99,17 @@ func TestCreateFromJSON(t *testing.T) {
 		},
 	} {
 		tc := tc
-		t.Run(tc.jsonText, func(tt *testing.T) {
-			tt.Parallel()
+		t.Run(tc.jsonText, func(t *testing.T) {
+			t.Parallel()
 
 			plugins, err := CreateFromJSON(tc.jsonText)
 			if err != nil {
-				tt.Error(err)
+				t.Errorf("CreateFromJSON(%q) error = %v", tc.jsonText, err)
 			}
 
-			assert.Equal(tt, tc.plugins, plugins)
+			if diff := cmp.Diff(tc.plugins, plugins); diff != "" {
+				t.Errorf("CreateFromJSON(%q) diff (-got +want)\n%s", tc.jsonText, diff)
+			}
 		})
 	}
 }
@@ -132,12 +135,12 @@ func TestCreateFromJSONFailsOnParseErrors(t *testing.T) {
 		},
 	} {
 		tc := tc
-		t.Run("", func(tt *testing.T) {
-			tt.Parallel()
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
 
 			plugins, err := CreateFromJSON(tc.jsonText)
-			assert.Equal(t, 0, len(plugins))
 			assert.Error(t, err, tc.err)
+			assert.Equal(t, 0, len(plugins))
 		})
 	}
 }
@@ -162,10 +165,10 @@ func TestPluginNameParsedFromLocation(t *testing.T) {
 		{"", ""},
 	} {
 		tc := tc
-		t.Run(tc.location, func(tt *testing.T) {
-			tt.Parallel()
+		t.Run(tc.location, func(t *testing.T) {
+			t.Parallel()
 			plugin := &Plugin{Location: tc.location}
-			assert.Equal(tt, tc.expectedName, plugin.Name())
+			assert.Equal(t, tc.expectedName, plugin.Name())
 		})
 	}
 }

--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -7,13 +7,12 @@ import (
 
 	"github.com/buildkite/agent/v3/env"
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateFromJSON(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
+	tests := []struct {
 		jsonText string
 		plugins  []*Plugin
 	}{
@@ -97,7 +96,9 @@ func TestCreateFromJSON(t *testing.T) {
 				Configuration: map[string]interface{}{},
 			}},
 		},
-	} {
+	}
+
+	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.jsonText, func(t *testing.T) {
 			t.Parallel()
@@ -117,12 +118,12 @@ func TestCreateFromJSON(t *testing.T) {
 func TestCreateFromJSONFailsOnParseErrors(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
+	tests := []struct {
 		jsonText string
 		err      string
 	}{
 		{
-			`blah`,
+			"blah",
 			"invalid character 'b' looking for beginning of value",
 		},
 		{
@@ -133,14 +134,21 @@ func TestCreateFromJSONFailsOnParseErrors(t *testing.T) {
 			`["github.com/buildkite-plugins/ping#master#lololo"]`,
 			"Too many #'s in \"github.com/buildkite-plugins/ping#master#lololo\"",
 		},
-	} {
+	}
+
+	for _, tc := range tests {
 		tc := tc
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
 
 			plugins, err := CreateFromJSON(tc.jsonText)
-			assert.Error(t, err, tc.err)
-			assert.Equal(t, 0, len(plugins))
+			if err.Error() != tc.err {
+				// TODO: Testing error strings is fragile - replace with a more semantic test.
+				t.Errorf("CreateFromJSON(%q) error = %q, want %q", tc.jsonText, err, tc.err)
+			}
+			if got, want := len(plugins), 0; got != want {
+				t.Errorf("len(CreateFromJSON(%q)) = %d, want %d", tc.jsonText, got, want)
+			}
 		})
 	}
 }
@@ -148,27 +156,64 @@ func TestCreateFromJSONFailsOnParseErrors(t *testing.T) {
 func TestPluginNameParsedFromLocation(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
-		location     string
-		expectedName string
+	tests := []struct {
+		location string
+		wantName string
 	}{
-		{"github.com/buildkite-plugins/docker-compose-buildkite-plugin.git", "docker-compose"},
-		{"github.com/buildkite-plugins/docker-compose-buildkite-plugin", "docker-compose"},
-		{"github.com/my-org/docker-compose-buildkite-plugin", "docker-compose"},
-		{"github.com/buildkite/plugins/docker-compose", "docker-compose"},
-		{"~/Development/plugins/test", "test"},
-		{"~/Development/plugins/UPPER     CASE_party", "upper-case-party"},
-		{"vendor/src/vendored with a space", "vendored-with-a-space"},
-		{"./.buildkite/plugins/docker-compose", "docker-compose"},
-		{".\\.buildkite\\plugins\\docker-compose", "docker-compose"},
-		{".buildkite/plugins/docker-compose", "docker-compose"},
-		{"", ""},
-	} {
+		{
+			location: "github.com/buildkite-plugins/docker-compose-buildkite-plugin.git",
+			wantName: "docker-compose",
+		},
+		{
+			location: "github.com/buildkite-plugins/docker-compose-buildkite-plugin",
+			wantName: "docker-compose",
+		},
+		{
+			location: "github.com/my-org/docker-compose-buildkite-plugin",
+			wantName: "docker-compose",
+		},
+		{
+			location: "github.com/buildkite/plugins/docker-compose",
+			wantName: "docker-compose",
+		},
+		{
+			location: "~/Development/plugins/test",
+			wantName: "test",
+		},
+		{
+			location: "~/Development/plugins/UPPER     CASE_party",
+			wantName: "upper-case-party",
+		},
+		{
+			location: "vendor/src/vendored with a space",
+			wantName: "vendored-with-a-space",
+		},
+		{
+			location: "./.buildkite/plugins/docker-compose",
+			wantName: "docker-compose",
+		},
+		{
+			location: ".\\.buildkite\\plugins\\docker-compose",
+			wantName: "docker-compose",
+		},
+		{
+			location: ".buildkite/plugins/docker-compose",
+			wantName: "docker-compose",
+		},
+		{
+			location: "",
+			wantName: "",
+		},
+	}
+
+	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.location, func(t *testing.T) {
 			t.Parallel()
 			plugin := &Plugin{Location: tc.location}
-			assert.Equal(t, tc.expectedName, plugin.Name())
+			if got, want := plugin.Name(), tc.wantName; got != want {
+				t.Errorf("Plugin(Location: %q).Name() = %q, want %q", tc.location, got, want)
+			}
 		})
 	}
 }
@@ -176,261 +221,335 @@ func TestPluginNameParsedFromLocation(t *testing.T) {
 func TestIdentifier(t *testing.T) {
 	t.Parallel()
 
-	var plugin *Plugin
-	var id string
-	var err error
+	tests := []struct {
+		location, wantID string
+	}{
+		{
+			location: "github.com/buildkite/plugins/docker-compose/beta#master",
+			wantID:   "github-com-buildkite-plugins-docker-compose-beta-master",
+		},
+		{
+			location: "github.com/buildkite/plugins/docker-compose/beta",
+			wantID:   "github-com-buildkite-plugins-docker-compose-beta",
+		},
+		{
+			location: "192.168.0.1/foo.git#12341234",
+			wantID:   "192-168-0-1-foo-git-12341234",
+		},
+		{
+			location: "/foo/bar/",
+			wantID:   "foo-bar",
+		},
+		{
+			location: "./.buildkite/plugins/llamas/",
+			wantID:   "buildkite-plugins-llamas",
+		},
+	}
 
-	plugin = &Plugin{Location: "github.com/buildkite/plugins/docker-compose/beta#master"}
-	id, err = plugin.Identifier()
-	assert.Equal(t, id, "github-com-buildkite-plugins-docker-compose-beta-master")
-	assert.Nil(t, err)
-
-	plugin = &Plugin{Location: "github.com/buildkite/plugins/docker-compose/beta"}
-	id, err = plugin.Identifier()
-	assert.Equal(t, id, "github-com-buildkite-plugins-docker-compose-beta")
-	assert.Nil(t, err)
-
-	plugin = &Plugin{Location: "192.168.0.1/foo.git#12341234"}
-	id, err = plugin.Identifier()
-	assert.Equal(t, id, "192-168-0-1-foo-git-12341234")
-	assert.Nil(t, err)
-
-	plugin = &Plugin{Location: "/foo/bar/"}
-	id, err = plugin.Identifier()
-	assert.Equal(t, id, "foo-bar")
-	assert.Nil(t, err)
-
-	plugin = &Plugin{Location: "./.buildkite/plugins/llamas/"}
-	id, err = plugin.Identifier()
-	assert.Equal(t, id, "buildkite-plugins-llamas")
-	assert.Nil(t, err)
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.location, func(t *testing.T) {
+			t.Parallel()
+			plugin := &Plugin{Location: tc.location}
+			id, err := plugin.Identifier()
+			if err != nil {
+				t.Errorf("Plugin{Location: %q}.Identifier() error = %v", tc.location, err)
+			}
+			if got, want := id, tc.wantID; got != want {
+				t.Errorf("Plugin{Location: %q}.Identifier() = %q, want %q", tc.location, got, want)
+			}
+		})
+	}
 }
 
 func TestRepositoryAndSubdirectory(t *testing.T) {
 	t.Parallel()
 
-	var plugin *Plugin
-	var repo string
-	var sub string
-	var err error
+	tests := []struct {
+		plugin            *Plugin
+		wantRepo, wantSub string
+	}{
+		{
+			plugin:   &Plugin{Location: "github.com/buildkite/plugins/docker-compose/beta"},
+			wantRepo: "https://github.com/buildkite/plugins",
+			wantSub:  "docker-compose/beta",
+		},
+		{
+			plugin:   &Plugin{Location: "github.com/buildkite/test-plugin"},
+			wantRepo: "https://github.com/buildkite/test-plugin",
+			wantSub:  "",
+		},
+		{
+			plugin:   &Plugin{Location: "bitbucket.org/user/project/sub/directory"},
+			wantRepo: "https://bitbucket.org/user/project",
+			wantSub:  "sub/directory",
+		},
+		{
+			plugin:   &Plugin{Location: "bitbucket.org/user/project/sub/directory", Scheme: "http", Authentication: "foo:bar"},
+			wantRepo: "http://foo:bar@bitbucket.org/user/project",
+			wantSub:  "sub/directory",
+		},
+		{
+			plugin:   &Plugin{Location: "114.135.234.212/foo.git"},
+			wantRepo: "https://114.135.234.212/foo.git",
+			wantSub:  "",
+		},
+		{
+			plugin:   &Plugin{Location: "github.com/buildkite/plugins/docker-compose/beta"},
+			wantRepo: "https://github.com/buildkite/plugins",
+			wantSub:  "docker-compose/beta",
+		},
+		{
+			plugin:   &Plugin{Location: "/Users/keithpitt/Development/plugins.git/test-plugin"},
+			wantRepo: "/Users/keithpitt/Development/plugins.git",
+			wantSub:  "test-plugin",
+		},
+	}
 
-	plugin = &Plugin{Location: "github.com/buildkite/plugins/docker-compose/beta"}
-	repo, err = plugin.Repository()
-	assert.Equal(t, repo, "https://github.com/buildkite/plugins")
-	assert.Nil(t, err)
-	sub, err = plugin.RepositorySubdirectory()
-	assert.Equal(t, sub, "docker-compose/beta")
-	assert.Nil(t, err)
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.plugin.Label(), func(t *testing.T) {
+			t.Parallel()
+			repo, err := tc.plugin.Repository()
+			if err != nil {
+				t.Errorf("plugin.Repository() error = %v", err)
+			}
+			if got, want := repo, tc.wantRepo; got != want {
+				t.Errorf("plugin.Repository() = %q, want %q", got, want)
+			}
+			sub, err := tc.plugin.RepositorySubdirectory()
+			if err != nil {
+				t.Errorf("plugin.RepositorySubdirectory() error = %v", err)
+			}
+			if got, want := sub, tc.wantSub; got != want {
+				t.Errorf("plugin.RepositorySubdirectory() = %q, want %q", got, want)
+			}
+		})
+	}
+}
 
-	plugin = &Plugin{Location: "github.com/buildkite/test-plugin"}
-	repo, err = plugin.Repository()
-	assert.Equal(t, repo, "https://github.com/buildkite/test-plugin")
-	assert.Nil(t, err)
-	sub, err = plugin.RepositorySubdirectory()
-	assert.Equal(t, sub, "")
-	assert.Nil(t, err)
+func TestRespositoryAndSubdirectoryErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		location string
+		wantErr  string
+	}{
+		{
+			location: "github.com/buildkite",
+			wantErr:  `Incomplete plugin path "github.com/buildkite"`,
+		},
+		{
+			location: "bitbucket.org/buildkite",
+			wantErr:  `Incomplete plugin path "bitbucket.org/buildkite"`,
+		},
+		{
+			location: "",
+			wantErr:  "Missing plugin location",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.location, func(t *testing.T) {
+			t.Parallel()
 
-	plugin = &Plugin{Location: "github.com/buildkite"}
-	repo, err = plugin.Repository()
-	assert.Equal(t, repo, "")
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), `Incomplete plugin path "github.com/buildkite"`)
-	sub, err = plugin.RepositorySubdirectory()
-	assert.Equal(t, sub, "")
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), `Incomplete plugin path "github.com/buildkite"`)
-
-	plugin = &Plugin{Location: "bitbucket.org/buildkite"}
-	repo, err = plugin.Repository()
-	assert.Equal(t, repo, "")
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), `Incomplete plugin path "bitbucket.org/buildkite"`)
-	sub, err = plugin.RepositorySubdirectory()
-	assert.Equal(t, sub, "")
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), `Incomplete plugin path "bitbucket.org/buildkite"`)
-
-	plugin = &Plugin{Location: "bitbucket.org/user/project/sub/directory"}
-	repo, err = plugin.Repository()
-	assert.Equal(t, repo, "https://bitbucket.org/user/project")
-	assert.Nil(t, err)
-	sub, err = plugin.RepositorySubdirectory()
-	assert.Equal(t, sub, "sub/directory")
-	assert.Nil(t, err)
-
-	plugin = &Plugin{Location: "bitbucket.org/user/project/sub/directory", Scheme: "http", Authentication: "foo:bar"}
-	repo, err = plugin.Repository()
-	assert.Equal(t, repo, "http://foo:bar@bitbucket.org/user/project")
-	assert.Nil(t, err)
-	sub, err = plugin.RepositorySubdirectory()
-	assert.Equal(t, sub, "sub/directory")
-	assert.Nil(t, err)
-
-	plugin = &Plugin{Location: "114.135.234.212/foo.git"}
-	repo, err = plugin.Repository()
-	assert.Equal(t, repo, "https://114.135.234.212/foo.git")
-	assert.Nil(t, err)
-	sub, err = plugin.RepositorySubdirectory()
-	assert.Equal(t, sub, "")
-	assert.Nil(t, err)
-
-	plugin = &Plugin{Location: "github.com/buildkite/plugins/docker-compose/beta"}
-	repo, err = plugin.Repository()
-	assert.Equal(t, repo, "https://github.com/buildkite/plugins")
-	assert.Nil(t, err)
-	sub, err = plugin.RepositorySubdirectory()
-	assert.Equal(t, sub, "docker-compose/beta")
-	assert.Nil(t, err)
-
-	plugin = &Plugin{Location: "/Users/keithpitt/Development/plugins.git/test-plugin"}
-	repo, err = plugin.Repository()
-	assert.Equal(t, repo, "/Users/keithpitt/Development/plugins.git")
-	assert.Nil(t, err)
-	sub, err = plugin.RepositorySubdirectory()
-	assert.Equal(t, sub, "test-plugin")
-	assert.Nil(t, err)
-
-	plugin = &Plugin{Location: ""}
-	repo, err = plugin.Repository()
-	assert.Equal(t, repo, "")
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "Missing plugin location")
+			plugin := &Plugin{Location: tc.location}
+			_, err := plugin.Repository()
+			if got, want := err.Error(), tc.wantErr; got != want {
+				// TODO: Testing error strings is fragile - replace with a more semantic test.
+				t.Errorf("plugin.Repository() error = %q, want %q", got, want)
+			}
+			_, err = plugin.RepositorySubdirectory()
+			if got, want := err.Error(), tc.wantErr; got != want {
+				// TODO: Testing error strings is fragile - replace with a more semantic test.
+				t.Errorf("plugin.RepositorySubdirectory() error = %q, want %q", got, want)
+			}
+		})
+	}
 }
 
 func TestConfigurationToEnvironment(t *testing.T) {
 	t.Parallel()
 
-	var envMap env.Environment
-	var err error
+	tests := []struct {
+		configJSON string
+		wantEnvMap env.Environment
+	}{
+		{
+			configJSON: `{ "config-key": 42 }`,
+			wantEnvMap: env.Environment{
+				"BUILDKITE_PLUGIN_CONFIGURATION":             `{"config-key":42}`,
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_KEY": "42",
+				"BUILDKITE_PLUGIN_NAME":                      "DOCKER_COMPOSE",
+			},
+		},
+		{
+			configJSON: `{ "container": "app", "some-other-setting": "else right here" }`,
+			wantEnvMap: env.Environment{
+				"BUILDKITE_PLUGIN_CONFIGURATION":                     `{"container":"app","some-other-setting":"else right here"}`,
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONTAINER":          "app",
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_SOME_OTHER_SETTING": "else right here",
+				"BUILDKITE_PLUGIN_NAME":                              "DOCKER_COMPOSE",
+			},
+		},
+		{
+			configJSON: `{ "and _ with a    - number": 12 }`,
+			wantEnvMap: env.Environment{
+				"BUILDKITE_PLUGIN_CONFIGURATION":                    `{"and _ with a    - number":12}`,
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_AND_WITH_A_NUMBER": "12",
+				"BUILDKITE_PLUGIN_NAME":                             "DOCKER_COMPOSE",
+			},
+		},
+		{
+			configJSON: `{ "bool-true-key": true, "bool-false-key": false }`,
+			wantEnvMap: env.Environment{
+				"BUILDKITE_PLUGIN_CONFIGURATION":                 `{"bool-false-key":false,"bool-true-key":true}`,
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_BOOL_FALSE_KEY": "false",
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_BOOL_TRUE_KEY":  "true",
+				"BUILDKITE_PLUGIN_NAME":                          "DOCKER_COMPOSE",
+			},
+		},
+		{
+			configJSON: `{ "array-key": [ "array-val-1", "array-val-2" ] }`,
+			wantEnvMap: env.Environment{
+				"BUILDKITE_PLUGIN_CONFIGURATION":              `{"array-key":["array-val-1","array-val-2"]}`,
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0": "array-val-1",
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_1": "array-val-2",
+				"BUILDKITE_PLUGIN_NAME":                       "DOCKER_COMPOSE",
+			},
+		},
+		{
+			configJSON: `{ "array-key": [ 42, 43, 44 ] }`,
+			wantEnvMap: env.Environment{
+				"BUILDKITE_PLUGIN_CONFIGURATION":              `{"array-key":[42,43,44]}`,
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0": "42",
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_1": "43",
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_2": "44",
+				"BUILDKITE_PLUGIN_NAME":                       "DOCKER_COMPOSE",
+			},
+		},
+		{
+			configJSON: `{ "array-key": [ 42, 43, "foo" ] }`,
+			wantEnvMap: env.Environment{
+				"BUILDKITE_PLUGIN_CONFIGURATION":              `{"array-key":[42,43,"foo"]}`,
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0": "42",
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_1": "43",
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_2": "foo",
+				"BUILDKITE_PLUGIN_NAME":                       "DOCKER_COMPOSE",
+			},
+		},
+		{
+			configJSON: `{ "array-key": [ { "subkey": "subval" } ] }`,
+			wantEnvMap: env.Environment{
+				"BUILDKITE_PLUGIN_CONFIGURATION":                     `{"array-key":[{"subkey":"subval"}]}`,
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0_SUBKEY": "subval",
+				"BUILDKITE_PLUGIN_NAME":                              "DOCKER_COMPOSE",
+			},
+		},
+		{
+			configJSON: `{ "array-key": [ { "subkey": [1, 2, "llamas"] } ] }`,
+			wantEnvMap: env.Environment{
+				"BUILDKITE_PLUGIN_CONFIGURATION":                       `{"array-key":[{"subkey":[1,2,"llamas"]}]}`,
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0_SUBKEY_0": "1",
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0_SUBKEY_1": "2",
+				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0_SUBKEY_2": "llamas",
+				"BUILDKITE_PLUGIN_NAME":                                "DOCKER_COMPOSE",
+			},
+		},
+	}
 
-	envMap, err = pluginEnvFromConfig(t, `{ "config-key": 42 }`)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{
-		"BUILDKITE_PLUGIN_CONFIGURATION={\"config-key\":42}",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_KEY=42",
-		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
-	}, envMap.ToSlice())
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.configJSON, func(t *testing.T) {
+			t.Parallel()
+			plugin, err := pluginFromConfig(tc.configJSON)
+			if err != nil {
+				t.Fatalf("pluginFromConfig(%q) error = %v", tc.configJSON, err)
+			}
+			envMap, err := plugin.ConfigurationToEnvironment()
+			if err != nil {
+				t.Errorf("plugin.ConfigurationToEnvironment() error = %v", err)
+			}
+			if diff := cmp.Diff(envMap, tc.wantEnvMap); diff != "" {
+				t.Errorf("plugin.ConfigurationToEnvironment() envMap diff (-got +want)\n%s", diff)
+			}
+		})
+	}
 
-	envMap, err = pluginEnvFromConfig(t, `{ "container": "app", "some-other-setting": "else right here" }`)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{
-		"BUILDKITE_PLUGIN_CONFIGURATION={\"container\":\"app\",\"some-other-setting\":\"else right here\"}",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONTAINER=app",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_SOME_OTHER_SETTING=else right here",
-		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
-	}, envMap.ToSlice())
-
-	envMap, err = pluginEnvFromConfig(t, `{ "and _ with a    - number": 12 }`)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{
-		"BUILDKITE_PLUGIN_CONFIGURATION={\"and _ with a    - number\":12}",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_AND_WITH_A_NUMBER=12",
-		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
-	}, envMap.ToSlice())
-
-	envMap, err = pluginEnvFromConfig(t, `{ "bool-true-key": true, "bool-false-key": false }`)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{
-		"BUILDKITE_PLUGIN_CONFIGURATION={\"bool-false-key\":false,\"bool-true-key\":true}",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_BOOL_FALSE_KEY=false",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_BOOL_TRUE_KEY=true",
-		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
-	}, envMap.ToSlice())
-
-	envMap, err = pluginEnvFromConfig(t, `{ "array-key": [ "array-val-1", "array-val-2" ] }`)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{
-		"BUILDKITE_PLUGIN_CONFIGURATION={\"array-key\":[\"array-val-1\",\"array-val-2\"]}",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0=array-val-1",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_1=array-val-2",
-		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
-	}, envMap.ToSlice())
-
-	envMap, err = pluginEnvFromConfig(t, `{ "array-key": [ 42, 43, 44 ] }`)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{
-		"BUILDKITE_PLUGIN_CONFIGURATION={\"array-key\":[42,43,44]}",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0=42",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_1=43",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_2=44",
-		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
-	}, envMap.ToSlice())
-
-	envMap, err = pluginEnvFromConfig(t, `{ "array-key": [ 42, 43, "foo" ] }`)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{
-		"BUILDKITE_PLUGIN_CONFIGURATION={\"array-key\":[42,43,\"foo\"]}",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0=42",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_1=43",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_2=foo",
-		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
-	}, envMap.ToSlice())
-
-	envMap, err = pluginEnvFromConfig(t, `{ "array-key": [ { "subkey": "subval" } ] }`)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{
-		"BUILDKITE_PLUGIN_CONFIGURATION={\"array-key\":[{\"subkey\":\"subval\"}]}",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0_SUBKEY=subval",
-		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
-	}, envMap.ToSlice())
-
-	envMap, err = pluginEnvFromConfig(t, `{ "array-key": [ { "subkey": [1, 2, "llamas"] } ] }`)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{
-		"BUILDKITE_PLUGIN_CONFIGURATION={\"array-key\":[{\"subkey\":[1,2,\"llamas\"]}]}",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0_SUBKEY_0=1",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0_SUBKEY_1=2",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_ARRAY_KEY_0_SUBKEY_2=llamas",
-		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
-	}, envMap.ToSlice())
-
-	// Ensure on duplicate plugin definition, each plugin gets its respective config exported
-	plugins, err := duplicatePluginFromConfig(t, `{ "config-key": 41 }`, `{ "second-ref-key": 42 }`)
-	assert.NoError(t, err)
-	envMap1, err := plugins[0].ConfigurationToEnvironment()
-	assert.NoError(t, err)
-	assert.Equal(t, []string{
-		"BUILDKITE_PLUGIN_CONFIGURATION={\"config-key\":41}",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_KEY=41",
-		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
-	}, envMap1.ToSlice())
-	envMap2, err := plugins[1].ConfigurationToEnvironment()
-	assert.NoError(t, err)
-	assert.Equal(t, []string{
-		"BUILDKITE_PLUGIN_CONFIGURATION={\"second-ref-key\":42}",
-		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_SECOND_REF_KEY=42",
-		"BUILDKITE_PLUGIN_NAME=DOCKER_COMPOSE",
-	}, envMap2.ToSlice())
 }
 
-func pluginEnvFromConfig(t *testing.T, configJson string) (env.Environment, error) {
+func pluginFromConfig(configJson string) (*Plugin, error) {
 	var config map[string]interface{}
 
-	json.Unmarshal([]byte(configJson), &config)
+	if err := json.Unmarshal([]byte(configJson), &config); err != nil {
+		return nil, err
+	}
 
 	jsonString := fmt.Sprintf(`[ { "%s": %s } ]`, "github.com/buildkite-plugins/docker-compose-buildkite-plugin", configJson)
 
 	plugins, err := CreateFromJSON(jsonString)
+	if err != nil {
+		return nil, err
+	}
+	if len(plugins) != 1 {
+		return nil, fmt.Errorf("parsed wrong number of plugins [%d != 1]", len(plugins))
+	}
 
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(plugins))
-
-	return plugins[0].ConfigurationToEnvironment()
+	return plugins[0], nil
 }
 
-func duplicatePluginFromConfig(t *testing.T, configJson1, configJson2 string) ([]*Plugin, error) {
-	var config1 map[string]interface{}
-	var config2 map[string]interface{}
+func TestConfigurationToEnvironment_DuplicatePlugin(t *testing.T) {
+	// Ensure on duplicate plugin definition, each plugin gets its respective config exported
+	plugins, err := duplicatePluginFromConfig(`{ "config-key": 41 }`, `{ "second-ref-key": 42 }`)
+	if err != nil {
+		t.Fatalf("duplicatePluginFromConfig({config-key:41},{second-ref-key:42}) error = %v", err)
+	}
 
-	json.Unmarshal([]byte(configJson1), &config1)
-	json.Unmarshal([]byte(configJson1), &config2)
+	envMap1, err := plugins[0].ConfigurationToEnvironment()
+	if err != nil {
+		t.Errorf("plugins[0].ConfigurationToEnvironment() error = %v", err)
+	}
+	wantEnv1 := env.Environment{
+		"BUILDKITE_PLUGIN_CONFIGURATION":             `{"config-key":41}`,
+		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_KEY": "41",
+		"BUILDKITE_PLUGIN_NAME":                      "DOCKER_COMPOSE",
+	}
+	if diff := cmp.Diff(envMap1, wantEnv1); diff != "" {
+		t.Errorf("plugins[0].ConfigurationToEnvironment() envMap diff (-got +want)\n%s", diff)
+	}
 
-	jsonString := fmt.Sprintf(`[ { "%s": %s }, { "%s": %s } ]`, "github.com/buildkite-plugins/docker-compose-buildkite-plugin", configJson1, "github.com/buildkite-plugins/docker-compose-buildkite-plugin", configJson2)
+	envMap2, err := plugins[1].ConfigurationToEnvironment()
+	if err != nil {
+		t.Errorf("plugins[1].ConfigurationToEnvironment() error = %v", err)
+	}
+	wantEnv2 := env.Environment{
+		"BUILDKITE_PLUGIN_CONFIGURATION":                 `{"second-ref-key":42}`,
+		"BUILDKITE_PLUGIN_DOCKER_COMPOSE_SECOND_REF_KEY": "42",
+		"BUILDKITE_PLUGIN_NAME":                          "DOCKER_COMPOSE",
+	}
+	if diff := cmp.Diff(envMap2, wantEnv2); diff != "" {
+		t.Errorf("plugins[0].ConfigurationToEnvironment() envMap diff (-got +want)\n%s", diff)
+	}
+}
+
+func duplicatePluginFromConfig(cfgJSON1, cfgJSON2 string) ([]*Plugin, error) {
+	var config1, config2 map[string]interface{}
+
+	if err := json.Unmarshal([]byte(cfgJSON1), &config1); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal([]byte(cfgJSON1), &config2); err != nil {
+		return nil, err
+	}
+
+	jsonString := fmt.Sprintf(`[ { "%s": %s }, { "%s": %s } ]`, "github.com/buildkite-plugins/docker-compose-buildkite-plugin", cfgJSON1, "github.com/buildkite-plugins/docker-compose-buildkite-plugin", cfgJSON2)
 
 	plugins, err := CreateFromJSON(jsonString)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(plugins))
+	if err != nil {
+		return nil, err
+	}
+	if len(plugins) != 2 {
+		return nil, fmt.Errorf("parsed wrong number of plugins [%d != 2]", len(plugins))
+	}
 
 	return plugins, nil
 }


### PR DESCRIPTION
This PR adds a package comment and doc comments to all exported top-level identifiers to the plugin package. It also makes some opportunistic cleanups:

- All the tests are more consistent, using table-driven tests throughout
- ValidateResult stores errors directly rather than error strings, so as to be more useful under the forthcoming Go 1.20 multi-errors Unwrap convention
- New sentinel error values enable more semantic error checking
- Consolidated regexps: declaration and compilation are within single var block, and previously duplicated regexps are un-duplicated.

