### PR TITLE
Fix verification for steps with plugins, part 2

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -35,7 +36,23 @@ func (j *Job) ValuesForFields(fields []string) (map[string]string, error) {
 			o[f] = j.Env["BUILDKITE_COMMAND"]
 
 		case "plugins":
-			o[f] = j.Env["BUILDKITE_PLUGINS"]
+			if j.Env["BUILDKITE_PLUGINS"] == "" {
+				o[f] = ""
+				continue
+			}
+			// Plugins needs to be normalised, because key order in each plugin
+			// config is frequently varied by the backend.
+			// The reliable way to make it consistent is an unmarshal-remarshal
+			// round-trip.
+			var ps pipeline.Plugins
+			if err := json.Unmarshal([]byte(j.Env["BUILDKITE_PLUGINS"]), &ps); err != nil {
+				return nil, fmt.Errorf("unmarshaling BUIDLKITE_PLUGINS: %w", err)
+			}
+			normalised, err := json.Marshal(ps)
+			if err != nil {
+				return nil, fmt.Errorf("re-marshaling BUIDLKITE_PLUGINS: %w", err)
+			}
+			o[f] = string(normalised)
 
 		default:
 			if e, has := strings.CutPrefix(f, pipeline.EnvNamespacePrefix); has {

--- a/internal/ordered/map_test.go
+++ b/internal/ordered/map_test.go
@@ -772,3 +772,53 @@ hello:
 		})
 	}
 }
+
+func TestToMapRecursive(t *testing.T) {
+	t.Parallel()
+
+	src := MapFromItems(
+		TupleSA{Key: "llama", Value: "Kuzco"},
+		TupleSA{Key: "alpaca", Value: "Geronimo"},
+		TupleSA{Key: "nil", Value: nil},
+		TupleSA{Key: "nested", Value: []any{
+			MapFromItems(
+				TupleSA{Key: "llama", Value: "Kuzco1"},
+				TupleSA{Key: "alpaca", Value: "Geronimo1"},
+			),
+			MapFromItems(
+				TupleSA{Key: "llama", Value: "Kuzco2"},
+				TupleSA{Key: "alpaca", Value: "Geronimo2"},
+				TupleSA{Key: "nested again", Value: MapFromItems(
+					TupleSA{Key: "llama", Value: "Kuzco3"},
+					TupleSA{Key: "alpaca", Value: "Geronimo3"},
+				)},
+			),
+		}},
+	)
+
+	got := ToMapRecursive(src)
+
+	want := map[string]any{
+		"llama":  "Kuzco",
+		"alpaca": "Geronimo",
+		"nil":    nil,
+		"nested": []any{
+			map[string]any{
+				"llama":  "Kuzco1",
+				"alpaca": "Geronimo1",
+			},
+			map[string]any{
+				"llama":  "Kuzco2",
+				"alpaca": "Geronimo2",
+				"nested again": map[string]any{
+					"llama":  "Kuzco3",
+					"alpaca": "Geronimo3",
+				},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("ToMapRecursive output diff (-got +want):\n%s", diff)
+	}
+}

--- a/internal/pipeline/parser_test.go
+++ b/internal/pipeline/parser_test.go
@@ -930,10 +930,10 @@ steps:
 				Plugins: Plugins{
 					{
 						Source: "ecr#v2.7.0",
-						Config: ordered.MapFromItems(
-							ordered.TupleSA{Key: "login", Value: true},
-							ordered.TupleSA{Key: "account_ids", Value: "0123456789"},
-						),
+						Config: map[string]any{
+							"login":       true,
+							"account_ids": "0123456789",
+						},
 					},
 				},
 				RemainingFields: map[string]any{
@@ -1018,29 +1018,27 @@ steps:
 				Plugins: Plugins{
 					{
 						Source: "xxx/aws-assume-role#v0.1.0",
-						Config: ordered.MapFromItems(
-							ordered.TupleSA{Key: "role", Value: "arn:aws:iam::xxx:role/xxx"},
-						),
+						Config: map[string]any{"role": "arn:aws:iam::xxx:role/xxx"},
 					},
 					{
 						Source: "ecr#v1.1.4",
-						Config: ordered.MapFromItems(
-							ordered.TupleSA{Key: "login", Value: true},
-							ordered.TupleSA{Key: "account_ids", Value: "xxx"},
-							ordered.TupleSA{Key: "registry_region", Value: "us-east-1"},
-						),
+						Config: map[string]any{
+							"login":           true,
+							"account_ids":     "xxx",
+							"registry_region": "us-east-1",
+						},
 					},
 					{
 						Source: "docker-compose#v2.5.1",
-						Config: ordered.MapFromItems(
-							ordered.TupleSA{Key: "run", Value: "xxx"},
-							ordered.TupleSA{Key: "config", Value: ".buildkite/docker/docker-compose.yml"},
-							ordered.TupleSA{Key: "env", Value: []any{
+						Config: map[string]any{
+							"run":    "xxx",
+							"config": ".buildkite/docker/docker-compose.yml",
+							"env": []any{
 								"AWS_ACCESS_KEY_ID",
 								"AWS_SECRET_ACCESS_KEY",
 								"AWS_SESSION_TOKEN",
-							}},
-						),
+							},
+						},
 					},
 				},
 				RemainingFields: map[string]any{
@@ -1076,20 +1074,20 @@ steps:
         },
         {
           "github.com/buildkite-plugins/ecr-buildkite-plugin#v1.1.4": {
-            "login": true,
             "account_ids": "xxx",
+            "login": true,
             "registry_region": "us-east-1"
           }
         },
         {
           "github.com/buildkite-plugins/docker-compose-buildkite-plugin#v2.5.1": {
-            "run": "xxx",
             "config": ".buildkite/docker/docker-compose.yml",
             "env": [
               "AWS_ACCESS_KEY_ID",
               "AWS_SECRET_ACCESS_KEY",
               "AWS_SESSION_TOKEN"
-            ]
+            ],
+            "run": "xxx"
           }
         }
       ]
@@ -1131,9 +1129,9 @@ func TestParserParsesScalarPlugins(t *testing.T) {
 					},
 					{
 						Source: "docker-compose#v2.5.1",
-						Config: ordered.MapFromItems(
-							ordered.TupleSA{Key: "config", Value: ".buildkite/docker/docker-compose.yml"},
-						),
+						Config: map[string]any{
+							"config": ".buildkite/docker/docker-compose.yml",
+						},
 					},
 				},
 				RemainingFields: map[string]any{

--- a/internal/pipeline/plugin.go
+++ b/internal/pipeline/plugin.go
@@ -27,7 +27,7 @@ type Plugin struct {
 }
 
 // MarshalJSON returns the plugin in "one-key object" form, or "single string"
-// form (no config, only plugin name). Plugin sources are marshalled into "full"
+// form (no config, only plugin source). Plugin sources are marshalled into "full"
 // form.
 func (p *Plugin) MarshalJSON() ([]byte, error) {
 	// NB: MarshalYAML (as seen below) never returns an error.
@@ -36,7 +36,7 @@ func (p *Plugin) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the plugin in either "one-item map" form, or "scalar"
-// form (no config, only plugin name). Plugin sources are marshalled into "full"
+// form (no config, only plugin source). Plugin sources are marshalled into "full"
 // form.
 func (p *Plugin) MarshalYAML() (any, error) {
 	if p.Config == nil {

--- a/internal/pipeline/plugins.go
+++ b/internal/pipeline/plugins.go
@@ -1,10 +1,17 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/buildkite/agent/v3/internal/ordered"
+	"gopkg.in/yaml.v3"
 )
+
+var _ interface {
+	json.Unmarshaler
+	ordered.Unmarshaler
+} = (*Plugins)(nil)
 
 // Plugins is a sequence of plugins. It is useful for unmarshaling.
 type Plugins []*Plugin
@@ -22,16 +29,21 @@ func (p *Plugins) UnmarshalOrdered(o any) error {
 	// Parse each "key: value" as "name: config", then append in order.
 	unmarshalMap := func(m *ordered.MapSA) error {
 		return m.Range(func(k string, v any) error {
-			*p = append(*p, &Plugin{
+			// ToMapRecursive demolishes any ordering within the plugin config.
+			// This is needed because the backend likes to reorder the keys,
+			// and for signing we need the JSON form to be stable.
+			plugin := &Plugin{
 				Source: k,
-				Config: v,
-			})
+				Config: ordered.ToMapRecursive(v),
+			}
+			*p = append(*p, plugin)
 			return nil
 		})
 	}
 
 	switch o := o.(type) {
 	case nil:
+		// Someone wrote `plugins: null` (possibly us).
 		*p = nil
 		return nil
 
@@ -81,4 +93,14 @@ func (p *Plugins) UnmarshalOrdered(o any) error {
 
 	}
 	return nil
+}
+
+// UnmarshalJSON is used mainly to normalise the BUILDKITE_PLUGINS env var.
+func (p *Plugins) UnmarshalJSON(b []byte) error {
+	// JSON is just a specific kind of YAML.
+	var n yaml.Node
+	if err := yaml.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	return ordered.Unmarshal(&n, &p)
 }

--- a/internal/pipeline/plugins_test.go
+++ b/internal/pipeline/plugins_test.go
@@ -1,0 +1,74 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPluginsUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`[
+	{
+		"xxx/aws-assume-role#v0.1.0": {
+			"role": "arn:aws:iam::xxx:role/xxx"
+		}
+	},
+	{
+		"ecr#v1.1.4": {
+			"account_ids": "xxx",
+			"login": true,
+			"registry_region": "us-east-1"
+		}
+	},
+	{
+		"docker-compose#v2.5.1": {
+			"config": ".buildkite/docker/docker-compose.yml",
+			"env": [
+				"AWS_ACCESS_KEY_ID",
+				"AWS_SECRET_ACCESS_KEY",
+				"AWS_SESSION_TOKEN"
+			],
+			"run": "xxx"
+		}
+	}
+]`)
+
+	var got Plugins
+	if err := json.Unmarshal(src, &got); err != nil {
+		t.Fatalf("json.Unmarshal(%q, &got) = %v", src, err)
+	}
+	want := Plugins{
+		{
+			Source: "xxx/aws-assume-role#v0.1.0",
+			Config: map[string]any{"role": "arn:aws:iam::xxx:role/xxx"},
+		},
+		{
+			Source: "ecr#v1.1.4",
+			Config: map[string]any{
+				"login":           true,
+				"account_ids":     "xxx",
+				"registry_region": "us-east-1",
+			},
+		},
+		{
+			Source: "docker-compose#v2.5.1",
+			Config: map[string]any{
+				"run":    "xxx",
+				"config": ".buildkite/docker/docker-compose.yml",
+				"env": []any{
+					"AWS_ACCESS_KEY_ID",
+					"AWS_SECRET_ACCESS_KEY",
+					"AWS_SESSION_TOKEN",
+				},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unmarshaled Plugin diff (-got +want):\n%s", diff)
+	}
+
+}

--- a/internal/pipeline/sign_test.go
+++ b/internal/pipeline/sign_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/buildkite/agent/v3/internal/ordered"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 )
@@ -22,12 +21,7 @@ func TestSignVerify(t *testing.T) {
 			},
 			{
 				Source: "another-plugin#v3.4.5",
-				Config: ordered.MapFromItems(
-					ordered.TupleSA{
-						Key:   "llama",
-						Value: "Kuzco",
-					},
-				),
+				Config: map[string]any{"llama": "Kuzco"},
 			},
 		},
 		Env: map[string]string{

--- a/internal/pipeline/sign_test.go
+++ b/internal/pipeline/sign_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/elliptic"
 	"errors"
 	"fmt"
+	"math/rand"
 	"strings"
 	"testing"
 
@@ -307,5 +308,46 @@ func TestSignVerifyEnv(t *testing.T) {
 				t.Errorf("sig.Verify(CommandStep, verifier) = %v", err)
 			}
 		})
+	}
+}
+
+func TestSignatureStability(t *testing.T) {
+	t.Parallel()
+
+	// The idea here is to sign and verify a step that is likely to encode in a
+	// non-stable way if there are ordering bugs.
+
+	pluginSubCfg := make(map[string]any)
+	pluginCfg := map[string]any{
+		"subcfg": pluginSubCfg,
+	}
+	step := &CommandStep{
+		Command: "echo 'hello friend'",
+		Env:     make(map[string]string),
+		Plugins: Plugins{&Plugin{
+			Source: "huge-config#v1.0.0",
+			Config: pluginCfg,
+		}},
+	}
+	env := make(map[string]string)
+
+	// there are n! permutations of n items, but only one is correct
+	// 128! is absurdly large, and we fill four maps...
+	for i := 0; i < 128; i++ {
+		env[fmt.Sprintf("VAR%08x", rand.Uint32())] = fmt.Sprintf("VAL%08x", rand.Uint32())
+		step.Env[fmt.Sprintf("VAR%08x", rand.Uint32())] = fmt.Sprintf("VAL%08x", rand.Uint32())
+		pluginCfg[fmt.Sprintf("key%08x", rand.Uint32())] = fmt.Sprintf("value%08x", rand.Uint32())
+		pluginSubCfg[fmt.Sprintf("key%08x", rand.Uint32())] = fmt.Sprintf("value%08x", rand.Uint32())
+	}
+
+	signer, verifier := newECKeyPair(t, jwa.ES256, elliptic.P256())
+
+	sig, err := Sign(env, step, signer)
+	if err != nil {
+		t.Fatalf("Sign(env, CommandStep, signer) error = %v", err)
+	}
+
+	if err := sig.Verify(env, step, verifier); err != nil {
+		t.Errorf("sig.Verify(env, CommandStep, verifier) = %v", err)
 	}
 }

--- a/internal/pipeline/step_command_test.go
+++ b/internal/pipeline/step_command_test.go
@@ -44,29 +44,27 @@ func TestCommandStepUnmarshalJSON(t *testing.T) {
 		Plugins: Plugins{
 			{
 				Source: "github.com/xxx/aws-assume-role-buildkite-plugin#v0.1.0",
-				Config: ordered.MapFromItems(
-					ordered.TupleSA{Key: "role", Value: "arn:aws:iam::xxx:role/xxx"},
-				),
+				Config: map[string]any{"role": "arn:aws:iam::xxx:role/xxx"},
 			},
 			{
 				Source: "github.com/buildkite-plugins/ecr-buildkite-plugin#v1.1.4",
-				Config: ordered.MapFromItems(
-					ordered.TupleSA{Key: "login", Value: true},
-					ordered.TupleSA{Key: "account_ids", Value: "xxx"},
-					ordered.TupleSA{Key: "registry_region", Value: "us-east-1"},
-				),
+				Config: map[string]any{
+					"login":           true,
+					"account_ids":     "xxx",
+					"registry_region": "us-east-1",
+				},
 			},
 			{
 				Source: "github.com/buildkite-plugins/docker-compose-buildkite-plugin#v2.5.1",
-				Config: ordered.MapFromItems(
-					ordered.TupleSA{Key: "run", Value: "xxx"},
-					ordered.TupleSA{Key: "config", Value: ".buildkite/docker/docker-compose.yml"},
-					ordered.TupleSA{Key: "env", Value: []any{
+				Config: map[string]any{
+					"run":    "xxx",
+					"config": ".buildkite/docker/docker-compose.yml",
+					"env": []any{
 						"AWS_ACCESS_KEY_ID",
 						"AWS_SECRET_ACCESS_KEY",
 						"AWS_SESSION_TOKEN",
-					}},
-				),
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Dogfooding showed that signed steps with plugins still tended to fail verification. After digging around with `--debug-http`, it turns out that plugin config maps/hashes tend to be reordered by the backend.

On the plus side: we're free to reorder keys within plugin configs! 🎉

Changes here:

- `pipeline.Plugins` can now be unmarshaled directly from JSON. For consistency it reuses the underlying `UnmarshalOrdered` using the same technique as for `CommandStep`.
- `ordered` now has `ToMapRecursive`, which replaces `*Map[string, any]` with `map[string]any` recursively.
- Each `Plugin` is unmarshaled using `ToMapRecursive`.
- `api.Job.ValuesForFields` now passes `BUILDKITE_PLUGINS` through a JSON unmarshal-marshal round-trip. The JSON marshaler writes (plain) map keys in sorted order. 

Net effect - signatures should verify.