### PR TITLE
Add option to configure location of Job Log tmp file

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -31,6 +31,7 @@ type AgentConfiguration struct {
 	DisconnectAfterIdleTimeout int
 	CancelGracePeriod          int
 	EnableJobLogTmpfile        bool
+	JobLogPath                 string
 	WriteJobLogsToStdout       bool
 	LogFormat                  string
 	Shell                      string

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -216,10 +216,16 @@ func NewJobRunner(l logger.Logger, scope *metrics.Scope, ag *api.AgentRegisterRe
 	var allWriters []io.Writer
 
 	// if agent config "EnableJobLogTmpfile" is set, we extend the outputWriter to write to a temporary file.
-	// BUILDKITE_JOB_LOG_TMPFILE is an environment variable that contains the path to this temporary file.
+	// By default, the tmp file will be created on os.TempDir unless config "JobLogPath" is specified.
+	// BUILDKITE_JOB_LOG_TMPFILE is an environment variable that contains the full path to this temporary file.
 	var tmpFile *os.File
 	if conf.AgentConfiguration.EnableJobLogTmpfile {
-		tmpFile, err = os.CreateTemp("", "buildkite_job_log")
+		jobLogDir := ""
+		if conf.AgentConfiguration.JobLogPath != "" {
+			jobLogDir = conf.AgentConfiguration.JobLogPath
+			l.Debug("[JobRunner] Job Log Path: %s", jobLogDir)
+		}
+		tmpFile, err = os.CreateTemp(jobLogDir, "buildkite_job_log")
 		if err != nil {
 			return nil, err
 		}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -69,6 +69,7 @@ type AgentStartConfig struct {
 	BootstrapScript             string   `cli:"bootstrap-script" normalize:"commandpath"`
 	CancelGracePeriod           int      `cli:"cancel-grace-period"`
 	EnableJobLogTmpfile         bool     `cli:"enable-job-log-tmpfile"`
+	JobLogPath                  string   `cli:"job-log-path" normalize:"filepath"`
 	WriteJobLogsToStdout        bool     `cli:"write-job-logs-to-stdout"`
 	BuildPath                   string   `cli:"build-path" normalize:"filepath" validate:"required"`
 	HooksPath                   string   `cli:"hooks-path" normalize:"filepath"`
@@ -287,6 +288,11 @@ var AgentStartCommand = cli.Command{
 			Name:   "enable-job-log-tmpfile",
 			Usage:  "Store the job logs in a temporary file ′BUILDKITE_JOB_LOG_TMPFILE′ that is accessible during the job and removed at the end of the job",
 			EnvVar: "BUILDKITE_ENABLE_JOB_LOG_TMPFILE",
+		},
+		cli.StringFlag{
+			Name:   "job-log-path",
+			Usage:  "Location to store job logs created by configuring ′enable-job-log-tmpfile`, by default job log will be stored in TempDir",
+			EnvVar: "BUILDKITE_JOB_LOG_PATH",
 		},
 		cli.BoolFlag{
 			Name:   "write-job-logs-to-stdout",
@@ -794,6 +800,7 @@ var AgentStartCommand = cli.Command{
 			DisconnectAfterIdleTimeout: cfg.DisconnectAfterIdleTimeout,
 			CancelGracePeriod:          cfg.CancelGracePeriod,
 			EnableJobLogTmpfile:        cfg.EnableJobLogTmpfile,
+			JobLogPath:                 cfg.JobLogPath,
 			WriteJobLogsToStdout:       cfg.WriteJobLogsToStdout,
 			LogFormat:                  cfg.LogFormat,
 			Shell:                      cfg.Shell,


### PR DESCRIPTION
Extending from this job log tmp feature https://github.com/buildkite/agent/pull/1564

We need the ability to move job log files into a different folder than tmp to share them. This will allow us to use different containers between job and runner and pre-exit hooks for example. 