### PR TITLE
Allow adding claims to the OIDC token request

### DIFF
--- a/api/oidc.go
+++ b/api/oidc.go
@@ -13,15 +13,18 @@ type OIDCTokenRequest struct {
 	Job      string
 	Audience string
 	Lifetime int
+	Claims   []string
 }
 
 func (c *Client) OIDCToken(ctx context.Context, methodReq *OIDCTokenRequest) (*OIDCToken, *Response, error) {
 	m := &struct {
-		Audience string `json:"audience,omitempty"`
-		Lifetime int    `json:"lifetime,omitempty"`
+		Audience string   `json:"audience,omitempty"`
+		Lifetime int      `json:"lifetime,omitempty"`
+		Claims   []string `json:"claims,omitempty"`
 	}{
 		Audience: methodReq.Audience,
 		Lifetime: methodReq.Lifetime,
+		Claims:   methodReq.Claims,
 	}
 
 	u := fmt.Sprintf("jobs/%s/oidc/tokens", methodReq.Job)

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -17,6 +17,8 @@ type OIDCTokenConfig struct {
 	Audience string `cli:"audience"`
 	Lifetime int    `cli:"lifetime"`
 	Job      string `cli:"job"      validate:"required"`
+	// TODO: enumerate possible values, perhaps by adding a link to the documentation
+	Claims []string `cli:"claim"    normalize:"list"`
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
@@ -69,6 +71,13 @@ var OIDCRequestTokenCommand = cli.Command{
 			Name:   "job",
 			Usage:  "Buildkite Job Id to claim in the OIDC token",
 			EnvVar: "BUILDKITE_JOB_ID",
+		},
+
+		cli.StringSliceFlag{
+			Name:   "claim",
+			Value:  &cli.StringSlice{},
+			Usage:  "Claims to add to the OIDC Token",
+			EnvVar: "BUILDKITE_OIDC_TOKEN_CLAIMS",
 		},
 
 		// API Flags
@@ -127,6 +136,7 @@ var OIDCRequestTokenCommand = cli.Command{
 				Job:      cfg.Job,
 				Audience: cfg.Audience,
 				Lifetime: cfg.Lifetime,
+				Claims:   cfg.Claims,
 			}
 
 			var resp *api.Response


### PR DESCRIPTION
This adds a new `claim` flag that may be specified multiple times to add elements to a `claims` field to the JSON body of the OIDC token request to buildkite.com.