### PR TITLE
Use stdlib errors instead of github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/oleiade/reflections v0.0.0-20160817071559-0e86b3c98b2f
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pborman/uuid v0.0.0-20170112150404-1b00554d8222
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/qri-io/jsonschema v0.0.0-20180607150648-d0d3b10ec792
 	github.com/rjeczalik/interfaces v0.1.1
 	github.com/sergi/go-diff v1.0.0 // indirect


### PR DESCRIPTION
github.com/pkg/errors is archived, and the README says it is in maintenance mode. The standard library `errors` package is built-in.