### PR TITLE
Escape path segments in URLs made with fmt.Sprintf

### DIFF
--- a/api/annotations.go
+++ b/api/annotations.go
@@ -15,7 +15,7 @@ type Annotation struct {
 
 // Annotate a build in the Buildkite UI
 func (c *Client) Annotate(ctx context.Context, jobId string, annotation *Annotation) (*Response, error) {
-	u := fmt.Sprintf("jobs/%s/annotations", jobId)
+	u := fmt.Sprintf("jobs/%s/annotations", railsPathEscape(jobId))
 
 	req, err := c.newRequest(ctx, "POST", u, annotation)
 	if err != nil {
@@ -27,7 +27,7 @@ func (c *Client) Annotate(ctx context.Context, jobId string, annotation *Annotat
 
 // Remove an annotation from a build
 func (c *Client) AnnotationRemove(ctx context.Context, jobId string, context string) (*Response, error) {
-	u := fmt.Sprintf("jobs/%s/annotations/%s", jobId, context)
+	u := fmt.Sprintf("jobs/%s/annotations/%s", railsPathEscape(jobId), railsPathEscape(context))
 
 	req, err := c.newRequest(ctx, "DELETE", u, nil)
 	if err != nil {

--- a/api/artifacts.go
+++ b/api/artifacts.go
@@ -93,7 +93,7 @@ type ArtifactBatchUpdateRequest struct {
 
 // CreateArtifacts takes a slice of artifacts, and creates them on Buildkite as a batch.
 func (c *Client) CreateArtifacts(ctx context.Context, jobId string, batch *ArtifactBatch) (*ArtifactBatchCreateResponse, *Response, error) {
-	u := fmt.Sprintf("jobs/%s/artifacts", jobId)
+	u := fmt.Sprintf("jobs/%s/artifacts", railsPathEscape(jobId))
 
 	req, err := c.newRequest(ctx, "POST", u, batch)
 	if err != nil {
@@ -111,7 +111,7 @@ func (c *Client) CreateArtifacts(ctx context.Context, jobId string, batch *Artif
 
 // Updates a particular artifact
 func (c *Client) UpdateArtifacts(ctx context.Context, jobId string, artifactStates map[string]string) (*Response, error) {
-	u := fmt.Sprintf("jobs/%s/artifacts", jobId)
+	u := fmt.Sprintf("jobs/%s/artifacts", railsPathEscape(jobId))
 	payload := ArtifactBatchUpdateRequest{}
 
 	for id, state := range artifactStates {
@@ -133,7 +133,7 @@ func (c *Client) UpdateArtifacts(ctx context.Context, jobId string, artifactStat
 
 // SearchArtifacts searches Buildkite for a set of artifacts
 func (c *Client) SearchArtifacts(ctx context.Context, buildId string, opt *ArtifactSearchOptions) ([]*Artifact, *Response, error) {
-	u := fmt.Sprintf("builds/%s/artifacts/search", buildId)
+	u := fmt.Sprintf("builds/%s/artifacts/search", railsPathEscape(buildId))
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err

--- a/api/chunks.go
+++ b/api/chunks.go
@@ -27,7 +27,7 @@ func (c *Client) UploadChunk(ctx context.Context, jobId string, chunk *Chunk) (*
 	}
 
 	// Pass most params as query
-	u := fmt.Sprintf("jobs/%s/chunks?sequence=%d&offset=%d&size=%d", jobId, chunk.Sequence, chunk.Offset, chunk.Size)
+	u := fmt.Sprintf("jobs/%s/chunks?sequence=%d&offset=%d&size=%d", railsPathEscape(jobId), chunk.Sequence, chunk.Offset, chunk.Size)
 	req, err := c.newFormRequest(ctx, "POST", u, body)
 	if err != nil {
 		return nil, err

--- a/api/client.go
+++ b/api/client.go
@@ -364,3 +364,8 @@ func addOptions(s string, opt any) (string, error) {
 func joinURLPath(endpoint string, path string) string {
 	return strings.TrimRight(endpoint, "/") + "/" + strings.TrimLeft(path, "/")
 }
+
+// Rails doesn't accept dots in some path segments.
+func railsPathEscape(s string) string {
+	return strings.ReplaceAll(url.PathEscape(s), ".", "%2E")
+}

--- a/api/client_internal_test.go
+++ b/api/client_internal_test.go
@@ -1,0 +1,12 @@
+package api
+
+import "testing"
+
+func TestRailsPathEscape(t *testing.T) {
+	input := "path.segment/containing#various?characters%lol"
+	got := railsPathEscape(input)
+	want := "path%2Esegment%2Fcontaining%23various%3Fcharacters%25lol"
+	if got != want {
+		t.Errorf("railsPathEscape(%q) = %q, want %q", input, got, want)
+	}
+}

--- a/api/header_times.go
+++ b/api/header_times.go
@@ -13,7 +13,7 @@ type HeaderTimes struct {
 
 // SaveHeaderTimes saves the header times to the job
 func (c *Client) SaveHeaderTimes(ctx context.Context, jobId string, headerTimes *HeaderTimes) (*Response, error) {
-	u := fmt.Sprintf("jobs/%s/header_times", jobId)
+	u := fmt.Sprintf("jobs/%s/header_times", railsPathEscape(jobId))
 
 	req, err := c.newRequest(ctx, "POST", u, headerTimes)
 	if err != nil {

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -85,7 +85,7 @@ type jobFinishRequest struct {
 
 // GetJobState returns the state of a given job
 func (c *Client) GetJobState(ctx context.Context, id string) (*JobState, *Response, error) {
-	u := fmt.Sprintf("jobs/%s", id)
+	u := fmt.Sprintf("jobs/%s", railsPathEscape(id))
 
 	req, err := c.newRequest(ctx, "GET", u, nil)
 	if err != nil {
@@ -103,7 +103,7 @@ func (c *Client) GetJobState(ctx context.Context, id string) (*JobState, *Respon
 
 // Acquires a job using its ID
 func (c *Client) AcquireJob(ctx context.Context, id string, headers ...Header) (*Job, *Response, error) {
-	u := fmt.Sprintf("jobs/%s/acquire", id)
+	u := fmt.Sprintf("jobs/%s/acquire", railsPathEscape(id))
 
 	req, err := c.newRequest(ctx, "PUT", u, nil, headers...)
 	if err != nil {
@@ -123,7 +123,7 @@ func (c *Client) AcquireJob(ctx context.Context, id string, headers ...Header) (
 // environment variables (when a job is accepted, the agents environment is
 // applied to the job)
 func (c *Client) AcceptJob(ctx context.Context, job *Job) (*Job, *Response, error) {
-	u := fmt.Sprintf("jobs/%s/accept", job.ID)
+	u := fmt.Sprintf("jobs/%s/accept", railsPathEscape(job.ID))
 
 	req, err := c.newRequest(ctx, "PUT", u, nil)
 	if err != nil {
@@ -141,7 +141,7 @@ func (c *Client) AcceptJob(ctx context.Context, job *Job) (*Job, *Response, erro
 
 // StartJob starts the passed in job
 func (c *Client) StartJob(ctx context.Context, job *Job) (*Response, error) {
-	u := fmt.Sprintf("jobs/%s/start", job.ID)
+	u := fmt.Sprintf("jobs/%s/start", railsPathEscape(job.ID))
 
 	req, err := c.newRequest(ctx, "PUT", u, &jobStartRequest{
 		StartedAt: job.StartedAt,
@@ -155,7 +155,7 @@ func (c *Client) StartJob(ctx context.Context, job *Job) (*Response, error) {
 
 // FinishJob finishes the passed in job
 func (c *Client) FinishJob(ctx context.Context, job *Job) (*Response, error) {
-	u := fmt.Sprintf("jobs/%s/finish", job.ID)
+	u := fmt.Sprintf("jobs/%s/finish", railsPathEscape(job.ID))
 
 	req, err := c.newRequest(ctx, "PUT", u, &jobFinishRequest{
 		FinishedAt:        job.FinishedAt,

--- a/api/meta_data.go
+++ b/api/meta_data.go
@@ -20,7 +20,7 @@ type MetaDataExists struct {
 
 // Sets the meta data value
 func (c *Client) SetMetaData(ctx context.Context, jobId string, metaData *MetaData) (*Response, error) {
-	u := fmt.Sprintf("jobs/%s/data/set", jobId)
+	u := fmt.Sprintf("jobs/%s/data/set", railsPathEscape(jobId))
 
 	req, err := c.newRequest(ctx, "POST", u, metaData)
 	if err != nil {
@@ -36,7 +36,7 @@ func (c *Client) GetMetaData(ctx context.Context, scope, id, key string) (*MetaD
 		return nil, nil, errors.New("scope must either be job or build")
 	}
 
-	u := fmt.Sprintf("%ss/%s/data/get", scope, id)
+	u := fmt.Sprintf("%ss/%s/data/get", scope, railsPathEscape(id))
 	m := &MetaData{Key: key}
 
 	req, err := c.newRequest(ctx, "POST", u, m)
@@ -58,7 +58,7 @@ func (c *Client) ExistsMetaData(ctx context.Context, scope, id, key string) (*Me
 		return nil, nil, errors.New("scope must either be job or build")
 	}
 
-	u := fmt.Sprintf("%ss/%s/data/exists", scope, id)
+	u := fmt.Sprintf("%ss/%s/data/exists", scope, railsPathEscape(id))
 	m := &MetaData{Key: key}
 
 	req, err := c.newRequest(ctx, "POST", u, m)
@@ -80,7 +80,7 @@ func (c *Client) MetaDataKeys(ctx context.Context, scope, id string) ([]string, 
 		return nil, nil, errors.New("scope must either be job or build")
 	}
 
-	u := fmt.Sprintf("%ss/%s/data/keys", scope, id)
+	u := fmt.Sprintf("%ss/%s/data/keys", scope, railsPathEscape(id))
 
 	req, err := c.newRequest(ctx, "POST", u, nil)
 	if err != nil {

--- a/api/oidc.go
+++ b/api/oidc.go
@@ -27,7 +27,7 @@ func (c *Client) OIDCToken(ctx context.Context, methodReq *OIDCTokenRequest) (*O
 		Claims:   methodReq.Claims,
 	}
 
-	u := fmt.Sprintf("jobs/%s/oidc/tokens", methodReq.Job)
+	u := fmt.Sprintf("jobs/%s/oidc/tokens", railsPathEscape(methodReq.Job))
 	httpReq, err := c.newRequest(ctx, "POST", u, m)
 	if err != nil {
 		return nil, nil, err

--- a/api/oidc_test.go
+++ b/api/oidc_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/buildkite/agent/v3/api"
@@ -24,8 +25,8 @@ type testOIDCTokenServer struct {
 
 func (s *testOIDCTokenServer) New(t *testing.T) *httptest.Server {
 	t.Helper()
-	path := fmt.Sprintf("/jobs/%s/oidc/tokens", s.jobID)
-	forbiddenPath := fmt.Sprintf("/jobs/%s/oidc/tokens", s.forbiddenJobID)
+	path := fmt.Sprintf("/jobs/%s/oidc/tokens", url.PathEscape(s.jobID))
+	forbiddenPath := fmt.Sprintf("/jobs/%s/oidc/tokens", url.PathEscape(s.forbiddenJobID))
 	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if got, want := authToken(req), s.accessToken; got != want {
 			http.Error(

--- a/api/pipelines.go
+++ b/api/pipelines.go
@@ -28,7 +28,7 @@ func (c *Client) UploadPipeline(
 	pipeline *PipelineChange,
 	headers ...Header,
 ) (*Response, error) {
-	u := fmt.Sprintf("jobs/%s/pipelines?async=true", jobId)
+	u := fmt.Sprintf("jobs/%s/pipelines?async=true", railsPathEscape(jobId))
 
 	req, err := c.newRequest(ctx, "POST", u, pipeline, headers...)
 	if err != nil {
@@ -44,7 +44,7 @@ func (c *Client) PipelineUploadStatus(
 	uuid string,
 	headers ...Header,
 ) (*PipelineUploadStatus, *Response, error) {
-	u := fmt.Sprintf("jobs/%s/pipelines/%s", jobId, uuid)
+	u := fmt.Sprintf("jobs/%s/pipelines/%s", railsPathEscape(jobId), railsPathEscape(uuid))
 
 	req, err := c.newRequest(ctx, "GET", u, nil, headers...)
 	if err != nil {

--- a/api/steps.go
+++ b/api/steps.go
@@ -18,7 +18,7 @@ type StepExportResponse struct {
 
 // StepExport gets an attribute from step
 func (c *Client) StepExport(ctx context.Context, stepIdOrKey string, stepGetRequest *StepExportRequest) (*StepExportResponse, *Response, error) {
-	u := fmt.Sprintf("steps/%s/export", stepIdOrKey)
+	u := fmt.Sprintf("steps/%s/export", railsPathEscape(stepIdOrKey))
 
 	req, err := c.newRequest(ctx, "POST", u, stepGetRequest)
 	if err != nil {
@@ -45,7 +45,7 @@ type StepUpdate struct {
 
 // StepUpdate updates a step
 func (c *Client) StepUpdate(ctx context.Context, stepIdOrKey string, stepUpdate *StepUpdate) (*Response, error) {
-	u := fmt.Sprintf("steps/%s", stepIdOrKey)
+	u := fmt.Sprintf("steps/%s", railsPathEscape(stepIdOrKey))
 
 	req, err := c.newRequest(ctx, "PUT", u, stepUpdate)
 	if err != nil {


### PR DESCRIPTION
Making up URLs with `fmt.Sprintf` can be dicey. 

Most of these are no-ops in the normal case because job IDs and build IDs have nice formats. However, annotation contexts are arbitrary strings. 

Currently, an annotation context containing `.` can be created (passed through a JSON encoded request body) but not deleted (passed through the URL path). The reason was a bit surprising: Rails handles `.` in path segments specially. So `.` also needs to be escaped. Fortunately, this seems to be sufficient to fix the bug without any backend changes.