### PR TITLE
Use git log to get commit information

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -692,7 +692,8 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 		//    may span multiple lines.
 		gitArgs := []string{
 			"--no-pager",
-			"show",
+			"log",
+			"-1",
 			"HEAD",
 			"-s", // --no-patch was introduced in v1.8.4 in 2013, but e.g. CentOS 7 isn't there yet
 			"--no-color",

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -47,7 +47,7 @@ func TestCheckingOutGitHubPullRequests_WithGitMirrors(t *testing.T) {
 		{"rev-parse", "FETCH_HEAD"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-ffxdq"},
-		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -92,7 +92,7 @@ func TestWithResolvingCommitExperiment_WithGitMirrors(t *testing.T) {
 		{"fetch", "-v", "--", "origin", "main"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
-		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 		{"rev-parse", "HEAD"},
 	})
 
@@ -137,7 +137,7 @@ func TestCheckingOutLocalGitProject_WithGitMirrors(t *testing.T) {
 		{"fetch", "-v", "--", "origin", "main"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
-		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -209,7 +209,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules_WithGitMirrors(t *testing.T) {
 		{"submodule", "foreach", "--recursive", "git reset --hard"},
 		{"clean", "-fdq"},
 		{"submodule", "foreach", "--recursive", "git clean -fdq"},
-		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -275,7 +275,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled_WithGitMirrors(t *test
 		{"fetch", "-v", "--", "origin", "main"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
-		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -319,7 +319,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject_WithGitMirrors(t *testing.T) {
 		{"fetch", "--depth=1", "--", "origin", "main"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
-		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -709,7 +709,7 @@ func TestGitMirrorEnv(t *testing.T) {
 		{"fetch", "-v", "--", "origin", "main"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
-		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -57,7 +57,7 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 		{"fetch", "-v", "--", "origin", "main"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
-		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 		{"rev-parse", "HEAD"},
 	})
 
@@ -97,7 +97,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 		{"fetch", "-v", "--", "origin", "main"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
-		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -163,7 +163,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 		{"submodule", "foreach", "--recursive", "git reset --hard"},
 		{"clean", "-fdq"},
 		{"submodule", "foreach", "--recursive", "git clean -fdq"},
-		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -224,7 +224,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 		{"fetch", "-v", "--", "origin", "main"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
-		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -263,7 +263,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 		{"fetch", "--depth=1", "--", "origin", "main"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
-		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -326,7 +326,7 @@ func TestCheckoutErrorIsRetried(t *testing.T) {
 		{"fetch", "-v", "--", "origin", "main"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
-		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -388,7 +388,7 @@ func TestFetchErrorIsRetried(t *testing.T) {
 		{"fetch", "-v", "--prune", "--depth=1", "--", "origin", "main"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-ffxdq"},
-		{"--no-pager", "show", "HEAD", "-s", "--no-color", gitShowFormatArg},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout


### PR DESCRIPTION
We have very large repositories at Cruise. And I found it's very slow to `Preparing working directory` when the commit is a merge commit that contains a lots of changes as below:

<img width="1138" alt="Screenshot 2023-08-26 at 5 59 23 PM" src="https://github.com/buildkite/agent/assets/5259480/c4979cf4-d50d-4911-b1fc-a910b0ee791e">

( I can send a build link in private if you need)

More investigation shows that's the `git show` during agent bootstrap that's taking more of the time to do `git diff` underneath. Since the AFAIK, buildkite agent know needs to get the HEAD commit's commit information rather than the actual `git diff`. we can simply replace the `git show` with `git log`, which prints out identical information for this purpose.

**Testing**
using git log
```
$ git --no-pager log -1 HEAD -s --format=fuller --no-color
commit 7bfab5fd5419feeeb6d3e9a21ad165fc2eb332be (HEAD -> cheng/step0-git-log, origin/cheng/step0-git-log)
Author:     Cheng Pan <cheng.pan@getcruise.com>
AuthorDate: Sat Aug 26 17:43:35 2023 -0700
Commit:     Cheng Pan <cheng.pan@getcruise.com>
CommitDate: Sat Aug 26 17:43:35 2023 -0700
```
using git show:
```
$ git --no-pager show HEAD -s --format=fuller --no-color
commit 7bfab5fd5419feeeb6d3e9a21ad165fc2eb332be (HEAD -> cheng/step0-git-log, origin/cheng/step0-git-log)
Author:     Cheng Pan <cheng.pan@getcruise.com>
AuthorDate: Sat Aug 26 17:43:35 2023 -0700
Commit:     Cheng Pan <cheng.pan@getcruise.com>
CommitDate: Sat Aug 26 17:43:35 2023 -0700
```