### PR TITLE
Use capacity hint in `concat`

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -3,6 +3,7 @@ package clicommand
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -511,7 +512,7 @@ func concat[T any](a ...[]T) []T {
 		cap += len(s)
 	}
 
-	var result []T
+	result := make([]T, 0, cap)
 	for _, s := range a {
 		result = append(result, s...)
 	}


### PR DESCRIPTION
I assume this is what @moskyb intended to do here... but didn't.

([I, too, like to make values and never use them.](https://github.com/buildkite/agent/pull/2257))