### PR TITLE
Use sh instead of bash in RunScript

### DIFF
--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -376,7 +376,7 @@ func (s *Shell) RunScript(ctx context.Context, path string, extra env.Environmen
 		args = []string{"-file", path}
 
 	case !isWindows && isBash:
-		bashPath, err := s.AbsolutePath("bash")
+		bashPath, err := s.AbsolutePath("sh")
 		if err != nil {
 			return fmt.Errorf("Error finding bash, needed to run scripts: %v.", err)
 		}


### PR DESCRIPTION
To allow building in docker images without bash (e.g. alpine). While this should respect `BUILDKITE_SHELL`, it did not before, so I'm not going to make it do so here.