### PR TITLE
Add ordered.Unmarshal, and use it

### DIFF
--- a/internal/ordered/unmarshal.go
+++ b/internal/ordered/unmarshal.go
@@ -1,0 +1,375 @@
+package ordered
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Errors that can be returned by Unmarshal
+// (typically wrapped - use errors.Is).
+var (
+	ErrIntoNonPointer       = errors.New("cannot unmarshal into non-pointer")
+	ErrIntoNil              = errors.New("cannot unmarshal into nil")
+	ErrIncompatibleTypes    = errors.New("incompatible types")
+	ErrUnsupportedSrc       = errors.New("cannot unmarshal from src")
+	ErrMultipleInlineFields = errors.New(`multiple fields tagged with yaml:",inline"`)
+)
+
+// Unmarshaler is an interface that types can use to override the default
+// unmarshaling behaviour.
+type Unmarshaler interface {
+	// UnmarshalOrdered should unmarshal src into the implementing value. src
+	// will generally be one of *Map[string, any], []any, or a "scalar" built-in
+	// type.
+	UnmarshalOrdered(src any) error
+}
+
+// Unmarshal recursively unmarshals src into dst. src and dst can be a variety
+// of types under the hood, but some combinations don't work. Good luck!
+//
+//   - If dst is nil, then src must be nil.
+//   - If src is *yaml.Node, then DecodeYAML is called to translate the node
+//     into another type.
+//   - If dst is a pointer and src is nil, then the value dst points to is set
+//     to zero.
+//   - If dst is a pointer to a pointer, Unmarshal recursively calls Unmarshal
+//     on the inner pointer, creating a new value of the type being pointed to
+//     as needed.
+//   - If dst implements Unmarshaler, Unmarshal returns
+//     dst.UnmarshalOrdered(src).
+//   - If dst is *any, Unmarshal copies src directly into *dst.
+//
+// Otherwise, it acts a lot like yaml.Unmarshal, except that the type S of src
+// and type D of dst can be one of the following:
+//
+//   - S = *Map[string, any] (recursively containing values with types from this
+//     list); D must be one of: a pointer to a struct with yaml tags,
+//     or a map or a pointer to a map (either *Map or map) with string keys.
+//     yaml tags includes ",inline". Inline fields must themselves be a type
+//     that Unmarshal can unmarshal *Map[string, any] into - another struct or
+//     Map or map with string keys.
+//   - S = []any (also recursively containing values with types from this list),
+//     which is recursively unmarshaled elementwise; D is *[]any or
+//     *[]somethingElse.
+//   - S ∊ {string, float64, int, bool}; D must be *S (value copied directly),
+//     *[]S or *[]any (value appended), *string (value formatted through
+//     fmt.Sprint) or *[]string (formatted value appended).
+func Unmarshal(src, dst any) error {
+	if dst == nil {
+		// This is interface nil (not typed nil, which has to be tested after
+		// figuring out the types).
+		if src == nil {
+			// Unmarshal nil into nil? Seems legit
+			return nil
+		}
+		return ErrIntoNil
+	}
+
+	if n, ok := src.(*yaml.Node); ok {
+		o, err := DecodeYAML(n)
+		if err != nil {
+			return err
+		}
+		src = o
+	}
+
+	if um, ok := dst.(Unmarshaler); ok {
+		return um.UnmarshalOrdered(src)
+	}
+
+	// Handle typed nil pointers, pointers to nil, and pointers to pointers.
+	// Note that vdst could still be a map.
+	vdst := reflect.ValueOf(dst)
+
+	// First, handle src == nil. dst must be a pointer to something or nil.
+	if src == nil {
+		if vdst.Kind() != reflect.Pointer {
+			return fmt.Errorf("%w (%T)", ErrIntoNonPointer, dst)
+		}
+		if vdst.IsNil() {
+			// Unmarshaling nil into nil... seems legit.
+			return nil
+		}
+		// Zero out the value pointed to by dst.
+		vdst.Elem().SetZero()
+		return nil
+	}
+
+	// src is not nil. dst is usually a pointer - is it nil? pointer to pointer?
+	if vdst.Kind() == reflect.Pointer {
+		// Unmarshaling into typed nil value?
+		if vdst.IsNil() {
+			return ErrIntoNil
+		}
+
+		// Non-nil pointer to something. Another pointer?
+		if edst := vdst.Elem(); edst.Kind() == reflect.Pointer {
+			// The type of the value being double-pointed to.
+			innerType := edst.Type().Elem()
+			if edst.IsNil() {
+				// Create a new value of the inner type.
+				edst.Set(reflect.New(innerType))
+			}
+
+			// Handle double pointers by recursing on the inner layer.
+			return Unmarshal(src, edst.Interface())
+		}
+	}
+
+	if tdst, ok := dst.(*any); ok {
+		*tdst = src
+		return nil
+	}
+
+	switch tsrc := src.(type) {
+	case *Map[string, any]:
+		return tsrc.decodeInto(dst)
+
+	case []any:
+		switch tdst := dst.(type) {
+		case *[]any:
+			*tdst = append(*tdst, tsrc...)
+
+		default:
+			if vdst.Kind() != reflect.Pointer {
+				return fmt.Errorf("%w (%T)", ErrIntoNonPointer, dst)
+			}
+			sdst := vdst.Elem() // The slice we append to, reflectively
+			if sdst.Kind() != reflect.Slice {
+				return fmt.Errorf("%w: cannot unmarshal []any into %T", ErrIncompatibleTypes, dst)
+			}
+			etype := sdst.Type().Elem() // E = Type of the slice's elements
+			for _, a := range tsrc {
+				x := reflect.New(etype) // *E
+				if err := Unmarshal(a, x.Interface()); err != nil {
+					return err
+				}
+				sdst = reflect.Append(sdst, x.Elem())
+			}
+			vdst.Elem().Set(sdst)
+		}
+
+	case string:
+		return unmarshalScalar(tsrc, dst)
+
+	case float64:
+		return unmarshalScalar(tsrc, dst)
+
+	case int:
+		return unmarshalScalar(tsrc, dst)
+
+	case bool:
+		return unmarshalScalar(tsrc, dst)
+
+	default:
+		return fmt.Errorf("%w %T", ErrUnsupportedSrc, src)
+	}
+
+	return nil
+}
+
+func unmarshalScalar[S any](src S, dst any) error {
+	switch tdst := dst.(type) {
+	case *S:
+		*tdst = src
+
+	case *[]S:
+		*tdst = append(*tdst, src)
+
+	case *[]any:
+		*tdst = append(*tdst, src)
+
+	case *string:
+		*tdst = fmt.Sprint(src)
+
+	case *[]string:
+		*tdst = append(*tdst, fmt.Sprint(src))
+
+	default:
+		return fmt.Errorf("%w: cannot unmarshal %T into %T", ErrIncompatibleTypes, src, dst)
+	}
+	return nil
+}
+
+// decodeInto loads the contents of the map into the target (pointer to struct).
+// It behaves sort of like `yaml.Node.Decode`:
+//
+//   - If target is a map type with string keys, it unmarshals its contents
+//     elementwise, with values passed through Unmarshal.
+//   - If target is *struct{...}, it matches keys to exported fields either
+//     by looking at `yaml` tags, or using lowercased field names.
+//   - If a field has a yaml:",inline" tag, it copies any leftover values into
+//     that field, which must have type map[string]any or any. (Structs are not
+//     supported for inline.)
+func (m *Map[K, V]) decodeInto(target any) error {
+	tm, ok := any(m).(*Map[string, any])
+	if !ok {
+		return fmt.Errorf("%w: cannot unmarshal from %T, want K=string, V=any", ErrIncompatibleTypes, m)
+	}
+
+	// Work out the kind of target being used.
+	// Dereference the target to find the inner value, if needed.
+	targetValue := reflect.ValueOf(target)
+	var innerValue reflect.Value
+	switch targetValue.Kind() {
+	case reflect.Pointer:
+		// Passed a pointer to something.
+		if targetValue.IsNil() {
+			return ErrIntoNil
+		}
+		innerValue = targetValue.Elem()
+
+	case reflect.Map:
+		// Passed a map directly.
+		innerValue = targetValue
+		if innerValue.IsNil() {
+			return ErrIntoNil
+		}
+
+	default:
+		return fmt.Errorf("%w: cannot unmarshal %T into %T, want map or *struct{...}", ErrIncompatibleTypes, m, target)
+	}
+
+	switch innerValue.Kind() {
+	case reflect.Map:
+		// Process the map directly.
+		mapType := innerValue.Type()
+		// For simplicity, require the key type to be string.
+		if keyType := mapType.Key(); keyType.Kind() != reflect.String {
+			return fmt.Errorf("%w for map key: cannot unmarshal %T into %T", ErrIncompatibleTypes, m, target)
+		}
+
+		// If target is a pointer to a nil map (with type), create a new map.
+		if innerValue.IsNil() {
+			innerValue.Set(reflect.MakeMapWithSize(mapType, tm.Len()))
+		}
+
+		valueType := mapType.Elem()
+		return tm.Range(func(k string, v any) error {
+			nv := reflect.New(valueType)
+			if err := Unmarshal(v, nv.Interface()); err != nil {
+				return err
+			}
+			innerValue.SetMapIndex(reflect.ValueOf(k), nv.Elem())
+			return nil
+		})
+
+	case reflect.Struct:
+		// The rest of the method is concerned with this.
+	default:
+		return fmt.Errorf("%w: cannot unmarshal %T into %T", ErrIncompatibleTypes, m, target)
+	}
+
+	// These are the (accessible by reflection) fields it has.
+	// This includes non-exported fields.
+	fields := reflect.VisibleFields(innerValue.Type())
+
+	var inlineField reflect.StructField
+	outlineKeys := make(map[string]struct{})
+
+	for _, field := range fields {
+		// Skip non-exported fields. This is conventional *and* correct.
+		if !field.IsExported() {
+			continue
+		}
+
+		// No worries if the tag is not there - apply defaults.
+		tag, _ := field.Tag.Lookup("yaml")
+
+		switch tag {
+		case "-":
+			// Note: if a field is skipped with "-", yaml.v3 still puts it into
+			// inline.
+			continue
+
+		case ",inline":
+			if inlineField.Index != nil {
+				return fmt.Errorf("%w %T", ErrMultipleInlineFields, target)
+			}
+			inlineField = field
+			continue
+		}
+
+		// default:
+		key, _, _ := strings.Cut(tag, ",")
+		if key == "" {
+			// yaml.v3 convention:
+			// "Struct fields ... are unmarshalled using the field name
+			// lowercased as the default key."
+			key = strings.ToLower(field.Name)
+		}
+
+		// Is there a value for this key?
+		v, has := tm.Get(key)
+		if !has {
+			continue
+		}
+
+		// Now load v into this field.
+		outlineKeys[key] = struct{}{}
+
+		// Get a pointer to the field. This works because target is a pointer.
+		ptrToField := innerValue.FieldByIndex(field.Index).Addr()
+		if err := Unmarshal(v, ptrToField.Interface()); err != nil {
+			return err
+		}
+	}
+
+	if inlineField.Index == nil {
+		return nil
+	}
+	// The rest is handling the ",inline" field.
+	// We support any field that Unmarshal can unmarshal tm into.
+
+	inlinePtr := innerValue.FieldByIndex(inlineField.Index).Addr()
+
+	// Copy all values that weren't non-inline fields into a temporary map.
+	// This is just to avoid mutating tm.
+	temp := NewMap[string, any](tm.Len())
+	tm.Range(func(k string, v any) error {
+		if _, outline := outlineKeys[k]; outline {
+			return nil
+		}
+		temp.Set(k, v)
+		return nil
+	})
+
+	// If the inline map contains nothing, then don't bother setting it.
+	if temp.Len() == 0 {
+		return nil
+	}
+
+	return Unmarshal(temp, inlinePtr.Interface())
+}
+
+// UnmarshalOrdered unmarshals a value into this map.
+// K must be string, src must be *Map[string, any], and each value in src must
+// be unmarshallable into *V.
+func (m *Map[K, V]) UnmarshalOrdered(src any) error {
+	if m == nil {
+		return ErrIntoNil
+	}
+
+	tm, ok := any(m).(*Map[string, V])
+	if !ok {
+		return fmt.Errorf("%w: receiver type %T, want K = string", ErrIncompatibleTypes, m)
+	}
+
+	tsrc, ok := src.(*Map[string, any])
+	if !ok {
+		return fmt.Errorf("%w: src type %T, want *Map[string, any]", ErrIncompatibleTypes, src)
+	}
+
+	return tsrc.Range(func(k string, v any) error {
+		var dv V
+		if err := Unmarshal(v, &dv); err != nil {
+			return err
+		}
+		tm.Set(k, dv)
+		return nil
+	})
+}

--- a/internal/ordered/unmarshal_test.go
+++ b/internal/ordered/unmarshal_test.go
@@ -1,0 +1,986 @@
+package ordered
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+)
+
+type ordinaryStruct struct {
+	Key      string
+	Mountain string `yaml:"molehill"`
+	Ignore   string `yaml:"-"`
+	Switch   bool
+	Count    int
+	Fader    float64
+	Slicey   []int
+	hidden   string
+
+	Next  *ordinaryStruct
+	Inner struct {
+		Llama string
+	}
+
+	Remaining map[string]any `yaml:",inline"`
+}
+
+type inlineAnyStruct struct {
+	Llama     string
+	Remaining any `yaml:",inline"`
+}
+
+type inlineOrderedMapStruct struct {
+	Llama     string
+	Remaining *Map[string, any] `yaml:",inline"`
+}
+
+type customUnmarshalStruct struct {
+	Llama string
+}
+
+type namedMap map[string]string
+
+func (o *customUnmarshalStruct) UnmarshalOrdered(src any) error {
+	if src != "Kuzco" {
+		o.Llama = "Not Kuzco"
+	} else {
+		o.Llama = "Kuzco"
+	}
+	return nil
+}
+
+type testNestedOverride struct {
+	Llama   string
+	Another *customUnmarshalStruct
+}
+
+func ptr[T any](x T) *T { return &x }
+
+func TestUnmarshal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc           string
+		src, dst, want any
+	}{
+		{
+			desc: "nil into nil",
+			src:  nil,
+			dst:  nil,
+			want: nil,
+		},
+		{
+			desc: "nil into nil (but typed)",
+			src:  nil,
+			dst:  (*struct{})(nil),
+			want: (*struct{})(nil),
+		},
+		{
+			desc: "string to *string",
+			src:  "hello",
+			dst:  new(string),
+			want: ptr("hello"),
+		},
+		{
+			desc: "string to *any",
+			src:  "hello",
+			dst:  new(any),
+			want: ptr[any]("hello"),
+		},
+		{
+			desc: "string to *[]string",
+			src:  "hello",
+			dst:  new([]string),
+			want: ptr([]string{"hello"}),
+		},
+		{
+			desc: "string to *[]any",
+			src:  "hello",
+			dst:  new([]any),
+			want: ptr([]any{"hello"}),
+		},
+		{
+			desc: "int to *int",
+			src:  42,
+			dst:  new(int),
+			want: ptr(42),
+		},
+		{
+			desc: "int into *string",
+			src:  42,
+			dst:  new(string),
+			want: ptr("42"),
+		},
+		{
+			desc: "int to *any",
+			src:  42,
+			dst:  new(any),
+			want: ptr[any](42),
+		},
+		{
+			desc: "int to *[]int",
+			src:  42,
+			dst:  new([]int),
+			want: ptr([]int{42}),
+		},
+		{
+			desc: "int to *[]string",
+			src:  42,
+			dst:  new([]string),
+			want: ptr([]string{"42"}),
+		},
+		{
+			desc: "int to *[]any",
+			src:  42,
+			dst:  new([]any),
+			want: ptr([]any{42}),
+		},
+		{
+			desc: "float64 to *float64",
+			src:  2.71828,
+			dst:  new(float64),
+			want: ptr(2.71828),
+		},
+		{
+			desc: "float64 into *string",
+			src:  2.71828,
+			dst:  new(string),
+			want: ptr("2.71828"),
+		},
+		{
+			desc: "float64 to *any",
+			src:  2.71828,
+			dst:  new(any),
+			want: ptr[any](2.71828),
+		},
+		{
+			desc: "float64 to *[]float64",
+			src:  2.71828,
+			dst:  new([]float64),
+			want: ptr([]float64{2.71828}),
+		},
+		{
+			desc: "float64 to *[]string",
+			src:  2.71828,
+			dst:  new([]string),
+			want: ptr([]string{"2.71828"}),
+		},
+		{
+			desc: "float64 to *[]any",
+			src:  2.71828,
+			dst:  new([]any),
+			want: ptr([]any{2.71828}),
+		},
+		{
+			desc: "bool to *bool",
+			src:  true,
+			dst:  new(bool),
+			want: ptr(true),
+		},
+		{
+			desc: "bool to *string",
+			src:  true,
+			dst:  new(string),
+			want: ptr("true"),
+		},
+		{
+			desc: "bool to *any",
+			src:  true,
+			dst:  new(any),
+			want: ptr[any](true),
+		},
+		{
+			desc: "bool to *[]bool",
+			src:  true,
+			dst:  new([]bool),
+			want: ptr([]bool{true}),
+		},
+		{
+			desc: "bool to *[]string",
+			src:  true,
+			dst:  new([]string),
+			want: ptr([]string{"true"}),
+		},
+		{
+			desc: "bool to *[]any",
+			src:  true,
+			dst:  new([]any),
+			want: ptr([]any{true}),
+		},
+		{
+			desc: "[]any to []string",
+			src:  []any{"hello", "yes", "this is dog"},
+			dst:  new([]string), // it feels so wrong, it feels so right
+			want: ptr([]string{"hello", "yes", "this is dog"}),
+		},
+		{
+			desc: "[]any to *[]any",
+			src:  []any{"hello", "yes", "this is dog"},
+			dst:  new([]any), // it feels so wrong, it feels so right
+			want: ptr([]any{"hello", "yes", "this is dog"}),
+		},
+		{
+			desc: "[]any to *any",
+			src:  []any{"hello", "yes", "this is dog"},
+			dst:  new(any),
+			want: ptr[any]([]any{"hello", "yes", "this is dog"}),
+		},
+		{
+			desc: "[]any containing ints into *[]string",
+			src:  []any{42, 43},
+			dst:  new([]string),
+			want: ptr([]string{"42", "43"}),
+		},
+		{
+			desc: "*MapSA to **MapSA",
+			src: MapFromItems(
+				TupleSA{Key: "key", Value: "value"},
+				TupleSA{Key: "molehill", Value: "large"},
+				TupleSA{Key: "switch", Value: true},
+				TupleSA{Key: "count", Value: 42},
+				TupleSA{Key: "fader", Value: 2.71828},
+				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+			),
+			dst: new(*MapSA), // &((*MapSA)(nil))
+			want: ptr(MapFromItems(
+				TupleSA{Key: "key", Value: "value"},
+				TupleSA{Key: "molehill", Value: "large"},
+				TupleSA{Key: "switch", Value: true},
+				TupleSA{Key: "count", Value: 42},
+				TupleSA{Key: "fader", Value: 2.71828},
+				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+			)),
+		},
+		{
+			desc: "*MapSA to *MapSA",
+			src: MapFromItems(
+				TupleSA{Key: "key", Value: "value"},
+				TupleSA{Key: "molehill", Value: "large"},
+				TupleSA{Key: "switch", Value: true},
+				TupleSA{Key: "count", Value: 42},
+				TupleSA{Key: "fader", Value: 2.71828},
+				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+			),
+			dst: NewMap[string, any](0),
+			want: MapFromItems(
+				TupleSA{Key: "key", Value: "value"},
+				TupleSA{Key: "molehill", Value: "large"},
+				TupleSA{Key: "switch", Value: true},
+				TupleSA{Key: "count", Value: 42},
+				TupleSA{Key: "fader", Value: 2.71828},
+				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+			),
+		},
+		{
+			desc: "*MapSA to *map[string]any",
+			src: MapFromItems(
+				TupleSA{Key: "key", Value: "value"},
+				TupleSA{Key: "molehill", Value: "large"},
+				TupleSA{Key: "switch", Value: true},
+				TupleSA{Key: "count", Value: 42},
+				TupleSA{Key: "fader", Value: 2.71828},
+				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+			),
+			dst: new(map[string]any), // it feels so wrong, it feels so right
+			want: ptr(map[string]any{
+				"key":      "value",
+				"molehill": "large",
+				"switch":   true,
+				"count":    42,
+				"fader":    2.71828,
+				"slicey":   []any{5, 6, 7, 8},
+			}),
+		},
+		{
+			desc: "*MapSA to map[string]any",
+			src: MapFromItems(
+				TupleSA{Key: "key", Value: "value"},
+				TupleSA{Key: "molehill", Value: "large"},
+				TupleSA{Key: "switch", Value: true},
+				TupleSA{Key: "count", Value: 42},
+				TupleSA{Key: "fader", Value: 2.71828},
+				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+			),
+			dst: make(map[string]any),
+			want: map[string]any{
+				"key":      "value",
+				"molehill": "large",
+				"switch":   true,
+				"count":    42,
+				"fader":    2.71828,
+				"slicey":   []any{5, 6, 7, 8},
+			},
+		},
+		{
+			desc: "*MapSA to *any",
+			src: MapFromItems(
+				TupleSA{Key: "key", Value: "value"},
+				TupleSA{Key: "molehill", Value: "large"},
+				TupleSA{Key: "switch", Value: true},
+				TupleSA{Key: "count", Value: 42},
+				TupleSA{Key: "fader", Value: 2.71828},
+				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+			),
+			dst: new(any),
+			want: ptr(any(MapFromItems(
+				TupleSA{Key: "key", Value: "value"},
+				TupleSA{Key: "molehill", Value: "large"},
+				TupleSA{Key: "switch", Value: true},
+				TupleSA{Key: "count", Value: 42},
+				TupleSA{Key: "fader", Value: 2.71828},
+				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+			))),
+		},
+		{
+			desc: "*MapSA to *any secretly containing *MapSA",
+			src: MapFromItems(
+				TupleSA{Key: "key", Value: "value"},
+				TupleSA{Key: "molehill", Value: "large"},
+				TupleSA{Key: "switch", Value: true},
+				TupleSA{Key: "count", Value: 42},
+				TupleSA{Key: "fader", Value: 2.71828},
+				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+			),
+			dst: ptr(any(NewMap[string, any](0))),
+			want: ptr(any(MapFromItems(
+				TupleSA{Key: "key", Value: "value"},
+				TupleSA{Key: "molehill", Value: "large"},
+				TupleSA{Key: "switch", Value: true},
+				TupleSA{Key: "count", Value: 42},
+				TupleSA{Key: "fader", Value: 2.71828},
+				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+			))),
+		},
+		{
+			desc: "*MapSA to *testStruct without inline",
+			src: MapFromItems(
+				TupleSA{Key: "key", Value: "value"},
+				TupleSA{Key: "molehill", Value: "large"},
+				TupleSA{Key: "switch", Value: true},
+				TupleSA{Key: "count", Value: 42},
+				TupleSA{Key: "fader", Value: 2.71828},
+				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+			),
+			dst: &ordinaryStruct{},
+			want: &ordinaryStruct{
+				Key:      "value",
+				Mountain: "large",
+				Switch:   true,
+				Count:    42,
+				Fader:    2.71828,
+				Slicey:   []int{5, 6, 7, 8},
+			},
+		},
+		{
+			desc: "*MapSA to *testStruct with inline",
+			src: MapFromItems(
+				TupleSA{Key: "key", Value: "value"},
+				TupleSA{Key: "molehill", Value: "large"},
+				TupleSA{Key: "mountain", Value: "actually we call them molehills here"},
+				TupleSA{Key: "ignore", Value: "YOU CANNOT DO THIS!!!"},
+				TupleSA{Key: "switch", Value: true},
+				TupleSA{Key: "count", Value: 42},
+				TupleSA{Key: "fader", Value: 2.71828},
+				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+				TupleSA{Key: "notAField", Value: "super important"},
+			),
+			dst: &ordinaryStruct{},
+			want: &ordinaryStruct{
+				Key:      "value",
+				Mountain: "large",
+				Switch:   true,
+				Count:    42,
+				Fader:    2.71828,
+				Slicey:   []int{5, 6, 7, 8},
+				Remaining: map[string]any{
+					"ignore":    "YOU CANNOT DO THIS!!!",
+					"mountain":  "actually we call them molehills here",
+					"notAField": "super important",
+				},
+			},
+		},
+		{
+			desc: "*MapSA to *testStruct with existing",
+			src: MapFromItems(
+				TupleSA{Key: "key", Value: "value"},
+				TupleSA{Key: "molehill", Value: "large"},
+				TupleSA{Key: "ignore", Value: "YOU CANNOT DO THIS!!!"},
+				TupleSA{Key: "switch", Value: true},
+				TupleSA{Key: "count", Value: nil},
+				TupleSA{Key: "fader", Value: 2.71828},
+				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+				TupleSA{Key: "hidden", Value: "no"},
+				TupleSA{Key: "notAField", Value: "super important"},
+			),
+			dst: &ordinaryStruct{
+				Key:      "old",
+				Mountain: "Kilimanjaro",
+				Ignore:   "super secret existing data",
+				Switch:   false,
+				Count:    69,
+				Fader:    3.14159,
+				Slicey:   []int{1, 2, 3, 4},
+				hidden:   "yes",
+				Remaining: map[string]any{
+					"existing": "wombat",
+				},
+			},
+			want: &ordinaryStruct{
+				Key:      "value",
+				Mountain: "large",
+				Ignore:   "super secret existing data",
+				Switch:   true,
+				Count:    0, // nil becomes a SetZero call
+				Fader:    2.71828,
+				Slicey:   []int{1, 2, 3, 4, 5, 6, 7, 8},
+				hidden:   "yes",
+				Remaining: map[string]any{
+					"existing":  "wombat",
+					"hidden":    "no",
+					"ignore":    "YOU CANNOT DO THIS!!!",
+					"notAField": "super important",
+				},
+			},
+		},
+		{
+			desc: "nested structs",
+			src: MapFromItems(
+				TupleSA{Key: "key", Value: "value"},
+				TupleSA{Key: "molehill", Value: "large"},
+				TupleSA{Key: "switch", Value: true},
+				TupleSA{Key: "count", Value: 42},
+				TupleSA{Key: "fader", Value: 2.71828},
+				TupleSA{Key: "notAField", Value: "super important"},
+				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+				TupleSA{Key: "inner", Value: MapFromItems(
+					TupleSA{Key: "llama", Value: "Kuzco"},
+				)},
+				TupleSA{Key: "next", Value: MapFromItems(
+					TupleSA{Key: "key", Value: "another value"},
+					TupleSA{Key: "molehill", Value: "extra large"},
+					TupleSA{Key: "switch", Value: true},
+					TupleSA{Key: "count", Value: 42000},
+					TupleSA{Key: "fader", Value: 1.618},
+				)},
+			),
+			dst: &ordinaryStruct{},
+			want: &ordinaryStruct{
+				Key:      "value",
+				Mountain: "large",
+				Switch:   true,
+				Count:    42,
+				Fader:    2.71828,
+				Slicey:   []int{5, 6, 7, 8},
+				Inner:    struct{ Llama string }{"Kuzco"},
+				Next: &ordinaryStruct{
+					Key:      "another value",
+					Mountain: "extra large",
+					Switch:   true,
+					Count:    42000,
+					Fader:    1.618,
+				},
+				Remaining: map[string]any{
+					"notAField": "super important",
+				},
+			},
+		},
+		{
+			desc: "inline field is any",
+			src: MapFromItems(
+				TupleSA{Key: "llama", Value: "Kuzco"},
+				TupleSA{Key: "alpaca", Value: "Geronimo"},
+			),
+			dst: &inlineAnyStruct{},
+			want: &inlineAnyStruct{
+				Llama: "Kuzco",
+				Remaining: MapFromItems(
+					TupleSA{Key: "alpaca", Value: "Geronimo"},
+				),
+			},
+		},
+		{
+			desc: "inline field is *MapSA",
+			src: MapFromItems(
+				TupleSA{Key: "llama", Value: "Kuzco"},
+				TupleSA{Key: "alpaca", Value: "Geronimo"},
+			),
+			dst: &inlineOrderedMapStruct{},
+			want: &inlineOrderedMapStruct{
+				Llama: "Kuzco",
+				Remaining: MapFromItems(
+					TupleSA{Key: "alpaca", Value: "Geronimo"},
+				),
+			},
+		},
+		{
+			desc: "nil into *any",
+			src:  nil,
+			dst:  new(any),
+			want: new(any),
+		},
+		{
+			desc: "nil into **struct{}",
+			src:  nil,
+			dst:  ptr(new(struct{})),
+			want: ptr((*struct{})(nil)),
+		},
+		{
+			desc: "UnmarshalOrdered override",
+			src:  "Kuzco",
+			dst:  &customUnmarshalStruct{},
+			want: &customUnmarshalStruct{Llama: "Kuzco"},
+		},
+		{
+			desc: "field is UnmarshalOrdered",
+			src: MapFromItems(
+				TupleSA{Key: "llama", Value: "Kuzco"},
+				TupleSA{Key: "another", Value: "Kronk"},
+			),
+			dst: &testNestedOverride{},
+			want: &testNestedOverride{
+				Llama: "Kuzco",
+				Another: &customUnmarshalStruct{
+					Llama: "Not Kuzco",
+				},
+			},
+		},
+		{
+			desc: "*MapSA into namedMap",
+			src: MapFromItems(
+				TupleSA{Key: "llama", Value: "Kuzco"},
+				TupleSA{Key: "another", Value: "Kronk"},
+			),
+			dst: make(namedMap),
+			want: namedMap{
+				"llama":   "Kuzco",
+				"another": "Kronk",
+			},
+		},
+		{
+			desc: "*MapSA into *namedMap",
+			src: MapFromItems(
+				TupleSA{Key: "llama", Value: "Kuzco"},
+				TupleSA{Key: "another", Value: "Kronk"},
+			),
+			dst: new(namedMap),
+			want: &namedMap{
+				"llama":   "Kuzco",
+				"another": "Kronk",
+			},
+		},
+		{
+			desc: "*yaml.Node into testStruct",
+			src: &yaml.Node{
+				Kind: yaml.MappingNode,
+				Tag:  "!!map",
+				Content: []*yaml.Node{
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "key"},
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "value"},
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "molehill"},
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "large"},
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "switch"},
+					{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"},
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "count"},
+					{Kind: yaml.ScalarNode, Tag: "!!int", Value: "42"},
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "fader"},
+					{Kind: yaml.ScalarNode, Tag: "!!float", Value: "2.71828"},
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "slicey"},
+					{Kind: yaml.SequenceNode, Tag: "!!seq", Content: []*yaml.Node{
+						{Kind: yaml.ScalarNode, Tag: "!!int", Value: "5"},
+						{Kind: yaml.ScalarNode, Tag: "!!int", Value: "6"},
+						{Kind: yaml.ScalarNode, Tag: "!!int", Value: "7"},
+						{Kind: yaml.ScalarNode, Tag: "!!int", Value: "8"},
+					}},
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "next"},
+					{Kind: yaml.MappingNode, Tag: "!!map", Content: []*yaml.Node{
+						{Kind: yaml.ScalarNode, Tag: "!!str", Value: "key"},
+						{Kind: yaml.ScalarNode, Tag: "!!str", Value: "another value"},
+						{Kind: yaml.ScalarNode, Tag: "!!str", Value: "molehill"},
+						{Kind: yaml.ScalarNode, Tag: "!!str", Value: "extra large"},
+						{Kind: yaml.ScalarNode, Tag: "!!str", Value: "switch"},
+						{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"},
+						{Kind: yaml.ScalarNode, Tag: "!!str", Value: "count"},
+						{Kind: yaml.ScalarNode, Tag: "!!int", Value: "42000"},
+						{Kind: yaml.ScalarNode, Tag: "!!str", Value: "fader"},
+						{Kind: yaml.ScalarNode, Tag: "!!float", Value: "1.618"},
+					}},
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "inner"},
+					{Kind: yaml.MappingNode, Tag: "!!map", Content: []*yaml.Node{
+						{Kind: yaml.ScalarNode, Tag: "!!str", Value: "llama"},
+						{Kind: yaml.ScalarNode, Tag: "!!str", Value: "Kuzco"},
+					}},
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "notAField"},
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "super important"},
+				},
+			},
+			dst: &ordinaryStruct{},
+			want: &ordinaryStruct{
+				Key:      "value",
+				Mountain: "large",
+				Switch:   true,
+				Count:    42,
+				Fader:    2.71828,
+				Slicey:   []int{5, 6, 7, 8},
+				Inner:    struct{ Llama string }{"Kuzco"},
+				Next: &ordinaryStruct{
+					Key:      "another value",
+					Mountain: "extra large",
+					Switch:   true,
+					Count:    42000,
+					Fader:    1.618,
+				},
+				Remaining: map[string]any{
+					"notAField": "super important",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			if err := Unmarshal(test.src, test.dst); err != nil {
+				t.Fatalf("Unmarshal(%T, %T) = %v", test.src, test.dst, err)
+			}
+			if diff := cmp.Diff(test.dst, test.want, cmp.AllowUnexported(ordinaryStruct{}), cmp.Comparer(EqualSA)); diff != "" {
+				t.Errorf("Unmarshal(%T, %T) diff (-got, want):\n%s", test.src, test.dst, diff)
+			}
+		})
+	}
+}
+
+func TestUnmarshalIntoNilErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc     string
+		src, dst any
+	}{
+		{
+			desc: "*MapSA into interface nil",
+			src:  MapFromItems(TupleSA{}),
+			dst:  nil,
+		},
+		{
+			desc: "*MapSA into **MapSA nil",
+			src:  MapFromItems(TupleSA{}),
+			dst:  (**MapSA)(nil),
+		},
+		{
+			desc: "*MapSA into *MapSA nil",
+			src:  MapFromItems(TupleSA{}),
+			dst:  (*MapSA)(nil),
+		},
+		{
+			desc: "*MapSA into *map[string]any nil",
+			src:  MapFromItems(TupleSA{}),
+			dst:  (*map[string]any)(nil),
+		},
+		{
+			desc: "*MapSA into map[string]any nil",
+			src:  MapFromItems(TupleSA{}),
+			dst:  (map[string]any)(nil),
+		},
+		{
+			desc: "*MapSA into *any nil",
+			src:  MapFromItems(TupleSA{}),
+			dst:  (*any)(nil),
+		},
+		{
+			desc: "*MapSA into *struct nil",
+			src:  MapFromItems(TupleSA{}),
+			dst:  (*struct{})(nil),
+		},
+		{
+			desc: "[]any into *[]any nil",
+			src:  []any{},
+			dst:  (*[]any)(nil),
+		},
+		{
+			desc: "[]any into *any nil",
+			src:  []any{},
+			dst:  (*any)(nil),
+		},
+		{
+			desc: "[]any into *[]string nil",
+			src:  []any{},
+			dst:  (*[]string)(nil),
+		},
+		{
+			desc: "string into *string nil",
+			src:  "hello",
+			dst:  (*string)(nil),
+		},
+		{
+			desc: "float64 into *float64 nil",
+			src:  3.14159,
+			dst:  (*float64)(nil),
+		},
+		{
+			desc: "int into *int nil",
+			src:  42,
+			dst:  (*int)(nil),
+		},
+		{
+			desc: "bool into *bool nil",
+			src:  true,
+			dst:  (*bool)(nil),
+		},
+		{
+			desc: "string into *any nil",
+			src:  "hello",
+			dst:  (*any)(nil),
+		},
+		{
+			desc: "float64 into *any nil",
+			src:  3.14159,
+			dst:  (*any)(nil),
+		},
+		{
+			desc: "int into *any nil",
+			src:  42,
+			dst:  (*any)(nil),
+		},
+		{
+			desc: "bool into *any nil",
+			src:  true,
+			dst:  (*any)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			if err := Unmarshal(test.src, test.dst); !errors.Is(err, ErrIntoNil) {
+				t.Errorf("Unmarshal(%T, %T) = %v, want %v", test.src, test.dst, err, ErrIntoNil)
+			}
+		})
+	}
+}
+
+func TestUnmarshalIncompatibleTypesErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc     string
+		src, dst any
+	}{
+		{
+			desc: "string into *int",
+			src:  "forty-two",
+			dst:  new(int),
+		},
+		{
+			desc: "bool into *float64",
+			src:  true,
+			dst:  new(float64),
+		},
+		{
+			desc: "float64 into *bool",
+			src:  3.14159,
+			dst:  new(bool),
+		},
+		{
+			desc: "[]any into *string",
+			src:  []any{"string"},
+			dst:  new(string),
+		},
+		{
+			desc: "[]any containing ints into *[]bool",
+			src:  []any{42, 43},
+			dst:  new([]bool),
+		},
+		{
+			desc: "*MapSA into *[]any",
+			src:  MapFromItems(TupleSA{}),
+			dst:  new([]any),
+		},
+		{
+			desc: "*MapSA into **[]any",
+			src:  MapFromItems(TupleSA{}),
+			dst:  ptr(new([]any)),
+		},
+		{
+			desc: "*MapSA into map[int]string",
+			src:  MapFromItems(TupleSA{}),
+			dst:  map[int]string{},
+		},
+		{
+			desc: "*MapSA into *map[int]string",
+			src:  MapFromItems(TupleSA{}),
+			dst:  &map[int]string{},
+		},
+		{
+			desc: "*MapSA into map[string]int",
+			src:  MapFromItems(TupleSA{Key: "llama", Value: "drama"}),
+			dst:  map[string]int{},
+		},
+		{
+			desc: "*MapSA into *map[string]int",
+			src:  MapFromItems(TupleSA{Key: "llama", Value: "drama"}),
+			dst:  &map[string]int{},
+		},
+		{
+			desc: "*MapSA into string",
+			src:  MapFromItems(TupleSA{}),
+			dst:  "hello",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			if err := Unmarshal(test.src, test.dst); !errors.Is(err, ErrIncompatibleTypes) {
+				t.Errorf("Unmarshal(%T, %T) = %v, want %v", test.src, test.dst, err, ErrIncompatibleTypes)
+			}
+		})
+	}
+}
+
+func TestUnmarshalNotAPointerErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc     string
+		src, dst any
+	}{
+		{
+			desc: "nil into string",
+			src:  nil,
+			dst:  "hello",
+		},
+		{
+			desc: "[]any into []any",
+			src:  []any{42},
+			dst:  []any{69},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			if err := Unmarshal(test.src, test.dst); !errors.Is(err, ErrIntoNonPointer) {
+				t.Errorf("Unmarshal(%T, %T) = %v, want %v", test.src, test.dst, err, ErrIntoNonPointer)
+			}
+		})
+	}
+}
+
+func TestUnmarshalUnsupportedSrcError(t *testing.T) {
+	t.Parallel()
+	if err := Unmarshal(make(chan struct{}), new(string)); !errors.Is(err, ErrUnsupportedSrc) {
+		t.Errorf("Unmarshal(chan struct{}, new(string)) = %v, want %v", err, ErrUnsupportedSrc)
+	}
+}
+
+func TestUnmarshalIncompatibleFieldTypeError(t *testing.T) {
+	t.Parallel()
+
+	type hasAFloat struct {
+		Llama float64
+	}
+	src := MapFromItems(
+		TupleSA{Key: "llama", Value: "drama"},
+	)
+	if err := Unmarshal(src, &hasAFloat{}); !errors.Is(err, ErrIncompatibleTypes) {
+		t.Errorf("Unmarshal(*MapSA, &hasAFloat{}) = %v, want %v", err, ErrIncompatibleTypes)
+	}
+}
+
+func TestUnmarshalInvalidInlineError(t *testing.T) {
+	t.Parallel()
+
+	src := MapFromItems(TupleSA{
+		Key: "llama", Value: "not a bool",
+	})
+	type testInvalidInline struct {
+		Llama map[string]bool `yaml:",inline"`
+	}
+	if err := Unmarshal(src, &testInvalidInline{}); !errors.Is(err, ErrIncompatibleTypes) {
+		t.Errorf("Unmarshal(*MapSA, &testInvalidInline{}) = %v, want %v", err, ErrIncompatibleTypes)
+	}
+}
+
+func TestUnmarshalMultipleInlineError(t *testing.T) {
+	t.Parallel()
+
+	type testMultipleInline struct {
+		Llama  map[string]any `yaml:",inline"`
+		Alpaca map[string]any `yaml:",inline"`
+	}
+	if err := Unmarshal(MapFromItems(TupleSA{}), &testMultipleInline{}); !errors.Is(err, ErrMultipleInlineFields) {
+		t.Errorf("Unmarshal(*MapSA, &testMultipleInline{}) = %v, want %v", err, ErrMultipleInlineFields)
+	}
+}
+
+func TestMapUnmarshalOrderedErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		src  any
+		dst  Unmarshaler
+	}{
+		{
+			desc: "receiver with non-string key",
+			src:  nil,
+			dst:  NewMap[int, string](0),
+		},
+		{
+			desc: "src is not *MapSA",
+			src:  map[string]any{},
+			dst:  NewMap[string, int](0),
+		},
+		{
+			desc: "incompatible values",
+			src:  MapFromItems(TupleSA{Key: "llama", Value: "drama"}),
+			dst:  NewMap[string, int](0),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			if err := test.dst.UnmarshalOrdered(test.src); !errors.Is(err, ErrIncompatibleTypes) {
+				t.Errorf("%T.UnmarshalOrdered(%T) = %v, want %v", test.dst, test.src, err, ErrIncompatibleTypes)
+			}
+		})
+	}
+}
+
+func TestYAMLInlineDashBehaviour(t *testing.T) {
+	// This test just confirms a potential edge case in how yaml.v3 does things.
+	type what struct {
+		Llama     string         `yaml:"-"`
+		Remaining map[string]any `yaml:",inline"`
+	}
+
+	input := []byte(`---
+llama: Kuzco
+alpaca: Geronimo
+`)
+
+	var got what
+	if err := yaml.Unmarshal(input, &got); err != nil {
+		t.Fatalf("yaml.Unmarshal(input, &got) = %v", err)
+	}
+
+	want := what{
+		Llama: "",
+		Remaining: map[string]any{
+			"llama":  "Kuzco",
+			"alpaca": "Geronimo",
+		},
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("yaml.Unmarshal diff (-got +want):\n%s", diff)
+	}
+}

--- a/internal/pipeline/parser.go
+++ b/internal/pipeline/parser.go
@@ -22,15 +22,9 @@ func Parse(src io.Reader) (*Pipeline, error) {
 	// *yaml.Node into *ordered.Map, []any, or any (recursively).
 	// This resolves aliases and merges and gives a more convenient form to work
 	// with when handling different structural representations of the same
-	// configuration.
-	o, err := ordered.DecodeYAML(n)
-	if err != nil {
-		return nil, err
-	}
-
-	// Then decode _that_ into a pipeline.
+	// configuration. Then decode _that_ into a pipeline.
 	p := new(Pipeline)
-	return p, p.unmarshalAny(o)
+	return p, ordered.Unmarshal(n, p)
 }
 
 func formatYAMLError(err error) error {

--- a/internal/pipeline/parser_test.go
+++ b/internal/pipeline/parser_test.go
@@ -683,9 +683,11 @@ func TestParserPreservesBools(t *testing.T) {
 
 	want := &Pipeline{
 		Steps: Steps{
-			TriggerStep{
-				"trigger": "hello",
-				"async":   true,
+			&TriggerStep{
+				Contents: map[string]any{
+					"trigger": "hello",
+					"async":   true,
+				},
 			},
 		},
 	}
@@ -790,9 +792,11 @@ func TestParserPreservesFloats(t *testing.T) {
 
 	want := &Pipeline{
 		Steps: Steps{
-			TriggerStep{
-				"trigger": "hello",
-				"llamas":  3.142,
+			&TriggerStep{
+				Contents: map[string]any{
+					"trigger": "hello",
+					"llamas":  3.142,
+				},
 			},
 		},
 	}
@@ -831,9 +835,11 @@ func TestParserHandlesDates(t *testing.T) {
 	}
 	want := &Pipeline{
 		Steps: Steps{
-			TriggerStep{
-				"trigger": "hello",
-				"llamas":  llamatime,
+			&TriggerStep{
+				Contents: map[string]any{
+					"trigger": "hello",
+					"llamas":  llamatime,
+				},
 			},
 		},
 	}

--- a/internal/pipeline/plugins.go
+++ b/internal/pipeline/plugins.go
@@ -9,14 +9,14 @@ import (
 // Plugins is a sequence of plugins. It is useful for unmarshaling.
 type Plugins []*Plugin
 
-// unmarshalAny unmarshals Plugins from either
+// UnmarshalOrdered unmarshals Plugins from either
 //   - []any - originally a sequence of "one-item mappings" (normal form), or
 //   - *ordered.MapSA - a mapping (where order is important...non-normal form).
 //
 // "plugins" is supposed to be a sequence of one-item maps, since order matters.
 // But some people (even us) write plugins into one big mapping and rely on
 // order preservation.
-func (p *Plugins) unmarshalAny(o any) error {
+func (p *Plugins) UnmarshalOrdered(o any) error {
 	// Whether processing one big map, or a sequence of small maps, the central
 	// part remains the same.
 	// Parse each "key: value" as "name: config", then append in order.

--- a/internal/pipeline/sign.go
+++ b/internal/pipeline/sign.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"sort"
 
-	"github.com/buildkite/agent/v3/internal/ordered"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
 )
@@ -81,50 +80,6 @@ func (s *Signature) Verify(sf SignedFielder, keySet jwk.Set) error {
 		jws.WithDetachedPayload(payload.Bytes()),
 	)
 	return err
-}
-
-// unmarshalAny unmarshals an *ordered.Map[string, any] into this Signature.
-// Any other type is an error.
-func (s *Signature) unmarshalAny(o any) error {
-	m, ok := o.(*ordered.MapSA)
-	if !ok {
-		return fmt.Errorf("unmarshaling signature: got %T, want *ordered.Map[string, any]", o)
-	}
-
-	return m.Range(func(k string, v any) error {
-		switch k {
-		case "algorithm":
-			a, ok := v.(string)
-			if !ok {
-				return fmt.Errorf("unmarshaling signature: algorithm has type %T, want string", v)
-			}
-			s.Algorithm = a
-
-		case "signed_fields":
-			os, ok := v.([]any)
-			if !ok {
-				return fmt.Errorf("unmarshaling signature: signed_fields has type %T, want []any", v)
-			}
-			for _, of := range os {
-				f, ok := of.(string)
-				if !ok {
-					return fmt.Errorf("unmarshaling signature: item in signed_fields has type %T, want string", of)
-				}
-				s.SignedFields = append(s.SignedFields, f)
-			}
-
-		case "value":
-			a, ok := v.(string)
-			if !ok {
-				return fmt.Errorf("unmarshaling signature: value has type %T, want string", v)
-			}
-			s.Value = a
-
-		default:
-			return fmt.Errorf("unmarshaling signature: unsupported key %q", k)
-		}
-		return nil
-	})
 }
 
 // SignedFielder describes types that can be signed and have signatures

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -1,9 +1,5 @@
 package pipeline
 
-import (
-	"github.com/buildkite/agent/v3/internal/ordered"
-)
-
 // Step models a step in the pipeline. It will be a pointer to one of:
 // - CommandStep
 // - WaitStep
@@ -12,11 +8,6 @@ import (
 // - GroupStep
 type Step interface {
 	stepTag() // allow only the step types below
-
-	// unmarshalStep is responsible for choosing the right kind of step to
-	// unmarshal, but it uses the map representation to figure this out.
-	// So we can assume *ordered.MapSA input for unmarshaling.
-	unmarshalMap(*ordered.MapSA) error
 
 	selfInterpolater
 }

--- a/internal/pipeline/step_group.go
+++ b/internal/pipeline/step_group.go
@@ -22,29 +22,11 @@ type GroupStep struct {
 	RemainingFields map[string]any `yaml:",inline"`
 }
 
-// unmarshalMap unmarshals a group step from an ordered map.
-func (g *GroupStep) unmarshalMap(m *ordered.MapSA) error {
-	err := m.Range(func(k string, v any) error {
-		switch k {
-		case "group":
-			g.Group = v
-
-		case "steps":
-			if err := g.Steps.unmarshalAny(v); err != nil {
-				return fmt.Errorf("unmarshaling steps: %v", err)
-			}
-
-		default:
-			// Preserve any other key.
-			if g.RemainingFields == nil {
-				g.RemainingFields = make(map[string]any)
-			}
-			g.RemainingFields[k] = v
-		}
-		return nil
-	})
-	if err != nil {
-		return err
+// UnmarshalOrdered unmarshals a group step from an ordered map.
+func (g *GroupStep) UnmarshalOrdered(src any) error {
+	type wrappedGroup GroupStep
+	if err := ordered.Unmarshal(src, (*wrappedGroup)(g)); err != nil {
+		return fmt.Errorf("unmarshalling GroupStep: %w", err)
 	}
 
 	// Ensure Steps is never nil. Server side expects a sequence.

--- a/internal/pipeline/step_input.go
+++ b/internal/pipeline/step_input.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/buildkite/agent/v3/internal/ordered"
 	"github.com/buildkite/interpolate"
 )
 
@@ -32,11 +31,6 @@ func (s *InputStep) MarshalJSON() ([]byte, error) {
 
 func (s InputStep) interpolate(env interpolate.Env) error {
 	return interpolateMap(env, s.Contents)
-}
-
-func (s *InputStep) unmarshalMap(m *ordered.MapSA) error {
-	s.Contents = m.ToMap()
-	return nil
 }
 
 func (*InputStep) stepTag() {}

--- a/internal/pipeline/step_trigger.go
+++ b/internal/pipeline/step_trigger.go
@@ -1,24 +1,25 @@
 package pipeline
 
 import (
-	"github.com/buildkite/agent/v3/internal/ordered"
+	"encoding/json"
+
 	"github.com/buildkite/interpolate"
 )
 
 // TriggerStep models a trigger step.
 //
 // Standard caveats apply - see the package comment.
-type TriggerStep map[string]any
-
-func (s TriggerStep) interpolate(env interpolate.Env) error {
-	return interpolateMap(env, s)
+type TriggerStep struct {
+	Contents map[string]any `yaml:",inline"`
 }
 
-func (s TriggerStep) unmarshalMap(m *ordered.MapSA) error {
-	return m.Range(func(k string, v any) error {
-		s[k] = v
-		return nil
-	})
+// MarshalJSON marshals the contents of the step.
+func (t TriggerStep) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Contents)
+}
+
+func (s TriggerStep) interpolate(env interpolate.Env) error {
+	return interpolateMap(env, s.Contents)
 }
 
 func (TriggerStep) stepTag() {}

--- a/internal/pipeline/step_unknown.go
+++ b/internal/pipeline/step_unknown.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"encoding/json"
 
-	"github.com/buildkite/agent/v3/internal/ordered"
 	"github.com/buildkite/interpolate"
 )
 
@@ -25,9 +24,9 @@ func (u UnknownStep) MarshalYAML() (any, error) {
 	return u.Contents, nil
 }
 
-// unmarshalMap unmarshals an unknown step from an ordered map.
-func (u *UnknownStep) unmarshalMap(m *ordered.MapSA) error {
-	u.Contents = m
+// UnmarshalOrdered unmarshals an unknown step.
+func (u *UnknownStep) UnmarshalOrdered(src any) error {
+	u.Contents = src
 	return nil
 }
 

--- a/internal/pipeline/step_wait.go
+++ b/internal/pipeline/step_wait.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"encoding/json"
 
-	"github.com/buildkite/agent/v3/internal/ordered"
 	"github.com/buildkite/interpolate"
 )
 
@@ -33,11 +32,6 @@ func (s *WaitStep) MarshalJSON() ([]byte, error) {
 
 func (s *WaitStep) interpolate(env interpolate.Env) error {
 	return interpolateMap(env, s.Contents)
-}
-
-func (s *WaitStep) unmarshalMap(m *ordered.MapSA) error {
-	s.Contents = m.ToMap()
-	return nil
 }
 
 func (*WaitStep) stepTag() {}

--- a/internal/pipeline/steps.go
+++ b/internal/pipeline/steps.go
@@ -15,8 +15,8 @@ var errSigningRefusedUnknownStepType = errors.New("refusing to sign pipeline con
 // since it has custom logic for determining the correct step type.
 type Steps []Step
 
-// unmarshalAny unmarshals a slice ([]any) into a slice of steps.
-func (s *Steps) unmarshalAny(o any) error {
+// UnmarshalOrdered unmarshals a slice ([]any) into a slice of steps.
+func (s *Steps) UnmarshalOrdered(o any) error {
 	if o == nil {
 		if *s == nil {
 			// `steps: null` is normalised to an empty slice.
@@ -87,7 +87,7 @@ func stepFromMap(o *ordered.MapSA) (Step, error) {
 	}
 
 	// Decode the step (into the right step type).
-	if err := step.unmarshalMap(o); err != nil {
+	if err := ordered.Unmarshal(o, step); err != nil {
 		// Hmm, maybe we picked the wrong kind of step?
 		return &UnknownStep{Contents: o}, nil
 	}
@@ -103,7 +103,7 @@ func stepByType(sType string) (Step, error) {
 	case "block", "input", "manual":
 		return &InputStep{Contents: map[string]any{}}, nil
 	case "trigger":
-		return make(TriggerStep), nil
+		return new(TriggerStep), nil
 	case "group": // as far as i know this doesn't happen, but it's here for completeness
 		return new(GroupStep), nil
 	default:
@@ -125,7 +125,7 @@ func stepByKeyInference(o *ordered.MapSA) (Step, error) {
 		return new(InputStep), nil
 
 	case o.Contains("trigger"):
-		return make(TriggerStep), nil
+		return new(TriggerStep), nil
 
 	case o.Contains("group"):
 		return new(GroupStep), nil


### PR DESCRIPTION
The main affordance of `encoding/json`, `gopkg.in/yaml.v3`, etc is the ability to unmarshal data into a struct. This PR adds similar functionality to the `ordered` package.
    
Because `DecodeYAML` returns a variety of types, `Unmarshal` handles `*MapSA`, `[]any`, and a variety of scalars as sources.

The second commit applies the new `ordered.Unmarshal` to pipeline parsing.