### PR TITLE
Make interpolation helpers transform-agnostic

### DIFF
--- a/internal/pipeline/interpolate.go
+++ b/internal/pipeline/interpolate.go
@@ -8,17 +8,33 @@ import (
 // This file contains helpers for recursively interpolating all the strings in
 // pipeline objects.
 
+// stringTransformer implementations mutate strings.
+type stringTransformer interface {
+	Transform(string) (string, error)
+}
+
+// envInterpolator returns a reusable string transform that replaces
+// variables (${FOO}) with their values from a map.
+type envInterpolator struct {
+	envMap interpolate.Env
+}
+
+// Transform calls interpolate.Interpolate to transform the string.
+func (e envInterpolator) Transform(s string) (string, error) {
+	return interpolate.Interpolate(e.envMap, s)
+}
+
 // selfInterpolater describes types that can interpolate themselves in-place.
-// They can call interpolate.Interpolate on strings, or
+// They can use the string transformer on string fields, or use
 // interpolate{Slice,Map,OrderedMap,Any} on their other contents, to do this.
 type selfInterpolater interface {
-	interpolate(interpolate.Env) error
+	interpolate(stringTransformer) error
 }
 
 // interpolateAny interpolates (almost) anything in-place. When passed a string,
 // it returns a new string. Anything it doesn't know how to interpolate is
 // returned unaltered.
-func interpolateAny[T any](env interpolate.Env, o T) (T, error) {
+func interpolateAny[T any](tf stringTransformer, o T) (T, error) {
 	// The box-typeswitch-unbox dance is required because the Go compiler
 	// has no type switch for type parameters.
 	var err error
@@ -26,38 +42,38 @@ func interpolateAny[T any](env interpolate.Env, o T) (T, error) {
 
 	switch t := a.(type) {
 	case selfInterpolater:
-		err = t.interpolate(env)
+		err = t.interpolate(tf)
 
 	case *string:
 		if t == nil {
 			return o, nil
 		}
-		*t, err = interpolate.Interpolate(env, *t)
+		*t, err = tf.Transform(*t)
 		a = t
 
 	case string:
-		a, err = interpolate.Interpolate(env, t)
+		a, err = tf.Transform(t)
 
 	case []any:
-		err = interpolateSlice(env, t)
+		err = interpolateSlice(tf, t)
 
 	case []string:
-		err = interpolateSlice(env, t)
+		err = interpolateSlice(tf, t)
 
 	case ordered.Slice:
-		err = interpolateSlice(env, t)
+		err = interpolateSlice(tf, t)
 
 	case map[string]any:
-		err = interpolateMap(env, t)
+		err = interpolateMap(tf, t)
 
 	case map[string]string:
-		err = interpolateMap(env, t)
+		err = interpolateMap(tf, t)
 
 	case *ordered.Map[string, any]:
-		err = interpolateOrderedMap(env, t)
+		err = interpolateOrderedMap(tf, t)
 
 	case *ordered.Map[string, string]:
-		err = interpolateOrderedMap(env, t)
+		err = interpolateOrderedMap(tf, t)
 
 	default:
 		return o, nil
@@ -74,10 +90,10 @@ func interpolateAny[T any](env interpolate.Env, o T) (T, error) {
 
 // interpolateSlice applies interpolateAny over any type of slice. Values in the
 // slice are updated in-place.
-func interpolateSlice[E any, S ~[]E](env interpolate.Env, s S) error {
+func interpolateSlice[E any, S ~[]E](tf stringTransformer, s S) error {
 	for i, e := range s {
 		// It could be a string, so replace the old value with the new.
-		inte, err := interpolateAny(env, e)
+		inte, err := interpolateAny(tf, e)
 		if err != nil {
 			return err
 		}
@@ -88,16 +104,16 @@ func interpolateSlice[E any, S ~[]E](env interpolate.Env, s S) error {
 
 // interpolateMap applies interpolateAny over any type of map. The map is
 // altered in-place.
-func interpolateMap[K comparable, V any, M ~map[K]V](env interpolate.Env, m M) error {
+func interpolateMap[K comparable, V any, M ~map[K]V](tf stringTransformer, m M) error {
 	for k, v := range m {
 		// We interpolate both keys and values.
-		intk, err := interpolateAny(env, k)
+		intk, err := interpolateAny(tf, k)
 		if err != nil {
 			return err
 		}
 
 		// V could be string, so be sure to replace the old value with the new.
-		intv, err := interpolateAny(env, v)
+		intv, err := interpolateAny(tf, v)
 		if err != nil {
 			return err
 		}
@@ -113,14 +129,14 @@ func interpolateMap[K comparable, V any, M ~map[K]V](env interpolate.Env, m M) e
 
 // interpolateOrderedMap applies interpolateAny over any type of ordered.Map.
 // The map is altered in-place.
-func interpolateOrderedMap[K comparable, V any](env interpolate.Env, m *ordered.Map[K, V]) error {
+func interpolateOrderedMap[K comparable, V any](tf stringTransformer, m *ordered.Map[K, V]) error {
 	return m.Range(func(k K, v V) error {
 		// We interpolate both keys and values.
-		intk, err := interpolateAny(env, k)
+		intk, err := interpolateAny(tf, k)
 		if err != nil {
 			return err
 		}
-		intv, err := interpolateAny(env, v)
+		intv, err := interpolateAny(tf, v)
 		if err != nil {
 			return err
 		}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -83,12 +83,14 @@ func (p *Pipeline) Interpolate(envMap *env.Environment) error {
 		return err
 	}
 
+	tf := envInterpolator{envMap: envMap}
+
 	// Recursively go through the rest of the pipeline and perform environment
 	// variable interpolation on strings. Interpolation is performed in-place.
-	if err := interpolateSlice(envMap, p.Steps); err != nil {
+	if err := interpolateSlice(tf, p.Steps); err != nil {
 		return err
 	}
-	return interpolateMap(envMap, p.RemainingFields)
+	return interpolateMap(tf, p.RemainingFields)
 }
 
 // interpolateEnvBlock runs interpolate.Interpolate on each pair in p.Env,

--- a/internal/pipeline/plugin.go
+++ b/internal/pipeline/plugin.go
@@ -6,7 +6,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/buildkite/interpolate"
 	"gopkg.in/yaml.v3"
 )
 
@@ -98,12 +97,12 @@ func (p *Plugin) FullSource() string {
 	}
 }
 
-func (p *Plugin) interpolate(env interpolate.Env) error {
-	name, err := interpolate.Interpolate(env, p.Source)
+func (p *Plugin) interpolate(tf stringTransformer) error {
+	name, err := tf.Transform(p.Source)
 	if err != nil {
 		return err
 	}
-	cfg, err := interpolateAny(env, p.Config)
+	cfg, err := interpolateAny(tf, p.Config)
 	if err != nil {
 		return err
 	}

--- a/internal/pipeline/step_command.go
+++ b/internal/pipeline/step_command.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/buildkite/agent/v3/internal/ordered"
-	"github.com/buildkite/interpolate"
 	"gopkg.in/yaml.v3"
 )
 
@@ -143,27 +142,27 @@ func (c *CommandStep) ValuesForFields(fields []string) (map[string]any, error) {
 	return out, nil
 }
 
-func (c *CommandStep) interpolate(env interpolate.Env) error {
-	cmd, err := interpolate.Interpolate(env, c.Command)
+func (c *CommandStep) interpolate(tf stringTransformer) error {
+	cmd, err := tf.Transform(c.Command)
 	if err != nil {
 		return err
 	}
 
-	if err := interpolateSlice(env, c.Plugins); err != nil {
+	if err := interpolateSlice(tf, c.Plugins); err != nil {
 		return err
 	}
 
-	if err := interpolateMap(env, c.Env); err != nil {
+	if err := interpolateMap(tf, c.Env); err != nil {
 		return err
 	}
 
 	// NB: Do not interpolate Signature.
 
-	if c.Matrix, err = interpolateAny(env, c.Matrix); err != nil {
+	if c.Matrix, err = interpolateAny(tf, c.Matrix); err != nil {
 		return err
 	}
 
-	if err := interpolateMap(env, c.RemainingFields); err != nil {
+	if err := interpolateMap(tf, c.RemainingFields); err != nil {
 		return err
 	}
 

--- a/internal/pipeline/step_command_matrix.go
+++ b/internal/pipeline/step_command_matrix.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/buildkite/agent/v3/internal/ordered"
-	"github.com/buildkite/interpolate"
 	"gopkg.in/yaml.v3"
 )
 
@@ -102,17 +101,17 @@ func (m *Matrix) MarshalYAML() (any, error) {
 	return (*wrappedMatrix)(m), nil
 }
 
-func (m *Matrix) interpolate(env interpolate.Env) error {
+func (m *Matrix) interpolate(tf stringTransformer) error {
 	if m == nil {
 		return nil
 	}
-	if err := interpolateMap(env, m.Setup); err != nil {
+	if err := interpolateMap(tf, m.Setup); err != nil {
 		return err
 	}
-	if err := interpolateSlice(env, m.Adjustments); err != nil {
+	if err := interpolateSlice(tf, m.Adjustments); err != nil {
 		return err
 	}
-	return interpolateMap(env, m.RemainingFields)
+	return interpolateMap(tf, m.RemainingFields)
 }
 
 // MatrixSetup is the main setup of a matrix - one or more dimensions. The cross
@@ -200,14 +199,14 @@ func (ma *MatrixAdjustment) MarshalJSON() ([]byte, error) {
 	return inlineFriendlyMarshalJSON(ma)
 }
 
-func (ma *MatrixAdjustment) interpolate(env interpolate.Env) error {
+func (ma *MatrixAdjustment) interpolate(tf stringTransformer) error {
 	if ma == nil {
 		return nil
 	}
-	if err := interpolateMap(env, ma.With); err != nil {
+	if err := interpolateMap(tf, ma.With); err != nil {
 		return err
 	}
-	return interpolateMap(env, ma.RemainingFields)
+	return interpolateMap(tf, ma.RemainingFields)
 }
 
 // MatrixAdjustmentWith is either a map of dimension key -> dimension value,
@@ -297,6 +296,6 @@ func (s *MatrixScalars) UnmarshalOrdered(o any) error {
 
 // This is necessary because interpolateAny, which uses a type switch, matches
 // []any strictly.
-func (s MatrixScalars) interpolate(env interpolate.Env) error {
-	return interpolateSlice(env, s)
+func (s MatrixScalars) interpolate(tf stringTransformer) error {
+	return interpolateSlice(tf, s)
 }

--- a/internal/pipeline/step_group.go
+++ b/internal/pipeline/step_group.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/buildkite/agent/v3/internal/ordered"
-	"github.com/buildkite/interpolate"
 )
 
 // GroupStep models a group step.
@@ -36,17 +35,17 @@ func (g *GroupStep) UnmarshalOrdered(src any) error {
 	return nil
 }
 
-func (g *GroupStep) interpolate(env interpolate.Env) error {
-	grp, err := interpolateAny(env, g.Group)
+func (g *GroupStep) interpolate(tf stringTransformer) error {
+	grp, err := interpolateAny(tf, g.Group)
 	if err != nil {
 		return err
 	}
 	g.Group = grp
 
-	if err := g.Steps.interpolate(env); err != nil {
+	if err := g.Steps.interpolate(tf); err != nil {
 		return err
 	}
-	return interpolateMap(env, g.RemainingFields)
+	return interpolateMap(tf, g.RemainingFields)
 }
 
 func (GroupStep) stepTag() {}

--- a/internal/pipeline/step_input.go
+++ b/internal/pipeline/step_input.go
@@ -3,8 +3,6 @@ package pipeline
 import (
 	"encoding/json"
 	"errors"
-
-	"github.com/buildkite/interpolate"
 )
 
 // See the comment in step_scalar.go.
@@ -29,8 +27,8 @@ func (s *InputStep) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.Contents)
 }
 
-func (s InputStep) interpolate(env interpolate.Env) error {
-	return interpolateMap(env, s.Contents)
+func (s InputStep) interpolate(tf stringTransformer) error {
+	return interpolateMap(tf, s.Contents)
 }
 
 func (*InputStep) stepTag() {}

--- a/internal/pipeline/step_trigger.go
+++ b/internal/pipeline/step_trigger.go
@@ -2,8 +2,6 @@ package pipeline
 
 import (
 	"encoding/json"
-
-	"github.com/buildkite/interpolate"
 )
 
 // TriggerStep models a trigger step.
@@ -18,8 +16,8 @@ func (t TriggerStep) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.Contents)
 }
 
-func (s TriggerStep) interpolate(env interpolate.Env) error {
-	return interpolateMap(env, s.Contents)
+func (s TriggerStep) interpolate(tf stringTransformer) error {
+	return interpolateMap(tf, s.Contents)
 }
 
 func (TriggerStep) stepTag() {}

--- a/internal/pipeline/step_unknown.go
+++ b/internal/pipeline/step_unknown.go
@@ -2,8 +2,6 @@ package pipeline
 
 import (
 	"encoding/json"
-
-	"github.com/buildkite/interpolate"
 )
 
 // UnknownStep models any step we don't know how to represent in this version.
@@ -30,8 +28,8 @@ func (u *UnknownStep) UnmarshalOrdered(src any) error {
 	return nil
 }
 
-func (u *UnknownStep) interpolate(env interpolate.Env) error {
-	c, err := interpolateAny(env, u.Contents)
+func (u *UnknownStep) interpolate(tf stringTransformer) error {
+	c, err := interpolateAny(tf, u.Contents)
 	if err != nil {
 		return err
 	}

--- a/internal/pipeline/step_wait.go
+++ b/internal/pipeline/step_wait.go
@@ -2,8 +2,6 @@ package pipeline
 
 import (
 	"encoding/json"
-
-	"github.com/buildkite/interpolate"
 )
 
 // See the comment in step_scalar.go.
@@ -30,8 +28,8 @@ func (s *WaitStep) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.Contents)
 }
 
-func (s *WaitStep) interpolate(env interpolate.Env) error {
-	return interpolateMap(env, s.Contents)
+func (s *WaitStep) interpolate(tf stringTransformer) error {
+	return interpolateMap(tf, s.Contents)
 }
 
 func (*WaitStep) stepTag() {}

--- a/internal/pipeline/steps.go
+++ b/internal/pipeline/steps.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/buildkite/agent/v3/internal/ordered"
-	"github.com/buildkite/interpolate"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 )
 
@@ -42,8 +41,8 @@ func (s *Steps) UnmarshalOrdered(o any) error {
 	return nil
 }
 
-func (s Steps) interpolate(env interpolate.Env) error {
-	return interpolateSlice(env, s)
+func (s Steps) interpolate(tf stringTransformer) error {
+	return interpolateSlice(tf, s)
 }
 
 // unmarshalStep unmarshals into the right kind of Step.


### PR DESCRIPTION
The current approach to interpolation assumes `${VAR}`-style interpolation, but we also want to do basically the same thing with the template-like `{{matrix}}` tokens. 

I considered using a func type like in #2395, but if we want to exclude matrix from interpolating into itself, it might make sense to do that by introspecting the type of the string transformer.