### PR TITLE
Remove docker-compose v1 from ubuntu 22.04 and replace with compatibility script

### DIFF
--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -63,6 +63,7 @@ trap "docker buildx rm $builder_name || true" EXIT
 echo --- Copying files into build context
 cp -a packaging/linux/root/usr/share/buildkite-agent/hooks/ "${packaging_dir}/hooks/"
 cp pkg/buildkite-agent-linux-{amd64,arm64} "$packaging_dir"
+cp packaging/docker/common/docker-compose "$packaging_dir"
 
 echo "--- Building :docker: $image_tag for all architectures"
 docker buildx build --progress plain --builder "$builder_name" --platform linux/amd64,linux/arm64 "$packaging_dir"

--- a/packaging/.gitignore
+++ b/packaging/.gitignore
@@ -1,1 +1,3 @@
 buildkite-agent-*
+docker-compose
+!common/**/*

--- a/packaging/docker/alpine-k8s/Dockerfile
+++ b/packaging/docker/alpine-k8s/Dockerfile
@@ -20,7 +20,7 @@ RUN apk update && apk add --no-cache \
     tini \
     tzdata
 
-RUN ln -sf /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
+COPY docker-compose /usr/local/bin/docker-compose
 
 FROM alpine:3.18.2 AS kubectl-downloader
 ARG TARGETOS

--- a/packaging/docker/alpine/Dockerfile
+++ b/packaging/docker/alpine/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add --no-cache \
     tini \
     tzdata
 
-RUN ln -sf /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
+COPY docker-compose /usr/local/bin/docker-compose
 
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg
 

--- a/packaging/docker/common/docker-compose
+++ b/packaging/docker/common/docker-compose
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+# Prepends the --compatibility flag to arguments to docker compose if not present
+
+set -eu
+
+has_compatibility_flag=false
+
+for arg in "$@"; do
+  if [ "$arg" = "--compatibility" ]; then
+    has_compatibility_flag=true
+    break
+  fi
+done
+
+if ! $has_compatibility_flag; then
+  set -- "--compatibility" "$@"
+fi
+
+exec docker compose "$@"

--- a/packaging/docker/ubuntu-22.04/Dockerfile
+++ b/packaging/docker/ubuntu-22.04/Dockerfile
@@ -5,8 +5,6 @@ FROM ubuntu:22.04
 ARG TARGETOS
 ARG TARGETARCH
 
-ARG DOCKER_COMPOSE_VERSION=1.27.4
-
 RUN <<BASH
 #!/usr/bin/env bash
 
@@ -37,9 +35,6 @@ apt-get update
 apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin docker-buildx-plugin
 rm -rf /var/lib/apt/lists/*
 
-echo "pyyaml!=6.0.0,!=5.4.0,!=5.4.1" > ./pip-constraints # pyyaml is broken with cython 3, see: https://github.com/yaml/pyyaml/issues/724
-pip3 install --constraint ./pip-constraints docker-compose==$DOCKER_COMPOSE_VERSION
-
 ln -s /usr/bin/tini /usr/sbin/tini
 
 mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins
@@ -50,6 +45,7 @@ BASH
 ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \
   PATH="/usr/local/bin:${PATH}"
 
+COPY ./docker-compose /usr/local/bin/docker-compose
 COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
 COPY ./buildkite-agent-$TARGETOS-$TARGETARCH /usr/local/bin/buildkite-agent
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint


### PR DESCRIPTION
Docker Compose V1 is very much deprecated. We don't offer it on the latest major version of the Elastic CI Stack (v6) and on the alpine docker images, we have been symlinking it to docker-compose v2.

This PR removes docker-compose v1 from the ubuntu 22.04 docker image and replaces it with the compatibility script that calls docker compose v2 with the `--compatbility` flag prepended to the arguments.
Also, it replaces the symlink in the alpine docker images with that script.

Fixes: \#2232
Closes: \#2241