### PR TITLE
Update help text with suggestions from docs code review

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -599,7 +599,7 @@ var AgentStartCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name:   "job-signing-algorithm",
-			Usage:  "The algorithm to use when signing pipelines. Must be a valid RF7518 JWA algorithm. Required when using a JWKS, and the given key doesn't have an alg parameter",
+			Usage:  "The algorithm to use when signing pipelines. Must be an algorithm specified in RFC 7518: JWA. Required when using a JWKS, and the given key doesn't have an alg parameter",
 			EnvVar: "BUILDKITE_PIPELINE_UPLOAD_SIGNING_ALGORITHM",
 		},
 		cli.StringFlag{

--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -29,7 +29,7 @@ var (
 	signalGracePeriodSecondsFlag = cli.IntFlag{
 		Name: "signal-grace-period-seconds",
 		Usage: "The number of seconds given to a subprocess to handle being sent ′cancel-signal′. " +
-			"After this period has elaspsed, SIGKILL will be sent.",
+			"After this period has elapsed, SIGKILL will be sent.",
 		EnvVar: "BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS",
 		Value:  defaultSignalGracePeriod,
 	}

--- a/clicommand/env_unset.go
+++ b/clicommand/env_unset.go
@@ -26,7 +26,7 @@ Description:
 
 Examples:
 
-   Unsetting the variables ′LLAMA′ and ′ALPACA′)
+   Unsetting the variables ′LLAMA′ and ′ALPACA′:
 
    $ buildkite-agent env unset LLAMA ALPACA
    Unset:

--- a/clicommand/lock_acquire.go
+++ b/clicommand/lock_acquire.go
@@ -54,7 +54,7 @@ func lockAcquireFlags() []cli.Flag {
 		[]cli.Flag{
 			cli.DurationFlag{
 				Name:   "lock-wait-timeout",
-				Usage:  "If specified, sets a maximum duration to wait for a lock before giving up",
+				Usage:  "Sets a maximum duration to wait for a lock before giving up",
 				EnvVar: "BUILDKITE_LOCK_WAIT_TIMEOUT",
 			},
 		},

--- a/clicommand/lock_do.go
+++ b/clicommand/lock_do.go
@@ -33,12 +33,10 @@ Description:
 Examples:
 
    #!/bin/bash
-   if [ $(buildkite-agent lock do llama) = 'do' ] ; then
-      setup_code()
-      buildkite-agent lock done llama
-   fi
-
-`
+   if [[ $(buildkite-agent lock do llama) == 'do' ]]; then
+     # your critical section here...
+     buildkite-agent lock done llama
+   fi`
 
 type LockDoConfig struct {
 	// Common config options

--- a/clicommand/lock_done.go
+++ b/clicommand/lock_done.go
@@ -11,7 +11,7 @@ import (
 
 const lockDoneHelpDescription = `Usage:
 
-   buildkite-agent lock release [key]
+   buildkite-agent lock done [key]
 
 Description:
    Completes a do-once lock. This should only be used by the process performing
@@ -23,12 +23,10 @@ Description:
 Examples:
 
    #!/bin/bash
-   if [ $(buildkite-agent lock do llama) = 'do' ] ; then
-	  setup_code()
-	  buildkite-agent lock done llama
-   fi
-
-`
+   if [[ $(buildkite-agent lock do llama) == 'do' ]]; then
+     # your critical section here...
+     buildkite-agent lock done llama
+   fi`
 
 type LockDoneConfig struct {
 	// Common config options

--- a/clicommand/lock_get.go
+++ b/clicommand/lock_get.go
@@ -27,9 +27,7 @@ Description:
 Examples:
 
    $ buildkite-agent lock get llama
-   Kuzco
-
-`
+   Kuzco`
 
 type LockGetConfig struct {
 	// Common config options

--- a/clicommand/lock_release.go
+++ b/clicommand/lock_release.go
@@ -24,11 +24,10 @@ Description:
 
 Examples:
 
-   $ token=$(buildkite-agent lock acquire llama)
-   $ critical_section()
-   $ buildkite-agent lock release llama "${token}"
-
-`
+   #!/bin/bash
+   token=$(buildkite-agent lock acquire llama)
+   # your critical section here...
+   buildkite-agent lock release llama "${token}"`
 
 type LockReleaseConfig struct {
 	// Common config options


### PR DESCRIPTION
You may be wondering about the removal of line breaks from the code examples. This was done to reflected changes in the docs. It seems to still look good for the cli:
```shell
Usage:

   buildkite-agent lock release [key] [token]

Description:
   Releases the lock for the given key. This should only be called by the
   process that acquired the lock. To help prevent different processes unlocking
   each other unintentionally, the output from ′lock acquire′ is required as the
   second argument.

   Note that this subcommand is only available when an agent has been started
   with the ′agent-api′ experiment enabled.

Examples:

   #!/bin/bash
   token=$(buildkite-agent lock acquire llama)
   # your critical section here...
   buildkite-agent lock release llama "${token}"

Options:

   --no-color            Don't show colors in logging [$BUILDKITE_AGENT_NO_COLOR]
   --debug               Enable debug mode. Synonym for ′--log-level debug′. Takes precedence over ′--log-level′ [$BUILDKITE_AGENT_DEBUG]
   --log-level value     Set the log level for the agent, making logging more or less verbose. Defaults to notice. Allowed values are: debug, info, error, warn, fatal (default: "notice") [$BUILDKITE_AGENT_LOG_LEVEL]
   --experiment value    Enable experimental features within the buildkite-agent [$BUILDKITE_AGENT_EXPERIMENT]
   --profile value       Enable a profiling mode, either cpu, memory, mutex or block [$BUILDKITE_AGENT_PROFILE]
   --config value        Path to a configuration file [$BUILDKITE_AGENT_CONFIG]
   --lock-scope value    The scope for locks used in this operation. Currently only 'machine' scope is supported (default: "machine") [$BUILDKITE_LOCK_SCOPE]
   --sockets-path value  Directory where the agent will place sockets (default: "/home/narthana/.buildkite-agent/sockets") [$BUILDKITE_SOCKETS_PATH]
```