### PR TITLE
Cache paths env var

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -430,6 +430,11 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 		}
 	}
 
+	cache := r.conf.Job.Step.Cache
+	if cache != nil && len(cache.Paths) > 0 {
+		env["BUILDKITE_AGENT_CACHE_PATHS"] = strings.Join(cache.Paths, ",")
+	}
+
 	// Set BUILDKITE_IGNORED_ENV so the bootstrap can show warnings
 	if len(ignoredEnv) > 0 {
 		env["BUILDKITE_IGNORED_ENV"] = strings.Join(ignoredEnv, ",")

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go v1.51.11
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 	github.com/buildkite/bintest/v3 v3.2.0
-	github.com/buildkite/go-pipeline v0.5.1
+	github.com/buildkite/go-pipeline v0.6.0
 	github.com/buildkite/roko v1.2.0
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/creack/pty v1.1.21

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf/go.mod h1:CeKhh8xSs3WZAc50xABMxu+FlfAAd5PNumo7NfOv7EE=
 github.com/buildkite/bintest/v3 v3.2.0 h1:1GqUILGGni5UViGPH/PbSq0MxB9gzY3J/P7vNVqCkX4=
 github.com/buildkite/bintest/v3 v3.2.0/go.mod h1:+AdQZcVlzCiW2UyZWeG63xeH5z011XUBW6kWcRdaMtU=
-github.com/buildkite/go-pipeline v0.5.1 h1:xe7crWDQRmWObhPEZMQlhCfjdeNLsFGl64Nj0T1fsHs=
-github.com/buildkite/go-pipeline v0.5.1/go.mod h1:lHk0pJoZ8yxlOaUMRwzS/HyY0W6xh+ne8u+Cabw+DeM=
+github.com/buildkite/go-pipeline v0.6.0 h1:1CgdUeTswvT2pkYtfSm6Pve9JIAWxhWZYqXX7/GdBB4=
+github.com/buildkite/go-pipeline v0.6.0/go.mod h1:4aqMzJ3iagc0wcI5h8NQpON9xfyq27QGDi4xfnKiCUs=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/buildkite/roko v1.2.0 h1:hbNURz//dQqNl6Eo9awjQOVOZwSDJ8VEbBDxSfT9rGQ=


### PR DESCRIPTION
### Description

Buildkite's upcoming hosted compute product will include a feature to mount cache volumes when instructed to do so by the buildkite backend. Though the mounting itself happens outside of the agent, the agent needs to tell the mounter where to mount the cache volumes.

This PR adds the ability for the agent to consume the cache paths from the accept job response, and pipes those paths through to an envar `BUILDKITE_AGENT_CACHE_PATHS`.

### Context

COMP-321 

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
