### PR TITLE
ArtifactBatchCreator & ArtifactUploader: use roko.ExponentialSubsecond

### DIFF
--- a/agent/artifact_batch_creator.go
+++ b/agent/artifact_batch_creator.go
@@ -76,11 +76,8 @@ func (a *ArtifactBatchCreator) Create(ctx context.Context) ([]*api.Artifact, err
 
 		// Retry the batch upload a couple of times
 		err = roko.NewRetrier(
-			// TODO: e.g. roko.ExponentialSubsecond(500*time.Millisecond) WithMaxAttempts(10)
-			// see: https://github.com/buildkite/roko/pull/8
-			// Meanwhile, 8 roko.Exponential(2sec) attempts is 1,2,4,8,16,32,64 seconds delay (~2 mins)
-			roko.WithMaxAttempts(8),
-			roko.WithStrategy(roko.Exponential(2*time.Second, 0)),
+			roko.WithMaxAttempts(10),
+			roko.WithStrategy(roko.ExponentialSubsecond(500*time.Millisecond)),
 		).DoWithContext(ctx, func(r *roko.Retrier) error {
 
 			ctxTimeout := ctx

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -329,11 +329,8 @@ func (a *ArtifactUploader) upload(ctx context.Context, artifacts []*api.Artifact
 
 				// Update the states of the artifacts in bulk.
 				err := roko.NewRetrier(
-					// TODO: e.g. roko.ExponentialSubsecond(500*time.Millisecond) WithMaxAttempts(10)
-					// see: https://github.com/buildkite/roko/pull/8
-					// Meanwhile, 8 roko.Exponential(2sec) attempts is 1,2,4,8,16,32,64 seconds delay (~2 mins)
-					roko.WithMaxAttempts(8),
-					roko.WithStrategy(roko.Exponential(2*time.Second, 0)),
+					roko.WithMaxAttempts(10),
+					roko.WithStrategy(roko.ExponentialSubsecond(500*time.Millisecond)),
 				).DoWithContext(ctx, func(r *roko.Retrier) error {
 					ctxShort, cancel := context.WithTimeout(ctx, 5*time.Second)
 					defer cancel()


### PR DESCRIPTION
For `ArtifactBatchCreator` & `ArtifactUploader` retries, use the new `roko.ExponentialSubsecond` from https://github.com/buildkite/roko/pull/8 as intended in https://github.com/buildkite/agent/pull/2028 (at that point `ExponentialSubsecond` wasn't merged into roko yet).

This means more retries happen sooner, with a gentler growth curve, and the retry limit is reached sooner; the total retry wait across 10 attempts is ~33 seconds. Assuming the requests are timing out after 10 seconds, that's 100+33 = 133 seconds (just over 2 minutes). I think that's a good amount of time to try for.

[Here's](https://www.wolframalpha.com/input?i=y%3D500%5E%28x%2F16+%2B+1%29+for+x+from+0+to+8) the **new curve** of `ExponentialSubsecond` for 10 attempts (9 “between” delays) with a 500ms start, growing to ~10 seconds:
(Y axis is **milliseconds**)

<img width="373" alt="image" src="https://user-images.githubusercontent.com/15759/236087480-db09ca48-3033-4463-8f52-c95dcf572a1c.png">

[Here's](https://www.wolframalpha.com/input?i=y%3D2%5Ex+for+x+from+0+to+6) the **previous curve** of `roko.Exponential(2*time.Second, 0)` for 8 attempts, growing to ~60 seconds:
(Y axis is in **seconds**)

<img width="375" alt="image" src="https://user-images.githubusercontent.com/15759/236088490-37ac826e-2559-43dd-8e06-6752c5ef73ce.png">




Here's a failure retrying to exhaustion with the new strategy:

<img width="1084" alt="image" src="https://user-images.githubusercontent.com/15759/236085519-f49442f7-1df9-4ab6-a4c1-57df7fbef47d.png">

And here's one succeeding after a few timeouts:

<img width="1096" alt="image" src="https://user-images.githubusercontent.com/15759/236085581-1f176bb8-063c-4b73-a856-9f38cec9e0b2.png">


Related:
- https://github.com/buildkite/roko/pull/8
- https://github.com/buildkite/agent/pull/2028