### PR TITLE
Stop linking docker compose to docker-compose

### DIFF
--- a/packaging/docker/alpine-k8s/Dockerfile
+++ b/packaging/docker/alpine-k8s/Dockerfile
@@ -20,8 +20,6 @@ RUN apk update && apk add --no-cache \
     tini \
     tzdata
 
-RUN ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
-
 FROM alpine:3.18.0 AS kubectl-downloader
 ARG TARGETOS
 ARG TARGETARCH

--- a/packaging/docker/alpine-k8s/Dockerfile
+++ b/packaging/docker/alpine-k8s/Dockerfile
@@ -20,6 +20,8 @@ RUN apk update && apk add --no-cache \
     tini \
     tzdata
 
+RUN ln -sf /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
+
 FROM alpine:3.18.0 AS kubectl-downloader
 ARG TARGETOS
 ARG TARGETARCH

--- a/packaging/docker/alpine/Dockerfile
+++ b/packaging/docker/alpine/Dockerfile
@@ -21,6 +21,8 @@ RUN apk add --no-cache \
     tini \
     tzdata
 
+RUN ln -sf /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
+
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg
 
 RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \

--- a/packaging/docker/alpine/Dockerfile
+++ b/packaging/docker/alpine/Dockerfile
@@ -21,8 +21,6 @@ RUN apk add --no-cache \
     tini \
     tzdata
 
-RUN ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
-
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg
 
 RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \


### PR DESCRIPTION
It looks like the package on alpine linux is doing this for us now:
```bash
/ # apk add docker-cli docker-compose
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
(1/3) Installing ca-certificates (20230506-r0)
(2/3) Installing docker-cli (23.0.6-r2)
(3/3) Installing docker-cli-compose (2.17.3-r3)
Executing busybox-1.36.1-r0.trigger
Executing ca-certificates-20230506-r0.trigger
OK: 83 MiB in 18 packages
/ # ls -lA /usr/bin/docker-compose
lrwxrwxrwx    1 root     root            44 Jun 21 02:42 /usr/bin/docker-compose -> ../libexec/docker/cli-plugins/docker-compose
```

We have tests that `docker-compose` is executable in these docker images, so I'm pretty comfortable dropping the creation of the symlink rather than just ignoring its failure.