### PR TITLE
Ensure that disabled warnings get passed to the logger in kubernetes agents

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1296,8 +1296,8 @@ func agentLifecycleHook(hookName string, log logger.Logger, cfg AgentStartConfig
 
 	// pipe from hook output to logger
 	r, w := io.Pipe()
-	sh.Logger = &shell.WriterLogger{Writer: w, Ansi: !cfg.NoColor} // for Promptf
-	sh.Writer = w                                                  // for stdout+stderr
+	sh.Logger = shell.NewWriterLogger(w, !cfg.NoColor, nil) // for Promptf
+	sh.Writer = w                                           // for stdout+stderr
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -1150,18 +1150,19 @@ func (e *Executor) startKubernetesClient(ctx context.Context, kubernetesClient *
 		e.shell.Env.Set("BUILDKITE_AGENT_ACCESS_TOKEN", connect.AccessToken)
 		writer := io.MultiWriter(os.Stdout, kubernetesClient)
 		e.shell.Writer = writer
-		e.shell.Logger = &shell.WriterLogger{
-			Writer: writer,
-			Ansi:   true,
-		}
+		e.shell.Logger = shell.NewWriterLogger(writer, true, e.DisabledWarnings)
+
 		return nil
 	})
+
 	if err != nil {
 		return fmt.Errorf("error connecting to kubernetes runner: %w", err)
 	}
+
 	if err := kubernetesClient.Await(ctx, kubernetes.RunStateStart); err != nil {
 		return fmt.Errorf("error waiting for client to become ready: %w", err)
 	}
+
 	go func() {
 		if err := kubernetesClient.Await(ctx, kubernetes.RunStateInterrupt); err != nil {
 			e.shell.Errorf("Error waiting for client interrupt: %v", err)

--- a/internal/job/shell/logger.go
+++ b/internal/job/shell/logger.go
@@ -55,6 +55,14 @@ type WriterLogger struct {
 	DisabledWarningIDs []string
 }
 
+func NewWriterLogger(writer io.Writer, ansi bool, disabledWarningIDs []string) *WriterLogger {
+	return &WriterLogger{
+		Writer:             writer,
+		Ansi:               ansi,
+		DisabledWarningIDs: disabledWarningIDs,
+	}
+}
+
 func (wl *WriterLogger) Write(b []byte) (int, error) {
 	wl.Printf("%s", b)
 	return len(b), nil

--- a/internal/job/shell/logger_test.go
+++ b/internal/job/shell/logger_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAnsiLogger(t *testing.T) {
 	got := &bytes.Buffer{}
-	l := shell.WriterLogger{Writer: got, Ansi: false}
+	l := shell.NewWriterLogger(got, false, nil)
 
 	l.Headerf("Testing header: %q", "llamas")
 	l.Printf("Testing print: %q", "llamas")
@@ -44,7 +44,7 @@ func TestAnsiLogger(t *testing.T) {
 
 func TestLoggerStreamer(t *testing.T) {
 	got := &bytes.Buffer{}
-	l := &shell.WriterLogger{Writer: got, Ansi: false}
+	l := shell.NewWriterLogger(got, false, nil)
 
 	streamer := shell.NewLoggerStreamer(l)
 	streamer.Prefix = "TEST>"

--- a/internal/job/shell/shell_test.go
+++ b/internal/job/shell/shell_test.go
@@ -90,7 +90,7 @@ func TestRun(t *testing.T) {
 	sh := newShellForTest(t)
 	sh.PTY = false
 	sh.Writer = out
-	sh.Logger = &shell.WriterLogger{Writer: out, Ansi: false}
+	sh.Logger = shell.NewWriterLogger(out, false, nil)
 
 	go func() {
 		call := <-sshKeygen.Ch

--- a/jobapi/server_test.go
+++ b/jobapi/server_test.go
@@ -465,8 +465,8 @@ func TestDebugLogging(t *testing.T) {
 	assert.NilError(t, err)
 
 	logBuf := &bytes.Buffer{}
-	logger := shell.WriterLogger{Writer: logBuf, Ansi: true}
-	srv, token, err := jobapi.NewServer(&logger, sockName, env, nil, jobapi.WithDebug())
+	logger := shell.NewWriterLogger(logBuf, true, nil)
+	srv, token, err := jobapi.NewServer(logger, sockName, env, nil, jobapi.WithDebug())
 	assert.NilError(t, err)
 
 	assert.NilError(t, srv.Start())
@@ -511,8 +511,8 @@ func TestNoLogging(t *testing.T) {
 	assert.NilError(t, err)
 
 	logBuf := &bytes.Buffer{}
-	logger := shell.WriterLogger{Writer: logBuf, Ansi: true}
-	srv, token, err := jobapi.NewServer(&logger, sockName, env, nil)
+	logger := shell.NewWriterLogger(logBuf, true, nil)
+	srv, token, err := jobapi.NewServer(logger, sockName, env, nil)
 	assert.NilError(t, err)
 
 	assert.NilError(t, srv.Start())


### PR DESCRIPTION
### Description

In #2674, we added a feature to the agent where some warnings would be "dismissable" through CLI flags - for example, one could disable this warning:
![CleanShot 2024-03-22 at 15 20 58@2x](https://github.com/buildkite/agent/assets/15753101/d0a12989-08d5-48cf-94de-d01d8d651ed4)

by passing `--disable-warnings-for "submodules-disabled"`.

However, due to an oversight, this feature wasn't working on Kubernetes agents. This PR fixes that issue by correctly passing the config down the the customised logger that K8s pods use, and making it harder for developers to miss this kind of thing in the future.

### Context

#2674

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
