### PR TITLE
fix: dedup arguments to git when fetching submodule

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1410,6 +1410,8 @@ func (b *Bootstrap) defaultCheckoutPhase(ctx context.Context) error {
 			b.shell.Warningf("Failed to enumerate git submodules: %v", err)
 		} else {
 			for idx, repository := range submoduleRepos {
+				// Ensure we don't append duplicate arguments.
+				final_args := append([]string(nil), args...)
 				// submodules might need their fingerprints verified too
 				if b.SSHKeyscan {
 					addRepositoryHostToSSHKnownHosts(ctx, b.shell, repository)
@@ -1434,11 +1436,11 @@ func (b *Bootstrap) defaultCheckoutPhase(ctx context.Context) error {
 					} else {
 						repositoryPath = repository
 					}
-					args = append(args, "submodule", "update", "--init", "--recursive", "--force", "--reference", repositoryPath)
+					final_args = append(final_args, "submodule", "update", "--init", "--recursive", "--force", "--reference", repositoryPath)
 				} else {
-					args = append(args, "submodule", "update", "--init", "--recursive", "--force")
+					final_args = append(final_args, "submodule", "update", "--init", "--recursive", "--force")
 				}
-				if err := b.shell.Run(ctx, "git", args...); err != nil {
+				if err := b.shell.Run(ctx, "git", final_args...); err != nil {
 					return err
 				}
 


### PR DESCRIPTION
For a git repository that uses submodules, the agent currently appends the same arguments per submodule to the git command line, which is less than ideal and results in the following error (for 2 submodules):

```
$ git submodule update --init --recursive --force submodule update --init --recursive --force
error: pathspec 'submodule' did not match any file(s) known to git
error: pathspec 'update' did not match any file(s) known to git
error: pathspec '--init' did not match any file(s) known to git
error: pathspec '--recursive' did not match any file(s) known to git
error: pathspec '--force' did not match any file(s) known to git
```

The goal of this commit is to ensure the arguments are reinitialized per submodule in order to prevent this situation.