### PR TITLE
Fix an error where exit status wasn't getting captured by the cleanup process

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -576,7 +576,7 @@ func (r *JobRunner) startJob(ctx context.Context, startedAt time.Time) error {
 
 // finishJob finishes the job in the Buildkite Agent API. If the FinishJob call
 // cannot return successfully, this will retry for a long time.
-func (r *JobRunner) finishJob(ctx context.Context, finishedAt time.Time, exit *processExit, failedChunkCount int) error {
+func (r *JobRunner) finishJob(ctx context.Context, finishedAt time.Time, exit processExit, failedChunkCount int) error {
 	r.conf.Job.FinishedAt = finishedAt.UTC().Format(time.RFC3339Nano)
 	r.conf.Job.ExitStatus = strconv.Itoa(exit.Status)
 	r.conf.Job.Signal = exit.Signal


### PR DESCRIPTION
tl;dr before:
```Go
defer cancel()
defer r.cleanup(cctx, &wg, exit)
```
after:
```Go
defer func(ctx context.Context, wg *sync.WaitGroup) {
	cancel()
	r.cleanup(ctx, wg, exit)
}(ctx, &wg)
```

previously we were capturing the value of `exit` at the time of the call to `defer`, now we're capturing the value at the time the defer is actually executed, which is what we wanted in the first place.

this PR also adds a regression test to ensure that this doesn't happen again