### PR TITLE
Create a panic log level

### DIFF
--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -120,7 +120,7 @@ var AnnotateCommand = cli.Command{
 		defer done()
 
 		if err := annotate(ctx, cfg, l); err != nil {
-			l.Fatal(err.Error())
+			l.Panic("%s", err)
 		}
 	},
 }

--- a/clicommand/annotation_remove.go
+++ b/clicommand/annotation_remove.go
@@ -104,7 +104,7 @@ var AnnotationRemoveCommand = cli.Command{
 			}
 			return nil
 		}); err != nil {
-			l.Fatal("Failed to remove annotation: %s", err)
+			l.Panic("Failed to remove annotation: %s", err)
 		}
 
 		l.Debug("Successfully removed annotation")

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -121,7 +121,7 @@ var ArtifactDownloadCommand = cli.Command{
 
 		// Download the artifacts
 		if err := downloader.Download(ctx); err != nil {
-			l.Fatal("Failed to download artifacts: %s", err)
+			l.Panic("Failed to download artifacts: %s", err)
 		}
 	},
 }

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -152,7 +152,7 @@ Format specifiers:
 			if cfg.AllowEmptyResults {
 				l.Info("No matches found for %q", cfg.Query)
 			} else {
-				l.Fatal("No matches found for %q", cfg.Query)
+				l.Panic("No matches found for %q", cfg.Query)
 			}
 		}
 

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -115,7 +115,7 @@ var ArtifactShasumCommand = cli.Command{
 		defer done()
 
 		if err := searchAndPrintShaSum(ctx, cfg, l, os.Stdout); err != nil {
-			l.Fatal(err.Error())
+			l.Panic("%s", err)
 		}
 	},
 }

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -162,7 +162,7 @@ var ArtifactUploadCommand = cli.Command{
 
 		// Upload the artifacts
 		if err := uploader.Upload(ctx); err != nil {
-			l.Fatal("Failed to upload artifacts: %s", err)
+			l.Panic("Failed to upload artifacts: %s", err)
 		}
 	},
 }

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -360,6 +360,9 @@ var BootstrapCommand = cli.Command{
 		StrictSingleHooksFlag,
 	},
 	Action: func(c *cli.Context) {
+		var exitCode int
+		defer func() { os.Exit(exitCode) }()
+
 		ctx := context.Background()
 		cfg, l, _, done := setupLoggerAndConfig[BootstrapConfig](c)
 		defer done()
@@ -376,13 +379,13 @@ var BootstrapCommand = cli.Command{
 			case "plugin", "checkout", "command":
 				// Valid phase
 			default:
-				l.Fatal("Invalid phase %q", phase)
+				l.Panic("Invalid phase %q", phase)
 			}
 		}
 
 		cancelSig, err := process.ParseSignal(cfg.CancelSignal)
 		if err != nil {
-			l.Fatal("Failed to parse cancel-signal: %v", err)
+			l.Panic("Failed to parse cancel-signal: %v", err)
 		}
 
 		signalGracePeriod := time.Duration(cfg.SignalGracePeriodSeconds) * time.Second
@@ -474,7 +477,7 @@ var BootstrapCommand = cli.Command{
 		}()
 
 		// Run the bootstrap and get the exit code
-		exitCode := bootstrap.Run(cctx)
+		exitCode = bootstrap.Run(cctx)
 
 		signalMu.Lock()
 		defer signalMu.Unlock()
@@ -493,7 +496,5 @@ var BootstrapCommand = cli.Command{
 				l.Error("Failed to signal self: %v", err)
 			}
 		}
-
-		os.Exit(exitCode)
 	},
 }

--- a/clicommand/env_dump.go
+++ b/clicommand/env_dump.go
@@ -70,7 +70,7 @@ var EnvDumpCommand = cli.Command{
 		}
 
 		if err := enc.Encode(envMap); err != nil {
-			l.Fatal("Error marshalling JSON: %v", err)
+			l.Panic("Error marshalling JSON: %v", err)
 		}
 
 		return nil

--- a/clicommand/env_set.go
+++ b/clicommand/env_set.go
@@ -86,7 +86,7 @@ func envSetAction(c *cli.Context) error {
 
 	client, err := jobapi.NewDefaultClient(ctx)
 	if err != nil {
-		l.Fatal(envClientErrMessage, err)
+		l.Panic(envClientErrMessage, err)
 	}
 
 	req := &jobapi.EnvUpdateRequest{
@@ -113,7 +113,7 @@ func envSetAction(c *cli.Context) error {
 		}
 
 	default:
-		l.Fatal("Invalid input format %q\n", c.String("input-format"))
+		l.Panic("Invalid input format %q\n", c.String("input-format"))
 	}
 
 	// Inspect each arg, which could either be "-" for stdin, or "KEY=value"
@@ -124,18 +124,18 @@ func envSetAction(c *cli.Context) error {
 			line := 1
 			for sc.Scan() {
 				if err := parse(sc.Text()); err != nil {
-					l.Fatal("Couldn't parse input line %d: %v\n", line, err)
+					l.Panic("Couldn't parse input line %d: %v\n", line, err)
 				}
 				line++
 			}
 			if err := sc.Err(); err != nil {
-				l.Fatal("Couldn't scan the input buffer: %v\n", err)
+				l.Panic("Couldn't scan the input buffer: %v\n", err)
 			}
 			continue
 		}
 		// Parse args directly
 		if err := parse(arg); err != nil {
-			l.Fatal("Couldn't parse the command-line argument %q: %v\n", arg, err)
+			l.Panic("Couldn't parse the command-line argument %q: %v\n", arg, err)
 		}
 	}
 
@@ -171,11 +171,11 @@ func envSetAction(c *cli.Context) error {
 			enc.SetIndent("", "  ")
 		}
 		if err := enc.Encode(resp); err != nil {
-			l.Fatal("Error marshalling JSON: %v\n", err)
+			l.Panic("Error marshalling JSON: %v\n", err)
 		}
 
 	default:
-		l.Fatal("Invalid output format %q\n", c.String("output-format"))
+		l.Panic("Invalid output format %q\n", c.String("output-format"))
 	}
 
 	return nil

--- a/clicommand/env_unset.go
+++ b/clicommand/env_unset.go
@@ -85,7 +85,7 @@ func envUnsetAction(c *cli.Context) error {
 
 	client, err := jobapi.NewDefaultClient(ctx)
 	if err != nil {
-		l.Fatal(envClientErrMessage, err)
+		l.Panic(envClientErrMessage, err)
 	}
 
 	var del []string
@@ -116,21 +116,18 @@ func envUnsetAction(c *cli.Context) error {
 			line := 1
 			for sc.Scan() {
 				if err := parse(sc.Text()); err != nil {
-					fmt.Fprintf(c.App.ErrWriter, "Couldn't parse input line %d: %v\n", line, err)
-					os.Exit(1)
+					l.Panic("Couldn't parse input line %d: %v", line, err)
 				}
 				line++
 			}
 			if err := sc.Err(); err != nil {
-				fmt.Fprintf(c.App.ErrWriter, "Couldn't scan the input buffer: %v\n", err)
-				os.Exit(1)
+				l.Panic("Couldn't scan the input buffer: %v", err)
 			}
 			continue
 		}
 		// Parse args directly
 		if err := parse(arg); err != nil {
-			fmt.Fprintf(c.App.ErrWriter, "Couldn't parse the command-line argument %q: %v\n", arg, err)
-			os.Exit(1)
+			l.Panic("Couldn't parse the command-line argument %q: %v", arg, err)
 		}
 	}
 
@@ -159,8 +156,7 @@ func envUnsetAction(c *cli.Context) error {
 			enc.SetIndent("", "  ")
 		}
 		if err := enc.Encode(unset); err != nil {
-			fmt.Fprintf(c.App.ErrWriter, "Error marshalling JSON: %v\n", err)
-			os.Exit(1)
+			l.Panic("Error marshalling JSON: %v", err)
 		}
 
 	default:

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -326,6 +326,8 @@ func setupLoggerAndConfig[T any](c *cli.Context, opts ...configOpts) (
 		cleanup()
 
 		switch r := recover(); r {
+		case nil:
+			// there was no panic
 		case logger.Panic{}:
 			os.Exit(1)
 		default:

--- a/clicommand/lock_acquire.go
+++ b/clicommand/lock_acquire.go
@@ -83,7 +83,7 @@ func lockAcquireAction(c *cli.Context) error {
 	defer done()
 
 	if cfg.LockScope != "machine" {
-		l.Fatal("Only 'machine' scope for locks is supported in this version.")
+		l.Panic("Only 'machine' scope for locks is supported in this version.")
 	}
 
 	if cfg.LockWaitTimeout != 0 {
@@ -94,12 +94,12 @@ func lockAcquireAction(c *cli.Context) error {
 
 	client, err := lock.NewClient(ctx, cfg.SocketsPath)
 	if err != nil {
-		l.Fatal(lockClientErrMessage, err)
+		l.Panic(lockClientErrMessage, err)
 	}
 
 	token, err := client.Lock(ctx, key)
 	if err != nil {
-		l.Fatal("Could not acquire lock: %v\n", err)
+		l.Panic("Could not acquire lock: %v\n", err)
 	}
 
 	fmt.Fprintln(c.App.Writer, token)

--- a/clicommand/lock_do.go
+++ b/clicommand/lock_do.go
@@ -89,7 +89,7 @@ func lockDoAction(c *cli.Context) error {
 	defer done()
 
 	if cfg.LockScope != "machine" {
-		l.Fatal("Only 'machine' scope for locks is supported in this version.")
+		l.Panic("Only 'machine' scope for locks is supported in this version.")
 	}
 
 	if cfg.LockWaitTimeout != 0 {
@@ -100,12 +100,12 @@ func lockDoAction(c *cli.Context) error {
 
 	client, err := lock.NewClient(ctx, cfg.SocketsPath)
 	if err != nil {
-		l.Fatal(lockClientErrMessage, err)
+		l.Panic(lockClientErrMessage, err)
 	}
 
 	do, err := client.DoOnceStart(ctx, key)
 	if err != nil {
-		l.Fatal("Couldn't start do-once lock: %v\n", err)
+		l.Panic("Couldn't start do-once lock: %v\n", err)
 	}
 
 	if do {

--- a/clicommand/lock_done.go
+++ b/clicommand/lock_done.go
@@ -63,16 +63,16 @@ func lockDoneAction(c *cli.Context) error {
 	defer done()
 
 	if cfg.LockScope != "machine" {
-		l.Fatal("Only 'machine' scope for locks is supported in this version.")
+		l.Panic("Only 'machine' scope for locks is supported in this version.")
 	}
 
 	client, err := lock.NewClient(ctx, cfg.SocketsPath)
 	if err != nil {
-		l.Fatal(lockClientErrMessage, err)
+		l.Panic(lockClientErrMessage, err)
 	}
 
 	if err := client.DoOnceEnd(ctx, key); err != nil {
-		l.Fatal("Couldn't complete do-once lock: %v", err)
+		l.Panic("Couldn't complete do-once lock: %v", err)
 	}
 
 	return nil

--- a/clicommand/lock_get.go
+++ b/clicommand/lock_get.go
@@ -64,17 +64,17 @@ func lockGetAction(c *cli.Context) error {
 	defer done()
 
 	if cfg.LockScope != "machine" {
-		l.Fatal("Only 'machine' scope for locks is supported in this version.")
+		l.Panic("Only 'machine' scope for locks is supported in this version.")
 	}
 
 	client, err := lock.NewClient(ctx, cfg.SocketsPath)
 	if err != nil {
-		l.Fatal(lockClientErrMessage, err)
+		l.Panic(lockClientErrMessage, err)
 	}
 
 	v, err := client.Get(ctx, key)
 	if err != nil {
-		l.Fatal("Couldn't get lock state: %v", err)
+		l.Panic("Couldn't get lock state: %v", err)
 	}
 
 	fmt.Fprintln(c.App.Writer, v)

--- a/clicommand/lock_release.go
+++ b/clicommand/lock_release.go
@@ -63,16 +63,16 @@ func lockReleaseAction(c *cli.Context) error {
 	defer done()
 
 	if cfg.LockScope != "machine" {
-		l.Fatal("Only 'machine' scope for locks is supported in this version.")
+		l.Panic("Only 'machine' scope for locks is supported in this version.")
 	}
 
 	client, err := lock.NewClient(ctx, cfg.SocketsPath)
 	if err != nil {
-		l.Fatal(lockClientErrMessage, err)
+		l.Panic(lockClientErrMessage, err)
 	}
 
 	if err := client.Unlock(ctx, key, token); err != nil {
-		l.Fatal("Could not release lock: %v", err)
+		l.Panic("Could not release lock: %v", err)
 	}
 
 	return nil

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -74,6 +74,14 @@ var MetaDataExistsCommand = cli.Command{
 		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {
+		var exists *api.MetaDataExists
+		defer func() {
+			// If the meta data didn't exist, exit with an error.
+			if exists != nil && !exists.Exists {
+				os.Exit(100)
+			}
+		}()
+
 		ctx := context.Background()
 		cfg, l, _, done := setupLoggerAndConfig[MetaDataExistsConfig](c)
 		defer done()
@@ -82,7 +90,6 @@ var MetaDataExistsCommand = cli.Command{
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
 
 		// Find the meta data value
-		var exists *api.MetaDataExists
 		var resp *api.Response
 
 		scope := "job"
@@ -108,12 +115,7 @@ var MetaDataExistsCommand = cli.Command{
 			}
 			return nil
 		}); err != nil {
-			l.Fatal("Failed to see if meta-data exists: %s", err)
-		}
-
-		// If the meta data didn't exist, exit with an error.
-		if !exists.Exists {
-			os.Exit(100)
+			l.Panic("Failed to see if meta-data exists: %s", err)
 		}
 	},
 }

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -127,7 +127,7 @@ var MetaDataGetCommand = cli.Command{
 				return
 			}
 
-			l.Fatal("Failed to get meta-data: %s", err)
+			l.Panic("Failed to get meta-data: %s", err)
 		}
 
 		// Output the value to STDOUT

--- a/clicommand/meta_data_keys.go
+++ b/clicommand/meta_data_keys.go
@@ -107,7 +107,7 @@ var MetaDataKeysCommand = cli.Command{
 			}
 			return nil
 		}); err != nil {
-			l.Fatal("Failed to find meta-data keys: %s", err)
+			l.Panic("Failed to find meta-data keys: %s", err)
 		}
 
 		for _, key := range keys {

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -87,17 +87,17 @@ var MetaDataSetCommand = cli.Command{
 
 			input, err := io.ReadAll(os.Stdin)
 			if err != nil {
-				l.Fatal("Failed to read from STDIN: %s", err)
+				l.Panic("Failed to read from STDIN: %s", err)
 			}
 			cfg.Value = string(input)
 		}
 
 		if strings.TrimSpace(cfg.Key) == "" {
-			l.Fatal("Key cannot be empty, or composed of only whitespace characters")
+			l.Panic("Key cannot be empty, or composed of only whitespace characters")
 		}
 
 		if strings.TrimSpace(cfg.Value) == "" {
-			l.Fatal("Value cannot be empty, or composed of only whitespace characters")
+			l.Panic("Value cannot be empty, or composed of only whitespace characters")
 		}
 
 		// Create the API client
@@ -124,7 +124,7 @@ var MetaDataSetCommand = cli.Command{
 			}
 			return nil
 		}); err != nil {
-			l.Fatal("Failed to set meta-data: %s", err)
+			l.Panic("Failed to set meta-data: %s", err)
 		}
 	},
 }

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -98,7 +98,7 @@ var OIDCRequestTokenCommand = cli.Command{
 
 		// Note: if --lifetime is omitted, cfg.Lifetime = 0
 		if cfg.Lifetime < 0 {
-			l.Fatal("Lifetime %d must be a non-negative integer.", cfg.Lifetime)
+			l.Panic("Lifetime %d must be a non-negative integer.", cfg.Lifetime)
 		}
 
 		// Create the API client

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -16,7 +16,7 @@ func TestSearchForSecrets(t *testing.T) {
 		RejectSecrets: true,
 	}
 
-	pipeline := &pipeline.Pipeline{
+	p := &pipeline.Pipeline{
 		Steps: pipeline.Steps{
 			&pipeline.CommandStep{
 				Command: "secret squirrels and alpacas",
@@ -38,14 +38,14 @@ func TestSearchForSecrets(t *testing.T) {
 			desc:    "one secret",
 			environ: map[string]string{"SEKRET": "squirrel", "PYTHON": "not a chance"},
 			wantLog: []string{
-				`[fatal] Pipeline "cat-o-matic.yaml" contains values interpolated from the following secret environment variables: [SEKRET], and cannot be uploaded to Buildkite`,
+				`[panic] Pipeline "cat-o-matic.yaml" contains values interpolated from the following secret environment variables: [SEKRET], and cannot be uploaded to Buildkite`,
 			},
 		},
 		{
 			desc:    "two secrets",
 			environ: map[string]string{"SEKRET": "squirrel", "SSH_KEY": "alpacas", "SPECIES": "Felix sylvestris"},
 			wantLog: []string{
-				`[fatal] Pipeline "cat-o-matic.yaml" contains values interpolated from the following secret environment variables: [SEKRET SSH_KEY], and cannot be uploaded to Buildkite`,
+				`[panic] Pipeline "cat-o-matic.yaml" contains values interpolated from the following secret environment variables: [SEKRET SSH_KEY], and cannot be uploaded to Buildkite`,
 			},
 		},
 	}
@@ -56,7 +56,7 @@ func TestSearchForSecrets(t *testing.T) {
 			t.Parallel()
 			l := logger.NewBuffer()
 
-			searchForSecrets(l, cfg, test.environ, pipeline, "cat-o-matic.yaml")
+			searchForSecrets(l, cfg, test.environ, p, "cat-o-matic.yaml")
 
 			if diff := cmp.Diff(l.Messages, test.wantLog); diff != "" {
 				t.Errorf("searchForSecrets log output diff (-got +want):\n%s", diff)

--- a/clicommand/profiler.go
+++ b/clicommand/profiler.go
@@ -45,7 +45,7 @@ func Profile(l logger.Logger, mode string) func() {
 	case "trace":
 		p.mode = traceMode
 	default:
-		p.logger.Fatal("Unknown profile mode %q", mode)
+		p.logger.Panic("Unknown profile mode %q", mode)
 	}
 
 	p.Start()
@@ -61,27 +61,27 @@ func (p *profiler) Stop() {
 func (p *profiler) Start() {
 	path, err := os.MkdirTemp("", "profile")
 	if err != nil {
-		p.logger.Fatal("Could not create initial output directory: %v", err)
+		p.logger.Panic("Could not create initial output directory: %v", err)
 	}
 
 	// create a pprof file for the mode
 	fn := filepath.Join(path, string(p.mode)+".pprof")
 	f, err := os.Create(fn)
 	if err != nil {
-		p.logger.Fatal("Could not create %s profile %q: %v", p.mode, fn, err)
+		p.logger.Panic("Could not create %s profile %q: %v", p.mode, fn, err)
 	}
 
 	// called after mode specific closers
 	closer := func() {
 		if err := f.Close(); err != nil {
-			p.logger.Fatal("Failed to close %s: %v", fn, err)
+			p.logger.Panic("Failed to close %s: %v", fn, err)
 		}
 		p.logger.Info("Finished %s profiling finished, %s", p.mode, fn)
 	}
 
 	must := func(err error) {
 		if err != nil {
-			p.logger.Fatal("Profiler mode %s failed: %v", p.mode, err)
+			p.logger.Panic("Profiler mode %s failed: %v", p.mode, err)
 		}
 	}
 
@@ -132,7 +132,7 @@ func (p *profiler) Start() {
 
 	case traceMode:
 		if err := trace.Start(f); err != nil {
-			p.logger.Fatal("Could not start profiling trace: %v", err)
+			p.logger.Panic("Could not start profiling trace: %v", err)
 		}
 		p.logger.Info("Trace enabled, %s", fn)
 		p.closer = func() {

--- a/clicommand/step_get.go
+++ b/clicommand/step_get.go
@@ -121,7 +121,7 @@ var StepGetCommand = cli.Command{
 			}
 			return nil
 		}); err != nil {
-			l.Fatal("Failed to get step: %s", err)
+			l.Panic("Failed to get step: %s", err)
 		}
 
 		// Output the value to STDOUT

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -104,7 +104,7 @@ var StepUpdateCommand = cli.Command{
 
 			input, err := io.ReadAll(os.Stdin)
 			if err != nil {
-				l.Fatal("Failed to read from STDIN: %s", err)
+				l.Panic("Failed to read from STDIN: %s", err)
 			}
 			cfg.Value = string(input)
 		}
@@ -141,7 +141,7 @@ var StepUpdateCommand = cli.Command{
 			}
 			return nil
 		}); err != nil {
-			l.Fatal("Failed to change step: %s", err)
+			l.Panic("Failed to change step: %s", err)
 		}
 	},
 }

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -1709,6 +1709,8 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 		return nil
 	}
 
+	e.shell.Commentf("############### exp: %t", experiments.IsEnabled(experiments.ResolveCommitAfterCheckout))
+
 	// resolve BUILDKITE_COMMIT based on the local git repo
 	if experiments.IsEnabled(experiments.ResolveCommitAfterCheckout) {
 		e.shell.Commentf("Using resolve-commit-after-checkout experiment 🧪")

--- a/internal/job/integration/main_test.go
+++ b/internal/job/integration/main_test.go
@@ -22,6 +22,9 @@ func TestMain(m *testing.M) {
 			clicommand.BootstrapCommand,
 		}
 
+		app.Writer = os.Stdout
+		app.ErrWriter = os.Stderr
+
 		if err := app.Run(os.Args); err != nil {
 			fmt.Printf("%v\n", err)
 			os.Exit(1)

--- a/logger/buffer.go
+++ b/logger/buffer.go
@@ -31,6 +31,9 @@ func (b *Buffer) Error(format string, v ...any) {
 	defer b.mu.Unlock()
 	b.Messages = append(b.Messages, "[error] "+fmt.Sprintf(format, v...))
 }
+func (b *Buffer) Panic(format string, v ...any) {
+	b.Messages = append(b.Messages, "[panic] "+fmt.Sprintf(format, v...))
+}
 func (b *Buffer) Fatal(format string, v ...any) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/logger/level.go
+++ b/logger/level.go
@@ -13,6 +13,7 @@ const (
 	INFO
 	WARN
 	ERROR
+	PANIC
 	FATAL
 )
 
@@ -22,6 +23,7 @@ var levelNames = []string{
 	"INFO",
 	"WARN",
 	"ERROR",
+	"PANIC",
 	"FATAL",
 }
 
@@ -37,6 +39,8 @@ func LevelFromString(s string) (Level, error) {
 		return WARN, nil
 	case "error":
 		return ERROR, nil
+	case "panic":
+		return PANIC, nil
 	case "fatal":
 		return FATAL, nil
 	default:

--- a/logger/log.go
+++ b/logger/log.go
@@ -18,6 +18,9 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+// Panic is used as a sentinel value for panics issued by the PANIC log level
+type Panic struct{}
+
 const (
 	nocolor   = "0"
 	red       = "31"
@@ -27,9 +30,7 @@ const (
 	graybold  = "1;38;5;251"
 	lightgray = "38;5;243"
 	cyan      = "1;36"
-)
 
-const (
 	DateFormat = "2006-01-02 15:04:05"
 )
 
@@ -42,6 +43,7 @@ type Logger interface {
 	Debug(format string, v ...any)
 	Error(format string, v ...any)
 	Fatal(format string, v ...any)
+	Panic(format string, v ...any)
 	Notice(format string, v ...any)
 	Warn(format string, v ...any)
 	Info(format string, v ...any)
@@ -96,6 +98,11 @@ func (l *ConsoleLogger) Error(format string, v ...any) {
 func (l *ConsoleLogger) Fatal(format string, v ...any) {
 	l.printer.Print(FATAL, fmt.Sprintf(format, v...), l.fields)
 	l.exitFn(1)
+}
+
+func (l *ConsoleLogger) Panic(format string, v ...any) {
+	l.printer.Print(PANIC, fmt.Sprintf(format, v...), l.fields)
+	panic(Panic{})
 }
 
 func (l *ConsoleLogger) Notice(format string, v ...any) {
@@ -165,6 +172,7 @@ func (l *TextPrinter) Print(level Level, msg string, fields Fields) {
 		fieldColor := graybold
 
 		switch level {
+		case INFO: // use default colors
 		case DEBUG:
 			levelColor = gray
 			messageColor = gray
@@ -174,6 +182,9 @@ func (l *TextPrinter) Print(level Level, msg string, fields Fields) {
 			levelColor = yellow
 		case ERROR:
 			levelColor = red
+		case PANIC:
+			levelColor = red
+			messageColor = red
 		case FATAL:
 			levelColor = red
 			messageColor = red


### PR DESCRIPTION
Unlike the fatal log level, this will allow defers to run.

I'm mainly putting this up for discussion, I don't intend to merge as is.

We have a few options here, but the outcome that MUST happen is that `defer`s from cli command actions must be run when an error is encountered. Some options are:
1. This PR, always use `l.Panic`
2. Modify this PR to modify the `FATAL` log level to behave like `PANIC` does and remove panic
3. Always return errors from methods called by cli command actions, return those errors up to the main function and determine how they should be handled there.

3 is the most idiomatic solution, but it requires diving deep into the code and eliminating all `os.Exit` and `l.Fatal` calls. And also, it is likely that not all methods that call `os.Exit` or `l.Fatal` return errors that make it all the way to main.go. We would have to change the method signature and how their return values are handled if they call `l.Fatal`.

2 seems like the most pragmatic choice to me.