### PR TITLE
Change annotation priority default from 3 to 1

### DIFF
--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -97,8 +97,9 @@ var AnnotateCommand = cli.Command{
 		},
 		cli.IntFlag{
 			Name:   "priority",
-			Usage:  "Priority of the annotation (1 to 10). By default annotations have a priority of 3. Annotations with a priority of 10 will be shown first, and annotations with a priority of 1 will be shown last.",
+			Usage:  "Priority of the annotation (1 to 10). Annotations with a priority of 10 will be shown first, and annotations with a priority of 1 will be shown last.",
 			EnvVar: "BUILDKITE_ANNOTATION_PRIORITY",
+			Value:  1,
 		},
 		cli.StringFlag{
 			Name:   "job",


### PR DESCRIPTION
Currently annotation priority defaults are set server side, this means that agent version doesn't currently control the default (even if they mention it in the help text). This means that we're not able to pin a default annotation priority to an agent version.

This updates the annotation priority to be set on the agent, not the server. It also changes the default from 3 to 1 because priority of 3 has been considered to be confusing and not intuitive. This now matches agent priority.

Agent version v3.65.0 will continue to use the server side default (which will be updated to 1).