### PR TITLE
Fix NPE when decoding token response

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -292,9 +292,11 @@ func (c *Client) doRequest(req *http.Request, v any) (*Response, error) {
 			io.Copy(w, resp.Body)
 		} else {
 			if strings.Contains(req.Header.Get("Content-Type"), "application/msgpack") {
-				err = errors.New("Msgpack not supported")
-			} else {
-				err = json.NewDecoder(resp.Body).Decode(v)
+				return response, errors.New("Msgpack not supported")
+			}
+
+			if err = json.NewDecoder(resp.Body).Decode(v); err != nil {
+				return response, fmt.Errorf("failed to decode JSON response: %v", err)
 			}
 		}
 	}

--- a/api/github_code_access_token.go
+++ b/api/github_code_access_token.go
@@ -30,12 +30,12 @@ func (c *Client) GenerateGithubCodeAccessToken(ctx context.Context, repoURL, job
 		roko.WithStrategy(roko.Constant(5*time.Second)),
 	)
 
-	var g *GithubCodeAccessTokenResponse
+	var g GithubCodeAccessTokenResponse
 	var resp *Response
 
 	err = r.Do(func(r *roko.Retrier) error {
 		var err error
-		resp, err = c.doRequest(req, g)
+		resp, err = c.doRequest(req, &g)
 		if err == nil {
 			return nil
 		}


### PR DESCRIPTION
### Description

a minor refactoring slipup in #2599 meant that the json package was complaining when trying to decode into a `GithubCodeAccessTokenResponse` struct. 

this PR fixes that issue.

### Context

#2599 


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

