### PR TITLE
Publish RPMs: sync less data

### DIFF
--- a/.buildkite/steps/publish-rpm-package.sh
+++ b/.buildkite/steps/publish-rpm-package.sh
@@ -13,11 +13,34 @@ dry_run() {
 
 # createrepo_c is much faster and more resilient than createrepo
 createrepo() {
+  # Ignores old metadata, builds repodata from scratch.
   createrepo_c \
     --no-database \
     --unique-md-filenames \
     --retain-old-md-by-age=180d \
     "$@"
+}
+
+updaterepo() {
+  # Reuses the old package metadata, and add new packages with --pkglist.
+  createrepo_c \
+    --no-database \
+    --unique-md-filenames \
+    --retain-old-md-by-age=180d \
+    --update \
+    --pkglist <(find "$1" -type f -name "*.rpm") \
+    --recycle-pkglist \
+    "$@"
+}
+
+sync_from_s3() {
+  echo "--- Syncing $1 to $2 on $(hostname)"
+  aws --region us-east-1 \
+    s3 sync \
+    --delete \
+    --only-show-errors \
+    "$1" "$2"
+  du -hs "$2"
 }
 
 if [[ "${CODENAME}" == "" ]]; then
@@ -48,35 +71,47 @@ apk add --update-cache --no-progress \
 # createrepo_c requires some exotic flags on the cp, which aren't available on the busybox version
 apk add --no-progress coreutils aws-cli
 
-# Make sure we have a local copy of the yum repo
-echo "--- Syncing s3://${RPM_S3_BUCKET} to $(hostname)"
 mkdir -p "${YUM_PATH}"
-aws --region us-east-1 \
-  s3 sync \
-  --delete \
-  --only-show-errors \
-  "s3://${RPM_S3_BUCKET}" "${YUM_PATH}"
-du -hs "${YUM_PATH}"
 
-# Add the rpms and update meta-data
+# Add the RPMs and update meta-data
 for ARCH in "x86_64" "i386" "aarch64"; do
-  echo "--- Updating yum repository for ${CODENAME}/${ARCH}"
-
   ARCH_PATH="${YUM_PATH}/buildkite-agent/${CODENAME}/${ARCH}"
-  mkdir -p "${ARCH_PATH}"
+  mkdir -p "${ARCH_PATH}/repodata"
+
+  # Only sync /repodata - no need for all the old packages (hopefully)
+  sync_from_s3 \
+    "s3://${RPM_S3_BUCKET}/buildkite-agent/${CODENAME}/${ARCH}/repodata" \
+    "${ARCH_PATH}/repodata"
+
+  # Copy the new RPMs in.
   find "rpm/" -type f -name "*${ARCH}*" | xargs cp -t "${ARCH_PATH}"
 
-  if ! createrepo --update "${ARCH_PATH}"; then
-    rm -fr "${ARCH_PATH}/.repodata"
-    createrepo "${ARCH_PATH}"
+  echo "--- Updating yum repository for ${CODENAME}/${ARCH}"
+  if updaterepo "${ARCH_PATH}"; then
+    continue
   fi
+
+  # Quick update failed - fall back to recreating the repo.
+  # createrepo_c probably left a temp .repodata lying around.
+  rm -fr "${ARCH_PATH}/.repodata"
+
+  # Next we will need all the old RPMs.
+  sync_from_s3 \
+    "s3://${RPM_S3_BUCKET}/buildkite-agent/${CODENAME}/${ARCH}" \
+    "${ARCH_PATH}"
+
+  # Copy the new RPMs in again.
+  find "rpm/" -type f -name "*${ARCH}*" | xargs cp -t "${ARCH_PATH}"
+
+  echo "--- Recreating yum repository for ${CODENAME}/${ARCH}"
+  createrepo "${ARCH_PATH}"
 done
 
 # Sync back our changes to S3
 echo "--- Syncing local ${YUM_PATH} changes back to s3://${RPM_S3_BUCKET}"
+du -hs "${YUM_PATH}"
 dry_run aws --region us-east-1 \
   s3 sync \
-  --delete \
   --no-guess-mime-type \
   --exclude "lost+found" \
   --exclude ".repodata" \


### PR DESCRIPTION
The core idea is to use `--recycle-pkglist` to skip recalculating metadata for all the old packages, which avoids the need to have the old packages there to begin with.