### PR TITLE
Fix plugin interpolation

### DIFF
--- a/internal/pipeline/plugin.go
+++ b/internal/pipeline/plugin.go
@@ -47,7 +47,7 @@ func (p *Plugin) interpolate(env interpolate.Env) error {
 		return err
 	}
 	p.Name = name
-	if _, err := interpolateAny(env, p.Config); err != nil {
+	if err := interpolateOrderedMap(env, p.Config); err != nil {
 		return err
 	}
 	return nil

--- a/internal/pipeline/plugins.go
+++ b/internal/pipeline/plugins.go
@@ -4,17 +4,13 @@ import (
 	"fmt"
 
 	"github.com/buildkite/agent/v3/internal/ordered"
-	"github.com/buildkite/interpolate"
 	"gopkg.in/yaml.v3"
 )
 
-var _ interface {
-	yaml.Unmarshaler
-	selfInterpolater
-} = (*Plugins)(nil)
+var _ yaml.Unmarshaler = (*Plugins)(nil)
 
 // Plugins is a sequence of plugins. It is useful for unmarshaling.
-type Plugins []Plugin
+type Plugins []*Plugin
 
 // UnmarshalYAML unmarshals Plugins from either
 //   - a sequence of "one-item mappings" (normal form), or
@@ -33,7 +29,7 @@ func (p *Plugins) UnmarshalYAML(n *yaml.Node) error {
 			return err
 		}
 		return plugin.Range(func(name string, cfg *ordered.MapSA) error {
-			*p = append(*p, Plugin{
+			*p = append(*p, &Plugin{
 				Name:   name,
 				Config: cfg,
 			})
@@ -62,8 +58,4 @@ func (p *Plugins) UnmarshalYAML(n *yaml.Node) error {
 
 	}
 	return nil
-}
-
-func (p Plugins) interpolate(env interpolate.Env) error {
-	return interpolateSlice(env, p)
 }

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -117,11 +117,11 @@ func (c *CommandStep) interpolate(env interpolate.Env) error {
 	if err != nil {
 		return err
 	}
-	if err := c.Plugins.interpolate(env); err != nil {
+	if err := interpolateSlice(env, c.Plugins); err != nil {
 		return err
 	}
 	// NB: Do not interpolate Signature.
-	if _, err := interpolateAny(env, c.RemainingFields); err != nil {
+	if err := interpolateMap(env, c.RemainingFields); err != nil {
 		return err
 	}
 	c.Command = cmd


### PR DESCRIPTION
The bug is: `Plugins` was `[]Plugin`, but `*Plugin` was the thing that was `selfInterpolator`, so `interpolateAny` never called `*Plugin.interpolate`. Changing `Plugins` to be `[]*Plugin` neatly resolves that.

Plus various tweaks and comments on interpolation generally.

@moskyb was right about making `interpolateAny` generic, it was a matter of moving the type assertion.