### PR TITLE
Fix test of JobAPI requiring socket set

### DIFF
--- a/jobapi/client.go
+++ b/jobapi/client.go
@@ -10,6 +10,8 @@ import (
 
 const envURL = "http://job/api/current-job/v0/env"
 
+var errNoSocketEnv = errors.New("BUILDKITE_AGENT_JOB_API_SOCKET empty or undefined")
+
 // Client connects to the Job API.
 type Client struct {
 	client *socket.Client
@@ -30,11 +32,11 @@ func NewDefaultClient(ctx context.Context) (*Client, error) {
 func DefaultSocketPath() (path, token string, err error) {
 	path = os.Getenv("BUILDKITE_AGENT_JOB_API_SOCKET")
 	if path == "" {
-		return "", "", errors.New("BUILDKITE_AGENT_JOB_API_SOCKET empty or undefined")
+		return "", "", errNoSocketEnv
 	}
 	token = os.Getenv("BUILDKITE_AGENT_JOB_API_TOKEN")
 	if token == "" {
-		return "", "", errors.New("BUILDKITE_AGENT_JOB_API_TOKEN empty or undefined")
+		return "", "", errNoSocketEnv
 	}
 	return path, token, nil
 }

--- a/jobapi/client_test.go
+++ b/jobapi/client_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/buildkite/agent/v3/internal/socket"
 	"github.com/google/go-cmp/cmp"
+	"gotest.tools/v3/assert"
 )
 
 type fakeServer struct {
@@ -126,9 +127,10 @@ func TestClient_NoSocket(t *testing.T) {
 	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(canc)
 
-	if _, err := NewDefaultClient(ctx); err == nil {
-		t.Errorf("NewDefaultClient(ctx) error = %v, want nil", err)
-	}
+	// This may be set if the test is being run by a buildkite agent!
+	os.Unsetenv("BUILDKITE_AGENT_JOB_API_SOCKET")
+	_, err := NewDefaultClient(ctx)
+	assert.ErrorIs(t, err, errNoSocketEnv, "NewDefaultClient() error = %v, want %v", err, errNoSocketEnv)
 }
 
 func TestClientEnvGet(t *testing.T) {


### PR DESCRIPTION
### Description

When this test was run locally, it always passed. However, when run is
run in CI, it can fail as the BUILDKITE_AGENT_JOB_API_SOCKET will be set
for the buildkite job that the test is run in!


### Context
https://buildkite-corp.slack.com/archives/C061U5PG9K5/p1708649091079859

### Changes
Fixed a test


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)