### PR TITLE
Restore old tini path on ubuntu 20.04

### DIFF
--- a/.buildkite/steps/test-docker-image.sh
+++ b/.buildkite/steps/test-docker-image.sh
@@ -62,6 +62,16 @@ test_docker_compose_v2() {
   docker run --rm --platform "$platform" --entrypoint docker "$image_tag" compose version
 }
 
+test_tini() {
+  echo "--- :hammer: Testing $image_tag has tini"
+  docker run --rm --platform "$platform" --entrypoint tini "$image_tag" --version
+}
+
+test_tini_old_path() {
+  echo "--- :hammer: Test $image_tag has tini executable at /sbin/tini"
+  docker run --rm --platform "$platform" --entrypoint sh "$image_tag" -c '[ -x /sbin/tini ]'
+}
+
 
 # Test Cases
 
@@ -73,6 +83,8 @@ case $variant in
     test_docker_socket
     test_docker_compose
     test_docker_compose_v2
+    test_tini
+    test_tini_old_path
     ;;
   sidecar)
     test_buildkite_agent_sidecar

--- a/packaging/docker/ubuntu-20.04/Dockerfile
+++ b/packaging/docker/ubuntu-20.04/Dockerfile
@@ -34,6 +34,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \
     PATH="/usr/local/bin:${PATH}"
 
+RUN ln -s /usr/bin/tini /usr/sbin/tini
+
 RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
     && curl -Lfs -o /usr/local/bin/ssh-env-config.sh https://raw.githubusercontent.com/buildkite/docker-ssh-env-config/master/ssh-env-config.sh \
     && chmod +x /usr/local/bin/ssh-env-config.sh


### PR DESCRIPTION
Tini used to be downloaded from github to /usr/sbin/tini. Now we install it
from the ubuntu repositories which installs to /usr/bin/tini.

Both are in the $PATH, so there should be no issue if a user invokes the
command as `tini`. Also, the default entrypoint is using the new path to
tini, so users starting the docker container without overriding the default
entrypoint should not have experienced any issues.

Fixes: #1928