### PR TITLE
Document IdleMonitor

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -709,11 +709,11 @@ func (a *AgentWorker) Disconnect(ctx context.Context) error {
 // This monitor has a 3rd implicit state we will call "initializing" that all agents start in
 // Agents can transition to busy and/or idle but always start in the "initializing" state
 /*
-//                - Busy
-//              /    |
-// Initializing      |
-//              \    |
-//                - Idle
+//                -> Busy
+//              /     ^
+// Initializing       |
+//              \     v
+//                -> Idle
 */
 // This (intentionally?) ensures the DisconnectAfterIdleTimeout doesn't fire before agents have had a chance to run a job
 type IdleMonitor struct {

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -706,6 +706,16 @@ func (a *AgentWorker) Disconnect(ctx context.Context) error {
 	return nil
 }
 
+// This monitor has a 3rd implicit state we will call "initializing" that all agents start in
+// Agents can transition to busy and/or idle but always start in the "initializing" state
+/*
+//                - Busy
+//              /    |
+// Initializing      |
+//              \    |
+//                - Idle
+*/
+// This (intentionally?) ensures the DisconnectAfterIdleTimeout doesn't fire before agents have had a chance to run a job
 type IdleMonitor struct {
 	sync.Mutex
 	totalAgents int


### PR DESCRIPTION
### Description

It's a bit deceiving at first glance

### Changes

Add some code comments

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

