### PR TITLE
Allow empty steps

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,7 +1,6 @@
 package pipeline
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/buildkite/agent/v3/env"
@@ -10,9 +9,6 @@ import (
 	"github.com/buildkite/interpolate"
 	"gopkg.in/yaml.v3"
 )
-
-// Returned when a pipeline has no steps.
-var ErrNoSteps = errors.New("pipeline has no steps")
 
 // Pipeline models a pipeline.
 //
@@ -56,9 +52,6 @@ func (p *Pipeline) UnmarshalYAML(n *yaml.Node) error {
 		var q pipelineWrapper
 		if err := n.Decode(&q); err != nil {
 			return err
-		}
-		if len(q.Steps) == 0 {
-			return ErrNoSteps
 		}
 		*p = Pipeline(q)
 

--- a/internal/pipeline/steps.go
+++ b/internal/pipeline/steps.go
@@ -18,9 +18,6 @@ func (s *Steps) UnmarshalYAML(n *yaml.Node) error {
 	if n.Kind != yaml.SequenceNode {
 		return fmt.Errorf("line %d, col %d: wrong node kind %v for step sequence", n.Line, n.Column, n.Kind)
 	}
-	if len(n.Content) == 0 {
-		return fmt.Errorf("line %d, col %d: %w", n.Line, n.Column, ErrNoSteps)
-	}
 
 	seen := make(map[*yaml.Node]bool)
 	for _, c := range n.Content {


### PR DESCRIPTION
Some (usually automatically-produced) pipelines have no steps. Previously we didn't error on this case, but while changing the pipeline parser I added these checks. There's no reason for the agent to care about it, so remove the check.