### PR TITLE
Make the the agent send a SIGTERM (configurable) before a SIGKILL to subprocesses

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -1,5 +1,7 @@
 package agent
 
+import "time"
+
 // AgentConfiguration is the run-time configuration for an agent that
 // has been loaded from the config file and command-line params
 type AgentConfiguration struct {
@@ -30,6 +32,7 @@ type AgentConfiguration struct {
 	DisconnectAfterJob         bool
 	DisconnectAfterIdleTimeout int
 	CancelGracePeriod          int
+	SignalGracePeriod          time.Duration
 	EnableJobLogTmpfile        bool
 	JobLogPath                 string
 	WriteJobLogsToStdout       bool

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -29,6 +29,10 @@ type AgentWorkerConfig struct {
 	// What signal to use for worker cancellation
 	CancelSignal process.Signal
 
+	// Time wait between sending the CancelSignal and SIGKILL to the process
+	// groups that the executor starts
+	SignalGracePeriod time.Duration
+
 	// The index of this agent worker
 	SpawnIndex int
 

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -329,14 +329,15 @@ func NewJobRunner(l logger.Logger, apiClient APIClient, conf JobRunnerConfig) (j
 		}
 
 		r.process = process.New(r.logger, process.Config{
-			Path:            cmd[0],
-			Args:            cmd[1:],
-			Dir:             conf.AgentConfiguration.BuildPath,
-			Env:             processEnv,
-			PTY:             conf.AgentConfiguration.RunInPty,
-			Stdout:          processWriter,
-			Stderr:          processWriter,
-			InterruptSignal: conf.CancelSignal,
+			Path:              cmd[0],
+			Args:              cmd[1:],
+			Dir:               conf.AgentConfiguration.BuildPath,
+			Env:               processEnv,
+			PTY:               conf.AgentConfiguration.RunInPty,
+			Stdout:            processWriter,
+			Stderr:            processWriter,
+			InterruptSignal:   conf.CancelSignal,
+			SignalGracePeriod: conf.AgentConfiguration.SignalGracePeriod,
 		})
 	}
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -953,8 +953,8 @@ var AgentStartCommand = cli.Command{
 			}
 
 			// Create an agent worker to run the agent
-			workers = append(workers, agent.NewAgentWorker(l.WithFields(
-				logger.StringField("agent", ag.Name)),
+			workers = append(workers, agent.NewAgentWorker(
+				l.WithFields(logger.StringField("agent", ag.Name)),
 				ag,
 				mc,
 				client,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -117,6 +117,7 @@ type AgentStartConfig struct {
 	SpawnWithPriority           bool     `cli:"spawn-with-priority"`
 	LogFormat                   string   `cli:"log-format"`
 	CancelSignal                string   `cli:"cancel-signal"`
+	SignalGracePeriodSeconds    int      `cli:"signal-grace-period-seconds"`
 	RedactedVars                []string `cli:"redacted-vars" normalize:"list"`
 
 	// Global flags
@@ -278,12 +279,7 @@ var AgentStartCommand = cli.Command{
 			Usage:  "The maximum idle time in seconds to wait for a job before disconnecting. The default of 0 means no timeout",
 			EnvVar: "BUILDKITE_AGENT_DISCONNECT_AFTER_IDLE_TIMEOUT",
 		},
-		cli.IntFlag{
-			Name:   "cancel-grace-period",
-			Value:  10,
-			Usage:  "The number of seconds a canceled or timed out job is given to gracefully terminate and upload its artifacts",
-			EnvVar: "BUILDKITE_CANCEL_GRACE_PERIOD",
-		},
+		cancelGracePeriodFlag,
 		cli.BoolFlag{
 			Name:   "enable-job-log-tmpfile",
 			Usage:  "Store the job logs in a temporary file ′BUILDKITE_JOB_LOG_TMPFILE′ that is accessible during the job and removed at the end of the job",
@@ -548,12 +544,8 @@ var AgentStartCommand = cli.Command{
 			Usage:  "Assign priorities to every spawned agent (when using --spawn) equal to the agent's index",
 			EnvVar: "BUILDKITE_AGENT_SPAWN_WITH_PRIORITY",
 		},
-		cli.StringFlag{
-			Name:   "cancel-signal",
-			Usage:  "The signal to use for cancellation",
-			EnvVar: "BUILDKITE_CANCEL_SIGNAL",
-			Value:  "SIGTERM",
-		},
+		cancelSignalFlag,
+		signalGracePeriodSecondsFlag,
 		cli.StringFlag{
 			Name:   "tracing-backend",
 			Usage:  `Enable tracing for build jobs by specifying a backend, "datadog" or "opentelemetry"`,
@@ -756,6 +748,12 @@ var AgentStartCommand = cli.Command{
 			}
 		}
 
+		if cfg.CancelGracePeriod <= cfg.SignalGracePeriodSeconds {
+			l.Fatal("cancel-grace-period must be greater than signal-grace-period-seconds")
+		}
+
+		signalGracePeriod := time.Duration(cfg.SignalGracePeriodSeconds) * time.Second
+
 		mc := metrics.NewCollector(l, metrics.CollectorConfig{
 			Datadog:              cfg.MetricsDatadog,
 			DatadogHost:          cfg.MetricsDatadogHost,
@@ -799,6 +797,7 @@ var AgentStartCommand = cli.Command{
 			DisconnectAfterJob:         cfg.DisconnectAfterJob,
 			DisconnectAfterIdleTimeout: cfg.DisconnectAfterIdleTimeout,
 			CancelGracePeriod:          cfg.CancelGracePeriod,
+			SignalGracePeriod:          signalGracePeriod,
 			EnableJobLogTmpfile:        cfg.EnableJobLogTmpfile,
 			JobLogPath:                 cfg.JobLogPath,
 			WriteJobLogsToStdout:       cfg.WriteJobLogsToStdout,
@@ -954,16 +953,21 @@ var AgentStartCommand = cli.Command{
 			}
 
 			// Create an agent worker to run the agent
-			workers = append(workers,
-				agent.NewAgentWorker(
-					l.WithFields(logger.StringField("agent", ag.Name)), ag, mc, client, agent.AgentWorkerConfig{
-						AgentConfiguration: agentConf,
-						CancelSignal:       cancelSig,
-						Debug:              cfg.Debug,
-						DebugHTTP:          cfg.DebugHTTP,
-						SpawnIndex:         i,
-						AgentStdout:        os.Stdout,
-					}))
+			workers = append(workers, agent.NewAgentWorker(l.WithFields(
+				logger.StringField("agent", ag.Name)),
+				ag,
+				mc,
+				client,
+				agent.AgentWorkerConfig{
+					AgentConfiguration: agentConf,
+					CancelSignal:       cancelSig,
+					SignalGracePeriod:  signalGracePeriod,
+					Debug:              cfg.Debug,
+					DebugHTTP:          cfg.DebugHTTP,
+					SpawnIndex:         i,
+					AgentStdout:        os.Stdout,
+				},
+			))
 		}
 
 		// Setup the agent pool that spawns agent workers
@@ -1034,7 +1038,7 @@ func handlePoolSignals(ctx context.Context, l logger.Logger, pool *agent.AgentPo
 
 		for sig := range signals {
 			l.Debug("Received signal `%v`", sig)
-			setStatus(fmt.Sprintf("Recieved signal `%v`", sig))
+			setStatus(fmt.Sprintf("Received signal `%v`", sig))
 
 			switch sig {
 			case syscall.SIGQUIT:
@@ -1062,6 +1066,7 @@ func handlePoolSignals(ctx context.Context, l logger.Logger, pool *agent.AgentPo
 func agentStartupHook(log logger.Logger, cfg AgentStartConfig) error {
 	return agentLifecycleHook("agent-startup", log, cfg)
 }
+
 func agentShutdownHook(log logger.Logger, cfg AgentStartConfig) {
 	_ = agentLifecycleHook("agent-shutdown", log, cfg)
 }

--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -1,0 +1,34 @@
+package clicommand
+
+import "github.com/urfave/cli"
+
+const (
+	defaultCancelGracePeriod = 10
+	defaultSignalGracePeriod = 9
+)
+
+var (
+	// cancel grace period must be stricly longer than signal grace period
+	_ uint = defaultCancelGracePeriod - defaultSignalGracePeriod - 1
+
+	cancelGracePeriodFlag = cli.IntFlag{
+		Name:  "cancel-grace-period",
+		Value: defaultCancelGracePeriod,
+		Usage: "The number of seconds a canceled or timed out job is given " +
+			"to gracefully terminate and upload its artifacts",
+		EnvVar: "BUILDKITE_CANCEL_GRACE_PERIOD",
+	}
+	cancelSignalFlag = cli.StringFlag{
+		Name:   "cancel-signal",
+		Usage:  "The signal to use for cancellation",
+		EnvVar: "BUILDKITE_CANCEL_SIGNAL",
+		Value:  "SIGTERM",
+	}
+	signalGracePeriodSecondsFlag = cli.IntFlag{
+		Name: "signal-grace-period-seconds",
+		Usage: "The number of seconds given to a subprocess to handle being sent ′cancel-signal′. " +
+			"After this period has elaspsed, SIGKILL will be sent.",
+		EnvVar: "BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS",
+		Value:  defaultSignalGracePeriod,
+	}
+)

--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -10,7 +10,7 @@ const (
 )
 
 var (
-	// cancel grace period must be stricly longer than signal grace period
+	// cancel grace period must be strictly longer than signal grace period
 	_ uint = defaultCancelGracePeriod - defaultSignalGracePeriod - 1
 
 	cancelGracePeriodFlag = cli.IntFlag{

--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -4,7 +4,9 @@ import "github.com/urfave/cli"
 
 const (
 	defaultCancelGracePeriod = 10
-	defaultSignalGracePeriod = 9
+
+	// This will be increased to 9 in a future release of the agent.
+	defaultSignalGracePeriod = 0
 )
 
 var (

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -1,10 +1,10 @@
 package job
 
 import (
+	"log"
 	"reflect"
 	"strconv"
-
-	"log"
+	"time"
 
 	"github.com/buildkite/agent/v3/env"
 	"github.com/buildkite/agent/v3/process"
@@ -148,6 +148,10 @@ type ExecutorConfig struct {
 
 	// What signal to use for command cancellation
 	CancelSignal process.Signal
+
+	// Amount of time to wait between sending the CancelSignal and SIGKILL to the process groups
+	// that the executor starts. The subprocesses should use this time to clean up after themselves.
+	SignalGracePeriod time.Duration
 
 	// List of environment variable globs to redact from job output
 	RedactedVars []string

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -80,6 +80,7 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 		e.shell.PTY = e.ExecutorConfig.RunInPty
 		e.shell.Debug = e.ExecutorConfig.Debug
 		e.shell.InterruptSignal = e.ExecutorConfig.CancelSignal
+		e.shell.SignalGracePeriod = e.ExecutorConfig.SignalGracePeriod
 	}
 	if experiments.IsEnabled(experiments.KubernetesExec) {
 		kubernetesClient := &kubernetes.Client{}

--- a/process/main_test.go
+++ b/process/main_test.go
@@ -1,0 +1,86 @@
+package process_test
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent/v3/process"
+)
+
+// Invoked by `go test`, switch between helper and running tests based on env
+func TestMain(m *testing.M) {
+	switch os.Getenv("TEST_MAIN") {
+	case "tester":
+		for _, line := range strings.Split(strings.TrimSuffix(longTestOutput, "\n"), "\n") {
+			fmt.Printf("%s\n", line)
+			time.Sleep(time.Millisecond * 20)
+		}
+		os.Exit(0)
+
+	case "output":
+		fmt.Fprintf(os.Stdout, "llamas1")
+		fmt.Fprintf(os.Stderr, "alpacas1")
+		fmt.Fprintf(os.Stdout, "llamas2")
+		fmt.Fprintf(os.Stderr, "alpacas2")
+		os.Exit(0)
+
+	// don't handle the signals so that we can detect the process was signaled
+	case "tester-no-handler":
+		fmt.Println("Ready")
+		time.Sleep(10 * time.Second)
+		os.Exit(0)
+
+	// takes too long to handle the signals, so will be sigkilled
+	case "tester-slow-handler":
+		signals := make(chan os.Signal, 1)
+		signal.Notify(
+			signals,
+			os.Interrupt,
+			syscall.SIGINT,
+			syscall.SIGTERM,
+		)
+
+		go func() {
+			for s := range signals {
+				fmt.Fprintf(os.Stdout, "received signal: %d", s)
+				time.Sleep(10 * time.Second)
+				os.Exit(0)
+			}
+		}()
+
+		fmt.Println("Ready")
+		time.Sleep(15 * time.Second)
+		os.Exit(0)
+
+	case "tester-signal":
+		signals := make(chan os.Signal, 1)
+		signal.Notify(signals, os.Interrupt,
+			syscall.SIGTERM,
+			syscall.SIGINT,
+		)
+		fmt.Println("Ready")
+		fmt.Printf("SIG %v", <-signals)
+		os.Exit(0)
+
+	case "tester-pgid":
+		pid := syscall.Getpid()
+		pgid, err := process.GetPgid(pid)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if pgid != pid {
+			log.Fatalf("Bad pgid, expected %d, got %d", pid, pgid)
+		}
+		fmt.Printf("pid %d == pgid %d", pid, pgid)
+		os.Exit(0)
+
+	default:
+		os.Exit(m.Run())
+	}
+}

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/agent/v3/process"
@@ -101,8 +102,9 @@ func TestProcessRunsAndSignalsStartedAndStopped(t *testing.T) {
 	var done int32
 
 	p := process.New(logger.Discard, process.Config{
-		Path: os.Args[0],
-		Env:  []string{"TEST_MAIN=tester"},
+		Path:              os.Args[0],
+		Env:               []string{"TEST_MAIN=tester"},
+		SignalGracePeriod: time.Millisecond,
 	})
 
 	var wg sync.WaitGroup
@@ -144,9 +146,10 @@ func TestProcessTerminatesWhenContextDone(t *testing.T) {
 	stdoutr, stdoutw := io.Pipe()
 
 	p := process.New(logger.Discard, process.Config{
-		Path:   os.Args[0],
-		Env:    []string{"TEST_MAIN=tester-no-handler"},
-		Stdout: stdoutw,
+		Path:              os.Args[0],
+		Env:               []string{"TEST_MAIN=tester-no-handler"},
+		Stdout:            stdoutw,
+		SignalGracePeriod: time.Second,
 	})
 
 	go func() {
@@ -185,9 +188,10 @@ func TestProcessWithSlowHandlerKilledWhenContextDone(t *testing.T) {
 	stdoutr, stdoutw := io.Pipe()
 
 	p := process.New(logger.Discard, process.Config{
-		Path:   os.Args[0],
-		Env:    []string{"TEST_MAIN=tester-slow-handler"},
-		Stdout: stdoutw,
+		Path:              os.Args[0],
+		Env:               []string{"TEST_MAIN=tester-slow-handler"},
+		Stdout:            stdoutw,
+		SignalGracePeriod: time.Millisecond,
 	})
 
 	go func() {
@@ -227,9 +231,10 @@ func TestProcessInterrupts(t *testing.T) {
 	stdoutr, stdoutw := io.Pipe()
 
 	p := process.New(logger.Discard, process.Config{
-		Path:   os.Args[0],
-		Env:    []string{"TEST_MAIN=tester-signal"},
-		Stdout: stdoutw,
+		Path:              os.Args[0],
+		Env:               []string{"TEST_MAIN=tester-signal"},
+		Stdout:            stdoutw,
+		SignalGracePeriod: time.Millisecond,
 	})
 
 	go func() {
@@ -267,10 +272,11 @@ func TestProcessInterruptsWithCustomSignal(t *testing.T) {
 	stdoutr, stdoutw := io.Pipe()
 
 	p := process.New(logger.Discard, process.Config{
-		Path:            os.Args[0],
-		Env:             []string{"TEST_MAIN=tester-signal"},
-		Stdout:          stdoutw,
-		InterruptSignal: process.SIGINT,
+		Path:              os.Args[0],
+		Env:               []string{"TEST_MAIN=tester-signal"},
+		Stdout:            stdoutw,
+		InterruptSignal:   process.SIGINT,
+		SignalGracePeriod: time.Millisecond,
 	})
 
 	go func() {

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -3,18 +3,14 @@ package process_test
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
-	"log"
 	"os"
-	"os/signal"
 	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
 	"testing"
-	"time"
 
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/agent/v3/process"
@@ -139,7 +135,7 @@ func TestProcessRunsAndSignalsStartedAndStopped(t *testing.T) {
 	assertProcessDoesntExist(t, p)
 }
 
-func TestProcessTerminatesWhenContextDoes(t *testing.T) {
+func TestProcessTerminatesWhenContextDone(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -149,7 +145,7 @@ func TestProcessTerminatesWhenContextDoes(t *testing.T) {
 
 	p := process.New(logger.Discard, process.Config{
 		Path:   os.Args[0],
-		Env:    []string{"TEST_MAIN=tester-signal"},
+		Env:    []string{"TEST_MAIN=tester-no-handler"},
 		Stdout: stdoutw,
 	})
 
@@ -165,7 +161,50 @@ func TestProcessTerminatesWhenContextDoes(t *testing.T) {
 	cancel()
 
 	// wait until stdout is closed
-	io.ReadAll(stdoutr)
+	if _, err := io.ReadAll(stdoutr); err != nil {
+		t.Errorf("error reading stdout: %s", err)
+	}
+
+	if runtime.GOOS != "windows" {
+		if got, want := p.WaitStatus().Signaled(), true; got != want {
+			t.Fatalf("p.WaitStatus().Signaled() = %t, want %t", got, want)
+		}
+	}
+
+	<-p.Done()
+
+	assertProcessDoesntExist(t, p)
+}
+
+func TestProcessWithSlowHandlerKilledWhenContextDone(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stdoutr, stdoutw := io.Pipe()
+
+	p := process.New(logger.Discard, process.Config{
+		Path:   os.Args[0],
+		Env:    []string{"TEST_MAIN=tester-slow-handler"},
+		Stdout: stdoutw,
+	})
+
+	go func() {
+		defer stdoutw.Close()
+		if err := p.Run(ctx); err != nil {
+			t.Errorf("p.Run(ctx) = %v", err)
+		}
+	}()
+
+	waitUntilReady(t, stdoutr)
+
+	cancel()
+
+	// wait until stdout is closed
+	if _, err := io.ReadAll(stdoutr); err != nil {
+		t.Errorf("error reading stdout: %s", err)
+	}
 
 	if runtime.GOOS != "windows" {
 		if got, want := p.WaitStatus().Signaled(), true; got != want {
@@ -314,49 +353,5 @@ func waitUntilReady(t *testing.T, stdoutr *io.PipeReader) {
 	}
 	if got := string(buf); got != wantReady {
 		t.Fatalf("io.ReadFull(stdoutr, buf) read %q, want %q", got, wantReady)
-	}
-}
-
-// Invoked by `go test`, switch between helper and running tests based on env
-func TestMain(m *testing.M) {
-	switch os.Getenv("TEST_MAIN") {
-	case "tester":
-		for _, line := range strings.Split(strings.TrimSuffix(longTestOutput, "\n"), "\n") {
-			fmt.Printf("%s\n", line)
-			time.Sleep(time.Millisecond * 20)
-		}
-		os.Exit(0)
-
-	case "output":
-		fmt.Fprintf(os.Stdout, "llamas1")
-		fmt.Fprintf(os.Stderr, "alpacas1")
-		fmt.Fprintf(os.Stdout, "llamas2")
-		fmt.Fprintf(os.Stderr, "alpacas2")
-		os.Exit(0)
-
-	case "tester-signal":
-		signals := make(chan os.Signal, 1)
-		signal.Notify(signals, os.Interrupt,
-			syscall.SIGTERM,
-			syscall.SIGINT,
-		)
-		fmt.Println("Ready")
-		fmt.Printf("SIG %v", <-signals)
-		os.Exit(0)
-
-	case "tester-pgid":
-		pid := syscall.Getpid()
-		pgid, err := process.GetPgid(pid)
-		if err != nil {
-			log.Fatal(err)
-		}
-		if pgid != pid {
-			log.Fatalf("Bad pgid, expected %d, got %d", pid, pgid)
-		}
-		fmt.Printf("pid %d == pgid %d", pid, pgid)
-		os.Exit(0)
-
-	default:
-		os.Exit(m.Run())
 	}
 }


### PR DESCRIPTION
The agent start process already does something similar to the job executor process when it detects that the buildkite job had been cancelled. However, every other process launched by the agent is unceremoniously killed with a SIGKILL when the job is cancelled. This has been causing issues with the checkout directory becoming corrupted if the job is cancelled during checkout.

This PR makes the agent first send a SIGTERM (which is configurable by the `cancel-signal` config option) and give the process a grace period to clean up before sending a SIGKILL. The grace period is also configurable, but it needs to be smaller than the grace period allowed to the job executor by the agent start process. I've tried to avoid confusion between the two - the grace period for the job executor is contained in the setting `cancel-grace-period`, while the grace periods for the sub processes of the job executor is called contained in the setting `signal-grace-period-seconds`. After it is parsed, it is converted to a `time.Duration` and passes around as `SignalGracePeriod`. But it seems inevitable that there will be confusion to the uninitiated. In a better world, `cancel-grace-period` would be `cancel-grace-period-seconds`. In an even better world, we would drop the units and parse them as durations from the config. 

Finally, I have set the default signal grace period to 0s. This effectively makes this PR a no-op. The plan is to dog-food it at a value of 9s on our internal pipelines before making that the default in a future version of the agent.