### PR TITLE
Experiment: Polyglot hooks

### DIFF
--- a/.buildkite/Dockerfile-compile
+++ b/.buildkite/Dockerfile-compile
@@ -1,3 +1,6 @@
 FROM golang:1.20.4@sha256:6876eff5b20336c5c2896b0c3055f3258bdeba7aa38bbdabcb5a4abb5cdd39c7
 COPY build/ssh.conf /etc/ssh/ssh_config.d/
 RUN go install github.com/google/go-licenses@latest
+
+# Ruby used for polyglot hook integration tests
+RUN apt update && apt install -y ruby

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -297,6 +297,10 @@ func (b *Bootstrap) executeHook(ctx context.Context, hookCfg HookConfig) error {
 
 	b.shell.Headerf("Running %s hook", hookName)
 
+	if !experiments.IsEnabled(experiments.PolyglotHooks) {
+		return b.runWrappedShellScriptHook(ctx, hookName, hookCfg)
+	}
+
 	hookType, err := hook.Type(hookCfg.Path)
 	if err != nil {
 		return fmt.Errorf("determining hook type for %q hook: %w", hookName, err)

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -297,11 +297,56 @@ func (b *Bootstrap) executeHook(ctx context.Context, hookCfg HookConfig) error {
 
 	b.shell.Headerf("Running %s hook", hookName)
 
+	isBinary, err := shellscript.IsBinaryExecutable(hookCfg.Path)
+	if err != nil {
+		return fmt.Errorf("checking if %s hook is a binary: %w", hookName, err)
+	}
+
+	shebangLine, err := shellscript.ShebangLine(hookCfg.Path)
+	if err != nil {
+		return fmt.Errorf("reading shebang line for %s hook: %w", hookName, err)
+	}
+
+	switch {
+	case isBinary:
+		// It's a binary, so we'll just run it directly, no wrapping needed or possible
+		return b.runUnwrappedHook(ctx, hookName, hookCfg)
+	case shellscript.IsPOSIXShell(shebangLine):
+		// It's definitely a shell script, wrap it so that we can snaffle the changed environment variables
+		return b.runWrappedShellScriptHook(ctx, hookName, hookCfg)
+	case shebangLine != "" && !shellscript.IsPOSIXShell(shebangLine):
+		// It's an interpretable-something with a shebang line, and it almost certainly isn't a shell script,
+		// so it won't be capable of setting environment variables (outside of the job api), so just run it directly
+		return b.runUnwrappedHook(ctx, hookName, hookCfg)
+	case shebangLine == "":
+		// If there's no shebang line in the hook, and it's not a binary, so let's just assume that it's a shell script
+		// The OS will complain if we do something stupid, so we'll just give it a shot
+		return b.runWrappedShellScriptHook(ctx, hookName, hookCfg)
+	default:
+		return fmt.Errorf(`the buildkite agent wasn't able to determine the type of hook it was trying to run.
+This is a bug, please contact support@buildkite.com and/or submit an issue on the github.com/buildkite/agent repo with the following information:
+Hook scope: %q
+Hook path: %q
+Hook type: %q
+Shebang line: %q
+Is binary?: %t`, hookCfg.Scope, hookCfg.Path, hookName, shebangLine, isBinary)
+	}
+}
+
+func (b *Bootstrap) runUnwrappedHook(ctx context.Context, hookName string, hookCfg HookConfig) error {
+	environ := hookCfg.Env.Copy()
+
+	environ.Set("BUILDKITE_HOOK_PHASE", hookCfg.Name)
+	environ.Set("BUILDKITE_HOOK_PATH", hookCfg.Path)
+	environ.Set("BUILDKITE_HOOK_TRIGGERED_FROM", hookCfg.Scope)
+
+	return b.shell.RunWithEnv(ctx, environ, hookCfg.Path)
+}
+
+func (b *Bootstrap) runWrappedShellScriptHook(ctx context.Context, hookName string, hookCfg HookConfig) error {
 	redactors := b.setupRedactors()
 	defer redactors.Flush()
 
-	// We need a script to wrap the hook script so that we can snaffle the changed
-	// environment variables
 	script, err := hook.NewScriptWrapper(hook.WithHookPath(hookCfg.Path))
 	if err != nil {
 		b.shell.Errorf("Error creating hook script: %v", err)

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -321,9 +321,9 @@ func (b *Bootstrap) executeHook(ctx context.Context, hookCfg HookConfig) error {
 			// Regardless: not supported right now, or potentially ever.
 			sheb, _ := shellscript.ShebangLine(hookCfg.Path) // we know this won't error because it must have a shebang to be a script
 
-			err := fmt.Sprintf(`when trying to run the hook at %q, the agent found that it was a script with a shebang that isn't for a shellscripting language - in this case, %q.
+			err := fmt.Errorf(`when trying to run the hook at %q, the agent found that it was a script with a shebang that isn't for a shellscripting language - in this case, %q.
 Hooks of this kind are unfortunately not supported on Windows, as we have no way of interpreting a shebang on Windows`, hookCfg.Path, sheb)
-			return fmt.Errorf(err)
+			return err
 		}
 
 		// It's a script, and we can rely on the OS to figure out how to run it (because we're not on windows), so run it

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -307,12 +308,45 @@ func (b *Bootstrap) executeHook(ctx context.Context, hookCfg HookConfig) error {
 	}
 
 	switch hookType {
-	case hook.TypeBinary, hook.TypeScript:
+	case hook.TypeScript:
+		if runtime.GOOS == "windows" {
+			// We use shebangs to figure out how to run scripts, and Windows has no way to interpret a shebang
+			// ie, on linux, we can just point the OS to a file of some sort and say "run that", and as part of that it will try to
+			// read a shebang, and run the script using the interpreter specified. Windows can't do this, so we can't run scripts
+			// directly on Windows
+
+			// Potentially there's something that we could do with file extensions, but that's a bit of a minefield, and would
+			// probably mean that we have to have a list of blessed hook runtimes on windows only... or something.
+
+			// Regardless: not supported right now, or potentially ever.
+			sheb, _ := shellscript.ShebangLine(hookCfg.Path) // we know this won't error because it must have a shebang to be a script
+
+			err := fmt.Sprintf(`when trying to run the hook at %q, the agent found that it was a script with a shebang that isn't for a shellscripting language - in this case, %q.
+Hooks of this kind are unfortunately not supported on Windows, as we have no way of interpreting a shebang on Windows`, hookCfg.Path, sheb)
+			return fmt.Errorf(err)
+		}
+
+		// It's a script, and we can rely on the OS to figure out how to run it (because we're not on windows), so run it
+		// directly without wrapping
+		if err := b.runUnwrappedHook(ctx, hookName, hookCfg); err != nil {
+			return fmt.Errorf("running %q script hook: %w", hookName, err)
+		}
+
+		return nil
+	case hook.TypeBinary:
 		// It's a binary, so we'll just run it directly, no wrapping needed or possible
-		return b.runUnwrappedHook(ctx, hookName, hookCfg)
+		if err := b.runUnwrappedHook(ctx, hookName, hookCfg); err != nil {
+			return fmt.Errorf("running %q binary hook: %w", hookName, err)
+		}
+
+		return nil
 	case hook.TypeShell:
 		// It's definitely a shell script, wrap it so that we can snaffle the changed environment variables
-		return b.runWrappedShellScriptHook(ctx, hookName, hookCfg)
+		if err := b.runWrappedShellScriptHook(ctx, hookName, hookCfg); err != nil {
+			return fmt.Errorf("running %q shell hook: %w", hookName, err)
+		}
+
+		return nil
 	default:
 		return fmt.Errorf("unknown hook type %q for %q hook", hookType, hookName)
 	}

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -26,21 +26,9 @@ var commitPattern = bintest.MatchPattern(`(?ms)\Acommit [0-9a-f]+\nabbrev-commit
 // We expect this arg multiple times, just define it once.
 var gitShowFormatArg = "--format=commit %H%nabbrev-commit %h%nAuthor: %an <%ae>%n%n%w(0,4,4)%B"
 
-// Enable an experiment, returning a function to restore the previous state.
-// Usage: defer experimentWithUndo("foo")()
-func experimentWithUndo(name string) func() {
-	prev := experiments.IsEnabled(name)
-	experiments.Enable(name)
-	return func() {
-		if !prev {
-			experiments.Disable(name)
-		}
-	}
-}
-
 func TestCheckingOutGitHubPullRequestsWithGitMirrorsExperiment(t *testing.T) {
 	// t.Parallel() cannot be used with experiments.Enable()
-	defer experimentWithUndo(experiments.GitMirrors)()
+	defer experiments.EnableWithUndo(experiments.GitMirrors)()
 
 	tester, err := NewBootstrapTester()
 	if err != nil {
@@ -81,7 +69,7 @@ func TestCheckingOutGitHubPullRequestsWithGitMirrorsExperiment(t *testing.T) {
 
 func TestWithResolvingCommitExperiment(t *testing.T) {
 	// t.Parallel() cannot be used with experiments.Enable()
-	defer experimentWithUndo(experiments.ResolveCommitAfterCheckout)()
+	defer experiments.EnableWithUndo(experiments.ResolveCommitAfterCheckout)()
 
 	tester, err := NewBootstrapTester()
 	if err != nil {
@@ -691,7 +679,7 @@ func TestRepositorylessCheckout(t *testing.T) {
 
 func TestGitMirrorEnv(t *testing.T) {
 	// t.Parallel() cannot test experiment flags in parallel
-	defer experimentWithUndo(experiments.GitMirrors)()
+	defer experiments.EnableWithUndo(experiments.GitMirrors)()
 
 	tester, err := NewBootstrapTester()
 	if err != nil {

--- a/bootstrap/integration/hooks_integration_test.go
+++ b/bootstrap/integration/hooks_integration_test.go
@@ -492,6 +492,10 @@ func TestPreExitHooksFireAfterCancel(t *testing.T) {
 }
 
 func TestPolyglotScriptHooksCanBeRun(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script hooks aren't supported on windows")
+	}
+
 	path, err := exec.LookPath("ruby")
 	if err != nil {
 		t.Fatal("error finding path to ruby executable: %w", err)

--- a/bootstrap/integration/hooks_integration_test.go
+++ b/bootstrap/integration/hooks_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/v3/bootstrap/shell"
+	"github.com/buildkite/agent/v3/experiments"
 	"github.com/buildkite/bintest/v3"
 )
 
@@ -500,7 +501,7 @@ func TestPolyglotScriptHooksCanBeRun(t *testing.T) {
 		t.Fatal("ruby not found in $PATH. This test requires ruby to be installed on the host")
 	}
 
-	defer experiments.WithUndo(experiments.PolyglotHooks)()
+	defer experiments.EnableWithUndo(experiments.PolyglotHooks)()
 
 	tester, err := NewBootstrapTester()
 	if err != nil {
@@ -526,8 +527,8 @@ func TestPolyglotScriptHooksCanBeRun(t *testing.T) {
 }
 
 func TestPolyglotBinaryHooksCanBeRun(t *testing.T) {
-	defer experiments.WithUndo(experiments.PolyglotHooks)()
-	defer experiments.WithUndo(experiments.JobAPI)()
+	defer experiments.EnableWithUndo(experiments.PolyglotHooks)()
+	defer experiments.EnableWithUndo(experiments.JobAPI)()
 
 	tester, err := NewBootstrapTester()
 	if err != nil {

--- a/bootstrap/integration/hooks_integration_test.go
+++ b/bootstrap/integration/hooks_integration_test.go
@@ -498,7 +498,7 @@ func TestPolyglotScriptHooksCanBeRun(t *testing.T) {
 
 	path, err := exec.LookPath("ruby")
 	if err != nil {
-		t.Fatal("error finding path to ruby executable: %w", err)
+		t.Fatalf("error finding path to ruby executable: %v", err)
 	}
 
 	if path == "" {
@@ -520,13 +520,13 @@ func TestPolyglotScriptHooksCanBeRun(t *testing.T) {
 	}
 
 	if err := os.WriteFile(filepath.Join(tester.HooksDir, filename), []byte(strings.Join(script, "\n")), 0755); err != nil {
-		t.Fatalf("os.WriteFile(%q, script, 0755 = %v", filename, err)
+		t.Fatalf("os.WriteFile(%q, script, 0755) = %v", filename, err)
 	}
 
 	tester.RunAndCheck(t)
 
 	if !strings.Contains(tester.Output, "ohai, it's ruby!") {
-		t.Fatalf("tester.Output %s does not contain expected output: %q", tester.Output, "ohai, it's ruby!")
+		t.Fatalf("tester.Output %q does not contain expected output: %q", tester.Output, "ohai, it's ruby!")
 	}
 }
 

--- a/bootstrap/integration/hooks_integration_test.go
+++ b/bootstrap/integration/hooks_integration_test.go
@@ -546,6 +546,11 @@ func TestPolyglotBinaryHooksCanBeRun(t *testing.T) {
 
 	fmt.Println("Building test-binary-hook")
 	hookPath := filepath.Join(tester.HooksDir, "environment")
+
+	if runtime.GOOS == "windows" {
+		hookPath += ".exe"
+	}
+
 	output, err := exec.Command("go", "build", "-o", hookPath, "./test-binary-hook").CombinedOutput()
 	if err != nil {
 		t.Fatalf("Failed to build test-binary-hook: %v, output: %s", err, string(output))

--- a/bootstrap/integration/job_api_integration_test.go
+++ b/bootstrap/integration/job_api_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestBootstrapRunsJobAPI(t *testing.T) {
-	defer experimentWithUndo(experiments.JobAPI)()
+	defer experiments.EnableWithUndo(experiments.JobAPI)()
 
 	tester, err := NewBootstrapTester()
 	if err != nil {

--- a/bootstrap/integration/job_api_integration_test.go
+++ b/bootstrap/integration/job_api_integration_test.go
@@ -87,7 +87,7 @@ func TestBootstrapRunsJobAPI(t *testing.T) {
 		}
 
 		mtn := "chimborazo"
-		b, err := json.Marshal(jobapi.EnvUpdateRequest{Env: map[string]*string{"MOUNTAIN": &mtn}})
+		b, err := json.Marshal(jobapi.EnvUpdateRequest{Env: map[string]string{"MOUNTAIN": mtn}})
 		if err != nil {
 			t.Errorf("marshaling env update request: %v", err)
 			c.Exit(1)

--- a/bootstrap/integration/test-binary-hook/main.go
+++ b/bootstrap/integration/test-binary-hook/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/buildkite/agent/v3/jobapi"
+)
+
+// This file gets built and commited to this repo, then used as part of the hooks integration test to ensure that the
+// bootstrap can run binary hooks
+func main() {
+	c, err := jobapi.NewDefaultClient(context.TODO())
+	if err != nil {
+		log.Fatalf("error: %v", fmt.Errorf("creating job api client: %w", err))
+	}
+
+	_, err = c.EnvUpdate(context.TODO(), &jobapi.EnvUpdateRequest{
+		Env: map[string]string{
+			"OCEAN":    "Pacífico",
+			"MOUNTAIN": "chimborazo",
+		},
+	})
+
+	if err != nil {
+		log.Fatalf("error: %v", fmt.Errorf("updating env: %w", err))
+	}
+
+	fmt.Println("hi there from golang 🌊")
+}

--- a/clicommand/env_set.go
+++ b/clicommand/env_set.go
@@ -72,7 +72,7 @@ func envSetAction(c *cli.Context) error {
 	}
 
 	req := &jobapi.EnvUpdateRequest{
-		Env: make(map[string]*string),
+		Env: make(map[string]string),
 	}
 
 	var parse func(string) error
@@ -84,7 +84,7 @@ func envSetAction(c *cli.Context) error {
 			if !ok {
 				return fmt.Errorf("%q is not in key=value format", input)
 			}
-			req.Env[e] = &v
+			req.Env[e] = v
 			return nil
 		}
 

--- a/env/environment.go
+++ b/env/environment.go
@@ -197,6 +197,10 @@ func (e *Environment) Apply(diff Diff) {
 
 // Copy returns a copy of the env
 func (e *Environment) Copy() *Environment {
+	if e == nil {
+		return New()
+	}
+
 	c := New()
 
 	e.underlying.Range(func(k, v string) bool {

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -34,6 +34,11 @@ var (
 	experiments = make(map[string]bool, len(Available))
 )
 
+func EnableWithUndo(key string) func() {
+	Enable(key)
+	return func() { Disable(key) }
+}
+
 // Enable a particular experiment in the agent.
 func Enable(key string) (known bool) {
 	experiments[key] = true

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -5,6 +5,7 @@
 package experiments
 
 const (
+	PolyglotHooks              = "polyglot-hooks"
 	JobAPI                     = "job-api"
 	KubernetesExec             = "kubernetes-exec"
 	ANSITimestamps             = "ansi-timestamps"
@@ -19,6 +20,7 @@ const (
 
 var (
 	Available = map[string]struct{}{
+		PolyglotHooks:              {},
 		JobAPI:                     {},
 		KubernetesExec:             {},
 		ANSITimestamps:             {},

--- a/hook/binary.go
+++ b/hook/binary.go
@@ -1,0 +1,75 @@
+package hook
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+)
+
+// Magic numbers for various types of executable files
+var (
+	// Linux and many other Unix-like systems use ELF binaries
+	ELFMagic = []byte{0x7F, 0x45, 0x4C, 0x46}
+
+	// Windows uses MS-DOS MZ-style executables. This includes PE32 and PE32+ (which is 64-bit 🙃) binaries,
+	// which are what modern windowses tend to use.
+	MZMagic = []byte{0x4D, 0x5A}
+
+	// macOS uses Mach-O binaries. There are two variants: fat and thin.
+	// Thin binaries are further divided into 32-bit and 64-bit variants,
+	// which are furtherer subdivided by processor endianess. It's a mess.
+
+	// For "fat" binaries, which contain multiple architectures
+	MachOFatMagic = []byte{0xCA, 0xFE, 0xBA, 0xBE}
+
+	// For "thin" binaries, which contain a single architecture
+	// (ie 32 and 64 bit variants, on top of different processor architectures)
+	MachOThin32Magic = []byte{0xFE, 0xED, 0xFA, 0xCE}
+	MachOThin64Magic = []byte{0xFE, 0xED, 0xFA, 0xCF}
+
+	// Mach-O thin binaries can also be in reverse byte order, apparently?
+	// I think this is for big endian processors like PowerPC, in which case we don't need these here,
+	// but we might as well include them for completeness.
+	MachOThin32ReverseMagic = []byte{0xCE, 0xFA, 0xED, 0xFE}
+	MachOThin64ReverseMagic = []byte{0xCF, 0xFA, 0xED, 0xFE}
+
+	BinaryMagicks = [][]byte{
+		ELFMagic,
+		MZMagic,
+		MachOFatMagic,
+		MachOThin32Magic,
+		MachOThin64Magic,
+		MachOThin32ReverseMagic,
+		MachOThin64ReverseMagic,
+	}
+)
+
+// ExecutableType returns the type of file executable at the given path.
+// The file at the given path is assumed to be an executable, and executability is not checked.
+func isBinaryExecutable(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, fmt.Errorf("open file %q: %w", path, err)
+	}
+
+	defer f.Close()
+	r := bufio.NewReader(f)
+	firstFour, err := r.Peek(4)
+	if err != nil {
+		return false, fmt.Errorf("reading first four bytes of file %q: %w", path, err)
+	}
+
+	if len(firstFour) < 4 {
+		// there are less than four bytes in the file, there's nothing that we can do with it
+		return false, nil
+	}
+
+	for _, magicNumber := range BinaryMagicks {
+		if bytes.HasPrefix(firstFour, magicNumber) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -18,7 +18,7 @@ import (
 func Find(hookDir string, name string) (string, error) {
 	if runtime.GOOS == "windows" {
 		// check for windows types first
-		if p, err := shell.LookPath(name, hookDir, ".BAT;.CMD;.PS1"); err == nil {
+		if p, err := shell.LookPath(name, hookDir, ".BAT;.CMD;.PS1;.EXE"); err == nil {
 			return p, nil
 		}
 	}

--- a/hook/scriptwrapper.go
+++ b/hook/scriptwrapper.go
@@ -145,9 +145,9 @@ func NewScriptWrapper(opts ...scriptWrapperOpt) (*ScriptWrapper, error) {
 	//
 	// But if the shebang specifies something weird like Ruby 🤪
 	// the wrapper won't work. Stick to POSIX shells for now.
-	if shebang != "" && !shellscript.IsPOSIXShell(shebang) {
-		return nil, fmt.Errorf("hook starts with an unsupported shebang line %q", shebang)
-	}
+	// if shebang != "" && !shellscript.IsPOSIXShell(shebang) {
+	// 	return nil, fmt.Errorf("hook starts with an unsupported shebang line %q", shebang)
+	// }
 
 	var isPOSIXHook, isPwshHook bool
 

--- a/hook/scriptwrapper.go
+++ b/hook/scriptwrapper.go
@@ -144,10 +144,11 @@ func NewScriptWrapper(opts ...scriptWrapperOpt) (*ScriptWrapper, error) {
 	// responsibility of the job executor.
 	//
 	// But if the shebang specifies something weird like Ruby 🤪
-	// the wrapper won't work. Stick to POSIX shells for now.
-	// if shebang != "" && !shellscript.IsPOSIXShell(shebang) {
-	// 	return nil, fmt.Errorf("hook starts with an unsupported shebang line %q", shebang)
-	// }
+	// the wrapper won't work. We do support ruby (and other interpreted) hooks via polyglot hooks (see: https://github.com/buildkite/agent/pull/2040),
+	// but they should never be wrapped, and if they have been, something has gone wrong.
+	if shebang != "" && !shellscript.IsPOSIXShell(shebang) {
+		return nil, fmt.Errorf("scriptwrapper tried to wrap hook with invalid shebang: %q", shebang)
+	}
 
 	var isPOSIXHook, isPwshHook bool
 

--- a/hook/type.go
+++ b/hook/type.go
@@ -1,0 +1,54 @@
+package hook
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/buildkite/agent/v3/shellscript"
+)
+
+const (
+	TypeShell   = "shell"
+	TypeBinary  = "binary"
+	TypeScript  = "script" // Something with a shebang that isn't a shell script, but is an interpretable something-or-other
+	TypeUnknown = "unknown"
+)
+
+func Type(path string) (string, error) {
+	_, err := os.Open(path)
+	if err != nil {
+		return TypeUnknown, fmt.Errorf("opening hook: %w", err)
+	}
+
+	isBinary, err := isBinaryExecutable(path)
+	if err != nil {
+		return TypeUnknown, fmt.Errorf("determining if %q is a binary: %w", path, err)
+	}
+
+	if isBinary {
+		return TypeBinary, nil
+	}
+
+	shebangLine, err := shellscript.ShebangLine(path)
+	if err != nil {
+		return TypeUnknown, fmt.Errorf("reading shebang line for hook: %w", err)
+	}
+
+	switch {
+	case shellscript.IsPOSIXShell(shebangLine):
+		return TypeShell, nil
+
+	case shebangLine != "" && !shellscript.IsPOSIXShell(shebangLine):
+		return TypeScript, nil
+
+	case shebangLine == "":
+		return TypeShell, nil // Assume shell if no shebang line is present and it's not a binary
+
+	default:
+		return TypeUnknown, fmt.Errorf(`the buildkite agent wasn't able to determine the type of hook it was trying to run.
+This is a bug, please contact support@buildkite.com and/or submit an issue on the github.com/buildkite/agent repo with the following information:
+Hook path: %q
+Shebang line: %q
+Is binary?: %t`, path, shebangLine, isBinary)
+	}
+}

--- a/hook/type_test.go
+++ b/hook/type_test.go
@@ -72,10 +72,8 @@ func TestHookType(t *testing.T) {
 		for _, arch := range []string{"amd64", "arm64"} {
 
 			binaryName := fmt.Sprintf("test-binary-%s-%s", operatingSystem, arch)
-			binaryPath := hookFixture(root, binaryName)
+			binaryPath := filepath.Join(os.TempDir(), binaryName)
 			sourcePath := hookFixture(root)
-
-			fmt.Println(binaryPath)
 
 			cmd := exec.Command("go", "build", "-o", binaryPath, sourcePath)
 			extraEnv := []string{
@@ -87,17 +85,9 @@ func TestHookType(t *testing.T) {
 			cmd.Env = append(os.Environ(), extraEnv...)
 
 			output, err := cmd.CombinedOutput()
-			fmt.Println(string(output))
 			if err != nil {
 				t.Fatalf("Failed to build test-binary-hook: %v, output: %s", err, string(output))
 			}
-
-			t.Cleanup(func() {
-				err = os.Remove(binaryPath)
-				if err != nil {
-					t.Fatalf("Failed to remove test-binary-hook: %v", err)
-				}
-			})
 
 			cases = append(cases, testCase{
 				name:             fmt.Sprintf("binary for %s/%s", operatingSystem, arch),

--- a/hook/type_test.go
+++ b/hook/type_test.go
@@ -1,0 +1,130 @@
+package hook_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildkite/agent/v3/hook"
+)
+
+type testCase struct {
+	name             string
+	hookPath         string
+	expectedHookType string
+	errCheck         func(*testing.T, error) bool
+}
+
+func noErr(t *testing.T, err error) bool {
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return true
+	}
+	return false
+}
+
+func isNotExist(t *testing.T, err error) bool {
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected os.ErrNotExist, got %v", err)
+		return true
+	}
+
+	return false
+}
+
+func TestHookType(t *testing.T) {
+	// The test working dir is at $REPO_ROOT/hook, but the fixtures are in $REPO_ROOT/test/fixtures/hook, so we need to
+	// go up a directory to get to the root
+	wd, _ := os.Getwd()
+	root := filepath.Join(wd, "..")
+
+	cases := []testCase{
+		{
+			name:             "non-shell script with shebang",
+			hookPath:         hookFixture(root, "hook.rb"),
+			expectedHookType: hook.TypeScript,
+			errCheck:         noErr,
+		},
+		{
+			name:             "shell script with shebang",
+			hookPath:         hookFixture(root, "shebanged.sh"),
+			expectedHookType: hook.TypeShell,
+			errCheck:         noErr,
+		},
+		{
+			name:             "shell script without shebang",
+			hookPath:         hookFixture(root, "un-shebanged.sh"),
+			expectedHookType: hook.TypeShell,
+			errCheck:         noErr,
+		},
+		{
+			name:             "non-existent hook",
+			hookPath:         hookFixture(root, "some", "path", "that", "doesnt", "exist"),
+			expectedHookType: hook.TypeUnknown,
+			errCheck:         isNotExist,
+		},
+	}
+
+	for _, operatingSystem := range []string{"linux", "darwin", "windows"} {
+		for _, arch := range []string{"amd64", "arm64"} {
+
+			binaryName := fmt.Sprintf("test-binary-%s-%s", operatingSystem, arch)
+			binaryPath := hookFixture(root, binaryName)
+			sourcePath := hookFixture(root)
+
+			fmt.Println(binaryPath)
+
+			cmd := exec.Command("go", "build", "-o", binaryPath, sourcePath)
+			extraEnv := []string{
+				fmt.Sprintf("GOOS=%s", operatingSystem),
+				fmt.Sprintf("GOARCH=%s", arch),
+				"CGO_ENABLED=0",
+			}
+
+			cmd.Env = append(os.Environ(), extraEnv...)
+
+			output, err := cmd.CombinedOutput()
+			fmt.Println(string(output))
+			if err != nil {
+				t.Fatalf("Failed to build test-binary-hook: %v, output: %s", err, string(output))
+			}
+
+			t.Cleanup(func() {
+				err = os.Remove(binaryPath)
+				if err != nil {
+					t.Fatalf("Failed to remove test-binary-hook: %v", err)
+				}
+			})
+
+			cases = append(cases, testCase{
+				name:             fmt.Sprintf("binary for %s/%s", operatingSystem, arch),
+				hookPath:         binaryPath,
+				expectedHookType: hook.TypeBinary,
+				errCheck:         noErr,
+			})
+		}
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			hookType, err := hook.Type(c.hookPath)
+			if c.errCheck(t, err) {
+				t.Fatalf("error check failed")
+			}
+
+			if hookType != c.expectedHookType {
+				t.Fatalf("Expected hook type %q, got %q", c.expectedHookType, hookType)
+			}
+		})
+	}
+}
+
+func hookFixture(wd string, fixturePath ...string) string {
+	return filepath.Join(append([]string{wd, "test", "fixtures", "hook"}, fixturePath...)...)
+}

--- a/jobapi/client_test.go
+++ b/jobapi/client_test.go
@@ -64,7 +64,7 @@ func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 	case "PATCH":
-		var req EnvUpdateRequest
+		var req EnvUpdateRequestPayload
 		var resp EnvUpdateResponse
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			socket.WriteError(w, fmt.Sprintf("decoding request: %v", err), http.StatusBadRequest)
@@ -181,11 +181,10 @@ func TestClientEnvUpdate(t *testing.T) {
 		t.Fatalf("NewClient(%q, %q) error = %v", svr.sock, svr.token, err)
 	}
 
-	sp := func(s string) *string { return &s }
 	req := &EnvUpdateRequest{
-		Env: map[string]*string{
-			"PACHA": sp("Friend"),
-			"YZMA":  sp("Kitten"),
+		Env: map[string]string{
+			"PACHA": "Friend",
+			"YZMA":  "Kitten",
 		},
 	}
 

--- a/jobapi/payloads.go
+++ b/jobapi/payloads.go
@@ -16,6 +16,11 @@ type EnvGetResponse struct {
 
 // EnvUpdateRequest is the request body for the PATCH /env endpoint
 type EnvUpdateRequest struct {
+	Env map[string]string `json:"env"`
+}
+
+// EnvUpdateRequestPayload is the request body that the PATCH /env endpoint unmarshalls requests into
+type EnvUpdateRequestPayload struct {
 	Env map[string]*string `json:"env"`
 }
 

--- a/jobapi/routes.go
+++ b/jobapi/routes.go
@@ -45,7 +45,7 @@ func (s *Server) getEnv(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) patchEnv(w http.ResponseWriter, r *http.Request) {
-	var req EnvUpdateRequest
+	var req EnvUpdateRequestPayload
 	err := json.NewDecoder(r.Body).Decode(&req)
 	defer r.Body.Close()
 	if err != nil {

--- a/jobapi/server_test.go
+++ b/jobapi/server_test.go
@@ -213,10 +213,10 @@ func TestDeleteEnv(t *testing.T) {
 func TestPatchEnv(t *testing.T) {
 	t.Parallel()
 
-	cases := []apiTestCase[jobapi.EnvUpdateRequest, jobapi.EnvUpdateResponse]{
+	cases := []apiTestCase[jobapi.EnvUpdateRequestPayload, jobapi.EnvUpdateResponse]{
 		{
 			name: "happy case",
-			requestBody: &jobapi.EnvUpdateRequest{
+			requestBody: &jobapi.EnvUpdateRequestPayload{
 				Env: map[string]*string{
 					"MOUNTAIN":       pt("chimborazo"),
 					"CAPITAL":        pt("quito"),
@@ -236,7 +236,7 @@ func TestPatchEnv(t *testing.T) {
 		},
 		{
 			name: "setting to nil returns a 422",
-			requestBody: &jobapi.EnvUpdateRequest{
+			requestBody: &jobapi.EnvUpdateRequestPayload{
 				Env: map[string]*string{
 					"NATIONAL_PARKS": nil,
 					"MOUNTAIN":       pt("chimborazo"),
@@ -250,7 +250,7 @@ func TestPatchEnv(t *testing.T) {
 		},
 		{
 			name: "setting protected variables returns a 422",
-			requestBody: &jobapi.EnvUpdateRequest{
+			requestBody: &jobapi.EnvUpdateRequestPayload{
 				Env: map[string]*string{
 					"BUILDKITE_AGENT_PID": pt("12345"),
 					"MOUNTAIN":            pt("antisana"),

--- a/scripts/generate-test-binaries.sh
+++ b/scripts/generate-test-binaries.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+indir=$1
+outdir=$2
+binary_name=$3
+
+for os in "darwin" "linux" "windows"; do
+  for arch in "amd64" "arm64"; do
+    echo "Building test binary for $os/$arch"
+    GOOS=$os GOARCH=$arch go build -o "$outdir/$binary_name-$os-$arch" "$indir"
+  done
+done

--- a/shellscript/shellscript.go
+++ b/shellscript/shellscript.go
@@ -3,12 +3,85 @@ package shellscript
 
 import (
 	"bufio"
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/buildkite/shellwords"
 )
+
+// Magic numbers for various types of executable files
+var (
+	// Linux and many other Unix-like systems use ELF binaries
+	ELFMagic = []byte{0x7F, 0x45, 0x4C, 0x46}
+
+	// Windows uses MS-DOS MZ-style executables. This includes PE32 and PE32+ (which is 64-bit 🙃) binaries,
+	// which a are what modern windowses tend to use.
+	MZMagic = []byte{0x4D, 0x5A}
+
+	// macOS uses Mach-O binaries. There are two variants: fat and thin.
+	// Thin binaries are further divided into 32-bit and 64-bit variants,
+	// which are furtherer subdivided by processor endianess. It's a mess.
+
+	// For "fat" binaries, which contain multiple architectures
+	MachOFatMagic = []byte{0xCA, 0xFE, 0xBA, 0xBE}
+
+	// For "thin" binaries, which contain a single architecture
+	// (ie 32 and 64 bit variants, on top of different processor architectures)
+	MachOThin32Magic = []byte{0xFE, 0xED, 0xFA, 0xCE}
+	MachOThin64Magic = []byte{0xFE, 0xED, 0xFA, 0xCF}
+
+	// Mach-O thin binaries can also be in reverse byte order, apparently?
+	// I think this is for big endian processors like PowerPC, in which case we don't need these here,
+	// but we might as well include them for completeness.
+	MachOThin32ReverseMagic = []byte{0xCE, 0xFA, 0xED, 0xFE}
+	MachOThin64ReverseMagic = []byte{0xCF, 0xFA, 0xED, 0xFE}
+
+	BinaryMagicks = [][]byte{
+		ELFMagic,
+		MZMagic,
+		MachOFatMagic,
+		MachOThin32Magic,
+		MachOThin64Magic,
+		MachOThin32ReverseMagic,
+		MachOThin64ReverseMagic,
+	}
+)
+
+// ExecutableType returns the type of file executable at the given path.
+// The file at the given path is assumed to be an executable, and executability is not checked.
+func IsBinaryExecutable(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, fmt.Errorf("open file %q: %w", path, err)
+	}
+
+	defer f.Close()
+	r := bufio.NewReader(f)
+	firstFour, err := r.Peek(4)
+	if err != nil {
+		return false, fmt.Errorf("reading first four bytes of file %q: %w", path, err)
+	}
+
+	if len(firstFour) < 4 {
+		// there are less than four bytes in the file, there's nothing that we can do with it
+		return false, nil
+	}
+
+	for _, magicNumber := range BinaryMagicks {
+		if sliceHasPrefix(firstFour, magicNumber) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func sliceHasPrefix(s, prefix []byte) bool {
+	return len(s) >= len(prefix) && bytes.Equal(s[:len(prefix)], prefix)
+}
 
 // ShebangLine extracts the shebang line from the file, if present. If the file
 // is readable but contains no shebang line, it will return an empty string.

--- a/shellscript/shellscript.go
+++ b/shellscript/shellscript.go
@@ -3,85 +3,12 @@ package shellscript
 
 import (
 	"bufio"
-	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/buildkite/shellwords"
 )
-
-// Magic numbers for various types of executable files
-var (
-	// Linux and many other Unix-like systems use ELF binaries
-	ELFMagic = []byte{0x7F, 0x45, 0x4C, 0x46}
-
-	// Windows uses MS-DOS MZ-style executables. This includes PE32 and PE32+ (which is 64-bit 🙃) binaries,
-	// which a are what modern windowses tend to use.
-	MZMagic = []byte{0x4D, 0x5A}
-
-	// macOS uses Mach-O binaries. There are two variants: fat and thin.
-	// Thin binaries are further divided into 32-bit and 64-bit variants,
-	// which are furtherer subdivided by processor endianess. It's a mess.
-
-	// For "fat" binaries, which contain multiple architectures
-	MachOFatMagic = []byte{0xCA, 0xFE, 0xBA, 0xBE}
-
-	// For "thin" binaries, which contain a single architecture
-	// (ie 32 and 64 bit variants, on top of different processor architectures)
-	MachOThin32Magic = []byte{0xFE, 0xED, 0xFA, 0xCE}
-	MachOThin64Magic = []byte{0xFE, 0xED, 0xFA, 0xCF}
-
-	// Mach-O thin binaries can also be in reverse byte order, apparently?
-	// I think this is for big endian processors like PowerPC, in which case we don't need these here,
-	// but we might as well include them for completeness.
-	MachOThin32ReverseMagic = []byte{0xCE, 0xFA, 0xED, 0xFE}
-	MachOThin64ReverseMagic = []byte{0xCF, 0xFA, 0xED, 0xFE}
-
-	BinaryMagicks = [][]byte{
-		ELFMagic,
-		MZMagic,
-		MachOFatMagic,
-		MachOThin32Magic,
-		MachOThin64Magic,
-		MachOThin32ReverseMagic,
-		MachOThin64ReverseMagic,
-	}
-)
-
-// ExecutableType returns the type of file executable at the given path.
-// The file at the given path is assumed to be an executable, and executability is not checked.
-func IsBinaryExecutable(path string) (bool, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return false, fmt.Errorf("open file %q: %w", path, err)
-	}
-
-	defer f.Close()
-	r := bufio.NewReader(f)
-	firstFour, err := r.Peek(4)
-	if err != nil {
-		return false, fmt.Errorf("reading first four bytes of file %q: %w", path, err)
-	}
-
-	if len(firstFour) < 4 {
-		// there are less than four bytes in the file, there's nothing that we can do with it
-		return false, nil
-	}
-
-	for _, magicNumber := range BinaryMagicks {
-		if sliceHasPrefix(firstFour, magicNumber) {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-func sliceHasPrefix(s, prefix []byte) bool {
-	return len(s) >= len(prefix) && bytes.Equal(s[:len(prefix)], prefix)
-}
 
 // ShebangLine extracts the shebang line from the file, if present. If the file
 // is readable but contains no shebang line, it will return an empty string.

--- a/test/fixtures/hook/hook.rb
+++ b/test/fixtures/hook/hook.rb
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+puts "hi there world"
+puts "this script isn't meant to be run, only checked for its signature"

--- a/test/fixtures/hook/main.go
+++ b/test/fixtures/hook/main.go
@@ -1,0 +1,6 @@
+package main
+
+func main() {
+	println("Hello, world!")
+	println("This file is not meant to be run, just generate a couple of binaries")
+}

--- a/test/fixtures/hook/shebanged.sh
+++ b/test/fixtures/hook/shebanged.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Hello, world!"
+echo "This is a shebanged script."

--- a/test/fixtures/hook/un-shebanged.sh
+++ b/test/fixtures/hook/un-shebanged.sh
@@ -1,0 +1,3 @@
+# shellcheck disable=all
+echo "Hello world!"
+echo "This is an un-shebanged script."


### PR DESCRIPTION
**This PR:** Removes the requirement that hooks for the buildkite-agent be written in a shell scripting language a la bash. With the use of this branch, hooks can also either be compiled executable binaries (ie those produced by languages like Golang or Rust), or any interpreted scripting language (ie python, ruby, lua), so long as an appropriate shebang is specified at the top of the file.

note that neither binary hooks nor non-shell script hooks have environment variable changes captured as bash script hooks do; they _must_ use the Job API to modify the environment of the job.