### PR TITLE
Retry fork/exec errors when running hook

### DIFF
--- a/hook/scriptwrapper.go
+++ b/hook/scriptwrapper.go
@@ -233,7 +233,7 @@ func NewScriptWrapper(opts ...scriptWrapperOpt) (*ScriptWrapper, error) {
 	// Make script executable
 	err = utils.ChmodExecutable(wrap.scriptFile.Name())
 	if err != nil {
-		return wrap, err
+		return nil, err
 	}
 
 	// the defered close attempt will discard any errors,

--- a/internal/file/is_opened.go
+++ b/internal/file/is_opened.go
@@ -8,7 +8,7 @@ import (
 	"github.com/buildkite/agent/v3/internal/job/shell"
 )
 
-func IsOpened(l shell.Logger, path string) (bool, error) {
+func IsOpened(l shell.Logger, debug bool, path string) (bool, error) {
 	fdEntries, err := os.ReadDir("/dev/fd")
 	if err != nil {
 		return false, fmt.Errorf("failed to read /dev/fd: %w", err)
@@ -17,6 +17,9 @@ func IsOpened(l shell.Logger, path string) (bool, error) {
 	for _, fdEntry := range fdEntries {
 		fd, err := strconv.ParseInt(fdEntry.Name(), 10, 64)
 		if err != nil {
+			if debug {
+				l.Warningf("Failed to parse fd %s: %s", fd, err)
+			}
 			continue
 		}
 
@@ -26,6 +29,9 @@ func IsOpened(l shell.Logger, path string) (bool, error) {
 
 		fdPath, err := os.Readlink(fmt.Sprintf("/dev/fd/%d", fd))
 		if err != nil {
+			if debug {
+				l.Warningf("Failed to readlink /dev/fd/%d: %v", fd, err)
+			}
 			continue
 		}
 

--- a/internal/file/is_opened.go
+++ b/internal/file/is_opened.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildkite/agent/v3/internal/job/shell"
 )
 
+// IsOpened returns true if the file at the given path is opened by the current process.
 func IsOpened(l shell.Logger, debug bool, path string) (bool, error) {
 	fdEntries, err := os.ReadDir("/dev/fd")
 	if err != nil {

--- a/internal/file/opened_by.go
+++ b/internal/file/opened_by.go
@@ -1,0 +1,82 @@
+package file
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+
+	"github.com/buildkite/agent/v3/internal/job/shell"
+)
+
+const stderrFd = 2
+
+var (
+	ErrFileNotOpen = errors.New("file not open, or the procces that opened it can't be found")
+	numeric        = regexp.MustCompile("^[0-9]+$")
+)
+
+func OpenedBy(l shell.Logger, path string) (string, error) {
+	pidEntries, err := os.ReadDir("/proc")
+	if err != nil {
+		return "", fmt.Errorf("failed to read /proc: %w", err)
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	for _, p := range pidEntries {
+		pid := p.Name()
+
+		if !numeric.MatchString(pid) || !openedByPid(l, absPath, pid) {
+			continue
+		}
+
+		// /proc/<pid>/exe is a symlink to the executable
+		exe, err := os.Readlink(fmt.Sprintf("/proc/%s/exe", pid))
+		if err != nil {
+			l.Warningf("Failed to read executable for pid %s: %v", pid, err)
+			continue
+		}
+
+		return exe, nil
+	}
+
+	return "", ErrFileNotOpen
+}
+
+func openedByPid(l shell.Logger, absPath string, pid string) bool {
+	dirEntries, err := os.ReadDir(fmt.Sprintf("/proc/%s/fd", pid))
+	if err != nil {
+		// the process has gone away, or we don't have permission to read it, ignore and move on
+		return false
+	}
+
+	for _, dirEntry := range dirEntries {
+		fd, err := strconv.ParseInt(dirEntry.Name(), 10, 64)
+		if err != nil {
+			continue
+		}
+
+		// 0 = stdin, 1 = stdout, 2 = stderr
+		if fd <= stderrFd {
+			continue
+		}
+
+		fPath, err := os.Readlink(fmt.Sprintf("/proc/%s/fd/%s", pid, dirEntry.Name()))
+		if err != nil {
+			l.Warningf("Failed to read link for fd", "error", err)
+			continue
+		}
+
+		if fPath == absPath {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/file/opened_by.go
+++ b/internal/file/opened_by.go
@@ -18,7 +18,7 @@ var (
 	numeric        = regexp.MustCompile("^[0-9]+$")
 )
 
-func OpenedBy(l shell.Logger, path string) (string, error) {
+func OpenedBy(l shell.Logger, debug bool, path string) (string, error) {
 	pidEntries, err := os.ReadDir("/proc")
 	if err != nil {
 		return "", fmt.Errorf("failed to read /proc: %w", err)
@@ -32,14 +32,16 @@ func OpenedBy(l shell.Logger, path string) (string, error) {
 	for _, p := range pidEntries {
 		pid := p.Name()
 
-		if !numeric.MatchString(pid) || !openedByPid(l, absPath, pid) {
+		if !numeric.MatchString(pid) || !openedByPid(l, debug, absPath, pid) {
 			continue
 		}
 
 		// /proc/<pid>/exe is a symlink to the executable
 		exe, err := os.Readlink(fmt.Sprintf("/proc/%s/exe", pid))
 		if err != nil {
-			l.Warningf("Failed to read executable for pid %s: %v", pid, err)
+			if debug {
+				l.Warningf("Failed to read executable for pid %s: %v", pid, err)
+			}
 			continue
 		}
 
@@ -49,9 +51,12 @@ func OpenedBy(l shell.Logger, path string) (string, error) {
 	return "", ErrFileNotOpen
 }
 
-func openedByPid(l shell.Logger, absPath string, pid string) bool {
+func openedByPid(l shell.Logger, debug bool, absPath string, pid string) bool {
 	dirEntries, err := os.ReadDir(fmt.Sprintf("/proc/%s/fd", pid))
 	if err != nil {
+		if debug {
+			l.Warningf("Failed to read /proc/%s/fd: %v", pid, err)
+		}
 		// the process has gone away, or we don't have permission to read it, ignore and move on
 		return false
 	}
@@ -59,6 +64,9 @@ func openedByPid(l shell.Logger, absPath string, pid string) bool {
 	for _, dirEntry := range dirEntries {
 		fd, err := strconv.ParseInt(dirEntry.Name(), 10, 64)
 		if err != nil {
+			if debug {
+				l.Warningf("Failed to parse fd %s: %s", fd, err)
+			}
 			continue
 		}
 
@@ -69,7 +77,9 @@ func openedByPid(l shell.Logger, absPath string, pid string) bool {
 
 		fPath, err := os.Readlink(fmt.Sprintf("/proc/%s/fd/%s", pid, dirEntry.Name()))
 		if err != nil {
-			l.Warningf("Failed to read link for fd", "error", err)
+			if debug {
+				l.Warningf("Failed to read link for fd", "error", err)
+			}
 			continue
 		}
 

--- a/internal/file/opened_by.go
+++ b/internal/file/opened_by.go
@@ -18,6 +18,7 @@ var (
 	numeric        = regexp.MustCompile("^[0-9]+$")
 )
 
+// OpenedBy attempts to find the executable that opened the given file.
 func OpenedBy(l shell.Logger, debug bool, path string) (string, error) {
 	pidEntries, err := os.ReadDir("/proc")
 	if err != nil {

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -364,17 +364,17 @@ func (e *Executor) runUnwrappedHook(ctx context.Context, hookName string, hookCf
 	return e.shell.RunWithEnv(ctx, environ, hookCfg.Path)
 }
 
-func logOpenedHookInfo(l shell.Logger, hookName, path string) {
+func logOpenedHookInfo(l shell.Logger, debug bool, hookName, path string) {
 	switch {
 	case runtime.GOOS == "linux":
-		procPath, err := file.OpenedBy(l, path)
+		procPath, err := file.OpenedBy(l, debug, path)
 		if err != nil {
 			l.Errorf("The %s hook failed to run because and we could not find the process that had it opened", hookName)
 		} else {
 			l.Errorf("The %s hook failed to run because it was open by %s", hookName, procPath)
 		}
 	case utils.FileExists("/dev/fd"):
-		isOpened, err := file.IsOpened(l, path)
+		isOpened, err := file.IsOpened(l, debug, path)
 		if err == nil {
 			if isOpened {
 				l.Errorf("The %s hook failed to run because it was opened by this buildkite-agent")
@@ -448,7 +448,7 @@ func (e *Executor) runWrappedShellScriptHook(ctx context.Context, hookName strin
 		// If the error is from fork/exec, then inspect the file to see why it failed to be executed,
 		// even after the retry
 		if perr := new(os.PathError); errors.As(err, &perr) && perr.Op == "fork/exec" {
-			logOpenedHookInfo(e.shell.Logger, hookName, perr.Path)
+			logOpenedHookInfo(e.shell.Logger, e.Debug, hookName, perr.Path)
 		}
 
 		return err

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -386,7 +386,7 @@ func (e *Executor) runWrappedShellScriptHook(ctx context.Context, hookName strin
 
 	// Show the hook runner in debug, but the thing being run otherwise 💅🏻
 	if e.Debug {
-		e.shell.Commentf("A hook runner was written to \"%s\" with the following:", script.Path())
+		e.shell.Commentf("A hook runner was written to %q with the following:", script.Path())
 		e.shell.Promptf("%s", process.FormatCommand(script.Path(), nil))
 	} else {
 		e.shell.Promptf("%s", process.FormatCommand(cleanHookPath, []string{}))

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -369,9 +369,10 @@ func logOpenedHookInfo(l shell.Logger, debug bool, hookName, path string) {
 	case runtime.GOOS == "linux":
 		procPath, err := file.OpenedBy(l, debug, path)
 		if err != nil {
-			l.Errorf("The %s hook failed to run because and we could not find the process that had it opened", hookName)
+			l.Errorf("The %s hook failed to run because it was already open. We couldn't find out what process had the hook open", hookName)
+
 		} else {
-			l.Errorf("The %s hook failed to run because it was open by %s", hookName, procPath)
+			l.Errorf("The %s hook failed to run the %s process has the hook file open", hookName, procPath)
 		}
 	case utils.FileExists("/dev/fd"):
 		isOpened, err := file.IsOpened(l, debug, path)

--- a/internal/job/shell/shell.go
+++ b/internal/job/shell/shell.go
@@ -589,7 +589,7 @@ func (s *Shell) executeCommand(
 	s.cmdLock.Unlock()
 
 	if err := p.Run(ctx); err != nil {
-		return fmt.Errorf("Error running %q: %w", cmdStr, err)
+		return fmt.Errorf("error running %q: %w", cmdStr, err)
 	}
 
 	return p.WaitResult()


### PR DESCRIPTION
A customer reported that their jobs were unable to run a hook because the hook wrapper script was locked.

The hooks should have collision avoidant names, and they should have closed by the agent worker goroutine that created them prior to execution, which is in the same goroutine. So it's a bit of a mystery how the script wrapper could remain open.

We could just add more retry to work around this, but it would like to find the cause. So, I've done two things in this PR:

- Retry executing the hook if we get a fork/exec error
- If the retry is exhausted, log the error and try to determine what process has the file open

That latter will only work if:
- the process that has the file open is long-lived enough for the error handling to catch it with the file open, and
- the agent has permission to read the open file descriptors of the other processes

So we can't be certain what the other process is, but at least we should be able to prove or disprove that it is the agent itself.

Detecting other processes only works on Linux because it uses the [procfs](https://docs.kernel.org/filesystems/proc.html). For other Unixes, we can use `/dev/fd` to check that the agent process does not have the file open. I'm not sure if this will work if the two goroutines are scheduled on different OS threads, however.