### PR TITLE
Replace roko.TryForever with exponential backoff for ~24 hours

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -703,8 +703,9 @@ func (r *JobRunner) onUploadChunk(ctx context.Context, chunk *LogStreamerChunk) 
 	defer cancel()
 
 	return roko.NewRetrier(
-		roko.TryForever(),
-		roko.WithStrategy(roko.Constant(5*time.Second)),
+		// retry for ~a day with exponential backoff
+		roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
+		roko.WithMaxAttempts(20),
 		roko.WithJitter(),
 	).DoWithContext(ctx, func(retrier *roko.Retrier) error {
 		response, err := r.apiClient.UploadChunk(ctx, r.conf.Job.ID, &api.Chunk{

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -385,9 +385,10 @@ func (r *JobRunner) finishJob(ctx context.Context, finishedAt time.Time, exit pr
 	defer cancel()
 
 	return roko.NewRetrier(
-		roko.TryForever(),
+		// retry for ~a day with exponential backoff
+		roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
+		roko.WithMaxAttempts(20),
 		roko.WithJitter(),
-		roko.WithStrategy(roko.Constant(1*time.Second)),
 	).DoWithContext(ctx, func(retrier *roko.Retrier) error {
 		response, err := r.apiClient.FinishJob(ctx, r.conf.Job)
 		if err != nil {


### PR DESCRIPTION
Occasionally something goes wrong and the agent gets stuck retrying job log uploads or job finish calls forever (eg because the agent's access token is revoked). Forever is a really long time. Instead just retry for ~24 hours. I also changed these to exponential backoff rather than constant time because if a request fails, it's likely to either be fixed very quickly (network blip) or take a long time (incident). So no point retrying every second if it's already failed a hundred times. I also made them both the same and 2 seconds initial interval to match other parts of the code.

Using the `ExponentialSubsecond` algorithm with a 2 second initial interval, this is what the retry intervals looks like:

Retry attempt | Delay | Cumulative delay
-- | -- | --
0 | 0:00:02 | 0:00:02
1 | 0:00:03 | 0:00:05
2 | 0:00:05 | 0:00:10
3 | 0:00:08 | 0:00:19
4 | 0:00:13 | 0:00:32
5 | 0:00:22 | 0:00:54
6 | 0:00:35 | 0:01:28
7 | 0:00:56 | 0:02:24
8 | 0:01:29 | 0:03:53
9 | 0:02:24 | 0:06:17
10 | 0:03:51 | 0:10:08
11 | 0:06:12 | 0:16:20
12 | 0:09:58 | 0:26:18
13 | 0:16:02 | 0:42:20
14 | 0:25:47 | 1:08:07
15 | 0:41:27 | 1:49:35
16 | 1:06:40 | 2:56:15
17 | 1:47:12 | 4:43:27
18 | 2:52:24 | 7:35:51
19 | 4:37:14 | 12:13:05
20 | 7:25:50 | 19:38:55
21 | 11:56:56 | 31:35:51

