### PR TITLE
Update all alpine images to 3.18

### DIFF
--- a/packaging/docker/alpine-k8s/Dockerfile
+++ b/packaging/docker/alpine-k8s/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM alpine:3.17.3 AS base
+FROM alpine:3.18.0 AS base
 
 RUN apk update && apk add --no-cache \
     bash \
@@ -8,7 +8,6 @@ RUN apk update && apk add --no-cache \
     docker-cli \
     docker-cli-buildx \
     docker-cli-compose \
-    docker-compose \
     git \
     jq \
     libc6-compat \
@@ -21,7 +20,9 @@ RUN apk update && apk add --no-cache \
     tini \
     tzdata
 
-FROM alpine:3.17.3 AS kubectl-downloader
+RUN ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
+
+FROM alpine:3.18.0 AS kubectl-downloader
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -34,7 +35,7 @@ wget -qO kubectl \
 chmod +x kubectl
 EOF
 
-FROM alpine:3.17.3 AS kustomize-downloader
+FROM alpine:3.18.0 AS kustomize-downloader
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/packaging/docker/alpine/Dockerfile
+++ b/packaging/docker/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.18.0
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -7,9 +7,8 @@ RUN apk add --no-cache \
     bash \
     curl \
     docker-cli \
-    docker-cli-buildx \
     docker-cli-compose \
-    docker-compose \
+    docker-cli-buildx \
     git \
     jq \
     libc6-compat \
@@ -21,6 +20,8 @@ RUN apk add --no-cache \
     su-exec \
     tini \
     tzdata
+
+RUN ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg
 

--- a/packaging/docker/sidecar/Dockerfile
+++ b/packaging/docker/sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.18.0
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Also, remove docker-compose v1 and replace it with a symlink to docker compose v2. docker-compose v1 is no longer offered on the apkn registry on alpine versions >3.18, so we'll have to make do.