### PR TITLE
Fix typo in environment variable name for allowed-plugins

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -555,7 +555,7 @@ var AgentStartCommand = cli.Command{
 			Name:   "allowed-plugins",
 			Value:  &cli.StringSlice{},
 			Usage:  `A comma-separated list of regular expressions representing plugins the agent is allowed to use (for example, "^buildkite-plugins/.*$" or "^/var/lib/buildkite-plugins/.*")`,
-			EnvVar: "BUILDKITE_PLUGINSS",
+			EnvVar: "BUILDKITE_ALLOWED_PLUGINS",
 		},
 		cli.BoolFlag{
 			Name:   "metrics-datadog",


### PR DESCRIPTION
i came across this when reviewing https://github.com/buildkite/agent/pull/2406 - i'm kind of shocked that this made it through review. i blame the reviewer (me).

sigh. this is technically a breaking change. what do we do about that?

cc/ @jakubm-canva @david-poirier 