### PR TITLE
More log streamer cleanups

### DIFF
--- a/agent/log_streamer_test.go
+++ b/agent/log_streamer_test.go
@@ -1,0 +1,86 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestLogStreamer(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	logger := logger.NewConsoleLogger(
+		logger.NewTextPrinter(os.Stderr),
+		func(c int) { t.Errorf("exit(%d)", c) },
+	)
+
+	var got []*LogStreamerChunk
+	callback := func(ctx context.Context, chunk *LogStreamerChunk) error {
+		got = append(got, chunk)
+		return nil
+	}
+
+	ls := NewLogStreamer(logger, callback, LogStreamerConfig{
+		Concurrency:       3,
+		MaxChunkSizeBytes: 10,
+		MaxSizeBytes:      30,
+	})
+
+	if err := ls.Start(ctx); err != nil {
+		t.Fatalf("LogStreamer.Start(ctx) = %v", err)
+	}
+
+	input := "0123456789abcdefghijklmnopqrstuvwxyz!@#$%^&*()" // 46 bytes
+	if err := ls.Process(ctx, []byte(input)); err != nil {
+		t.Errorf("LogStreamer.Process(ctx, %q) = %v", input, err)
+	}
+
+	ls.Stop()
+
+	want := []*LogStreamerChunk{
+		{
+			Data:   []byte("0123456789"),
+			Order:  1,
+			Offset: 0,
+			Size:   10,
+		},
+		{
+			Data:   []byte("abcdefghij"),
+			Order:  2,
+			Offset: 10,
+			Size:   10,
+		},
+		{
+			Data:   []byte("klmnopqrst"),
+			Order:  3,
+			Offset: 20,
+			Size:   10,
+		},
+		{
+			Data:   []byte("uvwxyz!@#$"),
+			Order:  4,
+			Offset: 30,
+			Size:   10,
+		},
+		{
+			Data:   []byte("%^&*()"),
+			Order:  5,
+			Offset: 40,
+			Size:   6,
+		},
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("LogStreamer chunks diff (-got +want):\n%s", diff)
+	}
+
+	input = "¿more log after stop?"
+	if err := ls.Process(ctx, []byte(input)); !errors.Is(err, errStreamerStopped) {
+		t.Errorf("after Stop: LogStreamer.Process(ctx, %q) err = %v, want %v", input, err, errStreamerStopped)
+	}
+}


### PR DESCRIPTION
### What
- Use the WaitGroup to count workers instead of pending log uploads, averting any potential races on the WaitGroup
- Signal to workers that work is complete by closing the channel, instead of sending nil several times
- Handle context cancellation in worker with a select
- Add context arg to Process, and a select to handle it there, too
- Track whether the streamer has been stopped, and use that to return an error from Process after Stop
- Reinstate error handling inside streamJobLogsAfterProcessStart and output buffer closing (with explanatory comment)
- Neaten up core of Process loop
- Doc comments
- A test!

### Why 
Handling context cancellation in a select with the channel operations is, strictly speaking, a bug fix (context should be available as a lever to cancel blocked operations), but practically isn't used here.

Returning an error from Process after Stop is a behaviour change that is similarly theoretical (if the job is always stopped, and Process is never called again before Stop). But it is an improvement: before, if Stop is called then there is the possibility that, if all the workers are stopped and Process is called again, the chunk is left in the channel until the program exits, or potentially the queue fills up and the goroutine managing the streamer blocks forever. Now, Process at least returns an error.

This also means that we can be more explicit about closing the queue and then actually wait for for the workers to finish, rather than waiting for _current_ work to finish before yeeting nil several times into the (buffered) queue channel and not actually waiting them to shut down (this always seemed weird and backwards to me). 

### Notes
Note that this does not enable log limit enforcement (yet).