### PR TITLE
Promote `avoid-recursive-trap` experiment

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -68,20 +68,6 @@ The API is exposed via a Unix Domain Socket. The path to the socket is not avail
 
 **Status:** Experimental while we iron out the API and test it out in the wild. We'll probably promote this to non-experiment soon™.
 
-### `avoid-recursive-trap`
-
-Some jobs are run as a bash script of the form:
-
-```shell
-trap "kill -- $$" INT TERM QUIT; <command>
-```
-
-We now understand this causes a bug, and we want to avoid it. Enabling this experiment removes the `trap` that surrounds non-script commands.
-
-https://github.com/buildkite/agent/blob/40b8a5f3794b04bd64da6e2527857add849a35bd/internal/job/executor.go#L1980-L1993
-
-**Status:** Since the default behaviour is buggy, we will be promoting this to non-experiment soon™️.
-
 ### `isolated-plugin-checkout`
 
 Checks out each plugin to an directory that that is namespaced by the agent name. Thus each agent worker will have an isolated copy of the plugin. This removes the need to lock the plugin checkout directories in a single agent process with spawned workers. However, if your plugin directory is shared between multiple agent processes *with the same agent name* , you may run into race conditions. This is just one reason we recommend you ensure agents have unique names.

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -30,37 +30,37 @@ const (
 	PTYRaw                     = "pty-raw"
 	PolyglotHooks              = "polyglot-hooks"
 	ResolveCommitAfterCheckout = "resolve-commit-after-checkout"
-	AvoidRecursiveTrap         = "avoid-recursive-trap"
 	IsolatedPluginCheckout     = "isolated-plugin-checkout"
 	UseZZGlob                  = "use-zzglob"
 
 	// Promoted experiments
-	ANSITimestamps    = "ansi-timestamps"
-	FlockFileLocks    = "flock-file-locks"
-	GitMirrors        = "git-mirrors"
-	InbuiltStatusPage = "inbuilt-status-page"
-	JobAPI            = "job-api"
+	ANSITimestamps     = "ansi-timestamps"
+	FlockFileLocks     = "flock-file-locks"
+	GitMirrors         = "git-mirrors"
+	InbuiltStatusPage  = "inbuilt-status-page"
+	JobAPI             = "job-api"
+	AvoidRecursiveTrap = "avoid-recursive-trap"
 )
 
 var (
 	Available = map[string]struct{}{
 		AgentAPI:                   {},
 		DescendingSpawnPrioity:     {},
+		IsolatedPluginCheckout:     {},
 		KubernetesExec:             {},
 		NormalisedUploadPaths:      {},
 		PolyglotHooks:              {},
 		ResolveCommitAfterCheckout: {},
-		AvoidRecursiveTrap:         {},
-		IsolatedPluginCheckout:     {},
 		UseZZGlob:                  {},
 	}
 
 	Promoted = map[string]string{
-		ANSITimestamps:    standardPromotionMsg(ANSITimestamps, "v3.48.0"),
-		FlockFileLocks:    standardPromotionMsg(FlockFileLocks, "v3.48.0"),
-		GitMirrors:        standardPromotionMsg(GitMirrors, "v3.47.0"),
-		InbuiltStatusPage: standardPromotionMsg(InbuiltStatusPage, "v3.48.0"),
-		JobAPI:            standardPromotionMsg(JobAPI, "v3.64.0"),
+		ANSITimestamps:     standardPromotionMsg(ANSITimestamps, "v3.48.0"),
+		AvoidRecursiveTrap: standardPromotionMsg(AvoidRecursiveTrap, "v3.66.0"),
+		FlockFileLocks:     standardPromotionMsg(FlockFileLocks, "v3.48.0"),
+		GitMirrors:         standardPromotionMsg(GitMirrors, "v3.47.0"),
+		InbuiltStatusPage:  standardPromotionMsg(InbuiltStatusPage, "v3.48.0"),
+		JobAPI:             standardPromotionMsg(JobAPI, "v3.64.0"),
 	}
 
 	// Used to track experiments possibly in use.

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -25,21 +25,21 @@ const (
 	// Available experiments
 	AgentAPI                   = "agent-api"
 	DescendingSpawnPrioity     = "descending-spawn-priority"
+	IsolatedPluginCheckout     = "isolated-plugin-checkout"
 	KubernetesExec             = "kubernetes-exec"
 	NormalisedUploadPaths      = "normalised-upload-paths"
 	PTYRaw                     = "pty-raw"
 	PolyglotHooks              = "polyglot-hooks"
 	ResolveCommitAfterCheckout = "resolve-commit-after-checkout"
-	IsolatedPluginCheckout     = "isolated-plugin-checkout"
 	UseZZGlob                  = "use-zzglob"
 
 	// Promoted experiments
 	ANSITimestamps     = "ansi-timestamps"
+	AvoidRecursiveTrap = "avoid-recursive-trap"
 	FlockFileLocks     = "flock-file-locks"
 	GitMirrors         = "git-mirrors"
 	InbuiltStatusPage  = "inbuilt-status-page"
 	JobAPI             = "job-api"
-	AvoidRecursiveTrap = "avoid-recursive-trap"
 )
 
 var (

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -852,10 +852,9 @@ func (e *Executor) CommandPhase(ctx context.Context) (hookErr error, commandErr 
 
 	isExitError := shell.IsExitError(commandErr)
 	isExitSignaled := shell.IsExitSignaled(commandErr)
-	avoidRecursiveTrap := experiments.IsEnabled(ctx, experiments.AvoidRecursiveTrap)
 
 	switch {
-	case isExitError && isExitSignaled && avoidRecursiveTrap:
+	case isExitError && isExitSignaled:
 		// The recursive trap created a segfault that we were previously inadvertently suppressing
 		// in the next branch. Once the experiment is promoted, we should keep this branch in case
 		// to show the error to users.
@@ -863,12 +862,6 @@ func (e *Executor) CommandPhase(ctx context.Context) (hookErr error, commandErr 
 
 		// although error is an exit error, it's not returned. (seems like a bug)
 		// TODO: investigate phasing this out under a experiment
-		return nil, nil
-	case isExitError && isExitSignaled && !avoidRecursiveTrap:
-		// TODO: remove this branch when the experiment is promoted
-		e.shell.Errorf("The command was interrupted by a signal")
-
-		// although error is an exit error, it's not returned. (seems like a bug)
 		return nil, nil
 	case isExitError && !isExitSignaled:
 		e.shell.Errorf("The command exited with status %d", shell.GetExitCode(commandErr))
@@ -999,24 +992,6 @@ func (e *Executor) defaultCommandPhase(ctx context.Context) error {
 		}
 		err = runDeprecatedDockerIntegration(ctx, e.shell, []string{cmdToExec})
 		return err
-	}
-
-	// We added the `trap` below because we used to think that:
-	//
-	// If we aren't running a script, try and detect if we are using a posix shell
-	// and if so add a trap so that the intermediate shell doesn't swallow signals
-	// from cancellation
-	//
-	// But on further investigation:
-	// 1. The trap is recursive and leads to an infinite loop of signals and a segfault.
-	// 2. It just signals the intermediate shell again. If the intermediate shell swallowed signals
-	//    in the first place then signaling it again won't change that.
-	// 3. Propogating signals to child processes is handled by signalling their process group
-	//    elsewhere in the agent.
-	//
-	// Therefore, we are phasing it out under an experiment.
-	if !experiments.IsEnabled(ctx, experiments.AvoidRecursiveTrap) && !commandIsScript && shellscript.IsPOSIXShell(e.Shell) {
-		cmdToExec = fmt.Sprintf("trap 'kill -- $$' INT TERM QUIT; %s", cmdToExec)
 	}
 
 	redactors := e.setupRedactors()


### PR DESCRIPTION
### Description

This has been operating for some time in our dogfood stacks and we have not
noticed any issues. It is time to promote experiment. I have not added any
code to invert the experiment, as I believe it is safe to promote without
that.

### Context

https://3.basecamp.com/3453178/buckets/27608512/messages/6299400220

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)