### PR TITLE
Move check from upload-release-steps.sh to pipeline.yml

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -255,3 +255,4 @@ steps:
       - build-debian-packages
       - build-github-release
     command: ".buildkite/steps/upload-release-steps.sh"
+    if: 'build.env("DRY_RUN") == "false" && build.branch =~ /^(main|.*-.*-stable)$$/'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -255,4 +255,4 @@ steps:
       - build-debian-packages
       - build-github-release
     command: ".buildkite/steps/upload-release-steps.sh"
-    if: 'build.env("DRY_RUN") == "false" && build.branch =~ /^(main|.*-.*-stable)$$/'
+    if: build.env("DRY_RUN") == "true" || build.branch =~ /^(main|.*-.*-stable)$$/

--- a/.buildkite/steps/upload-release-steps.sh
+++ b/.buildkite/steps/upload-release-steps.sh
@@ -71,11 +71,6 @@ output_steps_yaml() {
   fi
 }
 
-if [[ "${BUILDKITE_BRANCH}" != "main" && "${DRY_RUN}" != "true" && "${BUILDKITE_BRANCH}" != *-*-stable ]] ; then
-  echo "No release steps to be uploaded"
-  exit 0
-fi
-
 agent_version=$(buildkite-agent meta-data get "agent-version")
 build_version=$(buildkite-agent meta-data get "agent-version-build")
 full_agent_version=$(buildkite-agent meta-data get "agent-version-full")


### PR DESCRIPTION
### Description

Remove the first `$DRY_RUN` and branch check from the script, and make it a pipeline conditional instead.

This means one less script for an agent to run, when cycling on a PR.

### Context

None, it's just something I spotted.

I did some archaeology: the `$DRY_RUN` check was added to the script (and `branches` removed from the pipeline step) in 341b1f4 (March 2018), but pipeline conditionals were introduced later.

### Changes

See Description.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
