### PR TITLE
ArtifactUploader API calls: faster timeout & retry

### DIFF
--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -327,10 +327,14 @@ func (a *ArtifactUploader) upload(ctx context.Context, artifacts []*api.Artifact
 
 				// Update the states of the artifacts in bulk.
 				err := roko.NewRetrier(
-					roko.WithMaxAttempts(10),
-					roko.WithStrategy(roko.Constant(5*time.Second)),
+					// TODO: roko.ExponentialSubsecond(500*time.Millisecond) WithMaxAttempts(10)
+					// Meanwhile, 8 roko.Exponential(2sec) attempts is 1,2,4,8,16,32,64 seconds delay (~2 mins)
+					roko.WithMaxAttempts(8),
+					roko.WithStrategy(roko.Exponential(2*time.Second, 0)),
 				).DoWithContext(ctx, func(r *roko.Retrier) error {
-					if _, err := a.apiClient.UpdateArtifacts(ctx, a.conf.JobID, statesToUpload); err != nil {
+					ctxShort, cancel := context.WithTimeout(ctx, 5*time.Second)
+					defer cancel()
+					if _, err := a.apiClient.UpdateArtifacts(ctxShort, a.conf.JobID, statesToUpload); err != nil {
 						a.logger.Warn("%s (%s)", err, r)
 						return err
 					}

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -275,9 +275,10 @@ func (a *ArtifactUploader) upload(ctx context.Context, artifacts []*api.Artifact
 
 	// Create the artifacts on Buildkite
 	batchCreator := NewArtifactBatchCreator(a.logger, a.apiClient, ArtifactBatchCreatorConfig{
-		JobID:             a.conf.JobID,
-		Artifacts:         artifacts,
-		UploadDestination: a.conf.Destination,
+		JobID:                  a.conf.JobID,
+		Artifacts:              artifacts,
+		UploadDestination:      a.conf.Destination,
+		CreateArtifactsTimeout: 10 * time.Second,
 	})
 
 	artifacts, err = batchCreator.Create(ctx)
@@ -327,7 +328,8 @@ func (a *ArtifactUploader) upload(ctx context.Context, artifacts []*api.Artifact
 
 				// Update the states of the artifacts in bulk.
 				err := roko.NewRetrier(
-					// TODO: roko.ExponentialSubsecond(500*time.Millisecond) WithMaxAttempts(10)
+					// TODO: e.g. roko.ExponentialSubsecond(500*time.Millisecond) WithMaxAttempts(10)
+					// see: https://github.com/buildkite/roko/pull/8
 					// Meanwhile, 8 roko.Exponential(2sec) attempts is 1,2,4,8,16,32,64 seconds delay (~2 mins)
 					roko.WithMaxAttempts(8),
 					roko.WithStrategy(roko.Exponential(2*time.Second, 0)),


### PR DESCRIPTION
When ArtifactUploader calls `UpdateArtifacts` (`PUT /v3/jobs/{uuid}/artifacts`), in the uncommon event of something stalling server-side or network-wise, the server and the client each take 60 seconds to time out, and the retry would wait a further 5 seconds. `UpdateArtifacts` is idempotent and called inside a retry loop, so we're better off timing out sooner and retrying sooner.

The p99 response time for this endpoint is ~50ms, so timing out after 5 seconds (100x the p99) seems more than reasonable. And reducing the initial retry delay (but backing off exponentially) also keeps things moving faster.

This means if `buildkite-agent artifact upload …` is invoked with a reasonable _external_ timeout of e.g. 30 or 60 seconds, a single server/network stall won't use up all that time, and a repeated server/network stall will be more visible due to the timeouts being logged.

Only the verified-idempotent `UpdateArtifacts` API call is updated in this pull request, although the same treatment could be applied to other endpoints, e.g. the API call that creates the artifact batch is also idempotent, ~but out of scope for this PR~.

Update: I've also applied a timeout (10 seconds) to `ArtifactBatchCreator` making the `CreateArtifacts` call; that one has a longer p99/max duration server side, hence the longer context timeout for this one. I've verified it is indeed idempotent. Also, the agent splits large numbers of artifacts into batches of up to 30, and this timeout is per-batch, so it won't scale beyond that with the total number of artifacts being uploaded.