### PR TITLE
Include plugins in command step signatures

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -32,6 +32,10 @@ func (j *Job) ValuesForFields(fields []string) (map[string]string, error) {
 		switch f {
 		case "command":
 			o[f] = j.Env["BUILDKITE_COMMAND"]
+
+		case "plugins":
+			o[f] = j.Env["BUILDKITE_PLUGINS"]
+
 		default:
 			return nil, fmt.Errorf("unknown or unsupported field on Job struct for signing/verification: %q", f)
 		}

--- a/internal/pipeline/sign.go
+++ b/internal/pipeline/sign.go
@@ -25,7 +25,10 @@ type Signature struct {
 func Sign(sf SignedFielder, key jwk.Key) (*Signature, error) {
 	payload := &bytes.Buffer{}
 
-	values := sf.SignedFields()
+	values, err := sf.SignedFields()
+	if err != nil {
+		return nil, err
+	}
 	if len(values) == 0 {
 		return nil, errors.New("sign: no fields to sign")
 	}
@@ -134,7 +137,7 @@ func (s *Signature) unmarshalAny(o any) error {
 type SignedFielder interface {
 	// SignedFields returns the default set of fields to sign, and their values.
 	// This is called by Sign.
-	SignedFields() map[string]string
+	SignedFields() (map[string]string, error)
 
 	// ValuesForFields looks up each field and produces a map of values. This is
 	// called by Verify. The set of fields might differ from the default, e.g.

--- a/internal/pipeline/sign_test.go
+++ b/internal/pipeline/sign_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/buildkite/agent/v3/internal/ordered"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 )
@@ -14,6 +15,21 @@ import (
 func TestSignVerify(t *testing.T) {
 	step := &CommandStep{
 		Command: "llamas",
+		Plugins: Plugins{
+			{
+				Name:   "some-plugin#v1.0.0",
+				Config: nil,
+			},
+			{
+				Name: "another-plugin#v3.4.5",
+				Config: ordered.MapFromItems(
+					ordered.TupleSA{
+						Key:   "llama",
+						Value: "Kuzco",
+					},
+				),
+			},
+		},
 	}
 
 	cases := []struct {
@@ -26,19 +42,19 @@ func TestSignVerify(t *testing.T) {
 			name:                           "HMAC-SHA256",
 			generateSigner:                 func(alg jwa.SignatureAlgorithm) (jwk.Key, jwk.Set) { return newSymmetricKeyPair(t, "alpacas", alg) },
 			alg:                            jwa.HS256,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzI1NiIsImtpZCI6IlRlc3RTaWduVmVyaWZ5In0..f5NQYQtR0Eg-0pzzCon2ykzGy5oDPYtQw0C0fTKGI38",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzI1NiIsImtpZCI6IlRlc3RTaWduVmVyaWZ5In0..NDiUjV0myH279-OQi6eOKjgyhAPUnc5ZmZoynhUUvIo",
 		},
 		{
 			name:                           "HMAC-SHA384",
 			generateSigner:                 func(alg jwa.SignatureAlgorithm) (jwk.Key, jwk.Set) { return newSymmetricKeyPair(t, "alpacas", alg) },
 			alg:                            jwa.HS384,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzM4NCIsImtpZCI6IlRlc3RTaWduVmVyaWZ5In0..HgHltOlatth2TCc4swArP1UL_Zm2Rh2ccEC26s1sFBO6FOW5qfW37uQ9CHAz6dhh",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzM4NCIsImtpZCI6IlRlc3RTaWduVmVyaWZ5In0..XGdZ7TG0lBSg7rXc091A3OaXAjODyI7aFkAjFJblD0YUnC5WW6WHgmJqlrG94x7z",
 		},
 		{
 			name:                           "HMAC-SHA512",
 			generateSigner:                 func(alg jwa.SignatureAlgorithm) (jwk.Key, jwk.Set) { return newSymmetricKeyPair(t, "alpacas", alg) },
 			alg:                            jwa.HS512,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzUxMiIsImtpZCI6IlRlc3RTaWduVmVyaWZ5In0..mcph5zwioGkmx-aPrxExzc9QRzO4afn_kK_89aEuo4xYD0tcUD8OJom09x2xcvK6eRkOpvVlkrKLBzvh-7uu6w",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzUxMiIsImtpZCI6IlRlc3RTaWduVmVyaWZ5In0..GvKR_cGqNcF8EgffnkSoymJORoH60W36O80tYnGwnKXTUTh0XVmnEp0gT03YYRdf39JnwqbMGCticQJFFA_jWg",
 		},
 		{
 			name:           "RSA-PSS 256",
@@ -110,7 +126,7 @@ func TestSignVerify(t *testing.T) {
 
 type testFields map[string]string
 
-func (m testFields) SignedFields() map[string]string { return m }
+func (m testFields) SignedFields() (map[string]string, error) { return m, nil }
 
 func (m testFields) ValuesForFields(fields []string) (map[string]string, error) {
 	out := make(map[string]string, len(fields))

--- a/internal/pipeline/step_command.go
+++ b/internal/pipeline/step_command.go
@@ -1,7 +1,7 @@
 package pipeline
 
 import (
-	"errors"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -89,25 +89,62 @@ func (c *CommandStep) unmarshalMap(m *ordered.MapSA) error {
 }
 
 // SignedFields returns the default fields for signing.
-func (c *CommandStep) SignedFields() map[string]string {
+func (c *CommandStep) SignedFields() (map[string]string, error) {
+	plugins := ""
+	if len(c.Plugins) > 0 {
+		// TODO: Reconsider using JSON here - is it stable enough?
+		pj, err := json.Marshal(c.Plugins)
+		if err != nil {
+			return nil, err
+		}
+		plugins = string(pj)
+	}
 	return map[string]string{
 		"command": c.Command,
-	}
+		"plugins": plugins,
+	}, nil
 }
 
 // ValuesForFields returns the contents of fields to sign.
 func (c *CommandStep) ValuesForFields(fields []string) (map[string]string, error) {
+	// Make a set of required fields. As fields is processed, mark them off by
+	// deleting them.
+	required := map[string]struct{}{
+		"command": {},
+		"plugins": {},
+	}
+
 	out := make(map[string]string, len(fields))
 	for _, f := range fields {
+		delete(required, f)
+
 		switch f {
 		case "command":
 			out["command"] = c.Command
+
+		case "plugins":
+			if len(c.Plugins) == 0 {
+				out["plugins"] = ""
+				break
+			}
+			// TODO: Reconsider using JSON here - is it stable enough?
+			val, err := json.Marshal(c.Plugins)
+			if err != nil {
+				return nil, err
+			}
+			out["plugins"] = string(val)
+
 		default:
 			return nil, fmt.Errorf("unknown or unsupported field for signing %q", f)
 		}
 	}
-	if _, ok := out["command"]; !ok {
-		return nil, errors.New("command is required for signature verification")
+
+	if len(required) > 0 {
+		missing := make([]string, 0, len(required))
+		for k := range required {
+			missing = append(missing, k)
+		}
+		return nil, fmt.Errorf("one or more required fields are not present: %v", missing)
 	}
 	return out, nil
 }


### PR DESCRIPTION
Plugins alter the execution of a step completely, so the list of plugins and their configurations must be included in the signature for it to be secure.

This PR currently encodes plugin configs into JSON. This is potentially not a great encoding (what stability guarantees do we really have?), but because this is how the whole pipeline is uploaded, it ought to round-trip well enough.