### PR TITLE
Fix checkout of short commit hashes

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -532,6 +532,8 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 			switch gerr.Type {
 			case gitErrorFetchRetryClean, gitErrorFetchBadObject:
 				return fmt.Errorf("fetching commit %q: %w", e.Commit, err)
+			case gitErrorFetchBadReference:
+				// fallback to fetching all heads and tags
 			}
 		}
 

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -321,6 +321,13 @@ func TestCheckingOutLocalGitProjectWithShortCommitHash(t *testing.T) {
 		fmt.Sprintf("BUILDKITE_COMMIT=%s", shortCommitHash),
 	}
 	tester.RunAndCheck(t, env...)
+
+	// Check state of the build directory
+	checkoutRepo := &gitRepository{Path: tester.CheckoutDir()}
+	checkoutRepoCommit, err := checkoutRepo.RevParse("HEAD")
+	assert.NilError(t, err)
+
+	assert.Equal(t, checkoutRepoCommit, commitHash)
 }
 
 func TestCheckoutErrorIsRetried(t *testing.T) {

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -322,7 +322,7 @@ func TestCheckingOutLocalGitProjectWithShortCommitHash(t *testing.T) {
 	}
 	tester.RunAndCheck(t, env...)
 
-	// Check state of the build directory
+	// Check state of the checkout directory
 	checkoutRepo := &gitRepository{Path: tester.CheckoutDir()}
 	checkoutRepoCommit, err := checkoutRepo.RevParse("HEAD")
 	assert.NilError(t, err)

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/buildkite/agent/v3/internal/experiments"
 	"github.com/buildkite/bintest/v3"
+	"gotest.tools/v3/assert"
 )
 
 // Example commit info:
@@ -271,6 +272,54 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
 	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
 
+	tester.RunAndCheck(t, env...)
+}
+
+func TestCheckingOutLocalGitProjectWithShortCommitHash(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewBootstrapTester(mainCtx)
+	assert.NilError(t, err)
+	defer tester.Close()
+
+	// Do one checkout
+	tester.RunAndCheck(t)
+
+	// Create another commit on the same branch in the remote repo
+	err = tester.Repo.ExecuteAll([][]string{
+		{"commit", "--allow-empty", "-m", "Another commit"},
+	})
+	assert.NilError(t, err)
+
+	commitHash, err := tester.Repo.RevParse("HEAD")
+	assert.NilError(t, err)
+	shortCommitHash := commitHash[:7]
+
+	git := tester.
+		MustMock(t, "git").
+		PassthroughToLocalCommand()
+
+	// Git should attempt to fetch the shortHash, but fail. Then fallback to fetching
+	// all the heads and tags and checking out the short hash.
+	git.ExpectAll([][]any{
+		{"remote", "get-url", "origin"},
+		{"clean", "-ffxdq"},
+		{"fetch", "--", "origin", shortCommitHash},
+		{"config", "remote.origin.fetch"},
+		{"fetch", "--", "origin", "+refs/heads/*:refs/remotes/origin/*", "+refs/tags/*:refs/tags/*"},
+		{"checkout", "-f", shortCommitHash},
+		{"clean", "-ffxdq"},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
+	})
+
+	// Mock out the meta-data calls to the agent after checkout
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
+	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+
+	env := []string{
+		fmt.Sprintf("BUILDKITE_COMMIT=%s", shortCommitHash),
+	}
 	tester.RunAndCheck(t, env...)
 }
 

--- a/internal/job/integration/git.go
+++ b/internal/job/integration/git.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 )
 
+type gitRepository struct {
+	Path string
+}
+
 func createTestGitRespository() (*gitRepository, error) {
 	repo, err := newGitRepository()
 	if err != nil {
@@ -64,10 +68,6 @@ func createTestGitRespository() (*gitRepository, error) {
 	}
 
 	return repo, nil
-}
-
-type gitRepository struct {
-	Path string
 }
 
 func newGitRepository() (*gitRepository, error) {


### PR DESCRIPTION
When `BUILDKITE_COMMIT` is set to a short commit hash, the agent will first attempt to just fetch that hash, but this will not work and git will return an error. Recently we changed the behaviour so that this error would delete the checkout directory, and try again, but it would still attempt to fetch the short hash. After a few attempts, the checkout would fail.

Instead, the old behaviour allowed the agent to fetch all heads and tags, and then checkout (instead of fetch) the short commit hash. This successfully sets the state of the build directory to the commit that was intended to be checked out.

In this PR, we use the `olefactor` to read the error message that git prints when the `fetch` fails and fall through from retrying the checkout to fetching all the heads and tags. I've also added a test that recreates this behaviour.

That this was broken was reported to us in #2437, but unfortunately the solution suggested there - to use `git rev-parse` to resolve the short commit hash to a long commit hash would not work because the checkout directory will generally not know about a new commit until a `git fetch` is run, and the issue here is that such a `git fetch` fails. It was also independent of BitBucket - this was broken for all providers when `BUILDKITE_COMMIT` was a short commit hash, and that's easily reproducible by creating a commit from the UI.

Closes: #2437