### PR TITLE
Disable git advice on detached checkout

### DIFF
--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -44,7 +44,7 @@ func gitCheckout(ctx context.Context, sh shellRunner, gitCheckoutFlags, referenc
 		return fmt.Errorf("%q is not a valid git ref format", reference)
 	}
 
-	commandArgs := []string{ "-c", "advice.detachedHead=false", "checkout"}
+	commandArgs := []string{"-c", "advice.detachedHead=false", "checkout"}
 	commandArgs = append(commandArgs, individualCheckoutFlags...)
 	commandArgs = append(commandArgs, reference)
 

--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -44,7 +44,7 @@ func gitCheckout(ctx context.Context, sh shellRunner, gitCheckoutFlags, referenc
 		return fmt.Errorf("%q is not a valid git ref format", reference)
 	}
 
-	commandArgs := []string{"checkout"}
+	commandArgs := []string{ "-c", "advice.detachedHead=false", "checkout"}
 	commandArgs = append(commandArgs, individualCheckoutFlags...)
 	commandArgs = append(commandArgs, reference)
 

--- a/bootstrap/git_test.go
+++ b/bootstrap/git_test.go
@@ -176,7 +176,7 @@ func TestGitCheckoutValidatesRef(t *testing.T) {
 }
 
 func TestGitCheckout(t *testing.T) {
-	sh := new(mockShellRunner).Expect("git", "checkout", "-f", "-q", "main")
+	sh := new(mockShellRunner).Expect("git", "-c", "advice.detachedHead=false", "checkout", "-f", "-q", "main")
 	defer sh.Check(t)
 	err := gitCheckout(context.Background(), sh, "-f -q", "main")
 	require.NoError(t, err)


### PR DESCRIPTION
We're seeing this git advice in our build logs about detached HEAD state due to how BuildKite agent checks out build commits. It isn't really helpful for automated flows, it's aimed at new git users I guess.

PR should save 16 lines of output for Buildkite users, we're trying to reduce noise in our build logs so they're more actionable when a developer opens the log 😬 

```java
$ git clone XXXX
Cloning into '.'...
Warning: Permanently added the ECDSA host key for IP address '' to the list of known hosts.
remote: Enumerating objects: 87, done.
remote: Counting objects: 100% (61/61), done.
remote: Compressing objects: 100% (14/14), done.
remote: Total 45 (delta 13), reused 38 (delta 7), pack-reused 0
Receiving objects: 100% (45/45), done.
Resolving deltas: 100% (13/13), completed with 7 local objects.
Updating files: 100% (xx/xx), done.
$ git clean -ffxdq
# Fetch and checkout pull request head from GitHub
$ git fetch -- origin refs/pull/xxxxxx/head
Warning: Permanently added the ECDSA host key for IP address 'xxxx' to the list of known hosts.
From github.com:lyft/instant-android
 * branch                      refs/pull/xxx/head -> FETCH_HEAD
# FETCH_HEAD is now `yyy`
$ git checkout -f yyy
Note: switching to 'yyy'.
 
You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.
 
If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:
 
  git switch -c <new-branch-name>
 
Or undo this operation with:
 
  git switch -
 
Turn off this advice by setting config variable advice.detachedHead to false
```