### PR TITLE
Include abbrev-commit in `buildkite:git:commit` meta-data

### DIFF
--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -17,13 +17,14 @@ import (
 // Example commit info:
 //
 // commit 65e2f46931cf9fe1ba9e445d92d213cfa3be5312
+// abbrev-commit 65e2f46931
 // Author:     Example Human <legit@example.com>
-// AuthorDate: Thu Jan 15 11:05:16 2015 +0800
-// Commit:     Example Human <legit@example.com>
-// CommitDate: Thu Jan 15 11:05:16 2015 +0800
 //
 //	hello world
-var commitPattern = bintest.MatchPattern(`(?ms)\Acommit [0-9a-f]+\n.*^Author:`)
+var commitPattern = bintest.MatchPattern(`(?ms)\Acommit [0-9a-f]+\nabbrev-commit [0-9a-f]+\n.*^Author:`)
+
+// We expect this arg multiple times, just define it once.
+var gitShowFormatArg = "--format=commit %H%nabbrev-commit %h%nAuthor: %an <%ae>%n%n%w(0,4,4)%B"
 
 // Enable an experiment, returning a function to restore the previous state.
 // Usage: defer experimentWithUndo("foo")()
@@ -67,7 +68,7 @@ func TestCheckingOutGitHubPullRequestsWithGitMirrorsExperiment(t *testing.T) {
 		{"rev-parse", "FETCH_HEAD"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-ffxdq"},
-		{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+		{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -109,7 +110,7 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
 			{"rev-parse", "HEAD"},
 		})
 	} else {
@@ -119,7 +120,7 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
 			{"rev-parse", "HEAD"},
 		})
 	}
@@ -162,7 +163,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
 		})
 	} else {
 		git.ExpectAll([][]any{
@@ -171,7 +172,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
 		})
 	}
 
@@ -241,7 +242,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 			{"submodule", "foreach", "--recursive", "git reset --hard"},
 			{"clean", "-fdq"},
 			{"submodule", "foreach", "--recursive", "git clean -fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
 		})
 	} else {
 		git.ExpectAll([][]any{
@@ -256,7 +257,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 			{"submodule", "foreach", "--recursive", "git reset --hard"},
 			{"clean", "-fdq"},
 			{"submodule", "foreach", "--recursive", "git clean -fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
 		})
 	}
 
@@ -320,7 +321,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
 		})
 	} else {
 		git.ExpectAll([][]any{
@@ -330,7 +331,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
 		})
 	}
 
@@ -372,7 +373,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 			{"fetch", "--depth=1", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
 		})
 	} else {
 		git.ExpectAll([][]any{
@@ -381,7 +382,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 			{"fetch", "--depth=1", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
 		})
 	}
 
@@ -726,7 +727,7 @@ func TestGitMirrorEnv(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
 		})
 	} else {
 		git.ExpectAll([][]any{
@@ -735,7 +736,7 @@ func TestGitMirrorEnv(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "-s", "--format=fuller", "--no-color", "--"},
+			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
 		})
 	}
 


### PR DESCRIPTION
Reformat the `git show` data sent to `buildkite-agent meta-data set buildkite:git:commit` so that it includes the abbreviated commit hash as `abbrev-commit`.

This could be used to help Buildkite server-side know the commit SHA abbreviation short length suitable for this repository, without having access to the repository. The default short length increases as commits are added and probability of prefix-collision increases.

The existing `commit` and `Author` fields that Buildkite uses are also still included. The `AuthorDate`, `Commit` (author) and `CommitDate` from the old `--format=fuller` that Buildkite ignores are no longer included. This is arguably a breaking change for customers parsing that extra information out of `buildkite:git:commit`, although I think that's only an API in the [Hyrum's Law](https://www.hyrumslaw.com/) sense. It wouldn't be hard to add them back, but it would make the format string more unwieldy than may be necessary.

Before (using a commit from this PR as an example):

```
commit bae6d8620f726f538255d1b243796c0dab32d594
Author:     Paul Annesley <paul@annesley.cc>
AuthorDate: Wed Apr 19 12:44:45 2023 +0930
Commit:     Paul Annesley <paul@annesley.cc>
CommitDate: Wed Apr 19 12:49:26 2023 +0930

    Include abbrev-commit in buildkite:git:commit meta-data
    
    This could be used to help Buildkite server-side know the commit SHA
    abbreviation short length suitable for this repository, without having
    access to the repository. The default short length increases as commits
    are added and probability of prefix-collision increases.
```

After:

```
commit bae6d8620f726f538255d1b243796c0dab32d594
abbrev-commit bae6d862
Author: Paul Annesley <paul@annesley.cc>

    Include abbrev-commit in buildkite:git:commit meta-data
    
    This could be used to help Buildkite server-side know the commit SHA
    abbreviation short length suitable for this repository, without having
    access to the repository. The default short length increases as commits
    are added and probability of prefix-collision increases.
```

I have verified that Buildkite server-side still correctly extracts the `commit` SHA from the new format.

While I was there, I also:
- preferred `--no-patch` over `-s`
- removed the almost-certainly-unnecessary `--` suffix from the `git show` command line — there's never any arguments following the double-hyphen arg terminator.
- re-ordered args so that `--no-patch` and `--no-color` are adjacent; they seem like friends.