### PR TITLE
Separate step/pipeline env vars for job validation

### DIFF
--- a/agent/verify_job.go
+++ b/agent/verify_job.go
@@ -73,30 +73,74 @@ func (r *JobRunner) verifyJob(keySet jwk.Set) error {
 	// Note that each field needs a different consistency check:
 	//
 	// - command should match BUILDKITE_COMMAND exactly
-	// - env vars not listed in the signature as signed fields are allowed
+	// - env vars are complicated
 	// - plugins should match BUILDKITE_PLUGINS semantically
-	// - matrix interpolates into the others, and does not itself compare
+	// - matrix interpolates into the other fields, and does not itself compare
 	//   (not yet implemented).
 	//
 	// We can't check that the job is consistent with fields we don't know
 	// about yet, so these are rejected.
 	//
-	// More notes on `env::`:
-	// 1. Signature.Verify ensures every signed env var has the right value, and
-	// 2. step env can be overridden by the pipeline env, but each step only
-	//    knows about its own env. So the job env and step env can disagree
-	//    under normal circumstances.
-	// We still have to catch when a signature validates only because the step
-	// has an env var (not used to run the job), that is not present in the
-	// job env (is actually used).
+	// Notes on env vars:
+	// 1. Pipeline env values are included individually in the "env::" namespace
+	//    of fields, and step env vars are a single map under the "env" field.
+	// 2. When producing the job env, pipeline env overrides step env. This may
+	//    seem backwards but it is our documented behaviour:
+	//    https://buildkite.com/docs/pipelines/environment-variables#defining-your-own
+	// 3. The backend also adds env vars that can't be known in advance for
+	//    signing.
+	// 4. Step env vars can have matrix tokens (in both names and values).
+	// 5. Pipeline env is uploaded as a distinct map, but is not fully available
+	//    for verifying here - we only have job env and step env to work with,
+	//    and only know which vars were pipeline env vars from "env::".
+	//
+	// As a result, the job env, pipeline env, and step env can all disagree
+	// under normal circumstances, and verifying it all is a bit complex.
+	//
+	// 1. Every step env var must at least exist in the job env.
+	// 2. Every pipline env var must exist in the job env, and have an equal
+	//    value in the job env, because it overrides step env.
+	// 3. If a var was a pipeline env var, it went in the "env::" namespace, and
+	//    Signature.Verify has checked its value implicitly.
+	// 3. If a var was a step env var, it is an element in step.Env and
+	//    Signature.Verify has checked its pre-matrix value.
+	// 4. If a var was a step env var *and* wasn't overridden by a pipeline env
+	//    var, *then* its (post-matrix) value must equal the job env var.
 	signedFields := step.Signature.SignedFields
 
+	// These env vars came from the pipeline-level env block.
+	pipelineEnv := make(map[string]bool)
+	for _, field := range signedFields {
+		if name, has := strings.CutPrefix(field, pipeline.EnvNamespacePrefix); has {
+			pipelineEnv[name] = true
+		}
+	}
+
+	// Compare each field to the job.
 	for _, field := range signedFields {
 		switch field {
 		case "command": // compare directly
 			jobCommand := r.conf.Job.Env["BUILDKITE_COMMAND"]
 			if step.Command != jobCommand {
 				return newInvalidSignatureError(fmt.Errorf("job %q was signed with signature %q, but the value of BUILDKITE_COMMAND (%q) does not match the value of step.command (%q)", r.conf.Job.ID, step.Signature.Value, jobCommand, step.Command))
+			}
+
+		case "env":
+			for name, stepEnvValue := range step.Env {
+				// It must at least exist in the job env.
+				jobEnvValue, has := r.conf.Job.Env[name]
+				if !has {
+					return newInvalidSignatureError(fmt.Errorf("job %q was signed with signature %q, but step.env defines %s which is missing from the job environment", r.conf.Job.ID, step.Signature.Value, name))
+				}
+
+				// If it is not overridden by the pipeline...
+				if pipelineEnv[name] {
+					continue
+				}
+				// ...then it must match the step.
+				if jobEnvValue != stepEnvValue {
+					return newInvalidSignatureError(fmt.Errorf("job %q was signed with signature %q, but the value of %s (%q) does not match the value of step.env[%s] (%q)", r.conf.Job.ID, step.Signature.Value, name, jobEnvValue, name, stepEnvValue))
+				}
 			}
 
 		case "plugins": // compare canonicalised JSON
@@ -141,19 +185,14 @@ func (r *JobRunner) verifyJob(keySet jwk.Set) error {
 
 		default:
 			// env:: - skip any that were verified with Verify.
-			if envName, ok := strings.CutPrefix(field, pipeline.EnvNamespacePrefix); ok {
-				jobEnv, has := r.conf.Job.Env[envName]
-				if has {
-					// Signature.Verify used the variable value from Env,
-					// handling this case.
-					continue
+			if name, isEnv := strings.CutPrefix(field, pipeline.EnvNamespacePrefix); isEnv {
+				if _, has := r.conf.Job.Env[name]; !has {
+					// A pipeline env var that is now missing.
+					return newInvalidSignatureError(fmt.Errorf("job %q was signed with signature %q, but pipeline.env defines %s which is missing from the job environment", r.conf.Job.ID, step.Signature.Value, name))
 				}
-
-				// It's not in the job env, so ensure that it was blank in the
-				// step env too.
-				if step.Env[envName] != jobEnv {
-					return newInvalidSignatureError(fmt.Errorf("job %q was signed with signature %q, but the value of %s (%q) does not match the value of step.env[%s] (%q)", r.conf.Job.ID, step.Signature.Value, envName, jobEnv, envName, step.Env[envName]))
-				}
+				// The env var is present. Signature.Verify used the value from
+				// the job env, handling this case.
+				continue
 			}
 
 			// We don't know this field, so we cannot ensure it is consistent

--- a/agent/verify_job.go
+++ b/agent/verify_job.go
@@ -87,7 +87,8 @@ func (r *JobRunner) verifyJob(keySet jwk.Set) error {
 	// 2. When producing the job env, step env overrides pipeline env. Easy.
 	// 3. The backend also adds env vars that can't be known in advance for
 	//    signing.
-	// 4. Step env vars can have matrix tokens (in both names and values).
+	// 4. Step env vars can have matrix tokens (interpolated within values, but
+	//    not variable names).
 	// 5. Pipeline env is uploaded as a distinct map, but is not fully available
 	//    for verifying here - we only have job env and step env to work with,
 	//    and only know which vars were pipeline env vars from "env::".

--- a/internal/pipeline/interpolate.go
+++ b/internal/pipeline/interpolate.go
@@ -102,8 +102,22 @@ func interpolateSlice[E any, S ~[]E](tf stringTransformer, s S) error {
 	return nil
 }
 
-// interpolateMap applies interpolateAny over any type of map. The map is
-// altered in-place.
+// interpolateMapValues applies interpolateAny over the values of any type of
+// map. The map is altered in-place.
+func interpolateMapValues[K comparable, V any, M ~map[K]V](tf stringTransformer, m M) error {
+	for k, v := range m {
+		// V could be string, so be sure to replace the old value with the new.
+		intv, err := interpolateAny(tf, v)
+		if err != nil {
+			return err
+		}
+		m[k] = intv
+	}
+	return nil
+}
+
+// interpolateMap applies interpolateAny over both keys and values of any type
+// of map. The map is altered in-place.
 func interpolateMap[K comparable, V any, M ~map[K]V](tf stringTransformer, m M) error {
 	for k, v := range m {
 		// We interpolate both keys and values.

--- a/internal/pipeline/sign.go
+++ b/internal/pipeline/sign.go
@@ -49,6 +49,7 @@ func Sign(env map[string]string, sf SignedFielder, key jwk.Key) (*Signature, err
 		values[EnvNamespacePrefix+k] = v
 	}
 
+	// Extract the names of the fields.
 	fields := make([]string, 0, len(values))
 	for field := range values {
 		fields = append(fields, field)
@@ -83,8 +84,7 @@ func (s *Signature) Verify(env map[string]string, sf SignedFielder, keySet jwk.S
 		return errors.New("signature covers no fields")
 	}
 
-	// Ask the object for all fields, including env:: (which may be overridden
-	// by the pipeline env).
+	// Ask the object for values for all fields.
 	values, err := sf.ValuesForFields(s.SignedFields)
 	if err != nil {
 		return fmt.Errorf("obtaining values for fields: %w", err)

--- a/internal/pipeline/sign.go
+++ b/internal/pipeline/sign.go
@@ -34,13 +34,8 @@ func Sign(env map[string]string, sf SignedFielder, key jwk.Key) (*Signature, err
 		return nil, errors.New("no fields to sign")
 	}
 
-	// Namespace the env values.
-	env = prefixKeys(env, EnvNamespacePrefix)
-
-	// NB: env overrides values from sf. This may seem backwards but it is
-	// our documented behaviour:
-	// https://buildkite.com/docs/pipelines/environment-variables#defining-your-own
-	for k, v := range env {
+	// Namespace the env values and include them in the values to sign.
+	for k, v := range prefixKeys(env, EnvNamespacePrefix) {
 		values[k] = v
 	}
 
@@ -85,16 +80,12 @@ func (s *Signature) Verify(env map[string]string, sf SignedFielder, keySet jwk.S
 		return fmt.Errorf("obtaining values for fields: %w", err)
 	}
 
-	// Namespace the env values.
-	env = prefixKeys(env, EnvNamespacePrefix)
-
-	// NB: env overrides values from sf (see comment in Sign).
-	for k, v := range env {
+	// Namespace the env values and include them in the values to sign.
+	for k, v := range prefixKeys(env, EnvNamespacePrefix) {
 		values[k] = v
 	}
 
-	// env:: fields that were signed are all required from either the env map or
-	// the step env map.
+	// env:: fields that were signed are all required from the env map.
 	// We can't verify other env vars though - they can vary for lots of reasons
 	// (e.g. Buildkite-provided vars added by the backend.)
 	// This is still strong enough for a user to enforce any particular env var

--- a/internal/pipeline/sign_test.go
+++ b/internal/pipeline/sign_test.go
@@ -39,7 +39,7 @@ func TestSignVerify(t *testing.T) {
 	// The backend combines the pipeline and step envs, providing a new env:
 	verifyEnv := map[string]string{
 		"CONTEXT": "cats",
-		"DEPLOY":  "1", // NB: pipeline env overrides step env.
+		"DEPLOY":  "0",
 		"MISC":    "llama drama",
 	}
 
@@ -55,7 +55,7 @@ func TestSignVerify(t *testing.T) {
 				return jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", alg)
 			},
 			alg:                            jwa.HS256,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzI1NiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..yZI860Srtl1d2T3VKgTUVugFF_SX4VLqH-vN8zTw5fs",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzI1NiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..F8xH79r8o7GbKKyYViKsbKhMtSGsAXbGIZJfoH9cWS8",
 		},
 		{
 			name: "HMAC-SHA384",
@@ -63,7 +63,7 @@ func TestSignVerify(t *testing.T) {
 				return jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", alg)
 			},
 			alg:                            jwa.HS384,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzM4NCIsImtpZCI6ImNoYXJ0cmV1c2UifQ..dvKFu43gBBy3nKz4JgtqJbo4z4mNUZkOuD9nIGlslrnmQkcznE9pzbd-GtBtAetF",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzM4NCIsImtpZCI6ImNoYXJ0cmV1c2UifQ..nykiFmX1mQUAU8jCkmEFTudWXuQiR9mfQKEwWcH5Vc59aL5dOqfk5IWlKxNGYB9v",
 		},
 		{
 			name: "HMAC-SHA512",
@@ -71,7 +71,7 @@ func TestSignVerify(t *testing.T) {
 				return jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", alg)
 			},
 			alg:                            jwa.HS512,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzUxMiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..LciCRCDL_MgOph-1I6vYMEViwanJFdrF9Bh5eiUy9PKIc1RyGnHh7y07ydkwo5Fxf3GqQojhEtTlB8JWvGtaxg",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzUxMiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..3iFiqkOS0M5uptlFNBf_KABj6RHBugwPHCld_LH2U5H4Peiv-cxqr2EWTfy19j_iRkyr-LGHt-lqUuiC27t2Qw",
 		},
 		{
 			name:           "RSA-PSS 256",

--- a/internal/pipeline/sign_test.go
+++ b/internal/pipeline/sign_test.go
@@ -55,7 +55,7 @@ func TestSignVerify(t *testing.T) {
 				return jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", alg)
 			},
 			alg:                            jwa.HS256,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzI1NiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..IS-xyKZIK0iUXOs0DRRkr6uCqTXCYIl9YXBODZa-c_Q",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzI1NiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..yZI860Srtl1d2T3VKgTUVugFF_SX4VLqH-vN8zTw5fs",
 		},
 		{
 			name: "HMAC-SHA384",
@@ -63,7 +63,7 @@ func TestSignVerify(t *testing.T) {
 				return jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", alg)
 			},
 			alg:                            jwa.HS384,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzM4NCIsImtpZCI6ImNoYXJ0cmV1c2UifQ..OjgQkbm7Z835QYoD1KvvHV6TQLvEs3G-JnFkOKzsjMOLgcUPd2DHHvKv0uf93gDM",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzM4NCIsImtpZCI6ImNoYXJ0cmV1c2UifQ..dvKFu43gBBy3nKz4JgtqJbo4z4mNUZkOuD9nIGlslrnmQkcznE9pzbd-GtBtAetF",
 		},
 		{
 			name: "HMAC-SHA512",
@@ -71,7 +71,7 @@ func TestSignVerify(t *testing.T) {
 				return jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", alg)
 			},
 			alg:                            jwa.HS512,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzUxMiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..S3jnKQItD63trOQtIddkBu98Xql8_lfl4KEPOy6s1WH8AUI7eNTesfzRZ3l04uVBBU_FWZSWTY5afUbpbjMpvA",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzUxMiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..LciCRCDL_MgOph-1I6vYMEViwanJFdrF9Bh5eiUy9PKIc1RyGnHh7y07ydkwo5Fxf3GqQojhEtTlB8JWvGtaxg",
 		},
 		{
 			name:           "RSA-PSS 256",

--- a/internal/pipeline/step_command.go
+++ b/internal/pipeline/step_command.go
@@ -76,16 +76,12 @@ func (c *CommandStep) UnmarshalOrdered(src any) error {
 
 // SignedFields returns the default fields for signing.
 func (c *CommandStep) SignedFields() (map[string]any, error) {
-	out := map[string]any{
+	return map[string]any{
 		"command": c.Command,
+		"env":     c.Env,
 		"plugins": c.Plugins,
 		"matrix":  c.Matrix,
-	}
-	// Steps can have their own env. These can be overridden by the pipeline!
-	for e, v := range c.Env {
-		out[EnvNamespacePrefix+e] = v
-	}
-	return out, nil
+	}, nil
 }
 
 // ValuesForFields returns the contents of fields to sign.
@@ -94,14 +90,9 @@ func (c *CommandStep) ValuesForFields(fields []string) (map[string]any, error) {
 	// deleting them.
 	required := map[string]struct{}{
 		"command": {},
+		"env":     {},
 		"plugins": {},
 		"matrix":  {},
-	}
-	// Env vars that the step has, but the pipeline doesn't have, are required.
-	// But we don't know what the pipeline has without passing it in, so treat
-	// all step env vars as required.
-	for e := range c.Env {
-		required[EnvNamespacePrefix+e] = struct{}{}
 	}
 
 	out := make(map[string]any, len(fields))
@@ -112,6 +103,9 @@ func (c *CommandStep) ValuesForFields(fields []string) (map[string]any, error) {
 		case "command":
 			out["command"] = c.Command
 
+		case "env":
+			out["env"] = c.Env
+
 		case "plugins":
 			out["plugins"] = c.Plugins
 
@@ -119,12 +113,8 @@ func (c *CommandStep) ValuesForFields(fields []string) (map[string]any, error) {
 			out["matrix"] = c.Matrix
 
 		default:
-			if e, has := strings.CutPrefix(f, EnvNamespacePrefix); has {
-				// Env vars requested in `fields`, but are not in this step, are
-				// skipped.
-				if v, ok := c.Env[e]; ok {
-					out[f] = v
-				}
+			// All env:: values come from outside the step.
+			if strings.HasPrefix(f, EnvNamespacePrefix) {
 				break
 			}
 

--- a/internal/pipeline/step_command_test.go
+++ b/internal/pipeline/step_command_test.go
@@ -113,17 +113,16 @@ func TestStepCommandMatrixInterpolate(t *testing.T) {
 			},
 		},
 		{
-			name: "it interplates environment variable names and values",
+			name: "it interplates environment variable values",
 			ms: MatrixPermutation{
 				{Dimension: "name", Value: "Taylor Launtner"},
-				{Dimension: "demonym_suffix", Value: "DER"},
 				{Dimension: "value", Value: "true"},
 			},
 			step: &CommandStep{
 				Command: "script/buildkite/xxx.sh",
 				Env: map[string]string{
-					"NAME":                              "{{matrix.name}}",
-					"MICHIGAN{{matrix.demonym_suffix}}": "{{matrix.value}}",
+					"NAME":        "{{matrix.name}}",
+					"MICHIGANDER": "{{matrix.value}}",
 				},
 			},
 			want: &CommandStep{


### PR DESCRIPTION
Matrix interpolation is going to thwart the existing `env::` scheme. Splitting pipeline and step env checks should get ahead of the problem.

**The problem:** in the existing scheme, all vars (step and pipeline) are combined into the one "namespace" of signed fields. This happens "pre-matrix". Pipeline env vars should make it through unscathed, but step env vars will have matrix interpolation applied in the backend. So any step env var (~~not overridden by the pipeline env~~ lol turns out step vars should take precedence over pipeline vars) containing a matrix token is going to have a different value in the job env than it had when it was signed, and will fail to verify.

**The solution:** Preserve the step env as its own field, and keep it separate from pipeline env during signing.

**Also:** This switches the precedence of env vars to match https://buildkite.com/docs/tutorials/pipeline-upgrade#what-is-the-yaml-steps-editor-compatibility-issues and also removes interpolation of matrix tokens into env var names.

Step env vars cause pipeline vars with the same names to be excluded from `env::`, and hence from the signature, because at verify time the job env var will have the step var value, not the pipeline var value. If the pipeline var was still present under `env::`, then it would need to match the pipeline var value during signing, which the job won't have.

Interpolating matrix tokens into env var names would cause further problems: no pipeline env vars could be excluded from the signature, because matrix interpolation may or may not cause a corresponding step env var to exist. Thankfully, the backend doesn't interpolate matrix tokens in env var names. I think I was under the impression that it would do the same thing as env var interpolation.