### PR TITLE
bootstrap: Replace mock ssh with container preparation

### DIFF
--- a/.buildkite/Dockerfile-compile
+++ b/.buildkite/Dockerfile-compile
@@ -1,1 +1,2 @@
 FROM golang:1.19.3@sha256:7ffa70183b7596e6bc1b78c132dbba9a6e05a26cd30eaa9832fecad64b83f029
+COPY build/ssh.conf /etc/ssh/ssh_config.d/

--- a/.buildkite/build/ssh.conf
+++ b/.buildkite/build/ssh.conf
@@ -1,0 +1,11 @@
+# The following config is used by bootstrap/git_test.go
+Host github.com-alias1
+    Hostname github.com
+
+Host cool-alias
+    User cool-admin
+    Port 443
+    Hostname rad-git-host.com
+
+Host *
+    User buildkite

--- a/bootstrap/docker.go
+++ b/bootstrap/docker.go
@@ -2,11 +2,11 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/buildkite/agent/v3/bootstrap/shell"
-	"github.com/pkg/errors"
 )
 
 var dockerEnv = []string{

--- a/bootstrap/shell/test.go
+++ b/bootstrap/shell/test.go
@@ -26,20 +26,20 @@ func NewTestShell(t *testing.T) *Shell {
 
 	// Windows requires certain env variables to be present
 	if runtime.GOOS == "windows" {
-		sh.Env = env.FromSlice([]string{
-			//			"PATH=" + os.Getenv("PATH"),
-			"SystemRoot=" + os.Getenv("SystemRoot"),
-			"WINDIR=" + os.Getenv("WINDIR"),
-			"COMSPEC=" + os.Getenv("COMSPEC"),
-			"PATHEXT=" + os.Getenv("PATHEXT"),
-			"TMP=" + os.Getenv("TMP"),
-			"TEMP=" + os.Getenv("TEMP"),
-			"ProgramData=" + os.Getenv("ProgramData"),
-		})
+		sh.Env = env.Environment{
+			//"PATH":        os.Getenv("PATH"),
+			"SystemRoot":  os.Getenv("SystemRoot"),
+			"WINDIR":      os.Getenv("WINDIR"),
+			"COMSPEC":     os.Getenv("COMSPEC"),
+			"PATHEXT":     os.Getenv("PATHEXT"),
+			"TMP":         os.Getenv("TMP"),
+			"TEMP":        os.Getenv("TEMP"),
+			"ProgramData": os.Getenv("ProgramData"),
+		}
 	} else {
-		sh.Env = env.FromSlice([]string{
-			"PATH=" + os.Getenv("PATH"),
-		})
+		sh.Env = env.Environment{
+			"PATH": os.Getenv("PATH"),
+		}
 	}
 
 	return sh

--- a/process/process.go
+++ b/process/process.go
@@ -5,6 +5,7 @@ package process
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,7 +17,6 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/v3/logger"
-	"github.com/pkg/errors"
 )
 
 const (


### PR DESCRIPTION
This mainly changes a test from invoking a bintest mock, to invoking the real `ssh` and testing the string parsing logic separately. 

`resolveGitHost` is refactored into two parts: "invoking `ssh -G`" and "parsing the output" (`hostFromSSHG`).

The new tests will detect if SSH ever formats its output differently in a breaking way, and removes two instances of bintest, which may be the source of test flakes.
