### PR TITLE
Fix a flaky shell test

### DIFF
--- a/internal/job/shell/main_test.go
+++ b/internal/job/shell/main_test.go
@@ -45,6 +45,12 @@ func acquiringLockHelperProcess() error {
 	}
 
 	log.Printf("Acquired lock %s", fileName)
-	// sleep forever
-	select {}
+	// sleep forever, but keep the main goroutine busy
+	c := make(chan struct{}, 1)
+	for {
+		select {
+		case <-c:
+		case c <- struct{}{}:
+		}
+	}
 }

--- a/internal/job/shell/main_test.go
+++ b/internal/job/shell/main_test.go
@@ -46,11 +46,7 @@ func acquiringLockHelperProcess() error {
 
 	log.Printf("Acquired lock %s", fileName)
 	// sleep forever, but keep the main goroutine busy
-	c := make(chan struct{}, 1)
 	for {
-		select {
-		case <-c:
-		case c <- struct{}{}:
-		}
+		time.Sleep(1 * time.Second)
 	}
 }

--- a/internal/job/shell/shell_test.go
+++ b/internal/job/shell/shell_test.go
@@ -316,15 +316,14 @@ func TestLockFileRetriesAndTimesOut(t *testing.T) {
 
 	lockPath := filepath.Join(dir, "my.lock")
 
-	cmd, err := acquireLockInOtherProcess(t, lockPath)
-	assert.NilError(t, err)
+	cmd := acquireLockInOtherProcess(t, lockPath)
 	defer func() { assert.NilError(t, cmd.Process.Kill()) }()
 
 	_, err = sh.LockFile(context.Background(), lockPath, 2*time.Second)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
-func acquireLockInOtherProcess(t *testing.T, lockfile string) (*exec.Cmd, error) {
+func acquireLockInOtherProcess(t *testing.T, lockfile string) *exec.Cmd {
 	t.Helper()
 
 	expectedLockPath := lockfile + "f" // flock-locked files are created with the suffix 'f'
@@ -348,7 +347,7 @@ func acquireLockInOtherProcess(t *testing.T, lockfile string) (*exec.Cmd, error)
 		break
 	}
 
-	return cmd, nil
+	return cmd
 }
 
 func newShellForTest(t *testing.T) *shell.Shell {


### PR DESCRIPTION
The shell test ran the test binary in a separate process. The test binary is supposed to sleep forever, but the go runtime terminates it because all its goroutines are idle. This is because the test binary is not doing anything in the main goroutine. This PR fixes the issue by making the test binary do something in the main goroutine.

I've also kept the changes I made to make the test more debuggable. Here is the output from when I debugged. Note the output `fatal error: all goroutines are asleep - deadlock!`.
```shell
DONE 1 tests in 3.267s
gotestsum -- -count=1 -v ./internal/job/shell -run ^TestLockFileRetriesAndTimesOut$
✖  internal/job/shell (14ms)

=== Failed
=== FAIL: internal/job/shell TestLockFileRetriesAndTimesOut (0.01s)
    shell_test.go:319: acquiring lock in other process: /tmp/shelltest3604204178/my.lock
2023/08/22 13:20:35 Locking /tmp/shelltest3604204178/my.lock
2023/08/22 13:20:35 Acquired lock /tmp/shelltest3604204178/my.lock
fatal error: all goroutines are asleep - deadlock!

goroutine 1 [select (no cases)]:
github.com/buildkite/agent/v3/internal/job/shell_test.acquiringLockHelperProcess()
	/home/narthana/devel/buildkite/agent/internal/job/shell/main_test.go:49 +0x2d1
github.com/buildkite/agent/v3/internal/job/shell_test.TestMain(0xc0000666f0?)
	/home/narthana/devel/buildkite/agent/internal/job/shell/main_test.go:23 +0x4f
main.main()
	_testmain.go:77 +0x1c6
    shell_test.go:324: assertion failed: error is nil, not "context deadline exceeded" (context.DeadlineExceeded context.deadlineExceededError)

DONE 1 tests, 1 failure in 0.229s
```
