### PR TITLE
Upgrade to yaml.v3

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -235,12 +235,13 @@ var PipelineUploadCommand = cli.Command{
 		}
 
 		// Parse the pipeline
-		result, err := agent.PipelineParser{
+		parser := agent.PipelineParser{
 			Env:             environ,
 			Filename:        filename,
 			Pipeline:        input,
 			NoInterpolation: cfg.NoInterpolation,
-		}.Parse()
+		}
+		result, err := parser.Parse()
 		if err != nil {
 			l.Fatal("Pipeline parsing of \"%s\" failed (%s)", src, err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/buildkite/bintest/v3 v3.1.1
 	github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
-	github.com/buildkite/yaml v0.0.0-20210326113714-4a3f40911396
 	github.com/creack/pty v1.1.18
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/gofrs/flock v0.8.1
@@ -48,6 +47,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.12.0
 	go.opentelemetry.io/otel/trace v1.12.0
 	golang.org/x/exp v0.0.0-20220428152302-39d4317da171
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -103,6 +103,5 @@ require (
 	google.golang.org/genproto v0.0.0-20221206210731-b1a01be3a5f6 // indirect
 	google.golang.org/grpc v1.52.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	inet.af/netaddr v0.0.0-20220617031823-097006376321 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,6 @@ github.com/buildkite/roko v1.0.3-0.20221121010703-599521c80157 h1:lqcTyaty4fY7Xm
 github.com/buildkite/roko v1.0.3-0.20221121010703-599521c80157/go.mod h1:b3U4GZW/n8GbCh9+pIFLvdY+B+jlh5zOgS8s3WdELbs=
 github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000 h1:hiVSLk7s3yFKFOHF/huoShLqrj13RMguWX2yzfvy7es=
 github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000/go.mod h1:gv0DYOzHEsKgo31lTCDGauIg4DTTGn41Bzp+t3wSOlk=
-github.com/buildkite/yaml v0.0.0-20210326113714-4a3f40911396 h1:qLN32md48xyTEqw6XEZMyNMre7njm0XXvDrea6NVwOM=
-github.com/buildkite/yaml v0.0.0-20210326113714-4a3f40911396/go.mod h1:AV5wtJnn1/CRaRGlJ8xspkMWfKXV0/pkJVgGleTIrfk=
 github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
 github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/yamltojson/yaml.go
+++ b/yamltojson/yaml.go
@@ -1,74 +1,471 @@
-// Package yamltojson provides a helper for converting map slices to JSON.
+// Package yamltojson provides helpers for using yaml.Node, particularly a
+// converter into JSON.
 //
 // It is intended for internal use by buildkite-agent only.
 package yamltojson
 
 import (
-	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"math"
+	"regexp"
+	"strconv"
 
-	// This is a fork of gopkg.in/yaml.v2 that fixes anchors with MapSlice
-	"github.com/buildkite/yaml"
+	"gopkg.in/yaml.v3"
 )
 
-func MarshalMapSliceJSON(m yaml.MapSlice) ([]byte, error) {
-	buffer := bytes.NewBufferString("{")
-	length := len(m)
-	count := 0
+// Patterns that match the different ways boolean values can be written in YAML
+// (particularly older versions).
+var (
+	trueRE  = regexp.MustCompile(`y|Y|yes|Yes|YES|true|True|TRUE|on|On|ON`)
+	falseRE = regexp.MustCompile(`n|N|no|No|NO|false|False|FALSE|off|Off|OFF`)
+)
 
-	for _, item := range m {
-		jsonValue, err := marshalInterfaceJSON(item.Value)
-		if err != nil {
-			return nil, err
-		}
-		buffer.WriteString(fmt.Sprintf("%q:%s", item.Key, string(jsonValue)))
-		count++
-		if count < length {
-			buffer.WriteString(",")
-		}
-	}
+// ErrNotFound is returned when an item is not found.
+var ErrNotFound = errors.New("not found")
 
-	buffer.WriteString("}")
-	return buffer.Bytes(), nil
+// Encode writes a JSON equivalent of a YAML node n to out.
+//
+//   - The order of the input is preserved, where possible. This includes
+//     mapping keys introduced via merges.
+//   - Aliases to anchors are followed, and mapping merges are merged. Merges
+//     follow YAML rules for resolving values (keys in the top-level mapping are
+//     not overridden by merges, and earlier merges win over later merges).
+//   - If n is nil, nothing is written and no error is returned.
+//   - Non-scalar keys in mapping nodes are not supported, and will error.
+//   - Nulls are normalised to null. Nulls are not permitted for map keys, but
+//     allowed for ordinary values.
+//   - Booleans are normalised to true and false. If used as keys, quoted.
+//   - Integers are normalised to decimal. If used as keys, quoted.
+//   - Floats are normalised to scientific notation. If used as keys, quoted.
+//     NaN and ±Inf are always quoted, since JSON cannot accept these as
+//     numeric literals.
+//   - Strings are escaped using encoding/json.Marshal.
+//   - Infinite recursion using aliases will cause an error.
+//   - Recursive mapping merges are fine, however.
+func Encode(out io.Writer, n *yaml.Node) error {
+	return encode(make(map[*yaml.Node]bool), out, n)
 }
 
-func marshalSliceJSON(m []any) ([]byte, error) {
-	buffer := bytes.NewBufferString("[")
-	length := len(m)
-	count := 0
-
-	for _, item := range m {
-		jsonValue, err := marshalInterfaceJSON(item)
-		if err != nil {
-			return nil, err
-		}
-		buffer.WriteString(fmt.Sprintf("%s", string(jsonValue)))
-		count++
-		if count < length {
-			buffer.WriteString(",")
-		}
+// encode implements Encode, with an extra set of nodes used to return an error
+// if there is an alias that causes infinite recursion.
+func encode(seen map[*yaml.Node]bool, out io.Writer, n *yaml.Node) error {
+	// If n is nil, do nothing.
+	if n == nil {
+		return nil
 	}
 
-	buffer.WriteString("]")
-	return buffer.Bytes(), nil
-}
+	// If n has been seen already while processing the parents of n, it's an
+	// infinite recursion.
+	// Simple example:
+	// ---
+	// a: &a  // seen is empty on encoding a
+	//   b: *a   // seen contains a while encoding b
+	if seen[n] {
+		return fmt.Errorf("line %d, col %d: infinite recursion", n.Line, n.Column)
+	}
+	seen[n] = true
 
-func marshalInterfaceJSON(i any) ([]byte, error) {
-	switch t := i.(type) {
-	case yaml.MapItem:
-		return marshalInterfaceJSON(t.Value)
-	case yaml.MapSlice:
-		return MarshalMapSliceJSON(t)
-	case []yaml.MapItem:
-		var s []any
-		for _, mi := range t {
-			s = append(s, mi.Value)
+	// n needs to be "un-seen" when this layer of recursion is done:
+	defer delete(seen, n)
+	// Why? seen is a map, which is used by reference, so it will be shared
+	// between calls to encode, which is recursive. And unlike a merge, the
+	// same alias can be validly used for different subtrees:
+	// ---
+	// a: &a
+	//   b: c
+	// d:
+	//   da: *a
+	//   db: *a
+	// ...
+	// (d contains two copies of a).
+	// So *a needs to be "unseen" between encoding "da" and "db".
+
+	switch n.Kind {
+	case yaml.DocumentNode:
+		// There's generally only one element in a document, but in case there's
+		// more, comma-separate them.
+		for i, e := range n.Content {
+			if i > 0 {
+				if _, err := out.Write([]byte(",")); err != nil {
+					return err
+				}
+			}
+			if err := encode(seen, out, e); err != nil {
+				return err
+			}
 		}
-		return marshalSliceJSON(s)
-	case []any:
-		return marshalSliceJSON(t)
+
+	case yaml.MappingNode:
+		// A MappingNode's content is a flat list of [key, value, key, value...]
+		// Because of merges, these have to be traversed more flexibly than with
+		// a single loop, hence the need for RangeMap.
+		if _, err := out.Write([]byte("{")); err != nil {
+			return err
+		}
+		first := true
+		processPair := func(k string, v *yaml.Node) error {
+			// Emit a comma separator, if needed
+			if !first {
+				if _, err := out.Write([]byte{','}); err != nil {
+					return err
+				}
+			}
+			first = false
+
+			// Emit "key":value
+			b, err := json.Marshal(k)
+			if err != nil {
+				return err
+			}
+			if _, err := out.Write(append(b, ':')); err != nil {
+				return err
+			}
+			return encode(seen, out, v)
+		}
+		if err := RangeMap(n, processPair); err != nil {
+			return err
+		}
+		if _, err := out.Write([]byte("}")); err != nil {
+			return err
+		}
+
+	case yaml.SequenceNode:
+		// A SequenceNode is a list. Recursively encode each element.
+		if _, err := out.Write([]byte("[")); err != nil {
+			return err
+		}
+		for i, e := range n.Content {
+			// If this isn't the first item, add a comma separator.
+			if i != 0 {
+				if _, err := out.Write([]byte(",")); err != nil {
+					return err
+				}
+			}
+			// Each item can be anything.
+			if err := encode(seen, out, e); err != nil {
+				return err
+			}
+		}
+		if _, err := out.Write([]byte("]")); err != nil {
+			return err
+		}
+
+	case yaml.ScalarNode:
+		// json.Marshal knows how to render scalars if they have the right Go
+		// type.
+		x, err := parseScalar(n)
+		if err != nil {
+			return err
+		}
+		b, err := json.Marshal(x)
+		if err != nil {
+			return err
+		}
+		if _, err := out.Write(b); err != nil {
+			return err
+		}
+
+	case yaml.AliasNode:
+		// Follow the alias and encode that.
+		return encode(seen, out, n.Alias)
+
 	default:
-		return json.Marshal(i)
+		return fmt.Errorf("line %d, col %d: unsupported node kind %x", n.Line, n.Column, n.Kind)
+	}
+	return nil
+}
+
+// RangeMap calls f with each key/value pair in a mapping node.
+// It only supports scalar keys, and converts them to canonical string values.
+// Non-scalar and non-stringable keys result in an error.
+// Because mapping nodes can contain merges from other mapping nodes,
+// potentially via sequence nodes and aliases, this function also accepts
+// sequences and aliases (that must themselves recursively only contain
+// mappings, sequences, and aliases...).
+func RangeMap(n *yaml.Node, f func(key string, val *yaml.Node) error) error {
+	return rangeMap(make(map[*yaml.Node]bool), n, f)
+}
+
+// rangeMap implements RangeMap. It tracks mapping nodes already merged, to
+// prevent infinite merge loops and avoid unnecessarily merging the same mapping
+// repeatedly.
+func rangeMap(merged map[*yaml.Node]bool, n *yaml.Node, f func(key string, val *yaml.Node) error) error {
+	// Go-like semantics: no entries in "nil".
+	if n == nil {
+		return nil
+	}
+
+	// If this node has already been merged into the top-level map being ranged,
+	// we don't need to merge it again.
+	if merged[n] {
+		return nil
+	}
+	merged[n] = true
+
+	switch n.Kind {
+	case yaml.MappingNode:
+		// gopkg.in/yaml.v3 parses mapping node contents as a flat list:
+		// key, value, key, value...
+		if len(n.Content)%2 != 0 {
+			return fmt.Errorf("line %d, col %d: mapping node has odd content length %d", n.Line, n.Column, len(n.Content))
+		}
+
+		// Keys at an outer level take precedence over keys being merged:
+		// "its key/value pairs is inserted into the current mapping, unless the
+		// key already exists in it." https://yaml.org/type/merge.html
+		// But we care about key ordering!
+		// This necessitates two passes:
+		// 1. Obtain the keys in this map
+		// 2. Range over the map again, recursing into merges.
+		// While merging, ignore keys in the outer level.
+		// Merges may produce new keys to ignore in subsequent merges:
+		// "Keys in mapping nodes earlier in the sequence override keys
+		// specified in later mapping nodes."
+
+		// 1. A pass to get the keys at this level.
+		keys := make(map[string]bool)
+		for i := 0; i < len(n.Content); i += 2 {
+			k := n.Content[i]
+
+			// Ignore merges in this pass.
+			if k.Tag == "!!merge" {
+				continue
+			}
+
+			// Canonicalise the key into a string and store it.
+			ck, err := canonicalMapKey(k)
+			if err != nil {
+				return err
+			}
+			keys[ck] = true
+		}
+
+		// Ignore existing keys when merging. Record new keys to ignore in
+		// subsequent merges.
+		skipKeys := func(k string, v *yaml.Node) error {
+			if keys[k] {
+				return nil
+			}
+			keys[k] = true
+			return f(k, v)
+		}
+
+		// 2. Range over each pair, recursing into merges.
+		for i := 0; i < len(n.Content); i += 2 {
+			k, v := n.Content[i], n.Content[i+1]
+
+			// Is this pair a merge? (`<<: *foo`)
+			if k.Tag == "!!merge" {
+				// Recursively range over the contents of the value, which
+				// could be an alias to a mapping node, or a sequence of aliases
+				// to mapping nodes, which could themselves contain merges...
+				if err := rangeMap(merged, v, skipKeys); err != nil {
+					return err
+				}
+				continue
+			}
+
+			// Canonicalise the key into a string (again).
+			ck, err := canonicalMapKey(k)
+			if err != nil {
+				return err
+			}
+
+			// Yield the canonical key and the value.
+			if err := f(ck, v); err != nil {
+				return err
+			}
+		}
+
+	case yaml.SequenceNode:
+		// Range over each element e in the sequence.
+		for _, e := range n.Content {
+			if err := rangeMap(merged, e, f); err != nil {
+				return err
+			}
+		}
+
+	case yaml.AliasNode:
+		// Follow the alias and range over that.
+		if err := rangeMap(merged, n.Alias, f); err != nil {
+			return err
+		}
+
+	default:
+		// TODO: Use %v once yaml.Kind has a String method
+		return fmt.Errorf("line %d, col %d: cannot range over node kind %x", n.Line, n.Column, n.Kind)
+	}
+	return nil
+}
+
+// IntNode is a convenience function for making a scalar node containing an int.
+func IntNode(x int) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: strconv.Itoa(x)}
+}
+
+// StringNode is a convenience function for making a scalar node containing a string.
+func StringNode(s string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: s}
+}
+
+// UpsertItem will replace a value in the given mapping node with the
+// given replacement or insert it if it doesn't exist.
+// The existing key must have tag !!str.
+// If m is nil, it returns a new mapping node.
+func UpsertItem(m *yaml.Node, key string, val *yaml.Node) (*yaml.Node, error) {
+	// If it is nil, make a new one.
+	if m == nil {
+		return &yaml.Node{
+			Kind:    yaml.MappingNode,
+			Tag:     "!!map",
+			Content: []*yaml.Node{StringNode(key), val},
+		}, nil
+	}
+
+	// It's not nil, so at least make sure it is a mapping node.
+	if m.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("line %d, col %d: node is not a mapping node", m.Line, m.Column)
+	}
+	if len(m.Content)%2 != 0 {
+		return nil, fmt.Errorf("line %d, col %d: mapping node contains odd number of items %d", m.Line, m.Column, len(m.Content))
+	}
+
+	// Linear scan for the key.
+	found := -1
+	for i := 0; i < len(m.Content); i += 2 {
+		k := m.Content[i]
+		if k.Kind != yaml.ScalarNode || k.Tag != "!!str" {
+			continue
+		}
+		if k.Value == key {
+			found = i + 1
+		}
+	}
+
+	// Update the existing value.
+	if found != -1 {
+		m.Content[found] = val
+		return m, nil
+	}
+
+	// Insert a new value.
+	m.Content = append(m.Content, StringNode(key), val)
+	return m, nil
+}
+
+// LookupItem retrieves the value associated with a key from a mapping node.
+// The matching key in the map, if any, must be a scalar node with tag !!str.
+func LookupItem(m *yaml.Node, key string) (*yaml.Node, error) {
+	if m == nil {
+		return nil, ErrNotFound
+	}
+
+	var val *yaml.Node
+	success := errors.New("found it")
+
+	err := RangeMap(m, func(k string, v *yaml.Node) error {
+		if k != key {
+			return nil
+		}
+		val = v
+		return success
+	})
+	if err == success {
+		return val, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return nil, ErrNotFound
+}
+
+// canonicalMapKey converts a scalar value into a string suitable for use as
+// a map key. YAML expects different representations of the same value, e.g.
+// 0xb and 11, to be equivalent, and therefore a duplicate key. JSON requires
+// all keys to be strings.
+func canonicalMapKey(n *yaml.Node) (string, error) {
+	x, err := parseScalar(n)
+	if err != nil {
+		return "", err
+	}
+	if x == nil {
+		// Nulls are not valid JSON keys.
+		return "", fmt.Errorf("line %d, col %d: null not supported as a map key", n.Line, n.Column)
+	}
+	switch n.Tag {
+	case "!!bool":
+		// Canonicalise to true or false.
+		return fmt.Sprintf("%t", x), nil
+	case "!!int":
+		// Canonicalise to decimal.
+		return fmt.Sprintf("%d", x), nil
+	case "!!float":
+		// Canonicalise to scientific notation.
+		// Don't handle Inf or NaN specially, as they will be quoted.
+		return fmt.Sprintf("%e", x), nil
+	default:
+		// Assume the value is already a suitable key.
+		return n.Value, nil
+	}
+}
+
+// parseScalar parses the value of a node according to its tag. It chooses
+// types and values that have appropriate equivalents when marshalled by
+// encoding/json.Marshal.
+func parseScalar(n *yaml.Node) (any, error) {
+	if n.Kind != yaml.ScalarNode {
+		return "", fmt.Errorf("line %d, col %d: non-scalar node not supported here (kind = %x, want %x)", n.Line, n.Column, n.Kind, yaml.ScalarNode)
+	}
+	switch n.Tag {
+	case "!!null":
+		// Represent null as nil.
+		return nil, nil
+
+	case "!!bool":
+		// Accepts all possible YAML boolean values.
+		switch {
+		case trueRE.MatchString(n.Value):
+			return true, nil
+
+		case falseRE.MatchString(n.Value):
+			return false, nil
+
+		default:
+			return "", fmt.Errorf("line %d, col %d: %q is not a valid YAML bool value", n.Line, n.Column, n.Value)
+		}
+
+	case "!!int":
+		// Base-60 notation is not supported.
+		x, err := strconv.ParseInt(n.Value, 0, 64)
+		if err != nil {
+			return "", fmt.Errorf("line %d, col %d: %q is not a supported int value", n.Line, n.Column, n.Value)
+		}
+		return x, nil
+
+	case "!!float":
+		// Base-60 notation is not supported.
+		// Manually parse values that ParseFloat doesn't understand.
+		switch n.Value {
+		case ".nan":
+			return math.NaN(), nil
+		case "-.inf":
+			return math.Inf(-1), nil
+		case ".inf", "+.inf":
+			return math.Inf(1), nil
+		}
+		// Hope that everything else is parseable.
+		x, err := strconv.ParseFloat(n.Value, 64)
+		if err != nil {
+			return "", fmt.Errorf("line %d, col %d: %q is not a supported float value", n.Line, n.Column, n.Value)
+		}
+		return x, nil
+
+	default:
+		// Assume strings, and any other kinds of scalar, are already
+		// represented canonically as the n.Value string.
+		return n.Value, nil
 	}
 }

--- a/yamltojson/yaml_test.go
+++ b/yamltojson/yaml_test.go
@@ -1,0 +1,268 @@
+package yamltojson
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+)
+
+func TestJSONise(t *testing.T) {
+	tests := []struct {
+		desc  string
+		input string
+		want  string
+	}{
+		{
+			desc: "3GZX: Spec Example 7.1. Alias Nodes",
+			input: `First occurrence: &anchor Foo
+Second occurrence: *anchor
+Override anchor: &anchor Bar
+Reuse anchor: *anchor`,
+			want: `{"First occurrence":"Foo","Second occurrence":"Foo","Override anchor":"Bar","Reuse anchor":"Bar"}`,
+		},
+		{
+			desc: "4ABK: Flow Mapping Separate Values",
+			input: `{
+				unquoted : "separate",
+				http://foo.com,
+				omitted value:,
+}`,
+			want: `{"unquoted":"separate","http://foo.com":null,"omitted value:":null}`,
+		},
+		{
+			desc: "4CQQ: Spec Example 2.18. Multi-line Flow Scalars",
+			input: `plain:
+  This unquoted scalar
+  spans many lines.
+
+quoted: "So does this
+  quoted scalar.\n"
+`,
+			want: `{"plain":"This unquoted scalar spans many lines.","quoted":"So does this quoted scalar.\n"}`,
+		},
+		{
+			desc: "Pipe syntax",
+			input: `pipe: |
+  This is a multiline literal
+  here is the other line
+  the newlines should be preserved`,
+			want: `{"pipe":"This is a multiline literal\nhere is the other line\nthe newlines should be preserved"}`,
+		},
+		{
+			desc: "Left crocodile",
+			input: `left_croc: >
+  This is another multiline literal
+  that behaves slightly differently
+  (it replaces newlines with spaces)`,
+			want: `{"left_croc":"This is another multiline literal that behaves slightly differently (it replaces newlines with spaces)"}`,
+		},
+		{
+			desc: "go-yaml/yaml#184",
+			input: `---
+world: &world
+  greeting: Hello
+earth:
+  << : *world`,
+			want: `{"world":{"greeting":"Hello"},"earth":{"greeting":"Hello"}}`,
+		},
+		{
+			desc: "Various map keys",
+			input: `---
+foo: llama
+.nan: llama
+!!int 12345: alpaca
+!!bool false: gerbil
+.inf: hyperllama
+-.inf: hypollama`,
+			want: `{"foo":"llama","NaN":"llama","12345":"alpaca","false":"gerbil","+Inf":"hyperllama","-Inf":"hypollama"}`,
+		},
+		{
+			desc: "Various values",
+			input: `---
+llamas: TRUE
+alpacas: False
+gerbils: !!bool NO
+hex: 0x2A
+oct: 0o52
+unders: 123_456
+float: 0.0000000025`,
+			want: `{"llamas":true,"alpacas":false,"gerbils":false,"hex":42,"oct":42,"unders":123456,"float":2.5e-9}`,
+		},
+		{
+			desc: "Sequence node",
+			input: `---
+- a
+- b
+- c:
+    d: e
+- f:
+  - g
+  - h
+  - i`,
+			want: `["a","b",{"c":{"d":"e"}},{"f":["g","h","i"]}]`,
+		},
+		{
+			desc: "Merge sequence of aliases",
+			input: `---
+a: &a
+  b: c
+d: &d
+  b: d
+e:
+  << : [*a, *d]`,
+			want: `{"a":{"b":"c"},"d":{"b":"d"},"e":{"b":"c"}}`,
+		},
+		{
+			desc: "Infinite recursive merge",
+			input: `---
+a: &a
+  b: c
+  << : *a`,
+			want: `{"a":{"b":"c"}}`,
+		},
+		{
+			desc: "Multiple aliases",
+			input: `---
+a: &a
+  b: c
+d:
+  da: *a
+  db: *a`,
+			want: `{"a":{"b":"c"},"d":{"da":{"b":"c"},"db":{"b":"c"}}}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var n yaml.Node
+			if err := yaml.Unmarshal([]byte(test.input), &n); err != nil {
+				t.Fatalf("yaml.Unmarshal(input) = %v", err)
+			}
+
+			var out strings.Builder
+			if err := Encode(&out, &n); err != nil {
+				t.Fatalf("Encode(&out, &n) = %v", err)
+			}
+			got, want := out.String(), test.want
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("Encode diff (-got +want):\n%s", diff)
+			}
+
+			// Smoke test that the output parses as JSON
+			var dummy any
+			if err := json.Unmarshal([]byte(out.String()), &dummy); err != nil {
+				t.Errorf("json.Unmarshal(%q) error = %v", out.String(), err)
+			}
+		})
+	}
+}
+
+func TestEncodeInfiniteAlias(t *testing.T) {
+	input := `---
+a: &a
+  b: c
+  d: *a`
+	var n yaml.Node
+	if err := yaml.Unmarshal([]byte(input), &n); err != nil {
+		t.Fatalf("yaml.Unmarshal(input) = %v", err)
+	}
+	var dummy bytes.Buffer
+	if err := Encode(&dummy, &n); err == nil {
+		t.Errorf("Encode(&dummy, &n) error = %v, want non-nil error (and not a stack overflow)", err)
+	}
+}
+
+func TestUpsertItem(t *testing.T) {
+	y, err := UpsertItem(nil, "a", StringNode("b"))
+	if err != nil {
+		t.Errorf("UpsertItem(nil, a, b) error = %v", err)
+	}
+	want0 := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+		Content: []*yaml.Node{
+			StringNode("a"),
+			StringNode("b"),
+		},
+	}
+	if diff := cmp.Diff(y, want0); diff != "" {
+		t.Errorf("UpsertItem(nil, a, b) diff (-got +want):\n%s", diff)
+	}
+
+	got1, err := UpsertItem(y, "a", StringNode("c"))
+	if err != nil {
+		t.Errorf("UpsertItem(y, a, c) error = %v", err)
+	}
+	want1 := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+		Content: []*yaml.Node{
+			StringNode("a"),
+			StringNode("c"),
+		},
+	}
+	if diff := cmp.Diff(got1, want1); diff != "" {
+		t.Errorf("UpsertItem(y, a, c) diff (-got +want):\n%s", diff)
+	}
+
+	got2, err := UpsertItem(y, "b", IntNode(1))
+	if err != nil {
+		t.Errorf("UpsertItem(y, b, 1) error = %v", err)
+	}
+	want2 := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+		Content: []*yaml.Node{
+			StringNode("a"),
+			StringNode("c"),
+			StringNode("b"),
+			IntNode(1),
+		},
+	}
+	if diff := cmp.Diff(got2, want2); diff != "" {
+		t.Errorf("UpsertItem(y, b, 1) diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestLookupItem(t *testing.T) {
+	characters := `---
+Kuzco: llama
+Yzma: evil
+Kronk: himbo`
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(characters), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal(characters, &mapping) = %v", err)
+	}
+	mapping := doc.Content[0]
+
+	// Unimportant differences for this test
+	for _, e := range mapping.Content {
+		e.Line, e.Column = 0, 0
+	}
+
+	tests := []struct {
+		input   string
+		want    *yaml.Node
+		wantErr error
+	}{
+		{"Kuzco", StringNode("llama"), nil},
+		{"Yzma", StringNode("evil"), nil},
+		{"Kronk", StringNode("himbo"), nil},
+		{"Pacha", nil, ErrNotFound},
+	}
+
+	for _, test := range tests {
+		got, err := LookupItem(mapping, test.input)
+		if err != test.wantErr {
+			t.Errorf("LookupItem(mapping, %q) error = %v, want %v", test.input, err, test.wantErr)
+		}
+		if diff := cmp.Diff(got, test.want); diff != "" {
+			t.Errorf("LookupItem(mapping, %q) diff (-got +want):\n%s", test.input, diff)
+		}
+	}
+}


### PR DESCRIPTION
I took a crack at upgrading to v3 of the YAML package, gopkg.in/yaml.v3. This removes the need for our own fork of v2, at the expense of some hairy processing code. I think this is a win, because the new code exposes exactly how we are handling the YAML, rather than hiding it in an unmaintained fork.

yaml.v3 replaces `yaml.MapSlice` and `yaml.MapItem` with a far more flexible type, `yaml.Node`. Unmarshalling into `yaml.Node` provides just about all possible information contained in the input YAML, but replacing `MapSlice` with `Node` is definitely not straightforward. A mapping node's contents is no longer represented by a slice of `MapItem`s (key/value pairs) but rather a slice of `Node`s [key, value, key, value... ]. Using `Node` directly necessitates a bunch of helper code, as seen in `yamltojson`. Complications arise from aliases and merges and the need to preserve ordering.

Unfortunately we are relying on map ordering, or I would replace all this with `yaml.Umarshal` into some more rigid types. An alternative might be to convert, at runtime, the "ordered" mappings with sequences of one-key mappings, but we'd then need to handle the extra layer in the JSON on the other end.