### PR TITLE
Add cli command to read from Pipelines Secrets

### DIFF
--- a/agent/api.go
+++ b/agent/api.go
@@ -24,7 +24,7 @@ type APIClient interface {
 	GenerateGithubCodeAccessToken(context.Context, string, string) (string, *api.Response, error)
 	GetJobState(context.Context, string) (*api.JobState, *api.Response, error)
 	GetMetaData(context.Context, string, string, string) (*api.MetaData, *api.Response, error)
-	GetSecret(context.Context, *api.SecretGetRequest) (*api.Secret, *api.Response, error)
+	GetSecret(context.Context, *api.GetSecretRequest) (*api.Secret, *api.Response, error)
 	Heartbeat(context.Context) (*api.Heartbeat, *api.Response, error)
 	MetaDataKeys(context.Context, string, string) ([]string, *api.Response, error)
 	OIDCToken(context.Context, *api.OIDCTokenRequest) (*api.OIDCToken, *api.Response, error)

--- a/agent/api.go
+++ b/agent/api.go
@@ -24,6 +24,7 @@ type APIClient interface {
 	GenerateGithubCodeAccessToken(context.Context, string, string) (string, *api.Response, error)
 	GetJobState(context.Context, string) (*api.JobState, *api.Response, error)
 	GetMetaData(context.Context, string, string, string) (*api.MetaData, *api.Response, error)
+	GetSecret(context.Context, *api.SecretGetRequest) (*api.Secret, *api.Response, error)
 	Heartbeat(context.Context) (*api.Heartbeat, *api.Response, error)
 	MetaDataKeys(context.Context, string, string) ([]string, *api.Response, error)
 	OIDCToken(context.Context, *api.OIDCTokenRequest) (*api.OIDCToken, *api.Response, error)

--- a/api/secrets.go
+++ b/api/secrets.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"net/url"
 	"path"
 )
 
@@ -12,19 +11,20 @@ type GetSecretRequest struct {
 }
 
 type Secret struct {
-	Key   string `json:"name"`
+	Key   string `json:"key"`
 	Value string `json:"value"`
 	UUID  string `json:"uuid"`
 }
 
 func (c *Client) GetSecret(ctx context.Context, req *GetSecretRequest) (*Secret, *Response, error) {
-	u := url.URL{Path: path.Join("jobs", req.JobID, "secrets")}
-	u.Query().Add("key", req.Key)
-
-	httpReq, err := c.newRequest(ctx, "GET", railsPathEscape(u.String()), nil)
+	httpReq, err := c.newRequest(ctx, "GET", path.Join("jobs", req.JobID, "secrets"), nil)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	q := httpReq.URL.Query()
+	q.Add("key", req.Key)
+	httpReq.URL.RawQuery = q.Encode()
 
 	secret := &Secret{}
 	resp, err := c.doRequest(httpReq, secret)

--- a/api/secrets.go
+++ b/api/secrets.go
@@ -2,21 +2,24 @@ package api
 
 import (
 	"context"
-	"fmt"
+	"net/url"
 )
 
-type SecretGetRequest struct {
-	Name string
+type GetSecretRequest struct {
+	Key string
 }
 
 type Secret struct {
-	Name  string `json:"name"`
+	Key   string `json:"name"`
 	Value string `json:"value"`
+	UUID  string `json:"uuid"`
 }
 
-func (c *Client) GetSecret(ctx context.Context, req *SecretGetRequest) (*Secret, *Response, error) {
-	u := fmt.Sprintf("secrets/%s", railsPathEscape(req.Name))
-	httpReq, err := c.newRequest(ctx, "GET", u, nil)
+func (c *Client) GetSecret(ctx context.Context, req *GetSecretRequest) (*Secret, *Response, error) {
+	u := url.URL{Path: "secrets"}
+	u.Query().Add("key", req.Key)
+
+	httpReq, err := c.newRequest(ctx, "GET", railsPathEscape(u.String()), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api/secrets.go
+++ b/api/secrets.go
@@ -3,10 +3,12 @@ package api
 import (
 	"context"
 	"net/url"
+	"path"
 )
 
 type GetSecretRequest struct {
-	Key string
+	Key   string
+	JobID string
 }
 
 type Secret struct {
@@ -16,7 +18,7 @@ type Secret struct {
 }
 
 func (c *Client) GetSecret(ctx context.Context, req *GetSecretRequest) (*Secret, *Response, error) {
-	u := url.URL{Path: "secrets"}
+	u := url.URL{Path: path.Join("jobs", req.JobID, "secrets")}
 	u.Query().Add("key", req.Key)
 
 	httpReq, err := c.newRequest(ctx, "GET", railsPathEscape(u.String()), nil)

--- a/api/secrets.go
+++ b/api/secrets.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"context"
+	"fmt"
+)
+
+type SecretGetRequest struct {
+	Name string
+}
+
+type Secret struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+func (c *Client) GetSecret(ctx context.Context, req *SecretGetRequest) (*Secret, *Response, error) {
+	u := fmt.Sprintf("secrets/%s", railsPathEscape(req.Name))
+	httpReq, err := c.newRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	secret := &Secret{}
+	resp, err := c.doRequest(httpReq, secret)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return secret, resp, nil
+}

--- a/api/secrets.go
+++ b/api/secrets.go
@@ -5,18 +5,22 @@ import (
 	"path"
 )
 
+// GetSecretRequest represents a request to read a secret from the Buildkite Agent API.
 type GetSecretRequest struct {
 	Key   string
 	JobID string
 }
 
+// Secret represents a secret read from the Buildkite Agent API.
 type Secret struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 	UUID  string `json:"uuid"`
 }
 
+// GetSecret reads a secret from the Buildkite Agent API.
 func (c *Client) GetSecret(ctx context.Context, req *GetSecretRequest) (*Secret, *Response, error) {
+	// the endpoint is /jobs/:job_id/secrets?key=:key
 	httpReq, err := c.newRequest(ctx, "GET", path.Join("jobs", req.JobID, "secrets"), nil)
 	if err != nil {
 		return nil, nil, err

--- a/api/secrets.go
+++ b/api/secrets.go
@@ -21,7 +21,7 @@ type Secret struct {
 // GetSecret reads a secret from the Buildkite Agent API.
 func (c *Client) GetSecret(ctx context.Context, req *GetSecretRequest) (*Secret, *Response, error) {
 	// the endpoint is /jobs/:job_id/secrets?key=:key
-	httpReq, err := c.newRequest(ctx, "GET", path.Join("jobs", req.JobID, "secrets"), nil)
+	httpReq, err := c.newRequest(ctx, "GET", path.Join("jobs", railsPathEscape(req.JobID), "secrets"), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api/secrets_test.go
+++ b/api/secrets_test.go
@@ -1,0 +1,141 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"testing"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/logger"
+	"gotest.tools/v3/assert"
+)
+
+func TestGetSecret(t *testing.T) {
+	t.Parallel()
+
+	const (
+		jobID          = "job-id"
+		nonJobID       = "non-job-id"
+		secretKey      = "NOT_TEST_SECRET"
+		nonSecretKey   = "TEST_SECRET"
+		secretValue    = "super-secret"
+		secretUUID     = "secret-id"
+		accessToken    = "llamas"
+		nonAccessToken = "alpacas"
+	)
+
+	ctx := context.Background()
+
+	for _, test := range []struct {
+		name             string
+		accessToken      string
+		getSecretRequest *api.GetSecretRequest
+		expectedSecret   *api.Secret
+		expectedError    error
+		expectedCode     int
+	}{
+		{
+			name:        "success",
+			accessToken: accessToken,
+			getSecretRequest: &api.GetSecretRequest{
+				Key:   secretKey,
+				JobID: jobID,
+			},
+			expectedSecret: &api.Secret{
+				Key:   secretKey,
+				Value: secretValue,
+				UUID:  secretUUID,
+			},
+			expectedError: nil,
+			expectedCode:  http.StatusOK,
+		},
+		{
+			name:        "unauthorized",
+			accessToken: nonAccessToken,
+			getSecretRequest: &api.GetSecretRequest{
+				Key:   secretKey,
+				JobID: jobID,
+			},
+			expectedError: errors.New("Unauthorized: got alpacas, want llamas"),
+			expectedCode:  http.StatusUnauthorized,
+		},
+		{
+			name:        "job_not_found",
+			accessToken: accessToken,
+			getSecretRequest: &api.GetSecretRequest{
+				Key:   secretKey,
+				JobID: nonJobID,
+			},
+			expectedError: fmt.Errorf("Not Found: method = GET, url = /jobs/%s/secrets?key=%s", nonJobID, secretKey),
+			expectedCode:  http.StatusNotFound,
+		},
+		{
+			name:        "secret_not_found",
+			accessToken: accessToken,
+			getSecretRequest: &api.GetSecretRequest{
+				Key:   nonSecretKey,
+				JobID: jobID,
+			},
+			expectedError: fmt.Errorf("Not Found: method = GET, url = /jobs/%s/secrets?key=%s", jobID, nonSecretKey),
+			expectedCode:  http.StatusNotFound,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			secretPath := path.Join("/jobs", jobID, "secrets")
+			buildkiteAPI := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				if got, want := authToken(req), accessToken; got != want {
+					http.Error(
+						rw,
+						fmt.Sprintf(`{"message": "Unauthorized: got %s, want %s"}`, got, want),
+						http.StatusUnauthorized,
+					)
+					return
+				}
+
+				if req.URL.Path == secretPath && req.URL.Query().Get("key") == secretKey {
+					_, err := io.WriteString(
+						rw, fmt.Sprintf(`{"key":%q,"value":%q,"uuid":%q}`, secretKey, secretValue, secretUUID),
+					)
+					assert.NilError(t, err)
+					return
+				}
+
+				http.Error(
+					rw,
+					fmt.Sprintf(
+						`{"message":"Not Found: method = %s, url = %s"}`,
+						req.Method,
+						req.URL.String(),
+					),
+					http.StatusNotFound,
+				)
+			}))
+			t.Cleanup(buildkiteAPI.Close)
+
+			// Initial client with a registration token
+			client := api.NewClient(logger.Discard, api.Config{
+				UserAgent: "Test",
+				Endpoint:  buildkiteAPI.URL,
+				Token:     test.accessToken,
+				DebugHTTP: true,
+			})
+
+			secret, resp, err := client.GetSecret(ctx, test.getSecretRequest)
+			assert.Check(t, resp.StatusCode == test.expectedCode, "expected status code %d, got %d", test.expectedCode, resp.StatusCode)
+			if test.expectedError == nil {
+				assert.DeepEqual(t, secret, test.expectedSecret)
+			} else if aerr := new(api.ErrorResponse); errors.As(err, &aerr) {
+				assert.DeepEqual(t, aerr.Message, test.expectedError.Error())
+			} else {
+				assert.ErrorIs(t, err, test.expectedError)
+			}
+		})
+	}
+}

--- a/clicommand/commands.go
+++ b/clicommand/commands.go
@@ -14,6 +14,13 @@ var BuildkiteAgentCommands = []cli.Command{
 		},
 	},
 	{
+		Name:  "secret",
+		Usage: "Get a secret",
+		Subcommands: []cli.Command{
+			SecretGetCommand,
+		},
+	},
+	{
 		Name:  "artifact",
 		Usage: "Upload/download artifacts from Buildkite jobs",
 		Subcommands: []cli.Command{

--- a/clicommand/config_completeness_test.go
+++ b/clicommand/config_completeness_test.go
@@ -39,11 +39,11 @@ var commandConfigPairs = []configCommandPair{
 	{Config: MetaDataSetConfig{}, Command: MetaDataSetCommand},
 	{Config: OIDCTokenConfig{}, Command: OIDCRequestTokenCommand},
 	{Config: PipelineUploadConfig{}, Command: PipelineUploadCommand},
+	{Config: SecretGetConfig{}, Command: SecretGetCommand},
 	{Config: StepGetConfig{}, Command: StepGetCommand},
 	{Config: StepUpdateConfig{}, Command: StepUpdateCommand},
 	{Config: ToolKeygenConfig{}, Command: ToolKeygenCommand},
 	{Config: ToolSignConfig{}, Command: ToolSignCommand},
-	{Config: SecretGetConfig{}, Command: SecretGetCommand},
 }
 
 func TestAllCommandConfigStructsHaveCorrespondingCLIFlags(t *testing.T) {
@@ -87,6 +87,8 @@ func TestAllCommandConfigStructsHaveCorrespondingCLIFlags(t *testing.T) {
 }
 
 func TestAllCommandsAreTestedForConfigCompleteness(t *testing.T) {
+	t.Parallel()
+
 	allCommands := make([]cli.Command, 0, len(commandConfigPairs))
 	for _, command := range BuildkiteAgentCommands {
 		if len(command.Subcommands) > 0 {

--- a/clicommand/config_completeness_test.go
+++ b/clicommand/config_completeness_test.go
@@ -43,6 +43,7 @@ var commandConfigPairs = []configCommandPair{
 	{Config: StepUpdateConfig{}, Command: StepUpdateCommand},
 	{Config: ToolKeygenConfig{}, Command: ToolKeygenCommand},
 	{Config: ToolSignConfig{}, Command: ToolSignCommand},
+	{Config: SecretGetConfig{}, Command: SecretGetCommand},
 }
 
 func TestAllCommandConfigStructsHaveCorrespondingCLIFlags(t *testing.T) {

--- a/clicommand/secret_get.go
+++ b/clicommand/secret_get.go
@@ -27,8 +27,8 @@ type SecretGetConfig struct {
 
 var SecretGetCommand = cli.Command{
 	Name:        "get",
-	Usage:       "Get a secret",
-	Description: "🤫",
+	Usage:       "Get a secret by its key",
+	Description: "Get a secret by key from Buildkite and print it to stdout.",
 	Flags: []cli.Flag{
 		// API Flags
 		AgentAccessTokenFlag,

--- a/clicommand/secret_get.go
+++ b/clicommand/secret_get.go
@@ -43,7 +43,7 @@ var SecretGetCommand = cli.Command{
 		ExperimentsFlag,
 		ProfileFlag,
 	},
-	Action: func(c *cli.Context) {
+	Action: func(c *cli.Context) error {
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[SecretGetConfig](ctx, c)
 		defer done()
@@ -52,9 +52,11 @@ var SecretGetCommand = cli.Command{
 
 		secret, _, err := client.GetSecret(ctx, &api.GetSecretRequest{Key: cfg.Key})
 		if err != nil {
-			l.Fatal("Failed to get secret: %v", err)
+			return NewExitError(1, err)
 		}
 
-		fmt.Println(secret.Value)
+		_, err = fmt.Fprintf(c.App.Writer, "%s\n", secret.Value)
+
+		return err
 	},
 }

--- a/clicommand/secret_get.go
+++ b/clicommand/secret_get.go
@@ -64,7 +64,7 @@ var SecretGetCommand = cli.Command{
 			return NewExitError(1, err)
 		}
 
-		_, err = fmt.Fprintf(c.App.Writer, "%s\n", secret.Value)
+		_, err = fmt.Fprintln(c.App.Writer, secret.Value)
 
 		return err
 	},

--- a/clicommand/secret_get.go
+++ b/clicommand/secret_get.go
@@ -9,7 +9,7 @@ import (
 )
 
 type SecretGetConfig struct {
-	SecretPath string `cli:"arg:0"`
+	Key string `cli:"arg:0"`
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
@@ -50,7 +50,7 @@ var SecretGetCommand = cli.Command{
 
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
 
-		secret, _, err := client.GetSecret(ctx, &api.SecretGetRequest{Name: cfg.SecretPath})
+		secret, _, err := client.GetSecret(ctx, &api.GetSecretRequest{Key: cfg.Key})
 		if err != nil {
 			l.Fatal("Failed to get secret: %v", err)
 		}

--- a/clicommand/secret_get.go
+++ b/clicommand/secret_get.go
@@ -1,0 +1,60 @@
+package clicommand
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/urfave/cli"
+)
+
+type SecretGetConfig struct {
+	SecretPath string `cli:"arg:0"`
+
+	// Global flags
+	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
+	NoColor     bool     `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile     string   `cli:"profile"`
+
+	// API config
+	DebugHTTP        bool   `cli:"debug-http"`
+	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
+	Endpoint         string `cli:"endpoint" validate:"required"`
+	NoHTTP2          bool   `cli:"no-http2"`
+}
+
+var SecretGetCommand = cli.Command{
+	Name:        "get",
+	Usage:       "Get a secret",
+	Description: "🤫",
+	Flags: []cli.Flag{
+		// API Flags
+		AgentAccessTokenFlag,
+		EndpointFlag,
+		NoHTTP2Flag,
+		DebugHTTPFlag,
+
+		// Global flags
+		NoColorFlag,
+		DebugFlag,
+		LogLevelFlag,
+		ExperimentsFlag,
+		ProfileFlag,
+	},
+	Action: func(c *cli.Context) {
+		ctx := context.Background()
+		ctx, cfg, l, _, done := setupLoggerAndConfig[SecretGetConfig](ctx, c)
+		defer done()
+
+		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
+
+		secret, _, err := client.GetSecret(ctx, &api.SecretGetRequest{Name: cfg.SecretPath})
+		if err != nil {
+			l.Fatal("Failed to get secret: %v", err)
+		}
+
+		fmt.Println(secret.Value)
+	},
+}


### PR DESCRIPTION
### Description
Pipelines Secrets will allow an agent to read a secret by key from the Agent API. This adds a cli command that wraps that API call and prints the secret to stdout.
In a future PR we will add support for redacting that from the job logs.

This feature is currently under development and is not yet generally available in the Agent API.

You can see it in action with my local bk/bk here:
![2024-02-21-11-48-18](https://github.com/buildkite/agent/assets/11096602/dbf9ea44-e8b5-4cd7-b741-62f0295397be)


### Context
https://linear.app/buildkite/issue/COMP-199/read-secret-from-agent


### Changes
- Add `agent secret get` command

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->