### PR TITLE
Auto-create tracing spans for log groups

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -57,4 +57,5 @@ type AgentConfiguration struct {
 	AcquireJob                 string
 	TracingBackend             string
 	TracingServiceName         string
+	TraceLogGroups             bool
 }

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -523,6 +523,7 @@ func (r *JobRunner) createEnvironment() ([]string, error) {
 	if r.conf.AgentConfiguration.TracingBackend != "" {
 		env["BUILDKITE_TRACING_BACKEND"] = r.conf.AgentConfiguration.TracingBackend
 		env["BUILDKITE_TRACING_SERVICE_NAME"] = r.conf.AgentConfiguration.TracingServiceName
+		env["BUILDKITE_TRACE_LOG_GROUPS"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.TraceLogGroups)
 	}
 
 	// see documentation for BuildkiteMessageMax

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -142,6 +142,7 @@ type AgentStartConfig struct {
 	MetricsDatadogDistributions bool   `cli:"metrics-datadog-distributions"`
 	TracingBackend              string `cli:"tracing-backend"`
 	TracingServiceName          string `cli:"tracing-service-name"`
+	TraceLogGroups              bool   `cli:"trace-log-groups"`
 
 	// Global flags
 	Debug             bool     `cli:"debug"`
@@ -582,6 +583,11 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_TRACING_SERVICE_NAME",
 			Value:  "buildkite-agent",
 		},
+		cli.BoolFlag{
+			Name:   "trace-log-groups",
+			Usage:  "Automatically creates tracing spans for log groups when tracing is enabled.",
+			EnvVar: "BUILDKITE_TRACE_LOG_GROUPS",
+		},
 		cli.StringFlag{
 			Name:   "job-verification-key-path",
 			Usage:  "Path to a file containing a verification key. Passing this flag enables job verification. For hmac-sha256, the raw file content is used as the shared key",
@@ -800,8 +806,12 @@ var AgentStartCommand = cli.Command{
 		})
 
 		// Sense check supported tracing backends, we don't want bootstrapped jobs to silently have no tracing
-		if _, has := tracetools.ValidTracingBackends[cfg.TracingBackend]; !has {
+		_, tracingEnabled := tracetools.ValidTracingBackends[cfg.TracingBackend]
+		if !tracingEnabled {
 			l.Fatal("The given tracing backend %q is not supported. Valid backends are: %q", cfg.TracingBackend, maps.Keys(tracetools.ValidTracingBackends))
+		}
+		if !tracingEnabled && cfg.TraceLogGroups {
+			l.Fatal("Log group tracing cannot be enabled without a tracing backend.")
 		}
 
 		if experiments.IsEnabled(experiments.AgentAPI) {
@@ -864,6 +874,7 @@ var AgentStartCommand = cli.Command{
 			AcquireJob:                              cfg.AcquireJob,
 			TracingBackend:                          cfg.TracingBackend,
 			TracingServiceName:                      cfg.TracingServiceName,
+			TraceLogGroups:                          cfg.TraceLogGroups,
 			JobVerificationNoSignatureBehavior:      cfg.JobVerificationNoSignatureBehavior,
 			JobVerificationInvalidSignatureBehavior: cfg.JobVerificationInvalidSignatureBehavior,
 

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -94,6 +94,7 @@ type BootstrapConfig struct {
 	RedactedVars                 []string `cli:"redacted-vars" normalize:"list"`
 	TracingBackend               string   `cli:"tracing-backend"`
 	TracingServiceName           string   `cli:"tracing-service-name"`
+	TraceLogGroups               bool     `cli:"trace-log-groups"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -355,6 +356,11 @@ var BootstrapCommand = cli.Command{
 			EnvVar: "BUILDKITE_TRACING_SERVICE_NAME",
 			Value:  "buildkite-agent",
 		},
+		cli.BoolFlag{
+			Name:   "trace-log-groups",
+			Usage:  "Automatically creates tracing spans for log groups when tracing is enabled.",
+			EnvVar: "BUILDKITE_TRACE_LOG_GROUPS",
+		},
 		DebugFlag,
 		LogLevelFlag,
 		ExperimentsFlag,
@@ -439,6 +445,7 @@ var BootstrapCommand = cli.Command{
 			Tag:                          cfg.Tag,
 			TracingBackend:               cfg.TracingBackend,
 			TracingServiceName:           cfg.TracingServiceName,
+			TraceLogGroups:               cfg.TraceLogGroups,
 		})
 
 		cctx, cancel := context.WithCancel(ctx)

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -164,6 +164,9 @@ type ExecutorConfig struct {
 
 	// Service name to use when reporting traces.
 	TracingServiceName string
+
+	// Whether to auto-create tracing spans for log groups.
+	TraceLogGroups bool
 }
 
 // ReadFromEnvironment reads configuration from the Environment, returns a map

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -82,6 +82,7 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 		e.shell.Debug = e.ExecutorConfig.Debug
 		e.shell.InterruptSignal = e.ExecutorConfig.CancelSignal
 		e.shell.SignalGracePeriod = e.ExecutorConfig.SignalGracePeriod
+		e.shell.TraceLogGroups = e.ExecutorConfig.TraceLogGroups
 	}
 	if experiments.IsEnabled(experiments.KubernetesExec) {
 		kubernetesClient := &kubernetes.Client{}


### PR DESCRIPTION
This will make it easy for CI users to trace and analyze their CI jobs without requiring additional work or scripting on their part. They can just look at tracing information on their tracing provider.

Example with Datadog tracing:
![image](https://github.com/buildkite/agent/assets/29210237/ed0e4c3a-68ed-443c-adb0-f5ae2dab8297)

Associated CI job:
![Screenshot 2023-08-21 173042](https://github.com/buildkite/agent/assets/29210237/97cb043f-273d-4273-a335-1ac2eae8f1f1)
