### PR TITLE
Use a unique name for each agent started using the systemd template unit file

### DIFF
--- a/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent@.service
+++ b/packaging/linux/root/usr/share/buildkite-agent/systemd/buildkite-agent@.service
@@ -8,7 +8,7 @@ After=network.target
 Type=simple
 User=buildkite-agent
 Environment=HOME=/var/lib/buildkite-agent
-ExecStart=/usr/bin/buildkite-agent start
+ExecStart=/usr/bin/buildkite-agent start --name %H-%i
 RestartSec=5
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE


### PR DESCRIPTION
Relates to https://github.com/buildkite/docs/issues/2252.

The docs currently advise users that they can [run multiple agents using the same configuration](https://buildkite.com/docs/agent/v3/ubuntu#running-multiple-agents) by using the systemd template unit file.

However, this results in starting multiple agents with the same name, which the [configuration docs](https://buildkite.com/docs/agent/v3/configuration#name) advise against doing.

This PR uses [unit file specifiers](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Specifiers) to give each agent a unique name based on the hostname and the systemd service instance name.