### PR TITLE
Use oidc roles in release pipelines

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -5,9 +5,9 @@ steps:
     command: ".buildkite/steps/publish-to-s3.sh"
     env:
       CODENAME: "experimental"
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -21,9 +21,9 @@ steps:
     env:
       CODENAME: "experimental"
       RPM_S3_BUCKET: "yum.buildkite.com"
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
       - docker#v5.8.0:
           image: "buildkite/agent:3.55.0-ubuntu"
           entrypoint: bash
@@ -37,9 +37,9 @@ steps:
     env:
       REPOSITORY: "buildkite/agent-rpm-experimental"
       DISTRO_VERSION: rpm_any/rpm_any
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
       - docker#v5.8.0:
           image: "public.ecr.aws/docker/library/ruby:3.0"
           entrypoint: bash
@@ -52,9 +52,9 @@ steps:
     env:
       CODENAME: "experimental"
       DEB_S3_BUCKET: "apt.buildkite.com/buildkite-agent"
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -74,9 +74,9 @@ steps:
     env:
       REPOSITORY: "buildkite/agent-deb-experimental"
       DISTRO_VERSION: any/any
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
       - docker#v5.8.0:
           image: "public.ecr.aws/docker/library/ruby:3.0"
           entrypoint: bash
@@ -88,9 +88,9 @@ steps:
     command: ".buildkite/steps/publish-docker-images.sh"
     env:
       CODENAME: "experimental"
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
       - ecr#v2.7.0:
           login: true
           account-ids: "445615400570"

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -10,9 +10,9 @@ steps:
     command: ".buildkite/steps/publish-to-s3.sh"
     env:
       CODENAME: "stable"
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -25,9 +25,9 @@ steps:
     command: ".buildkite/steps/github-release.sh"
     env:
       CODENAME: "stable"
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -41,9 +41,9 @@ steps:
     env:
       CODENAME: "stable"
       RPM_S3_BUCKET: "yum.buildkite.com"
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
       - docker#v5.8.0:
           image: "buildkite/agent:3.55.0-ubuntu"
           entrypoint: bash
@@ -61,9 +61,9 @@ steps:
     env:
       REPOSITORY: "buildkite/agent-rpm"
       DISTRO_VERSION: rpm_any/rpm_any
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
       - docker#v5.8.0:
           image: "public.ecr.aws/docker/library/ruby:3.0"
           entrypoint: bash
@@ -76,9 +76,9 @@ steps:
     env:
       CODENAME: "stable"
       DEB_S3_BUCKET: "apt.buildkite.com/buildkite-agent"
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -94,9 +94,9 @@ steps:
     env:
       REPOSITORY: "buildkite/agent-deb"
       DISTRO_VERSION: any/any
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
       - docker#v5.8.0:
           image: "public.ecr.aws/docker/library/ruby:3.0"
           entrypoint: bash
@@ -108,9 +108,9 @@ steps:
     command: ".buildkite/steps/publish-docker-images.sh"
     env:
       CODENAME: "stable"
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
       - ecr#v2.7.0:
           login: true
           account-ids: "445615400570"
@@ -122,9 +122,9 @@ steps:
     artifact_paths: "pkg/*.rb;pkg/*.json"
     env:
       CODENAME: "stable"
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -10,9 +10,9 @@ steps:
     command: ".buildkite/steps/publish-to-s3.sh"
     env:
       CODENAME: "unstable"
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -25,9 +25,9 @@ steps:
     command: ".buildkite/steps/github-release.sh"
     env:
       CODENAME: "unstable"
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -41,9 +41,9 @@ steps:
     env:
       CODENAME: "unstable"
       RPM_S3_BUCKET: "yum.buildkite.com"
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
       - docker#v5.8.0:
           image: "buildkite/agent:3.55.0-ubuntu"
           entrypoint: bash
@@ -61,9 +61,9 @@ steps:
     env:
       REPOSITORY: "buildkite/agent-rpm-unstable"
       DISTRO_VERSION: rpm_any/rpm_any
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
       - docker#v5.8.0:
           image: "public.ecr.aws/docker/library/ruby:3.0"
           entrypoint: bash
@@ -79,6 +79,8 @@ steps:
     agents:
       queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -94,9 +96,9 @@ steps:
     env:
       REPOSITORY: "buildkite/agent-deb-unstable"
       DISTRO_VERSION: any/any
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
       - docker#v5.8.0:
           image: "public.ecr.aws/docker/library/ruby:3.0"
           entrypoint: bash
@@ -108,9 +110,9 @@ steps:
     command: ".buildkite/steps/publish-docker-images.sh"
     env:
       CODENAME: "unstable"
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
       - ecr#v2.7.0:
           login: true
           account-ids: "445615400570"
@@ -122,9 +124,9 @@ steps:
     artifact_paths: "pkg/*.rb;pkg/*.json"
     env:
       CODENAME: "unstable"
-    agents:
-      queue: "deploy"
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"


### PR DESCRIPTION
### Description

We are sunsetting the `deploy` queue that the agent release pipelines currently use. 
This PR moves release steps to the default queue, using OIDC assumable roles to access the required AWS resources.

https://github.com/buildkite/ops/pull/2306 created OIDC assumable roles for the `edge` `beta` and `stable` pipelines. 

There's a risk that the roles are missing some permissions required by the release steps. Platform team can be available to help. 

More info:
https://3.basecamp.com/3453178/buckets/34063888/messages/7327195755
