### PR TITLE
Fix build number incorporation

### DIFF
--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -10,7 +10,7 @@ fi
 export GOOS=${1}
 export GOARCH=${2}
 
-BUILD_VERSION=${3}
+BUILD_NUMBER=${3}
 NAME="buildkite-agent"
 
 if [[ "$GOOS" = "dragonflybsd" ]]; then
@@ -32,7 +32,7 @@ echo "GOARCH=$GOARCH"
 if [[ -n "$GOARM" ]]; then
   echo "GOARM=$GOARM"
 fi
-echo "BUILD_VERSION=$BUILD_VERSION"
+echo "BUILD_NUMBER=$BUILD_NUMBER"
 echo ""
 
 # Add .exe for Windows builds
@@ -47,7 +47,7 @@ export CGO_ENABLED=0
 "$(dirname $0)"/generate-acknowledgements.sh
 
 mkdir -p $BUILD_PATH
-go build -v -ldflags "-X github.com/buildkite/agent/v3/version.buildVersion=$BUILD_VERSION" -o $BUILD_PATH/$BINARY_FILENAME .
+go build -v -ldflags "-X github.com/buildkite/agent/v3/version.buildNumber=$BUILD_NUMBER" -o $BUILD_PATH/$BINARY_FILENAME .
 
 chmod +x $BUILD_PATH/$BINARY_FILENAME
 

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -7,37 +7,37 @@ then
   exit 1
 fi
 
-export GOOS=${1}
-export GOARCH=${2}
+export GOOS="$1"
+export GOARCH="$2"
 
-BUILD_NUMBER=${3}
+BUILD_NUMBER="$3"
 NAME="buildkite-agent"
 
-if [[ "$GOOS" = "dragonflybsd" ]]; then
+if [[ "${GOOS}" = "dragonflybsd" ]]; then
   export GOOS="dragonfly"
 fi
 
 BUILD_PATH="pkg"
-BINARY_FILENAME="$NAME-$GOOS-$GOARCH"
+BINARY_FILENAME="${NAME}-${GOOS}-${GOARCH}"
 
-if [[ "$GOARCH" = "armhf" ]]; then
+if [[ "${GOARCH}" = "armhf" ]]; then
   export GOARCH="arm"
   export GOARM="7"
 fi
 
-echo -e "Building $NAME with:\n"
+echo -e "Building ${NAME} with:\n"
 
-echo "GOOS=$GOOS"
-echo "GOARCH=$GOARCH"
-if [[ -n "$GOARM" ]]; then
-  echo "GOARM=$GOARM"
+echo "GOOS=${GOOS}"
+echo "GOARCH=${GOARCH}"
+if [[ -n "${GOARM}" ]]; then
+  echo "GOARM=${GOARM}"
 fi
-echo "BUILD_NUMBER=$BUILD_NUMBER"
+echo "BUILD_NUMBER=${BUILD_NUMBER}"
 echo ""
 
 # Add .exe for Windows builds
 if [[ "$GOOS" == "windows" ]]; then
-  BINARY_FILENAME="$BINARY_FILENAME.exe"
+  BINARY_FILENAME="${BINARY_FILENAME}.exe"
 fi
 
 # Disable CGO completely
@@ -47,8 +47,8 @@ export CGO_ENABLED=0
 "$(dirname $0)"/generate-acknowledgements.sh
 
 mkdir -p $BUILD_PATH
-go build -v -ldflags "-X github.com/buildkite/agent/v3/version.buildNumber=$BUILD_NUMBER" -o $BUILD_PATH/$BINARY_FILENAME .
+go build -v -ldflags "-X github.com/buildkite/agent/v3/version.buildNumber=${BUILD_NUMBER}" -o "${BUILD_PATH}/${BINARY_FILENAME}" .
 
-chmod +x $BUILD_PATH/$BINARY_FILENAME
+chmod +x "${BUILD_PATH}/${BINARY_FILENAME}"
 
-echo -e "\nDone: \033[33m$BUILD_PATH/$BINARY_FILENAME\033[0m 💪"
+echo -e "\nDone: \033[33m${BUILD_PATH}/${BINARY_FILENAME}\033[0m 💪"

--- a/version/version.go
+++ b/version/version.go
@@ -14,6 +14,9 @@ import (
 var (
 	//go:embed VERSION
 	baseVersion string
+
+	// buildNumber is filled in by scripts/build-binary.sh by passing -ldflags
+	// "-X github.com/buildkite/agent/v3/version.buildNumber=${BUILDKITE_BUILD_NUMBER}"
 	buildNumber = "x"
 )
 


### PR DESCRIPTION
scripts/build-binary.sh was setting buildVersion, but the variable is now buildNumber.

Plus an opportunistic shell style cleanup.