### PR TITLE
Internalise pipeline parser

### DIFF
--- a/agent/pipeline_uploader_test.go
+++ b/agent/pipeline_uploader_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/clicommand"
+	"github.com/buildkite/agent/v3/internal/pipeline"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/stretchr/testify/assert"
 )
@@ -77,7 +78,7 @@ steps:
     agents:
       queue: xxx`
 
-			parser := agent.PipelineParser{Pipeline: []byte(pipelineStr), Env: nil}
+			parser := pipeline.Parser{Pipeline: []byte(pipelineStr), Env: nil}
 			pipeline, err := parser.Parse()
 			assert.NoError(t, err)
 
@@ -204,7 +205,7 @@ steps:
     agents:
       queue: xxx`
 
-			parser := agent.PipelineParser{Pipeline: []byte(pipelineStr), Env: nil}
+			parser := pipeline.Parser{Pipeline: []byte(pipelineStr), Env: nil}
 			pipeline, err := parser.Parse()
 			assert.NoError(t, err)
 

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -17,6 +17,7 @@ import (
 	"github.com/buildkite/agent/v3/bootstrap/shell"
 	"github.com/buildkite/agent/v3/cliconfig"
 	"github.com/buildkite/agent/v3/env"
+	"github.com/buildkite/agent/v3/internal/pipeline"
 	"github.com/buildkite/agent/v3/internal/redaction"
 	"github.com/buildkite/agent/v3/internal/stdin"
 	"github.com/urfave/cli"
@@ -236,7 +237,7 @@ var PipelineUploadCommand = cli.Command{
 		}
 
 		// Parse the pipeline
-		parser := agent.PipelineParser{
+		parser := pipeline.Parser{
 			Env:             environ,
 			Filename:        filename,
 			Pipeline:        input,

--- a/internal/pipeline/doc.go
+++ b/internal/pipeline/doc.go
@@ -1,0 +1,3 @@
+// Package pipeline implements the pieces necessary for the agent to work with
+// pipelines (typically in YAML or JSON form).
+package pipeline


### PR DESCRIPTION
`agent` is overloaded with stuff. Making a separate `pipeline` package improves the spelling IMO (`pipeline.Parser` vs `agent.PipelineParser`). 

Since it's not intended for external consumption (in current form, anyway), hide it in `internal`.