### PR TITLE
Enable mount-buildkite-agent in release containers

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -14,6 +14,7 @@ steps:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
+          mount-buildkite-agent: true
 
   - name: ":redhat: Publish Edge RPM Package"
     command: ".buildkite/steps/publish-rpm-package.sh"
@@ -27,6 +28,7 @@ steps:
           image: "buildkite/agent:3.51.0"
           entrypoint: bash
           propagate-environment: true
+          mount-buildkite-agent: true
           volumes:
             - "/yum.buildkite.com"
 
@@ -44,6 +46,7 @@ steps:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
+          mount-buildkite-agent: true
           tmpfs:
             - "/root/.gnupg"
     retry:

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -19,6 +19,7 @@ steps:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
+          mount-buildkite-agent: true
 
   - name: ":octocat: :rocket: Create Github Release (if necessary)"
     command: ".buildkite/steps/github-release.sh"
@@ -33,6 +34,7 @@ steps:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
+          mount-buildkite-agent: true
 
   - name: ":redhat: Publish RPM Package"
     command: ".buildkite/steps/publish-rpm-package.sh"
@@ -46,6 +48,7 @@ steps:
           image: "buildkite/agent:3.51.0"
           entrypoint: bash
           propagate-environment: true
+          mount-buildkite-agent: true
           volumes:
             - "/yum.buildkite.com"
     retry:
@@ -67,6 +70,7 @@ steps:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
+          mount-buildkite-agent: true
           tmpfs:
             - "/root/.gnupg"
 
@@ -97,3 +101,4 @@ steps:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
+          mount-buildkite-agent: true

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -19,6 +19,7 @@ steps:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
+          mount-buildkite-agent: true
 
   - name: ":octocat: :rocket: Create Github Release (if necessary)"
     command: ".buildkite/steps/github-release.sh"
@@ -33,6 +34,7 @@ steps:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
+          mount-buildkite-agent: true
 
   - name: ":redhat: Publish Unstable RPM Package"
     command: ".buildkite/steps/publish-rpm-package.sh"
@@ -46,6 +48,7 @@ steps:
           image: "buildkite/agent:3.51.0"
           entrypoint: bash
           propagate-environment: true
+          mount-buildkite-agent: true
           volumes:
             - "/yum.buildkite.com"
     retry:
@@ -67,6 +70,7 @@ steps:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
+          mount-buildkite-agent: true
           tmpfs:
             - "/root/.gnupg"
 
@@ -97,3 +101,4 @@ steps:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
+          mount-buildkite-agent: true


### PR DESCRIPTION
The default changed in docker#v5.0.0 from true (on Linux) to false.
Enabling this propagates the agent access token as well as bind-mounts
the host agent into the container.

(So the agent container version didn't really matter.)