### PR TITLE
Extend lock to image building

### DIFF
--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -60,61 +60,74 @@ builder_name=$(docker buildx create --use)
 # shellcheck disable=SC2064 # we want the current $builder_name to be trapped, not the runtime one
 trap "docker buildx rm $builder_name || true" EXIT
 
-# Needed a more recent version of QEMU than what's on the host for building multiarch images.
-# See https://github.com/docker/buildx/issues/314
-QEMU_VERSION=6.2.0
-echo "--- Installing QEMU $QEMU_VERSION"
 # There isn't a good way to see if this script has already installed qemu-binfmt.
 # So we uninstall and install it each time. This would create a race condition between the
-# uninstall and install if multiple agents are running on an agent's host.
+# uninstall, install, and image building if multiple agents are running on an agent's host.
 #
-# Thus, we use flock(1) to hold an exclusive lock while this is happening.
+# Thus, we use flock(1) to hold an exclusive lock while any of these are happening.
 # The syntax is a bit arcane, but the jist is:
 # ```bash
 # (
 #   flock -x "$variable"
-#   commands to run under lock
+#
+#   ...commands to run under lock...
+#
 # ) {variable}>filename
 # ```
-# This first set of round braces run the commands in a subshell. In the subshell, flock(1) is
-# executed with a file descriptor number. This will wait for the lock. The lock will be released
-# by the kernel when the subshell exists (and the file descriptor is closed).
+# The parens run the commands in a subshell. In the subshell, flock(1) is executed with a file
+# descriptor number. This will wait for the lock. The lock will be released by the kernel when the
+# subshell exits (and the file descriptor is closed).
 # See https://linux.die.net/man/1/flock, in particular the "third form".
 #
 # The curly braces are an automatic file descriptor allocation introduced in bash 4.1.
 # See https://wiki.bash-hackers.org/scripting/bashchanges
 # Finally, the file with the path `filename` in the filesystem is opened with that file descriptor.
+LOCKFILE_NAME=/tmp/install-qemu-binfmt.lock
 (
-  echo Obtaining lock with file descriptor "$file_descriptor" at
   flock -x "$file_descriptor"
+
+  # Need a more recent version of QEMU than what's on the host for building multiarch images.
+  # See https://github.com/docker/buildx/issues/314
+  QEMU_VERSION=6.2.0
+  echo "--- Installing QEMU $QEMU_VERSION"
   docker run --privileged --userns=host --rm "tonistiigi/binfmt:qemu-v$QEMU_VERSION" --uninstall qemu-*
   docker run --privileged --userns=host --rm "tonistiigi/binfmt:qemu-v$QEMU_VERSION" --install all
-) {file_descriptor}>/tmp/install-qemu-binfmt.flock
+) {file_descriptor}>"$LOCKFILE_NAME"
 
-echo "--- Building :docker: $image_tag"
+echo "--- Copying files into build context"
 cp -a packaging/linux/root/usr/share/buildkite-agent/hooks/ "${packaging_dir}/hooks/"
 cp pkg/buildkite-agent-linux-{amd64,arm64} "$packaging_dir"
 
-# Build images for all architectures
-docker buildx build --progress plain --builder "$builder_name" --platform linux/amd64,linux/arm64 "$packaging_dir"
+(
+  flock -x "$file_descriptor"
+
+  echo "--- Building :docker: $image_tag for all architectures"
+  docker buildx build --progress plain --builder "$builder_name" --platform linux/amd64,linux/arm64 "$packaging_dir"
+) {file_descriptor}>"$LOCKFILE_NAME"
+
 # Tag images for just the native architecture. There is a limitation in docker that prevents this
 # from being done in one command. Luckliy the second build will be quick because of docker layer caching
+# As this is just a native build, we don't need the lock.
 docker buildx build --progress plain --builder "$builder_name" --tag "$image_tag" --load "$packaging_dir"
 
-# Sanity check test before pushing. Only works for current arch. CI will test all arches as well.
+# Confidence check before pushing. Only works for current arch. CI will test all arches as well.
 .buildkite/steps/test-docker-image.sh "$variant" "$image_tag" "$(uname -m)"
 
-if [[ $push == "true" ]] ; then
-  echo "--- Pushing to ECR :ecr:"
-  # Do another build with all architectures. The layers should be cached from the previous build
-  # with all architectures.
-  # Pushing to the docker registry in this way greatly simplifies creating the manifest list on the
-  # docker registry so that either architecture can be pulled with the same tag.
-  docker buildx build \
-    --progress plain \
-    --builder "$builder_name" \
-    --tag "$image_tag" \
-    --platform linux/amd64,linux/arm64 \
-    --push \
-    "$packaging_dir"
+if [[ $push == "true" ]]; then
+  (
+    flock -x "$file_descriptor"
+
+    echo "--- Pushing to ECR :ecr:"
+    # Do another build with all architectures. The layers should be cached from the previous build
+    # with all architectures.
+    # Pushing to the docker registry in this way greatly simplifies creating the manifest list on
+    # the docker registry so that either architecture can be pulled with the same tag.
+    docker buildx build \
+      --progress plain \
+      --builder "$builder_name" \
+      --tag "$image_tag" \
+      --platform linux/amd64,linux/arm64 \
+      --push \
+      "$packaging_dir"
+  ) {file_descriptor}>"$LOCKFILE_NAME"
 fi


### PR DESCRIPTION
The race condition mentioned in https://github.com/buildkite/agent/pull/1990 can also happen while one worker is building an image (on a non-native architecture) and other is installing qemu-binfmt. So this PR protects those operations with flock as well.