### PR TITLE
Add ordered.Map

### DIFF
--- a/internal/ordered/map.go
+++ b/internal/ordered/map.go
@@ -1,0 +1,434 @@
+// Package ordered implements an ordered map type.
+package ordered
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/buildkite/agent/v3/internal/yamltojson"
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+)
+
+var _ interface {
+	json.Marshaler
+	json.Unmarshaler
+	yaml.IsZeroer
+	yaml.Marshaler
+	yaml.Unmarshaler
+} = (*Map[string, any])(nil)
+
+// Map is an order-preserving map with string keys. It is intended for working
+// with YAML in an order-preserving way (off-spec, strictly speaking) and JSON
+// (more of the same).
+type Map[K comparable, V any] struct {
+	items []Tuple[K, V]
+	index map[K]int
+}
+
+// MapSS is a convenience alias to reduce keyboard wear.
+type MapSS = Map[string, string]
+
+// MapSA is a convenience alias to reduce keyboard wear.
+type MapSA = Map[string, any]
+
+// NewMap returns a new empty map with a given initial capacity.
+func NewMap[K comparable, V any](cap int) *Map[K, V] {
+	return &Map[K, V]{
+		items: make([]Tuple[K, V], 0, cap),
+		index: make(map[K]int, cap),
+	}
+}
+
+// MapFromItems creates an Map with some items.
+func MapFromItems[K comparable, V any](ps ...Tuple[K, V]) *Map[K, V] {
+	m := NewMap[K, V](len(ps))
+	for _, p := range ps {
+		m.Set(p.Key, p.Value)
+	}
+	return m
+}
+
+// Len returns the number of items in the map.
+func (m *Map[K, V]) Len() int {
+	if m == nil {
+		return 0
+	}
+	return len(m.index)
+}
+
+// IsZero reports if m is nil or empty. It is used by yaml.v3 to check
+// emptiness.
+func (m *Map[K, V]) IsZero() bool {
+	return m == nil || len(m.index) == 0
+}
+
+// Get retrieves the value associated with a key, and reports if it was found.
+func (m *Map[K, V]) Get(k K) (V, bool) {
+	var zv V
+	if m == nil {
+		return zv, false
+	}
+	idx, ok := m.index[k]
+	if !ok {
+		return zv, false
+	}
+	return m.items[idx].Value, true
+}
+
+// Set sets the value for the given key. If the key exists, it remains in its
+// existing spot, otherwise it is added to the end of the map.
+func (m *Map[K, V]) Set(k K, v V) {
+	// Suppose someone makes Map with new(Map). The one thing we need to not be
+	// nil will be nil.
+	if m.index == nil {
+		m.index = make(map[K]int, 1)
+	}
+
+	// Replace existing value?
+	if idx, exists := m.index[k]; exists {
+		m.items[idx].Value = v
+		return
+	}
+
+	// Append new item.
+	m.index[k] = len(m.items)
+	m.items = append(m.items, Tuple[K, V]{
+		Key:   k,
+		Value: v,
+	})
+}
+
+// Replace replaces an old key in the same spot with a new key and value.
+// If the old key doesn't exist in the map, the item is inserted at the end.
+// If the new key already exists in the map (and isn't equal to the old key),
+// then it is deleted.
+// This provides a way to change a single key in-place (easier than deleting the
+// old key and all later keys, adding the new key, then restoring the rest).
+func (m *Map[K, V]) Replace(old, new K, v V) {
+	// Suppose someone makes Map with new(Map). The one thing we need to not be
+	// nil will be nil.
+	if m.index == nil {
+		m.index = make(map[K]int, 1)
+	}
+
+	// idx is where the item will go
+	idx, exists := m.index[old]
+	if !exists {
+		// Point idx at the end of m.items and ensure there is an item there.
+		idx = len(m.items)
+		m.items = append(m.items, Tuple[K, V]{})
+	}
+
+	// If the key changed, there's some tidyup...
+	if old != new {
+		// If "new" already exists in the map, then delete it first. The intent
+		// of Replace is to put the item where "old" is but under "new", so if
+		// "new" already exists somewhere else, adding it where "old" is would
+		// be getting out of hand (now there are two of them).
+		if newidx, exists := m.index[new]; exists {
+			m.items[newidx].deleted = true
+		}
+
+		// Delete "old" from the index and update "new" to point to idx
+		delete(m.index, old)
+		m.index[new] = idx
+	}
+
+	// Put the item into m.items at idx.
+	m.items[idx] = Tuple[K, V]{
+		Key:   new,
+		Value: v,
+	}
+}
+
+// Delete deletes a key from the map. It does nothing if the key is not in the
+// map.
+func (m *Map[K, V]) Delete(k K) {
+	if m == nil {
+		return
+	}
+	idx, ok := m.index[k]
+	if !ok {
+		return
+	}
+	m.items[idx].deleted = true
+	delete(m.index, k)
+
+	// If half the pairs have been deleted, perform a compaction.
+	if len(m.items) >= 2*len(m.index) {
+		m.compact()
+	}
+}
+
+// ToMap creates a regular (un-ordered) map containing the same data.
+func (m *Map[K, V]) ToMap() map[K]V {
+	um := make(map[K]V, len(m.index))
+	m.Range(func(k K, v V) error {
+		um[k] = v
+		return nil
+	})
+	return um
+}
+
+// Equal reports if the two maps are equal (they contain the same items in the
+// same order). Keys are compared directly; values are compared using go-cmp
+// (provided with Equal[string, any] and Equal[string, string] as a comparers).
+func Equal[K comparable, V any](a, b *Map[K, V]) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.Len() != b.Len() {
+		return false
+	}
+	i, j := 0, 0
+	for i < len(a.items) && j < len(b.items) {
+		for a.items[i].deleted {
+			i++
+		}
+		for b.items[j].deleted {
+			j++
+		}
+		if a.items[i].Key != b.items[j].Key {
+			return false
+		}
+		if !cmp.Equal(a.items[i].Value, b.items[j].Value, cmp.Comparer(Equal[string, string]), cmp.Comparer(Equal[string, any])) {
+			return false
+		}
+		i++
+		j++
+	}
+	return true
+}
+
+// EqualSS is a convenience alias to reduce keyboard wear.
+var EqualSS = Equal[string, string]
+
+// EqualSA is a convenience alias to reduce keyboard wear.
+var EqualSA = Equal[string, any]
+
+// compact re-organises the internal storage of the Map.
+func (m *Map[K, V]) compact() {
+	pairs := make([]Tuple[K, V], 0, len(m.index))
+	for _, p := range m.items {
+		if p.deleted {
+			continue
+		}
+		m.index[p.Key] = len(pairs)
+		pairs = append(pairs, Tuple[K, V]{
+			Key:   p.Key,
+			Value: p.Value,
+		})
+	}
+	m.items = pairs
+}
+
+// Range ranges over the map (in order). If f returns an error, it stops ranging
+// and returns that error.
+func (m *Map[K, V]) Range(f func(k K, v V) error) error {
+	if m.IsZero() {
+		return nil
+	}
+	for _, p := range m.items {
+		if p.deleted {
+			continue
+		}
+		if err := f(p.Key, p.Value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MarshalJSON marshals the ordered map to JSON. It preserves the map order in
+// the output.
+func (m *Map[K, V]) MarshalJSON() ([]byte, error) {
+	// NB: writes to b don't error, but JSON encoding could error.
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	b.WriteRune('{')
+	first := true
+	err := m.Range(func(k K, v V) error {
+		if !first {
+			// Separating comma.
+			b.WriteRune(',')
+		}
+		first = false
+		if err := enc.Encode(k); err != nil {
+			return err
+		}
+		b.WriteRune(':')
+		return enc.Encode(v)
+	})
+	if err != nil {
+		return nil, err
+	}
+	b.WriteRune('}')
+	return b.Bytes(), nil
+}
+
+// MarshalYAML returns a *yaml.Node encoding this map (in order), or an error
+// if any of the items could not be encoded into a *yaml.Node.
+func (m *Map[K, V]) MarshalYAML() (any, error) {
+	n := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+	}
+	err := m.Range(func(k K, v V) error {
+		nk, nv := new(yaml.Node), new(yaml.Node)
+		if err := nk.Encode(k); err != nil {
+			return err
+		}
+		if err := nv.Encode(v); err != nil {
+			return err
+		}
+		n.Content = append(n.Content, nk, nv)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return n, nil
+}
+
+// UnmarshalJSON unmarshals to JSON. It only supports K = string.
+// This is yaml.Unmarshal in a trenchcoat (YAML is a superset of JSON).
+func (m *Map[K, V]) UnmarshalJSON(b []byte) error {
+	return yaml.Unmarshal(b, m)
+}
+
+// UnmarshalYAML unmarshals a YAML mapping node into this map. It only supports
+// K = string. Where yaml.v3 typically infers map[string]any for unmarshaling
+// mappings into any, this method chooses *Map[string, any] instead.
+func (m *Map[K, V]) UnmarshalYAML(n *yaml.Node) error {
+	om, ok := (any)(m).(*Map[string, V])
+	if !ok {
+		var zk K
+		return fmt.Errorf("cannot unmarshal into ordered.Map with key type %T (want string)", zk)
+	}
+
+	if n.Kind != yaml.MappingNode {
+		return fmt.Errorf("line %d, col %d: wrong kind (got %x, want %x)", n.Line, n.Column, n.Kind, yaml.MappingNode)
+	}
+
+	if sam, ok := (any)(m).(*Map[string, any]); ok {
+		// Use decode, then steal the contents.
+		sam2, err := decode(make(map[*yaml.Node]bool), n)
+		if err != nil {
+			return err
+		}
+		*sam = *(sam2.(*Map[string, any]))
+		return nil
+	}
+
+	return yamltojson.RangeMap(n, func(key string, val *yaml.Node) error {
+		// Try decode? (maybe V is a type like []any).
+		nv, err := decode(make(map[*yaml.Node]bool), val)
+		if err != nil {
+			return err
+		}
+		v, ok := nv.(V)
+		if !ok {
+			// Let yaml.v3 choose what to do with the specific type.
+			if err := val.Decode(&v); err != nil {
+				return err
+			}
+		}
+		om.Set(key, v)
+		return nil
+	})
+}
+
+// decode recursively unmarshals n into a generic type (any, []any, or
+// *Map[string, any]) depending on the kind of n.
+func decode(seen map[*yaml.Node]bool, n *yaml.Node) (any, error) {
+	// nil decodes to nil.
+	if n == nil {
+		return nil, nil
+	}
+
+	// If n has been seen already while processing the parents of n, it's an
+	// infinite recursion.
+	// Simple example:
+	// ---
+	// a: &a  // seen is empty on encoding a
+	//   b: *a   // seen contains a while encoding b
+	if seen[n] {
+		return nil, fmt.Errorf("line %d, col %d: infinite recursion", n.Line, n.Column)
+	}
+	seen[n] = true
+
+	// n needs to be "un-seen" when this layer of recursion is done:
+	defer delete(seen, n)
+	// Why? seen is a map, which is used by reference, so it will be shared
+	// between calls to decode, which is recursive. And unlike a merge, the
+	// same alias can be validly used for different subtrees:
+	// ---
+	// a: &a
+	//   b: c
+	// d:
+	//   da: *a
+	//   db: *a
+	// ...
+	// (d contains two copies of a).
+	// So *a needs to be "unseen" between encoding "da" and "db".
+
+	switch n.Kind {
+	case yaml.ScalarNode:
+		// If we need to parse more kinds of scalar, this is where we would
+		// do something like yamltojson.parseScalar.
+		var v any
+		if err := n.Decode(&v); err != nil {
+			return nil, err
+		}
+		return v, nil
+
+	case yaml.SequenceNode:
+		v := make([]any, 0, len(n.Content))
+		for _, c := range n.Content {
+			cv, err := decode(seen, c)
+			if err != nil {
+				return nil, err
+			}
+			v = append(v, cv)
+		}
+		return v, nil
+
+	case yaml.MappingNode:
+		m := NewMap[string, any](len(n.Content) / 2)
+		// Why not call m.UnmarshalYAML(n) ?
+		// Because we can't pass `seen` through that.
+		err := yamltojson.RangeMap(n, func(key string, val *yaml.Node) error {
+			v, err := decode(seen, val)
+			if err != nil {
+				return err
+			}
+			m.Set(key, v)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return m, nil
+
+	case yaml.AliasNode:
+		// This is one of the two ways this can blow up recursively.
+		// The other (map merges) is handled by yamltojson.RangeMap.
+		return decode(seen, n.Alias)
+
+	case yaml.DocumentNode:
+		switch len(n.Content) {
+		case 0:
+			return nil, nil
+		case 1:
+			return decode(seen, n.Content[0])
+		default:
+			return nil, fmt.Errorf("line %d, col %d: document contains more than 1 content item (%d)", n.Line, n.Column, len(n.Content))
+		}
+
+	default:
+		return nil, fmt.Errorf("line %d, col %d: unsupported kind %x", n.Line, n.Column, n.Kind)
+	}
+}

--- a/internal/ordered/map_test.go
+++ b/internal/ordered/map_test.go
@@ -1,0 +1,735 @@
+package ordered
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+)
+
+func TestMapGet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc   string
+		input  *MapSS
+		key    string
+		want   string
+		wantOk bool
+	}{
+		{
+			desc:   "nil map",
+			input:  nil,
+			key:    "foo",
+			want:   "",
+			wantOk: false,
+		},
+		{
+			desc:   "empty map",
+			input:  NewMap[string, string](3),
+			key:    "foo",
+			want:   "",
+			wantOk: false,
+		},
+		{
+			desc:   "empty map created with new()",
+			input:  new(MapSS),
+			key:    "foo",
+			want:   "",
+			wantOk: false,
+		},
+		{
+			desc: "present key",
+			input: MapFromItems(
+				TupleSS{Key: "foo", Value: "bar"},
+			),
+			key:    "foo",
+			want:   "bar",
+			wantOk: true,
+		},
+		{
+			desc: "wrong key",
+			input: MapFromItems(
+				TupleSS{Key: "baz", Value: "bar"},
+			),
+			key:    "foo",
+			want:   "",
+			wantOk: false,
+		},
+		{
+			desc: "larger map",
+			input: MapFromItems(
+				TupleSS{Key: "", Value: "quz"},
+				TupleSS{Key: "foo", Value: "bar"},
+				TupleSS{Key: "baz", Value: "qux"},
+			),
+			key:    "foo",
+			want:   "bar",
+			wantOk: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := test.input.Get(test.key)
+			if got != test.want || ok != test.wantOk {
+				t.Errorf("input.Get(%q) = (%q, %t); want (%q, %t)", test.key, got, ok, test.want, test.wantOk)
+			}
+		})
+	}
+}
+
+func TestMapSet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc  string
+		input *MapSS
+		key   string
+		value string
+		want  *MapSS
+	}{
+		// setting in a nil map will panic, just like Go's map.
+		{
+			desc:  "empty map",
+			input: NewMap[string, string](3),
+			key:   "foo",
+			value: "bar",
+			want:  MapFromItems(TupleSS{Key: "foo", Value: "bar"}),
+		},
+		{
+			desc:  "empty map created with new()",
+			input: new(MapSS),
+			key:   "foo",
+			value: "bar",
+			want:  MapFromItems(TupleSS{Key: "foo", Value: "bar"}),
+		},
+		{
+			desc: "new value",
+			input: MapFromItems(
+				TupleSS{Key: "foo", Value: "bar"},
+			),
+			key:   "baz",
+			value: "qux",
+			want: MapFromItems(
+				TupleSS{Key: "foo", Value: "bar"},
+				TupleSS{Key: "baz", Value: "qux"},
+			),
+		},
+		{
+			desc: "change value",
+			input: MapFromItems(
+				TupleSS{Key: "baz", Value: "bar"},
+				TupleSS{Key: "foo", Value: "bar"},
+			),
+			key:   "baz",
+			value: "qux",
+			want: MapFromItems(
+				TupleSS{Key: "baz", Value: "qux"},
+				TupleSS{Key: "foo", Value: "bar"},
+			),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			test.input.Set(test.key, test.value)
+			if diff := cmp.Diff(test.input, test.want, cmp.Comparer(EqualSS)); diff != "" {
+				t.Errorf("after Set(%q, %q), map diff (-got +want):\n%s", test.key, test.value, diff)
+			}
+		})
+	}
+}
+
+func TestMapReplace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc   string
+		input  *MapSS
+		oldkey string
+		newkey string
+		value  string
+		want   *MapSS
+	}{
+		// setting in a nil map will panic, just like Go's map.
+		{
+			desc:   "empty map",
+			input:  NewMap[string, string](3),
+			oldkey: "zzz",
+			newkey: "foo",
+			value:  "bar",
+			want:   MapFromItems(TupleSS{Key: "foo", Value: "bar"}),
+		},
+		{
+			desc:   "empty map created with new()",
+			input:  new(MapSS),
+			oldkey: "zzz",
+			newkey: "foo",
+			value:  "bar",
+			want:   MapFromItems(TupleSS{Key: "foo", Value: "bar"}),
+		},
+		{
+			desc: "old = new",
+			input: MapFromItems(
+				TupleSS{Key: "foo", Value: "bar"},
+			),
+			oldkey: "foo",
+			newkey: "foo",
+			value:  "qux",
+			want: MapFromItems(
+				TupleSS{Key: "foo", Value: "qux"},
+			),
+		},
+		{
+			desc: "old != new",
+			input: MapFromItems(
+				TupleSS{Key: "baz", Value: "qux"},
+				TupleSS{Key: "foo", Value: "bar"},
+			),
+			oldkey: "baz",
+			newkey: "biz",
+			value:  "tux",
+			want: MapFromItems(
+				TupleSS{Key: "biz", Value: "tux"},
+				TupleSS{Key: "foo", Value: "bar"},
+			),
+		},
+		{
+			desc: "old != new and new already exists",
+			input: MapFromItems(
+				TupleSS{Key: "baz", Value: "qux"},
+				TupleSS{Key: "foo", Value: "bar"},
+			),
+			oldkey: "baz",
+			newkey: "foo",
+			value:  "tux",
+			want: MapFromItems(
+				TupleSS{Key: "foo", Value: "tux"},
+			),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			test.input.Replace(test.oldkey, test.newkey, test.value)
+			if diff := cmp.Diff(test.input, test.want, cmp.Comparer(EqualSS)); diff != "" {
+				t.Errorf("after Replace(%q, %q, %q), map diff (-got +want):\n%s", test.oldkey, test.newkey, test.value, diff)
+			}
+		})
+	}
+}
+
+func TestMapDelete(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc  string
+		input *MapSS
+		key   string
+		want  *MapSS
+	}{
+		{
+			desc:  "nil map",
+			input: nil,
+			key:   "foo",
+			want:  nil,
+		},
+		{
+			desc:  "empty map",
+			input: NewMap[string, string](3),
+			key:   "foo",
+			want:  NewMap[string, string](0),
+		},
+		{
+			desc:  "empty map created with new()",
+			input: new(MapSS),
+			key:   "foo",
+			want:  NewMap[string, string](0),
+		},
+		{
+			desc: "deleting the one value",
+			input: MapFromItems(
+				TupleSS{Key: "foo", Value: "bar"},
+			),
+			key:  "foo",
+			want: NewMap[string, string](0),
+		},
+		{
+			desc: "deleting one of two values",
+			input: MapFromItems(
+				TupleSS{Key: "baz", Value: "bar"},
+				TupleSS{Key: "foo", Value: "bar"},
+			),
+			key: "baz",
+			want: MapFromItems(
+				TupleSS{Key: "foo", Value: "bar"},
+			),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			test.input.Delete(test.key)
+			if diff := cmp.Diff(test.input, test.want, cmp.Comparer(EqualSS)); diff != "" {
+				t.Errorf("after Delete(%q), map diff (-got +want):\n%s", test.key, diff)
+			}
+		})
+	}
+}
+
+func TestMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc  string
+		input any
+		want  string
+	}{
+		{
+			desc: "String-string map",
+			input: MapFromItems(
+				TupleSS{Key: "llama", Value: "llama"},
+				TupleSS{Key: "alpaca", Value: "drama"},
+			),
+			want: `{"llama":"llama","alpaca":"drama"}`,
+		},
+		{
+			desc: "String-any map",
+			input: MapFromItems(
+				TupleSA{Key: "llama", Value: "llama"},
+				TupleSA{Key: "alpaca", Value: "drama"},
+			),
+			want: `{"llama":"llama","alpaca":"drama"}`,
+		},
+		{
+			desc:  "Nil map",
+			input: (*MapSA)(nil),
+			want:  "null",
+		},
+		{
+			desc:  "Empty map",
+			input: NewMap[string, any](0),
+			want:  "{}",
+		},
+		{
+			desc: "Nested maps",
+			input: MapFromItems(
+				TupleSA{
+					Key: "llama",
+					Value: MapFromItems(
+						TupleSS{Key: "Kuzco", Value: "Emperor"},
+						TupleSS{Key: "Geronimo", Value: "Incredible"},
+					),
+				},
+				TupleSA{Key: "alpaca", Value: "drama"},
+			),
+			want: `{"llama":{"Kuzco":"Emperor","Geronimo":"Incredible"},"alpaca":"drama"}`,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			got, err := json.Marshal(test.input)
+			if err != nil {
+				t.Fatalf("json.Marshal(%v) error = %v", test.input, err)
+			}
+			if diff := cmp.Diff(string(got), test.want); diff != "" {
+				t.Errorf("json.Marshal(%v) diff (-got +want):\n%s", test.input, diff)
+			}
+		})
+	}
+}
+
+func TestMarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc  string
+		input any
+		want  string
+	}{
+		{
+			desc: "String-string map",
+			input: MapFromItems(
+				TupleSS{Key: "llama", Value: "llama"},
+				TupleSS{Key: "alpaca", Value: "drama"},
+			),
+			want: "llama: llama\nalpaca: drama\n",
+		},
+		{
+			desc: "String-any map",
+			input: MapFromItems(
+				TupleSA{Key: "llama", Value: "llama"},
+				TupleSA{Key: "alpaca", Value: "drama"},
+			),
+			want: "llama: llama\nalpaca: drama\n",
+		},
+		{
+			desc:  "Nil map",
+			input: (*MapSA)(nil),
+			want:  "null\n",
+		},
+		{
+			desc:  "Empty map",
+			input: NewMap[string, any](0),
+			want:  "{}\n",
+		},
+		{
+			desc: "Nested maps",
+			input: MapFromItems(
+				TupleSA{
+					Key: "llama",
+					Value: MapFromItems(
+						TupleSS{Key: "Kuzco", Value: "Emperor"},
+						TupleSS{Key: "Geronimo", Value: "Incredible"},
+					),
+				},
+				TupleSA{Key: "alpaca", Value: "drama"},
+			),
+			want: `llama:
+    Kuzco: Emperor
+    Geronimo: Incredible
+alpaca: drama
+`,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			got, err := yaml.Marshal(test.input)
+			if err != nil {
+				t.Fatalf("yaml.Marshal(%v) error = %v", test.input, err)
+			}
+			if diff := cmp.Diff(string(got), test.want); diff != "" {
+				t.Errorf("yaml.Marshal(%v) diff (-got +want):\n%s", test.input, diff)
+			}
+		})
+	}
+}
+
+func TestUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc  string
+		input string
+		want  any
+	}{
+		{
+			desc: "Map containing sequence containing map",
+			input: `---
+hello:
+  - yes
+  - this
+  - is: dog
+    how: are you today
+    i am: good thanks
+`,
+			want: MapFromItems(
+				TupleSA{Key: "hello", Value: []any{
+					"yes",
+					"this",
+					MapFromItems(
+						TupleSA{Key: "is", Value: "dog"},
+						TupleSA{Key: "how", Value: "are you today"},
+						TupleSA{Key: "i am", Value: "good thanks"},
+					),
+				}},
+			),
+		},
+		{
+			desc: "3GZX: Spec Example 7.1. Alias Nodes",
+			input: `First occurrence: &anchor Foo
+Second occurrence: *anchor
+Override anchor: &anchor Bar
+Reuse anchor: *anchor`,
+			want: MapFromItems(
+				TupleSA{Key: "First occurrence", Value: "Foo"},
+				TupleSA{Key: "Second occurrence", Value: "Foo"},
+				TupleSA{Key: "Override anchor", Value: "Bar"},
+				TupleSA{Key: "Reuse anchor", Value: "Bar"},
+			),
+		},
+		{
+			desc: "4ABK: Flow Mapping Separate Values",
+			input: `{
+				unquoted : "separate",
+				http://foo.com,
+				omitted value:,
+}`,
+			want: MapFromItems(
+				TupleSA{Key: "unquoted", Value: "separate"},
+				TupleSA{Key: "http://foo.com", Value: nil},
+				TupleSA{Key: "omitted value:", Value: nil},
+			),
+		},
+		{
+			desc: "4CQQ: Spec Example 2.18. Multi-line Flow Scalars",
+			input: `plain:
+  This unquoted scalar
+  spans many lines.
+
+quoted: "So does this
+  quoted scalar.\n"
+`,
+			want: MapFromItems(
+				TupleSA{Key: "plain", Value: "This unquoted scalar spans many lines."},
+				TupleSA{Key: "quoted", Value: "So does this quoted scalar.\n"},
+			),
+		},
+		{
+			desc: "Pipe syntax",
+			input: `pipe: |
+  This is a multiline literal
+  here is the other line
+  the newlines should be preserved`,
+			want: MapFromItems(
+				TupleSA{Key: "pipe", Value: "This is a multiline literal\nhere is the other line\nthe newlines should be preserved"},
+			),
+		},
+		{
+			desc: "Left crocodile",
+			input: `left_croc: >
+  This is another multiline literal
+  that behaves slightly differently
+  (it replaces newlines with spaces)`,
+			want: MapFromItems(
+				TupleSA{Key: "left_croc", Value: "This is another multiline literal that behaves slightly differently (it replaces newlines with spaces)"},
+			),
+		},
+		{
+			desc: "go-yaml/yaml#184",
+			input: `---
+world: &world
+  greeting: Hello
+earth:
+  << : *world`,
+			want: MapFromItems(
+				TupleSA{
+					Key:   "world",
+					Value: MapFromItems(TupleSA{Key: "greeting", Value: "Hello"}),
+				},
+				TupleSA{
+					Key:   "earth",
+					Value: MapFromItems(TupleSA{Key: "greeting", Value: "Hello"}),
+				},
+			),
+		},
+		{
+			desc: "Various map keys",
+			input: `---
+foo: llama
+.nan: llama
+!!int 12345: alpaca
+!!bool false: gerbil
+.inf: hyperllama
+-.inf: hypollama`,
+			want: MapFromItems(
+				TupleSA{Key: "foo", Value: "llama"},
+				TupleSA{Key: "NaN", Value: "llama"},
+				TupleSA{Key: "12345", Value: "alpaca"},
+				TupleSA{Key: "false", Value: "gerbil"},
+				TupleSA{Key: "+Inf", Value: "hyperllama"},
+				TupleSA{Key: "-Inf", Value: "hypollama"},
+			),
+		},
+		{
+			desc: "Various values",
+			input: `---
+llamas: TRUE
+alpacas: False
+gerbils: !!bool false
+hex: 0x2A
+oct: 0o52
+unders: 123_456
+float: 0.0000000025`,
+			want: MapFromItems(
+				TupleSA{Key: "llamas", Value: true},
+				TupleSA{Key: "alpacas", Value: false},
+				TupleSA{Key: "gerbils", Value: false},
+				TupleSA{Key: "hex", Value: 42},
+				TupleSA{Key: "oct", Value: 42},
+				TupleSA{Key: "unders", Value: 123456},
+				TupleSA{Key: "float", Value: 2.5e-9},
+			),
+		},
+		{
+			desc: "Merge sequence of aliases",
+			input: `---
+a: &a
+  b: c
+d: &d
+  b: d
+e:
+  << : [*a, *d]`,
+			want: MapFromItems(
+				TupleSA{Key: "a", Value: MapFromItems(TupleSA{Key: "b", Value: "c"})},
+				TupleSA{Key: "d", Value: MapFromItems(TupleSA{Key: "b", Value: "d"})},
+				TupleSA{Key: "e", Value: MapFromItems(TupleSA{Key: "b", Value: "c"})},
+			),
+		},
+		{
+			desc: "Infinite recursive merge",
+			input: `---
+a: &a
+  b: c
+  << : *a`,
+			want: MapFromItems(
+				TupleSA{Key: "a", Value: MapFromItems(TupleSA{Key: "b", Value: "c"})},
+			),
+		},
+		{
+			desc: "Multiple aliases",
+			input: `---
+a: &a
+  b: c
+d:
+  da: *a
+  db: *a`,
+			want: MapFromItems(
+				TupleSA{Key: "a", Value: MapFromItems(TupleSA{Key: "b", Value: "c"})},
+				TupleSA{Key: "d", Value: MapFromItems(
+					TupleSA{Key: "da", Value: MapFromItems(TupleSA{Key: "b", Value: "c"})},
+					TupleSA{Key: "db", Value: MapFromItems(TupleSA{Key: "b", Value: "c"})},
+				)},
+			),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got := NewMap[string, any](0)
+			if err := yaml.Unmarshal([]byte(test.input), &got); err != nil {
+				t.Fatalf("yaml.Unmarshal(input, &got) = %v", err)
+			}
+
+			if diff := cmp.Diff(got, test.want, cmp.Comparer(EqualSA)); diff != "" {
+				t.Errorf("unmarshaled map diff (-got +want):\n%s", diff)
+			}
+
+			// Now round-trip via JSON.
+			out, err := json.Marshal(got)
+			if err != nil {
+				t.Errorf("json.Marshal(got) error = %v", err)
+			}
+			got2 := NewMap[string, any](0)
+			if err := json.Unmarshal(out, &got2); err != nil {
+				t.Errorf("json.Unmarshal(out, &got2) = %v", err)
+			}
+
+			if diff := cmp.Diff(got2, test.want, cmp.Comparer(EqualSA)); diff != "" {
+				t.Errorf("unmarshaled JSON-round-trip map diff (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUnmarshalInfiniteAlias(t *testing.T) {
+	t.Parallel()
+
+	input := `---
+a: &a
+  b: c
+  d: *a`
+	m := NewMap[string, any](1)
+	if err := yaml.Unmarshal([]byte(input), &m); err == nil {
+		t.Errorf("yaml.Unmarshal(%q, &m) error = %v, want non-nil error (and not a stack overflow)", input, err)
+	}
+}
+
+func TestUnmarshalYAMLUnusual(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc     string
+		start    any
+		input    string
+		want     any
+		comparer cmp.Option
+	}{
+		{
+			desc:  "Map containing sequence containing map",
+			start: NewMap[string, []any](0),
+			input: `---
+hello:
+  - yes
+  - this
+  - is: dog
+    how: are you today
+    i am: good thanks
+`,
+			want: MapFromItems(
+				Tuple[string, []any]{Key: "hello", Value: []any{
+					"yes",
+					"this",
+					MapFromItems(
+						TupleSA{Key: "is", Value: "dog"},
+						TupleSA{Key: "how", Value: "are you today"},
+						TupleSA{Key: "i am", Value: "good thanks"},
+					),
+				}},
+			),
+			comparer: cmp.Comparer(Equal[string, []any]),
+		},
+		{
+			desc:  "Map containing sequence containing map 2",
+			start: NewMap[string, []*MapSS](0),
+			input: `---
+hello:
+  - yes: this
+  - is: dog
+    how: are you today
+    i am: good thanks
+`,
+			want: MapFromItems(
+				Tuple[string, []*MapSS]{Key: "hello", Value: []*MapSS{
+					MapFromItems(
+						TupleSS{Key: "yes", Value: "this"},
+					),
+					MapFromItems(
+						TupleSS{Key: "is", Value: "dog"},
+						TupleSS{Key: "how", Value: "are you today"},
+						TupleSS{Key: "i am", Value: "good thanks"},
+					),
+				}},
+			),
+			comparer: cmp.Comparer(Equal[string, []*MapSS]),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			if err := yaml.Unmarshal([]byte(test.input), test.start); err != nil {
+				t.Fatalf("yaml.Unmarshal(input, &test.start) = %v", err)
+			}
+
+			if diff := cmp.Diff(test.start, test.want, test.comparer); diff != "" {
+				t.Errorf("unmarshaled map diff (-got +want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/ordered/tuple.go
+++ b/internal/ordered/tuple.go
@@ -1,0 +1,15 @@
+package ordered
+
+// Tuple is used for storing values in Map.
+type Tuple[K comparable, V any] struct {
+	Key   K
+	Value V
+
+	deleted bool
+}
+
+// TupleSS is a convenience alias to reduce keyboard wear.
+type TupleSS = Tuple[string, string]
+
+// TupleSA is a convenience alias to reduce keyboard wear.
+type TupleSA = Tuple[string, any]


### PR DESCRIPTION
In the process of trying to parse pipelines with a greater semantic understanding (in order to do things with them, like sign command steps), but retain compatibility, I kept hitting the need for YAML unmarshaling into an *ordered* map. For example, even though the "env" block is essentially unordered, we step through it *in order* so that variables can interpolate into one another *in order*. Another example is plugin config: we reflect it to plugins both via env vars, but also as a JSON blob, and there's a fair chance some plugin is going to be (maybe even deliberately) relying on ordering within its config.

So I implemented an ordered map. It's the next evolution of yamltojson, in that it provides the same sort of order-preserving translation when you unmarshal YAML and marshal JSON, but you can also work with the contents of the map in a more map-like way. It's almost like the good old days of yaml.v2, but better!

Under the hood, ordered.Map is based on a slice of tuples, and an index (map from keys to slice indexes).

To be extra trendy, ordered.Map is generic. However, for now, unmarshaling requires string keys, and the only two uses are Map[string, string] and Map[string, any]. 

If you tell yaml.v3 to unmarshal into any, it will give you a map[string]any for mapping nodes. So any trickery is actually around co-opting UnmarshalYAML to prefer unmarshaling as a *Map[string,any] instead.

The unmarshalling tests are copied fairly closely from yamltojson, so I'm reasonably confident it's about as good as yamltojson is.