### PR TITLE
Extend default signal grace period to 9 seconds

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -830,7 +830,11 @@ var AgentStartCommand = cli.Command{
 		}
 
 		if cfg.CancelGracePeriod <= cfg.SignalGracePeriodSeconds {
-			return errors.New("cancel-grace-period must be greater than signal-grace-period-seconds")
+			return fmt.Errorf(
+				"cancel-grace-period (%d) must be greater than signal-grace-period-seconds (%d)",
+				cfg.CancelGracePeriod,
+				cfg.SignalGracePeriodSeconds,
+			)
 		}
 
 		signalGracePeriod := time.Duration(cfg.SignalGracePeriodSeconds) * time.Second

--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -4,9 +4,7 @@ import "github.com/urfave/cli"
 
 const (
 	defaultCancelGracePeriod = 10
-
-	// This will be increased to 9 in a future release of the agent.
-	defaultSignalGracePeriod = 0
+	defaultSignalGracePeriod = 9
 )
 
 var (


### PR DESCRIPTION
### Description
When a job is cancelled, the agent sends a SIGTERM to the bootstrap process of the job. This immediately sends a SIGTERM[^1] to child processes of the bootstrap process. After the signal-grace-period, a SIGKILL is sent to these child processes and the bootstrap process exits. Currently, the signal-grace-period, though configurable, defaulted to 0s. This was done to simulate the previous behaviour where a SIGKILL was sent immediately. This PR changes the default to 9s. This value was chosen because it is the largest integer less than 10, which is the default value of the cancel-grace-period. That is the time the bootstrap process has to exit before it is itself sent a SIGKILL by the agent worker process.


[^1]: It's SIGTERM by default but that's configurable.

### Context
https://github.com/buildkite/agent/pull/2250
https://github.com/buildkite/agent/pull/2654

### Changes
- `signal-grace-period-seconds` is now 9 by default.
- a more helpful error message when the assertion `signal-grace-period-seconds < cancel-grace-period` fails.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)