### PR TITLE
clicommand: Descriptions unexported and const

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -34,7 +34,7 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-var StartDescription = `Usage:
+const startDescription = `Usage:
 
    buildkite-agent start [options...]
 
@@ -234,7 +234,7 @@ func DefaultConfigFilePaths() (paths []string) {
 var AgentStartCommand = cli.Command{
 	Name:        "start",
 	Usage:       "Starts a Buildkite agent",
-	Description: StartDescription,
+	Description: startDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "config",

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -20,7 +20,7 @@ const (
 	maxBodySize = 1024 * 1024
 )
 
-var AnnotateHelpDescription = `Usage:
+const annotateHelpDescription = `Usage:
 
    buildkite-agent annotate [body] [options...]
 
@@ -78,7 +78,7 @@ type AnnotateConfig struct {
 var AnnotateCommand = cli.Command{
 	Name:        "annotate",
 	Usage:       "Annotate the build page within the Buildkite UI with text from within a Buildkite job",
-	Description: AnnotateHelpDescription,
+	Description: annotateHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "context",

--- a/clicommand/annotation_remove.go
+++ b/clicommand/annotation_remove.go
@@ -12,7 +12,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var AnnotationRemoveHelpDescription = `Usage:
+const annotationRemoveHelpDescription = `Usage:
 
    buildkite-agent annotation remove [arguments...]
 
@@ -49,7 +49,7 @@ type AnnotationRemoveConfig struct {
 var AnnotationRemoveCommand = cli.Command{
 	Name:        "remove",
 	Usage:       "Remove an existing annotation from a Buildkite build",
-	Description: AnnotationRemoveHelpDescription,
+	Description: annotationRemoveHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "context",

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -11,7 +11,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var DownloadHelpDescription = `Usage:
+const downloadHelpDescription = `Usage:
 
    buildkite-agent artifact download [options] <query> <destination>
 
@@ -72,7 +72,7 @@ type ArtifactDownloadConfig struct {
 var ArtifactDownloadCommand = cli.Command{
 	Name:        "download",
 	Usage:       "Downloads artifacts from Buildkite to the local machine",
-	Description: DownloadHelpDescription,
+	Description: downloadHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "step",

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -14,7 +14,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var SearchHelpDescription = `Usage:
+const searchHelpDescription = `Usage:
 
    buildkite-agent artifact search [options] <query>
 
@@ -71,7 +71,7 @@ type ArtifactSearchConfig struct {
 var ArtifactSearchCommand = cli.Command{
 	Name:        "search",
 	Usage:       "Searches artifacts in Buildkite",
-	Description: SearchHelpDescription,
+	Description: searchHelpDescription,
 	CustomHelpTemplate: `{{.Description}}
 
 Options:

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -13,7 +13,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var ShasumHelpDescription = `Usage:
+const shasumHelpDescription = `Usage:
 
    buildkite-agent artifact shasum [options...]
 
@@ -74,7 +74,7 @@ type ArtifactShasumConfig struct {
 var ArtifactShasumCommand = cli.Command{
 	Name:        "shasum",
 	Usage:       "Prints the SHA-1 hash for a single artifact specified by a search query",
-	Description: ShasumHelpDescription,
+	Description: shasumHelpDescription,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "sha256",

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -11,7 +11,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var UploadHelpDescription = `Usage:
+const uploadHelpDescription = `Usage:
 
    buildkite-agent artifact upload [options] <pattern> [destination]
 
@@ -89,7 +89,7 @@ type ArtifactUploadConfig struct {
 var ArtifactUploadCommand = cli.Command{
 	Name:        "upload",
 	Usage:       "Uploads files to a job as artifacts",
-	Description: UploadHelpDescription,
+	Description: uploadHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "job",

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -16,7 +16,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var BootstrapHelpDescription = `Usage:
+const bootstrapHelpDescription = `Usage:
 
    buildkite-agent bootstrap [options...]
 
@@ -95,7 +95,7 @@ type BootstrapConfig struct {
 var BootstrapCommand = cli.Command{
 	Name:        "bootstrap",
 	Usage:       "Run a Buildkite job locally",
-	Description: BootstrapHelpDescription,
+	Description: bootstrapHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "command",

--- a/clicommand/env_dump.go
+++ b/clicommand/env_dump.go
@@ -9,7 +9,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var EnvDumpHelpDescription = `Usage:
+const envDumpHelpDescription = `Usage:
   buildkite-agent env dump [options]
 
 Description:
@@ -27,7 +27,7 @@ type EnvDumpConfig struct {
 var EnvDumpCommand = cli.Command{
 	Name:        "dump",
 	Usage:       "Print the environment of the current process as a JSON object",
-	Description: EnvDumpHelpDescription,
+	Description: envDumpHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "format",

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -12,7 +12,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var MetaDataExistsHelpDescription = `Usage:
+const metaDataExistsHelpDescription = `Usage:
 
    buildkite-agent meta-data exists <key> [options...]
 
@@ -46,7 +46,7 @@ type MetaDataExistsConfig struct {
 var MetaDataExistsCommand = cli.Command{
 	Name:        "exists",
 	Usage:       "Check to see if the meta data key exists for a build",
-	Description: MetaDataExistsHelpDescription,
+	Description: metaDataExistsHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "job",

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -12,7 +12,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var MetaDataGetHelpDescription = `Usage:
+const metaDataGetHelpDescription = `Usage:
 
    buildkite-agent meta-data get <key> [options...]
 
@@ -46,7 +46,7 @@ type MetaDataGetConfig struct {
 var MetaDataGetCommand = cli.Command{
 	Name:        "get",
 	Usage:       "Get data from a build",
-	Description: MetaDataGetHelpDescription,
+	Description: metaDataGetHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "default",

--- a/clicommand/meta_data_keys.go
+++ b/clicommand/meta_data_keys.go
@@ -12,7 +12,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var MetaDataKeysHelpDescription = `Usage:
+const metaDataKeysHelpDescription = `Usage:
 
    buildkite-agent meta-data keys [options...]
 
@@ -45,7 +45,7 @@ type MetaDataKeysConfig struct {
 var MetaDataKeysCommand = cli.Command{
 	Name:        "keys",
 	Usage:       "Lists all meta-data keys that have been previously set",
-	Description: MetaDataKeysHelpDescription,
+	Description: metaDataKeysHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "job",

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -13,7 +13,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var MetaDataSetHelpDescription = `Usage:
+const metaDataSetHelpDescription = `Usage:
 
    buildkite-agent meta-data set <key> [value] [options...]
 
@@ -52,7 +52,7 @@ type MetaDataSetConfig struct {
 var MetaDataSetCommand = cli.Command{
 	Name:        "set",
 	Usage:       "Set data on a build",
-	Description: MetaDataSetHelpDescription,
+	Description: metaDataSetHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "job",

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -23,7 +23,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var PipelineUploadHelpDescription = `Usage:
+const pipelineUploadHelpDescription = `Usage:
 
    buildkite-agent pipeline upload [file] [options...]
 
@@ -78,7 +78,7 @@ type PipelineUploadConfig struct {
 var PipelineUploadCommand = cli.Command{
 	Name:        "upload",
 	Usage:       "Uploads a description of a build pipeline adds it to the currently running build after the current job",
-	Description: PipelineUploadHelpDescription,
+	Description: pipelineUploadHelpDescription,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:   "replace",

--- a/clicommand/step_get.go
+++ b/clicommand/step_get.go
@@ -12,7 +12,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var StepGetHelpDescription = `Usage:
+const stepGetHelpDescription = `Usage:
 
    buildkite-agent step get <attribute> [options...]
 
@@ -55,7 +55,7 @@ type StepGetConfig struct {
 var StepGetCommand = cli.Command{
 	Name:        "get",
 	Usage:       "Get the value of an attribute",
-	Description: StepGetHelpDescription,
+	Description: stepGetHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "step",

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -13,7 +13,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var StepUpdateHelpDescription = `Usage:
+const stepUpdateHelpDescription = `Usage:
 
    buildkite-agent step update <attribute> <value> [options...]
 
@@ -62,7 +62,7 @@ type StepUpdateConfig struct {
 var StepUpdateCommand = cli.Command{
 	Name:        "update",
 	Usage:       "Change the value of an attribute",
-	Description: StepUpdateHelpDescription,
+	Description: stepUpdateHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "step",

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var AppHelpTemplate = `Usage:
+const appHelpTemplate = `Usage:
 
   {{.Name}} <command> [options...]
 
@@ -27,7 +27,7 @@ Use "{{.Name}} <command> --help" for more information about a command.
 
 `
 
-var SubcommandHelpTemplate = `Usage:
+const subcommandHelpTemplate = `Usage:
 
   {{.Name}} {{if .VisibleFlags}}<command>{{end}} [options...]
 
@@ -41,7 +41,7 @@ Options:
    {{end}}{{end}}
 `
 
-var CommandHelpTemplate = `{{.Description}}
+const commandHelpTemplate = `{{.Description}}
 
 Options:
 
@@ -54,9 +54,9 @@ func printVersion(c *cli.Context) {
 }
 
 func main() {
-	cli.AppHelpTemplate = AppHelpTemplate
-	cli.CommandHelpTemplate = CommandHelpTemplate
-	cli.SubcommandHelpTemplate = SubcommandHelpTemplate
+	cli.AppHelpTemplate = appHelpTemplate
+	cli.CommandHelpTemplate = commandHelpTemplate
+	cli.SubcommandHelpTemplate = subcommandHelpTemplate
 	cli.VersionPrinter = printVersion
 
 	app := cli.NewApp()


### PR DESCRIPTION
The CLI command descriptions aren't ever changed, nor are they used outside the clicommand package.

For consistency, the templates in main.go are updated the same way.