### PR TITLE
Always set git commit

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -219,7 +219,7 @@ func (e *Executor) CheckoutPhase(ctx context.Context) error {
 
 	err = e.sendCommitToBuildkite(ctx)
 	if err != nil {
-		return err
+		e.shell.OptionalWarningf("commit-metadata", err.Error())
 	}
 
 	// Store the current value of BUILDKITE_BUILD_CHECKOUT_PATH, so we can detect if

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -219,7 +219,7 @@ func (e *Executor) CheckoutPhase(ctx context.Context) error {
 
 	err = e.sendCommitToBuildkite(ctx)
 	if err != nil {
-		e.shell.OptionalWarningf("commit-metadata", err.Error())
+		e.shell.OptionalWarningf("git-commit-resolution-failed", err.Error())
 	}
 
 	// Store the current value of BUILDKITE_BUILD_CHECKOUT_PATH, so we can detect if

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -726,7 +726,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 	return nil
 }
 
-const commitMetadataKey = "buildkite:git:commit"
+const CommitMetadataKey = "buildkite:git:commit"
 
 // sendCommitToBuildkite sends commit information (commit, author, subject, body) to Buildkite, as the BK backend doesn't
 // have access to user's VCSes. To do this, we set a special meta-data key in the build, but only if it isn't already present
@@ -735,7 +735,7 @@ const commitMetadataKey = "buildkite:git:commit"
 // note that we bail early if the key already exists, as we don't want to overwrite it
 func (e *Executor) sendCommitToBuildkite(ctx context.Context) error {
 	e.shell.Commentf("Checking to see if git commit information needs to be sent to Buildkite...")
-	if err := e.shell.Run(ctx, "buildkite-agent", "meta-data", "exists", commitMetadataKey); err == nil {
+	if err := e.shell.Run(ctx, "buildkite-agent", "meta-data", "exists", CommitMetadataKey); err == nil {
 		// Command exited 0, ie the key exists, so we don't need to send it again
 		e.shell.Commentf("Git commit information has already been sent to Buildkite")
 		return nil
@@ -767,7 +767,7 @@ func (e *Executor) sendCommitToBuildkite(ctx context.Context) error {
 	}
 
 	stdin := strings.NewReader(out)
-	if err := e.shell.WithStdin(stdin).Run(ctx, "buildkite-agent", "meta-data", "set", commitMetadataKey); err != nil {
+	if err := e.shell.WithStdin(stdin).Run(ctx, "buildkite-agent", "meta-data", "set", CommitMetadataKey); err != nil {
 		return fmt.Errorf("sending git commit information to Buildkite: %w", err)
 	}
 

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -217,6 +217,11 @@ func (e *Executor) CheckoutPhase(ctx context.Context) error {
 		}
 	}
 
+	err = e.sendCommitToBuildkite(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Store the current value of BUILDKITE_BUILD_CHECKOUT_PATH, so we can detect if
 	// one of the post-checkout hooks changed it.
 	previousCheckoutPath, exists := e.shell.Env.Get("BUILDKITE_BUILD_CHECKOUT_PATH")
@@ -718,38 +723,52 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 		e.resolveCommit(ctx)
 	}
 
-	// Grab author and commit information and send it back to Buildkite. But before we do, we'll check
-	// to see if someone else has done it first.
-	e.shell.Commentf("Checking to see if Git data needs to be sent to Buildkite")
-	if err := e.shell.Run(ctx, "buildkite-agent", "meta-data", "exists", "buildkite:git:commit"); err != nil {
-		e.shell.Commentf("Sending Git commit information back to Buildkite")
-		// Format:
-		//
-		// commit 0123456789abcdef0123456789abcdef01234567
-		// abbrev-commit 0123456789
-		// Author: John Citizen <john@example.com>
-		//
-		//    Subject of the commit message
-		//
-		//    Body of the commit message, which
-		//    may span multiple lines.
-		gitArgs := []string{
-			"--no-pager",
-			"log",
-			"-1",
-			"HEAD",
-			"-s", // --no-patch was introduced in v1.8.4 in 2013, but e.g. CentOS 7 isn't there yet
-			"--no-color",
-			"--format=commit %H%nabbrev-commit %h%nAuthor: %an <%ae>%n%n%w(0,4,4)%B",
-		}
-		out, err := e.shell.RunAndCapture(ctx, "git", gitArgs...)
-		if err != nil {
-			return fmt.Errorf("getting git commit information: %w", err)
-		}
-		stdin := strings.NewReader(out)
-		if err := e.shell.WithStdin(stdin).Run(ctx, "buildkite-agent", "meta-data", "set", "buildkite:git:commit"); err != nil {
-			return fmt.Errorf("sending git commit information to Buildkite: %w", err)
-		}
+	return nil
+}
+
+const commitMetadataKey = "buildkite:git:commit"
+
+// sendCommitToBuildkite sends commit information (commit, author, subject, body) to Buildkite, as the BK backend doesn't
+// have access to user's VCSes. To do this, we set a special meta-data key in the build, but only if it isn't already present
+// Functionally, this means that the first job in a build (usually a pipeline upload or similar) will push the commit info
+// to buildkite, which uses this info to display commit info in the UI eg in the title for the build
+// note that we bail early if the key already exists, as we don't want to overwrite it
+func (e *Executor) sendCommitToBuildkite(ctx context.Context) error {
+	e.shell.Commentf("Checking to see if git commit information needs to be sent to Buildkite...")
+	if err := e.shell.Run(ctx, "buildkite-agent", "meta-data", "exists", commitMetadataKey); err == nil {
+		// Command exited 0, ie the key exists, so we don't need to send it again
+		e.shell.Commentf("Git commit information has already been sent to Buildkite")
+		return nil
+	}
+
+	e.shell.Commentf("Sending Git commit information back to Buildkite")
+	// Format:
+	//
+	// commit 0123456789abcdef0123456789abcdef01234567
+	// abbrev-commit 0123456789
+	// Author: John Citizen <john@example.com>
+	//
+	//    Subject of the commit message
+	//
+	//    Body of the commit message, which
+	//    may span multiple lines.
+	gitArgs := []string{
+		"--no-pager",
+		"log",
+		"-1",
+		"HEAD",
+		"-s", // --no-patch was introduced in v1.8.4 in 2013, but e.g. CentOS 7 isn't there yet
+		"--no-color",
+		"--format=commit %H%nabbrev-commit %h%nAuthor: %an <%ae>%n%n%w(0,4,4)%B",
+	}
+	out, err := e.shell.RunAndCapture(ctx, "git", gitArgs...)
+	if err != nil {
+		return fmt.Errorf("getting git commit information: %w", err)
+	}
+
+	stdin := strings.NewReader(out)
+	if err := e.shell.WithStdin(stdin).Run(ctx, "buildkite-agent", "meta-data", "set", commitMetadataKey); err != nil {
+		return fmt.Errorf("sending git commit information to Buildkite: %w", err)
 	}
 
 	return nil

--- a/internal/job/integration/artifact_integration_test.go
+++ b/internal/job/integration/artifact_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/buildkite/agent/v3/internal/job"
 	"github.com/buildkite/bintest/v3"
 )
 
@@ -28,7 +29,7 @@ func TestArtifactsUploadAfterCommand(t *testing.T) {
 	// Mock out the artifact calls
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 	agent.
 		Expect("artifact", "upload", "llamas.txt").
@@ -57,7 +58,7 @@ func TestArtifactsUploadAfterCommandFails(t *testing.T) {
 	// Mock out the artifact calls
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 	agent.
 		Expect("artifact", "upload", "llamas.txt").
@@ -92,7 +93,7 @@ func TestArtifactsUploadAfterCommandHookFails(t *testing.T) {
 	// Mock out the artifact calls
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 	agent.
 		Expect("artifact", "upload", "llamas.txt").

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/agent/v3/internal/experiments"
+	"github.com/buildkite/agent/v3/internal/job"
 	"github.com/buildkite/bintest/v3"
 )
 
@@ -52,8 +53,8 @@ func TestCheckingOutGitHubPullRequests_WithGitMirrors(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -98,8 +99,8 @@ func TestWithResolvingCommitExperiment_WithGitMirrors(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -142,8 +143,8 @@ func TestCheckingOutLocalGitProject_WithGitMirrors(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -214,8 +215,8 @@ func TestCheckingOutLocalGitProjectWithSubmodules_WithGitMirrors(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -280,8 +281,8 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled_WithGitMirrors(t *test
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -324,8 +325,8 @@ func TestCheckingOutShallowCloneOfLocalGitProject_WithGitMirrors(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -344,8 +345,8 @@ func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite_WithGitMirrors(t
 	}
 
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t)
 }
@@ -466,7 +467,7 @@ func TestCleaningAnExistingCheckout_WithGitMirrors(t *testing.T) {
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
 	tester.RunAndCheck(t)
@@ -496,7 +497,7 @@ func TestForcingACleanCheckout_WithGitMirrors(t *testing.T) {
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
 	tester.RunAndCheck(t, "BUILDKITE_CLEAN_CHECKOUT=true")
@@ -531,7 +532,7 @@ func TestCheckoutOnAnExistingRepositoryWithoutAGitFolder_WithGitMirrors(t *testi
 
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
 	tester.RunAndCheck(t)
@@ -714,8 +715,8 @@ func TestGitMirrorEnv(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/agent/v3/internal/experiments"
+	"github.com/buildkite/agent/v3/internal/job"
 	"github.com/buildkite/bintest/v3"
 	"gotest.tools/v3/assert"
 )
@@ -64,8 +65,8 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -103,8 +104,8 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -169,8 +170,8 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -230,8 +231,8 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -269,8 +270,8 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -314,8 +315,8 @@ func TestCheckingOutLocalGitProjectWithShortCommitHash(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	env := []string{
 		fmt.Sprintf("BUILDKITE_COMMIT=%s", shortCommitHash),
@@ -387,8 +388,8 @@ func TestCheckoutErrorIsRetried(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -449,8 +450,8 @@ func TestFetchErrorIsRetried(t *testing.T) {
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }
@@ -465,8 +466,8 @@ func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite(t *testing.T) {
 	defer tester.Close()
 
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", "buildkite:git:commit").AndExitWith(1)
-	agent.Expect("meta-data", "set", "buildkite:git:commit").WithStdin(commitPattern)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t)
 }
@@ -571,7 +572,7 @@ func TestCleaningAnExistingCheckout(t *testing.T) {
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
 	tester.RunAndCheck(t)
@@ -597,7 +598,7 @@ func TestForcingACleanCheckout(t *testing.T) {
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
 	tester.RunAndCheck(t, "BUILDKITE_CLEAN_CHECKOUT=true")
@@ -628,7 +629,7 @@ func TestCheckoutOnAnExistingRepositoryWithoutAGitFolder(t *testing.T) {
 
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
 	tester.RunAndCheck(t)

--- a/internal/job/integration/command_integration_test.go
+++ b/internal/job/integration/command_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/buildkite/agent/v3/internal/job"
 	"github.com/buildkite/bintest/v3"
 )
 
@@ -53,7 +54,7 @@ func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
 	preExitFunc := func(c *bintest.Call) {

--- a/internal/job/integration/docker_integration_test.go
+++ b/internal/job/integration/docker_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/buildkite/agent/v3/internal/job"
 	"github.com/buildkite/bintest/v3"
 )
 
@@ -26,7 +27,7 @@ func TestRunningCommandWithDocker(t *testing.T) {
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
 	env := []string{
@@ -59,7 +60,7 @@ func TestRunningCommandWithDockerAndCustomDockerfile(t *testing.T) {
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
 	env := []string{
@@ -93,7 +94,7 @@ func TestRunningFailingCommandWithDocker(t *testing.T) {
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
 	env := []string{
@@ -132,7 +133,7 @@ func TestRunningCommandWithDockerCompose(t *testing.T) {
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
 	env := []string{
@@ -165,7 +166,7 @@ func TestRunningFailingCommandWithDockerCompose(t *testing.T) {
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
 	env := []string{
@@ -205,7 +206,7 @@ func TestRunningCommandWithDockerComposeAndExtraConfig(t *testing.T) {
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
 	env := []string{
@@ -239,7 +240,7 @@ func TestRunningCommandWithDockerComposeAndBuildAll(t *testing.T) {
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
 	agent.
-		Expect("meta-data", "exists", "buildkite:git:commit").
+		Expect("meta-data", "exists", job.CommitMetadataKey).
 		AndExitWith(0)
 
 	env := []string{

--- a/internal/job/integration/executor_tester.go
+++ b/internal/job/integration/executor_tester.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/buildkite/agent/v3/env"
 	"github.com/buildkite/agent/v3/internal/experiments"
+	"github.com/buildkite/agent/v3/internal/job"
 	"github.com/buildkite/agent/v3/internal/job/shell"
 	"gotest.tools/v3/assert"
 
@@ -264,7 +265,7 @@ func (e *ExecutorTester) Run(t *testing.T, env ...string) error {
 	if !e.HasMock("buildkite-agent") {
 		agent := e.MockAgent(t)
 		agent.
-			Expect("meta-data", "exists", "buildkite:git:commit").
+			Expect("meta-data", "exists", job.CommitMetadataKey).
 			Optionally().
 			AndExitWith(0)
 	}

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/v3/internal/experiments"
+	"github.com/buildkite/agent/v3/internal/job"
+
 	"github.com/buildkite/agent/v3/internal/job/shell"
 	"github.com/buildkite/bintest/v3"
 )
@@ -416,7 +418,7 @@ func TestPreExitHooksFireAfterHookFailures(t *testing.T) {
 
 			if tc.expectCheckout {
 				agent.
-					Expect("meta-data", "exists", "buildkite:git:commit").
+					Expect("meta-data", "exists", job.CommitMetadataKey).
 					Once().
 					AndExitWith(0)
 			}


### PR DESCRIPTION
### Description

As a part of the checkout process, the agent sets a special metadata key called `buildkite:git:commit` to a string containing information about the commit that the agent has checked out. This metadata is used by the buildkite backend to populate VCS-related information on the build, like the commit message, author and commit hash - highlighted below:
![CleanShot 2024-03-08 at 13 53 57@2x](https://github.com/buildkite/agent/assets/15753101/d75ff9ca-d24a-4fee-a779-f18f2bfb3dd3)

(note that in some cases this information can come from webhooks when builds are triggered that way, but not all builds are triggered by webhooks)

this information is also used set the commit used for the rest of the build; often a build will get triggered at the HEAD of a specific branch, but the HEAD of a branch will change if extra commits are added over time, so the agent needs to know the "canonical" commit for the build, which is stored in this metadata value.

However, this metadata is only set during the default checkout phase - if a user overrides the checkout phase using agent hooks or plugins, this special metadata value will never get set, and it can lead to a build running across multiple commits by accident if the checkout hook is overridden.

**This PR** hoists the commit metadata setting process up a level in the checkout process, and it will now happen after _any_ checkout hook, not just the default one.

### Context

[Coda link](https://coda.io/d/Escalations-Feedback_dHnUHNps1YO/Pipelines-Escalations_su7FT#Pipelines-Escalations-Board_tu__K/r297)

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
