### PR TITLE
Add `allow-repositories` param to enable repository allow-listing

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -24,6 +24,7 @@ type AgentConfiguration struct {
 	GitCleanFlags         string
 	GitFetchFlags         string
 	GitSubmodules         bool
+	AllowedRepositories   []string
 	SSHKeyscan            bool
 	CommandEval           bool
 	PluginsEnabled        bool

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -567,6 +568,19 @@ type LogWriter struct {
 func (w LogWriter) Write(bytes []byte) (int, error) {
 	w.l.Info("%s", bytes)
 	return len(bytes), nil
+}
+
+func validateRepository(allowedRepos []string, pipelineRepo string) error {
+	if len(allowedRepos) == 0 {
+		return nil
+	}
+
+	for _, allowedRepo := range allowedRepos {
+		if match, _ := regexp.MatchString(allowedRepo, pipelineRepo); match {
+			return nil
+		}
+	}
+	return fmt.Errorf("repository %s isn't allowed", pipelineRepo)
 }
 
 func (r *JobRunner) executePreBootstrapHook(ctx context.Context, hook string) (bool, error) {

--- a/agent/job_runner_test.go
+++ b/agent/job_runner_test.go
@@ -18,3 +18,22 @@ func TestTruncateEnv(t *testing.T) {
 	assert.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaa[value truncated 100 -> 59 bytes]", env["FOO"])
 	assert.Equal(t, 64, len(fmt.Sprintf("FOO=%s\000", env["FOO"])))
 }
+
+func TestValidateRepository(t *testing.T) {
+	pipelineRepo := "github.com/buildkite/test"
+	allowedRepos := []string{}
+
+	// empty allow list
+	err := validateRepository(allowedRepos, pipelineRepo)
+	require.NoError(t, err)
+
+	// not allowed
+	allowedRepos = append(allowedRepos, "^github.com/nope/.*")
+	err = validateRepository(allowedRepos, pipelineRepo)
+	require.Error(t, err)
+
+	// allowed
+	allowedRepos = append(allowedRepos, "^github.com/buildkite/.*")
+	err = validateRepository(allowedRepos, pipelineRepo)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
The `allowed-repositories` command line param allows users to specify an allow-list of regular expression strings. E.g.:

```
buildkite-agent start \
    --build-path=/tmp/buildkite-builds \
    --token 123 \
    --allowed-repositories "^git@github.com:buildkite/.*"
```

If the `allowed-repositories` param is used and a job arrives with a `BUILDKITE_REPO` value that doesn't match an entry in the list then the job is rejected. 

If the `allowed-repositories` param is unused then the behaviour is unchanged from current.