### PR TITLE
Chill out credential helper logging

### DIFF
--- a/clicommand/git_credentials_helper.go
+++ b/clicommand/git_credentials_helper.go
@@ -31,7 +31,8 @@ if the pipeline has this feature enabled. All hosted compute jobs automatically 
 This command is intended to be used as a git credential helper, and not called directly.`
 
 type GitCredentialsHelperConfig struct {
-	JobID string `cli:"job-id" validate:"required"`
+	JobID  string `cli:"job-id" validate:"required"`
+	Action string `cli:"arg:0"`
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
@@ -75,6 +76,12 @@ var GitCredentialsHelperCommand = cli.Command{
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[GitCredentialsHelperConfig](ctx, c)
 		defer done()
+
+		if cfg.Action != "get" {
+			// other actions are store and erase, which we don't support
+			// see: https://git-scm.com/docs/gitcredentials#Documentation/gitcredentials.txt-codegetcode
+			return nil
+		}
 
 		l.Info("Authenticating checkout using Buildkite Github App Credentials...")
 


### PR DESCRIPTION
### Description

This PR makes two changes to the git credential helper:
- It makes it only respond to the `get` git credential helper action, reducing the number of calls we have to do to the backend - previously, we were still pinging the buildkite backend when git asked us to store and erase credentials, which this helper isn't able to do. now, it'll just exit 0 when git sends us those actions. [this is what git recommends you do](https://git-scm.com/docs/gitcredentials#Documentation/gitcredentials.txt-codegetcode:~:text=If%20it%20does%20not%20support%20the%20requested%20operation%20(e.g.%2C%20a%20read%2Donly%20store%20or%20generator)%2C%20it%20should%20silently%20ignore%20the%20request.).
- It chills out a lot of the logging, bumping everything down to `debug` level. we also include a little more detail in the debug logs, adding the credential input and the action type to the debug logs

### Context

COMP-211

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)