### PR TITLE
Push all new agent packages to Packagecloud

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -69,6 +69,21 @@ steps:
         - exit_status: 1
           limit: 3
 
+  - name: ":debian: Publish Edge Debian Package to Packagecloud"
+    command: ".buildkite/steps/publish-debian-packagecloud.sh"
+    env:
+      REPOSITORY: "buildkite/agent-experimental"
+      DISTRO_VERSION: any/any
+    agents:
+      queue: "deploy"
+    plugins:
+      - docker#v5.8.0:
+          image: "public.ecr.aws/docker/library/ruby:3.0"
+          entrypoint: bash
+          propagate-environment: true
+          mount-buildkite-agent: true
+    soft_fail: true
+
   - name: ":docker: Publish Edge Docker Images"
     command: ".buildkite/steps/publish-docker-images.sh"
     env:

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -56,6 +56,21 @@ steps:
         - exit_status: 1
           limit: 3
 
+  - name: ":redhat: Publish RPM Package to Packagecloud"
+    command: ".buildkite/steps/publish-rpm-packagecloud.sh"
+    env:
+      REPOSITORY: "buildkite/agent"
+      DISTRO_VERSION: rpm_any/rpm_any
+    agents:
+      queue: "deploy"
+    plugins:
+      - docker#v5.8.0:
+          image: "public.ecr.aws/docker/library/ruby:3.0"
+          entrypoint: bash
+          propagate-environment: true
+          mount-buildkite-agent: true
+    soft_fail: true
+
   - name: ":debian: Publish Debian Package"
     command: ".buildkite/steps/publish-debian-package.sh"
     env:
@@ -73,6 +88,21 @@ steps:
           mount-buildkite-agent: true
           tmpfs:
             - "/root/.gnupg"
+
+  - name: ":debian: Publish Debian Package to Packagecloud"
+    command: ".buildkite/steps/publish-debian-packagecloud.sh"
+    env:
+      REPOSITORY: "buildkite/agent"
+      DISTRO_VERSION: any/any
+    agents:
+      queue: "deploy"
+    plugins:
+      - docker#v5.8.0:
+          image: "public.ecr.aws/docker/library/ruby:3.0"
+          entrypoint: bash
+          propagate-environment: true
+          mount-buildkite-agent: true
+    soft_fail: true
 
   - name: ":docker: Publish Docker Images"
     command: ".buildkite/steps/publish-docker-images.sh"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -56,6 +56,21 @@ steps:
         - exit_status: 1
           limit: 3
 
+  - name: ":redhat: Publish Unstable RPM Package to Packagecloud"
+    command: ".buildkite/steps/publish-rpm-packagecloud.sh"
+    env:
+      REPOSITORY: "buildkite/agent-unstable"
+      DISTRO_VERSION: rpm_any/rpm_any
+    agents:
+      queue: "deploy"
+    plugins:
+      - docker#v5.8.0:
+          image: "public.ecr.aws/docker/library/ruby:3.0"
+          entrypoint: bash
+          propagate-environment: true
+          mount-buildkite-agent: true
+    soft_fail: true
+
   - name: ":debian: Publish Unstable Debian Package"
     command: ".buildkite/steps/publish-debian-package.sh"
     env:
@@ -73,6 +88,21 @@ steps:
           mount-buildkite-agent: true
           tmpfs:
             - "/root/.gnupg"
+
+  - name: ":debian: Publish Unstable Debian Package to Packagecloud"
+    command: ".buildkite/steps/publish-debian-packagecloud.sh"
+    env:
+      REPOSITORY: "buildkite/agent-unstable"
+      DISTRO_VERSION: any/any
+    agents:
+      queue: "deploy"
+    plugins:
+      - docker#v5.8.0:
+          image: "public.ecr.aws/docker/library/ruby:3.0"
+          entrypoint: bash
+          propagate-environment: true
+          mount-buildkite-agent: true
+    soft_fail: true
 
   - name: ":docker: Publish Unstable Docker Images"
     command: ".buildkite/steps/publish-docker-images.sh"

--- a/.buildkite/steps/publish-debian-packagecloud.sh
+++ b/.buildkite/steps/publish-debian-packagecloud.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+artifacts_build="$(buildkite-agent meta-data get "agent-artifacts-build")"
+
+dry_run() {
+  if [[ "${DRY_RUN:-}" == "false" ]] ; then
+    "$@"
+  else
+    echo "[dry-run] $*"
+  fi
+}
+
+if [[ "${REPOSITORY:-}" == "" ]]; then
+  echo "Error: Missing \$REPOSITORY (<user>/<repository>; i.e. buildkite/agent-experimental)"
+  exit 1
+fi
+
+if [[ "${DISTRO_VERSION:-}" == "" ]]; then
+  echo "Error: Missing \$DISTRO_VERSION (<os>/<version>; i.e. any/any)"
+  exit 1
+fi
+
+echo "--- Clearing deb directory"
+rm -rvf deb
+mkdir -p deb
+
+echo "--- Downloading built debian packages"
+buildkite-agent artifact download --build "${artifacts_build}" "deb/*.deb" deb/
+
+echo "--- Installing dependencies"
+gem install package_cloud
+
+echo "--- Requesting OIDC token"
+export PACKAGECLOUD_TOKEN="$(buildkite-agent oidc request-token --audience "https://packagecloud.io/${REPOSITORY}" --lifetime 300)"
+
+echo "--- Pushing to Packagecloud"
+dry_run package_cloud push "${REPOSITORY}/${DISTRO_VERSION}" deb/*.deb


### PR DESCRIPTION
Now that the step from #2438 is [functional](https://buildkite.com/buildkite/agent-release-edge/builds/987#018b4563-e579-4417-a557-2d9e6ec2f59c), this should complete coverage over stable, unstable and experimental repositories for both debian and rpm.

The appropriate policies have been set up for these package repositories ahead of time.

Fixes PKG-5934.