### PR TITLE
Experiment: override zero exit code on cancel

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -92,3 +92,14 @@ running in a terminal, using ANSI escapes to provide colours, progress meters et
 the PTY to modify the stream. (Or do we? That's why this is an experiment)
 
 **Status:** Experimental for some opt-in testing before being promoted to always-on.
+
+### `override-zero-exit-on-cancel`
+
+If the job is cancelled, and the exit status of the process is 0, it is overridden to be 1 instead.
+
+When cancelling a job, the agent signals the process, which typically causes it to exit with a
+non-zero status code. On Windows this is not true - the process exits with code 0 instead, which
+makes the job appear to be successful. (It successfully exited, no?) By overriding the status to 1,
+a cancelled job should appear as a failure, regardless of the OS the agent is running on.
+
+**Status:** Experimental for some opt-in testing. We hope to promote this to be the default soon™.

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -27,6 +27,7 @@ const (
 	DescendingSpawnPrioity     = "descending-spawn-priority"
 	KubernetesExec             = "kubernetes-exec"
 	NormalisedUploadPaths      = "normalised-upload-paths"
+	OverrideZeroExitOnCancel   = "override-zero-exit-on-cancel"
 	PTYRaw                     = "pty-raw"
 	PolyglotHooks              = "polyglot-hooks"
 	ResolveCommitAfterCheckout = "resolve-commit-after-checkout"
@@ -48,6 +49,7 @@ var (
 		DescendingSpawnPrioity:     {},
 		KubernetesExec:             {},
 		NormalisedUploadPaths:      {},
+		OverrideZeroExitOnCancel:   {},
 		PolyglotHooks:              {},
 		ResolveCommitAfterCheckout: {},
 		UseZZGlob:                  {},


### PR DESCRIPTION
### Description

Fixes #1489

### Changes

* Add a new experiment, `override-zero-exit-on-cancel`
* If the job is cancelled, and the exit status of the process is 0, override it to be 1 instead.


### Testing
- [X] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [X] Code is formatted (with `go fmt ./...`)
