### PR TITLE
fix 353 - fix this Error when using ssh : 'launchctl on macos fails with "Could not find domain for"'

### DIFF
--- a/templates/launchd.plist
+++ b/templates/launchd.plist
@@ -54,5 +54,12 @@
       <key>BUILDKITE_AGENT_CONFIG</key>
       <string>/Users/your-build-user/.buildkite-agent/buildkite-agent.cfg</string>
     </dict>
+    <key>LimitLoadToSessionType</key>
+    <array>
+      <string>Aqua</string>
+      <string>LoginWindow</string>
+      <string>Background</string>
+      <string>StandardIO</string>
+    </array>
   </dict>
 </plist>


### PR DESCRIPTION
fix 353 see https://github.com/buildkite/docs/issues/353#issuecomment-1435758739
edit: 
The Error occurs because by default (without LimitLoadToSessionType) launchd tries to load the agent into the Aqua context but this context doesnt exist when you are only logged in using ssh. 
The -S Background option tells launchd to load the agent into the Background Context. See changes in this PR for matching changes to the docs: https://github.com/buildkite/docs/pull/1875#issue-1590513215