### PR TITLE
Add a newline after printing errors from the config parser

### DIFF
--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -301,7 +301,7 @@ func setupLoggerAndConfig[T any](c *cli.Context, opts ...configOpts) (
 
 	warnings, err := loader.Load()
 	if err != nil {
-		fmt.Fprintf(c.App.ErrWriter, "%s", err)
+		fmt.Fprintf(c.App.ErrWriter, "%s\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Terminal programs should always print a new line when they exit so that the new prompt can start at the left.

Since in #2281, we consolidated all the configuration error printing into a single location, this PR can fix it just here. There might be a more systematic way to do this, for all situations where the agent exits, but for now, this is a quick fix for a place where we noticed it happening.

Before:
```shell
❯ buildkite-agent --version
buildkite-agent version 3.49.0, build x
agent (9619ad6) [$] via 🐹 v1.21.0 via 💎 v3.2.2 on ☁️
❯ buildkite-agent artifact upload f
Missing job. See: `buildkite-agent artifact upload --help`⏎
```

After:
```shell
❯ buildkite-agent --version
buildkite-agent version 3.51.0, build x
agent on  pdp-1466-fix-new-missing-args-needs-newline [$!+] via 🐹 v1.21.0 via 💎 v3.2.2 on ☁️
❯ buildkite-agent artifact upload f
Missing job. See: `buildkite-agent artifact upload --help`
```

Fish (and zsh?) aficionados will recognise that `⏎` indicates that there is no newline at the end of the output.

In this case, the agent was launching itself as a subprocess, but this is a problem for all subproceses launched by the agent that write to the logs. I think it would be good to insert such a character in the job logs when *any* process writing to the job logs does not terminate in a newline. 