### PR TITLE
Artifact creation: Break retry on any 4xx code except 429

### DIFF
--- a/agent/artifact_batch_creator.go
+++ b/agent/artifact_batch_creator.go
@@ -87,7 +87,8 @@ func (a *ArtifactBatchCreator) Create(ctx context.Context) ([]*api.Artifact, err
 
 			creation, resp, err := a.apiClient.CreateArtifacts(ctxTimeout, a.conf.JobID, batch)
 			// the server returns a 403 code if the artifact has exceeded the service quota
-			if resp != nil && (resp.StatusCode >= 400 && resp.StatusCode <= 499) {
+			// Break the retry on any 4xx code except for 429 Too Many Requests.
+			if resp != nil && (resp.StatusCode != 429 && resp.StatusCode >= 400 && resp.StatusCode <= 499) {
 				a.logger.Warn("Artifact creation failed with status code %d, breaking the retry loop", resp.StatusCode)
 				r.Break()
 			}

--- a/agent/artifact_batch_creator.go
+++ b/agent/artifact_batch_creator.go
@@ -87,7 +87,7 @@ func (a *ArtifactBatchCreator) Create(ctx context.Context) ([]*api.Artifact, err
 
 			creation, resp, err := a.apiClient.CreateArtifacts(ctxTimeout, a.conf.JobID, batch)
 			// the server returns a 403 code if the artifact has exceeded the service quota
-			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 404) {
+			if resp != nil && (resp.StatusCode >= 400 && resp.StatusCode <= 499) {
 				a.logger.Warn("Artifact creation failed with status code %d, breaking the retry loop", resp.StatusCode)
 				r.Break()
 			}


### PR DESCRIPTION
There's a debate around which 4xx code we're going to use. #2697 mentions 422 in the title but adds handling for 403. Some people think 429 is better.

Rather than playing whack-a-mole with all the 4xx codes across multiple releases, I think we should do the same thing as the log uploader and break on any of them.