### PR TITLE
Clarify code around creating a process group

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -127,10 +127,7 @@ func (p *Process) Run(ctx context.Context) error {
 	p.command = exec.Command(p.conf.Path, p.conf.Args...)
 
 	// Setup the process to create a process group if supported
-	// See https://github.com/kr/pty/issues/35 for context
-	if !p.conf.PTY {
-		p.setupProcessGroup()
-	}
+	p.setupProcessGroup()
 
 	// Configure working dir and fail if it doesn't exist, otherwise
 	// we get confusing errors about fork/exec failing because the file

--- a/process/signal.go
+++ b/process/signal.go
@@ -10,13 +10,20 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// setupProcessGroup causes the process to be run in its own process group
+// This is useful for sending signals to the process and all its children that
+// won't be sent to the bootstrap process.
 func (p *Process) setupProcessGroup() {
-	// See https://github.com/kr/pty/issues/35 for context
-	if !p.conf.PTY {
-		p.command.SysProcAttr = &syscall.SysProcAttr{
-			Setpgid: true,
-			Pgid:    0,
-		}
+	// PTY mode already creates a process group, using setsid instead of setpgid
+	// Attempting to do so again will cause errors.
+	// See https://github.com/creack/pty/issues/35#issuecomment-147947212 for more details.
+	if p.conf.PTY {
+		return
+	}
+
+	p.command.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+		Pgid:    0,
 	}
 }
 

--- a/process/signal_windows.go
+++ b/process/signal_windows.go
@@ -20,6 +20,9 @@ import (
 // See https://docs.microsoft.com/en-us/windows/console/generateconsolectrlevent
 
 func (p *Process) setupProcessGroup() {
+	if p.conf.PTY {
+		return
+	}
 	p.command.SysProcAttr = &windows.SysProcAttr{
 		CreationFlags: windows.CREATE_UNICODE_ENVIRONMENT | windows.CREATE_NEW_PROCESS_GROUP,
 	}


### PR DESCRIPTION
This PR should be a no-op.

When the agent creates processes (for bootstrap, hooks or commands)
it creates a process group for the process. This is done so that
signals can be sent to the process group without affecting the process
that created the process group.

However, when launching a process in a pseudo-terminal (a PTY), there
was an error caused by explicit telling the process to be created in a
group, because the library that creates the PTY also creates a process
group (by some other means, see [here](https://github.com/creack/pty/blob/0d412c9fbeb14954aa65830dcfdb84005cd0cd96/start.go#L22)).

So we created a check for if the process was in a PTY before
doing this. But we appear to be checking this twice on non-windows
systems - both inside and outside the `setupProcessGroup` method.

So in this commit, I have removed the check from the outside and applied
it inside the method both on windows and non-windows.

Also, the only documentation of why we needed to do this was a dead link,
which I have found the new location of, and I've updated the comments to
detail enough of the contents of the dead link so that we won't miss it
if the new link goes dead.