### PR TITLE
Fix checkout race condition on GitHub PR builds

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -708,9 +708,11 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 }
 
 func gitFetchCommitWithFallback(ctx context.Context, shell *shell.Shell, gitFetchFlags, commit string) error {
-	if err := gitFetch(ctx, shell, gitFetchFlags, "origin", commit); err == nil {
+	err := gitFetch(ctx, shell, gitFetchFlags, "origin", commit)
+	if err == nil {
 		return nil // it worked
-	} else if gerr := new(gitError); errors.As(err, &gerr) {
+	}
+	if gerr := new(gitError); errors.As(err, &gerr) {
 		// if we fail in a way that means the repository is corrupt, we should bail
 		switch gerr.Type {
 		case gitErrorFetchRetryClean, gitErrorFetchBadObject:

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -720,8 +720,9 @@ func gitFetchCommitWithFallback(ctx context.Context, shell *shell.Shell, gitFetc
 		}
 	}
 
-	// Some repositories don't support fetching a specific commit so we fall
-	// back to fetching all heads and tags, hoping that the commit is included.
+	// The commit might be something that's not possible to fetch directly
+	// (eg. a short commit hash), so we fall back to fetching all heads and tags,
+	// hoping that the commit is included.
 	shell.Commentf("Commit fetch failed, trying to fetch all heads and tags")
 	// By default `git fetch origin` will only fetch tags which are
 	// reachable from a fetches branch. git 1.9.0+ changed `--tags` to

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -544,8 +544,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 
 	case e.PullRequest != "false" && strings.Contains(e.PipelineProvider, "github"):
 		// GitHub has a special ref which lets us fetch a pull request head, whether
-		// or not there is a current head in this repository or another which
-		// references the commit. We presume a commit sha is provided. See:
+		// or not it's a current head in this repository or a fork. See:
 		// https://help.github.com/articles/checking-out-pull-requests-locally/#modifying-an-inactive-pull-request-locally
 		e.shell.Commentf("Fetch and checkout pull request head from GitHub")
 		refspec := fmt.Sprintf("refs/pull/%s/head", e.PullRequest)
@@ -557,6 +556,14 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 		gitFetchHead, _ := e.shell.RunAndCapture(ctx, "git", "rev-parse", "FETCH_HEAD")
 		e.shell.Commentf("FETCH_HEAD is now `%s`", gitFetchHead)
 
+		if e.Commit != "HEAD" {
+			// If we know the commit, also fetch it directly. The commit might not be in the history of `refspec` if there
+			// have been force pushes to the pull request, so this ensures we have it.
+			if err := gitFetchCommitWithFallback(ctx, e.shell, gitFetchFlags, e.Commit); err != nil {
+				return err
+			}
+		}
+
 	case e.Commit == "HEAD":
 		// If the commit is "HEAD" then we can't do a commit-specific fetch and will
 		// need to fetch the remote head and checkout the fetched head explicitly.
@@ -567,34 +574,8 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 
 	default:
 		// Otherwise fetch and checkout the commit directly.
-		if err := gitFetch(ctx, e.shell, gitFetchFlags, "origin", e.Commit); err == nil {
-			break // it worked, break out of the switch statement
-		} else if gerr := new(gitError); errors.As(err, &gerr) {
-			// if we fail in a way that means the repository is corrupt, we should bail
-			switch gerr.Type {
-			case gitErrorFetchRetryClean, gitErrorFetchBadObject:
-				return fmt.Errorf("fetching commit %q: %w", e.Commit, err)
-			case gitErrorFetchBadReference:
-				// fallback to fetching all heads and tags
-			}
-		}
-
-		// Some repositories don't support fetching a specific commit so we fall
-		// back to fetching all heads and tags, hoping that the commit is included.
-		e.shell.Commentf("Commit fetch failed, trying to fetch all heads and tags")
-		// By default `git fetch origin` will only fetch tags which are
-		// reachable from a fetches branch. git 1.9.0+ changed `--tags` to
-		// fetch all tags in addition to the default refspec, but pre 1.9.0 it
-		// excludes the default refspec.
-		gitFetchRefspec, err := e.shell.RunAndCapture(ctx, "git", "config", "remote.origin.fetch")
-		if err != nil {
-			return fmt.Errorf("getting remote.origin.fetch: %w", err)
-		}
-
-		if err := gitFetch(ctx, e.shell,
-			gitFetchFlags, "origin", gitFetchRefspec, "+refs/tags/*:refs/tags/*",
-		); err != nil {
-			return fmt.Errorf("fetching commit %q: %w", e.Commit, err)
+		if err := gitFetchCommitWithFallback(ctx, e.shell, gitFetchFlags, e.Commit); err != nil {
+			return err
 		}
 	}
 
@@ -721,6 +702,40 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 	if experiments.IsEnabled(ctx, experiments.ResolveCommitAfterCheckout) {
 		e.shell.Commentf("Using resolve-commit-after-checkout experiment 🧪")
 		e.resolveCommit(ctx)
+	}
+
+	return nil
+}
+
+func gitFetchCommitWithFallback(ctx context.Context, shell *shell.Shell, gitFetchFlags, commit string) error {
+	if err := gitFetch(ctx, shell, gitFetchFlags, "origin", commit); err == nil {
+		return nil // it worked
+	} else if gerr := new(gitError); errors.As(err, &gerr) {
+		// if we fail in a way that means the repository is corrupt, we should bail
+		switch gerr.Type {
+		case gitErrorFetchRetryClean, gitErrorFetchBadObject:
+			return fmt.Errorf("fetching commit %q: %w", commit, err)
+		case gitErrorFetchBadReference:
+			// fallback to fetching all heads and tags
+		}
+	}
+
+	// Some repositories don't support fetching a specific commit so we fall
+	// back to fetching all heads and tags, hoping that the commit is included.
+	shell.Commentf("Commit fetch failed, trying to fetch all heads and tags")
+	// By default `git fetch origin` will only fetch tags which are
+	// reachable from a fetches branch. git 1.9.0+ changed `--tags` to
+	// fetch all tags in addition to the default refspec, but pre 1.9.0 it
+	// excludes the default refspec.
+	gitFetchRefspec, err := shell.RunAndCapture(ctx, "git", "config", "remote.origin.fetch")
+	if err != nil {
+		return fmt.Errorf("getting remote.origin.fetch: %w", err)
+	}
+
+	if err := gitFetch(ctx, shell,
+		gitFetchFlags, "origin", gitFetchRefspec, "+refs/tags/*:refs/tags/*",
+	); err != nil {
+		return fmt.Errorf("fetching commit %q: %w", commit, err)
 	}
 
 	return nil

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -331,6 +331,94 @@ func TestCheckingOutLocalGitProjectWithShortCommitHash(t *testing.T) {
 	assert.Equal(t, checkoutRepoCommit, commitHash)
 }
 
+func TestCheckingOutGitHubPullRequestWithCommitHash(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewBootstrapTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewBootstrapTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	commitHash, err := tester.Repo.RevParse("refs/pull/123/head")
+	assert.NilError(t, err)
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_FLAGS=--no-local", // Disable the fast local clone method, which automatically copies all refs
+		"BUILDKITE_BRANCH=update-test-txt",
+		"BUILDKITE_PULL_REQUEST=123",
+		"BUILDKITE_PIPELINE_PROVIDER=github",
+		fmt.Sprintf("BUILDKITE_COMMIT=%s", strings.TrimSpace(commitHash)),
+	}
+
+	tester.RunAndCheck(t, env...)
+
+	// Check state of the checkout directory
+	checkoutRepo := &gitRepository{Path: tester.CheckoutDir()}
+	checkoutRepoCommit, err := checkoutRepo.RevParse("HEAD")
+	assert.NilError(t, err)
+	assert.Equal(t, checkoutRepoCommit, commitHash)
+}
+
+func TestCheckingOutGitHubPullRequestWithShortCommitHash(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewBootstrapTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewBootstrapTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	commitHash, err := tester.Repo.RevParse("refs/pull/123/head")
+	assert.NilError(t, err)
+	shortCommitHash := commitHash[:7]
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_FLAGS=--no-local", // Disable the fast local clone method, which automatically copies all refs
+		"BUILDKITE_BRANCH=update-test-txt",
+		"BUILDKITE_PULL_REQUEST=123",
+		"BUILDKITE_PIPELINE_PROVIDER=github",
+		fmt.Sprintf("BUILDKITE_COMMIT=%s", shortCommitHash),
+	}
+
+	tester.RunAndCheck(t, env...)
+
+	// Check state of the checkout directory
+	checkoutRepo := &gitRepository{Path: tester.CheckoutDir()}
+	checkoutRepoCommit, err := checkoutRepo.RevParse("HEAD")
+	assert.NilError(t, err)
+	assert.Equal(t, checkoutRepoCommit, commitHash)
+}
+
+func TestCheckingOutGitHubPullRequestAtHead(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewBootstrapTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewBootstrapTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	commitHash, err := tester.Repo.RevParse("refs/pull/123/head")
+	assert.NilError(t, err)
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_FLAGS=--no-local", // Disable the fast local clone method, which automatically copies all refs
+		"BUILDKITE_BRANCH=update-test-txt",
+		"BUILDKITE_PULL_REQUEST=123",
+		"BUILDKITE_PIPELINE_PROVIDER=github",
+		"BUILDKITE_COMMIT=HEAD",
+	}
+
+	tester.RunAndCheck(t, env...)
+
+	// Check state of the checkout directory
+	checkoutRepo := &gitRepository{Path: tester.CheckoutDir()}
+	checkoutRepoCommit, err := checkoutRepo.RevParse("HEAD")
+	assert.NilError(t, err)
+	assert.Equal(t, checkoutRepoCommit, commitHash)
+}
+
 func TestCheckoutErrorIsRetried(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Description

The agent has a [special case for GitHub PRs](https://github.com/buildkite/agent/blob/3ebb9d6ff79364ba4329713f1616520022898de8/internal/job/checkout.go#L545-L558), where it fetches `refs/pull/{id}/head`, instead of [directly fetching the commit](https://github.com/buildkite/agent/blob/3ebb9d6ff79364ba4329713f1616520022898de8/internal/job/checkout.go#L570) we want to build.

This can cause the build to fail if there is a force push to the PR branch, as the commit that we wanted to build will no longer be a parent of the current `refs/pull/{id}/head` and so won't be fetched. That causes the checkout to fail with "reference is not a tree".

#### Reproduction steps
1. Set up a Buildkite pipeline that triggers on GitHub pull requests
2. Ensure no agents are connected
3. Create a pull request (a Buildkite build will be created, but will be waiting for agent)
4. Amend the latest commit in the pull request and force push to the PR's branch (a second Buildkite build will be created, but will be waiting for the agent)
5. Start an agent

#### Expected behaviour

Both builds succeed

#### Actual behaviour

The first build fails to checkout its commit with:
```
reference is not a tree: <commit hash>
```

#### Use cases we need to cover

* Pull request build with commit = (full commit hash)
* Pull request build after a force push, with commit = (full commit hash) (this is what we want to fix)
* Pull request build with commit = "HEAD"
* Pull request build with commit = (short commit hash)
* Pull request build from a fork with commit = (full commit hash)
* Pull request build from a fork with commit = "HEAD"
  * This is rare, but has happened. It does mean we can't completely remove the special case, as the only way to find the latest commit for a fork PR is to fetch `refs/pull/{id}/head`, because we can't fetch the fork's branch directly.
* ~~Pull request build from a fork with commit = (short commit hash)~~
  * This hasn't occurred in the last 12 months
* Repos configured with [custom remote tracking](https://git-scm.com/docs/git-fetch#_configured_remote_tracking_branches) that includes `refs/pull/*`
  * This doesn't seem super likely, but better to be backwards compatible where we can
  * We need to ensure we always fetch `refs/pull/{id}/head` for PRs, so the local ref is updated
* ...did I miss anything?

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

[Coda](https://coda.io/d/Escalations-Feedback_dHnUHNps1YO/Escalations_sudOj#escalations-board_tu9Bj/r365&view=modal)

This behaviour was introduced in https://github.com/buildkite/agent/pull/74, where it related to a fix for building PRs from forks.

### Changes

For GitHub pull request builds where the commit is known (ie. not `HEAD`), fetch the commit directly.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
