### PR TITLE
BUILDKITE_GIT_CLONE_MIRROR_FLAGS not working

### DIFF
--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -81,7 +81,7 @@ type Config struct {
 	GitFetchFlags string `env:"BUILDKITE_GIT_FETCH_FLAGS"`
 
 	// Flags to pass to "git clone" command for mirroring
-	GitCloneMirrorFlags string
+	GitCloneMirrorFlags string `env:"BUILDKITE_GIT_CLONE_MIRROR_FLAGS"`
 
 	// Flags to pass to "git clean" command
 	GitCleanFlags string `env:"BUILDKITE_GIT_CLEAN_FLAGS"`


### PR DESCRIPTION
Ran into this when trying to get clone flags working in mirror mode. I tried using the environment variable listed in the docs (https://buildkite.com/docs/agent/v3/configuration), but it wasn't working.

I got the `BUILDKITE_GIT_CLONE_FLAGS` working properly in the same method and when I ran a regular clean it worked just fine, but the `BUILDKITE_GIT_CLONE_MIRROR_FLAGS` never worked. Dug through the agent code and saw this `env` was missed during a refactor so I figured that was the issue.