### PR TITLE
add missing 'an' in annotation help

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func main() {
 		clicommand.AnnotateCommand,
 		{
 			Name:  "annotation",
-			Usage: "Make changes an annotation on the currently running build",
+			Usage: "Make changes to an annotation on the currently running build",
 			Subcommands: []cli.Command{
 				clicommand.AnnotationRemoveCommand,
 			},


### PR DESCRIPTION
This corrects...

```
buildkite-agent --help
Usage:

  buildkite-agent <command> [options...]
...
  annotation        Make changes an annotation on the currently running build
...

```

To read...

```
buildkite-agent --help
Usage:

  buildkite-agent <command> [options...]
...
  annotation        Make changes to an annotation on the currently running build
...
```