### PR TITLE
Revert "Upgrade pre-installed packages in docker images" and Pin docker images by digest

### DIFF
--- a/.buildkite/Dockerfile-compile
+++ b/.buildkite/Dockerfile-compile
@@ -1,4 +1,4 @@
-FROM golang:1.20.10@sha256:098d628490c97d4419ed44a23d893f37b764f3bea06e0827183e8af4120e19be
+FROM public.ecr.aws/docker/library/golang:1.20.10@sha256:098d628490c97d4419ed44a23d893f37b764f3bea06e0827183e8af4120e19be
 COPY build/ssh.conf /etc/ssh/ssh_config.d/
 RUN go install github.com/google/go-licenses@latest
 

--- a/.buildkite/Dockerfile-github-release
+++ b/.buildkite/Dockerfile-github-release
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/alpine:3.18.4
+FROM public.ecr.aws/docker/library/alpine:3.18.4@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
 
 # We need buildkite-agent to download artifacts, and zip for Windows zipping
 RUN apk --no-cache add bash zip curl \

--- a/packaging/docker/alpine-k8s/Dockerfile
+++ b/packaging/docker/alpine-k8s/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM public.ecr.aws/docker/library/alpine:3.18.4 AS base
+FROM public.ecr.aws/docker/library/alpine:3.18.4@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978 AS base
 
 RUN apk update && apk add --no-cache \
     bash \
@@ -22,7 +22,7 @@ RUN apk update && apk add --no-cache \
 
 COPY docker-compose /usr/local/bin/docker-compose
 
-FROM public.ecr.aws/docker/library/alpine:3.18.4 AS kubectl-downloader
+FROM public.ecr.aws/docker/library/alpine:3.18.4@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978 AS kubectl-downloader
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -35,7 +35,7 @@ wget -qO kubectl \
 chmod +x kubectl
 EOF
 
-FROM public.ecr.aws/docker/library/alpine:3.18.4 AS kustomize-downloader
+FROM public.ecr.aws/docker/library/alpine:3.18.4@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978 AS kustomize-downloader
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/packaging/docker/alpine-k8s/Dockerfile
+++ b/packaging/docker/alpine-k8s/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM public.ecr.aws/docker/library/alpine:3.18.4 AS base
 
-RUN apk update && apk upgrade && apk add --no-cache \
+RUN apk update && apk add --no-cache \
     bash \
     curl \
     docker-cli \

--- a/packaging/docker/alpine/Dockerfile
+++ b/packaging/docker/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM public.ecr.aws/docker/library/alpine:3.18.4
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk update && apk upgrade && apk add --no-cache \
+RUN apk add --no-cache \
     bash \
     curl \
     docker-cli \

--- a/packaging/docker/alpine/Dockerfile
+++ b/packaging/docker/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/alpine:3.18.4
+FROM public.ecr.aws/docker/library/alpine:3.18.4@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/packaging/docker/sidecar/Dockerfile
+++ b/packaging/docker/sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/alpine:3.18.4
+FROM public.ecr.aws/docker/library/alpine:3.18.4@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -12,6 +12,6 @@ RUN mkdir /buildkite \
 COPY buildkite-agent.cfg /buildkite/
 COPY buildkite-agent-$TARGETOS-$TARGETARCH /buildkite/bin/buildkite-agent
 
-FROM public.ecr.aws/docker/library/busybox:1-musl
+FROM public.ecr.aws/docker/library/busybox:1-musl@sha256:f553b7484625f0c73bfa3888e013e70e99ec6ae1c424ee0e8a85052bd135a28a
 COPY --from=0 /buildkite /buildkite
 VOLUME /buildkite

--- a/packaging/docker/ubuntu-18.04/Dockerfile
+++ b/packaging/docker/ubuntu-18.04/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV DOCKER_COMPOSE_VERSION=1.27.4
 ENV TINI_VERSION=0.19.0
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
     curl \
     ca-certificates \

--- a/packaging/docker/ubuntu-18.04/Dockerfile
+++ b/packaging/docker/ubuntu-18.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/ubuntu/ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04@sha256:975b418c2c6c72bdfb978ac631c3fae2f42b752f5ab29dec706a01f3f6acc14b
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/packaging/docker/ubuntu-20.04/Dockerfile
+++ b/packaging/docker/ubuntu-20.04/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM public.ecr.aws/ubuntu/ubuntu:20.04
+FROM public.ecr.aws/ubuntu/ubuntu:20.04@sha256:7278dbd46cfaba8553efcf27152e8d8d56a2ed9d0f61e0df4a77ce15d0ed373a
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/packaging/docker/ubuntu-20.04/Dockerfile
+++ b/packaging/docker/ubuntu-20.04/Dockerfile
@@ -8,7 +8,7 @@ ARG TARGETARCH
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DOCKER_COMPOSE_VERSION=1.27.4
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
     bash \
     ca-certificates \

--- a/packaging/docker/ubuntu-22.04/Dockerfile
+++ b/packaging/docker/ubuntu-22.04/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM public.ecr.aws/ubuntu/ubuntu:22.04
+FROM public.ecr.aws/ubuntu/ubuntu:22.04@sha256:c6871ae8b54fb3ed0ba4df4eb98527e9a6692088fe0c2f2260a9334853092b47
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/packaging/docker/ubuntu-22.04/Dockerfile
+++ b/packaging/docker/ubuntu-22.04/Dockerfile
@@ -13,7 +13,6 @@ set -eufo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
-apt-get upgrade -y
 apt-get install -y --no-install-recommends \
   apt-transport-https \
   bash \


### PR DESCRIPTION
In #2410 I responded to a report that the system packages in our docker images were out of date by upgrading the system packages at build time. However, this has a notable disadvantage - the version in an image is now determined both by the commit of the build and the time that the build ran. So we have lost some reproducibility. So in this PR, we revert that.

However, we can do a bit better than the situation before. Previously, we only pinned the tags of the base image, for example we pinned the `ubuntu` image to the tag `22.04`. Dependabot would only update the image when a newer tag emerged, which is very infrequent in the case of `ubuntu`. However, maintainers of the base image regularly push newer images to the tag that we have pinned. This mutates the "digest" of the image, and dependabot is [capable of detecting updates to the digest](https://github.com/buildkite/agent/pull/2179). So in this PR, we pin all docker base images by digest.

Notably, this is MORE reproducible than the original situation, as it now two builds at the same commit will always use the same base image.

Reverts buildkite/agent#2410