### PR TITLE
CLI: 'env' command moved to 'env dump' subcommand

### DIFF
--- a/bootstrap/integration/bootstrap_tester.go
+++ b/bootstrap/integration/bootstrap_tester.go
@@ -180,7 +180,7 @@ func (b *BootstrapTester) HasMock(name string) bool {
 // MockAgent creates a mock for the buildkite-agent binary
 func (b *BootstrapTester) MockAgent(t *testing.T) *bintest.Mock {
 	agent := b.MustMock(t, "buildkite-agent")
-	agent.Expect("env").
+	agent.Expect("env", "dump").
 		Min(0).
 		Max(bintest.InfiniteTimes).
 		AndCallFunc(mockEnvAsJSONOnStdout(b))

--- a/clicommand/env_dump.go
+++ b/clicommand/env_dump.go
@@ -9,8 +9,8 @@ import (
 	"github.com/urfave/cli"
 )
 
-const envDescription = `Usage:
-  buildkite-agent env [options]
+var EnvDumpHelpDescription = `Usage:
+  buildkite-agent env dump [options]
 
 Description:
    Prints out the environment of the current process as a JSON object, easily
@@ -18,20 +18,22 @@ Description:
    that hooks make to the environment.
 
 Example:
-   $ buildkite-agent env
 
-   Prints the environment passed into the process
-`
+    $ buildkite-agent env dump --format json-pretty`
 
-var EnvCommand = cli.Command{
-	Name:        "env",
-	Usage:       "Prints out the environment of the current process as a JSON object",
-	Description: envDescription,
+type EnvDumpConfig struct {
+}
+
+var EnvDumpCommand = cli.Command{
+	Name:        "dump",
+	Usage:       "Print the environment of the current process as a JSON object",
+	Description: EnvDumpHelpDescription,
 	Flags: []cli.Flag{
-		cli.BoolFlag{
-			Name:   "pretty",
-			Usage:  "Pretty print the JSON output",
-			EnvVar: "BUILDKITE_AGENT_ENV_PRETTY",
+		cli.StringFlag{
+			Name:   "format",
+			Usage:  "Output format; json or json-pretty",
+			EnvVar: "BUILDKITE_AGENT_ENV_DUMP_FORMAT",
+			Value:  "json",
 		},
 	},
 	Action: func(c *cli.Context) error {
@@ -45,7 +47,7 @@ var EnvCommand = cli.Command{
 		}
 
 		enc := json.NewEncoder(c.App.Writer)
-		if c.Bool("pretty") {
+		if c.String("format") == "json-pretty" {
 			enc.SetIndent("", "  ")
 		}
 

--- a/hook/scriptwrapper.go
+++ b/hook/scriptwrapper.go
@@ -20,26 +20,26 @@ const (
 
 	batchScript = `@echo off
 SETLOCAL ENABLEDELAYEDEXPANSION
-buildkite-agent env > "{{.BeforeEnvFileName}}"
+buildkite-agent env dump > "{{.BeforeEnvFileName}}"
 CALL "{{.PathToHook}}"
 SET BUILDKITE_HOOK_EXIT_STATUS=!ERRORLEVEL!
 SET BUILDKITE_HOOK_WORKING_DIR=%CD%
-buildkite-agent env > "{{.AfterEnvFileName}}"
+buildkite-agent env dump > "{{.AfterEnvFileName}}"
 EXIT %BUILDKITE_HOOK_EXIT_STATUS%`
 
 	powershellScript = `$ErrorActionPreference = "STOP"
-buildkite-agent env | Set-Content "{{.BeforeEnvFileName}}"
+buildkite-agent env dump | Set-Content "{{.BeforeEnvFileName}}"
 {{.PathToHook}}
 if ($LASTEXITCODE -eq $null) {$Env:BUILDKITE_HOOK_EXIT_STATUS = 0} else {$Env:BUILDKITE_HOOK_EXIT_STATUS = $LASTEXITCODE}
 $Env:BUILDKITE_HOOK_WORKING_DIR = $PWD | Select-Object -ExpandProperty Path
-buildkite-agent env | Set-Content "{{.AfterEnvFileName}}"
+buildkite-agent env dump | Set-Content "{{.AfterEnvFileName}}"
 exit $Env:BUILDKITE_HOOK_EXIT_STATUS`
 
-	bashScript = `buildkite-agent env > "{{.BeforeEnvFileName}}"
+	bashScript = `buildkite-agent env dump > "{{.BeforeEnvFileName}}"
 . "{{.PathToHook}}"
 export BUILDKITE_HOOK_EXIT_STATUS=$?
 export BUILDKITE_HOOK_WORKING_DIR=$PWD
-buildkite-agent env > "{{.AfterEnvFileName}}"
+buildkite-agent env dump > "{{.AfterEnvFileName}}"
 exit $BUILDKITE_HOOK_EXIT_STATUS`
 )
 

--- a/hook/scriptwrapper_test.go
+++ b/hook/scriptwrapper_test.go
@@ -104,11 +104,11 @@ func TestHookScriptsAreGeneratedCorrectlyOnWindowsBatch(t *testing.T) {
 	// See: https://pkg.go.dev/fmt > ctrl-f for "%%"
 	scriptTemplate := `@echo off
 SETLOCAL ENABLEDELAYEDEXPANSION
-buildkite-agent env > "%s"
+buildkite-agent env dump > "%s"
 CALL "%s"
 SET BUILDKITE_HOOK_EXIT_STATUS=!ERRORLEVEL!
 SET BUILDKITE_HOOK_WORKING_DIR=%%CD%%
-buildkite-agent env > "%s"
+buildkite-agent env dump > "%s"
 EXIT %%BUILDKITE_HOOK_EXIT_STATUS%%`
 
 	assertScriptLike(t, scriptTemplate, hookFile.Name(), wrapper)
@@ -134,11 +134,11 @@ func TestHookScriptsAreGeneratedCorrectlyOnWindowsPowershell(t *testing.T) {
 	defer wrapper.Close()
 
 	scriptTemplate := `$ErrorActionPreference = "STOP"
-buildkite-agent env | Set-Content "%s"
+buildkite-agent env dump | Set-Content "%s"
 %s
 if ($LASTEXITCODE -eq $null) {$Env:BUILDKITE_HOOK_EXIT_STATUS = 0} else {$Env:BUILDKITE_HOOK_EXIT_STATUS = $LASTEXITCODE}
 $Env:BUILDKITE_HOOK_WORKING_DIR = $PWD | Select-Object -ExpandProperty Path
-buildkite-agent env | Set-Content "%s"
+buildkite-agent env dump | Set-Content "%s"
 exit $Env:BUILDKITE_HOOK_EXIT_STATUS`
 
 	assertScriptLike(t, scriptTemplate, hookFile.Name(), wrapper)
@@ -163,11 +163,11 @@ func TestHookScriptsAreGeneratedCorrectlyOnUnix(t *testing.T) {
 
 	defer wrapper.Close()
 
-	scriptTemplate := `buildkite-agent env > "%s"
+	scriptTemplate := `buildkite-agent env dump > "%s"
 . "%s"
 export BUILDKITE_HOOK_EXIT_STATUS=$?
 export BUILDKITE_HOOK_WORKING_DIR=$PWD
-buildkite-agent env > "%s"
+buildkite-agent env dump > "%s"
 exit $BUILDKITE_HOOK_EXIT_STATUS`
 
 	assertScriptLike(t, scriptTemplate, hookFile.Name(), wrapper)

--- a/hook/scriptwrapper_test.go
+++ b/hook/scriptwrapper_test.go
@@ -307,7 +307,7 @@ func mockAgent() (*bintest.Mock, func(), error) {
 		return nil, func() {}, err
 	}
 
-	agent.Expect("env").
+	agent.Expect("env", "dump").
 		Exactly(2).
 		AndCallFunc(func(c *bintest.Call) {
 			envMap := map[string]string{}

--- a/main.go
+++ b/main.go
@@ -83,6 +83,13 @@ func main() {
 			},
 		},
 		{
+			Name:  "env",
+			Usage: "Something something environment variables",
+			Subcommands: []cli.Command{
+				clicommand.EnvDumpCommand,
+			},
+		},
+		{
 			Name:  "meta-data",
 			Usage: "Get/set data from Buildkite jobs",
 			Subcommands: []cli.Command{
@@ -114,7 +121,6 @@ func main() {
 				clicommand.StepUpdateCommand,
 			},
 		},
-		clicommand.EnvCommand,
 		clicommand.BootstrapCommand,
 	}
 

--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func main() {
 		},
 		{
 			Name:  "env",
-			Usage: "Something something environment variables",
+			Usage: "Process environment subcommands",
 			Subcommands: []cli.Command{
 				clicommand.EnvDumpCommand,
 			},


### PR DESCRIPTION
Move the `buildkite-agent env` command (which dumps environment to stdout) to `buildkite-agent env dump`, making `buildkite-agent env` just a container for this and any future subcommands relating to environment.

As suggested by @sj26 in October: https://github.com/buildkite/agent/pull/1803#issuecomment-1296327269

More recently the idea of a `buildkite-agent env set <key> <value>` command came up in [Re: 💡 Agent sockets - Pipelines Dispatch ⚙️](https://3.basecamp.com/3453178/buckets/27608512/messages/5721116595#__recording_5725223825)

It's relatively safe to assume that the only usage of the existing `buildkite-agent env` command is by the agent itself, making it essentially a private/internal API which we can safely change.