### PR TITLE
CI: test-acknowledgements-diff shows the diff output

### DIFF
--- a/.buildkite/steps/test-acknowledgements-diff.sh
+++ b/.buildkite/steps/test-acknowledgements-diff.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-trap "rm ACKNOWLEDGEMENTS-{orig,new}.md" EXIT
+trap "rm -f ACKNOWLEDGEMENTS-{orig,new}.md" EXIT
 
 # Make a comparison copy without the generate timestamp
 sed -e '$d' ACKNOWLEDGEMENTS.md > ACKNOWLEDGEMENTS-orig.md
@@ -10,7 +10,7 @@ sed -e '$d' ACKNOWLEDGEMENTS.md > ACKNOWLEDGEMENTS-orig.md
 ./scripts/generate-acknowledgements.sh
 sed -e '$d' ACKNOWLEDGEMENTS.md > ACKNOWLEDGEMENTS-new.md
 
-if diff -q ACKNOWLEDGEMENTS-{orig,new}.md ; then
+if diff -u ACKNOWLEDGEMENTS-{orig,new}.md ; then
   echo "Acknowledgements are up-to-date! 🎉"
   exit 0
 fi

--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -7416,4 +7416,4 @@ limitations under the License.
 ---
 
 File generated using ./scripts/generate-acknowledgements.sh
-Wed 15 Mar 2023 14:20:09 NZDT
+Wed 19 Apr 2023 11:21:05 ACST

--- a/scripts/generate-acknowledgements.sh
+++ b/scripts/generate-acknowledgements.sh
@@ -42,8 +42,14 @@ addfile() {
 
 ## The Go standard library also counts.
 license_path="$(go env GOROOT)/LICENSE"
-if [[ "$(go env GOROOT)" == /opt/homebrew/* ]]; then
+if [[ ! -f $license_path ]]; then
+  # Homebrew and/or macOS does it different? Try up a directory.
+  echo "Could not find Go's LICENSE file at $license_path"
   license_path="$(go env GOROOT)/../LICENSE"
+fi
+if [[ ! -f $license_path ]]; then
+  echo "Could not find Go's LICENSE file at $license_path"
+  exit 1
 fi
 
 addfile "$license_path" "Go standard library"


### PR DESCRIPTION
Show the delta of `ACKNOWLEDGEMENTS.md` changes when changes are detected in CI.
This makes it easier to understand why it's changed when looking at a failed build, e.g. when dependabot is bumping a dependency.