### PR TITLE
Die, bootstrap, die: Rename `Bootstrap` struct (and friends) to `Executor`

### DIFF
--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -411,7 +411,7 @@ var BootstrapCommand = cli.Command{
 		}
 
 		// Configure the bootstraper
-		bootstrap := job.New(job.Config{
+		bootstrap := job.New(job.ExecutorConfig{
 			AgentName:                    cfg.AgentName,
 			ArtifactUploadDestination:    cfg.ArtifactUploadDestination,
 			AutomaticArtifactUploadPaths: cfg.AutomaticArtifactUploadPaths,

--- a/internal/job/api.go
+++ b/internal/job/api.go
@@ -11,7 +11,7 @@ import (
 // startJobAPI starts the job API server, iff the job API experiment is enabled, and the OS of the box supports it
 // otherwise it returns a noop cleanup function
 // It also sets the BUILDKITE_AGENT_JOB_API_SOCKET and BUILDKITE_AGENT_JOB_API_TOKEN environment variables
-func (b *Bootstrap) startJobAPI() (cleanup func(), err error) {
+func (e *Executor) startJobAPI() (cleanup func(), err error) {
 	cleanup = func() {}
 
 	if !experiments.IsEnabled(experiments.JobAPI) {
@@ -19,24 +19,24 @@ func (b *Bootstrap) startJobAPI() (cleanup func(), err error) {
 	}
 
 	if !socket.Available() {
-		b.shell.Warningf("The Job API isn't available on this machine, as it's running an unsupported version of Windows")
-		b.shell.Warningf("The Job API is available on Unix agents, and agents running Windows versions after build 17063")
-		b.shell.Warningf("We'll continue to run your job, but you won't be able to use the Job API")
+		e.shell.Warningf("The Job API isn't available on this machine, as it's running an unsupported version of Windows")
+		e.shell.Warningf("The Job API is available on Unix agents, and agents running Windows versions after build 17063")
+		e.shell.Warningf("We'll continue to run your job, but you won't be able to use the Job API")
 		return cleanup, nil
 	}
 
-	socketPath, err := jobapi.NewSocketPath(b.Config.SocketsPath)
+	socketPath, err := jobapi.NewSocketPath(e.ExecutorConfig.SocketsPath)
 	if err != nil {
 		return cleanup, fmt.Errorf("creating job API socket path: %v", err)
 	}
 
-	srv, token, err := jobapi.NewServer(b.shell.Logger, socketPath, b.shell.Env)
+	srv, token, err := jobapi.NewServer(e.shell.Logger, socketPath, e.shell.Env)
 	if err != nil {
 		return cleanup, fmt.Errorf("creating job API server: %v", err)
 	}
 
-	b.shell.Env.Set("BUILDKITE_AGENT_JOB_API_SOCKET", socketPath)
-	b.shell.Env.Set("BUILDKITE_AGENT_JOB_API_TOKEN", token)
+	e.shell.Env.Set("BUILDKITE_AGENT_JOB_API_SOCKET", socketPath)
+	e.shell.Env.Set("BUILDKITE_AGENT_JOB_API_TOKEN", token)
 
 	if err := srv.Start(); err != nil {
 		return cleanup, fmt.Errorf("starting Job API server: %v", err)
@@ -45,7 +45,7 @@ func (b *Bootstrap) startJobAPI() (cleanup func(), err error) {
 	return func() {
 		err = srv.Stop()
 		if err != nil {
-			b.shell.Errorf("Error stopping Job API server: %v", err)
+			e.shell.Errorf("Error stopping Job API server: %v", err)
 		}
 	}, nil
 }

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/buildkite/agent/v3/process"
 )
 
-// Config provides the configuration for the Bootstrap. Some of the keys are
+// Config provides the configuration for the job executor. Some of the keys are
 // read from the environment after hooks are run, so we use struct tags to provide
 // that mapping along with some reflection. It's a little bit magical but it's
 // less work to maintain in the long run.
@@ -19,14 +19,14 @@ import (
 // struct tag, then don't forget to add a corresponding CLI flag over in the
 // clicommand/bootstrap.go(BootstrapConfig) struct, otherwise it won't work.
 
-type Config struct {
+type ExecutorConfig struct {
 	// The command to run
 	Command string
 
 	// The ID of the job being run
 	JobID string
 
-	// If the bootstrap is in debug mode
+	// If the executor is in debug mode
 	Debug bool
 
 	// The repository that needs to be cloned
@@ -62,13 +62,13 @@ type Config struct {
 	// Slug of the current pipeline
 	PipelineSlug string
 
-	// Name of the agent running the bootstrap
+	// Name of the agent running the job
 	AgentName string
 
 	// Name of the queue the agent belongs to, if tagged
 	Queue string
 
-	// Should the bootstrap remove an existing checkout before running the job
+	// Should the executor remove an existing checkout before running the job
 	CleanCheckout bool `env:"BUILDKITE_CLEAN_CHECKOUT"`
 
 	// Flags to pass to "git checkout" command
@@ -161,7 +161,7 @@ type Config struct {
 
 // ReadFromEnvironment reads configuration from the Environment, returns a map
 // of the env keys that changed and the new values
-func (c *Config) ReadFromEnvironment(environ *env.Environment) map[string]string {
+func (c *ExecutorConfig) ReadFromEnvironment(environ *env.Environment) map[string]string {
 	changed := map[string]string{}
 
 	// Use reflection for the type and values
@@ -196,7 +196,7 @@ func (c *Config) ReadFromEnvironment(environ *env.Environment) map[string]string
 				v.SetBool(newBool)
 				changed[tag] = newStr
 			default:
-				log.Printf("warning: bootstrap.Config.ReadFromEnvironment does not support %v for %s", v.Kind(), tag)
+				log.Printf("warning: job.ExecutorConfig.ReadFromEnvironment does not support %v for %s", v.Kind(), tag)
 			}
 		}
 	}

--- a/internal/job/config_test.go
+++ b/internal/job/config_test.go
@@ -10,7 +10,7 @@ import (
 func TestEnvVarsAreMappedToConfig(t *testing.T) {
 	t.Parallel()
 
-	config := &Config{
+	config := &ExecutorConfig{
 		Repository:                   "https://original.host/repo.git",
 		AutomaticArtifactUploadPaths: "llamas/",
 		GitCloneFlags:                "--prune",
@@ -61,7 +61,7 @@ func TestEnvVarsAreMappedToConfig(t *testing.T) {
 
 func TestReadFromEnvironmentIgnoresMalformedBooleans(t *testing.T) {
 	t.Parallel()
-	config := &Config{
+	config := &ExecutorConfig{
 		CleanCheckout:           true,
 		PluginsAlwaysCloneFresh: false,
 	}

--- a/internal/job/executor_test.go
+++ b/internal/job/executor_test.go
@@ -86,13 +86,13 @@ func TestStartTracing_NoTracingBackend(t *testing.T) {
 	var err error
 
 	// When there's no tracing backend, the tracer should be a no-op.
-	b := New(Config{})
+	e := New(ExecutorConfig{})
 
 	oriCtx := context.Background()
-	b.shell, err = shell.New()
+	e.shell, err = shell.New()
 	assert.NoError(t, err)
 
-	span, _, stopper := b.startTracing(oriCtx)
+	span, _, stopper := e.startTracing(oriCtx)
 	assert.Equal(t, span, &tracetools.NoopSpan{})
 	span.FinishWithError(nil) // Finish the nil span, just for completeness' sake
 
@@ -106,14 +106,14 @@ func TestStartTracing_Datadog(t *testing.T) {
 	var err error
 
 	// With the Datadog tracing backend, the global tracer should be from Datadog.
-	cfg := Config{TracingBackend: "datadog"}
-	b := New(cfg)
+	cfg := ExecutorConfig{TracingBackend: "datadog"}
+	e := New(cfg)
 
 	oriCtx := context.Background()
-	b.shell, err = shell.New()
+	e.shell, err = shell.New()
 	assert.NoError(t, err)
 
-	span, ctx, stopper := b.startTracing(oriCtx)
+	span, ctx, stopper := e.startTracing(oriCtx)
 	span.FinishWithError(nil)
 
 	assert.IsType(t, opentracer.New(), opentracing.GlobalTracer())

--- a/internal/job/integration/doc.go
+++ b/internal/job/integration/doc.go
@@ -1,4 +1,4 @@
-// Package integration defines a series of integration tests for the bootstrap.
+// Package integration defines a series of integration tests for the job executor.
 //
 // It is intended for internal use by buildkite-agent only.
 package integration

--- a/internal/job/integration/docker_integration_test.go
+++ b/internal/job/integration/docker_integration_test.go
@@ -254,7 +254,7 @@ func TestRunningCommandWithDockerComposeAndBuildAll(t *testing.T) {
 	tester.RunAndCheck(t, env...)
 }
 
-func expectCommandHooks(exitStatus string, t *testing.T, tester *BootstrapTester) {
+func expectCommandHooks(exitStatus string, t *testing.T, tester *ExecutorTester) {
 	tester.ExpectGlobalHook("pre-command").Once()
 	tester.ExpectLocalHook("pre-command").Once()
 	tester.ExpectGlobalHook("post-command").Once()

--- a/internal/job/integration/job_api_integration_test.go
+++ b/internal/job/integration/job_api_integration_test.go
@@ -47,7 +47,7 @@ func TestBootstrapRunsJobAPI(t *testing.T) {
 			},
 		}
 
-		req, err := http.NewRequest(http.MethodGet, "http://bootstrap/api/current-job/v0/env", nil)
+		req, err := http.NewRequest(http.MethodGet, "http://job-executor/api/current-job/v0/env", nil)
 		if err != nil {
 			t.Errorf("creating request: %v", err)
 			c.Exit(1)
@@ -94,7 +94,7 @@ func TestBootstrapRunsJobAPI(t *testing.T) {
 			return
 		}
 
-		req, err = http.NewRequest(http.MethodPatch, "http://bootstrap/api/current-job/v0/env", bytes.NewBuffer(b))
+		req, err = http.NewRequest(http.MethodPatch, "http://job-executor/api/current-job/v0/env", bytes.NewBuffer(b))
 		if err != nil {
 			t.Errorf("creating patch request: %v", err)
 			c.Exit(1)

--- a/jobapi/server_test.go
+++ b/jobapi/server_test.go
@@ -198,7 +198,7 @@ func TestDeleteEnv(t *testing.T) {
 				t.Fatalf("JSON-encoding c.requestBody into buf: %v", err)
 			}
 
-			req, err := http.NewRequest(http.MethodDelete, "http://bootstrap/api/current-job/v0/env", buf)
+			req, err := http.NewRequest(http.MethodDelete, "http://job/api/current-job/v0/env", buf)
 			if err != nil {
 				t.Fatalf("creating request: %v", err)
 			}
@@ -295,7 +295,7 @@ func TestPatchEnv(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			req, err := http.NewRequest(http.MethodPatch, "http://bootstrap/api/current-job/v0/env", buf)
+			req, err := http.NewRequest(http.MethodPatch, "http://job/api/current-job/v0/env", buf)
 			if err != nil {
 				t.Fatalf("creating request: %v", err)
 			}
@@ -331,7 +331,7 @@ func TestGetEnv(t *testing.T) {
 		}
 	}()
 
-	req, err := http.NewRequest(http.MethodGet, "http://bootstrap/api/current-job/v0/env", nil)
+	req, err := http.NewRequest(http.MethodGet, "http://job/api/current-job/v0/env", nil)
 	if err != nil {
 		t.Fatalf("creating request: %v", err)
 	}


### PR DESCRIPTION
**This PR follows from #2187**

**This PR:** Renames the `job.Bootstrap` struct to `job.Executor`, as well as a couple of its friends. it also updates comments and associated variable names etc to be appropriately named.