### PR TITLE
Silence Job API Log Group

### DIFF
--- a/jobapi/server.go
+++ b/jobapi/server.go
@@ -80,8 +80,10 @@ func (s *Server) Start() error {
 		return fmt.Errorf("starting socket server: %w", err)
 	}
 
-	s.Logger.Printf("~~~ Job API")
-	s.Logger.Printf("Server listening on %s", s.SocketPath)
+	if s.debug {
+		s.Logger.Printf("~~~ Job API")
+		s.Logger.Printf("Server listening on %s", s.SocketPath)
+	}
 
 	return nil
 }


### PR DESCRIPTION
### Description

The Job API prints a log group whenever it starts, which is usually once
per job, but can be more than on agent-stack-k8s. However, I think the
Job API should be transparent to the user: it is not that relevant to
them unless they are developing against it, which should the minority of
the time they are using buildkite. This removes the log group appearing in
the job logs unless debug is enabled.

### Context
This is a screenshot showing multiple job api log groups in a k8s job. It's a bit spammy.
![Screenshot 2024-03-12 at 20-52-30 test-testsshrepoclone-018e31fe-9738-43c7-8bbc-08cf2424a0b6 #1 · Buildkite Kubernetes Stack](https://github.com/buildkite/agent/assets/11096602/a9b2acd5-973b-48d0-bb5b-7ed3e3ca8fe5)


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)