### PR TITLE
Adjust HTTP response errors to separate the response code and the error

### DIFF
--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -104,8 +104,8 @@ func TestDisconnectRetry(t *testing.T) {
 
 	require.Equal(t, 4, len(l.Messages))
 	assert.Equal(t, "[info] Disconnecting...", l.Messages[0])
-	assert.Regexp(t, regexp.MustCompile(`\[warn\] POST http.*/disconnect: 500 \(Attempt 1/4`), l.Messages[1])
-	assert.Regexp(t, regexp.MustCompile(`\[warn\] POST http.*/disconnect: 500 \(Attempt 2/4`), l.Messages[2])
+	assert.Regexp(t, regexp.MustCompile(`\[warn\] POST http.*/disconnect: 500 Internal Server Error \(Attempt 1/4`), l.Messages[1])
+	assert.Regexp(t, regexp.MustCompile(`\[warn\] POST http.*/disconnect: 500 Internal Server Error \(Attempt 2/4`), l.Messages[2])
 	assert.Equal(t, "[info] Disconnected", l.Messages[3])
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -299,12 +299,12 @@ type ErrorResponse struct {
 }
 
 func (r *ErrorResponse) Error() string {
-	s := fmt.Sprintf("%v %v: %d",
+	s := fmt.Sprintf("%v %v: %s",
 		r.Response.Request.Method, r.Response.Request.URL,
-		r.Response.StatusCode)
+		r.Response.Status)
 
 	if r.Message != "" {
-		s = fmt.Sprintf("%s %v", s, r.Message)
+		s = fmt.Sprintf("%s: %v", s, r.Message)
 	}
 
 	return s


### PR DESCRIPTION
A customer was running into an error:
```
POST https://agent.buildkite.com/v3/register: 400 Agents can only be part of a single queue when registering to a cluster (Attempt 14/30 Retrying in 10s)
```
which due to a set of quite funny coincidences, makes it seem like there can only be 400 agents per cluster queue, when what's actually happening is that the log is telling us that that POST got a 400 Bad Request response code, and was telling the user that each agent is only allowed to be part of a single cluster queue.

This commit adjusts the error so that it will now be:
```
POST https://agent.buildkite.com/v3/register: 400 Bad Request: Agents can only be part of a single queue when registering to a cluster (Attempt 14/30 Retrying in 10s)
```
hopefully making the various clauses in that sentence a little easier to parse out