### PR TITLE
Upload agent images to GHCR

### DIFF
--- a/.buildkite/steps/publish-docker-image.sh
+++ b/.buildkite/steps/publish-docker-image.sh
@@ -36,8 +36,10 @@ parse_version() {
 
 release_image() {
   local tag="$1"
-  echo "--- :docker: Tagging ${target_image}:${tag}"
-  dry_run skopeo copy --multi-arch all "docker://$source_image" "docker://docker.io/${target_image}:${tag}"
+  echo "--- :docker: Copying ${target_image}:${tag} to Docker Hub"
+  dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://docker.io/${target_image}:${tag}"
+  echo "--- :github: Copying ${target_image}:${tag} to GHCR"
+  dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://ghcr.io/${target_image}:${tag}"
 }
 
 variant="${1:-}"

--- a/.buildkite/steps/publish-docker-images.sh
+++ b/.buildkite/steps/publish-docker-images.sh
@@ -14,11 +14,35 @@ if [[ "$CODENAME" == "" ]]; then
   exit 1
 fi
 
-echo "--- Logging in to Docker Hub"
+echo "--- docker login to Docker Hub"
 
-dockerhub_user="$(aws ssm get-parameter --name /pipelines/agent/DOCKER_HUB_USER --with-decryption --output text --query Parameter.Value --region us-east-1)"
+dockerhub_user="$(aws ssm get-parameter \
+  --name /pipelines/agent/DOCKER_HUB_USER \
+  --with-decryption \
+  --output text \
+  --query Parameter.Value \
+  --region us-east-1\
+)"
 
-aws ssm get-parameter --name /pipelines/agent/DOCKER_HUB_PASSWORD --with-decryption --output text --query Parameter.Value --region us-east-1 | docker login --username="${dockerhub_user}" --password-stdin
+aws ssm get-parameter \
+  --name /pipelines/agent/DOCKER_HUB_PASSWORD \
+  --with-decryption \
+  --output text \
+  --query Parameter.Value \
+  --region us-east-1 \
+  | docker login --username="${dockerhub_user}" --password-stdin
+
+
+echo "--- docker login to GitHub"
+
+ghcr_user=buildkite-agent-releaser
+aws ssm get-parameter \
+  --name /pipelines/agent/GITHUB_RELEASE_ACCESS_TOKEN \
+  --with-decryption \
+  --output text \
+  --query Parameter.Value \
+  --region us-east-1 \
+  | docker login ghcr.io --username="${ghcr_user}" --password-stdin
 
 version=$(buildkite-agent meta-data get "agent-version")
 build=$(buildkite-agent meta-data get "agent-version-build")


### PR DESCRIPTION
### Description

Make agent images accessible directly from GHCR.

This relates to pinning agent versions used by the k8s stack, which currently publishes images and helm charts to GHCR. Some customers might also be interested in pulling from GHCR instead of Docker Hub.

### Context

https://linear.app/buildkite/issue/PENT-9/pin-the-version-of-the-buildkite-agent-used-by-agent-stack-k8s

### Changes

- `docker login` to GitHub using the existing credential
- `skopeo copy` the image to ghcr.io/buildkite/agent

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

I also ran a modified release pipeline to verify that it works.
