### PR TITLE
Switch to 2-space tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,2 @@
-# See http://editorconfig.org
-
-# In Go files we indent with tabs but still 
-# set indent_size to control the GitHub web viewer.  
 [*.go]
-indent_size=4
-
+indent_size=2


### PR DESCRIPTION
This controls how wide tabs are in some text editors. The rest of the
org uses two space tabs in the backend, so lets be consistent with them.