### PR TITLE
Fix annotate client-side length check

### DIFF
--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -150,7 +150,7 @@ func annotate(ctx context.Context, cfg AnnotateConfig, l logger.Logger) error {
 		body = string(stdin[:])
 	}
 
-	if bodySize := len(cfg.Body); bodySize > maxBodySize {
+	if bodySize := len(body); bodySize > maxBodySize {
 		return fmt.Errorf("annotation body size (%dB) exceeds maximum (%dB)", bodySize, maxBodySize)
 	}
 


### PR DESCRIPTION
### Description

Client-side validation of the annotation body length (< 1MiB) isn't working when the annotation body is read from STDIN - instead it always falls through to the server-side validation.

Before:
```
$ /bin/bash -e -c "ruby -e \"a = ('A'..'Z').to_a; (2 * 1024 * 1024).times { putc a.sample }\" | buildkite-agent annotate"
2024-04-12 09:23:30 INFO   Reading annotation body from STDIN command=annotate
fatal: failed to annotate build: POST https://agent.buildkite.com/v3/jobs/018ecf79-1b8c-48a7-9252-7a33cd980743/annotations: 400 Bad Request: The annotation body must be less than 1 MB
```

After:
```
$ /bin/bash -e -c "ruby -e \"a = ('A'..'Z').to_a; (2 * 1024 * 1024).times { putc a.sample }\" | buildkite-agent annotate"
2024-04-12 09:24:54 INFO   Reading annotation body from STDIN command=annotate
fatal: annotation body size (2097152B) exceeds maximum (1048576B)
```

### Context

[Support escalation](https://coda.io/d/_dHnUHNps1YO#Escalations-Table_tuS42/r369&view=modal)

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
