### PR TITLE
Fix data race on Process.pid

### DIFF
--- a/process/signal.go
+++ b/process/signal.go
@@ -33,11 +33,15 @@ func (p *Process) postStart() error {
 }
 
 func (p *Process) terminateProcessGroup() error {
+	// Note: terminateProcessGroup is called from within p.Terminate, which
+	// holds p.mu.
 	p.logger.Debug("[Process] Sending signal SIGKILL to PGID: %d", p.pid)
 	return syscall.Kill(-p.pid, syscall.SIGKILL)
 }
 
 func (p *Process) interruptProcessGroup() error {
+	// Note: interruptProcessGroup is called from within p.Interrupt, which
+	// holds p.mu.
 	intSignal := p.conf.InterruptSignal
 
 	// TODO: this should be SIGINT, but will be a breaking change


### PR DESCRIPTION
The process can start, run, and output "Ready" before `p.pid` is set. Use of `p.pid` in `Interrupt` and `Terminate` is guarded by `p.mu`, but setting `p.pid` was not guarded. Even with the guard, it is still possible that `Interrupt` is called before `p.pid` is set, so I restored `<-p.Started()` (that I removed in #1852).