### PR TITLE
Fix detection of missing commits on checkout

### DIFF
--- a/internal/job/git.go
+++ b/internal/job/git.go
@@ -57,8 +57,9 @@ func gitCheckout(ctx context.Context, sh shellRunner, gitCheckoutFlags, referenc
 	commandArgs = append(commandArgs, individualCheckoutFlags...)
 	commandArgs = append(commandArgs, reference)
 
-	if err := sh.Run(ctx, "git", commandArgs...); err != nil {
-		if strings.HasPrefix(err.Error(), "fatal: reference is not a tree: ") {
+	const badReference = "fatal: reference is not a tree"
+	if err := sh.RunWithOlfactor(ctx, badReference, "git", commandArgs...); err != nil {
+		if oerr := new(shell.OlfactoryError); errors.As(err, &oerr) && oerr.Smell == badReference {
 			return &gitError{error: err, Type: gitErrorCheckoutReferenceIsNotATree}
 		}
 


### PR DESCRIPTION
I upgraded from 3.31 to 3.52 and started seeing 'reference is not a tree' errors in CI. Something in the Buildkite code was not catching this properly and causing the agent to recreate the repo.

In my case, this was being caused by force pushes to branches with open PRs happening soon after a previous push.

```
$ git fetch -v --prune -- origin refs/pull/123/head
...
From github.com:my/repo
 * branch                    refs/pull/123/head -> FETCH_HEAD
$ git checkout -f 7890000000
fatal: reference is not a tree: 7890000000
⚠️ Warning: Checkout failed! checking out commit "7890000000": exit status 128 (Attempt 1/3 Retrying in 2s)
$ git clone -v -- git@github.com:my/repo.git .
Cloning into '.'...
...
$ git clean -fdqx -e /.local
$ git fetch -v --prune -- origin refs/pull/123/head
```

Based on https://github.com/buildkite/agent/pull/2286, I assume something similar is happening - the output of the process isn't being properly captured.