### PR TITLE
Add git config protocol.file.allow=always to tests

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1416,7 +1416,7 @@ func (b *Bootstrap) defaultCheckoutPhase(ctx context.Context) error {
 		for _, config := range b.GitSubmoduleCloneConfig {
 			args = append(args, "-c", config)
 		}
-		args = append(args, []string{"submodule", "update", "--init", "--recursive", "--force"}...)
+		args = append(args, "submodule", "update", "--init", "--recursive", "--force")
 		if err := b.shell.Run(ctx, "git", args...); err != nil {
 			return err
 		}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1412,7 +1412,12 @@ func (b *Bootstrap) defaultCheckoutPhase(ctx context.Context) error {
 			}
 		}
 
-		if err := b.shell.Run(ctx, "git", "submodule", "update", "--init", "--recursive", "--force"); err != nil {
+		args := []string{}
+		for _, config := range b.GitSubmoduleCloneConfig {
+			args = append(args, "-c", config)
+		}
+		args = append(args, []string{"submodule", "update", "--init", "--recursive", "--force"}...)
+		if err := b.shell.Run(ctx, "git", args...); err != nil {
 			return err
 		}
 

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -83,7 +83,7 @@ type Config struct {
 	// Flags to pass to "git clean" command
 	GitCleanFlags string `env:"BUILDKITE_GIT_CLEAN_FLAGS"`
 
-	// Flags to pass to "git" when submodule init commands are invoked
+	// Config key=value pairs to pass to "git" when submodule init commands are invoked
 	GitSubmoduleCloneConfig []string `env:"BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG" normalize:"list"`
 
 	// Whether or not to run the hooks/commands in a PTY

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -83,6 +83,9 @@ type Config struct {
 	// Flags to pass to "git clean" command
 	GitCleanFlags string `env:"BUILDKITE_GIT_CLEAN_FLAGS"`
 
+	// Flags to pass to "git" when submodule init commands are invoked
+	GitSubmoduleCloneConfig []string `env:"BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG" normalize:"list"`
+
 	// Whether or not to run the hooks/commands in a PTY
 	RunInPty bool
 

--- a/bootstrap/integration/bootstrap_tester.go
+++ b/bootstrap/integration/bootstrap_tester.go
@@ -107,7 +107,7 @@ func NewBootstrapTester() (*BootstrapTester, error) {
 
 	// Support testing experiments
 	if exp := experiments.Enabled(); len(exp) > 0 {
-		bt.Env = append(bt.Env, `BUILDKITE_AGENT_EXPERIMENT=`+strings.Join(exp, ","))
+		bt.Env = append(bt.Env, "BUILDKITE_AGENT_EXPERIMENT="+strings.Join(exp, ","))
 
 		if experiments.IsEnabled("git-mirrors") {
 			gitMirrorsDir, err := os.MkdirTemp("", "bootstrap-git-mirrors")

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -203,7 +203,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 	}
 	defer submoduleRepo.Close()
 
-	out, err := tester.Repo.Execute("submodule", "add", submoduleRepo.Path)
+	out, err := tester.Repo.Execute("-c", "protocol.file.allow=always", "submodule", "add", submoduleRepo.Path)
 	if err != nil {
 		t.Fatalf("tester.Repo.Execute(submodule, add, %q) error = %v\nout = %s", submoduleRepo.Path, err, out)
 	}
@@ -217,6 +217,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 		"BUILDKITE_GIT_CLONE_FLAGS=-v",
 		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
 		"BUILDKITE_GIT_FETCH_FLAGS=-v",
+		"BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG=protocol.file.allow=always",
 	}
 
 	// Actually execute git commands, but with expectations
@@ -235,7 +236,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"submodule", "sync", "--recursive"},
 			{"config", "--file", ".gitmodules", "--null", "--get-regexp", "submodule\\..+\\.url"},
-			{"submodule", "update", "--init", "--recursive", "--force"},
+			{"-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--force"},
 			{"submodule", "foreach", "--recursive", "git reset --hard"},
 			{"clean", "-fdq"},
 			{"submodule", "foreach", "--recursive", "git clean -fdq"},
@@ -250,7 +251,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"submodule", "sync", "--recursive"},
 			{"config", "--file", ".gitmodules", "--null", "--get-regexp", "submodule\\..+\\.url"},
-			{"submodule", "update", "--init", "--recursive", "--force"},
+			{"-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--force"},
 			{"submodule", "foreach", "--recursive", "git reset --hard"},
 			{"clean", "-fdq"},
 			{"submodule", "foreach", "--recursive", "git clean -fdq"},
@@ -286,7 +287,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 	}
 	defer submoduleRepo.Close()
 
-	out, err := tester.Repo.Execute("submodule", "add", submoduleRepo.Path)
+	out, err := tester.Repo.Execute("-c", "protocol.file.allow=always", "submodule", "add", submoduleRepo.Path)
 	if err != nil {
 		t.Fatalf("tester.Repo.Execute(submodule, add, %q) error = %v\nout = %s", submoduleRepo.Path, err, out)
 	}

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -69,6 +69,7 @@ type BootstrapConfig struct {
 	GitMirrorsPath               string   `cli:"git-mirrors-path" normalize:"filepath"`
 	GitMirrorsLockTimeout        int      `cli:"git-mirrors-lock-timeout"`
 	GitMirrorsSkipUpdate         bool     `cli:"git-mirrors-skip-update"`
+	GitSubmoduleCloneConfig      []string `cli:"git-submodule-clone-config"`
 	BinPath                      string   `cli:"bin-path" normalize:"filepath"`
 	BuildPath                    string   `cli:"build-path" normalize:"filepath"`
 	HooksPath                    string   `cli:"hooks-path" normalize:"filepath"`
@@ -220,6 +221,12 @@ var BootstrapCommand = cli.Command{
 			Value:  "",
 			Usage:  "Flags to pass to \"git fetch\" command",
 			EnvVar: "BUILDKITE_GIT_FETCH_FLAGS",
+		},
+		cli.StringSliceFlag{
+			Name:   "git-submodule-clone-config",
+			Value:  &cli.StringSlice{},
+			Usage:  "Config key=value for git submodule clone commands",
+			EnvVar: "BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG",
 		},
 		cli.StringFlag{
 			Name:   "git-mirrors-path",
@@ -411,6 +418,7 @@ var BootstrapCommand = cli.Command{
 			GitMirrorsPath:               cfg.GitMirrorsPath,
 			GitMirrorsSkipUpdate:         cfg.GitMirrorsSkipUpdate,
 			GitSubmodules:                cfg.GitSubmodules,
+			GitSubmoduleCloneConfig:      cfg.GitSubmoduleCloneConfig,
 			HooksPath:                    cfg.HooksPath,
 			JobID:                        cfg.JobID,
 			LocalHooksEnabled:            cfg.LocalHooksEnabled,


### PR DESCRIPTION
This was disabled upstream due to a [security vulnerability in git](https://github.blog/2022-10-18-git-security-vulnerabilities-announced/#cve-2022-39253). That caused the test TestCheckingOutLocalGitProjectWithSubmodules to fail. It has only been passing in CI because we run a version of git in CI that did not receive the patch.

One solution would have been to set `protocol.file.allow=always` globally. However, that would mean that anyone who ran the tests would expose their environment to that vulnerability, and permanently if the global config were not unset afterwards.

Thus, in this PR, the config is only applied for the commands that need it. As one such command was in the default checkout hook, a configuration option was added so that the config would only be enabled in the test that needed it.

There is also some very minor clone cleanup in a separate commit.