### PR TITLE
Replace all usages of interface{} with any

### DIFF
--- a/agent/pipeline_parser.go
+++ b/agent/pipeline_parser.go
@@ -39,7 +39,7 @@ func (p PipelineParser) Parse() (*PipelineParserResult, error) {
 
 	// We support top-level arrays of steps, so try that first
 	if err := yaml.Unmarshal(p.Pipeline, &pipelineAsSlice); err == nil {
-		var steps []interface{}
+		var steps []any
 
 		// Unwrap our custom topLevelStep types for marshaling later
 		for _, step := range pipelineAsSlice {
@@ -103,7 +103,7 @@ func (p PipelineParser) Parse() (*PipelineParserResult, error) {
 
 // upsertSliceItem will replace a key's value in the given MapSlice with the given
 // replacement or insert it if it doesn't exist.
-func upsertSliceItem(key string, s yaml.MapSlice, val interface{}) yaml.MapSlice {
+func upsertSliceItem(key string, s yaml.MapSlice, val any) yaml.MapSlice {
 	found := -1
 	for i, item := range s {
 		if k, ok := item.Key.(string); ok && k == key {
@@ -155,7 +155,7 @@ func formatYAMLError(err error) error {
 
 // interpolate function inspired from: https://gist.github.com/hvoecking/10772475
 
-func (p PipelineParser) interpolate(obj interface{}) (interface{}, error) {
+func (p PipelineParser) interpolate(obj any) (any, error) {
 	// Make sure there's something actually to interpolate
 	if obj == nil {
 		return nil, nil
@@ -301,7 +301,7 @@ type topLevelStep struct {
 	Body string
 }
 
-func (s *topLevelStep) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *topLevelStep) UnmarshalYAML(unmarshal func(any) error) error {
 	// Some steps are plain old strings like "wait". To avoid unmarshaling errors
 	// we check for plain old strings
 	if err := unmarshal(&s.Body); err == nil {

--- a/agent/pipeline_parser_test.go
+++ b/agent/pipeline_parser_test.go
@@ -270,7 +270,7 @@ func TestPipelineParserLoadsGlobalEnvBlockFirst(t *testing.T) {
 	assert.Equal(t, "echo England smashes Australia to win the ashes in 1912!!", decoded.Steps[0].Command)
 }
 
-func decodeIntoStruct(into interface{}, from interface{}) error {
+func decodeIntoStruct(into any, from any) error {
 	b, err := json.Marshal(from)
 	if err != nil {
 		return err

--- a/agent/plugin/definition.go
+++ b/agent/plugin/definition.go
@@ -95,7 +95,7 @@ type Validator struct {
 
 // Validate checks the plugin definition for errors, including missing commands
 // from $PATH and invalid configuration under the definition's JSON Schema.
-func (v Validator) Validate(def *Definition, config map[string]interface{}) ValidateResult {
+func (v Validator) Validate(def *Definition, config map[string]any) ValidateResult {
 	var result ValidateResult
 
 	configJSON, err := json.Marshal(config)

--- a/agent/plugin/definition_test.go
+++ b/agent/plugin/definition_test.go
@@ -90,7 +90,7 @@ func TestDefinitionValidatesConfiguration(t *testing.T) {
 		}`),
 	}
 
-	res := validator.Validate(def, map[string]interface{}{
+	res := validator.Validate(def, map[string]any{
 		"llamas": "always",
 	})
 
@@ -123,7 +123,7 @@ func TestDefinitionWithoutAdditionalProperties(t *testing.T) {
 		}`),
 	}
 
-	res := validator.Validate(def, map[string]interface{}{
+	res := validator.Validate(def, map[string]any{
 		"alpacas": "definitely",
 		"camels":  "never",
 	})
@@ -157,7 +157,7 @@ func TestDefinitionWithAdditionalProperties(t *testing.T) {
 		}`),
 	}
 
-	res := validator.Validate(def, map[string]interface{}{
+	res := validator.Validate(def, map[string]any{
 		"alpacas": "definitely",
 		"camels":  "never",
 	})

--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -22,7 +22,7 @@ func TestCreateFromJSON(t *testing.T) {
 				Location:      "github.com/buildkite-plugins/docker-compose",
 				Version:       "a34fa34",
 				Scheme:        "https",
-				Configuration: map[string]interface{}{"container": "app"},
+				Configuration: map[string]any{"container": "app"},
 			}},
 		},
 		{
@@ -31,7 +31,7 @@ func TestCreateFromJSON(t *testing.T) {
 				Location:      "github.com/buildkite-plugins/docker-compose",
 				Version:       "a34fa34",
 				Scheme:        "",
-				Configuration: map[string]interface{}{},
+				Configuration: map[string]any{},
 			}},
 		},
 		{
@@ -40,7 +40,7 @@ func TestCreateFromJSON(t *testing.T) {
 				Location:      "github.com/buildkite-plugins/docker-compose",
 				Version:       "a34fa34",
 				Scheme:        "http",
-				Configuration: map[string]interface{}{},
+				Configuration: map[string]any{},
 			}},
 		},
 		{`[{"https://gitlab.example.com/path/to/repo#main":{}}]`,
@@ -48,7 +48,7 @@ func TestCreateFromJSON(t *testing.T) {
 				Location:      "gitlab.example.com/path/to/repo",
 				Version:       "main",
 				Scheme:        "https",
-				Configuration: map[string]interface{}{},
+				Configuration: map[string]any{},
 			}},
 		},
 		{`[{"https://gitlab.com/group/team/path/to/repo#main":{}}]`,
@@ -56,7 +56,7 @@ func TestCreateFromJSON(t *testing.T) {
 				Location:      "gitlab.com/group/team/path/to/repo",
 				Version:       "main",
 				Scheme:        "https",
-				Configuration: map[string]interface{}{},
+				Configuration: map[string]any{},
 			}},
 		},
 		{
@@ -66,7 +66,7 @@ func TestCreateFromJSON(t *testing.T) {
 				Version:        "a34fa34",
 				Scheme:         "ssh",
 				Authentication: "git:foo",
-				Configuration:  map[string]interface{}{},
+				Configuration:  map[string]any{},
 			}},
 		},
 		{
@@ -75,7 +75,7 @@ func TestCreateFromJSON(t *testing.T) {
 				Location:      "github.com/buildkite-plugins/docker-compose",
 				Version:       "a34fa34",
 				Scheme:        "file",
-				Configuration: map[string]interface{}{},
+				Configuration: map[string]any{},
 			}},
 		},
 		{
@@ -84,7 +84,7 @@ func TestCreateFromJSON(t *testing.T) {
 				Location:      "github.com/buildkite-plugins/fake-plugin",
 				Version:       "master",
 				Scheme:        "",
-				Configuration: map[string]interface{}{},
+				Configuration: map[string]any{},
 			}},
 		},
 		{
@@ -93,7 +93,7 @@ func TestCreateFromJSON(t *testing.T) {
 				Location:      "./.buildkite/plugins/llamas",
 				Scheme:        "",
 				Vendored:      true,
-				Configuration: map[string]interface{}{},
+				Configuration: map[string]any{},
 			}},
 		},
 	}
@@ -478,7 +478,7 @@ func TestConfigurationToEnvironment(t *testing.T) {
 }
 
 func pluginFromConfig(configJson string) (*Plugin, error) {
-	var config map[string]interface{}
+	var config map[string]any
 
 	if err := json.Unmarshal([]byte(configJson), &config); err != nil {
 		return nil, err
@@ -532,7 +532,7 @@ func TestConfigurationToEnvironment_DuplicatePlugin(t *testing.T) {
 }
 
 func duplicatePluginFromConfig(cfgJSON1, cfgJSON2 string) ([]*Plugin, error) {
-	var config1, config2 map[string]interface{}
+	var config1, config2 map[string]any
 
 	if err := json.Unmarshal([]byte(cfgJSON1), &config1); err != nil {
 		return nil, err

--- a/api/client.go
+++ b/api/client.go
@@ -144,7 +144,7 @@ func (c *Client) FromPing(resp *Ping) *Client {
 // Relative URLs should always be specified without a preceding slash. If
 // specified, the value pointed to by body is JSON encoded and included as the
 // request body.
-func (c *Client) newRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
+func (c *Client) newRequest(ctx context.Context, method, urlStr string, body any) (*http.Request, error) {
 	u := joinURLPath(c.conf.Endpoint, urlStr)
 
 	buf := new(bytes.Buffer)
@@ -205,7 +205,7 @@ func newResponse(r *http.Response) *Response {
 // error if an API error has occurred.  If v implements the io.Writer
 // interface, the raw response body will be written to v, without attempting to
 // first decode it.
-func (c *Client) doRequest(req *http.Request, v interface{}) (*Response, error) {
+func (c *Client) doRequest(req *http.Request, v any) (*Response, error) {
 	var err error
 
 	if c.conf.DebugHTTP {
@@ -312,7 +312,7 @@ func checkResponse(r *http.Response) error {
 
 // addOptions adds the parameters in opt as URL query parameters to s. opt must
 // be a struct whose fields may contain "url" tags.
-func addOptions(s string, opt interface{}) (string, error) {
+func addOptions(s string, opt any) (string, error) {
 	v := reflect.ValueOf(opt)
 	if v.Kind() == reflect.Ptr && v.IsNil() {
 		return s, nil

--- a/api/pipelines.go
+++ b/api/pipelines.go
@@ -7,9 +7,9 @@ import (
 
 // Pipeline represents a Buildkite Agent API Pipeline
 type Pipeline struct {
-	UUID     string      `json:"uuid"`
-	Pipeline interface{} `json:"pipeline"`
-	Replace  bool        `json:"replace,omitempty"`
+	UUID     string `json:"uuid"`
+	Pipeline any    `json:"pipeline"`
+	Replace  bool   `json:"replace,omitempty"`
 }
 
 // Uploads the pipeline to the Buildkite Agent API. This request doesn't use JSON,

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -59,7 +59,7 @@ func TestCheckingOutGitHubPullRequestsWithGitMirrorsExperiment(t *testing.T) {
 		PassthroughToLocalCommand()
 
 	// But assert which ones are called
-	git.ExpectAll([][]interface{}{
+	git.ExpectAll([][]any{
 		{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
@@ -102,7 +102,7 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 
 	// But assert which ones are called
 	if experiments.IsEnabled("git-mirrors") {
-		git.ExpectAll([][]interface{}{
+		git.ExpectAll([][]any{
 			{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
@@ -113,7 +113,7 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 			{"rev-parse", "HEAD"},
 		})
 	} else {
-		git.ExpectAll([][]interface{}{
+		git.ExpectAll([][]any{
 			{"clone", "-v", "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
 			{"fetch", "-v", "--", "origin", "master"},
@@ -155,7 +155,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 
 	// But assert which ones are called
 	if experiments.IsEnabled("git-mirrors") {
-		git.ExpectAll([][]interface{}{
+		git.ExpectAll([][]any{
 			{"clone", "--mirror", "--config", "pack.threads=35", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
@@ -165,7 +165,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
 		})
 	} else {
-		git.ExpectAll([][]interface{}{
+		git.ExpectAll([][]any{
 			{"clone", "-v", "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
 			{"fetch", "-v", "--", "origin", "master"},
@@ -227,7 +227,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 
 	// But assert which ones are called
 	if experiments.IsEnabled("git-mirrors") {
-		git.ExpectAll([][]interface{}{
+		git.ExpectAll([][]any{
 			{"clone", "--mirror", "-v", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
@@ -243,7 +243,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
 		})
 	} else {
-		git.ExpectAll([][]interface{}{
+		git.ExpectAll([][]any{
 			{"clone", "-v", "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
 			{"submodule", "foreach", "--recursive", "git clean -fdq"},
@@ -311,7 +311,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 
 	// But assert which ones are called
 	if experiments.IsEnabled("git-mirrors") {
-		git.ExpectAll([][]interface{}{
+		git.ExpectAll([][]any{
 			{"clone", "--mirror", "-v", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
@@ -322,7 +322,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
 		})
 	} else {
-		git.ExpectAll([][]interface{}{
+		git.ExpectAll([][]any{
 			{"clone", "-v", "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
 			{"submodule", "foreach", "--recursive", "git clean -fdq"},
@@ -364,7 +364,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 
 	// But assert which ones are called
 	if experiments.IsEnabled("git-mirrors") {
-		git.ExpectAll([][]interface{}{
+		git.ExpectAll([][]any{
 			{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "--depth=1", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
@@ -374,7 +374,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
 		})
 	} else {
-		git.ExpectAll([][]interface{}{
+		git.ExpectAll([][]any{
 			{"clone", "--depth=1", "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
 			{"fetch", "--depth=1", "--", "origin", "master"},
@@ -718,7 +718,7 @@ func TestGitMirrorEnv(t *testing.T) {
 
 	// But assert which ones are called
 	if experiments.IsEnabled("git-mirrors") {
-		git.ExpectAll([][]interface{}{
+		git.ExpectAll([][]any{
 			{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
@@ -728,7 +728,7 @@ func TestGitMirrorEnv(t *testing.T) {
 			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
 		})
 	} else {
-		git.ExpectAll([][]interface{}{
+		git.ExpectAll([][]any{
 			{"clone", "-v", "--", tester.Repo.Path, "."},
 			{"clean", "-fdq"},
 			{"fetch", "-v", "--", "origin", "master"},

--- a/bootstrap/integration/docker_integration_test.go
+++ b/bootstrap/integration/docker_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/buildkite/bintest/v3"
 )
 
-func argumentForCommand(cmd string) interface{} {
+func argumentForCommand(cmd string) any {
 	// This is unpleasant, but we have to work around the fact that we generate
 	// batch scripts for windows and plain commands for everything else
 	if runtime.GOOS == "windows" {
@@ -38,7 +38,7 @@ func TestRunningCommandWithDocker(t *testing.T) {
 	containerId := "buildkite_" + jobId + "_container"
 
 	docker := tester.MustMock(t, "docker")
-	docker.ExpectAll([][]interface{}{
+	docker.ExpectAll([][]any{
 		{"build", "-f", "Dockerfile", "-t", imageId, "."},
 		{"run", "--name", containerId, imageId, argumentForCommand("true")},
 		{"rm", "-f", "-v", containerId},
@@ -72,7 +72,7 @@ func TestRunningCommandWithDockerAndCustomDockerfile(t *testing.T) {
 	containerId := "buildkite_" + jobId + "_container"
 
 	docker := tester.MustMock(t, "docker")
-	docker.ExpectAll([][]interface{}{
+	docker.ExpectAll([][]any{
 		{"build", "-f", "Dockerfile.llamas", "-t", imageId, "."},
 		{"run", "--name", containerId, imageId, argumentForCommand("true")},
 		{"rm", "-f", "-v", containerId},
@@ -105,7 +105,7 @@ func TestRunningFailingCommandWithDocker(t *testing.T) {
 	containerId := "buildkite_" + jobId + "_container"
 
 	docker := tester.MustMock(t, "docker")
-	docker.ExpectAll([][]interface{}{
+	docker.ExpectAll([][]any{
 		{"build", "-f", "Dockerfile", "-t", imageId, "."},
 		{"rm", "-f", "-v", containerId},
 	})
@@ -142,7 +142,7 @@ func TestRunningCommandWithDockerCompose(t *testing.T) {
 	projectName := "buildkite1111111111111111"
 
 	dockerCompose := tester.MustMock(t, "docker-compose")
-	dockerCompose.ExpectAll([][]interface{}{
+	dockerCompose.ExpectAll([][]any{
 		{"-f", "docker-compose.yml", "-p", projectName, "--verbose", "build", "--pull", "llamas"},
 		{"-f", "docker-compose.yml", "-p", projectName, "--verbose", "run", "llamas", argumentForCommand("true")},
 		{"-f", "docker-compose.yml", "-p", projectName, "--verbose", "kill"},
@@ -175,7 +175,7 @@ func TestRunningFailingCommandWithDockerCompose(t *testing.T) {
 	projectName := "buildkite1111111111111111"
 
 	dockerCompose := tester.MustMock(t, "docker-compose")
-	dockerCompose.ExpectAll([][]interface{}{
+	dockerCompose.ExpectAll([][]any{
 		{"-f", "docker-compose.yml", "-p", projectName, "--verbose", "build", "--pull", "llamas"},
 		{"-f", "docker-compose.yml", "-p", projectName, "--verbose", "kill"},
 		{"-f", "docker-compose.yml", "-p", projectName, "--verbose", "rm", "--force", "--all", "-v"},
@@ -216,7 +216,7 @@ func TestRunningCommandWithDockerComposeAndExtraConfig(t *testing.T) {
 	projectName := "buildkite1111111111111111"
 
 	dockerCompose := tester.MustMock(t, "docker-compose")
-	dockerCompose.ExpectAll([][]interface{}{
+	dockerCompose.ExpectAll([][]any{
 		{"-f", "dc1.yml", "-f", "dc2.yml", "-f", "dc3.yml", "-p", projectName, "--verbose", "build", "--pull", "llamas"},
 		{"-f", "dc1.yml", "-f", "dc2.yml", "-f", "dc3.yml", "-p", projectName, "--verbose", "run", "llamas", argumentForCommand("true")},
 		{"-f", "dc1.yml", "-f", "dc2.yml", "-f", "dc3.yml", "-p", projectName, "--verbose", "kill"},

--- a/bootstrap/integration/git.go
+++ b/bootstrap/integration/git.go
@@ -104,7 +104,7 @@ func (gr *gitRepository) Add(path string) error {
 	return nil
 }
 
-func (gr *gitRepository) Commit(message string, params ...interface{}) error {
+func (gr *gitRepository) Commit(message string, params ...any) error {
 	if _, err := gr.Execute("commit", "-m", fmt.Sprintf(message, params...)); err != nil {
 		return err
 	}

--- a/bootstrap/integration/plugin_integration_test.go
+++ b/bootstrap/integration/plugin_integration_test.go
@@ -560,7 +560,7 @@ func (tp *testPlugin) ToJSON() (string, error) {
 func (tp *testPlugin) MarshalJSON() ([]byte, error) {
 	normalizedPath := strings.TrimPrefix(strings.Replace(tp.Path, "\\", "/", -1), "/")
 
-	p := map[string]interface{}{
+	p := map[string]any{
 		fmt.Sprintf("file:///%s#%s", normalizedPath, strings.TrimSpace(tp.versionTag)): map[string]string{
 			"settings": "blah",
 		},

--- a/bootstrap/shell/logger.go
+++ b/bootstrap/shell/logger.go
@@ -15,22 +15,22 @@ type Logger interface {
 	io.Writer
 
 	// Printf prints a line of output
-	Printf(format string, v ...interface{})
+	Printf(format string, v ...any)
 
 	// Headerf prints a Buildkite formatted header
-	Headerf(format string, v ...interface{})
+	Headerf(format string, v ...any)
 
 	// Commentf prints a comment line, e.g `# my comment goes here`
-	Commentf(format string, v ...interface{})
+	Commentf(format string, v ...any)
 
 	// Errorf shows a Buildkite formatted error expands the previous group
-	Errorf(format string, v ...interface{})
+	Errorf(format string, v ...any)
 
 	// Warningf shows a buildkite bootstrap warning
-	Warningf(format string, v ...interface{})
+	Warningf(format string, v ...any)
 
 	// Promptf prints a shell prompt
-	Promptf(format string, v ...interface{})
+	Promptf(format string, v ...any)
 }
 
 // StderrLogger is a Logger that writes to Stderr
@@ -55,17 +55,17 @@ func (wl *WriterLogger) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-func (wl *WriterLogger) Printf(format string, v ...interface{}) {
+func (wl *WriterLogger) Printf(format string, v ...any) {
 	fmt.Fprintf(wl.Writer, "%s", fmt.Sprintf(format, v...))
 	fmt.Fprintln(wl.Writer)
 }
 
-func (wl *WriterLogger) Headerf(format string, v ...interface{}) {
+func (wl *WriterLogger) Headerf(format string, v ...any) {
 	fmt.Fprintf(wl.Writer, "~~~ %s", fmt.Sprintf(format, v...))
 	fmt.Fprintln(wl.Writer)
 }
 
-func (wl *WriterLogger) Commentf(format string, v ...interface{}) {
+func (wl *WriterLogger) Commentf(format string, v ...any) {
 	if wl.Ansi {
 		wl.Printf(ansiColor("# %s", "90"), fmt.Sprintf(format, v...))
 	} else {
@@ -73,7 +73,7 @@ func (wl *WriterLogger) Commentf(format string, v ...interface{}) {
 	}
 }
 
-func (wl *WriterLogger) Errorf(format string, v ...interface{}) {
+func (wl *WriterLogger) Errorf(format string, v ...any) {
 	if wl.Ansi {
 		wl.Printf(ansiColor("🚨 Error: %s", "31"), fmt.Sprintf(format, v...))
 	} else {
@@ -82,7 +82,7 @@ func (wl *WriterLogger) Errorf(format string, v ...interface{}) {
 	wl.Printf("^^^ +++")
 }
 
-func (wl *WriterLogger) Warningf(format string, v ...interface{}) {
+func (wl *WriterLogger) Warningf(format string, v ...any) {
 	if wl.Ansi {
 		wl.Printf(ansiColor("⚠️ Warning: %s", "33"), fmt.Sprintf(format, v...))
 	} else {
@@ -91,7 +91,7 @@ func (wl *WriterLogger) Warningf(format string, v ...interface{}) {
 	wl.Printf("^^^ +++")
 }
 
-func (wl *WriterLogger) Promptf(format string, v ...interface{}) {
+func (wl *WriterLogger) Promptf(format string, v ...any) {
 	prompt := "$"
 	if runtime.GOOS == "windows" {
 		prompt = ">"
@@ -116,27 +116,27 @@ func (tl TestingLogger) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-func (tl TestingLogger) Printf(format string, v ...interface{}) {
+func (tl TestingLogger) Printf(format string, v ...any) {
 	tl.Logf(format, v...)
 }
 
-func (tl TestingLogger) Headerf(format string, v ...interface{}) {
+func (tl TestingLogger) Headerf(format string, v ...any) {
 	tl.Logf("~~~ "+format, v...)
 }
 
-func (tl TestingLogger) Commentf(format string, v ...interface{}) {
+func (tl TestingLogger) Commentf(format string, v ...any) {
 	tl.Logf("# %s", fmt.Sprintf(format, v...))
 }
 
-func (tl TestingLogger) Errorf(format string, v ...interface{}) {
+func (tl TestingLogger) Errorf(format string, v ...any) {
 	tl.Logf("🚨 Error: %s", fmt.Sprintf(format, v...))
 }
 
-func (tl TestingLogger) Warningf(format string, v ...interface{}) {
+func (tl TestingLogger) Warningf(format string, v ...any) {
 	tl.Logf("⚠️ Warning: %s", fmt.Sprintf(format, v...))
 }
 
-func (tl TestingLogger) Promptf(format string, v ...interface{}) {
+func (tl TestingLogger) Promptf(format string, v ...any) {
 	prompt := "$"
 	if runtime.GOOS == "windows" {
 		prompt = ">"

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -91,7 +91,7 @@ var RedactedVars = cli.StringSliceFlag{
 	Value:  &cli.StringSlice{"*_PASSWORD", "*_SECRET", "*_TOKEN", "*_ACCESS_KEY", "*_SECRET_KEY"},
 }
 
-func CreateLogger(cfg interface{}) logger.Logger {
+func CreateLogger(cfg any) logger.Logger {
 	var l logger.Logger
 	logFormat := "text"
 
@@ -149,7 +149,7 @@ func CreateLogger(cfg interface{}) logger.Logger {
 	return l
 }
 
-func HandleProfileFlag(l logger.Logger, cfg interface{}) func() {
+func HandleProfileFlag(l logger.Logger, cfg any) func() {
 	// Enable profiling a profiling mode if Profile is present
 	modeField, _ := reflections.GetField(cfg, "Profile")
 	if mode, ok := modeField.(string); ok && mode != "" {
@@ -158,7 +158,7 @@ func HandleProfileFlag(l logger.Logger, cfg interface{}) func() {
 	return func() {}
 }
 
-func HandleGlobalFlags(l logger.Logger, cfg interface{}) func() {
+func HandleGlobalFlags(l logger.Logger, cfg any) func() {
 	// Enable experiments
 	experimentNames, err := reflections.GetField(cfg, "Experiments")
 	if err == nil {
@@ -175,7 +175,7 @@ func HandleGlobalFlags(l logger.Logger, cfg interface{}) func() {
 	return HandleProfileFlag(l, cfg)
 }
 
-func handleLogLevelFlag(l logger.Logger, cfg interface{}) error {
+func handleLogLevelFlag(l logger.Logger, cfg any) error {
 	logLevel, err := reflections.GetField(cfg, "LogLevel")
 	if err != nil {
 		return err
@@ -214,7 +214,7 @@ func UnsetConfigFromEnvironment(c *cli.Context) error {
 	return nil
 }
 
-func loadAPIClientConfig(cfg interface{}, tokenField string) api.Config {
+func loadAPIClientConfig(cfg any, tokenField string) api.Config {
 	conf := api.Config{
 		UserAgent: version.UserAgent(),
 	}

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -22,7 +22,7 @@ type Loader struct {
 	CLI *cli.Context
 
 	// The struct that the config values will be loaded into
-	Config interface{}
+	Config any
 
 	// The logger used
 	Logger logger.Logger
@@ -178,7 +178,7 @@ func (l Loader) setFieldValueFromCLI(fieldName string, cliName string) error {
 		return fmt.Errorf("Failed to get the type of struct field %s", fieldName)
 	}
 
-	var value interface{}
+	var value any
 
 	// See the if the cli option is using the arg format (arg:1)
 	argMatch := argCliNameRegexp.FindStringSubmatch(cliName)
@@ -258,7 +258,7 @@ func (l Loader) setFieldValueFromCLI(fieldName string, cliName string) error {
 	return nil
 }
 
-func (l Loader) Errorf(format string, v ...interface{}) error {
+func (l Loader) Errorf(format string, v ...any) error {
 	suffix := fmt.Sprintf(" See: `%s %s --help`", l.CLI.App.Name, l.CLI.Command.Name)
 
 	return fmt.Errorf(format+suffix, v...)

--- a/logger/buffer.go
+++ b/logger/buffer.go
@@ -19,22 +19,22 @@ func NewBuffer() *Buffer {
 	}
 }
 
-func (b *Buffer) Debug(format string, v ...interface{}) {
+func (b *Buffer) Debug(format string, v ...any) {
 	b.Messages = append(b.Messages, "[debug] "+fmt.Sprintf(format, v...))
 }
-func (b *Buffer) Error(format string, v ...interface{}) {
+func (b *Buffer) Error(format string, v ...any) {
 	b.Messages = append(b.Messages, "[error] "+fmt.Sprintf(format, v...))
 }
-func (b *Buffer) Fatal(format string, v ...interface{}) {
+func (b *Buffer) Fatal(format string, v ...any) {
 	b.Messages = append(b.Messages, "[fatal] "+fmt.Sprintf(format, v...))
 }
-func (b *Buffer) Notice(format string, v ...interface{}) {
+func (b *Buffer) Notice(format string, v ...any) {
 	b.Messages = append(b.Messages, "[notice] "+fmt.Sprintf(format, v...))
 }
-func (b *Buffer) Warn(format string, v ...interface{}) {
+func (b *Buffer) Warn(format string, v ...any) {
 	b.Messages = append(b.Messages, "[warn] "+fmt.Sprintf(format, v...))
 }
-func (b *Buffer) Info(format string, v ...interface{}) {
+func (b *Buffer) Info(format string, v ...any) {
 	b.Messages = append(b.Messages, "[info] "+fmt.Sprintf(format, v...))
 }
 func (b *Buffer) WithFields(fields ...Field) Logger {

--- a/logger/field.go
+++ b/logger/field.go
@@ -28,7 +28,7 @@ func (f *Fields) Get(key string) []Field {
 
 type GenericField struct {
 	key    string
-	value  interface{}
+	value  any
 	format string
 }
 

--- a/logger/log.go
+++ b/logger/log.go
@@ -38,12 +38,12 @@ var (
 )
 
 type Logger interface {
-	Debug(format string, v ...interface{})
-	Error(format string, v ...interface{})
-	Fatal(format string, v ...interface{})
-	Notice(format string, v ...interface{})
-	Warn(format string, v ...interface{})
-	Info(format string, v ...interface{})
+	Debug(format string, v ...any)
+	Error(format string, v ...any)
+	Fatal(format string, v ...any)
+	Notice(format string, v ...any)
+	Warn(format string, v ...any)
+	Info(format string, v ...any)
 
 	WithFields(fields ...Field) Logger
 	SetLevel(level Level)
@@ -78,34 +78,34 @@ func (l *ConsoleLogger) SetLevel(level Level) {
 	l.level = level
 }
 
-func (l *ConsoleLogger) Debug(format string, v ...interface{}) {
+func (l *ConsoleLogger) Debug(format string, v ...any) {
 	if l.level == DEBUG {
 		l.printer.Print(DEBUG, fmt.Sprintf(format, v...), l.fields)
 	}
 }
 
-func (l *ConsoleLogger) Error(format string, v ...interface{}) {
+func (l *ConsoleLogger) Error(format string, v ...any) {
 	l.printer.Print(ERROR, fmt.Sprintf(format, v...), l.fields)
 }
 
-func (l *ConsoleLogger) Fatal(format string, v ...interface{}) {
+func (l *ConsoleLogger) Fatal(format string, v ...any) {
 	l.printer.Print(FATAL, fmt.Sprintf(format, v...), l.fields)
 	l.exitFn(1)
 }
 
-func (l *ConsoleLogger) Notice(format string, v ...interface{}) {
+func (l *ConsoleLogger) Notice(format string, v ...any) {
 	if l.level <= NOTICE {
 		l.printer.Print(NOTICE, fmt.Sprintf(format, v...), l.fields)
 	}
 }
 
-func (l *ConsoleLogger) Info(format string, v ...interface{}) {
+func (l *ConsoleLogger) Info(format string, v ...any) {
 	if l.level <= INFO {
 		l.printer.Print(INFO, fmt.Sprintf(format, v...), l.fields)
 	}
 }
 
-func (l *ConsoleLogger) Warn(format string, v ...interface{}) {
+func (l *ConsoleLogger) Warn(format string, v ...any) {
 	if l.level <= WARN {
 		l.printer.Print(WARN, fmt.Sprintf(format, v...), l.fields)
 	}

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -73,7 +73,7 @@ func TestJSONPrinter(t *testing.T) {
 	printer := logger.NewJSONPrinter(b)
 	printer.Print(logger.INFO, "llamas rock", logger.Fields{logger.StringField("key", "val")})
 
-	var results map[string]interface{}
+	var results map[string]any
 	err := json.Unmarshal(b.Bytes(), &results)
 	if err != nil {
 		t.Fatalf("bad json: %v", err)

--- a/mime/generate.go
+++ b/mime/generate.go
@@ -57,7 +57,7 @@ var types = map[string]string{
 }
 `))
 
-func writeMimeFile(file string, data interface{}) error {
+func writeMimeFile(file string, data any) error {
 	f, err := os.Create(file)
 	if err != nil {
 		return err

--- a/tracetools/span_test.go
+++ b/tracetools/span_test.go
@@ -18,28 +18,28 @@ type TestOpenTracingSpan struct {
 	finished bool
 	fields   []log.Field
 	err      error
-	tags     map[string]interface{}
+	tags     map[string]any
 }
 
 func (t *TestOpenTracingSpan) Finish()                                       { t.finished = true }
 func (t *TestOpenTracingSpan) FinishWithOptions(_ opentracing.FinishOptions) { t.finished = true }
 func (t *TestOpenTracingSpan) Context() opentracing.SpanContext              { return t.ctx }
 func (t *TestOpenTracingSpan) SetOperationName(_ string) opentracing.Span    { return t }
-func (t *TestOpenTracingSpan) SetTag(k string, v interface{}) opentracing.Span {
+func (t *TestOpenTracingSpan) SetTag(k string, v any) opentracing.Span {
 	t.tags[k] = v
 	return t
 }
 func (t *TestOpenTracingSpan) LogFields(f ...log.Field)                    { t.fields = append(t.fields, f...) }
-func (t *TestOpenTracingSpan) LogKV(_ ...interface{})                      {}
+func (t *TestOpenTracingSpan) LogKV(_ ...any)                              {}
 func (t *TestOpenTracingSpan) SetBaggageItem(_, _ string) opentracing.Span { return t }
 func (t *TestOpenTracingSpan) BaggageItem(_ string) string                 { return "" }
 func (t *TestOpenTracingSpan) Tracer() opentracing.Tracer                  { return nil }
 func (t *TestOpenTracingSpan) LogEvent(_ string)                           {}
-func (t *TestOpenTracingSpan) LogEventWithPayload(_ string, _ interface{}) {}
+func (t *TestOpenTracingSpan) LogEventWithPayload(_ string, _ any)         {}
 func (t *TestOpenTracingSpan) Log(_ opentracing.LogData)                   {}
 
 func newTestOpenTracingSpan() *OpenTracingSpan {
-	return &OpenTracingSpan{Span: &TestOpenTracingSpan{tags: map[string]interface{}{}}}
+	return &OpenTracingSpan{Span: &TestOpenTracingSpan{tags: map[string]any{}}}
 }
 
 type TestOtelSpan struct {
@@ -87,7 +87,7 @@ func TestAddAttribute_OpenTracing(t *testing.T) {
 	assert.Empty(t, implSpan.tags)
 
 	span.AddAttributes(map[string]string{"colour": "green", "flavour": "spicy"})
-	assert.Equal(t, map[string]interface{}{"colour": "green", "flavour": "spicy"}, implSpan.tags)
+	assert.Equal(t, map[string]any{"colour": "green", "flavour": "spicy"}, implSpan.tags)
 }
 
 func TestAddAttributeToSpan_OpenTelemetry(t *testing.T) {

--- a/yamltojson/yaml.go
+++ b/yamltojson/yaml.go
@@ -33,7 +33,7 @@ func MarshalMapSliceJSON(m yaml.MapSlice) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-func marshalSliceJSON(m []interface{}) ([]byte, error) {
+func marshalSliceJSON(m []any) ([]byte, error) {
 	buffer := bytes.NewBufferString("[")
 	length := len(m)
 	count := 0
@@ -54,19 +54,19 @@ func marshalSliceJSON(m []interface{}) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-func marshalInterfaceJSON(i interface{}) ([]byte, error) {
+func marshalInterfaceJSON(i any) ([]byte, error) {
 	switch t := i.(type) {
 	case yaml.MapItem:
 		return marshalInterfaceJSON(t.Value)
 	case yaml.MapSlice:
 		return MarshalMapSliceJSON(t)
 	case []yaml.MapItem:
-		var s []interface{}
+		var s []any
 		for _, mi := range t {
 			s = append(s, mi.Value)
 		}
 		return marshalSliceJSON(s)
-	case []interface{}:
+	case []any:
 		return marshalSliceJSON(t)
 	default:
 		return json.Marshal(i)


### PR DESCRIPTION
We currently use a mix of `interface{}` and `any` to refer to values of any type in our codebase. For the sake of consistency, i've run an `s/interface{}/any/g` over the codebase.

This is the world's most useless change, i'm not really fussed if it doesn't make it in, but i do much prefer `any` over `interface{}`. Knowing that the empty interface means any type (and, indeed that the type `interface{}` refers to an empty interface and not something else, and that an empty interface matches any type) requires a bit more go knowledge than seeing the word `any` and thinking "oh that can be any type"