### PR TITLE
Add --skip-stat

### DIFF
--- a/.buildkite/steps/publish-rpm-package.sh
+++ b/.buildkite/steps/publish-rpm-package.sh
@@ -25,6 +25,8 @@ updaterepo() {
   # Reuses the old package metadata, and add new packages with --pkglist.
   # createrepo_c tests that pkglist is a _regular_ file, so we can't use 
   # a Bash process substitution i.e. <(find ...)
+  # --skip-stat prevents createrepo_c from trying to stat all the RPMs that 
+  # aren't synced here.
   # Note also that createrepo_c appends pkglist lines to the path it is given
   # to find files. Busybox find (in Alpine) has no -printf verb, so...........
   # go go gadget `awk`
@@ -34,6 +36,7 @@ updaterepo() {
     --no-database \
     --unique-md-filenames \
     --retain-old-md-by-age=180d \
+    --skip-stat \
     --update \
     --pkglist "${pkglist}" \
     --recycle-pkglist \


### PR DESCRIPTION
This should cut down on the thousands of (hopefully meaningless?) attempts to stat each and every previous RPM?