### PR TITLE
Fix pipeline interpolation case sensitivity on Windows, and runtime environment variable precedence

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -273,7 +273,7 @@ var PipelineUploadCommand = cli.Command{
 				}
 				result.Env.Set(tracetools.EnvVarTraceContextKey, tracing)
 			}
-			if err := result.Interpolate(environ.Dump()); err != nil {
+			if err := result.Interpolate(environ); err != nil {
 				return fmt.Errorf("pipeline interpolation of %q failed: %w", src, err)
 			}
 		}

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -1,10 +1,15 @@
 package clicommand
 
 import (
+	"runtime"
+	"strings"
 	"testing"
 
+	"github.com/buildkite/agent/v3/env"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/go-pipeline"
+	"github.com/buildkite/go-pipeline/ordered"
+	"github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
 )
 
@@ -59,4 +64,49 @@ func TestSearchForSecrets(t *testing.T) {
 			assert.ErrorContains(t, err, test.wantLog)
 		})
 	}
+}
+
+// Most of this is tested in go-pipeline, here we just need to check that env.Environment
+// also works with go-pipeline's interpolation.
+func TestPipelineInterpolationCaseSensitivity(t *testing.T) {
+	t.Parallel()
+
+	cfg := &PipelineUploadConfig{
+		RedactedVars:  []string{},
+		RejectSecrets: true,
+	}
+
+	// this is the data structure we use for environment variables in the agent
+	// we test here it is suitable for interpolation with platform-dependent case sensitivity
+	environ := env.FromMap(map[string]string{
+		"FOO": "bar",
+	})
+
+	const pipelineYAML = `---
+steps:
+- command: echo $foo
+`
+
+	var expectedPipeline *pipeline.Pipeline
+	if runtime.GOOS == "windows" {
+		expectedPipeline = &pipeline.Pipeline{
+			Steps: pipeline.Steps{
+				&pipeline.CommandStep{
+					Command: "echo bar",
+				},
+			},
+		}
+	} else {
+		expectedPipeline = &pipeline.Pipeline{
+			Steps: pipeline.Steps{
+				&pipeline.CommandStep{
+					Command: "echo ",
+				},
+			},
+		}
+	}
+
+	p, err := cfg.parseAndInterpolate("test", strings.NewReader(pipelineYAML), environ)
+	assert.NilError(t, err, `cfg.parseAndInterpolate("test", %q, %q) = %v; want nil`, pipelineYAML, environ, err)
+	assert.DeepEqual(t, p, expectedPipeline, cmp.Comparer(ordered.EqualSA), cmp.Comparer(ordered.EqualSS))
 }

--- a/env/environment.go
+++ b/env/environment.go
@@ -105,9 +105,8 @@ func (e *Environment) Exists(key string) bool {
 }
 
 // Set sets a key in the environment
-func (e *Environment) Set(key string, value string) string {
+func (e *Environment) Set(key string, value string) {
 	e.underlying.Store(normalizeKeyName(key), value)
-	return value
 }
 
 // Remove a key from the Environment and return its value

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go v1.50.10
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 	github.com/buildkite/bintest/v3 v3.2.0
-	github.com/buildkite/go-pipeline v0.3.2
+	github.com/buildkite/go-pipeline v0.4.0
 	github.com/buildkite/roko v1.1.1
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/creack/pty v1.1.21

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,10 @@ github.com/buildkite/bintest/v3 v3.2.0 h1:1GqUILGGni5UViGPH/PbSq0MxB9gzY3J/P7vNV
 github.com/buildkite/bintest/v3 v3.2.0/go.mod h1:+AdQZcVlzCiW2UyZWeG63xeH5z011XUBW6kWcRdaMtU=
 github.com/buildkite/go-pipeline v0.3.2 h1:SW4EaXNwfjow7xDRPGgX0Rcx+dPj5C1kV9LKCLjWGtM=
 github.com/buildkite/go-pipeline v0.3.2/go.mod h1:iY5jzs3Afc8yHg6KDUcu3EJVkfaUkd9x/v/OH98qyUA=
+github.com/buildkite/go-pipeline v0.3.3-0.20240208112315-ccc810363dd8 h1:tIHPicEw9Ws9nszCfqN5SksWRHAHSOKke/kK6oadfnA=
+github.com/buildkite/go-pipeline v0.3.3-0.20240208112315-ccc810363dd8/go.mod h1:/8zdWlpn40HsxZql5iUbr00P8/Fm/yud9+Bqrar8S3s=
+github.com/buildkite/go-pipeline v0.4.0 h1:l5t8CpemEhsA/EWgIJlPzjlOpLJOK5yrdTLCoQvZrtE=
+github.com/buildkite/go-pipeline v0.4.0/go.mod h1:/8zdWlpn40HsxZql5iUbr00P8/Fm/yud9+Bqrar8S3s=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/buildkite/roko v1.1.1 h1:Yg4Y90rNsOtQFzwaLx6DMooiznDsPBUQs1IS7mm7nWY=

--- a/go.sum
+++ b/go.sum
@@ -60,10 +60,6 @@ github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf/go.mod h1:CeKhh8xSs3WZAc50xABMxu+FlfAAd5PNumo7NfOv7EE=
 github.com/buildkite/bintest/v3 v3.2.0 h1:1GqUILGGni5UViGPH/PbSq0MxB9gzY3J/P7vNVqCkX4=
 github.com/buildkite/bintest/v3 v3.2.0/go.mod h1:+AdQZcVlzCiW2UyZWeG63xeH5z011XUBW6kWcRdaMtU=
-github.com/buildkite/go-pipeline v0.3.2 h1:SW4EaXNwfjow7xDRPGgX0Rcx+dPj5C1kV9LKCLjWGtM=
-github.com/buildkite/go-pipeline v0.3.2/go.mod h1:iY5jzs3Afc8yHg6KDUcu3EJVkfaUkd9x/v/OH98qyUA=
-github.com/buildkite/go-pipeline v0.3.3-0.20240208112315-ccc810363dd8 h1:tIHPicEw9Ws9nszCfqN5SksWRHAHSOKke/kK6oadfnA=
-github.com/buildkite/go-pipeline v0.3.3-0.20240208112315-ccc810363dd8/go.mod h1:/8zdWlpn40HsxZql5iUbr00P8/Fm/yud9+Bqrar8S3s=
 github.com/buildkite/go-pipeline v0.4.0 h1:l5t8CpemEhsA/EWgIJlPzjlOpLJOK5yrdTLCoQvZrtE=
 github.com/buildkite/go-pipeline v0.4.0/go.mod h1:/8zdWlpn40HsxZql5iUbr00P8/Fm/yud9+Bqrar8S3s=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=


### PR DESCRIPTION
### Description

On windows, we should allow interpolation of runtime environment variables into pipeline YAML to be case insensitive, as that's what would happen if the commands ruan in a Windows shell.

### Context

https://coda.io/d/Escalations-Feedback_dHnUHNps1YO/Pipelines-Escalations_su7FT#Pipelines-Escalations-Board_tu__K/r251&view=modal

### Changes

Use a [v0.4.0](https://github.com/buildkite/go-pipeline/releases/tag/v0.4.0) of `go-pipeline`, which has a fix for case sensitivity on Windows. This version also rectifies the [precedence](https://buildkite.com/docs/pipelines/environment-variables#environment-variable-precedence) of runtime environment variables over pipeline environment variable when interpolating a pipeline.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->