### PR TITLE
Add status.json endpoint to health check endpoints

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -2,21 +2,52 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
 	"sync"
 
+	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/agent/v3/status"
 )
 
 // AgentPool manages multiple parallel AgentWorkers
 type AgentPool struct {
-	workers []*AgentWorker
+	workers     []*AgentWorker
+	idleMonitor *IdleMonitor
 }
 
 // NewAgentPool returns a new AgentPool
 func NewAgentPool(workers []*AgentWorker) *AgentPool {
 	return &AgentPool{
-		workers: workers,
+		workers:     workers,
+		idleMonitor: NewIdleMonitor(len(workers)),
 	}
+}
+
+func (ap *AgentPool) StartStatusServer(ctx context.Context, l logger.Logger, addr string) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", healthHandler(l))
+	mux.HandleFunc("/status", status.Handle)
+	mux.HandleFunc("/status.json", ap.statusJSONHandler(l))
+
+	for _, worker := range ap.workers {
+		mux.HandleFunc("/agent/"+strconv.Itoa(worker.spawnIndex), worker.healthHandler())
+	}
+
+	go func() {
+		_, setStatus, done := status.AddSimpleItem(ctx, "Health check server")
+		defer done()
+		setStatus("👂 Listening")
+
+		l.Notice("Starting HTTP health check server on %v", addr)
+		err := http.ListenAndServe(addr, mux)
+		if err != nil {
+			l.Error("Could not start health check server: %v", err)
+		}
+	}()
 }
 
 // Start kicks off the parallel AgentWorkers and waits for them to finish
@@ -29,9 +60,6 @@ func (r *AgentPool) Start(ctx context.Context) error {
 	var spawn int = len(r.workers)
 	var errs = make(chan error, spawn)
 
-	// Co-ordinate idle state across agents
-	idleMonitor := NewIdleMonitor(len(r.workers))
-
 	// Spawn goroutines for each parallel worker
 	for _, worker := range r.workers {
 		wg.Add(1)
@@ -39,7 +67,7 @@ func (r *AgentPool) Start(ctx context.Context) error {
 		go func(worker *AgentWorker) {
 			defer wg.Done()
 
-			if err := r.runWorker(ctx, worker, idleMonitor); err != nil {
+			if err := r.runWorker(ctx, worker); err != nil {
 				errs <- err
 			}
 		}(worker)
@@ -55,7 +83,7 @@ func (r *AgentPool) Start(ctx context.Context) error {
 	return <-errs
 }
 
-func (r *AgentPool) runWorker(ctx context.Context, worker *AgentWorker, im *IdleMonitor) error {
+func (r *AgentPool) runWorker(ctx context.Context, worker *AgentWorker) error {
 	// Connect the worker to the API
 	if err := worker.Connect(ctx); err != nil {
 		return err
@@ -64,11 +92,63 @@ func (r *AgentPool) runWorker(ctx context.Context, worker *AgentWorker, im *Idle
 	defer worker.Disconnect(ctx)
 
 	// Starts the agent worker and wait for it to finish.
-	return worker.Start(ctx, im)
+	return worker.Start(ctx, r.idleMonitor)
 }
 
 func (r *AgentPool) Stop(graceful bool) {
 	for _, worker := range r.workers {
 		worker.Stop(graceful)
+	}
+}
+
+func (ap *AgentPool) statusJSONHandler(l logger.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		type agentWorkerStatus struct {
+			Status       agentWorkerState `json:"status"`
+			CurrentJobID string           `json:"current_job_id,omitempty"`
+			ID           string           `json:"id"`
+			SpawnIndex   int              `json:"spawn_index"`
+		}
+
+		aggregateState := agentWorkerStateIdle
+		statuses := make([]agentWorkerStatus, 0, len(ap.workers))
+		for _, worker := range ap.workers {
+			// If any worker is busy, the aggregate state is busy
+			workerState := worker.getState()
+			if workerState == agentWorkerStateBusy {
+				aggregateState = agentWorkerStateBusy
+			}
+			statuses = append(statuses, agentWorkerStatus{
+				ID:           worker.agent.UUID,
+				Status:       workerState,
+				CurrentJobID: worker.getCurrentJobID(),
+				SpawnIndex:   worker.spawnIndex,
+			})
+		}
+
+		err := json.NewEncoder(w).Encode(struct {
+			Health          string              `json:"health"`
+			AggregateStatus agentWorkerState    `json:"aggregate_status"`
+			Workers         []agentWorkerStatus `json:"workers"`
+		}{
+			Health:          "ok",
+			AggregateStatus: aggregateState,
+			Workers:         statuses,
+		})
+
+		if err != nil {
+			l.Error("Could not encode status.json response: %v", err)
+		}
+	}
+}
+
+func healthHandler(l logger.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		l.Info("%s %s", r.Method, r.URL.Path)
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+		} else {
+			fmt.Fprintf(w, "OK: Buildkite agent is running")
+		}
 	}
 }


### PR DESCRIPTION
### Description

This PR adds a new endpoint to the healthcheck server, `/status.json`. the idea is that this endpoint will be a very cut-down version of the information available at `/status`, but in a format (JSON) that's easily machine-readable.

A sample of this output is:
```JSONC
{
  "health": "ok",
  "aggregate_status": "busy", # One of the workers below is busy, so the "aggregate status" of the agent is busy
  "worker_statuses": [
    {
      "status": "idle",
      "id": "018f2d68-1d0c-42cd-be6c-c1a89bda6453",
      "spawn_index": 1
    },
    {
      "status": "idle",
      "id": "018f2d68-1e33-4f09-ae1e-8b962f4e4e77",
      "spawn_index": 2
    },
    {
      "status": "busy",
      "current_job_id": "018f2d68-5e54-4255-a99e-829aa4691dc1", # only busy agents have a current job ID
      "id": "018f2d68-1f57-4374-9dbe-ec033f915c75",
      "spawn_index": 3
    },
    {
      "status": "idle",
      "id": "018f2d68-2080-4eaf-a33d-e1c3d0521206",
      "spawn_index": 4
    }
  ]
}
```

This PR also refactors the healthcheck server to be fully owned by the `AgentPool`, and replaces the use of the default mux (used when `http.HandleFunc` is called) with a dedicated mux for just the healthcheck server.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
