### PR TITLE
Fix parsing pipelines what use a string as the skip key in a matrix adjustment

### DIFF
--- a/internal/pipeline/parser_matrix_test.go
+++ b/internal/pipeline/parser_matrix_test.go
@@ -104,6 +104,8 @@ steps:
           skip: true
         - with: 42
           soft_fail: true
+        - with: banana
+          skip: "how dare you, you know i'm allergic to bananas!"
 `,
 			want: &Pipeline{
 				Steps: Steps{
@@ -119,8 +121,14 @@ steps:
 									Skip: true,
 								},
 								{
-									With:     MatrixAdjustmentWith{"": 42},
-									SoftFail: true,
+									With: MatrixAdjustmentWith{"": 42},
+									RemainingFields: map[string]any{
+										"soft_fail": true,
+									},
+								},
+								{
+									With: MatrixAdjustmentWith{"": "banana"},
+									Skip: "how dare you, you know i'm allergic to bananas!",
 								},
 							},
 						},
@@ -140,6 +148,10 @@ steps:
           {
             "soft_fail": true,
             "with": 42
+          },
+          {
+            "skip": "how dare you, you know i'm allergic to bananas!",
+            "with": "banana"
           }
         ],
         "setup": [
@@ -265,7 +277,9 @@ steps:
 										"arch": "ppc",
 										"os":   8,
 									},
-									SoftFail: true,
+									RemainingFields: map[string]any{
+										"soft_fail": true,
+									},
 								},
 							},
 						},
@@ -369,7 +383,9 @@ steps:
 										"arch": "s390x",
 										"os":   "zos",
 									},
-									SoftFail: true,
+									RemainingFields: map[string]any{
+										"soft_fail": true,
+									},
 								},
 							},
 						},

--- a/internal/pipeline/step_command_matrix.go
+++ b/internal/pipeline/step_command_matrix.go
@@ -176,11 +176,23 @@ type MatrixAdjustments []*MatrixAdjustment
 // MatrixAdjustment models an adjustment - a combination of (possibly new)
 // matrix values, and skip/soft fail configuration.
 type MatrixAdjustment struct {
-	With     MatrixAdjustmentWith `yaml:"with"`
-	Skip     bool                 `yaml:"skip,omitempty"`
-	SoftFail bool                 `yaml:"soft_fail,omitempty"`
+	With MatrixAdjustmentWith `yaml:"with"`
+	Skip any                  `yaml:"skip,omitempty"`
 
-	RemainingFields map[string]any `yaml:",inline"`
+	RemainingFields map[string]any `yaml:",inline"` // NB: soft_fail is in the remaining fields
+}
+
+func (ma *MatrixAdjustment) ShouldSkip() bool {
+	switch s := ma.Skip.(type) {
+	case bool:
+		return s
+
+	case nil:
+		return false
+
+	default:
+		return true
+	}
 }
 
 // MarshalJSON is needed to use inlineFriendlyMarshalJSON.


### PR DESCRIPTION
Also, demote SoftFail on matrix adjustments to being a RemainingField, as it's unused by the agent