### PR TITLE
clicommand/bootstrap.go: Change backticks to primes

### DIFF
--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -232,7 +232,7 @@ var BootstrapCommand = cli.Command{
 		cli.StringSliceFlag{
 			Name:   "git-submodule-clone-config",
 			Value:  &cli.StringSlice{},
-			Usage:  "Comma separated key=value git config pairs applied before git submodule clone commands, e.g. `update --init`. If the config is needed to be applied to all git commands, supply it in a global git config file for the system that the agent runs in instead.",
+			Usage:  "Comma separated key=value git config pairs applied before git submodule clone commands, e.g. ′update --init′. If the config is needed to be applied to all git commands, supply it in a global git config file for the system that the agent runs in instead.",
 			EnvVar: "BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG",
 		},
 		cli.StringFlag{


### PR DESCRIPTION
See prime-signs.md.