### PR TITLE
Provide new glob library with experiment

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -38,6 +38,7 @@ After repository checkout, resolve `BUILDKITE_COMMIT` to a commit hash. This mak
 **Status**: broadly useful, we'd like this to be the standard behaviour in 4.0. 👍👍
 
 ### `kubernetes-exec`
+
 Modifies `start` and `bootstrap` in such a way that they can run in separate Kubernetes containers in the same pod.
 
 Currently, this experiment is being used by [agent-stack-k8s](https://github.com/buildkite/agent-stack-k8s).
@@ -99,6 +100,20 @@ https://github.com/buildkite/agent/blob/40b8a5f3794b04bd64da6e2527857add849a35bd
 **Status:** Since the default behaviour is buggy, we will be promoting this to non-experiment soon™️.
 
 ### `isolated-plugin-checkout`
+
 Checks out each plugin to an directory that that is namespaced by the agent name. Thus each agent worker will have an isolated copy of the plugin. This removes the need to lock the plugin checkout directories in a single agent process with spawned workers. However, if your plugin directory is shared between multiple agent processes *with the same agent name* , you may run into race conditions. This is just one reason we recommend you ensure agents have unique names.
 
-***Status:*** Likely to be the default behaviour in the future.
+**Status:** Likely to be the default behaviour in the future.
+
+### `use-zzglob`
+
+Uses a different library for resolving glob expressions used for `artifact upload`.
+The new glob library should resolve a few issues experienced with the old library:
+
+- Because `**` is used to mean "zero or more path segments", `/**/` should match `/`.
+- Directories that cannot match the glob pattern shouldn't be walked while resolving the pattern. Failure to do this makes `artifact upload` difficult to use when run in a directory containing a mix of subdirectories with different permissions.
+- Failures to walk potential file paths should be reported individually.
+
+The new library should handle all syntax supported by the old library, but because of the chance of incompatibilities and bugs, we're providing it via experiment only for now.
+
+**Status:** Since using the old library causes problems, we hope to promote this to be the default soon™️.

--- a/agent/artifact_uploader_test.go
+++ b/agent/artifact_uploader_test.go
@@ -346,3 +346,326 @@ func TestCollectMatchesUploadSymlinks(t *testing.T) {
 		paths,
 	)
 }
+
+func TestCollect_WithZZGlob(t *testing.T) {
+	ctx, _ := experiments.Enable(context.Background(), experiments.UseZZGlob)
+
+	wd, _ := os.Getwd()
+	root := filepath.Join(wd, "..")
+	os.Chdir(root)
+	defer os.Chdir(wd)
+
+	volumeName := filepath.VolumeName(root)
+	rootWithoutVolume := strings.TrimPrefix(root, volumeName)
+
+	var testCases = []struct {
+		Name         string
+		Path         []string
+		AbsolutePath string
+		GlobPath     string
+		FileSize     int
+		Sha1Sum      string
+		Sha256Sum    string
+	}{
+		{
+			Name:         "Mr Freeze.jpg",
+			Path:         []string{"test", "fixtures", "artifacts", "Mr Freeze.jpg"},
+			AbsolutePath: filepath.Join(root, "test", "fixtures", "artifacts", "Mr Freeze.jpg"),
+			GlobPath:     filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
+			FileSize:     362371,
+			Sha1Sum:      "f5bc7bc9f5f9c3e543dde0eb44876c6f9acbfb6b",
+			Sha256Sum:    "0c657a363d92093e68224e0716ed8b8b5d4bbc3dfe9b026e32b241fc9b369d47",
+		},
+		{
+			Name:         "Commando.jpg",
+			Path:         []string{"test", "fixtures", "artifacts", "folder", "Commando.jpg"},
+			AbsolutePath: filepath.Join(root, "test", "fixtures", "artifacts", "folder", "Commando.jpg"),
+			GlobPath:     filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
+			FileSize:     113000,
+			Sha1Sum:      "811d7cb0317582e22ebfeb929d601cdabea4b3c0",
+			Sha256Sum:    "fcfbe62fd7b6638165a61e8de901ac9df93fc1389906f2772bdefed5de115426",
+		},
+		{
+			Name:         "The Terminator.jpg",
+			Path:         []string{"test", "fixtures", "artifacts", "this is a folder with a space", "The Terminator.jpg"},
+			AbsolutePath: filepath.Join(root, "test", "fixtures", "artifacts", "this is a folder with a space", "The Terminator.jpg"),
+			GlobPath:     filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
+			FileSize:     47301,
+			Sha1Sum:      "ed76566ede9cb6edc975fcadca429665aad8785a",
+			Sha256Sum:    "5b4228a4bbef3d9f676e0a2e8cf6ea06759124ef0fbdb27a6c35df8759fcd39d",
+		},
+		{
+			Name:         "Smile.gif",
+			Path:         []string{rootWithoutVolume[1:], "test", "fixtures", "artifacts", "gifs", "Smile.gif"},
+			AbsolutePath: filepath.Join(root, "test", "fixtures", "artifacts", "gifs", "Smile.gif"),
+			GlobPath:     filepath.Join(root, "test", "fixtures", "artifacts", "**", "*.gif"),
+			FileSize:     2038453,
+			Sha1Sum:      "bd4caf2e01e59777744ac1d52deafa01c2cb9bfd",
+			Sha256Sum:    "fc5e8608c7772e4ae834fbc47eec3d902099eb3599f5191e40d9e3d9b3764b0e",
+		},
+	}
+
+	uploader := NewArtifactUploader(logger.Discard, nil, ArtifactUploaderConfig{
+		Paths: fmt.Sprintf("%s;%s",
+			filepath.Join("test", "fixtures", "artifacts", "**/*.jpg"),
+			filepath.Join(root, "test", "fixtures", "artifacts", "**/*.gif"),
+		),
+	})
+
+	// For the normalised-upload-paths experiment, uploaded artifact paths are
+	// normalised with Unix/URI style path separators, even on Windows.
+	// Without the experiment on, we use the file path given by the file system
+	//
+	// To simulate that in this test, we collect artifacts from the file system
+	// twice, once with the experiment explicitly disabled, and one with it
+	// enabled. We then check the test cases against both sets of artifacts,
+	// comparing to paths processed with filepath.Join (which uses native OS
+	// path separators), and then with the experiment enabled and with the
+	// path.Join function instead (which uses Unix/URI-style path separators,
+	// regardless of platform)
+
+	ctxExpEnabled, _ := experiments.Enable(ctx, experiments.NormalisedUploadPaths)
+	ctxExpDisabled := experiments.Disable(ctx, experiments.NormalisedUploadPaths)
+
+	artifactsWithoutExperimentEnabled, err := uploader.Collect(ctxExpDisabled)
+	if err != nil {
+		t.Fatalf("[normalised-upload-paths disabled] uploader.Collect() error = %v", err)
+	}
+	assert.Equal(t, 5, len(artifactsWithoutExperimentEnabled))
+
+	artifactsWithExperimentEnabled, err := uploader.Collect(ctxExpEnabled)
+	if err != nil {
+		t.Fatalf("[normalised-upload-paths enabled] uploader.Collect() error = %v", err)
+	}
+	assert.Equal(t, 5, len(artifactsWithExperimentEnabled))
+
+	// These test cases use filepath.Join, which uses per-OS path separators;
+	// this is the behaviour without normalised-upload-paths.
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			a := findArtifact(artifactsWithoutExperimentEnabled, tc.Name)
+			if a == nil {
+				t.Fatalf("findArtifact(%q) == nil", tc.Name)
+			}
+
+			assert.Equal(t, filepath.Join(tc.Path...), a.Path)
+			assert.Equal(t, tc.AbsolutePath, a.AbsolutePath)
+			assert.Equal(t, tc.GlobPath, a.GlobPath)
+			assert.Equal(t, tc.FileSize, int(a.FileSize))
+			assert.Equal(t, tc.Sha1Sum, a.Sha1Sum)
+			assert.Equal(t, tc.Sha256Sum, a.Sha256Sum)
+		})
+	}
+
+	// These test cases uses filepath.ToSlash(), which always emits forward-slashes.
+	// this is the behaviour with normalised-upload-paths.
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			a := findArtifact(artifactsWithExperimentEnabled, tc.Name)
+			if a == nil {
+				t.Fatalf("findArtifact(%q) == nil", tc.Name)
+			}
+
+			// Note that the rootWithoutVolume component of some tc.Path values
+			// may already have backslashes in them on Windows:
+			// []string{"path\to\codebase", "test", "fixtures", "hello"}
+			// So forward-slash joining them with path.Join(tc.Path...} isn't enough.
+			forwardSlashed := filepath.ToSlash(filepath.Join(tc.Path...))
+
+			assert.Equal(t, forwardSlashed, a.Path)
+			assert.Equal(t, tc.AbsolutePath, a.AbsolutePath)
+			assert.Equal(t, tc.GlobPath, a.GlobPath)
+			assert.Equal(t, tc.FileSize, int(a.FileSize))
+			assert.Equal(t, tc.Sha1Sum, a.Sha1Sum)
+			assert.Equal(t, tc.Sha256Sum, a.Sha256Sum)
+		})
+	}
+}
+
+func TestCollectThatDoesntMatchAnyFiles_WithZZGlob(t *testing.T) {
+	ctx, _ := experiments.Enable(context.Background(), experiments.UseZZGlob)
+
+	wd, _ := os.Getwd()
+	root := filepath.Join(wd, "..")
+	os.Chdir(root)
+	defer os.Chdir(wd)
+
+	uploader := NewArtifactUploader(logger.Discard, nil, ArtifactUploaderConfig{
+		Paths: strings.Join([]string{
+			filepath.Join("log", "*"),
+			filepath.Join("tmp", "capybara", "**", "*"),
+			filepath.Join("mkmf.log"),
+			filepath.Join("log", "mkmf.log"),
+		}, ";"),
+	})
+
+	artifacts, err := uploader.Collect(ctx)
+	if err != nil {
+		t.Fatalf("uploader.Collect() error = %v", err)
+	}
+
+	assert.Equal(t, len(artifacts), 0)
+}
+
+func TestCollectWithSomeGlobsThatDontMatchAnything_WithZZGlob(t *testing.T) {
+	ctx, _ := experiments.Enable(context.Background(), experiments.UseZZGlob)
+
+	wd, _ := os.Getwd()
+	root := filepath.Join(wd, "..")
+	os.Chdir(root)
+	defer os.Chdir(wd)
+
+	uploader := NewArtifactUploader(logger.Discard, nil, ArtifactUploaderConfig{
+		Paths: strings.Join([]string{
+			filepath.Join("dontmatchanything", "*"),
+			filepath.Join("dontmatchanything.zip"),
+			filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
+		}, ";"),
+	})
+
+	artifacts, err := uploader.Collect(ctx)
+	if err != nil {
+		t.Fatalf("uploader.Collect() error = %v", err)
+	}
+
+	if len(artifacts) != 4 {
+		t.Errorf("len(artifacts) = %d, want 4", len(artifacts))
+	}
+}
+
+func TestCollectWithSomeGlobsThatDontMatchAnythingFollowingSymlinks_WithZZGlob(t *testing.T) {
+	ctx, _ := experiments.Enable(context.Background(), experiments.UseZZGlob)
+
+	wd, _ := os.Getwd()
+	root := filepath.Join(wd, "..")
+	os.Chdir(root)
+	defer os.Chdir(wd)
+
+	uploader := NewArtifactUploader(logger.Discard, nil, ArtifactUploaderConfig{
+		Paths: strings.Join([]string{
+			filepath.Join("dontmatchanything", "*"),
+			filepath.Join("dontmatchanything.zip"),
+			filepath.Join("test", "fixtures", "artifacts", "links", "folder-link", "dontmatchanything", "**", "*.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
+		}, ";"),
+		GlobResolveFollowSymlinks: true,
+	})
+
+	artifacts, err := uploader.Collect(ctx)
+	if err != nil {
+		t.Fatalf("uploader.Collect() error = %v", err)
+	}
+
+	if len(artifacts) != 5 {
+		t.Errorf("len(artifacts) = %d, want 5", len(artifacts))
+	}
+}
+
+func TestCollectWithDuplicateMatches_WithZZGlob(t *testing.T) {
+	ctx, _ := experiments.Enable(context.Background(), experiments.UseZZGlob)
+
+	wd, _ := os.Getwd()
+	root := filepath.Join(wd, "..")
+	os.Chdir(root)
+	defer os.Chdir(wd)
+
+	uploader := NewArtifactUploader(logger.Discard, nil, ArtifactUploaderConfig{
+		Paths: strings.Join([]string{
+			filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "folder", "Commando.jpg"), // dupe
+		}, ";"),
+	})
+
+	artifacts, err := uploader.Collect(ctx)
+	if err != nil {
+		t.Fatalf("uploader.Collect() error = %v", err)
+	}
+
+	paths := []string{}
+	for _, a := range artifacts {
+		paths = append(paths, a.Path)
+	}
+	assert.ElementsMatch(
+		t,
+		[]string{
+			filepath.Join("test", "fixtures", "artifacts", "Mr Freeze.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "folder", "Commando.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "this is a folder with a space", "The Terminator.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "links", "terminator", "terminator2.jpg"),
+		},
+		paths,
+	)
+}
+
+func TestCollectWithDuplicateMatchesFollowingSymlinks_WithZZGlob(t *testing.T) {
+	ctx, _ := experiments.Enable(context.Background(), experiments.UseZZGlob)
+
+	wd, _ := os.Getwd()
+	root := filepath.Join(wd, "..")
+	os.Chdir(root)
+	defer os.Chdir(wd)
+
+	uploader := NewArtifactUploader(logger.Discard, nil, ArtifactUploaderConfig{
+		Paths: strings.Join([]string{
+			filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "folder", "Commando.jpg"), // dupe
+		}, ";"),
+		GlobResolveFollowSymlinks: true,
+	})
+
+	artifacts, err := uploader.Collect(ctx)
+	if err != nil {
+		t.Fatalf("uploader.Collect() error = %v", err)
+	}
+
+	paths := []string{}
+	for _, a := range artifacts {
+		paths = append(paths, a.Path)
+	}
+	assert.ElementsMatch(
+		t,
+		[]string{
+			filepath.Join("test", "fixtures", "artifacts", "Mr Freeze.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "folder", "Commando.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "this is a folder with a space", "The Terminator.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "links", "terminator", "terminator2.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "links", "folder-link", "terminator2.jpg"),
+		},
+		paths,
+	)
+}
+
+func TestCollectMatchesUploadSymlinks_WithZZGlob(t *testing.T) {
+	ctx, _ := experiments.Enable(context.Background(), experiments.UseZZGlob)
+
+	wd, _ := os.Getwd()
+	root := filepath.Join(wd, "..")
+	os.Chdir(root)
+	defer os.Chdir(wd)
+
+	uploader := NewArtifactUploader(logger.Discard, nil, ArtifactUploaderConfig{
+		Paths: strings.Join([]string{
+			filepath.Join("test", "fixtures", "artifacts", "**", "*.jpg"),
+		}, ";"),
+		UploadSkipSymlinks: true,
+	})
+
+	artifacts, err := uploader.Collect(ctx)
+	if err != nil {
+		t.Fatalf("uploader.Collect() error = %v", err)
+	}
+
+	paths := []string{}
+	for _, a := range artifacts {
+		paths = append(paths, a.Path)
+	}
+	assert.ElementsMatch(
+		t,
+		[]string{
+			filepath.Join("test", "fixtures", "artifacts", "Mr Freeze.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "folder", "Commando.jpg"),
+			filepath.Join("test", "fixtures", "artifacts", "this is a folder with a space", "The Terminator.jpg"),
+		},
+		paths,
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0
 	github.com/DataDog/datadog-go/v5 v5.3.0
+	github.com/DrJosh9000/zzglob v0.0.15
 	github.com/aws/aws-sdk-go v1.44.334
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 	github.com/buildkite/bintest/v3 v3.1.1

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/DataDog/go-tuf v1.0.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOA
 github.com/DataDog/gostackparse v0.5.0 h1:jb72P6GFHPHz2W0onsN51cS3FkaMDcjb0QzgxxA4gDk=
 github.com/DataDog/sketches-go v1.2.1 h1:qTBzWLnZ3kM2kw39ymh6rMcnN+5VULwFs++lEYUUsro=
 github.com/DataDog/sketches-go v1.2.1/go.mod h1:1xYmPLY1So10AwxV6MJV0J53XVH+WL9Ad1KetxVivVI=
+github.com/DrJosh9000/zzglob v0.0.15 h1:LoukPRH8OHn6hs3wAzoz8VoszQBAe8R5H6SmGiNhkqU=
+github.com/DrJosh9000/zzglob v0.0.15/go.mod h1:+iLI/qvROFsS1A/jl+B8MVYNu/0cjveYOJqU37O8fcs=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -32,6 +32,7 @@ const (
 	ResolveCommitAfterCheckout = "resolve-commit-after-checkout"
 	AvoidRecursiveTrap         = "avoid-recursive-trap"
 	IsolatedPluginCheckout     = "isolated-plugin-checkout"
+	UseZZGlob                  = "use-zzglob"
 
 	// Promoted experiments
 	ANSITimestamps    = "ansi-timestamps"
@@ -51,6 +52,7 @@ var (
 		ResolveCommitAfterCheckout: {},
 		AvoidRecursiveTrap:         {},
 		IsolatedPluginCheckout:     {},
+		UseZZGlob:                  {},
 	}
 
 	Promoted = map[string]string{


### PR DESCRIPTION
Why a new glob library? 

- We've had issues reported where `artifact upload` tries to walk into subdirectories it has no permissions to enter, despite the pattern not matching those subdirectories at all.
- It's also inconvenient to have the glob bomb out half way with ambiguous-sounding errors.
- Syntax problems, e.g. #2305

Why _write_ a new glob library?

- I have doubts about the use of `fastwalk` (which is vendored in go-zglob).
- I have doubts that go-zglob could be adapted to fix some of the problems above (it translates glob patterns into regexes under the hood, which makes partial matching for candidate directories difficult, and the code harder to read).
- There are probably other glob libraries that would work, but wheee I'd already started

I realise I'm sneaking in a significant amount of unreviewed code through a new dependency. Please forgive me 🙏 I wanted to iterate quickly on design for the new library. At this point I believe it's at syntax and feature parity with go-zglob, has fewer bugs, and will provide a better experience. 

But because of the risks, it comes under an experiment.