### PR TITLE
Revert "Hotfix: Try ruby image"

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -41,7 +41,7 @@ steps:
       queue: "deploy"
     plugins:
       - docker#v5.8.0:
-          image: "public.ecr.aws/docker/library/ruby:3.0"
+          image: "buildkite/agent:3.55.0-ubuntu"
           entrypoint: bash
           propagate-environment: true
           mount-buildkite-agent: true


### PR DESCRIPTION
This reverts commit 0d7bd6c50dc54bc9ed6783d74c0a7ba74f6ba702.

Due to a misconfiguration in branch protection settings, this commit was erroneously pushed straight to main. We've fixed the issue across this and other repos, and will re-submit this change with review.