### PR TITLE
Bump go-pipeline to v0.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go v1.48.12
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 	github.com/buildkite/bintest/v3 v3.2.0
-	github.com/buildkite/go-pipeline v0.3.0
+	github.com/buildkite/go-pipeline v0.3.1
 	github.com/buildkite/roko v1.1.1
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/creack/pty v1.1.21

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf/go.mod h1:CeKhh8xSs3WZAc50xABMxu+FlfAAd5PNumo7NfOv7EE=
 github.com/buildkite/bintest/v3 v3.2.0 h1:1GqUILGGni5UViGPH/PbSq0MxB9gzY3J/P7vNVqCkX4=
 github.com/buildkite/bintest/v3 v3.2.0/go.mod h1:+AdQZcVlzCiW2UyZWeG63xeH5z011XUBW6kWcRdaMtU=
-github.com/buildkite/go-pipeline v0.3.0 h1:Y1GCqe4oWiHcZ1hw9ozqBhPJJFGBr5Eggd7YtkyXwn8=
-github.com/buildkite/go-pipeline v0.3.0/go.mod h1:/etaqoaD56kCkahFd33ghL7z/ZqQoHgdA2jQzyULqHQ=
+github.com/buildkite/go-pipeline v0.3.1 h1:dWfpHVh2Z+BjHv0ZEgqqWmO7Qqcldh9J+f0DJ4ALQAQ=
+github.com/buildkite/go-pipeline v0.3.1/go.mod h1:iY5jzs3Afc8yHg6KDUcu3EJVkfaUkd9x/v/OH98qyUA=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/buildkite/roko v1.1.1 h1:Yg4Y90rNsOtQFzwaLx6DMooiznDsPBUQs1IS7mm7nWY=


### PR DESCRIPTION
This fixes a bug in the interpolation of command step labels.