### PR TITLE
Update outdated option name

### DIFF
--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -264,7 +264,7 @@ func (r *JobRunner) verificationFailureLogs(behavior string, err error) {
 
 	if behavior == VerificationBehaviourWarn {
 		l.Warn("Job will be run whether or not it can be verified - this is not recommended.")
-		l.Warn("You can change this behavior with the `job-verification-failure-behavior` agent configuration option.")
+		l.Warn("You can change this behavior with the `verification-failure-behavior` agent configuration option.")
 		fmt.Fprintln(r.jobLogs, "Job will be run without verification")
 	}
 }


### PR DESCRIPTION
### Description

The `job-` prefix was used during development/beta but when it was made stable it was dropped and the name changed. This message was just not updated then.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
