### PR TITLE
Fix parsing an interval as another interval

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -697,7 +697,7 @@ func (r *JobRunner) jobCancellationChecker(ctx context.Context, wg *sync.WaitGro
 
 		// Sleep for a bit, or until the job is finished
 		select {
-		case <-time.After(time.Duration(r.conf.JobStatusInterval) * time.Second):
+		case <-time.After(r.conf.JobStatusInterval):
 		case <-ctx.Done():
 			return
 		case <-r.process.Done():


### PR DESCRIPTION
`JobStatusInterval` is already a duration. Casting it to a duration again is a no-op. However, multiplying it by `time.Second` is not.

This is because the `time.Duration` type is an alias for `int64` and represents nanoseconds. `time.Second` is therefore a constant `1_000_000_000`. Thus, multiplying `JobStatusInterval` by `time.Second` makes it a billion times longer.

See https://go.dev/play/p/PNlEW_b-8YF