### PR TITLE
Move os.MkdirAll to socket.NewServer

### DIFF
--- a/internal/socket/server.go
+++ b/internal/socket/server.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 )
 
 // Server hosts a HTTP server on a Unix domain socket.
@@ -20,6 +22,10 @@ type Server struct {
 func NewServer(socketPath string, handler http.Handler) (*Server, error) {
 	if len(socketPath) >= socketPathLength() {
 		return nil, fmt.Errorf("socket path %s is too long (path length: %d, max %d characters). This is a limitation of your host OS", socketPath, len(socketPath), socketPathLength())
+	}
+
+	if err := os.MkdirAll(filepath.Dir(socketPath), os.FileMode(0700)); err != nil {
+		return nil, fmt.Errorf("creating socket directory: %w", err)
 	}
 
 	exists, err := socketExists(socketPath)

--- a/jobapi/socket.go
+++ b/jobapi/socket.go
@@ -15,12 +15,6 @@ func init() {
 // NewSocketPath generates a path to a socket file (without actually creating the file itself) that can be used with the
 // job api.
 func NewSocketPath(base string) (string, error) {
-	path := filepath.Join(base, "job-api")
-	err := os.MkdirAll(path, 0700)
-	if err != nil {
-		return "", fmt.Errorf("creating socket directory: %w", err)
-	}
-
 	sockNum := rand.Int63() % 100_000
-	return filepath.Join(path, fmt.Sprintf("%d-%d.sock", os.Getpid(), sockNum)), nil
+	return filepath.Join(base, "job-api", fmt.Sprintf("%d-%d.sock", os.Getpid(), sockNum)), nil
 }


### PR DESCRIPTION
Unless `job-api` was used previously, there's little chance of the socket directory existing. If the directory doesn't exist, enabling `agent-api` crashes the agent on startup. Using `MkdirAll` in `NewServer` ensures the directory exists.