### PR TITLE
Add flag for setting annotation priority

### DIFF
--- a/api/annotations.go
+++ b/api/annotations.go
@@ -7,10 +7,11 @@ import (
 
 // Annotation represents a Buildkite Agent API Annotation
 type Annotation struct {
-	Body    string `json:"body,omitempty"`
-	Context string `json:"context,omitempty"`
-	Style   string `json:"style,omitempty"`
-	Append  bool   `json:"append,omitempty"`
+	Body     string `json:"body,omitempty"`
+	Context  string `json:"context,omitempty"`
+	Style    string `json:"style,omitempty"`
+	Append   bool   `json:"append,omitempty"`
+	Priority int    `json:"priority,omitempty"`
 }
 
 // Annotate a build in the Buildkite UI

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -97,7 +97,7 @@ var AnnotateCommand = cli.Command{
 		},
 		cli.IntFlag{
 			Name:   "priority",
-			Usage:  "Priority of the annotation (1 to 10), default is 3",
+			Usage:  "Priority of the annotation (1 to 10). By default annotations have a priority of 3. Annotations with a priority of 10 will be shown first, and annotations with a priority of 1 will be shown last.",
 			EnvVar: "BUILDKITE_ANNOTATION_PRIORITY",
 		},
 		cli.StringFlag{

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -54,11 +54,12 @@ Example:
     $ ./script/dynamic_annotation_generator | buildkite-agent annotate --style "success"`
 
 type AnnotateConfig struct {
-	Body    string `cli:"arg:0" label:"annotation body"`
-	Style   string `cli:"style"`
-	Context string `cli:"context"`
-	Append  bool   `cli:"append"`
-	Job     string `cli:"job" validate:"required"`
+	Body     string `cli:"arg:0" label:"annotation body"`
+	Style    string `cli:"style"`
+	Context  string `cli:"context"`
+	Append   bool   `cli:"append"`
+	Priority int    `cli:"priority"`
+	Job      string `cli:"job" validate:"required"`
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
@@ -93,6 +94,11 @@ var AnnotateCommand = cli.Command{
 			Name:   "append",
 			Usage:  "Append to the body of an existing annotation",
 			EnvVar: "BUILDKITE_ANNOTATION_APPEND",
+		},
+		cli.IntFlag{
+			Name:   "priority",
+			Usage:  "Priority of the annotation (1 to 10), default is 3",
+			EnvVar: "BUILDKITE_ANNOTATION_PRIORITY",
 		},
 		cli.StringFlag{
 			Name:   "job",
@@ -153,10 +159,11 @@ func annotate(ctx context.Context, cfg AnnotateConfig, l logger.Logger) error {
 
 	// Create the annotation we'll send to the Buildkite API
 	annotation := &api.Annotation{
-		Body:    body,
-		Style:   cfg.Style,
-		Context: cfg.Context,
-		Append:  cfg.Append,
+		Body:     body,
+		Style:    cfg.Style,
+		Context:  cfg.Context,
+		Append:   cfg.Append,
+		Priority: cfg.Priority,
 	}
 
 	// Retry the annotation a few times before giving up

--- a/clicommand/annotate_test.go
+++ b/clicommand/annotate_test.go
@@ -33,6 +33,7 @@ func TestAnnotate(t *testing.T) {
 		Job:              "jobid",
 		AgentAccessToken: "agentaccesstoken",
 		Endpoint:         server.URL,
+		Priority:         1,
 	}
 	l := logger.NewBuffer()
 


### PR DESCRIPTION
### Description

Introduce a new `--priority` flag for `buildkite-agent annotate` that allows setting a priority on annotations. This allows customers to influence the ordering of annotations. Annotations have a default priority of 3 and a manual priority can be set with `buildkite-agent annotate --body "Test Annotation" --priority 5` to influence the ordering of annotations. GraphQL and Agent API changes have been merged to support this new flag.

There's a feature flag that enables the new ordering in the UI. We'll need to time enabling that feature flag with this agent version being released.

Fixes COMP-175.

### Testing

I've added `priority` to the existing tests. I've also tested the feature against a locally running copy of Buildkite.



Here's a test running against the production Buildkite Agent API, with the changes compiled locally:

```
steps:
  - label: ":console: Annotation Test"
    command: |
      /usr/local/bin/buildkite-agent annotate 'Example 1`info` style' --style 'info' --context 'ctx-info'
      /usr/local/bin/buildkite-agent annotate 'Example 2`error` style' --style 'error' --context 'ctx-error2'
      /usr/local/bin/buildkite-agent annotate 'Example 3`warning` style' --style 'warning' --context 'ctx-warn'
      /usr/local/bin/buildkite-agent annotate 'Example 4`success` style' --style 'success' --context 'ctx-success'
      /usr/local/bin/buildkite-agent annotate 'Example 5 Priority 6 `error` style' --style 'error' --context 'ctx-error' --priority 6
      /usr/local/bin/buildkite-agent annotate 'Example 6 `default` style' --context 'ctx-default1'
      /usr/local/bin/buildkite-agent annotate 'Example 7 `default` style' --context 'ctx-default2'
      /usr/local/bin/buildkite-agent annotate 'Example 8 `default` style' --context 'ctx-default3'
      /usr/local/bin/buildkite-agent annotate 'Example 9 Priority 10 `default` style' --context 'ctx-default4' --priority 10
      /usr/local/bin/buildkite-agent annotate 'Example 10 Priority 10 `default` style' --context 'ctx-default5' --priority 10
      /usr/local/bin/buildkite-agent annotate 'Example 11 Priority 2 `default` style' --context 'ctx-default6' --priority 2
      /usr/local/bin/buildkite-agent annotate 'Example 12 `default` style' --context 'ctx-default7'
      /usr/local/bin/buildkite-agent annotate 'Example 12 `default` style' --context 'ctx-default8'
      /usr/local/bin/buildkite-agent annotate 'Example 13 `default` style' --context 'ctx-default9'
 ```
 
<img width="783" alt="Screenshot 2024-02-19 at 8 24 56 pm" src="https://github.com/buildkite/agent/assets/2132506/76e5b2c7-bcaf-4638-8f1a-c6a3d8223ab0">