### PR TITLE
Artifacts package

### DIFF
--- a/agent/aws.go
+++ b/agent/aws.go
@@ -13,7 +13,7 @@ var awsSess *session.Session
 // The aws sdk relies on being given a region, which is a breaking change for us
 // This applies a heuristic that detects where the agent might be based on the env
 // but also the local isntance metadata if available
-func awsRegion() (string, error) {
+func AWSRegion() (string, error) {
 	if r := os.Getenv("AWS_REGION"); r != "" {
 		return r, nil
 	}
@@ -39,7 +39,7 @@ func awsRegion() (string, error) {
 }
 
 func awsSession() (*session.Session, error) {
-	region, err := awsRegion()
+	region, err := AWSRegion()
 	if err != nil {
 		return nil, err
 	}

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -132,7 +132,7 @@ var ArtifactDownloadCommand = cli.Command{
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
 
 		// Setup the downloader
-		downloader := artifact.NewArtifactDownloader(l, client, artifact.ArtifactDownloaderConfig{
+		downloader := artifact.NewDownloader(l, client, artifact.DownloaderConfig{
 			Query:              cfg.Query,
 			Destination:        cfg.Destination,
 			BuildID:            cfg.Build,

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/cliconfig"
+	"github.com/buildkite/agent/v3/internal/artifact"
 	"github.com/urfave/cli"
 )
 
@@ -132,7 +132,7 @@ var ArtifactDownloadCommand = cli.Command{
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
 
 		// Setup the downloader
-		downloader := agent.NewArtifactDownloader(l, client, agent.ArtifactDownloaderConfig{
+		downloader := artifact.NewArtifactDownloader(l, client, artifact.ArtifactDownloaderConfig{
 			Query:              cfg.Query,
 			Destination:        cfg.Destination,
 			BuildID:            cfg.Build,

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -163,7 +163,7 @@ Format specifiers:
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
 
 		// Setup the searcher and try get the artifacts
-		searcher := artifact.NewArtifactSearcher(l, client, cfg.Build)
+		searcher := artifact.NewSearcher(l, client, cfg.Build)
 		artifacts, err := searcher.Search(ctx, cfg.Query, cfg.Step, cfg.IncludeRetriedJobs, true)
 		if err != nil {
 			return err

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/cliconfig"
+	"github.com/buildkite/agent/v3/internal/artifact"
 	"github.com/urfave/cli"
 )
 
@@ -163,7 +163,7 @@ Format specifiers:
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
 
 		// Setup the searcher and try get the artifacts
-		searcher := agent.NewArtifactSearcher(l, client, cfg.Build)
+		searcher := artifact.NewArtifactSearcher(l, client, cfg.Build)
 		artifacts, err := searcher.Search(ctx, cfg.Query, cfg.Step, cfg.IncludeRetriedJobs, true)
 		if err != nil {
 			return err

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -145,7 +145,7 @@ func searchAndPrintShaSum(ctx context.Context, cfg ArtifactShasumConfig, l logge
 	client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
 
 	// Find the artifact we want to show the SHASUM for
-	searcher := artifact.NewArtifactSearcher(l, client, cfg.Build)
+	searcher := artifact.NewSearcher(l, client, cfg.Build)
 	artifacts, err := searcher.Search(ctx, cfg.Query, cfg.Step, cfg.IncludeRetriedJobs, false)
 	if err != nil {
 		return fmt.Errorf("Error searching for artifacts: %s", err)

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/cliconfig"
+	"github.com/buildkite/agent/v3/internal/artifact"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/urfave/cli"
 )
@@ -145,7 +145,7 @@ func searchAndPrintShaSum(ctx context.Context, cfg ArtifactShasumConfig, l logge
 	client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
 
 	// Find the artifact we want to show the SHASUM for
-	searcher := agent.NewArtifactSearcher(l, client, cfg.Build)
+	searcher := artifact.NewArtifactSearcher(l, client, cfg.Build)
 	artifacts, err := searcher.Search(ctx, cfg.Query, cfg.Step, cfg.IncludeRetriedJobs, false)
 	if err != nil {
 		return fmt.Errorf("Error searching for artifacts: %s", err)

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -169,7 +169,7 @@ var ArtifactUploadCommand = cli.Command{
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
 
 		// Setup the uploader
-		uploader := artifact.NewArtifactUploader(l, client, artifact.ArtifactUploaderConfig{
+		uploader := artifact.NewUploader(l, client, artifact.UploaderConfig{
 			JobID:       cfg.Job,
 			Paths:       cfg.UploadPaths,
 			Destination: cfg.Destination,

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/cliconfig"
+	"github.com/buildkite/agent/v3/internal/artifact"
 	"github.com/urfave/cli"
 )
 
@@ -169,7 +169,7 @@ var ArtifactUploadCommand = cli.Command{
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
 
 		// Setup the uploader
-		uploader := agent.NewArtifactUploader(l, client, agent.ArtifactUploaderConfig{
+		uploader := artifact.NewArtifactUploader(l, client, artifact.ArtifactUploaderConfig{
 			JobID:       cfg.Job,
 			Paths:       cfg.UploadPaths,
 			Destination: cfg.Destination,

--- a/internal/artifact/artifact_batch_creator.go
+++ b/internal/artifact/artifact_batch_creator.go
@@ -10,7 +10,7 @@ import (
 	"github.com/buildkite/roko"
 )
 
-type ArtifactBatchCreatorConfig struct {
+type BatchCreatorConfig struct {
 	// The ID of the Job that these artifacts belong to
 	JobID string
 
@@ -25,9 +25,9 @@ type ArtifactBatchCreatorConfig struct {
 	CreateArtifactsTimeout time.Duration
 }
 
-type ArtifactBatchCreator struct {
+type BatchCreator struct {
 	// The creation config
-	conf ArtifactBatchCreatorConfig
+	conf BatchCreatorConfig
 
 	// The logger instance to use
 	logger logger.Logger
@@ -36,15 +36,15 @@ type ArtifactBatchCreator struct {
 	apiClient agent.APIClient
 }
 
-func NewArtifactBatchCreator(l logger.Logger, ac agent.APIClient, c ArtifactBatchCreatorConfig) *ArtifactBatchCreator {
-	return &ArtifactBatchCreator{
+func NewBatchCreator(l logger.Logger, ac agent.APIClient, c BatchCreatorConfig) *BatchCreator {
+	return &BatchCreator{
 		logger:    l,
 		conf:      c,
 		apiClient: ac,
 	}
 }
 
-func (a *ArtifactBatchCreator) Create(ctx context.Context) ([]*api.Artifact, error) {
+func (a *BatchCreator) Create(ctx context.Context) ([]*api.Artifact, error) {
 	length := len(a.conf.Artifacts)
 	chunks := 30
 

--- a/internal/artifact/artifact_batch_creator.go
+++ b/internal/artifact/artifact_batch_creator.go
@@ -1,9 +1,10 @@
-package agent
+package artifact
 
 import (
 	"context"
 	"time"
 
+	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/roko"
@@ -31,11 +32,11 @@ type ArtifactBatchCreator struct {
 	// The logger instance to use
 	logger logger.Logger
 
-	// The APIClient that will be used when uploading jobs
-	apiClient APIClient
+	// The agent.APIClient that will be used when uploading jobs
+	apiClient agent.APIClient
 }
 
-func NewArtifactBatchCreator(l logger.Logger, ac APIClient, c ArtifactBatchCreatorConfig) *ArtifactBatchCreator {
+func NewArtifactBatchCreator(l logger.Logger, ac agent.APIClient, c ArtifactBatchCreatorConfig) *ArtifactBatchCreator {
 	return &ArtifactBatchCreator{
 		logger:    l,
 		conf:      c,

--- a/internal/artifact/artifact_downloader.go
+++ b/internal/artifact/artifact_downloader.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"context"
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/agent/v3/pool"
@@ -43,11 +44,11 @@ type ArtifactDownloader struct {
 	// The logger instance to use
 	logger logger.Logger
 
-	// The APIClient that will be used when uploading jobs
-	apiClient APIClient
+	// The agent.APIClient that will be used when uploading jobs
+	apiClient agent.APIClient
 }
 
-func NewArtifactDownloader(l logger.Logger, ac APIClient, c ArtifactDownloaderConfig) ArtifactDownloader {
+func NewArtifactDownloader(l logger.Logger, ac agent.APIClient, c ArtifactDownloaderConfig) ArtifactDownloader {
 	return ArtifactDownloader{
 		logger:    l,
 		apiClient: ac,

--- a/internal/artifact/artifact_downloader_test.go
+++ b/internal/artifact/artifact_downloader_test.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"context"

--- a/internal/artifact/artifact_downloader_test.go
+++ b/internal/artifact/artifact_downloader_test.go
@@ -40,7 +40,7 @@ func TestArtifactDownloaderConnectsToEndpoint(t *testing.T) {
 		Token:    "llamasforever",
 	})
 
-	d := NewArtifactDownloader(logger.Discard, ac, ArtifactDownloaderConfig{
+	d := NewDownloader(logger.Discard, ac, DownloaderConfig{
 		BuildID: "my-build",
 	})
 

--- a/internal/artifact/artifact_searcher.go
+++ b/internal/artifact/artifact_searcher.go
@@ -1,9 +1,10 @@
-package agent
+package artifact
 
 import (
 	"context"
 	"time"
 
+	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/roko"
@@ -13,14 +14,14 @@ type ArtifactSearcher struct {
 	// The logger instance to use
 	logger logger.Logger
 
-	// The APIClient that will be used when uploading jobs
-	apiClient APIClient
+	// The agent.APIClient that will be used when uploading jobs
+	apiClient agent.APIClient
 
 	// The ID of the Build that these artifacts belong to
 	buildID string
 }
 
-func NewArtifactSearcher(l logger.Logger, ac APIClient, buildID string) *ArtifactSearcher {
+func NewArtifactSearcher(l logger.Logger, ac agent.APIClient, buildID string) *ArtifactSearcher {
 	return &ArtifactSearcher{
 		logger:    l,
 		apiClient: ac,

--- a/internal/artifact/artifact_searcher.go
+++ b/internal/artifact/artifact_searcher.go
@@ -10,7 +10,7 @@ import (
 	"github.com/buildkite/roko"
 )
 
-type ArtifactSearcher struct {
+type Searcher struct {
 	// The logger instance to use
 	logger logger.Logger
 
@@ -21,15 +21,15 @@ type ArtifactSearcher struct {
 	buildID string
 }
 
-func NewArtifactSearcher(l logger.Logger, ac agent.APIClient, buildID string) *ArtifactSearcher {
-	return &ArtifactSearcher{
+func NewSearcher(l logger.Logger, ac agent.APIClient, buildID string) *Searcher {
+	return &Searcher{
 		logger:    l,
 		apiClient: ac,
 		buildID:   buildID,
 	}
 }
 
-func (a *ArtifactSearcher) Search(ctx context.Context, query, scope string, includeRetriedJobs, includeDuplicates bool) ([]*api.Artifact, error) {
+func (a *Searcher) Search(ctx context.Context, query, scope string, includeRetriedJobs, includeDuplicates bool) ([]*api.Artifact, error) {
 	if scope == "" {
 		a.logger.Info("Searching for artifacts: \"%s\"", query)
 	} else {

--- a/internal/artifact/artifact_searcher_test.go
+++ b/internal/artifact/artifact_searcher_test.go
@@ -40,7 +40,7 @@ func TestArtifactSearcherConnectsToEndpoint(t *testing.T) {
 		Token:    "llamasforever",
 	})
 
-	s := NewArtifactSearcher(logger.Discard, ac, "my-build")
+	s := NewSearcher(logger.Discard, ac, "my-build")
 
 	artifacts, err := s.Search(ctx, "llamas.txt", "my-build", false, false)
 	if err != nil {

--- a/internal/artifact/artifact_searcher_test.go
+++ b/internal/artifact/artifact_searcher_test.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"context"

--- a/internal/artifact/artifact_uploader.go
+++ b/internal/artifact/artifact_uploader.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/experiments"
 	"github.com/buildkite/agent/v3/internal/mime"
@@ -59,11 +60,11 @@ type ArtifactUploader struct {
 	// The logger instance to use
 	logger logger.Logger
 
-	// The APIClient that will be used when uploading jobs
-	apiClient APIClient
+	// The agent.APIClient that will be used when uploading jobs
+	apiClient agent.APIClient
 }
 
-func NewArtifactUploader(l logger.Logger, ac APIClient, c ArtifactUploaderConfig) *ArtifactUploader {
+func NewArtifactUploader(l logger.Logger, ac agent.APIClient, c ArtifactUploaderConfig) *ArtifactUploader {
 	return &ArtifactUploader{
 		logger:    l,
 		apiClient: ac,

--- a/internal/artifact/artifact_uploader_test.go
+++ b/internal/artifact/artifact_uploader_test.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"fmt"
@@ -27,7 +27,7 @@ func TestCollect(t *testing.T) {
 	// t.Parallel() cannot be used with experiments.Enable
 
 	wd, _ := os.Getwd()
-	root := filepath.Join(wd, "..")
+	root := filepath.Join(wd, "..", "..")
 	os.Chdir(root)
 	defer os.Chdir(wd)
 
@@ -168,7 +168,7 @@ func TestCollect(t *testing.T) {
 
 func TestCollectThatDoesntMatchAnyFiles(t *testing.T) {
 	wd, _ := os.Getwd()
-	root := filepath.Join(wd, "..")
+	root := filepath.Join(wd, "..", "..")
 	os.Chdir(root)
 	defer os.Chdir(wd)
 
@@ -191,7 +191,7 @@ func TestCollectThatDoesntMatchAnyFiles(t *testing.T) {
 
 func TestCollectWithSomeGlobsThatDontMatchAnything(t *testing.T) {
 	wd, _ := os.Getwd()
-	root := filepath.Join(wd, "..")
+	root := filepath.Join(wd, "..", "..")
 	os.Chdir(root)
 	defer os.Chdir(wd)
 
@@ -215,7 +215,7 @@ func TestCollectWithSomeGlobsThatDontMatchAnything(t *testing.T) {
 
 func TestCollectWithSomeGlobsThatDontMatchAnythingFollowingSymlinks(t *testing.T) {
 	wd, _ := os.Getwd()
-	root := filepath.Join(wd, "..")
+	root := filepath.Join(wd, "..", "..")
 	os.Chdir(root)
 	defer os.Chdir(wd)
 
@@ -241,7 +241,7 @@ func TestCollectWithSomeGlobsThatDontMatchAnythingFollowingSymlinks(t *testing.T
 
 func TestCollectWithDuplicateMatches(t *testing.T) {
 	wd, _ := os.Getwd()
-	root := filepath.Join(wd, "..")
+	root := filepath.Join(wd, "..", "..")
 	os.Chdir(root)
 	defer os.Chdir(wd)
 
@@ -275,7 +275,7 @@ func TestCollectWithDuplicateMatches(t *testing.T) {
 
 func TestCollectWithDuplicateMatchesFollowingSymlinks(t *testing.T) {
 	wd, _ := os.Getwd()
-	root := filepath.Join(wd, "..")
+	root := filepath.Join(wd, "..", "..")
 	os.Chdir(root)
 	defer os.Chdir(wd)
 
@@ -311,7 +311,7 @@ func TestCollectWithDuplicateMatchesFollowingSymlinks(t *testing.T) {
 
 func TestCollectMatchesUploadSymlinks(t *testing.T) {
 	wd, _ := os.Getwd()
-	root := filepath.Join(wd, "..")
+	root := filepath.Join(wd, "..", "..")
 	os.Chdir(root)
 	defer os.Chdir(wd)
 

--- a/internal/artifact/artifact_uploader_test.go
+++ b/internal/artifact/artifact_uploader_test.go
@@ -81,7 +81,7 @@ func TestCollect(t *testing.T) {
 		},
 	}
 
-	uploader := NewArtifactUploader(logger.Discard, nil, ArtifactUploaderConfig{
+	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
 		Paths: fmt.Sprintf("%s;%s",
 			filepath.Join("test", "fixtures", "artifacts", "**/*.jpg"),
 			filepath.Join(root, "test", "fixtures", "artifacts", "**/*.gif"),
@@ -172,7 +172,7 @@ func TestCollectThatDoesntMatchAnyFiles(t *testing.T) {
 	os.Chdir(root)
 	defer os.Chdir(wd)
 
-	uploader := NewArtifactUploader(logger.Discard, nil, ArtifactUploaderConfig{
+	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
 		Paths: strings.Join([]string{
 			filepath.Join("log", "*"),
 			filepath.Join("tmp", "capybara", "**", "*"),
@@ -195,7 +195,7 @@ func TestCollectWithSomeGlobsThatDontMatchAnything(t *testing.T) {
 	os.Chdir(root)
 	defer os.Chdir(wd)
 
-	uploader := NewArtifactUploader(logger.Discard, nil, ArtifactUploaderConfig{
+	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
 		Paths: strings.Join([]string{
 			filepath.Join("dontmatchanything", "*"),
 			filepath.Join("dontmatchanything.zip"),
@@ -219,7 +219,7 @@ func TestCollectWithSomeGlobsThatDontMatchAnythingFollowingSymlinks(t *testing.T
 	os.Chdir(root)
 	defer os.Chdir(wd)
 
-	uploader := NewArtifactUploader(logger.Discard, nil, ArtifactUploaderConfig{
+	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
 		Paths: strings.Join([]string{
 			filepath.Join("dontmatchanything", "*"),
 			filepath.Join("dontmatchanything.zip"),
@@ -245,7 +245,7 @@ func TestCollectWithDuplicateMatches(t *testing.T) {
 	os.Chdir(root)
 	defer os.Chdir(wd)
 
-	uploader := NewArtifactUploader(logger.Discard, nil, ArtifactUploaderConfig{
+	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
 		Paths: strings.Join([]string{
 			filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
 			filepath.Join("test", "fixtures", "artifacts", "folder", "Commando.jpg"), // dupe
@@ -279,7 +279,7 @@ func TestCollectWithDuplicateMatchesFollowingSymlinks(t *testing.T) {
 	os.Chdir(root)
 	defer os.Chdir(wd)
 
-	uploader := NewArtifactUploader(logger.Discard, nil, ArtifactUploaderConfig{
+	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
 		Paths: strings.Join([]string{
 			filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
 			filepath.Join("test", "fixtures", "artifacts", "folder", "Commando.jpg"), // dupe
@@ -315,7 +315,7 @@ func TestCollectMatchesUploadSymlinks(t *testing.T) {
 	os.Chdir(root)
 	defer os.Chdir(wd)
 
-	uploader := NewArtifactUploader(logger.Discard, nil, ArtifactUploaderConfig{
+	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
 		Paths: strings.Join([]string{
 			filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
 		}, ";"),

--- a/internal/artifact/artifactory_downloader.go
+++ b/internal/artifact/artifactory_downloader.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"context"

--- a/internal/artifact/artifactory_downloader_test.go
+++ b/internal/artifact/artifactory_downloader_test.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"testing"

--- a/internal/artifact/artifactory_uploader.go
+++ b/internal/artifact/artifactory_uploader.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"crypto/md5"

--- a/internal/artifact/artifactory_uploader_test.go
+++ b/internal/artifact/artifactory_uploader_test.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"testing"

--- a/internal/artifact/download.go
+++ b/internal/artifact/download.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"context"

--- a/internal/artifact/download_test.go
+++ b/internal/artifact/download_test.go
@@ -1,11 +1,12 @@
 //go:build !windows
 // +build !windows
 
-package agent
+package artifact
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetTargetPath(t *testing.T) {

--- a/internal/artifact/form_uploader.go
+++ b/internal/artifact/form_uploader.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"bytes"
@@ -21,7 +21,7 @@ import (
 	"github.com/buildkite/agent/v3/logger"
 )
 
-var ArtifactPathVariableRegex = regexp.MustCompile("\\$\\{artifact\\:path\\}")
+var ArtifactPathVariableRegex = regexp.MustCompile(`\$\{artifact\:path\}`)
 
 // FormUploader uploads to S3 as a single signed POST, which have a hard limit of 5Gb.
 var maxFormUploadedArtifactSize = int64(5368709120)

--- a/internal/artifact/form_uploader_test.go
+++ b/internal/artifact/form_uploader_test.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"bytes"

--- a/internal/artifact/gs_downloader.go
+++ b/internal/artifact/gs_downloader.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"context"

--- a/internal/artifact/gs_uploader.go
+++ b/internal/artifact/gs_uploader.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"context"

--- a/internal/artifact/gs_uploader_test.go
+++ b/internal/artifact/gs_uploader_test.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"testing"

--- a/internal/artifact/s3.go
+++ b/internal/artifact/s3.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"errors"
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/logger"
 )
 
@@ -136,7 +137,7 @@ func NewS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 	} else {
 		// Otherwise, use the current region (or a guess) to dynamically find
 		// where the bucket lives.
-		region, err := awsRegion()
+		region, err := agent.AWSRegion()
 		if err != nil {
 			region = "us-east-1"
 		}

--- a/internal/artifact/s3_downloader.go
+++ b/internal/artifact/s3_downloader.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"context"

--- a/internal/artifact/s3_downloader_test.go
+++ b/internal/artifact/s3_downloader_test.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"testing"

--- a/internal/artifact/s3_uploader.go
+++ b/internal/artifact/s3_uploader.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"fmt"

--- a/internal/artifact/s3_uploader_test.go
+++ b/internal/artifact/s3_uploader_test.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"os"

--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -1,4 +1,4 @@
-package agent
+package artifact
 
 import (
 	"github.com/buildkite/agent/v3/api"

--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -4,7 +4,7 @@ import (
 	"github.com/buildkite/agent/v3/api"
 )
 
-type Uploader interface {
+type UploadDoer interface {
 	// The Artifact.URL property is populated with what ever is returned
 	// from this method prior to uploading.
 	URL(*api.Artifact) string


### PR DESCRIPTION
Artifacts are very much their own thing, and take up a lot of space in the `agent` module without actually being used in it anywhere at all.

This PR takes all of the artifact gear out of the `agent` module, and puts it in its own (internal) module called `artifact`. It also renames some of the types and funcs within to remove [stuttering](https://michaelwhatcott.com/go-code-that-stutters/).