### PR TITLE
Fix environment variable changes in hooks logged incorrectly

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -521,7 +521,7 @@ func (e *Executor) applyEnvironmentChanges(changes hook.EnvChanges, redactors re
 	}
 	for k, v := range changes.Diff.Changed {
 		if _, ok := executorConfigEnvChanges[k]; ok {
-			e.shell.Commentf("%s is now %q", k, v)
+			e.shell.Commentf("%s was %q and is now %q", k, v.Old, v.New)
 		} else {
 			e.shell.Commentf("%s changed", k)
 		}


### PR DESCRIPTION
### Description

When a hook changes an environment variable, and the environment
variable is on an allow list of known non-secrets, the change is logged
as
```
<env var> is now <new value>
```
At least that was the intention. However, what was actually logged was
```
<env var> is now {<old value> <new value>}
```

This changes it to
```
<env var> was <old value> and is now <new value>
```

### Context

https://coda.io/d/Escalations-Feedback_dHnUHNps1YO/Pipelines-Escalations_su7FT#Pipelines-Escalations-Board_tu__K/r252&view=modal

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->