### PR TITLE
Add integration test ensuring that cache paths are passed to the bootstrap correctly

### DIFF
--- a/agent/integration/job_environment_integration_test.go
+++ b/agent/integration/job_environment_integration_test.go
@@ -1,0 +1,48 @@
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildkite/agent/v3/agent"
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/bintest/v3"
+	"github.com/buildkite/go-pipeline"
+)
+
+func TestWhenCachePathsSetInJobStep_CachePathsEnvVarIsSet(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	job := &api.Job{
+		ID:                 "my-job-id",
+		ChunksMaxSizeBytes: 1024,
+		Step: pipeline.CommandStep{
+			Cache: &pipeline.Cache{
+				Paths: []string{"foo", "bar"},
+			},
+		},
+	}
+
+	mb := mockBootstrap(t)
+	defer mb.CheckAndClose(t)
+
+	mb.Expect().Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
+		if got, want := c.GetEnv("BUILDKITE_AGENT_CACHE_PATHS"), "foo,bar"; got != want {
+			t.Errorf("c.GetEnv(BUILDKITE_AGENT_CACHE_PATHS) = %q, want %q", got, want)
+		}
+		c.Exit(0)
+	})
+
+	// create a mock agent API
+	e := createTestAgentEndpoint()
+	server := e.server("my-job-id")
+	defer server.Close()
+
+	runJob(t, ctx, testRunJobConfig{
+		job:           job,
+		server:        server,
+		agentCfg:      agent.AgentConfiguration{},
+		mockBootstrap: mb,
+	})
+}


### PR DESCRIPTION
### Description

In #2720, we added functionality to allow buildkite to send a list of cache paths to be mounted to the agent, and plumb those through to the job executor as an environment variable.

This PR adds a test to ensure that this functionality doesn't regress.

### Context

#2720


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
