### PR TITLE
Add some pipeline invariants to the signature and create a cli subcommand to sign a pipeline

### DIFF
--- a/agent/integration/job_verification_integration_test.go
+++ b/agent/integration/job_verification_integration_test.go
@@ -607,6 +607,8 @@ func symmetricJWKFor(t *testing.T, payload string) jwk.Key {
 }
 
 func jwksFromKeys(t *testing.T, jwkes ...jwk.Key) jwk.Set {
+	t.Helper()
+
 	set := jwk.NewSet()
 	for _, jwk := range jwkes {
 		err := set.AddKey(jwk)

--- a/agent/integration/job_verification_integration_test.go
+++ b/agent/integration/job_verification_integration_test.go
@@ -534,7 +534,7 @@ func TestJobVerification(t *testing.T) {
 				PipelineInvariants: tc.pipelineInvariants,
 			}
 
-			tc.job.Step = signStep(t, pipelineUploadEnv, stepWithInvariants, tc.signingKey)
+			tc.job.Step = signStep(t, tc.signingKey, pipelineUploadEnv, stepWithInvariants)
 			runJob(t, ctx, testRunJobConfig{
 				job:              &tc.job,
 				server:           server,
@@ -622,9 +622,9 @@ func jwksFromKeys(t *testing.T, jwkes ...jwk.Key) jwk.Set {
 
 func signStep(
 	t *testing.T,
+	key jwk.Key,
 	env map[string]string,
 	stepWithInvariants pipeline.CommandStepWithPipelineInvariants,
-	key jwk.Key,
 ) pipeline.CommandStep {
 	t.Helper()
 
@@ -633,7 +633,7 @@ func signStep(
 		return stepWithInvariants.CommandStep
 	}
 
-	signature, err := pipeline.Sign(env, &stepWithInvariants, key)
+	signature, err := pipeline.Sign(key, env, &stepWithInvariants)
 	if err != nil {
 		t.Fatalf("signing step: %v", err)
 	}

--- a/agent/verify_job.go
+++ b/agent/verify_job.go
@@ -189,7 +189,7 @@ func (r *JobRunner) verifyJob(keySet jwk.Set) error {
 			continue
 
 		case "pipeline_invariants":
-			// These were sourced from the job itself, not the step when the signature was verified.
+			// These were sourced from the job itself, not the step, when the signature was verified.
 			// So, we don't need to compare that the values in the job are the same as those in the step.
 			continue
 

--- a/agent/verify_job.go
+++ b/agent/verify_job.go
@@ -67,7 +67,7 @@ func (r *JobRunner) verifyJob(keySet jwk.Set) error {
 	}
 
 	// Verify the signature
-	if err := step.Signature.Verify(r.conf.Job.Env, stepWithInvariants, r.conf.JWKS); err != nil {
+	if err := step.Signature.Verify(r.conf.JWKS, r.conf.Job.Env, stepWithInvariants); err != nil {
 		r.logger.Debug("verifyJob: step.Signature.Verify(Job.Env, stepWithInvariants, JWKS) = %v", err)
 		return newInvalidSignatureError(ErrVerificationFailed)
 	}

--- a/clicommand/commands.go
+++ b/clicommand/commands.go
@@ -82,6 +82,7 @@ var BuildkiteAgentCommands = []cli.Command{
 		Usage: "Utility commands, intended for users and operators of the agent to run directly on their machines, and not as part of a Buildkite job",
 		Subcommands: []cli.Command{
 			KeygenCommand,
+			SignCommand,
 		},
 	},
 }

--- a/clicommand/commands.go
+++ b/clicommand/commands.go
@@ -82,7 +82,7 @@ var BuildkiteAgentCommands = []cli.Command{
 		Usage: "Utility commands, intended for users and operators of the agent to run directly on their machines, and not as part of a Buildkite job",
 		Subcommands: []cli.Command{
 			KeygenCommand,
-			SignCommand,
+			ToolSignCommand,
 		},
 	},
 }

--- a/clicommand/commands.go
+++ b/clicommand/commands.go
@@ -81,7 +81,7 @@ var BuildkiteAgentCommands = []cli.Command{
 		Name:  "tool",
 		Usage: "Utility commands, intended for users and operators of the agent to run directly on their machines, and not as part of a Buildkite job",
 		Subcommands: []cli.Command{
-			KeygenCommand,
+			ToolKeygenCommand,
 			ToolSignCommand,
 		},
 	},

--- a/clicommand/config_completeness_test.go
+++ b/clicommand/config_completeness_test.go
@@ -41,6 +41,7 @@ var commandConfigPairs = []configCommandPair{
 	{Config: StepGetConfig{}, Command: StepGetCommand},
 	{Config: StepUpdateConfig{}, Command: StepUpdateCommand},
 	{Config: KeygenConfig{}, Command: KeygenCommand},
+	{Config: ToolSignConfig{}, Command: ToolSignCommand},
 }
 
 func TestAllCommandConfigStructsHaveCorrespondingCLIFlags(t *testing.T) {

--- a/clicommand/config_completeness_test.go
+++ b/clicommand/config_completeness_test.go
@@ -40,7 +40,7 @@ var commandConfigPairs = []configCommandPair{
 	{Config: PipelineUploadConfig{}, Command: PipelineUploadCommand},
 	{Config: StepGetConfig{}, Command: StepGetCommand},
 	{Config: StepUpdateConfig{}, Command: StepUpdateCommand},
-	{Config: KeygenConfig{}, Command: KeygenCommand},
+	{Config: ToolKeygenConfig{}, Command: ToolKeygenCommand},
 	{Config: ToolSignConfig{}, Command: ToolSignCommand},
 }
 

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -72,6 +72,7 @@ type PipelineUploadConfig struct {
 
 	JWKSFilePath string `cli:"jwks-file-path"`
 	SigningKeyID string `cli:"signing-key-id"`
+	ExpireAfter  string `cli:"expire-after"`
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
@@ -133,6 +134,12 @@ var PipelineUploadCommand = cli.Command{
 			Name:   "signing-key-id",
 			Usage:  "EXPERIMENTAL: The JWKS key ID to use when signing the pipeline. Required when using a JWKS",
 			EnvVar: "BUILDKITE_PIPELINE_UPLOAD_SIGNING_KEY_ID",
+		},
+		cli.StringFlag{
+			Name:   "expire-after",
+			Usage:  "EXPERIMENTAL: The duration after which the pipeline signature expires. The format is a duration string, e.g. 24h30m",
+			EnvVar: "BUILDKITE_PIPELINE_UPLOAD_EXPIRE_AFTER",
+			Value:  "24h",
 		},
 
 		// API Flags
@@ -277,6 +284,12 @@ var PipelineUploadCommand = cli.Command{
 		if cfg.JWKSFilePath != "" {
 			l.Warn("Pipeline signing is experimental and the user interface might change! Also it might not work, it might sign the pipeline only partially, or it might eat your pet dog. You have been warned!")
 
+			// TODO: find a place to store expiry in the backend
+			// expireAfter, err := time.ParseDuration(cfg.ExpireAfter)
+			_, err := time.ParseDuration(cfg.ExpireAfter)
+			if err != nil {
+				return fmt.Errorf("couldn't parse expire-after duration: %w", err)
+			}
 			key, err := loadSigningKey(cfg)
 			if err != nil {
 				return fmt.Errorf("couldn't read the signing key file: %w", err)

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -72,7 +72,6 @@ type PipelineUploadConfig struct {
 
 	JWKSFilePath string `cli:"jwks-file-path"`
 	SigningKeyID string `cli:"signing-key-id"`
-	ExpireAfter  string `cli:"expire-after"`
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
@@ -134,12 +133,6 @@ var PipelineUploadCommand = cli.Command{
 			Name:   "signing-key-id",
 			Usage:  "EXPERIMENTAL: The JWKS key ID to use when signing the pipeline. Required when using a JWKS",
 			EnvVar: "BUILDKITE_PIPELINE_UPLOAD_SIGNING_KEY_ID",
-		},
-		cli.StringFlag{
-			Name:   "expire-after",
-			Usage:  "EXPERIMENTAL: The duration after which the pipeline signature expires. The format is a duration string, e.g. 24h30m",
-			EnvVar: "BUILDKITE_PIPELINE_UPLOAD_EXPIRE_AFTER",
-			Value:  "24h",
 		},
 
 		// API Flags
@@ -283,13 +276,6 @@ var PipelineUploadCommand = cli.Command{
 
 		if cfg.JWKSFilePath != "" {
 			l.Warn("Pipeline signing is experimental and the user interface might change! Also it might not work, it might sign the pipeline only partially, or it might eat your pet dog. You have been warned!")
-
-			// TODO: find a place to store expiry in the backend
-			// expireAfter, err := time.ParseDuration(cfg.ExpireAfter)
-			_, err := time.ParseDuration(cfg.ExpireAfter)
-			if err != nil {
-				return fmt.Errorf("couldn't parse expire-after duration: %w", err)
-			}
 
 			pInv := &pipeline.PipelineInvariants{
 				OrganizationSlug: environ.GetStringDefaultEmpty("BUILDKITE_ORGANIZATION_SLUG"),

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -117,7 +117,7 @@ var PipelineUploadCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name:   "no-interpolation",
-			Usage:  "Skip variable interpolation the pipeline when uploaded",
+			Usage:  "Skip variable interpolation into the pipeline prior to upload",
 			EnvVar: "BUILDKITE_PIPELINE_NO_INTERPOLATION",
 		},
 		cli.BoolFlag{

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -291,23 +291,10 @@ var PipelineUploadCommand = cli.Command{
 				return fmt.Errorf("couldn't parse expire-after duration: %w", err)
 			}
 
-			inv := &pipeline.Invariants{
-				Pipeline: pipeline.PipelineInvariants{
-					OrganizationSlug: environ.GetStringDefaultEmpty("BUILDKITE_ORGANIZATION_SLUG"),
-					PipelineSlug:     environ.GetStringDefaultEmpty("BUILDKITE_PIPELINE_SLUG"),
-					Repository:       environ.GetStringDefaultEmpty("BUILDKITE_REPO"),
-				},
-				Build: pipeline.BuildInvariants{
-					Id:     environ.GetStringDefaultEmpty("BUILDKITE_BUILD_ID"),
-					Number: environ.GetStringDefaultEmpty("BUILDKITE_BUILD_NUMBER"),
-					Branch: environ.GetStringDefaultEmpty("BUILDKITE_BRANCH"),
-					Tag:    environ.GetStringDefaultEmpty("BUILDKITE_TAG"),
-					Commit: environ.GetStringDefaultEmpty("BUILDKITE_COMMIT"),
-				},
-				Time: pipeline.TimeInvariants{
-					// TODO: find a place to store expiry in the backend
-					// Expiry: time.Now().Add(expireAfter),
-				},
+			pInv := &pipeline.PipelineInvariants{
+				OrganizationSlug: environ.GetStringDefaultEmpty("BUILDKITE_ORGANIZATION_SLUG"),
+				PipelineSlug:     environ.GetStringDefaultEmpty("BUILDKITE_PIPELINE_SLUG"),
+				Repository:       environ.GetStringDefaultEmpty("BUILDKITE_REPO"),
 			}
 
 			key, err := loadSigningKey(&cfg)
@@ -315,7 +302,7 @@ var PipelineUploadCommand = cli.Command{
 				return fmt.Errorf("couldn't read the signing key file: %w", err)
 			}
 
-			if err := result.Sign(key, inv); err != nil {
+			if err := result.Sign(key, pInv); err != nil {
 				return fmt.Errorf("couldn't sign pipeline: %w", err)
 			}
 		}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -290,12 +290,32 @@ var PipelineUploadCommand = cli.Command{
 			if err != nil {
 				return fmt.Errorf("couldn't parse expire-after duration: %w", err)
 			}
+
+			inv := &pipeline.Invariants{
+				Pipeline: pipeline.PipelineInvariants{
+					OrganizationSlug: environ.GetStringDefaultEmpty("BUILDKITE_ORGANIZATION_SLUG"),
+					PipelineSlug:     environ.GetStringDefaultEmpty("BUILDKITE_PIPELINE_SLUG"),
+					Repository:       environ.GetStringDefaultEmpty("BUILDKITE_REPO"),
+				},
+				Build: pipeline.BuildInvariants{
+					Id:     environ.GetStringDefaultEmpty("BUILDKITE_BUILD_ID"),
+					Number: environ.GetStringDefaultEmpty("BUILDKITE_BUILD_NUMBER"),
+					Branch: environ.GetStringDefaultEmpty("BUILDKITE_BRANCH"),
+					Tag:    environ.GetStringDefaultEmpty("BUILDKITE_TAG"),
+					Commit: environ.GetStringDefaultEmpty("BUILDKITE_COMMIT"),
+				},
+				Time: pipeline.TimeInvariants{
+					// TODO: find a place to store expiry in the backend
+					// Expiry: time.Now().Add(expireAfter),
+				},
+			}
+
 			key, err := loadSigningKey(cfg)
 			if err != nil {
 				return fmt.Errorf("couldn't read the signing key file: %w", err)
 			}
 
-			if err := result.Sign(key); err != nil {
+			if err := result.Sign(key, inv); err != nil {
 				return fmt.Errorf("couldn't sign pipeline: %w", err)
 			}
 		}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -277,10 +277,11 @@ var PipelineUploadCommand = cli.Command{
 		if cfg.JWKSFilePath != "" {
 			l.Warn("Pipeline signing is experimental and the user interface might change! Also it might not work, it might sign the pipeline only partially, or it might eat your pet dog. You have been warned!")
 
+			// we populate this with env vars whether or not interpolation is enabled, so we can't use `environ`
 			pInv := &pipeline.PipelineInvariants{
-				OrganizationSlug: environ.GetStringDefaultEmpty("BUILDKITE_ORGANIZATION_SLUG"),
-				PipelineSlug:     environ.GetStringDefaultEmpty("BUILDKITE_PIPELINE_SLUG"),
-				Repository:       environ.GetStringDefaultEmpty("BUILDKITE_REPO"),
+				OrganizationSlug: os.Getenv("BUILDKITE_ORGANIZATION_SLUG"),
+				PipelineSlug:     os.Getenv("BUILDKITE_PIPELINE_SLUG"),
+				Repository:       os.Getenv("BUILDKITE_REPO"),
 			}
 
 			key, err := loadSigningKey(&cfg)

--- a/clicommand/tool_keygen.go
+++ b/clicommand/tool_keygen.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-type KeygenConfig struct {
+type ToolKeygenConfig struct {
 	Alg                   string `cli:"alg" validate:"required"`
 	KeyID                 string `cli:"key-id"`
 	PrivateKeySetFilename string `cli:"private-keyset-filename" normalize:"filepath"`
@@ -27,7 +27,7 @@ type KeygenConfig struct {
 }
 
 // TODO: Add docs link when there is one.
-var KeygenCommand = cli.Command{
+var ToolKeygenCommand = cli.Command{
 	Name:  "keygen",
 	Usage: "Generate a new JWS key pair, used for signing and verifying jobs in Buildkite",
 	Description: `Usage:
@@ -71,7 +71,7 @@ For more information about JWS, see https://tools.ietf.org/html/rfc7515 and for 
 		ProfileFlag,
 	},
 	Action: func(c *cli.Context) {
-		_, cfg, l, _, done := setupLoggerAndConfig[KeygenConfig](context.Background(), c)
+		_, cfg, l, _, done := setupLoggerAndConfig[ToolKeygenConfig](context.Background(), c)
 		defer done()
 
 		l.Warn("Pipeline signing is experimental and the user interface might change! Also it might not work, it might sign the pipeline only partially, or it might eat your pet dog. You have been warned!")

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -1,0 +1,161 @@
+package clicommand
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/buildkite/agent/v3/internal/pipeline"
+	"github.com/buildkite/agent/v3/internal/stdin"
+	"github.com/urfave/cli"
+	"gopkg.in/yaml.v3"
+)
+
+type ToolSignConfig struct {
+	FilePath string `cli:"arg:0" label:"upload paths"`
+
+	JWKSFilePath string `cli:"jwks-file-path"`
+	SigningKeyID string `cli:"signing-key-id"`
+
+	// Pipeline invariants
+	OrganizationSlug string `cli:"organization-slug"`
+	PipelineSlug     string `cli:"pipeline-slug"`
+	Repository       string `cli:"repo"`
+
+	// Global flags
+	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
+	NoColor     bool     `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile     string   `cli:"profile"`
+}
+
+var ErrNoPipeline = errors.New("no pipeline file found")
+
+var SignCommand = cli.Command{
+	Name:  "sign",
+	Usage: "Sign pipeline steps",
+	Description: `Usage:
+
+    buildkite-agent tool sign-pipeline [options...]
+
+Description:
+
+This (experimental!) command takes a pipeline in YAML or JSON format as input, and annotates the
+appropriate parts of the pipeline with signatures. This can then be input into the YAML steps
+editor in the Buildkite UI so that the agents running these steps can verify the signatures.`,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:     "jwks-file-path",
+			Usage:    "Path to a file containing a JWKS.",
+			EnvVar:   "BUILDKITE_PIPELINE_UPLOAD_JWKS_FILE_PATH",
+			Required: true,
+		},
+		cli.StringFlag{
+			Name:     "signing-key-id",
+			Usage:    "The JWKS key ID to use when signing the pipeline.",
+			EnvVar:   "BUILDKITE_PIPELINE_UPLOAD_SIGNING_KEY_ID",
+			Required: true,
+		},
+
+		// Pipeline invariants
+		cli.StringFlag{
+			Name:     "organization-slug",
+			Usage:    "The organization slug to use when signing the pipeline.",
+			EnvVar:   "BUILDKITE_ORGANIZATION_SLUG",
+			Required: true,
+		},
+		cli.StringFlag{
+			Name:     "pipeline-slug",
+			Usage:    "The pipeline slug to use when signing the pipeline.",
+			EnvVar:   "BUILDKITE_PIPELINE_SLUG",
+			Required: true,
+		},
+		cli.StringFlag{
+			Name:     "repo",
+			Usage:    "The repository to use when signing the pipeline.",
+			EnvVar:   "BUILDKITE_REPO",
+			Required: true,
+		},
+
+		// Global flags
+		NoColorFlag,
+		DebugFlag,
+		LogLevelFlag,
+		ExperimentsFlag,
+		ProfileFlag,
+	},
+
+	Action: func(c *cli.Context) error {
+		_, cfg, l, _, done := setupLoggerAndConfig[ToolSignConfig](context.Background(), c)
+		defer done()
+
+		// Find the pipeline either from STDIN or the first argument
+		var input *os.File
+		var filename string
+
+		switch {
+		case cfg.FilePath != "":
+			l.Info("Reading pipeline config from %q", cfg.FilePath)
+
+			file, err := os.Open(cfg.FilePath)
+			if err != nil {
+				return fmt.Errorf("failed to read file: %w", err)
+			}
+			defer file.Close()
+
+			input = file
+			filename = cfg.FilePath
+
+		case stdin.IsReadable():
+			l.Info("Reading pipeline config from STDIN")
+
+			// Actually read the file from STDIN
+			input = os.Stdin
+			filename = "(stdin)"
+
+		default:
+			return ErrNoPipeline
+		}
+
+		// Parse the pipeline
+		result, err := pipeline.Parse(input)
+		if err != nil {
+			return fmt.Errorf("pipeline parsing of %q failed: %v", filename, err)
+		}
+
+		l.Debug("Pipeline parsed successfully: %v", result)
+
+		inv := &pipeline.Invariants{
+			Pipeline: pipeline.PipelineInvariants{
+				OrganizationSlug: cfg.OrganizationSlug,
+				PipelineSlug:     cfg.PipelineSlug,
+				Repository:       cfg.Repository,
+			},
+			Build: pipeline.BuildInvariants{},
+			Time:  pipeline.TimeInvariants{},
+		}
+
+		key, err := loadSigningKey(&cfg)
+		if err != nil {
+			return fmt.Errorf("couldn't read the signing key file: %w", err)
+		}
+
+		if err := result.Sign(key, inv); err != nil {
+			return fmt.Errorf("couldn't sign pipeline: %w", err)
+		}
+
+		enc := yaml.NewEncoder(c.App.Writer)
+		enc.SetIndent(2)
+		return enc.Encode(result)
+	},
+}
+
+func (cfg *ToolSignConfig) jwksFilePath() string {
+	return cfg.JWKSFilePath
+}
+
+func (cfg *ToolSignConfig) signingKeyId() string {
+	return cfg.SigningKeyID
+}

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -33,7 +33,7 @@ type ToolSignConfig struct {
 
 var ErrNoPipeline = errors.New("no pipeline file found")
 
-var SignCommand = cli.Command{
+var ToolSignCommand = cli.Command{
 	Name:  "sign",
 	Usage: "Sign pipeline steps",
 	Description: `Usage:

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -127,14 +127,10 @@ editor in the Buildkite UI so that the agents running these steps can verify the
 
 		l.Debug("Pipeline parsed successfully: %v", result)
 
-		inv := &pipeline.Invariants{
-			Pipeline: pipeline.PipelineInvariants{
-				OrganizationSlug: cfg.OrganizationSlug,
-				PipelineSlug:     cfg.PipelineSlug,
-				Repository:       cfg.Repository,
-			},
-			Build: pipeline.BuildInvariants{},
-			Time:  pipeline.TimeInvariants{},
+		pInv := &pipeline.PipelineInvariants{
+			OrganizationSlug: cfg.OrganizationSlug,
+			PipelineSlug:     cfg.PipelineSlug,
+			Repository:       cfg.Repository,
 		}
 
 		key, err := loadSigningKey(&cfg)
@@ -142,7 +138,7 @@ editor in the Buildkite UI so that the agents running these steps can verify the
 			return fmt.Errorf("couldn't read the signing key file: %w", err)
 		}
 
-		if err := result.Sign(key, inv); err != nil {
+		if err := result.Sign(key, pInv); err != nil {
 			return fmt.Errorf("couldn't sign pipeline: %w", err)
 		}
 

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -42,7 +42,7 @@ var ToolSignCommand = cli.Command{
 
 Description:
 
-This (experimental!) command takes a pipeline in YAML or JSON format as input, and annotates the
+This (experimental!) command takes a pipeline in YAML format as input, and annotates the
 appropriate parts of the pipeline with signatures. This can then be input into the YAML steps
 editor in the Buildkite UI so that the agents running these steps can verify the signatures.`,
 	Flags: []cli.Flag{

--- a/env/environment.go
+++ b/env/environment.go
@@ -98,6 +98,11 @@ func (e *Environment) GetBool(key string, defaultValue bool) bool {
 	}
 }
 
+func (e *Environment) GetStringDefaultEmpty(key string) string {
+	v, _ := e.Get(key)
+	return v
+}
+
 // Exists returns true/false depending on whether or not the key exists in the env
 func (e *Environment) Exists(key string) bool {
 	_, ok := e.underlying.Load(normalizeKeyName(key))

--- a/env/environment.go
+++ b/env/environment.go
@@ -98,11 +98,6 @@ func (e *Environment) GetBool(key string, defaultValue bool) bool {
 	}
 }
 
-func (e *Environment) GetStringDefaultEmpty(key string) string {
-	v, _ := e.Get(key)
-	return v
-}
-
 // Exists returns true/false depending on whether or not the key exists in the env
 func (e *Environment) Exists(key string) bool {
 	_, ok := e.underlying.Load(normalizeKeyName(key))

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -126,6 +126,6 @@ func (p *Pipeline) interpolateEnvBlock(envMap *env.Environment) error {
 // plugin configurations and the pipeline "env". Parts of the pipeline are
 // mutated directly, so an error part-way through may leave some steps
 // un-signed.
-func (p *Pipeline) Sign(key jwk.Key) error {
-	return p.Steps.sign(p.Env.ToMap(), key)
+func (p *Pipeline) Sign(key jwk.Key, inv *Invariants) error {
+	return p.Steps.sign(key, p.Env.ToMap(), inv)
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -126,6 +126,6 @@ func (p *Pipeline) interpolateEnvBlock(envMap *env.Environment) error {
 // plugin configurations and the pipeline "env". Parts of the pipeline are
 // mutated directly, so an error part-way through may leave some steps
 // un-signed.
-func (p *Pipeline) Sign(key jwk.Key, inv *Invariants) error {
+func (p *Pipeline) Sign(key jwk.Key, inv *PipelineInvariants) error {
 	return p.Steps.sign(key, p.Env.ToMap(), inv)
 }

--- a/internal/pipeline/pipeline_invariants.go
+++ b/internal/pipeline/pipeline_invariants.go
@@ -1,0 +1,80 @@
+package pipeline
+
+import (
+	"fmt"
+	"strings"
+)
+
+type PipelineInvariants struct {
+	OrganizationSlug string
+	PipelineSlug     string
+	Repository       string
+}
+
+type CommandStepWithPipelineInvariants struct {
+	CommandStep
+	PipelineInvariants
+}
+
+// SignedFields returns the default fields for signing.
+func (c *CommandStepWithPipelineInvariants) SignedFields() (map[string]any, error) {
+	return map[string]any{
+		"command":             c.Command,
+		"env":                 c.Env,
+		"plugins":             c.Plugins,
+		"matrix":              c.Matrix,
+		"pipeline_invariants": c.PipelineInvariants,
+	}, nil
+}
+
+// ValuesForFields returns the contents of fields to sign.
+func (c *CommandStepWithPipelineInvariants) ValuesForFields(fields []string) (map[string]any, error) {
+	// Make a set of required fields. As fields is processed, mark them off by
+	// deleting them.
+	required := map[string]struct{}{
+		"command":             {},
+		"env":                 {},
+		"plugins":             {},
+		"matrix":              {},
+		"pipeline_invariants": {},
+	}
+
+	out := make(map[string]any, len(fields))
+	for _, f := range fields {
+		delete(required, f)
+
+		switch f {
+		case "command":
+			out["command"] = c.Command
+
+		case "env":
+			out["env"] = c.Env
+
+		case "plugins":
+			out["plugins"] = c.Plugins
+
+		case "matrix":
+			out["matrix"] = c.Matrix
+
+		case "pipeline_invariants":
+			out["pipeline_invariants"] = c.PipelineInvariants
+
+		default:
+			// All env:: values come from outside the step.
+			if strings.HasPrefix(f, EnvNamespacePrefix) {
+				break
+			}
+
+			return nil, fmt.Errorf("unknown or unsupported field for signing %q", f)
+		}
+	}
+
+	if len(required) > 0 {
+		missing := make([]string, 0, len(required))
+		for k := range required {
+			missing = append(missing, k)
+		}
+		return nil, fmt.Errorf("one or more required fields are not present: %v", missing)
+	}
+	return out, nil
+}

--- a/internal/pipeline/pipeline_invariants.go
+++ b/internal/pipeline/pipeline_invariants.go
@@ -11,6 +11,8 @@ type PipelineInvariants struct {
 	Repository       string
 }
 
+var _ SignedFielder = (*CommandStepWithPipelineInvariants)(nil)
+
 type CommandStepWithPipelineInvariants struct {
 	CommandStep
 	PipelineInvariants

--- a/internal/pipeline/sign.go
+++ b/internal/pipeline/sign.go
@@ -44,9 +44,9 @@ type SignedFielder interface {
 // Sign computes a new signature for an environment (env) combined with an
 // object containing values (sf) using a given key.
 func Sign(
+	key jwk.Key,
 	env map[string]string,
 	sf SignedFielder,
-	key jwk.Key,
 ) (*Signature, error) {
 	values, err := sf.SignedFields()
 	if err != nil {
@@ -102,9 +102,9 @@ func Sign(
 // Verify verifies an existing signature against environment (env) combined with
 // an object containing values (sf) using keys from a keySet.
 func (s *Signature) Verify(
+	keySet jwk.Set,
 	env map[string]string,
 	sf SignedFielder,
-	keySet jwk.Set,
 ) error {
 	if len(s.SignedFields) == 0 {
 		return errors.New("signature covers no fields")

--- a/internal/pipeline/sign_test.go
+++ b/internal/pipeline/sign_test.go
@@ -135,7 +135,7 @@ func TestSignVerify(t *testing.T) {
 				t.Fatalf("signer.Key(0) = _, false, want true")
 			}
 
-			sig, err := Sign(signEnv, stepWithInvariants, key)
+			sig, err := Sign(key, signEnv, stepWithInvariants)
 			if err != nil {
 				t.Fatalf("Sign(CommandStep, signer) error = %v", err)
 			}
@@ -153,7 +153,7 @@ func TestSignVerify(t *testing.T) {
 				}
 			}
 
-			if err := sig.Verify(verifyEnv, stepWithInvariants, verifier); err != nil {
+			if err := sig.Verify(verifier, verifyEnv, stepWithInvariants); err != nil {
 				t.Errorf("sig.Verify(CommandStep, verifier) = %v", err)
 			}
 		})
@@ -214,7 +214,7 @@ func TestSignConcatenatedFields(t *testing.T) {
 	}
 
 	for _, m := range maps {
-		sig, err := Sign(nil, m, key)
+		sig, err := Sign(key, nil, m)
 		if err != nil {
 			t.Fatalf("Sign(%v, pts) error = %v", m, err)
 		}
@@ -249,9 +249,9 @@ func TestUnknownAlgorithm(t *testing.T) {
 	key.Set(jwk.AlgorithmKey, "rot13")
 
 	if _, err := Sign(
+		key,
 		nil,
 		&CommandStepWithPipelineInvariants{CommandStep: CommandStep{Command: "llamas"}},
-		key,
 	); err == nil {
 		t.Errorf("Sign(nil, CommandStep, signer) = %v, want non-nil error", err)
 	}
@@ -273,7 +273,7 @@ func TestVerifyBadSignature(t *testing.T) {
 		t.Fatalf("NewSymmetricKeyPairFromString(alpacas) error = %v", err)
 	}
 
-	if err := sig.Verify(nil, cs, verifier); err == nil {
+	if err := sig.Verify(verifier, nil, cs); err == nil {
 		t.Errorf("sig.Verify(CommandStep, alpacas) = %v, want non-nil error", err)
 	}
 }
@@ -386,12 +386,12 @@ func TestSignVerifyEnv(t *testing.T) {
 				PipelineInvariants: *tc.pipelineInvariants,
 			}
 
-			sig, err := Sign(tc.pipelineEnv, stepWithInvariants, key)
+			sig, err := Sign(key, tc.pipelineEnv, stepWithInvariants)
 			if err != nil {
 				t.Fatalf("Sign(CommandStep, signer) error = %v", err)
 			}
 
-			if err := sig.Verify(tc.verifyEnv, stepWithInvariants, verifier); err != nil {
+			if err := sig.Verify(verifier, tc.verifyEnv, stepWithInvariants); err != nil {
 				t.Errorf("sig.Verify(CommandStep, verifier) = %v", err)
 			}
 		})
@@ -442,12 +442,12 @@ func TestSignatureStability(t *testing.T) {
 		t.Fatalf("signer.Key(0) = _, false, want true")
 	}
 
-	sig, err := Sign(env, stepWithInvariants, key)
+	sig, err := Sign(key, env, stepWithInvariants)
 	if err != nil {
 		t.Fatalf("Sign(env, CommandStep, signer) error = %v", err)
 	}
 
-	if err := sig.Verify(env, stepWithInvariants, verifier); err != nil {
+	if err := sig.Verify(verifier, env, stepWithInvariants); err != nil {
 		t.Errorf("sig.Verify(env, CommandStep, verifier) = %v", err)
 	}
 }

--- a/internal/pipeline/sign_test.go
+++ b/internal/pipeline/sign_test.go
@@ -166,6 +166,8 @@ func (m testFields) ValuesForFields(fields []string) (map[string]any, error) {
 }
 
 func TestSignConcatenatedFields(t *testing.T) {
+	t.Parallel()
+
 	// Tests that Sign is resilient to concatenation.
 	// Specifically, these maps should all have distinct "content". (If you
 	// simply wrote the strings one after the other, they could be equal.)
@@ -221,6 +223,8 @@ func TestSignConcatenatedFields(t *testing.T) {
 }
 
 func TestUnknownAlgorithm(t *testing.T) {
+	t.Parallel()
+
 	signer, _, err := jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", jwa.HS256)
 	if err != nil {
 		t.Fatalf("NewSymmetricKeyPairFromString(alpacas) error = %v", err)
@@ -239,6 +243,8 @@ func TestUnknownAlgorithm(t *testing.T) {
 }
 
 func TestVerifyBadSignature(t *testing.T) {
+	t.Parallel()
+
 	cs := &CommandStep{
 		Command: "llamas",
 	}
@@ -260,6 +266,8 @@ func TestVerifyBadSignature(t *testing.T) {
 }
 
 func TestSignUnknownStep(t *testing.T) {
+	t.Parallel()
+
 	steps := Steps{
 		&UnknownStep{
 			Contents: "secret third thing",
@@ -276,12 +284,14 @@ func TestSignUnknownStep(t *testing.T) {
 		t.Fatalf("signer.Key(0) = _, false, want true")
 	}
 
-	if err := steps.sign(nil, key); !errors.Is(err, errSigningRefusedUnknownStepType) {
+	if err := steps.sign(key, nil, nil); !errors.Is(err, errSigningRefusedUnknownStepType) {
 		t.Errorf("steps.sign(signer) = %v, want %v", err, errSigningRefusedUnknownStepType)
 	}
 }
 
 func TestSignVerifyEnv(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name        string
 		step        *CommandStep

--- a/internal/pipeline/steps.go
+++ b/internal/pipeline/steps.go
@@ -137,13 +137,13 @@ func stepByKeyInference(o *ordered.MapSA) (Step, error) {
 // sign adds signatures to each command step (and recursively to any command
 // steps that are within group steps. The steps are mutated directly, so an
 // error part-way through may leave some steps un-signed.
-func (s Steps) sign(key jwk.Key, env map[string]string, inv *Invariants) error {
+func (s Steps) sign(key jwk.Key, env map[string]string, pInv *PipelineInvariants) error {
 	for _, step := range s {
 		switch step := step.(type) {
 		case *CommandStep:
-			stepWithInvariants := &CommandStepWithInvariants{
-				CommandStep: *step,
-				Invariants:  *inv,
+			stepWithInvariants := &CommandStepWithPipelineInvariants{
+				CommandStep:        *step,
+				PipelineInvariants: *pInv,
 			}
 
 			sig, err := Sign(env, stepWithInvariants, key)
@@ -153,7 +153,7 @@ func (s Steps) sign(key jwk.Key, env map[string]string, inv *Invariants) error {
 			step.Signature = sig
 
 		case *GroupStep:
-			if err := step.Steps.sign(key, env, inv); err != nil {
+			if err := step.Steps.sign(key, env, pInv); err != nil {
 				return fmt.Errorf("signing group step: %w", err)
 			}
 

--- a/internal/pipeline/steps.go
+++ b/internal/pipeline/steps.go
@@ -146,7 +146,7 @@ func (s Steps) sign(key jwk.Key, env map[string]string, pInv *PipelineInvariants
 				PipelineInvariants: *pInv,
 			}
 
-			sig, err := Sign(env, stepWithInvariants, key)
+			sig, err := Sign(key, env, stepWithInvariants)
 			if err != nil {
 				return fmt.Errorf("signing step with command %q: %w", step.Command, err)
 			}


### PR DESCRIPTION
The pipeline invariants are:
- pipeline slug
- organization slug
- repository

An agent configured to verify signatures will now check that the pipeline slug, organization slug and repository in the accepted job definition are the same as the ones in the signature.

The cli subcommand
```
buildkite-agnet tool sign --jwks-file-path <keyfile> --signing-key-id <key-id> --pipeline-slug <pipeline-slug> --organization-slug <organization-slug> --repo <repository> <pipeline-yaml-file>
```
can be used to sign the initial pipeline. Its output may be pasted into the Steps Editor in the Buildkite Web UI so that the initial pipeline may be verified as well.


## Implementation details
I created a new struct `CommandStepWithInvariants` and moved the `SignedFielder` implementation from `CommandStep` to it. I went back and forth on a few ways to do this, but I think it's easier to reason about if the marshalling of fields to sign happens in one place.