### PR TITLE
[2558] Buildkite build script is broken due to missing version default value

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -41,7 +41,7 @@ if ([string]::IsNullOrEmpty($url)) {
     if($null -eq $version){
       $version = "latest"
     }
-    $releaseInfoUrl = "https://buildkite.com/agent/releases/$version?platform=windows&arch=$arch"
+    $releaseInfoUrl = "https://buildkite.com/agent/releases/$($version)?platform=windows&arch=$arch"
     if($beta) {
         $releaseInfoUrl = $releaseInfoUrl + "&prerelease=true"
     }

--- a/install.ps1
+++ b/install.ps1
@@ -3,6 +3,8 @@ $beta = $env:buildkiteAgentBeta
 $token = $env:buildkiteAgentToken
 $tags = $env:buildkiteAgentTags
 $url = $env:buildkiteAgentUrl
+$version = $env:buildkiteAgentVersion
+
 
 if ($(Get-ComputerInfo -Property OsArchitecture).OsArchitecture -eq "ARM 64-bit Processor") {
   $arch = "arm64"
@@ -36,6 +38,9 @@ if($elevated -eq $false) {
 }
 
 if ([string]::IsNullOrEmpty($url)) {
+    if($null -eq $version){
+      $version = "latest"
+    }
     $releaseInfoUrl = "https://buildkite.com/agent/releases/$version?platform=windows&arch=$arch"
     if($beta) {
         $releaseInfoUrl = $releaseInfoUrl + "&prerelease=true"


### PR DESCRIPTION
The script is throwing "page not found" error due to the changes to the $version parameter. the string interpolation is also not working as expected due to the "?" after $version parameter in the request URL variable