### PR TITLE
Add a User-Agent header when uploading artifacts to Buildkite's default location

### DIFF
--- a/agent/form_uploader.go
+++ b/agent/form_uploader.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/logger"
+	"github.com/buildkite/agent/v3/version"
 )
 
 var ArtifactPathVariableRegex = regexp.MustCompile("\\$\\{artifact\\:path\\}")
@@ -180,6 +181,8 @@ func createUploadRequest(l logger.Logger, artifact *api.Artifact) (*http.Request
 
 	// Setup the content type and length that s3 requires
 	req.Header.Add("Content-Type", streamer.ContentType)
+	// Letting the server know the agent version can be helpful for debugging
+	req.Header.Add("User-Agent", version.UserAgent())
 	req.ContentLength = streamer.Len()
 
 	return req, nil


### PR DESCRIPTION
If the agent isn't configured with a custom artifact storage location, it defaults to uploading them to an S3 bucket provided by Buildkite. The upload is performed by FormUploader, which wasn't setting a User-Agent header.

This PR adds the header, using the same tooling we have for setting User-Agent on requests to the Buildkite API.

The header is primarily for debugging. It is occasionally helpful for us to see which version of the agent was used for particular uploaded artifacts.

I have not attempted to set the User-Agent header on uploads when a custom artifact storage location (S3, GCS, Artifactory, etc) is in use. That might be a useful thing to do, but we can consider it separately.

Fixes PLT-2222

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)