### PR TITLE
Ubuntu 22.04 Docker Image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -155,6 +155,7 @@ steps:
             - "alpine-k8s"
             - "ubuntu-18.04"
             - "ubuntu-20.04"
+            - "ubuntu-22.04"
             - "sidecar"
 
   - group: ":docker: Docker Image Tests"
@@ -173,6 +174,7 @@ steps:
               - alpine-k8s
               - ubuntu-18.04
               - ubuntu-20.04
+              - ubuntu-22.04
               - sidecar
 
       - name: ":docker: {{matrix.variant}} arm64 image test"
@@ -189,6 +191,7 @@ steps:
               - alpine-k8s
               - ubuntu-18.04
               - ubuntu-20.04
+              - ubuntu-22.04
               - sidecar
 
   - name: ":debian: Debian package build"

--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -60,6 +60,13 @@ builder_name=$(docker buildx create --use)
 # shellcheck disable=SC2064 # we want the current $builder_name to be trapped, not the runtime one
 trap "docker buildx rm $builder_name || true" EXIT
 
+# Needed for buildking multiarch
+# See https://github.com/docker/buildx/issues/314
+QEMU_VERSION=6.2.0
+echo "--- Installing QEMU $QEMU_VERSION"
+docker run --privileged --userns=host --rm "tonistiigi/binfmt:qemu-v$QEMU_VERSION" --uninstall qemu-*
+docker run --privileged --userns=host --rm "tonistiigi/binfmt:qemu-v$QEMU_VERSION" --install all
+
 echo "--- Building :docker: $image_tag"
 cp -a packaging/linux/root/usr/share/buildkite-agent/hooks/ "${packaging_dir}/hooks/"
 cp pkg/buildkite-agent-linux-{amd64,arm64} "$packaging_dir"

--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -4,7 +4,7 @@ set -Eeufo pipefail
 
 ## This script can be run locally like this:
 ##
-## .buildkite/steps/build-docker-image.sh (alpine|alpine-k8s|ubuntu-18.04|ubuntu-20.04|sidecar) (image tag) (codename) (version)
+## .buildkite/steps/build-docker-image.sh (alpine|alpine-k8s|ubuntu-18.04|ubuntu-20.04|ubuntu-22.04|sidecar) (image tag) (codename) (version)
 ## e.g: .buildkite/steps/build-docker-image.sh alpine buildkiteci/agent:lox-manual-build stable 3.1.1
 ##
 ## You can then publish that image with
@@ -21,7 +21,7 @@ codename="${3:-}"
 version="${4:-}"
 push="${PUSH_IMAGE:-true}"
 
-if [[ ! "$variant" =~ ^(alpine|alpine-k8s|ubuntu-18\.04|ubuntu-20\.04|sidecar)$ ]] ; then
+if [[ ! "$variant" =~ ^(alpine|alpine-k8s|ubuntu-18\.04|ubuntu-20\.04|ubuntu-22\.04|sidecar)$ ]] ; then
   echo "Unknown docker variant $variant"
   exit 1
 fi

--- a/.buildkite/steps/extract-agent-version-metadata.sh
+++ b/.buildkite/steps/extract-agent-version-metadata.sh
@@ -11,6 +11,8 @@ docker_alpine_image_tag="$registry:alpine-build-${BUILDKITE_BUILD_NUMBER}"
 docker_alpine_k8s_image_tag="$registry:alpine-k8s-build-${BUILDKITE_BUILD_NUMBER}"
 docker_ubuntu_bionic_image_tag="$registry:ubuntu-18.04-build-${BUILDKITE_BUILD_NUMBER}"
 docker_ubuntu_focal_image_tag="$registry:ubuntu-20.04-build-${BUILDKITE_BUILD_NUMBER}"
+docker_ubuntu_jammy_image_tag="$registry:ubuntu-22.04-build-${BUILDKITE_BUILD_NUMBER}"
+
 docker_sidecar_image_tag="$registry:sidecar-build-${BUILDKITE_BUILD_NUMBER}"
 
 is_prerelease=0
@@ -24,6 +26,7 @@ echo "Build version: $build_version"
 echo "Docker Alpine Image Tag: $docker_alpine_image_tag"
 echo "Docker Ubuntu 18.04 Image Tag: $docker_ubuntu_bionic_image_tag"
 echo "Docker Ubuntu 20.04 Image Tag: $docker_ubuntu_focal_image_tag"
+echo "Docker Ubuntu 22.04 Image Tag: $docker_ubuntu_jammy_image_tag"
 echo "Docker Sidecar Image Tag: $docker_sidecar_image_tag"
 echo "Is prerelease? $is_prerelease"
 
@@ -34,5 +37,6 @@ buildkite-agent meta-data set "agent-docker-image-alpine" "$docker_alpine_image_
 buildkite-agent meta-data set "agent-docker-image-alpine-k8s" "$docker_alpine_k8s_image_tag"
 buildkite-agent meta-data set "agent-docker-image-ubuntu-18.04" "$docker_ubuntu_bionic_image_tag"
 buildkite-agent meta-data set "agent-docker-image-ubuntu-20.04" "$docker_ubuntu_focal_image_tag"
+buildkite-agent meta-data set "agent-docker-image-ubuntu-22.04" "$docker_ubuntu_jammy_image_tag"
 buildkite-agent meta-data set "agent-docker-image-sidecar" "$docker_sidecar_image_tag"
 buildkite-agent meta-data set "agent-is-prerelease" "$is_prerelease"

--- a/.buildkite/steps/publish-docker-image.sh
+++ b/.buildkite/steps/publish-docker-image.sh
@@ -64,8 +64,8 @@ if [[ "$codename" == "stable" ]] ; then
   done
   release_image "${variant}"
 
-  # publish bare 'ubuntu' only from ubuntu-20.04
-  if [[ "$variant" == "ubuntu-20.04" ]] ; then
+  # publish bare 'ubuntu' only from ubuntu-22.04
+  if [[ "$variant" == "ubuntu-22.04" ]] ; then
     for tag in $(parse_version "$version") ; do
       release_image "${tag}-ubuntu"
     done

--- a/.buildkite/steps/publish-docker-images.sh
+++ b/.buildkite/steps/publish-docker-images.sh
@@ -23,7 +23,7 @@ aws ssm get-parameter --name /pipelines/agent/DOCKER_HUB_PASSWORD --with-decrypt
 version=$(buildkite-agent meta-data get "agent-version")
 build=$(buildkite-agent meta-data get "agent-version-build")
 
-for variant in "alpine" "alpine-k8s" "ubuntu-18.04" "ubuntu-20.04" "sidecar" ; do
+for variant in "alpine" "alpine-k8s" "ubuntu-18.04" "ubuntu-20.04" "ubuntu-22.04" "sidecar" ; do
   echo "--- Getting docker image tag for $variant from build meta data"
   source_image=$(buildkite-agent meta-data get "agent-docker-image-$variant")
   echo "Docker Image Tag for $variant: $source_image"

--- a/.buildkite/steps/upload-release-steps.sh
+++ b/.buildkite/steps/upload-release-steps.sh
@@ -31,6 +31,7 @@ trigger_step() {
         'agent-docker-image-alpine-k8s': "${agent_docker_image_alpine_k8s}"
         'agent-docker-image-ubuntu-18.04': "${agent_docker_image_ubuntu_bionic}"
         'agent-docker-image-ubuntu-20.04': "${agent_docker_image_ubuntu_focal}"
+        'agent-docker-image-ubuntu-22.04': "${agent_docker_image_ubuntu_jammy}"
         agent-docker-image-sidecar: "${agent_docker_image_sidecar}"
         agent-is-prerelease: "${agent_is_prerelease}"
       env:
@@ -82,6 +83,7 @@ agent_docker_image_alpine=$(buildkite-agent meta-data get "agent-docker-image-al
 agent_docker_image_alpine_k8s=$(buildkite-agent meta-data get "agent-docker-image-alpine-k8s")
 agent_docker_image_ubuntu_bionic=$(buildkite-agent meta-data get "agent-docker-image-ubuntu-18.04")
 agent_docker_image_ubuntu_focal=$(buildkite-agent meta-data get "agent-docker-image-ubuntu-20.04")
+agent_docker_image_ubuntu_jammy=$(buildkite-agent meta-data get "agent-docker-image-ubuntu-22.04")
 agent_docker_image_sidecar=$(buildkite-agent meta-data get "agent-docker-image-sidecar")
 agent_is_prerelease=$(buildkite-agent meta-data get "agent-is-prerelease")
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,12 @@ updates:
     ignore:
       - dependency-name: ubuntu
   - package-ecosystem: "docker"
+    directory: /packaging/docker/ubuntu-22.04
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: ubuntu
+  - package-ecosystem: "docker"
     directory: /.buildkite
     schedule:
       interval: "monthly"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ For example, agent version 3.30.0 is published as:
 - Alpine 3.12
 - Ubuntu 18.04 LTS (x86_64), supported to end of life for 18.04
 - Ubuntu 20.04 LTS (x86_64), supported to end of life for 20.04
+- Ubuntu 22.04 LTS (x86_64), supported to end of life for 22.04
 
 ## Starting
 

--- a/packaging/docker/ubuntu-22.04/Dockerfile
+++ b/packaging/docker/ubuntu-22.04/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1.4
+
+FROM ubuntu:22.04
+
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DOCKER_COMPOSE_VERSION=1.27.4
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    gnupg-agent \
+    jq \
+    openssh-client \
+    perl \
+    python \
+    python3-pip \
+    rsync \
+    software-properties-common \
+    tini \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+    && add-apt-repository \
+    "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip3 install docker-compose==$DOCKER_COMPOSE_VERSION
+
+ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \
+    PATH="/usr/local/bin:${PATH}"
+
+RUN ln -s /usr/bin/tini /usr/sbin/tini
+
+RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
+    && curl -Lfs -o /usr/local/bin/ssh-env-config.sh https://raw.githubusercontent.com/buildkite/docker-ssh-env-config/master/ssh-env-config.sh \
+    && chmod +x /usr/local/bin/ssh-env-config.sh
+
+COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
+COPY ./buildkite-agent-$TARGETOS-$TARGETARCH /usr/local/bin/buildkite-agent
+COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
+
+VOLUME /buildkite
+ENTRYPOINT ["buildkite-agent-entrypoint"]
+CMD ["start"]

--- a/packaging/docker/ubuntu-22.04/Dockerfile
+++ b/packaging/docker/ubuntu-22.04/Dockerfile
@@ -5,40 +5,48 @@ FROM ubuntu:22.04
 ARG TARGETOS
 ARG TARGETARCH
 
-ENV DEBIAN_FRONTEND=noninteractive
-ENV DOCKER_COMPOSE_VERSION=1.27.4
+ARG DOCKER_COMPOSE_VERSION=1.27.4
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    apt-transport-https \
-    bash \
-    ca-certificates \
-    curl \
-    git \
-    gnupg-agent \
-    jq \
-    openssh-client \
-    perl \
-    python3 \
-    python3-pip \
-    rsync \
-    software-properties-common \
-    tini \
-    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
-    && add-apt-repository \
-    "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip3 install docker-compose==$DOCKER_COMPOSE_VERSION
+SHELL [ "bash", "-euc" ]
+
+RUN <<BASH
+export DEBIAN_FRONTEND=noninteractive
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+add-apt-repository "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+
+apt-get update
+apt-get install -y --no-install-recommends \
+  apt-transport-https \
+  bash \
+  ca-certificates \
+  curl \
+  docker-ce-cli \
+  docker-compose-plugin \
+  git \
+  gnupg-agent \
+  jq \
+  openssh-client \
+  perl \
+  python3 \
+  python3-pip \
+  rsync \
+  software-properties-common \
+  tini
+
+rm -rf /var/lib/apt/lists/*
+
+pip3 install docker-compose==$DOCKER_COMPOSE_VERSION
+
+ln -s /usr/bin/tini /usr/sbin/tini
+
+mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins
+curl -Lfs -o /usr/local/bin/ssh-env-config.sh https://raw.githubusercontent.com/buildkite/docker-ssh-env-config/master/ssh-env-config.sh
+chmod +x /usr/local/bin/ssh-env-config.sh
+BASH
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \
     PATH="/usr/local/bin:${PATH}"
-
-RUN ln -s /usr/bin/tini /usr/sbin/tini
-
-RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
-    && curl -Lfs -o /usr/local/bin/ssh-env-config.sh https://raw.githubusercontent.com/buildkite/docker-ssh-env-config/master/ssh-env-config.sh \
-    && chmod +x /usr/local/bin/ssh-env-config.sh
 
 COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
 COPY ./buildkite-agent-$TARGETOS-$TARGETARCH /usr/local/bin/buildkite-agent

--- a/packaging/docker/ubuntu-22.04/Dockerfile
+++ b/packaging/docker/ubuntu-22.04/Dockerfile
@@ -7,13 +7,12 @@ ARG TARGETARCH
 
 ARG DOCKER_COMPOSE_VERSION=1.27.4
 
-SHELL [ "bash", "-euc" ]
-
 RUN <<BASH
-export DEBIAN_FRONTEND=noninteractive
+#!/usr/bin/env bash
 
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-add-apt-repository "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+set -eufo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install -y --no-install-recommends \
@@ -21,8 +20,6 @@ apt-get install -y --no-install-recommends \
   bash \
   ca-certificates \
   curl \
-  docker-ce-cli \
-  docker-compose-plugin \
   git \
   gnupg-agent \
   jq \
@@ -34,6 +31,10 @@ apt-get install -y --no-install-recommends \
   software-properties-common \
   tini
 
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+add-apt-repository "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+apt-get update
+apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin
 rm -rf /var/lib/apt/lists/*
 
 pip3 install docker-compose==$DOCKER_COMPOSE_VERSION

--- a/packaging/docker/ubuntu-22.04/Dockerfile
+++ b/packaging/docker/ubuntu-22.04/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     openssh-client \
     perl \
-    python \
+    python3 \
     python3-pip \
     rsync \
     software-properties-common \

--- a/packaging/docker/ubuntu-22.04/buildkite-agent.cfg
+++ b/packaging/docker/ubuntu-22.04/buildkite-agent.cfg
@@ -1,0 +1,67 @@
+# The token from your Buildkite "Agents" page
+#token="xxx"
+
+# The name of the agent
+name="%hostname-%spawn"
+
+# The number of agents to spawn in parallel (default is "1")
+# spawn=1
+
+# The priority of the agent (higher priorities are assigned work first)
+# priority=1
+
+# Tags for the agent (default is "queue=default")
+# tags="key1=val2,key2=val2"
+
+# Include the host's EC2 meta-data as tags (instance-id, instance-type, and ami-id)
+# tags-from-ec2=true
+
+# Include the host's EC2 tags as tags
+# tags-from-ec2-tags=true
+
+# Include the host's Google Cloud instance meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
+# tags-from-gcp=true
+
+# Include the host's Google Cloud instance labels as tags
+# tags-from-gcp-labels=true
+
+# Path to a custom bootstrap command to run. By default this is `buildkite-agent bootstrap`.
+# This allows you to override the entire execution of a job. Generally you should use hooks instead!
+# See https://buildkite.com/docs/agent/hooks
+# bootstrap-script=""
+
+# Path to where the builds will run from
+build-path="/buildkite/builds"
+
+# Directory where the hook scripts are found
+hooks-path="/buildkite/hooks"
+
+# Directory where plugins will be installed
+plugins-path="/buildkite/plugins"
+
+# Flags to pass to the `git clone` command
+# git-clone-flags=-v
+
+# Flags to pass to the `git clean` command
+# git-clean-flags=-ffxdq
+
+# Do not run jobs within a pseudo terminal
+# no-pty=true
+
+# Don't automatically verify SSH fingerprints
+# no-automatic-ssh-fingerprint-verification=true
+
+# Don't allow this agent to run arbitrary console commands
+# no-command-eval=true
+
+# Don't allow this agent to run plugins
+# no-plugins=true
+
+# Enable debug mode
+# debug=true
+
+# Don't show colors in logging
+# no-color=true
+
+# If set and valid, the given tracing backend will be enabled. Eg: datadog
+# tracing-backend=""

--- a/packaging/docker/ubuntu-22.04/entrypoint.sh
+++ b/packaging/docker/ubuntu-22.04/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+DIR=/docker-entrypoint.d
+
+if [[ -d "$DIR" ]] ; then
+  echo "Executing scripts in $DIR"
+  /bin/run-parts --exit-on-error "$DIR"
+fi
+
+exec /usr/bin/tini -- ssh-env-config.sh /usr/local/bin/buildkite-agent "$@"


### PR DESCRIPTION
Provide the agent on an Ubuntu 22.04 image.

There were some complications with building a multiarch image for Ubuntu 22.04.
The version of qemu on the agent's instance is out of date an this is the most likely reason for the failure.
We attempted to solve this at the Elastic CI Stack level, but to no avail.

We had more success with upgrading binfmt in the build script, so that is what we do in this PR.
For more details about the solution see https://github.com/docker/buildx/issues/314.