### PR TITLE
Fix flaky TestLockFileRetriesAndTimesOut

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -258,7 +258,9 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string) (stri
 	}
 
 	// Lock the mirror dir to prevent concurrent clones
-	mirrorCloneLock, err := e.shell.LockFile(ctx, mirrorDir+".clonelock", lockTimeout)
+	cloneCtx, canc := context.WithTimeout(ctx, lockTimeout)
+	defer canc()
+	mirrorCloneLock, err := e.shell.LockFile(cloneCtx, mirrorDir+".clonelock")
 	if err != nil {
 		return "", err
 	}
@@ -295,7 +297,9 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string) (stri
 	}
 
 	// Lock the mirror dir to prevent concurrent updates
-	mirrorUpdateLock, err := e.shell.LockFile(ctx, mirrorDir+".updatelock", lockTimeout)
+	updateCtx, canc := context.WithTimeout(ctx, lockTimeout)
+	defer canc()
+	mirrorUpdateLock, err := e.shell.LockFile(updateCtx, mirrorDir+".updatelock")
 	if err != nil {
 		return "", err
 	}

--- a/internal/job/knownhosts.go
+++ b/internal/job/knownhosts.go
@@ -91,7 +91,9 @@ func (kh *knownHosts) Contains(host string) (bool, error) {
 
 func (kh *knownHosts) Add(ctx context.Context, host string) error {
 	// Use a lockfile to prevent parallel processes stepping on each other
-	lock, err := kh.Shell.LockFile(ctx, kh.Path+".lock", time.Second*30)
+	lockCtx, canc := context.WithTimeout(ctx, 30*time.Second)
+	defer canc()
+	lock, err := kh.Shell.LockFile(lockCtx, kh.Path+".lock")
 	if err != nil {
 		return err
 	}

--- a/internal/job/plugin.go
+++ b/internal/job/plugin.go
@@ -451,7 +451,9 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 	// Try and lock this particular plugin while we check it out (we create
 	// the file outside of the plugin directory so git clone doesn't have
 	// a cry about the directory not being empty)
-	pluginCheckoutLock, err := e.shell.LockFile(ctx, filepath.Join(e.PluginsPath, id+".lock"), time.Minute*5)
+	checkoutCtx, canc := context.WithTimeout(ctx, 5*time.Minute)
+	defer canc()
+	pluginCheckoutLock, err := e.shell.LockFile(checkoutCtx, filepath.Join(e.PluginsPath, id+".lock"))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/job/shell/main_test.go
+++ b/internal/job/shell/main_test.go
@@ -39,12 +39,15 @@ func acquiringLockHelperProcess() error {
 	}
 	sh.Logger = shell.DiscardLogger
 
-	log.Printf("Locking %s", fileName)
-	if _, err := sh.LockFile(context.Background(), fileName, 10*time.Second); err != nil {
+	log.Printf("🔓 Locking %s forever...", fileName)
+	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
+	defer canc()
+	if _, err := sh.LockFile(ctx, fileName); err != nil {
 		return fmt.Errorf("sh.LockFile(%q) error = %w", fileName, err)
 	}
 
-	log.Printf("Acquired lock %s", fileName)
+	log.Printf("🔒 Acquired lock %s", fileName)
+
 	// sleep forever, but keep the main goroutine busy
 	for {
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
The flake is probably because the `os.Stat` loop exits when the lock file exists, but not when it is locked, because [`flock(2)`](https://linux.die.net/man/2/flock) is a separate syscall to `open(2)`.

This also:

- changes the API for `LockFile` to remove the timeout arg in favour of context cancellation
- changes from `time.Sleep` to a timer, allowing the lock loop to be cancelled more quickly
- exits from the retry loop when `TryLock` returns an error