### PR TITLE
Fix step get is printing the address of the stdout stream at the start

### DIFF
--- a/clicommand/step_get.go
+++ b/clicommand/step_get.go
@@ -125,7 +125,7 @@ var StepGetCommand = cli.Command{
 		}
 
 		// Output the value to STDOUT
-		_, err := fmt.Println(c.App.Writer, stepExportResponse.Output)
+		_, err := fmt.Fprintln(c.App.Writer, stepExportResponse.Output)
 		return err
 	},
 }


### PR DESCRIPTION
Apologies for this, everyone. I made a typo.