### PR TITLE
Add retry on socket connection issues

### DIFF
--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -297,7 +297,7 @@ func (c *Client) Connect() (RegisterResponse, error) {
 		client, err := rpc.DialHTTP("unix", c.SocketPath)
 		if err != nil {
 			r.logger.Warn("client socket dial failed (try %n): %w", i, err)
-			if (i > 10) {
+			if (i > 30) {
 				return RegisterResponse{}, err
 			}
 			time.Sleep(time.Second)


### PR DESCRIPTION
### Description

- Wait up to 30 seconds for agent container to start and create socket, to avoid race condition

### Context

Fixes https://github.com/buildkite/agent/issues/2744

### Testing
Not tested, just a suggestion :)
