### PR TITLE
Add signatures when marshalling steps to json

### DIFF
--- a/internal/pipeline/json.go
+++ b/internal/pipeline/json.go
@@ -1,0 +1,94 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/oleiade/reflections"
+)
+
+// inlineFriendlyMarshalJSON marshals the given object to JSON, but with special handling given to fields tagged with ",inline".
+// This is needed because yaml.v3 has "inline" but encoding/json has no concept of it.
+func inlineFriendlyMarshalJSON(q any) ([]byte, error) {
+	fieldNames, err := reflections.Fields(q)
+	if err != nil {
+		return nil, fmt.Errorf("could not get fields of %T: %w", q, err)
+	}
+
+	var inlineFields map[string]any // no need to pre-allocate, we directly set it if we find inline fields
+	outlineFields := make(map[string]any, len(fieldNames))
+
+	for _, fieldName := range fieldNames {
+		tag, err := reflections.GetFieldTag(q, fieldName, "yaml")
+		if err != nil {
+			return nil, fmt.Errorf("could not get yaml tag of %T.%s: %w", q, fieldName, err)
+		}
+
+		switch tag {
+		case "-":
+			continue
+
+		case ",inline":
+			inlineFieldsValue, err := reflections.GetField(q, fieldName)
+			if err != nil {
+				return nil, fmt.Errorf("could not get inline fields value of %T.%s: %w", q, fieldName, err)
+			}
+
+			if inf, ok := inlineFieldsValue.(map[string]any); ok {
+				inlineFields = inf
+			} else {
+				return nil, fmt.Errorf("inline fields value of %T.%s must be a map[string]any, was %T instead", q, fieldName, inlineFieldsValue)
+			}
+
+		default:
+			fieldValue, err := reflections.GetField(q, fieldName)
+			if err != nil {
+				return nil, fmt.Errorf("could not get value of %T.%s: %w", q, fieldName, err)
+			}
+
+			tags := strings.Split(tag, ",")
+			keyName := tags[0] // e.g. "foo,omitempty" -> "foo"
+			if len(tags) > 1 && tags[1] == "omitempty" && isEmptyValue(fieldValue) {
+				continue
+			}
+
+			outlineFields[keyName] = fieldValue
+		}
+	}
+
+	allFields := make(map[string]any, len(outlineFields)+len(inlineFields))
+
+	for k, v := range inlineFields {
+		allFields[k] = v
+	}
+
+	// "outline" (non-inline) fields should take precedence over inline fields
+	for k, v := range outlineFields {
+		allFields[k] = v
+	}
+
+	return json.Marshal(allFields)
+}
+
+// stolen from encoding/json
+func isEmptyValue(q any) bool {
+	v := reflect.ValueOf(q)
+
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Pointer:
+		return v.IsNil()
+	}
+	return false
+}

--- a/internal/pipeline/json_test.go
+++ b/internal/pipeline/json_test.go
@@ -1,0 +1,80 @@
+package pipeline
+
+import "testing"
+
+type strukt struct {
+	Foo string         `yaml:"foo"`
+	Bar string         `yaml:"bar,omitempty"`
+	Baz string         `yaml:"-"`
+	Qux map[string]any `yaml:",inline"`
+}
+
+func TestInlineFriendlyMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name   string
+		strukt strukt
+		want   string
+	}{
+		{
+			name: "it combines inline and outline fields into one object",
+			want: `{"bar":"bar","country":"ecuador","foo":"foo","mountain":"cotopaxi"}`,
+			strukt: strukt{
+				Foo: "foo",
+				Bar: "bar",
+				Qux: map[string]any{
+					"mountain": "cotopaxi",
+					"country":  "ecuador",
+				},
+			},
+		},
+		{
+			name: "it correctly omits empty fields when they have omitempty",
+			want: `{"foo":""}`,
+			strukt: strukt{
+				Foo: "", // doesn't have omitempty, should show up in the result object
+				Bar: "",
+			},
+		},
+		{
+			name: `it correctly omits fields with yaml:"-"`,
+			want: `{"foo":"foo"}`,
+			strukt: strukt{
+				Foo: "foo",
+				Baz: "this shouldn't be here",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := inlineFriendlyMarshalJSON(tt.strukt)
+			if err != nil {
+				t.Errorf("inlineFriendlyMarshalJSON() error = %v", err)
+				return
+			}
+
+			if string(got) != tt.want {
+				t.Errorf("inlineFriendlyMarshalJSON() = %v, want %v", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestInlineFriendlyMarshalJSON_FailsWhenInlineFieldsIsntAMap(t *testing.T) {
+	type test struct {
+		Qux string `yaml:",inline"`
+	}
+
+	_, err := inlineFriendlyMarshalJSON(test{
+		Qux: "this isn't a map",
+	})
+
+	if err == nil {
+		t.Fatalf("inlineFriendlyMarshalJSON() == nil, want error")
+	}
+
+	wantError := "inline fields value of pipeline.test.Qux must be a map[string]any, was string instead"
+	if err.Error() != wantError {
+		t.Errorf("inlineFriendlyMarshalJSON() error = %v, want %v", err, wantError)
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,7 +1,6 @@
 package pipeline
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -30,20 +29,7 @@ type Pipeline struct {
 // MarshalJSON marshals a pipeline to JSON. Special handling is needed because
 // yaml.v3 has "inline" but encoding/json has no concept of it.
 func (p *Pipeline) MarshalJSON() ([]byte, error) {
-	// Steps and Env have precedence over anything in RemainingFields.
-	out := make(map[string]any, len(p.RemainingFields)+2)
-	for k, v := range p.RemainingFields {
-		if v != nil {
-			out[k] = v
-		}
-	}
-
-	out["steps"] = p.Steps
-	if !p.Env.IsZero() {
-		out["env"] = p.Env
-	}
-
-	return json.Marshal(out)
+	return inlineFriendlyMarshalJSON(p)
 }
 
 // UnmarshalYAML unmarshals a pipeline from YAML. A custom unmarshaler is

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -27,7 +27,6 @@ type Step interface {
 
 // CommandStep models a command step.
 //
-// If you add a field to this struct, ensure you add a corresponding block to the `MarshallJSON` method! It won't happen automatically.
 // Standard caveats apply - see the package comment.
 type CommandStep struct {
 	Command   string     `yaml:"command"`
@@ -42,26 +41,7 @@ type CommandStep struct {
 // MarshalJSON marshals the step to JSON. Special handling is needed because
 // yaml.v3 has "inline" but encoding/json has no concept of it.
 func (c *CommandStep) MarshalJSON() ([]byte, error) {
-	out := make(map[string]any, len(c.RemainingFields)+2)
-	for k, v := range c.RemainingFields {
-		if v != nil {
-			out[k] = v
-		}
-	}
-
-	if c.Command != "" {
-		out["command"] = c.Command
-	}
-
-	if len(c.Plugins) > 0 {
-		out["plugins"] = c.Plugins
-	}
-
-	if c.Signature != nil {
-		out["signature"] = c.Signature
-	}
-
-	return json.Marshal(out)
+	return inlineFriendlyMarshalJSON(c)
 }
 
 // UnmarshalYAML unmarshals the command step. Special handling is needed to

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -27,6 +27,7 @@ type Step interface {
 
 // CommandStep models a command step.
 //
+// If you add a field to this struct, ensure you add a corresponding block to the `MarshallJSON` method! It won't happen automatically.
 // Standard caveats apply - see the package comment.
 type CommandStep struct {
 	Command   string     `yaml:"command"`
@@ -47,11 +48,17 @@ func (c *CommandStep) MarshalJSON() ([]byte, error) {
 			out[k] = v
 		}
 	}
+
 	if c.Command != "" {
 		out["command"] = c.Command
 	}
+
 	if len(c.Plugins) > 0 {
 		out["plugins"] = c.Plugins
+	}
+
+	if c.Signature != nil {
+		out["signature"] = c.Signature
 	}
 
 	return json.Marshal(out)


### PR DESCRIPTION
The pipeline is actually marshalled to json by the agent, and then back to yaml again on the backend, as it turns out.