### PR TITLE
experiment: pty-raw avoids LF→CRLF mapping by setting PTY to raw mode

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -117,3 +117,15 @@ The new glob library should resolve a few issues experienced with the old librar
 The new library should handle all syntax supported by the old library, but because of the chance of incompatibilities and bugs, we're providing it via experiment only for now.
 
 **Status:** Since using the old library causes problems, we hope to promote this to be the default soon™️.
+
+### `pty-raw`
+
+Set PTY to raw mode, to avoid mapping LF (\n) to CR,LF (\r\n) in job command output.
+These extra newline characters are normally not noticed, but can make raw logs appear double-spaced
+in some circumstances.
+
+We run commands in a PTY mostly (entirely?) so that the program detects a PTY and behaves like it's
+running in a terminal, using ANSI escapes to provide colours, progress meters etc. But we don't need
+the PTY to modify the stream. (Or do we? That's why this is an experiment)
+
+**Status:** Experimental for some opt-in testing before being promoted to always-on.

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	golang.org/x/oauth2 v0.13.0
 	golang.org/x/sys v0.13.0
+	golang.org/x/term v0.13.0
 	google.golang.org/api v0.147.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.55.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -112,7 +113,6 @@ require (
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/term v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.12.1-0.20230815132531-74c255bcf846 // indirect

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -28,6 +28,7 @@ const (
 	JobAPI                     = "job-api"
 	KubernetesExec             = "kubernetes-exec"
 	NormalisedUploadPaths      = "normalised-upload-paths"
+	PTYRaw                     = "pty-raw"
 	PolyglotHooks              = "polyglot-hooks"
 	ResolveCommitAfterCheckout = "resolve-commit-after-checkout"
 	AvoidRecursiveTrap         = "avoid-recursive-trap"

--- a/process/main_test.go
+++ b/process/main_test.go
@@ -24,10 +24,10 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 
 	case "output":
-		fmt.Fprintf(os.Stdout, "llamas1")
-		fmt.Fprintf(os.Stderr, "alpacas1")
-		fmt.Fprintf(os.Stdout, "llamas2")
-		fmt.Fprintf(os.Stderr, "alpacas2")
+		fmt.Fprintf(os.Stdout, "llamas1\n")
+		fmt.Fprintf(os.Stderr, "alpacas1\r")
+		fmt.Fprintf(os.Stdout, "llamas2\r\n")
+		fmt.Fprintf(os.Stderr, "alpacas2\n")
 		os.Exit(0)
 
 	// don't handle the signals so that we can detect the process was signaled


### PR DESCRIPTION
The command inside a build job is allocated and attached to a [Pseudoterminal](https://en.wikipedia.org/wiki/Pseudoterminal) so that programs detect that their output will be interpreted by a terminal emulator, and so they default to emitting colours, cursor movement, and other escape sequences.

This pull request sets that PTY into raw mode, disabling any default processing of the input/output streams, most specifically the [`ONLCR` flag](https://man.archlinux.org/man/termios.h.0p#ONLCR): “Map NL to CR-NL on output”.

Otherwise the PTY driver in the kernel will map `LF` (`\n`) to `CR` `LF` (`\r\n`), and possibly do other unwanted processing of the output stream. This is particularly vexing when programs intentionally (misguidedly?) emit `CR LF` newlines which get mapped to `CR CR LF`.

This is behind an experiment because it's _possible_ that by entering raw mode we're turning off some default PTY input or output processing that some programs actually rely on in some situations.

- Fixes #736