### PR TITLE
Force GitHub URLs to use HTTPS if the agent's git-credential-helper if it is enabled

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -42,6 +42,12 @@ func (e *Executor) configureGitCredentialHelper(ctx context.Context) error {
 		return fmt.Errorf("configuring git credential.helper: %v", err)
 	}
 
+	// so that the new credential helper will be used for all github urls
+	err = e.shell.RunWithoutPrompt(ctx, "git", "config", "--global", "url.https://github.com/.insteadOf", "git@github.com:")
+	if err != nil {
+		return fmt.Errorf("enabling git rewrite: %v", err)
+	}
+
 	return nil
 }
 

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -42,13 +42,15 @@ func (e *Executor) configureGitCredentialHelper(ctx context.Context) error {
 		return fmt.Errorf("configuring git credential.helper: %v", err)
 	}
 
-	// so that the new credential helper will be used for all github urls
-	err = e.shell.RunWithoutPrompt(ctx, "git", "config", "--global", "url.https://github.com/.insteadOf", "git@github.com:")
-	if err != nil {
-		return fmt.Errorf("enabling git rewrite: %v", err)
-	}
-
 	return nil
+}
+
+// Disables SSH keyscan and configures git to use HTTPS instead of SSH for github.
+// We may later expand this for other SCMs.
+func (e *Executor) configureHTTPSInsteadOfSSH(ctx context.Context) error {
+	return e.shell.RunWithoutPrompt(ctx,
+		"git", "config", "--global", "url.https://github.com/.insteadOf", "git@github.com:",
+	)
 }
 
 func (e *Executor) removeCheckoutDir() error {

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -148,6 +148,13 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 			e.shell.Errorf("Error configuring git credential helper: %v", err)
 			return shell.GetExitCode(err)
 		}
+
+		// so that the new credential helper will be used for all github urls
+		err = e.configureHTTPSInsteadOfSSH(ctx)
+		if err != nil {
+			e.shell.Errorf("Error configuring https instead of ssh: %v", err)
+			return shell.GetExitCode(err)
+		}
 	}
 
 	// Initialize the environment, a failure here will still call the tearDown

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -143,6 +143,12 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 	}()
 
 	if env, ok := e.shell.Env.Get("BUILDKITE_USE_GITHUB_APP_GIT_CREDENTIALS"); ok && env == "true" {
+		// On hosted compute, we are not going to use SSH keys, so we don't need to scan for SSH keys.
+		//
+		// TODO: This may break non-GitHub SSH checkout for other SCMs on self-hosted compute.
+		// So we need to revise this before enabling the code access app on self-hosted agents.
+		e.SSHKeyscan = false
+
 		err := e.configureGitCredentialHelper(ctx)
 		if err != nil {
 			e.shell.Errorf("Error configuring git credential helper: %v", err)


### PR DESCRIPTION
### Description
When using buildkite's git-credential-helper, the agent may still attempt to checkout with ssh. But users who use the git-credential-helper would have set up the Github App that provides code access. This only works with https URLs. So, here, we force git to use https URLs instead of the ssh ones. We also disable the ssh key scan in this case.

I've limited this to all of GitHub. We may expand it for other SCM providers in the future.

There's a risk that this will break existing setups of self-hosted agents that already have a ssh key that works for some repos that the GitHub App with code access has not been set up for. As the git-credential-helper is not supported on self-hosted agents at the moment, and this circumstance is expected to be rare, we think that risk is acceptable. Users that do encounter this should just esure that the code access app has been configured with ALL the repositories that need to be checked out, including submodules.

### Context
https://linear.app/buildkite/issue/COMP-216/rewrite-ssh-to-https-on-agent
https://buildkite-corp.slack.com/archives/C06D36S59N1/p1708899990413789

### Changes
When the git credential helper is enabled, we run
```
git config --global url."https://github.com/".insteadOf git@github.com:
```

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)