### PR TITLE
Fix origin for mirrored submodules

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1325,7 +1325,7 @@ func (b *Bootstrap) updateGitMirror(ctx context.Context, repository string) (str
 	b.shell.Commentf("Updating existing repository mirror to find commit %s", b.Commit)
 
 	// Update the origin of the repository so we can gracefully handle repository renames
-	if err := b.shell.Run(ctx, "git", "--git-dir", mirrorDir, "remote", "set-url", "origin", b.Repository); err != nil {
+	if err := b.shell.Run(ctx, "git", "--git-dir", mirrorDir, "remote", "set-url", "origin", repository); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
In `defaultCheckoutPhase`, if there are mirrored submodules, the `repository` arg to `getOrUpdateMirrorDir` varies (per submodule). The clone in `updateGitMirror` uses the arg, but if the mirror exists and the commit is not present, the origin is replaced with `b.Repository`, pointing the mirror at the wrong remote before fetching.

Fixes a bug introduced in #1959