### PR TITLE
Update CHANGELOG title for v3.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [v3.41.0](https://github.com/buildkite/agent/tree/v3.42.0) (2023-01-05)
+## [v3.42.0](https://github.com/buildkite/agent/tree/v3.42.0) (2023-01-05)
 [Full Changelog](https://github.com/buildkite/agent/compare/v3.41.0...v3.42.0)
 
  ### Added


### PR DESCRIPTION
I just realised I made a typo in the CHANGELOG.md title for the v.3.42.0 release 🙁. 