### PR TITLE
Add tags from env variables provided by the controller in agent-stack-k8s if kuberenetes-exec experiment is enabled

### DIFF
--- a/agent/k8s_tags.go
+++ b/agent/k8s_tags.go
@@ -1,0 +1,26 @@
+package agent
+
+import (
+	"strings"
+
+	"github.com/buildkite/agent/v3/env"
+)
+
+const k8sEnvVarPrefix = "BUILDKITE_K8S_"
+
+func K8sTagsFromEnv(envn []string) (map[string]string, error) {
+	envMap := make(map[string]string, len(envn))
+	for _, e := range envn {
+		if k, v, ok := env.Split(e); ok && strings.HasPrefix(k, k8sEnvVarPrefix) {
+			envMap[envVarToTagKey(k)] = v
+		}
+	}
+	return envMap, nil
+}
+
+func envVarToTagKey(k string) string {
+	trimmed := strings.TrimPrefix(k, k8sEnvVarPrefix)
+	lowered := strings.ToLower(trimmed)
+	kebabed := strings.ReplaceAll(lowered, "_", "-")
+	return "k8s:" + kebabed
+}

--- a/agent/k8s_tags_test.go
+++ b/agent/k8s_tags_test.go
@@ -1,0 +1,52 @@
+package agent_test
+
+import (
+	"testing"
+
+	"github.com/buildkite/agent/v3/agent"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestK8sTags(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name         string
+		env          []string
+		expectedTags map[string]string
+	}{
+		{
+			name:         "empty",
+			env:          []string{},
+			expectedTags: map[string]string{},
+		},
+		{
+			name: "node_name",
+			env:  []string{"BUILDKITE_K8S_NODE=my-node"},
+			expectedTags: map[string]string{
+				"k8s:node": "my-node",
+			},
+		},
+		{
+			name: "full",
+			env: []string{
+				"BUILDKITE_K8S_NODE=my-node",
+				"BUILDKITE_K8S_NAMESPACE=buildkite",
+				"BUILDKITE_K8S_SERVICE_ACCOUNT=raas",
+			},
+			expectedTags: map[string]string{
+				"k8s:node":            "my-node",
+				"k8s:namespace":       "buildkite",
+				"k8s:service-account": "raas",
+			},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			actualTags, err := agent.K8sTagsFromEnv(test.env)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedTags, actualTags)
+		})
+	}
+}


### PR DESCRIPTION
These are set by the controller in the companion PR: https://github.com/buildkite/agent-stack-k8s/pull/137