### PR TITLE
Go 1.22

### DIFF
--- a/.buildkite/Dockerfile-compile
+++ b/.buildkite/Dockerfile-compile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.21.6@sha256:76aadd914a29a2ee7a6b0f3389bb2fdb87727291d688e1d972abe6c0fa6f2ee0
+FROM public.ecr.aws/docker/library/golang:1.22.0@sha256:ef61a20960397f4d44b0e729298bf02327ca94f1519239ddc6d91689615b1367
 COPY build/ssh.conf /etc/ssh/ssh_config.d/
 
 RUN go install github.com/google/go-licenses@latest

--- a/agent/artifact_downloader.go
+++ b/agent/artifact_downloader.go
@@ -90,10 +90,6 @@ func (a *ArtifactDownloader) Download(ctx context.Context) error {
 	}
 
 	for _, artifact := range artifacts {
-		// Create new instance of the artifact for the goroutine
-		// See: http://golang.org/doc/effective_go.html#channels
-		artifact := artifact
-
 		p.Spawn(func() {
 			// Convert windows paths to slashes, otherwise we get a literal
 			// download of "dir/dir/file" vs sub-directories on non-windows agents

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -130,7 +130,7 @@ func (a *ArtifactUploader) Collect(ctx context.Context) ([]*api.Artifact, error)
 	// goroutine per file).
 	wctx, cancel := context.WithCancelCause(ctx)
 	var wg sync.WaitGroup
-	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
+	for range runtime.GOMAXPROCS(0) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/agent/artifact_uploader.go
+++ b/agent/artifact_uploader.go
@@ -525,10 +525,6 @@ func (a *ArtifactUploader) upload(ctx context.Context, artifacts []*api.Artifact
 	}()
 
 	for _, artifact := range artifacts {
-		// Create new instance of the artifact for the goroutine
-		// See: http://golang.org/doc/effective_go.html#channels
-		artifact := artifact
-
 		p.Spawn(func() {
 			// Show a nice message that we're starting to upload the file
 			a.logger.Info("Uploading artifact %s %s (%s)", artifact.ID, artifact.Path, humanize.IBytes(uint64(artifact.FileSize)))

--- a/agent/gs_downloader.go
+++ b/agent/gs_downloader.go
@@ -86,7 +86,7 @@ func (d GSDownloader) destinationParts() []string {
 func escape(s string) string {
 	// See https://golang.org/src/net/url/url.go
 	hexCount := 0
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		c := s[i]
 		if shouldEscape(c) {
 			hexCount++
@@ -99,7 +99,7 @@ func escape(s string) string {
 
 	t := make([]byte, len(s)+2*hexCount)
 	j := 0
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		switch c := s[i]; {
 		case shouldEscape(c):
 			t[j] = '%'

--- a/agent/integration/config_allowlisting_integration_test.go
+++ b/agent/integration/config_allowlisting_integration_test.go
@@ -106,7 +106,6 @@ func TestConfigAllowlisting(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -73,7 +73,6 @@ func TestPreBootstrapHookScripts(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -183,7 +182,6 @@ func TestJobRunner_WhenBootstrapExits_ItSendsTheExitStatusToTheAPI(t *testing.T)
 
 	exits := []int{0, 1, 2, 3}
 	for _, exit := range exits {
-		exit := exit
 		t.Run(fmt.Sprintf("exit-%d", exit), func(t *testing.T) {
 			t.Parallel()
 

--- a/agent/integration/job_verification_integration_test.go
+++ b/agent/integration/job_verification_integration_test.go
@@ -551,7 +551,6 @@ func TestJobVerification(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/agent/k8s_tags_test.go
+++ b/agent/k8s_tags_test.go
@@ -41,7 +41,6 @@ func TestK8sTags(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			actualTags, err := agent.K8sTagsFromEnv(test.env)

--- a/agent/log_streamer.go
+++ b/agent/log_streamer.go
@@ -106,7 +106,7 @@ func (ls *LogStreamer) Start(ctx context.Context) error {
 	}
 
 	ls.workerWG.Add(ls.conf.Concurrency)
-	for i := 0; i < ls.conf.Concurrency; i++ {
+	for i := range ls.conf.Concurrency {
 		go ls.worker(ctx, i)
 	}
 

--- a/agent/pipeline_uploader_test.go
+++ b/agent/pipeline_uploader_test.go
@@ -42,7 +42,7 @@ func TestAsyncPipelineUpload(t *testing.T) {
 			state: "pending",
 			expectedSleeps: func() []time.Duration {
 				sleeps := make([]time.Duration, 0, 59)
-				for i := 0; i < 59; i++ {
+				for range 59 {
 					sleeps = append(sleeps, 5*time.Second)
 				}
 				return sleeps
@@ -138,7 +138,7 @@ func TestFallbackPipelineUpload(t *testing.T) {
 
 	genSleeps := func(n int, s time.Duration) []time.Duration {
 		sleeps := make([]time.Duration, 0, n)
-		for i := 0; i < n; i++ {
+		for range n {
 			sleeps = append(sleeps, s)
 		}
 		return sleeps

--- a/agent/pipeline_uploader_test.go
+++ b/agent/pipeline_uploader_test.go
@@ -50,8 +50,6 @@ func TestAsyncPipelineUpload(t *testing.T) {
 			err: errors.New("Failed to upload and process pipeline: Pipeline upload not yet applied: pending"),
 		},
 	} {
-		// reassign loop variable to ensure it gets the old value when run concurrently (due to t.Parrallel below)
-		test := test
 		t.Run(test.state, func(t *testing.T) {
 			t.Parallel()
 
@@ -177,7 +175,6 @@ func TestFallbackPipelineUpload(t *testing.T) {
 			errStatus:       529,
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/agent/plugin/error_test.go
+++ b/agent/plugin/error_test.go
@@ -93,7 +93,6 @@ func TestDeprecatedNameErrorsOrder(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			errs := make([]DeprecatedNameError, len(test.errs))

--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -101,7 +101,6 @@ func TestCreateFromJSON(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.jsonText, func(t *testing.T) {
 			t.Parallel()
 
@@ -139,7 +138,6 @@ func TestCreateFromJSONFailsOnParseErrors(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
 
@@ -209,7 +207,6 @@ func TestPluginNameParsedFromLocation(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.location, func(t *testing.T) {
 			t.Parallel()
 			plugin := &Plugin{Location: tc.location}
@@ -249,7 +246,6 @@ func TestIdentifier(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.location, func(t *testing.T) {
 			t.Parallel()
 			plugin := &Plugin{Location: tc.location}
@@ -309,7 +305,6 @@ func TestRepositoryAndSubdirectory(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.plugin.Label(), func(t *testing.T) {
 			t.Parallel()
 			repo, err := tc.plugin.Repository()
@@ -350,7 +345,6 @@ func TestRespositoryAndSubdirectoryErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.location, func(t *testing.T) {
 			t.Parallel()
 
@@ -489,7 +483,6 @@ func TestConfigurationToEnvironment(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.configJSON, func(t *testing.T) {
 			t.Parallel()
 			plugin, err := pluginFromConfig(tc.configJSON)

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -52,7 +52,6 @@ func TestSearchForSecrets(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			l := logger.NewBuffer()

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/buildkite/agent/v3
 
-go 1.21
+go 1.22
 
-toolchain go1.21.4
+toolchain go1.22.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3

--- a/internal/artifact/azure_blob_test.go
+++ b/internal/artifact/azure_blob_test.go
@@ -34,7 +34,6 @@ func TestParseAzureBlobLocation(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -75,7 +74,6 @@ func TestParseAzureBlobLocationErrors(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -121,7 +119,6 @@ func TestAzureBlobLocationURL(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -22,7 +22,7 @@ func (e *Executor) removeCheckoutDir() error {
 	// on windows, sometimes removing large dirs can fail for various reasons
 	// for instance having files open
 	// see https://github.com/golang/go/issues/20841
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		e.shell.Commentf("Removing %s", checkoutPath)
 		if err := os.RemoveAll(checkoutPath); err != nil {
 			e.shell.Errorf("Failed to remove \"%s\" (%s)", checkoutPath, err)

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -176,7 +176,7 @@ func (c *ExecutorConfig) ReadFromEnvironment(environ *env.Environment) map[strin
 	values := reflect.ValueOf(c).Elem()
 
 	// Iterate over all available fields and read the tag value
-	for i := 0; i < fields.NumField(); i++ {
+	for i := range fields.NumField() {
 		f := fields.Field(i)
 		v := values.Field(i)
 

--- a/internal/job/git_test.go
+++ b/internal/job/git_test.go
@@ -52,7 +52,6 @@ func TestParseGittableURL(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.url, func(t *testing.T) {
 			t.Parallel()
 			u, err := parseGittableURL(test.url)
@@ -143,7 +142,6 @@ func TestResolvingGitHostAliasesWithFlagSupport(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.alias, func(t *testing.T) {
 			t.Parallel()
 			if got := resolveGitHost(ctx, sh, test.alias); got != test.want {
@@ -172,8 +170,6 @@ func TestGitCheckRefFormat(t *testing.T) {
 		"@":              false,
 		"back\\slash":    false,
 	} {
-		ref := ref
-		want := want
 		t.Run(ref, func(t *testing.T) {
 			t.Parallel()
 			if got := gitCheckRefFormat(ref); got != want {

--- a/internal/job/hook/type_test.go
+++ b/internal/job/hook/type_test.go
@@ -107,7 +107,6 @@ func TestHookType(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/job/hook/wrapper_test.go
+++ b/internal/job/hook/wrapper_test.go
@@ -67,7 +67,6 @@ echo "hello world"
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -156,7 +155,6 @@ echo hello world
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -398,7 +398,6 @@ func TestPreExitHooksFireAfterHookFailures(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.failingHook, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/job/shell/shell_test.go
+++ b/internal/job/shell/shell_test.go
@@ -436,7 +436,6 @@ func TestRunWithOlfactor(t *testing.T) {
 			smellsInOutput: []string{"how"},
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -510,7 +509,6 @@ func TestRound(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.wantStr, func(t *testing.T) {
 			t.Parallel()
 			got := shell.Round(tt.in)

--- a/internal/olfactor/olfactor_test.go
+++ b/internal/olfactor/olfactor_test.go
@@ -60,7 +60,6 @@ func TestOlfactor(t *testing.T) {
 			expected: []bool{false, false},
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/replacer/bm_redactor_test.go
+++ b/internal/replacer/bm_redactor_test.go
@@ -10,7 +10,7 @@ import (
 func BenchmarkBMRedactor(b *testing.B) {
 	b.ResetTimer()
 	r := NewBMRedactor(io.Discard, "[REDACTED]", bigLipsumSecrets)
-	for n := 0; n < b.N; n++ {
+	for range b.N {
 		fmt.Fprintln(r, bigLipsum)
 	}
 	r.Flush()

--- a/internal/replacer/replacer_test.go
+++ b/internal/replacer/replacer_test.go
@@ -93,7 +93,6 @@ func TestReplacerLoremIpsum(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		// Write input in a single Write call
 		t.Run("One write;"+test.desc, func(t *testing.T) {
 			t.Parallel()
@@ -159,7 +158,6 @@ func TestReplacerWriteBoundaries(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			var buf strings.Builder

--- a/internal/replacer/replacer_test.go
+++ b/internal/replacer/replacer_test.go
@@ -238,7 +238,7 @@ func TestReplacerMultiLine(t *testing.T) {
 func BenchmarkReplacer(b *testing.B) {
 	b.ResetTimer()
 	r := replacer.New(io.Discard, bigLipsumSecrets, redact.Redact)
-	for n := 0; n < b.N; n++ {
+	for range b.N {
 		fmt.Fprintln(r, bigLipsum)
 	}
 	r.Flush()

--- a/internal/socket/client_test.go
+++ b/internal/socket/client_test.go
@@ -80,7 +80,6 @@ func TestClientDo(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.method+" "+test.url, func(t *testing.T) {
 			t.Parallel()
 			var got messageResponse
@@ -147,7 +146,6 @@ func TestClientDoErrors(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.method+" "+test.url, func(t *testing.T) {
 			t.Parallel()
 			var dummy messageResponse

--- a/internal/socket/middleware_test.go
+++ b/internal/socket/middleware_test.go
@@ -73,7 +73,6 @@ func TestAuthMiddleware(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.title, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/socket/server_test.go
+++ b/internal/socket/server_test.go
@@ -141,7 +141,6 @@ func TestServerHandler(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.method+" "+test.url, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/trie/trie_test.go
+++ b/internal/trie/trie_test.go
@@ -67,7 +67,6 @@ func TestTrieExists(t *testing.T) {
 			checks: []check{{"veni", false}, {"vidi", false}, {"vici", false}, {"veni vidi vici", true}},
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -137,7 +136,6 @@ func TestTriePrefixExists(t *testing.T) {
 			checks: []check{{"veni", true}, {"vidi", false}, {"vici", false}, {"veni vidi vici", true}},
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -181,7 +179,6 @@ func TestTrieSizeAndContent(t *testing.T) {
 			insert: []string{"veni", "vidi", "vici", "veni", "vidi", "vici"},
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/jobapi/server_test.go
+++ b/jobapi/server_test.go
@@ -168,7 +168,6 @@ func TestDeleteEnv(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -265,7 +264,6 @@ func TestPatchEnv(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -30,7 +30,7 @@ func New(l logger.Logger, c Config) *Runner {
 		c.SocketPath = defaultSocketPath
 	}
 	clients := make(map[int]*clientResult, c.ClientCount)
-	for i := 0; i < c.ClientCount; i++ {
+	for i := range c.ClientCount {
 		clients[i] = &clientResult{}
 	}
 	return &Runner{

--- a/lock/lock_test.go
+++ b/lock/lock_test.go
@@ -98,7 +98,7 @@ func TestLocker(t *testing.T) {
 
 	var wg sync.WaitGroup
 	var locks int
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		go func() {
 			l.Lock()
@@ -125,7 +125,7 @@ func TestDoOnce(t *testing.T) {
 
 	var wg sync.WaitGroup
 	var calls atomic.Int32
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		go func() {
 			if err := cli.DoOnce(ctx, "once", func() {

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -30,7 +30,7 @@ func New(concurrencyLimit int) *Pool {
 	wg := sync.WaitGroup{}
 	completionChan := make(chan bool, concurrencyLimit)
 
-	for i := 0; i < concurrencyLimit; i++ {
+	for range concurrencyLimit {
 		completionChan <- true
 	}
 

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -383,7 +383,7 @@ func assertProcessDoesntExist(t *testing.T, p *process.Process) {
 }
 
 func BenchmarkProcess(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for range b.N {
 		proc := process.New(logger.Discard, process.Config{
 			Path: os.Args[0],
 			Env:  []string{"TEST_MAIN=output"},

--- a/process/timestamper_test.go
+++ b/process/timestamper_test.go
@@ -40,7 +40,6 @@ func TestTimestamper(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
### Description

Updates Golang to 1.22, and makes use of the easy-to-convert features it brings. Most notably:
- Makes use of the new [range-over-int](https://tip.golang.org/doc/go1.22#language) technology
  - i used the regex `for (a-z) := 0; (.*); \1\+\+` to find, and then `for $1 := range $2` to replace. Golang then complained that some of the loop variables weren't being used, so i went through those and manually removed the variables that it was complaining about
- Removes redeclarations of loop variables, as they're now scoped to the body of the loop. hooray!
  - i used the regex `(\w+) := \1\n` to find, and replaced with an empty string

### Context

https://tip.golang.org/doc/go1.22

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
