### PR TITLE
Even More Pipeline Parsing Fixes

### DIFF
--- a/.buildkite/steps/test-go-fmt.sh
+++ b/.buildkite/steps/test-go-fmt.sh
@@ -8,8 +8,12 @@ if [[ $(gofmt -l ./ | head -c 1 | wc -c) != 0 ]]; then
   exit 1
 fi
 
-if [[ $(go mod tidy -v 2> >(wc -c)) != 0 ]]; then # go mod tidy -v outputs to stderr for some reason
+tidy_output=$(go mod tidy -v 2>&1)
+
+if [[ "${#tidy_output}" -gt 0 ]]; then # go mod tidy -v outputs to stderr for some reason
   echo "The go.mod file is out of sync with the source code"
+  echo "Output of \`go mod tidy -v\`:"
+  echo "$tidy_output"
   echo "Please run \`go mod tidy\` locally, and commit the result."
   exit 1
 fi

--- a/internal/pipeline/maybe_scalar_steps.go
+++ b/internal/pipeline/maybe_scalar_steps.go
@@ -1,0 +1,112 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/buildkite/agent/v3/internal/ordered"
+	"github.com/buildkite/interpolate"
+)
+
+// In the buildkite pipeline yaml, some step types (broadly, wait steps, input steps and block steps) can be represented
+// either by a scalar string (ie "wait") or by a mapping with keys and values and such
+//
+// This behaviour is difficult to cleanly model in go, which leads to the somewhat odd structure of the structs defined
+// in this file - each type (WaitStep, InputStep) has a Scalar field which is set to the scalar value if the step was
+// if, during pipeline parsing, the step was represented as a scalar, and is left empty if the step was represented as
+// a mapping. In essence, if one of the fields of these structs is filled, the other should be empty.
+//
+// On the unmarshalling side, the differing types is handled by the steps parser - see the unmarshalStep() function in
+// ./steps.go - it infers the underlying type of the thing it's unmarshalling, and if it's a string, calls NewScalarStep()
+// (below) to create the appropriate struct. If it's a mapping, it creates the appropriate struct directly.
+//
+// On the marshalling side, the MarshalJSON() function on each struct handles the different cases. In general, if the
+// Scalar field is set, it marshals that, otherwise it marshals the other fields.
+//
+// In reading this file, you may have noticed that I mentioned that there are three types of step that can be represented
+// as a scalar, but there are only two structs defined here. This is because the third type, block steps, are represented
+// in exactly the same way as input steps, so they can share the same struct. This is liable to change in the future,
+// as conceptually they're different types, and it makes sense to have them as different types in go as well.
+//
+// Also also! The implementations for WaitStep and InputStep **almost**, but not quite identical. This is due to the behaviour
+// of marshalling an empty struct into into JSON. For WaitStep, it makes sense that the empty &WaitStep{} struct marshals
+// to "wait", but with InputStep, there's no way to tell whether it should be marshalled to "input" or "block", which
+// have very different behaviour on the backend.
+
+var validStepScalars = []string{"wait", "waiter", "block", "input", "manual"}
+
+func NewScalarStep(s string) (Step, error) {
+	switch s {
+	case "wait", "waiter":
+		return &WaitStep{Scalar: s}, nil
+	case "block", "input", "manual":
+		return &InputStep{Scalar: s}, nil
+	default:
+		return nil, fmt.Errorf("unmarshaling step: unsupported scalar step type %q, want one of %v", s, validStepScalars)
+	}
+}
+
+// WaitStep models a wait step.
+//
+// Standard caveats apply - see the package comment.
+type WaitStep struct {
+	Scalar   string         `yaml:"-"`
+	Contents map[string]any `yaml:",inline"`
+}
+
+// MarshalJSON marshals a wait step as "wait" if w is empty, or as the step's scalar if it's set.
+// If scalar is empty, it marshals as the remaining fields
+func (s *WaitStep) MarshalJSON() ([]byte, error) {
+	if s.Scalar != "" {
+		return json.Marshal(s.Scalar)
+	}
+
+	if len(s.Contents) == 0 {
+		return json.Marshal("wait")
+	}
+
+	return json.Marshal(s.Contents)
+}
+
+func (s *WaitStep) interpolate(env interpolate.Env) error {
+	return interpolateMap(env, s.Contents)
+}
+
+func (s *WaitStep) unmarshalMap(m *ordered.MapSA) error {
+	s.Contents = m.ToMap()
+	return nil
+}
+
+func (*WaitStep) stepTag() {}
+
+// InputStep models a block or input step.
+//
+// Standard caveats apply - see the package comment.
+type InputStep struct {
+	Scalar   string         `yaml:"-"`
+	Contents map[string]any `yaml:",inline"`
+}
+
+func (s *InputStep) MarshalJSON() ([]byte, error) {
+	if s.Scalar != "" {
+		return json.Marshal(s.Scalar)
+	}
+
+	if len(s.Contents) == 0 {
+		return []byte{}, errors.New("empty input step")
+	}
+
+	return json.Marshal(s.Contents)
+}
+
+func (s InputStep) interpolate(env interpolate.Env) error {
+	return interpolateMap(env, s.Contents)
+}
+
+func (s *InputStep) unmarshalMap(m *ordered.MapSA) error {
+	s.Contents = m.ToMap()
+	return nil
+}
+
+func (*InputStep) stepTag() {}

--- a/internal/pipeline/parser_test.go
+++ b/internal/pipeline/parser_test.go
@@ -306,14 +306,18 @@ steps:
 
 	want := &Pipeline{
 		Steps: Steps{
-			InputStep{
-				"key":   "hello there",
-				"label": "🤖",
-				"type":  "block",
+			&InputStep{
+				Contents: map[string]any{
+					"key":   "hello there",
+					"label": "🤖",
+					"type":  "block",
+				},
 			},
-			WaitStep{
-				"continue_on_failure": true,
-				"type":                "wait",
+			&WaitStep{
+				Contents: map[string]any{
+					"continue_on_failure": true,
+					"type":                "wait",
+				},
 			},
 		},
 	}
@@ -384,8 +388,8 @@ steps:
 			&GroupStep{
 				Steps: Steps{
 					&CommandStep{Command: `hello "friend"`},
-					ScalarStep("wait"),
-					InputStep{"block": "goodbye"},
+					&WaitStep{Scalar: "wait"},
+					&InputStep{Contents: map[string]any{"block": "goodbye"}},
 				},
 			},
 			&GroupStep{
@@ -444,11 +448,11 @@ steps:
 
 	want := &Pipeline{
 		Steps: Steps{
-			ScalarStep("wait"),
-			ScalarStep("block"),
-			ScalarStep("waiter"),
-			ScalarStep("block"),
-			ScalarStep("input"),
+			&WaitStep{Scalar: "wait"},
+			&InputStep{Scalar: "block"},
+			&WaitStep{Scalar: "waiter"},
+			&InputStep{Scalar: "block"},
+			&InputStep{Scalar: "input"},
 		},
 	}
 
@@ -586,7 +590,7 @@ func TestParserParsesTopLevelSteps(t *testing.T) {
 					"name": "Build",
 				},
 			},
-			ScalarStep("wait"),
+			&WaitStep{Scalar: "wait"},
 		},
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
@@ -694,7 +698,7 @@ func TestParserPreservesNull(t *testing.T) {
 
 	want := &Pipeline{
 		Steps: Steps{
-			WaitStep{"wait": nil, "if": "foo"},
+			&WaitStep{Contents: map[string]any{"wait": nil, "if": "foo"}},
 		},
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
@@ -818,7 +822,7 @@ func TestParserInterpolatesKeysAsWellAsValues(t *testing.T) {
 			ordered.TupleSS{Key: "TEST2", Value: "llamas"},
 		),
 		Steps: Steps{
-			ScalarStep("wait"),
+			&WaitStep{Scalar: "wait"},
 		},
 	}
 	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSS), cmp.Comparer(ordered.EqualSA)); diff != "" {
@@ -1058,9 +1062,11 @@ steps:
 
 	want := &Pipeline{
 		Steps: Steps{
-			WaitStep{
-				"wait": nil,
-				"if":   "build.env(\"ACCOUNT\") =~ /^(foo|bar)$/",
+			&WaitStep{
+				Contents: map[string]any{
+					"wait": nil,
+					"if":   "build.env(\"ACCOUNT\") =~ /^(foo|bar)$/",
+				},
 			},
 		},
 	}

--- a/internal/pipeline/parser_test.go
+++ b/internal/pipeline/parser_test.go
@@ -288,6 +288,41 @@ steps:
 	}
 }
 
+func TestParserCanDetermineStepTypeFromTypeKey(t *testing.T) {
+	const yaml = `---
+steps:
+  - type: "block"
+    key: "hello there"
+    label: "🤖"
+  - type: "wait"
+    continue_on_failure: true
+`
+
+	input := strings.NewReader(yaml)
+	got, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Parse(input) error = %v", err)
+	}
+
+	want := &Pipeline{
+		Steps: Steps{
+			InputStep{
+				"key":   "hello there",
+				"label": "🤖",
+				"type":  "block",
+			},
+			WaitStep{
+				"continue_on_failure": true,
+				"type":                "wait",
+			},
+		},
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("parsed pipeline diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestParserParsesNoSteps(t *testing.T) {
 	tests := []string{
 		"steps: null\n",

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -67,7 +67,7 @@ func (p *Pipeline) unmarshalAny(o any) error {
 	case []any:
 		// A pipeline can be a sequence of steps.
 		if err := p.Steps.unmarshalAny(o); err != nil {
-			fmt.Errorf("unmarshaling steps: %w", err)
+			return fmt.Errorf("unmarshaling steps: %w", err)
 		}
 
 	default:

--- a/internal/pipeline/steps.go
+++ b/internal/pipeline/steps.go
@@ -50,34 +50,77 @@ func unmarshalStep(o any) (Step, error) {
 		return step, nil
 
 	case *ordered.MapSA:
-		var step Step
-		switch {
-		case o.Contains("command") || o.Contains("commands") || o.Contains("plugins"):
-			// NB: Some "command" step are commandless containers that exist
-			// just to run plugins!
-			step = new(CommandStep)
-
-		case o.Contains("wait") || o.Contains("waiter"):
-			step = make(WaitStep)
-
-		case o.Contains("block") || o.Contains("input") || o.Contains("manual"):
-			step = make(InputStep)
-
-		case o.Contains("trigger"):
-			step = make(TriggerStep)
-
-		case o.Contains("group"):
-			step = new(GroupStep)
-
-		default:
-			return nil, fmt.Errorf("unknown step type")
-		}
-
-		// Decode the step (into the right step type).
-		return step, step.unmarshalMap(o)
+		return stepFromMap(o)
 
 	default:
 		return nil, fmt.Errorf("unmarshaling step: unsupported type %T", o)
+	}
+}
+
+func stepFromMap(o *ordered.MapSA) (Step, error) {
+	sType, hasType := o.Get("type")
+
+	var step Step
+	var err error
+	if hasType {
+		sTypeStr, ok := sType.(string)
+		if !ok {
+			return nil, fmt.Errorf("unmarshaling step: step's `type` key was %T (value %v), want string", sType, sType)
+		}
+
+		step, err = stepByType(sTypeStr)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshaling step: %w", err)
+		}
+	} else {
+		step, err = stepByKeyInference(o)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshaling step: %w", err)
+		}
+	}
+
+	// Decode the step (into the right step type).
+	return step, step.unmarshalMap(o)
+}
+
+func stepByType(sType string) (Step, error) {
+	switch sType {
+	case "command", "script":
+		return new(CommandStep), nil
+	case "wait", "waiter":
+		return make(WaitStep), nil
+	case "block", "input", "manual":
+		return make(InputStep), nil
+	case "trigger":
+		return make(TriggerStep), nil
+	case "group": // as far as i know this doesn't happen, but it's here for completeness
+		return new(GroupStep), nil
+	default:
+		return nil, fmt.Errorf("unknown step type %q", sType)
+	}
+}
+
+func stepByKeyInference(o *ordered.MapSA) (Step, error) {
+	switch {
+	case o.Contains("command") || o.Contains("commands") || o.Contains("plugins"):
+		// NB: Some "command" step are commandless containers that exist
+		// just to run plugins!
+		return new(CommandStep), nil
+
+	case o.Contains("wait") || o.Contains("waiter"):
+		return make(WaitStep), nil
+
+	case o.Contains("block") || o.Contains("input") || o.Contains("manual"):
+		return make(InputStep), nil
+
+	case o.Contains("trigger"):
+		return make(TriggerStep), nil
+
+	case o.Contains("group"):
+		return new(GroupStep), nil
+
+	default:
+		return nil, fmt.Errorf("unknown step type")
 	}
 }
 

--- a/internal/pipeline/steps.go
+++ b/internal/pipeline/steps.go
@@ -88,9 +88,9 @@ func stepByType(sType string) (Step, error) {
 	case "command", "script":
 		return new(CommandStep), nil
 	case "wait", "waiter":
-		return make(WaitStep), nil
+		return &WaitStep{Contents: map[string]any{}}, nil
 	case "block", "input", "manual":
-		return make(InputStep), nil
+		return &InputStep{Contents: map[string]any{}}, nil
 	case "trigger":
 		return make(TriggerStep), nil
 	case "group": // as far as i know this doesn't happen, but it's here for completeness
@@ -108,10 +108,10 @@ func stepByKeyInference(o *ordered.MapSA) (Step, error) {
 		return new(CommandStep), nil
 
 	case o.Contains("wait") || o.Contains("waiter"):
-		return make(WaitStep), nil
+		return new(WaitStep), nil
 
 	case o.Contains("block") || o.Contains("input") || o.Contains("manual"):
-		return make(InputStep), nil
+		return new(InputStep), nil
 
 	case o.Contains("trigger"):
 		return make(TriggerStep), nil

--- a/internal/pipeline/steps.go
+++ b/internal/pipeline/steps.go
@@ -43,15 +43,11 @@ func (s Steps) interpolate(env interpolate.Env) error {
 func unmarshalStep(o any) (Step, error) {
 	switch o := o.(type) {
 	case string:
-		// It's just "wait".
-		switch o {
-		case "wait":
-			return WaitStep{}, nil
-
-		default:
-			// ????
-			return nil, fmt.Errorf("invalid step (value = %q)", o)
+		step, err := NewScalarStep(o)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshaling step: %w", err)
 		}
+		return step, nil
 
 	case *ordered.MapSA:
 		var step Step


### PR DESCRIPTION
**This PR:** Fixes two issues in the pipeline parser:
- [x] Block steps represented by a bare string were causing pipeline parsing to fail. Now, they'll be accepted and transformed into the equivalent `{"block": ""}`
- [x] We were only ever inferring step type from attributes (eg. command steps have a command attribute. Turns out, step types can be explicit too (eg. `type: "block"`). We should also support these steps.