### PR TITLE
Persist Go module cache in a bind mount

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -7,12 +7,14 @@ services:
       dockerfile: Dockerfile-compile
     volumes:
       - ../:/work:cached
+      - ~/gomodcache:/gomodcache
     working_dir: /work
     environment:
       - BUILDKITE_BUILD_NUMBER
       - BUILDKITE_JOB_ID
       - "BUILDKITE_AGENT_TAGS=queue=default"
       - "BUILDKITE_BUILD_PATH=/buildkite"
+      - GOMODCACHE=/gomodcache
 
   ruby:
     image: ruby:2.7.6


### PR DESCRIPTION
To speed up tests, store the Go module cache in a common bind mount. Given the design of Go modules, I expect this to be safe and robust.

While it would work in a named volume with a fixed name, the Docker compose plugin helpfully cleans up named volumes in its exit hook.