### PR TITLE
Use Agent API for locking mirrors and known_hosts

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -732,7 +732,7 @@ func (w LogWriter) Write(bytes []byte) (int, error) {
 func (r *JobRunner) executePreBootstrapHook(ctx context.Context, hook string) (bool, error) {
 	r.logger.Info("Running pre-bootstrap hook %q", hook)
 
-	sh, err := shell.New()
+	sh, err := shell.New(ctx, shell.Config{})
 	if err != nil {
 		return false, err
 	}

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -86,7 +86,7 @@ func TestStartTracing_NoTracingBackend(t *testing.T) {
 	b := New(Config{})
 
 	oriCtx := context.Background()
-	b.shell, err = shell.New()
+	b.shell, err = shell.New(oriCtx, shell.Config{})
 	assert.NoError(t, err)
 
 	span, _, stopper := b.startTracing(oriCtx)
@@ -107,7 +107,7 @@ func TestStartTracing_Datadog(t *testing.T) {
 	b := New(cfg)
 
 	oriCtx := context.Background()
-	b.shell, err = shell.New()
+	b.shell, err = shell.New(oriCtx, shell.Config{})
 	assert.NoError(t, err)
 
 	span, ctx, stopper := b.startTracing(oriCtx)

--- a/bootstrap/shell/shell_test.go
+++ b/bootstrap/shell/shell_test.go
@@ -131,7 +131,7 @@ func TestContextCancelTerminates(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sh, err := shell.New()
+	sh, err := shell.New(ctx, shell.Config{})
 	if err != nil {
 		t.Fatalf("shell.New() error = %v", err)
 	}
@@ -165,7 +165,7 @@ func TestInterrupt(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sh, err := shell.New()
+	sh, err := shell.New(ctx, shell.Config{})
 	if err != nil {
 		t.Fatalf("shell.New() error = %v", err)
 	}
@@ -190,7 +190,7 @@ func TestInterrupt(t *testing.T) {
 }
 
 func TestDefaultWorkingDirFromSystem(t *testing.T) {
-	sh, err := shell.New()
+	sh, err := shell.New(context.Background(), shell.Config{})
 	if err != nil {
 		t.Fatalf("shell.New() error = %v", err)
 	}
@@ -231,7 +231,7 @@ func TestWorkingDir(t *testing.T) {
 		t.Fatalf("os.Getwd() error = %v", err)
 	}
 
-	sh, err := shell.New()
+	sh, err := shell.New(context.Background(), shell.Config{})
 	if err != nil {
 		t.Fatalf("shell.New() error = %v", err)
 	}
@@ -353,7 +353,7 @@ func TestAcquiringLockHelperProcess(t *testing.T) {
 }
 
 func newShellForTest(t *testing.T) *shell.Shell {
-	sh, err := shell.New()
+	sh, err := shell.New(context.Background(), shell.Config{})
 	if err != nil {
 		t.Fatalf("shell.New() error = %v", err)
 	}
@@ -362,7 +362,7 @@ func newShellForTest(t *testing.T) *shell.Shell {
 }
 
 func TestRunWithoutPrompt(t *testing.T) {
-	sh, err := shell.New()
+	sh, err := shell.New(context.Background(), shell.Config{})
 	if err != nil {
 		t.Fatalf("shell.New() error = %v", err)
 	}

--- a/bootstrap/shell/test.go
+++ b/bootstrap/shell/test.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"context"
 	"io"
 	"os"
 	"runtime"
@@ -11,7 +12,7 @@ import (
 
 // NewTestShell creates a minimal shell suitable for tests.
 func NewTestShell(t *testing.T) *Shell {
-	sh, err := New()
+	sh, err := New(context.Background(), Config{})
 	if err != nil {
 		t.Fatalf("shell.New() error = %v", err)
 	}

--- a/bootstrap/ssh_test.go
+++ b/bootstrap/ssh_test.go
@@ -18,7 +18,7 @@ func init() {
 func TestFindingSSHTools(t *testing.T) {
 	t.Parallel()
 
-	sh, err := shell.New()
+	sh, err := shell.New(context.Background(), shell.Config{})
 	if err != nil {
 		t.Fatalf("shell.New() error = %v", err)
 	}

--- a/clicommand/agent_start_test.go
+++ b/clicommand/agent_start_test.go
@@ -1,6 +1,7 @@
 package clicommand
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -50,7 +51,7 @@ func TestAgentStartupHook(t *testing.T) {
 		defer closer()
 		filepath := writeAgentHook(t, hooksPath, "agent-startup")
 		log := logger.NewBuffer()
-		err := agentStartupHook(log, cfg(hooksPath))
+		err := agentStartupHook(context.Background(), log, cfg(hooksPath))
 
 		if assert.NoError(t, err, log.Messages) {
 			assert.Equal(t, []string{
@@ -64,14 +65,14 @@ func TestAgentStartupHook(t *testing.T) {
 		defer closer()
 
 		log := logger.NewBuffer()
-		err := agentStartupHook(log, cfg(hooksPath))
+		err := agentStartupHook(context.Background(), log, cfg(hooksPath))
 		if assert.NoError(t, err, log.Messages) {
 			assert.Equal(t, []string{}, log.Messages)
 		}
 	})
 	t.Run("with bad hooks path", func(t *testing.T) {
 		log := logger.NewBuffer()
-		err := agentStartupHook(log, cfg("zxczxczxc"))
+		err := agentStartupHook(context.Background(), log, cfg("zxczxczxc"))
 
 		if assert.NoError(t, err, log.Messages) {
 			assert.Equal(t, []string{}, log.Messages)
@@ -95,7 +96,7 @@ func TestAgentShutdownHook(t *testing.T) {
 		defer closer()
 		filepath := writeAgentHook(t, hooksPath, "agent-shutdown")
 		log := logger.NewBuffer()
-		agentShutdownHook(log, cfg(hooksPath))
+		agentShutdownHook(context.Background(), log, cfg(hooksPath))
 
 		assert.Equal(t, []string{
 			"[info] " + prompt + " " + filepath, // prompt
@@ -107,12 +108,12 @@ func TestAgentShutdownHook(t *testing.T) {
 		defer closer()
 
 		log := logger.NewBuffer()
-		agentShutdownHook(log, cfg(hooksPath))
+		agentShutdownHook(context.Background(), log, cfg(hooksPath))
 		assert.Equal(t, []string{}, log.Messages)
 	})
 	t.Run("with bad hooks path", func(t *testing.T) {
 		log := logger.NewBuffer()
-		agentShutdownHook(log, cfg("zxczxczxc"))
+		agentShutdownHook(context.Background(), log, cfg("zxczxczxc"))
 		assert.Equal(t, []string{}, log.Messages)
 	})
 }


### PR DESCRIPTION
If the Agent API experiment is enabled and working, then shell will now use it for locking instead of `flock`. 

At least two reasons for this:

1. The API socket can be bind-mounted into a container and "just work", whereas flock is harder to make work correctly across a container boundary.
2. Locking and unlocking in the Agent API has no disk cost, so can be polled more frequently, so should be slightly faster.