### PR TITLE
Add key.Validate call

### DIFF
--- a/internal/jwkutil/validate.go
+++ b/internal/jwkutil/validate.go
@@ -31,6 +31,10 @@ var (
 )
 
 func Validate(key jwk.Key) error {
+	if err := key.Validate(); err != nil {
+		return err
+	}
+
 	validKeyTypes := []jwa.KeyType{jwa.RSA, jwa.EC, jwa.OctetSeq, jwa.OKP}
 	if !slices.Contains(validKeyTypes, key.KeyType()) {
 		return fmt.Errorf(


### PR DESCRIPTION
This new method was added in https://github.com/lestrrat-go/jwx/releases/tag/v2.0.16, and might not be called automatically.

Same as buildkite/go-pipeline#6