### PR TITLE
Add signatures

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -20,6 +20,7 @@ import (
 	"github.com/buildkite/agent/v3/internal/redactor"
 	"github.com/buildkite/agent/v3/internal/stdin"
 	"github.com/urfave/cli"
+	"gopkg.in/yaml.v3"
 )
 
 const pipelineUploadHelpDescription = `Usage:
@@ -54,13 +55,16 @@ Example:
    $ ./script/dynamic_step_generator | buildkite-agent pipeline upload`
 
 type PipelineUploadConfig struct {
-	FilePath        string   `cli:"arg:0" label:"upload paths"`
-	Replace         bool     `cli:"replace"`
-	Job             string   `cli:"job"`
-	DryRun          bool     `cli:"dry-run"`
-	NoInterpolation bool     `cli:"no-interpolation"`
-	RedactedVars    []string `cli:"redacted-vars" normalize:"list"`
-	RejectSecrets   bool     `cli:"reject-secrets"`
+	FilePath         string   `cli:"arg:0" label:"upload paths"`
+	Replace          bool     `cli:"replace"`
+	Job              string   `cli:"job"` // required, but not in dry-run mode
+	DryRun           bool     `cli:"dry-run"`
+	DryRunFormat     string   `cli:"format"`
+	NoInterpolation  bool     `cli:"no-interpolation"`
+	RedactedVars     []string `cli:"redacted-vars" normalize:"list"`
+	RejectSecrets    bool     `cli:"reject-secrets"`
+	SigningKeyFile   string   `cli:"signing-key"`
+	SigningAlgorithm string   `cli:"signing-algorithm"`
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
@@ -71,7 +75,7 @@ type PipelineUploadConfig struct {
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
-	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
+	AgentAccessToken string `cli:"agent-access-token"` // required, but not in dry-run mode
 	Endpoint         string `cli:"endpoint" validate:"required"`
 	NoHTTP2          bool   `cli:"no-http2"`
 }
@@ -97,6 +101,12 @@ var PipelineUploadCommand = cli.Command{
 			Usage:  "Rather than uploading the pipeline, it will be echoed to stdout",
 			EnvVar: "BUILDKITE_PIPELINE_UPLOAD_DRY_RUN",
 		},
+		cli.StringFlag{
+			Name:   "format",
+			Usage:  "In dry-run mode, specifies the form to output the pipeline in. Must be one of: json,yaml",
+			Value:  "json",
+			EnvVar: "BUILDKITE_PIPELINE_UPLOAD_DRY_RUN_FORMAT",
+		},
 		cli.BoolFlag{
 			Name:   "no-interpolation",
 			Usage:  "Skip variable interpolation the pipeline when uploaded",
@@ -106,6 +116,17 @@ var PipelineUploadCommand = cli.Command{
 			Name:   "reject-secrets",
 			Usage:  "When true, fail the pipeline upload early if the pipeline contains secrets",
 			EnvVar: "BUILDKITE_AGENT_PIPELINE_UPLOAD_REJECT_SECRETS",
+		},
+		cli.StringFlag{
+			Name:   "signing-key",
+			Usage:  "Path to a file containing a signing key. Passing this flag enables pipeline signing. The format of the file depends on the chosen signing algorithm",
+			EnvVar: "BUILDKITE_PIPELINE_SIGNING_KEY_FILE",
+		},
+		cli.StringFlag{
+			Name:   "signing-algorithm",
+			Usage:  "Signing algorithm to use when signing parts of the pipeline. Available algorithms are: hmac-sha256",
+			Value:  "hmac-sha256",
+			EnvVar: "BUILDKITE_PIPELINE_SIGNING_ALGORITHM",
 		},
 
 		// API Flags
@@ -287,14 +308,47 @@ var PipelineUploadCommand = cli.Command{
 			}
 		}
 
-		// In dry-run mode we just output the generated pipeline to stdout
-		if cfg.DryRun {
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "  ")
+		if cfg.SigningKeyFile != "" {
+			key, err := os.ReadFile(cfg.SigningKeyFile)
+			if err != nil {
+				l.Fatal("Couldn't read the signing key file: %v", err)
+			}
 
-			// Dump json indented to stdout. All logging happens to stderr
-			// this can be used with other tools to get interpolated json
-			if err := enc.Encode(result); err != nil {
+			// TODO: Parse the key based on the algorithm, or put key parsing
+			// into pipeline.New{Signer,Verifier}.
+			// For now it must be hmac-sha256, which takes []byte.
+
+			signer, err := pipeline.NewSigner(cfg.SigningAlgorithm, key)
+			if err != nil {
+				l.Fatal("Couldn't create a pipeline signer for the chosen algorithm or key: %v", err)
+			}
+
+			if err := result.Sign(signer); err != nil {
+				l.Fatal("Couldn't sign pipeline with the chosen algorithm or key: %v", err)
+			}
+		}
+
+		// In dry-run mode we just output the generated pipeline to stdout.
+		if cfg.DryRun {
+			var encode func(any) error
+
+			switch cfg.DryRunFormat {
+			case "json":
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				encode = enc.Encode
+
+			case "yaml":
+				encode = yaml.NewEncoder(os.Stdout).Encode
+
+			default:
+				l.Fatal("Unknown output format %q", cfg.DryRunFormat)
+			}
+
+			// All logging happens to stderr.
+			// So this can be used with other tools to get interpolated, signed
+			// JSON or YAML.
+			if err := encode(result); err != nil {
 				l.Fatal("%#v", err)
 			}
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -150,20 +150,10 @@ func (p *Pipeline) interpolateEnvBlock(envMap *env.Environment) error {
 }
 
 // Sign signs each signable part of the pipeline. Currently this is limited to
-// command steps. The Signer is reset before starting, and after each part.
+// command steps (including command steps within group steps). The Signer is
+// reset before starting, and after each part. Parts are mutated directly, so an
+// error part-way through may leave some steps un-signed.
 func (p *Pipeline) Sign(signer Signer) error {
 	signer.Reset()
-	for _, step := range p.Steps {
-		cmd, ok := step.(*CommandStep)
-		if !ok {
-			continue
-		}
-
-		sig, err := Sign(cmd, signer)
-		if err != nil {
-			return err
-		}
-		cmd.Signature = sig
-	}
-	return nil
+	return p.Steps.sign(signer)
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -148,3 +148,22 @@ func (p *Pipeline) interpolateEnvBlock(envMap *env.Environment) error {
 		return nil
 	})
 }
+
+// Sign signs each signable part of the pipeline. Currently this is limited to
+// command steps. The Signer is reset before starting, and after each part.
+func (p *Pipeline) Sign(signer Signer) error {
+	signer.Reset()
+	for _, step := range p.Steps {
+		cmd, ok := step.(*CommandStep)
+		if !ok {
+			continue
+		}
+
+		sig, err := Sign(cmd, signer)
+		if err != nil {
+			return err
+		}
+		cmd.Signature = sig
+	}
+	return nil
+}


### PR DESCRIPTION
- The pipeline can sign itself, given a signer. 
- `Signer` and `Verifier` now exposes more of `hash.Hash`, particularly so it can be `Reset`.
- pipeline upload `--dry-run` no longer requires the agent access token (which wasn't used in that path)
- pipeline upload now has a `--format` flag

Question: Is it time for `pipeline sign` ?