### PR TITLE
Always test in race mode

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,20 +46,6 @@ steps:
         files: "junit-*.xml"
         format: "junit"
 
-  - name: ":satellite: Detect Data Races"
-    key: test-race-linux-arm64
-    command: ".buildkite/steps/tests.sh -race"
-    artifact_paths: junit-*.xml
-    agents:
-      queue: agent-runners-linux-arm64
-    plugins:
-      docker-compose#v3.0.0:
-        config: .buildkite/docker-compose.yml
-        run: agent
-      test-collector#v1.2.0:
-        files: "junit-*.xml"
-        format: "junit"
-
   - name: ":windows: Windows AMD64 Tests"
     key: test-windows
     command: "bash .buildkite\\steps\\tests.sh"

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -4,10 +4,11 @@ set -euo pipefail
 go version
 echo arch is "$(uname -m)"
 
+export CGO_ENABLED=0
 go install gotest.tools/gotestsum@v1.8.0
 
 echo '+++ Running tests'
-gotestsum --junitfile "junit-${BUILDKITE_JOB_ID}.xml" -- -count=1 -failfast "$@" ./...
+gotestsum --junitfile "junit-${BUILDKITE_JOB_ID}.xml" -- -count=1 -failfast -race ./...
 
 echo '+++ Running integration tests for git-mirrors experiment'
-TEST_EXPERIMENT=git-mirrors gotestsum --junitfile "junit-${BUILDKITE_JOB_ID}-git-mirrors.xml" -- -count=1 -failfast "$@" ./bootstrap/integration
+TEST_EXPERIMENT=git-mirrors gotestsum --junitfile "junit-${BUILDKITE_JOB_ID}-git-mirrors.xml" -- -count=1 -failfast -race ./bootstrap/integration


### PR DESCRIPTION
We currently have one step in CI for running the tests in race mode, but it only runs those race tests against the linux-arm64 target.

We originally added the one race test because there were certain tests that we knew contained data races, and wanted to be able to skip them only in race mode. Now though, i think we've resolved all of those data races (largely due to @DrJosh9000's amazing work 🎉), so we should just always test in race mode.