### PR TITLE
Add agent tags from ECS container metadata

### DIFF
--- a/agent/ecs_meta_data.go
+++ b/agent/ecs_meta_data.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"context"
+	metadata "github.com/brunoscheufler/aws-ecs-metadata-go"
+	"net/http"
+)
+
+type ECSMetadata struct {
+}
+
+func (e ECSMetadata) Get() (map[string]string, error) {
+	metaData := make(map[string]string)
+
+	ecsMeta, err := metadata.GetContainer(context.Background(), &http.Client{})
+	if err != nil {
+		return metaData, err
+	}
+
+	switch m := ecsMeta.(type) {
+	case *metadata.ContainerMetadataV3:
+		metaData["ecs:container-name"] = m.DockerName
+		metaData["ecs:image"] = m.Image
+		metaData["ecs:task-arn"] = m.Labels.EcsTaskArn
+	case *metadata.ContainerMetadataV4:
+		metaData["ecs:container-name"] = m.DockerName
+		metaData["ecs:image"] = m.Image
+		metaData["ecs:task-arn"] = m.Labels.EcsTaskArn
+	}
+
+	return metaData, nil
+}

--- a/agent/ecs_meta_data.go
+++ b/agent/ecs_meta_data.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	metadata "github.com/brunoscheufler/aws-ecs-metadata-go"
 	"net/http"
 )
@@ -26,6 +27,8 @@ func (e ECSMetadata) Get() (map[string]string, error) {
 		metaData["ecs:container-name"] = m.DockerName
 		metaData["ecs:image"] = m.Image
 		metaData["ecs:task-arn"] = m.Labels.EcsTaskArn
+	default:
+		return metaData, fmt.Errorf("ecs metadata returned unknown type %T", m)
 	}
 
 	return metaData, nil

--- a/agent/tags_test.go
+++ b/agent/tags_test.go
@@ -86,8 +86,8 @@ func TestFetchingTagsFromECS(t *testing.T) {
 	fetcher := &tagFetcher{
 		ecsMetaDataDefault: func() (map[string]string, error) {
 			return map[string]string{
-				`ecs:container-name`: "ecs-buildkite-agent-blahblah",
-				`ecs:image`:          "buildkite/agent",
+				"ecs:container-name": "ecs-buildkite-agent-blahblah",
+				"ecs:image":          "buildkite/agent",
 				"ecs:task-arn":       "arn:aws:ecs:us-east-1:123456789012:task/MyCluster/4d590253bb114126b7afa7b58EXAMPLE",
 			}, nil
 		},

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/DataDog/sketches-go v1.2.1 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
+	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf // indirect
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuW
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aws/aws-sdk-go v1.44.152 h1:L9aaepO8wHB67gwuGD8VgIYH/cmQDxieCt7FeLa0+fI=
 github.com/aws/aws-sdk-go v1.44.152/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf h1:WCnJxXZXx9c8gwz598wvdqmu+YTzB9wx2X1OovK3Le8=
+github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf/go.mod h1:CeKhh8xSs3WZAc50xABMxu+FlfAAd5PNumo7NfOv7EE=
 github.com/buildkite/bintest/v3 v3.1.1 h1:bS924OU8Ljm46DesONXzxxTBMjbliQRnPB+H4DOeUDE=
 github.com/buildkite/bintest/v3 v3.1.1/go.mod h1:T3Et1VwEizryWfwLLruFqExHsEU+wjkxOlL54283ccc=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=


### PR DESCRIPTION
Adds selected ECS metadata as agent tags. The metadata that I felt was useful to add was:
- Container name
- Docker image
- ECS task ARN

Tested a custom build on our infrastructure:
![image](https://user-images.githubusercontent.com/3876970/205983614-95aba0c8-b714-43c2-9fd6-c6b9e074af9c.png)
