### PR TITLE
Extend graceful cancellation to all job phases

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -480,6 +480,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	env["BUILDKITE_AGENT_EXPERIMENT"] = strings.Join(experiments.Enabled(ctx), ",")
 	env["BUILDKITE_REDACTED_VARS"] = strings.Join(r.conf.AgentConfiguration.RedactedVars, ",")
 	env["BUILDKITE_STRICT_SINGLE_HOOKS"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.StrictSingleHooks)
+	env["BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS"] = fmt.Sprintf("%d", int(r.conf.AgentConfiguration.SignalGracePeriod/time.Second))
 
 	// propagate CancelSignal to bootstrap, unless it's the default SIGTERM
 	if r.conf.CancelSignal != process.SIGTERM {


### PR DESCRIPTION
### Description

We want to be able to gracefully cancel all phases of a job.

### Context

The graceful job cancellation feature introduced [here](https://github.com/buildkite/agent/pull/2250) is great but only applies to the checkout phase of a job.

### Changes

- Use a cancellable context in all phases where processes are being run
- Pass `BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS` between the agent and executor

### Testing

- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
