### PR TITLE
Update ecr, docker plugins, and agent image ver

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -8,10 +8,10 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - ecr#v2.0.0:
+      - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
-      - docker#v3.5.0:
+      - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
 
@@ -23,8 +23,8 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - docker#v3.5.0:
-          image: "buildkite/agent:3.45.0"
+      - docker#v5.8.0:
+          image: "buildkite/agent:3.51.0"
           entrypoint: bash
           propagate-environment: true
           volumes:
@@ -38,10 +38,10 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - ecr#v2.0.0:
+      - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
-      - docker#v3.5.0:
+      - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
           tmpfs:
@@ -58,6 +58,6 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - ecr#v2.0.0:
+      - ecr#v2.7.0:
           login: true
           account-ids: "445615400570"

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -13,10 +13,10 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - ecr#v2.0.0:
+      - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
-      - docker#v3.5.0:
+      - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
 
@@ -27,10 +27,10 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - ecr#v2.0.0:
+      - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
-      - docker#v3.5.0:
+      - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
 
@@ -42,8 +42,8 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - docker#v3.5.0:
-          image: "buildkite/agent:3.45.0"
+      - docker#v5.8.0:
+          image: "buildkite/agent:3.51.0"
           entrypoint: bash
           propagate-environment: true
           volumes:
@@ -61,10 +61,10 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - ecr#v2.0.0:
+      - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
-      - docker#v3.5.0:
+      - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
           tmpfs:
@@ -77,7 +77,7 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - ecr#v2.0.0:
+      - ecr#v2.7.0:
           login: true
           account-ids: "445615400570"
 
@@ -91,9 +91,9 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - ecr#v2.0.0:
+      - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
-      - docker#v3.5.0:
+      - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -13,10 +13,10 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - ecr#v2.0.0:
+      - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
-      - docker#v3.5.0:
+      - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
 
@@ -27,10 +27,10 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - ecr#v2.0.0:
+      - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
-      - docker#v3.5.0:
+      - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
 
@@ -42,8 +42,8 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - docker#v3.5.0:
-          image: "buildkite/agent:3.45.0"
+      - docker#v5.8.0:
+          image: "buildkite/agent:3.51.0"
           entrypoint: bash
           propagate-environment: true
           volumes:
@@ -61,10 +61,10 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - ecr#v2.0.0:
+      - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
-      - docker#v3.5.0:
+      - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
           tmpfs:
@@ -77,7 +77,7 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - ecr#v2.0.0:
+      - ecr#v2.7.0:
           login: true
           account-ids: "445615400570"
 
@@ -91,9 +91,9 @@ steps:
     agents:
       queue: "deploy"
     plugins:
-      - ecr#v2.0.0:
+      - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
-      - docker#v3.5.0:
+      - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true

--- a/internal/pipeline/parser_test.go
+++ b/internal/pipeline/parser_test.go
@@ -898,7 +898,7 @@ func TestParserInterpolatesKeysAsWellAsValues(t *testing.T) {
 func TestParserInterpolatesPluginConfigs(t *testing.T) {
 	envMap := env.New()
 	input := strings.NewReader(`env:
-  ECR_PLUGIN_VER: "v2.0.0"
+  ECR_PLUGIN_VER: "v2.7.0"
   ECR_ACCOUNT: "0123456789"
 steps:
 - label: ":docker: Docker Build"
@@ -918,7 +918,7 @@ steps:
 	}
 	want := &Pipeline{
 		Env: ordered.MapFromItems(
-			ordered.TupleSS{Key: "ECR_PLUGIN_VER", Value: "v2.0.0"},
+			ordered.TupleSS{Key: "ECR_PLUGIN_VER", Value: "v2.7.0"},
 			ordered.TupleSS{Key: "ECR_ACCOUNT", Value: "0123456789"},
 		),
 		Steps: Steps{
@@ -926,7 +926,7 @@ steps:
 				Command: "echo foo",
 				Plugins: Plugins{
 					{
-						Name: "ecr#v2.0.0",
+						Name: "ecr#v2.7.0",
 						Config: ordered.MapFromItems(
 							ordered.TupleSA{Key: "login", Value: true},
 							ordered.TupleSA{Key: "account_ids", Value: "0123456789"},


### PR DESCRIPTION
ecr#v2.0.0 fails with the newer AWS CLI.

I updated a few other things while I'm here: docker from v3.5.0 to v5.8.0, and the agent image used for deply to ~~v3.50.4~~ v3.51.0.