### PR TITLE
More aws tags

### DIFF
--- a/agent/ec2_meta_data.go
+++ b/agent/ec2_meta_data.go
@@ -59,6 +59,16 @@ func (e EC2MetaData) Get() (map[string]string, error) {
 		metaData["aws:instance-life-cycle"] = string(instanceLifeCycle)
 	}
 
+	availabilityZone, err := c.GetMetadata("placement/availability-zone")
+	if err == nil {
+		metaData["aws:availability-zone"] = string(availabilityZone)
+	}
+
+	region, err := c.GetMetadata("placement/region")
+	if err == nil {
+		metaData["aws:region"] = string(region)
+	}
+
 	return metaData, nil
 }
 

--- a/agent/ec2_meta_data.go
+++ b/agent/ec2_meta_data.go
@@ -36,37 +36,20 @@ func (e EC2MetaData) Get() (map[string]string, error) {
 		return metaData, err
 	}
 
-	instanceId, err := c.GetMetadata("instance-id")
+	document, err := c.GetInstanceIdentityDocument()
 	if err != nil {
 		return metaData, err
 	}
-	metaData["aws:instance-id"] = string(instanceId)
 
-	instanceType, err := c.GetMetadata("instance-type")
-	if err != nil {
-		return metaData, err
-	}
-	metaData["aws:instance-type"] = string(instanceType)
-
-	amiId, err := c.GetMetadata("ami-id")
-	if err != nil {
-		return metaData, err
-	}
-	metaData["aws:ami-id"] = string(amiId)
+	metaData["aws:instance-id"] = string(document.InstanceID)
+	metaData["aws:instance-type"] = string(document.InstanceType)
+	metaData["aws:ami-id"] = string(document.ImageID)
+	metaData["aws:availability-zone"] = string(document.AvailabilityZone)
+	metaData["aws:region"] = string(document.Region)
 
 	instanceLifeCycle, err := c.GetMetadata("instance-life-cycle")
 	if err == nil {
 		metaData["aws:instance-life-cycle"] = string(instanceLifeCycle)
-	}
-
-	availabilityZone, err := c.GetMetadata("placement/availability-zone")
-	if err == nil {
-		metaData["aws:availability-zone"] = string(availabilityZone)
-	}
-
-	region, err := c.GetMetadata("placement/region")
-	if err == nil {
-		metaData["aws:region"] = string(region)
 	}
 
 	return metaData, nil

--- a/agent/ec2_meta_data.go
+++ b/agent/ec2_meta_data.go
@@ -41,15 +41,15 @@ func (e EC2MetaData) Get() (map[string]string, error) {
 		return metaData, err
 	}
 
-	metaData["aws:instance-id"] = string(document.InstanceID)
-	metaData["aws:instance-type"] = string(document.InstanceType)
-	metaData["aws:ami-id"] = string(document.ImageID)
-	metaData["aws:availability-zone"] = string(document.AvailabilityZone)
-	metaData["aws:region"] = string(document.Region)
+	metaData["aws:instance-id"] = document.InstanceID
+	metaData["aws:instance-type"] = document.InstanceType
+	metaData["aws:ami-id"] = document.ImageID
+	metaData["aws:availability-zone"] = document.AvailabilityZone
+	metaData["aws:region"] = document.Region
 
 	instanceLifeCycle, err := c.GetMetadata("instance-life-cycle")
 	if err == nil {
-		metaData["aws:instance-life-cycle"] = string(instanceLifeCycle)
+		metaData["aws:instance-life-cycle"] = instanceLifeCycle
 	}
 
 	return metaData, nil

--- a/agent/ecs_meta_data.go
+++ b/agent/ecs_meta_data.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	metadata "github.com/brunoscheufler/aws-ecs-metadata-go"
 	"net/http"
+	"strconv"
 )
 
 type ECSMetadata struct {
@@ -13,20 +14,46 @@ type ECSMetadata struct {
 func (e ECSMetadata) Get() (map[string]string, error) {
 	metaData := make(map[string]string)
 
-	ecsMeta, err := metadata.GetContainer(context.Background(), &http.Client{})
+	taskMeta, err := metadata.GetTask(context.Background(), &http.Client{})
 	if err != nil {
 		return metaData, err
 	}
 
-	switch m := ecsMeta.(type) {
+	switch m := taskMeta.(type) {
+	case *metadata.TaskMetadataV3:
+		metaData["ecs:task-arn"] = m.TaskARN
+		if m.Limits.CPU != 0 {
+			metaData["ecs:cpu-limit"] = strconv.FormatFloat(m.Limits.CPU, 'f', -1, 64)
+		}
+		if m.Limits.Memory != 0 {
+			metaData["ecs:memory-limit"] = strconv.Itoa(m.Limits.Memory)
+		}
+	case *metadata.TaskMetadataV4:
+		metaData["ecs:availability-zone"] = m.AvailabilityZone
+		metaData["ecs:launch-type"] = m.LaunchType
+		metaData["ecs:task-arn"] = m.TaskARN
+		if m.Limits.CPU != 0 {
+			metaData["ecs:cpu-limit"] = strconv.FormatFloat(m.Limits.CPU, 'f', -1, 64)
+		}
+		if m.Limits.Memory != 0 {
+			metaData["ecs:memory-limit"] = strconv.Itoa(m.Limits.Memory)
+		}
+	default:
+		return metaData, fmt.Errorf("ecs metadata returned unknown type %T", m)
+	}
+
+	containerMeta, err := metadata.GetContainer(context.Background(), &http.Client{})
+	if err != nil {
+		return metaData, err
+	}
+
+	switch m := containerMeta.(type) {
 	case *metadata.ContainerMetadataV3:
 		metaData["ecs:container-name"] = m.DockerName
 		metaData["ecs:image"] = m.Image
-		metaData["ecs:task-arn"] = m.Labels.EcsTaskArn
 	case *metadata.ContainerMetadataV4:
 		metaData["ecs:container-name"] = m.DockerName
 		metaData["ecs:image"] = m.Image
-		metaData["ecs:task-arn"] = m.Labels.EcsTaskArn
 	default:
 		return metaData, fmt.Errorf("ecs metadata returned unknown type %T", m)
 	}

--- a/agent/ecs_meta_data.go
+++ b/agent/ecs_meta_data.go
@@ -29,7 +29,11 @@ func (e ECSMetadata) Get() (map[string]string, error) {
 			metaData["ecs:memory-limit"] = strconv.Itoa(m.Limits.Memory)
 		}
 	case *metadata.TaskMetadataV4:
-		metaData["ecs:availability-zone"] = m.AvailabilityZone
+		// This might be missing on some versions of Fargate which
+		// seems to unmarshal as "true"
+		if m.AvailabilityZone != "true" {
+			metaData["ecs:availability-zone"] = m.AvailabilityZone
+		}
 		metaData["ecs:launch-type"] = m.LaunchType
 		metaData["ecs:task-arn"] = m.TaskARN
 		if m.Limits.CPU != 0 {

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/aws/aws-sdk-go v1.44.181 h1:w4OzE8bwIVo62gUTAp/uEFO2HSsUtf1pjXpSs36cl
 github.com/aws/aws-sdk-go v1.44.181/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf h1:WCnJxXZXx9c8gwz598wvdqmu+YTzB9wx2X1OovK3Le8=
 github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf/go.mod h1:CeKhh8xSs3WZAc50xABMxu+FlfAAd5PNumo7NfOv7EE=
+github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20221221133751-67e37ae746cd h1:C0dfBzAdNMqxokqWUysk2KTJSMmqvh9cNW1opdy5+0Q=
+github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20221221133751-67e37ae746cd/go.mod h1:CeKhh8xSs3WZAc50xABMxu+FlfAAd5PNumo7NfOv7EE=
 github.com/buildkite/bintest/v3 v3.1.1 h1:bS924OU8Ljm46DesONXzxxTBMjbliQRnPB+H4DOeUDE=
 github.com/buildkite/bintest/v3 v3.1.1/go.mod h1:T3Et1VwEizryWfwLLruFqExHsEU+wjkxOlL54283ccc=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=


### PR DESCRIPTION
Add some more meta-data tags to agents running on aws.

This switches ec2 meta-data to a single instance identity document which should be slightly more efficient, and adds some more useful meta-data including region and az when running on ec2.

This also upgrades the ecs metadata library we were using so it can grab task meta-data as well as container meta-data, and uses that to add availability zone, launch type (fargate or not) and cpu/memory limits ("size") there as well.

AWS have some example data here:

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v3.html#task-metadata-endpoint-v3-examples
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html#task-metadata-endpoint-v4-examples

and the ecs meta-data module is a useful reference:

https://github.com/BrunoScheufler/aws-ecs-metadata-go/blob/master/v3.go
https://github.com/BrunoScheufler/aws-ecs-metadata-go/blob/master/v4.go

The best way to test this is probably to run an agent in these environments. Does anyone have a handy way to do that?

Fixes PDP-627.