### PR TITLE
Check that a pipeline upload error actually comes from the JSON marshaller and exit early

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -319,6 +319,8 @@ var PipelineUploadCommand = cli.Command{
 				if jsonerr := new(json.MarshalerError); errors.As(err, &jsonerr) {
 					l.Error("Unrecoverable error, skipping retries")
 					r.Break()
+
+					return jsonerr
 				}
 
 				// 422 responses will always fail no need to retry

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -248,8 +248,8 @@ var PipelineUploadCommand = cli.Command{
 
 		if len(cfg.RedactedVars) > 0 {
 			needles := redaction.GetKeyValuesToRedact(shell.StderrLogger, cfg.RedactedVars, env.FromSlice(os.Environ()))
-			serialisedPipeline, err := result.MarshalJSON()
 
+			serialisedPipeline, err := result.MarshalJSON()
 			if err != nil {
 				l.Fatal("Couldn’t scan the %q pipeline for redacted variables. This parsed pipeline could not be serialized, ensure the pipeline YAML is valid, or ignore interpolated secrets for this upload by passing --redacted-vars=''. (%s)", src, err)
 			}


### PR DESCRIPTION
In all cases where the pipeline cannot be marshaled to JSON, there is no point to retry the upload.
Retries will keep the agent busy for about 5 min, which is a waste of customers' compute time.