### PR TITLE
Implement Async Pipeline Upload Flow

### DIFF
--- a/.buildkite/pipeline.bk-test.yml
+++ b/.buildkite/pipeline.bk-test.yml
@@ -53,34 +53,54 @@ steps:
 
   - wait
 
-  - label: "upload relative artifact"
+  - label: upload relative artifact
     command: |
-      echo "hello world" > llamas.txt
-      buildkite-agent artifact upload llamas.txt
-      rm llamas.txt
+      set -Eeufo pipefail
 
-  - label: "upload absolute artifact"
+      trap "rm llamas.txt" EXIT
+
+      echo "relative llamas" > llamas.txt
+      buildkite-agent artifact upload llamas.txt
+
+      shasum=$(buildkite-agent artifact shasum llamas.txt)
+      expected_shasum=fb60f84c2bd316e18a2f11e4da13684e41a16f31
+      if [[ \$shasum != \$expected_shasum ]]; then
+        echo expected: \$expected_shasum received: \$shasum
+        exit 1
+      fi
+
+  - label: upload absolute artifact
     command: |
-      echo "hello world" > /tmp/llamas.txt
+      set -Eeufo pipefail
+
+      trap "rm /tmp/llamas.txt" EXIT
+
+      echo "absolute llamas" > /tmp/llamas.txt
       buildkite-agent artifact upload /tmp/llamas.txt
-      rm /tmp/llamas.txt
+
+      shasum=$(buildkite-agent artifact shasum tmp/llamas.txt)
+      expected_shasum=9ce999892fbca0da31b2a781b2730ac11a2fc8a2
+      if [[ \$shasum != \$expected_shasum ]]; then
+        echo expected: \$expected_shasum received: \$shasum
+        exit 1
+      fi
 
   - wait
 
-  - label: "download absolute artifact"
+  - label: download relative artifact
     command: |
-      shasum=$(buildkite-agent artifact shasum tmp/llamas.txt)
-      [[ \$shasum == "22596363b3de40b06f981fb85d82312e8c0ed511" ]]
-      buildkite-agent artifact download tmp/llamas.txt .
-      cat tmp/llamas.txt
-      grep "hello world" tmp/llamas.txt
-      rm -rf tmp/
+      set -Eeufo pipefail
 
-  - label: "download relative artifact"
-    command: |
-      shasum=$(buildkite-agent artifact shasum llamas.txt)
-      [[ \$shasum == "22596363b3de40b06f981fb85d82312e8c0ed511" ]]
+      trap "rm llamas.txt" EXIT
+
       buildkite-agent artifact download llamas.txt .
-      cat llamas.txt
-      grep "hello world" llamas.txt
-      rm llamas.txt
+      echo "ee756d1e307dc245b0df42f81845a4ff559531bc4cb287e35b15e4115844e903 llamas.txt" | sha256sum --check
+
+  - label: download absolute artifact
+    command: |
+      set -Eeufo pipefail
+
+      trap "rm tmp/llamas.txt" EXIT
+
+      buildkite-agent artifact download tmp/llamas.txt .
+      echo "e14227c78a206decdf9e869aaa2c44f3ff546a8324874e7442ef02b1f41a0099 tmp/llamas.txt" | sha256sum --check

--- a/.buildkite/steps/test-bk.sh
+++ b/.buildkite/steps/test-bk.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 
 
 echo "--- :package: Downloading bk binary"
-curl -Lfs -o bk https://github.com/buildkite/cli/releases/download/v1.2.0/cli-linux-amd64
-chmod +x ./bk
+go install github.com/buildkite/cli/v2/cmd/bk@main
 
 echo "--- :package: Downloading built binary"
 rm -rf pkg/*
@@ -12,5 +11,6 @@ buildkite-agent artifact download pkg/buildkite-agent-linux-amd64 .
 mv pkg/buildkite-agent-linux-amd64 pkg/buildkite-agent
 chmod +x pkg/buildkite-agent
 
+echo "--- :buildkite: Uploading a pipeline with bk cli as a backend"
 export PATH="$PWD/pkg:$PATH"
-./bk run --debug .buildkite/pipeline.bk-test.yml
+bk run --debug .buildkite/pipeline.bk-test.yml

--- a/agent/api.go
+++ b/agent/api.go
@@ -27,6 +27,7 @@ type APIClient interface {
 	Heartbeat(context.Context) (*api.Heartbeat, *api.Response, error)
 	MetaDataKeys(context.Context, string) ([]string, *api.Response, error)
 	Ping(context.Context) (*api.Ping, *api.Response, error)
+	PipelineUploadStatus(context.Context, string, string, ...api.Header) (*api.PipelineUploadStatus, *api.Response, error)
 	Register(context.Context, *api.AgentRegisterRequest) (*api.AgentRegisterResponse, *api.Response, error)
 	SaveHeaderTimes(context.Context, string, *api.HeaderTimes) (*api.Response, error)
 	SearchArtifacts(context.Context, string, *api.ArtifactSearchOptions) ([]*api.Artifact, *api.Response, error)
@@ -36,5 +37,6 @@ type APIClient interface {
 	StepUpdate(context.Context, string, *api.StepUpdate) (*api.Response, error)
 	UpdateArtifacts(context.Context, string, map[string]string) (*api.Response, error)
 	UploadChunk(context.Context, string, *api.Chunk) (*api.Response, error)
-	UploadPipeline(context.Context, string, *api.Pipeline) (*api.Response, error)
+	UploadPipeline(context.Context, string, *api.PipelineChange, ...api.Header) (*api.Response, error)
+	UploadPipelineAsync(context.Context, string, *api.PipelineChange, ...api.Header) (*api.Response, error)
 }

--- a/agent/pipeline_uploader.go
+++ b/agent/pipeline_uploader.go
@@ -21,10 +21,7 @@ const (
 	defaultSleepAfterUploadDuration = time.Second
 )
 
-var (
-	locationRegex = regexp.MustCompile(`jobs/(?P<jobID>[^/]+)/pipelines/(?P<uploadUUID>[^/]+)`)
-	ErrRegex      = func(s string, r *regexp.Regexp) error { return fmt.Errorf("regex %s failed to match %s", r, s) }
-)
+var locationRegex = regexp.MustCompile(`jobs/(?P<jobID>[^/]+)/pipelines/(?P<uploadUUID>[^/]+)`)
 
 type PipelineUploader struct {
 	Client         APIClient
@@ -232,12 +229,20 @@ func (u *PipelineUploader) pollForPiplineUploadStatus(ctx context.Context, l log
 	})
 }
 
+type ErrLocationParse struct {
+	location string
+}
+
+func (e *ErrLocationParse) Error() string {
+	return fmt.Sprintf("could not extract job and upload UUIDs from Location %s", e.location)
+}
+
 func extractJobIdUUID(location string) (string, string, error) {
 	matches := locationRegex.FindStringSubmatch(location)
 	jobIDIndex := locationRegex.SubexpIndex("jobID")
 	uuidIndex := locationRegex.SubexpIndex("uploadUUID")
 	if jobIDIndex < 0 || jobIDIndex >= len(matches) || uuidIndex < 0 || uuidIndex >= len(matches) {
-		return "", "", ErrRegex(location, locationRegex)
+		return "", "", &ErrLocationParse{location: location}
 	}
 	return matches[jobIDIndex], matches[uuidIndex], nil
 }

--- a/agent/pipeline_uploader.go
+++ b/agent/pipeline_uploader.go
@@ -106,9 +106,7 @@ func (u *PipelineUploader) pipelineUploadWithRetry(ctx context.Context, l logger
 			}
 
 			// 422 responses will always fail no need to retry
-			if apierr := new(
-				api.ErrorResponse,
-			); errors.As(err, &apierr) && apierr.Response.StatusCode == http.StatusUnprocessableEntity {
+			if api.IsErrHavingStatus(err, http.StatusUnprocessableEntity) {
 				l.Error("Unrecoverable error, skipping retries")
 				r.Break()
 				return err
@@ -151,9 +149,7 @@ func (u *PipelineUploader) pipelineUploadAsyncWithRetry(
 			}
 
 			// 422 responses will always fail no need to retry
-			if apierr := new(
-				api.ErrorResponse,
-			); errors.As(err, &apierr) && apierr.Response.StatusCode == http.StatusUnprocessableEntity {
+			if api.IsErrHavingStatus(err, http.StatusUnprocessableEntity) {
 				l.Error("Unrecoverable error, skipping retries")
 				r.Break()
 				return err
@@ -206,9 +202,7 @@ func (u *PipelineUploader) pollForPiplineUploadStatus(ctx context.Context, l log
 			l.Warn("%s (%s)", err, r)
 
 			// 422 responses will always fail no need to retry
-			if apierr := new(
-				api.ErrorResponse,
-			); errors.As(err, &apierr) && apierr.Response.StatusCode == http.StatusUnprocessableEntity {
+			if api.IsErrHavingStatus(err, http.StatusUnprocessableEntity) {
 				l.Error("Unrecoverable error, skipping retries")
 				r.Break()
 				return err

--- a/agent/pipeline_uploader.go
+++ b/agent/pipeline_uploader.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	defatultAttempts                = 60
+	defaultAttempts                 = 60
 	defaultSleepDuration            = 5 * time.Second
 	defaultSleepAfterUploadDuration = time.Second
 )
@@ -80,7 +80,7 @@ type pipelineUploadAsyncResult struct {
 func (u *PipelineUploader) pipelineUploadWithRetry(ctx context.Context, l logger.Logger) error {
 	// Retry the pipeline upload a few times before giving up
 	return roko.NewRetrier(
-		roko.WithMaxAttempts(defatultAttempts),
+		roko.WithMaxAttempts(defaultAttempts),
 		roko.WithStrategy(roko.Constant(defaultSleepDuration)),
 		roko.WithSleepFunc(u.RetrySleepFunc),
 	).DoWithContext(ctx, func(r *roko.Retrier) error {
@@ -123,7 +123,7 @@ func (u *PipelineUploader) pipelineUploadAsyncWithRetry(
 	result := &pipelineUploadAsyncResult{}
 	// Retry the pipeline upload a few times before giving up
 	if err := roko.NewRetrier(
-		roko.WithMaxAttempts(defatultAttempts),
+		roko.WithMaxAttempts(defaultAttempts),
 		roko.WithStrategy(roko.Constant(defaultSleepDuration)),
 		roko.WithSleepFunc(u.RetrySleepFunc),
 	).DoWithContext(ctx, func(r *roko.Retrier) error {
@@ -182,7 +182,7 @@ func (u *PipelineUploader) pipelineUploadAsyncWithRetry(
 
 func (u *PipelineUploader) pollForPiplineUploadStatus(ctx context.Context, l logger.Logger) error {
 	return roko.NewRetrier(
-		roko.WithMaxAttempts(defatultAttempts),
+		roko.WithMaxAttempts(defaultAttempts),
 		roko.WithStrategy(roko.Constant(defaultSleepDuration)),
 		roko.WithSleepFunc(u.RetrySleepFunc),
 	).DoWithContext(ctx, func(r *roko.Retrier) error {

--- a/agent/pipeline_uploader.go
+++ b/agent/pipeline_uploader.go
@@ -1,0 +1,262 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"time"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/buildkite/roko"
+)
+
+const (
+	defatultAttempts                = 60
+	defaultSleepDuration            = 5 * time.Second
+	defaultSleepAfterUploadDuration = time.Second
+)
+
+var (
+	locationRegex = regexp.MustCompile(`jobs/(?P<jobID>[^/]+)/pipelines/(?P<uploadUUID>[^/]+)`)
+	ErrRegex      = func(s string, r *regexp.Regexp) error { return fmt.Errorf("regex %s failed to match %s", r, s) }
+)
+
+type PipelineUploader struct {
+	Client         APIClient
+	Change         *api.PipelineChange
+	JobID          string
+	RetrySleepFunc func(time.Duration)
+}
+
+func (u *PipelineUploader) AsyncUploadFlow(ctx context.Context, l logger.Logger) error {
+	result, err := u.pipelineUploadAsyncWithRetry(ctx, l)
+	if err != nil {
+		return fmt.Errorf("Failed to upload and accept pipeline: %w", err)
+	}
+
+	if result.revertToSyncUpload {
+		return u.pipelineUploadWithRetry(ctx, l)
+	}
+
+	time.Sleep(result.sleepDuration)
+
+	jobIDFromResponse, uuidFromResponse, err := extractJobIdUUID(result.pipelineStatusURL.String())
+	if err != nil {
+		return fmt.Errorf("Failed to parse location to check status of pipeline: %w", err)
+	}
+
+	if jobIDFromResponse != u.JobID {
+		return fmt.Errorf(
+			"JobID from API: %s does not match request: %s",
+			jobIDFromResponse,
+			u.JobID,
+		)
+	}
+
+	if uuidFromResponse != u.Change.UUID {
+		return fmt.Errorf(
+			"Pipeline Upload UUID from API: %s does not match request: %s",
+			uuidFromResponse,
+			u.Change.UUID,
+		)
+	}
+
+	if err := u.pollForPiplineUploadStatus(ctx, l); err != nil {
+		return fmt.Errorf("Failed to upload and process pipeline: %w", err)
+	}
+
+	return nil
+}
+
+type pipelineUploadAsyncResult struct {
+	pipelineStatusURL  *url.URL
+	revertToSyncUpload bool
+	sleepDuration      time.Duration
+}
+
+// TODO: remove this once we are happy that the AsyncUploadFlow works
+func (u *PipelineUploader) pipelineUploadWithRetry(ctx context.Context, l logger.Logger) error {
+	// Retry the pipeline upload a few times before giving up
+	return roko.NewRetrier(
+		roko.WithMaxAttempts(defatultAttempts),
+		roko.WithStrategy(roko.Constant(defaultSleepDuration)),
+		roko.WithSleepFunc(u.RetrySleepFunc),
+	).DoWithContext(ctx, func(r *roko.Retrier) error {
+		_, err := u.Client.UploadPipeline(
+			ctx,
+			u.JobID,
+			u.Change,
+			api.Header{
+				Name:  "X-Buildkite-Backoff-Sequence",
+				Value: fmt.Sprintf("%d", r.AttemptCount()),
+			},
+		)
+		if err != nil {
+			l.Warn("%s (%s)", err, r)
+
+			if jsonerr := new(json.MarshalerError); errors.As(err, &jsonerr) {
+				l.Error("Unrecoverable error, skipping retries")
+				r.Break()
+				return err
+			}
+
+			// 422 responses will always fail no need to retry
+			if apierr := new(
+				api.ErrorResponse,
+			); errors.As(err, &apierr) && apierr.Response.StatusCode == http.StatusUnprocessableEntity {
+				l.Error("Unrecoverable error, skipping retries")
+				r.Break()
+				return err
+			}
+
+			return err
+		}
+
+		return nil
+	})
+}
+
+func (u *PipelineUploader) pipelineUploadAsyncWithRetry(
+	ctx context.Context,
+	l logger.Logger,
+) (*pipelineUploadAsyncResult, error) {
+	result := &pipelineUploadAsyncResult{}
+	// Retry the pipeline upload a few times before giving up
+	if err := roko.NewRetrier(
+		roko.WithMaxAttempts(defatultAttempts),
+		roko.WithStrategy(roko.Constant(defaultSleepDuration)),
+		roko.WithSleepFunc(u.RetrySleepFunc),
+	).DoWithContext(ctx, func(r *roko.Retrier) error {
+		resp, err := u.Client.UploadPipelineAsync(
+			ctx,
+			u.JobID,
+			u.Change,
+			api.Header{
+				Name:  "X-Buildkite-Backoff-Sequence",
+				Value: fmt.Sprintf("%d", r.AttemptCount()),
+			},
+		)
+		if err != nil {
+			l.Warn("%s (%s)", err, r)
+
+			if jsonerr := new(json.MarshalerError); errors.As(err, &jsonerr) {
+				l.Error("Unrecoverable error, skipping retries")
+				r.Break()
+				return err
+			}
+
+			// 422 responses will always fail no need to retry
+			if apierr := new(
+				api.ErrorResponse,
+			); errors.As(err, &apierr) && apierr.Response.StatusCode == http.StatusUnprocessableEntity {
+				l.Error("Unrecoverable error, skipping retries")
+				r.Break()
+				return err
+			}
+
+			return err
+		}
+
+		// An API that has the AsyncUploadFlow enabled will return 202 with a Location header
+		// Otherwise, the API is telling us to fall back to the previous pipeline upload flow
+		if resp.StatusCode != http.StatusAccepted {
+			l.Warn("Falling out of async pipeline upload flow, the pipeline will be re-uploaded on each retry.")
+			result.revertToSyncUpload = true
+			return nil
+		}
+
+		if result.sleepDuration, err = time.ParseDuration(resp.Header.Get("Retry-After") + "s"); err != nil {
+			result.sleepDuration = defaultSleepAfterUploadDuration
+		}
+
+		if result.pipelineStatusURL, err = resp.Location(); err != nil {
+			l.Warn("%s (%s)", err, r)
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (u *PipelineUploader) pollForPiplineUploadStatus(ctx context.Context, l logger.Logger) error {
+	return roko.NewRetrier(
+		roko.WithMaxAttempts(defatultAttempts),
+		roko.WithStrategy(roko.Constant(defaultSleepDuration)),
+		roko.WithSleepFunc(u.RetrySleepFunc),
+	).DoWithContext(ctx, func(r *roko.Retrier) error {
+		uploadStatus, resp, err := u.Client.PipelineUploadStatus(
+			ctx,
+			u.JobID,
+			u.Change.UUID,
+			api.Header{
+				Name:  "X-Buildkite-Backoff-Sequence",
+				Value: fmt.Sprintf("%d", r.AttemptCount()),
+			},
+		)
+		if err != nil {
+			l.Warn("%s (%s)", err, r)
+
+			// 422 responses will always fail no need to retry
+			if apierr := new(
+				api.ErrorResponse,
+			); errors.As(err, &apierr) && apierr.Response.StatusCode == http.StatusUnprocessableEntity {
+				l.Error("Unrecoverable error, skipping retries")
+				r.Break()
+				return err
+			}
+
+			setNextIntervalFromResponse(r, resp)
+			return err
+		}
+
+		switch uploadStatus.State {
+		case "applied":
+			return nil
+		case "pending", "processing":
+			setNextIntervalFromResponse(r, resp)
+			err := fmt.Errorf("Pipeline upload not yet applied: %s", uploadStatus.State)
+			l.Warn("%s (%s)", err, r)
+			return err
+		case "rejected", "failed":
+			l.Error("Unrecoverable error, skipping retries")
+			r.Break()
+			return fmt.Errorf("Pipeline upload %s: %s", uploadStatus.State, uploadStatus.Message)
+		default:
+			l.Error("Unrecoverable error, skipping retries")
+			r.Break()
+			return fmt.Errorf("Unexpected pipeline upload state from API: %s", uploadStatus.State)
+		}
+	})
+}
+
+func extractJobIdUUID(location string) (string, string, error) {
+	matches := locationRegex.FindStringSubmatch(location)
+	jobIDIndex := locationRegex.SubexpIndex("jobID")
+	uuidIndex := locationRegex.SubexpIndex("uploadUUID")
+	if jobIDIndex < 0 || jobIDIndex >= len(matches) || uuidIndex < 0 || uuidIndex >= len(matches) {
+		return "", "", ErrRegex(location, locationRegex)
+	}
+	return matches[jobIDIndex], matches[uuidIndex], nil
+}
+
+// If a "Retry-After" Header is set, sets the next retry interval to that value in seconds,
+// otherwise, does nothing to the retrier
+func setNextIntervalFromResponse(r *roko.Retrier, resp *api.Response) {
+	if r == nil || resp == nil {
+		return
+	}
+
+	duration, err := time.ParseDuration(resp.Header.Get("Retry-After") + "s")
+	if err == nil {
+		r.SetNextInterval(duration)
+	}
+}

--- a/agent/pipeline_uploader_test.go
+++ b/agent/pipeline_uploader_test.go
@@ -1,0 +1,208 @@
+package agent_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent/v3/agent"
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/clicommand"
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAsyncPipelineUpload(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	l := clicommand.CreateLogger(&clicommand.PipelineUploadConfig{LogLevel: "notice"})
+
+	type Test struct {
+		replace        bool
+		state          string
+		expectedSleeps []time.Duration
+		err            error
+	}
+
+	tests := []Test{
+		{
+			state:          "applied",
+			expectedSleeps: []time.Duration{},
+		},
+		{
+			state:          "rejected",
+			expectedSleeps: []time.Duration{},
+			err:            errors.New("Failed to upload and process pipeline: Pipeline upload rejected: "),
+		},
+		{
+			state: "pending",
+			expectedSleeps: func() []time.Duration {
+				sleeps := make([]time.Duration, 0, 59)
+				for i := 0; i < 59; i++ {
+					sleeps = append(sleeps, 5*time.Second)
+				}
+				return sleeps
+			}(),
+			err: errors.New("Failed to upload and process pipeline: Pipeline upload not yet applied: pending"),
+		},
+	}
+
+	for _, test := range tests {
+		func(test Test) {
+			t.Run(test.state, func(t *testing.T) {
+				t.Parallel()
+
+				jobID := api.NewUUID()
+				stepUploadUUID := api.NewUUID()
+				pipelineStr := `---
+steps:
+  - name: ":s3: xxx"
+    command: "script/buildkite/xxx.sh"
+    plugins:
+      xxx/aws-assume-role#v0.1.0:
+        role: arn:aws:iam::xxx:role/xxx
+      ecr#v1.1.4:
+        login: true
+        account_ids: xxx
+        registry_region: us-east-1
+      docker-compose#v2.5.1:
+        run: xxx
+        config: .buildkite/docker/docker-compose.yml
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+    agents:
+      queue: xxx`
+
+				parser := agent.PipelineParser{Pipeline: []byte(pipelineStr), Env: nil}
+				pipeline, err := parser.Parse()
+				assert.NoError(t, err)
+
+				server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+					switch req.URL.Path {
+					case fmt.Sprintf("/jobs/%s/pipelines", jobID):
+						assert.Equal(t, req.URL.Query().Get("async"), "true")
+						if req.Method == "POST" {
+							rw.Header().Add("Retry-After", "5")
+							rw.Header().Add("Location", fmt.Sprintf("/jobs/%s/pipelines/%s", jobID, stepUploadUUID))
+							rw.WriteHeader(http.StatusAccepted)
+							return
+						}
+					case fmt.Sprintf("/jobs/%s/pipelines/%s", jobID, stepUploadUUID):
+						if req.Method == "GET" {
+							_, _ = fmt.Fprintf(rw, `{"state": "%s"}`, test.state)
+							return
+						}
+					}
+					t.Errorf("Unknown endpoint %s %s", req.Method, req.URL.Path)
+					http.Error(rw, "Not found", http.StatusNotFound)
+				}))
+				defer server.Close()
+
+				retrySleeps := []time.Duration{}
+				uploader := &agent.PipelineUploader{
+					Client: api.NewClient(logger.Discard, api.Config{
+						Endpoint: server.URL,
+						Token:    "llamas",
+					}),
+					JobID: jobID,
+					Change: &api.PipelineChange{
+						UUID:     stepUploadUUID,
+						Pipeline: pipeline,
+						Replace:  test.replace,
+					},
+					RetrySleepFunc: func(d time.Duration) {
+						retrySleeps = append(retrySleeps, d)
+					},
+				}
+
+				err = uploader.AsyncUploadFlow(ctx, l)
+				if test.err == nil {
+					assert.NoError(t, err)
+				} else {
+					assert.ErrorContains(t, err, test.err.Error())
+				}
+				assert.Equal(t, test.expectedSleeps, retrySleeps)
+			})
+		}(test)
+	}
+}
+
+func TestFallbackPipelineUpload(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	l := clicommand.CreateLogger(&clicommand.PipelineUploadConfig{LogLevel: "notice"})
+
+	jobID := api.NewUUID()
+	stepUploadUUID := api.NewUUID()
+	pipelineStr := `---
+steps:
+  - name: ":s3: xxx"
+    command: "script/buildkite/xxx.sh"
+    plugins:
+      xxx/aws-assume-role#v0.1.0:
+        role: arn:aws:iam::xxx:role/xxx
+      ecr#v1.1.4:
+        login: true
+        account_ids: xxx
+        registry_region: us-east-1
+      docker-compose#v2.5.1:
+        run: xxx
+        config: .buildkite/docker/docker-compose.yml
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+    agents:
+      queue: xxx`
+
+	parser := agent.PipelineParser{Pipeline: []byte(pipelineStr), Env: nil}
+	pipeline, err := parser.Parse()
+	assert.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case fmt.Sprintf("/jobs/%s/pipelines", jobID):
+			if req.Method == "POST" {
+				rw.WriteHeader(http.StatusOK)
+				return
+			}
+		case fmt.Sprintf("/jobs/%s/pipelines/%s", jobID, stepUploadUUID):
+			assert.Fail(t, "should not call the async route")
+			http.Error(rw, "This route should not have been called", http.StatusServiceUnavailable)
+			return
+		}
+		t.Errorf("Unknown endpoint %s %s", req.Method, req.URL.Path)
+		http.Error(rw, "Not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	retrySleeps := []time.Duration{}
+	uploader := &agent.PipelineUploader{
+		Client: api.NewClient(logger.Discard, api.Config{
+			Endpoint: server.URL,
+			Token:    "llamas",
+		}),
+		JobID: jobID,
+		Change: &api.PipelineChange{
+			UUID:     stepUploadUUID,
+			Pipeline: pipeline,
+		},
+		RetrySleepFunc: func(d time.Duration) {
+			retrySleeps = append(retrySleeps, d)
+		},
+	}
+
+	expectedSleeps := []time.Duration{}
+
+	err = uploader.AsyncUploadFlow(ctx, l)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedSleeps, retrySleeps)
+}

--- a/api/client.go
+++ b/api/client.go
@@ -310,6 +310,11 @@ func (r *ErrorResponse) Error() string {
 	return s
 }
 
+func IsErrHavingStatus(err error, code int) bool {
+	var apierr *ErrorResponse
+	return errors.As(err, &apierr) && apierr.Response.StatusCode == code
+}
+
 func checkResponse(r *http.Response) error {
 	if c := r.StatusCode; 200 <= c && c <= 299 {
 		return nil

--- a/api/pipelines.go
+++ b/api/pipelines.go
@@ -5,22 +5,69 @@ import (
 	"fmt"
 )
 
-// Pipeline represents a Buildkite Agent API Pipeline
-type Pipeline struct {
+// PipelineChange represents a Buildkite Agent API PipelineChange
+type PipelineChange struct {
+	// UUID identifies this pipeline change. We keep this constant during
+	// retry loops so that work is not repeated on the API server
 	UUID     string `json:"uuid"`
 	Pipeline any    `json:"pipeline"`
 	Replace  bool   `json:"replace,omitempty"`
 }
 
-// Uploads the pipeline to the Buildkite Agent API. This request doesn't use JSON,
-// but a multi-part HTTP form upload
-func (c *Client) UploadPipeline(ctx context.Context, jobId string, pipeline *Pipeline) (*Response, error) {
+type PipelineUploadStatus struct {
+	State   string `json:"state"`
+	Message string `json:"message"`
+}
+
+// Uploads the pipeline to the Buildkite Agent API.
+func (c *Client) UploadPipeline(
+	ctx context.Context,
+	jobId string,
+	pipeline *PipelineChange,
+	headers ...Header,
+) (*Response, error) {
 	u := fmt.Sprintf("jobs/%s/pipelines", jobId)
 
-	req, err := c.newRequest(ctx, "POST", u, pipeline)
+	req, err := c.newRequest(ctx, "POST", u, pipeline, headers...)
 	if err != nil {
 		return nil, err
 	}
 
 	return c.doRequest(req, nil)
+}
+
+// UploadPipelineAsync uploads the pipeline to the Buildkite Agent API. It does not wait for the upload to complete.
+// but will instead return with a redirect to the location to check the upload's status
+func (c *Client) UploadPipelineAsync(
+	ctx context.Context,
+	jobId string,
+	pipeline *PipelineChange,
+	headers ...Header,
+) (*Response, error) {
+	u := fmt.Sprintf("jobs/%s/pipelines?async=true", jobId)
+
+	req, err := c.newRequest(ctx, "POST", u, pipeline, headers...)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.doRequest(req, nil)
+}
+
+func (c *Client) PipelineUploadStatus(
+	ctx context.Context,
+	jobId string,
+	uuid string,
+	headers ...Header,
+) (*PipelineUploadStatus, *Response, error) {
+	u := fmt.Sprintf("jobs/%s/pipelines/%s", jobId, uuid)
+
+	req, err := c.newRequest(ctx, "GET", u, nil, headers...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	status := &PipelineUploadStatus{}
+	resp, err := c.doRequest(req, status)
+	return status, resp, err
 }

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -308,7 +308,7 @@ var PipelineUploadCommand = cli.Command{
 			RetrySleepFunc: time.Sleep,
 		}
 		if err := uploader.AsyncUploadFlow(ctx, l); err != nil {
-			l.Fatal("%e", err)
+			l.Fatal("%v", err)
 		}
 
 		l.Info("Successfully uploaded and parsed pipeline config")

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path"
@@ -324,7 +325,8 @@ var PipelineUploadCommand = cli.Command{
 				}
 
 				// 422 responses will always fail no need to retry
-				if apierr, ok := err.(*api.ErrorResponse); ok && apierr.Response.StatusCode == 422 {
+				apierr := &api.ErrorResponse{}
+				if errors.As(err, &apierr) && apierr.Response.StatusCode == http.StatusUnprocessableEntity {
 					l.Error("Unrecoverable error, skipping retries")
 					r.Break()
 				}


### PR DESCRIPTION
This is a new method of uploading pipelines introduced in the agent API 
which will reduce long held connections between client and server. It works
by first uploading the Pipeline with a client generated UUID to the same
route as before, but with the query parameter `async=true` set.

Unlike waiting up to 15 seconds as before, this will return status 202 immediately 
with a `Location` header set to where to check the status of the upload.
The API will also set a `Retry-After` header to inform the client to sleep for this duration. 
The agent will then poll the route returned as the `Location` header until the status of the upload is "applied".

If the API does not support the Async Upload Flow, it will return 200 for the initial pipeline upload instead of 202. Then the agent will revert to its previous behaviour and poll the pipeline upload route with a new pipeline upload each time (although with the same UUID so the API will not create new steps).