### PR TITLE
Revert "Use sh instead of bash in RunScript"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Upstart is no longer supported [#1946](https://github.com/buildkite/agent/pull/1946) (@sj26)
-- For increased compatibility with various container images, `sh` is used instead of `bash` [#1974](https://github.com/buildkite/agent/pull/1974) (@triarius)
 - `pipeline upload` internally uses a new asynchronous upload flow, reducing the number of connections held open [#1927](https://github.com/buildkite/agent/pull/1927) (@triarius)
 - Faster failure when trying to `pipeline upload` a malformed pipeline [#1963](https://github.com/buildkite/agent/pull/1963) (@triarius)
 - Better errors when config loading fails [#1937](https://github.com/buildkite/agent/pull/1937) (@moskyb)

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -376,7 +376,7 @@ func (s *Shell) RunScript(ctx context.Context, path string, extra env.Environmen
 		args = []string{"-file", path}
 
 	case !isWindows && isBash:
-		bashPath, err := s.AbsolutePath("sh")
+		bashPath, err := s.AbsolutePath("bash")
 		if err != nil {
 			return fmt.Errorf("Error finding bash, needed to run scripts: %v.", err)
 		}


### PR DESCRIPTION
Reverts buildkite/agent#1974

This might need further consideration.

When testing on a (what I consider fairly stock-standard) Debian machine I have handy, my (what I consider perfectly reasonable) command hook:

```shell
#!/bin/bash
set -euo pipefail
...snip...
```

fails with the error:

```
/tmp/buildkite-agent-bootstrap-hook-runner-3400400749: 2: set: Illegal option -o pipefail
```

because it turns out that `/bin/sh` is symlinked to `dash`, not `bash`, and I think `RunScript` passes scripts directly to whatever shell binary it picks.
