### PR TITLE
Fix apt install awscli

### DIFF
--- a/.buildkite/steps/publish-rpm-package.sh
+++ b/.buildkite/steps/publish-rpm-package.sh
@@ -67,7 +67,7 @@ buildkite-agent artifact download --build "${artifacts_build}" "rpm/*.rpm" rpm/
 
 echo '--- Installing dependencies'
 apt update
-apt install -y createrepo-c awscli
+DEBIAN_FRONTEND=noninteractive apt install -y createrepo-c awscli
 
 mkdir -p "${YUM_PATH}"
 


### PR DESCRIPTION
It installs tzdata, which by default prompts for input when it can't discover what timezone you're in. We fix this by passing the magic variable DEBIAN_FRONTEND=noninteractive