### PR TITLE
Preserve plugin config env var names with consecutive underscores

### DIFF
--- a/agent/plugin/error.go
+++ b/agent/plugin/error.go
@@ -22,6 +22,10 @@ func (e *DeprecatedNameErrors) IsEmpty() bool {
 // Errors returns the contained set of errors in sorted order
 func (e *DeprecatedNameErrors) Errors() []DeprecatedNameError {
 	if e == nil {
+		return nil
+	}
+
+	if e.errs == nil {
 		return []DeprecatedNameError{}
 	}
 

--- a/agent/plugin/error.go
+++ b/agent/plugin/error.go
@@ -1,0 +1,129 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// DeprecatedNameErrors contains an aggregation of DeprecatedNameError
+type DeprecatedNameErrors struct {
+	errs []DeprecatedNameError
+}
+
+// Errors returns the contained set of errors in sorted order
+func (e *DeprecatedNameErrors) Errors() []DeprecatedNameError {
+	if e == nil {
+		return []DeprecatedNameError{}
+	}
+
+	errs := e.errs
+	sort.Slice(errs, func(i, j int) bool {
+		if errs[i].old == errs[j].old {
+			return errs[i].new < errs[j].new
+		}
+		return errs[i].old < errs[j].old
+	})
+
+	return errs
+}
+
+// Len is the length of the underlying slice or 0 if nil
+func (e *DeprecatedNameErrors) Len() int {
+	if e == nil {
+		return 0
+	}
+	return len(e.errs)
+}
+
+// Error returns each contained error on a new line
+func (e *DeprecatedNameErrors) Error() string {
+	builder := strings.Builder{}
+	for i, err := range e.Errors() {
+		_, _ = builder.WriteString(err.Error())
+		if i < len(e.errs)-1 {
+			_, _ = builder.WriteRune('\n')
+		}
+	}
+	return builder.String()
+}
+
+// Append adds DeprecatedNameError contained set and returns the reciver.
+// Returning the reveiver is necessary to support appending to nil. So this
+// should be used just like the builtin `append` function.
+func (e *DeprecatedNameErrors) Append(errs ...DeprecatedNameError) *DeprecatedNameErrors {
+	if e == nil {
+		return &DeprecatedNameErrors{errs: errs}
+	}
+
+	e.errs = append(e.errs, errs...)
+
+	return e
+}
+
+// Is returns true if and only if a error that is wrapped in target
+// contains the same set of DeprecatedNameError as the receiver.
+func (e *DeprecatedNameErrors) Is(target error) bool {
+	if e == nil {
+		return target == nil
+	}
+
+	var targetErr *DeprecatedNameErrors
+	if !errors.As(target, &targetErr) {
+		return false
+	}
+
+	dict := make(map[DeprecatedNameError]int, len(e.errs))
+	for _, err := range e.errs {
+		if c, exists := dict[err]; !exists {
+			dict[err] = 1
+		} else {
+			dict[err] = c + 1
+		}
+	}
+
+	for _, err := range targetErr.errs {
+		c, exists := dict[err]
+		if !exists {
+			return false
+		}
+		dict[err] = c - 1
+	}
+
+	for _, v := range dict {
+		if v != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// DeprecatedNameError contains information about environment variable names that
+// are deprecated. Both the deprecated name and its replacement are held
+type DeprecatedNameError struct {
+	old string
+	new string
+}
+
+func NewDeprecatedNameError(oldName, newName string) DeprecatedNameError {
+	return DeprecatedNameError{old: oldName, new: newName}
+}
+
+func (e *DeprecatedNameError) Error() string {
+	return fmt.Sprintf(" deprecated: %q\nreplacement: %q\n", e.old, e.new)
+}
+
+func (e *DeprecatedNameError) Is(target error) bool {
+	if e == nil {
+		return target == nil
+	}
+
+	var targetErr *DeprecatedNameError
+	if !errors.As(target, &targetErr) {
+		return false
+	}
+
+	return e.old == targetErr.old && e.new == targetErr.new
+}

--- a/agent/plugin/error.go
+++ b/agent/plugin/error.go
@@ -18,7 +18,9 @@ func (e *DeprecatedNameErrors) Errors() []DeprecatedNameError {
 		return []DeprecatedNameError{}
 	}
 
-	errs := e.errs
+	errs := make([]DeprecatedNameError, len(e.errs))
+	copy(errs, e.errs)
+
 	sort.Slice(errs, func(i, j int) bool {
 		if errs[i].old == errs[j].old {
 			return errs[i].new < errs[j].new

--- a/agent/plugin/error_test.go
+++ b/agent/plugin/error_test.go
@@ -1,0 +1,115 @@
+package plugin
+
+import (
+	"errors"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func cyclicPermute[T any](arr []T) {
+	if len(arr) < 2 {
+		return
+	}
+
+	for i := len(arr) - 1; i > 0; i-- {
+		j := rand.Intn(i)
+		arr[i], arr[j] = arr[j], arr[i]
+	}
+}
+
+func TestDeprecatedNameErrorsOrder(t *testing.T) {
+	t.Parallel()
+	seed := time.Now().UnixNano() % ((1 << 31) - 1)
+	t.Logf("seed = %d", seed)
+	rand.Seed(seed)
+
+	for _, test := range []struct {
+		name string
+		errs []DeprecatedNameError
+	}{
+		{
+			name: "0_error",
+			errs: []DeprecatedNameError{},
+		},
+		{
+			name: "1_error",
+			errs: []DeprecatedNameError{
+				{
+					old: "a",
+					new: "b",
+				},
+			},
+		},
+		{
+			name: "2_errors",
+			errs: []DeprecatedNameError{
+				{
+					old: "a",
+					new: "b",
+				},
+				{
+					old: "c",
+					new: "d",
+				},
+			},
+		},
+		{
+			name: "3_errors",
+			errs: []DeprecatedNameError{
+				{
+					old: "a",
+					new: "b",
+				},
+				{
+					old: "c",
+					new: "d",
+				},
+				{
+					old: "e",
+					new: "f",
+				},
+			},
+		},
+		{
+			name: "4_errors",
+			errs: []DeprecatedNameError{
+				{
+					old: "a",
+					new: "b",
+				},
+				{
+					old: "c",
+					new: "d",
+				},
+				{
+					old: "e",
+					new: "f",
+				},
+				{
+					old: "g",
+					new: "h",
+				},
+			},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			errs := make([]DeprecatedNameError, len(test.errs))
+			copy(errs, test.errs)
+			cyclicPermute(errs)
+
+			var err1, err2 *DeprecatedNameErrors
+			err1 = err1.Append(test.errs...)
+			err2 = err2.Append(errs...)
+			if err1.Error() != err2.Error() {
+				t.Errorf("expected DeprecatedNameErrors Error() to be ordered")
+			}
+
+			if !errors.Is(err1, err2) {
+				t.Errorf("expected DeprecatedNameErrors Is() to not be sensitive to order")
+			}
+		})
+	}
+}

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -93,7 +93,7 @@ func CreateFromJSON(j string) ([]*Plugin, error) {
 		switch vv := v.(type) {
 		case string:
 			// Add the plugin with no config to the array
-			plugin, err := CreatePlugin(string(vv), map[string]any{})
+			plugin, err := CreatePlugin(vv, map[string]any{})
 			if err != nil {
 				return nil, err
 			}
@@ -103,7 +103,7 @@ func CreateFromJSON(j string) ([]*Plugin, error) {
 			for location, config := range vv {
 				// Plugins without configs are easy!
 				if config == nil {
-					plugin, err := CreatePlugin(string(location), map[string]any{})
+					plugin, err := CreatePlugin(location, map[string]any{})
 					if err != nil {
 						return nil, err
 					}
@@ -119,7 +119,7 @@ func CreateFromJSON(j string) ([]*Plugin, error) {
 				}
 
 				// Add the plugin with config to the array
-				plugin, err := CreatePlugin(string(location), config)
+				plugin, err := CreatePlugin(location, config)
 				if err != nil {
 					return nil, err
 				}
@@ -214,7 +214,6 @@ func formatEnvKey(key string) string {
 
 func walkConfigValues(prefix string, v any, into *[]string) error {
 	switch vv := v.(type) {
-
 	// handles all of our primitive types, golang provides a good string representation
 	case string, bool, json.Number:
 		*into = append(*into, fmt.Sprintf("%s=%v", prefix, vv))

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -243,6 +243,14 @@ type DeprecatedNameErrors struct {
 	errs []DeprecatedNameError
 }
 
+func (e *DeprecatedNameErrors) Errors() []DeprecatedNameError {
+	if e == nil {
+		return []DeprecatedNameError{}
+	}
+
+	return e.errs
+}
+
 func (e *DeprecatedNameErrors) Len() int {
 	if e == nil {
 		return 0
@@ -299,7 +307,7 @@ type DeprecatedNameError struct {
 }
 
 func (e *DeprecatedNameError) Error() string {
-	return fmt.Sprintf(`old name: %q, new name: %q`, e.old, e.new)
+	return fmt.Sprintf("deprecated name: %q, replacement name: %q", e.old, e.new)
 }
 
 func (e *DeprecatedNameError) Is(target error) bool {

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -341,7 +341,7 @@ type DeprecatedNameError struct {
 }
 
 func (e *DeprecatedNameError) Error() string {
-	return fmt.Sprintf("deprecated name: %q, replacement name: %q", e.old, e.new)
+	return fmt.Sprintf(" deprecated: %q\nreplacement: %q\n", e.old, e.new)
 }
 
 func (e *DeprecatedNameError) Is(target error) bool {

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/buildkite/agent/v3/env"
@@ -355,8 +354,6 @@ func fanOutDeprectatedEnvVarNames(envSlice []string) ([]string, error) {
 			dnerrs = dnerrs.Append(DeprecatedNameError{old: noConsecutiveUnderScoreKey, new: k})
 		}
 	}
-
-	sort.Strings(envSliceAfter)
 
 	// guarantee that the error value is nil if there are no deprecations
 	if dnerrs.Len() != 0 {

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -18,7 +18,7 @@ import (
 var (
 	nonIDCharacterRE        = regexp.MustCompile(`[^a-zA-Z0-9]`)
 	consecutiveHyphenRE     = regexp.MustCompile(`-+`)
-	dashOrSpace             = regexp.MustCompile(`-|\s`)
+	hypenOrSpaceRE          = regexp.MustCompile(`-|\s`)
 	whitespaceRE            = regexp.MustCompile(`\s+`)
 	consecutiveUnderscoreRE = regexp.MustCompile(`_+`)
 )
@@ -207,7 +207,7 @@ func (p *Plugin) RepositorySubdirectory() (string, error) {
 // formatEnvKey converts strings into an ENV key friendly format
 func formatEnvKey(key string) string {
 	newKey := strings.ToUpper(key)
-	return dashOrSpace.ReplaceAllString(newKey, "_")
+	return hypenOrSpaceRE.ReplaceAllString(newKey, "_")
 }
 
 func walkConfigValues(prefix string, v any, into *[]string) error {

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -239,10 +239,12 @@ func walkConfigValues(prefix string, v any, into *[]string) error {
 	return fmt.Errorf("Unknown type %T %v", v, v)
 }
 
+// DeprecatedNameErrors contains an aggregation of DeprecatedNameError
 type DeprecatedNameErrors struct {
 	errs []DeprecatedNameError
 }
 
+// Errors returns the underlying slice
 func (e *DeprecatedNameErrors) Errors() []DeprecatedNameError {
 	if e == nil {
 		return []DeprecatedNameError{}
@@ -251,6 +253,7 @@ func (e *DeprecatedNameErrors) Errors() []DeprecatedNameError {
 	return e.errs
 }
 
+// Len is the length of the underlying slice or 0 if nil
 func (e *DeprecatedNameErrors) Len() int {
 	if e == nil {
 		return 0
@@ -258,6 +261,7 @@ func (e *DeprecatedNameErrors) Len() int {
 	return len(e.errs)
 }
 
+// Error returns each error message in the underlying slice on new line
 func (e *DeprecatedNameErrors) Error() string {
 	builder := strings.Builder{}
 	for i, err := range e.errs {
@@ -270,6 +274,9 @@ func (e *DeprecatedNameErrors) Error() string {
 	return builder.String()
 }
 
+// Append DeprecatedNameError to the underlying slice and return the reciver
+// returning the reveiver is necessary to support appending to nil. So this
+// should be used just like the builtin append function
 func (e *DeprecatedNameErrors) Append(errs ...DeprecatedNameError) *DeprecatedNameErrors {
 	if e == nil {
 		return &DeprecatedNameErrors{errs: errs}
@@ -281,7 +288,7 @@ func (e *DeprecatedNameErrors) Append(errs ...DeprecatedNameError) *DeprecatedNa
 }
 
 // Is returns true if and only if a error that is wrapped in target
-// has the same []DeprecatedNameError slice as the receiver.
+// has the same underlying slice as the receiver. The order is significant.
 func (e *DeprecatedNameErrors) Is(target error) bool {
 	if e == nil {
 		return target == nil
@@ -301,6 +308,8 @@ func (e *DeprecatedNameErrors) Is(target error) bool {
 	return true
 }
 
+// DeprecatedNameError contains information about environment variable names that
+// are deprecated. Both the deprecated name and its replacement are held
 type DeprecatedNameError struct {
 	old string
 	new string

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -264,7 +264,7 @@ func (p *Plugin) ConfigurationToEnvironment() (*env.Environment, error) {
 	for k, v := range p.Configuration {
 		configPrefix := fmt.Sprintf("%s_%s", envPrefix, formatEnvKey(k))
 		if err := walkConfigValues(configPrefix, v, &envSlice); err != nil {
-			return nil, err
+			return env.New(), err
 		}
 	}
 
@@ -295,9 +295,9 @@ func (p *Plugin) ConfigurationToEnvironment() (*env.Environment, error) {
 	envSlice = append(envSlice, fmt.Sprintf("BUILDKITE_PLUGIN_NAME=%s", formatEnvKey(p.Name())))
 
 	// Append current plugin configuration as JSON
-	configJSON, err := json.Marshal(p.Configuration)
+	configJSON, marshalErr := json.Marshal(p.Configuration)
 	if err != nil {
-		return nil, err
+		return env.New(), marshalErr
 	}
 	envSlice = append(envSlice, fmt.Sprintf("BUILDKITE_PLUGIN_CONFIGURATION=%s", configJSON))
 

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -262,7 +262,7 @@ func fanOutDeprectatedEnvVarNames(envSlice []string) ([]string, error) {
 	}
 
 	// guarantee that the error value is nil if there are no deprecations
-	if dnerrs.Len() != 0 {
+	if !dnerrs.IsEmpty() {
 		return envSliceAfter, dnerrs
 	}
 	return envSliceAfter, nil

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -272,7 +272,7 @@ func (e *DeprecatedNameErrors) Len() int {
 // Error returns each error message in the underlying slice on new line
 func (e *DeprecatedNameErrors) Error() string {
 	builder := strings.Builder{}
-	for i, err := range e.errs {
+	for i, err := range e.Errors() {
 		_, _ = builder.WriteString(err.Error())
 		if i < len(e.errs)-1 {
 			_, _ = builder.WriteRune('\n')

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -242,7 +242,7 @@ func walkConfigValues(prefix string, v any, into *[]string) error {
 // deprecation, either as the deprecated variable name or its replacement, append both to the
 // returned slice, and also append a deprecation error to the error value. If there are no
 // deprecations, the error value is guaranteed to be nil.
-func fanOutDeprectatedEnvVarNames(envSlice []string) ([]string, error) {
+func fanOutDeprecatedEnvVarNames(envSlice []string) ([]string, error) {
 	envSliceAfter := envSlice
 
 	var dnerrs *DeprecatedNameErrors
@@ -291,7 +291,7 @@ func (p *Plugin) ConfigurationToEnvironment() (*env.Environment, error) {
 		}
 	}
 
-	envSlice, err = fanOutDeprectatedEnvVarNames(envSlice)
+	envSlice, err = fanOutDeprecatedEnvVarNames(envSlice)
 	return env.FromSlice(envSlice), err
 }
 

--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -42,7 +42,8 @@ func TestCreateFromJSON(t *testing.T) {
 				Configuration: map[string]any{},
 			}},
 		},
-		{`[{"https://gitlab.example.com/path/to/repo#main":{}}]`,
+		{
+			`[{"https://gitlab.example.com/path/to/repo#main":{}}]`,
 			[]*Plugin{{
 				Location:      "gitlab.example.com/path/to/repo",
 				Version:       "main",
@@ -50,7 +51,8 @@ func TestCreateFromJSON(t *testing.T) {
 				Configuration: map[string]any{},
 			}},
 		},
-		{`[{"https://gitlab.com/group/team/path/to/repo#main":{}}]`,
+		{
+			`[{"https://gitlab.com/group/team/path/to/repo#main":{}}]`,
 			[]*Plugin{{
 				Location:      "gitlab.com/group/team/path/to/repo",
 				Version:       "main",
@@ -477,14 +479,18 @@ func TestConfigurationToEnvironment(t *testing.T) {
 
 }
 
-func pluginFromConfig(configJson string) (*Plugin, error) {
+func pluginFromConfig(configJSON string) (*Plugin, error) {
 	var config map[string]any
 
-	if err := json.Unmarshal([]byte(configJson), &config); err != nil {
+	if err := json.Unmarshal([]byte(configJSON), &config); err != nil {
 		return nil, err
 	}
 
-	jsonString := fmt.Sprintf(`[ { "%s": %s } ]`, "github.com/buildkite-plugins/docker-compose-buildkite-plugin", configJson)
+	jsonString := fmt.Sprintf(
+		`[ { "%s": %s } ]`,
+		"github.com/buildkite-plugins/docker-compose-buildkite-plugin",
+		configJSON,
+	)
 
 	plugins, err := CreateFromJSON(jsonString)
 	if err != nil {
@@ -498,6 +504,8 @@ func pluginFromConfig(configJson string) (*Plugin, error) {
 }
 
 func TestConfigurationToEnvironment_DuplicatePlugin(t *testing.T) {
+	t.Parallel()
+
 	// Ensure on duplicate plugin definition, each plugin gets its respective config exported
 	plugins, err := duplicatePluginFromConfig(`{ "config-key": 41 }`, `{ "second-ref-key": 42 }`)
 	if err != nil {
@@ -543,7 +551,13 @@ func duplicatePluginFromConfig(cfgJSON1, cfgJSON2 string) ([]*Plugin, error) {
 		return nil, err
 	}
 
-	jsonString := fmt.Sprintf(`[ { "%s": %s }, { "%s": %s } ]`, "github.com/buildkite-plugins/docker-compose-buildkite-plugin", cfgJSON1, "github.com/buildkite-plugins/docker-compose-buildkite-plugin", cfgJSON2)
+	jsonString := fmt.Sprintf(
+		`[ { "%s": %s }, { "%s": %s } ]`,
+		"github.com/buildkite-plugins/docker-compose-buildkite-plugin",
+		cfgJSON1,
+		"github.com/buildkite-plugins/docker-compose-buildkite-plugin",
+		cfgJSON2,
+	)
 
 	plugins, err := CreateFromJSON(jsonString)
 	if err != nil {

--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -402,14 +402,12 @@ func TestConfigurationToEnvironment(t *testing.T) {
 				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_AND___WITH_A______NUMBER": "12",
 				"BUILDKITE_PLUGIN_NAME":                                    "DOCKER_COMPOSE",
 			},
-			expectedErr: &DeprecatedNameErrors{
-				errs: []DeprecatedNameError{
-					{
-						old: "BUILDKITE_PLUGIN_DOCKER_COMPOSE_AND_WITH_A_NUMBER",
-						new: "BUILDKITE_PLUGIN_DOCKER_COMPOSE_AND___WITH_A______NUMBER",
-					},
+			expectedErr: (&DeprecatedNameErrors{}).Append(
+				DeprecatedNameError{
+					old: "BUILDKITE_PLUGIN_DOCKER_COMPOSE_AND_WITH_A_NUMBER",
+					new: "BUILDKITE_PLUGIN_DOCKER_COMPOSE_AND___WITH_A______NUMBER",
 				},
-			},
+			),
 		},
 		{
 			configJSON: `{ "and _ with a    - number": 12, "A - B": 13 }`,
@@ -421,18 +419,16 @@ func TestConfigurationToEnvironment(t *testing.T) {
 				"BUILDKITE_PLUGIN_DOCKER_COMPOSE_A___B":                    "13",
 				"BUILDKITE_PLUGIN_NAME":                                    "DOCKER_COMPOSE",
 			},
-			expectedErr: &DeprecatedNameErrors{
-				errs: []DeprecatedNameError{
-					{
-						old: "BUILDKITE_PLUGIN_DOCKER_COMPOSE_AND_WITH_A_NUMBER",
-						new: "BUILDKITE_PLUGIN_DOCKER_COMPOSE_AND___WITH_A______NUMBER",
-					},
-					{
-						old: "BUILDKITE_PLUGIN_DOCKER_COMPOSE_A_B",
-						new: "BUILDKITE_PLUGIN_DOCKER_COMPOSE_A___B",
-					},
+			expectedErr: (&DeprecatedNameErrors{}).Append(
+				DeprecatedNameError{
+					old: "BUILDKITE_PLUGIN_DOCKER_COMPOSE_AND_WITH_A_NUMBER",
+					new: "BUILDKITE_PLUGIN_DOCKER_COMPOSE_AND___WITH_A______NUMBER",
 				},
-			},
+				DeprecatedNameError{
+					old: "BUILDKITE_PLUGIN_DOCKER_COMPOSE_A_B",
+					new: "BUILDKITE_PLUGIN_DOCKER_COMPOSE_A___B",
+				},
+			),
 		},
 		{
 			configJSON: `{ "bool-true-key": true, "bool-false-key": false }`,

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -859,9 +859,9 @@ func (b *Bootstrap) executePluginHook(ctx context.Context, name string, checkout
 		if dnerr := (&plugin.DeprecatedNameErrors{}); err != nil && errors.As(err, &dnerr) {
 			b.shell.Logger.Headerf("Deprecated environment variables for plugin %s", p.Plugin.Name())
 			b.shell.Logger.Printf(
-				"The way that environment variables are derived from the plugin configuration is changing." +
-					"We'll export both the deprecated and the replacement names for now." +
-					"You may be able avoid this by removing consecutive underscore, hypen, or whitespace" +
+				"The way that environment variables are derived from the plugin configuration is changing. " +
+					"We'll export both the deprecated and the replacement names for now. " +
+					"You may be able avoid this by removing consecutive underscore, hypen, or whitespace " +
 					"characters in your plugin configuration.",
 			)
 			for _, err := range dnerr.Errors() {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -857,7 +857,12 @@ func (b *Bootstrap) executePluginHook(ctx context.Context, name string, checkout
 
 		envMap, err := p.ConfigurationToEnvironment()
 		if err != nil {
-			b.shell.Logger.Warningf("%s", err)
+			if dnerr := (&plugin.DeprecatedNameErrors{}); errors.As(err, &dnerr) {
+				b.shell.Logger.Warningf("Exporting plugin environment variables whose names are deprecated and will be replaced.")
+				for _, err := range dnerr.Errors() {
+					b.shell.Logger.Warningf("%s", err.Error())
+				}
+			}
 		}
 
 		if err := b.executeHook(ctx, HookConfig{

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -859,8 +859,10 @@ func (b *Bootstrap) executePluginHook(ctx context.Context, name string, checkout
 		if dnerr := (&plugin.DeprecatedNameErrors{}); err != nil && errors.As(err, &dnerr) {
 			b.shell.Logger.Headerf("Deprecated environment variables for plugin %s", p.Plugin.Name())
 			b.shell.Logger.Printf(
-				"The configuration would export environment variables with the following names in a deprecated manner." +
-					"We'll export both the deprecated and the replacement names, but this behaviour may change in future",
+				"The way that environment variables are derived from the plugin configuration is changing." +
+					"We'll export both the deprecated and the replacement names for now." +
+					"You may be able avoid this by removing consecutive underscore, hypen, or whitespace" +
+					"characters in your plugin configuration.",
 			)
 			for _, err := range dnerr.Errors() {
 				b.shell.Logger.Printf("%s", err.Error())

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -867,6 +867,8 @@ func (b *Bootstrap) executePluginHook(ctx context.Context, name string, checkout
 			for _, err := range dnerr.Errors() {
 				b.shell.Logger.Printf("%s", err.Error())
 			}
+		} else if err != nil {
+			b.shell.Logger.Warningf("Error configuring plugin environment: %s", err)
 		}
 
 		if err := b.executeHook(ctx, HookConfig{

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -855,12 +855,16 @@ func (b *Bootstrap) executePluginHook(ctx context.Context, name string, checkout
 			return err
 		}
 
-		env, _ := p.ConfigurationToEnvironment()
-		err = b.executeHook(ctx, HookConfig{
+		envMap, err := p.ConfigurationToEnvironment()
+		if err != nil {
+			b.shell.Logger.Warningf("%s", err)
+		}
+
+		if err := b.executeHook(ctx, HookConfig{
 			Scope:      "plugin",
 			Name:       name,
 			Path:       hookPath,
-			Env:        env,
+			Env:        envMap,
 			PluginName: p.Plugin.Name(),
 			SpanAttributes: map[string]string{
 				"plugin.name":        p.Plugin.Name(),
@@ -868,8 +872,7 @@ func (b *Bootstrap) executePluginHook(ctx context.Context, name string, checkout
 				"plugin.location":    p.Plugin.Location,
 				"plugin.is_vendored": strconv.FormatBool(p.Vendored),
 			},
-		})
-		if err != nil {
+		}); err != nil {
 			return err
 		}
 	}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -859,7 +859,8 @@ func (b *Bootstrap) executePluginHook(ctx context.Context, name string, checkout
 		if dnerr := (&plugin.DeprecatedNameErrors{}); err != nil && errors.As(err, &dnerr) {
 			b.shell.Logger.Headerf("Deprecated environment variables for plugin %s", p.Plugin.Name())
 			b.shell.Logger.Warningf(
-				"The configuration would export environment variables with the following names in a deprecated manner",
+				"The configuration would export environment variables with the following names in a deprecated manner." +
+					"We'll export both the deprecated and the replacement names, but this behaviour may change in future",
 			)
 			for _, err := range dnerr.Errors() {
 				b.shell.Logger.Printf("%s", err.Error())

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -858,12 +858,12 @@ func (b *Bootstrap) executePluginHook(ctx context.Context, name string, checkout
 		envMap, err := p.ConfigurationToEnvironment()
 		if dnerr := (&plugin.DeprecatedNameErrors{}); err != nil && errors.As(err, &dnerr) {
 			b.shell.Logger.Headerf("Deprecated environment variables for plugin %s", p.Plugin.Name())
-			b.shell.Logger.Printf(
-				"The way that environment variables are derived from the plugin configuration is changing. " +
-					"We'll export both the deprecated and the replacement names for now. " +
-					"You may be able avoid this by removing consecutive underscore, hypen, or whitespace " +
-					"characters in your plugin configuration.",
-			)
+			b.shell.Logger.Printf("%s", strings.Join([]string{
+				"The way that environment variables are derived from the plugin configuration is changing.",
+				"We'll export both the deprecated and the replacement names for now,",
+				"You may be able to avoid this by removing consecutive underscore, hyphen, or whitespace",
+				"characters in your plugin configuration.",
+			}, " "))
 			for _, err := range dnerr.Errors() {
 				b.shell.Logger.Printf("%s", err.Error())
 			}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -858,7 +858,7 @@ func (b *Bootstrap) executePluginHook(ctx context.Context, name string, checkout
 		envMap, err := p.ConfigurationToEnvironment()
 		if dnerr := (&plugin.DeprecatedNameErrors{}); err != nil && errors.As(err, &dnerr) {
 			b.shell.Logger.Headerf("Deprecated environment variables for plugin %s", p.Plugin.Name())
-			b.shell.Logger.Warningf(
+			b.shell.Logger.Printf(
 				"The configuration would export environment variables with the following names in a deprecated manner." +
 					"We'll export both the deprecated and the replacement names, but this behaviour may change in future",
 			)

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -856,12 +856,13 @@ func (b *Bootstrap) executePluginHook(ctx context.Context, name string, checkout
 		}
 
 		envMap, err := p.ConfigurationToEnvironment()
-		if err != nil {
-			if dnerr := (&plugin.DeprecatedNameErrors{}); errors.As(err, &dnerr) {
-				b.shell.Logger.Warningf("Exporting plugin environment variables whose names are deprecated and will be replaced.")
-				for _, err := range dnerr.Errors() {
-					b.shell.Logger.Warningf("%s", err.Error())
-				}
+		if dnerr := (&plugin.DeprecatedNameErrors{}); err != nil && errors.As(err, &dnerr) {
+			b.shell.Logger.Headerf("Deprecated environment variables for plugin %s", p.Plugin.Name())
+			b.shell.Logger.Warningf(
+				"The configuration would export environment variables with the following names in a deprecated manner",
+			)
+			for _, err := range dnerr.Errors() {
+				b.shell.Logger.Printf("%s", err.Error())
 			}
 		}
 


### PR DESCRIPTION
When an env var name, that was derived from a plugin config, had consecutive underscores, the consecutive underscores were replaced by a single one. (For later reference, this will be called the underscore collapsing transformation). Now, both versions of the variable before and after this transformation are exported.

We also log a warning about this and log both the deprecated variable name and its replacement.
We need to keep the deprecated version around, as these environment variables are how plugins read their config without depending on a tool like `jq` to parse the config.
So removing them would mean that plugins could be inadvertently misconfigured, and they would have to be rewritten to start using the replacement environment variables instead.

Implementing this was not that straightforward, as the function that creates the environment slice from the plugin config is recursive and did not take a logger or return errors. It is recursive as that is the most straightforward way to turn a tree like object such as 
```yaml
parameter:
  ci:
    _api_key: /path
    db:
      host: localhost
      port: 5432
```
Into the list of environment variables, similar to:
```bash
PARAMETER_CI_API_KEY=/path
PARAMETER_CI_DB_HOST=localhost
PARAMETER_CI_DB_PORT=5432
```
I could have adapted it to do something when it hits a leaf node and the path to root had consecutive underscores, but I think that would complicate the recursion too much.

Instead, I just removed the underscore collapsing transformation and added a pass over the result that "fans-out" environment variable names with consecutive underscores into two environment variables with and without the underscore collapsing transformation applied.

So in the example above, there will now be an additional environment variable:
```bash
PARAMETER_CI__API_KEY=/path
PARAMETER_CI_API_KEY=/path
PARAMETER_CI_DB_HOST=localhost
PARAMETER_CI_DB_PORT=5432
```

Also, for passing the errors back to bootstrap, I made two custom error types. It's arguably a little overengineered, but I tried to find a way to use error wrapping and/or `errors.Join` to do the job, but they weren't powerful enough, or I was holding them wrong. There could be some generics libraries we could import to eliminate a lot of the code written for the error types. I would be glad to do this.

Fixes: #2100

### Screenshots
#### Before
![2023-05-26T15:14:46,282867146+10:00](https://github.com/buildkite/agent/assets/11096602/c154dcd9-c080-41b4-a0e5-48056c51cba6)


#### After
![2023-05-26T15:14:26,392941516+10:00](https://github.com/buildkite/agent/assets/11096602/4c5bafa6-5981-430f-a745-0ccd2723d6b1)
