### PR TITLE
Prevent job cancellation during checkout from retrying

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -84,3 +84,7 @@ See [jobapi/payloads.go](./jobapi/payloads.go) for the full API request/response
 The Job API is unavailable on windows agents running versions of windows prior to build 17063, as this was when windows added Unix Domain Socket support. Using this experiment on such agents will output a warning, and the API will be unavailable.
 
 **Status:** Experimental while we iron out the API and test it out in the wild. We'll probably promote this to non-experiment soon™️.
+
+## `cancel-checkout`
+
+Bug fix in testing: Don't retry git checkout when the job has been canceled during the checkout phase

--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -87,4 +87,6 @@ The Job API is unavailable on windows agents running versions of windows prior t
 
 ## `cancel-checkout`
 
-Bug fix in testing: Don't retry git checkout when the job has been canceled during the checkout phase
+Don't retry git checkout when the job has been canceled during the checkout phase.
+
+**Status:** Bug fix in testing. We well remove or promote it soon.

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -14,6 +14,7 @@ var (
 		"resolve-commit-after-checkout": {},
 		"descending-spawn-priority":     {},
 		"inbuilt-status-page":           {},
+		"cancel-checkout":               {},
 	}
 
 	experiments = make(map[string]bool, len(Available))


### PR DESCRIPTION
We've received reports that when an agent is checking out a commit and the job is canceled, that the agent does not gracefully respond to the interrupt signal, and instead will retry the git checkout and continue with the job. This means that the job is forcibly killed.

My understanding of job cancelation is that:

JobRunner polls the Agent API for the [state of the job](https://github.com/buildkite/agent/blob/cancelation_for_checkout/agent/job_runner.go#L890:L891) and calls [JobRunner.cancel()](https://github.com/buildkite/agent/blob/v3.45.0/agent/job_runner.go#L499) which then [interrupts](https://github.com/buildkite/agent/blob/cancelation_for_checkout/agent/job_runner.go#L542:L543) the bootstrap process [with](https://github.com/buildkite/agent/blob/cancelation_for_checkout/process/process.go#L308:L308) SIGTERM. The SIGTERM is [handled](https://github.com/buildkite/agent/blob/cancelation_for_checkout/clicommand/bootstrap.go#L490:L491) by the bootstrap process which then sends a [signal](https://github.com/buildkite/agent/blob/cancelation_for_checkout/bootstrap/bootstrap.go#L246:L247) on the cancel channel which interrupts the shell. However, if the shell doesn't exit with a status code of [-1](https://github.com/buildkite/agent/blob/cancelation_for_checkout/bootstrap/bootstrap.go#L1076:L1077), or `defaultCheckoutPhase` doesn't accurately wrap errors with the appropriate context, then the error handling will fall through to the default case and retry the [checkout](https://github.com/buildkite/agent/blob/cancelation_for_checkout/bootstrap/bootstrap.go#L1088).

This introduces a new cancelable Context that is passed to `CheckoutPhase`, and currently only `CheckoutPhase`, the context will be canceled on the cancel channel when the job is interrupted.

I've put the change behind an experiment to allow additional verification from the reporting customers.

I've tested that cancelation works with the `cancel-checkout` feature enabled:
<img width="1185" alt="Screen Shot 2023-04-14 at 2 31 10 pm" src="https://user-images.githubusercontent.com/2132506/231942397-3183ed31-2a54-4a40-9700-c99459feaed3.png">


I've also tested cancelation works without the `cancel-checkout` feature enabled:
<img width="1067" alt="Screen Shot 2023-04-14 at 2 38 28 pm" src="https://user-images.githubusercontent.com/2132506/231943051-426bd050-c0f8-4055-a9a8-9b8338275345.png">



