### PR TITLE
Allow omitting the key ID when signing pipelines

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -35,11 +35,11 @@ type AgentConfiguration struct {
 	StrictSingleHooks     bool
 	RunInPty              bool
 
-	JobSigningJWKSPath string // Where to find the key to sign jobs with (passed through to jobs, they might be uploading pipelines)
-	JobSigningKeyID    string // The key ID to sign jobs with
+	SigningJWKSFile  string // Where to find the key to sign pipeline uploads with (passed through to jobs, they might be uploading pipelines)
+	SigningJWKSKeyID string // The key ID to sign pipeline uploads with
 
-	JobVerificationJWKS             jwk.Set // The set of keys to verify jobs with
-	JobVerificationFailureBehaviour string  // What to do if job verification fails (one of `block` or `warn`)
+	VerificationJWKS             jwk.Set // The set of keys to verify jobs with
+	VerificationFailureBehaviour string  // What to do if job verification fails (one of `block` or `warn`)
 
 	ANSITimestamps             bool
 	TimestampLines             bool

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -653,7 +653,7 @@ func (a *AgentWorker) RunJob(ctx context.Context, acceptResponse *api.Job) error
 	// Now that we've got a job to do, we can start it.
 	jr, err := NewJobRunner(ctx, a.logger, a.apiClient, JobRunnerConfig{
 		Job:                acceptResponse,
-		JWKS:               a.agentConfiguration.JobVerificationJWKS,
+		JWKS:               a.agentConfiguration.VerificationJWKS,
 		Debug:              a.debug,
 		DebugHTTP:          a.debugHTTP,
 		CancelSignal:       a.cancelSig,

--- a/agent/integration/job_verification_integration_test.go
+++ b/agent/integration/job_verification_integration_test.go
@@ -265,7 +265,7 @@ func TestJobVerification(t *testing.T) {
 	}{
 		{
 			name:                     "when job signature is invalid, and JobVerificationFailureBehaviour is block, it refuses the job",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      job,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas), // different signing and verification keys
@@ -277,7 +277,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when job signature is invalid, and JobVerificationFailureBehaviour is warn, it warns and runs the job",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourWarn},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourWarn},
 			job:                      job,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas), // different signing and verification keys
@@ -288,7 +288,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when job signature is valid, it runs the job",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      job,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas),
@@ -299,7 +299,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when job signature is valid and there are no plugins, it runs the job",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      jobWithNoPlugins,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas),
@@ -310,7 +310,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when job signature is valid and plugins is null, it runs the job",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      jobWithNullPlugins,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas),
@@ -321,7 +321,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when job signature is missing, and JobVerificationFailureBehaviour is block, it refuses the job",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      job,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               nil,
@@ -333,7 +333,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when job signature is missing, and JobVerificationFailureBehaviour is warn, it warns and runs the job",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourWarn},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourWarn},
 			job:                      job,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               nil,
@@ -344,7 +344,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when the step signature matches, but the job doesn't match the step, it fails signature verification",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      jobWithMismatchedStepAndJob,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas),
@@ -359,7 +359,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when the step signature matches, but the plugins are missing from the job, it fails signature verification",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      jobWithMissingPlugins,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas),
@@ -374,7 +374,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when the step signature matches, but the plugins doesn't match the step, it fails signature verification",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      jobWithMismatchedPlugins,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas),
@@ -404,7 +404,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when the step has a signature, but the env does not match, it fails signature verification",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      jobWithMismatchedEnv,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas),
@@ -419,7 +419,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when the step has a signature, but the step env is not in the job env, it fails signature verification",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      jobWithStepEnvButNoCorrespondingJobEnv,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas),
@@ -434,7 +434,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when the step has a signature, but the pipeline env is not in the job env, it fails signature verification",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      jobWithPipelineEnvButNoCorrespondingJobEnv,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas),
@@ -449,7 +449,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when job signature is valid, and there is a valid matrix permutation, it runs the job",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      jobWithMatrix,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas),
@@ -460,7 +460,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when the step signature matches, but the matrix permutation isn't valid, it fails signature verification",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      jobWithInvalidMatrixPermutation,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas),
@@ -475,7 +475,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when the step signature matches, but the post-matrix env doesn't match, it fails signature verification",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      jobWithMatrixMismatch,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas),
@@ -490,7 +490,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when job has pipeline invariants and the sigature is valid, it runs the job",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      jobWithPipelineInvariantsInEnv,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas),
@@ -501,7 +501,7 @@ func TestJobVerification(t *testing.T) {
 		},
 		{
 			name:                     "when job has invalid pipeline invariants, it fails the job",
-			agentConf:                agent.AgentConfiguration{JobVerificationFailureBehaviour: agent.VerificationBehaviourBlock},
+			agentConf:                agent.AgentConfiguration{VerificationFailureBehaviour: agent.VerificationBehaviourBlock},
 			job:                      jobWithInvalidPipelineInvariantsInEnv,
 			repositoryURL:            defaultRepositoryURL,
 			signingKey:               symmetricJWKFor(t, signingKeyLlamas),

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -175,7 +175,7 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient APIClient, con
 	}
 
 	var err error
-	r.VerificationFailureBehavior, err = r.normalizeVerificationBehavior(conf.AgentConfiguration.JobVerificationFailureBehaviour)
+	r.VerificationFailureBehavior, err = r.normalizeVerificationBehavior(conf.AgentConfiguration.VerificationFailureBehaviour)
 	if err != nil {
 		return nil, fmt.Errorf("setting no signature behavior: %w", err)
 	}
@@ -498,12 +498,12 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	}
 
 	// Pass signing details through to the executor - any pipelines uploaded by this agent will be signed
-	if r.conf.AgentConfiguration.JobSigningJWKSPath != "" {
-		env["BUILDKITE_PIPELINE_UPLOAD_JWKS_FILE_PATH"] = r.conf.AgentConfiguration.JobSigningJWKSPath
+	if r.conf.AgentConfiguration.SigningJWKSFile != "" {
+		env["BUILDKITE_AGENT_JWKS_FILE"] = r.conf.AgentConfiguration.SigningJWKSFile
 	}
 
-	if r.conf.AgentConfiguration.JobSigningKeyID != "" {
-		env["BUILDKITE_PIPELINE_UPLOAD_SIGNING_KEY_ID"] = r.conf.AgentConfiguration.JobSigningKeyID
+	if r.conf.AgentConfiguration.SigningJWKSKeyID != "" {
+		env["BUILDKITE_AGENT_JWKS_KEY_ID"] = r.conf.AgentConfiguration.SigningJWKSKeyID
 	}
 
 	enablePluginValidation := r.conf.AgentConfiguration.PluginValidation

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/buildkite/agent/v3/internal/pipeline"
 	"github.com/buildkite/agent/v3/logger"
-	"github.com/lestrrat-go/jwx/v2/jwa"
-	"github.com/lestrrat-go/jwx/v2/jwk"
 	"gotest.tools/v3/assert"
 )
 
@@ -59,96 +57,6 @@ func TestSearchForSecrets(t *testing.T) {
 				return
 			}
 			assert.ErrorContains(t, err, test.wantLog)
-		})
-	}
-}
-
-func TestValidateJWKDisallows(t *testing.T) {
-	t.Parallel()
-
-	globallyDisallowed := []jwa.SignatureAlgorithm{"", "none", "foo", "bar", "baz"}
-
-	cases := []struct {
-		name           string
-		key            jwk.Key
-		allowedAlgs    []jwa.SignatureAlgorithm
-		disallowedAlgs []jwa.SignatureAlgorithm
-	}{
-		{
-			name:        "RSA only allows PS256, PS384, PS512",
-			key:         newRSAJWK(t),
-			allowedAlgs: ValidRSAAlgorithms,
-			disallowedAlgs: concat(
-				[]jwa.SignatureAlgorithm{jwa.RS256, jwa.RS384, jwa.RS512}, // Specific to RSA, these are possible but we choose not to support them
-				globallyDisallowed,
-				ValidECAlgorithms,
-				ValidOKPAlgorithms,
-				ValidOctetAlgorithms,
-			),
-		},
-		{
-			name:        "EC only allows ES256, ES384, ES512",
-			key:         newECJWK(t),
-			allowedAlgs: ValidECAlgorithms,
-			disallowedAlgs: concat(
-				globallyDisallowed,
-				ValidRSAAlgorithms,
-				ValidOKPAlgorithms,
-				ValidOctetAlgorithms,
-			),
-		},
-		{
-			name:        "OKP only allows EdDSA",
-			key:         newOKPJWK(t),
-			allowedAlgs: ValidOKPAlgorithms,
-			disallowedAlgs: concat(
-				globallyDisallowed,
-				ValidRSAAlgorithms,
-				ValidECAlgorithms,
-				ValidOctetAlgorithms,
-			),
-		},
-		{
-			name:        "Octet only allows HS256, HS384, HS512",
-			key:         newOctetSeqJWK(t),
-			allowedAlgs: ValidOctetAlgorithms,
-			disallowedAlgs: concat(
-				globallyDisallowed,
-				ValidRSAAlgorithms,
-				ValidECAlgorithms,
-				ValidOKPAlgorithms,
-			),
-		},
-	}
-
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			for _, alg := range tc.allowedAlgs {
-				err := tc.key.Set(jwk.AlgorithmKey, alg)
-				if err != nil {
-					t.Fatalf("key.Set(%v, %v) error = %v", jwk.AlgorithmKey, alg, err)
-				}
-
-				err = validateJWK(tc.key)
-				if err != nil {
-					t.Errorf("validateJWK({keyType: %s, alg: %s}) error = %v", tc.key.KeyType(), tc.key.Algorithm(), err)
-				}
-			}
-
-			for _, alg := range tc.disallowedAlgs {
-				err := tc.key.Set(jwk.AlgorithmKey, alg)
-				if err != nil {
-					t.Fatalf("key.Set(%v, %v) error = %v", jwk.AlgorithmKey, alg, err)
-				}
-
-				err = validateJWK(tc.key)
-				if err == nil {
-					t.Errorf("validateJWK({keyType: %s, alg: %s}) expected error, got nil", tc.key.KeyType(), tc.key.Algorithm())
-				}
-			}
 		})
 	}
 }

--- a/clicommand/tool_keygen.go
+++ b/clicommand/tool_keygen.go
@@ -55,7 +55,7 @@ For more information about JWS, see https://tools.ietf.org/html/rfc7515 and for 
 		},
 		cli.StringFlag{
 			Name:   "private-keyset-filename",
-			EnvVar: "BUILDKITE_AGENT_KEYGEN_PRIVATE_KEY_FILENAME",
+			EnvVar: "BUILDKITE_AGENT_KEYGEN_PRIVATE_KEYSET_FILENAME",
 			Usage:  "The filename to write the private key to. Defaults to a name based on the key id in the current directory",
 		},
 		cli.StringFlag{

--- a/clicommand/tool_keygen.go
+++ b/clicommand/tool_keygen.go
@@ -14,10 +14,10 @@ import (
 )
 
 type ToolKeygenConfig struct {
-	Alg               string `cli:"alg" validate:"required"`
-	KeyID             string `cli:"key-id"`
-	PrivateKeysetFile string `cli:"private-keyset-file" normalize:"filepath"`
-	PublicKeysetFile  string `cli:"public-keyset-file" normalize:"filepath"`
+	Alg             string `cli:"alg" validate:"required"`
+	KeyID           string `cli:"key-id"`
+	PrivateJWKSFile string `cli:"private-jwks-file" normalize:"filepath"`
+	PublicJWKSFile  string `cli:"public-jwks-file" normalize:"filepath"`
 
 	NoColor     bool     `cli:"no-color"`
 	Debug       bool     `cli:"debug"`
@@ -36,11 +36,15 @@ var ToolKeygenCommand = cli.Command{
 
 Description:
 
-This (experimental!) command generates a new JWS key pair, used for signing and verifying jobs in Buildkite.
-The key pair is written to two files, a private keyset and a public keyset. The private keyset should be used
-as for signing, and the public for verification. The keysets are written in JWKS format.
+This (experimental!) command generates a new JWS key pair, used for signing and
+verifying jobs in Buildkite.
 
-For more information about JWS, see https://tools.ietf.org/html/rfc7515 and for information about JWKS, see https://tools.ietf.org/html/rfc7517`,
+The pair is written as a JSON Web Key Set (JWKS) to two files, a private JWKS
+file and a public JWKS file. The private JWKS should be used as for signing,
+and the public JWKS for verification.
+
+For more information about JWS, see https://tools.ietf.org/html/rfc7515 and
+for information about JWKS, see https://tools.ietf.org/html/rfc7517`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:     "alg",
@@ -54,13 +58,13 @@ For more information about JWS, see https://tools.ietf.org/html/rfc7515 and for 
 			Usage:  "The ID to use for the keys generated. If none is provided, a random one will be generated",
 		},
 		cli.StringFlag{
-			Name:   "private-keyset-file",
-			EnvVar: "BUILDKITE_AGENT_KEYGEN_PRIVATE_KEYSET_FILE",
+			Name:   "private-jwks-file",
+			EnvVar: "BUILDKITE_AGENT_KEYGEN_PRIVATE_JWKS_FILE",
 			Usage:  "The filename to write the private key to. Defaults to a name based on the key id in the current directory",
 		},
 		cli.StringFlag{
-			Name:   "public-keyset-file",
-			EnvVar: "BUILDKITE_AGENT_KEYGEN_PUBLIC_KEYSET_FILE",
+			Name:   "public-jwks-file",
+			EnvVar: "BUILDKITE_AGENT_KEYGEN_PUBLIC_JWKS_FILE",
 			Usage:  "The filename to write the public keyset to. Defaults to a name based on the key id in the current directory",
 		},
 
@@ -93,32 +97,32 @@ For more information about JWS, see https://tools.ietf.org/html/rfc7515 and for 
 			l.Fatal("Failed to generate key pair: %v", err)
 		}
 
-		if cfg.PrivateKeysetFile == "" {
-			cfg.PrivateKeysetFile = fmt.Sprintf("./%s-%s-private.json", cfg.Alg, cfg.KeyID)
+		if cfg.PrivateJWKSFile == "" {
+			cfg.PrivateJWKSFile = fmt.Sprintf("./%s-%s-private.json", cfg.Alg, cfg.KeyID)
 		}
 
-		if cfg.PublicKeysetFile == "" {
-			cfg.PublicKeysetFile = fmt.Sprintf("./%s-%s-public.json", cfg.Alg, cfg.KeyID)
+		if cfg.PublicJWKSFile == "" {
+			cfg.PublicJWKSFile = fmt.Sprintf("./%s-%s-public.json", cfg.Alg, cfg.KeyID)
 		}
 
-		l.Info("Writing private key set to %s...", cfg.PrivateKeysetFile)
+		l.Info("Writing private key set to %s...", cfg.PrivateJWKSFile)
 		pKey, err := json.Marshal(priv)
 		if err != nil {
 			l.Fatal("Failed to marshal private key: %v", err)
 		}
 
-		err = writeIfNotExists(cfg.PrivateKeysetFile, pKey)
+		err = writeIfNotExists(cfg.PrivateJWKSFile, pKey)
 		if err != nil {
 			l.Fatal("Failed to write private key file: %v", err)
 		}
 
-		l.Info("Writing public key set to %s...", cfg.PublicKeysetFile)
+		l.Info("Writing public key set to %s...", cfg.PublicJWKSFile)
 		pubKey, err := json.Marshal(pub)
 		if err != nil {
 			l.Fatal("Failed to marshal private key: %v", err)
 		}
 
-		err = writeIfNotExists(cfg.PublicKeysetFile, pubKey)
+		err = writeIfNotExists(cfg.PublicJWKSFile, pubKey)
 		if err != nil {
 			l.Fatal("Failed to write private key file: %v", err)
 		}

--- a/clicommand/tool_keygen.go
+++ b/clicommand/tool_keygen.go
@@ -16,7 +16,7 @@ import (
 type ToolKeygenConfig struct {
 	Alg               string `cli:"alg" validate:"required"`
 	KeyID             string `cli:"key-id"`
-	PrivateKeySetFile string `cli:"private-keyset-file" normalize:"filepath"`
+	PrivateKeysetFile string `cli:"private-keyset-file" normalize:"filepath"`
 	PublicKeysetFile  string `cli:"public-keyset-file" normalize:"filepath"`
 
 	NoColor     bool     `cli:"no-color"`
@@ -93,21 +93,21 @@ For more information about JWS, see https://tools.ietf.org/html/rfc7515 and for 
 			l.Fatal("Failed to generate key pair: %v", err)
 		}
 
-		if cfg.PrivateKeySetFile == "" {
-			cfg.PrivateKeySetFile = fmt.Sprintf("./%s-%s-private.json", cfg.Alg, cfg.KeyID)
+		if cfg.PrivateKeysetFile == "" {
+			cfg.PrivateKeysetFile = fmt.Sprintf("./%s-%s-private.json", cfg.Alg, cfg.KeyID)
 		}
 
 		if cfg.PublicKeysetFile == "" {
 			cfg.PublicKeysetFile = fmt.Sprintf("./%s-%s-public.json", cfg.Alg, cfg.KeyID)
 		}
 
-		l.Info("Writing private key set to %s...", cfg.PrivateKeySetFile)
+		l.Info("Writing private key set to %s...", cfg.PrivateKeysetFile)
 		pKey, err := json.Marshal(priv)
 		if err != nil {
 			l.Fatal("Failed to marshal private key: %v", err)
 		}
 
-		err = writeIfNotExists(cfg.PrivateKeySetFile, pKey)
+		err = writeIfNotExists(cfg.PrivateKeysetFile, pKey)
 		if err != nil {
 			l.Fatal("Failed to write private key file: %v", err)
 		}

--- a/clicommand/tool_keygen.go
+++ b/clicommand/tool_keygen.go
@@ -14,10 +14,10 @@ import (
 )
 
 type ToolKeygenConfig struct {
-	Alg                   string `cli:"alg" validate:"required"`
-	KeyID                 string `cli:"key-id"`
-	PrivateKeySetFilename string `cli:"private-keyset-filename" normalize:"filepath"`
-	PublicKeysetFilename  string `cli:"public-keyset-filename" normalize:"filepath"`
+	Alg               string `cli:"alg" validate:"required"`
+	KeyID             string `cli:"key-id"`
+	PrivateKeySetFile string `cli:"private-keyset-file" normalize:"filepath"`
+	PublicKeysetFile  string `cli:"public-keyset-file" normalize:"filepath"`
 
 	NoColor     bool     `cli:"no-color"`
 	Debug       bool     `cli:"debug"`
@@ -54,13 +54,13 @@ For more information about JWS, see https://tools.ietf.org/html/rfc7515 and for 
 			Usage:  "The ID to use for the keys generated. If none is provided, a random one will be generated",
 		},
 		cli.StringFlag{
-			Name:   "private-keyset-filename",
-			EnvVar: "BUILDKITE_AGENT_KEYGEN_PRIVATE_KEYSET_FILENAME",
+			Name:   "private-keyset-file",
+			EnvVar: "BUILDKITE_AGENT_KEYGEN_PRIVATE_KEYSET_FILE",
 			Usage:  "The filename to write the private key to. Defaults to a name based on the key id in the current directory",
 		},
 		cli.StringFlag{
-			Name:   "public-keyset-filename",
-			EnvVar: "BUILDKITE_AGENT_KEYGEN_PUBLIC_KEYSET_FILENAME",
+			Name:   "public-keyset-file",
+			EnvVar: "BUILDKITE_AGENT_KEYGEN_PUBLIC_KEYSET_FILE",
 			Usage:  "The filename to write the public keyset to. Defaults to a name based on the key id in the current directory",
 		},
 
@@ -93,32 +93,32 @@ For more information about JWS, see https://tools.ietf.org/html/rfc7515 and for 
 			l.Fatal("Failed to generate key pair: %v", err)
 		}
 
-		if cfg.PrivateKeySetFilename == "" {
-			cfg.PrivateKeySetFilename = fmt.Sprintf("./%s-%s-private.json", cfg.Alg, cfg.KeyID)
+		if cfg.PrivateKeySetFile == "" {
+			cfg.PrivateKeySetFile = fmt.Sprintf("./%s-%s-private.json", cfg.Alg, cfg.KeyID)
 		}
 
-		if cfg.PublicKeysetFilename == "" {
-			cfg.PublicKeysetFilename = fmt.Sprintf("./%s-%s-public.json", cfg.Alg, cfg.KeyID)
+		if cfg.PublicKeysetFile == "" {
+			cfg.PublicKeysetFile = fmt.Sprintf("./%s-%s-public.json", cfg.Alg, cfg.KeyID)
 		}
 
-		l.Info("Writing private key set to %s...", cfg.PrivateKeySetFilename)
+		l.Info("Writing private key set to %s...", cfg.PrivateKeySetFile)
 		pKey, err := json.Marshal(priv)
 		if err != nil {
 			l.Fatal("Failed to marshal private key: %v", err)
 		}
 
-		err = writeIfNotExists(cfg.PrivateKeySetFilename, pKey)
+		err = writeIfNotExists(cfg.PrivateKeySetFile, pKey)
 		if err != nil {
 			l.Fatal("Failed to write private key file: %v", err)
 		}
 
-		l.Info("Writing public key set to %s...", cfg.PublicKeysetFilename)
+		l.Info("Writing public key set to %s...", cfg.PublicKeysetFile)
 		pubKey, err := json.Marshal(pub)
 		if err != nil {
 			l.Fatal("Failed to marshal private key: %v", err)
 		}
 
-		err = writeIfNotExists(cfg.PublicKeysetFilename, pubKey)
+		err = writeIfNotExists(cfg.PublicKeysetFile, pubKey)
 		if err != nil {
 			l.Fatal("Failed to write private key file: %v", err)
 		}

--- a/clicommand/tool_keygen.go
+++ b/clicommand/tool_keygen.go
@@ -43,9 +43,10 @@ as for signing, and the public for verification. The keysets are written in JWKS
 For more information about JWS, see https://tools.ietf.org/html/rfc7515 and for information about JWKS, see https://tools.ietf.org/html/rfc7517`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
-			Name:   "alg",
-			EnvVar: "BUILDKITE_AGENT_KEYGEN_ALG",
-			Usage:  fmt.Sprintf("The JWS signing algorithm to use for the key pair. Valid algorithms are: %v", ValidSigningAlgorithms),
+			Name:     "alg",
+			EnvVar:   "BUILDKITE_AGENT_KEYGEN_ALG",
+			Usage:    fmt.Sprintf("The JWS signing algorithm to use for the key pair. Valid algorithms are: %v", jwkutil.ValidSigningAlgorithms),
+			Required: true,
 		},
 		cli.StringFlag{
 			Name:   "key-id",
@@ -83,8 +84,8 @@ For more information about JWS, see https://tools.ietf.org/html/rfc7515 and for 
 
 		sigAlg := jwa.SignatureAlgorithm(cfg.Alg)
 
-		if !slices.Contains(ValidSigningAlgorithms, sigAlg) {
-			l.Fatal("Invalid signing algorithm: %s. Valid signing algorithms are: %s", cfg.Alg, ValidSigningAlgorithms)
+		if !slices.Contains(jwkutil.ValidSigningAlgorithms, sigAlg) {
+			l.Fatal("Invalid signing algorithm: %s. Valid signing algorithms are: %s", cfg.Alg, jwkutil.ValidSigningAlgorithms)
 		}
 
 		priv, pub, err := jwkutil.NewKeyPair(cfg.KeyID, sigAlg)
@@ -124,7 +125,7 @@ For more information about JWS, see https://tools.ietf.org/html/rfc7515 and for 
 
 		l.Info("Done! Enjoy your new keys ^_^")
 
-		if slices.Contains(ValidOctetAlgorithms, sigAlg) {
+		if slices.Contains(jwkutil.ValidOctetAlgorithms, sigAlg) {
 			l.Info("Note: Because you're using the %s algorithm, which is symmetric, the public and private keys are identical", sigAlg)
 		}
 	},

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -242,8 +242,7 @@ func signWithGraphQL(
 	debugL.Debug("Pipeline retrieved successfully: %#v", resp)
 	l.Info("Signing pipeline with the repository URL:\n%s", resp.Pipeline.Repository.Url)
 
-	pipelineYaml := strings.NewReader(resp.Pipeline.Steps.Yaml)
-	parsedPipeline, err := pipeline.Parse(pipelineYaml)
+	parsedPipeline, err := pipeline.Parse(strings.NewReader(resp.Pipeline.Steps.Yaml))
 	if err != nil {
 		return fmt.Errorf("pipeline parsing failed: %w", err)
 	}

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -75,7 +75,7 @@ update the pipeline definition with the signed version using the GraphQL API too
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "graphql-token",
-			Usage:  "A token for the buildkite graphql API. This will be used to populate the value of the repository URL, and download the pipeline definition. Both ′repo′ and ′pipeline-file′ will be ignored in preferance of values from the GraphQL API if the token in provided.",
+			Usage:  "A token for the buildkite graphql API. This will be used to populate the value of the repository URL, and download the pipeline definition. Both ′repo′ and ′pipeline-file′ will be ignored in preference of values from the GraphQL API if the token in provided.",
 			EnvVar: "BUILDKITE_GRAPHQL_TOKEN",
 		},
 		cli.BoolFlag{

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -61,65 +61,63 @@ var ToolSignCommand = cli.Command{
 	Usage: "Sign pipeline steps",
 	Description: `Usage:
 
-    buildkite-agent tool sign-pipeline [options...]
+    buildkite-agent tool sign-pipeline [options...] [pipeline-file]
 
 Description:
 
 This (experimental!) command takes a pipeline in YAML format as input, and annotates the
 appropriate parts of the pipeline with signatures. This can then be input into the YAML steps
-editor in the Buildkite UI so that the agents running these steps can verify the signatures.`,
+editor in the Buildkite UI so that the agents running these steps can verify the signatures.
+
+If a token is provided using the ′graphql-token′ flag, the tool will attempt to retrieve the
+pipeline definition and repo using the Buildkite GraphQL API. If ′update′ is also set, it will
+update the pipeline definition with the signed version using the GraphQL API too.`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
-			Name:     "graphql-token",
-			Usage:    "A token for the buildkite graphql API. This will be used to populate the pipeline invariants if they are not provided.",
-			EnvVar:   "BUILDKITE_GRAPHQL_TOKEN",
-			Required: false,
+			Name:   "graphql-token",
+			Usage:  "A token for the buildkite graphql API. This will be used to populate the value of the repository URL, and download the pipeline definition. Both ′repo′ and ′pipeline-file′ will be ignored in preferance of values from the GraphQL API if the token in provided.",
+			EnvVar: "BUILDKITE_GRAPHQL_TOKEN",
 		},
 		cli.BoolFlag{
 			Name:   "update",
-			Usage:  "Update the pipeline online after signing it. This can only be used if the GraphQL token is provided.",
+			Usage:  "Update the pipeline using the GraphQL API after signing it. This can only be used if ′graphql-token′ is provided.",
 			EnvVar: "BUILDKITE_TOOL_SIGN_UPDATE",
 		},
 		cli.BoolFlag{
 			Name:   "no-confirm",
-			Usage:  "Show confirmation prompts before updating the pipeline online.",
+			Usage:  "Show confirmation prompts before updating the pipeline with the GraphQL API.",
 			EnvVar: "BUILDKITE_TOOL_SIGN_NO_CONFIRM",
 		},
 
 		// Used for signing
 		cli.StringFlag{
-			Name:     "jwks-file",
-			Usage:    "Path to a file containing a JWKS.",
-			EnvVar:   "BUILDKITE_AGENT_JWKS_FILE",
-			Required: true,
+			Name:   "jwks-file",
+			Usage:  "Path to a file containing a JWKS.",
+			EnvVar: "BUILDKITE_AGENT_JWKS_FILE",
 		},
 		cli.StringFlag{
-			Name:     "jwks-key-id",
-			Usage:    "The JWKS key ID to use when signing the pipeline. If none is provided and the JWKS file contains only one key, that key will be used.",
-			EnvVar:   "BUILDKITE_AGENT_JWKS_KEY_ID",
-			Required: false,
+			Name:   "jwks-key-id",
+			Usage:  "The JWKS key ID to use when signing the pipeline. If none is provided and the JWKS file contains only one key, that key will be used.",
+			EnvVar: "BUILDKITE_AGENT_JWKS_KEY_ID",
 		},
 
-		// These are required to use the GraphQL API
+		// These are required for GraphQL
 		cli.StringFlag{
-			Name:     "organization-slug",
-			Usage:    "The organization slug. Used to connect to the GraphQL API.",
-			EnvVar:   "BUILDKITE_ORGANIZATION_SLUG",
-			Required: false,
+			Name:   "organization-slug",
+			Usage:  "The organization slug. Required to connect to the GraphQL API.",
+			EnvVar: "BUILDKITE_ORGANIZATION_SLUG",
 		},
 		cli.StringFlag{
-			Name:     "pipeline-slug",
-			Usage:    "The pipeline slug. Used to connect to the GraphQL API.",
-			EnvVar:   "BUILDKITE_PIPELINE_SLUG",
-			Required: false,
+			Name:   "pipeline-slug",
+			Usage:  "The pipeline slug. Required to connect to the GraphQL API.",
+			EnvVar: "BUILDKITE_PIPELINE_SLUG",
 		},
 
 		// Added to signature
 		cli.StringFlag{
-			Name:     "repo",
-			Usage:    "The URL of the pipeline's repository, which is used in the pipeline signature. If the GraphQL token is provided, this will be ignored.",
-			EnvVar:   "BUILDKITE_REPO",
-			Required: false,
+			Name:   "repo",
+			Usage:  "The URL of the pipeline's repository, which is used in the pipeline signature. If the GraphQL token is provided, this will be ignored.",
+			EnvVar: "BUILDKITE_REPO",
 		},
 
 		// Global flags

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -245,7 +245,7 @@ func signWithGraphQL(
 	pipelineYaml := strings.NewReader(resp.Pipeline.Steps.Yaml)
 	parsedPipeline, err := pipeline.Parse(pipelineYaml)
 	if err != nil {
-		return fmt.Errorf("pipeline parsing failed: %v", err)
+		return fmt.Errorf("pipeline parsing failed: %w", err)
 	}
 
 	if cfg.Debug {

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -190,7 +190,7 @@ func signOffline(
 
 	parsedPipeline, err := pipeline.Parse(input)
 	if err != nil {
-		return fmt.Errorf("pipeline parsing of %q failed: %v", filename, err)
+		return fmt.Errorf("pipeline parsing of %q failed: %w", filename, err)
 	}
 
 	if cfg.Debug {

--- a/internal/jwkutil/doc.go
+++ b/internal/jwkutil/doc.go
@@ -1,0 +1,5 @@
+// Package jwkutil provides utilities for working with JSON Web Keys and JSON
+// Web Key Sets as defined in [RFC 7517].
+//
+// [RFC 7517]: https://tools.ietf.org/html/rfc7517
+package jwkutil

--- a/internal/jwkutil/generate.go
+++ b/internal/jwkutil/generate.go
@@ -14,6 +14,8 @@ import (
 
 const symmetricKeyLength = 2048
 
+// NewKeyPair generates a new key pair for the given algorithm and gives it the kid specified in
+// `keyID`. The returned key sets contain the public and private keys and an error in that order.
 func NewKeyPair(keyID string, alg jwa.SignatureAlgorithm) (jwk.Set, jwk.Set, error) {
 	switch alg {
 	case jwa.HS256, jwa.HS384, jwa.HS512:
@@ -53,6 +55,8 @@ func NewKeyPair(keyID string, alg jwa.SignatureAlgorithm) (jwk.Set, jwk.Set, err
 	}
 }
 
+// NewSymmetricKeyPairFromString creates a symmetric key pair from the given key string and gives it
+// the kid specified in `keyID`. Both returned jwk.Set values are the same symmetric key.
 func NewSymmetricKeyPairFromString(id, key string, alg jwa.SignatureAlgorithm) (jwk.Set, jwk.Set, error) {
 	return newSymmetricKeyPair(id, []byte(key), alg)
 }

--- a/internal/jwkutil/key_in_jwks_file.go
+++ b/internal/jwkutil/key_in_jwks_file.go
@@ -1,0 +1,73 @@
+package jwkutil
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/lestrrat-go/jwx/v2/jwk"
+)
+
+var (
+	ErrNoSigningKeyID = errors.New(
+		"a signing key ID is required when using a JWKS that does not have exactly one signing key",
+	)
+	ErrNoFirstKey = errors.New(
+		"could not retrieve first key from a JWKS that has exactly one signing key. Maybe the JWKS file is corrupt?",
+	)
+	ErrCounldNotFindKeyByID = errors.New("could not be found in JWKS")
+)
+
+func LoadKey(path, keyID string) (jwk.Key, error) {
+	jwksFile, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening JWKS file: %w", err)
+	}
+	defer jwksFile.Close()
+
+	jwksBody, err := io.ReadAll(jwksFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading JWKS file: %w", err)
+	}
+
+	jwks, err := jwk.Parse(jwksBody)
+	if err != nil {
+		return nil, fmt.Errorf("parsing JWKS file: %w", err)
+	}
+
+	key, keyId, err := fromIdOrOnlyKey(jwks, keyID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := Validate(key); err != nil {
+		return nil, fmt.Errorf("signing key ID %q is invalid: %w", keyId, err)
+	}
+
+	return key, nil
+}
+
+// fromIdOrOnlyKey looks up the key by ID if the ID is not empty.
+// It falls back to returning the first key if the ID is empty.
+func fromIdOrOnlyKey(jwks jwk.Set, keyID string) (jwk.Key, string, error) {
+	if keyID == "" {
+		if jwks.Len() != 1 {
+			return nil, "", ErrNoSigningKeyID
+		}
+
+		key, found := jwks.Key(0)
+		if !found {
+			return nil, "", ErrNoFirstKey
+		}
+
+		return key, key.KeyID(), nil
+	}
+
+	key, found := jwks.LookupKeyID(keyID)
+	if !found {
+		return nil, "", fmt.Errorf("signing key ID %q %w", keyID, ErrCounldNotFindKeyByID)
+	}
+
+	return key, keyID, nil
+}

--- a/internal/jwkutil/load_key.go
+++ b/internal/jwkutil/load_key.go
@@ -16,9 +16,12 @@ var (
 	ErrNoFirstKey = errors.New(
 		"could not retrieve first key from a JWKS that has exactly one signing key. Maybe the JWKS file is corrupt?",
 	)
-	ErrCounldNotFindKeyByID = errors.New("could not be found in JWKS")
+	ErrCouldNotFindKeyByID = errors.New("could not be found in JWKS")
 )
 
+// LoadKey parses a JSON Web Key Set from a file path and returns the JSON Web
+// Key identified by `keyID`. If the `keyID` is empty and the JSON Web Key Set
+// is a singleton, it returns the only key in the key set.
 func LoadKey(path, keyID string) (jwk.Key, error) {
 	jwksFile, err := os.Open(path)
 	if err != nil {
@@ -48,8 +51,8 @@ func LoadKey(path, keyID string) (jwk.Key, error) {
 	return key, nil
 }
 
-// fromIdOrOnlyKey looks up the key by ID if the ID is not empty.
-// It falls back to returning the first key if the ID is empty.
+// fromIdOrOnlyKey looks up the key by ID. If the `keyID` is empty and the JSON Web Key Set
+// is a singleton, it returns the only key in the key set.
 func fromIdOrOnlyKey(jwks jwk.Set, keyID string) (jwk.Key, string, error) {
 	if keyID == "" {
 		if jwks.Len() != 1 {
@@ -66,7 +69,7 @@ func fromIdOrOnlyKey(jwks jwk.Set, keyID string) (jwk.Key, string, error) {
 
 	key, found := jwks.LookupKeyID(keyID)
 	if !found {
-		return nil, "", fmt.Errorf("signing key ID %q %w", keyID, ErrCounldNotFindKeyByID)
+		return nil, "", fmt.Errorf("signing key ID %q %w", keyID, ErrCouldNotFindKeyByID)
 	}
 
 	return key, keyID, nil

--- a/internal/jwkutil/validate.go
+++ b/internal/jwkutil/validate.go
@@ -1,0 +1,85 @@
+package jwkutil
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"golang.org/x/exp/slices"
+)
+
+var (
+	ValidRSAAlgorithms   = []jwa.SignatureAlgorithm{jwa.PS256, jwa.PS384, jwa.PS512}
+	ValidECAlgorithms    = []jwa.SignatureAlgorithm{jwa.ES256, jwa.ES384, jwa.ES512}
+	ValidOctetAlgorithms = []jwa.SignatureAlgorithm{jwa.HS256, jwa.HS384, jwa.HS512}
+	ValidOKPAlgorithms   = []jwa.SignatureAlgorithm{jwa.EdDSA}
+
+	ValidSigningAlgorithms = concat(
+		ValidOctetAlgorithms,
+		ValidRSAAlgorithms,
+		ValidECAlgorithms,
+		ValidOKPAlgorithms,
+	)
+)
+
+var (
+	ErrKeyMissingAlg             = errors.New("key is missing algorithm")
+	ErrUnsupportedAlgForKeyType  = errors.New("unsupported key type")
+	ErrInvalidSigningAlgorithm   = errors.New("invalid signing algorithm")
+	ErrUnsupportSigningAlgorithm = errors.New("unsupported signing algorithm for key type")
+)
+
+func Validate(key jwk.Key) error {
+	validKeyTypes := []jwa.KeyType{jwa.RSA, jwa.EC, jwa.OctetSeq, jwa.OKP}
+	if !slices.Contains(validKeyTypes, key.KeyType()) {
+		return fmt.Errorf(
+			"%w: %q. Key type must be one of %q",
+			ErrUnsupportedAlgForKeyType,
+			key.KeyType(),
+			validKeyTypes,
+		)
+	}
+
+	if _, ok := key.Get(jwk.AlgorithmKey); !ok {
+		return ErrKeyMissingAlg
+	}
+
+	signingAlg, ok := key.Algorithm().(jwa.SignatureAlgorithm)
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrInvalidSigningAlgorithm, key.Algorithm())
+	}
+
+	validAlgsForType := map[jwa.KeyType][]jwa.SignatureAlgorithm{
+		// We don't suppport RSA-PKCS1v1.5 because it's arguably less secure than RSA-PSS
+		jwa.RSA:      {jwa.PS256, jwa.PS384, jwa.PS512},
+		jwa.EC:       {jwa.ES256, jwa.ES384, jwa.ES512},
+		jwa.OctetSeq: {jwa.HS256, jwa.HS384, jwa.HS512},
+		jwa.OKP:      {jwa.EdDSA},
+	}
+
+	if !slices.Contains(validAlgsForType[key.KeyType()], signingAlg) {
+		return fmt.Errorf(
+			"%w: alg: %q, key type: %q. Expected alg to be one of %q",
+			ErrUnsupportedAlgForKeyType,
+			signingAlg,
+			key.KeyType(),
+			validAlgsForType[key.KeyType()],
+		)
+	}
+
+	return nil
+}
+
+func concat[T any](a ...[]T) []T {
+	capacity := 0
+	for _, s := range a {
+		capacity += len(s)
+	}
+
+	result := make([]T, 0, capacity)
+	for _, s := range a {
+		result = append(result, s...)
+	}
+	return result
+}

--- a/internal/jwkutil/validate_test.go
+++ b/internal/jwkutil/validate_test.go
@@ -1,0 +1,98 @@
+package jwkutil
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+)
+
+func TestValidateJWKDisallows(t *testing.T) {
+	t.Parallel()
+
+	globallyDisallowed := []jwa.SignatureAlgorithm{"", "none", "foo", "bar", "baz"}
+
+	cases := []struct {
+		name           string
+		key            jwk.Key
+		allowedAlgs    []jwa.SignatureAlgorithm
+		disallowedAlgs []jwa.SignatureAlgorithm
+	}{
+		{
+			name:        "RSA only allows PS256, PS384, PS512",
+			key:         newRSAJWK(t),
+			allowedAlgs: ValidRSAAlgorithms,
+			disallowedAlgs: concat(
+				[]jwa.SignatureAlgorithm{jwa.RS256, jwa.RS384, jwa.RS512}, // Specific to RSA, these are possible but we choose not to support them
+				globallyDisallowed,
+				ValidECAlgorithms,
+				ValidOKPAlgorithms,
+				ValidOctetAlgorithms,
+			),
+		},
+		{
+			name:        "EC only allows ES256, ES384, ES512",
+			key:         newECJWK(t),
+			allowedAlgs: ValidECAlgorithms,
+			disallowedAlgs: concat(
+				globallyDisallowed,
+				ValidRSAAlgorithms,
+				ValidOKPAlgorithms,
+				ValidOctetAlgorithms,
+			),
+		},
+		{
+			name:        "OKP only allows EdDSA",
+			key:         newOKPJWK(t),
+			allowedAlgs: ValidOKPAlgorithms,
+			disallowedAlgs: concat(
+				globallyDisallowed,
+				ValidRSAAlgorithms,
+				ValidECAlgorithms,
+				ValidOctetAlgorithms,
+			),
+		},
+		{
+			name:        "Octet only allows HS256, HS384, HS512",
+			key:         newOctetSeqJWK(t),
+			allowedAlgs: ValidOctetAlgorithms,
+			disallowedAlgs: concat(
+				globallyDisallowed,
+				ValidRSAAlgorithms,
+				ValidECAlgorithms,
+				ValidOKPAlgorithms,
+			),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, alg := range tc.allowedAlgs {
+				err := tc.key.Set(jwk.AlgorithmKey, alg)
+				if err != nil {
+					t.Fatalf("key.Set(%v, %v) error = %v", jwk.AlgorithmKey, alg, err)
+				}
+
+				err = Validate(tc.key)
+				if err != nil {
+					t.Errorf("Validate({keyType: %s, alg: %s}) error = %v", tc.key.KeyType(), tc.key.Algorithm(), err)
+				}
+			}
+
+			for _, alg := range tc.disallowedAlgs {
+				err := tc.key.Set(jwk.AlgorithmKey, alg)
+				if err != nil {
+					t.Fatalf("key.Set(%v, %v) error = %v", jwk.AlgorithmKey, alg, err)
+				}
+
+				err = Validate(tc.key)
+				if err == nil {
+					t.Errorf("Validate({keyType: %s, alg: %s}) expected error, got nil", tc.key.KeyType(), tc.key.Algorithm())
+				}
+			}
+		})
+	}
+}

--- a/internal/jwkutil/validate_test_helpers_test.go
+++ b/internal/jwkutil/validate_test_helpers_test.go
@@ -1,4 +1,4 @@
-package clicommand
+package jwkutil
 
 import (
 	"crypto/ecdsa"


### PR DESCRIPTION
It will be inferred from the key set if the key set has only one key. I decided to move most of the common parts of key signing shared between `pipeline upload` and `tool sign` to the `jwkutils` module.

Also, I made some of the arguments a bit shorter.

In `pipeline upload` and `tool sign`, the following arguments were changed:
- `jwks-file-path` -> `jwks-file`
- `signing-key-id` -> `jwks-key-id`

I've preferred `file` to `path` because `path` suggests that a directory may be given, but that's not the case. It's also obvious that the key id is used for signing in these sub-commands.

In `start`, there remains a need to distinguish the signing key and verification key to discourage users from distributing both keys everywhere. However, I make the follow changes:
- `job-signing-jwks-path` -> `signing-jwks-file`
- `job-signing-key-id` -> `signing-key-id`
- `job-verification-jwks-path` -> `verification-jwks-path`
- `job-verification-failure-behaviour` -> `verification-jwks-path` 

The reason I've removed `job` from these is
1. jobs aren't signed, steps are.
2. while jobs are verified in some sense, it is more accurate to say that the step signature is cryptographically verified and the job is checked for consistency with the step
3. In any case, I think this type of verification is important enough that we don't need to add the "job" qualifier to it.

In `tool keygen`:
- `private-keyset-filename` -> `private-jwks-file`
- `public-keyset-filename` -> `public-jwks-file`
This is to make it consistent with the other commands, which just specify `file`.