### PR TITLE
Set a non-zero exit status when a job is cancelled in Kubernetes

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -404,6 +404,10 @@ func (r *JobRunner) Run(ctx context.Context) error {
 			exitStatus = "-1"
 			signalReason = "process_run_error"
 		} else {
+			if experiments.IsEnabled("kubernetes-exec") && r.process.WaitStatus().ExitStatus() < 0 && r.process.WaitStatus().ExitStatus()%10 == 0 {
+				_ = r.logStreamer.Process([]byte(":k8s: Some containers had unknown exit statuses. Perhaps they were in ImagePullBackOff :k8s:"))
+			}
+
 			// Add the final output to the streamer
 			r.logStreamer.Process(r.output.ReadAndTruncate())
 

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -165,12 +165,21 @@ func (r *Runner) WaitStatus() process.WaitStatus {
 			return waitStatus{Code: client.ExitStatus}
 		}
 
+		// use an unusual status code to distinguish this unusual state
 		if client.State == stateUnknown {
-			// use an unusual status code to distinguish this unusual state
 			ws.Code += -10
 		}
 	}
 	return ws
+}
+
+func (r *Runner) ClientStateUnknown() bool {
+	for _, client := range r.clients {
+		if client.State == stateUnknown {
+			return true
+		}
+	}
+	return false
 }
 
 // ==== sidecar api ====

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -159,13 +159,16 @@ func (w waitStatus) Signaled() bool {
 }
 
 func (r *Runner) WaitStatus() process.WaitStatus {
-	var ws process.WaitStatus
+	ws := waitStatus{}
 	for _, client := range r.clients {
 		if client.ExitStatus != 0 {
 			return waitStatus{Code: client.ExitStatus}
 		}
-		// just return any ExitStatus if we don't find any "interesting" ones
-		ws = waitStatus{Code: client.ExitStatus}
+
+		if client.State == stateUnknown {
+			// use an unusual status code to distinguish this unusual state
+			ws.Code += -10
+		}
 	}
 	return ws
 }

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -167,7 +167,7 @@ func (r *Runner) WaitStatus() process.WaitStatus {
 
 		// use an unusual status code to distinguish this unusual state
 		if client.State == stateUnknown {
-			ws.Code += -10
+			ws.Code -= 10
 		}
 	}
 	return ws


### PR DESCRIPTION
If a job is cancelled via the Buildkite API, for example, by clicking the cancel button on the website and the bootstrap container in the Kubernetes pod has not started, the exit status will be 0. This causes the build to pass in situations where it should not.

In this PR, we detect if child containers of the agent start container have not run and provide a non-zero exit status. In addition, the agent start container will emit a faked job log that informs the user that a container may not have run. Otherwise, if the Buildkite job was automatically cancelled, as will be the case after https://github.com/buildkite/agent-stack-k8s/pull/143 is merged, the user would not have a good idea what the cause of the cancellation was.

## Screenshot
![2023-03-15T21:57:25,215979237+11:00](https://user-images.githubusercontent.com/11096602/225289341-d4c63f66-b954-4c07-a4e5-51ad02be4ba6.png)
