### PR TITLE
Set EnvVar for Submodule mirrors

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -600,6 +600,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 			e.shell.Warningf("Failed to enumerate git submodules: %v", err)
 		} else {
 			mirrorSubmodules := e.ExecutorConfig.GitMirrorsPath != ""
+			submoduleMirrorDirs := make([]string, 0)
 			for _, repository := range submoduleRepos {
 				submoduleArgs := append([]string(nil), args...)
 				// submodules might need their fingerprints verified too
@@ -616,6 +617,8 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 				if err != nil {
 					return fmt.Errorf("getting/updating mirror dir for submodules: %w", err)
 				}
+
+				submoduleMirrorDirs = append(submoduleMirrorDirs, mirrorDir)
 
 				// Switch back to the checkout dir, doing other operations from GitMirrorsPath will fail.
 				if err := e.createCheckoutDir(); err != nil {
@@ -640,6 +643,10 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 				if err := e.shell.Run(ctx, "git", submoduleArgs...); err != nil {
 					return fmt.Errorf("updating submodules: %w", err)
 				}
+			}
+
+			for i, dir := range submoduleMirrorDirs {
+				e.shell.Env.Set(fmt.Sprintf("BUILDKITE_REPO_SUBMODULE_MIRROR_%d", i), dir)
 			}
 
 			if !mirrorSubmodules {


### PR DESCRIPTION
A quick attempt at solving this issue. https://github.com/buildkite/agent/issues/2511

TL;DR: The agent doesn't provide an env var containing the directories of submodule git mirrors, so plugins (docker, in my case) can't mount those directories, causing git issues in containers.

Let me know if I missed anything obvious.

For testing, I've been struggling to get tests to pass locally (both on main, and on my branch). Do I need to be using a valid buildkite agent token in order to run tests? It looks like it's failing to send real data off to buildkite's API. Once I get the tests working I can add an expectation in the checkout integration test.