### PR TITLE
Store GOCACHE outside container

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: Dockerfile-compile
     volumes:
       - ../:/work:cached
+      - ~/gocache:/gocache
       - ~/gomodcache:/gomodcache
     working_dir: /work
     environment:
@@ -14,6 +15,7 @@ services:
       - BUILDKITE_JOB_ID
       - "BUILDKITE_AGENT_TAGS=queue=default"
       - "BUILDKITE_BUILD_PATH=/buildkite"
+      - GOCACHE=/gocache
       - GOMODCACHE=/gomodcache
 
   ruby:


### PR DESCRIPTION
This should enable test caching between runs on the same machine, which should slightly reduce time to run the pipeline.