### PR TITLE
PDP-2032 when api returns a 401 stop retrying and bail out

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -646,8 +646,9 @@ func (r *JobRunner) jobCancellationChecker(ctx context.Context, wg *sync.WaitGro
 
 		if err != nil {
 			if response != nil && response.StatusCode == 401 {
+				r.agentLogger.Error("Invalid access token, cancelling job %s", r.conf.Job.ID)
 				if err := r.Cancel(); err != nil {
-					r.agentLogger.Error("Invalid access token: an error occurred in the canceling process (job: %s) (err: %s)", r.conf.Job.ID, err)
+					r.agentLogger.Error("Failed to cancel the process (job: %s): %v", r.conf.Job.ID, err)
 				}
 			} else {
 				// We don't really care if it fails, we'll just try again soon anyway

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -397,10 +397,13 @@ func (r *JobRunner) finishJob(ctx context.Context, finishedAt time.Time, exit pr
 			// sometimes mean that Buildkite has cancelled the job
 			// before we get a chance to send the final API call
 			// (maybe this agent took too long to kill the
-			// process). In that case, we don't want to keep trying
+			// process).
+			// The API may also return a 401 when job tokens
+			// are enabled.
+			// In either case, we don't want to keep trying
 			// to finish the job forever so we'll just bail out and
 			// go find some more work to do.
-			if response != nil && response.StatusCode == 422 {
+			if response != nil && (response.StatusCode == 422 || response.StatusCode == 401) {
 				r.agentLogger.Warn("Buildkite rejected the call to finish the job (%s)", err)
 				retrier.Break()
 			} else {


### PR DESCRIPTION
https://linear.app/buildkite/issue/PDP-2032/on-the-agent-side-we-need-to-not-retry-on-a-401

This PR is related to job tokens

When the agent receives a 401 from the api due to invalid tokens we don't want to keep retrying. Below is a screen shot of what happens when the token expires

This PR is my very poor attempt to stop the agent retrying when it gets a 401. The screenshot below gives a bit more detail

![Screenshot 2023-12-22 at 3 58 30 pm](https://github.com/buildkite/agent/assets/3770233/7343234a-248f-44ae-9e0b-36eaae344e8f)

Testing on Localhost
Now when a token expires (buildkite returns a 401) the agent will eventually stop trying however it does seem to repeatedly loop thru the whole process (assigned..started..process is running..job token error..finished..and then back to assigned again). In my test I have a job that has timed out but I'm worried if a job doesn't have `timeout_in_minutes:` would it just run for 30 days or 24 hours (lost grace period exceeded) 😬 
![Screenshot 2024-01-05 at 11 13 25 am](https://github.com/buildkite/agent/assets/3770233/fe9017cf-7377-4805-9a64-7b02f6b304fc)


