### PR TITLE
Parse command and commands the same

### DIFF
--- a/internal/ordered/strings.go
+++ b/internal/ordered/strings.go
@@ -1,0 +1,39 @@
+package ordered
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Strings is []string, but unmarshaling handles both sequences and single
+// scalars.
+type Strings []string
+
+// UnmarshalYAML unmarshals n depending on its Kind as either
+// - a sequence of strings (into a slice), or
+// - a single string (into a one-element slice).
+// For example, unmarshaling either `["foo"]` or `"foo"` should result in a
+// one-element slice (`Strings{"foo"}`).
+func (s *Strings) UnmarshalYAML(n *yaml.Node) error {
+	switch n.Kind {
+	case yaml.ScalarNode:
+		var x string
+		if err := n.Decode(&x); err != nil {
+			return err
+		}
+		*s = append(*s, x)
+
+	case yaml.SequenceNode:
+		var xs []string
+		if err := n.Decode(&xs); err != nil {
+			return err
+		}
+		*s = append(*s, xs...)
+
+	default:
+		return fmt.Errorf("line %d, col %d: unsupported kind %x for unmarshaling Strings (want %x or %x)", n.Line, n.Column, n.Kind, yaml.ScalarNode, yaml.SequenceNode)
+	}
+
+	return nil
+}

--- a/internal/ordered/strings_test.go
+++ b/internal/ordered/strings_test.go
@@ -1,0 +1,46 @@
+package ordered
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+)
+
+func TestStringsUnmarshal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc  string
+		input string
+		want  Strings
+	}{
+		{
+			desc:  "Two items in a sequence",
+			input: "- foo\n- bar",
+			want:  Strings{"foo", "bar"},
+		},
+		{
+			desc:  "One item in a sequence",
+			input: `- foo`,
+			want:  Strings{"foo"},
+		},
+		{
+			desc:  "One scalar",
+			input: `"foo"`,
+			want:  Strings{"foo"},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			var got Strings
+			if err := yaml.Unmarshal([]byte(test.input), &got); err != nil {
+				t.Errorf("yaml.Unmarshal(%q, &got) = %v", test.input, err)
+			}
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("Strings unmarshal diff (-got +want):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The docs say `commands` is an alias for `command`. So one could write `command`’s value as multiple strings in a sequence, or write `commands`’ value as a single string.

Something that parses either single strings or sequences of strings into `[]string` is too generic for `pipeline`, so I put it in `ordered`.