### PR TITLE
Add experiment to avoid a recursive trap

### DIFF
--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -28,6 +28,7 @@ const (
 	NormalisedUploadPaths      = "normalised-upload-paths"
 	PolyglotHooks              = "polyglot-hooks"
 	ResolveCommitAfterCheckout = "resolve-commit-after-checkout"
+	AvoidRecursiveTrap         = "avoid-recursive-trap"
 
 	// Promoted experiments
 	ANSITimestamps    = "ansi-timestamps"

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -1838,6 +1838,7 @@ func (e *Executor) CommandPhase(ctx context.Context) (hookErr error, commandErr 
 		e.shell.Errorf("The command was interrupted by a signal: %v", commandErr)
 
 		// although error is an exit error, it's not returned. (seems like a bug)
+		// TODO: investigate phasing this out under a experiment
 		return nil, nil
 	case isExitError && isExitSignaled && !avoidRecursiveTrap:
 		// TODO: remove this branch when the experiment is promoted


### PR DESCRIPTION
Some jobs are run as a bash script of the form:
```bash
trap "kill -- $$" INT TERM QUIT; <command>
```
We now understand this causes a bug (see the code comments), and we want to avoid it.

This PR adds an experiment to avoid adding the trap to the script.