### PR TITLE
Fix submodule mirror repository remote using main repo URL

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1325,7 +1325,7 @@ func (b *Bootstrap) updateGitMirror(ctx context.Context, repository string) (str
 	b.shell.Commentf("Updating existing repository mirror to find commit %s", b.Commit)
 
 	// Update the origin of the repository so we can gracefully handle repository renames
-	if err := b.shell.Run(ctx, "git", "--git-dir", mirrorDir, "remote", "set-url", "origin", b.Repository); err != nil {
+	if err := b.shell.Run(ctx, "git", "--git-dir", mirrorDir, "remote", "set-url", "origin", repository); err != nil {
 		return "", err
 	}
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1329,17 +1329,19 @@ func (b *Bootstrap) updateGitMirror(ctx context.Context, repository string) (str
 		return "", err
 	}
 
-	if b.PullRequest != "false" && strings.Contains(b.PipelineProvider, "github") {
-		b.shell.Commentf("Fetch and mirror pull request head from GitHub")
-		refspec := fmt.Sprintf("refs/pull/%s/head", b.PullRequest)
-		// Fetch the PR head from the upstream repository into the mirror.
-		if err := b.shell.Run(ctx, "git", "--git-dir", mirrorDir, "fetch", "origin", refspec); err != nil {
-			return "", err
-		}
-	} else {
-		// Fetch the build branch from the upstream repository into the mirror.
-		if err := b.shell.Run(ctx, "git", "--git-dir", mirrorDir, "fetch", "origin", b.Branch); err != nil {
-			return "", err
+	if repository == b.Repository {
+		if b.PullRequest != "false" && strings.Contains(b.PipelineProvider, "github") {
+			b.shell.Commentf("Fetch and mirror pull request head from GitHub")
+			refspec := fmt.Sprintf("refs/pull/%s/head", b.PullRequest)
+			// Fetch the PR head from the upstream repository into the mirror.
+			if err := b.shell.Run(ctx, "git", "--git-dir", mirrorDir, "fetch", "origin", refspec); err != nil {
+				return "", err
+			}
+		} else {
+			// Fetch the build branch from the upstream repository into the mirror.
+			if err := b.shell.Run(ctx, "git", "--git-dir", mirrorDir, "fetch", "origin", b.Branch); err != nil {
+				return "", err
+			}
 		}
 	}
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1256,6 +1256,7 @@ func hasGitCommit(ctx context.Context, sh *shell.Shell, gitDir string, commit st
 func (b *Bootstrap) updateGitMirror(ctx context.Context, repository string) (string, error) {
 	// Create a unique directory for the repository mirror
 	mirrorDir := filepath.Join(b.Config.GitMirrorsPath, dirForRepository(repository))
+	isMainRepository := repository == b.Repository
 
 	// Create the mirrors path if it doesn't exist
 	if baseDir := filepath.Dir(mirrorDir); !utils.FileExists(baseDir) {
@@ -1300,9 +1301,11 @@ func (b *Bootstrap) updateGitMirror(ctx context.Context, repository string) (str
 	mirrorCloneLock.Unlock()
 
 	// Check if the mirror has a commit, this is atomic so should be safe to do
-	if hasGitCommit(ctx, b.shell, mirrorDir, b.Commit) {
-		b.shell.Commentf("Commit %q exists in mirror", b.Commit)
-		return mirrorDir, nil
+	if isMainRepository {
+		if hasGitCommit(ctx, b.shell, mirrorDir, b.Commit) {
+			b.shell.Commentf("Commit %q exists in mirror", b.Commit)
+			return mirrorDir, nil
+		}
 	}
 
 	if b.Debug {
@@ -1316,10 +1319,12 @@ func (b *Bootstrap) updateGitMirror(ctx context.Context, repository string) (str
 	}
 	defer mirrorUpdateLock.Unlock()
 
-	// Check again after we get a lock, in case the other process has already updated
-	if hasGitCommit(ctx, b.shell, mirrorDir, b.Commit) {
-		b.shell.Commentf("Commit %q exists in mirror", b.Commit)
-		return mirrorDir, nil
+	if isMainRepository {
+		// Check again after we get a lock, in case the other process has already updated
+		if hasGitCommit(ctx, b.shell, mirrorDir, b.Commit) {
+			b.shell.Commentf("Commit %q exists in mirror", b.Commit)
+			return mirrorDir, nil
+		}
 	}
 
 	b.shell.Commentf("Updating existing repository mirror to find commit %s", b.Commit)
@@ -1329,7 +1334,7 @@ func (b *Bootstrap) updateGitMirror(ctx context.Context, repository string) (str
 		return "", err
 	}
 
-	if repository == b.Repository {
+	if isMainRepository {
 		if b.PullRequest != "false" && strings.Contains(b.PipelineProvider, "github") {
 			b.shell.Commentf("Fetch and mirror pull request head from GitHub")
 			refspec := fmt.Sprintf("refs/pull/%s/head", b.PullRequest)


### PR DESCRIPTION
Followup to https://github.com/buildkite/agent/pull/1959.

Upon updating to 3.44, we started seeing the new submodule mirror directories having their `origin` remote set to the URL of the pipeline's repo instead of the submodule's repo. This is causing a double `git fetch` of the main repo to happen, once when checking out the commit to build and once when updating submodules.

We also don't want to be running any fetches in the submodule mirror repo since the only branch or PR information the agent has is for the main repo, and those fetches would most likely fail in the submodule mirror.

Reproed in https://github.com/francoiscampbell/buildkite-submodule-test:
```
# Acquiring mirror repository update lock
--
  | # Using flock-file-locks experiment 🧪
  | $ git --git-dir /nvme/reference_repos/https---github-com-apache-incubator-airflow-git rev-parse 1e54b01ba9676cf74089a2c50e30495e2c16c0e2^{commit}
  | fatal: ambiguous argument '1e54b01ba9676cf74089a2c50e30495e2c16c0e2^{commit}': unknown revision or path not in the working tree.
  | Use '--' to separate paths from revisions, like this:
  | 'git <command> [<revision>...] -- [<file>...]'
  | # ↳ Command completed in 1.6023ms
  | # Updating existing repository mirror to find commit 1e54b01ba9676cf74089a2c50e30495e2c16c0e2
  | $ git --git-dir /nvme/reference_repos/https---github-com-apache-incubator-airflow-git remote set-url origin git@github.com:francoiscampbell/buildkite-submodule-test.git
  | # ↳ Command completed in 1.5309ms
  | $ git --git-dir /nvme/reference_repos/https---github-com-apache-incubator-airflow-git fetch origin master
  | remote: Enumerating objects: 10, done.
  | remote: Counting objects: 100% (10/10), done.
  | remote: Compressing objects: 100% (7/7), done.
  | remote: Total 10 (delta 1), reused 7 (delta 1), pack-reused 0
  | Unpacking objects: 100% (10/10), 1.35 KiB \| 1.35 MiB/s, done.
  | From github.com:francoiscampbell/buildkite-submodule-test
  | * branch                  master     -> FETCH_HEAD
  | * [new branch]            master     -> master
```
We can see that it's setting the `origin` to the wrong URL:
```
$ git --git-dir /nvme/reference_repos/https---github-com-apache-incubator-airflow-git remote set-url origin git@github.com:francoiscampbell/buildkite-submodule-test.git
```
and then running a fetch in the submodule mirror directory with the `origin` of the main repo:
```
$ git --git-dir /nvme/reference_repos/https---github-com-apache-incubator-airflow-git fetch origin master
...
From github.com:francoiscampbell/buildkite-submodule-test
```