### PR TITLE
remove remote add from ref repo submodule handling

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1430,7 +1430,7 @@ func (b *Bootstrap) defaultCheckoutPhase(ctx context.Context) error {
 			b.shell.Warningf("Failed to enumerate git submodules: %v", err)
 		} else {
 			mirrorSubmodules := experiments.IsEnabled(`git-mirrors`) && b.Config.GitMirrorsPath != ""
-			for idx, repository := range submoduleRepos {
+			for _, repository := range submoduleRepos {
 				submoduleArgs := append([]string(nil), args...)
 				// submodules might need their fingerprints verified too
 				if b.SSHKeyscan {
@@ -1444,15 +1444,6 @@ func (b *Bootstrap) defaultCheckoutPhase(ctx context.Context) error {
 					// Switch back to the checkout dir, doing other operations from GitMirrorsPath will fail.
 					if err := b.createCheckoutDir(); err != nil {
 						return err
-					}
-					name := fmt.Sprintf("submodule-%d", idx+1)
-					if err := b.shell.Run(ctx, "git", "--git-dir", mirrorDir, "remote", "add", name, repository); err != nil {
-						// Per https://git-scm.com/docs/git-remote#_exit_status: When the remote already exists, the exit status is 3
-						// That shouldn't be a fatal error in this case, so ignore it.
-						if shell.GetExitCode(err) != 3 {
-							return err
-						}
-						b.shell.Commentf("Skipping adding %s as the remote %s as it already exists", repository, name)
 					}
 					// Tests use a local temp path for the repository, real repositories don't. Handle both.
 					var repositoryPath string

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -238,7 +238,6 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 			{"submodule", "sync", "--recursive"},
 			{"config", "--file", ".gitmodules", "--null", "--get-regexp", "submodule\\..+\\.url"},
 			{"-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--force", "--reference", submoduleRepo.Path},
-			{"--git-dir", matchSubDir(tester.GitMirrorsDir), "remote", "add", "submodule-1", submoduleRepo.Path},
 			{"submodule", "foreach", "--recursive", "git reset --hard"},
 			{"clean", "-fdq"},
 			{"submodule", "foreach", "--recursive", "git clean -fdq"},


### PR DESCRIPTION
Hi, it's me again :wave:

After rolling out v3.44.0 of the agent in our production environment, I found yet another bug in my latest attempt at the deceptively complex task of supporting reference repositories for submodules. It's less bad than the previous ones, but still! :cry: [This call](https://github.com/buildkite/agent/blob/ccbe12d16daf6760779bc26ad99c3330b902cfed/bootstrap/bootstrap.go#L1440) to `getOrUpdateMirrorDir` can return an empty string for `mirrorDir` if the mirror doesn't exist, and then we don't check the value of `mirrorDir` before we attempt to use it [here](https://github.com/buildkite/agent/blob/ccbe12d16daf6760779bc26ad99c3330b902cfed/bootstrap/bootstrap.go#L1449).

Luckily it seems like that's only a problem in the case that someone:

1. has enabled the `git-mirror` experiment
2. configured the `git-mirror` experiment to skip updating the mirrors
3. has submodules as part of their repository
4. the mirror for the submodule doesn't exist yet

If all those conditions are true, then we try to run the below command with an empty string as the argument to `--git-dir` :disappointed:

```
$ git --git-dir  remote add submodule-1 git@github.com:foo/some-repo.git
fatal: not a git repository: ''
⚠️ Warning: Checkout failed! exit status 128 (Attempt 1/3 Retrying in 2s)
```

Normally the fix for that would be to wrap that whole block in a `if mirrorDir != ""` conditional, but an astute colleague pointed out that the `remote add...` step probably isn't actually necessary. That is, if you skip directly to `git submodule update --init --recursive...` then the correct remote gets added to the main repo's config. Also, it probably doesn't make a lot of sense to add a remote for the submodule's repository to the _mirror_ of the submodule repository anyway? For example, here's what the `config` looks like for a submodule repository's mirror with the current code:

```ini
[core]
	repositoryformatversion = 0
	filemode = true
	bare = true
[remote "origin"]
	url = git@github.com:org/repo-name.git
	fetch = +refs/*:refs/*
	mirror = true
[remote "submodule-1"]
	url = git@github.com:org/repo-name.git
	fetch = +refs/heads/*:refs/remotes/submodule-1/*
```

I don't think that additional `submodule-1` remote is ever going to get used. Pretty sure I cargo-culted the `remote add...` bit from the [initial discarded implementation of reference repositories for submodules](https://github.com/buildkite/agent/pull/936/commits/93b80d25187a9f03901a0976ca5590efecc80054) and looking at it now with more experience/context, it seems like that code was attempting to add a remote for the submodule's repository to the _main_ repository's mirror, which is not the same situation we have now.

Removing the `remote add....` call is also important because in our case, the reference repositories for agents running on k8s are on an NFS share, but the volume gets mounted read-only so attempting to add the remote will always fail because `git` needs write access to be able to lock the repository's config file.

Hope this makes sense, happy to have a more involved discusssion if necessary.
