### PR TITLE
Use roko to retry k8s socket dial

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -1184,7 +1184,7 @@ func (e *Executor) startKubernetesClient(ctx context.Context, kubernetesClient *
 			return fmt.Errorf("failed to parse container id, %s", os.Getenv("BUILDKITE_CONTAINER_ID"))
 		}
 		kubernetesClient.ID = id
-		connect, err := kubernetesClient.Connect()
+		connect, err := kubernetesClient.Connect(ctx)
 		if err != nil {
 			return err
 		}

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -171,6 +171,6 @@ func intptr(x int) *int {
 
 // helper for ignoring the response from regular client.Connect
 func connect(c *Client) error {
-	_, err := c.Connect()
+	_, err := c.Connect(context.Background())
 	return err
 }


### PR DESCRIPTION
### Description

Retry the socket connection several times.

Thanks to @bpoland for raising #2745

### Context

Fixes #2744 


### Testing
- [X] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [X] Code is formatted (with `go fmt ./...`)

