### PR TITLE
[Update] Updating `tool sign` usage description to match actual command

### DIFF
--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -62,7 +62,7 @@ var ToolSignCommand = cli.Command{
 	Usage: "Sign pipeline steps",
 	Description: `Usage:
 
-    buildkite-agent tool sign-pipeline [options...] [pipeline-file]
+    buildkite-agent tool sign [options...] [pipeline-file]
 
 Description:
 


### PR DESCRIPTION
### Description

For the pipeline signing, `buildkite-agent` uses `buildkite-agent tool sign.` However, the command's usage description prints `buildkite-agent tool sign-pipeline,` which can confuse people when there is an error.


### Context

<img width="1320" alt="Screenshot 2024-03-11 at 11 40 46 AM" src="https://github.com/buildkite/agent/assets/9913103/5e23ed1d-ba99-4939-b6d6-95713a55907e">

Like the above screenshot, it's something minor but can be pretty confusing. 😅 


### Changes

This PR updates the usage text in the code to match the actual command.

