### PR TITLE
Two-phase pipeline parsing

### DIFF
--- a/internal/ordered/slice.go
+++ b/internal/ordered/slice.go
@@ -20,7 +20,7 @@ func (s *Slice) UnmarshalYAML(n *yaml.Node) error {
 	}
 	seen := make(map[*yaml.Node]bool)
 	for _, c := range n.Content {
-		cv, err := decode(seen, c)
+		cv, err := decodeYAML(seen, c)
 		if err != nil {
 			return err
 		}

--- a/internal/pipeline/parser_test.go
+++ b/internal/pipeline/parser_test.go
@@ -158,6 +158,7 @@ steps:
 }
 
 func TestParserSupportsDoubleMerge(t *testing.T) {
+	t.Parallel()
 	const complexYAML = `---
 base_step: &base_step
   type: script

--- a/internal/pipeline/plugins.go
+++ b/internal/pipeline/plugins.go
@@ -4,57 +4,51 @@ import (
 	"fmt"
 
 	"github.com/buildkite/agent/v3/internal/ordered"
-	"gopkg.in/yaml.v3"
 )
-
-var _ yaml.Unmarshaler = (*Plugins)(nil)
 
 // Plugins is a sequence of plugins. It is useful for unmarshaling.
 type Plugins []*Plugin
 
-// UnmarshalYAML unmarshals Plugins from either
-//   - a sequence of "one-item mappings" (normal form), or
-//   - a mapping (where order is important...non-normal form).
+// unmarshalAny unmarshals Plugins from either
+//   - []any - originally a sequence of "one-item mappings" (normal form), or
+//   - *ordered.MapSA - a mapping (where order is important...non-normal form).
 //
 // "plugins" is supposed to be a sequence of one-item maps, since order matters.
 // But some people (even us) write plugins into one big mapping and rely on
 // order preservation.
-func (p *Plugins) UnmarshalYAML(n *yaml.Node) error {
+func (p *Plugins) unmarshalAny(o any) error {
 	// Whether processing one big map, or a sequence of small maps, the central
 	// part remains the same.
 	// Parse each "key: value" as "name: config", then append in order.
-	unmarshalMap := func(n *yaml.Node) error {
-		plugin := ordered.NewMap[string, *ordered.MapSA](len(n.Content) / 2)
-		if err := n.Decode(plugin); err != nil {
-			return err
-		}
-		return plugin.Range(func(name string, cfg *ordered.MapSA) error {
+	unmarshalMap := func(m *ordered.MapSA) error {
+		return m.Range(func(k string, v any) error {
 			*p = append(*p, &Plugin{
-				Name:   name,
-				Config: cfg,
+				Name:   k,
+				Config: v,
 			})
 			return nil
 		})
 	}
 
-	switch n.Kind {
-	case yaml.AliasNode:
-		return p.UnmarshalYAML(n.Alias)
-
-	case yaml.SequenceNode:
-		for _, c := range n.Content {
-			if err := unmarshalMap(c); err != nil {
+	switch o := o.(type) {
+	case []any:
+		for _, c := range o {
+			m, ok := c.(*ordered.MapSA)
+			if !ok {
+				return fmt.Errorf("unmarshaling plugins: plugin type %T, want *ordered.Map[string, any]", c)
+			}
+			if err := unmarshalMap(m); err != nil {
 				return err
 			}
 		}
 
-	case yaml.MappingNode:
-		if err := unmarshalMap(n); err != nil {
+	case *ordered.MapSA:
+		if err := unmarshalMap(o); err != nil {
 			return err
 		}
 
 	default:
-		return fmt.Errorf("line %d, col %d: unsupported YAML node kind %x for Plugins", n.Line, n.Column, n.Kind)
+		return fmt.Errorf("unmarshaling plugins: got %T, want []any or *ordered.Map[string, any]", o)
 
 	}
 	return nil

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/buildkite/agent/v3/internal/ordered"
 	"github.com/buildkite/interpolate"
-	"gopkg.in/yaml.v3"
 )
 
 var _ SignedFielder = (*CommandStep)(nil)
@@ -21,6 +20,11 @@ var _ SignedFielder = (*CommandStep)(nil)
 // - GroupStep
 type Step interface {
 	stepTag() // allow only the step types below
+
+	// unmarshalStep is responsible for choosing the right kind of step to
+	// unmarshal, but it uses the map representation to figure this out.
+	// So we can assume *ordered.MapSA input for unmarshaling.
+	unmarshalMap(*ordered.MapSA) error
 
 	selfInterpolater
 }
@@ -44,35 +48,58 @@ func (c *CommandStep) MarshalJSON() ([]byte, error) {
 	return inlineFriendlyMarshalJSON(c)
 }
 
-// UnmarshalYAML unmarshals the command step. Special handling is needed to
-// normalise the input (e.g. changing "commands" to "command").
-func (c *CommandStep) UnmarshalYAML(n *yaml.Node) error {
-	// Unmarshal into this secret type, then normalise.
-	var full struct {
-		// "command" and "commands" are two ways to spell the same thing.
-		// They can both be single strings, or sequences of strings.
-		Command   ordered.Strings `yaml:"command"`
-		Commands  ordered.Strings `yaml:"commands"`
-		Plugins   Plugins         `yaml:"plugins"`
-		Signature *Signature      `yaml:"signature"`
+// unmarshalMap unmarshals a command step from an ordered map.
+func (c *CommandStep) unmarshalMap(m *ordered.MapSA) error {
+	return m.Range(func(k string, v any) error {
+		switch k {
+		case "command", "commands":
+			// command and commands are aliases for the same thing, which can be
+			// either one big string or a sequence of strings.
+			// So we need to act as though we are unmarshaling either string or
+			// []string (but with type []any).
+			switch x := v.(type) {
+			case []any:
+				cmds := make([]string, 0, len(x))
+				for _, cx := range x {
+					cmds = append(cmds, fmt.Sprint(cx))
+				}
+				// Normalise cmds into one single command string.
+				// This makes signing easier later on - it's easier to hash one
+				// string consistently than it is to pick apart multiple strings
+				// in a consistent way in order to hash all of them
+				// consistently.
+				c.Command = strings.Join(cmds, "\n")
 
-		RemainingFields map[string]any `yaml:",inline"`
-	}
-	if err := n.Decode(&full); err != nil {
-		return err
-	}
+			case string:
+				c.Command = x
 
-	// Normalise command and commands into one single command string.
-	// This makes signing easier later on - it's easier to hash one string
-	// consistently than it is to pick apart multiple strings in a consistent
-	// way in order to hash all of them consistently.
-	c.Command = strings.Join(append(full.Command, full.Commands...), "\n")
+			default:
+				// Some weird-looking command that's not a string...
+				c.Command = fmt.Sprint(x)
+			}
 
-	// Copy remaining fields.
-	c.Plugins = full.Plugins
-	c.Signature = full.Signature
-	c.RemainingFields = full.RemainingFields
-	return nil
+		case "plugins":
+			if err := c.Plugins.unmarshalAny(v); err != nil {
+				return fmt.Errorf("unmarshaling plugins: %w", err)
+			}
+
+		case "signature":
+			sig := new(Signature)
+			if err := sig.unmarshalAny(v); err != nil {
+				return fmt.Errorf("unmarshaling signature: %w", err)
+			}
+			c.Signature = sig
+
+		default:
+			// Preserve any other key.
+			if c.RemainingFields == nil {
+				c.RemainingFields = make(map[string]any)
+			}
+			c.RemainingFields[k] = v
+		}
+
+		return nil
+	})
 }
 
 // SignedFields returns the default fields for signing.
@@ -135,6 +162,13 @@ func (s WaitStep) interpolate(env interpolate.Env) error {
 	return interpolateMap(env, s)
 }
 
+func (s WaitStep) unmarshalMap(m *ordered.MapSA) error {
+	return m.Range(func(k string, v any) error {
+		s[k] = v
+		return nil
+	})
+}
+
 func (WaitStep) stepTag() {}
 
 // InputStep models a block or input step.
@@ -144,6 +178,13 @@ type InputStep map[string]any
 
 func (s InputStep) interpolate(env interpolate.Env) error {
 	return interpolateMap(env, s)
+}
+
+func (s InputStep) unmarshalMap(m *ordered.MapSA) error {
+	return m.Range(func(k string, v any) error {
+		s[k] = v
+		return nil
+	})
 }
 
 func (InputStep) stepTag() {}
@@ -157,12 +198,23 @@ func (s TriggerStep) interpolate(env interpolate.Env) error {
 	return interpolateMap(env, s)
 }
 
+func (s TriggerStep) unmarshalMap(m *ordered.MapSA) error {
+	return m.Range(func(k string, v any) error {
+		s[k] = v
+		return nil
+	})
+}
+
 func (TriggerStep) stepTag() {}
 
 // GroupStep models a group step.
 //
 // Standard caveats apply - see the package comment.
 type GroupStep struct {
+	// Group is typically a key with no value. Since it must always exist in
+	// a group step, here it is.
+	Group any `yaml:"group"`
+
 	Steps Steps `yaml:"steps"`
 
 	// RemainingFields stores any other top-level mapping items so they at least
@@ -170,31 +222,43 @@ type GroupStep struct {
 	RemainingFields map[string]any `yaml:",inline"`
 }
 
-// UnmarshalYAML unmarshals n into a group step. This is needed because yaml.v3
-// likes to normalise empty slices into nil, but we want Steps to be Steps{}
-// when empty.
-func (s *GroupStep) UnmarshalYAML(n *yaml.Node) error {
-	// Decode into this secret wrapper (to avoid infinite recursion), then copy
-	// the contents
-	type groupStepWrapper GroupStep
-	var t groupStepWrapper
-	if err := n.Decode(&t); err != nil {
+// unmarshalMap unmarshals a group step from an ordered map.
+func (g *GroupStep) unmarshalMap(m *ordered.MapSA) error {
+	err := m.Range(func(k string, v any) error {
+		switch k {
+		case "group":
+			g.Group = v
+
+		case "steps":
+			if err := g.Steps.unmarshalAny(v); err != nil {
+				return fmt.Errorf("unmarshaling steps: %v", err)
+			}
+
+		default:
+			// Preserve any other key.
+			if g.RemainingFields == nil {
+				g.RemainingFields = make(map[string]any)
+			}
+			g.RemainingFields[k] = v
+		}
+		return nil
+	})
+	if err != nil {
 		return err
 	}
-	*s = GroupStep(t)
 
 	// Ensure Steps is never nil. Server side expects a sequence.
-	if s.Steps == nil {
-		s.Steps = Steps{}
+	if g.Steps == nil {
+		g.Steps = Steps{}
 	}
 	return nil
 }
 
-func (s *GroupStep) interpolate(env interpolate.Env) error {
-	if err := s.Steps.interpolate(env); err != nil {
+func (g *GroupStep) interpolate(env interpolate.Env) error {
+	if err := g.Steps.interpolate(env); err != nil {
 		return err
 	}
-	return interpolateMap(env, s.RemainingFields)
+	return interpolateMap(env, g.RemainingFields)
 }
 
 func (GroupStep) stepTag() {}


### PR DESCRIPTION
There's a bug where multiple [map merges](https://yaml.org/type/merge.html) aren't unmarshaled into structs in the way we've supported them.

To address this we need to go back to having greater control over the YAML unmarshaling process. It will also help if we, say, want to switch YAML library later on - if a new library supports the things we need to do, then we can simplify, and if it doesn't (or has subtle differences) then the intermediate processing can be the place where we make up the gap.

The key change here is from allowing `yaml.v3` to unmarshal into structs using its reflective logic to:

- Use yaml.v3 to parse into `*yaml.Node`, which provides all the relevant information in the document without further processing.
- Unmarshal that node using `ordered`, which handles merges and aliases (including multiple merges).
- Unmarshal the dynamic, weakly-typed structure made up of `*ordered.MapSA`, `[]any`, and basic types into each struct manually.

The last manual part could be converted into a `yaml.v3`-like or `encoding/json`-like reflection-based approach at some point.
