### PR TITLE
Add subcommands to modify env vars using Job API

### DIFF
--- a/clicommand/env_get.go
+++ b/clicommand/env_get.go
@@ -1,0 +1,143 @@
+package clicommand
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/buildkite/agent/v3/env"
+	"github.com/buildkite/agent/v3/jobapi"
+	"github.com/urfave/cli"
+)
+
+const envClientErrMessage = `Could not create Job API client: %v
+This command can only be used from hooks or plugins running under a job executor
+where the "job-api" experiment is enabled.
+`
+
+const envGetHelpDescription = `Usage:
+  buildkite-agent env get [variables]
+
+Description:
+   Retrieves environment variables and their current values from the current job
+   execution environment. 
+
+   Note that this subcommand is only available from within the job executor with
+   the ′job-api′ experiment enabled.
+   
+   Changes to the job environment only apply to the environments of subsequent
+   phases of the job. However, ′env get′ can be used to inspect the changes made
+   with ′env set′ and ′env delete′.
+
+Example (gets all variables in key=value format):
+
+    $ buildkite-agent env get
+	ALPACA=Geronimo the Incredible
+	BUILDKITE=true
+	LLAMA=Kuzco
+	...
+	
+Example (gets the value of one variable):
+
+    $ buildkite-agent env get LLAMA
+	Kuzco
+	
+Example (gets multiple specific variables):
+
+	$ buildkite-agent env get LLAMA ALPACA
+	ALPACA=Geronimo the Incredible
+	LLAMA=Kuzco
+	
+Example (gets variables as a JSON object):
+
+    $ buildkite-agent env get --format=json-pretty
+	{
+	  "ALPACA": "Geronimo the Incredible",
+	  "BUILDKITE": "true",
+	  "LLAMA": "Kuzco",
+	  ...
+	}
+`
+
+type EnvGetConfig struct{}
+
+var EnvGetCommand = cli.Command{
+	Name:        "get",
+	Usage:       "Gets variables from the job execution environment",
+	Description: envGetHelpDescription,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:   "format",
+			Usage:  "Output format: plain, json, or json-pretty",
+			EnvVar: "BUILDKITE_AGENT_ENV_GET_FORMAT",
+			Value:  "plain",
+		},
+	},
+	Action: envGetAction,
+}
+
+func envGetAction(c *cli.Context) error {
+	cli, err := jobapi.NewDefaultClient()
+	if err != nil {
+		fmt.Fprintf(c.App.ErrWriter, envClientErrMessage, err)
+		os.Exit(1)
+	}
+
+	envMap, err := cli.EnvGet(context.Background())
+	if err != nil {
+		fmt.Fprintf(c.App.ErrWriter, "Couldn't fetch the job executor environment variables: %v\n", err)
+		os.Exit(1)
+	}
+
+	var notFound []string
+
+	// Filter envMap by any remaining args.
+	if len(c.Args()) > 0 {
+		em := make(map[string]string)
+		for _, arg := range c.Args() {
+			v, ok := envMap[arg]
+			if !ok {
+				notFound = append(notFound, arg)
+				fmt.Fprintf(c.App.ErrWriter, "%q is not set\n", arg)
+				continue
+			}
+			em[arg] = v
+		}
+		envMap = em
+	}
+
+	switch c.String("format") {
+	case "plain":
+		if len(c.Args()) == 1 {
+			// Just print the value.
+			for _, v := range envMap {
+				fmt.Fprintln(c.App.Writer, v)
+			}
+			break
+		}
+
+		// Print everything.
+		for _, v := range env.FromMap(envMap).ToSlice() {
+			fmt.Fprintln(c.App.Writer, v)
+		}
+
+	case "json", "json-pretty":
+		enc := json.NewEncoder(c.App.Writer)
+		if c.String("format") == "json-pretty" {
+			enc.SetIndent("", "  ")
+		}
+		if err := enc.Encode(envMap); err != nil {
+			fmt.Fprintf(c.App.ErrWriter, "Error marshalling JSON: %v\n", err)
+			os.Exit(1)
+		}
+
+	default:
+		fmt.Fprintf(c.App.ErrWriter, "Invalid output format %q\n", c.String("format"))
+	}
+
+	if len(notFound) > 0 {
+		os.Exit(1)
+	}
+	return nil
+}

--- a/clicommand/env_set.go
+++ b/clicommand/env_set.go
@@ -1,0 +1,169 @@
+package clicommand
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/buildkite/agent/v3/env"
+	"github.com/buildkite/agent/v3/jobapi"
+	"github.com/urfave/cli"
+)
+
+const envSetHelpDescription = `Usage:
+  buildkite-agent env set [variable]
+
+Description:
+   Sets environment variable values in the current job execution environment. 
+   Existing variables will be overwritten.
+
+   Note that this subcommand is only available from within the job executor with
+   the ′job-api′ experiment enabled.
+   
+   Note that changes to the job environment variables only apply to subsequent
+   phases of the job. To read the new values of variables from within the
+   current phase, use ′env get′.
+
+   Note that Buildkite read-only variables cannot be overwritten.
+
+Example (sets the variables ′LLAMA′ and ′ALPACA′):
+
+    $ buildkite-agent env set LLAMA=Kuzco "ALPACA=Geronimo the Incredible"
+	Added:
+	+ LLAMA
+	Updated:
+	~ ALPACA	
+	
+Example (sets the variables ′LLAMA′ and ′ALPACA′ using a JSON object supplied
+over standard input):
+
+    $ echo '{"ALPACA":"Geronimo the Incredible","LLAMA":"Kuzco"}' | buildkite-agent env set --input-format=json --output-format=quiet -
+`
+
+type EnvSetConfig struct{}
+
+var EnvSetCommand = cli.Command{
+	Name:        "set",
+	Usage:       "Sets variables in the job execution environment",
+	Description: envSetHelpDescription,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:   "input-format",
+			Usage:  "Input format: plain or json",
+			EnvVar: "BUILDKITE_AGENT_ENV_SET_INPUT_FORMAT",
+			Value:  "plain",
+		},
+		cli.StringFlag{
+			Name:   "output-format",
+			Usage:  "Output format: quiet (no output), plain, json, or json-pretty",
+			EnvVar: "BUILDKITE_AGENT_ENV_SET_OUTPUT_FORMAT",
+			Value:  "plain",
+		},
+	},
+	Action: envSetAction,
+}
+
+func envSetAction(c *cli.Context) error {
+	cli, err := jobapi.NewDefaultClient()
+	if err != nil {
+		fmt.Fprintf(c.App.ErrWriter, envClientErrMessage, err)
+		os.Exit(1)
+	}
+
+	req := &jobapi.EnvUpdateRequest{
+		Env: make(map[string]*string),
+	}
+
+	var parse func(string) error
+
+	switch c.String("input-format") {
+	case "plain":
+		parse = func(input string) error {
+			e, v, ok := env.Split(input)
+			if !ok {
+				return fmt.Errorf("%q is not in key=value format", input)
+			}
+			req.Env[e] = &v
+			return nil
+		}
+
+	case "json":
+		// Parse directly into the map
+		parse = func(input string) error {
+			return json.Unmarshal([]byte(input), &req.Env)
+		}
+
+	default:
+		fmt.Fprintf(c.App.ErrWriter, "Invalid input format %q\n", c.String("input-format"))
+	}
+
+	// Inspect each arg, which could either be "-" for stdin, or "KEY=value"
+	for _, arg := range c.Args() {
+		if arg == "-" {
+			// Parse standard input
+			sc := bufio.NewScanner(os.Stdin)
+			line := 1
+			for sc.Scan() {
+				if err := parse(sc.Text()); err != nil {
+					fmt.Fprintf(c.App.ErrWriter, "Couldn't parse input line %d: %v\n", line, err)
+					os.Exit(1)
+				}
+				line++
+			}
+			if err := sc.Err(); err != nil {
+				fmt.Fprintf(c.App.ErrWriter, "Couldn't scan the input buffer: %v\n", err)
+				os.Exit(1)
+			}
+			continue
+		}
+		// Parse args directly
+		if err := parse(arg); err != nil {
+			fmt.Fprintf(c.App.ErrWriter, "Couldn't parse the command-line argument %q: %v\n", arg, err)
+			os.Exit(1)
+		}
+	}
+
+	resp, err := cli.EnvUpdate(context.Background(), req)
+	if err != nil {
+		fmt.Fprintf(c.App.ErrWriter, "Couldn't update the job executor environment: %v\n", err)
+	}
+
+	switch c.String("output-format") {
+	case "quiet":
+		return nil
+
+	case "plain":
+		if len(resp.Added) > 0 {
+			fmt.Fprintln(c.App.Writer, "Added:")
+			for _, a := range resp.Added {
+				fmt.Fprintf(c.App.Writer, "+ %s\n", a)
+			}
+		}
+		if len(resp.Updated) > 0 {
+			fmt.Fprintln(c.App.Writer, "Updated:")
+			for _, u := range resp.Updated {
+				fmt.Fprintf(c.App.Writer, "~ %s\n", u)
+			}
+		}
+		if len(resp.Added) == 0 && len(resp.Updated) == 0 {
+			fmt.Fprintln(c.App.Writer, "No variables added or updated.")
+		}
+
+	case "json", "json-pretty":
+		enc := json.NewEncoder(c.App.Writer)
+		if c.String("output-format") == "json-pretty" {
+			enc.SetIndent("", "  ")
+		}
+		if err := enc.Encode(resp); err != nil {
+			fmt.Fprintf(c.App.ErrWriter, "Error marshalling JSON: %v\n", err)
+			os.Exit(1)
+		}
+
+	default:
+		fmt.Fprintf(c.App.ErrWriter, "Invalid output format %q\n", c.String("output-format"))
+	}
+
+	return nil
+}

--- a/clicommand/env_set.go
+++ b/clicommand/env_set.go
@@ -67,7 +67,7 @@ var EnvSetCommand = cli.Command{
 }
 
 func envSetAction(c *cli.Context) error {
-	cl, err := jobapi.NewDefaultClient()
+	client, err := jobapi.NewDefaultClient()
 	if err != nil {
 		fmt.Fprintf(c.App.ErrWriter, envClientErrMessage, err)
 		os.Exit(1)
@@ -126,7 +126,7 @@ func envSetAction(c *cli.Context) error {
 		}
 	}
 
-	resp, err := cl.EnvUpdate(context.Background(), req)
+	resp, err := client.EnvUpdate(context.Background(), req)
 	if err != nil {
 		fmt.Fprintf(c.App.ErrWriter, "Couldn't update the job executor environment: %v\n", err)
 	}

--- a/clicommand/env_set.go
+++ b/clicommand/env_set.go
@@ -13,6 +13,7 @@ import (
 )
 
 const envSetHelpDescription = `Usage:
+
   buildkite-agent env set [variable]
 
 Description:
@@ -30,16 +31,16 @@ Description:
 
 Example (sets the variables ′LLAMA′ and ′ALPACA′):
 
-    $ buildkite-agent env set LLAMA=Kuzco "ALPACA=Geronimo the Incredible"
-	Added:
-	+ LLAMA
-	Updated:
-	~ ALPACA	
+   $ buildkite-agent env set LLAMA=Kuzco "ALPACA=Geronimo the Incredible"
+   Added:
+   + LLAMA
+   Updated:
+   ~ ALPACA	
 	
 Example (sets the variables ′LLAMA′ and ′ALPACA′ using a JSON object supplied
 over standard input):
 
-    $ echo '{"ALPACA":"Geronimo the Incredible","LLAMA":"Kuzco"}' | buildkite-agent env set --input-format=json --output-format=quiet -
+   $ echo '{"ALPACA":"Geronimo the Incredible","LLAMA":"Kuzco"}' | buildkite-agent env set --input-format=json --output-format=quiet -
 `
 
 type EnvSetConfig struct{}
@@ -66,7 +67,7 @@ var EnvSetCommand = cli.Command{
 }
 
 func envSetAction(c *cli.Context) error {
-	cli, err := jobapi.NewDefaultClient()
+	cl, err := jobapi.NewDefaultClient()
 	if err != nil {
 		fmt.Fprintf(c.App.ErrWriter, envClientErrMessage, err)
 		os.Exit(1)
@@ -125,7 +126,7 @@ func envSetAction(c *cli.Context) error {
 		}
 	}
 
-	resp, err := cli.EnvUpdate(context.Background(), req)
+	resp, err := cl.EnvUpdate(context.Background(), req)
 	if err != nil {
 		fmt.Fprintf(c.App.ErrWriter, "Couldn't update the job executor environment: %v\n", err)
 	}

--- a/clicommand/env_unset.go
+++ b/clicommand/env_unset.go
@@ -12,6 +12,7 @@ import (
 )
 
 const envUnsetHelpDescription = `Usage:
+
   buildkite-agent env unset [variables]
 
 Description:
@@ -28,15 +29,15 @@ Description:
 
 Example (un-sets the variables ′LLAMA′ and ′ALPACA′):
 
-    $ buildkite-agent env unset LLAMA ALPACA
-    Un-set:
-    - ALPACA
-    - LLAMA
+   $ buildkite-agent env unset LLAMA ALPACA
+   Un-set:
+   - ALPACA
+   - LLAMA
 	
 Example (Un-sets the variables ′LLAMA′ and ′ALPACA′ with a JSON list supplied
 over standard input):
     
-    $ echo '["LLAMA","ALPACA"]' | buildkite-agent env unset --input-format=json --output-format=quiet -
+   $ echo '["LLAMA","ALPACA"]' | buildkite-agent env unset --input-format=json --output-format=quiet -
 `
 
 type EnvUnsetConfig struct{}
@@ -63,7 +64,7 @@ var EnvUnsetCommand = cli.Command{
 }
 
 func envUnsetAction(c *cli.Context) error {
-	cli, err := jobapi.NewDefaultClient()
+	client, err := jobapi.NewDefaultClient()
 	if err != nil {
 		fmt.Fprintf(c.App.ErrWriter, envClientErrMessage, err)
 		os.Exit(1)
@@ -115,7 +116,7 @@ func envUnsetAction(c *cli.Context) error {
 		}
 	}
 
-	unset, err := cli.EnvDelete(context.Background(), del)
+	unset, err := client.EnvDelete(context.Background(), del)
 	if err != nil {
 		fmt.Fprintf(c.App.ErrWriter, "Couldn't un-set the job executor environment variables: %v\n", err)
 	}

--- a/clicommand/env_unset.go
+++ b/clicommand/env_unset.go
@@ -1,0 +1,152 @@
+package clicommand
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/buildkite/agent/v3/jobapi"
+	"github.com/urfave/cli"
+)
+
+const envUnsetHelpDescription = `Usage:
+  buildkite-agent env unset [variables]
+
+Description:
+   Un-sets environment variables in the current job execution environment. 
+
+   Note that this subcommand is only available from within the job executor with
+   the ′job-api′ experiment enabled.
+
+   Note that changes to the job environment variables only apply to subsequent
+   phases of the job. To read the new values of variables from within the
+   current phase, use ′env get′.
+
+   Note that Buildkite read-only variables cannot be un-set.
+
+Example (un-sets the variables ′LLAMA′ and ′ALPACA′):
+
+    $ buildkite-agent env unset LLAMA ALPACA
+    Un-set:
+    - ALPACA
+    - LLAMA
+	
+Example (Un-sets the variables ′LLAMA′ and ′ALPACA′ with a JSON list supplied
+over standard input):
+    
+    $ echo '["LLAMA","ALPACA"]' | buildkite-agent env unset --input-format=json --output-format=quiet -
+`
+
+type EnvUnsetConfig struct{}
+
+var EnvUnsetCommand = cli.Command{
+	Name:        "unset",
+	Usage:       "Un-sets variables from the job execution environment",
+	Description: envUnsetHelpDescription,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:   "input-format",
+			Usage:  "Input format: plain or json",
+			EnvVar: "BUILDKITE_AGENT_ENV_UNSET_INPUT_FORMAT",
+			Value:  "plain",
+		},
+		cli.StringFlag{
+			Name:   "output-format",
+			Usage:  "Output format: quiet (no output), plain, json, or json-pretty",
+			EnvVar: "BUILDKITE_AGENT_ENV_UNSET_OUTPUT_FORMAT",
+			Value:  "plain",
+		},
+	},
+	Action: envUnsetAction,
+}
+
+func envUnsetAction(c *cli.Context) error {
+	cli, err := jobapi.NewDefaultClient()
+	if err != nil {
+		fmt.Fprintf(c.App.ErrWriter, envClientErrMessage, err)
+		os.Exit(1)
+	}
+
+	var del []string
+
+	var parse func(string) error
+
+	switch c.String("input-format") {
+	case "plain":
+		parse = func(input string) error {
+			del = append(del, input)
+			return nil
+		}
+
+	case "json":
+		parse = func(input string) error {
+			return json.Unmarshal([]byte(input), &del)
+		}
+
+	default:
+		fmt.Fprintf(c.App.ErrWriter, "Invalid input format %q\n", c.String("input-format"))
+	}
+
+	// Inspect each arg, which could either be "-" for stdin, or "KEY"
+	for _, arg := range c.Args() {
+		if arg == "-" {
+			// Parse standard input
+			sc := bufio.NewScanner(os.Stdin)
+			line := 1
+			for sc.Scan() {
+				if err := parse(sc.Text()); err != nil {
+					fmt.Fprintf(c.App.ErrWriter, "Couldn't parse input line %d: %v\n", line, err)
+					os.Exit(1)
+				}
+				line++
+			}
+			if err := sc.Err(); err != nil {
+				fmt.Fprintf(c.App.ErrWriter, "Couldn't scan the input buffer: %v\n", err)
+				os.Exit(1)
+			}
+			continue
+		}
+		// Parse args directly
+		if err := parse(arg); err != nil {
+			fmt.Fprintf(c.App.ErrWriter, "Couldn't parse the command-line argument %q: %v\n", arg, err)
+			os.Exit(1)
+		}
+	}
+
+	unset, err := cli.EnvDelete(context.Background(), del)
+	if err != nil {
+		fmt.Fprintf(c.App.ErrWriter, "Couldn't un-set the job executor environment variables: %v\n", err)
+	}
+
+	switch c.String("output-format") {
+	case "quiet":
+		return nil
+
+	case "plain":
+		if len(unset) > 0 {
+			fmt.Fprintln(c.App.Writer, "Un-set:")
+			for _, d := range unset {
+				fmt.Fprintf(c.App.Writer, "- %s\n", d)
+			}
+		} else {
+			fmt.Fprintln(c.App.Writer, "No variables un-set.")
+		}
+
+	case "json", "json-pretty":
+		enc := json.NewEncoder(c.App.Writer)
+		if c.String("output-format") == "json-pretty" {
+			enc.SetIndent("", "  ")
+		}
+		if err := enc.Encode(unset); err != nil {
+			fmt.Fprintf(c.App.ErrWriter, "Error marshalling JSON: %v\n", err)
+			os.Exit(1)
+		}
+
+	default:
+		fmt.Fprintf(c.App.ErrWriter, "Invalid output format %q\n", c.String("output-format"))
+	}
+
+	return nil
+}

--- a/jobapi/client.go
+++ b/jobapi/client.go
@@ -1,0 +1,157 @@
+package jobapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"runtime"
+)
+
+const envURL = "http://job/api/current-job/v0/env"
+
+// Client connects to the Job API.
+type Client struct {
+	client *http.Client
+	token  string
+}
+
+// NewDefaultClient returns a new Client with the default socket path and token.
+func NewDefaultClient() (*Client, error) {
+	sock, token, err := DefaultSocketPath()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewClient(sock, token)
+}
+
+// DefaultSocketPath returns the socket path and access token, if available.
+func DefaultSocketPath() (path, token string, err error) {
+	path = os.Getenv("BUILDKITE_AGENT_JOB_API_SOCKET")
+	if path == "" {
+		return "", "", errors.New("BUILDKITE_AGENT_JOB_API_SOCKET empty or undefined")
+	}
+	token = os.Getenv("BUILDKITE_AGENT_JOB_API_TOKEN")
+	if token == "" {
+		return "", "", errors.New("BUILDKITE_AGENT_JOB_API_TOKEN empty or undefined")
+	}
+	return path, token, nil
+}
+
+// NewClient creates a new Client.
+func NewClient(sock, token string) (*Client, error) {
+	// Check the socket path exists and is a socket.
+	// Note that os.ModeSocket might not be set on Windows.
+	// (https://github.com/golang/go/issues/33357)
+	if runtime.GOOS != "windows" {
+		fi, err := os.Stat(sock)
+		if err != nil {
+			return nil, fmt.Errorf("stat socket: %w", err)
+		}
+		if fi.Mode()&os.ModeSocket == 0 {
+			return nil, fmt.Errorf("%q is not a socket", sock)
+		}
+	}
+
+	// Try to connect to the socket.
+	test, err := net.Dial("unix", sock)
+	if err != nil {
+		return nil, fmt.Errorf("socket test connection: %w", err)
+	}
+	test.Close()
+
+	dialer := net.Dialer{}
+	return &Client{
+		client: &http.Client{
+			Transport: &http.Transport{
+				// Ignore arguments, dial socket
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					return dialer.DialContext(ctx, "unix", sock)
+				},
+			},
+		},
+		token: token,
+	}, nil
+}
+
+// do implements the common bits of an API call. req is serialised to JSON and
+// passed as the request body if not nil. The method is called, with the token
+// added in the Authorization header. The response is deserialised, either into
+// the object passed into resp if the status is 200 OK, otherwise into an error.
+func (c *Client) do(ctx context.Context, method, url string, req, resp any) error {
+	var body io.Reader
+	if req != nil {
+		buf, err := json.Marshal(req)
+		if err != nil {
+			return fmt.Errorf("marshalling request: %w", err)
+		}
+		body = bytes.NewReader(buf)
+	}
+
+	hreq, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return fmt.Errorf("creating a request: %w", err)
+	}
+
+	hreq.Header.Set("Authorization", "Bearer "+c.token)
+	hresp, err := c.client.Do(hreq)
+	if err != nil {
+		return err
+	}
+	defer hresp.Body.Close()
+	dec := json.NewDecoder(hresp.Body)
+
+	if hresp.StatusCode != 200 {
+		var er ErrorResponse
+		if err := dec.Decode(&er); err != nil {
+			return fmt.Errorf("decoding error response: %w", err)
+		}
+		return fmt.Errorf("error from job executor: %s", er.Error)
+	}
+
+	if resp == nil {
+		return nil
+	}
+	if err := dec.Decode(resp); err != nil {
+		return fmt.Errorf("decoding response: %w:", err)
+	}
+	return nil
+}
+
+// EnvGet gets the current environment variables from within the job executor.
+func (c *Client) EnvGet(ctx context.Context) (map[string]string, error) {
+	var resp EnvGetResponse
+	if err := c.do(ctx, "GET", envURL, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Env, nil
+}
+
+// EnvUpdate updates environment variables within the job executor.
+func (c *Client) EnvUpdate(ctx context.Context, req *EnvUpdateRequest) (*EnvUpdateResponse, error) {
+	var resp EnvUpdateResponse
+	if err := c.do(ctx, "PATCH", envURL, req, &resp); err != nil {
+		return nil, err
+	}
+	resp.Normalize()
+	return &resp, nil
+}
+
+// EnvDelete deletes environment variables within the job executor.
+func (c *Client) EnvDelete(ctx context.Context, del []string) (deleted []string, err error) {
+	req := EnvDeleteRequest{
+		Keys: del,
+	}
+	var resp EnvDeleteResponse
+	if err := c.do(ctx, "DELETE", envURL, &req, &resp); err != nil {
+		return nil, err
+	}
+	resp.Normalize()
+	return resp.Deleted, nil
+}

--- a/jobapi/client_test.go
+++ b/jobapi/client_test.go
@@ -1,0 +1,219 @@
+package jobapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type fakeServer struct {
+	env         map[string]string
+	sock, token string
+	svr         *http.Server
+}
+
+func runFakeServer() (svr *fakeServer, err error) {
+	f := &fakeServer{
+		env: map[string]string{
+			"KUZCO":    "Llama",
+			"KRONK":    "Himbo",
+			"YZMA":     "Villain",
+			"READONLY": "Should never change",
+		},
+		sock:  filepath.Join(os.TempDir(), fmt.Sprintf("testsocket-%d-%x", os.Getpid(), rand.Int())),
+		token: "to_the_secret_lab",
+	}
+
+	f.svr = &http.Server{Handler: f}
+
+	ln, err := net.Listen("unix", f.sock)
+	if err != nil {
+		return nil, fmt.Errorf("net.Listen(unix, %q) error = %w", f.sock, err)
+	}
+	go f.svr.Serve(ln)
+	return f, nil
+}
+
+func (f *fakeServer) Close() { f.svr.Close() }
+
+func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("Authorization") != "Bearer "+f.token {
+		writeError(w, "invalid Authorization header", http.StatusForbidden)
+		return
+	}
+	if r.URL.Path != "/api/current-job/v0/env" {
+		writeError(w, fmt.Sprintf("not found: %q", r.URL.Path), http.StatusNotFound)
+		return
+	}
+
+	switch r.Method {
+	case "GET":
+		b := EnvGetResponse{Env: f.env}
+		if err := json.NewEncoder(w).Encode(&b); err != nil {
+			writeError(w, fmt.Sprintf("encoding response: %v", err), http.StatusInternalServerError)
+		}
+
+	case "PATCH":
+		var req EnvUpdateRequest
+		var resp EnvUpdateResponse
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, fmt.Sprintf("decoding request: %v", err), http.StatusBadRequest)
+			return
+		}
+		for k, v := range req.Env {
+			if k == "READONLY" {
+				writeError(w, "mutating READONLY is not allowed", http.StatusBadRequest)
+				return
+			}
+			if v == nil {
+				writeError(w, fmt.Sprintf("setting %q to null is not allowed", k), http.StatusBadRequest)
+				return
+			}
+		}
+		for k, v := range req.Env {
+			if _, ok := f.env[k]; ok {
+				resp.Updated = append(resp.Updated, k)
+			} else {
+				resp.Added = append(resp.Added, k)
+			}
+			f.env[k] = *v
+		}
+		resp.Normalize()
+		if err := json.NewEncoder(w).Encode(&resp); err != nil {
+			writeError(w, fmt.Sprintf("encoding response: %v", err), http.StatusInternalServerError)
+		}
+
+	case "DELETE":
+		var req EnvDeleteRequest
+		var resp EnvDeleteResponse
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, fmt.Sprintf("decoding request: %v", err), http.StatusBadRequest)
+			return
+		}
+		for _, k := range req.Keys {
+			if k == "READONLY" {
+				writeError(w, "deleting READONLY is not allowed", http.StatusBadRequest)
+			}
+		}
+		for _, k := range req.Keys {
+			if _, ok := f.env[k]; !ok {
+				continue
+			}
+			resp.Deleted = append(resp.Deleted, k)
+			delete(f.env, k)
+		}
+		resp.Normalize()
+		if err := json.NewEncoder(w).Encode(&resp); err != nil {
+			writeError(w, fmt.Sprintf("encoding response: %v", err), http.StatusInternalServerError)
+		}
+
+	default:
+		writeError(w, fmt.Sprintf("unsupported method %q", r.Method), http.StatusBadRequest)
+	}
+}
+
+func TestClient_NoSocket(t *testing.T) {
+	if _, err := NewDefaultClient(); err == nil {
+		t.Errorf("NewDefaultClient() error = %v, want nil", err)
+	}
+}
+
+func TestClientEnvGet(t *testing.T) {
+	t.Parallel()
+
+	svr, err := runFakeServer()
+	if err != nil {
+		t.Fatalf("runFakeServer() = %v", err)
+	}
+	defer svr.Close()
+
+	cli, err := NewClient(svr.sock, svr.token)
+	if err != nil {
+		t.Fatalf("NewClient(%q, %q) error = %v", svr.sock, svr.token, err)
+	}
+
+	got, err := cli.EnvGet(context.Background())
+	if err != nil {
+		t.Fatalf("cli.EnvGet() error = %v", err)
+	}
+
+	want := map[string]string{
+		"KUZCO":    "Llama",
+		"KRONK":    "Himbo",
+		"YZMA":     "Villain",
+		"READONLY": "Should never change",
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("cli.EnvGet diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestClientEnvUpdate(t *testing.T) {
+	t.Parallel()
+
+	svr, err := runFakeServer()
+	if err != nil {
+		t.Fatalf("runFakeServer() = %v", err)
+	}
+	defer svr.Close()
+
+	cli, err := NewClient(svr.sock, svr.token)
+	if err != nil {
+		t.Fatalf("NewClient(%q, %q) error = %v", svr.sock, svr.token, err)
+	}
+
+	sp := func(s string) *string { return &s }
+	req := &EnvUpdateRequest{
+		Env: map[string]*string{
+			"PACHA": sp("Friend"),
+			"YZMA":  sp("Kitten"),
+		},
+	}
+
+	got, err := cli.EnvUpdate(context.Background(), req)
+	if err != nil {
+		t.Fatalf("cli.EnvUpdate() error = %v", err)
+	}
+
+	want := &EnvUpdateResponse{
+		Added:   []string{"PACHA"},
+		Updated: []string{"YZMA"},
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("cli.EnvUpdate diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestClientEnvDelete(t *testing.T) {
+	t.Parallel()
+
+	svr, err := runFakeServer()
+	if err != nil {
+		t.Fatalf("runFakeServer() = %v", err)
+	}
+	defer svr.Close()
+
+	cli, err := NewClient(svr.sock, svr.token)
+	if err != nil {
+		t.Fatalf("NewClient(%q, %q) error = %v", svr.sock, svr.token, err)
+	}
+
+	req := []string{"YZMA"}
+	got, err := cli.EnvDelete(context.Background(), req)
+	if err != nil {
+		t.Fatalf("cli.EnvUpdate() error = %v", err)
+	}
+
+	want := []string{"YZMA"}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("cli.EnvDelete diff (-got +want):\n%s", diff)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -88,6 +88,9 @@ func main() {
 			Usage: "Process environment subcommands",
 			Subcommands: []cli.Command{
 				clicommand.EnvDumpCommand,
+				clicommand.EnvGetCommand,
+				clicommand.EnvSetCommand,
+				clicommand.EnvUnsetCommand,
 			},
 		},
 		{


### PR DESCRIPTION
This is the "client half" of #1943. It adds a client for the socket-based current-job API, and three new subcommands that exercise the Get, Update, and Delete methods:

```shell
# Get the current environment variables and values from the job executor
buildkite-agent env get
# Add or update one or more environment variable values in the job executor
buildkite-agent env set ...
# Un-set one or more environment variable values in the job executor
buildkite-agent env unset ...
```

Edit 1: renamed "delete" to "unset"