### PR TITLE
Add an info log of which experiments are known and enabled on agent start

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -281,7 +281,7 @@ func defaultConfigFilePaths() (paths []string) {
 		}
 	}
 
-	return
+	return paths
 }
 
 var AgentStartCommand = cli.Command{

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -968,7 +968,7 @@ var AgentStartCommand = cli.Command{
 		l.Debug("Plugins directory: %s", agentConf.PluginsPath)
 
 		if exps := experiments.KnownAndEnabled(ctx); len(exps) > 0 {
-			l.Info("The following experiments are enabled: %q", exps)
+			l.WithFields(logger.StringField("experiments", fmt.Sprintf("%v", exps))).Info("Experiments are enabled")
 		}
 
 		if !agentConf.SSHKeyscan {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -250,7 +250,7 @@ func DefaultShell() string {
 }
 
 func defaultConfigFilePaths() (paths []string) {
-	// Toggle beetwen windows and *nix paths
+	// Toggle between windows and *nix paths
 	if runtime.GOOS == "windows" {
 		paths = []string{
 			"C:\\buildkite-agent\\buildkite-agent.cfg",

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -967,6 +967,10 @@ var AgentStartCommand = cli.Command{
 		l.Debug("Hooks directory: %s", agentConf.HooksPath)
 		l.Debug("Plugins directory: %s", agentConf.PluginsPath)
 
+		if exps := experiments.KnownAndEnabled(ctx); len(exps) > 0 {
+			l.Info("The following experiments are enabled: %q", exps)
+		}
+
 		if !agentConf.SSHKeyscan {
 			l.Info("Automatic ssh-keyscan has been disabled")
 		}

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -127,6 +127,19 @@ func IsEnabled(ctx context.Context, key string) bool {
 	return state != nil && state.(bool)
 }
 
+// KnownAndEnabled returns the keys of all the known and enabled experiments.
+func KnownAndEnabled(ctx context.Context) []string {
+	allMu.Lock()
+	defer allMu.Unlock()
+	var keys []string
+	for key := range all {
+		if _, known := Available[key]; known && IsEnabled(ctx, key) {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
 // Enabled returns the keys of all the enabled experiments.
 func Enabled(ctx context.Context) []string {
 	allMu.Lock()


### PR DESCRIPTION
### Description
I often find myself wanting to know which experiments are known and enabled on an agent. While this information is in the debug logs, I think having it also available in the info logs would be useful.


### Context
None

### Changes
The agent startup now looks like this:
![2024-02-21-11-01-31](https://github.com/buildkite/agent/assets/11096602/74c8cec7-54b6-43ed-b1d5-adc3d4ef937f)


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)