### PR TITLE
Handle warnings from go-pipeline `Parse`

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -264,7 +264,7 @@ var PipelineUploadCommand = cli.Command{
 
 		result, err := cfg.parseAndInterpolate(src, input, environ)
 		if w := warning.As(err); w != nil {
-			l.Warn("There were some issues with the pipeline input:\n%v", w)
+			l.Warn("There were some issues with the pipeline input - pipeline upload will proceed, but might not succeed:\n%v", w)
 		} else if err != nil {
 			return err
 		}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -26,6 +26,7 @@ import (
 	"github.com/buildkite/go-pipeline/jwkutil"
 	"github.com/buildkite/go-pipeline/ordered"
 	"github.com/buildkite/go-pipeline/signature"
+	"github.com/buildkite/go-pipeline/warning"
 	"github.com/urfave/cli"
 	"gopkg.in/yaml.v3"
 )
@@ -262,7 +263,9 @@ var PipelineUploadCommand = cli.Command{
 		}
 
 		result, err := cfg.parseAndInterpolate(src, input, environ)
-		if err != nil {
+		if w := warning.As(err); w != nil {
+			l.Warn("There were some issues with the pipeline input:\n%v", w)
+		} else if err != nil {
 			return err
 		}
 
@@ -388,7 +391,7 @@ func searchForSecrets(
 
 func (cfg *PipelineUploadConfig) parseAndInterpolate(src string, input io.Reader, environ *env.Environment) (*pipeline.Pipeline, error) {
 	result, err := pipeline.Parse(input)
-	if err != nil {
+	if err != nil && !warning.Is(err) {
 		return nil, fmt.Errorf("pipeline parsing of %q failed: %w", src, err)
 	}
 	if !cfg.NoInterpolation {
@@ -402,5 +405,6 @@ func (cfg *PipelineUploadConfig) parseAndInterpolate(src string, input io.Reader
 			return nil, fmt.Errorf("pipeline interpolation of %q failed: %w", src, err)
 		}
 	}
-	return result, nil
+	// err may be nil or a warning from pipeline.Parse
+	return result, err
 }

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildkite/go-pipeline"
 	"github.com/buildkite/go-pipeline/jwkutil"
 	"github.com/buildkite/go-pipeline/signature"
+	"github.com/buildkite/go-pipeline/warning"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/urfave/cli"
 	"gopkg.in/yaml.v3"
@@ -186,7 +187,9 @@ func signOffline(
 	}
 
 	parsedPipeline, err := pipeline.Parse(input)
-	if err != nil {
+	if w := warning.As(err); w != nil {
+		l.Warn("There were some issues with the pipeline input:\n%v", w)
+	} else if err != nil {
 		return fmt.Errorf("pipeline parsing of %q failed: %w", filename, err)
 	}
 
@@ -240,7 +243,9 @@ func signWithGraphQL(
 	l.Info("Signing pipeline with the repository URL:\n%s", resp.Pipeline.Repository.Url)
 
 	parsedPipeline, err := pipeline.Parse(strings.NewReader(resp.Pipeline.Steps.Yaml))
-	if err != nil {
+	if w := warning.As(err); w != nil {
+		l.Warn("There were some issues with the pipeline input:\n%v", w)
+	} else if err != nil {
 		return fmt.Errorf("pipeline parsing failed: %w", err)
 	}
 

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -188,7 +188,7 @@ func signOffline(
 
 	parsedPipeline, err := pipeline.Parse(input)
 	if w := warning.As(err); w != nil {
-		l.Warn("There were some issues with the pipeline input:\n%v", w)
+		l.Warn("There were some issues with the pipeline input - signing will be attempted but might not succeed:\n%v", w)
 	} else if err != nil {
 		return fmt.Errorf("pipeline parsing of %q failed: %w", filename, err)
 	}
@@ -244,7 +244,7 @@ func signWithGraphQL(
 
 	parsedPipeline, err := pipeline.Parse(strings.NewReader(resp.Pipeline.Steps.Yaml))
 	if w := warning.As(err); w != nil {
-		l.Warn("There were some issues with the pipeline input:\n%v", w)
+		l.Warn("There were some issues with the pipeline input - signing will be attempted but might not succeed:\n%v", w)
 	} else if err != nil {
 		return fmt.Errorf("pipeline parsing failed: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go v1.51.11
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 	github.com/buildkite/bintest/v3 v3.2.0
-	github.com/buildkite/go-pipeline v0.4.1
+	github.com/buildkite/go-pipeline v0.5.0
 	github.com/buildkite/roko v1.2.0
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/creack/pty v1.1.21

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf/go.mod h1:CeKhh8xSs3WZAc50xABMxu+FlfAAd5PNumo7NfOv7EE=
 github.com/buildkite/bintest/v3 v3.2.0 h1:1GqUILGGni5UViGPH/PbSq0MxB9gzY3J/P7vNVqCkX4=
 github.com/buildkite/bintest/v3 v3.2.0/go.mod h1:+AdQZcVlzCiW2UyZWeG63xeH5z011XUBW6kWcRdaMtU=
-github.com/buildkite/go-pipeline v0.4.1 h1:RZ1afSHOt5mUcTzhFab0WxKm90vvJsOUAPpfQBETgkE=
-github.com/buildkite/go-pipeline v0.4.1/go.mod h1:/8zdWlpn40HsxZql5iUbr00P8/Fm/yud9+Bqrar8S3s=
+github.com/buildkite/go-pipeline v0.5.0 h1:V8TaxKIzvhvIMIcHGtR1Z6Q9RFyTrtaO0e0N1A4BwdY=
+github.com/buildkite/go-pipeline v0.5.0/go.mod h1:lHk0pJoZ8yxlOaUMRwzS/HyY0W6xh+ne8u+Cabw+DeM=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/buildkite/roko v1.2.0 h1:hbNURz//dQqNl6Eo9awjQOVOZwSDJ8VEbBDxSfT9rGQ=


### PR DESCRIPTION
### Description

* Update go-pipeline to v0.5.0
* Display new parser warnings produced by go-pipeline

### Context

https://linear.app/buildkite/issue/PS-46/json-valued-env-vars-in-pipelineyml-silently-dropped

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
