### PR TITLE
bootstrap: avoid --no-patch, support old git (pre v1.8.4; 2013)

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1534,7 +1534,7 @@ func (b *Bootstrap) defaultCheckoutPhase(ctx context.Context) error {
 			"--no-pager",
 			"show",
 			"HEAD",
-			"--no-patch",
+			"-s", // --no-patch was introduced in v1.8.4 in 2013, but e.g. CentOS 7 isn't there yet
 			"--no-color",
 			"--format=commit %H%nabbrev-commit %h%nAuthor: %an <%ae>%n%n%w(0,4,4)%B",
 		}

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -68,7 +68,7 @@ func TestCheckingOutGitHubPullRequestsWithGitMirrorsExperiment(t *testing.T) {
 		{"rev-parse", "FETCH_HEAD"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-ffxdq"},
-		{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
+		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -110,7 +110,7 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
+			{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
 			{"rev-parse", "HEAD"},
 		})
 	} else {
@@ -120,7 +120,7 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
+			{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
 			{"rev-parse", "HEAD"},
 		})
 	}
@@ -163,7 +163,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
+			{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
 		})
 	} else {
 		git.ExpectAll([][]any{
@@ -172,7 +172,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
+			{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
 		})
 	}
 
@@ -242,7 +242,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 			{"submodule", "foreach", "--recursive", "git reset --hard"},
 			{"clean", "-fdq"},
 			{"submodule", "foreach", "--recursive", "git clean -fdq"},
-			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
+			{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
 		})
 	} else {
 		git.ExpectAll([][]any{
@@ -257,7 +257,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 			{"submodule", "foreach", "--recursive", "git reset --hard"},
 			{"clean", "-fdq"},
 			{"submodule", "foreach", "--recursive", "git clean -fdq"},
-			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
+			{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
 		})
 	}
 
@@ -321,7 +321,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
+			{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
 		})
 	} else {
 		git.ExpectAll([][]any{
@@ -331,7 +331,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
+			{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
 		})
 	}
 
@@ -373,7 +373,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 			{"fetch", "--depth=1", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
+			{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
 		})
 	} else {
 		git.ExpectAll([][]any{
@@ -382,7 +382,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 			{"fetch", "--depth=1", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
+			{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
 		})
 	}
 
@@ -727,7 +727,7 @@ func TestGitMirrorEnv(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
+			{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
 		})
 	} else {
 		git.ExpectAll([][]any{
@@ -736,7 +736,7 @@ func TestGitMirrorEnv(t *testing.T) {
 			{"fetch", "-v", "--", "origin", "main"},
 			{"checkout", "-f", "FETCH_HEAD"},
 			{"clean", "-fdq"},
-			{"--no-pager", "show", "HEAD", "--no-patch", "--no-color", gitShowFormatArg},
+			{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
 		})
 	}
 


### PR DESCRIPTION
#2054 replaced `git show … -s`… with `git show … --no-patch …` to be more self-documenting. The long form of that option was added a decade ago in Git 1.8.4 in 2013, and breaks in even-older versions. Some still-supported operating systems like CentOS 7 (EOL June 2024) still use Git 1.8.3 (_presumably_ with backported security fixes 😅) so we should keep using the old short arg for now.

Related:
- #2054 
- #2073 
- Git adding `--no-patch`:
  - https://lwn.net/Articles/565031/
  - https://github.com/git/git/releases/tag/v1.8.4
  - https://github.com/git/git/commit/d09cd15d19de23aca532a85f6d27a71b2baceb3f


