### PR TITLE
Add a flag to `artifact upload` to allow skipping symlinks when uploading files

### DIFF
--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -46,10 +46,10 @@ type ArtifactUploaderConfig struct {
 	DebugHTTP bool
 
 	// Whether to follow symbolic links when resolving globs
-	FollowSymlinks bool
+	GlobResolveFollowSymlinks bool
 
 	// Whether to not upload symlinks
-	NoUploadSymlinks bool
+	UploadSkipSymlinks bool
 }
 
 type ArtifactUploader struct {
@@ -127,7 +127,7 @@ func (a *ArtifactUploader) Collect() (artifacts []*api.Artifact, err error) {
 		// Resolve the globs (with * and ** in them), if it's a non-globbed path and doesn't exists
 		// then we will get the ErrNotExist that is handled below
 		globfunc := zglob.Glob
-		if a.conf.FollowSymlinks {
+		if a.conf.GlobResolveFollowSymlinks {
 			// Follow symbolic links for files & directories while expanding globs
 			globfunc = zglob.GlobFollowSymlinks
 		}
@@ -159,7 +159,7 @@ func (a *ArtifactUploader) Collect() (artifacts []*api.Artifact, err error) {
 				continue
 			}
 
-			if a.conf.NoUploadSymlinks && isSymlink(absolutePath) {
+			if a.conf.UploadSkipSymlinks && isSymlink(absolutePath) {
 				a.logger.Debug("Skipping symlink %s", file)
 				continue
 			}

--- a/agent/artifact_uploader_test.go
+++ b/agent/artifact_uploader_test.go
@@ -226,7 +226,7 @@ func TestCollectWithSomeGlobsThatDontMatchAnythingFollowingSymlinks(t *testing.T
 			filepath.Join("test", "fixtures", "artifacts", "links", "folder-link", "dontmatchanything", "**", "*.jpg"),
 			filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
 		}, ";"),
-		FollowSymlinks: true,
+		GlobResolveFollowSymlinks: true,
 	})
 
 	artifacts, err := uploader.Collect()
@@ -284,7 +284,7 @@ func TestCollectWithDuplicateMatchesFollowingSymlinks(t *testing.T) {
 			filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
 			filepath.Join("test", "fixtures", "artifacts", "folder", "Commando.jpg"), // dupe
 		}, ";"),
-		FollowSymlinks: true,
+		GlobResolveFollowSymlinks: true,
 	})
 
 	artifacts, err := uploader.Collect()
@@ -319,7 +319,7 @@ func TestCollectMatchesUploadSymlinks(t *testing.T) {
 		Paths: strings.Join([]string{
 			filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
 		}, ";"),
-		NoUploadSymlinks: true,
+		UploadSkipSymlinks: true,
 	})
 
 	artifacts, err := uploader.Collect()

--- a/agent/artifact_uploader_test.go
+++ b/agent/artifact_uploader_test.go
@@ -308,3 +308,36 @@ func TestCollectWithDuplicateMatchesFollowingSymlinks(t *testing.T) {
 		paths,
 	)
 }
+
+func TestCollectMatchesUploadSymlinks(t *testing.T) {
+	wd, _ := os.Getwd()
+	root := filepath.Join(wd, "..")
+	os.Chdir(root)
+	defer os.Chdir(wd)
+
+	uploader := NewArtifactUploader(logger.Discard, nil, ArtifactUploaderConfig{
+		Paths: strings.Join([]string{
+			filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
+		}, ";"),
+		NoUploadSymlinks: true,
+	})
+
+	artifacts, err := uploader.Collect()
+	if err != nil {
+		t.Fatalf("uploader.Collect() error = %v", err)
+	}
+
+	paths := []string{}
+	for _, a := range artifacts {
+		paths = append(paths, a.Path)
+	}
+	assert.ElementsMatch(
+		t,
+		[]string{
+			filepath.Join("test", "fixtures", "artifacts", "Mr Freeze.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "folder", "Commando.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "this is a folder with a space", "The Terminator.jpg"),
+		},
+		paths,
+	)
+}

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -55,7 +55,18 @@ Example:
    $ export BUILDKITE_ARTIFACTORY_URL=http://my-artifactory-instance.com/artifactory
    $ export BUILDKITE_ARTIFACTORY_USER=carol-danvers
    $ export BUILDKITE_ARTIFACTORY_PASSWORD=xxx
-   $ buildkite-agent artifact upload "log/**/*.log" rt://name-of-your-artifactory-repo/$BUILDKITE_JOB_ID`
+   $ buildkite-agent artifact upload "log/**/*.log" rt://name-of-your-artifactory-repo/$BUILDKITE_JOB_ID
+
+   By default, symlinks to directories will not be explored when resolving the glob, but symlinks to files will be uploaded as the linked files.
+   To ignore symlinks to files use:
+
+   $ buildkite-agent artifact upload --upload-skip-symlinks "log/**/*.log"
+
+   Note uploading symlinks to files without following them is not supported.
+   If you need to preserve them in direcotory, we recommend creating a tar archive:
+
+   $ tar -cvf log.tar log/**/*
+   $ buildkite-agent upload log.tar`
 
 type ArtifactUploadConfig struct {
 	UploadPaths string `cli:"arg:0" label:"upload paths" validate:"required"`
@@ -103,17 +114,17 @@ var ArtifactUploadCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name:   "glob-resolve-follow-symlinks",
-			Usage:  "Follow symbolic links to directories while resolving globs",
+			Usage:  "Follow symbolic links to directories while resolving globs. Note: this will not prevent symlinks to files from being uploaded. Use --upload-skip-symlinks to do that",
 			EnvVar: "BUILDKITE_AGENT_ARTIFACT_GLOB_RESOLVE_FOLLOW_SYMLINKS",
 		},
 		cli.BoolFlag{
 			Name:   "upload-skip-symlinks",
-			Usage:  "After the glob has been resolved to a list of files to upload, skip symbolic links to files",
+			Usage:  "After the glob has been resolved to a list of files to upload, skip uploading those that are symlinks to files",
 			EnvVar: "BUILDKITE_ARTIFACT_UPLOAD_FOLLOW_SYMLINKS",
 		},
 		cli.BoolFlag{ // Deprecated
 			Name:   "follow-symlinks",
-			Usage:  "Follow symbolic links while resolving globs. Note this argument is deprecated. Use `--glob-resolve-follow-symlinks` instead.",
+			Usage:  "Follow symbolic links while resolving globs. Note this argument is deprecated. Use `--glob-resolve-follow-symlinks` instead",
 			EnvVar: "BUILDKITE_AGENT_ARTIFACT_SYMLINKS",
 		},
 

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -57,12 +57,6 @@ Example:
    $ export BUILDKITE_ARTIFACTORY_PASSWORD=xxx
    $ buildkite-agent artifact upload "log/**/*.log" rt://name-of-your-artifactory-repo/$BUILDKITE_JOB_ID`
 
-var FollowSymlinksFlag = cli.BoolFlag{
-	Name:   "follow-symlinks",
-	Usage:  "Follow symbolic links while resolving globs",
-	EnvVar: "BUILDKITE_AGENT_ARTIFACT_SYMLINKS",
-}
-
 type ArtifactUploadConfig struct {
 	UploadPaths string `cli:"arg:0" label:"upload paths" validate:"required"`
 	Destination string `cli:"arg:1" label:"destination" env:"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"`
@@ -83,8 +77,10 @@ type ArtifactUploadConfig struct {
 	NoHTTP2          bool   `cli:"no-http2"`
 
 	// Uploader flags
-	FollowSymlinks bool `cli:"follow-symlinks"`
 	UploadSymlinks bool `cli:"no-upload-symlinks"`
+
+	// deprecated
+	FollowSymlinks bool `cli:"follow-symlinks"`
 }
 
 var ArtifactUploadCommand = cli.Command{
@@ -122,7 +118,6 @@ var ArtifactUploadCommand = cli.Command{
 		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
-		FollowSymlinksFlag,
 	},
 	Action: func(c *cli.Context) {
 		ctx := context.Background()

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -84,6 +84,7 @@ type ArtifactUploadConfig struct {
 
 	// Uploader flags
 	FollowSymlinks bool `cli:"follow-symlinks"`
+	UploadSymlinks bool `cli:"no-upload-symlinks"`
 }
 
 var ArtifactUploadCommand = cli.Command{
@@ -102,6 +103,11 @@ var ArtifactUploadCommand = cli.Command{
 			Value:  "",
 			Usage:  "A specific Content-Type to set for the artifacts (otherwise detected)",
 			EnvVar: "BUILDKITE_ARTIFACT_CONTENT_TYPE",
+		},
+		cli.BoolTFlag{
+			Name:   "upload-symlinks",
+			Usage:  "Whether, after the glob has been resolved, symlinks to files should be uploaded",
+			EnvVar: "BUILDKITE_ARTIFACT_UPLOAD_SYMLINKS",
 		},
 
 		// API Flags
@@ -147,12 +153,13 @@ var ArtifactUploadCommand = cli.Command{
 
 		// Setup the uploader
 		uploader := agent.NewArtifactUploader(l, client, agent.ArtifactUploaderConfig{
-			JobID:          cfg.Job,
-			Paths:          cfg.UploadPaths,
-			Destination:    cfg.Destination,
-			ContentType:    cfg.ContentType,
-			DebugHTTP:      cfg.DebugHTTP,
-			FollowSymlinks: cfg.FollowSymlinks,
+			JobID:            cfg.Job,
+			Paths:            cfg.UploadPaths,
+			Destination:      cfg.Destination,
+			ContentType:      cfg.ContentType,
+			DebugHTTP:        cfg.DebugHTTP,
+			FollowSymlinks:   cfg.FollowSymlinks,
+			NoUploadSymlinks: !cfg.UploadSymlinks,
 		})
 
 		// Upload the artifacts

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -120,7 +120,7 @@ var ArtifactUploadCommand = cli.Command{
 		cli.BoolFlag{
 			Name:   "upload-skip-symlinks",
 			Usage:  "After the glob has been resolved to a list of files to upload, skip uploading those that are symlinks to files",
-			EnvVar: "BUILDKITE_ARTIFACT_UPLOAD_FOLLOW_SYMLINKS",
+			EnvVar: "BUILDKITE_ARTIFACT_UPLOAD_SKIP_SYMLINKS",
 		},
 		cli.BoolFlag{ // Deprecated
 			Name:   "follow-symlinks",


### PR DESCRIPTION
TL;DR: There is a new flag `--upload-skip-symlinks` that prevents files that are symlinks from being uploaded. The flag `--follow-symlinks` has been deprecated and renamed to `--glob-resolve-follow-symlinks`.

# Description

Some users may misinterpret specifying `false` to the `--follow-symlinks` flag to mean that the agent will not upload symlinks.

However, this is not the case. Until this PR, the agent will always upload all files that match the glob provided to the `artifact upload` subcommand. The `--follow-symlinks` flag only affected whether symlinked directories would be followed when resolving the glob.

However, I think it is a reasonable expectation that `--follow-symlinks=false` WOULD prevent symlinked files from being uploaded. Indeed, on the `aws s3 sync` command, [that is the case](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/sync.html#options). 

However, I think we are constrained from changing the behaviour of the existing flag. Some customers may have been uploading artifacts unaware that they are actually symlinks. As the flag is confusing, we should deprecate it. However, it is not straightforward if we should replace it with one flag that both does not follow symlinks when resolving the glob, and skips uploading files that are symlinks, or create a flag for each of these.

I decided on the former so that there will be an exact replacement for the deprecated `--follow-symlinks` flag, `--glob-resolve-follow-symlinks`. The new feature of not uploading symlinks is enabled by the `--upload-skip-symlink` flag.

This gives the follow table
glob-resolve-follow-symlinks|upload-skip-symlinks| outcome
------|-----|--------
 F | F | glob does not enter symlinked dirs and symlinked files are not uploaded
 F | T | glob does not enter symlinked dirs and symlinked files are uploaded
 T | F | glob does enter symlinked dirs and symlinked files are not uploaded
 T | T | glob does enter symlinked dirs and symlinked files are uploaded

As all four possibilities are meaningfully different, I think it's justified to have 2 flags even if the backward compatibility need not be maintained.

# Uploading just the symlink
The binary nature of the `--upload-skip-symlinks` flag precludes a third behaviour where instead of uploading the file behind the symlink, the agent could endeavour to preserve the symlink.
 
While this is an interesting use case, S3 does not support symlinks. An implementation of the feature would have to choose a representation of the symlink in the object storage, and on downloading such a representation, reconstruct the symlink on the target file system. Also, the upload and download could occur on different file systems and by agents on different operating systems, each with differing levels of implementations of symlinks, exposing us to many edge cases.  I think that if users want to preserve what's on the file system to that extent, they are better served by creating a tarball.

## Implementation Note:
The implementation uses a call to `lstat` to determine if the file is a link. There is a previous call to `stat` to determine if the file is a directory. I thought about ways to combine these, but it seems both calls need to be made to determine if a path is a symlink to a directory.