### PR TITLE
Go pipeline 0.3.0

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -285,8 +285,6 @@ var PipelineUploadCommand = cli.Command{
 		}
 
 		if cfg.JWKSFile != "" {
-			l.Warn("Pipeline signing is experimental and the user interface might change!")
-
 			key, err := jwkutil.LoadKey(cfg.JWKSFile, cfg.JWKSKeyID)
 			if err != nil {
 				return fmt.Errorf("couldn't read the signing key file: %w", err)

--- a/clicommand/tool_keygen.go
+++ b/clicommand/tool_keygen.go
@@ -132,10 +132,6 @@ for information about JWKS, see https://tools.ietf.org/html/rfc7517`,
 		}
 
 		l.Info("Done! Enjoy your new keys ^_^")
-
-		if slices.Contains(jwkutil.ValidOctetAlgorithms, sigAlg) {
-			l.Info("Note: Because you're using the %s algorithm, which is symmetric, the public and private keys are identical", sigAlg)
-		}
 	},
 }
 

--- a/clicommand/tool_keygen.go
+++ b/clicommand/tool_keygen.go
@@ -36,8 +36,8 @@ var ToolKeygenCommand = cli.Command{
 
 Description:
 
-This (experimental!) command generates a new JWS key pair, used for signing and
-verifying jobs in Buildkite.
+This command generates a new JWS key pair, used for signing and verifying jobs
+in Buildkite.
 
 The pair is written as a JSON Web Key Set (JWKS) to two files, a private JWKS
 file and a public JWKS file. The private JWKS should be used as for signing,
@@ -77,8 +77,6 @@ for information about JWKS, see https://tools.ietf.org/html/rfc7517`,
 	Action: func(c *cli.Context) {
 		_, cfg, l, _, done := setupLoggerAndConfig[ToolKeygenConfig](context.Background(), c)
 		defer done()
-
-		l.Warn("Pipeline signing is experimental and the user interface might change!")
 
 		if cfg.Alg == "" {
 			cfg.Alg = "EdDSA"

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -66,9 +66,9 @@ var ToolSignCommand = cli.Command{
 
 Description:
 
-This (experimental!) command takes a pipeline in YAML format as input, and annotates the
-appropriate parts of the pipeline with signatures. This can then be input into the YAML steps
-editor in the Buildkite UI so that the agents running these steps can verify the signatures.
+This command takes a pipeline in YAML format as input, and annotates the appropriate parts of
+the pipeline with signatures. This can then be input into the YAML steps editor in the Buildkite
+UI so that the agents running these steps can verify the signatures.
 
 If a token is provided using the ′graphql-token′ flag, the tool will attempt to retrieve the
 pipeline definition and repo using the Buildkite GraphQL API. If ′update′ is also set, it will
@@ -132,8 +132,6 @@ update the pipeline definition with the signed version using the GraphQL API too
 	Action: func(c *cli.Context) error {
 		ctx, cfg, l, _, done := setupLoggerAndConfig[ToolSignConfig](context.Background(), c)
 		defer done()
-
-		l.Warn("Pipeline signing is experimental and the user interface might change!")
 
 		key, err := jwkutil.LoadKey(cfg.JWKSFile, cfg.JWKSKeyID)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go v1.48.4
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 	github.com/buildkite/bintest/v3 v3.2.0
-	github.com/buildkite/go-pipeline v0.2.1
+	github.com/buildkite/go-pipeline v0.3.0
 	github.com/buildkite/roko v1.1.1
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/creack/pty v1.1.21

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf/go.mod h1:CeKhh8xSs3WZAc50xABMxu+FlfAAd5PNumo7NfOv7EE=
 github.com/buildkite/bintest/v3 v3.2.0 h1:1GqUILGGni5UViGPH/PbSq0MxB9gzY3J/P7vNVqCkX4=
 github.com/buildkite/bintest/v3 v3.2.0/go.mod h1:+AdQZcVlzCiW2UyZWeG63xeH5z011XUBW6kWcRdaMtU=
-github.com/buildkite/go-pipeline v0.2.1 h1:uNePBUeLvL/xRx9IHOoIM1rCUFFFZTPXkccIqsj+VN4=
-github.com/buildkite/go-pipeline v0.2.1/go.mod h1:Wkiq1SFvic/GcDem1mg4o8BrtA8JJubTlsBMLPHYoSQ=
+github.com/buildkite/go-pipeline v0.3.0 h1:Y1GCqe4oWiHcZ1hw9ozqBhPJJFGBr5Eggd7YtkyXwn8=
+github.com/buildkite/go-pipeline v0.3.0/go.mod h1:/etaqoaD56kCkahFd33ghL7z/ZqQoHgdA2jQzyULqHQ=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/buildkite/roko v1.1.1 h1:Yg4Y90rNsOtQFzwaLx6DMooiznDsPBUQs1IS7mm7nWY=


### PR DESCRIPTION
**This PR:** Updates go-pipeline to [v0.3.0](https://github.com/buildkite/go-pipeline/releases/tag/v0.3.0). This removes several signing algos (HS**, **256 and **384).

It also marks pipeline signing as GA! Woo!