### PR TITLE
Fix DD trace setup warning

### DIFF
--- a/bootstrap/tracing.go
+++ b/bootstrap/tracing.go
@@ -73,7 +73,7 @@ func (b *Bootstrap) ddResourceName() string {
 // abstraction so the agent can support multiple libraries if needbe.
 func (b *Bootstrap) startTracingDatadog(ctx context.Context) (tracetools.Span, context.Context, stopper) {
 	opts := []tracer.StartOption{
-		tracer.WithServiceName(b.Config.TracingServiceName),
+		tracer.WithService(b.Config.TracingServiceName),
 		tracer.WithSampler(tracer.NewAllSampler()),
 		tracer.WithAnalytics(true),
 	}


### PR DESCRIPTION
We're seeing this in our job logs:
```
2023/03/10 00:53:18 Datadog Tracer v1.46.0 WARN: ddtrace/tracer: deprecated config WithServiceName should not be used with `WithService` or `DD_SERVICE`; integration service name will not be set.
```