### PR TITLE
Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,15 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      otel:
+        patterns:
+        - go.opentelemetry.io/*
+      golang-x:
+        patterns:
+        - golang.org/x/*
+      cloud-providers:
+        patterns:
+        - github.com/Azure/*
+        - github.com/aws/*
+        - google.golang.org/*

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/agent/v3
 
-go 1.18
+go 1.20
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3


### PR DESCRIPTION
This PR adds three new [groups](https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/) to our dependabot config - this means that updates to the following:
- Opentelemetry libs
- "extended stdlib" `golang.org/x/*` libraries
- Cloud provider (aws, gcp, azure) libraries

will be grouped together into PRs (per group) when they come in

While i'm here, this PR updates the `go` directive in our `go.mod` file from `1.18` to `1.20`. **This is not a go version update**, it just tells the go toolchain what features are available.