### PR TITLE
Fix ECR authentication failure

### DIFF
--- a/.buildkite/steps/publish-docker-image.sh
+++ b/.buildkite/steps/publish-docker-image.sh
@@ -15,7 +15,11 @@ dry_run() {
 }
 
 skopeo() {
-  docker run --rm -v "${DOCKER_CONFIG:-$HOME/.docker}:/root/.docker:ro" quay.io/skopeo/stable:v1 "$@"
+  docker run --rm \
+    -v "${DOCKER_CONFIG:-$HOME/.docker}:/root/.docker:ro" \
+    -e "REGISTRY_AUTH_FILE=/root/.docker/config.json" \
+    quay.io/skopeo/stable:v1 \
+    "$@"
 }
 
 # Convert 2.3.2 into [ 2.3.2 2.3 2 ] or 3.0-beta.42 in [ 3.0-beta.42 3.0 3 ]


### PR DESCRIPTION
https://github.com/containers/skopeo/issues/1909 summary:

Skopeo 1.11 changed behavior - when an `--authfile` flag or `REGISTRY_AUTH_FILE` env var is present, it read only that file for creds. We weren't setting that flag/var ourselves but the skopeo container does: 

https://github.com/containers/skopeo/blob/7f2f46e1b97df36b2b82d1b1d87c81b8b3d21601/contrib/skopeoimage/stable/Containerfile#L44