### PR TITLE
MetaDataSetCommand: retry longer (exponential backoff)

### DIFF
--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -113,8 +113,9 @@ var MetaDataSetCommand = cli.Command{
 
 		// Set the meta data
 		if err := roko.NewRetrier(
+			// 10x2 sec -> 2, 3, 5, 8, 13, 21, 34, 55, 89 seconds (total delay: 233 seconds)
 			roko.WithMaxAttempts(10),
-			roko.WithStrategy(roko.Constant(5*time.Second)),
+			roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
 		).DoWithContext(ctx, func(r *roko.Retrier) error {
 			resp, err := client.SetMetaData(ctx, cfg.Job, metaData)
 			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404) {


### PR DESCRIPTION
Retry longer in `buildkite-agent meta-data set <key> <value>`

Was 10x5 sec constant:

> 5, 5, 5, 5, 5, 5, 5, 5, 5, 5 seconds (total delay: 45 seconds)

Now 10x2 sec exp (see https://github.com/buildkite/roko/pull/15):

> 2, 3, 5, 8, 13, 21, 34, 55, 89 seconds (total delay: 233 seconds)

This means if the meta-data set endpoint is rate-limited for a whole minute, there's a much higher chance of the operation eventually succeeding in one of the next few one-minute rate limit buckets, rather than failing the job it's running in.