### PR TITLE
Gracefully cancel checkout by default

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -84,9 +84,3 @@ See [jobapi/payloads.go](./jobapi/payloads.go) for the full API request/response
 The Job API is unavailable on windows agents running versions of windows prior to build 17063, as this was when windows added Unix Domain Socket support. Using this experiment on such agents will output a warning, and the API will be unavailable.
 
 **Status:** Experimental while we iron out the API and test it out in the wild. We'll probably promote this to non-experiment soon™️.
-
-## `cancel-checkout`
-
-Don't retry git checkout when the job has been canceled during the checkout phase.
-
-**Status:** Bug fix in testing. We well remove or promote it soon.

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -97,14 +97,7 @@ func (b *Bootstrap) Run(ctx context.Context) (exitCode int) {
 	defer func() { span.FinishWithError(err) }()
 
 	// Create a context to use for cancelation of the job
-	var cancelCtx context.Context
-	var cancel context.CancelFunc
-	if experiments.IsEnabled(experiments.CancelCheckout) {
-		cancelCtx, cancel = context.WithCancel(ctx)
-	} else {
-		cancelCtx = ctx
-		cancel = func() {}
-	}
+	cancelCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	// Listen for cancellation
@@ -1081,7 +1074,7 @@ func (b *Bootstrap) CheckoutPhase(ctx context.Context) error {
 					b.shell.Warningf("Checkout was cancelled")
 					r.Break()
 
-				case experiments.IsEnabled(experiments.CancelCheckout) && errors.Is(ctx.Err(), context.Canceled):
+				case errors.Is(ctx.Err(), context.Canceled):
 					b.shell.Warningf("Checkout was cancelled due to context cancellation")
 					r.Break()
 

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -13,7 +13,6 @@ const (
 	ResolveCommitAfterCheckout = "resolve-commit-after-checkout"
 	DescendingSpawnPrioity     = "descending-spawn-priority"
 	InbuiltStatusPage          = "inbuilt-status-page"
-	CancelCheckout             = "cancel-checkout"
 )
 
 var (
@@ -26,7 +25,6 @@ var (
 		ResolveCommitAfterCheckout: {},
 		DescendingSpawnPrioity:     {},
 		InbuiltStatusPage:          {},
-		CancelCheckout:             {},
 	}
 
 	experiments = make(map[string]bool, len(Available))


### PR DESCRIPTION
This feature/fix was originally committed as an experiment, but we want to turn it on by default - it seems fairly safe