### PR TITLE
Fix docker builds for Ubuntu 22.04

### DIFF
--- a/packaging/docker/ubuntu-22.04/Dockerfile
+++ b/packaging/docker/ubuntu-22.04/Dockerfile
@@ -37,7 +37,8 @@ apt-get update
 apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin docker-buildx-plugin
 rm -rf /var/lib/apt/lists/*
 
-pip3 install docker-compose==$DOCKER_COMPOSE_VERSION
+echo "pyyaml!=6.0.0,!=5.4.0,!=5.4.1" > ./pip-constraints # pyyaml is broken with cython 3, see: https://github.com/yaml/pyyaml/issues/724
+pip3 install --constraint ./pip-constraints docker-compose==$DOCKER_COMPOSE_VERSION
 
 ln -s /usr/bin/tini /usr/sbin/tini
 
@@ -47,7 +48,7 @@ chmod +x /usr/local/bin/ssh-env-config.sh
 BASH
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \
-    PATH="/usr/local/bin:${PATH}"
+  PATH="/usr/local/bin:${PATH}"
 
 COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
 COPY ./buildkite-agent-$TARGETOS-$TARGETARCH /usr/local/bin/buildkite-agent


### PR DESCRIPTION
Python dependency snafus mean we have to constrain pyyaml to an older version, see: https://github.com/yaml/pyyaml/issues/724