### PR TITLE
Make preferring runtime env default off

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -103,3 +103,11 @@ makes the job appear to be successful. (It successfully exited, no?) By overridi
 a cancelled job should appear as a failure, regardless of the OS the agent is running on.
 
 **Status:** Experimental for some opt-in testing. We hope to promote this to be the default soon™.
+
+### `interpolation-prefers-runtime-env`
+
+When interpolating the pipeline level environment block, a pipeline level environment variable could take precedence over environment variables depending on the ordering. This may contravene Buildkite's [documentation](https://buildkite.com/docs/pipelines/environment-variables#environment-variable-precedence) that suggests the Job runtime environment takes precedence over that defined by combining environment variables defined in a pipeline. 
+
+We previously made this the default behaviour of the agent (as of v3.63.0) but have since reverted it.
+
+**Status:** Available as an experiment to allow users who have since depended on this behaviour to re-enable it. If you use this feature please let us know so we may better understand your use case.

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1127,7 +1127,7 @@ var AgentStartCommand = cli.Command{
 
 			if cfg.SpawnWithPriority {
 				p := i
-				if experiments.IsEnabled(ctx, experiments.DescendingSpawnPrioity) {
+				if experiments.IsEnabled(ctx, experiments.DescendingSpawnPriority) {
 					// This experiment helps jobs be assigned across all hosts
 					// in cases where the value of --spawn varies between hosts.
 					p = -i

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -401,7 +401,7 @@ func (cfg *PipelineUploadConfig) parseAndInterpolate(src string, input io.Reader
 			}
 			result.Env.Set(tracetools.EnvVarTraceContextKey, tracing)
 		}
-		if err := result.Interpolate(environ); err != nil {
+		if err := result.Interpolate(environ, false); err != nil {
 			return nil, fmt.Errorf("pipeline interpolation of %q failed: %w", src, err)
 		}
 	}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/env"
+	"github.com/buildkite/agent/v3/internal/experiments"
 	"github.com/buildkite/agent/v3/internal/job/shell"
 	"github.com/buildkite/agent/v3/internal/redact"
 	"github.com/buildkite/agent/v3/internal/replacer"
@@ -262,7 +263,7 @@ var PipelineUploadCommand = cli.Command{
 			src = "(stdin)"
 		}
 
-		result, err := cfg.parseAndInterpolate(src, input, environ)
+		result, err := cfg.parseAndInterpolate(src, input, environ, ctx)
 		if w := warning.As(err); w != nil {
 			l.Warn("There were some issues with the pipeline input - pipeline upload will proceed, but might not succeed:\n%v", w)
 		} else if err != nil {
@@ -389,7 +390,7 @@ func searchForSecrets(
 	return nil
 }
 
-func (cfg *PipelineUploadConfig) parseAndInterpolate(src string, input io.Reader, environ *env.Environment) (*pipeline.Pipeline, error) {
+func (cfg *PipelineUploadConfig) parseAndInterpolate(src string, input io.Reader, environ *env.Environment, ctx context.Context) (*pipeline.Pipeline, error) {
 	result, err := pipeline.Parse(input)
 	if err != nil && !warning.Is(err) {
 		return nil, fmt.Errorf("pipeline parsing of %q failed: %w", src, err)
@@ -401,7 +402,11 @@ func (cfg *PipelineUploadConfig) parseAndInterpolate(src string, input io.Reader
 			}
 			result.Env.Set(tracetools.EnvVarTraceContextKey, tracing)
 		}
-		if err := result.Interpolate(environ, false); err != nil {
+		preferRuntimeEnv := false
+		if experiments.IsEnabled(ctx, experiments.InterpolationPrefersRuntimeEnv) {
+			preferRuntimeEnv = true
+		}
+		if err := result.Interpolate(environ, preferRuntimeEnv); err != nil {
 			return nil, fmt.Errorf("pipeline interpolation of %q failed: %w", src, err)
 		}
 	}

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -108,8 +108,8 @@ steps:
 	}
 	ctx := context.Background()
 
-	p, err := cfg.parseAndInterpolate("test", strings.NewReader(pipelineYAML), environ, ctx)
-	assert.NilError(t, err, `cfg.parseAndInterpolate("test", %q, %q) = %v; want nil`, pipelineYAML, environ, err)
+	p, err := cfg.parseAndInterpolate(ctx, "test", strings.NewReader(pipelineYAML), environ)
+	assert.NilError(t, err, `cfg.parseAndInterpolate(ctx, "test", %q, %q) = %v; want nil`, pipelineYAML, environ, err)
 	assert.DeepEqual(t, p, expectedPipeline, cmp.Comparer(ordered.EqualSA), cmp.Comparer(ordered.EqualSS))
 }
 
@@ -156,8 +156,8 @@ steps:
 				ctx, _ = experiments.Enable(ctx, experiments.InterpolationPrefersRuntimeEnv)
 			}
 
-			p, err := cfg.parseAndInterpolate("test", strings.NewReader(pipelineYAML), environ, ctx)
-			assert.NilError(t, err, `cfg.parseAndInterpolate("test", %q, %q) = %v; want nil`, pipelineYAML, environ, err)
+			p, err := cfg.parseAndInterpolate(ctx, "test", strings.NewReader(pipelineYAML), environ)
+			assert.NilError(t, err, `cfg.parseAndInterpolate(ctx, "test", %q, %q) = %v; want nil`, pipelineYAML, environ, err)
 			s := p.Steps[len(p.Steps)-1]
 			commandStep, ok := s.(*pipeline.CommandStep)
 			if !ok {

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -117,17 +117,17 @@ func TestPipelineInterpolationRuntimeEnvPrecedence(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		desc string
+		desc             string
 		preferRuntimeEnv bool
-		expectedCommand string
+		expectedCommand  string
 	}{
 		{
-			desc: "With experiment disabled",
+			desc:             "With experiment disabled",
 			preferRuntimeEnv: false,
 			expectedCommand:  "echo Hi bob",
 		},
 		{
-			desc: "With experiment enabled",
+			desc:             "With experiment enabled",
 			preferRuntimeEnv: true,
 			expectedCommand:  "echo Hi alice",
 		},
@@ -135,7 +135,7 @@ func TestPipelineInterpolationRuntimeEnvPrecedence(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-				// With the experiment enabled this variable takes precedence over the one defined in the pipeline yaml
+			// With the experiment enabled this variable takes precedence over the one defined in the pipeline yaml
 			environ := env.FromMap(map[string]string{
 				"NAME": "alice",
 			})

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go v1.51.21
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 	github.com/buildkite/bintest/v3 v3.2.0
-	github.com/buildkite/go-pipeline v0.7.0
+	github.com/buildkite/go-pipeline v0.9.0
 	github.com/buildkite/roko v1.2.0
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/creack/pty v1.1.21

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf/go.mod h1:CeKhh8xSs3WZAc50xABMxu+FlfAAd5PNumo7NfOv7EE=
 github.com/buildkite/bintest/v3 v3.2.0 h1:1GqUILGGni5UViGPH/PbSq0MxB9gzY3J/P7vNVqCkX4=
 github.com/buildkite/bintest/v3 v3.2.0/go.mod h1:+AdQZcVlzCiW2UyZWeG63xeH5z011XUBW6kWcRdaMtU=
-github.com/buildkite/go-pipeline v0.7.0 h1:3p6Prmn25GFD6/8fjNEDjhvV+eKFootubikE5mswCVU=
-github.com/buildkite/go-pipeline v0.7.0/go.mod h1:4aqMzJ3iagc0wcI5h8NQpON9xfyq27QGDi4xfnKiCUs=
+github.com/buildkite/go-pipeline v0.9.0 h1:2a2bibJ9dCCyyNReH73jkQVUYyUnhYAxISyf3+mrQNs=
+github.com/buildkite/go-pipeline v0.9.0/go.mod h1:4aqMzJ3iagc0wcI5h8NQpON9xfyq27QGDi4xfnKiCUs=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/buildkite/roko v1.2.0 h1:hbNURz//dQqNl6Eo9awjQOVOZwSDJ8VEbBDxSfT9rGQ=

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -24,7 +24,7 @@ const (
 const (
 	// Available experiments
 	AgentAPI                   = "agent-api"
-	DescendingSpawnPrioity     = "descending-spawn-priority"
+	DescendingSpawnPriority    = "descending-spawn-priority"
 	KubernetesExec             = "kubernetes-exec"
 	NormalisedUploadPaths      = "normalised-upload-paths"
 	OverrideZeroExitOnCancel   = "override-zero-exit-on-cancel"
@@ -46,7 +46,7 @@ const (
 var (
 	Available = map[string]struct{}{
 		AgentAPI:                   {},
-		DescendingSpawnPrioity:     {},
+		DescendingSpawnPriority:     {},
 		KubernetesExec:             {},
 		NormalisedUploadPaths:      {},
 		OverrideZeroExitOnCancel:   {},

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -23,15 +23,16 @@ const (
 
 const (
 	// Available experiments
-	AgentAPI                   = "agent-api"
-	DescendingSpawnPriority    = "descending-spawn-priority"
-	KubernetesExec             = "kubernetes-exec"
-	NormalisedUploadPaths      = "normalised-upload-paths"
-	OverrideZeroExitOnCancel   = "override-zero-exit-on-cancel"
-	PTYRaw                     = "pty-raw"
-	PolyglotHooks              = "polyglot-hooks"
-	ResolveCommitAfterCheckout = "resolve-commit-after-checkout"
-	UseZZGlob                  = "use-zzglob"
+	AgentAPI                       = "agent-api"
+	DescendingSpawnPriority        = "descending-spawn-priority"
+	KubernetesExec                 = "kubernetes-exec"
+	NormalisedUploadPaths          = "normalised-upload-paths"
+	OverrideZeroExitOnCancel       = "override-zero-exit-on-cancel"
+	PTYRaw                         = "pty-raw"
+	PolyglotHooks                  = "polyglot-hooks"
+	ResolveCommitAfterCheckout     = "resolve-commit-after-checkout"
+	UseZZGlob                      = "use-zzglob"
+	InterpolationPrefersRuntimeEnv = "interpolation-prefers-runtime-env"
 
 	// Promoted experiments
 	ANSITimestamps         = "ansi-timestamps"
@@ -46,7 +47,7 @@ const (
 var (
 	Available = map[string]struct{}{
 		AgentAPI:                   {},
-		DescendingSpawnPriority:     {},
+		DescendingSpawnPriority:    {},
 		KubernetesExec:             {},
 		NormalisedUploadPaths:      {},
 		OverrideZeroExitOnCancel:   {},

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -25,6 +25,7 @@ const (
 	// Available experiments
 	AgentAPI                       = "agent-api"
 	DescendingSpawnPriority        = "descending-spawn-priority"
+	InterpolationPrefersRuntimeEnv = "interpolation-prefers-runtime-env"
 	KubernetesExec                 = "kubernetes-exec"
 	NormalisedUploadPaths          = "normalised-upload-paths"
 	OverrideZeroExitOnCancel       = "override-zero-exit-on-cancel"
@@ -32,7 +33,6 @@ const (
 	PolyglotHooks                  = "polyglot-hooks"
 	ResolveCommitAfterCheckout     = "resolve-commit-after-checkout"
 	UseZZGlob                      = "use-zzglob"
-	InterpolationPrefersRuntimeEnv = "interpolation-prefers-runtime-env"
 
 	// Promoted experiments
 	ANSITimestamps         = "ansi-timestamps"
@@ -46,14 +46,15 @@ const (
 
 var (
 	Available = map[string]struct{}{
-		AgentAPI:                   {},
-		DescendingSpawnPriority:    {},
-		KubernetesExec:             {},
-		NormalisedUploadPaths:      {},
-		OverrideZeroExitOnCancel:   {},
-		PolyglotHooks:              {},
-		ResolveCommitAfterCheckout: {},
-		UseZZGlob:                  {},
+		AgentAPI:                       {},
+		DescendingSpawnPriority:        {},
+		InterpolationPrefersRuntimeEnv: {},
+		KubernetesExec:                 {},
+		NormalisedUploadPaths:          {},
+		OverrideZeroExitOnCancel:       {},
+		PolyglotHooks:                  {},
+		ResolveCommitAfterCheckout:     {},
+		UseZZGlob:                      {},
 	}
 
 	Promoted = map[string]string{


### PR DESCRIPTION
### Description

In v3.63.0 we made a breaking change to how pipelines were parsed, specifically the precedence of environment variables in a pipeline upload step.

This undoes that breaking change to restore the original behaviour (see https://github.com/buildkite/go-pipeline/pull/35)

### Changes

The following pipeline example exhibits the breaking change (Credit to @lizrabuya for the reproducible test case).

Pipeline Steps:

```yaml
env:
  HEADER_ENV: "123"
​
steps:
  - command:
      - buildkite-agent pipeline upload pipeline.yml
```

pipeline.yml:

```yaml
env:
  HEADER_ENV: "789" 
  NEW_ENV: "NEW-${HEADER_ENV:-}"
steps: 
- label: "Fixed Values ENV: ${NEW_ENV}" 
  commands: echo "Checking fixed env values ${NEW_ENV} "
- label: "Fixed Values Runtime ENV"
  commands: echo "Checking fixed env values $${NEW_ENV} "
```

Prior to agent version v3.63.0 this pipeline printed Checking fixed env values NEW-789 for both the first and second command jobs.
As of v3.63.0 and above the steps now prints NEW-123.

This restores the original behaviour.

This PR also adds an experiment flag `interpolation-prefers-runtime-env` which enables the behaviour introduced in v3.63.0.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
