### PR TITLE
Upgrade pre-installed packages in docker images

### DIFF
--- a/packaging/docker/alpine-k8s/Dockerfile
+++ b/packaging/docker/alpine-k8s/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM alpine:3.18.3 AS base
 
-RUN apk update && apk add --no-cache \
+RUN apk update && apk upgrade && apk add --no-cache \
     bash \
     curl \
     docker-cli \

--- a/packaging/docker/alpine/Dockerfile
+++ b/packaging/docker/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.18.3
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache \
+RUN apk update && apk upgrade && apk add --no-cache \
     bash \
     curl \
     docker-cli \

--- a/packaging/docker/ubuntu-18.04/Dockerfile
+++ b/packaging/docker/ubuntu-18.04/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV DOCKER_COMPOSE_VERSION=1.27.4
 ENV TINI_VERSION=0.19.0
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     apt-transport-https \
     curl \
     ca-certificates \

--- a/packaging/docker/ubuntu-20.04/Dockerfile
+++ b/packaging/docker/ubuntu-20.04/Dockerfile
@@ -8,7 +8,7 @@ ARG TARGETARCH
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DOCKER_COMPOSE_VERSION=1.27.4
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     apt-transport-https \
     bash \
     ca-certificates \

--- a/packaging/docker/ubuntu-22.04/Dockerfile
+++ b/packaging/docker/ubuntu-22.04/Dockerfile
@@ -13,6 +13,7 @@ set -eufo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
+apt-get upgrade -y
 apt-get install -y --no-install-recommends \
   apt-transport-https \
   bash \


### PR DESCRIPTION
Sometimes, the upstream distro will release a package but we had to wait
until they made a new image before our images would get the new package.
This means the security scanners will report fixable vulnerabilities that a
rebuild would not fix. With this change, we just have to make a new
build to pull in the patched packages.

Fixes: \#2408