### PR TITLE
Fix extra pipeline uploaded in fallback upload flow

### DIFF
--- a/agent/pipeline_uploader.go
+++ b/agent/pipeline_uploader.go
@@ -35,14 +35,14 @@ type PipelineUploader struct {
 //
 // There are 3 "routes" that are relevant
 // 1. Async Route:  /jobs/:job_uuid/pipelines?async=true
-// 2. Upload Route: /jobs/:job_uuid/pipelines
+// 2. Sync Route: /jobs/:job_uuid/pipelines
 // 3. Status Route: /jobs/:job_uuid/pipelines/:upload_uuid
 //
 // In this method, the agent will first upload the pipeline to the Async Route.
 // Then, depending on the response it will behave differetly
 //
 // 1. The Async Route responds 202: poll the Status Route until the upload has beed "applied"
-// 2. The Async Route responds with other 2xx: exit, the upload succeeded synchronously
+// 2. The Async Route responds with other 2xx: exit, the upload succeeded synchronously (possibly after retry)
 // 3. The Async Route responds with other xxx: retry uploading the pipeine to the Async Route
 func (u *PipelineUploader) AsyncUploadFlow(ctx context.Context, l logger.Logger) error {
 	result, err := u.pipelineUploadAsyncWithRetry(ctx, l)

--- a/agent/pipeline_uploader_test.go
+++ b/agent/pipeline_uploader_test.go
@@ -175,7 +175,7 @@ steps:
 				return
 			}
 		case fmt.Sprintf("/jobs/%s/pipelines/%s", jobID, stepUploadUUID):
-			assert.Fail(t, "should not call the async route")
+			assert.Fail(t, "should not call the status route")
 			http.Error(rw, "This route should not have been called", http.StatusServiceUnavailable)
 			return
 		}

--- a/agent/pipeline_uploader_test.go
+++ b/agent/pipeline_uploader_test.go
@@ -153,7 +153,7 @@ func TestFallbackPipelineUpload(t *testing.T) {
 		num529s         int
 		expectedSleeps  []time.Duration
 		expectedUploads int
-		errStatus       *int
+		errStatus       int // 0 indicates no error should occur
 	}{
 		{
 			name:            "happy",
@@ -178,7 +178,7 @@ func TestFallbackPipelineUpload(t *testing.T) {
 			num529s:         61,
 			expectedSleeps:  genSleeps(59, 5*time.Second),
 			expectedUploads: 60,
-			errStatus:       func(i int) *int { return &i }(529),
+			errStatus:       529,
 		},
 	} {
 		test := test
@@ -266,14 +266,14 @@ steps:
 			}
 
 			err = uploader.AsyncUploadFlow(ctx, l)
-			if test.errStatus == nil {
+			if test.errStatus == 0 {
 				assert.NoError(t, err)
 			} else {
 				assert.True(
 					t,
-					api.IsErrHavingStatus(err, *test.errStatus),
+					api.IsErrHavingStatus(err, test.errStatus),
 					"expected api error with status: %d, received: %v",
-					*test.errStatus, err,
+					test.errStatus, err,
 				)
 			}
 			assert.Equal(t, test.expectedSleeps, retrySleeps)

--- a/agent/pipeline_uploader_test.go
+++ b/agent/pipeline_uploader_test.go
@@ -140,9 +140,54 @@ func TestFallbackPipelineUpload(t *testing.T) {
 	ctx := context.Background()
 	l := clicommand.CreateLogger(&clicommand.PipelineUploadConfig{LogLevel: "notice"})
 
-	jobID := api.NewUUID()
-	stepUploadUUID := api.NewUUID()
-	pipelineStr := `---
+	genSleeps := func(n int, s time.Duration) []time.Duration {
+		sleeps := make([]time.Duration, 0, n)
+		for i := 0; i < n; i++ {
+			sleeps = append(sleeps, s)
+		}
+		return sleeps
+	}
+
+	for _, test := range []struct {
+		name            string
+		num529s         int
+		expectedSleeps  []time.Duration
+		expectedUploads int
+		errStatus       *int
+	}{
+		{
+			name:            "happy",
+			num529s:         0,
+			expectedSleeps:  []time.Duration{},
+			expectedUploads: 1,
+		},
+		{
+			name:            "59_529s",
+			num529s:         59,
+			expectedSleeps:  genSleeps(58, 5*time.Second),
+			expectedUploads: 59,
+		},
+		{
+			name:            "60_529s",
+			num529s:         60,
+			expectedSleeps:  genSleeps(59, 5*time.Second),
+			expectedUploads: 60,
+		},
+		{
+			name:            "61_529s",
+			num529s:         61,
+			expectedSleeps:  genSleeps(59, 5*time.Second),
+			expectedUploads: 60,
+			errStatus:       func(i int) *int { return &i }(529),
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			jobID := api.NewUUID()
+			stepUploadUUID := api.NewUUID()
+			pipelineStr := `---
 steps:
   - name: ":s3: xxx"
     command: "script/buildkite/xxx.sh"
@@ -163,53 +208,75 @@ steps:
     agents:
       queue: xxx`
 
-	parser := agent.PipelineParser{Pipeline: []byte(pipelineStr), Env: nil}
-	pipeline, err := parser.Parse()
-	assert.NoError(t, err)
+			parser := agent.PipelineParser{Pipeline: []byte(pipelineStr), Env: nil}
+			pipeline, err := parser.Parse()
+			assert.NoError(t, err)
 
-	countUploadCalls := 0
-	maxUploadCalls := 1
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		switch req.URL.Path {
-		case fmt.Sprintf("/jobs/%s/pipelines", jobID):
-			if req.Method == "POST" {
-				countUploadCalls++
-				if countUploadCalls > maxUploadCalls {
-					http.Error(rw, `{"message":"too many call to pipeline upload"}`, http.StatusBadRequest)
-					return
-				}
-				rw.WriteHeader(http.StatusOK)
-				return
+			countUploadCalls := 0
+			server := httptest.NewServer(
+				http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+					switch req.URL.Path {
+					case fmt.Sprintf("/jobs/%s/pipelines", jobID):
+						if req.Method == "POST" {
+							countUploadCalls++
+							if countUploadCalls < test.num529s {
+								http.Error(rw, `{"message":"still waiting"}`, 529)
+								return
+							}
+							if countUploadCalls > test.expectedUploads {
+								http.Error(
+									rw,
+									`{"message":"too many calls to pipeline upload"}`,
+									http.StatusBadRequest,
+								)
+								return
+							}
+							rw.WriteHeader(http.StatusOK)
+							return
+						}
+					case fmt.Sprintf("/jobs/%s/pipelines/%s", jobID, stepUploadUUID):
+						assert.Fail(t, "should not call the status route")
+						http.Error(
+							rw,
+							"This route should not have been called",
+							http.StatusServiceUnavailable,
+						)
+						return
+					}
+					t.Errorf("Unknown endpoint %s %s", req.Method, req.URL.Path)
+					http.Error(rw, "Not found", http.StatusNotFound)
+				}),
+			)
+			defer server.Close()
+
+			retrySleeps := []time.Duration{}
+			uploader := &agent.PipelineUploader{
+				Client: api.NewClient(logger.Discard, api.Config{
+					Endpoint: server.URL,
+					Token:    "llamas",
+				}),
+				JobID: jobID,
+				Change: &api.PipelineChange{
+					UUID:     stepUploadUUID,
+					Pipeline: pipeline,
+				},
+				RetrySleepFunc: func(d time.Duration) {
+					retrySleeps = append(retrySleeps, d)
+				},
 			}
-		case fmt.Sprintf("/jobs/%s/pipelines/%s", jobID, stepUploadUUID):
-			assert.Fail(t, "should not call the status route")
-			http.Error(rw, "This route should not have been called", http.StatusServiceUnavailable)
-			return
-		}
-		t.Errorf("Unknown endpoint %s %s", req.Method, req.URL.Path)
-		http.Error(rw, "Not found", http.StatusNotFound)
-	}))
-	defer server.Close()
 
-	retrySleeps := []time.Duration{}
-	uploader := &agent.PipelineUploader{
-		Client: api.NewClient(logger.Discard, api.Config{
-			Endpoint: server.URL,
-			Token:    "llamas",
-		}),
-		JobID: jobID,
-		Change: &api.PipelineChange{
-			UUID:     stepUploadUUID,
-			Pipeline: pipeline,
-		},
-		RetrySleepFunc: func(d time.Duration) {
-			retrySleeps = append(retrySleeps, d)
-		},
+			err = uploader.AsyncUploadFlow(ctx, l)
+			if test.errStatus == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.True(
+					t,
+					api.IsErrHavingStatus(err, *test.errStatus),
+					"expected api error with status: %d, received: %v",
+					*test.errStatus, err,
+				)
+			}
+			assert.Equal(t, test.expectedSleeps, retrySleeps)
+		})
 	}
-
-	expectedSleeps := []time.Duration{}
-
-	err = uploader.AsyncUploadFlow(ctx, l)
-	assert.NoError(t, err)
-	assert.Equal(t, expectedSleeps, retrySleeps)
 }

--- a/agent/pipeline_uploader_test.go
+++ b/agent/pipeline_uploader_test.go
@@ -167,10 +167,17 @@ steps:
 	pipeline, err := parser.Parse()
 	assert.NoError(t, err)
 
+	countUploadCalls := 0
+	maxUploadCalls := 1
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
 		case fmt.Sprintf("/jobs/%s/pipelines", jobID):
 			if req.Method == "POST" {
+				countUploadCalls++
+				if countUploadCalls > maxUploadCalls {
+					http.Error(rw, `{"message":"too many call to pipeline upload"}`, http.StatusBadRequest)
+					return
+				}
 				rw.WriteHeader(http.StatusOK)
 				return
 			}


### PR DESCRIPTION
I made a snafu in https://github.com/buildkite/agent/pull/1927 that meant that if the API only supported the old upload flow, the pipeline would be uploaded once more than necessary.

This is evidenced by the failure of the test in this build: https://buildkite.com/buildkite/agent/builds/5316.

This is not impacting the correctness of uploads, as they are deduped by a UUID would have been the same between all the uploads. However, it is not necessary to perform the extra upload, so let's remove it.