### PR TITLE
Remove requests logging in the Job API unless if in debug mode

### DIFF
--- a/internal/job/api.go
+++ b/internal/job/api.go
@@ -25,7 +25,11 @@ func (e *Executor) startJobAPI() (cleanup func(), err error) {
 		return cleanup, fmt.Errorf("creating job API socket path: %v", err)
 	}
 
-	srv, token, err := jobapi.NewServer(e.shell.Logger, socketPath, e.shell.Env)
+	jobAPIOpts := []jobapi.ServerOpts{}
+	if e.ExecutorConfig.Debug {
+		jobAPIOpts = append(jobAPIOpts, jobapi.WithDebug())
+	}
+	srv, token, err := jobapi.NewServer(e.shell.Logger, socketPath, e.shell.Env, jobAPIOpts...)
 	if err != nil {
 		return cleanup, fmt.Errorf("creating job API server: %v", err)
 	}

--- a/jobapi/routes.go
+++ b/jobapi/routes.go
@@ -14,14 +14,20 @@ import (
 
 // router returns a chi router with the jobapi routes and appropriate middlewares mounted
 func (s *Server) router() chi.Router {
-	r := chi.NewRouter()
-	r.Use(
-		socket.LoggerMiddleware("Job API", s.Logger.Commentf),
+	middlewares := [](func(http.Handler) http.Handler){}
+	if s.debug {
+		middlewares = append(middlewares, socket.LoggerMiddleware("Job API", s.Logger.Commentf))
+	}
+	middlewares = append(middlewares,
 		middleware.Recoverer,
+
 		// All responses are in JSON.
 		socket.HeadersMiddleware(http.Header{"Content-Type": []string{"application/json"}}),
 		socket.AuthMiddleware(s.token, s.Logger.Errorf),
 	)
+
+	r := chi.NewRouter()
+	r.Use(middlewares...)
 
 	r.Route("/api/current-job/v0", func(r chi.Router) {
 		r.Get("/env", s.getEnv)


### PR DESCRIPTION
### Description
The Job API would always log that a request occurred because of some middleware. This clutters the logs.
I think it should not be necessary to see this in the logs unless the server is in debug mode.
Much of the time, the server will be called by our own cli commands, which often log that they are running as well, so this will be redundant.


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->