### PR TITLE
Rename polyglot hook env BUILDKITE_HOOK_TRIGGERED_FROM -> BUILDKITE_HOOK_SCOPE

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -357,7 +357,7 @@ func (b *Bootstrap) runUnwrappedHook(ctx context.Context, hookName string, hookC
 
 	environ.Set("BUILDKITE_HOOK_PHASE", hookCfg.Name)
 	environ.Set("BUILDKITE_HOOK_PATH", hookCfg.Path)
-	environ.Set("BUILDKITE_HOOK_TRIGGERED_FROM", hookCfg.Scope)
+	environ.Set("BUILDKITE_HOOK_SCOPE", hookCfg.Scope)
 
 	return b.shell.RunWithEnv(ctx, environ, hookCfg.Path)
 }


### PR DESCRIPTION
It was a very weird decision for me to call it `TRIGGERED_FROM`, idk why i did that ¯\\\_(ツ)_/¯