### PR TITLE
Support fetch for bitbucket pull request events

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -491,6 +491,13 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 
 	gitFetchFlags := e.GitFetchFlags
 
+	// Bitbucket (at least) send the SHORT SHA1 in the event and git fetch requires the long SHA1
+	if o, err := e.shell.RunAndCapture(ctx, "git", "rev-parse", e.Commit); err != nil {
+		e.shell.Warningf("failed to rev-parse %s, %w", e.Commit, err)
+	} else {
+		e.Commit = o
+	}
+
 	switch {
 	case e.RefSpec != "":
 		// If a refspec is provided then use it instead.


### PR DESCRIPTION
When Bitucket send events for PullRequest created it contains the short SHA1 and not the long SHA1 that is required for `git fetch` in the checkout job. We do a `git rev-parse` on the short SHA1 to get the long SHA1 to fetch and update the value before fetching.