### PR TITLE
Add future-proofing UnknownStep type

### DIFF
--- a/internal/pipeline/sign_test.go
+++ b/internal/pipeline/sign_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"hash"
 	"testing"
@@ -146,5 +147,23 @@ func TestVerifyBadSignature(t *testing.T) {
 
 	if err := sig.Verify(cs, verifier); err == nil {
 		t.Errorf("sig.Verify(CommandStep, alpacas) = %v, want non-nil error", err)
+	}
+}
+
+func TestSignUnknownStep(t *testing.T) {
+	steps := Steps{
+		&UnknownStep{
+			Contents: "secret third thing",
+		},
+	}
+
+	const key = "alpacas"
+	signer, err := NewSigner("hmac-sha256", key)
+	if err != nil {
+		t.Errorf("NewSigner(hmac-sha256, alpacas) error = %v", err)
+	}
+
+	if err := steps.sign(signer); !errors.Is(err, errSigningRefusedUnknownStepType) {
+		t.Errorf("steps.sign(signer) = %v, want %v", err, errSigningRefusedUnknownStepType)
 	}
 }

--- a/internal/pipeline/unknown_step.go
+++ b/internal/pipeline/unknown_step.go
@@ -1,0 +1,43 @@
+package pipeline
+
+import (
+	"encoding/json"
+
+	"github.com/buildkite/agent/v3/internal/ordered"
+	"github.com/buildkite/interpolate"
+)
+
+// UnknownStep models any step we don't know how to represent in this version.
+// When future step types are added, they should be parsed with more specific
+// types. UnknownStep is present to allow older parsers to preserve newer
+// pipelines.
+type UnknownStep struct {
+	Contents any
+}
+
+// MarshalJSON marshals the contents of the step.
+func (u UnknownStep) MarshalJSON() ([]byte, error) {
+	return json.Marshal(u.Contents)
+}
+
+// MarshalYAML returns the contents of the step.
+func (u UnknownStep) MarshalYAML() (any, error) {
+	return u.Contents, nil
+}
+
+// unmarshalMap unmarshals an unknown step from an ordered map.
+func (u *UnknownStep) unmarshalMap(m *ordered.MapSA) error {
+	u.Contents = m
+	return nil
+}
+
+func (u *UnknownStep) interpolate(env interpolate.Env) error {
+	c, err := interpolateAny(env, u.Contents)
+	if err != nil {
+		return err
+	}
+	u.Contents = c
+	return nil
+}
+
+func (UnknownStep) stepTag() {}


### PR DESCRIPTION
It occurred to me that the new parser has no way of representing steps that we haven't invented yet.