### PR TITLE
Don't run pre-exit hooks without command phase

### DIFF
--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -322,6 +322,21 @@ func TestPreExitHooksFireAfterCommandFailures(t *testing.T) {
 	tester.CheckMocks(t)
 }
 
+func TestPreExitHooksDoesNotFireWithoutCommandPhase(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewBootstrapTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewBootstrapTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	tester.ExpectGlobalHook("pre-exit").NotCalled()
+	tester.ExpectLocalHook("pre-exit").NotCalled()
+
+	tester.RunAndCheck(t, "BUILDKITE_BOOTSTRAP_PHASES=plugin,checkout")
+}
+
 func TestPreExitHooksFireAfterHookFailures(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Description

The k8s stack uses phases to split job execution between multiple containers. In particular, the checkout phase happens in a separate container to the command phase. This makes pre-exit hook execute twice, once in each container - this is usually not what is intended by plugin authors, and often breaks when the different phase have different configs or environment variables.

Changing it so pre-exit hooks only run if the command phase is enabled makes it work, and is unlikely to break anybody (who isn't deep in the agent fiddling with phases).

### Context

https://linear.app/buildkite/issue/PENT-10/make-hooks-configurable

### Changes

* Refactor `includePhase` from inline closure to method
* Change pre-exit hooks to only run if phases includes `command`
* Add an integration test

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

