### PR TITLE
Allow interpolation of env into group step name

### DIFF
--- a/internal/ordered/map.go
+++ b/internal/ordered/map.go
@@ -220,6 +220,15 @@ var EqualSS = Equal[string, string]
 // EqualSA is a convenience alias to reduce keyboard wear.
 var EqualSA = Equal[string, any]
 
+func (m *Map[K, V]) Equal(target any) bool {
+	switch targetT := (target).(type) {
+	case *Map[K, V]:
+		return Equal(m, targetT)
+	default:
+		return false
+	}
+}
+
 // compact re-organises the internal storage of the Map.
 func (m *Map[K, V]) compact() {
 	pairs := make([]Tuple[K, V], 0, len(m.index))

--- a/internal/ordered/map.go
+++ b/internal/ordered/map.go
@@ -220,6 +220,11 @@ var EqualSS = Equal[string, string]
 // EqualSA is a convenience alias to reduce keyboard wear.
 var EqualSA = Equal[string, any]
 
+// Equal reports if the two maps are equal (they contain the same items in the
+// same order). Keys are compared directly; values are compared using go-cmp
+// (provided with Equal[string, any] and Equal[string, string] as a comparers).
+//
+// This method should only be used in tests as it uses go-cmp, which may panic.
 func (m *Map[K, V]) Equal(target any) bool {
 	switch targetT := (target).(type) {
 	case *Map[K, V]:

--- a/internal/ordered/tuple.go
+++ b/internal/ordered/tuple.go
@@ -8,6 +8,15 @@ type Tuple[K comparable, V any] struct {
 	deleted bool
 }
 
+// MkTuple may be used to create a Tuple[K, V] and take advantage of type
+// inference.
+func MkTuple[K comparable, V any](k K, v V) Tuple[K, V] {
+	return Tuple[K, V]{
+		Key:   k,
+		Value: v,
+	}
+}
+
 // TupleSS is a convenience alias to reduce keyboard wear.
 type TupleSS = Tuple[string, string]
 

--- a/internal/pipeline/group.go
+++ b/internal/pipeline/group.go
@@ -1,0 +1,37 @@
+package pipeline
+
+import (
+	"github.com/buildkite/interpolate"
+)
+
+// Group is typically a key with no value. But it may also be a string
+type Group interface {
+	groupTag() // to distinguish from other types
+	selfInterpolater
+}
+
+var _ Group = (*GroupString)(nil)
+
+type GroupString string
+
+func NewGroupString(s string) *GroupString {
+	g := GroupString(s)
+	return &g
+}
+
+func (*GroupString) groupTag() {}
+
+func (g *GroupString) interpolate(env interpolate.Env) error {
+	if g == nil {
+		return nil
+	}
+
+	gInterp, err := interpolate.Interpolate(env, string(*g))
+	if err != nil {
+		return err
+	}
+
+	*g = GroupString(gInterp)
+
+	return nil
+}


### PR DESCRIPTION
Before this commit, group steps like this:
```yaml
env:
  FOO: bar
steps:
- name: "group ${FOO}"
  steps:
  - commands: echo hello 
```
Would not interpolate the env variable into the group name. This was
impossible to detect server side as the interpolation happens in the
agent.

I've chosen to make a `Group` interface with only one implementation. It might not be strictly necessary - as an alternative, I could have just refined `Group` from `any` to `string` in the `(*GroupStep).interpolate` method. However, I think it is cleaner to not have to do type assertion in the `interpolate` methods. Now, the type of the `Group` field in a `GroupStep` is determined when the YAML node is unmarshalled. If it is not a string (or null), there will be an error. This will cause the step to be unmarshalled as an `UnknownStep` instead.