### PR TITLE
Kubernetes job runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ packaging/docker/*/buildkite-agent
 packaging/docker/*/hooks/
 
 .idea
+.vscode

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -85,7 +85,7 @@ type AgentWorker struct {
 
 	// When this worker runs a job, we'll store an instance of the
 	// JobRunner here
-	jobRunner *JobRunner
+	jobRunner jobRunner
 
 	// retrySleepFunc is useful for testing retry loops fast
 	// Hopefully this can be replaced with a global setting for tests in future:

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/buildkite/agent/v3/api"
@@ -114,7 +113,7 @@ type jobAPI interface {
 	Interrupt() error
 	Terminate() error
 	Run(ctx context.Context) error
-	WaitStatus() syscall.WaitStatus
+	WaitStatus() process.WaitStatus
 }
 
 var _ jobRunner = (*JobRunner)(nil)

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -257,10 +258,15 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 
 	// The process that will run the bootstrap script
 	if experiments.IsEnabled("kubernetes-exec") {
+		containerCount, err := strconv.Atoi(os.Getenv("BUILDKITE_CONTAINER_COUNT"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse BUILDKITE_CONTAINER_COUNT: %w", err)
+		}
 		runner.process = kubernetes.New(l, kubernetes.Config{
-			Env:    processEnv,
-			Stdout: processWriter,
-			Stderr: processWriter,
+			Env:         processEnv,
+			Stdout:      processWriter,
+			Stderr:      processWriter,
+			ClientCount: containerCount,
 		})
 	} else {
 		runner.process = process.New(l, process.Config{

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -263,7 +263,7 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 			return nil, fmt.Errorf("failed to parse BUILDKITE_CONTAINER_COUNT: %w", err)
 		}
 		runner.process = kubernetes.New(l, kubernetes.Config{
-			Env:         processEnv,
+			AccessToken: apiClient.Config().Token,
 			Stdout:      processWriter,
 			Stderr:      processWriter,
 			ClientCount: containerCount,

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -106,7 +106,13 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 			b.shell.Errorf("Error connecting to kubernetes runner: %v", err)
 			return 1
 		}
-		<-kubernetesClient.WaitReady()
+		status := <-kubernetesClient.WaitReady()
+		if status.Err != nil {
+			b.shell.Errorf("Error waiting for client to become ready: %v", err)
+			return 1
+		}
+		os.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", status.AccessToken)
+		b.shell.Env.Set("BUILDKITE_AGENT_ACCESS_TOKEN", status.AccessToken)
 		defer kubernetesClient.Exit(b.shell.WaitStatus())
 	}
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -113,7 +113,9 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 		}
 		os.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", status.AccessToken)
 		b.shell.Env.Set("BUILDKITE_AGENT_ACCESS_TOKEN", status.AccessToken)
-		defer kubernetesClient.Exit(b.shell.WaitStatus())
+		defer func() {
+			kubernetesClient.Exit(b.shell.WaitStatus())
+		}()
 	}
 
 	var err error

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -116,7 +116,6 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 		go func() {
 			if err := kubernetesClient.Await(ctx, kubernetes.RunStateInterrupt); err != nil {
 				b.shell.Errorf("Error waiting for client interrupt: %v", err)
-				return
 			}
 			b.cancelCh <- struct{}{}
 		}()

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -120,7 +120,12 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 			b.cancelCh <- struct{}{}
 		}()
 		defer func() {
-			kubernetesClient.Exit(b.shell.WaitStatus())
+			ws, err := b.shell.WaitStatus()
+			if err != nil {
+				b.shell.Errorf("Error getting wait status: %v", err)
+				return
+			}
+			kubernetesClient.Exit(ws)
 		}()
 	}
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -120,12 +120,10 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 			b.cancelCh <- struct{}{}
 		}()
 		defer func() {
-			ws, err := b.shell.WaitStatus()
-			if err != nil {
-				b.shell.Errorf("Error getting wait status: %v", err)
-				return
-			}
-			kubernetesClient.Exit(ws)
+			exitStatus, _ := b.shell.Env.Get("BUILDKITE_COMMAND_EXIT_STATUS")
+			exitStatusCode, _ := strconv.Atoi(exitStatus)
+
+			kubernetesClient.Exit(exitStatusCode)
 		}()
 	}
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -83,6 +83,7 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 		kubernetesClient := &kubernetes.Client{}
 		if err := b.startKubernetesClient(ctx, kubernetesClient); err != nil {
 			b.shell.Errorf("Failed to start kubernetes client: %v", err)
+			return 1
 		}
 		defer func() {
 			kubernetesClient.Exit(exitCode)

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -170,14 +170,14 @@ func (s *Shell) Terminate() {
 }
 
 // Terminate running command
-func (s *Shell) WaitStatus() syscall.WaitStatus {
+func (s *Shell) WaitStatus() process.WaitStatus {
 	s.cmdLock.Lock()
 	defer s.cmdLock.Unlock()
 
 	if s.cmd != nil && s.cmd.proc != nil {
 		return s.cmd.proc.WaitStatus()
 	}
-	return 0
+	return syscall.WaitStatus(0)
 }
 
 // LockFile is a pid-based lock for cross-process locking

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -169,16 +169,17 @@ func (s *Shell) Terminate() {
 	}
 }
 
-// Terminate running command
-func (s *Shell) WaitStatus() process.WaitStatus {
+// Returns the WaitStatus of the shell's process.
+//
+// The shell must have been started.
+func (s *Shell) WaitStatus() (process.WaitStatus, error) {
 	s.cmdLock.Lock()
 	defer s.cmdLock.Unlock()
 
-	if s.cmd != nil && s.cmd.proc != nil {
-		return s.cmd.proc.WaitStatus()
+	if s.cmd == nil || s.cmd.proc == nil {
+		return nil, errors.New("shell not started")
 	}
-	var ws syscall.WaitStatus
-	return ws
+	return s.cmd.proc.WaitStatus(), nil
 }
 
 // LockFile is a pid-based lock for cross-process locking

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -169,6 +169,17 @@ func (s *Shell) Terminate() {
 	}
 }
 
+// Terminate running command
+func (s *Shell) WaitStatus() syscall.WaitStatus {
+	s.cmdLock.Lock()
+	defer s.cmdLock.Unlock()
+
+	if s.cmd != nil && s.cmd.proc != nil {
+		return s.cmd.proc.WaitStatus()
+	}
+	return 0
+}
+
 // LockFile is a pid-based lock for cross-process locking
 type LockFile interface {
 	Unlock() error

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -177,7 +177,8 @@ func (s *Shell) WaitStatus() process.WaitStatus {
 	if s.cmd != nil && s.cmd.proc != nil {
 		return s.cmd.proc.WaitStatus()
 	}
-	return syscall.WaitStatus(0)
+	var ws syscall.WaitStatus
+	return ws
 }
 
 // LockFile is a pid-based lock for cross-process locking

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -3,14 +3,15 @@ package kubernetes
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/rpc"
 	"os"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/buildkite/agent/v3/logger"
 )
@@ -21,9 +22,18 @@ func New(l logger.Logger, c Config) *Runner {
 	if c.SocketPath == "" {
 		c.SocketPath = defaultSocketPath
 	}
+	clients := make(map[int]*clientResult, c.ClientCount)
+	for i := 0; i < c.ClientCount; i++ {
+		clients[i] = &clientResult{}
+	}
 	return &Runner{
-		logger: l,
-		conf:   c,
+		logger:  l,
+		conf:    c,
+		clients: clients,
+		server:  rpc.NewServer(),
+		mux:     http.NewServeMux(),
+		done:    make(chan struct{}),
+		started: make(chan struct{}),
 	}
 }
 
@@ -33,36 +43,46 @@ type Runner struct {
 	mu            sync.Mutex
 	listener      net.Listener
 	started, done chan struct{}
-	waitStatus    syscall.WaitStatus
-	once          sync.Once
+	startedOnce,
+	closedOnce sync.Once
+	server  *rpc.Server
+	mux     *http.ServeMux
+	clients map[int]*clientResult
 }
+
+type clientResult struct {
+	ExitStatus syscall.WaitStatus
+	State      clientState
+}
+
+type clientState int
+
+const (
+	stateUnknown clientState = iota
+	stateConnected
+	stateExited
+)
 
 type Config struct {
 	SocketPath     string
+	ClientCount    int
 	Env            []string
 	Stdout, Stderr io.Writer
 }
 
 func (r *Runner) Run(ctx context.Context) error {
-	rpc.Register(r)
-	rpc.HandleHTTP()
-	l, err := net.Listen("unix", r.conf.SocketPath)
+	r.server.Register(r)
+	r.mux.Handle(rpc.DefaultRPCPath, r.server)
+
+	l, err := (&net.ListenConfig{}).Listen(ctx, "unix", r.conf.SocketPath)
 	if err != nil {
-		log.Fatal("listen error:", err)
+		return fmt.Errorf("failed to listen: %w", err)
 	}
 	defer l.Close()
 	defer os.Remove(r.conf.SocketPath)
 	r.listener = l
-	go http.Serve(l, nil)
+	go http.Serve(l, r.mux)
 
-	r.mu.Lock()
-	if r.done == nil {
-		r.done = make(chan struct{})
-	}
-	if r.started == nil {
-		r.started = make(chan struct{})
-	}
-	r.mu.Unlock()
 	<-r.done
 	return nil
 }
@@ -94,7 +114,13 @@ func (r *Runner) Terminate() error {
 }
 
 func (r *Runner) WaitStatus() syscall.WaitStatus {
-	return r.waitStatus
+	// TODO: fix this somehow??
+	var ws syscall.WaitStatus
+	for _, client := range r.clients {
+		ws = client.ExitStatus
+		break
+	}
+	return ws
 }
 
 // ==== sidecar api ====
@@ -105,24 +131,73 @@ type Logs struct {
 }
 
 type ExitCode struct {
+	ID         int
 	ExitStatus syscall.WaitStatus
 }
 
-func (t *Runner) WriteLogs(args Logs, reply *Empty) error {
-	t.once.Do(func() {
-		close(t.started)
+type Status struct {
+	Ready bool
+}
+
+func (r *Runner) WriteLogs(args Logs, reply *Empty) error {
+	r.startedOnce.Do(func() {
+		close(r.started)
 	})
-	_, err := io.Copy(t.conf.Stdout, bytes.NewReader(args.Data))
+	_, err := io.Copy(r.conf.Stdout, bytes.NewReader(args.Data))
 	return err
 }
 
-func (t *Runner) Exit(args ExitCode, reply *Empty) error {
-	t.waitStatus = args.ExitStatus
-	close(t.done)
+func (r *Runner) Exit(args ExitCode, reply *Empty) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	client, found := r.clients[args.ID]
+	if !found {
+		return fmt.Errorf("unrecognized client id: %d", args.ID)
+	}
+	client.ExitStatus = args.ExitStatus
+	client.State = stateExited
+
+	allExited := true
+	for _, client := range r.clients {
+		allExited = client.State == stateExited && allExited
+	}
+	if allExited {
+		r.closedOnce.Do(func() {
+			close(r.done)
+		})
+	}
+	return nil
+}
+
+func (r *Runner) Register(id int, reply *Empty) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	client, found := r.clients[id]
+	if !found {
+		return fmt.Errorf("client id %d not found", id)
+	}
+	if client.State == stateConnected {
+		return fmt.Errorf("client id %d already registered", id)
+	}
+	client.State = stateConnected
+	return nil
+}
+
+func (r *Runner) Status(id int, reply *Status) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if id == 0 {
+		reply.Ready = true
+	} else if client, found := r.clients[id-1]; found && client.State == stateExited {
+		reply.Ready = true
+	}
 	return nil
 }
 
 type Client struct {
+	ID         int
 	SocketPath string
 	client     *rpc.Client
 }
@@ -136,7 +211,7 @@ func (c *Client) Connect() error {
 		return err
 	}
 	c.client = client
-	return nil
+	return c.client.Call("Runner.Register", c.ID, nil)
 }
 
 func (c *Client) Exit(exitStatus syscall.WaitStatus) error {
@@ -144,6 +219,7 @@ func (c *Client) Exit(exitStatus syscall.WaitStatus) error {
 		return nil
 	}
 	return c.client.Call("Runner.Exit", ExitCode{
+		ID:         c.ID,
 		ExitStatus: exitStatus,
 	}, nil)
 }
@@ -158,4 +234,28 @@ func (c *Client) Write(p []byte) (int, error) {
 		Data: p,
 	}, nil)
 	return n, err
+}
+
+func (c *Client) WaitReady() <-chan error {
+	result := make(chan error)
+	go func() {
+		for {
+			var reply Status
+			if err := c.client.Call("Runner.Status", c.ID, &reply); err != nil {
+				result <- err
+				return
+			}
+			if reply.Ready {
+				close(result)
+				return
+			}
+			// TODO: configurable interval
+			time.Sleep(time.Second)
+		}
+	}()
+	return result
+}
+
+func (c *Client) Close() {
+	c.client.Close()
 }

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -85,12 +85,15 @@ func (r *Runner) Run(ctx context.Context) error {
 	r.server.Register(r)
 	r.mux.Handle(rpc.DefaultRPCPath, r.server)
 
+	oldUmask := syscall.Umask(0) // set umask of socket file to 0777 (world read-write-executable)
 	l, err := (&net.ListenConfig{}).Listen(ctx, "unix", r.conf.SocketPath)
 	if err != nil {
 		return fmt.Errorf("failed to listen: %w", err)
 	}
 	defer l.Close()
 	defer os.Remove(r.conf.SocketPath)
+
+	syscall.Umask(oldUmask) // change back to regular umask
 	r.listener = l
 	go http.Serve(l, r.mux)
 

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -156,6 +156,7 @@ func (r *Runner) Exit(args ExitCode, reply *Empty) error {
 	if !found {
 		return fmt.Errorf("unrecognized client id: %d", args.ID)
 	}
+	r.logger.Info("client %d exited with code %d", args.ID, args.ExitStatus.ExitStatus())
 	client.ExitStatus = args.ExitStatus
 	client.State = stateExited
 

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -1,0 +1,161 @@
+package kubernetes
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/rpc"
+	"os"
+	"sync"
+	"syscall"
+
+	"github.com/buildkite/agent/v3/logger"
+)
+
+const defaultSocketPath = "/workspace/buildkite.sock"
+
+func New(l logger.Logger, c Config) *Runner {
+	if c.SocketPath == "" {
+		c.SocketPath = defaultSocketPath
+	}
+	return &Runner{
+		logger: l,
+		conf:   c,
+	}
+}
+
+type Runner struct {
+	logger        logger.Logger
+	conf          Config
+	mu            sync.Mutex
+	listener      net.Listener
+	started, done chan struct{}
+	waitStatus    syscall.WaitStatus
+	once          sync.Once
+}
+
+type Config struct {
+	SocketPath     string
+	Env            []string
+	Stdout, Stderr io.Writer
+}
+
+func (r *Runner) Run(ctx context.Context) error {
+	rpc.Register(r)
+	rpc.HandleHTTP()
+	l, err := net.Listen("unix", r.conf.SocketPath)
+	if err != nil {
+		log.Fatal("listen error:", err)
+	}
+	defer l.Close()
+	defer os.Remove(r.conf.SocketPath)
+	r.listener = l
+	go http.Serve(l, nil)
+
+	r.mu.Lock()
+	if r.done == nil {
+		r.done = make(chan struct{})
+	}
+	if r.started == nil {
+		r.started = make(chan struct{})
+	}
+	r.mu.Unlock()
+	<-r.done
+	return nil
+}
+
+func (r *Runner) Started() <-chan struct{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.started
+}
+
+func (r *Runner) Done() <-chan struct{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.done
+}
+
+func (r *Runner) Interrupt() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	panic("unimplemented")
+}
+
+func (r *Runner) Terminate() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	panic("unimplemented")
+}
+
+func (r *Runner) WaitStatus() syscall.WaitStatus {
+	return r.waitStatus
+}
+
+// ==== sidecar api ====
+
+type Empty struct{}
+type Logs struct {
+	Data []byte
+}
+
+type ExitCode struct {
+	ExitStatus syscall.WaitStatus
+}
+
+func (t *Runner) WriteLogs(args Logs, reply *Empty) error {
+	t.once.Do(func() {
+		close(t.started)
+	})
+	_, err := io.Copy(t.conf.Stdout, bytes.NewReader(args.Data))
+	return err
+}
+
+func (t *Runner) Exit(args ExitCode, reply *Empty) error {
+	t.waitStatus = args.ExitStatus
+	close(t.done)
+	return nil
+}
+
+type Client struct {
+	SocketPath string
+	client     *rpc.Client
+}
+
+func (c *Client) Connect() error {
+	if c.SocketPath == "" {
+		c.SocketPath = defaultSocketPath
+	}
+	client, err := rpc.DialHTTP("unix", c.SocketPath)
+	if err != nil {
+		return err
+	}
+	c.client = client
+	return nil
+}
+
+func (c *Client) Exit(exitStatus syscall.WaitStatus) error {
+	if c.client == nil {
+		return nil
+	}
+	return c.client.Call("Runner.Exit", ExitCode{
+		ExitStatus: exitStatus,
+	}, nil)
+}
+
+// Write implements io.Writer
+func (c *Client) Write(p []byte) (int, error) {
+	if c.client == nil {
+		return 0, nil
+	}
+	n := len(p)
+	err := c.client.Call("Runner.WriteLogs", Logs{
+		Data: p,
+	}, nil)
+	return n, err
+}

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -1,0 +1,138 @@
+package kubernetes
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrderedClients(t *testing.T) {
+	runner := newRunner(t, 3)
+	socketPath := runner.conf.SocketPath
+
+	client0 := &Client{ID: 0}
+	client1 := &Client{ID: 1}
+	client2 := &Client{ID: 2}
+	clients := []*Client{client0, client1, client2}
+
+	// wait for runner to listen
+	require.Eventually(t, func() bool {
+		_, err := os.Lstat(socketPath)
+		return err == nil
+
+	}, time.Second*10, time.Millisecond, "expected socket file to exist")
+
+	for _, client := range clients {
+		client.SocketPath = socketPath
+		require.NoError(t, client.Connect())
+		t.Cleanup(client.Close)
+	}
+	select {
+	case err := <-client0.WaitReady():
+		require.NoError(t, err)
+		break
+	case err := <-client1.WaitReady():
+		require.NoError(t, err)
+		require.FailNow(t, "client1 should not be ready")
+	case err := <-client2.WaitReady():
+		require.NoError(t, err)
+		require.FailNow(t, "client2 should not be ready")
+	case <-runner.Done():
+		require.FailNow(t, "runner should not be done")
+	case <-time.After(time.Second):
+		require.FailNow(t, "client0 should be ready")
+	}
+
+	require.NoError(t, client0.Exit(0))
+	select {
+	case err := <-client1.WaitReady():
+		require.NoError(t, err)
+		break
+	case err := <-client2.WaitReady():
+		require.NoError(t, err)
+		require.FailNow(t, "client2 should not be ready")
+	case <-runner.Done():
+		require.FailNow(t, "runner should not be done")
+	case <-time.After(time.Second):
+		require.FailNow(t, "client1 should be ready")
+	}
+
+	require.NoError(t, client1.Exit(0))
+	select {
+	case err := <-client2.WaitReady():
+		require.NoError(t, err)
+		break
+	case <-runner.Done():
+		require.FailNow(t, "runner should not be done")
+	case <-time.After(time.Second):
+		require.FailNow(t, "client2 should be ready")
+	}
+
+	require.NoError(t, client2.Exit(0))
+	select {
+	case <-runner.Done():
+		break
+	case <-time.After(time.Second):
+		require.FailNow(t, "runner should be done when all clients have exited")
+	}
+}
+
+func TestDuplicateClients(t *testing.T) {
+	runner := newRunner(t, 2)
+	socketPath := runner.conf.SocketPath
+
+	client0 := Client{ID: 0, SocketPath: socketPath}
+	client1 := Client{ID: 0, SocketPath: socketPath}
+
+	// wait for runner to listen
+	require.Eventually(t, func() bool {
+		_, err := os.Lstat(socketPath)
+		return err == nil
+
+	}, time.Second*10, time.Millisecond, "expected socket file to exist")
+
+	require.NoError(t, client0.Connect())
+	require.Error(t, client1.Connect(), "expected an error when connecting a client with a duplicate ID")
+}
+
+func TestExcessClients(t *testing.T) {
+	runner := newRunner(t, 1)
+	socketPath := runner.conf.SocketPath
+
+	client0 := Client{ID: 0, SocketPath: socketPath}
+	client1 := Client{ID: 1, SocketPath: socketPath}
+
+	// wait for runner to listen
+	require.Eventually(t, func() bool {
+		_, err := os.Lstat(socketPath)
+		return err == nil
+
+	}, time.Second*10, time.Millisecond, "expected socket file to exist")
+
+	require.NoError(t, client0.Connect())
+	require.Error(t, client1.Connect(), "expected an error when connecting too many clients")
+}
+
+func newRunner(t *testing.T, clientCount int) *Runner {
+	tempDir, err := os.MkdirTemp("", t.Name())
+	require.NoError(t, err)
+	socketPath := filepath.Join(tempDir, "bk.sock")
+	t.Cleanup(func() {
+		os.RemoveAll(tempDir)
+	})
+	runner := New(logger.Discard, Config{
+		SocketPath:  socketPath,
+		ClientCount: clientCount,
+	})
+	runnerCtx, cancelRunner := context.WithCancel(context.Background())
+	go runner.Run(runnerCtx)
+	t.Cleanup(func() {
+		cancelRunner()
+	})
+	return runner
+}

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package kubernetes
 
 import (

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -2,8 +2,10 @@ package kubernetes
 
 import (
 	"context"
+	"encoding/gob"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -48,7 +50,7 @@ func TestOrderedClients(t *testing.T) {
 		require.FailNow(t, "client0 should be ready")
 	}
 
-	require.NoError(t, client0.Exit(0))
+	require.NoError(t, client0.Exit(waitStatusSuccess))
 	select {
 	case err := <-client1.WaitReady():
 		require.NoError(t, err.Err)
@@ -62,7 +64,7 @@ func TestOrderedClients(t *testing.T) {
 		require.FailNow(t, "client1 should be ready")
 	}
 
-	require.NoError(t, client1.Exit(0))
+	require.NoError(t, client1.Exit(waitStatusSuccess))
 	select {
 	case err := <-client2.WaitReady():
 		require.NoError(t, err.Err)
@@ -73,7 +75,7 @@ func TestOrderedClients(t *testing.T) {
 		require.FailNow(t, "client2 should be ready")
 	}
 
-	require.NoError(t, client2.Exit(0))
+	require.NoError(t, client2.Exit(waitStatusSuccess))
 	select {
 	case <-runner.Done():
 		break
@@ -107,15 +109,35 @@ func TestExcessClients(t *testing.T) {
 	client0 := Client{ID: 0, SocketPath: socketPath}
 	client1 := Client{ID: 1, SocketPath: socketPath}
 
-	// wait for runner to listen
-	require.Eventually(t, func() bool {
-		_, err := os.Lstat(socketPath)
-		return err == nil
-
-	}, time.Second*10, time.Millisecond, "expected socket file to exist")
-
 	require.NoError(t, client0.Connect())
 	require.Error(t, client1.Connect(), "expected an error when connecting too many clients")
+}
+
+func TestWaitStatusNonZero(t *testing.T) {
+	runner := newRunner(t, 2)
+
+	client0 := Client{ID: 0, SocketPath: runner.conf.SocketPath}
+	client1 := Client{ID: 1, SocketPath: runner.conf.SocketPath}
+
+	require.NoError(t, client0.Connect())
+	require.NoError(t, client1.Connect())
+	require.NoError(t, client0.Exit(waitStatusFailure))
+	require.NoError(t, client1.Exit(waitStatusSuccess))
+	require.Equal(t, runner.WaitStatus().ExitStatus(), 1)
+}
+
+func TestWaitStatusSignaled(t *testing.T) {
+	runner := newRunner(t, 2)
+
+	client0 := Client{ID: 0, SocketPath: runner.conf.SocketPath}
+	client1 := Client{ID: 1, SocketPath: runner.conf.SocketPath}
+
+	require.NoError(t, client0.Connect())
+	require.NoError(t, client1.Connect())
+	require.NoError(t, client0.Exit(waitStatusSignaled))
+	require.NoError(t, client1.Exit(waitStatusSuccess))
+	require.Equal(t, runner.WaitStatus().ExitStatus(), 0)
+	require.True(t, runner.WaitStatus().Signaled())
 }
 
 func newRunner(t *testing.T, clientCount int) *Runner {
@@ -134,5 +156,44 @@ func newRunner(t *testing.T, clientCount int) *Runner {
 	t.Cleanup(func() {
 		cancelRunner()
 	})
+
+	// wait for runner to listen
+	require.Eventually(t, func() bool {
+		_, err := os.Lstat(socketPath)
+		return err == nil
+
+	}, time.Second*10, time.Millisecond, "expected socket file to exist")
+
 	return runner
+}
+
+var (
+	waitStatusSuccess  = waitStatus{Code: 0}
+	waitStatusFailure  = waitStatus{Code: 1}
+	waitStatusSignaled = waitStatus{Code: 0, SignalCode: intptr(1)}
+)
+
+func init() {
+	gob.Register(new(waitStatus))
+}
+
+type waitStatus struct {
+	Code       int
+	SignalCode *int
+}
+
+func (w waitStatus) ExitStatus() int {
+	return w.Code
+}
+
+func (w waitStatus) Signaled() bool {
+	return w.SignalCode != nil
+}
+
+func (w waitStatus) Signal() syscall.Signal {
+	return syscall.Signal(*w.SignalCode)
+}
+
+func intptr(x int) *int {
+	return &x
 }

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -34,13 +34,13 @@ func TestOrderedClients(t *testing.T) {
 	}
 	select {
 	case err := <-client0.WaitReady():
-		require.NoError(t, err)
+		require.NoError(t, err.Err)
 		break
 	case err := <-client1.WaitReady():
-		require.NoError(t, err)
+		require.NoError(t, err.Err)
 		require.FailNow(t, "client1 should not be ready")
 	case err := <-client2.WaitReady():
-		require.NoError(t, err)
+		require.NoError(t, err.Err)
 		require.FailNow(t, "client2 should not be ready")
 	case <-runner.Done():
 		require.FailNow(t, "runner should not be done")
@@ -51,10 +51,10 @@ func TestOrderedClients(t *testing.T) {
 	require.NoError(t, client0.Exit(0))
 	select {
 	case err := <-client1.WaitReady():
-		require.NoError(t, err)
+		require.NoError(t, err.Err)
 		break
 	case err := <-client2.WaitReady():
-		require.NoError(t, err)
+		require.NoError(t, err.Err)
 		require.FailNow(t, "client2 should not be ready")
 	case <-runner.Done():
 		require.FailNow(t, "runner should not be done")
@@ -65,7 +65,7 @@ func TestOrderedClients(t *testing.T) {
 	require.NoError(t, client1.Exit(0))
 	select {
 	case err := <-client2.WaitReady():
-		require.NoError(t, err)
+		require.NoError(t, err.Err)
 		break
 	case <-runner.Done():
 		require.FailNow(t, "runner should not be done")

--- a/kubernetes/umask.go
+++ b/kubernetes/umask.go
@@ -1,0 +1,13 @@
+//go:build !windows
+// +build !windows
+
+package kubernetes
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Umask is a wrapper for `unix.Umask()` on non-Windows platforms
+func Umask(mask int) (old int, err error) {
+	return unix.Umask(mask), nil
+}

--- a/kubernetes/umask_windows.go
+++ b/kubernetes/umask_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+// +build windows
+
+package kubernetes
+
+import (
+	"errors"
+)
+
+// Umask returns an error on Windows
+func Umask(mask int) (int, error) {
+	return 0, errors.New("platform and architecture is not supported")
+}

--- a/process/process.go
+++ b/process/process.go
@@ -43,6 +43,12 @@ var signalMap = map[string]Signal{
 	"SIGTERM": SIGTERM,
 }
 
+type WaitStatus interface {
+	ExitStatus() int
+	Signaled() bool
+	Signal() syscall.Signal
+}
+
 func (s Signal) String() string {
 	for k, sig := range signalMap {
 		if sig == s {
@@ -107,7 +113,7 @@ func (p *Process) WaitResult() error {
 }
 
 // WaitStatus returns the status of the Wait() call
-func (p *Process) WaitStatus() syscall.WaitStatus {
+func (p *Process) WaitStatus() WaitStatus {
 	return p.status
 }
 


### PR DESCRIPTION
Building this out as part of our work in https://github.com/buildkite/agent-stack-k8s/tree/v2

This changes the agent `start` and `bootstrap` commands to be able to operate in a client/server model, rather than a parent process/child process model.

This is what a successful run would look like, imagining `bootstrap 1` and `bootstrap 2` are running commands like cloning the git repository, running tests:

```mermaid
sequenceDiagram
participant bapi as Buildkite API
participant server as agent/server
participant c1 as bootstrap 1
participant c2 as bootstrap 2

server->>server: listen
server->>bapi: acquire job
c1->>server: connect
c2->>server: connect
c1->>server: wait for start
c2->>server: wait for start
server->>c1: start
c1->>c1: run to completion
c1->>server: exit 0
server->>c2: start
c2->>c2: run to completion
c1->>server: stream logs
server->>bapi: stream logs
c2->>server: exit 0
server->>bapi: exit 0
server->>server: shutdown
```