### PR TITLE
Clean up system build tags

### DIFF
--- a/internal/system/version_dump.go
+++ b/internal/system/version_dump.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package system
 

--- a/internal/system/version_dump_windows.go
+++ b/internal/system/version_dump_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package system
 
 import (


### PR DESCRIPTION
This commit adds a `//go:build windows` tag to `internal/system/version_dump_windows.go`, which *technically* isn't necessary, as golang interprets a `_windows.go` suffix on a filename as a build tag, but that's super weird behaviour, so this commit adds that tag in explicitly.

It also removes the old-style `// +build` style tag on `internal/system/version_dump.go`