### PR TITLE
Configurably optional warnings

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -59,4 +59,5 @@ type AgentConfiguration struct {
 	AcquireJob                 string
 	TracingBackend             string
 	TracingServiceName         string
+	NoWarnFor                  []string
 }

--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -59,5 +59,5 @@ type AgentConfiguration struct {
 	AcquireJob                 string
 	TracingBackend             string
 	TracingServiceName         string
-	NoWarnFor                  []string
+	DisableWarningsFor         []string
 }

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -522,6 +522,8 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 		env["BUILDKITE_TRACING_SERVICE_NAME"] = r.conf.AgentConfiguration.TracingServiceName
 	}
 
+	env["BUILDKITE_AGENT_NO_WARN_FOR"] = strings.Join(r.conf.AgentConfiguration.NoWarnFor, ",")
+
 	// see documentation for BuildkiteMessageMax
 	if err := truncateEnv(r.agentLogger, env, BuildkiteMessageName, BuildkiteMessageMax); err != nil {
 		r.agentLogger.Warn("failed to truncate %s: %v", BuildkiteMessageName, err)

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -522,7 +522,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 		env["BUILDKITE_TRACING_SERVICE_NAME"] = r.conf.AgentConfiguration.TracingServiceName
 	}
 
-	env["BUILDKITE_AGENT_NO_WARN_FOR"] = strings.Join(r.conf.AgentConfiguration.NoWarnFor, ",")
+	env["BUILDKITE_AGENT_DISABLE_WARNINGS_FOR"] = strings.Join(r.conf.AgentConfiguration.DisableWarningsFor, ",")
 
 	// see documentation for BuildkiteMessageMax
 	if err := truncateEnv(r.agentLogger, env, BuildkiteMessageName, BuildkiteMessageMax); err != nil {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -99,7 +99,7 @@ type AgentStartConfig struct {
 
 	LogFormat            string   `cli:"log-format"`
 	WriteJobLogsToStdout bool     `cli:"write-job-logs-to-stdout"`
-	NoWarnFor            []string `cli:"no-warn-for" normalize:"list"`
+	DisableWarningsFor   []string `cli:"disable-warnings-for" normalize:"list"`
 
 	BuildPath   string `cli:"build-path" normalize:"filepath" validate:"required"`
 	HooksPath   string `cli:"hooks-path" normalize:"filepath"`
@@ -655,9 +655,9 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_AGENT_JOB_VERIFICATION_NO_SIGNATURE_BEHAVIOR",
 		},
 		cli.StringSliceFlag{
-			Name:   "no-warn-for",
+			Name:   "disable-warnings-for",
 			Usage:  "A list of warning IDs to disable",
-			EnvVar: "BUILDKITE_AGENT_NO_WARN_FOR",
+			EnvVar: "BUILDKITE_AGENT_DISABLE_WARNINGS_FOR",
 		},
 
 		// API Flags
@@ -939,7 +939,7 @@ var AgentStartCommand = cli.Command{
 
 			VerificationJWKS: verificationJWKS,
 
-			NoWarnFor: cfg.NoWarnFor,
+			DisableWarningsFor: cfg.DisableWarningsFor,
 		}
 
 		if configFile != nil {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -97,8 +97,9 @@ type AgentStartConfig struct {
 	EnableJobLogTmpfile bool   `cli:"enable-job-log-tmpfile"`
 	JobLogPath          string `cli:"job-log-path" normalize:"filepath"`
 
-	LogFormat            string `cli:"log-format"`
-	WriteJobLogsToStdout bool   `cli:"write-job-logs-to-stdout"`
+	LogFormat            string   `cli:"log-format"`
+	WriteJobLogsToStdout bool     `cli:"write-job-logs-to-stdout"`
+	NoWarnFor            []string `cli:"no-warn-for" normalize:"list"`
 
 	BuildPath   string `cli:"build-path" normalize:"filepath" validate:"required"`
 	HooksPath   string `cli:"hooks-path" normalize:"filepath"`
@@ -653,6 +654,11 @@ var AgentStartCommand = cli.Command{
 			Usage:  fmt.Sprintf("The behavior when a job is received without a signature. One of: %v. Defaults to %s", verificationFailureBehaviors, agent.VerificationBehaviourBlock),
 			EnvVar: "BUILDKITE_AGENT_JOB_VERIFICATION_NO_SIGNATURE_BEHAVIOR",
 		},
+		cli.StringSliceFlag{
+			Name:   "no-warn-for",
+			Usage:  "A list of warning IDs to disable",
+			EnvVar: "BUILDKITE_AGENT_NO_WARN_FOR",
+		},
 
 		// API Flags
 		AgentRegisterTokenFlag,
@@ -932,6 +938,8 @@ var AgentStartCommand = cli.Command{
 			SigningJWKSKeyID: cfg.SigningJWKSKeyID,
 
 			VerificationJWKS: verificationJWKS,
+
+			NoWarnFor: cfg.NoWarnFor,
 		}
 
 		if configFile != nil {

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -96,7 +96,7 @@ type BootstrapConfig struct {
 	TracingBackend               string   `cli:"tracing-backend"`
 	TracingServiceName           string   `cli:"tracing-service-name"`
 	NoJobAPI                     bool     `cli:"no-job-api"`
-	NoWarnFor                    []string `cli:"no-warn-for" normalize:"list"`
+	DisableWarningsFor           []string `cli:"disable-warnings-for" normalize:"list"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -364,9 +364,9 @@ var BootstrapCommand = cli.Command{
 			EnvVar: "BUILDKITE_AGENT_NO_JOB_API",
 		},
 		cli.StringSliceFlag{
-			Name:   "no-warn-for",
+			Name:   "disable-warnings-for",
 			Usage:  "A list of warning IDs to disable",
-			EnvVar: "BUILDKITE_AGENT_NO_WARN_FOR",
+			EnvVar: "BUILDKITE_AGENT_DISABLE_WARNINGS_FOR",
 		},
 		DebugFlag,
 		LogLevelFlag,
@@ -453,7 +453,7 @@ var BootstrapCommand = cli.Command{
 			TracingBackend:               cfg.TracingBackend,
 			TracingServiceName:           cfg.TracingServiceName,
 			JobAPI:                       !cfg.NoJobAPI,
-			DisabledWarnings:             cfg.NoWarnFor,
+			DisabledWarnings:             cfg.DisableWarningsFor,
 		})
 
 		cctx, cancel := context.WithCancel(ctx)

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -96,6 +96,7 @@ type BootstrapConfig struct {
 	TracingBackend               string   `cli:"tracing-backend"`
 	TracingServiceName           string   `cli:"tracing-service-name"`
 	NoJobAPI                     bool     `cli:"no-job-api"`
+	NoWarnFor                    []string `cli:"no-warn-for" normalize:"list"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -362,6 +363,11 @@ var BootstrapCommand = cli.Command{
 			Usage:  "Disables the Job API, which gives commands in jobs some abilities to introspect and mutate the state of the job.",
 			EnvVar: "BUILDKITE_AGENT_NO_JOB_API",
 		},
+		cli.StringSliceFlag{
+			Name:   "no-warn-for",
+			Usage:  "A list of warning IDs to disable",
+			EnvVar: "BUILDKITE_AGENT_NO_WARN_FOR",
+		},
 		DebugFlag,
 		LogLevelFlag,
 		ExperimentsFlag,
@@ -447,6 +453,7 @@ var BootstrapCommand = cli.Command{
 			TracingBackend:               cfg.TracingBackend,
 			TracingServiceName:           cfg.TracingServiceName,
 			JobAPI:                       !cfg.NoJobAPI,
+			DisabledWarnings:             cfg.NoWarnFor,
 		})
 
 		cctx, cancel := context.WithCancel(ctx)

--- a/internal/job/api.go
+++ b/internal/job/api.go
@@ -14,9 +14,9 @@ func (e *Executor) startJobAPI() (cleanup func(), err error) {
 	cleanup = func() {}
 
 	if !socket.Available() {
-		e.shell.Warningf("The Job API isn't available on this machine, as it's running an unsupported version of Windows")
-		e.shell.Warningf("The Job API is available on Unix agents, and agents running Windows versions after build 17063")
-		e.shell.Warningf("We'll continue to run your job, but you won't be able to use the Job API")
+		e.shell.OptionalWarningf("job-api-unavailable", `The Job API isn't available on this machine, as it's running an unsupported version of Windows.
+The Job API is available on Unix agents, and agents running Windows versions after build 17063
+We'll continue to run your job, but you won't be able to use the Job API`)
 		return cleanup, nil
 	}
 

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -611,7 +611,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 			e.shell.Commentf("Git submodules detected")
 			gitSubmodules = true
 		} else {
-			e.shell.Warningf("This repository has submodules, but submodules are disabled at an agent level")
+			e.shell.OptionalWarningf("submodules-disabled", "This repository has submodules, but submodules are disabled at an agent level")
 		}
 	}
 

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -167,6 +167,9 @@ type ExecutorConfig struct {
 
 	// Whether to start the JobAPI
 	JobAPI bool
+
+	// The warnings that have been disabled by the user
+	DisabledWarnings []string
 }
 
 // ReadFromEnvironment reads configuration from the Environment, returns a map

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -73,7 +73,9 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 	// Check if not nil to allow for tests to overwrite shell
 	if e.shell == nil {
 		var err error
-		e.shell, err = shell.New()
+		logger := shell.StderrLogger
+		logger.DisabledWarningIDs = e.DisabledWarnings
+		e.shell, err = shell.New(shell.WithLogger(logger))
 		if err != nil {
 			fmt.Printf("Error creating shell: %v", err)
 			return 1

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -131,7 +131,7 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 		}
 		defer cleanup()
 	} else {
-		e.shell.Warningf("The Job API has been disabled. Features like automatic redaction of secrets and polyglot hooks will either not work or have degraded functionality")
+		e.shell.OptionalWarningf("job-api-disabled", "The Job API has been disabled. Features like automatic redaction of secrets and polyglot hooks will either not work or have degraded functionality")
 	}
 
 	// Tear down the environment (and fire pre-exit hook) before we exit

--- a/internal/job/shell/logger.go
+++ b/internal/job/shell/logger.go
@@ -98,10 +98,11 @@ func (wl *WriterLogger) Warningf(format string, v ...any) {
 
 func (wl *WriterLogger) OptionalWarningf(id, format string, v ...any) {
 	if slices.Contains(wl.DisabledWarningIDs, id) {
+		wl.Printf(format, v...)
 		return
 	}
 
-	warningFormatWithDisable := format + fmt.Sprintf(". You can disable this warning by passing the `--no-warn-for %s` flag", id)
+	warningFormatWithDisable := format + fmt.Sprintf(". You can disable this warning by passing the `--disable-warnings-for %s` flag", id)
 	wl.Warningf(warningFormatWithDisable, v...)
 }
 

--- a/internal/job/shell/shell.go
+++ b/internal/job/shell/shell.go
@@ -74,19 +74,33 @@ type Shell struct {
 	SignalGracePeriod time.Duration
 }
 
+type newShellOpt func(*Shell)
+
+func WithLogger(l Logger) newShellOpt {
+	return func(s *Shell) {
+		s.Logger = l
+	}
+}
+
 // New returns a new Shell
-func New() (*Shell, error) {
+func New(opts ...newShellOpt) (*Shell, error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to find current working directory: %w", err)
 	}
 
-	return &Shell{
+	shell := &Shell{
 		Logger: StderrLogger,
 		Env:    env.FromSlice(os.Environ()),
 		Writer: os.Stdout,
 		wd:     wd,
-	}, nil
+	}
+
+	for _, opt := range opts {
+		opt(shell)
+	}
+
+	return shell, nil
 }
 
 // WithStdin returns a copy of the Shell with the provided io.Reader set as the


### PR DESCRIPTION
### Description

there's a subset of warnings in the agent that are essentially us trying to clippy the users, saying "Hmm, something about this setup looks a little bit weird, but we'll proceed anyway" - notably a message about when [submodules are disabled, but the repo the agent is cloning containing submodules](https://github.com/buildkite/agent/issues/1773).

he somewhat frequently get feedback from users that when you know that you're doing the right thing - for example, if you know you're not going to need the submodules that aren't being cloned - these warnings are annoying, and pop open a large log group in the job log that isn't useful.

however, we're usually a bit reluctant to add flags to disable individual warnings - for example, a hypothetical `--disable-warning-about-submodules`, because the agent arguably has too many flags already.

this PR is a bit of a middle ground - certain warnings will become optional by using the `--no-warn-for` flag. Each optional warning is given an ID, and when not disabled, will have  "You can disable this warning by passing the `--no-warn-for <some warning name>`" appended to the end.

If users want to disable that warning - for example, the submodule warning mentioned above, `submodule-conflict` - they can pass `--no-warn-for submodule-conflict` to their `buildkite-agent start` command.

Thanks so much to @amu-g for pairing with me on this!

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
