### PR TITLE
Fix missing group key

### DIFF
--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -182,13 +182,5 @@ func (GroupStep) stepTag() {}
 // MarshalJSON marshals the step to JSON. Special handling is needed because
 // yaml.v3 has "inline" but encoding/json has no concept of it.
 func (g *GroupStep) MarshalJSON() ([]byte, error) {
-	out := map[string]any{
-		"steps": g.Steps,
-	}
-	for k, v := range g.RemainingFields {
-		if v != nil {
-			out[k] = v
-		}
-	}
-	return json.Marshal(out)
+	return inlineFriendlyMarshalJSON(g)
 }

--- a/internal/pipeline/steps.go
+++ b/internal/pipeline/steps.go
@@ -18,7 +18,10 @@ func (s *Steps) UnmarshalYAML(n *yaml.Node) error {
 	if n.Kind != yaml.SequenceNode {
 		return fmt.Errorf("line %d, col %d: wrong node kind %v for step sequence", n.Line, n.Column, n.Kind)
 	}
-
+	// Preallocate slice
+	if len(*s) == 0 && len(n.Content) > 0 {
+		*s = make(Steps, 0, len(n.Content))
+	}
 	seen := make(map[*yaml.Node]bool)
 	for _, c := range n.Content {
 		step, err := unmarshalStep(seen, c)


### PR DESCRIPTION
"group" was in `RemainingFields`, but is written in YAML with no value, which is parsed as null, represented as nil, but `GroupStep.MarshalJSON` filtered out nil values. 

We have better technology: `inlineFriendlyMarshalJSON`.

This also adds a test for empty steps.