### PR TITLE
Support spawn setting of 0 to mean number of cpus

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1102,7 +1102,7 @@ var AgentStartCommand = cli.Command{
 
 		if cfg.SpawnPerCPU > 0 {
 			if cfg.Spawn > 1 {
-				return errors.New("You can't specify spawn and spawn-per-cpu ath the same time")
+				return errors.New("You can't specify spawn and spawn-per-cpu at the same time")
 			}
 			cfg.Spawn = runtime.NumCPU() * cfg.SpawnPerCPU
 		}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -78,6 +78,7 @@ type AgentStartConfig struct {
 	Name              string   `cli:"name"`
 	Priority          string   `cli:"priority"`
 	Spawn             int      `cli:"spawn"`
+	SpawnPerCPU       int      `cli:"spawn-per-cpu"`
 	SpawnWithPriority bool     `cli:"spawn-with-priority"`
 	RedactedVars      []string `cli:"redacted-vars" normalize:"list"`
 	CancelSignal      string   `cli:"cancel-signal"`
@@ -610,13 +611,19 @@ var AgentStartCommand = cli.Command{
 		},
 		cli.IntFlag{
 			Name:   "spawn",
-			Usage:  "The number of agents to spawn in parallel",
+			Usage:  "The number of agents to spawn in parallel (mutually exclusive with --spawn-per-cpu)",
 			Value:  1,
 			EnvVar: "BUILDKITE_AGENT_SPAWN",
 		},
+		cli.IntFlag{
+			Name:   "spawn-per-cpu",
+			Usage:  "The number of agents to spawn per cpu in parallel (mutually exclusive with --spawn)",
+			Value:  0,
+			EnvVar: "BUILDKITE_AGENT_SPAWN_PER_CPU",
+		},
 		cli.BoolFlag{
 			Name:   "spawn-with-priority",
-			Usage:  "Assign priorities to every spawned agent (when using --spawn) equal to the agent's index",
+			Usage:  "Assign priorities to every spawned agent (when using --spawn or --spawn-per-cpu) equal to the agent's index",
 			EnvVar: "BUILDKITE_AGENT_SPAWN_WITH_PRIORITY",
 		},
 		cancelSignalFlag,
@@ -1091,6 +1098,13 @@ var AgentStartCommand = cli.Command{
 			// specific job.
 			IgnoreInDispatches: cfg.AcquireJob != "",
 			Features:           cfg.Features(ctx),
+		}
+
+		if cfg.SpawnPerCPU > 0 {
+			if cfg.Spawn > 1 {
+				return errors.New("You can't specify spawn and spawn-per-cpu ath the same time")
+			}
+			cfg.Spawn = runtime.NumCPU() * cfg.SpawnPerCPU
 		}
 
 		// Spawning multiple agents doesn't work if the agent is being


### PR DESCRIPTION
### Description

When setting up the agent config some setups may not have the number of CPUs available but want to spawn one worker per CPU. In this case we can interpret 0 to mean all CPUs.

Other options I considered were treating spawn as a string and doing some simple math but this seems saner (not to mention simpler). 

### Context

I'd like to run 1 agent worker per process running under NixOS, declaratively so can't use `nproc` other means. 


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)