### PR TITLE
fix: 🪶 experiment `normalised-upload-paths` was left out of the list of available experiments

### DIFF
--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -166,7 +166,7 @@ func (a *ArtifactUploader) Collect() (artifacts []*api.Artifact, err error) {
 				return nil, fmt.Errorf("resolving relative path for file %s: %w", file, err)
 			}
 
-			if experiments.IsEnabled(experiments.NormalizedUploadPaths) {
+			if experiments.IsEnabled(experiments.NormalisedUploadPaths) {
 				// Convert any Windows paths to Unix/URI form
 				path = filepath.ToSlash(path)
 			}

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -166,7 +166,7 @@ func (a *ArtifactUploader) Collect() (artifacts []*api.Artifact, err error) {
 				return nil, fmt.Errorf("resolving relative path for file %s: %w", file, err)
 			}
 
-			if experiments.IsEnabled("normalised-upload-paths") {
+			if experiments.IsEnabled(experiments.NormalizedUploadPaths) {
 				// Convert any Windows paths to Unix/URI form
 				path = filepath.ToSlash(path)
 			}

--- a/agent/artifact_uploader_test.go
+++ b/agent/artifact_uploader_test.go
@@ -100,7 +100,7 @@ func TestCollect(t *testing.T) {
 	// path.Join function instead (which uses Unix/URI-style path separators,
 	// regardless of platform)
 
-	experimentKey := experiments.NormalizedUploadPaths
+	experimentKey := experiments.NormalisedUploadPaths
 	experimentPrev := experiments.IsEnabled(experimentKey)
 	defer func() {
 		if experimentPrev {

--- a/agent/artifact_uploader_test.go
+++ b/agent/artifact_uploader_test.go
@@ -100,7 +100,7 @@ func TestCollect(t *testing.T) {
 	// path.Join function instead (which uses Unix/URI-style path separators,
 	// regardless of platform)
 
-	experimentKey := "normalised-upload-paths"
+	experimentKey := experiments.NormalizedUploadPaths
 	experimentPrev := experiments.IsEnabled(experimentKey)
 	defer func() {
 		if experimentPrev {
@@ -109,14 +109,14 @@ func TestCollect(t *testing.T) {
 			experiments.Disable(experimentKey)
 		}
 	}()
-	experiments.Disable("normalised-upload-paths")
+	experiments.Disable(experimentKey)
 	artifactsWithoutExperimentEnabled, err := uploader.Collect()
 	if err != nil {
 		t.Fatalf("[normalised-upload-paths disabled] uploader.Collect() error = %v", err)
 	}
 	assert.Equal(t, 5, len(artifactsWithoutExperimentEnabled))
 
-	experiments.Enable("normalised-upload-paths")
+	experiments.Enable(experimentKey)
 	artifactsWithExperimentEnabled, err := uploader.Collect()
 	if err != nil {
 		t.Fatalf("[normalised-upload-paths enabled] uploader.Collect() error = %v", err)

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1308,7 +1308,7 @@ func (b *Bootstrap) defaultCheckoutPhase(ctx context.Context) error {
 	var mirrorDir string
 
 	// If we can, get a mirror of the git repository to use for reference later
-	if experiments.IsEnabled(`git-mirrors`) && b.Config.GitMirrorsPath != "" && b.Config.Repository != "" {
+	if experiments.IsEnabled(experiments.GitMirrors) && b.Config.GitMirrorsPath != "" && b.Config.Repository != "" {
 		b.shell.Commentf("Using git-mirrors experiment 🧪")
 		span.AddAttributes(map[string]string{"checkout.is_using_git_mirrors": "true"})
 		mirrorDir, err = b.getOrUpdateMirrorDir(ctx, b.Repository)
@@ -1442,7 +1442,7 @@ func (b *Bootstrap) defaultCheckoutPhase(ctx context.Context) error {
 		if err != nil {
 			b.shell.Warningf("Failed to enumerate git submodules: %v", err)
 		} else {
-			mirrorSubmodules := experiments.IsEnabled(`git-mirrors`) && b.Config.GitMirrorsPath != ""
+			mirrorSubmodules := experiments.IsEnabled(experiments.GitMirrors) && b.Config.GitMirrorsPath != ""
 			for _, repository := range submoduleRepos {
 				submoduleArgs := append([]string(nil), args...)
 				// submodules might need their fingerprints verified too

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -14,7 +14,7 @@ const (
 	DescendingSpawnPrioity     = "descending-spawn-priority"
 	InbuiltStatusPage          = "inbuilt-status-page"
 	AgentAPI                   = "agent-api"
-	NormalizedUploadPaths      = "normalised-upload-paths"
+	NormalisedUploadPaths      = "normalised-upload-paths"
 )
 
 var (
@@ -28,7 +28,7 @@ var (
 		DescendingSpawnPrioity:     {},
 		InbuiltStatusPage:          {},
 		AgentAPI:                   {},
-		NormalizedUploadPaths:      {},
+		NormalisedUploadPaths:      {},
 	}
 
 	experiments = make(map[string]bool, len(Available))

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -14,6 +14,7 @@ const (
 	DescendingSpawnPrioity     = "descending-spawn-priority"
 	InbuiltStatusPage          = "inbuilt-status-page"
 	AgentAPI                   = "agent-api"
+	NormalizedUploadPaths      = "normalised-upload-paths"
 )
 
 var (
@@ -27,6 +28,7 @@ var (
 		DescendingSpawnPrioity:     {},
 		InbuiltStatusPage:          {},
 		AgentAPI:                   {},
+		NormalizedUploadPaths:      {},
 	}
 
 	experiments = make(map[string]bool, len(Available))


### PR DESCRIPTION
We are seeing this warning in our Buildkite jobs:

```
WARN   Unknown experiment enabled: "normalised-upload-paths"
```

It looks like the experiment is present and does do something.

I would hypothesize that this is just an accidental oversight to leave this out of the list.