### PR TITLE
Enable matrixes for step signing

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -9,21 +9,22 @@ import (
 
 // Job represents a Buildkite Agent API Job
 type Job struct {
-	ID                 string               `json:"id,omitempty"`
-	Endpoint           string               `json:"endpoint"`
-	State              string               `json:"state,omitempty"`
-	Env                map[string]string    `json:"env,omitempty"`
-	Step               pipeline.CommandStep `json:"step,omitempty"`
-	ChunksMaxSizeBytes uint64               `json:"chunks_max_size_bytes,omitempty"`
-	LogMaxSizeBytes    uint64               `json:"log_max_size_bytes,omitempty"`
-	Token              string               `json:"token,omitempty"`
-	ExitStatus         string               `json:"exit_status,omitempty"`
-	Signal             string               `json:"signal,omitempty"`
-	SignalReason       string               `json:"signal_reason,omitempty"`
-	StartedAt          string               `json:"started_at,omitempty"`
-	FinishedAt         string               `json:"finished_at,omitempty"`
-	RunnableAt         string               `json:"runnable_at,omitempty"`
-	ChunksFailedCount  int                  `json:"chunks_failed_count,omitempty"`
+	ID                 string                     `json:"id,omitempty"`
+	Endpoint           string                     `json:"endpoint"`
+	State              string                     `json:"state,omitempty"`
+	Env                map[string]string          `json:"env,omitempty"`
+	Step               pipeline.CommandStep       `json:"step,omitempty"`
+	MatrixPermutation  pipeline.MatrixPermutation `json:"matrix_permutation,omitempty"`
+	ChunksMaxSizeBytes uint64                     `json:"chunks_max_size_bytes,omitempty"`
+	LogMaxSizeBytes    uint64                     `json:"log_max_size_bytes,omitempty"`
+	Token              string                     `json:"token,omitempty"`
+	ExitStatus         string                     `json:"exit_status,omitempty"`
+	Signal             string                     `json:"signal,omitempty"`
+	SignalReason       string                     `json:"signal_reason,omitempty"`
+	StartedAt          string                     `json:"started_at,omitempty"`
+	FinishedAt         string                     `json:"finished_at,omitempty"`
+	RunnableAt         string                     `json:"runnable_at,omitempty"`
+	ChunksFailedCount  int                        `json:"chunks_failed_count,omitempty"`
 }
 
 type JobState struct {

--- a/internal/pipeline/step_command.go
+++ b/internal/pipeline/step_command.go
@@ -132,6 +132,19 @@ func (c *CommandStep) ValuesForFields(fields []string) (map[string]any, error) {
 	return out, nil
 }
 
+// InterpolateMatrixPermutation validates and then interpolates the choice of
+// matrix values into the step. This should only be used in order to validate
+// a job that's about to be run, and not used before pipeline upload.
+func (c *CommandStep) InterpolateMatrixPermutation(mp MatrixPermutation) error {
+	if err := c.Matrix.validatePermutation(mp); err != nil {
+		return err
+	}
+	if len(mp) == 0 {
+		return nil
+	}
+	return c.interpolate(newMatrixInterpolator(mp))
+}
+
 func (c *CommandStep) interpolate(tf stringTransformer) error {
 	cmd, err := tf.Transform(c.Command)
 	if err != nil {

--- a/internal/pipeline/steps.go
+++ b/internal/pipeline/steps.go
@@ -141,11 +141,6 @@ func (s Steps) sign(env map[string]string, key jwk.Key) error {
 	for _, step := range s {
 		switch step := step.(type) {
 		case *CommandStep:
-			if step.Matrix != nil {
-				// Don't sign matrix steps... yet
-				continue
-			}
-
 			sig, err := Sign(env, step, key)
 			if err != nil {
 				return fmt.Errorf("signing step with command %q: %w", step.Command, err)


### PR DESCRIPTION
- [x] Add MatrixPermutation to job response
- [x] Parse MatrixPermutation in a way compatible with backend
- [x] Use matrix interpolator on step after verifying signature
- [x] Disable checks for matrixes that disable signing and verifying
- [x] Integration test