### PR TITLE
Handle the case when unmarshalling a step where there aren't any plugins

### DIFF
--- a/internal/pipeline/plugins.go
+++ b/internal/pipeline/plugins.go
@@ -31,6 +31,10 @@ func (p *Plugins) UnmarshalOrdered(o any) error {
 	}
 
 	switch o := o.(type) {
+	case nil:
+		*p = nil
+		return nil
+
 	case []any:
 		for _, c := range o {
 			switch ct := c.(type) {


### PR DESCRIPTION
Previously, when unmarshalling a step that had no plugins, it would fail to accept the job:
```
2023-08-25 10:27:47 WARN   Bens-Macbook-Pro-1 Buildkite rejected the call to accept the job (unmarshalling CommandStep: unmarshaling plugins: got <nil>, want []any or *ordered.Map[string, any])
```