### PR TITLE
Add log group headers and timestamps to job verification success and failure logs

### DIFF
--- a/agent/integration/job_verification_integration_test.go
+++ b/agent/integration/job_verification_integration_test.go
@@ -264,7 +264,7 @@ func TestJobVerification(t *testing.T) {
 			mockBootstrapExpectation: func(bt *bintest.Mock) { bt.Expect().NotCalled() },
 			expectedExitStatus:       "-1",
 			expectedSignalReason:     agent.SignalReasonSignatureRejected,
-			expectLogsContain:        []string{"⚠️ ERROR"},
+			expectLogsContain:        []string{"+++ ⛔"},
 		},
 		{
 			name:                     "when job signature is invalid, and JobVerificationFailureBehaviour is warn, it warns and runs the job",
@@ -275,7 +275,7 @@ func TestJobVerification(t *testing.T) {
 			verificationJWKS:         jwksFromKeys(t, symmetricJWKFor(t, signingKeyAlpacas)),
 			mockBootstrapExpectation: func(bt *bintest.Mock) { bt.Expect().Once().AndExitWith(0) },
 			expectedExitStatus:       "0",
-			expectLogsContain:        []string{"⚠️ WARNING"},
+			expectLogsContain:        []string{"+++ ⚠️"},
 		},
 		{
 			name:                     "when job signature is valid, it runs the job",
@@ -320,7 +320,7 @@ func TestJobVerification(t *testing.T) {
 			mockBootstrapExpectation: func(bt *bintest.Mock) { bt.Expect().NotCalled() },
 			expectedExitStatus:       "-1",
 			expectedSignalReason:     agent.SignalReasonSignatureRejected,
-			expectLogsContain:        []string{"⚠️ ERROR"},
+			expectLogsContain:        []string{"+++ ⛔"},
 		},
 		{
 			name:                     "when job signature is missing, and JobVerificationFailureBehaviour is warn, it warns and runs the job",
@@ -331,7 +331,7 @@ func TestJobVerification(t *testing.T) {
 			verificationJWKS:         jwksFromKeys(t, symmetricJWKFor(t, signingKeyLlamas)),
 			mockBootstrapExpectation: func(bt *bintest.Mock) { bt.Expect().Once().AndExitWith(0) },
 			expectedExitStatus:       "0",
-			expectLogsContain:        []string{"⚠️ WARNING"},
+			expectLogsContain:        []string{"+++ ⚠️"},
 		},
 		{
 			name:                     "when the step signature matches, but the job doesn't match the step, it fails signature verification",
@@ -344,7 +344,7 @@ func TestJobVerification(t *testing.T) {
 			expectedExitStatus:       "-1",
 			expectedSignalReason:     agent.SignalReasonSignatureRejected,
 			expectLogsContain: []string{
-				"⚠️ ERROR",
+				"+++ ⛔",
 				"job does not match signed step",
 			},
 		},
@@ -359,7 +359,7 @@ func TestJobVerification(t *testing.T) {
 			expectedExitStatus:       "-1",
 			expectedSignalReason:     agent.SignalReasonSignatureRejected,
 			expectLogsContain: []string{
-				"⚠️ ERROR",
+				"+++ ⛔",
 				"job does not match signed step",
 			},
 		},
@@ -374,7 +374,7 @@ func TestJobVerification(t *testing.T) {
 			expectedExitStatus:       "-1",
 			expectedSignalReason:     agent.SignalReasonSignatureRejected,
 			expectLogsContain: []string{
-				"⚠️ ERROR",
+				"+++ ⛔",
 				"job does not match signed step",
 			},
 		},
@@ -389,8 +389,8 @@ func TestJobVerification(t *testing.T) {
 			expectedExitStatus:       "-1",
 			expectedSignalReason:     agent.SignalReasonSignatureRejected,
 			expectLogsContain: []string{
-				"⚠️ ERROR",
-				"but no verification key was provided, so the job can't be verified",
+				"+++ ⛔",
+				"but no verification key was provided",
 			},
 		},
 		{
@@ -404,7 +404,7 @@ func TestJobVerification(t *testing.T) {
 			expectedExitStatus:       "-1",
 			expectedSignalReason:     agent.SignalReasonSignatureRejected,
 			expectLogsContain: []string{
-				"⚠️ ERROR",
+				"+++ ⛔",
 				"signature verification failed",
 			},
 		},
@@ -419,7 +419,7 @@ func TestJobVerification(t *testing.T) {
 			expectedExitStatus:       "-1",
 			expectedSignalReason:     agent.SignalReasonSignatureRejected,
 			expectLogsContain: []string{
-				"⚠️ ERROR",
+				"+++ ⛔",
 				"job does not match signed step",
 			},
 		},
@@ -434,7 +434,7 @@ func TestJobVerification(t *testing.T) {
 			expectedExitStatus:       "-1",
 			expectedSignalReason:     agent.SignalReasonSignatureRejected,
 			expectLogsContain: []string{
-				"⚠️ ERROR",
+				"+++ ⛔",
 				"signature verification failed",
 			},
 		},
@@ -460,7 +460,7 @@ func TestJobVerification(t *testing.T) {
 			expectedExitStatus:       "-1",
 			expectedSignalReason:     agent.SignalReasonSignatureRejected,
 			expectLogsContain: []string{
-				"⚠️ ERROR",
+				"+++ ⛔",
 				"job does not match signed step",
 			},
 		},
@@ -475,7 +475,7 @@ func TestJobVerification(t *testing.T) {
 			expectedExitStatus:       "-1",
 			expectedSignalReason:     agent.SignalReasonSignatureRejected,
 			expectLogsContain: []string{
-				"⚠️ ERROR",
+				"+++ ⛔",
 				"job does not match signed step",
 			},
 		},
@@ -509,7 +509,7 @@ func TestJobVerification(t *testing.T) {
 			expectedExitStatus:       "-1",
 			expectedSignalReason:     agent.SignalReasonSignatureRejected,
 			expectLogsContain: []string{
-				"⚠️ ERROR",
+				"+++ ⛔",
 				"signature verification failed",
 			},
 		},

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -136,7 +136,7 @@ type JobRunner struct {
 	// The internal log streamer. Don't write to this directly, use `jobLogs` instead
 	logStreamer *LogStreamer
 
-	// jobLogs is a logger that outputs to the job logs
+	// jobLogs is an io.Writer that sends data to the job logs
 	jobLogs io.Writer
 
 	// If the job is being cancelled

--- a/agent/log_streamer.go
+++ b/agent/log_streamer.go
@@ -71,7 +71,11 @@ type LogStreamerChunk struct {
 }
 
 // Creates a new instance of the log streamer
-func NewLogStreamer(l logger.Logger, cb func(context.Context, *LogStreamerChunk) error, c LogStreamerConfig) *LogStreamer {
+func NewLogStreamer(
+	l logger.Logger,
+	cb func(context.Context, *LogStreamerChunk) error,
+	c LogStreamerConfig,
+) *LogStreamer {
 	return &LogStreamer{
 		logger:   l,
 		conf:     c,
@@ -153,7 +157,7 @@ func (ls *LogStreamer) Process(output []byte) {
 }
 
 // Waits for all the chunks to be uploaded, then shuts down all the workers
-func (ls *LogStreamer) Stop() error {
+func (ls *LogStreamer) Stop() {
 	ls.logger.Debug("[LogStreamer] Waiting for all the chunks to be uploaded")
 
 	ls.chunkWaitGroup.Wait()
@@ -163,8 +167,6 @@ func (ls *LogStreamer) Stop() error {
 	for n := 0; n < ls.conf.Concurrency; n++ {
 		ls.queue <- nil
 	}
-
-	return nil
 }
 
 // The actual log streamer worker

--- a/agent/log_streamer.go
+++ b/agent/log_streamer.go
@@ -102,7 +102,7 @@ func (ls *LogStreamer) FailedChunks() int {
 }
 
 // Process streams the output.
-func (ls *LogStreamer) Process(output []byte) error {
+func (ls *LogStreamer) Process(output []byte) {
 	// Only allow one streamer process at a time
 	ls.processMutex.Lock()
 	defer ls.processMutex.Unlock()
@@ -150,8 +150,6 @@ func (ls *LogStreamer) Process(output []byte) error {
 		// Save the new amount of bytes
 		ls.bytes += size
 	}
-
-	return nil
 }
 
 // Waits for all the chunks to be uploaded, then shuts down all the workers

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -114,7 +114,7 @@ func (r *JobRunner) Run(ctx context.Context) error {
 		default: // no error, all good, keep going
 			l := r.logger.WithFields(logger.StringField("jobID", job.ID), logger.StringField("signature", job.Step.Signature.Value))
 			l.Info("Successfully verified job")
-			r.logStreamer.Process(r.prependTimestampForLogs("~~~ ✅ Job verified\n"))
+			r.logStreamer.Process(r.prependTimestampForLogs("~~~ ✅ Job signature verified\n"))
 			r.logStreamer.Process(r.prependTimestampForLogs("signature: %s\n", job.Step.Signature.Value))
 		}
 	}
@@ -193,7 +193,7 @@ func (r *JobRunner) verificationFailureLogs(behavior string, err error) {
 	}
 
 	l.Warn("Job verification failed")
-	r.logStreamer.Process([]byte(r.prependTimestampForLogs("%s Job verification failed\n", prefix)))
+	r.logStreamer.Process([]byte(r.prependTimestampForLogs("%s Job signature verification failed\n", prefix)))
 	r.logStreamer.Process([]byte(r.prependTimestampForLogs("error: %s\n", err)))
 
 	if errors.Is(err, ErrNoSignature) {

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -36,7 +36,7 @@ func (e *missingKeyError) Error() string {
 
 // Runs the job
 func (r *JobRunner) Run(ctx context.Context) error {
-	r.logger.Info("Starting job %s", r.conf.Job.ID)
+	r.agentLogger.Info("Starting job %s", r.conf.Job.ID)
 
 	ctx, done := status.AddItem(ctx, "Job Runner", "", nil)
 	defer done()
@@ -55,7 +55,7 @@ func (r *JobRunner) Run(ctx context.Context) error {
 	if r.conf.Job.RunnableAt != "" {
 		runnableAt, err := time.Parse(time.RFC3339Nano, r.conf.Job.RunnableAt)
 		if err != nil {
-			r.logger.Error("Metric submission failed to parse %s", r.conf.Job.RunnableAt)
+			r.agentLogger.Error("Metric submission failed to parse %s", r.conf.Job.RunnableAt)
 		} else {
 			r.conf.MetricsScope.Timing("queue.duration", r.startedAt.Sub(runnableAt))
 		}
@@ -112,18 +112,18 @@ func (r *JobRunner) Run(ctx context.Context) error {
 			return nil
 
 		default: // no error, all good, keep going
-			l := r.logger.WithFields(logger.StringField("jobID", job.ID), logger.StringField("signature", job.Step.Signature.Value))
+			l := r.agentLogger.WithFields(logger.StringField("jobID", job.ID), logger.StringField("signature", job.Step.Signature.Value))
 			l.Info("Successfully verified job")
-			r.logStreamer.Process(r.prependTimestampForLogs("~~~ ✅ Job signature verified\n"))
-			r.logStreamer.Process(r.prependTimestampForLogs("signature: %s\n", job.Step.Signature.Value))
+			fmt.Fprintln(r.jobLogs, "~~~ ✅ Job signature verified")
+			fmt.Fprintf(r.jobLogs, "signature: %s\n", job.Step.Signature.Value)
 		}
 	}
 
 	// Validate the repository if the list of allowed repositories is set.
 	err := validateJobValue(r.conf.AgentConfiguration.AllowedRepositories, job.Env["BUILDKITE_REPO"])
 	if err != nil {
-		r.logStreamer.Process([]byte(fmt.Sprintf("%s", err)))
-		r.logger.Error("Repo %s", err)
+		fmt.Fprintln(r.jobLogs, err.Error())
+		r.agentLogger.Error("Failed to validate repo: %s", err)
 		exit.Status = -1
 		exit.SignalReason = SignalReasonAgentRefused
 		return nil
@@ -131,8 +131,8 @@ func (r *JobRunner) Run(ctx context.Context) error {
 	// Validate the plugins if the list of allowed plugins is set.
 	err = r.checkPlugins(ctx)
 	if err != nil {
-		r.logStreamer.Process([]byte(fmt.Sprintf("%s", err)))
-		r.logger.Error("Plugin %s", err)
+		fmt.Fprintln(r.jobLogs, err.Error())
+		r.agentLogger.Error("Failed to validate plugins: %s", err)
 		exit.Status = -1
 		exit.SignalReason = SignalReasonAgentRefused
 		return nil
@@ -145,9 +145,9 @@ func (r *JobRunner) Run(ctx context.Context) error {
 		ok, err := r.executePreBootstrapHook(ctx, hook)
 		if !ok {
 			// Ensure the Job UI knows why this job resulted in failure
-			r.logStreamer.Process([]byte("pre-bootstrap hook rejected this job, see the buildkite-agent logs for more details"))
+			fmt.Fprintln(r.jobLogs, "pre-bootstrap hook rejected this job, see the buildkite-agent logs for more details")
 			// But disclose more information in the agent logs
-			r.logger.Error("pre-bootstrap hook rejected this job: %s", err)
+			r.agentLogger.Error("pre-bootstrap hook rejected this job: %s", err)
 
 			exit.Status = -1
 			exit.SignalReason = SignalReasonAgentRefused
@@ -166,47 +166,29 @@ func (r *JobRunner) Run(ctx context.Context) error {
 	return nil
 }
 
-func (r *JobRunner) prependTimestampForLogs(s string, args ...any) []byte {
-	switch {
-	case r.conf.AgentConfiguration.ANSITimestamps:
-		return []byte(fmt.Sprintf(
-			"\x1b_bk;t=%d\x07%s",
-			time.Now().UnixNano()/int64(time.Millisecond),
-			fmt.Sprintf(s, args...),
-		))
-	case r.conf.AgentConfiguration.TimestampLines:
-		return []byte(fmt.Sprintf(
-			"[%s] %s",
-			time.Now().UTC().Format(time.RFC3339),
-			fmt.Sprintf(s, args...),
-		))
-	default:
-		return []byte(fmt.Sprintf(s, args...))
-	}
-}
-
 func (r *JobRunner) verificationFailureLogs(behavior string, err error) {
-	l := r.logger.WithFields(logger.StringField("jobID", r.conf.Job.ID), logger.StringField("error", err.Error()))
+	l := r.agentLogger.WithFields(logger.StringField("jobID", r.conf.Job.ID), logger.StringField("error", err.Error()))
 	prefix := "+++ ⚠️"
 	if behavior == VerificationBehaviourBlock {
 		prefix = "+++ ⛔"
 	}
 
 	l.Warn("Job verification failed")
-	r.logStreamer.Process([]byte(r.prependTimestampForLogs("%s Job signature verification failed\n", prefix)))
-	r.logStreamer.Process([]byte(r.prependTimestampForLogs("error: %s\n", err)))
+	fmt.Fprintf(r.jobLogs, "%s Job signature verification failed\n", prefix)
+	fmt.Fprintf(r.jobLogs, "error: %s\n", err)
 
 	if errors.Is(err, ErrNoSignature) {
-		r.logStreamer.Process([]byte(r.prependTimestampForLogs("no signature in job\n")))
+		fmt.Fprintln(r.jobLogs, "no signature in job")
 	} else if ise := new(invalidSignatureError); errors.As(err, &ise) {
-		r.logStreamer.Process([]byte(r.prependTimestampForLogs("signature: %s\n", r.conf.Job.Step.Signature.Value)))
+		fmt.Fprintf(r.jobLogs, "signature: %s\n", r.conf.Job.Step.Signature.Value)
 	} else if mke := new(missingKeyError); errors.As(err, &mke) {
-		r.logStreamer.Process([]byte(r.prependTimestampForLogs("signature: %s\n", mke.signature)))
+		fmt.Fprintf(r.jobLogs, "signature: %s\n", mke.signature)
 	}
 
 	if behavior == VerificationBehaviourWarn {
-		r.logger.Warn("Job will be run whether or not it can be verified - this is not recommended. You can change this behavior with the `job-verification-failure-behavior` agent configuration option.")
-		r.logStreamer.Process(r.prependTimestampForLogs("Job will be run without verification\n"))
+		l.Warn("Job will be run whether or not it can be verified - this is not recommended.")
+		l.Warn("You can change this behavior with the `job-verification-failure-behavior` agent configuration option.")
+		fmt.Fprintln(r.jobLogs, "Job will be run without verification")
 	}
 }
 
@@ -220,8 +202,8 @@ func (r *JobRunner) runJob(ctx context.Context) processExit {
 	exit := processExit{}
 	// Run the process. This will block until it finishes.
 	if err := r.process.Run(ctx); err != nil {
-		// Send the error as output
-		r.logStreamer.Process([]byte(err.Error()))
+		// Send the error as to job logs
+		fmt.Fprintf(r.jobLogs, "Error running job: %s\n", err)
 
 		// The process did not run at all, so make sure it fails
 		return processExit{
@@ -234,13 +216,14 @@ func (r *JobRunner) runJob(ctx context.Context) processExit {
 	// to the user as they may be the caused by errors in the pipeline definition.
 	k8sProcess, ok := r.process.(*kubernetes.Runner)
 	if ok && r.cancelled && !r.stopped && k8sProcess.ClientStateUnknown() {
-		r.logStreamer.Process([]byte(
+		fmt.Fprintln(
+			r.jobLogs,
 			"Some containers had unknown exit statuses. Perhaps they were in ImagePullBackOff.",
-		))
+		)
 	}
 
 	// Add the final output to the streamer
-	r.logStreamer.Process(r.output.ReadAndTruncate())
+	r.jobLogs.Write(r.output.ReadAndTruncate())
 
 	// Collect the finished process' exit status
 	exit.Status = r.process.WaitStatus().ExitStatus()
@@ -274,19 +257,19 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit proces
 
 	// Warn about failed chunks
 	if count := r.logStreamer.FailedChunks(); count > 0 {
-		r.logger.Warn("%d chunks failed to upload for this job", count)
+		r.agentLogger.Warn("%d chunks failed to upload for this job", count)
 	}
 
 	// Wait for the routines that we spun up to finish
-	r.logger.Debug("[JobRunner] Waiting for all other routines to finish")
+	r.agentLogger.Debug("[JobRunner] Waiting for all other routines to finish")
 	wg.Wait()
 
 	// Remove the env file, if any
 	if r.envFile != nil {
 		if err := os.Remove(r.envFile.Name()); err != nil {
-			r.logger.Warn("[JobRunner] Error cleaning up env file: %s", err)
+			r.agentLogger.Warn("[JobRunner] Error cleaning up env file: %s", err)
 		}
-		r.logger.Debug("[JobRunner] Deleted env file: %s", r.envFile.Name())
+		r.agentLogger.Debug("[JobRunner] Deleted env file: %s", r.envFile.Name())
 	}
 
 	// Write some metrics about the job run
@@ -304,7 +287,7 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit proces
 	// Once we tell the API we're finished it might assign us new work, so make sure everything else is done first.
 	r.finishJob(ctx, finishedAt, exit, r.logStreamer.FailedChunks())
 
-	r.logger.Info("Finished job %s", r.conf.Job.ID)
+	r.agentLogger.Info("Finished job %s", r.conf.Job.ID)
 }
 
 // finishJob finishes the job in the Buildkite Agent API. If the FinishJob call
@@ -316,7 +299,7 @@ func (r *JobRunner) finishJob(ctx context.Context, finishedAt time.Time, exit pr
 	r.conf.Job.SignalReason = exit.SignalReason
 	r.conf.Job.ChunksFailedCount = failedChunkCount
 
-	r.logger.Debug("[JobRunner] Finishing job with exit_status=%s, signal=%s and signal_reason=%s",
+	r.agentLogger.Debug("[JobRunner] Finishing job with exit_status=%s, signal=%s and signal_reason=%s",
 		r.conf.Job.ExitStatus, r.conf.Job.Signal, r.conf.Job.SignalReason)
 
 	ctx, cancel := context.WithTimeout(ctx, 48*time.Hour)
@@ -339,10 +322,10 @@ func (r *JobRunner) finishJob(ctx context.Context, finishedAt time.Time, exit pr
 			// to finish the job forever so we'll just bail out and
 			// go find some more work to do.
 			if response != nil && response.StatusCode == 422 {
-				r.logger.Warn("Buildkite rejected the call to finish the job (%s)", err)
+				r.agentLogger.Warn("Buildkite rejected the call to finish the job (%s)", err)
 				retrier.Break()
 			} else {
-				r.logger.Warn("%s (%s)", err, retrier)
+				r.agentLogger.Warn("%s (%s)", err, retrier)
 			}
 		}
 
@@ -359,7 +342,7 @@ func (r *JobRunner) jobLogStreamer(ctx context.Context, wg *sync.WaitGroup) {
 
 	defer func() {
 		wg.Done()
-		r.logger.Debug("[JobRunner] Routine that processes the log has finished")
+		r.agentLogger.Debug("[JobRunner] Routine that processes the log has finished")
 	}()
 
 	select {
@@ -371,17 +354,8 @@ func (r *JobRunner) jobLogStreamer(ctx context.Context, wg *sync.WaitGroup) {
 	for {
 		setStat("📨 Sending process output to log streamer")
 
-		// Send the output of the process to the log streamer
-		// for processing
-		chunk := r.output.ReadAndTruncate()
-		if err := r.logStreamer.Process(chunk); err != nil {
-			r.logger.Error("Could not stream the log output: %v", err)
-			// So far, the only error from logStreamer.Process is if the log has
-			// reached the limit.
-			// Since we're not writing any more, close the buffer, which will
-			// cause future Writes to return an error.
-			r.output.Close()
-		}
+		// Send the output of the process to the log streamer for processing
+		r.logStreamer.Process(r.output.ReadAndTruncate())
 
 		setStat("😴 Sleeping for a bit")
 
@@ -413,7 +387,7 @@ func (r *JobRunner) Cancel() error {
 	}
 
 	if r.process == nil {
-		r.logger.Error("No process to kill")
+		r.agentLogger.Error("No process to kill")
 		return nil
 	}
 
@@ -422,7 +396,12 @@ func (r *JobRunner) Cancel() error {
 		reason = "(agent stopping)"
 	}
 
-	r.logger.Info("Canceling job %s with a grace period of %ds %s", r.conf.Job.ID, r.conf.AgentConfiguration.CancelGracePeriod, reason)
+	r.agentLogger.Info(
+		"Canceling job %s with a grace period of %ds %s",
+		r.conf.Job.ID,
+		r.conf.AgentConfiguration.CancelGracePeriod,
+		reason,
+	)
 
 	r.cancelled = true
 
@@ -434,7 +413,7 @@ func (r *JobRunner) Cancel() error {
 	select {
 	// Grace period for cancelling
 	case <-time.After(time.Second * time.Duration(r.conf.AgentConfiguration.CancelGracePeriod)):
-		r.logger.Info("Job %s hasn't stopped in time, terminating", r.conf.Job.ID)
+		r.agentLogger.Info("Job %s hasn't stopped in time, terminating", r.conf.Job.ID)
 
 		// Terminate the process as we've exceeded our context
 		return r.process.Terminate()

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -187,7 +187,7 @@ func (r *JobRunner) prependTimestampForLogs(s string, args ...any) []byte {
 
 func (r *JobRunner) verificationFailureLogs(behavior string, err error) {
 	l := r.logger.WithFields(logger.StringField("jobID", r.conf.Job.ID), logger.StringField("error", err.Error()))
-	prefix := "~~~ ⚠️"
+	prefix := "+++ ⚠️"
 	if behavior == VerificationBehaviourBlock {
 		prefix = "+++ ⛔"
 	}

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -112,8 +112,10 @@ func (r *JobRunner) Run(ctx context.Context) error {
 			return nil
 
 		default: // no error, all good, keep going
-			r.logger.Info("Successfully verified job %s with signature %s", job.ID, job.Step.Signature.Value)
-			r.logStreamer.Process([]byte(fmt.Sprintf("✅ Verified job with signature %s\n", job.Step.Signature.Value)))
+			l := r.logger.WithFields(logger.StringField("jobID", job.ID), logger.StringField("signature", job.Step.Signature.Value))
+			l.Info("Successfully verified job")
+			r.logStreamer.Process(r.prependTimestampForLogs("~~~ ✅ Job verified\n"))
+			r.logStreamer.Process(r.prependTimestampForLogs("signature: %s\n", job.Step.Signature.Value))
 		}
 	}
 

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -254,11 +254,11 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit proces
 	// were left behind because the uploader goroutine exited before it could flush them.
 	r.logStreamer.Process(r.output.ReadAndTruncate())
 
-	// Stop the header time streamer. This will block until all the chunks have been uploaded
-	r.headerTimesStreamer.Stop()
-
 	// Stop the log streamer. This will block until all the chunks have been uploaded
 	r.logStreamer.Stop()
+
+	// Stop the header time streamer. This will block until all the chunks have been uploaded
+	r.headerTimesStreamer.Stop()
 
 	// Warn about failed chunks
 	if count := r.logStreamer.FailedChunks(); count > 0 {

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -205,7 +205,7 @@ func (r *JobRunner) runJob(ctx context.Context) processExit {
 	exit := processExit{}
 	// Run the process. This will block until it finishes.
 	if err := r.process.Run(ctx); err != nil {
-		// Send the error as to job logs
+		// Send the error to job logs
 		fmt.Fprintf(r.jobLogs, "Error running job: %s\n", err)
 
 		// The process did not run at all, so make sure it fails

--- a/agent/verify_job.go
+++ b/agent/verify_job.go
@@ -34,21 +34,6 @@ func (e *invalidSignatureError) Unwrap() error {
 	return e.underlying
 }
 
-func (r *JobRunner) verificationFailureLogs(err error, behavior string) {
-	label := "WARNING"
-	if behavior == VerificationBehaviourBlock {
-		label = "ERROR"
-	}
-
-	r.logger.Warn("Job verification failed: %s", err.Error())
-	r.logStreamer.Process([]byte(fmt.Sprintf("+++ ⚠️ %s: Job verification failed: %s\n", label, err.Error())))
-
-	if behavior == VerificationBehaviourWarn {
-		r.logger.Warn("Job will be run whether or not it can be verified - this is not recommended. You can change this behavior with the `job-verification-failure-behavior` agent configuration option.")
-		r.logStreamer.Process([]byte(fmt.Sprintf("⚠️ %s: Job will be run without verification\n", label)))
-	}
-}
-
 func (r *JobRunner) verifyJob(keySet jwk.Set) error {
 	step := r.conf.Job.Step
 

--- a/agent/verify_job.go
+++ b/agent/verify_job.go
@@ -41,7 +41,7 @@ func (r *JobRunner) verificationFailureLogs(err error, behavior string) {
 	}
 
 	r.logger.Warn("Job verification failed: %s", err.Error())
-	r.logStreamer.Process([]byte(fmt.Sprintf("⚠️ %s: Job verification failed: %s\n", label, err.Error())))
+	r.logStreamer.Process([]byte(fmt.Sprintf("+++ ⚠️ %s: Job verification failed: %s\n", label, err.Error())))
 
 	if behavior == VerificationBehaviourWarn {
 		r.logger.Warn("Job will be run whether or not it can be verified - this is not recommended. You can change this behavior with the `job-verification-failure-behavior` agent configuration option.")

--- a/jobapi/server.go
+++ b/jobapi/server.go
@@ -57,7 +57,8 @@ func (s *Server) Start() error {
 		return fmt.Errorf("starting socket server: %w", err)
 	}
 
-	s.Logger.Commentf("Job API server listening on %s", s.SocketPath)
+	s.Logger.Printf("~~~ Job API")
+	s.Logger.Printf("Server listening on %s", s.SocketPath)
 
 	return nil
 }


### PR DESCRIPTION
I had to also add a header to the Job API logs as otherwise they would appear to be part of the verification log group.
There are probably other such logs like this, we need to weed them out eventually.

I also simplified some of the logging, in particular, the signature is not printed as part of the log group header, but in a subsequent line.
As the log group will be collapsed unless there is a failure and the agent is configured to block, the signature will not be immediately visible.

Also, for the agent logs, I tried to add fields using the `logger.WithFields` method. These will be displayed in the logfmt format (or json if configured to do so). This will make the logs more structured.

Finally, I've removed the use of `(*JobRunner).logStreamer.Process` to send logs directly to the API as it bypasses various transformations that happen before (like timestamping). Users will still be able to call `logStreamer.Process`, but should use `(*JobRunner).jobLogs`, which exposes an `io.Writer` interface, instead.

## Screenshots
### Verification Failure Warning
#### Before
![2023-10-30T15:10:53,358662464+11:00](https://github.com/buildkite/agent/assets/11096602/b5298cd3-20f7-4a0e-bb61-19756a630a9a)
#### After
![2023-10-30T14:53:59,108749453+11:00](https://github.com/buildkite/agent/assets/11096602/5df5c82c-5acd-474a-ab53-fea1f57db274)
![2023-10-30T14:54:06,655403708+11:00](https://github.com/buildkite/agent/assets/11096602/5d305643-f99e-41db-9268-053192dd56ce)
### Verification Failure Block
#### Before
![2023-10-30T15:13:58,323915394+11:00](https://github.com/buildkite/agent/assets/11096602/dc351585-93c2-4b91-889a-0523b4469d1c)
#### After
![2023-10-30T15:14:31,964587642+11:00](https://github.com/buildkite/agent/assets/11096602/476d58e7-73e9-46b6-b2d0-2ace01e4dcf8)

### Verification Success
#### Before
![2023-10-30T15:17:01,810886339+11:00](https://github.com/buildkite/agent/assets/11096602/830806f8-5a75-4bd3-b712-ecda97fbcb8f)
#### After
![2023-10-30T15:16:09,340588835+11:00](https://github.com/buildkite/agent/assets/11096602/ce7809b5-a335-4d63-8683-208555269132)
![2023-10-30T15:16:17,748683530+11:00](https://github.com/buildkite/agent/assets/11096602/9aaf9e4a-737a-4445-a8bc-61b96d1c87ed)