### PR TITLE
Nil handling tweaks

### DIFF
--- a/internal/ordered/map.go
+++ b/internal/ordered/map.go
@@ -170,8 +170,12 @@ func (m *Map[K, V]) Delete(k K) {
 	}
 }
 
-// ToMap creates a regular (un-ordered) map containing the same data.
+// ToMap creates a regular (un-ordered) map containing the same data. If m is
+// nil, ToMap returns nil.
 func (m *Map[K, V]) ToMap() map[K]V {
+	if m == nil {
+		return nil
+	}
 	um := make(map[K]V, len(m.index))
 	m.Range(func(k K, v V) error {
 		um[k] = v

--- a/internal/ordered/map_test.go
+++ b/internal/ordered/map_test.go
@@ -356,6 +356,45 @@ func TestMarshalJSON(t *testing.T) {
 	}
 }
 
+func TestToMap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc  string
+		input *Map[string, any]
+		want  map[string]any
+	}{
+		{
+			desc:  "nil input",
+			input: nil,
+			want:  nil,
+		},
+		{
+			desc:  "empty input",
+			input: NewMap[string, any](0),
+			want:  map[string]any{},
+		},
+		{
+			desc: "basic input",
+			input: MapFromItems(
+				TupleSA{Key: "llama", Value: "drama"},
+			),
+			want: map[string]any{"llama": "drama"},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			got := test.input.ToMap()
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("test.input.ToMap() diff (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestMarshalYAML(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/parser_test.go
+++ b/internal/pipeline/parser_test.go
@@ -655,6 +655,25 @@ steps:
 	}
 }
 
+func TestParserParsesEnvAndStepsNull(t *testing.T) {
+	input := strings.NewReader(`---
+env: null
+steps: null
+`)
+	got, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Parse(input) error = %v", err)
+	}
+
+	want := &Pipeline{
+		Env:   nil,
+		Steps: Steps{},
+	}
+	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSA)); diff != "" {
+		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestParserPreservesBools(t *testing.T) {
 	input := strings.NewReader("steps:\n  - trigger: hello\n    async: true")
 	got, err := Parse(input)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -41,6 +41,12 @@ func (p *Pipeline) unmarshalAny(o any) error {
 				}
 
 			case "env":
+				// If they wrote `env: null` or similar, then they mean it.
+				if v == nil {
+					p.Env = nil
+					return nil
+				}
+
 				// v must be *ordered.MapSA. We want *ordered.MapSS.
 				msa, ok := v.(*ordered.MapSA)
 				if !ok {

--- a/internal/pipeline/steps.go
+++ b/internal/pipeline/steps.go
@@ -16,8 +16,11 @@ type Steps []Step
 
 // unmarshalAny unmarshals a slice ([]any) into a slice of steps.
 func (s *Steps) unmarshalAny(o any) error {
-	if o == nil && *s == nil {
-		*s = Steps{}
+	if o == nil {
+		if *s == nil {
+			// `steps: null` is normalised to an empty slice.
+			*s = Steps{}
+		}
 		return nil
 	}
 	sl, ok := o.([]any)


### PR DESCRIPTION
- Someone could write `env: null`, and this should be handled appropriately.
- Most of `Steps.unmarshalAny` should be skipped if `o == nil`, not just if `*s == nil` also.
- `ToMap` should handle nil receiver (like all the other methods).