### PR TITLE
BUILDKITE_S3_ENDPOINT env var (e.g. MinIO support)

### DIFF
--- a/agent/s3.go
+++ b/agent/s3.go
@@ -18,6 +18,7 @@ import (
 )
 
 const regionHintEnvVar = "BUILDKITE_S3_DEFAULT_REGION"
+const s3EndpointEnvVar = "BUILDKITE_S3_ENDPOINT"
 
 type buildkiteEnvProvider struct {
 	retrieved bool
@@ -125,6 +126,11 @@ func NewS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 		}
 
 		sess = session
+	}
+
+	if endpoint := os.Getenv(s3EndpointEnvVar); endpoint != "" {
+		l.Debug("Setting S3 endpoint from %s to %q", s3EndpointEnvVar, endpoint)
+		sess.Config.Endpoint = &endpoint
 	}
 
 	l.Debug("Testing AWS S3 credentials for bucket %q in region %q...", bucket, *sess.Config.Region)


### PR DESCRIPTION
**This introduces a new `BUILDKITE_S3_ENDPOINT` environment variable** to configure the S3 client used by artifact upload/download to use an alternate [endpoint](https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/), e.g. a [MinIO](https://min.io/) server.

Note that this is distinct from `BUILDKITE_S3_ACCESS_URL` which is intended to specify e.g. a proxy _in front of_ S3 to e.g. access artifacts from a private bucket via some other HTTP auth scheme.

~It also introduces `BUILDKITE_S3_FORCE_PATH_STYLE` environment variable~ _(`S3ForcePathStyle` is implicit now when `BUILDKITE_S3_ENDPOINT` is set)_; setting this to a [truthy](https://pkg.go.dev/strconv#ParseBool) value enables [`S3ForcePathStyle`](https://github.com/aws/aws-sdk-go/blob/v1.44.181/aws/config.go#L118-L127) on the S3 client session, causing it to use path-based bucket addressing instead of DNS-based. AWS S3 considers path-based bucket addressing deprecated, and MinIO apparently _can_ support DNS-based bucket addressing, but S3-emulating servers such as MinIO may be running in environments where they can't bind to subdomains.

As far as I can tell there's [no globally-understood AWS SDK env var to control these settings](https://docs.aws.amazon.com/sdkref/latest/guide/settings-reference.html#EVarSettings), so we have to invent `BUILDKITE_…` env vars for them.

I've been using this test script… it results in an error, but the contents of that error indicate what hostname is being used for S3 requests:

```
#!/bin/bash
set -e -o pipefail -u

export BUILDKITE_AGENT_ACCESS_TOKEN="buildkiteagentaccesstoken"
export BUILDKITE_JOB_ID="buildkitejobid"
export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="s3://the-bucket-name/${BUILDKITE_JOB_ID}"
export BUILDKITE_S3_ACCESS_URL="https://s3.custom.localhost"
export BUILDKITE_S3_ACCESS_KEY_ID="s3accesskeyid"
export BUILDKITE_S3_SECRET_ACCESS_KEY="s3secretaccesskey"

# Failing to set this results in a panic
# Fix: https://github.com/buildkite/agent/pull/1964
export BUILDKITE_S3_DEFAULT_REGION="dontpanic"

echo "hello" > hello.txt

go build -o buildkite-agent

./buildkite-agent artifact upload --debug --debug-http hello.txt
```

Without the new environment variables set, we see the default `{bucket}.s3.{region}.amazonaws.com` hostname:
```
2023-02-22 10:47:14 FATAL  Failed to upload artifacts: Error creating uploader: Could not s3:ListObjects in your AWS S3 bucket "the-bucket-name" in region "dontpanic": (RequestError: send request failed
caused by: Get "http://the-bucket-name.s3.dontpanic.amazonaws.com/?max-keys=0": dial tcp: lookup the-bucket-name.s3.dontpanic.amazonaws.com: no such host)
```

~With `BUILDKITE_S3_ENDPOINT="minio:9000"` we see `{bucket}.{endpoint}` hostname:~
```
2023-02-22 10:47:52 FATAL  Failed to upload artifacts: Error creating uploader: Could not s3:ListObjects in your AWS S3 bucket "the-bucket-name" in region "dontpanic": (RequestError: send request failed
caused by: Get "http://the-bucket-name.minio:9000/?max-keys=0": dial tcp: lookup the-bucket-name.minio: no such host)
```

With `BUILDKITE_S3_ENDPOINT="minio:9000"` ~and `BUILDKITE_S3_FORCE_PATH_STYLE=true`~ we see `{endpoint}` hostname, with the bucket in the path:
```
2023-02-22 10:48:12 FATAL  Failed to upload artifacts: Error creating uploader: Could not s3:ListObjects in your AWS S3 bucket "the-bucket-name" in region "dontpanic": (RequestError: send request failed
caused by: Get "http://minio:9000/the-bucket-name?max-keys=0": dial tcp: lookup minio: no such host)
```

Related:
- https://github.com/buildkite/agent/issues/857