### PR TITLE
Update packagecloud RPM release step to use `ruby:3.0` image

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -41,7 +41,7 @@ steps:
       queue: "deploy"
     plugins:
       - docker#v5.8.0:
-          image: "buildkite/agent:3.55.0-ubuntu"
+          image: "public.ecr.aws/docker/library/ruby:3.0"
           entrypoint: bash
           propagate-environment: true
           mount-buildkite-agent: true


### PR DESCRIPTION
Turns out the agent image doesn't have ruby, so can't gem install. The ruby image seems to work great in a dry-run, though.