### PR TITLE
Remove installing qemu-binfmt from agent pipeline

### DIFF
--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -21,13 +21,13 @@ codename="${3:-}"
 version="${4:-}"
 push="${PUSH_IMAGE:-true}"
 
-if [[ ! "$variant" =~ ^(alpine|alpine-k8s|ubuntu-18\.04|ubuntu-20\.04|ubuntu-22\.04|sidecar)$ ]] ; then
+if [[ ! "$variant" =~ ^(alpine|alpine-k8s|ubuntu-18\.04|ubuntu-20\.04|ubuntu-22\.04|sidecar)$ ]]; then
   echo "Unknown docker variant $variant"
   exit 1
 fi
 
 # Disable pushing if run manually
-if [[ -n "$image_tag" ]] ; then
+if [[ -n "$image_tag" ]]; then
   push="false"
 fi
 
@@ -36,11 +36,11 @@ packaging_dir="packaging/docker/$variant"
 rm -rf pkg
 mkdir -p pkg
 
-echo "--- Building"
+echo "--- Building :docker: image for $variant"
 
-for arch in amd64 arm64 ; do
-  if [[ -z "$version" ]] ; then
-    echo '--- Downloading :linux: binaries from artifacts'
+for arch in amd64 arm64; do
+  if [[ -z "$version" ]]; then
+    echo --- Downloading :linux: binaries from artifacts
     buildkite-agent artifact download "pkg/buildkite-agent-linux-$arch" .
   else
     echo "--- Downloading :linux: binaries for version $version and architecture $arch"
@@ -50,7 +50,7 @@ for arch in amd64 arm64 ; do
   chmod +x "pkg/buildkite-agent-linux-$arch"
 done
 
-if [[ -z "$image_tag" ]] ; then
+if [[ -z "$image_tag" ]]; then
   echo "--- Getting docker image tag for $variant from build meta data"
   image_tag=$(buildkite-agent meta-data get "agent-docker-image-$variant")
   echo "Docker Image Tag for $variant: $image_tag"
@@ -60,50 +60,12 @@ builder_name=$(docker buildx create --use)
 # shellcheck disable=SC2064 # we want the current $builder_name to be trapped, not the runtime one
 trap "docker buildx rm $builder_name || true" EXIT
 
-# There isn't a good way to see if this script has already installed qemu-binfmt.
-# So we uninstall and install it each time. This would create a race condition between the
-# uninstall, install, and image building if multiple agents are running on an agent's host.
-#
-# Thus, we use flock(1) to hold an exclusive lock while any of these are happening.
-# The syntax is a bit arcane, but the jist is:
-# ```bash
-# (
-#   flock -x "$variable"
-#
-#   ...commands to run under lock...
-#
-# ) {variable}>filename
-# ```
-# The parens run the commands in a subshell. In the subshell, flock(1) is executed with a file
-# descriptor number. This will wait for the lock. The lock will be released by the kernel when the
-# subshell exits (and the file descriptor is closed).
-# See https://linux.die.net/man/1/flock, in particular the "third form".
-#
-# The curly braces are an automatic file descriptor allocation introduced in bash 4.1.
-# See https://wiki.bash-hackers.org/scripting/bashchanges
-# Finally, the file with the path `filename` in the filesystem is opened with that file descriptor.
-LOCKFILE_NAME=/tmp/install-qemu-binfmt.lock
-(
-  flock -x "$file_descriptor"
-
-  # Need a more recent version of QEMU than what's on the host for building multiarch images.
-  # See https://github.com/docker/buildx/issues/314
-  QEMU_VERSION=6.2.0
-  echo "--- Installing QEMU $QEMU_VERSION"
-  docker run --privileged --userns=host --rm "tonistiigi/binfmt:qemu-v$QEMU_VERSION" --uninstall qemu-*
-  docker run --privileged --userns=host --rm "tonistiigi/binfmt:qemu-v$QEMU_VERSION" --install all
-) {file_descriptor}>"$LOCKFILE_NAME"
-
-echo "--- Copying files into build context"
+echo --- Copying files into build context
 cp -a packaging/linux/root/usr/share/buildkite-agent/hooks/ "${packaging_dir}/hooks/"
 cp pkg/buildkite-agent-linux-{amd64,arm64} "$packaging_dir"
 
-(
-  flock -x "$file_descriptor"
-
-  echo "--- Building :docker: $image_tag for all architectures"
-  docker buildx build --progress plain --builder "$builder_name" --platform linux/amd64,linux/arm64 "$packaging_dir"
-) {file_descriptor}>"$LOCKFILE_NAME"
+echo "--- Building :docker: $image_tag for all architectures"
+docker buildx build --progress plain --builder "$builder_name" --platform linux/amd64,linux/arm64 "$packaging_dir"
 
 # Tag images for just the native architecture. There is a limitation in docker that prevents this
 # from being done in one command. Luckliy the second build will be quick because of docker layer caching
@@ -114,20 +76,16 @@ docker buildx build --progress plain --builder "$builder_name" --tag "$image_tag
 .buildkite/steps/test-docker-image.sh "$variant" "$image_tag" "$(uname -m)"
 
 if [[ $push == "true" ]]; then
-  (
-    flock -x "$file_descriptor"
-
-    echo "--- Pushing to ECR :ecr:"
-    # Do another build with all architectures. The layers should be cached from the previous build
-    # with all architectures.
-    # Pushing to the docker registry in this way greatly simplifies creating the manifest list on
-    # the docker registry so that either architecture can be pulled with the same tag.
-    docker buildx build \
-      --progress plain \
-      --builder "$builder_name" \
-      --tag "$image_tag" \
-      --platform linux/amd64,linux/arm64 \
-      --push \
-      "$packaging_dir"
-  ) {file_descriptor}>"$LOCKFILE_NAME"
+  echo --- :ecr: Pushing to ECR
+  # Do another build with all architectures. The layers should be cached from the previous build
+  # with all architectures.
+  # Pushing to the docker registry in this way greatly simplifies creating the manifest list on
+  # the docker registry so that either architecture can be pulled with the same tag.
+  docker buildx build \
+    --progress plain \
+    --builder "$builder_name" \
+    --tag "$image_tag" \
+    --platform linux/amd64,linux/arm64 \
+    --push \
+    "$packaging_dir"
 fi


### PR DESCRIPTION
It's baked into v6 of the Elastic CI Stack that the builders are now dogfooding