### PR TITLE
Model steps and plugins

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -19,7 +19,7 @@ var ErrNoSteps = errors.New("pipeline has no steps")
 //
 // Standard caveats apply - see the package comment.
 type Pipeline struct {
-	Steps ordered.Slice  `yaml:"steps"`
+	Steps Steps          `yaml:"steps"`
 	Env   *ordered.MapSS `yaml:"env,omitempty"`
 
 	// RemainingFields stores any other top-level mapping items so they at least

--- a/internal/pipeline/plugin.go
+++ b/internal/pipeline/plugin.go
@@ -1,0 +1,54 @@
+package pipeline
+
+import (
+	"encoding/json"
+
+	"github.com/buildkite/agent/v3/internal/ordered"
+	"github.com/buildkite/interpolate"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	_ interface {
+		json.Marshaler
+		yaml.Marshaler
+		selfInterpolater
+	} = (*Plugin)(nil)
+)
+
+// Plugin models plugin configuration.
+//
+// Standard caveats apply - see the package comment.
+type Plugin struct {
+	Name string
+
+	// Config is stored in an ordered map in case any plugins are accidentally
+	// relying on ordering.
+	Config *ordered.MapSA
+}
+
+// MarshalJSON returns the plugin in "one-key object" form.
+func (p *Plugin) MarshalJSON() ([]byte, error) {
+	// NB: MarshalYAML (as seen below) never returns an error.
+	o, _ := p.MarshalYAML()
+	return json.Marshal(o)
+}
+
+// MarshalYAML returns the plugin in "one-item map" form.
+func (p *Plugin) MarshalYAML() (any, error) {
+	return map[string]*ordered.MapSA{
+		p.Name: p.Config,
+	}, nil
+}
+
+func (p *Plugin) interpolate(env interpolate.Env) error {
+	name, err := interpolate.Interpolate(env, p.Name)
+	if err != nil {
+		return err
+	}
+	p.Name = name
+	if _, err := interpolateAny(env, p.Config); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/pipeline/plugins.go
+++ b/internal/pipeline/plugins.go
@@ -1,0 +1,69 @@
+package pipeline
+
+import (
+	"fmt"
+
+	"github.com/buildkite/agent/v3/internal/ordered"
+	"github.com/buildkite/interpolate"
+	"gopkg.in/yaml.v3"
+)
+
+var _ interface {
+	yaml.Unmarshaler
+	selfInterpolater
+} = (*Plugins)(nil)
+
+// Plugins is a sequence of plugins. It is useful for unmarshaling.
+type Plugins []Plugin
+
+// UnmarshalYAML unmarshals Plugins from either
+//   - a sequence of "one-item mappings" (normal form), or
+//   - a mapping (where order is important...non-normal form).
+//
+// "plugins" is supposed to be a sequence of one-item maps, since order matters.
+// But some people (even us) write plugins into one big mapping and rely on
+// order preservation.
+func (p *Plugins) UnmarshalYAML(n *yaml.Node) error {
+	// Whether processing one big map, or a sequence of small maps, the central
+	// part remains the same.
+	// Parse each "key: value" as "name: config", then append in order.
+	unmarshalMap := func(n *yaml.Node) error {
+		plugin := ordered.NewMap[string, *ordered.MapSA](len(n.Content) / 2)
+		if err := n.Decode(plugin); err != nil {
+			return err
+		}
+		return plugin.Range(func(name string, cfg *ordered.MapSA) error {
+			*p = append(*p, Plugin{
+				Name:   name,
+				Config: cfg,
+			})
+			return nil
+		})
+	}
+
+	switch n.Kind {
+	case yaml.AliasNode:
+		return p.UnmarshalYAML(n.Alias)
+
+	case yaml.SequenceNode:
+		for _, c := range n.Content {
+			if err := unmarshalMap(c); err != nil {
+				return err
+			}
+		}
+
+	case yaml.MappingNode:
+		if err := unmarshalMap(n); err != nil {
+			return err
+		}
+
+	default:
+		return fmt.Errorf("line %d, col %d: unsupported YAML node kind %x for Plugins", n.Line, n.Column, n.Kind)
+
+	}
+	return nil
+}
+
+func (p Plugins) interpolate(env interpolate.Env) error {
+	return interpolateSlice(env, p)
+}

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -1,0 +1,172 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/buildkite/interpolate"
+	"gopkg.in/yaml.v3"
+)
+
+// Step models a step in the pipeline. It will be a pointer to one of:
+// - CommandStep
+// - WaitStep
+// - InputStep
+// - TriggerStep
+// - GroupStep
+type Step interface {
+	stepTag() // allow only the step types below
+
+	selfInterpolater
+}
+
+// CommandStep models a command step.
+//
+// Standard caveats apply - see the package comment.
+type CommandStep struct {
+	Command string  `yaml:"command"`
+	Plugins Plugins `yaml:"plugins,omitempty"`
+
+	// RemainingFields stores any other top-level mapping items so they at least
+	// survive an unmarshal-marshal round-trip.
+	RemainingFields map[string]any `yaml:",inline"`
+}
+
+// MarshalJSON marshals the step to JSON. Special handling is needed because
+// yaml.v3 has "inline" but encoding/json has no concept of it.
+func (c *CommandStep) MarshalJSON() ([]byte, error) {
+	out := make(map[string]any, len(c.RemainingFields)+2)
+	for k, v := range c.RemainingFields {
+		if v != nil {
+			out[k] = v
+		}
+	}
+	if c.Command != "" {
+		out["command"] = c.Command
+	}
+	if len(c.Plugins) > 0 {
+		out["plugins"] = c.Plugins
+	}
+
+	return json.Marshal(out)
+}
+
+// UnmarshalYAML unmarshals the command step. Special handling is needed to
+// normalise the input (e.g. changing "commands" to "command").
+func (c *CommandStep) UnmarshalYAML(n *yaml.Node) error {
+	// Unmarshal into this secret type, then normalise.
+	var full struct {
+		Command  string   `yaml:"command,omitempty"`
+		Commands []string `yaml:"commands,omitempty"`
+		Plugins  Plugins  `yaml:"plugins,omitempty"`
+
+		RemainingFields map[string]any `yaml:",inline"`
+	}
+	if err := n.Decode(&full); err != nil {
+		return err
+	}
+
+	// Normalise into Command.
+	c.Command = full.Command
+	if c.Command == "" {
+		c.Command = strings.Join(full.Commands, "\n")
+	}
+
+	// Copy remaining fields.
+	c.Plugins = full.Plugins
+	c.RemainingFields = full.RemainingFields
+	return nil
+}
+
+func (c *CommandStep) interpolate(env interpolate.Env) error {
+	cmd, err := interpolate.Interpolate(env, c.Command)
+	if err != nil {
+		return err
+	}
+	if err := c.Plugins.interpolate(env); err != nil {
+		return err
+	}
+	if _, err := interpolateAny(env, c.RemainingFields); err != nil {
+		return err
+	}
+	c.Command = cmd
+	return nil
+}
+
+func (CommandStep) stepTag() {}
+
+// WaitStep models a wait step.
+//
+// Standard caveats apply - see the package comment.
+type WaitStep map[string]any
+
+// MarshalJSON marshals a wait step as "wait" if w is empty, or the only key is
+// "wait" and it has nil value. Otherwise it marshals as a standard map.
+func (s WaitStep) MarshalJSON() ([]byte, error) {
+	if len(s) <= 1 && s["wait"] == nil {
+		return json.Marshal("wait")
+	}
+	return json.Marshal(map[string]any(s))
+}
+
+func (s WaitStep) interpolate(env interpolate.Env) error {
+	return interpolateMap(env, s)
+}
+
+func (WaitStep) stepTag() {}
+
+// InputStep models a block or input step.
+//
+// Standard caveats apply - see the package comment.
+type InputStep map[string]any
+
+func (s InputStep) interpolate(env interpolate.Env) error {
+	return interpolateMap(env, s)
+}
+
+func (InputStep) stepTag() {}
+
+// TriggerStep models a trigger step.
+//
+// Standard caveats apply - see the package comment.
+type TriggerStep map[string]any
+
+func (s TriggerStep) interpolate(env interpolate.Env) error {
+	return interpolateMap(env, s)
+}
+
+func (TriggerStep) stepTag() {}
+
+// GroupStep models a group step.
+//
+// Standard caveats apply - see the package comment.
+type GroupStep struct {
+	Steps Steps `yaml:"steps"`
+
+	// RemainingFields stores any other top-level mapping items so they at least
+	// survive an unmarshal-marshal round-trip.
+	RemainingFields map[string]any `yaml:",inline"`
+}
+
+func (s GroupStep) interpolate(env interpolate.Env) error {
+	if err := s.Steps.interpolate(env); err != nil {
+		return err
+	}
+	return interpolateMap(env, s.RemainingFields)
+}
+
+func (GroupStep) stepTag() {}
+
+// MarshalJSON marshals the step to JSON. Special handling is needed because
+// yaml.v3 has "inline" but encoding/json has no concept of it.
+func (g *GroupStep) MarshalJSON() ([]byte, error) {
+	out := map[string]any{
+		"steps": g.Steps,
+	}
+	for k, v := range g.RemainingFields {
+		if v != nil {
+			out[k] = v
+		}
+	}
+	return json.Marshal(out)
+}

--- a/internal/pipeline/steps.go
+++ b/internal/pipeline/steps.go
@@ -1,0 +1,105 @@
+package pipeline
+
+import (
+	"fmt"
+
+	"github.com/buildkite/agent/v3/internal/ordered"
+	"github.com/buildkite/interpolate"
+	"gopkg.in/yaml.v3"
+)
+
+// Steps contains multiple steps. It is useful for unmarshaling step sequences,
+// since it has custom logic for determining the correct step type.
+type Steps []Step
+
+// UnmarshalYAML unmarshals a sequence (of steps). An error wrapping ErrNoSteps
+// is returned if given an empty sequence.
+func (s *Steps) UnmarshalYAML(n *yaml.Node) error {
+	if n.Kind != yaml.SequenceNode {
+		return fmt.Errorf("line %d, col %d: wrong node kind %v for step sequence", n.Line, n.Column, n.Kind)
+	}
+	if len(n.Content) == 0 {
+		return fmt.Errorf("line %d, col %d: %w", n.Line, n.Column, ErrNoSteps)
+	}
+
+	seen := make(map[*yaml.Node]bool)
+	for _, c := range n.Content {
+		step, err := unmarshalStep(seen, c)
+		if err != nil {
+			return err
+		}
+		*s = append(*s, step)
+	}
+	return nil
+}
+
+func (s Steps) interpolate(env interpolate.Env) error {
+	return interpolateSlice(env, s)
+}
+
+// unmarshalStep unmarshals a step (usually a mapping node, but possibly a
+// scalar string) into the right kind of Step.
+func unmarshalStep(seen map[*yaml.Node]bool, n *yaml.Node) (Step, error) {
+	// Prevents infinite recursion.
+	seen[n] = true
+	defer delete(seen, n)
+
+	switch n.Kind {
+	case yaml.AliasNode:
+		return unmarshalStep(seen, n.Alias)
+
+	case yaml.ScalarNode:
+		if n.Tag != "!!str" {
+			// What kind of step is represented as a non-string scalar?
+			return nil, fmt.Errorf("line %d, col %d: invalid step (scalar tag = %q, value = %q)", n.Line, n.Column, n.Tag, n.Value)
+		}
+
+		// It's just "wait".
+		if n.Value == "wait" {
+			return WaitStep{}, nil
+		}
+
+		// ????
+		return nil, fmt.Errorf("line %d, col %d: invalid step (value = %q)", n.Line, n.Column, n.Value)
+
+	case yaml.MappingNode:
+		// Decode into a temporary map. Use *yaml.Node as the value to only
+		// decode the top level.
+		m := ordered.NewMap[string, *yaml.Node](len(n.Content) / 2)
+		if err := n.Decode(m); err != nil {
+			return nil, err
+		}
+
+		var step Step
+		switch {
+		case m.Contains("command") || m.Contains("commands") || m.Contains("plugins"):
+			// NB: Some "command" step are commandless containers that exist
+			// just to run plugins!
+			step = new(CommandStep)
+
+		case m.Contains("wait") || m.Contains("waiter"):
+			step = make(WaitStep)
+
+		case m.Contains("block") || m.Contains("input") || m.Contains("manual"):
+			step = make(InputStep)
+
+		case m.Contains("trigger"):
+			step = make(TriggerStep)
+
+		case m.Contains("group"):
+			step = new(GroupStep)
+
+		default:
+			return nil, fmt.Errorf("line %d, col %d: unknown step type", n.Line, n.Column)
+		}
+
+		// Decode the step (into the right step type).
+		if err := n.Decode(step); err != nil {
+			return nil, err
+		}
+		return step, nil
+
+	default:
+		return nil, fmt.Errorf("line %d, col %d: unsupported YAML node kind %x for Step", n.Line, n.Column, n.Kind)
+	}
+}


### PR DESCRIPTION
Adds:

- a `Step` interface,
- five implementing step types,
- `Steps`, responsible for fingerprinting each step to pick the right type for each,
- `Plugin`, which represents individual plugin configs, and
- `Plugins`, which handles unmarshaling either sequences or maps.

This PR throws out most ordering for our own types (though explicitly preserving plugin config ordering). This is most of the churn in the `wantJSON` test data. Normalising plugin maps into "sequence of one-item maps" form accounts for one test. 

Because `Steps` is responsible for fingerprinting step types, I've added diff checks against typed parser output.

This also adds a `Contains` method to `ordered.Map`, and a partial unmarshaling mode to handle `ordered.Map[string, *yaml.Node]`. (It gets given the raw value nodes. Previously, it would have asked `*yaml.Node` to decode itself into `*yaml.Node`, which doesn't work.) 