### PR TITLE
Do not print warning min len warning if value matches boolean pattern

### DIFF
--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -4,7 +4,7 @@ package redact
 import (
 	"github.com/buildkite/agent/v3/internal/job/shell"
 	"path"
-	"regexp"
+	"strings"
 )
 
 // LengthMin is the shortest string length that will be considered a
@@ -43,10 +43,6 @@ func Vars(logger shell.Logger, patterns []string, environment map[string]string)
 	// Lifted out of Bootstrap.setupRedactors to facilitate testing
 	vars := make(map[string]string)
 
-	// Define a regex pattern for "true," "false," "yes," or "no" (case-insensitive)
-	// This will be used to ignore the min length warning
-	booleanPattern := `^(?i:true|false|yes|no)$`
-
 	for name, val := range environment {
 		for _, pattern := range patterns {
 			matched, err := path.Match(pattern, name)
@@ -61,7 +57,7 @@ func Vars(logger shell.Logger, patterns []string, environment map[string]string)
 			}
 			if len(val) < LengthMin {
 				// Only if var length is greater than 0, and it doesn't match booleanPattern
-				if len(val) > 0 && !regexp.MustCompile(booleanPattern).MatchString(val) {
+				if len(val) > 0 && !path.Match("true|false|yes|no", strings.ToLower(val)) {
 					logger.Warningf("Value of %s below minimum length (%d bytes) and will not be redacted", name, LengthMin)
 				}
 				continue


### PR DESCRIPTION
Currently redactor part of code prints warning that it isn't going to redact because of
value being less than minimum length.

This warning gets a little annoying when its printed regularly for envs like `BUILDKIT_NO_CLIENT_TOKEN=true` which isn't sensitive but matches the redactor pattern of `*_TOKEN`.

This avoids printing warning for when value for env key matching redactor pattern and with value size less than min length with value `true`, `false`, `yes` or `no`.

![image](https://github.com/buildkite/agent/assets/102168038/4c9be33f-1e94-4f94-9559-f4c34c45d025)
