### PR TITLE
Fix missing group interpolation

### DIFF
--- a/internal/pipeline/interpolate.go
+++ b/internal/pipeline/interpolate.go
@@ -28,6 +28,13 @@ func interpolateAny[T any](env interpolate.Env, o T) (T, error) {
 	case selfInterpolater:
 		err = t.interpolate(env)
 
+	case *string:
+		if t == nil {
+			return o, nil
+		}
+		*t, err = interpolate.Interpolate(env, *t)
+		a = t
+
 	case string:
 		a, err = interpolate.Interpolate(env, t)
 

--- a/internal/pipeline/parser_test.go
+++ b/internal/pipeline/parser_test.go
@@ -14,7 +14,7 @@ import (
 func ptr[T any](x T) *T { return &x }
 
 func TestParserParsesYAML(t *testing.T) {
-	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND=friend`})
+	envMap := env.FromSlice([]string{"ENV_VAR_FRIEND=friend"})
 	input := strings.NewReader("steps:\n  - command: \"hello ${ENV_VAR_FRIEND}\"")
 	got, err := Parse(input)
 	if err != nil {
@@ -26,7 +26,7 @@ func TestParserParsesYAML(t *testing.T) {
 
 	want := &Pipeline{
 		Steps: Steps{
-			&CommandStep{Command: `hello friend`},
+			&CommandStep{Command: "hello friend"},
 		},
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
@@ -59,7 +59,7 @@ func TestParserParsesYAMLWithNoInterpolation(t *testing.T) {
 
 	want := &Pipeline{
 		Steps: Steps{
-			&CommandStep{Command: `hello ${ENV_VAR_FRIEND}`},
+			&CommandStep{Command: "hello ${ENV_VAR_FRIEND}"},
 		},
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
@@ -365,7 +365,7 @@ func TestParserParsesNoSteps(t *testing.T) {
 }
 
 func TestParserParsesGroups(t *testing.T) {
-	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND=friend`})
+	envMap := env.FromSlice([]string{"ENV_VAR_FRIEND=friend"})
 
 	input := strings.NewReader(`---
 steps:
@@ -488,7 +488,7 @@ func TestParserReturnsYAMLParsingErrors(t *testing.T) {
 	_, err := Parse(input)
 
 	// TODO: avoid testing for specific error strings
-	got, want := err.Error(), `found character that cannot start any token`
+	got, want := err.Error(), "found character that cannot start any token"
 	if got != want {
 		t.Errorf("Parse(input) error = %q, want %q", got, want)
 	}
@@ -499,14 +499,14 @@ func TestParserReturnsJSONParsingErrors(t *testing.T) {
 	_, err := Parse(input)
 
 	// TODO: avoid testing for specific error strings
-	got, want := err.Error(), `line 1: did not find expected node content`
+	got, want := err.Error(), "line 1: did not find expected node content"
 	if got != want {
 		t.Errorf("Parse(input) error = %q, want %q", got, want)
 	}
 }
 
 func TestParserParsesJSON(t *testing.T) {
-	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND=friend`})
+	envMap := env.FromSlice([]string{"ENV_VAR_FRIEND=friend"})
 	input := strings.NewReader("\n\n     \n  { \"steps\": [{\"command\" : \"bye ${ENV_VAR_FRIEND}\"  } ] }\n")
 	got, err := Parse(input)
 	if err != nil {
@@ -518,7 +518,7 @@ func TestParserParsesJSON(t *testing.T) {
 
 	want := &Pipeline{
 		Steps: Steps{
-			&CommandStep{Command: `bye friend`},
+			&CommandStep{Command: "bye friend"},
 		},
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
@@ -543,7 +543,7 @@ func TestParserParsesJSON(t *testing.T) {
 }
 
 func TestParserParsesJSONArrays(t *testing.T) {
-	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND=friend`})
+	envMap := env.FromSlice([]string{"ENV_VAR_FRIEND=friend"})
 	input := strings.NewReader("\n\n     \n  [ { \"command\": \"bye ${ENV_VAR_FRIEND}\" } ]\n")
 	got, err := Parse(input)
 	if err != nil {
@@ -555,7 +555,7 @@ func TestParserParsesJSONArrays(t *testing.T) {
 
 	want := &Pipeline{
 		Steps: Steps{
-			&CommandStep{Command: `bye friend`},
+			&CommandStep{Command: "bye friend"},
 		},
 	}
 	if diff := cmp.Diff(got, want); diff != "" {

--- a/internal/pipeline/parser_test.go
+++ b/internal/pipeline/parser_test.go
@@ -367,7 +367,7 @@ func TestParserParsesGroups(t *testing.T) {
 
 	input := strings.NewReader(`---
 steps:
-  - group:
+  - group: ${ENV_VAR_FRIEND}
     steps:
       - command: hello ${ENV_VAR_FRIEND}
       - wait
@@ -386,6 +386,7 @@ steps:
 	want := &Pipeline{
 		Steps: Steps{
 			&GroupStep{
+				Group: `"friend"`,
 				Steps: Steps{
 					&CommandStep{Command: `hello "friend"`},
 					&WaitStep{Scalar: "wait"},
@@ -409,7 +410,7 @@ steps:
 	const wantJSON = `{
   "steps": [
     {
-      "group": null,
+      "group": "\"friend\"",
       "steps": [
         {
           "command": "hello \"friend\""

--- a/internal/pipeline/parser_test.go
+++ b/internal/pipeline/parser_test.go
@@ -14,7 +14,7 @@ import (
 func ptr[T any](x T) *T { return &x }
 
 func TestParserParsesYAML(t *testing.T) {
-	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND="friend"`})
+	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND=friend`})
 	input := strings.NewReader("steps:\n  - command: \"hello ${ENV_VAR_FRIEND}\"")
 	got, err := Parse(input)
 	if err != nil {
@@ -26,7 +26,7 @@ func TestParserParsesYAML(t *testing.T) {
 
 	want := &Pipeline{
 		Steps: Steps{
-			&CommandStep{Command: `hello "friend"`},
+			&CommandStep{Command: `hello friend`},
 		},
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
@@ -41,7 +41,7 @@ func TestParserParsesYAML(t *testing.T) {
 	const wantJSON = `{
   "steps": [
     {
-      "command": "hello \"friend\""
+      "command": "hello friend"
     }
   ]
 }`
@@ -365,7 +365,7 @@ func TestParserParsesNoSteps(t *testing.T) {
 }
 
 func TestParserParsesGroups(t *testing.T) {
-	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND="friend"`})
+	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND=friend`})
 
 	input := strings.NewReader(`---
 steps:
@@ -388,9 +388,9 @@ steps:
 	want := &Pipeline{
 		Steps: Steps{
 			&GroupStep{
-				Group: ptr(`"friend"`),
+				Group: ptr("friend"),
 				Steps: Steps{
-					&CommandStep{Command: `hello "friend"`},
+					&CommandStep{Command: "hello friend"},
 					&WaitStep{Scalar: "wait"},
 					&InputStep{Contents: map[string]any{"block": "goodbye"}},
 				},
@@ -412,10 +412,10 @@ steps:
 	const wantJSON = `{
   "steps": [
     {
-      "group": "\"friend\"",
+      "group": "friend",
       "steps": [
         {
-          "command": "hello \"friend\""
+          "command": "hello friend"
         },
         "wait",
         {
@@ -506,7 +506,7 @@ func TestParserReturnsJSONParsingErrors(t *testing.T) {
 }
 
 func TestParserParsesJSON(t *testing.T) {
-	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND="friend"`})
+	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND=friend`})
 	input := strings.NewReader("\n\n     \n  { \"steps\": [{\"command\" : \"bye ${ENV_VAR_FRIEND}\"  } ] }\n")
 	got, err := Parse(input)
 	if err != nil {
@@ -518,7 +518,7 @@ func TestParserParsesJSON(t *testing.T) {
 
 	want := &Pipeline{
 		Steps: Steps{
-			&CommandStep{Command: `bye "friend"`},
+			&CommandStep{Command: `bye friend`},
 		},
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
@@ -533,7 +533,7 @@ func TestParserParsesJSON(t *testing.T) {
 	const wantJSON = `{
   "steps": [
     {
-      "command": "bye \"friend\""
+      "command": "bye friend"
     }
   ]
 }`
@@ -543,7 +543,7 @@ func TestParserParsesJSON(t *testing.T) {
 }
 
 func TestParserParsesJSONArrays(t *testing.T) {
-	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND="friend"`})
+	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND=friend`})
 	input := strings.NewReader("\n\n     \n  [ { \"command\": \"bye ${ENV_VAR_FRIEND}\" } ]\n")
 	got, err := Parse(input)
 	if err != nil {
@@ -555,7 +555,7 @@ func TestParserParsesJSONArrays(t *testing.T) {
 
 	want := &Pipeline{
 		Steps: Steps{
-			&CommandStep{Command: `bye "friend"`},
+			&CommandStep{Command: `bye friend`},
 		},
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
@@ -569,7 +569,7 @@ func TestParserParsesJSONArrays(t *testing.T) {
 	const wantJSON = `{
   "steps": [
     {
-      "command": "bye \"friend\""
+      "command": "bye friend"
     }
   ]
 }`

--- a/internal/pipeline/parser_test.go
+++ b/internal/pipeline/parser_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func ptr[T any](x T) *T { return &x }
+
 func TestParserParsesYAML(t *testing.T) {
 	envMap := env.FromSlice([]string{`ENV_VAR_FRIEND="friend"`})
 	input := strings.NewReader("steps:\n  - command: \"hello ${ENV_VAR_FRIEND}\"")
@@ -386,7 +388,7 @@ steps:
 	want := &Pipeline{
 		Steps: Steps{
 			&GroupStep{
-				Group: `"friend"`,
+				Group: ptr(`"friend"`),
 				Steps: Steps{
 					&CommandStep{Command: `hello "friend"`},
 					&WaitStep{Scalar: "wait"},

--- a/internal/pipeline/step_group.go
+++ b/internal/pipeline/step_group.go
@@ -13,7 +13,7 @@ import (
 type GroupStep struct {
 	// Group is typically a key with no value. Since it must always exist in
 	// a group step, here it is.
-	Group any `yaml:"group"`
+	Group *string `yaml:"group"`
 
 	Steps Steps `yaml:"steps"`
 

--- a/internal/pipeline/step_group.go
+++ b/internal/pipeline/step_group.go
@@ -37,6 +37,12 @@ func (g *GroupStep) UnmarshalOrdered(src any) error {
 }
 
 func (g *GroupStep) interpolate(env interpolate.Env) error {
+	grp, err := interpolateAny(env, g.Group)
+	if err != nil {
+		return err
+	}
+	g.Group = grp
+
 	if err := g.Steps.interpolate(env); err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes the missing interpolation, ~~but does not make `GroupStep.Group` more type-safe~~ changes the type to `*string`, and adds support for interpolating `*string`s.