### PR TITLE
Replace ParserResult with Pipeline

### DIFF
--- a/agent/pipeline_uploader_test.go
+++ b/agent/pipeline_uploader_test.go
@@ -79,7 +79,7 @@ steps:
     agents:
       queue: xxx`
 
-			pipeline, err := pipeline.Parse(strings.NewReader(pipelineStr), nil)
+			pipeline, err := pipeline.Parse(strings.NewReader(pipelineStr))
 			assert.NoError(t, err)
 
 			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -205,7 +205,7 @@ steps:
     agents:
       queue: xxx`
 
-			pipeline, err := pipeline.Parse(strings.NewReader(pipelineStr), nil)
+			pipeline, err := pipeline.Parse(strings.NewReader(pipelineStr))
 			assert.NoError(t, err)
 
 			countUploadCalls := 0

--- a/agent/pipeline_uploader_test.go
+++ b/agent/pipeline_uploader_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -78,8 +79,7 @@ steps:
     agents:
       queue: xxx`
 
-			parser := pipeline.Parser{Pipeline: []byte(pipelineStr), Env: nil}
-			pipeline, err := parser.Parse()
+			pipeline, err := pipeline.Parse(strings.NewReader(pipelineStr), nil)
 			assert.NoError(t, err)
 
 			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -205,8 +205,7 @@ steps:
     agents:
       queue: xxx`
 
-			parser := pipeline.Parser{Pipeline: []byte(pipelineStr), Env: nil}
-			pipeline, err := parser.Parse()
+			pipeline, err := pipeline.Parse(strings.NewReader(pipelineStr), nil)
 			assert.NoError(t, err)
 
 			countUploadCalls := 0

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -249,9 +249,14 @@ var PipelineUploadCommand = cli.Command{
 		}
 
 		// Parse the pipeline
-		result, err := pipeline.Parse(input, environ)
+		result, err := pipeline.Parse(input)
 		if err != nil {
-			l.Fatal("Pipeline parsing of %q failed: %s", src, err)
+			l.Fatal("Pipeline parsing of %q failed: %v", src, err)
+		}
+		if !cfg.NoInterpolation {
+			if err := result.Interpolate(environ); err != nil {
+				l.Fatal("Pipeline interpolation of %q failed: %v", src, err)
+			}
 		}
 
 		if len(cfg.RedactedVars) > 0 {

--- a/internal/ordered/slice.go
+++ b/internal/ordered/slice.go
@@ -1,0 +1,30 @@
+package ordered
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+var _ yaml.Unmarshaler = (*Slice)(nil)
+
+// Slice is []any, but unmarshaling into it prefers *Map[string,any] over
+// map[string]any.
+type Slice []any
+
+// UnmarshalYAML unmarshals sequence nodes. Any mapping nodes are unmarshaled
+// as *Map[string,any].
+func (s *Slice) UnmarshalYAML(n *yaml.Node) error {
+	if n.Kind != yaml.SequenceNode {
+		return fmt.Errorf("line %d, col %d: unsupported kind %x for unmarshaling Slice (want %x)", n.Line, n.Column, n.Kind, yaml.SequenceNode)
+	}
+	seen := make(map[*yaml.Node]bool)
+	for _, c := range n.Content {
+		cv, err := decode(seen, c)
+		if err != nil {
+			return err
+		}
+		*s = append(*s, cv)
+	}
+	return nil
+}

--- a/internal/pipeline/doc.go
+++ b/internal/pipeline/doc.go
@@ -1,3 +1,13 @@
 // Package pipeline implements the pieces necessary for the agent to work with
 // pipelines (typically in YAML or JSON form).
+//
+// The pipeline object model (Pipeline, Steps, Plugin, etc) have these caveats:
+//   - It is incomplete: there may be fields accepted by the API that are not
+//     listed. Do not treat Pipeline, CommandStep, etc, as comprehensive
+//     reference guides for how to write a pipeline.
+//   - It normalises: unmarshaling accepts a variety of step forms, but
+//     marshaling back out produces more normalised output. An unmarshal/marshal
+//     round-trip may produce different output.
+//   - It is non-canonical: using the object model does not guarantee that a
+//     pipeline will be accepted by the pipeline upload API.
 package pipeline

--- a/internal/pipeline/interpolate.go
+++ b/internal/pipeline/interpolate.go
@@ -1,0 +1,134 @@
+package pipeline
+
+import (
+	"github.com/buildkite/agent/v3/internal/ordered"
+	"github.com/buildkite/interpolate"
+)
+
+// This file contains helpers for recursively interpolating all the strings in
+// pipeline objects.
+
+// selfInterpolater describes types that can interpolate themselves in-place.
+// They can call interpolate.Interpolate on strings, or
+// interpolate{Slice,Map,OrderedMap,Any} on their other contents, to do this.
+type selfInterpolater interface {
+	interpolate(interpolate.Env) error
+}
+
+// interpolateAny interpolates (almost) anything in-place. It returns the same
+// type it is passed. When passed a string, it returns a new string. Anything
+// it doesn't know how to interpolate is returned unaltered.
+func interpolateAny(env interpolate.Env, o any) (any, error) {
+	switch o := any(o).(type) {
+	case selfInterpolater:
+		return o, o.interpolate(env)
+
+	case string:
+		return interpolate.Interpolate(env, o)
+
+	case []any:
+		return o, interpolateSlice(env, o)
+
+	case []string:
+		return o, interpolateSlice(env, o)
+
+	case ordered.Slice:
+		return o, interpolateSlice(env, o)
+
+	case map[string]any:
+		return o, interpolateMap(env, o)
+
+	case map[string]string:
+		return o, interpolateMap(env, o)
+
+	case *ordered.Map[string, any]:
+		return o, interpolateOrderedMap(env, o)
+
+	case *ordered.Map[string, string]:
+		return o, interpolateOrderedMap(env, o)
+
+	default:
+		return o, nil
+	}
+}
+
+// interpolateSlice applies interpolateAny over any type of slice.
+func interpolateSlice[E any, S ~[]E](env interpolate.Env, s S) error {
+	for i, e := range s {
+		// It could be a string, so replace the old value with the new.
+		inte, err := interpolateAny(env, e)
+		if err != nil {
+			return err
+		}
+		if inte == nil {
+			// Then e was nil to begin with. No need to update it.
+			// (Asserting nil interface to a type always panics.)
+			continue
+		}
+		s[i] = inte.(E)
+	}
+	return nil
+}
+
+// interpolateMap applies interpolateAny over any type of map with string keys.
+func interpolateMap[V any, M ~map[string]V](env interpolate.Env, m M) error {
+	for k, v := range m {
+		// We interpolate both keys and values.
+		intk, err := interpolate.Interpolate(env, k)
+		if err != nil {
+			return err
+		}
+
+		// V could be string, so be sure to replace the old value with the new.
+		intv, err := interpolateAny(env, v)
+		if err != nil {
+			return err
+		}
+
+		// If the key changed due to interpolation, delete the old key.
+		if k != intk {
+			delete(m, k)
+		}
+		if intv == nil {
+			// Then v was nil to begin with.
+			// In case we're changing keys, we should reassign.
+			// But we don't know the type, so can't assign nil.
+			// Fortunately, v itself must be the right type.
+			// (Asserting nil interface to a type always panics.)
+			m[intk] = v
+			continue
+		}
+		m[intk] = intv.(V)
+	}
+	return nil
+}
+
+// interpolateOrderedMap applies interpolateAny over any type of ordered.Map.
+func interpolateOrderedMap[K comparable, V any](env interpolate.Env, m *ordered.Map[K, V]) error {
+	return m.Range(func(k K, v V) error {
+		// We interpolate both keys and values.
+		intk, err := interpolateAny(env, k)
+		if err != nil {
+			return err
+		}
+		intv, err := interpolateAny(env, v)
+		if err != nil {
+			return err
+		}
+
+		if intk == nil {
+			// Then k was nil to begin with... weird.
+			return nil
+		}
+
+		if intv == nil {
+			// Then v was nil to begin with. See above.
+			m.Replace(k, intk.(K), v)
+			return nil
+		}
+
+		// interpolateAny preserves the type, so these assertions are safe.
+		m.Replace(k, intk.(K), intv.(V))
+		return nil
+	})
+}

--- a/internal/pipeline/parser.go
+++ b/internal/pipeline/parser.go
@@ -5,80 +5,16 @@ import (
 	"io"
 	"strings"
 
-	"github.com/buildkite/agent/v3/env"
-	"github.com/buildkite/agent/v3/internal/ordered"
-	"github.com/buildkite/agent/v3/tracetools"
-	"github.com/buildkite/interpolate"
-
 	"gopkg.in/yaml.v3"
 )
 
-// Parse parses a pipeline and applies interpolation. If nil envMap is provided,
-// interpolation is skipped. Otherwise, Parse mutates envMap to contain
-// variables from the pipeline's env block.
-// To interpolate only using variables defined the pipeline, pass an empty but
-// non-nil envMap.
-func Parse(src io.Reader, envMap *env.Environment) (*Pipeline, error) {
-	// Run the pipeline through the YAML parser.
+// Parse parses a pipeline. It does not apply interpolation.
+func Parse(src io.Reader) (*Pipeline, error) {
 	pipeline := new(Pipeline)
 	if err := yaml.NewDecoder(src).Decode(pipeline); err != nil {
 		return nil, formatYAMLError(err)
 	}
-
-	// No interpolation? No more to do.
-	if envMap == nil {
-		return pipeline, nil
-	}
-
-	// Propagate distributed tracing context to the new pipelines if available
-	if tracing, has := envMap.Get(tracetools.EnvVarTraceContextKey); has {
-		if pipeline.Env == nil {
-			pipeline.Env = ordered.NewMap[string, string](1)
-		}
-		pipeline.Env.Set(tracetools.EnvVarTraceContextKey, tracing)
-	}
-
-	// Preprocess any env that are defined in the top level block and place them
-	// into env for later interpolation into the rest of the pipeline.
-	if err := interpolateEnvBlock(envMap, pipeline.Env); err != nil {
-		return nil, err
-	}
-
-	// Recursively go through the entire pipeline and perform environment
-	// variable interpolation on strings. Interpolation is performed in-place.
-	if err := pipeline.interpolate(envMap); err != nil {
-		return nil, err
-	}
-
 	return pipeline, nil
-}
-
-// interpolateEnvBlock runs Interpolate on each string value in envBlock,
-// interpolating with the variables defined in envMap, and then adding the
-// results back into both envBlock and envMap. Each environment variable can
-// be interpolated into later environment variables, making the input ordering
-// potentially important.
-func interpolateEnvBlock(envMap *env.Environment, envBlock *ordered.Map[string, string]) error {
-	return envBlock.Range(func(k, v string) error {
-		// We interpolate both keys and values.
-		intk, err := interpolate.Interpolate(envMap, k)
-		if err != nil {
-			return err
-		}
-
-		// v is always a string in this case.
-		intv, err := interpolate.Interpolate(envMap, v)
-		if err != nil {
-			return err
-		}
-
-		envBlock.Replace(k, intk, intv)
-
-		// Bonus part for the env block!
-		// Add the results back into envMap.
-		envMap.Set(intk, intv)
-		return nil
-	})
 }
 
 func formatYAMLError(err error) error {

--- a/internal/pipeline/parser.go
+++ b/internal/pipeline/parser.go
@@ -1,184 +1,86 @@
 package pipeline
 
 import (
-	"bytes"
 	"errors"
-	"fmt"
+	"io"
 	"strings"
 
 	"github.com/buildkite/agent/v3/env"
-	"github.com/buildkite/agent/v3/internal/yamltojson"
+	"github.com/buildkite/agent/v3/internal/ordered"
 	"github.com/buildkite/agent/v3/tracetools"
 	"github.com/buildkite/interpolate"
 
 	"gopkg.in/yaml.v3"
 )
 
-// Parser parses a pipeline, optionally interpolating values from
-// a given environment.
-type Parser struct {
-	Env             *env.Environment
-	Filename        string
-	Pipeline        []byte
-	NoInterpolation bool
-}
-
-// Parse runs the parser.
-func (p *Parser) Parse() (*ParserResult, error) {
-	if p.Env == nil {
-		p.Env = env.New()
-	}
-
-	errPrefix := "Failed to parse pipeline"
-	if p.Filename != "" {
-		errPrefix = fmt.Sprintf("Failed to parse %s", p.Filename)
-	}
-
-	// Run the pipeline through the YAML parser. Parse to a *yaml.Node because
-	// that will accept anything, but means we have more work to do.
-	var doc yaml.Node
-	if err := yaml.Unmarshal(p.Pipeline, &doc); err != nil {
-		return nil, fmt.Errorf("%s: %v", errPrefix, formatYAMLError(err))
-	}
-
-	// Some quick paranoia checks...
-	// yaml.v3 parses the top level as a DocumentNode, and only parses one child
-	// node (that then has the content we care about).
-	if doc.Kind != yaml.DocumentNode {
-		// TODO: Use %v once yaml.Kind has a String method
-		return nil, fmt.Errorf("%s: line %d, col %d: pipeline is not a YAML document? (kind = %x)", errPrefix, doc.Line, doc.Column, doc.Kind)
-	}
-	if len(doc.Content) != 1 {
-		return nil, fmt.Errorf("%s: line %d, col %d: pipeline document contains %d top-level nodes, want 1", errPrefix, doc.Line, doc.Column, len(doc.Content))
-	}
-
-	// It's more useful to deal with the top-level mapping node than the
-	// document node.
-	pipeline := doc.Content[0]
-
-	// We support top-level arrays of steps. If the document content is
-	// a sequence node, hoist that out into a mapping node under the key "steps"
-	// to make it look like a modern pipeline.
-	if pipeline.Kind == yaml.SequenceNode {
-		steps := pipeline
-		pp, err := yamltojson.UpsertItem(nil, "steps", steps)
-		if err != nil {
-			return nil, fmt.Errorf("%s: %v", errPrefix, err)
-		}
-		pipeline = pp
+// Parse parses a pipeline and applies interpolation. If nil envMap is provided,
+// interpolation is skipped. Otherwise, Parse mutates envMap to contain
+// variables from the pipeline's env block.
+// To interpolate only using variables defined the pipeline, pass an empty but
+// non-nil envMap.
+func Parse(src io.Reader, envMap *env.Environment) (*Pipeline, error) {
+	// Run the pipeline through the YAML parser.
+	pipeline := new(Pipeline)
+	if err := yaml.NewDecoder(src).Decode(pipeline); err != nil {
+		return nil, formatYAMLError(err)
 	}
 
 	// No interpolation? No more to do.
-	if p.NoInterpolation {
-		return &ParserResult{pipeline: pipeline}, nil
-	}
-
-	// Find the env map, if present.
-	envMap, err := yamltojson.LookupItem(pipeline, "env")
-	if err != nil && err != yamltojson.ErrNotFound {
-		return nil, fmt.Errorf("%s: %w", errPrefix, err)
-	}
-	if envMap != nil && envMap.Kind != yaml.MappingNode {
-		return nil, fmt.Errorf("%s: line %d, col %d: top-level env block is not a map", errPrefix, envMap.Line, envMap.Column)
+	if envMap == nil {
+		return pipeline, nil
 	}
 
 	// Propagate distributed tracing context to the new pipelines if available
-	if tracing, has := p.Env.Get(tracetools.EnvVarTraceContextKey); has {
-		em, err := yamltojson.UpsertItem(envMap, tracetools.EnvVarTraceContextKey, yamltojson.StringNode(tracing))
-		if err != nil {
-			return nil, fmt.Errorf("Couldn't propagate distributed tracing context to the new pipeline: %v", err)
+	if tracing, has := envMap.Get(tracetools.EnvVarTraceContextKey); has {
+		if pipeline.Env == nil {
+			pipeline.Env = ordered.NewMap[string, string](1)
 		}
-
-		// Insert the new envMap into the pipeline in case it was nil before
-		if envMap == nil {
-			if _, err := yamltojson.UpsertItem(pipeline, "env", em); err != nil {
-				return nil, fmt.Errorf("Couldn't insert environment block into to the new pipeline: %v", err)
-			}
-		}
-		envMap = em
+		pipeline.Env.Set(tracetools.EnvVarTraceContextKey, tracing)
 	}
 
 	// Preprocess any env that are defined in the top level block and place them
-	// into env for later interpolation into env blocks
-	if err := p.interpolateEnvBlock(envMap); err != nil {
+	// into env for later interpolation into the rest of the pipeline.
+	if err := interpolateEnvBlock(envMap, pipeline.Env); err != nil {
 		return nil, err
 	}
 
 	// Recursively go through the entire pipeline and perform environment
 	// variable interpolation on strings. Interpolation is performed in-place.
-	if err := p.interpolateNode(pipeline); err != nil {
+	if err := pipeline.interpolate(envMap); err != nil {
 		return nil, err
 	}
 
-	return &ParserResult{pipeline: pipeline}, nil
+	return pipeline, nil
 }
 
-// interpolateEnvBlock runs Interpolate on each string value in the envMap,
-// interpolating with the variables defined in p.Env, and then adding the
-// results back into to p.Env.
-func (p *Parser) interpolateEnvBlock(envMap *yaml.Node) error {
-	return yamltojson.RangeMap(envMap, func(k string, v *yaml.Node) error {
-		if v.Kind != yaml.ScalarNode || v.Tag != "!!str" {
-			return nil
-		}
-		interped, err := interpolate.Interpolate(p.Env, v.Value)
+// interpolateEnvBlock runs Interpolate on each string value in envBlock,
+// interpolating with the variables defined in envMap, and then adding the
+// results back into both envBlock and envMap. Each environment variable can
+// be interpolated into later environment variables, making the input ordering
+// potentially important.
+func interpolateEnvBlock(envMap *env.Environment, envBlock *ordered.Map[string, string]) error {
+	return envBlock.Range(func(k, v string) error {
+		// We interpolate both keys and values.
+		intk, err := interpolate.Interpolate(envMap, k)
 		if err != nil {
 			return err
 		}
-		p.Env.Set(k, interped)
+
+		// v is always a string in this case.
+		intv, err := interpolate.Interpolate(envMap, v)
+		if err != nil {
+			return err
+		}
+
+		envBlock.Replace(k, intk, intv)
+
+		// Bonus part for the env block!
+		// Add the results back into envMap.
+		envMap.Set(intk, intv)
 		return nil
 	})
 }
 
 func formatYAMLError(err error) error {
 	return errors.New(strings.TrimPrefix(err.Error(), "yaml: "))
-}
-
-// interpolateNode interpolates the YAML in-place.
-func (p *Parser) interpolateNode(n *yaml.Node) error {
-	if n == nil {
-		return nil
-	}
-
-	switch n.Kind {
-	case yaml.AliasNode:
-		// Ignore; every node should be reachable without following aliases.
-
-	case yaml.DocumentNode, yaml.SequenceNode, yaml.MappingNode:
-		// Interpolate everything. Elements, keys, values, ...
-		for _, e := range n.Content {
-			if err := p.interpolateNode(e); err != nil {
-				return err
-			}
-		}
-
-	case yaml.ScalarNode:
-		// Only interpolate strings.
-		if n.Tag != "!!str" {
-			return nil
-		}
-		interped, err := interpolate.Interpolate(p.Env, n.Value)
-		if err != nil {
-			return err
-		}
-		n.Value = interped
-
-	default:
-		return fmt.Errorf("line %d, col %d: unsupported node kind %x", n.Line, n.Column, n.Kind)
-	}
-
-	return nil
-}
-
-// ParserResult is the ordered parse tree of a Pipeline document.
-type ParserResult struct {
-	pipeline *yaml.Node
-}
-
-func (p *ParserResult) MarshalJSON() ([]byte, error) {
-	var buf bytes.Buffer
-	if err := yamltojson.Encode(&buf, p.pipeline); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
 }

--- a/internal/pipeline/parser_test.go
+++ b/internal/pipeline/parser_test.go
@@ -1,50 +1,66 @@
 package pipeline
 
 import (
-	"bytes"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/buildkite/agent/v3/env"
-	"github.com/stretchr/testify/assert"
+	"github.com/buildkite/agent/v3/internal/ordered"
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestParserParsesYaml(t *testing.T) {
-	parser := Parser{
-		Env:      env.FromSlice([]string{`ENV_VAR_FRIEND="friend"`}),
-		Filename: "awesome.yml",
-		Pipeline: []byte("steps:\n  - label: \"hello ${ENV_VAR_FRIEND}\""),
-	}
-	result, err := parser.Parse()
-
-	assert.NoError(t, err)
-	j, err := json.Marshal(result)
+func TestParserParsesYAML(t *testing.T) {
+	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND="friend"`})
+	input := strings.NewReader("steps:\n  - command: \"hello ${ENV_VAR_FRIEND}\"")
+	got, err := Parse(input, envMap)
 	if err != nil {
-		t.Errorf("json.Marshal(result) error = %v", err)
+		t.Fatalf("Parse(input, %v) error = %v", envMap, err)
 	}
-	assert.Equal(t, `{"steps":[{"label":"hello \"friend\""}]}`, string(j))
+
+	gotJSON, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
+	}
+
+	const wantJSON = `{
+  "steps": [
+    {
+      "command": "hello \"friend\""
+    }
+  ]
+}`
+	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
+		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+	}
 }
 
-func TestParserParsesYamlWithNoInterpolation(t *testing.T) {
-	parser := Parser{
-		Filename:        "awesome.yml",
-		Pipeline:        []byte("steps:\n  - label: \"hello ${ENV_VAR_FRIEND}\""),
-		NoInterpolation: true,
-	}
-	result, err := parser.Parse()
-
-	assert.NoError(t, err)
-	j, err := json.Marshal(result)
+func TestParserParsesYAMLWithNoInterpolation(t *testing.T) {
+	input := strings.NewReader("steps:\n  - command: \"hello ${ENV_VAR_FRIEND}\"")
+	got, err := Parse(input, nil)
 	if err != nil {
-		t.Errorf("json.Marshal(result) error = %v", err)
+		t.Fatalf("Parse(input, nil) error = %v", err)
 	}
-	assert.Equal(t, `{"steps":[{"label":"hello ${ENV_VAR_FRIEND}"}]}`, string(j))
+
+	gotJSON, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
+	}
+
+	const wantJSON = `{
+  "steps": [
+    {
+      "command": "hello ${ENV_VAR_FRIEND}"
+    }
+  ]
+}`
+	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
+		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+	}
 }
 
-func TestParserSupportsYamlMergesAndAnchors(t *testing.T) {
-	complexYAML := `---
+func TestParserSupportsYAMLMergesAndAnchors(t *testing.T) {
+	const complexYAML = `---
 base_step: &base_step
   type: script
   agent_query_rules:
@@ -57,244 +73,320 @@ steps:
     agents:
       queue: default`
 
-	parser := Parser{
-		Filename: "awesome.yml",
-		Pipeline: []byte(complexYAML),
-	}
-	result, err := parser.Parse()
-
-	assert.NoError(t, err)
-	j, err := json.Marshal(result)
+	input := strings.NewReader(complexYAML)
+	got, err := Parse(input, nil)
 	if err != nil {
-		t.Errorf("json.Marshal(result) error = %v", err)
+		t.Fatalf("Parse(input, nil) error = %v", err)
 	}
-	assert.Equal(t, `{"base_step":{"type":"script","agent_query_rules":["queue=default"]},"steps":[{"type":"script","agent_query_rules":["queue=default"],"name":":docker: building image","command":"docker build .","agents":{"queue":"default"}}]}`, string(j))
-}
 
-func TestParserReturnsYamlParsingErrors(t *testing.T) {
-	parser := Parser{
-		Filename: "awesome.yml",
-		Pipeline: []byte("steps: %blah%"),
-	}
-	_, err := parser.Parse()
-
-	assert.Error(t, err, `Failed to parse awesome.yml: found character that cannot start any token`, fmt.Sprintf("%s", err))
-}
-
-func TestParserReturnsJsonParsingErrors(t *testing.T) {
-	parser := Parser{
-		Filename: "awesome.json",
-		Pipeline: []byte("{"),
-	}
-	_, err := parser.Parse()
-
-	assert.Error(t, err, `Failed to parse awesome.json: line 1: did not find expected node content`, fmt.Sprintf("%s", err))
-}
-
-func TestParserParsesJson(t *testing.T) {
-	parser := Parser{
-		Env:      env.FromSlice([]string{`ENV_VAR_FRIEND="friend"`}),
-		Filename: "thing.json",
-		Pipeline: []byte("\n\n     \n  { \"foo\": \"bye ${ENV_VAR_FRIEND}\" }\n"),
-	}
-	result, err := parser.Parse()
-
-	assert.NoError(t, err)
-	j, err := json.Marshal(result)
+	gotJSON, err := json.MarshalIndent(got, "", "  ")
 	if err != nil {
-		t.Errorf("json.Marshal(result) error = %v", err)
+		t.Fatalf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
 	}
-	assert.Equal(t, `{"foo":"bye \"friend\""}`, string(j))
+
+	const wantJSON = `{
+  "base_step": {
+    "agent_query_rules": [
+      "queue=default"
+    ],
+    "type": "script"
+  },
+  "steps": [
+    {
+      "type": "script",
+      "agent_query_rules": [
+        "queue=default"
+      ],
+      "name": ":docker: building image",
+      "command": "docker build .",
+      "agents": {
+        "queue": "default"
+      }
+    }
+  ]
+}`
+	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
+		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+	}
 }
 
-func TestParserParsesJsonObjects(t *testing.T) {
-	parser := Parser{
-		Env:      env.FromSlice([]string{`ENV_VAR_FRIEND="friend"`}),
-		Pipeline: []byte("\n\n     \n  { \"foo\": \"bye ${ENV_VAR_FRIEND}\" }\n"),
-	}
-	result, err := parser.Parse()
+func TestParserReturnsYAMLParsingErrors(t *testing.T) {
+	input := strings.NewReader("steps: %blah%")
+	_, err := Parse(input, nil)
 
-	assert.NoError(t, err)
-	j, err := json.Marshal(result)
-	if err != nil {
-		t.Errorf("json.Marshal(result) error = %v", err)
+	// TODO: avoid testing for specific error strings
+	got, want := err.Error(), `found character that cannot start any token`
+	if got != want {
+		t.Errorf("Parse(input, nil) error = %q, want %q", got, want)
 	}
-	assert.Equal(t, `{"foo":"bye \"friend\""}`, string(j))
 }
 
-func TestParserParsesJsonArrays(t *testing.T) {
-	parser := Parser{
-		Env:      env.FromSlice([]string{`ENV_VAR_FRIEND="friend"`}),
-		Pipeline: []byte("\n\n     \n  [ { \"foo\": \"bye ${ENV_VAR_FRIEND}\" } ]\n"),
-	}
-	result, err := parser.Parse()
+func TestParserReturnsJSONParsingErrors(t *testing.T) {
+	input := strings.NewReader("{")
+	_, err := Parse(input, nil)
 
-	assert.NoError(t, err)
-	j, err := json.Marshal(result)
-	if err != nil {
-		t.Errorf("json.Marshal(result) error = %v", err)
+	// TODO: avoid testing for specific error strings
+	got, want := err.Error(), `line 1: did not find expected node content`
+	if got != want {
+		t.Errorf("Parse(input, nil) error = %q, want %q", got, want)
 	}
-	assert.Equal(t, `{"steps":[{"foo":"bye \"friend\""}]}`, string(j))
+}
+
+func TestParserParsesJSON(t *testing.T) {
+	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND="friend"`})
+	input := strings.NewReader("\n\n     \n  { \"steps\": [{\"command\" : \"bye ${ENV_VAR_FRIEND}\"  } ] }\n")
+	got, err := Parse(input, envMap)
+	if err != nil {
+		t.Fatalf("Parse(input, %v) error = %v", envMap, err)
+	}
+
+	gotJSON, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
+	}
+
+	const wantJSON = `{
+  "steps": [
+    {
+      "command": "bye \"friend\""
+    }
+  ]
+}`
+	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
+		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestParserParsesJSONArrays(t *testing.T) {
+	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND="friend"`})
+	input := strings.NewReader("\n\n     \n  [ { \"command\": \"bye ${ENV_VAR_FRIEND}\" } ]\n")
+	got, err := Parse(input, envMap)
+	if err != nil {
+		t.Fatalf("Parse(input, %v) error = %v", envMap, err)
+	}
+
+	gotJSON, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
+	}
+	const wantJSON = `{
+  "steps": [
+    {
+      "command": "bye \"friend\""
+    }
+  ]
+}`
+	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
+		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+	}
 }
 
 func TestParserParsesTopLevelSteps(t *testing.T) {
-	parser := Parser{
-		Pipeline: []byte("---\n- name: Build\n  command: echo hello world\n- wait\n"),
-	}
-	result, err := parser.Parse()
-
-	assert.NoError(t, err)
-	j, err := json.Marshal(result)
+	input := strings.NewReader("---\n- name: Build\n  command: echo hello world\n- wait\n")
+	got, err := Parse(input, nil)
 	if err != nil {
-		t.Errorf("json.Marshal(result) error = %v", err)
+		t.Fatalf("Parse(input, nil) error = %v", err)
 	}
-	assert.Equal(t, `{"steps":[{"name":"Build","command":"echo hello world"},"wait"]}`, string(j))
+
+	gotJSON, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
+	}
+	const wantJSON = `{
+  "steps": [
+    {
+      "name": "Build",
+      "command": "echo hello world"
+    },
+    "wait"
+  ]
+}`
+	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
+		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+	}
 }
 
 func TestParserPreservesBools(t *testing.T) {
-	parser := Parser{
-		Pipeline: []byte("steps:\n  - trigger: hello\n    async: true"),
-	}
-	result, err := parser.Parse()
-
-	assert.Nil(t, err)
-	j, err := json.Marshal(result)
+	input := strings.NewReader("steps:\n  - trigger: hello\n    async: true")
+	got, err := Parse(input, nil)
 	if err != nil {
-		t.Errorf("json.Marshal(result) error = %v", err)
+		t.Fatalf("Parse(input, nil) error = %v", err)
 	}
-	assert.Equal(t, `{"steps":[{"trigger":"hello","async":true}]}`, string(j))
+
+	gotJSON, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
+	}
+	const wantJSON = `{
+  "steps": [
+    {
+      "trigger": "hello",
+      "async": true
+    }
+  ]
+}`
+	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
+		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+	}
 }
 
 func TestParserPreservesInts(t *testing.T) {
-	parser := Parser{
-		Pipeline: []byte("steps:\n  - label: hello\n    parallelism: 10"),
-	}
-	result, err := parser.Parse()
-
-	assert.Nil(t, err)
-	j, err := json.Marshal(result)
+	input := strings.NewReader("steps:\n  - command: hello\n    parallelism: 10")
+	got, err := Parse(input, nil)
 	if err != nil {
-		t.Errorf("json.Marshal(result) error = %v", err)
+		t.Fatalf("Parse(input, nil) error = %v", err)
 	}
-	assert.Equal(t, `{"steps":[{"label":"hello","parallelism":10}]}`, string(j))
+
+	gotJSON, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
+	}
+	const wantJSON = `{
+  "steps": [
+    {
+      "command": "hello",
+      "parallelism": 10
+    }
+  ]
+}`
+	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
+		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+	}
 }
 
 func TestParserPreservesNull(t *testing.T) {
-	parser := Parser{
-		Pipeline: []byte("steps:\n  - wait: ~"),
-	}
-	result, err := parser.Parse()
-
-	assert.Nil(t, err)
-	j, err := json.Marshal(result)
+	input := strings.NewReader("steps:\n  - wait: ~")
+	got, err := Parse(input, nil)
 	if err != nil {
-		t.Errorf("json.Marshal(result) error = %v", err)
+		t.Fatalf("Parse(input, nil) error = %v", err)
 	}
-	assert.Equal(t, `{"steps":[{"wait":null}]}`, string(j))
+
+	gotJSON, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
+	}
+	const wantJSON = `{
+  "steps": [
+    {
+      "wait": null
+    }
+  ]
+}`
+	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
+		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+	}
 }
 
 func TestParserPreservesFloats(t *testing.T) {
-	parser := Parser{
-		Pipeline: []byte("steps:\n  - trigger: hello\n    llamas: 3.142"),
-	}
-	result, err := parser.Parse()
-
-	assert.Nil(t, err)
-	j, err := json.Marshal(result)
+	input := strings.NewReader("steps:\n  - trigger: hello\n    llamas: 3.142")
+	got, err := Parse(input, nil)
 	if err != nil {
-		t.Errorf("json.Marshal(result) error = %v", err)
+		t.Fatalf("Parse(input, nil) error = %v", err)
 	}
-	assert.Equal(t, `{"steps":[{"trigger":"hello","llamas":3.142}]}`, string(j))
+
+	gotJSON, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
+	}
+	const wantJSON = `{
+  "steps": [
+    {
+      "trigger": "hello",
+      "llamas": 3.142
+    }
+  ]
+}`
+	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
+		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+	}
 }
 
 func TestParserHandlesDates(t *testing.T) {
-	parser := Parser{
-		Pipeline: []byte("steps:\n  - trigger: hello\n    llamas: 2002-08-15T17:18:23.18-06:00"),
-	}
-	result, err := parser.Parse()
-
-	assert.Nil(t, err)
-	j, err := json.Marshal(result)
+	input := strings.NewReader("steps:\n  - trigger: hello\n    llamas: 2002-08-15T17:18:23.18-06:00")
+	got, err := Parse(input, nil)
 	if err != nil {
-		t.Errorf("json.Marshal(result) error = %v", err)
+		t.Fatalf("Parse(input, nil) error = %v", err)
 	}
-	assert.Equal(t, `{"steps":[{"trigger":"hello","llamas":"2002-08-15T17:18:23.18-06:00"}]}`, string(j))
+
+	gotJSON, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
+	}
+	const wantJSON = `{
+  "steps": [
+    {
+      "trigger": "hello",
+      "llamas": "2002-08-15T17:18:23.18-06:00"
+    }
+  ]
+}`
+	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
+		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+	}
 }
 
 func TestParserInterpolatesKeysAsWellAsValues(t *testing.T) {
-	var pipeline = `{
-		"env": {
-			"${FROM_ENV}TEST1": "MyTest",
-			"TEST2": "${FROM_ENV}"
-		}
-	}`
+	envMap := env.FromSlice([]string{"FROM_ENV=llamas"})
+	input := strings.NewReader(`{
+	"env": {
+		"${FROM_ENV}TEST1": "MyTest",
+		"TEST2": "${FROM_ENV}"
+	},
+	"steps": ["wait"]
+}`)
 
-	var decoded struct {
-		Env map[string]string `json:"env"`
-	}
-
-	parser := Parser{
-		Env:      env.FromSlice([]string{"FROM_ENV=llamas"}),
-		Pipeline: []byte(pipeline),
-	}
-	result, err := parser.Parse()
-
+	got, err := Parse(input, envMap)
 	if err != nil {
-		t.Fatalf("Parser{}.Parse() error = %v", err)
+		t.Fatalf("Parse(input, %v) error = %v", envMap, err)
 	}
-	if err := decodeIntoStruct(&decoded, result); err != nil {
-		t.Fatalf("decodeIntoStruct(&decoded, result) error = %v", err)
+	want := &Pipeline{
+		Env: ordered.MapFromItems(
+			ordered.TupleSS{Key: "llamasTEST1", Value: "MyTest"},
+			ordered.TupleSS{Key: "TEST2", Value: "llamas"},
+		),
+		Steps: ordered.Slice{"wait"},
 	}
-	assert.Equal(t, `MyTest`, decoded.Env["llamasTEST1"])
-	assert.Equal(t, `llamas`, decoded.Env["TEST2"])
+	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSS), cmp.Comparer(ordered.EqualSA)); diff != "" {
+		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
+	}
 }
 
 func TestParserLoadsGlobalEnvBlockFirst(t *testing.T) {
-	var pipeline = `{
-		"env": {
-			"TEAM1": "England",
-			"TEAM2": "Australia",
-			"HEADLINE": "${TEAM1} smashes ${TEAM2} to win the ashes in ${YEAR_FROM_SHELL}!!"
+	envMap := env.FromSlice([]string{"YEAR_FROM_SHELL=1912"})
+	input := strings.NewReader(`
+{
+	"env": {
+		"TEAM1": "England",
+		"TEAM2": "Australia",
+		"HEADLINE": "${TEAM1} smashes ${TEAM2} to win the ashes in ${YEAR_FROM_SHELL}!!"
+	},
+	"steps": [{
+		"command": "echo ${HEADLINE}"
+	}]
+}`)
+	got, err := Parse(input, envMap)
+	if err != nil {
+		t.Fatalf("Parse(input, %v) error = %v", envMap, err)
+	}
+	want := &Pipeline{
+		Env: ordered.MapFromItems(
+			ordered.TupleSS{Key: "TEAM1", Value: "England"},
+			ordered.TupleSS{Key: "TEAM2", Value: "Australia"},
+			ordered.TupleSS{Key: "HEADLINE", Value: "England smashes Australia to win the ashes in 1912!!"},
+		),
+		Steps: ordered.Slice{
+			ordered.MapFromItems(
+				ordered.TupleSA{Key: "command", Value: "echo England smashes Australia to win the ashes in 1912!!"},
+			),
 		},
-		"steps": [{
-			"command": "echo ${HEADLINE}"
-		}]
-	}`
-
-	var decoded struct {
-		Env   map[string]string `json:"env"`
-		Steps []struct {
-			Command string `json:"command"`
-		} `json:"steps"`
 	}
-
-	parser := Parser{
-		Pipeline: []byte(pipeline),
-		Env:      env.FromSlice([]string{"YEAR_FROM_SHELL=1912"}),
+	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSS), cmp.Comparer(ordered.EqualSA)); diff != "" {
+		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
-	result, err := parser.Parse()
-
-	if err != nil {
-		t.Fatalf("Parser{}.Parse() error = %v", err)
-	}
-	if err := decodeIntoStruct(&decoded, result); err != nil {
-		t.Fatalf("decodeIntoStruct(&decoded, result) error = %v", err)
-	}
-	assert.Equal(t, "England", decoded.Env["TEAM1"])
-	assert.Equal(t, "England smashes Australia to win the ashes in 1912!!", decoded.Env["HEADLINE"])
-	assert.Equal(t, "echo England smashes Australia to win the ashes in 1912!!", decoded.Steps[0].Command)
-}
-
-func decodeIntoStruct(into any, from any) error {
-	b, err := json.Marshal(from)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(b, into)
 }
 
 func TestParserPreservesOrderOfPlugins(t *testing.T) {
-	var pipeline = `---
+	input := strings.NewReader(`---
 steps:
   - name: ":s3: xxx"
     command: "script/buildkite/xxx.sh"
@@ -313,64 +405,169 @@ steps:
           - AWS_SECRET_ACCESS_KEY
           - AWS_SESSION_TOKEN
     agents:
-      queue: xxx`
+      queue: xxx`)
 
-	parser := Parser{Pipeline: []byte(pipeline), Env: nil}
-	result, err := parser.Parse()
+	got, err := Parse(input, nil)
 	if err != nil {
-		t.Fatalf("Parser{}.Parse() error = %v", err)
+		t.Fatalf("Parse(input, nil) error = %v", err)
 	}
 
-	buf := &bytes.Buffer{}
-	if err := json.NewEncoder(buf).Encode(result); err != nil {
-		t.Fatalf("json.NewEncoder(buf).Encode(result) = %v", err)
+	gotJSON, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
 	}
-
-	expected := `{"steps":[{"name":":s3: xxx","command":"script/buildkite/xxx.sh","plugins":{"xxx/aws-assume-role#v0.1.0":{"role":"arn:aws:iam::xxx:role/xxx"},"ecr#v1.1.4":{"login":true,"account_ids":"xxx","registry_region":"us-east-1"},"docker-compose#v2.5.1":{"run":"xxx","config":".buildkite/docker/docker-compose.yml","env":["AWS_ACCESS_KEY_ID","AWS_SECRET_ACCESS_KEY","AWS_SESSION_TOKEN"]}},"agents":{"queue":"xxx"}}]}`
-	assert.Equal(t, expected, strings.TrimSpace(buf.String()))
+	const wantJSON = `{
+  "steps": [
+    {
+      "name": ":s3: xxx",
+      "command": "script/buildkite/xxx.sh",
+      "plugins": {
+        "xxx/aws-assume-role#v0.1.0": {
+          "role": "arn:aws:iam::xxx:role/xxx"
+        },
+        "ecr#v1.1.4": {
+          "login": true,
+          "account_ids": "xxx",
+          "registry_region": "us-east-1"
+        },
+        "docker-compose#v2.5.1": {
+          "run": "xxx",
+          "config": ".buildkite/docker/docker-compose.yml",
+          "env": [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN"
+          ]
+        }
+      },
+      "agents": {
+        "queue": "xxx"
+      }
+    }
+  ]
+}`
+	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
+		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+	}
 }
 
 func TestParserParsesConditionalWithEndOfLineAnchorDollarSign(t *testing.T) {
-	for _, row := range []struct {
-		noInterpolation bool
-		pipeline        string
+	tests := []struct {
+		desc     string
+		envMap   *env.Environment
+		pipeline string
 	}{
-		// dollar sign must be escaped when interpolation is in effect
-		{false, "steps:\n  - if: build.env(\"ACCOUNT\") =~ /^(foo|bar)\\$/"},
-		{true, "steps:\n  - if: build.env(\"ACCOUNT\") =~ /^(foo|bar)$/"},
-	} {
-		parser := Parser{
-			Pipeline:        []byte(row.pipeline),
-			NoInterpolation: row.noInterpolation,
-		}
-		result, err := parser.Parse()
-		assert.NoError(t, err)
-		j, _ := json.Marshal(result)
-		assert.Equal(t, `{"steps":[{"if":"build.env(\"ACCOUNT\") =~ /^(foo|bar)$/"}]}`, string(j))
+		{
+			desc:   "with interpolation",
+			envMap: env.New(),
+			// dollar sign must be escaped when interpolation is in effect
+			pipeline: `---
+steps:
+ - wait: ~
+   if: build.env("ACCOUNT") =~ /^(foo|bar)\$/
+`,
+		},
+		{
+			desc:   "without interpolation",
+			envMap: nil,
+			pipeline: `---
+steps:
+ - wait: ~
+   if: build.env("ACCOUNT") =~ /^(foo|bar)$/
+`,
+		},
+	}
+
+	const wantJSON = `{
+  "steps": [
+    {
+      "wait": null,
+      "if": "build.env(\"ACCOUNT\") =~ /^(foo|bar)$/"
+    }
+  ]
+}`
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			input := strings.NewReader(test.pipeline)
+			got, err := Parse(input, test.envMap)
+			if err != nil {
+				t.Fatalf("Parse(input, %v) error = %v", test.envMap, err)
+			}
+
+			gotJSON, err := json.MarshalIndent(got, "", "  ")
+			if err != nil {
+				t.Fatalf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
+			}
+			if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
+				t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+			}
+		})
 	}
 }
 
 func TestPipelinePropagatesTracingDataIfAvailable(t *testing.T) {
-	e := env.New()
-	e.Set("BUILDKITE_TRACE_CONTEXT", "123")
-	for _, row := range []struct {
-		hasExistingEnv bool
-		expected       string
+	tests := []struct {
+		desc     string
+		pipeline string
+		wantJSON string
 	}{
-		{false, `{"steps":[{"command":"echo asd"}],"env":{"BUILDKITE_TRACE_CONTEXT":"123"}}`},
-		{true, `{"steps":[{"command":"echo asd"}],"env":{"ASD":1,"BUILDKITE_TRACE_CONTEXT":"123"}}`},
-	} {
-		pipelineYaml := "steps:\n  - command: echo asd\n"
-		if row.hasExistingEnv {
-			pipelineYaml += "env:\n  ASD: 1"
-		}
-		parser := Parser{
-			Pipeline: []byte(pipelineYaml),
-			Env:      e,
-		}
-		result, err := parser.Parse()
-		assert.NoError(t, err)
-		j, _ := json.Marshal(result)
-		assert.Equal(t, row.expected, string(j))
+		{
+			desc: "without existing env",
+			pipeline: `---
+steps:
+ - command: echo asd
+`,
+			wantJSON: `{
+  "env": {
+    "BUILDKITE_TRACE_CONTEXT": "123"
+  },
+  "steps": [
+    {
+      "command": "echo asd"
+    }
+  ]
+}`,
+		},
+		{
+			desc: "with existing env",
+			pipeline: `---
+env:
+  ASD: 1
+steps:
+ - command: echo asd
+`,
+			wantJSON: `{
+  "env": {
+    "ASD": "1",
+    "BUILDKITE_TRACE_CONTEXT": "123"
+  },
+  "steps": [
+    {
+      "command": "echo asd"
+    }
+  ]
+}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			input := strings.NewReader(test.pipeline)
+			e := env.New()
+			e.Set("BUILDKITE_TRACE_CONTEXT", "123")
+			got, err := Parse(input, e)
+			if err != nil {
+				t.Fatalf("Parse(input, %v) error = %v", e, err)
+			}
+
+			gotJSON, err := json.MarshalIndent(got, "", "  ")
+			if err != nil {
+				t.Fatalf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
+			}
+			if diff := cmp.Diff(string(gotJSON), test.wantJSON); diff != "" {
+				t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+			}
+		})
 	}
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,0 +1,97 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/buildkite/agent/v3/internal/ordered"
+	"github.com/buildkite/interpolate"
+	"gopkg.in/yaml.v3"
+)
+
+// Returned when a pipeline has no steps.
+var ErrNoSteps = errors.New("pipeline has no steps")
+
+// Pipeline models a pipeline.
+//
+// Standard caveats apply - see the package comment.
+type Pipeline struct {
+	Steps ordered.Slice  `yaml:"steps"`
+	Env   *ordered.MapSS `yaml:"env,omitempty"`
+
+	// RemainingFields stores any other top-level mapping items so they at least
+	// survive an unmarshal-marshal round-trip.
+	RemainingFields map[string]any `yaml:",inline"`
+}
+
+// MarshalJSON marshals a pipeline to JSON. Special handling is needed because
+// yaml.v3 has "inline" but encoding/json has no concept of it.
+func (p *Pipeline) MarshalJSON() ([]byte, error) {
+	// Steps and Env have precedence over anything in RemainingFields.
+	out := make(map[string]any, len(p.RemainingFields)+2)
+	for k, v := range p.RemainingFields {
+		if v != nil {
+			out[k] = v
+		}
+	}
+
+	out["steps"] = p.Steps
+	if !p.Env.IsZero() {
+		out["env"] = p.Env
+	}
+
+	return json.Marshal(out)
+}
+
+// UnmarshalYAML unmarshals a pipeline from YAML. A custom unmarshaler is
+// needed since a pipeline document can either contain
+//   - a sequence of steps (legacy compatibility), or
+//   - a mapping with "steps" as a top-level key, that contains the steps.
+func (p *Pipeline) UnmarshalYAML(n *yaml.Node) error {
+	// If given a document, unwrap it first.
+	if n.Kind == yaml.DocumentNode {
+		if len(n.Content) != 1 {
+			return fmt.Errorf("line %d, col %d: empty document", n.Line, n.Column)
+		}
+
+		// n is now the content of the document.
+		n = n.Content[0]
+	}
+
+	switch n.Kind {
+	case yaml.MappingNode:
+		// Hack: we want to unmarshal into Pipeline, but have it not call the
+		// UnmarshalYAML method, because that would recurse infinitely...
+		// Answer: Wrap Pipeline in another type.
+		type pipelineWrapper Pipeline
+		var q pipelineWrapper
+		if err := n.Decode(&q); err != nil {
+			return err
+		}
+		if len(q.Steps) == 0 {
+			return ErrNoSteps
+		}
+		*p = Pipeline(q)
+
+	case yaml.SequenceNode:
+		// This sequence should be a sequence of steps.
+		// No other bits (e.g. env) are present in the pipeline.
+		return n.Decode(&p.Steps)
+
+	default:
+		return fmt.Errorf("line %d, col %d: unsupported YAML node kind %x for Pipeline document contents", n.Line, n.Column, n.Kind)
+	}
+
+	return nil
+}
+
+func (p *Pipeline) interpolate(env interpolate.Env) error {
+	if err := interpolateSlice(env, p.Steps); err != nil {
+		return err
+	}
+	if err := interpolateOrderedMap(env, p.Env); err != nil {
+		return err
+	}
+	return interpolateMap(env, p.RemainingFields)
+}


### PR DESCRIPTION
`Pipeline` uses an `ordered.Map[string, string]` for `Env`, and a new
`ordered.Slice` for `Steps`. Unmarshaling into `ordered.Slice` prefers
`ordered.Map[string, any]` over `map[string]any`.

Why not `[]*ordered.Map[string, any]`? Because of steps like `"wait"`, which are
scalars.

`Pipeline` stores anything else in a `RemainingFields` which is an ordinary map.
I can't think of a reason to preserve ordering in fields that are not `Env` or
`Steps`, but if there is something, I would like to hear about it!

Plus a couple of related things:

* Interpolation is updated to work with the new types.
* Interpolating keys in the `Env` map is moved to `interpolateEnvBlock` and
  interpolated keys replace the old keys, rather than preserving uninterpolated keys into the output.
* Changed the parser API from a `Parser` struct taking fully-read input, to having `Parse` be a function consuming an`io.Reader` and an env map.
* Tweaked the tests to use the updated ordering for the top-level pipeline, and
  format the remarshaled JSON to make diffs easier to comb through.
