### PR TITLE
ansi-timestamps: Compute prefixes at start of line

### DIFF
--- a/process/prefixer_test.go
+++ b/process/prefixer_test.go
@@ -53,9 +53,6 @@ func TestPrefixer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("pw.Write([]byte(%q)) error = %v", tc.input, err)
 			}
-			if err := pw.Flush(); err != nil {
-				t.Fatalf("pw.Flush() = %v", err)
-			}
 
 			if got, want := n, len(tc.input); got != want {
 				t.Errorf("pw.Write([]byte(%q)) length = %d, want %d", tc.input, got, want)


### PR DESCRIPTION
Looking at some of the log display code, we may need ANSI timestamps to reflect the start of each line, rather than the end. (sigh)

Fortunately, this admits a buffer-free implementation!

This PR should avoid the over-eager computation of the _next_ line's prefix, which was the main bug fixed with #1940.