### PR TITLE
Update go-pipeline to v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go v1.51.21
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 	github.com/buildkite/bintest/v3 v3.2.0
-	github.com/buildkite/go-pipeline v0.7.0
+	github.com/buildkite/go-pipeline v0.8.0
 	github.com/buildkite/roko v1.2.0
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/creack/pty v1.1.21

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf/go.mod h1:CeKhh8xSs3WZAc50xABMxu+FlfAAd5PNumo7NfOv7EE=
 github.com/buildkite/bintest/v3 v3.2.0 h1:1GqUILGGni5UViGPH/PbSq0MxB9gzY3J/P7vNVqCkX4=
 github.com/buildkite/bintest/v3 v3.2.0/go.mod h1:+AdQZcVlzCiW2UyZWeG63xeH5z011XUBW6kWcRdaMtU=
-github.com/buildkite/go-pipeline v0.7.0 h1:3p6Prmn25GFD6/8fjNEDjhvV+eKFootubikE5mswCVU=
-github.com/buildkite/go-pipeline v0.7.0/go.mod h1:4aqMzJ3iagc0wcI5h8NQpON9xfyq27QGDi4xfnKiCUs=
+github.com/buildkite/go-pipeline v0.8.0 h1:ZH2N+nXqOQBvzP5Q2f9FtAGP4X1xJs+as+MSWJU2jcM=
+github.com/buildkite/go-pipeline v0.8.0/go.mod h1:4aqMzJ3iagc0wcI5h8NQpON9xfyq27QGDi4xfnKiCUs=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/buildkite/roko v1.2.0 h1:hbNURz//dQqNl6Eo9awjQOVOZwSDJ8VEbBDxSfT9rGQ=


### PR DESCRIPTION
### Description

In v0.4.0 we made a breaking change to how pipelines were parsed, specifically the precedence of environment variables in a pipeline upload step.

This undoes that breaking change to restore the original behaviour (see https://github.com/buildkite/go-pipeline/pull/35)

### Changes

The following pipeline example exhibits the breaking change (Credit to @lizrabuya for the reproducible test case).

Pipeline Steps:
```yaml
env:
  HEADER_ENV: "123"
​
steps:
  - command:
      - buildkite-agent pipeline upload pipeline.yml
```

pipeline.yml
```yaml
env:
  HEADER_ENV: "789" 
  NEW_ENV: "NEW-${HEADER_ENV:-}"
steps: 
- label: "Fixed Values ENV: ${NEW_ENV}" 
  commands: echo "Checking fixed env values ${NEW_ENV} "
- label: "Fixed Values Runtime ENV"
  commands: echo "Checking fixed env values $${NEW_ENV} "
```

Prior to agent version v3.63.0 this pipeline printed `Checking fixed env values NEW-789` for both the first and second command jobs.
As of v3.63.0 and above the steps now prints `NEW-123`.

This restores the original behaviour.

### Testing

- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

