### PR TITLE
Warn on unknown experiments

### DIFF
--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -382,7 +382,10 @@ var BootstrapCommand = cli.Command{
 
 		// Enable experiments
 		for _, name := range cfg.Experiments {
-			experiments.Enable(name)
+			known := experiments.Enable(name)
+			if !known {
+				l.Warn("Unknown experiment enabled: %q", name)
+			}
 		}
 
 		// Handle profiling flag

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -165,8 +165,12 @@ func HandleGlobalFlags(l logger.Logger, cfg any) func() {
 		experimentNamesSlice, ok := experimentNames.([]string)
 		if ok {
 			for _, name := range experimentNamesSlice {
-				experiments.Enable(name)
-				l.Debug("Enabled experiment `%s`", name)
+				known := experiments.Enable(name)
+				if !known {
+					l.Warn("Unknown experiment enabled: %q", name)
+					continue
+				}
+				l.Debug("Enabled experiment %q", name)
 			}
 		}
 	}

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -4,11 +4,26 @@
 // It is intended for internal use by buildkite-agent only.
 package experiments
 
-var experiments = make(map[string]bool)
+var (
+	Available = map[string]struct{}{
+		"job-api":                       {},
+		"kubernetes-exec":               {},
+		"ansi-timestamps":               {},
+		"git-mirrors":                   {},
+		"flock-file-locks":              {},
+		"resolve-commit-after-checkout": {},
+		"descending-spawn-priority":     {},
+		"inbuilt-status-page":           {},
+	}
+
+	experiments = make(map[string]bool, len(Available))
+)
 
 // Enable a particular experiment in the agent.
-func Enable(key string) {
+func Enable(key string) (known bool) {
 	experiments[key] = true
+	_, known = Available[key] // is the experiment they've enabled one that we know of?
+	return known
 }
 
 // Disable a particular experiment in the agent.


### PR DESCRIPTION
**This PR:** Makes it so that if a user enables an unknown experiment (ie, one that's not in the codebase), we'll emit a warning on the logger.

Additionally, for us, it creates a canonical list of available experiments in code, meaning that to find which experiments are in progress, we no longer have to do a global search across the repo for `experiments.IsEnbabled(` to find all of them.