### PR TITLE
Use ExitCode method from standard library to inspect the exit code of a process

### DIFF
--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -533,12 +533,7 @@ func GetExitCode(err error) int {
 	}
 
 	if cause := new(exec.ExitError); errors.As(err, &cause) {
-		// The program has exited with an exit code != 0
-		// There is no platform independent way to retrieve
-		// the exit code, but the following will work on Unix/macOS
-		if status, ok := cause.Sys().(syscall.WaitStatus); ok {
-			return status.ExitStatus()
-		}
+		return cause.ExitCode()
 	}
 	return 1
 }


### PR DESCRIPTION
This was added in go1.12. Presumably, the replaced code may have originated prior to that. That code only claims support on Unixes, but the method from the standard library we are replacing it with should be more portable. Indeed, the [file](https://github.com/golang/go/blob/de4748c47c67392a57f250714509f590f68ad395/src/os/exec_posix.go#L130-L136) that defines the method is headed with `//go:build unix || (js && wasm) || windows`, so it should be available for windows as well. And it looks like it is [implemented for Plan 9](https://github.com/golang/go/blob/de4748c47c67392a57f250714509f590f68ad395/src/os/exec_plan9.go#L143-L149) as well.

From the [discussions](https://groups.google.com/g/golang-nuts/c/sFmzNL-0zq4) [around](https://github.com/golang/go/issues/26539) introducing the feature, it looks like it was initially left out because plan9 did not support integer exit codes. However, it looks like that has been resolved and this method will return either a 0 or 1 on Plan 9. In any case, the agent is not supported on Plan 9, so we don't need to be too concerned.
