### PR TITLE
Use canonicalised JSON as signature payload

### DIFF
--- a/agent/verify_job.go
+++ b/agent/verify_job.go
@@ -1,11 +1,14 @@
 package agent
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/buildkite/agent/v3/internal/pipeline"
+	"github.com/gowebpki/jcs"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 )
 
@@ -61,11 +64,24 @@ func (r *JobRunner) verifyJob(keySet jwk.Set) error {
 		return newInvalidSignatureError(err)
 	}
 
-	// Now that the signature of the job's step is verified, we need to check if the fields on the job match those on the
-	// step. If they don't, we need to fail the job - more or less the only reason that the job and the step would have
-	// different fields would be if someone had modified the job on the backend after it was signed (aka crimes)
+	// Now that the signature of the job's step is verified, we need to check if
+	// the fields on the job match those on the step. If they don't, we need to
+	// fail the job - more or less the only reason that the job and the step
+	// would have different fields would be if someone had modified the job on
+	// the backend after it was signed (aka crimes).
 	//
-	// However, this consistency check does not apply entirely to `env::`:
+	// Note that each field needs a different consistency check:
+	//
+	// - command should match BUILDKITE_COMMAND exactly
+	// - env vars not listed in the signature as signed fields are allowed
+	// - plugins should match BUILDKITE_PLUGINS semantically
+	// - matrix interpolates into the others, and does not itself compare
+	//   (not yet implemented).
+	//
+	// We can't check that the job is consistent with fields we don't know
+	// about yet, so these are rejected.
+	//
+	// More notes on `env::`:
 	// 1. Signature.Verify ensures every signed env var has the right value, and
 	// 2. step env can be overridden by the pipeline env, but each step only
 	//    knows about its own env. So the job env and step env can disagree
@@ -75,24 +91,55 @@ func (r *JobRunner) verifyJob(keySet jwk.Set) error {
 	// job env (is actually used).
 	signedFields := step.Signature.SignedFields
 
-	jobFields, err := r.conf.Job.ValuesForFields(signedFields)
-	if err != nil {
-		return fmt.Errorf("failed to get values for fields %v on job %s: %w", signedFields, r.conf.Job.ID, err)
-	}
-
 	stepFields, err := step.ValuesForFields(signedFields)
 	if err != nil {
 		return fmt.Errorf("failed to get values for fields %v on step: %w", signedFields, err)
 	}
 
 	for _, field := range signedFields {
-		if strings.HasPrefix(field, pipeline.EnvNamespacePrefix) && jobFields[field] != "" {
-			// Signature.Verify handled this case.
-			continue
-		}
+		switch field {
+		case "command": // compare directly
+			if jobCommand := r.conf.Job.Env["BUILDKITE_COMMAND"]; stepFields[field] != jobCommand {
+				return newInvalidSignatureError(fmt.Errorf("job %q was signed with signature %q, but the value of field %q on the job (%q) does not match the value of the field on the step (%q)", r.conf.Job.ID, step.Signature.Value, field, jobCommand, stepFields[field]))
+			}
 
-		if jobFields[field] != stepFields[field] {
-			return newInvalidSignatureError(fmt.Errorf("job %q was signed with signature %q, but the value of field %q on the job (%q) does not match the value of the field on the step (%q)", r.conf.Job.ID, step.Signature.Value, field, jobFields[field], stepFields[field]))
+		case "plugins": //  compare canonicalised JSON
+			stepPluginsJSON, err := json.Marshal(stepFields[field])
+			if err != nil {
+				return fmt.Errorf("marshaling step plugins JSON: %v", err)
+			}
+			stepPluginsNorm, err := jcs.Transform(stepPluginsJSON)
+			if err != nil {
+				return fmt.Errorf("canonicalising step plugins JSON: %v", err)
+			}
+			jobPluginsNorm, err := jcs.Transform([]byte(r.conf.Job.Env["BUILDKITE_PLUGINS"]))
+			if err != nil {
+				return fmt.Errorf("canonicalising BUILDKITE_PLUGINS: %v", err)
+			}
+
+			if !bytes.Equal(jobPluginsNorm, stepPluginsNorm) {
+				return newInvalidSignatureError(fmt.Errorf("job %q was signed with signature %q, but the value of field %q on the job (%q) does not match the value of the field on the step (%q)", r.conf.Job.ID, step.Signature.Value, field, jobPluginsNorm, stepPluginsNorm))
+			}
+
+		default:
+			// env:: - skip any that were verified with Verify.
+			if envName, ok := strings.CutPrefix(field, pipeline.EnvNamespacePrefix); ok {
+				if _, has := r.conf.Job.Env[envName]; has {
+					// Signature.Verify used the variable value from Env,
+					// handling this case.
+					continue
+				}
+
+				// It's not in the job env, so ensure that it was blank in the
+				// step env too.
+				if stepFields[field] != "" {
+					return newInvalidSignatureError(fmt.Errorf("job %q was signed with signature %q, but the value of field %q on the job (%q) does not match the value of the field on the step (%q)", r.conf.Job.ID, step.Signature.Value, field, "", stepFields[field]))
+				}
+			}
+
+			// We don't know this field, so we cannot ensure it is consistent
+			// with the job.
+			return fmt.Errorf("unknown or unsupported field %q on Job struct for signing/verification of job %s", field, r.conf.Job.ID)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/google/uuid v1.3.1 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.1 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
+	github.com/gowebpki/jcs v1.0.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.1 h1:SBWmZhjUDRorQxrN0nw
 github.com/googleapis/enterprise-certificate-proxy v0.3.1/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
+github.com/gowebpki/jcs v1.0.0 h1:0pZtOgGetfH/L7yXb4KWcJqIyZNA43WXFyMd7ftZACw=
+github.com/gowebpki/jcs v1.0.0/go.mod h1:CID1cNZ+sHp1CCpAR8mPf6QRtagFBgPJE0FCUQ6+BrI=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/internal/pipeline/sign_test.go
+++ b/internal/pipeline/sign_test.go
@@ -55,7 +55,7 @@ func TestSignVerify(t *testing.T) {
 				return jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", alg)
 			},
 			alg:                            jwa.HS256,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzI1NiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..SHbGJSyZadUIr8M591h_63VS-o0hwZ0n63YBfLfFxzo",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzI1NiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..nSJsm-oUkkCcikVFtt4xzeE1ahOKs6DUaijKUSnjulo",
 		},
 		{
 			name: "HMAC-SHA384",
@@ -63,7 +63,7 @@ func TestSignVerify(t *testing.T) {
 				return jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", alg)
 			},
 			alg:                            jwa.HS384,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzM4NCIsImtpZCI6ImNoYXJ0cmV1c2UifQ..i1cy6E6JfYtoHYmYxJXObV4zr3UD3fPTRLvhu9oi9nq3Shz2eSmLGkdqH8lkL9gQ",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzM4NCIsImtpZCI6ImNoYXJ0cmV1c2UifQ.._To-WQZzv3mQpN44Tajex526bjmoPJLuMgXd6JjpbbL_91gIe1j4cJiOYYFlZtej",
 		},
 		{
 			name: "HMAC-SHA512",
@@ -71,7 +71,7 @@ func TestSignVerify(t *testing.T) {
 				return jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", alg)
 			},
 			alg:                            jwa.HS512,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzUxMiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..QzsnwhNotMQHSHozrJfkohrpYa9usXPoGQGFUjNoD8kJBWa7zsRMEePo4MnP89P0kMfKOBds3HKR3xMc7X7ZyA",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzUxMiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..v_yGQkln9dygFz46IjYpO_jB-u9uXzoLwnIdS4UKQdMDJc96gc7ldq_19VdPRyGG2jE4kUnW4svkDDCOd6cBXw",
 		},
 		{
 			name:           "RSA-PSS 256",
@@ -149,12 +149,12 @@ func TestSignVerify(t *testing.T) {
 	}
 }
 
-type testFields map[string]string
+type testFields map[string]any
 
-func (m testFields) SignedFields() (map[string]string, error) { return m, nil }
+func (m testFields) SignedFields() (map[string]any, error) { return m, nil }
 
-func (m testFields) ValuesForFields(fields []string) (map[string]string, error) {
-	out := make(map[string]string, len(fields))
+func (m testFields) ValuesForFields(fields []string) (map[string]any, error) {
+	out := make(map[string]any, len(fields))
 	for _, f := range fields {
 		v, ok := m[f]
 		if !ok {

--- a/internal/pipeline/step_command.go
+++ b/internal/pipeline/step_command.go
@@ -76,19 +76,10 @@ func (c *CommandStep) UnmarshalOrdered(src any) error {
 }
 
 // SignedFields returns the default fields for signing.
-func (c *CommandStep) SignedFields() (map[string]string, error) {
-	plugins := ""
-	if len(c.Plugins) > 0 {
-		// TODO: Reconsider using JSON here - is it stable enough?
-		pj, err := json.Marshal(c.Plugins)
-		if err != nil {
-			return nil, err
-		}
-		plugins = string(pj)
-	}
-	out := map[string]string{
+func (c *CommandStep) SignedFields() (map[string]any, error) {
+	out := map[string]any{
 		"command": c.Command,
-		"plugins": plugins,
+		"plugins": c.Plugins,
 	}
 	// Steps can have their own env. These can be overridden by the pipeline!
 	for e, v := range c.Env {
@@ -98,7 +89,7 @@ func (c *CommandStep) SignedFields() (map[string]string, error) {
 }
 
 // ValuesForFields returns the contents of fields to sign.
-func (c *CommandStep) ValuesForFields(fields []string) (map[string]string, error) {
+func (c *CommandStep) ValuesForFields(fields []string) (map[string]any, error) {
 	// Make a set of required fields. As fields is processed, mark them off by
 	// deleting them.
 	required := map[string]struct{}{
@@ -112,7 +103,7 @@ func (c *CommandStep) ValuesForFields(fields []string) (map[string]string, error
 		required[EnvNamespacePrefix+e] = struct{}{}
 	}
 
-	out := make(map[string]string, len(fields))
+	out := make(map[string]any, len(fields))
 	for _, f := range fields {
 		delete(required, f)
 
@@ -121,16 +112,7 @@ func (c *CommandStep) ValuesForFields(fields []string) (map[string]string, error
 			out["command"] = c.Command
 
 		case "plugins":
-			if len(c.Plugins) == 0 {
-				out["plugins"] = ""
-				break
-			}
-			// TODO: Reconsider using JSON here - is it stable enough?
-			val, err := json.Marshal(c.Plugins)
-			if err != nil {
-				return nil, err
-			}
-			out["plugins"] = string(val)
+			out["plugins"] = c.Plugins
 
 		default:
 			if e, has := strings.CutPrefix(f, EnvNamespacePrefix); has {


### PR DESCRIPTION
This does a couple of things, the main one being removal of `writeFields` and `writeLengthPrefixed` and using JCS (RFC 8785) instead. 

Rather than keeping the JSON encoding for plugins separate, this changes the `SignedFielder` to  work with `map[string]any` and puts `Plugins` in there directly, so that when the canonical payload is encoded, it only needs to encode JSON and transform it once.

Changing `SignedFielder` implies making some changes to `verifyJob`. `Job` adopted the `ValuesForFields` approach as a way to simplify `verifyJob`. But `Plugins` doesn't neatly compare against `string`. I think that really, `ValuesForFields` isn't a good abstraction for `Job`, because each field needs a slightly different approach for consistency checking, and that should be more obvious.