### PR TITLE
De-experimentify ansi-timestamps (take 2)

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -24,6 +24,7 @@ type AgentConfiguration struct {
 	PluginValidation           bool
 	LocalHooksEnabled          bool
 	RunInPty                   bool
+	ANSITimestamps             bool
 	TimestampLines             bool
 	HealthCheckAddr            string
 	DisconnectAfterJob         bool

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -104,6 +104,7 @@ type AgentStartConfig struct {
 	NoPluginValidation          bool     `cli:"no-plugin-validation"`
 	NoPTY                       bool     `cli:"no-pty"`
 	NoFeatureReporting          bool     `cli:"no-feature-reporting"`
+	NoANSITimestamps            bool     `cli:"no-ansi-timestamps"`
 	TimestampLines              bool     `cli:"timestamp-lines"`
 	HealthCheckAddr             string   `cli:"health-check-addr"`
 	MetricsDatadog              bool     `cli:"metrics-datadog"`
@@ -454,8 +455,13 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_PLUGINS_PATH",
 		},
 		cli.BoolFlag{
+			Name:   "no-ansi-timestamps",
+			Usage:  "Do not insert ANSI timestamp codes at the start of each line of job output",
+			EnvVar: "BUILDKITE_NO_ANSI_TIMESTAMPS",
+		},
+		cli.BoolFlag{
 			Name:   "timestamp-lines",
-			Usage:  "Prepend timestamps on each line of output.",
+			Usage:  "Prepend timestamps on each line of job output. Has no effect unless --no-ansi-timestamps is also used",
 			EnvVar: "BUILDKITE_TIMESTAMP_LINES",
 		},
 		cli.StringFlag{
@@ -782,6 +788,7 @@ var AgentStartCommand = cli.Command{
 			PluginValidation:           !cfg.NoPluginValidation,
 			LocalHooksEnabled:          !cfg.NoLocalHooks,
 			RunInPty:                   !cfg.NoPTY,
+			ANSITimestamps:             !cfg.NoANSITimestamps,
 			TimestampLines:             cfg.TimestampLines,
 			DisconnectAfterJob:         cfg.DisconnectAfterJob,
 			DisconnectAfterIdleTimeout: cfg.DisconnectAfterIdleTimeout,

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -21,7 +21,6 @@ const (
 
 const (
 	// Available experiments
-	ANSITimestamps             = "ansi-timestamps"
 	AgentAPI                   = "agent-api"
 	DescendingSpawnPrioity     = "descending-spawn-priority"
 	JobAPI                     = "job-api"
@@ -31,6 +30,7 @@ const (
 	ResolveCommitAfterCheckout = "resolve-commit-after-checkout"
 
 	// Promoted experiments
+	ANSITimestamps    = "ansi-timestamps"
 	FlockFileLocks    = "flock-file-locks"
 	GitMirrors        = "git-mirrors"
 	InbuiltStatusPage = "inbuilt-status-page"
@@ -38,7 +38,6 @@ const (
 
 var (
 	Available = map[string]struct{}{
-		ANSITimestamps:             {},
 		AgentAPI:                   {},
 		DescendingSpawnPrioity:     {},
 		JobAPI:                     {},
@@ -49,6 +48,7 @@ var (
 	}
 
 	Promoted = map[string]string{
+		ANSITimestamps:    standardPromotionMsg(ANSITimestamps),
 		FlockFileLocks:    standardPromotionMsg(FlockFileLocks),
 		GitMirrors:        standardPromotionMsg(GitMirrors),
 		InbuiltStatusPage: standardPromotionMsg(InbuiltStatusPage),


### PR DESCRIPTION
Instead of enabling the current ANSI timestamp behaviour with no opt-out, this one provide an escape hatch to the old defaults with --no-ansi-timestamps.

I thought for a bit about how to make ANSI timestamps and TimestampLines work together. It could avoid having a header times streamer for the purpose of streaming header times, but would still need the logic in the header times streamer to distinguish headers from non-headers, as well as something else to buffer the first few bytes of each line (at least). That bit needs more thought, so for now, continue to not mix ANSI timestamps and TimestampLines.