### PR TITLE
Remove code for non async pipeline upload

### DIFF
--- a/agent/api.go
+++ b/agent/api.go
@@ -38,5 +38,4 @@ type APIClient interface {
 	UpdateArtifacts(context.Context, string, map[string]string) (*api.Response, error)
 	UploadChunk(context.Context, string, *api.Chunk) (*api.Response, error)
 	UploadPipeline(context.Context, string, *api.PipelineChange, ...api.Header) (*api.Response, error)
-	UploadPipelineAsync(context.Context, string, *api.PipelineChange, ...api.Header) (*api.Response, error)
 }

--- a/agent/pipeline_uploader.go
+++ b/agent/pipeline_uploader.go
@@ -45,6 +45,13 @@ type PipelineUploader struct {
 // 1. The Async Route responds 202: poll the Status Route until the upload has beed "applied"
 // 2. The Async Route responds with other 2xx: exit, the upload succeeded synchronously (possibly after retry)
 // 3. The Async Route responds with other xxx: retry uploading the pipeline to the Async Route
+//
+// Note that the Sync Route is not used at all. However, the API has the option to treat the Async
+// Route as if it were the Sync Route by not return in a 202 Accepted. While it currently does not
+// do this we want to maintain the flexbitity to do so in the future.
+// If so, the Status Route will not be polled, and either the Async Route will be retried (non 2xx)
+// until a 2xx is returned from the API, or the method will exit early with no error.
+// If the 2xx is a 202, then we assume the API change to supporting Async Uploads between retries.
 func (u *PipelineUploader) Upload(ctx context.Context, l logger.Logger) error {
 	result, err := u.pipelineUploadAsyncWithRetry(ctx, l)
 	if err != nil {

--- a/agent/pipeline_uploader.go
+++ b/agent/pipeline_uploader.go
@@ -106,7 +106,7 @@ func (u *PipelineUploader) pipelineUploadAsyncWithRetry(
 		roko.WithStrategy(roko.Constant(defaultSleepDuration)),
 		roko.WithSleepFunc(u.RetrySleepFunc),
 	).DoWithContext(ctx, func(r *roko.Retrier) error {
-		resp, err := u.Client.UploadPipelineAsync(
+		resp, err := u.Client.UploadPipeline(
 			ctx,
 			u.JobID,
 			u.Change,

--- a/api/pipelines.go
+++ b/api/pipelines.go
@@ -19,27 +19,10 @@ type PipelineUploadStatus struct {
 	Message string `json:"message"`
 }
 
-// Uploads the pipeline to the Buildkite Agent API.
-func (c *Client) UploadPipeline(
-	ctx context.Context,
-	jobId string,
-	pipeline *PipelineChange,
-	headers ...Header,
-) (*Response, error) {
-	u := fmt.Sprintf("jobs/%s/pipelines", jobId)
-
-	req, err := c.newRequest(ctx, "POST", u, pipeline, headers...)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.doRequest(req, nil)
-}
-
-// UploadPipelineAsync uploads the pipeline to the Buildkite Agent API. It does not wait for the
+// UploadPipeline uploads the pipeline to the Buildkite Agent API. It does not wait for the
 // pipeline to finish processing but will instead return with a redirect to the location to check
 // the pipeline's status.
-func (c *Client) UploadPipelineAsync(
+func (c *Client) UploadPipeline(
 	ctx context.Context,
 	jobId string,
 	pipeline *PipelineChange,


### PR DESCRIPTION
I've decided to keep the fallback mechanism. While the API current does NOT support falling back to a sync pipeline upload if the `?async=true` param is provided, we could decided to re-impliment it in the future. While this is unlikely, I think it is a good idea to leave this in the agent code base in cases users are stuck on a version that won't support such fallback.