### PR TITLE
core-103 break from retrying if we get a 422

### DIFF
--- a/agent/artifact_batch_creator.go
+++ b/agent/artifact_batch_creator.go
@@ -87,7 +87,8 @@ func (a *ArtifactBatchCreator) Create(ctx context.Context) ([]*api.Artifact, err
 
 			creation, resp, err := a.apiClient.CreateArtifacts(ctxTimeout, a.conf.JobID, batch)
 			// the server returns a 403 code if the artifact has exceeded the service quota
-			if resp != nil && (resp.StatusCode >= 400 && resp.StatusCode <= 499) {
+			// Break the retry on any 4xx code except for 429 Too Many Requests.
+			if resp != nil && (resp.StatusCode != 429 && resp.StatusCode >= 400 && resp.StatusCode <= 499) {
 				a.logger.Warn("Artifact creation failed with status code %d, breaking the retry loop", resp.StatusCode)
 				r.Break()
 			}

--- a/agent/artifact_batch_creator.go
+++ b/agent/artifact_batch_creator.go
@@ -86,7 +86,9 @@ func (a *ArtifactBatchCreator) Create(ctx context.Context) ([]*api.Artifact, err
 			}
 
 			creation, resp, err := a.apiClient.CreateArtifacts(ctxTimeout, a.conf.JobID, batch)
-			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404) {
+			// the server returns a 403 code if the artifact has exceeded the service quota
+			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 404) {
+				a.logger.Warn("Artifact creation failed with status code %d, breaking the retry loop", resp.StatusCode)
 				r.Break()
 			}
 			if err != nil {

--- a/agent/artifact_batch_creator.go
+++ b/agent/artifact_batch_creator.go
@@ -87,7 +87,7 @@ func (a *ArtifactBatchCreator) Create(ctx context.Context) ([]*api.Artifact, err
 
 			creation, resp, err := a.apiClient.CreateArtifacts(ctxTimeout, a.conf.JobID, batch)
 			// the server returns a 403 code if the artifact has exceeded the service quota
-			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 404) {
+			if resp != nil && (resp.StatusCode >= 400 && resp.StatusCode <= 499) {
 				a.logger.Warn("Artifact creation failed with status code %d, breaking the retry loop", resp.StatusCode)
 				r.Break()
 			}


### PR DESCRIPTION
### Description

If the server returns an error when uploading artifacts (i.e. 400 Bad Request) then the agent will retry 10 times. 
If the artifacts uploaded exceed the service quota the server will return a 403 and we don't want the agent to retry (link to server [PR](https://github.com/buildkite/buildkite/pull/16071))


The screenshot below is from local, the service quota for max artifacts per job is not really 2 :)



**Before changes**
<img width="1137" alt="Screenshot 2024-03-22 at 1 55 26 pm" src="https://github.com/buildkite/agent/assets/3770233/ce1d1bf8-9ade-401b-b398-348d84a4d432">

**After changes**
<img width="1143" alt="Screenshot 2024-03-22 at 2 01 12 pm" src="https://github.com/buildkite/agent/assets/3770233/83eb7165-14d4-49d8-aeaf-f0a58b4fbc10">




### Context

(https://linear.app/buildkite/issue/CORE-103/artifacts-per-job-communicate-when-limit-is-exceeded)

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
