### PR TITLE
Downgrade "submodules disabled" message to info

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -611,7 +611,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 			e.shell.Commentf("Git submodules detected")
 			gitSubmodules = true
 		} else {
-			e.shell.Warningf("This repository has submodules, but submodules are disabled at an agent level")
+			e.shell.Commentf("This repository has submodules, but submodules are disabled at an agent level")
 		}
 	}
 


### PR DESCRIPTION
### Description

- When submodules have been disabled intentionally, we don't want the group to auto-expand in the Buildkite UI (which happens when there is a warning logged)

### Context

- As discussed on Slack