### PR TITLE
Prefer `errors.Is(err, <whatever>)` over `err == <whatever>`

### DIFF
--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha1"
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"io"
 	"os"

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -162,7 +162,7 @@ func NewS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 		MaxKeys: aws.Int64(0),
 	})
 	if err != nil {
-		if err == credentials.ErrNoValidProvidersFoundInChain {
+		if errors.Is(err, credentials.ErrNoValidProvidersFoundInChain) {
 			hasProxy := os.Getenv("HTTP_PROXY") != "" || os.Getenv("HTTPS_PROXY") != ""
 			hasNoProxyIdmsException := strings.Contains(os.Getenv("NO_PROXY"), "169.254.169.254")
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -656,7 +656,7 @@ func (b *Bootstrap) validatePluginCheckout(checkout *pluginCheckout) error {
 		var err error
 		checkout.Definition, err = plugin.LoadDefinitionFromDir(checkout.CheckoutDir)
 
-		if err == plugin.ErrDefinitionNotFound {
+		if errors.Is(err, plugin.ErrDefinitionNotFound) {
 			b.shell.Warningf("Failed to find plugin definition for plugin %s", checkout.Plugin.Name())
 			return nil
 		} else if err != nil {


### PR DESCRIPTION
While investigating #2001, we ran into an issue where a direct error comparison `err == os.ErrNotExist` was causing test failures, where `errors.Is(err, os.ErrNotExist)` was okay. This is because `errors.Is` will unwrap errors, and return true if any of the unwrapped errors match the second arg.

**This PR:** Replaces most of the usages of `err == <whatever>` with `errors.Is(err, <whatever>)`. This makes these comparisons more robust, and establishes a better SOP within the agent codebase.

It also adds error wrapping to the artifact uploader, which also didn't quite fit in #2001, and is kinda-sorta more relevant to this PR.