### PR TITLE
Update URL for remote: look before leap

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -1327,9 +1327,10 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string) (stri
 
 	e.shell.Commentf("Updating existing repository mirror to find commit %s", e.Commit)
 
-	// Update the origin of the repository so we can gracefully handle repository renames
-	if err := e.shell.Run(ctx, "git", "--git-dir", mirrorDir, "remote", "set-url", "origin", repository); err != nil {
-		return "", err
+	// Update the origin of the repository so we can gracefully handle
+	// repository renames.
+	if err := e.updateRemoteURL(ctx, mirrorDir, repository); err != nil {
+		return "", fmt.Errorf("setting remote URL: %w", err)
 	}
 
 	if isMainRepository {
@@ -1349,6 +1350,47 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string) (stri
 	}
 
 	return mirrorDir, nil
+}
+
+// updateRemoteURL updates the URL for 'origin'. If gitDir == "", it assumes the
+// local repo is in the current directory, otherwise it includes --git-dir.
+// If the remote has changed, it logs some extra information.
+func (e *Executor) updateRemoteURL(ctx context.Context, gitDir, repository string) error {
+	// Update the origin of the repository so we can gracefully handle
+	// repository renames.
+
+	// First check what the existing remote is, for both logging and debugging
+	// purposes.
+	args := []string{"remote", "get-url", "origin"}
+	if gitDir != "" {
+		args = append([]string{"--git-dir", gitDir}, args...)
+	}
+	gotURL, err := e.shell.RunAndCapture(ctx, "git", args...)
+	if err != nil {
+		return err
+	}
+
+	if gotURL == repository {
+		// No need to update anything
+		return nil
+	}
+
+	gd := gitDir
+	if gd == "" {
+		// This is for logging a diagnostic (best effort), so ignore any
+		// inability to get the working directory.
+		gd, _ = os.Getwd()
+	}
+
+	e.shell.Commentf("Remote URL for git directory %s has changed (%s -> %s)!", gd, gotURL, repository)
+	e.shell.Commentf("This is usually because the repository has been renamed.")
+	e.shell.Commentf("If this is unexpected, you may see failures (e.g. 'bad object', 'did not send all necessary objects').")
+
+	args = []string{"remote", "set-url", "origin", repository}
+	if gitDir != "" {
+		args = append([]string{"--git-dir", gitDir}, args...)
+	}
+	return e.shell.Run(ctx, "git", args...)
 }
 
 func (e *Executor) getOrUpdateMirrorDir(ctx context.Context, repository string) (string, error) {
@@ -1416,8 +1458,9 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 	// Does the git directory exist?
 	existingGitDir := filepath.Join(e.shell.Getwd(), ".git")
 	if utils.FileExists(existingGitDir) {
-		// Update the origin of the repository so we can gracefully handle repository renames
-		if err := e.shell.Run(ctx, "git", "remote", "set-url", "origin", e.Repository); err != nil {
+		// Update the origin of the repository so we can gracefully handle
+		// repository renames
+		if err := e.updateRemoteURL(ctx, "", e.Repository); err != nil {
 			return fmt.Errorf("setting origin: %w", err)
 		}
 	} else {
@@ -1440,19 +1483,20 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 
 	gitFetchFlags := e.GitFetchFlags
 
-	// If a refspec is provided then use it instead.
-	// For example, `refs/not/a/head`
-	if e.RefSpec != "" {
+	switch {
+	case e.RefSpec != "":
+		// If a refspec is provided then use it instead.
+		// For example, `refs/not/a/head`
 		e.shell.Commentf("Fetch and checkout custom refspec")
 		if err := gitFetch(ctx, e.shell, gitFetchFlags, "origin", e.RefSpec); err != nil {
 			return fmt.Errorf("fetching refspec %q: %w", e.RefSpec, err)
 		}
 
+	case e.PullRequest != "false" && strings.Contains(e.PipelineProvider, "github"):
 		// GitHub has a special ref which lets us fetch a pull request head, whether
 		// or not there is a current head in this repository or another which
 		// references the commit. We presume a commit sha is provided. See:
 		// https://help.github.com/articles/checking-out-pull-requests-locally/#modifying-an-inactive-pull-request-locally
-	} else if e.PullRequest != "false" && strings.Contains(e.PipelineProvider, "github") {
 		e.shell.Commentf("Fetch and checkout pull request head from GitHub")
 		refspec := fmt.Sprintf("refs/pull/%s/head", e.PullRequest)
 
@@ -1463,18 +1507,18 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 		gitFetchHead, _ := e.shell.RunAndCapture(ctx, "git", "rev-parse", "FETCH_HEAD")
 		e.shell.Commentf("FETCH_HEAD is now `%s`", gitFetchHead)
 
+	case e.Commit == "HEAD":
 		// If the commit is "HEAD" then we can't do a commit-specific fetch and will
 		// need to fetch the remote head and checkout the fetched head explicitly.
-	} else if e.Commit == "HEAD" {
 		e.shell.Commentf("Fetch and checkout remote branch HEAD commit")
 		if err := gitFetch(ctx, e.shell, gitFetchFlags, "origin", e.Branch); err != nil {
 			return fmt.Errorf("fetching branch %q: %w", e.Branch, err)
 		}
 
+	default:
 		// Otherwise fetch and checkout the commit directly. Some repositories don't
 		// support fetching a specific commit so we fall back to fetching all heads
 		// and tags, hoping that the commit is included.
-	} else {
 		if err := gitFetch(ctx, e.shell, gitFetchFlags, "origin", e.Commit); err != nil {
 			// By default `git fetch origin` will only fetch tags which are
 			// reachable from a fetches branch. git 1.9.0+ changed `--tags` to
@@ -1500,11 +1544,13 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 	}
 
 	var gitSubmodules bool
-	if !e.GitSubmodules && hasGitSubmodules(e.shell) {
-		e.shell.Warningf("This repository has submodules, but submodules are disabled at an agent level")
-	} else if e.GitSubmodules && hasGitSubmodules(e.shell) {
-		e.shell.Commentf("Git submodules detected")
-		gitSubmodules = true
+	if hasGitSubmodules(e.shell) {
+		if e.GitSubmodules {
+			e.shell.Commentf("Git submodules detected")
+			gitSubmodules = true
+		} else {
+			e.shell.Warningf("This repository has submodules, but submodules are disabled at an agent level")
+		}
 	}
 
 	if gitSubmodules {

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -1377,9 +1377,7 @@ func (e *Executor) updateRemoteURL(ctx context.Context, gitDir, repository strin
 
 	gd := gitDir
 	if gd == "" {
-		// This is for logging a diagnostic (best effort), so ignore any
-		// inability to get the working directory.
-		gd, _ = os.Getwd()
+		gd = e.shell.Getwd()
 	}
 
 	e.shell.Commentf("Remote URL for git directory %s has changed (%s -> %s)!", gd, gotURL, repository)

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -1408,7 +1408,7 @@ func (e *Executor) updateRemoteURL(ctx context.Context, gitDir, repository strin
 
 	e.shell.Commentf("Remote URL for git directory %s has changed (%s -> %s)!", gd, gotURL, repository)
 	e.shell.Commentf("This is usually because the repository has been renamed.")
-	e.shell.Commentf("If this is unexpected, you may see failures (e.g. 'bad object', 'did not send all necessary objects').")
+	e.shell.Commentf("If this is unexpected, you may see failures.")
 
 	args = []string{"remote", "set-url", "origin", repository}
 	if gitDir != "" {

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -317,7 +317,7 @@ func TestCheckoutErrorIsRetried(t *testing.T) {
 
 	// But assert which ones are called
 	git.ExpectAll([][]any{
-		{"remote", "set-url", "origin", tester.Repo.Path},
+		{"remote", "get-url", "origin"},
 		{"clean", "-fdq"},
 		{"fetch", "-v", "--", "origin", "main"},
 		{"checkout", "-f", "FETCH_HEAD"},
@@ -380,7 +380,7 @@ func TestFetchErrorIsRetried(t *testing.T) {
 
 	// But assert which ones are called
 	git.ExpectAll([][]any{
-		{"remote", "set-url", "origin", tester.Repo.Path},
+		{"remote", "get-url", "origin"},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--depth=1", "--", "origin", "main"},
 		{"clone", "-v", "--depth=1", "--", tester.Repo.Path, "."},


### PR DESCRIPTION
I'm not certain yet, but the submodule-mirror-wrong-remote bug in older agents (see #2144) _might_ be related to recent "bad object" / "did not send all necessary objects" issues.

For submodules, older agents set the wrong remote URL in the directory. v3.49 (#2144) fixed it to set the correct remote. However, once upgraded to v3.49, the mirror dir is probably broken: the remote URL is updated correctly, but the local repo would still contain objects for the wrong remote. Afterwards, the repo is only fetched if it is the main repo. Woe betide you if you have multiple agents of different versions fighting over the mirror!

So this PR:

- uses `get-url` before using `set-url`, so that we can log a message
- if the remote URL changed, do a `fetch` for non-main repos to try to get out of bad object situations