### PR TITLE
var name typo: s/pluginCheckoutHook/pluginCheckoutLock/

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -932,11 +932,11 @@ func (b *Bootstrap) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plug
 	// Try and lock this particular plugin while we check it out (we create
 	// the file outside of the plugin directory so git clone doesn't have
 	// a cry about the directory not being empty)
-	pluginCheckoutHook, err := b.shell.LockFile(ctx, filepath.Join(b.PluginsPath, id+".lock"), time.Minute*5)
+	pluginCheckoutLock, err := b.shell.LockFile(ctx, filepath.Join(b.PluginsPath, id+".lock"), time.Minute*5)
 	if err != nil {
 		return nil, err
 	}
-	defer pluginCheckoutHook.Unlock()
+	defer pluginCheckoutLock.Unlock()
 
 	// If there is already a clone, the user may want to ensure it's fresh (e.g., by setting
 	// BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH=true).


### PR DESCRIPTION
I think this was just a typo that I happened to notice a week or two ago; the updated name now matches the other names near it:

https://github.com/buildkite/agent/blob/581a104634fa5749934a15613c230bdf390f5908/bootstrap/bootstrap.go#L1278

https://github.com/buildkite/agent/blob/581a104634fa5749934a15613c230bdf390f5908/bootstrap/bootstrap.go#L1313