### PR TITLE
Humanize bytes to IEC (1024 → KiB etc) not SI (1000 → KB etc)

### DIFF
--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -531,7 +531,7 @@ func (a *ArtifactUploader) upload(ctx context.Context, artifacts []*api.Artifact
 
 		p.Spawn(func() {
 			// Show a nice message that we're starting to upload the file
-			a.logger.Info("Uploading artifact %s %s (%s)", artifact.ID, artifact.Path, humanize.Bytes(uint64(artifact.FileSize)))
+			a.logger.Info("Uploading artifact %s %s (%s)", artifact.ID, artifact.Path, humanize.IBytes(uint64(artifact.FileSize)))
 
 			var state string
 

--- a/agent/download.go
+++ b/agent/download.go
@@ -153,7 +153,7 @@ func (d Download) try(ctx context.Context) error {
 		return fmt.Errorf("Error when copying data %s (%T: %v)", d.conf.URL, err, err)
 	}
 
-	d.logger.Info("Successfully downloaded \"%s\" %s", d.conf.Path, humanize.Bytes(uint64(bytes)))
+	d.logger.Info("Successfully downloaded \"%s\" %s", d.conf.Path, humanize.IBytes(uint64(bytes)))
 
 	return nil
 }

--- a/agent/log_streamer.go
+++ b/agent/log_streamer.go
@@ -122,7 +122,7 @@ func (ls *LogStreamer) Process(output []byte) {
 				"exceeded the maximum size (%s). Further logs may be dropped "+
 				"by the server, and a future version of the agent will stop "+
 				"sending logs at this point.",
-				humanize.Bytes(ls.bytes), humanize.Bytes(ls.conf.MaxSizeBytes))
+				humanize.IBytes(ls.bytes), humanize.IBytes(ls.conf.MaxSizeBytes))
 			ls.warnedAboutSize = true
 			// In a future version, this will error out, e.g.:
 			//return fmt.Errorf("job log has exceeded max job log size (%d > %d)", ls.bytes, ls.conf.MaxSizeBytes)


### PR DESCRIPTION
When displaying byte quantities, use IEC / base-2 (1024 → KiB etc) rather than SI / base-10 (1000 → KB etc) units.

Using IEC / base-2 units matches our server-side display; consistency reduces confusion.
(Rails defaults to IEC / base-2, although it labels them e.g. “KB” not “KiB”).

Related:
- https://en.wikipedia.org/wiki/Byte#Multiple-byte_units
- https://pkg.go.dev/github.com/dustin/go-humanize#IBytes