### PR TITLE
Simplify command phase

### DIFF
--- a/internal/job/integration/command_integration_test.go
+++ b/internal/job/integration/command_integration_test.go
@@ -42,6 +42,8 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 }
 
 func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {
+	t.Parallel()
+
 	tester, err := NewBootstrapTester()
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)


### PR DESCRIPTION
In preparation for some other work I intend to do in this area, simplify the CommandPhase method.

I aimed to make this PR a no-op, but technically, I've changed the order of some of the statements, which does change the internal state and the order of some log statements. But there should be minimal externally visible effects.

I recommend you review this PR with a side-by-side diff.