### PR TITLE
Ensure that unrecoverable errors for Hearbeat and Ping stop the agent

### DIFF
--- a/api/retryable.go
+++ b/api/retryable.go
@@ -31,7 +31,7 @@ var retryableStatuses = []int{
 
 // IsRetryableStatus returns true if the response's StatusCode is one that we should retry.
 func IsRetryableStatus(r *Response) bool {
-	return slices.Contains(retryableStatuses, r.StatusCode)
+	return r.StatusCode >= 400 && slices.Contains(retryableStatuses, r.StatusCode)
 }
 
 // Looks at a bunch of connection related errors, and returns true if the error


### PR DESCRIPTION
**Context:** A [recent incident](https://www.buildkitestatus.com/incidents/m8f0dnxtmjbz) at Buildkite caused an issue to occur with some agents where their connection state was invalidated,  and were marked as ‘lost’ in the buildkite backend. 

this caused them to get into a halfway-between state where the agent is still alive, but still unsuccessfully trying to talk to the buildkite agent API. because the agent is already past the point in its code where it would usually try to authenticate with the API, it just loops trying to connect to an API that will never successfully authenticate its requests.

the buildkite API was returning a 401 to all requests from the agent, and the agent would say "okay :)" and then retry a bit later, blissfully unaware that no requests would ever succeed.

when this  happens, it leaves the agent as a bit of a zombie; it’s still running, but it can’t pick up work and is basically useless to everyone.

**This PR:** Makes the agent die whenever it receives a non-retryable status from either the `Ping()` and `Heartbeat()` calls. This means that if agent connection states ever get invalidated in the future, the agents will fully die instead of becoming zombies.

It looks like this when it happens:
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/15753101/204925820-2ae6c214-9c7b-4a7c-bb52-cf4ccce1ecf2.png">
