### PR TITLE
Add experimental fix for agent workers can read plugin directories while they are being written to by other agent workers

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -97,3 +97,8 @@ We now understand this causes a bug, and we want to avoid it. Enabling this expe
 https://github.com/buildkite/agent/blob/40b8a5f3794b04bd64da6e2527857add849a35bd/internal/job/executor.go#L1980-L1993
 
 **Status:** Since the default behaviour is buggy, we will be promoting this to non-experiment soon™️.
+
+### `isolated-plugin-checkout`
+Checks out each plugin to an directory that that is namespaced by the agent name. Thus each agent worker will have an isolated copy of the plugin. This removes the need to lock the plugin checkout directories in a single agent process with spawned workers. However, if your plugin directory is shared between multiple agent processes *with the name agent name* , you may run into race conditions. This is just one reason we recommend you ensure agents have unique names.
+
+***Status:*** Likely to be the default behaviour in the future.

--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -99,6 +99,6 @@ https://github.com/buildkite/agent/blob/40b8a5f3794b04bd64da6e2527857add849a35bd
 **Status:** Since the default behaviour is buggy, we will be promoting this to non-experiment soon™️.
 
 ### `isolated-plugin-checkout`
-Checks out each plugin to an directory that that is namespaced by the agent name. Thus each agent worker will have an isolated copy of the plugin. This removes the need to lock the plugin checkout directories in a single agent process with spawned workers. However, if your plugin directory is shared between multiple agent processes *with the name agent name* , you may run into race conditions. This is just one reason we recommend you ensure agents have unique names.
+Checks out each plugin to an directory that that is namespaced by the agent name. Thus each agent worker will have an isolated copy of the plugin. This removes the need to lock the plugin checkout directories in a single agent process with spawned workers. However, if your plugin directory is shared between multiple agent processes *with the same agent name* , you may run into race conditions. This is just one reason we recommend you ensure agents have unique names.
 
 ***Status:*** Likely to be the default behaviour in the future.

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -29,6 +29,7 @@ const (
 	PolyglotHooks              = "polyglot-hooks"
 	ResolveCommitAfterCheckout = "resolve-commit-after-checkout"
 	AvoidRecursiveTrap         = "avoid-recursive-trap"
+	IsolatedPluginCheckout     = "isolated-plugin-checkout"
 
 	// Promoted experiments
 	ANSITimestamps    = "ansi-timestamps"
@@ -47,6 +48,7 @@ var (
 		PolyglotHooks:              {},
 		ResolveCommitAfterCheckout: {},
 		AvoidRecursiveTrap:         {},
+		IsolatedPluginCheckout:     {},
 	}
 
 	Promoted = map[string]string{

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -768,13 +768,12 @@ func (e *Executor) PluginPhase(ctx context.Context) error {
 		return nil
 	}
 
-	// NOTE: these are method expressions: https://go.dev/ref/spec#MethodExpr
-	checkoutPluginFunc := (*Executor).checkoutPlugin
+	checkoutPluginMethod := e.checkoutPlugin
 	if experiments.IsEnabled(experiments.IsolatedPluginCheckout) {
 		if e.Debug {
 			e.shell.Commentf("Using isolated plugin checkout")
 		}
-		checkoutPluginFunc = (*Executor).checkoutPluginIsolated
+		checkoutPluginMethod = e.checkoutPluginIsolated
 	}
 
 	checkouts := []*pluginCheckout{}
@@ -788,7 +787,7 @@ func (e *Executor) PluginPhase(ctx context.Context) error {
 			continue
 		}
 
-		checkout, err := checkoutPluginFunc(e, ctx, p)
+		checkout, err := checkoutPluginMethod(ctx, p)
 		if err != nil {
 			return fmt.Errorf("Failed to checkout plugin %s: %w", p.Name(), err)
 		}

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -947,6 +947,8 @@ func (e *Executor) hasPluginHook(name string) bool {
 
 // Checkout a given plugin to the plugins directory and return that directory. Each agent worker
 // will checkout the plugin to a different directory, so that they don't conflict with each other.
+// Because the plugin directory is unique to the agent worker, we don't lock it. However, if
+// multiple agent workers have access to the plugin directory, they need to have different names.
 func (e *Executor) checkoutPluginIsolated(ctx context.Context, p *plugin.Plugin) (*pluginCheckout, error) {
 	// Make sure we have a plugin path before trying to do anything
 	if e.PluginsPath == "" {

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -768,6 +768,15 @@ func (e *Executor) PluginPhase(ctx context.Context) error {
 		return nil
 	}
 
+	// NOTE: these are method expressions: https://go.dev/ref/spec#MethodExpr
+	checkoutPluginFunc := (*Executor).checkoutPlugin
+	if experiments.IsEnabled(experiments.IsolatedPluginCheckout) {
+		if e.Debug {
+			e.shell.Commentf("Using isolated plugin checkout")
+		}
+		checkoutPluginFunc = (*Executor).checkoutPluginIsolated
+	}
+
 	checkouts := []*pluginCheckout{}
 
 	// Checkout and validate plugins that aren't vendored
@@ -779,7 +788,7 @@ func (e *Executor) PluginPhase(ctx context.Context) error {
 			continue
 		}
 
-		checkout, err := e.checkoutPlugin(ctx, p)
+		checkout, err := checkoutPluginFunc(e, ctx, p)
 		if err != nil {
 			return fmt.Errorf("Failed to checkout plugin %s: %w", p.Name(), err)
 		}
@@ -935,6 +944,138 @@ func (e *Executor) hasPluginHook(name string) bool {
 		}
 	}
 	return false
+}
+
+// Checkout a given plugin to the plugins directory and return that directory. Each agent worker
+// will checkout the plugin to a different directory, so that they don't conflict with each other.
+func (e *Executor) checkoutPluginIsolated(ctx context.Context, p *plugin.Plugin) (*pluginCheckout, error) {
+	// Make sure we have a plugin path before trying to do anything
+	if e.PluginsPath == "" {
+		return nil, fmt.Errorf("Can't checkout plugin without a `plugins-path`")
+	}
+
+	id, err := p.Identifier()
+	if err != nil {
+		return nil, err
+	}
+
+	pluginParentDir := filepath.Join(e.PluginsPath, e.AgentName)
+
+	// Ensure the parent of the plugin directory exists, otherwise we can't move the temp git repo dir
+	// into it. The actual file permissions will be reduced by umask, and won't be 0o777 unless the
+	// user has manually changed the umask to 0o000
+	if err := os.MkdirAll(pluginParentDir, 0o777); err != nil {
+		return nil, err
+	}
+
+	// Create a path to the plugin
+	pluginDirectory := filepath.Join(pluginParentDir, id)
+	pluginGitDirectory := filepath.Join(pluginDirectory, ".git")
+	checkout := &pluginCheckout{
+		Plugin:      p,
+		CheckoutDir: pluginDirectory,
+		HooksDir:    filepath.Join(pluginDirectory, "hooks"),
+	}
+
+	// If there is already a clone, the user may want to ensure it's fresh (e.g., by setting
+	// BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH=true).
+	//
+	// Neither of the obvious options here is very nice.  Either we git-fetch and git-checkout on
+	// existing repos, which is probably fast, but it's _surprisingly hard_ to write a really robust
+	// chain of Git commands that'll definitely get you a clean version of a given upstream branch
+	// ref (the branch might have been force-pushed, the checkout might have become dirty and
+	// unmergeable, etc.).  Plus, then we're duplicating a bunch of fetch/checkout machinery and
+	// perhaps missing things (like `addRepositoryHostToSSHKnownHosts` which is called down below).
+	// Alternatively, we can DRY it up and simply `rm -rf` the plugin directory if it exists, but
+	// that means a potentially slow and unnecessary clone on every build step.  Sigh.  I think the
+	// tradeoff is favourable for just blowing away an existing clone if we want least-hassle
+	// guarantee that the user will get the latest version of their plugin branch/tag/whatever.
+	if e.ExecutorConfig.PluginsAlwaysCloneFresh && utils.FileExists(pluginDirectory) {
+		e.shell.Commentf("BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH is true; removing previous checkout of plugin %s", p.Label())
+		err = os.RemoveAll(pluginDirectory)
+		if err != nil {
+			e.shell.Errorf("Oh no, something went wrong removing %s", pluginDirectory)
+			return nil, err
+		}
+	}
+
+	if utils.FileExists(pluginGitDirectory) {
+		// It'd be nice to show the current commit of the plugin, so
+		// let's figure that out.
+		headCommit, err := gitRevParseInWorkingDirectory(ctx, e.shell, pluginDirectory, "--short=7", "HEAD")
+		if err != nil {
+			e.shell.Commentf("Plugin %q already checked out (can't `git rev-parse HEAD` plugin git directory)", p.Label())
+		} else {
+			e.shell.Commentf("Plugin %q already checked out (%s)", p.Label(), strings.TrimSpace(headCommit))
+		}
+
+		return checkout, nil
+	}
+
+	e.shell.Commentf("Plugin \"%s\" will be checked out to \"%s\"", p.Location, pluginDirectory)
+
+	repo, err := p.Repository()
+	if err != nil {
+		return nil, err
+	}
+
+	if e.SSHKeyscan {
+		addRepositoryHostToSSHKnownHosts(ctx, e.shell, repo)
+	}
+
+	// Make the directory
+	tempDir, err := os.MkdirTemp(e.PluginsPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	// Switch to the plugin directory
+	e.shell.Commentf("Switching to the temporary plugin directory")
+	previousWd := e.shell.Getwd()
+	if err := e.shell.Chdir(tempDir); err != nil {
+		return nil, err
+	}
+	// Switch back to the previous working directory
+	defer func() {
+		if err := e.shell.Chdir(previousWd); err != nil && e.Debug {
+			e.shell.Errorf("failed to switch back to previous working directory: %v", err)
+		}
+	}()
+
+	args := []string{"clone", "-v"}
+	if e.GitSubmodules {
+		// "--recursive" was added in Git 1.6.5, and is an alias to
+		// "--recurse-submodules" from Git 2.13.
+		args = append(args, "--recursive")
+	}
+	args = append(args, "--", repo, ".")
+
+	// Plugin clones shouldn't use custom GitCloneFlags
+	err = roko.NewRetrier(
+		roko.WithMaxAttempts(3),
+		roko.WithStrategy(roko.Constant(2*time.Second)),
+	).DoWithContext(ctx, func(r *roko.Retrier) error {
+		return e.shell.Run(ctx, "git", args...)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Switch to the version if we need to
+	if p.Version != "" {
+		e.shell.Commentf("Checking out `%s`", p.Version)
+		if err = e.shell.Run(ctx, "git", "checkout", "-f", p.Version); err != nil {
+			return nil, err
+		}
+	}
+
+	e.shell.Commentf("Moving temporary plugin directory to final location")
+	err = os.Rename(tempDir, pluginDirectory)
+	if err != nil {
+		return nil, err
+	}
+
+	return checkout, nil
 }
 
 // Checkout a given plugin to the plugins directory and return that directory

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -1033,7 +1033,11 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 		return nil, err
 	}
 	// Switch back to the previous working directory
-	defer e.shell.Chdir(previousWd)
+	defer func() {
+		if err := e.shell.Chdir(previousWd); err != nil && e.Debug {
+			e.shell.Errorf("failed to switch back to previous working directory: %v", err)
+		}
+	}()
 
 	args := []string{"clone", "-v"}
 	if e.GitSubmodules {

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -952,7 +952,7 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 
 	// Ensure the plugin directory exists, otherwise we can't create the lock
 	// Actual file permissions will be reduced by umask, and won't be 0777 unless the user has manually changed the umask to 000
-	if err := os.MkdirAll(e.PluginsPath, 0777); err != nil {
+	if err := os.MkdirAll(e.PluginsPath, 0o777); err != nil {
 		return nil, err
 	}
 

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -944,7 +944,6 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 		return nil, fmt.Errorf("Can't checkout plugin without a `plugins-path`")
 	}
 
-	// Get the identifer for the plugin
 	id, err := p.Identifier()
 	if err != nil {
 		return nil, err

--- a/internal/job/integration/isolated_plugin_integration_test.go
+++ b/internal/job/integration/isolated_plugin_integration_test.go
@@ -1,0 +1,236 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/buildkite/agent/v3/experiments"
+	"github.com/buildkite/bintest/v3"
+)
+
+// We want to support the situation where a user wants a plugin from a particular Git branch, e.g.,
+// org/repo#my-dev-feature.  By default, if the Buildkite agent finds a plugin Git clone that
+// matches the org, repo and ref, it will not try to pull or update it in any way, meaning that if
+// the ref is a branch, and upstream has new commits, they will not get pulled in.  For that, we're
+// introducing the BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH setting, which allows a user to force the
+// agent to always make a fresh clone of any plugins.  This integration test and the one after test
+// that a plugin modified upstream is treated as expected.  That is, by default, the updates won't
+// take effect, but with BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH set, they will.
+func TestModifiedIsolatedPluginNoForcePull(t *testing.T) {
+	// t.Parallel() cannot be used here because we are modifying the global experiments state
+
+	undo := experiments.EnableWithUndo(experiments.IsolatedPluginCheckout)
+	defer undo()
+
+	tester, err := NewBootstrapTester()
+	if err != nil {
+		t.Fatalf("NewBootstrapTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	// Let's set a fixed location for plugins, otherwise NewBootstrapTester() gives us a random new
+	// tempdir every time, which defeats our test.  Later we'll use this pluginsDir for the second
+	// test run, too.
+	pluginsDir, err := os.MkdirTemp("", "bootstrap-plugins")
+	if err != nil {
+		t.Fatalf(`os.MkdirTemp("", "bootstrap-plugins") error = %v`, err)
+	}
+	tester.PluginsDir = pluginsDir
+
+	// There's a bit of machinery in replacePluginPathInEnv to modify only the
+	// BUILDKITE_PLUGINS_PATH, leaving the rest of the environment variables NewBootstrapTester()
+	// gave us as-is.
+	tester.Env = replacePluginPathInEnv(tester.Env, pluginsDir)
+
+	// Create a test plugin that sets an environment variable.
+	hooks := map[string][]string{
+		"environment": {
+			"#!/bin/bash",
+			"export OSTRICH_EGGS=quite_large",
+		},
+	}
+	if runtime.GOOS == "windows" {
+		hooks = map[string][]string{
+			"environment.bat": {
+				"@echo off",
+				"set OSTRICH_EGGS=quite_large",
+			},
+		}
+	}
+	p := createTestPlugin(t, hooks)
+
+	// You may be surprised that we're creating a branch here.  This is so we can test the behaviour
+	// when a branch has had new commits added to it.
+	p.gitRepository.CreateBranch("something-fixed")
+	// To test this, we also set our testPlugin to version "something-fixed", so that the agent will
+	// check out that ref.
+	p.versionTag = "something-fixed"
+
+	json, err := p.ToJSON()
+	if err != nil {
+		t.Fatalf("testPlugin.ToJSON() error = %v", err)
+	}
+
+	env := []string{
+		"BUILDKITE_PLUGINS=" + json,
+	}
+
+	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
+		if err := bintest.ExpectEnv(t, c.Env, "OSTRICH_EGGS=quite_large"); err != nil {
+			fmt.Fprintf(c.Stderr, "%v\n", err)
+			c.Exit(1)
+		} else {
+			c.Exit(0)
+		}
+	})
+
+	tester.RunAndCheck(t, env...)
+
+	// Now, we want to "repeat" the test build, having modified the plugin's contents.
+	tester2, err := NewBootstrapTester()
+	if err != nil {
+		t.Fatalf("NewBootstrapTester() error = %v", err)
+	}
+	defer tester2.Close()
+
+	// Same modification of BUILDKITE_PLUGINS_PATH.
+	tester2.PluginsDir = pluginsDir
+	tester2.Env = replacePluginPathInEnv(tester2.Env, pluginsDir)
+
+	hooks2 := map[string][]string{
+		"environment": {
+			"#!/bin/bash",
+			"export OSTRICH_EGGS=huge_actually",
+		},
+	}
+	if runtime.GOOS == "windows" {
+		hooks2 = map[string][]string{
+			"environment.bat": {
+				"@echo off",
+				"set OSTRICH_EGGS=huge_actually",
+			},
+		}
+	}
+	modifyTestPlugin(t, hooks2, p)
+
+	tester2.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
+		if err := bintest.ExpectEnv(t, c.Env, "OSTRICH_EGGS=quite_large"); err != nil {
+			fmt.Fprintf(c.Stderr, "%v\n", err)
+			c.Exit(1)
+		} else {
+			c.Exit(0)
+		}
+	})
+
+	tester2.RunAndCheck(t, env...)
+}
+
+// As described above the previous integration test, this time we want to run the build both before
+// and after modifying a plugin's source, but this time with BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH
+// set to true.  So, we expect the upstream plugin changes to take effect on our second build.
+func TestModifiedIsolatedPluginWithForcePull(t *testing.T) {
+	// t.Parallel() cannot be used here because we are modifying the global experiments state
+
+	undo := experiments.EnableWithUndo(experiments.IsolatedPluginCheckout)
+	defer undo()
+
+	tester, err := NewBootstrapTester()
+	if err != nil {
+		t.Fatalf("NewBootstrapTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	// Let's set a fixed location for plugins, otherwise it'll be a random new tempdir every time
+	// which defeats our test.
+	pluginsDir, err := os.MkdirTemp("", "bootstrap-plugins")
+	if err != nil {
+		t.Fatalf(`os.MkdirTemp("", "bootstrap-plugins") error = %v`, err)
+	}
+
+	// Same resetting code for BUILDKITE_PLUGINS_PATH as in the previous test
+	tester.PluginsDir = pluginsDir
+	tester.Env = replacePluginPathInEnv(tester.Env, pluginsDir)
+
+	hooks := map[string][]string{
+		"environment": {
+			"#!/bin/bash",
+			"export OSTRICH_EGGS=quite_large",
+		},
+	}
+	if runtime.GOOS == "windows" {
+		hooks = map[string][]string{
+			"environment.bat": {
+				"@echo off",
+				"set OSTRICH_EGGS=quite_large",
+			},
+		}
+	}
+	p := createTestPlugin(t, hooks)
+
+	// Same branch-name jiggery pokery as in the previous integration test
+	p.gitRepository.CreateBranch("something-fixed")
+	p.versionTag = "something-fixed"
+
+	json, err := p.ToJSON()
+	if err != nil {
+		t.Fatalf("testPlugin.ToJSON() error = %v", err)
+	}
+
+	env := []string{
+		"BUILDKITE_PLUGINS=" + json,
+	}
+
+	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
+		if err := bintest.ExpectEnv(t, c.Env, "OSTRICH_EGGS=quite_large"); err != nil {
+			fmt.Fprintf(c.Stderr, "%v\n", err)
+			c.Exit(1)
+		} else {
+			c.Exit(0)
+		}
+	})
+
+	tester.RunAndCheck(t, env...)
+
+	tester2, err := NewBootstrapTester()
+	if err != nil {
+		t.Fatalf("NewBootstrapTester() error = %v", err)
+	}
+	defer tester2.Close()
+
+	tester2.PluginsDir = pluginsDir
+	tester2.Env = replacePluginPathInEnv(tester2.Env, pluginsDir)
+
+	// Notice the all-important setting, BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH, being enabled.
+	tester2.Env = append(tester2.Env, "BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH=true")
+
+	hooks2 := map[string][]string{
+		"environment": {
+			"#!/bin/bash",
+			"export OSTRICH_EGGS=huge_actually",
+		},
+	}
+	if runtime.GOOS == "windows" {
+		hooks2 = map[string][]string{
+			"environment.bat": {
+				"@echo off",
+				"set OSTRICH_EGGS=huge_actually",
+			},
+		}
+	}
+	modifyTestPlugin(t, hooks2, p)
+
+	// This time, we expect the value of OSTRICH_EGGS to have changed compared to the first test
+	// run.
+	tester2.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
+		if err := bintest.ExpectEnv(t, c.Env, "OSTRICH_EGGS=huge_actually"); err != nil {
+			fmt.Fprintf(c.Stderr, "%v\n", err)
+			c.Exit(1)
+		} else {
+			c.Exit(0)
+		}
+	})
+
+	tester2.RunAndCheck(t, env...)
+}


### PR DESCRIPTION
Previously, we took out an exclusive, filesystem lock while the plugin directory was being checked out or deleted. However, this is not sufficient, as one agent worker could be reading from the plugin directory while another is checking it out. This is likely to happen when jobs that use the same plugin at different versions are running on the same agent process, in separate workers. Or, when the `BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH` variable is set. This race condition can appear as plugins running hooks that are from different versions of the plugin, or not at all, and has been reported by customers.

To fix it, I have namespaced the plugin directory with the agent name. Then, the agent workers will have their own copy of the plugin. At the moment, most plugins are a collection of bash scripts, so checking them out is relatively lightweight, so it should not matter that each agent worker receives a separate copy of the plugin.

This new behaviour is behind an experiment `isolated-plugin-checkout`.

While I was in the area, I cleaned up some of the code in the `checkoutPlugin` method too.