### PR TITLE
Avoid holding full job logs

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -352,7 +352,7 @@ func (r *JobRunner) Run(ctx context.Context) error {
 			environmentCommandOkay = false
 
 			// Ensure the Job UI knows why this job resulted in failure
-			r.logStreamer.Process("pre-bootstrap hook rejected this job, see the buildkite-agent logs for more details")
+			r.logStreamer.Process([]byte("pre-bootstrap hook rejected this job, see the buildkite-agent logs for more details"))
 			// But disclose more information in the agent logs
 			r.logger.Error("pre-bootstrap hook rejected this job: %s", err)
 
@@ -378,14 +378,14 @@ func (r *JobRunner) Run(ctx context.Context) error {
 		// Run the process. This will block until it finishes.
 		if err := r.process.Run(cctx); err != nil {
 			// Send the error as output
-			r.logStreamer.Process(fmt.Sprintf("%s", err))
+			r.logStreamer.Process([]byte(err.Error()))
 
 			// The process did not run at all, so make sure it fails
 			exitStatus = "-1"
 			signalReason = "process_run_error"
 		} else {
 			// Add the final output to the streamer
-			r.logStreamer.Process(r.output.String())
+			r.logStreamer.Process(r.output.ReadAndTruncate())
 
 			// Collect the finished process' exit status
 			exitStatus = fmt.Sprintf("%d", r.process.WaitStatus().ExitStatus())
@@ -816,7 +816,7 @@ func (r *JobRunner) jobLogStreamer(ctx context.Context, wg *sync.WaitGroup) {
 
 		// Send the output of the process to the log streamer
 		// for processing
-		r.logStreamer.Process(r.output.String())
+		r.logStreamer.Process(r.output.ReadAndTruncate())
 
 		setStat("😴 Sleeping for a bit")
 

--- a/api/chunks.go
+++ b/api/chunks.go
@@ -9,7 +9,7 @@ import (
 
 // Chunk represents a Buildkite Agent API Chunk
 type Chunk struct {
-	Data     string
+	Data     []byte
 	Sequence int
 	Offset   int
 	Size     int
@@ -21,7 +21,7 @@ func (c *Client) UploadChunk(ctx context.Context, jobId string, chunk *Chunk) (*
 	// Create a compressed buffer of the log content
 	body := &bytes.Buffer{}
 	gzipper := gzip.NewWriter(body)
-	gzipper.Write([]byte(chunk.Data))
+	gzipper.Write(chunk.Data)
 	if err := gzipper.Close(); err != nil {
 		return nil, err
 	}

--- a/process/buffer.go
+++ b/process/buffer.go
@@ -1,0 +1,32 @@
+package process
+
+import "sync"
+
+// Buffer implements a concurrent-safe output buffer for processes.
+type Buffer struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+// Write appends data to the buffer.
+func (l *Buffer) Write(b []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.buf = append(l.buf, b...)
+	return len(b), nil
+}
+
+// ReadAndTruncate reads the unread contents of the buffer, and then truncates
+// (empties) the buffer.
+func (l *Buffer) ReadAndTruncate() []byte {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.buf) == 0 {
+		return nil
+	}
+	// Return the current buf, but put a new empty buf of the same capacity in
+	// its place. #IndianaJonesSwitchMeme
+	b := l.buf
+	l.buf = make([]byte, 0, cap(l.buf))
+	return b
+}

--- a/process/buffer_test.go
+++ b/process/buffer_test.go
@@ -1,0 +1,35 @@
+package process
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestBuffer(t *testing.T) {
+	var b Buffer
+
+	// New buffer should be empty.
+	if got, want := b.ReadAndTruncate(), []byte(nil); !cmp.Equal(got, want) {
+		t.Errorf("b.ReadAndTruncate() = %v, want %v", got, want)
+	}
+
+	text := []byte("Kronk! Pull the lever!")
+	got, err := b.Write(text)
+	if err != nil {
+		t.Errorf("b.Write(%q) error = %v", text, err)
+	}
+	if want := 22; got != want {
+		t.Errorf("b.Write(%q) = %d, want %d", text, got, want)
+	}
+
+	// ReadAndTruncate should return all current contents.
+	if diff := cmp.Diff(b.ReadAndTruncate(), text); diff != "" {
+		t.Errorf("b.ReadAndTruncate() diff (-got +want):\n%s", diff)
+	}
+
+	// Buffer should now be empty
+	if got, want := b.ReadAndTruncate(), []byte(nil); !cmp.Equal(got, want) {
+		t.Errorf("b.ReadAndTruncate() = %v, want %v", got, want)
+	}
+}

--- a/process/scanner.go
+++ b/process/scanner.go
@@ -2,9 +2,7 @@ package process
 
 import (
 	"bufio"
-	"bytes"
 	"io"
-	"sync"
 
 	"github.com/buildkite/agent/v3/logger"
 )
@@ -77,21 +75,4 @@ func (s *Scanner) ScanLines(r io.Reader, f func(line string)) error {
 
 	s.logger.Debug("[LineScanner] Finished")
 	return nil
-}
-
-type Buffer struct {
-	mu  sync.RWMutex
-	buf bytes.Buffer
-}
-
-func (l *Buffer) Write(b []byte) (int, error) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	return l.buf.Write(b)
-}
-
-func (l *Buffer) String() string {
-	l.mu.RLock()
-	defer l.mu.RUnlock()
-	return l.buf.String()
 }


### PR DESCRIPTION
The `String` method on `bytes.Buffer` does not consume the buffer in the same way that `Read` does - it leaves the contents in place. Because `output` is never `Read` or `Truncate`-d, it never shrinks. Also Go almost certainly copies the internal `[]byte` into a new `string` (or vice-versa).

It appears the agent never needs the whole copy of the logs, though.

This replaces the buffer implementation with a new one (in a new file, with a test) that _only_ has `Write` and `ReadAndTruncate` methods. This implementation, directly working on a byte slice, is (imo) at least as simple as a `bytes.Buffer` (but then you have to know how much you want to read, which, yes, you can get with `Len`, or you can use `io.ReadAll`, but it's about the same).

The output chunking logic is reworked, since it no longer has to track where in the (full) output buffer the next chunk will be.

Finally, it now uses `[]byte` throughout the data path, avoiding any potential copying to and from `string`.