### PR TITLE
Wipe checkout directory on `git checkout` and `git fetch` failure and retry

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1171,6 +1171,7 @@ func (b *Bootstrap) CheckoutPhase(ctx context.Context) error {
 					case gitErrorClean:
 					case gitErrorCleanSubmodules:
 					case gitErrorClone:
+					case gitErrorFetch:
 						// do nothing, this will fall through to destroy the checkout
 
 					default:

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1160,7 +1160,7 @@ func (b *Bootstrap) CheckoutPhase(ctx context.Context) error {
 					b.shell.Warningf("Checkout failed! %s (%s)", err, r)
 
 					// Specifically handle git errors
-					if ge, ok := err.(*gitError); ok {
+					if ge := new(gitError); errors.As(err, &ge) {
 						switch ge.Type {
 						// These types can fail because of corrupted checkouts
 						case gitErrorClone:
@@ -1186,7 +1186,6 @@ func (b *Bootstrap) CheckoutPhase(ctx context.Context) error {
 					if err := b.createCheckoutDir(); err != nil {
 						return err
 					}
-
 				}
 
 				return err

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1167,13 +1167,9 @@ func (b *Bootstrap) CheckoutPhase(ctx context.Context) error {
 				if ge := new(gitError); errors.As(err, &ge) {
 					switch ge.Type {
 					// These types can fail because of corrupted checkouts
-					case gitErrorCheckout:
-					case gitErrorClean:
-					case gitErrorCleanSubmodules:
-					case gitErrorClone:
-					case gitErrorFetch:
-						// do nothing, this will fall through to destroy the checkout
-
+					case gitErrorClean, gitErrorCleanSubmodules, gitErrorClone,
+						gitErrorCheckoutRetryClean, gitErrorFetchRetryClean:
+					// Otherwise, don't clean the checkout dir
 					default:
 						return err
 					}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1202,7 +1202,10 @@ func (b *Bootstrap) CheckoutPhase(ctx context.Context) error {
 
 	// Store the current value of BUILDKITE_BUILD_CHECKOUT_PATH, so we can detect if
 	// one of the post-checkout hooks changed it.
-	previousCheckoutPath, _ := b.shell.Env.Get("BUILDKITE_BUILD_CHECKOUT_PATH")
+	previousCheckoutPath, exists := b.shell.Env.Get("BUILDKITE_BUILD_CHECKOUT_PATH")
+	if !exists {
+		b.shell.Printf("Could not determine previous checkout path from BUILDKITE_BUILD_CHECKOUT_PATH")
+	}
 
 	// Run post-checkout hooks
 	if err := b.executeGlobalHook(ctx, "post-checkout"); err != nil {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1167,6 +1167,7 @@ func (b *Bootstrap) CheckoutPhase(ctx context.Context) error {
 				if ge := new(gitError); errors.As(err, &ge) {
 					switch ge.Type {
 					// These types can fail because of corrupted checkouts
+					case gitErrorCheckout:
 					case gitErrorClean:
 					case gitErrorCleanSubmodules:
 					case gitErrorClone:

--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -31,6 +31,10 @@ type gitError struct {
 	Type int
 }
 
+func (e *gitError) Unwrap() error {
+	return e.error
+}
+
 type shellRunner interface {
 	Run(context.Context, string, ...string) error
 }

--- a/bootstrap/git.go
+++ b/bootstrap/git.go
@@ -60,7 +60,7 @@ func gitCheckout(ctx context.Context, sh shellRunner, gitCheckoutFlags, referenc
 			return &gitError{error: err, Type: gitErrorCheckoutReferenceIsNotATree}
 		}
 
-		// 128 is extremely broad, but it seems permissions errors, network unreaable errors etc, don't result in it
+		// 128 is extremely broad, but it seems permissions errors, network unreachable errors etc, don't result in it
 		if exitErr := new(exec.ExitError); errors.As(err, &exitErr) && exitErr.ExitCode() == 128 {
 			return &gitError{error: err, Type: gitErrorCheckoutRetryClean}
 		}
@@ -139,7 +139,7 @@ func gitFetch(ctx context.Context, sh shellRunner, gitFetchFlags, repository str
 	}
 
 	if err := sh.Run(ctx, "git", commandArgs...); err != nil {
-		// 128 is extremely broad, but it seems permissions errors, network uncreachable errors etc, don't result in it
+		// 128 is extremely broad, but it seems permissions errors, network unreachable errors etc, don't result in it
 		if exitErr := new(exec.ExitError); errors.As(err, &exitErr) && exitErr.ExitCode() == 128 {
 			return &gitError{error: err, Type: gitErrorFetchRetryClean}
 		}

--- a/bootstrap/integration/bootstrap_tester.go
+++ b/bootstrap/integration/bootstrap_tester.go
@@ -171,6 +171,7 @@ func (b *BootstrapTester) Mock(name string) (*bintest.Mock, error) {
 
 // MustMock will fail the test if creating the mock fails
 func (b *BootstrapTester) MustMock(t *testing.T, name string) *bintest.Mock {
+	t.Helper()
 	mock, err := b.Mock(name)
 	if err != nil {
 		t.Fatalf("BootstrapTester.Mock(%q) error = %v", name, err)
@@ -190,6 +191,7 @@ func (b *BootstrapTester) HasMock(name string) bool {
 
 // MockAgent creates a mock for the buildkite-agent binary
 func (b *BootstrapTester) MockAgent(t *testing.T) *bintest.Mock {
+	t.Helper()
 	agent := b.MustMock(t, "buildkite-agent")
 	agent.Expect("env", "dump").
 		Min(0).
@@ -211,11 +213,11 @@ func (b *BootstrapTester) writeHookScript(m *bintest.Mock, name string, dir stri
 		body = "#!/bin/sh\n" + strings.Join(append([]string{m.Path}, args...), " ")
 	}
 
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}
 
-	return hookScript, os.WriteFile(hookScript, []byte(body), 0600)
+	return hookScript, os.WriteFile(hookScript, []byte(body), 0o600)
 }
 
 // ExpectLocalHook creates a mock object and a script in the git repository's buildkite hooks dir
@@ -223,7 +225,7 @@ func (b *BootstrapTester) writeHookScript(m *bintest.Mock, name string, dir stri
 func (b *BootstrapTester) ExpectLocalHook(name string) *bintest.Expectation {
 	hooksDir := filepath.Join(b.Repo.Path, ".buildkite", "hooks")
 
-	if err := os.MkdirAll(hooksDir, 0700); err != nil {
+	if err := os.MkdirAll(hooksDir, 0o700); err != nil {
 		panic(err)
 	}
 
@@ -255,6 +257,8 @@ func (b *BootstrapTester) ExpectGlobalHook(name string) *bintest.Expectation {
 
 // Run the bootstrap and return any errors
 func (b *BootstrapTester) Run(t *testing.T, env ...string) error {
+	t.Helper()
+
 	// Mock out the meta-data calls to the agent after checkout
 	if !b.HasMock("buildkite-agent") {
 		agent := b.MockAgent(t)
@@ -306,6 +310,7 @@ func (b *BootstrapTester) Cancel() error {
 }
 
 func (b *BootstrapTester) CheckMocks(t *testing.T) {
+	t.Helper()
 	for _, mock := range b.mocks {
 		mock.Check(t)
 	}
@@ -326,6 +331,8 @@ func (b *BootstrapTester) ReadEnvFromOutput(key string) (string, bool) {
 
 // Run the bootstrap and then check the mocks
 func (b *BootstrapTester) RunAndCheck(t *testing.T, env ...string) {
+	t.Helper()
+
 	err := b.Run(t, env...)
 	t.Logf("Bootstrap output:\n%s", b.Output)
 
@@ -402,6 +409,8 @@ type testLogWriter struct {
 }
 
 func newTestLogWriter(t *testing.T) *testLogWriter {
+	t.Helper()
+
 	r, w := io.Pipe()
 	in := bufio.NewScanner(r)
 	lw := &testLogWriter{Writer: w}

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -337,6 +337,68 @@ func TestCheckoutErrorIsRetried(t *testing.T) {
 	tester.RunAndCheck(t, env...)
 }
 
+func TestFetchErrorIsRetried(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewBootstrapTester()
+	if err != nil {
+		t.Fatalf("NewBootstrapTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_FLAGS=-v --depth=1",
+		"BUILDKITE_GIT_CLEAN_FLAGS=-ffxdq",
+		"BUILDKITE_GIT_FETCH_FLAGS=-v --prune --depth=1",
+	}
+
+	// Simulate state from a previous checkout
+	if err := os.MkdirAll(tester.CheckoutDir(), 0755); err != nil {
+		t.Fatalf("error creating dir to clone from: %s", err)
+	}
+	cmd := exec.Command("git", "clone", "-v", "--", tester.Repo.Path, ".")
+	cmd.Dir = tester.CheckoutDir()
+	if _, err = cmd.Output(); err != nil {
+		t.Fatalf("error cloning test repo: %s", err)
+	}
+
+	// Make the git dir dirty to simulate a SIGKILLed git process
+	gitDir := path.Join(tester.CheckoutDir(), ".git")
+	lockFilePath := path.Join(gitDir, "shallow.lock")
+	f, err := os.Create(lockFilePath)
+	if err != nil {
+		t.Fatalf("error creating lock file: %s", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("error closing lock file: %s", err)
+	}
+
+	// Actually execute git commands, but with expectations
+	git := tester.
+		MustMock(t, "git").
+		PassthroughToLocalCommand()
+
+	// But assert which ones are called
+	git.ExpectAll([][]any{
+		{"remote", "set-url", "origin", tester.Repo.Path},
+		{"clean", "-ffxdq"},
+		{"fetch", "-v", "--prune", "--depth=1", "--", "origin", "main"},
+		{"clone", "-v", "--depth=1", "--", tester.Repo.Path, "."},
+		{"clean", "-ffxdq"},
+		{"fetch", "-v", "--prune", "--depth=1", "--", "origin", "main"},
+		{"checkout", "-f", "FETCH_HEAD"},
+		{"clean", "-ffxdq"},
+		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+	})
+
+	// Mock out the meta-data calls to the agent after checkout
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
+	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+
+	tester.RunAndCheck(t, env...)
+}
+
 func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite(t *testing.T) {
 	t.Parallel()
 

--- a/bootstrap/integration/checkout_integration_test.go
+++ b/bootstrap/integration/checkout_integration_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -259,6 +261,69 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 		{"clone", "--depth=1", "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"fetch", "--depth=1", "--", "origin", "main"},
+		{"checkout", "-f", "FETCH_HEAD"},
+		{"clean", "-fdq"},
+		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+	})
+
+	// Mock out the meta-data calls to the agent after checkout
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
+	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+
+	tester.RunAndCheck(t, env...)
+}
+
+func TestCheckoutErrorIsRetried(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewBootstrapTester()
+	if err != nil {
+		t.Fatalf("NewBootstrapTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_FLAGS=-v",
+		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
+		"BUILDKITE_GIT_FETCH_FLAGS=-v",
+	}
+
+	// Simulate state from a previous checkout
+	if err := os.MkdirAll(tester.CheckoutDir(), 0755); err != nil {
+		t.Fatalf("error creating dir to clone from: %s", err)
+	}
+	cmd := exec.Command("git", "clone", "-v", "--", tester.Repo.Path, ".")
+	cmd.Dir = tester.CheckoutDir()
+	if _, err = cmd.Output(); err != nil {
+		t.Fatalf("error cloning test repo: %s", err)
+	}
+
+	// Make the git dir dirty to simulate a SIGKILLed git process
+	gitDir := path.Join(tester.CheckoutDir(), ".git")
+	lockFilePath := path.Join(gitDir, "index.lock")
+	f, err := os.Create(lockFilePath)
+	if err != nil {
+		t.Fatalf("error creating lock file: %s", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("error closing lock file: %s", err)
+	}
+
+	// Actually execute git commands, but with expectations
+	git := tester.
+		MustMock(t, "git").
+		PassthroughToLocalCommand()
+
+	// But assert which ones are called
+	git.ExpectAll([][]any{
+		{"remote", "set-url", "origin", tester.Repo.Path},
+		{"clean", "-fdq"},
+		{"fetch", "-v", "--", "origin", "main"},
+		{"checkout", "-f", "FETCH_HEAD"},
+		{"clone", "-v", "--", tester.Repo.Path, "."},
+		{"clean", "-fdq"},
+		{"fetch", "-v", "--", "origin", "main"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
 		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},


### PR DESCRIPTION
There are a certain class of errors from git in the `defaultCheckoutPhase` that would cause a retry, but before the retry, the checkout directory would be removed. This allows cleaning up in case an unclean exit from git had left the checkout directory in an unrecoverable state.

This PR adds failures in `git fetch` and `git checkout` when the exit code is 128 to that class of error. It also fixes the detection of errors for which the check directory needed to be clean, as previously, the detection would fail if the errors were wrapped, and they are wrapped in the `defaultCheckoutPhase` method.

I've done some refactoring to reduce the indentation level of the code, so I recommend reviewing with whitespace changes hidden.