### PR TITLE
Promote git-mirrors experiment to full functionality

### DIFF
--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -8,6 +8,3 @@ go install gotest.tools/gotestsum@v1.8.0
 
 echo '+++ Running tests'
 gotestsum --junitfile "junit-${BUILDKITE_JOB_ID}.xml" -- -count=1 -failfast "$@" ./...
-
-echo '+++ Running integration tests for git-mirrors experiment'
-TEST_EXPERIMENT=git-mirrors gotestsum --junitfile "junit-${BUILDKITE_JOB_ID}-git-mirrors.xml" -- -count=1 -failfast "$@" ./bootstrap/integration

--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -18,14 +18,6 @@ If an experiment doesn't exist, no error will be raised.
 
 ## Available Experiments
 
-### `git-mirrors`
-
-Maintain a single bare git mirror for each repository on a host that is shared amongst multiple agents and pipelines. Checkouts reference the git mirror using `git clone --reference`, as do submodules.
-
-You must set a `git-mirrors-path` in your config for this to work.
-
-**Status**: broadly useful, we'd like this to be the standard behaviour in 4.0. 👍👍
-
 ### `ansi-timestamps`
 
 Outputs inline ANSI timestamps for each line of log output which enables toggle-able timestamps in the Buildkite UI.

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1372,8 +1372,7 @@ func (b *Bootstrap) defaultCheckoutPhase(ctx context.Context) error {
 	var mirrorDir string
 
 	// If we can, get a mirror of the git repository to use for reference later
-	if experiments.IsEnabled(experiments.GitMirrors) && b.Config.GitMirrorsPath != "" && b.Config.Repository != "" {
-		b.shell.Commentf("Using git-mirrors experiment 🧪")
+	if b.Config.GitMirrorsPath != "" && b.Config.Repository != "" {
 		span.AddAttributes(map[string]string{"checkout.is_using_git_mirrors": "true"})
 		mirrorDir, err = b.getOrUpdateMirrorDir(ctx, b.Repository)
 		if err != nil {
@@ -1508,7 +1507,7 @@ func (b *Bootstrap) defaultCheckoutPhase(ctx context.Context) error {
 		if err != nil {
 			b.shell.Warningf("Failed to enumerate git submodules: %v", err)
 		} else {
-			mirrorSubmodules := experiments.IsEnabled(experiments.GitMirrors) && b.Config.GitMirrorsPath != ""
+			mirrorSubmodules := b.Config.GitMirrorsPath != ""
 			for _, repository := range submoduleRepos {
 				submoduleArgs := append([]string(nil), args...)
 				// submodules might need their fingerprints verified too

--- a/bootstrap/integration/bootstrap_tester.go
+++ b/bootstrap/integration/bootstrap_tester.go
@@ -114,18 +114,9 @@ func NewBootstrapTester() (*BootstrapTester, error) {
 	}
 
 	// Support testing experiments
-	if exp := experiments.Enabled(); len(exp) > 0 {
-		bt.Env = append(bt.Env, "BUILDKITE_AGENT_EXPERIMENT="+strings.Join(exp, ","))
-
-		if experiments.IsEnabled(experiments.GitMirrors) {
-			gitMirrorsDir, err := os.MkdirTemp("", "bootstrap-git-mirrors")
-			if err != nil {
-				return nil, fmt.Errorf("making bootstrap-git-mirrors directory: %w", err)
-			}
-
-			bt.GitMirrorsDir = gitMirrorsDir
-			bt.Env = append(bt.Env, "BUILDKITE_GIT_MIRRORS_PATH="+gitMirrorsDir)
-		}
+	experiments := experiments.Enabled()
+	if len(experiments) > 0 {
+		bt.Env = append(bt.Env, "BUILDKITE_AGENT_EXPERIMENT="+strings.Join(experiments, ","))
 	}
 
 	// Windows requires certain env variables to be present
@@ -153,6 +144,18 @@ func NewBootstrapTester() (*BootstrapTester, error) {
 	bt.hookMock = hook
 
 	return bt, nil
+}
+
+func (b *BootstrapTester) EnableGitMirrors() error {
+	gitMirrorsDir, err := os.MkdirTemp("", "bootstrap-git-mirrors")
+	if err != nil {
+		return fmt.Errorf("making bootstrap-git-mirrors directory: %w", err)
+	}
+
+	b.GitMirrorsDir = gitMirrorsDir
+	b.Env = append(b.Env, "BUILDKITE_GIT_MIRRORS_PATH="+gitMirrorsDir)
+
+	return nil
 }
 
 // Mock creates a mock for a binary using bintest

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -24,7 +24,7 @@ import (
 var commitPattern = bintest.MatchPattern(`(?ms)\Acommit [0-9a-f]+\nabbrev-commit [0-9a-f]+\n.*^Author:`)
 
 // We expect this arg multiple times, just define it once.
-var gitShowFormatArg = "--format=commit %H%nabbrev-commit %h%nAuthor: %an <%ae>%n%n%w(0,4,4)%B"
+const gitShowFormatArg = "--format=commit %H%nabbrev-commit %h%nAuthor: %an <%ae>%n%n%w(0,4,4)%B"
 
 func TestWithResolvingCommitExperiment(t *testing.T) {
 	// t.Parallel() cannot be used with experiments.Enable()

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -656,13 +656,6 @@ var AgentStartCommand = cli.Command{
 			os.Exit(1)
 		}
 
-		// Check if git-mirrors are enabled
-		if experiments.IsEnabled(experiments.GitMirrors) {
-			if cfg.GitMirrorsPath == "" {
-				l.Fatal("Must provide a git-mirrors-path in your configuration for git-mirrors experiment")
-			}
-		}
-
 		// Force some settings if on Windows (these aren't supported yet)
 		if runtime.GOOS == "windows" {
 			cfg.NoPTY = true

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -382,10 +382,7 @@ var BootstrapCommand = cli.Command{
 
 		// Enable experiments
 		for _, name := range cfg.Experiments {
-			known := experiments.Enable(name)
-			if !known {
-				l.Warn("Unknown experiment enabled: %q", name)
-			}
+			experiments.EnableWithWarnings(l, name)
 		}
 
 		// Handle profiling flag

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -172,12 +172,10 @@ func HandleGlobalFlags(l logger.Logger, cfg any) func() {
 		experimentNamesSlice, ok := experimentNames.([]string)
 		if ok {
 			for _, name := range experimentNamesSlice {
-				known := experiments.Enable(name)
-				if !known {
-					l.Warn("Unknown experiment enabled: %q", name)
-					continue
+				state := experiments.EnableWithWarnings(l, name)
+				if state == experiments.StateKnown {
+					l.Debug("Enabled experiment %q", name)
 				}
-				l.Debug("Enabled experiment %q", name)
 			}
 		}
 	}

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -4,6 +4,14 @@
 // It is intended for internal use by buildkite-agent only.
 package experiments
 
+import (
+	"fmt"
+
+	"github.com/buildkite/agent/v3/logger"
+)
+
+type State string
+
 const (
 	PolyglotHooks              = "polyglot-hooks"
 	JobAPI                     = "job-api"
@@ -16,6 +24,10 @@ const (
 	InbuiltStatusPage          = "inbuilt-status-page"
 	AgentAPI                   = "agent-api"
 	NormalisedUploadPaths      = "normalised-upload-paths"
+
+	StateKnown    State = "known"
+	StatePromoted State = "promoted"
+	StateUnknown  State = "unknown"
 )
 
 var (
@@ -32,6 +44,10 @@ var (
 		NormalisedUploadPaths:      {},
 	}
 
+	Promoted = map[string]string{
+		GitMirrors: fmt.Sprintf("The %s experiment has been promoted to a stable feature. You can safely remove the `--experiment %s` flag to silence this message and continue using the feature", GitMirrors, GitMirrors),
+	}
+
 	experiments = make(map[string]bool, len(Available))
 )
 
@@ -40,11 +56,32 @@ func EnableWithUndo(key string) func() {
 	return func() { Disable(key) }
 }
 
+func EnableWithWarnings(l logger.Logger, key string) State {
+	state := Enable(key)
+	switch state {
+	case StateKnown:
+	// Noop
+	case StateUnknown:
+		l.Warn("Unknown experiment %q", key)
+	case StatePromoted:
+		l.Warn(Promoted[key])
+	}
+	return state
+}
+
 // Enable a particular experiment in the agent.
-func Enable(key string) (known bool) {
+func Enable(key string) (state State) {
 	experiments[key] = true
-	_, known = Available[key] // is the experiment they've enabled one that we know of?
-	return known
+
+	if _, promoted := Promoted[key]; promoted {
+		return StatePromoted
+	}
+
+	if _, known := Available[key]; known {
+		return StateKnown
+	}
+
+	return StateUnknown
 }
 
 // Disable a particular experiment in the agent.

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -24,7 +24,6 @@ var (
 		JobAPI:                     {},
 		KubernetesExec:             {},
 		ANSITimestamps:             {},
-		GitMirrors:                 {},
 		FlockFileLocks:             {},
 		ResolveCommitAfterCheckout: {},
 		DescendingSpawnPrioity:     {},


### PR DESCRIPTION
Use of the git mirrors experiment will now be solely controlled by the --git-mirrors-dir flag