### PR TITLE
Clean-retry on "fatal: bad object"

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -1166,7 +1166,8 @@ func (e *Executor) CheckoutPhase(ctx context.Context) error {
 					switch ge.Type {
 					// These types can fail because of corrupted checkouts
 					case gitErrorClean, gitErrorCleanSubmodules, gitErrorClone,
-						gitErrorCheckoutRetryClean, gitErrorFetchRetryClean:
+						gitErrorCheckoutRetryClean, gitErrorFetchRetryClean,
+						gitErrorFetchBadObject:
 					// Otherwise, don't clean the checkout dir
 					default:
 						return err


### PR DESCRIPTION
On the theory that mirrors sometimes have objects gc-ed that are still referred to by existing checkout directories, make `fatal: bad object` an error that we can try to recover from by deleting the checkout directory and re-cloning.

I made `gitErrorFetchBadObject` its own enum value, in case we want to apply the recovery only when git mirrors are enabled.

cc #2208