### PR TITLE
All scalars in matrixes are now strings

### DIFF
--- a/agent/integration/job_verification_integration_test.go
+++ b/agent/integration/job_verification_integration_test.go
@@ -170,8 +170,8 @@ var (
 			"MESSAGE":           "hello world",
 		},
 		MatrixPermutation: pipeline.MatrixPermutation{
-			{Dimension: "greeting", Value: "hello"},
-			{Dimension: "object", Value: "world"},
+			"greeting": "hello",
+			"object":   "world",
 		},
 	}
 
@@ -186,8 +186,8 @@ var (
 			"MESSAGE":           "goodbye mister anderson",
 		},
 		MatrixPermutation: pipeline.MatrixPermutation{ // crimes here:
-			{Dimension: "greeting", Value: "goodbye"},
-			{Dimension: "object", Value: "mister anderson"},
+			"greeting": "goodbye",
+			"object":   "mister anderson",
 		},
 	}
 
@@ -202,8 +202,8 @@ var (
 			"MESSAGE":           "goodbye mister anderson", // crimes~!
 		},
 		MatrixPermutation: pipeline.MatrixPermutation{
-			{Dimension: "greeting", Value: "hello"},
-			{Dimension: "object", Value: "world"},
+			"greeting": "hello",
+			"object":   "world",
 		},
 	}
 )
@@ -491,8 +491,8 @@ func stepWithMatrix() pipeline.CommandStep {
 		},
 		Matrix: &pipeline.Matrix{
 			Setup: pipeline.MatrixSetup{
-				"greeting": pipeline.MatrixScalars{"hello", "今日は"},
-				"object":   pipeline.MatrixScalars{"world", 47},
+				"greeting": []string{"hello", "今日は"},
+				"object":   []string{"world", "47"},
 			},
 		},
 	}

--- a/internal/pipeline/interpolate_matrix.go
+++ b/internal/pipeline/interpolate_matrix.go
@@ -41,11 +41,11 @@ func (m matrixInterpolator) Transform(src string) (string, error) {
 // matrix interpolation.
 func newMatrixInterpolator(mp MatrixPermutation) matrixInterpolator {
 	replacements := make(map[string]string)
-	for _, sd := range mp {
-		if sd.Dimension == "" {
-			replacements[""] = fmt.Sprint(sd.Value)
+	for dim, val := range mp {
+		if dim == "" {
+			replacements[""] = val
 		} else {
-			replacements["."+sd.Dimension] = fmt.Sprint(sd.Value)
+			replacements["."+dim] = val
 		}
 	}
 

--- a/internal/pipeline/interpolate_matrix_test.go
+++ b/internal/pipeline/interpolate_matrix_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestMatrixInterpolater_Simple(t *testing.T) {
 	t.Parallel()
-	transform := newMatrixInterpolator(MatrixPermutation{{Dimension: "", Value: "llama"}})
+	transform := newMatrixInterpolator(MatrixPermutation{"": "llama"})
 
 	tests := []struct {
 		name, input, want string
@@ -53,9 +53,9 @@ func TestMatrixInterpolater_Simple(t *testing.T) {
 func TestMatrixInterpolater_Multiple(t *testing.T) {
 	t.Parallel()
 	transform := newMatrixInterpolator(MatrixPermutation{
-		{Dimension: "protagonist", Value: "kuzco"},
-		{Dimension: "animal", Value: "llama"},
-		{Dimension: "weapon", Value: "poison"},
+		"protagonist": "kuzco",
+		"animal":      "llama",
+		"weapon":      "poison",
 	})
 
 	tests := []struct {
@@ -106,25 +106,19 @@ func TestMatrixInterpolator_Errors(t *testing.T) {
 		transform   matrixInterpolator
 	}{
 		{
-			name:  "mismatched named dimensions",
-			input: "this isn't poison. it's extract of... {{matrix.alpaca}}!",
-			transform: newMatrixInterpolator(MatrixPermutation{
-				{Dimension: "animal", Value: "llama"},
-			}),
+			name:      "mismatched named dimensions",
+			input:     "this isn't poison. it's extract of... {{matrix.alpaca}}!",
+			transform: newMatrixInterpolator(MatrixPermutation{"animal": "llama"}),
 		},
 		{
-			name:  "interpolate anonymous dimension into named token",
-			input: "this isn't {{matrix.weapon}}. it's extract of... llama!",
-			transform: newMatrixInterpolator(MatrixPermutation{
-				{Dimension: "", Value: "poison"},
-			}),
+			name:      "interpolate anonymous dimension into named token",
+			input:     "this isn't {{matrix.weapon}}. it's extract of... llama!",
+			transform: newMatrixInterpolator(MatrixPermutation{"": "poison"}),
 		},
 		{
-			name:  "interpolate named dimensions into anonymous token",
-			input: "this isn't {{matrix}}. it's extract of... llama!",
-			transform: newMatrixInterpolator(MatrixPermutation{
-				{Dimension: "weapon", Value: "poison"},
-			}),
+			name:      "interpolate named dimensions into anonymous token",
+			input:     "this isn't {{matrix}}. it's extract of... llama!",
+			transform: newMatrixInterpolator(MatrixPermutation{"weapon": "poison"}),
 		},
 	}
 
@@ -155,18 +149,18 @@ func TestMatrixInterpolateAny(t *testing.T) {
 		{
 			name:        "string",
 			interpolate: "this is a {{matrix}}",
-			ms:          MatrixPermutation{{Dimension: "", Value: "llama"}},
+			ms:          MatrixPermutation{"": "llama"},
 			want:        "this is a llama",
 		},
 		{
 			name: "deeply nested interpolation",
 			ms: MatrixPermutation{
-				{Dimension: "mountain", Value: "cotopaxi"},
-				{Dimension: "country", Value: "ecuador"},
-				{Dimension: "food", Value: "bolon de verde"},
-				{Dimension: "animal", Value: "andean condor"},
-				{Dimension: "currency", Value: "usd"},
-				{Dimension: "language", Value: "spanish"},
+				"mountain": "cotopaxi",
+				"country":  "ecuador",
+				"food":     "bolon de verde",
+				"animal":   "andean condor",
+				"currency": "usd",
+				"language": "spanish",
 			},
 			interpolate: []any{
 				"one", "{{matrix.mountain}}", 3, "{{matrix.country}}", true,
@@ -188,8 +182,8 @@ func TestMatrixInterpolateAny(t *testing.T) {
 		{
 			name: "structs don't get interpolated",
 			ms: MatrixPermutation{
-				{Dimension: "name", Value: "cotopaxi"},
-				{Dimension: "altitude", Value: "5897m"},
+				"name":     "cotopaxi",
+				"altitude": "5897m",
 			},
 			interpolate: mountain{Name: "{{matrix.name}}", Altitude: "{{matrix.altitude}}"},
 			want:        mountain{Name: "{{matrix.name}}", Altitude: "{{matrix.altitude}}"},
@@ -197,9 +191,9 @@ func TestMatrixInterpolateAny(t *testing.T) {
 		{
 			name: "concrete containers get interpolated",
 			ms: MatrixPermutation{
-				{Dimension: "mountain", Value: "cotopaxi"},
-				{Dimension: "country", Value: "ecuador"},
-				{Dimension: "animal", Value: "andean condor"},
+				"mountain": "cotopaxi",
+				"country":  "ecuador",
+				"animal":   "andean condor",
 			},
 			interpolate: []any{[]string{"{{matrix.mountain}}", "{{matrix.country}}"}, map[string]string{"animal": "{{matrix.animal}}"}},
 			want:        []any{[]string{"cotopaxi", "ecuador"}, map[string]string{"animal": "andean condor"}},
@@ -207,14 +201,14 @@ func TestMatrixInterpolateAny(t *testing.T) {
 		{
 			name: "matrix doesn't interpolate itself",
 			ms: MatrixPermutation{
-				{Dimension: "mountain", Value: "cotopaxi"},
-				{Dimension: "country", Value: "ecuador"},
-				{Dimension: "animal", Value: "andean condor"},
+				"mountain": "cotopaxi",
+				"country":  "ecuador",
+				"animal":   "andean condor",
 			},
 			interpolate: &Matrix{
 				Setup: MatrixSetup{
-					"fruit": MatrixScalars{"banana", "{{matrix.mountain}}"},
-					"shape": MatrixScalars{"{{matrix.country}}", 42},
+					"fruit": []string{"banana", "{{matrix.mountain}}"},
+					"shape": []string{"{{matrix.country}}", "42"},
 				},
 				Adjustments: MatrixAdjustments{
 					{
@@ -227,8 +221,8 @@ func TestMatrixInterpolateAny(t *testing.T) {
 			},
 			want: &Matrix{
 				Setup: MatrixSetup{
-					"fruit": MatrixScalars{"banana", "{{matrix.mountain}}"},
-					"shape": MatrixScalars{"{{matrix.country}}", 42},
+					"fruit": []string{"banana", "{{matrix.mountain}}"},
+					"shape": []string{"{{matrix.country}}", "42"},
 				},
 				Adjustments: MatrixAdjustments{
 					{

--- a/internal/pipeline/parser_matrix_test.go
+++ b/internal/pipeline/parser_matrix_test.go
@@ -34,7 +34,7 @@ steps:
 						Command: "echo {{matrix}}",
 						Matrix: &Matrix{
 							Setup: MatrixSetup{
-								"": {"apple", 47, true},
+								"": {"apple", "47", "true"},
 							},
 						},
 					},
@@ -46,8 +46,8 @@ steps:
       "command": "echo {{matrix}}",
       "matrix": [
         "apple",
-        47,
-        true
+        "47",
+        "true"
       ]
     }
   ]
@@ -70,7 +70,7 @@ steps:
 						Command: "echo {{matrix}}",
 						Matrix: &Matrix{
 							Setup: MatrixSetup{
-								"": {"apple", true, 47},
+								"": {"apple", "true", "47"},
 							},
 						},
 					},
@@ -82,8 +82,8 @@ steps:
       "command": "echo {{matrix}}",
       "matrix": [
         "apple",
-        true,
-        47
+        "true",
+        "47"
       ]
     }
   ]
@@ -113,7 +113,7 @@ steps:
 						Command: "echo {{matrix}}",
 						Matrix: &Matrix{
 							Setup: MatrixSetup{
-								"": {"apple", 47, true},
+								"": {"apple", "47", "true"},
 							},
 							Adjustments: MatrixAdjustments{
 								{
@@ -121,7 +121,7 @@ steps:
 									Skip: true,
 								},
 								{
-									With: MatrixAdjustmentWith{"": 42},
+									With: MatrixAdjustmentWith{"": "42"},
 									RemainingFields: map[string]any{
 										"soft_fail": true,
 									},
@@ -147,7 +147,7 @@ steps:
           },
           {
             "soft_fail": true,
-            "with": 42
+            "with": "42"
           },
           {
             "skip": "how dare you, you know i'm allergic to bananas!",
@@ -156,8 +156,8 @@ steps:
         ],
         "setup": [
           "apple",
-          47,
-          true
+          "47",
+          "true"
         ]
       }
     }
@@ -275,7 +275,7 @@ steps:
 								{
 									With: MatrixAdjustmentWith{
 										"arch": "ppc",
-										"os":   8,
+										"os":   "8",
 									},
 									RemainingFields: map[string]any{
 										"soft_fail": true,
@@ -315,7 +315,7 @@ steps:
             "soft_fail": true,
             "with": {
               "arch": "ppc",
-              "os": 8
+              "os": "8"
             }
           }
         ],

--- a/internal/pipeline/plugin_test.go
+++ b/internal/pipeline/plugin_test.go
@@ -119,8 +119,8 @@ func TestPluginMatrixInterpolate(t *testing.T) {
 		{
 			name: "matrix",
 			ms: MatrixPermutation{
-				{Dimension: "docker_version", Value: "4.5.6"},
-				{Dimension: "image", Value: "alpine"},
+				"docker_version": "4.5.6",
+				"image":          "alpine",
 			},
 			p: &Plugin{
 				Source: "docker#{{matrix.docker_version}}",

--- a/internal/pipeline/step_command_matrix.go
+++ b/internal/pipeline/step_command_matrix.go
@@ -30,24 +30,16 @@ var (
 		(*MatrixSetup)(nil),
 		(*MatrixAdjustmentWith)(nil),
 	}
-
-	_ interface {
-		ordered.Unmarshaler
-		selfInterpolater
-	} = (*MatrixScalars)(nil)
-
-	_ json.Unmarshaler = (*MatrixPermutation)(nil)
 )
 
 var (
-	errNilMatrix                    = errors.New("non-empty permutation but matrix is nil")
-	errPermutationLengthMismatch    = errors.New("permutation has wrong length")
-	errPermutationRepeatedDimension = errors.New("permutation has repeated dimension")
-	errPermutationUnknownDimension  = errors.New("permutation has unknown dimension")
-	errAdjustmentLengthMismatch     = errors.New("adjustment has wrong length")
-	errAdjustmentUnknownDimension   = errors.New("adjustment has unknown dimension")
-	errPermutationSkipped           = errors.New("permutation is skipped by adjustment")
-	errPermutationNoMatch           = errors.New("permutation is neither a valid matrix combination nor an adjustment")
+	errNilMatrix                   = errors.New("non-empty permutation but matrix is nil")
+	errPermutationLengthMismatch   = errors.New("permutation has wrong length")
+	errPermutationUnknownDimension = errors.New("permutation has unknown dimension")
+	errAdjustmentLengthMismatch    = errors.New("adjustment has wrong length")
+	errAdjustmentUnknownDimension  = errors.New("adjustment has unknown dimension")
+	errPermutationSkipped          = errors.New("permutation is skipped by adjustment")
+	errPermutationNoMatch          = errors.New("permutation is neither a valid matrix combination nor an adjustment")
 )
 
 // Matrix models the matrix specification for command steps.
@@ -67,7 +59,7 @@ func (m *Matrix) UnmarshalOrdered(o any) error {
 		// matrix:
 		//   - apple
 		//   - 47
-		s := make(MatrixScalars, 0, len(src))
+		s := make([]string, 0, len(src))
 		if err := ordered.Unmarshal(src, &s); err != nil {
 			return err
 		}
@@ -148,25 +140,19 @@ func (m *Matrix) validatePermutation(p MatrixPermutation) error {
 
 	// Check that the dimensions in the permutation are unique and defined in
 	// the matrix setup.
-	seen := make(map[string]bool)
-	for _, sd := range p {
-		if seen[sd.Dimension] {
-			return fmt.Errorf("%w: %q", errPermutationRepeatedDimension, sd.Dimension)
-		}
-		seen[sd.Dimension] = true
-
-		if len(m.Setup[sd.Dimension]) == 0 {
-			return fmt.Errorf("%w: %q", errPermutationUnknownDimension, sd.Dimension)
+	for dim := range p {
+		if len(m.Setup[dim]) == 0 {
+			return fmt.Errorf("%w: %q", errPermutationUnknownDimension, dim)
 		}
 	}
 
 	// Check that the permutation values are in the matrix setup (a basic
 	// permutation). Whether they are or are not, we still check adjustments.
 	valid := true
-	for _, sd := range p {
+	for dim, val := range p {
 		match := false
-		for _, v := range m.Setup[sd.Dimension] {
-			if sd.Value == v {
+		for _, v := range m.Setup[dim] {
+			if val == v {
 				match = true
 				break
 			}
@@ -195,8 +181,8 @@ func (m *Matrix) validatePermutation(p MatrixPermutation) error {
 
 		// Now we can test whether p == adj.With.
 		match := true
-		for _, sd := range p {
-			if sd.Value != adj.With[sd.Dimension] {
+		for dim, val := range p {
+			if val != adj.With[dim] {
 				match = false
 				break
 			}
@@ -220,50 +206,13 @@ func (m *Matrix) validatePermutation(p MatrixPermutation) error {
 	return nil
 }
 
-// MatrixPermutation represents a possible permutation of a matrix. If a matrix
-// has three dimensions each with three values, there will be 27 permutations.
-// Each permutation is a slice of SelectedDimensions, with Dimension values
-// being implicitly unique.
-type MatrixPermutation []SelectedDimension
-
-// UnmarshalJSON unmarshals a matrix permutation from a JSON object.
-func (mp *MatrixPermutation) UnmarshalJSON(b []byte) error {
-	if mp == nil {
-		return errors.New("unmarshal into nil pointer")
-	}
-	// Unmarshal the JSON using yaml.v3, to be consistent with everything else.
-	// For example, encoding/json prefers unmarshaling integer-looking numbers
-	// as float64.
-	m := make(map[string]any)
-	if err := yaml.Unmarshal(b, &m); err != nil {
-		return err
-	}
-	for dim, val := range m {
-		switch val.(type) {
-		case bool, int, string:
-			*mp = append(*mp, SelectedDimension{
-				Dimension: dim,
-				Value:     val,
-			})
-
-		default:
-			return fmt.Errorf("unsupported item type %T for key %q; want one of bool, int, or string", val, dim)
-		}
-	}
-	return nil
-}
-
-// SelectedDimension represents a single dimension/value pair in a matrix
-// permutation.
-type SelectedDimension struct {
-	Dimension string
-	Value     any
-}
+// MatrixPermutation represents a possible permutation of a matrix.
+type MatrixPermutation map[string]string
 
 // MatrixSetup is the main setup of a matrix - one or more dimensions. The cross
 // product of the dimensions in the setup produces the base combinations of
 // matrix values.
-type MatrixSetup map[string]MatrixScalars
+type MatrixSetup map[string][]string
 
 // MarshalJSON returns either a list (if the setup is a single anonymous
 // dimension) or an object (if it contains one or more (named) dimensions).
@@ -279,7 +228,7 @@ func (ms MatrixSetup) MarshalYAML() (any, error) {
 	if len(ms) == 1 && len(ms[""]) > 0 {
 		return ms[""], nil
 	}
-	return map[string]MatrixScalars(ms), nil
+	return map[string][]string(ms), nil
 }
 
 // UnmarshalOrdered unmarshals from either []any or *ordered.MapSA.
@@ -296,7 +245,7 @@ func (ms *MatrixSetup) UnmarshalOrdered(o any) error {
 		//   setup:
 		//     - apple
 		//     - 47
-		s := make(MatrixScalars, 0, len(src))
+		s := make([]string, 0, len(src))
 		if err := ordered.Unmarshal(src, &s); err != nil {
 			return err
 		}
@@ -305,7 +254,7 @@ func (ms *MatrixSetup) UnmarshalOrdered(o any) error {
 	case *ordered.MapSA:
 		// One or more (named) dimensions.
 		// Unmarshal into the underlying type to avoid infinite recursion.
-		if err := ordered.Unmarshal(src, (*map[string]MatrixScalars)(ms)); err != nil {
+		if err := ordered.Unmarshal(src, (*map[string][]string)(ms)); err != nil {
 			return err
 		}
 
@@ -357,7 +306,7 @@ func (ma *MatrixAdjustment) interpolate(tf stringTransformer) error {
 
 // MatrixAdjustmentWith is either a map of dimension key -> dimension value,
 // or a single value (for single anonymous dimension matrices).
-type MatrixAdjustmentWith map[string]any
+type MatrixAdjustmentWith map[string]string
 
 // MarshalJSON returns either a single scalar or an object.
 func (maw MatrixAdjustmentWith) MarshalJSON() ([]byte, error) {
@@ -368,10 +317,10 @@ func (maw MatrixAdjustmentWith) MarshalJSON() ([]byte, error) {
 
 // MarshalYAML returns either a single scalar or a map.
 func (maw MatrixAdjustmentWith) MarshalYAML() (any, error) {
-	if len(maw) == 1 && maw[""] != nil {
+	if _, has := maw[""]; has && len(maw) == 1 {
 		return maw[""], nil
 	}
-	return map[string]any(maw), nil
+	return map[string]string(maw), nil
 }
 
 // UnmarshalOrdered unmarshals from either a scalar value (string, bool, or int)
@@ -393,7 +342,7 @@ func (maw *MatrixAdjustmentWith) UnmarshalOrdered(o any) error {
 		//   adjustments:
 		//     - with: banana
 		//       soft_fail: true
-		(*maw)[""] = src
+		(*maw)[""] = fmt.Sprint(src)
 
 	case *ordered.MapSA:
 		// A map of dimension key -> dimension value. (Tuple of dimension value
@@ -401,7 +350,7 @@ func (maw *MatrixAdjustmentWith) UnmarshalOrdered(o any) error {
 		return src.Range(func(k string, v any) error {
 			switch vt := v.(type) {
 			case bool, int, string:
-				(*maw)[k] = vt
+				(*maw)[k] = fmt.Sprint(vt)
 
 			default:
 				return fmt.Errorf("unsupported value type %T in key %q for MatrixAdjustmentsWith", v, k)
@@ -413,35 +362,4 @@ func (maw *MatrixAdjustmentWith) UnmarshalOrdered(o any) error {
 		return fmt.Errorf("unsupported src type for MatrixAdjustmentsWith: %T", o)
 	}
 	return nil
-}
-
-// MatrixScalars accept a list of matrix values (bool, int, or string).
-// Only these types are accepted by the backend, and their representations are
-// generally stable between encodings (YAML, JSON, canonical, etc).
-type MatrixScalars []any
-
-// UnmarshalOrdered unmarshals []any only (and enforces that each item is a
-// bool, int, or string).
-func (s *MatrixScalars) UnmarshalOrdered(o any) error {
-	src, ok := o.([]any)
-	if !ok {
-		return fmt.Errorf("unsupported type for matrix values: %T", o)
-	}
-
-	for i, a := range src {
-		switch a.(type) {
-		case bool, int, string:
-			*s = append(*s, a)
-
-		default:
-			return fmt.Errorf("unsupported item type %T at index %d; want one of bool, int, or string", a, i)
-		}
-	}
-	return nil
-}
-
-// This is necessary because interpolateAny, which uses a type switch, matches
-// []any strictly.
-func (s MatrixScalars) interpolate(tf stringTransformer) error {
-	return interpolateSlice(tf, s)
 }

--- a/internal/pipeline/step_command_matrix_test.go
+++ b/internal/pipeline/step_command_matrix_test.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"encoding/json"
 	"errors"
-	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -23,8 +22,6 @@ func TestMatrix_ValidatePermutation_Simple(t *testing.T) {
 				"Rose family",
 				"Citruses",
 				"Nightshades",
-				47,
-				true,
 			},
 		},
 		Adjustments: MatrixAdjustments{
@@ -49,54 +46,34 @@ func TestMatrix_ValidatePermutation_Simple(t *testing.T) {
 	}{
 		{
 			name: "basic match",
-			perm: MatrixPermutation{{Value: "Nightshades"}},
-			want: nil,
-		},
-		{
-			name: "basic match (47)",
-			perm: MatrixPermutation{{Value: 47}},
-			want: nil,
-		},
-		{
-			name: "basic match (true)",
-			perm: MatrixPermutation{{Value: true}},
+			perm: MatrixPermutation{"": "Nightshades"},
 			want: nil,
 		},
 		{
 			name: "basic mismatch",
-			perm: MatrixPermutation{{Value: "Grasses"}},
-			want: errPermutationNoMatch,
-		},
-		{
-			name: "basic mismatch (-66)",
-			perm: MatrixPermutation{{Value: -66}},
-			want: errPermutationNoMatch,
-		},
-		{
-			name: "basic mismatch (false)",
-			perm: MatrixPermutation{{Value: false}},
+			perm: MatrixPermutation{"": "Grasses"},
 			want: errPermutationNoMatch,
 		},
 		{
 			name: "adjustment match",
-			perm: MatrixPermutation{{Value: "Alliums"}},
+			perm: MatrixPermutation{"": "Alliums"},
 			want: nil,
 		},
 		{
 			name: "adjustment skip",
-			perm: MatrixPermutation{{Value: "Brassicas"}},
+			perm: MatrixPermutation{"": "Brassicas"},
 			want: errPermutationSkipped,
 		},
 		{
 			name: "invalid dimension",
-			perm: MatrixPermutation{{Dimension: "family", Value: "Rose family"}},
+			perm: MatrixPermutation{"family": "Rose family"},
 			want: errPermutationUnknownDimension,
 		},
 		{
 			name: "wrong dimension count",
 			perm: MatrixPermutation{
-				{Dimension: "", Value: "Mints"},
-				{Dimension: "", Value: "Rose family"},
+				"":       "Mints",
+				"family": "Rose family",
 			},
 			want: errPermutationLengthMismatch,
 		},
@@ -121,23 +98,23 @@ func TestMatrix_ValidatePermutation_Multiple(t *testing.T) {
 	matrix := &Matrix{
 		Setup: MatrixSetup{
 			"family":    {"Brassicas", "Rose family", "Nightshades"},
-			"plot":      {1, 2, 3, 4, 5},
-			"treatment": {false, true},
+			"plot":      {"1", "2", "3", "4", "5"},
+			"treatment": {"false", "true"},
 		},
 		Adjustments: MatrixAdjustments{
 			{
 				With: MatrixAdjustmentWith{
 					"family":    "Brassicas",
-					"plot":      3,
-					"treatment": true,
+					"plot":      "3",
+					"treatment": "true",
 				},
 				Skip: "yes",
 			},
 			{
 				With: MatrixAdjustmentWith{
 					"family":    "Alliums",
-					"plot":      6,
-					"treatment": true,
+					"plot":      "6",
+					"treatment": "true",
 				},
 			},
 		},
@@ -151,66 +128,57 @@ func TestMatrix_ValidatePermutation_Multiple(t *testing.T) {
 		{
 			name: "basic match",
 			perm: MatrixPermutation{
-				{Dimension: "family", Value: "Nightshades"},
-				{Dimension: "plot", Value: 2},
-				{Dimension: "treatment", Value: false},
+				"family":    "Nightshades",
+				"plot":      "2",
+				"treatment": "false",
 			},
 			want: nil,
 		},
 		{
 			name: "basic mismatch",
 			perm: MatrixPermutation{
-				{Dimension: "family", Value: "Nightshades"},
-				{Dimension: "plot", Value: 7},
-				{Dimension: "treatment", Value: false},
+				"family":    "Nightshades",
+				"plot":      "7",
+				"treatment": "false",
 			},
 			want: errPermutationNoMatch,
 		},
 		{
 			name: "adjustment match",
 			perm: MatrixPermutation{
-				{Dimension: "family", Value: "Alliums"},
-				{Dimension: "plot", Value: 6},
-				{Dimension: "treatment", Value: true},
+				"family":    "Alliums",
+				"plot":      "6",
+				"treatment": "true",
 			},
 			want: nil,
 		},
 		{
 			name: "adjustment skip",
 			perm: MatrixPermutation{
-				{Dimension: "family", Value: "Brassicas"},
-				{Dimension: "plot", Value: 3},
-				{Dimension: "treatment", Value: true},
+				"family":    "Brassicas",
+				"plot":      "3",
+				"treatment": "true",
 			},
 			want: errPermutationSkipped,
 		},
 		{
 			name: "wrong dimension count",
 			perm: MatrixPermutation{
-				{Dimension: "family", Value: "Rose family"},
-				{Dimension: "plot", Value: 3},
-				{Dimension: "treatment", Value: false},
-				{Dimension: "crimes", Value: "p-hacking"},
+				"family":    "Rose family",
+				"plot":      "3",
+				"treatment": "false",
+				"crimes":    "p-hacking",
 			},
 			want: errPermutationLengthMismatch,
 		},
 		{
 			name: "invalid dimension",
 			perm: MatrixPermutation{
-				{Dimension: "", Value: "Rose family"},
-				{Dimension: "plot", Value: 3},
-				{Dimension: "treatment", Value: false},
+				"":          "Rose family",
+				"plot":      "3",
+				"treatment": "false",
 			},
 			want: errPermutationUnknownDimension,
-		},
-		{
-			name: "repeated dimension",
-			perm: MatrixPermutation{
-				{Dimension: "family", Value: "Lamiaceae"},
-				{Dimension: "family", Value: "Rose family"},
-				{Dimension: "plot", Value: 1},
-			},
-			want: errPermutationRepeatedDimension,
 		},
 	}
 
@@ -245,7 +213,7 @@ func TestMatrix_ValidatePermutation_Nil(t *testing.T) {
 		{
 			name: "non-empty permutation",
 			perm: MatrixPermutation{
-				{Dimension: "Twin Peaks", Value: "cherry pie"},
+				"Twin Peaks": "cherry pie",
 			},
 			want: errNilMatrix,
 		},
@@ -268,9 +236,9 @@ func TestMatrix_ValidatePermutation_InvalidAdjustment(t *testing.T) {
 	t.Parallel()
 
 	perm := MatrixPermutation{
-		{Dimension: "family", Value: "Brassicas"},
-		{Dimension: "plot", Value: 3},
-		{Dimension: "treatment", Value: true},
+		"family":    "Brassicas",
+		"plot":      "3",
+		"treatment": "true",
 	}
 
 	tests := []struct {
@@ -283,14 +251,14 @@ func TestMatrix_ValidatePermutation_InvalidAdjustment(t *testing.T) {
 			matrix: &Matrix{
 				Setup: MatrixSetup{
 					"family":    {"Brassicas", "Rose family", "Nightshades"},
-					"plot":      {1, 2, 3, 4, 5},
-					"treatment": {false, true},
+					"plot":      {"1", "2", "3", "4", "5"},
+					"treatment": {"false", "true"},
 				},
 				Adjustments: MatrixAdjustments{
 					{
 						With: MatrixAdjustmentWith{
 							"family":    "Brassicas",
-							"treatment": true,
+							"treatment": "true",
 						},
 					},
 				},
@@ -302,8 +270,8 @@ func TestMatrix_ValidatePermutation_InvalidAdjustment(t *testing.T) {
 			matrix: &Matrix{
 				Setup: MatrixSetup{
 					"family":    {"Brassicas", "Rose family", "Nightshades"},
-					"plot":      {1, 2, 3, 4, 5},
-					"treatment": {false, true},
+					"plot":      {"1", "2", "3", "4", "5"},
+					"treatment": {"false", "true"},
 				},
 				Adjustments: MatrixAdjustments{
 					{
@@ -336,22 +304,22 @@ func TestMatrix_ValidatePermutation_RepeatAdjustment(t *testing.T) {
 	matrix := &Matrix{
 		Setup: MatrixSetup{
 			"family":    {"Brassicas", "Rose family", "Nightshades"},
-			"plot":      {1, 2, 3, 4, 5},
-			"treatment": {false, true},
+			"plot":      {"1", "2", "3", "4", "5"},
+			"treatment": {"false", "true"},
 		},
 		Adjustments: MatrixAdjustments{
 			{
 				With: MatrixAdjustmentWith{
 					"family":    "Brassicas",
-					"plot":      3,
-					"treatment": true,
+					"plot":      "3",
+					"treatment": "true",
 				},
 			},
 			{ // repeated adjustment! "skip: true" takes precedence.
 				With: MatrixAdjustmentWith{
 					"family":    "Brassicas",
-					"plot":      3,
-					"treatment": true,
+					"plot":      "3",
+					"treatment": "true",
 				},
 				Skip: "yes",
 			},
@@ -359,9 +327,9 @@ func TestMatrix_ValidatePermutation_RepeatAdjustment(t *testing.T) {
 	}
 
 	perm := MatrixPermutation{
-		{Dimension: "family", Value: "Brassicas"},
-		{Dimension: "plot", Value: 3},
-		{Dimension: "treatment", Value: true},
+		"family":    "Brassicas",
+		"plot":      "3",
+		"treatment": "true",
 	}
 
 	err := matrix.validatePermutation(perm)
@@ -376,22 +344,18 @@ func TestMatrixPermutation_UnmarshalJSON(t *testing.T) {
 	var got MatrixPermutation
 	const input = `{
 		"family": "Brassicas",
-		"plot": 3,
-		"treatment": true
+		"plot": "3",
+		"treatment": "true"
 	}`
 
 	if err := json.Unmarshal([]byte(input), &got); err != nil {
 		t.Fatalf("json.Unmarshal(%q, got) = %v", input, err)
 	}
 
-	sort.Slice(got, func(i, j int) bool {
-		return got[i].Dimension < got[j].Dimension
-	})
-
 	want := MatrixPermutation{
-		{Dimension: "family", Value: "Brassicas"},
-		{Dimension: "plot", Value: 3},
-		{Dimension: "treatment", Value: true},
+		"family":    "Brassicas",
+		"plot":      "3",
+		"treatment": "true",
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("unmarshalled MatrixPermutation diff (-got +want):\n%s", diff)

--- a/internal/pipeline/step_command_test.go
+++ b/internal/pipeline/step_command_test.go
@@ -115,8 +115,8 @@ func TestStepCommandMatrixInterpolate(t *testing.T) {
 		{
 			name: "it interplates environment variable values",
 			ms: MatrixPermutation{
-				{Dimension: "name", Value: "Taylor Launtner"},
-				{Dimension: "value", Value: "true"},
+				"name":  "Taylor Launtner",
+				"value": "true",
 			},
 			step: &CommandStep{
 				Command: "script/buildkite/xxx.sh",
@@ -136,8 +136,8 @@ func TestStepCommandMatrixInterpolate(t *testing.T) {
 		{
 			name: "it interpolates plugin config",
 			ms: MatrixPermutation{
-				{Dimension: "docker_version", Value: "4.5.6"},
-				{Dimension: "image", Value: "alpine"},
+				"docker_version": "4.5.6",
+				"image":          "alpine",
 			},
 			step: &CommandStep{
 				Command: "script/buildkite/xxx.sh",
@@ -165,8 +165,8 @@ func TestStepCommandMatrixInterpolate(t *testing.T) {
 		{
 			name: "it interpolates commands",
 			ms: MatrixPermutation{
-				{Dimension: "goos", Value: "linux"},
-				{Dimension: "goarch", Value: "amd64"},
+				"goos":   "linux",
+				"goarch": "amd64",
 			},
 			step: &CommandStep{Command: "GOOS={{matrix.goos}} GOARCH={{matrix.goarch}} go build -o foobar ."},
 			want: &CommandStep{Command: "GOOS=linux GOARCH=amd64 go build -o foobar ."},


### PR DESCRIPTION
This PR does two things:

1. (Fixes a verification bug) All scalars inside `Matrix` are stored as strings. During parsing they are all `fmt.Sprint`-ed. `MatrixScalars` is gone. `MatrixSetup` is now `map[string][]string` and `MatrixAdjustmentWith` is now `map[string]string`. This should fix verification when non-string scalars are used, because the backend at some point stringifies them all, before they are reflected back in the job payload, meaning that the JSONified `Matrix`es are different during verification, manifesting as a signature verification failure. Stringifying everything in advance should be no issue, because there is no difference between the results of interpolating `47` and `"47"` into a matrix token.
2. (Willing to go back on this) `MatrixPermutation` is now `map[string]string`, removing `SelectedDimension`. The alternative is to make the backend output be an array, but using a map removes one of the error cases in permutation validation (dupes) and also lets us remove `UnmarshalJSON` (without altering the current backend output - either way it's a PR here or there). But I didn't mind `MatrixPermutation` so much really.