### PR TITLE
add git-checkout-flags

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -11,6 +11,7 @@ type AgentConfiguration struct {
 	GitMirrorsLockTimeout      int
 	GitMirrorsSkipUpdate       bool
 	PluginsPath                string
+	GitCheckoutFlags           string
 	GitCloneFlags              string
 	GitCloneMirrorFlags        string
 	GitCleanFlags              string

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -523,6 +523,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 		"BUILDKITE_COMMAND_EVAL",
 		"BUILDKITE_PLUGINS_ENABLED",
 		"BUILDKITE_LOCAL_HOOKS_ENABLED",
+		"BUILDKITE_GIT_CHECKOUT_FLAGS",
 		"BUILDKITE_GIT_CLONE_FLAGS",
 		"BUILDKITE_GIT_FETCH_FLAGS",
 		"BUILDKITE_GIT_CLONE_MIRROR_FLAGS",
@@ -579,6 +580,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	env["BUILDKITE_COMMAND_EVAL"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.CommandEval)
 	env["BUILDKITE_PLUGINS_ENABLED"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.PluginsEnabled)
 	env["BUILDKITE_LOCAL_HOOKS_ENABLED"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.LocalHooksEnabled)
+	env["BUILDKITE_GIT_CHECKOUT_FLAGS"] = r.conf.AgentConfiguration.GitCheckoutFlags
 	env["BUILDKITE_GIT_CLONE_FLAGS"] = r.conf.AgentConfiguration.GitCloneFlags
 	env["BUILDKITE_GIT_FETCH_FLAGS"] = r.conf.AgentConfiguration.GitFetchFlags
 	env["BUILDKITE_GIT_CLONE_MIRROR_FLAGS"] = r.conf.AgentConfiguration.GitCloneMirrorFlags

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1370,12 +1370,14 @@ func (b *Bootstrap) defaultCheckoutPhase(ctx context.Context) error {
 		}
 	}
 
+	gitCheckoutFlags := b.GitCheckoutFlags
+
 	if b.Commit == "HEAD" {
-		if err := gitCheckout(ctx, b.shell, "-f", "FETCH_HEAD"); err != nil {
+		if err := gitCheckout(ctx, b.shell, gitCheckoutFlags, "FETCH_HEAD"); err != nil {
 			return err
 		}
 	} else {
-		if err := gitCheckout(ctx, b.shell, "-f", b.Commit); err != nil {
+		if err := gitCheckout(ctx, b.shell, gitCheckoutFlags, b.Commit); err != nil {
 			return err
 		}
 	}

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -71,6 +71,9 @@ type Config struct {
 	// Should the bootstrap remove an existing checkout before running the job
 	CleanCheckout bool `env:"BUILDKITE_CLEAN_CHECKOUT"`
 
+	// Flags to pass to "git checkout" command
+	GitCheckoutFlags string `env:"BUILDKITE_GIT_CHECKOUT_FLAGS"`
+
 	// Flags to pass to "git clone" command
 	GitCloneFlags string `env:"BUILDKITE_GIT_CLONE_FLAGS"`
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -84,6 +84,7 @@ type AgentStartConfig struct {
 	WaitForEC2MetaDataTimeout   string   `cli:"wait-for-ec2-meta-data-timeout"`
 	WaitForECSMetaDataTimeout   string   `cli:"wait-for-ecs-meta-data-timeout"`
 	WaitForGCPLabelsTimeout     string   `cli:"wait-for-gcp-labels-timeout"`
+	GitCheckoutFlags            string   `cli:"git-checkout-flags"`
 	GitCloneFlags               string   `cli:"git-clone-flags"`
 	GitCloneMirrorFlags         string   `cli:"git-clone-mirror-flags"`
 	GitCleanFlags               string   `cli:"git-clean-flags"`
@@ -361,6 +362,12 @@ var AgentStartCommand = cli.Command{
 			Usage:  "The amount of time to wait for labels from GCP before proceeding",
 			EnvVar: "BUILDKITE_AGENT_WAIT_FOR_GCP_LABELS_TIMEOUT",
 			Value:  time.Second * 10,
+		},
+		cli.StringFlag{
+			Name:   "git-checkout-flags",
+			Value:  "-f",
+			Usage:  "Flags to pass to \"git checkout\" command",
+			EnvVar: "BUILDKITE_GIT_CHECKOUT_FLAGS",
 		},
 		cli.StringFlag{
 			Name:   "git-clone-flags",
@@ -745,6 +752,7 @@ var AgentStartCommand = cli.Command{
 			GitMirrorsSkipUpdate:       cfg.GitMirrorsSkipUpdate,
 			HooksPath:                  cfg.HooksPath,
 			PluginsPath:                cfg.PluginsPath,
+			GitCheckoutFlags:           cfg.GitCheckoutFlags,
 			GitCloneFlags:              cfg.GitCloneFlags,
 			GitCloneMirrorFlags:        cfg.GitCloneMirrorFlags,
 			GitCleanFlags:              cfg.GitCleanFlags,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -62,6 +62,7 @@ type BootstrapConfig struct {
 	AutomaticArtifactUploadPaths string   `cli:"artifact-upload-paths"`
 	ArtifactUploadDestination    string   `cli:"artifact-upload-destination"`
 	CleanCheckout                bool     `cli:"clean-checkout"`
+	GitCheckoutFlags             string   `cli:"git-checkout-flags"`
 	GitCloneFlags                string   `cli:"git-clone-flags"`
 	GitFetchFlags                string   `cli:"git-fetch-flags"`
 	GitCloneMirrorFlags          string   `cli:"git-clone-mirror-flags"`
@@ -197,6 +198,12 @@ var BootstrapCommand = cli.Command{
 			Name:   "clean-checkout",
 			Usage:  "Whether or not the bootstrap should remove the existing repository before running the command",
 			EnvVar: "BUILDKITE_CLEAN_CHECKOUT",
+		},
+		cli.StringFlag{
+			Name:   "git-checkout-flags",
+			Value:  "-f",
+			Usage:  "Flags to pass to \"git checkout\" command",
+			EnvVar: "BUILDKITE_GIT_CHECKOUT_FLAGS",
 		},
 		cli.StringFlag{
 			Name:   "git-clone-flags",
@@ -410,6 +417,7 @@ var BootstrapCommand = cli.Command{
 			CommandEval:                  cfg.CommandEval,
 			Commit:                       cfg.Commit,
 			Debug:                        cfg.Debug,
+			GitCheckoutFlags:             cfg.GitCheckoutFlags,
 			GitCleanFlags:                cfg.GitCleanFlags,
 			GitCloneFlags:                cfg.GitCloneFlags,
 			GitCloneMirrorFlags:          cfg.GitCloneMirrorFlags,


### PR DESCRIPTION
Unfortunately, turns out `git checkout` doesn't have a `--no-verify` option, so not immediately useful to me. Opening in case it's useful for others.

Closes #1888