### PR TITLE
Add a job log length limit

### DIFF
--- a/api/chunks.go
+++ b/api/chunks.go
@@ -10,9 +10,9 @@ import (
 // Chunk represents a Buildkite Agent API Chunk
 type Chunk struct {
 	Data     []byte
-	Sequence int
-	Offset   int
-	Size     int
+	Sequence uint64
+	Offset   uint64
+	Size     uint64
 }
 
 // Uploads the chunk to the Buildkite Agent API. This request sends the

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -14,7 +14,8 @@ type Job struct {
 	State              string                `json:"state,omitempty"`
 	Env                map[string]string     `json:"env,omitempty"`
 	Step               *pipeline.CommandStep `json:"step,omitempty"`
-	ChunksMaxSizeBytes int                   `json:"chunks_max_size_bytes,omitempty"`
+	ChunksMaxSizeBytes uint64                `json:"chunks_max_size_bytes,omitempty"`
+	LogMaxSizeBytes    uint64                `json:"log_max_size_bytes,omitempty"`
 	Token              string                `json:"token,omitempty"`
 	ExitStatus         string                `json:"exit_status,omitempty"`
 	Signal             string                `json:"signal,omitempty"`

--- a/process/buffer_test.go
+++ b/process/buffer_test.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"io"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -31,5 +32,23 @@ func TestBuffer(t *testing.T) {
 	// Buffer should now be empty
 	if got, want := b.ReadAndTruncate(), []byte(nil); !cmp.Equal(got, want) {
 		t.Errorf("b.ReadAndTruncate() = %v, want %v", got, want)
+	}
+}
+
+func TestBufferClose(t *testing.T) {
+	var b Buffer
+
+	if err := b.Close(); err != nil {
+		t.Errorf("initial b.Close() = %v", err)
+	}
+
+	gotN, gotErr := b.Write([]byte("This shouldn't work"))
+	wantN, wantErr := 0, io.ErrClosedPipe
+	if gotN != wantN || gotErr != wantErr {
+		t.Errorf("after b.Close(): b.Write() = (%d, %v), want (%d, %v)", gotN, gotErr, wantN, wantErr)
+	}
+
+	if err := b.Close(); err != errAlreadyClosed {
+		t.Errorf("double b.Close() = %v, want %v", err, errAlreadyClosed)
 	}
 }


### PR DESCRIPTION
Since [removing the need to hold the whole log in memory](https://github.com/buildkite/agent/pull/2014), there have been a few cases of long-running jobs logging lots of logs. This adds a (server-specified) limit, with a default of 1GiB. 

Why not just limit it server side? Because the job itself should get some kind of pushback once it approaches or hits the limit. Returning errors when writing to the buffer feels like the right place.