### PR TITLE
Clear up artifact downlad step flag docs

### DIFF
--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -75,7 +75,7 @@ var ArtifactDownloadCommand = cli.Command{
 		cli.StringFlag{
 			Name:  "step",
 			Value: "",
-			Usage: "Scope the search to a particular step by using either its name or job ID",
+			Usage: "Scope the search to a particular step. Can be the step's key or label, or a Job ID",
 		},
 		cli.StringFlag{
 			Name:   "build",


### PR DESCRIPTION
Docs said that either name or job id was okay, but in this context 'name' is unclear. In reality, any of the step's key or label are okay, as is a job id