### PR TITLE
Print agent version and build in debug logs

### DIFF
--- a/logger/log.go
+++ b/logger/log.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/buildkite/agent/v3/version"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -80,7 +81,11 @@ func (l *ConsoleLogger) SetLevel(level Level) {
 
 func (l *ConsoleLogger) Debug(format string, v ...any) {
 	if l.level == DEBUG {
-		l.printer.Print(DEBUG, fmt.Sprintf(format, v...), l.fields)
+		debugFields := make(Fields, 0, len(l.fields)+2)
+		copy(debugFields, l.fields)
+		debugFields.Add(StringField("agent_version", version.Version()))
+		debugFields.Add(StringField("agent_build", version.BuildVersion()))
+		l.printer.Print(DEBUG, fmt.Sprintf(format, v...), debugFields)
 	}
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -24,11 +24,10 @@ func Version() string {
 }
 
 func BuildVersion() string {
-	if buildVersion != "" {
-		return buildVersion
-	} else {
+	if buildVersion == "" {
 		return "x"
 	}
+	return buildVersion
 }
 
 func UserAgent() string {


### PR DESCRIPTION
These are already pretty spammy, so I don't think this will make it much worse.
This is what it looks like:
```
2023-07-17 16:05:44 DEBUG  GET https://agent.buildkite.com/v3/ping agent_version=3.49.0 agent_build=x
2023-07-17 16:05:45 DEBUG  ↳ GET https://agent.buildkite.com/v3/ping agent_version=3.49.0 agent_build=x
```