### PR TITLE
Add Signature, Sign, and Verify

### DIFF
--- a/internal/mime/mime.go
+++ b/internal/mime/mime.go
@@ -294,6 +294,7 @@ var types = map[string]string{
 	".geo":         "application/vnd.dynageo",
 	".gex":         "application/vnd.geometry-explorer",
 	".ggb":         "application/vnd.geogebra.file",
+	".ggs":         "application/vnd.geogebra.slides",
 	".ggt":         "application/vnd.geogebra.tool",
 	".ghf":         "application/vnd.groove-help",
 	".gif":         "image/gif",

--- a/internal/pipeline/sign.go
+++ b/internal/pipeline/sign.go
@@ -1,0 +1,218 @@
+package pipeline
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"sort"
+)
+
+// Signature models a signature (on a step, etc).
+type Signature struct {
+	Algorithm    string   `json:"algorithm" yaml:"algorithm"`
+	SignedFields []string `json:"signed_fields" yaml:"signed_fields"`
+	Value        string   `json:"value" yaml:"value"`
+}
+
+// Sign computes a new signature for an object containing values using a given
+// signer.
+func Sign(sf SignedFielder, signer Signer) (*Signature, error) {
+	values := sf.SignedFields()
+	if len(values) == 0 {
+		return nil, errors.New("sign: no fields to sign")
+	}
+
+	// Ensure this part is the same as in Verify...
+	writeLengthPrefixed(signer, signer.AlgorithmName())
+	fields, err := writeFields(signer, values)
+	if err != nil {
+		return nil, err
+	}
+	// ...end
+
+	sig, err := signer.Sign()
+	if err != nil {
+		return nil, err
+	}
+	return &Signature{
+		Algorithm:    signer.AlgorithmName(),
+		SignedFields: fields,
+		Value:        base64.StdEncoding.EncodeToString(sig),
+	}, nil
+}
+
+// Verify verifies an existing signature against an object containing values
+// using the verifier.
+// (Verify does not create a new verifier based on the Algorithm field, in case
+// you want to use a non-standard algorithm, but it must match the verifier's
+// AlgorithmName).
+func (s *Signature) Verify(sf SignedFielder, verifier Verifier) error {
+	if s.Algorithm != verifier.AlgorithmName() {
+		return fmt.Errorf("algorithm name mismatch (signature alg = %q, verifier alg = %q)", s.Algorithm, verifier.AlgorithmName())
+	}
+
+	if len(s.SignedFields) == 0 {
+		return errors.New("signature covers no fields")
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(s.Value)
+	if err != nil {
+		return fmt.Errorf("decoding signature value: %w", err)
+	}
+
+	values, err := sf.ValuesForFields(s.SignedFields)
+	if err != nil {
+		return fmt.Errorf("obtaining values for fields: %w", err)
+	}
+
+	// Ensure this part is the same as in Sign...
+	writeLengthPrefixed(verifier, verifier.AlgorithmName())
+	if _, err := writeFields(verifier, values); err != nil {
+		return err
+	}
+	// ...end
+
+	return verifier.Verify(sig)
+}
+
+// SignedFielder describes types that can be signed and have signatures
+// verified.
+// Converting non-string fields into strings (in a stable, canonical way) is an
+// exercise left to the implementer.
+type SignedFielder interface {
+	// SignedFields returns the default set of fields to sign, and their values.
+	// This is called by Sign.
+	SignedFields() map[string]string
+
+	// ValuesForFields looks up each field and produces a map of values. This is
+	// called by Verify. The set of fields might differ from the default, e.g.
+	// when verifying older signatures computed with fewer fields or deprecated
+	// field names. signedFielder implementations should reject requests for
+	// values if "mandatory" fields are missing (e.g. signing a command step
+	// should always sign the command).
+	ValuesForFields([]string) (map[string]string, error)
+}
+
+// NewSigner returns a new Signer for the given algorithm,
+// provided with a signing/verification key.
+func NewSigner(algorithm string, key any) (Signer, error) {
+	switch algorithm {
+	case "hmac-sha256":
+		return newHMACSHA256(key)
+	default:
+		return nil, fmt.Errorf("unknown signing algorithm %q", algorithm)
+	}
+}
+
+// NewSigner returns a new Verifier for the given algorithm,
+// provided with a signing/verification key.
+func NewVerifier(algorithm string, key any) (Verifier, error) {
+	switch algorithm {
+	case "hmac-sha256":
+		return newHMACSHA256(key)
+	default:
+		return nil, fmt.Errorf("unknown signing algorithm %q", algorithm)
+	}
+}
+
+// Signer describes operations that support the Sign func.
+type Signer interface {
+	// Data written here is hashed into a digest. The signature is (at least
+	// nominally) computed from the digest.
+	io.Writer
+
+	// AlgorithmName returns the name of the algorithm (which should match the
+	// argument to NewSigner).
+	AlgorithmName() string
+
+	// Sign returns a signature for the data written so far.
+	Sign() ([]byte, error)
+}
+
+// Verifier describes operations that support the Signature.Verify method.
+type Verifier interface {
+	// Data written here is hashed into a digest. The signature is (at least
+	// nominally) computed from the digest.
+	io.Writer
+
+	// AlgorithmName returns the name of the algorithm (which should match the
+	// argument to NewVerifier).
+	AlgorithmName() string
+
+	// Verify checks a given signature is valid for the data written so far.
+	Verify([]byte) error
+}
+
+type hmacSHA256 struct {
+	hash.Hash
+}
+
+func newHMACSHA256(key any) (hmacSHA256, error) {
+	var bkey []byte
+	switch tkey := key.(type) {
+	case []byte:
+		bkey = tkey
+
+	case string:
+		bkey = []byte(tkey)
+
+	default:
+		return hmacSHA256{}, fmt.Errorf("wrong key type (got %T, want []byte or string)", key)
+	}
+	return hmacSHA256{
+		Hash: hmac.New(sha256.New, bkey),
+	}, nil
+}
+
+func (h hmacSHA256) AlgorithmName() string { return "hmac-sha256" }
+
+func (h hmacSHA256) Sign() ([]byte, error) {
+	return h.Hash.Sum(nil), nil
+}
+
+func (h hmacSHA256) Verify(sig []byte) error {
+	c := h.Hash.Sum(nil)
+	if !bytes.Equal(c, sig) {
+		return fmt.Errorf("message digest mismatch (%x != %x)", c, sig)
+	}
+	return nil
+}
+
+// writeFields writes the values (length-prefixed) into h. It also returns the
+// sorted field names it got from values (so that Sign doesn't end up extracting
+// them twice).
+func writeFields(h io.Writer, values map[string]string) (fields []string, err error) {
+	if len(values) == 0 {
+		return nil, errors.New("writeFields: no values to sign")
+	}
+
+	// Extract the field names and sort them.
+	fields = make([]string, 0, len(values))
+	for f := range values {
+		fields = append(fields, f)
+	}
+	sort.Strings(fields)
+
+	// If we blast strings at hash.Write, then you could get the same hash for
+	// different fields that happen to have the same data when concatenated.
+	// So write length-prefixed fields, and length-prefix the whole map.
+	binary.Write(h, binary.LittleEndian, uint32(len(fields)))
+	for _, f := range fields {
+		writeLengthPrefixed(h, f)
+		writeLengthPrefixed(h, values[f])
+	}
+
+	return fields, nil
+}
+
+// writeLengthPrefixed writes a length-prefixed string to h.
+func writeLengthPrefixed(h io.Writer, s string) {
+	binary.Write(h, binary.LittleEndian, uint32(len(s)))
+	h.Write([]byte(s))
+}

--- a/internal/pipeline/sign_test.go
+++ b/internal/pipeline/sign_test.go
@@ -1,0 +1,142 @@
+package pipeline
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSignVerify(t *testing.T) {
+	cs := &CommandStep{
+		Command: "llamas",
+	}
+
+	const key = "alpacas"
+	signer, err := NewSigner("hmac-sha256", key)
+	if err != nil {
+		t.Errorf("NewSigner(hmac-sha256, alpacas) error = %v", err)
+	}
+	sig, err := Sign(cs, signer)
+	if err != nil {
+		t.Errorf("Sign(CommandStep, signer) error = %v", err)
+	}
+
+	want := &Signature{
+		Algorithm:    "hmac-sha256",
+		SignedFields: []string{"command"},
+		Value:        "GMetJcA3JqBNVDwljHRGfuW3t3Raixu+4+4dRYa0Cg0=",
+	}
+	if diff := cmp.Diff(sig, want); diff != "" {
+		t.Errorf("Signature diff (-got +want):\n%s", diff)
+	}
+
+	verifier, err := NewVerifier("hmac-sha256", key)
+	if err != nil {
+		t.Errorf("NewVerifier(hmac-sha256, alpacas) error = %v", err)
+	}
+	if err := sig.Verify(cs, verifier); err != nil {
+		t.Errorf("sig.Verify(CommandStep, verifier) = %v", err)
+	}
+}
+
+type testFields map[string]string
+
+func (m testFields) SignedFields() map[string]string { return m }
+
+func (m testFields) ValuesForFields(fields []string) (map[string]string, error) {
+	out := make(map[string]string, len(fields))
+	for _, f := range fields {
+		v, ok := m[f]
+		if !ok {
+			return nil, fmt.Errorf("unknown field %q", f)
+		}
+		out[f] = v
+	}
+	return out, nil
+}
+
+// Do not use this type outside of tests!
+type plainTextSigner struct {
+	*bytes.Buffer
+}
+
+func (plainTextSigner) AlgorithmName() string { return "plaintext" }
+
+func (p plainTextSigner) Sign() ([]byte, error) {
+	return p.Buffer.Bytes(), nil
+}
+
+func TestSignConcatenatedFields(t *testing.T) {
+	// Tests that Sign is resilient to concatenation.
+	// Specifically, these maps should all have distinct "content". (If you
+	// simply wrote the strings one after the other, they could be equal.)
+
+	maps := []testFields{
+		testFields{
+			"foo": "bar",
+			"qux": "zap",
+		},
+		testFields{
+			"foob": "ar",
+			"qu":   "xzap",
+		},
+		testFields{
+			"foo": "barquxzap",
+		},
+		testFields{
+			// Try really hard to fake matching content
+			"foo": string([]byte{'b', 'a', 'r', 3, 0, 0, 0, 'q', 'u', 'x', 3, 0, 0, 0, 'z', 'a', 'p'}),
+		},
+	}
+
+	sigs := make(map[string][]testFields)
+
+	for _, m := range maps {
+		pts := plainTextSigner{Buffer: new(bytes.Buffer)}
+		sig, err := Sign(m, pts)
+		if err != nil {
+			t.Errorf("Sign(%v, pts) error = %v", m, err)
+		}
+
+		sigs[sig.Value] = append(sigs[sig.Value], m)
+	}
+
+	if len(sigs) != len(maps) {
+		t.Error("some of the maps signed to the same value:")
+		for _, ms := range sigs {
+			if len(ms) == 1 {
+				continue
+			}
+			t.Logf("had same signature: %v", ms)
+		}
+	}
+}
+
+func TestUnknownAlgorithm(t *testing.T) {
+	if _, err := NewSigner("rot13", "alpacas"); err == nil {
+		t.Errorf("NewSigner(rot13, alpacas) error = %v, want non-nil error", err)
+	}
+}
+
+func TestVerifyBadSignature(t *testing.T) {
+	cs := &CommandStep{
+		Command: "llamas",
+	}
+
+	sig := &Signature{
+		Algorithm:    "hmac-sha256",
+		SignedFields: []string{"command"},
+		Value:        "YWxwYWNhcw==", // base64("alpacas")
+	}
+
+	verifier, err := NewVerifier("hmac-sha256", "alpacas")
+	if err != nil {
+		t.Errorf("NewVerifier(hmac-sha256, alpacas) error = %v", err)
+	}
+
+	if err := sig.Verify(cs, verifier); err == nil {
+		t.Errorf("sig.Verify(CommandStep, alpacas) = %v, want non-nil error", err)
+	}
+}


### PR DESCRIPTION
The main design consideration was how to get objects to describe their default set of fields to sign, and to fetch ~arbitrary values for verifying, because Signature includes the list of signed fields. The rest pretty much flows from that.

Signatures can be attached to command steps (to begin with) and cover just the command itself. The core piece (throwing fields and values at a hash) is the same between Sign and Verify, so I implemented both.

I made the algorithm interface big enough to handle both symmetric and asymmetric schemes, but have only implemented HMAC-SHA256 here.