### PR TITLE
Add packagecloud upload step for rpms

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -32,6 +32,21 @@ steps:
           volumes:
             - "/yum.buildkite.com"
 
+  - name: ":redhat: Publish Edge RPM Package to Packagecloud"
+    command: ".buildkite/steps/publish-rpm-packagecloud.sh"
+    env:
+      REPOSITORY: "buildkite/agent-experimental"
+      DISTRO_VERSION: rpm_any/rpm_any
+    agents:
+      queue: "deploy"
+    plugins:
+      - docker#v5.8.0:
+          image: "buildkite/agent:3.55.0-ubuntu"
+          entrypoint: bash
+          propagate-environment: true
+          mount-buildkite-agent: true
+    soft_fail: true
+
   - name: ":debian: Publish Edge Debian Package"
     command: ".buildkite/steps/publish-debian-package.sh"
     env:

--- a/.buildkite/steps/publish-rpm-packagecloud.sh
+++ b/.buildkite/steps/publish-rpm-packagecloud.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+artifacts_build="$(buildkite-agent meta-data get "agent-artifacts-build")"
+
+dry_run() {
+  if [[ "${DRY_RUN:-}" == "false" ]] ; then
+    "$@"
+  else
+    echo "[dry-run] $*"
+  fi
+}
+
+if [[ "${REPOSITORY:-}" == "" ]]; then
+  echo "Error: Missing \$REPOSITORY (<user>/<repository>; i.e. buildkite/agent-experimental)"
+  exit 1
+fi
+
+if [[ "${DISTRO_VERSION:-}" == "" ]]; then
+  echo "Error: Missing \$DISTRO_VERSION (<os>/<version>; i.e. rpm_any/rpm_any)"
+  exit 1
+fi
+
+echo "--- Clearing rpm directory"
+rm -rvf rpm
+mkdir -p rpm
+
+echo "--- Downloading built rpm packages"
+buildkite-agent artifact download --build "${artifacts_build}" "rpm/*.rpm" rpm/
+
+echo "--- Installing dependencies"
+gem install package_cloud
+
+echo "--- Requesting OIDC token"
+export PACKAGECLOUD_TOKEN="$(buildkite-agent oidc request-token --audience "https://packagecloud.io/${REPOSITORY}" --lifetime 300)"
+
+echo "--- Pushing to Packagecloud"
+dry_run package_cloud push "${REPOSITORY}/${DISTRO_VERSION}" rpm/*.rpm


### PR DESCRIPTION
I'd like to try uploading new agent packages to packagecloud repositories. I'd also like to get it working using OIDC tokens, so we can avoid storing or transmitting long-lived secrets during the exchange.

This introduces a step which uploads new rpms to [a new agent-experimental repository](https://packagecloud.io/buildkite/agent-experimental). It's set to soft fail because I expect this to fail at first, but I'll be pushing through [the OIDC support](https://github.com/computology/packagecloud.io/pull/1815) to make this work.

Fixes PKG-5934.