### PR TITLE
Make dependabot ignore ubuntu docker image versions 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,14 @@ updates:
     directory: /packaging/docker/ubuntu-18.04
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: ubuntu
   - package-ecosystem: "docker"
     directory: /packaging/docker/ubuntu-20.04
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: ubuntu
   - package-ecosystem: "docker"
     directory: /.buildkite
     schedule:


### PR DESCRIPTION
We could pin the major and minor versions, but that may not work https://github.com/dependabot/dependabot-core/pull/6115.
Instead, because there is no patch version, dependabot should actually
never make a PR for these Dockerfiles. Thus, we can ignore them entirely