### PR TITLE
Even more silent Job API

### DIFF
--- a/internal/agentapi/lock_server.go
+++ b/internal/agentapi/lock_server.go
@@ -75,7 +75,7 @@ func (s *lockServer) patchLock(w http.ResponseWriter, r *http.Request) {
 	// information to include in your report:
 	// - an example input that the Go standard library encoding/json package
 	//   fails to correctly escape, thus leading to injection in the output, and
-	// - practical consequences of a succesful JSON injection, given that this
+	// - practical consequences of a successful JSON injection, given that this
 	//   API is, by default, only accessible to the same user on the same host.
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		s.logger.Error("Agent API: couldn't encode response body: %v", err)

--- a/jobapi/server.go
+++ b/jobapi/server.go
@@ -104,7 +104,9 @@ func (s *Server) Stop() error {
 		return fmt.Errorf("shutting down Job API server: %w", err)
 	}
 
-	s.Logger.Commentf("Successfully shut down Job API server")
+	if s.debug {
+		s.Logger.Commentf("Successfully shut down Job API server")
+	}
 
 	return nil
 }


### PR DESCRIPTION
### Description
I've made a few PRs to reduce the amount of logging that the job api does. But I kept missing a few places. This PR should fix that, and for good measure I've added a test to make sure that the job api doesn't log anything unless in debug mode. To test that the tests work, the commit that introduces the tests should fail and that failure should be fixed by the next commit.

In particular, it should stop printing the message that the Job API server has shut down. This was difficult to see if log headers (e.g. `+++`, `~~~`, etc) are being used in a job as it's often hidden in the last log group. But it's still an annoyance if log groups are not being used.

### Context
https://github.com/buildkite/agent/pull/2690
https://github.com/buildkite/agent/pull/2662

### Changes
- The Job API should no longer print *anything* to the job logs unless in debug mode.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->