### PR TITLE
Matrix signing

### DIFF
--- a/agent/verify_job.go
+++ b/agent/verify_job.go
@@ -136,6 +136,9 @@ func (r *JobRunner) verifyJob(keySet jwk.Set) error {
 				return newInvalidSignatureError(fmt.Errorf("job %q was signed with signature %q, but the value of BUILDKITE_PLUGINS (%q) does not match the value of step.plugins (%q)", r.conf.Job.ID, step.Signature.Value, jobPluginsNorm, stepPluginsNorm))
 			}
 
+		case "matrix": // compared indirectly through other fields
+			continue
+
 		default:
 			// env:: - skip any that were verified with Verify.
 			if envName, ok := strings.CutPrefix(field, pipeline.EnvNamespacePrefix); ok {

--- a/internal/pipeline/sign_test.go
+++ b/internal/pipeline/sign_test.go
@@ -55,7 +55,7 @@ func TestSignVerify(t *testing.T) {
 				return jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", alg)
 			},
 			alg:                            jwa.HS256,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzI1NiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..nSJsm-oUkkCcikVFtt4xzeE1ahOKs6DUaijKUSnjulo",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzI1NiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..IS-xyKZIK0iUXOs0DRRkr6uCqTXCYIl9YXBODZa-c_Q",
 		},
 		{
 			name: "HMAC-SHA384",
@@ -63,7 +63,7 @@ func TestSignVerify(t *testing.T) {
 				return jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", alg)
 			},
 			alg:                            jwa.HS384,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzM4NCIsImtpZCI6ImNoYXJ0cmV1c2UifQ.._To-WQZzv3mQpN44Tajex526bjmoPJLuMgXd6JjpbbL_91gIe1j4cJiOYYFlZtej",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzM4NCIsImtpZCI6ImNoYXJ0cmV1c2UifQ..OjgQkbm7Z835QYoD1KvvHV6TQLvEs3G-JnFkOKzsjMOLgcUPd2DHHvKv0uf93gDM",
 		},
 		{
 			name: "HMAC-SHA512",
@@ -71,7 +71,7 @@ func TestSignVerify(t *testing.T) {
 				return jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", alg)
 			},
 			alg:                            jwa.HS512,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzUxMiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..v_yGQkln9dygFz46IjYpO_jB-u9uXzoLwnIdS4UKQdMDJc96gc7ldq_19VdPRyGG2jE4kUnW4svkDDCOd6cBXw",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzUxMiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..S3jnKQItD63trOQtIddkBu98Xql8_lfl4KEPOy6s1WH8AUI7eNTesfzRZ3l04uVBBU_FWZSWTY5afUbpbjMpvA",
 		},
 		{
 			name:           "RSA-PSS 256",

--- a/internal/pipeline/step_command.go
+++ b/internal/pipeline/step_command.go
@@ -80,6 +80,7 @@ func (c *CommandStep) SignedFields() (map[string]any, error) {
 	out := map[string]any{
 		"command": c.Command,
 		"plugins": c.Plugins,
+		"matrix":  c.Matrix,
 	}
 	// Steps can have their own env. These can be overridden by the pipeline!
 	for e, v := range c.Env {
@@ -95,6 +96,7 @@ func (c *CommandStep) ValuesForFields(fields []string) (map[string]any, error) {
 	required := map[string]struct{}{
 		"command": {},
 		"plugins": {},
+		"matrix":  {},
 	}
 	// Env vars that the step has, but the pipeline doesn't have, are required.
 	// But we don't know what the pipeline has without passing it in, so treat
@@ -113,6 +115,9 @@ func (c *CommandStep) ValuesForFields(fields []string) (map[string]any, error) {
 
 		case "plugins":
 			out["plugins"] = c.Plugins
+
+		case "matrix":
+			out["matrix"] = c.Matrix
 
 		default:
 			if e, has := strings.CutPrefix(f, EnvNamespacePrefix); has {


### PR DESCRIPTION
This includes matrix in the signature. However, any matrix that is not `nil` will (still) fail to verify.

Matrix is required (sneaking in a matrix could alter how a step should be interpreted), which will invalidate any existing signatures. ~~so I'm also taking this opportunity to centralise the canonicalisation of data that gets signed. `writeCanonical` is a bit ASN.1-inspired, but I hate ASN.1, so you get this instead.~~ We went with [JCS](https://rfc-editor.org/rfc/rfc8785.html) instead.

Like `Plugins`, `Matrix` is included in the signed data wholesale. Reasons this is up for debate:

- Data from a future form of matrix (new fields that would unmarshal into `RemainingFields` today) might or might not affect valid matrix combinations in the future, so to be safe we should include `RemainingFields` in the signature...
- `soft_fail` doesn't affect whether a matrix combination is valid, so that could be excluded...
- We only use truthiness of `skip`, so we could canonicalise it to `bool` for signing...