### PR TITLE
De-experimentify Job API

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -47,23 +47,6 @@ This will result in errors unless orchestrated in a similar manner to that proje
 
 **Status**: Being used in a preview release of agent-stack-k8s. As it has little applicability outside of Kubernetes, this will not be the default behaviour.
 
-### `job-api`
-
-Exposes a local API for the currently running job to introspect and mutate its state in the form of environment variables. This allows you to write scripts, hooks and plugins in languages other than bash, using them to interact with the agent.
-
-The API is exposed via a Unix Domain Socket, whose path is exposed to running jobs with the `BUILDKITE_AGENT_JOB_API_SOCKET` envar, and authenticated with a token exposed using the `BUILDKITE_AGENT_JOB_API_TOKEN` envar, using the `Bearer` HTTP Authorization scheme.
-
-The API exposes the following endpoints:
-- `GET /api/current-job/v0/env` - returns a JSON object of all environment variables for the current job
-- `PATCH /api/current-job/v0/env` - accepts a JSON object of environment variables to set for the current job
-- `DELETE /api/current-job/v0/env` - accepts a JSON array of environment variable names to unset for the current job
-
-See [jobapi/payloads.go](./jobapi/payloads.go) for the full API request/response definitions.
-
-The Job API is unavailable on windows agents running versions of windows prior to build 17063, as this was when windows added Unix Domain Socket support. Using this experiment on such agents will output a warning, and the API will be unavailable.
-
-**Status:** Experimental while we iron out the API and test it out in the wild. We'll probably promote this to non-experiment soon™️.
-
 ### `polyglot-hooks`
 
 Allows the agent to run hooks written in languages other than bash. This enables the agent to run hooks written in any language, as long as the language has a runtime available on the agent. Polyglot hooks can be in interpreted languages, so long as they have a valid shebang, and the interpreter specified in the shebang is installed on the agent.
@@ -78,10 +61,10 @@ Binary hooks are available on all platforms, but interpreted hooks are unfortuna
 
 ### `agent-api`
 
-Like `job-api`, this exposes a local API for interacting with the agent process.
+This exposes a local API for interacting with the agent process.
 ...with primitives that can be used to solve local concurrency problems (such as multiple agents handling some shared local resource).
 
-The API is exposed via a Unix Domain Socket. Unlike the `job-api`, the path to the socket is not available via a environment variable - rather, there is a single (configurable) path on the system.
+The API is exposed via a Unix Domain Socket. The path to the socket is not available via a environment variable - rather, there is a single (configurable) path on the system.
 
 **Status:** Experimental while we iron out the API and test it out in the wild. We'll probably promote this to non-experiment soon™.
 

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -95,6 +95,7 @@ type BootstrapConfig struct {
 	RedactedVars                 []string `cli:"redacted-vars" normalize:"list"`
 	TracingBackend               string   `cli:"tracing-backend"`
 	TracingServiceName           string   `cli:"tracing-service-name"`
+	JobAPI                       bool     `cli:"job-api"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -356,6 +357,11 @@ var BootstrapCommand = cli.Command{
 			EnvVar: "BUILDKITE_TRACING_SERVICE_NAME",
 			Value:  "buildkite-agent",
 		},
+		cli.BoolTFlag{
+			Name:   "job-api",
+			Usage:  "Starts the job-api, giving the commands in the job some abilities to intropect and mutate the state of the job.",
+			EnvVar: "BUILDKITE_AGENT_JOB_API",
+		},
 		DebugFlag,
 		LogLevelFlag,
 		ExperimentsFlag,
@@ -440,6 +446,7 @@ var BootstrapCommand = cli.Command{
 			Tag:                          cfg.Tag,
 			TracingBackend:               cfg.TracingBackend,
 			TracingServiceName:           cfg.TracingServiceName,
+			JobAPI:                       cfg.JobAPI,
 		})
 
 		cctx, cancel := context.WithCancel(ctx)

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -95,7 +95,7 @@ type BootstrapConfig struct {
 	RedactedVars                 []string `cli:"redacted-vars" normalize:"list"`
 	TracingBackend               string   `cli:"tracing-backend"`
 	TracingServiceName           string   `cli:"tracing-service-name"`
-	JobAPI                       bool     `cli:"job-api"`
+	NoJobAPI                     bool     `cli:"no-job-api"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -357,10 +357,10 @@ var BootstrapCommand = cli.Command{
 			EnvVar: "BUILDKITE_TRACING_SERVICE_NAME",
 			Value:  "buildkite-agent",
 		},
-		cli.BoolTFlag{
-			Name:   "job-api",
-			Usage:  "Starts the job-api, giving the commands in the job some abilities to intropect and mutate the state of the job.",
-			EnvVar: "BUILDKITE_AGENT_JOB_API",
+		cli.BoolFlag{
+			Name:   "no-job-api",
+			Usage:  "Disables the Job API, which gives commands in jobs some abilities to introspect and mutate the state of the job.",
+			EnvVar: "BUILDKITE_AGENT_NO_JOB_API",
 		},
 		DebugFlag,
 		LogLevelFlag,
@@ -446,7 +446,7 @@ var BootstrapCommand = cli.Command{
 			Tag:                          cfg.Tag,
 			TracingBackend:               cfg.TracingBackend,
 			TracingServiceName:           cfg.TracingServiceName,
-			JobAPI:                       cfg.JobAPI,
+			JobAPI:                       !cfg.NoJobAPI,
 		})
 
 		cctx, cancel := context.WithCancel(ctx)

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -25,7 +25,6 @@ const (
 	// Available experiments
 	AgentAPI                   = "agent-api"
 	DescendingSpawnPrioity     = "descending-spawn-priority"
-	JobAPI                     = "job-api"
 	KubernetesExec             = "kubernetes-exec"
 	NormalisedUploadPaths      = "normalised-upload-paths"
 	PTYRaw                     = "pty-raw"
@@ -40,13 +39,13 @@ const (
 	FlockFileLocks    = "flock-file-locks"
 	GitMirrors        = "git-mirrors"
 	InbuiltStatusPage = "inbuilt-status-page"
+	JobAPI            = "job-api"
 )
 
 var (
 	Available = map[string]struct{}{
 		AgentAPI:                   {},
 		DescendingSpawnPrioity:     {},
-		JobAPI:                     {},
 		KubernetesExec:             {},
 		NormalisedUploadPaths:      {},
 		PolyglotHooks:              {},
@@ -61,6 +60,7 @@ var (
 		FlockFileLocks:    standardPromotionMsg(FlockFileLocks, "v3.48.0"),
 		GitMirrors:        standardPromotionMsg(GitMirrors, "v3.47.0"),
 		InbuiltStatusPage: standardPromotionMsg(InbuiltStatusPage, "v3.48.0"),
+		JobAPI:            standardPromotionMsg(JobAPI, "v3.64.0"),
 	}
 
 	// Used to track experiments possibly in use.

--- a/internal/job/api.go
+++ b/internal/job/api.go
@@ -1,23 +1,17 @@
 package job
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/buildkite/agent/v3/internal/experiments"
 	"github.com/buildkite/agent/v3/internal/socket"
 	"github.com/buildkite/agent/v3/jobapi"
 )
 
-// startJobAPI starts the job API server, iff the job API experiment is enabled, and the OS of the box supports it
-// otherwise it returns a noop cleanup function
-// It also sets the BUILDKITE_AGENT_JOB_API_SOCKET and BUILDKITE_AGENT_JOB_API_TOKEN environment variables
-func (e *Executor) startJobAPI(ctx context.Context) (cleanup func(), err error) {
+// startJobAPI starts the job API server, iff the OS of the box supports it otherwise it returns a
+// noop cleanup function. It also sets the BUILDKITE_AGENT_JOB_API_SOCKET and
+// BUILDKITE_AGENT_JOB_API_TOKEN environment variables
+func (e *Executor) startJobAPI() (cleanup func(), err error) {
 	cleanup = func() {}
-
-	if !experiments.IsEnabled(ctx, experiments.JobAPI) {
-		return cleanup, nil
-	}
 
 	if !socket.Available() {
 		e.shell.Warningf("The Job API isn't available on this machine, as it's running an unsupported version of Windows")

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -164,6 +164,9 @@ type ExecutorConfig struct {
 
 	// Service name to use when reporting traces.
 	TracingServiceName string
+
+	// Whether to start the JobAPI
+	JobAPI bool
 }
 
 // ReadFromEnvironment reads configuration from the Environment, returns a map

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -129,7 +129,7 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 		}
 		defer cleanup()
 	} else {
-		e.shell.Warningf("The Job API has been disabled.")
+		e.shell.Warningf("The Job API has been disabled. Features like automatic redaction of secrets and polyglot hooks will either not work or have degraded functionality")
 	}
 
 	// Tear down the environment (and fire pre-exit hook) before we exit

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -121,12 +121,11 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 	e.shell.Env = env.FromSlice(os.Environ())
 
 	// Initialize the job API, iff the experiment is enabled. Noop otherwise
-	cleanup, err := e.startJobAPI(ctx)
+	cleanup, err := e.startJobAPI()
 	if err != nil {
 		e.shell.Errorf("Error setting up job API: %v", err)
 		return 1
 	}
-
 	defer cleanup()
 
 	// Tear down the environment (and fire pre-exit hook) before we exit

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -124,10 +124,12 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 	if e.JobAPI {
 		cleanup, err := e.startJobAPI()
 		if err != nil {
-			e.shell.Errorf("Error setting up job API: %v", err)
+			e.shell.Errorf("Error setting up Job API: %v", err)
 			return 1
 		}
 		defer cleanup()
+	} else {
+		e.shell.Warningf("The Job API has been disabled.")
 	}
 
 	// Tear down the environment (and fire pre-exit hook) before we exit

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -121,12 +121,14 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 	e.shell.Env = env.FromSlice(os.Environ())
 
 	// Initialize the job API, iff the experiment is enabled. Noop otherwise
-	cleanup, err := e.startJobAPI()
-	if err != nil {
-		e.shell.Errorf("Error setting up job API: %v", err)
-		return 1
+	if e.JobAPI {
+		cleanup, err := e.startJobAPI()
+		if err != nil {
+			e.shell.Errorf("Error setting up job API: %v", err)
+			return 1
+		}
+		defer cleanup()
 	}
-	defer cleanup()
 
 	// Tear down the environment (and fire pre-exit hook) before we exit
 	defer func() {

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -592,7 +592,6 @@ func TestPolyglotBinaryHooksCanBeRun(t *testing.T) {
 
 	ctx := mainCtx
 	ctx, _ = experiments.Enable(ctx, experiments.PolyglotHooks)
-	ctx, _ = experiments.Enable(ctx, experiments.JobAPI)
 
 	tester, err := NewBootstrapTester(ctx)
 	if err != nil {
@@ -604,7 +603,7 @@ func TestPolyglotBinaryHooksCanBeRun(t *testing.T) {
 	// Forgive me for my sins, RSC, but it's better than the alternatives.
 	// The code that we're building is in ./test-binary-hook/main.go, it's pretty straightforward.
 
-	fmt.Println("Building test-binary-hook")
+	t.Logf("Building test-binary-hook")
 	hookPath := filepath.Join(tester.HooksDir, "environment")
 
 	if runtime.GOOS == "windows" {

--- a/internal/job/integration/job_api_integration_test.go
+++ b/internal/job/integration/job_api_integration_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/buildkite/agent/v3/internal/experiments"
 	"github.com/buildkite/agent/v3/jobapi"
 	"github.com/buildkite/bintest/v3"
 )
@@ -18,9 +17,7 @@ import (
 func TestBootstrapRunsJobAPI(t *testing.T) {
 	t.Parallel()
 
-	ctx, _ := experiments.Enable(mainCtx, experiments.JobAPI)
-
-	tester, err := NewBootstrapTester(ctx)
+	tester, err := NewBootstrapTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}


### PR DESCRIPTION
### Description
The Job API experiment has been running for a while and we have decided to promote it to a stable feature. This PR removes the experiment flag from the Job API and updates the `EXPERIMENTS.md` file to promote the JobAPI.
I've also added a toggle on `buildkite-agent bootstrap` to enable/disable the Job API. Let's dicuss the merits of this in this PR.

### Context

A meeting we had

### Changes
- Remove the `job-api` experiment
- Add a flag to enable/disable the Job API on `buildkite-agent bootstrap`

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)