### PR TITLE
Experiment constants

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -214,7 +214,7 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 	allWriters := []io.Writer{}
 
 	switch {
-	case experiments.IsEnabled("ansi-timestamps"):
+	case experiments.IsEnabled(experiments.ANSITimestamps):
 		// If we have ansi-timestamps, we can skip line timestamps AND header times
 		// this is the future of timestamping
 		prefixer := process.NewPrefixer(runner.output, func() string {
@@ -299,7 +299,7 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 	processEnv := append(os.Environ(), env...)
 
 	// The process that will run the bootstrap script
-	if experiments.IsEnabled("kubernetes-exec") {
+	if experiments.IsEnabled(experiments.KubernetesExec) {
 		containerCount, err := strconv.Atoi(os.Getenv("BUILDKITE_CONTAINER_COUNT"))
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse BUILDKITE_CONTAINER_COUNT: %w", err)

--- a/agent/tags.go
+++ b/agent/tags.go
@@ -78,7 +78,7 @@ type tagFetcher struct {
 func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsConfig) []string {
 	tags := conf.Tags
 
-	if experiments.IsEnabled("kubernetes-exec") {
+	if experiments.IsEnabled(experiments.KubernetesExec) {
 		k8sTags, err := t.k8s()
 		if err != nil {
 			l.Warn("Could not fetch tags from k8s: %s", err)

--- a/bootstrap/api.go
+++ b/bootstrap/api.go
@@ -13,7 +13,7 @@ import (
 func (b *Bootstrap) startJobAPI() (cleanup func(), err error) {
 	cleanup = func() {}
 
-	if !experiments.IsEnabled("job-api") {
+	if !experiments.IsEnabled(experiments.JobAPI) {
 		return cleanup, nil
 	}
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -80,7 +80,7 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 		b.shell.Debug = b.Config.Debug
 		b.shell.InterruptSignal = b.Config.CancelSignal
 	}
-	if experiments.IsEnabled("kubernetes-exec") {
+	if experiments.IsEnabled(experiments.KubernetesExec) {
 		kubernetesClient := &kubernetes.Client{}
 		if err := b.startKubernetesClient(ctx, kubernetesClient); err != nil {
 			b.shell.Errorf("Failed to start kubernetes client: %v", err)
@@ -99,7 +99,7 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 	// Create a context to use for cancelation of the job
 	var cancelCtx context.Context
 	var cancel context.CancelFunc
-	if experiments.IsEnabled("cancel-checkout") {
+	if experiments.IsEnabled(experiments.CancelCheckout) {
 		cancelCtx, cancel = context.WithCancel(ctx)
 	} else {
 		cancelCtx = ctx
@@ -1081,7 +1081,7 @@ func (b *Bootstrap) CheckoutPhase(ctx context.Context) error {
 					b.shell.Warningf("Checkout was cancelled")
 					r.Break()
 
-				case experiments.IsEnabled("cancel-checkout") && errors.Is(ctx.Err(), context.Canceled):
+				case experiments.IsEnabled(experiments.CancelCheckout) && errors.Is(ctx.Err(), context.Canceled):
 					b.shell.Warningf("Checkout was cancelled due to context cancellation")
 					r.Break()
 
@@ -1517,7 +1517,7 @@ func (b *Bootstrap) defaultCheckoutPhase(ctx context.Context) error {
 	}
 
 	// resolve BUILDKITE_COMMIT based on the local git repo
-	if experiments.IsEnabled("resolve-commit-after-checkout") {
+	if experiments.IsEnabled(experiments.ResolveCommitAfterCheckout) {
 		b.shell.Commentf("Using resolve-commit-after-checkout experiment 🧪")
 		b.resolveCommit(ctx)
 	}

--- a/bootstrap/integration/bootstrap_tester.go
+++ b/bootstrap/integration/bootstrap_tester.go
@@ -117,7 +117,7 @@ func NewBootstrapTester() (*BootstrapTester, error) {
 	if exp := experiments.Enabled(); len(exp) > 0 {
 		bt.Env = append(bt.Env, "BUILDKITE_AGENT_EXPERIMENT="+strings.Join(exp, ","))
 
-		if experiments.IsEnabled("git-mirrors") {
+		if experiments.IsEnabled(experiments.GitMirrors) {
 			gitMirrorsDir, err := os.MkdirTemp("", "bootstrap-git-mirrors")
 			if err != nil {
 				return nil, fmt.Errorf("making bootstrap-git-mirrors directory: %w", err)

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -40,7 +40,7 @@ func experimentWithUndo(name string) func() {
 
 func TestCheckingOutGitHubPullRequestsWithGitMirrorsExperiment(t *testing.T) {
 	// t.Parallel() cannot be used with experiments.Enable()
-	defer experimentWithUndo("git-mirrors")()
+	defer experimentWithUndo(experiments.GitMirrors)()
 
 	tester, err := NewBootstrapTester()
 	if err != nil {
@@ -81,7 +81,7 @@ func TestCheckingOutGitHubPullRequestsWithGitMirrorsExperiment(t *testing.T) {
 
 func TestWithResolvingCommitExperiment(t *testing.T) {
 	// t.Parallel() cannot be used with experiments.Enable()
-	defer experimentWithUndo("resolve-commit-after-checkout")()
+	defer experimentWithUndo(experiments.ResolveCommitAfterCheckout)()
 
 	tester, err := NewBootstrapTester()
 	if err != nil {
@@ -102,7 +102,7 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 		PassthroughToLocalCommand()
 
 	// But assert which ones are called
-	if experiments.IsEnabled("git-mirrors") {
+	if experiments.IsEnabled(experiments.GitMirrors) {
 		git.ExpectAll([][]any{
 			{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
@@ -155,7 +155,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 		PassthroughToLocalCommand()
 
 	// But assert which ones are called
-	if experiments.IsEnabled("git-mirrors") {
+	if experiments.IsEnabled(experiments.GitMirrors) {
 		git.ExpectAll([][]any{
 			{"clone", "--mirror", "--config", "pack.threads=35", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
@@ -227,7 +227,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 		PassthroughToLocalCommand()
 
 	// But assert which ones are called
-	if experiments.IsEnabled("git-mirrors") {
+	if experiments.IsEnabled(experiments.GitMirrors) {
 		git.ExpectAll([][]any{
 			{"clone", "--mirror", "-v", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "--mirror", "-v", "--", submoduleRepo.Path, matchSubDir(tester.GitMirrorsDir)},
@@ -312,7 +312,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 		PassthroughToLocalCommand()
 
 	// But assert which ones are called
-	if experiments.IsEnabled("git-mirrors") {
+	if experiments.IsEnabled(experiments.GitMirrors) {
 		git.ExpectAll([][]any{
 			{"clone", "--mirror", "-v", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
@@ -365,7 +365,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 		PassthroughToLocalCommand()
 
 	// But assert which ones are called
-	if experiments.IsEnabled("git-mirrors") {
+	if experiments.IsEnabled(experiments.GitMirrors) {
 		git.ExpectAll([][]any{
 			{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "--depth=1", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
@@ -427,7 +427,7 @@ func TestCheckingOutWithSSHKeyscan(t *testing.T) {
 	git := tester.MustMock(t, "git")
 	git.IgnoreUnexpectedInvocations()
 
-	if experiments.IsEnabled("git-mirrors") {
+	if experiments.IsEnabled(experiments.GitMirrors) {
 		git.Expect("clone", "--mirror", "-v", "--", "git@github.com:buildkite/agent.git", bintest.MatchAny()).
 			AndExitWith(0)
 	} else {
@@ -480,7 +480,7 @@ func TestCheckingOutWithSSHKeyscanAndUnscannableRepo(t *testing.T) {
 	git := tester.MustMock(t, "git")
 	git.IgnoreUnexpectedInvocations()
 
-	if experiments.IsEnabled("git-mirrors") {
+	if experiments.IsEnabled(experiments.GitMirrors) {
 		git.Expect("clone", "--mirror", "-v", "--", "https://github.com/buildkite/bash-example.git", bintest.MatchAny()).
 			AndExitWith(0)
 	} else {
@@ -691,7 +691,7 @@ func TestRepositorylessCheckout(t *testing.T) {
 
 func TestGitMirrorEnv(t *testing.T) {
 	// t.Parallel() cannot test experiment flags in parallel
-	defer experimentWithUndo("git-mirrors")()
+	defer experimentWithUndo(experiments.GitMirrors)()
 
 	tester, err := NewBootstrapTester()
 	if err != nil {
@@ -719,7 +719,7 @@ func TestGitMirrorEnv(t *testing.T) {
 		PassthroughToLocalCommand()
 
 	// But assert which ones are called
-	if experiments.IsEnabled("git-mirrors") {
+	if experiments.IsEnabled(experiments.GitMirrors) {
 		git.ExpectAll([][]any{
 			{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 			{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},

--- a/bootstrap/integration/job_api_integration_test.go
+++ b/bootstrap/integration/job_api_integration_test.go
@@ -10,12 +10,13 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/buildkite/agent/v3/experiments"
 	"github.com/buildkite/agent/v3/jobapi"
 	"github.com/buildkite/bintest/v3"
 )
 
 func TestBootstrapRunsJobAPI(t *testing.T) {
-	defer experimentWithUndo("job-api")()
+	defer experimentWithUndo(experiments.JobAPI)()
 
 	tester, err := NewBootstrapTester()
 	if err != nil {

--- a/bootstrap/shell/shell.go
+++ b/bootstrap/shell/shell.go
@@ -261,7 +261,7 @@ func (s *Shell) flock(ctx context.Context, path string, timeout time.Duration) (
 
 // Create a cross-process file-based lock based on pid files
 func (s *Shell) LockFile(ctx context.Context, path string, timeout time.Duration) (LockFile, error) {
-	if experiments.IsEnabled("flock-file-locks") {
+	if experiments.IsEnabled(experiments.FlockFileLocks) {
 		s.Commentf("Using flock-file-locks experiment 🧪")
 		return s.flock(ctx, path, timeout)
 	}

--- a/bootstrap/shell/shell_test.go
+++ b/bootstrap/shell/shell_test.go
@@ -313,8 +313,8 @@ func TestLockFileRetriesAndTimesOut(t *testing.T) {
 }
 
 func TestFlockRetriesAndTimesOut(t *testing.T) {
-	experiments.Enable("flock-file-locks")
-	defer experiments.Disable("flock-file-locks")
+	experiments.Enable(experiments.FlockFileLocks)
+	defer experiments.Disable(experiments.FlockFileLocks)
 
 	TestLockFileRetriesAndTimesOut(t)
 }
@@ -322,7 +322,7 @@ func TestFlockRetriesAndTimesOut(t *testing.T) {
 func acquireLockInOtherProcess(lockfile string) (*exec.Cmd, error) {
 	flockExperimentEnabled := false
 	expectedLockPath := lockfile
-	if experiments.IsEnabled("flock-file-locks") {
+	if experiments.IsEnabled(experiments.FlockFileLocks) {
 		flockExperimentEnabled = true
 		expectedLockPath = lockfile + "f" // flock-locked files are created with the suffix 'f'
 	}
@@ -354,9 +354,9 @@ func TestAcquiringLockHelperProcess(t *testing.T) {
 	}
 
 	if os.Getenv("FLOCK_EXPERIMENT_ENABLED") == "true" {
-		experiments.Enable("flock-file-locks")
+		experiments.Enable(experiments.FlockFileLocks)
 	} else {
-		experiments.Disable("flock-file-locks")
+		experiments.Disable(experiments.FlockFileLocks)
 	}
 
 	fileName := os.Args[len(os.Args)-1]

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -656,7 +656,7 @@ var AgentStartCommand = cli.Command{
 		}
 
 		// Check if git-mirrors are enabled
-		if experiments.IsEnabled("git-mirrors") {
+		if experiments.IsEnabled(experiments.GitMirrors) {
 			if cfg.GitMirrorsPath == "" {
 				l.Fatal("Must provide a git-mirrors-path in your configuration for git-mirrors experiment")
 			}
@@ -925,7 +925,7 @@ var AgentStartCommand = cli.Command{
 
 			if cfg.SpawnWithPriority {
 				p := i
-				if experiments.IsEnabled("descending-spawn-priority") {
+				if experiments.IsEnabled(experiments.DescendingSpawnPrioity) {
 					// This experiment helps jobs be assigned across all hosts
 					// in cases where the value of --spawn varies between hosts.
 					p = -i
@@ -982,7 +982,7 @@ var AgentStartCommand = cli.Command{
 				}
 			})
 
-			if experiments.IsEnabled("inbuilt-status-page") {
+			if experiments.IsEnabled(experiments.InbuiltStatusPage) {
 				http.HandleFunc("/status", status.Handle)
 			}
 

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -4,17 +4,29 @@
 // It is intended for internal use by buildkite-agent only.
 package experiments
 
+const (
+	JobAPI                     = "job-api"
+	KubernetesExec             = "kubernetes-exec"
+	ANSITimestamps             = "ansi-timestamps"
+	GitMirrors                 = "git-mirrors"
+	FlockFileLocks             = "flock-file-locks"
+	ResolveCommitAfterCheckout = "resolve-commit-after-checkout"
+	DescendingSpawnPrioity     = "descending-spawn-priority"
+	InbuiltStatusPage          = "inbuilt-status-page"
+	CancelCheckout             = "cancel-checkout"
+)
+
 var (
 	Available = map[string]struct{}{
-		"job-api":                       {},
-		"kubernetes-exec":               {},
-		"ansi-timestamps":               {},
-		"git-mirrors":                   {},
-		"flock-file-locks":              {},
-		"resolve-commit-after-checkout": {},
-		"descending-spawn-priority":     {},
-		"inbuilt-status-page":           {},
-		"cancel-checkout":               {},
+		JobAPI:                     {},
+		KubernetesExec:             {},
+		ANSITimestamps:             {},
+		GitMirrors:                 {},
+		FlockFileLocks:             {},
+		ResolveCommitAfterCheckout: {},
+		DescendingSpawnPrioity:     {},
+		InbuiltStatusPage:          {},
+		CancelCheckout:             {},
 	}
 
 	experiments = make(map[string]bool, len(Available))


### PR DESCRIPTION
Refactors all experiment strings into constants in the `experiments` package. Protects us from misspellings and the like.