### PR TITLE
Add buildx to docker images

### DIFF
--- a/.buildkite/steps/test-docker-image.sh
+++ b/.buildkite/steps/test-docker-image.sh
@@ -62,6 +62,11 @@ test_docker_compose_v2() {
   docker run --rm --platform "$platform" --entrypoint docker "$image_tag" compose version
 }
 
+test_docker_buildx() {
+  echo "--- :hammer: Testing $image_tag has buildx"
+  docker run --rm --platform "$platform" --entrypoint docker "$image_tag" buildx version
+}
+
 test_tini() {
   echo "--- :hammer: Testing $image_tag has tini"
   docker run --rm --platform "$platform" --entrypoint tini "$image_tag" --version

--- a/.buildkite/steps/test-docker-image.sh
+++ b/.buildkite/steps/test-docker-image.sh
@@ -88,6 +88,7 @@ case $variant in
     test_docker_socket
     test_docker_compose
     test_docker_compose_v2
+    test_docker_buildx
     test_tini
     test_tini_old_path
     ;;

--- a/packaging/docker/alpine-k8s/Dockerfile
+++ b/packaging/docker/alpine-k8s/Dockerfile
@@ -6,6 +6,7 @@ RUN apk update && apk add --no-cache \
     bash \
     curl \
     docker-cli \
+    docker-cli-buildx \
     docker-cli-compose \
     docker-compose \
     git \

--- a/packaging/docker/alpine/Dockerfile
+++ b/packaging/docker/alpine/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache \
     bash \
     curl \
     docker-cli \
+    docker-cli-buildx \
     docker-cli-compose \
     docker-compose \
     git \

--- a/packaging/docker/ubuntu-18.04/Dockerfile
+++ b/packaging/docker/ubuntu-18.04/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && add-apt-repository \
     "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
     && apt-get update \
-    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin \
+    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin docker-buildx-plugin \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install --upgrade pip setuptools \
     && pip3 install docker-compose==$DOCKER_COMPOSE_VERSION

--- a/packaging/docker/ubuntu-20.04/Dockerfile
+++ b/packaging/docker/ubuntu-20.04/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && add-apt-repository \
     "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
     && apt-get update \
-    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin \
+    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin docker-buildx-plugin \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install docker-compose==$DOCKER_COMPOSE_VERSION
 

--- a/packaging/docker/ubuntu-22.04/Dockerfile
+++ b/packaging/docker/ubuntu-22.04/Dockerfile
@@ -34,7 +34,7 @@ apt-get install -y --no-install-recommends \
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get update
-apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin
+apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin docker-buildx-plugin
 rm -rf /var/lib/apt/lists/*
 
 pip3 install docker-compose==$DOCKER_COMPOSE_VERSION


### PR DESCRIPTION
Some of the docker image building solutions on Kubernetes involve a [buildkit](https://docs.docker.com/build/buildkit/) service. The plugin `buildx` is used to give the docker CLI access to these, but it is not installed on our default agent image, even though the docker CLI is. If it were, we could instruct customers to use the agent image as the image in their image building step.