### PR TITLE
Backport fixes from docs

### DIFF
--- a/clicommand/env_dump.go
+++ b/clicommand/env_dump.go
@@ -10,7 +10,8 @@ import (
 )
 
 const envDumpHelpDescription = `Usage:
-  buildkite-agent env dump [options]
+
+   buildkite-agent env dump [options]
 
 Description:
    Prints out the environment of the current process as a JSON object, easily

--- a/clicommand/env_get.go
+++ b/clicommand/env_get.go
@@ -31,7 +31,8 @@ Description:
    phases of the job. However, ′env get′ can be used to inspect the changes made
    with ′env set′ and ′env unset′.
 
-Example (gets all variables in key=value format):
+Examples:
+   Getting all variables in key=value format:
 
    $ buildkite-agent env get
    ALPACA=Geronimo the Incredible
@@ -39,18 +40,18 @@ Example (gets all variables in key=value format):
    LLAMA=Kuzco
    ...
 
-Example (gets the value of one variable):
+   Getting the value of one variable:
 
    $ buildkite-agent env get LLAMA
    Kuzco
 
-Example (gets multiple specific variables):
+   Getting multiple specific variables:
 
    $ buildkite-agent env get LLAMA ALPACA
    ALPACA=Geronimo the Incredible
    LLAMA=Kuzco
 
-Example (gets variables as a JSON object):
+   Getting variables as a JSON object:
 
    $ buildkite-agent env get --format=json-pretty
    {

--- a/clicommand/env_get.go
+++ b/clicommand/env_get.go
@@ -18,7 +18,7 @@ where the "job-api" experiment is enabled.
 
 const envGetHelpDescription = `Usage:
 
-  buildkite-agent env get [variables]
+   buildkite-agent env get [variables]
 
 Description:
    Retrieves environment variables and their current values from the current job

--- a/clicommand/env_get.go
+++ b/clicommand/env_get.go
@@ -22,11 +22,11 @@ const envGetHelpDescription = `Usage:
 
 Description:
    Retrieves environment variables and their current values from the current job
-   execution environment. 
+   execution environment.
 
    Note that this subcommand is only available from within the job executor with
    the ′job-api′ experiment enabled.
-   
+
    Changes to the job environment only apply to the environments of subsequent
    phases of the job. However, ′env get′ can be used to inspect the changes made
    with ′env set′ and ′env unset′.
@@ -38,18 +38,18 @@ Example (gets all variables in key=value format):
    BUILDKITE=true
    LLAMA=Kuzco
    ...
-	
+
 Example (gets the value of one variable):
 
    $ buildkite-agent env get LLAMA
    Kuzco
-	
+
 Example (gets multiple specific variables):
 
    $ buildkite-agent env get LLAMA ALPACA
    ALPACA=Geronimo the Incredible
    LLAMA=Kuzco
-	
+
 Example (gets variables as a JSON object):
 
    $ buildkite-agent env get --format=json-pretty

--- a/clicommand/env_set.go
+++ b/clicommand/env_set.go
@@ -25,7 +25,8 @@ Description:
 
    Note that this subcommand is only available from within the job executor with the job-api experiment enabled.
 
-Example (sets the variables ′LLAMA′ and ′ALPACA′):
+Examples:
+   Setting the variables ′LLAMA′ and ′ALPACA′:
 
    $ buildkite-agent env set LLAMA=Kuzco "ALPACA=Geronimo the Incredible"
    Added:
@@ -33,8 +34,7 @@ Example (sets the variables ′LLAMA′ and ′ALPACA′):
    Updated:
    ~ ALPACA
 
-Example (sets the variables ′LLAMA′ and ′ALPACA′ using a JSON object supplied
-over standard input):
+   Setting the variables ′LLAMA′ and ′ALPACA′ using a JSON object supplied over standard input:
 
    $ echo '{"ALPACA":"Geronimo the Incredible","LLAMA":"Kuzco"}' | buildkite-agent env set --input-format=json --output-format=quiet -
 `

--- a/clicommand/env_set.go
+++ b/clicommand/env_set.go
@@ -17,12 +17,12 @@ const envSetHelpDescription = `Usage:
   buildkite-agent env set [variable]
 
 Description:
-   Sets environment variable values in the current job execution environment. 
+   Sets environment variable values in the current job execution environment.
    Existing variables will be overwritten.
 
    Note that this subcommand is only available from within the job executor with
    the ′job-api′ experiment enabled.
-   
+
    Note that changes to the job environment variables only apply to subsequent
    phases of the job. To read the new values of variables from within the
    current phase, use ′env get′.
@@ -35,8 +35,8 @@ Example (sets the variables ′LLAMA′ and ′ALPACA′):
    Added:
    + LLAMA
    Updated:
-   ~ ALPACA	
-	
+   ~ ALPACA
+
 Example (sets the variables ′LLAMA′ and ′ALPACA′ using a JSON object supplied
 over standard input):
 

--- a/clicommand/env_set.go
+++ b/clicommand/env_set.go
@@ -17,17 +17,13 @@ const envSetHelpDescription = `Usage:
    buildkite-agent env set [variable]
 
 Description:
-   Sets environment variable values in the current job execution environment.
-   Existing variables will be overwritten.
+   Sets environment variables in the current job execution environment.
+   Changes to the job environment variables only apply to subsequent phases of the job.
+   This command cannot unset Buildkite read-only variables.
 
-   Note that this subcommand is only available from within the job executor with
-   the ′job-api′ experiment enabled.
+   To read the new values of variables from within the current phase, use ′env get′.
 
-   Note that changes to the job environment variables only apply to subsequent
-   phases of the job. To read the new values of variables from within the
-   current phase, use ′env get′.
-
-   Note that Buildkite read-only variables cannot be overwritten.
+   Note that this subcommand is only available from within the job executor with the job-api experiment enabled.
 
 Example (sets the variables ′LLAMA′ and ′ALPACA′):
 

--- a/clicommand/env_set.go
+++ b/clicommand/env_set.go
@@ -14,7 +14,7 @@ import (
 
 const envSetHelpDescription = `Usage:
 
-  buildkite-agent env set [variable]
+   buildkite-agent env set [variable]
 
 Description:
    Sets environment variable values in the current job execution environment.

--- a/clicommand/env_unset.go
+++ b/clicommand/env_unset.go
@@ -24,15 +24,16 @@ Description:
 
    Note that this subcommand is only available from within the job executor with the job-api experiment enabled.
 
-Example (unsets the variables ′LLAMA′ and ′ALPACA′):
+Examples:
+
+   Unsetting the variables ′LLAMA′ and ′ALPACA′)
 
    $ buildkite-agent env unset LLAMA ALPACA
    Unset:
    - ALPACA
    - LLAMA
 
-Example (Unsets the variables ′LLAMA′ and ′ALPACA′ with a JSON list supplied
-over standard input):
+   Unsetting the variables ′LLAMA′ and ′ALPACA′ with a JSON list supplied over standard input
 
    $ echo '["LLAMA","ALPACA"]' | buildkite-agent env unset --input-format=json --output-format=quiet -
 `

--- a/clicommand/env_unset.go
+++ b/clicommand/env_unset.go
@@ -17,15 +17,12 @@ const envUnsetHelpDescription = `Usage:
 
 Description:
    Unsets environment variables in the current job execution environment.
+   Changes to the job environment variables only apply to subsequent phases of the job.
+   This command cannot unset Buildkite read-only variables.
 
-   Note that this subcommand is only available from within the job executor with
-   the ′job-api′ experiment enabled.
+   To read the new values of variables from within the current phase, use ′env get′.
 
-   Note that changes to the job environment variables only apply to subsequent
-   phases of the job. To read the new values of variables from within the
-   current phase, use ′env get′.
-
-   Note that Buildkite read-only variables cannot be un-set.
+   Note that this subcommand is only available from within the job executor with the job-api experiment enabled.
 
 Example (unsets the variables ′LLAMA′ and ′ALPACA′):
 

--- a/clicommand/env_unset.go
+++ b/clicommand/env_unset.go
@@ -16,7 +16,7 @@ const envUnsetHelpDescription = `Usage:
    buildkite-agent env unset [variables]
 
 Description:
-   Un-sets environment variables in the current job execution environment.
+   Unsets environment variables in the current job execution environment.
 
    Note that this subcommand is only available from within the job executor with
    the ′job-api′ experiment enabled.
@@ -27,14 +27,14 @@ Description:
 
    Note that Buildkite read-only variables cannot be un-set.
 
-Example (un-sets the variables ′LLAMA′ and ′ALPACA′):
+Example (unsets the variables ′LLAMA′ and ′ALPACA′):
 
    $ buildkite-agent env unset LLAMA ALPACA
-   Un-set:
+   Unset:
    - ALPACA
    - LLAMA
 
-Example (Un-sets the variables ′LLAMA′ and ′ALPACA′ with a JSON list supplied
+Example (Unsets the variables ′LLAMA′ and ′ALPACA′ with a JSON list supplied
 over standard input):
 
    $ echo '["LLAMA","ALPACA"]' | buildkite-agent env unset --input-format=json --output-format=quiet -
@@ -44,7 +44,7 @@ type EnvUnsetConfig struct{}
 
 var EnvUnsetCommand = cli.Command{
 	Name:        "unset",
-	Usage:       "Un-sets variables from the job execution environment",
+	Usage:       "Unsets variables from the job execution environment",
 	Description: envUnsetHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{
@@ -118,7 +118,7 @@ func envUnsetAction(c *cli.Context) error {
 
 	unset, err := client.EnvDelete(context.Background(), del)
 	if err != nil {
-		fmt.Fprintf(c.App.ErrWriter, "Couldn't un-set the job executor environment variables: %v\n", err)
+		fmt.Fprintf(c.App.ErrWriter, "Couldn't unset the job executor environment variables: %v\n", err)
 	}
 
 	switch c.String("output-format") {
@@ -127,12 +127,12 @@ func envUnsetAction(c *cli.Context) error {
 
 	case "plain":
 		if len(unset) > 0 {
-			fmt.Fprintln(c.App.Writer, "Un-set:")
+			fmt.Fprintln(c.App.Writer, "Unset:")
 			for _, d := range unset {
 				fmt.Fprintf(c.App.Writer, "- %s\n", d)
 			}
 		} else {
-			fmt.Fprintln(c.App.Writer, "No variables un-set.")
+			fmt.Fprintln(c.App.Writer, "No variables unset.")
 		}
 
 	case "json", "json-pretty":

--- a/clicommand/env_unset.go
+++ b/clicommand/env_unset.go
@@ -13,7 +13,7 @@ import (
 
 const envUnsetHelpDescription = `Usage:
 
-  buildkite-agent env unset [variables]
+   buildkite-agent env unset [variables]
 
 Description:
    Un-sets environment variables in the current job execution environment.

--- a/clicommand/env_unset.go
+++ b/clicommand/env_unset.go
@@ -16,7 +16,7 @@ const envUnsetHelpDescription = `Usage:
   buildkite-agent env unset [variables]
 
 Description:
-   Un-sets environment variables in the current job execution environment. 
+   Un-sets environment variables in the current job execution environment.
 
    Note that this subcommand is only available from within the job executor with
    the ′job-api′ experiment enabled.
@@ -33,10 +33,10 @@ Example (un-sets the variables ′LLAMA′ and ′ALPACA′):
    Un-set:
    - ALPACA
    - LLAMA
-	
+
 Example (Un-sets the variables ′LLAMA′ and ′ALPACA′ with a JSON list supplied
 over standard input):
-    
+
    $ echo '["LLAMA","ALPACA"]' | buildkite-agent env unset --input-format=json --output-format=quiet -
 `
 


### PR DESCRIPTION
During the collaboration to merge the docs PR https://github.com/buildkite/docs/pull/1954, some changes were made that need to be backported.
This DO NOT cover all of the changes, just a managable chunk of them. We will need to refine the docs generation process to reconcile some of the remainging differences.