### PR TITLE
Replace calls to %v for error values in fmt.Errorf with %w

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -515,9 +515,9 @@ func (a *AgentWorker) Ping(ctx context.Context) (*api.Job, error) {
 		// If a ping fails, we don't really care, because it'll
 		// ping again after the interval.
 		if a.stats.lastPing.IsZero() {
-			return nil, fmt.Errorf("Failed to ping: %v (No successful ping yet)", pingErr)
+			return nil, fmt.Errorf("Failed to ping: %w (No successful ping yet)", pingErr)
 		} else {
-			return nil, fmt.Errorf("Failed to ping: %v (Last successful was %v ago)", pingErr, time.Since(a.stats.lastPing))
+			return nil, fmt.Errorf("Failed to ping: %w (Last successful was %v ago)", pingErr, time.Since(a.stats.lastPing))
 		}
 	}
 
@@ -619,7 +619,7 @@ func (a *AgentWorker) AcquireAndRunJob(ctx context.Context, jobId string) error 
 
 	// If `acquiredJob` is nil, then the job was never acquired
 	if acquiredJob == nil {
-		return fmt.Errorf("Failed to acquire job: %v", err)
+		return fmt.Errorf("Failed to acquire job: %w", err)
 	}
 
 	// Now that we've acquired the job, let's run it
@@ -653,7 +653,7 @@ func (a *AgentWorker) AcceptAndRunJob(ctx context.Context, job *api.Job) error {
 
 	// If `accepted` is nil, then the job was never accepted
 	if accepted == nil {
-		return fmt.Errorf("Failed to accept job: %v", err)
+		return fmt.Errorf("Failed to accept job: %w", err)
 	}
 
 	// Now that we've accepted the job, let's run it
@@ -685,7 +685,7 @@ func (a *AgentWorker) RunJob(ctx context.Context, acceptResponse *api.Job) error
 		AgentStdout:        a.agentStdout,
 	})
 	if err != nil {
-		return fmt.Errorf("Failed to initialize job: %v", err)
+		return fmt.Errorf("Failed to initialize job: %w", err)
 	}
 	a.jobRunner = jr
 	defer func() {
@@ -695,7 +695,7 @@ func (a *AgentWorker) RunJob(ctx context.Context, acceptResponse *api.Job) error
 
 	// Start running the job
 	if err := jr.Run(ctx); err != nil {
-		return fmt.Errorf("Failed to run job: %v", err)
+		return fmt.Errorf("Failed to run job: %w", err)
 	}
 
 	return nil

--- a/agent/artifactory_uploader.go
+++ b/agent/artifactory_uploader.go
@@ -104,7 +104,7 @@ func (u *ArtifactoryUploader) Upload(_ context.Context, artifact *api.Artifact) 
 	u.logger.Debug("Reading file \"%s\"", artifact.AbsolutePath)
 	f, err := os.Open(artifact.AbsolutePath)
 	if err != nil {
-		return fmt.Errorf("failed to open file %q (%v)", artifact.AbsolutePath, err)
+		return fmt.Errorf("failed to open file %q (%w)", artifact.AbsolutePath, err)
 	}
 
 	// Upload the file to Artifactory.

--- a/agent/download.go
+++ b/agent/download.go
@@ -127,7 +127,7 @@ func (d Download) try(ctx context.Context) error {
 	// Start by downloading the file
 	response, err := d.client.Do(request)
 	if err != nil {
-		return fmt.Errorf("Error while downloading %s (%T: %v)", d.conf.URL, err, err)
+		return fmt.Errorf("Error while downloading %s (%T: %w)", d.conf.URL, err, err)
 	}
 	defer response.Body.Close()
 
@@ -148,20 +148,20 @@ func (d Download) try(ctx context.Context) error {
 	// Now make the folder for our file
 	// Actual file permissions will be reduced by umask, and won't be 0777 unless the user has manually changed the umask to 000
 	if err := os.MkdirAll(targetDirectory, 0777); err != nil {
-		return fmt.Errorf("Failed to create folder for %s (%T: %v)", targetFile, err, err)
+		return fmt.Errorf("Failed to create folder for %s (%T: %w)", targetFile, err, err)
 	}
 
 	// Create a file to handle the file
 	fileBuffer, err := os.Create(targetFile)
 	if err != nil {
-		return fmt.Errorf("Failed to create file %s (%T: %v)", targetFile, err, err)
+		return fmt.Errorf("Failed to create file %s (%T: %w)", targetFile, err, err)
 	}
 	defer fileBuffer.Close()
 
 	// Copy the data to the file
 	bytes, err := io.Copy(fileBuffer, response.Body)
 	if err != nil {
-		return fmt.Errorf("Error when copying data %s (%T: %v)", d.conf.URL, err, err)
+		return fmt.Errorf("Error when copying data %s (%T: %w)", d.conf.URL, err, err)
 	}
 
 	d.logger.Info("Successfully downloaded \"%s\" %s", d.conf.Path, humanize.IBytes(uint64(bytes)))

--- a/agent/s3.go
+++ b/agent/s3.go
@@ -129,7 +129,7 @@ func NewS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 		// If there is a region hint provided, we use it unconditionally
 		session, err := awsS3Session(regionHint, l)
 		if err != nil {
-			return nil, fmt.Errorf("Could not load the AWS SDK config (%v)", err)
+			return nil, fmt.Errorf("Could not load the AWS SDK config (%w)", err)
 		}
 
 		sess = session
@@ -147,7 +147,7 @@ func NewS3Client(l logger.Logger, bucket string) (*s3.S3, error) {
 		// bucket lives
 		session, err := awsS3Session(region, l)
 		if err != nil {
-			return nil, fmt.Errorf("Could not load the AWS SDK config (%v)", err)
+			return nil, fmt.Errorf("Could not load the AWS SDK config (%w)", err)
 		}
 
 		bucketRegion, bucketRegionErr := s3manager.GetBucketRegion(aws.BackgroundContext(), session, bucket, region)

--- a/agent/s3_downloader.go
+++ b/agent/s3_downloader.go
@@ -60,7 +60,7 @@ func (d S3Downloader) Start(ctx context.Context) error {
 
 	signedURL, err := req.Presign(time.Hour)
 	if err != nil {
-		return fmt.Errorf("error pre-signing request: %v", err)
+		return fmt.Errorf("error pre-signing request: %w", err)
 	}
 
 	// We can now cheat and pass the URL onto our regular downloader

--- a/agent/s3_uploader.go
+++ b/agent/s3_uploader.go
@@ -95,7 +95,7 @@ func (u *S3Uploader) Upload(_ context.Context, artifact *api.Artifact) error {
 	u.logger.Debug("Reading file \"%s\"", artifact.AbsolutePath)
 	f, err := os.Open(artifact.AbsolutePath)
 	if err != nil {
-		return fmt.Errorf("failed to open file %q (%v)", artifact.AbsolutePath, err)
+		return fmt.Errorf("failed to open file %q (%w)", artifact.AbsolutePath, err)
 	}
 
 	// Upload the file to S3.

--- a/api/client.go
+++ b/api/client.go
@@ -296,7 +296,7 @@ func (c *Client) doRequest(req *http.Request, v any) (*Response, error) {
 			}
 
 			if err = json.NewDecoder(resp.Body).Decode(v); err != nil {
-				return response, fmt.Errorf("failed to decode JSON response: %v", err)
+				return response, fmt.Errorf("failed to decode JSON response: %w", err)
 			}
 		}
 	}

--- a/clicommand/git_credentials_helper.go
+++ b/clicommand/git_credentials_helper.go
@@ -91,7 +91,7 @@ var GitCredentialsHelperCommand = cli.Command{
 		// see: https://git-scm.com/docs/git-credential
 		stdin, err := io.ReadAll(os.Stdin)
 		if err != nil {
-			return handleAuthError(c, l, fmt.Errorf("failed to read stdin: %v", err))
+			return handleAuthError(c, l, fmt.Errorf("failed to read stdin: %w", err))
 		}
 
 		l.Debug("Git credential input:\n%s\n", string(stdin))
@@ -106,13 +106,13 @@ var GitCredentialsHelperCommand = cli.Command{
 
 		repo, err := parseGitURLFromCredentialInput(string(stdin))
 		if err != nil {
-			return handleAuthError(c, l, fmt.Errorf("failed to parse git URL from stdin: %v", err))
+			return handleAuthError(c, l, fmt.Errorf("failed to parse git URL from stdin: %w", err))
 		}
 
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
 		tok, _, err := client.GenerateGithubCodeAccessToken(ctx, repo, cfg.JobID)
 		if err != nil {
-			return handleAuthError(c, l, fmt.Errorf("failed to get github app credentials: %v", err))
+			return handleAuthError(c, l, fmt.Errorf("failed to get github app credentials: %w", err))
 		}
 
 		fmt.Fprintln(c.App.Writer, "username=token")

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -233,7 +233,7 @@ var PipelineUploadCommand = cli.Command{
 		if input != os.Stdin {
 			fi, err := input.Stat()
 			if err != nil {
-				return fmt.Errorf("couldn't stat pipeline configuration file %q: %v", input.Name(), err)
+				return fmt.Errorf("couldn't stat pipeline configuration file %q: %w", input.Name(), err)
 			}
 			if fi.Size() == 0 {
 				return fmt.Errorf("pipeline file %q is empty", input.Name())

--- a/internal/artifact/azure_blob_uploader.go
+++ b/internal/artifact/azure_blob_uploader.go
@@ -93,7 +93,7 @@ func (u *AzureBlobUploader) Upload(ctx context.Context, artifact *api.Artifact) 
 	u.logger.Debug("Reading file %q", artifact.AbsolutePath)
 	f, err := os.Open(artifact.AbsolutePath)
 	if err != nil {
-		return fmt.Errorf("failed to open file %q (%v)", artifact.AbsolutePath, err)
+		return fmt.Errorf("failed to open file %q (%w)", artifact.AbsolutePath, err)
 	}
 	defer f.Close()
 

--- a/internal/job/api.go
+++ b/internal/job/api.go
@@ -22,7 +22,7 @@ We'll continue to run your job, but you won't be able to use the Job API`)
 
 	socketPath, err := jobapi.NewSocketPath(e.ExecutorConfig.SocketsPath)
 	if err != nil {
-		return cleanup, fmt.Errorf("creating job API socket path: %v", err)
+		return cleanup, fmt.Errorf("creating job API socket path: %w", err)
 	}
 
 	jobAPIOpts := []jobapi.ServerOpts{}
@@ -31,14 +31,14 @@ We'll continue to run your job, but you won't be able to use the Job API`)
 	}
 	srv, token, err := jobapi.NewServer(e.shell.Logger, socketPath, e.shell.Env, e.redactors, jobAPIOpts...)
 	if err != nil {
-		return cleanup, fmt.Errorf("creating job API server: %v", err)
+		return cleanup, fmt.Errorf("creating job API server: %w", err)
 	}
 
 	e.shell.Env.Set("BUILDKITE_AGENT_JOB_API_SOCKET", socketPath)
 	e.shell.Env.Set("BUILDKITE_AGENT_JOB_API_TOKEN", token)
 
 	if err := srv.Start(); err != nil {
-		return cleanup, fmt.Errorf("starting Job API server: %v", err)
+		return cleanup, fmt.Errorf("starting Job API server: %w", err)
 	}
 
 	return func() {

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -28,18 +28,18 @@ func (e *Executor) configureGitCredentialHelper(ctx context.Context) error {
 	// in, and not for any other repos that the step might clone.
 	err := e.shell.RunWithoutPrompt(ctx, "git", "config", "--global", "credential.useHttpPath", "true")
 	if err != nil {
-		return fmt.Errorf("enabling git credential.useHttpPath: %v", err)
+		return fmt.Errorf("enabling git credential.useHttpPath: %w", err)
 	}
 
 	buildkiteAgent, err := os.Executable()
 	if err != nil {
-		return fmt.Errorf("getting executable path: %v", err)
+		return fmt.Errorf("getting executable path: %w", err)
 	}
 
 	helper := fmt.Sprintf(`%s git-credentials-helper`, buildkiteAgent)
 	err = e.shell.RunWithoutPrompt(ctx, "git", "config", "--global", "credential.helper", helper)
 	if err != nil {
-		return fmt.Errorf("configuring git credential.helper: %v", err)
+		return fmt.Errorf("configuring git credential.helper: %w", err)
 	}
 
 	return nil

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -969,7 +969,7 @@ func (e *Executor) defaultCommandPhase(ctx context.Context) error {
 	// The shell gets parsed based on the operating system
 	shell, err := shellwords.Split(e.Shell)
 	if err != nil {
-		return fmt.Errorf("Failed to split shell (%q) into tokens: %v", e.Shell, err)
+		return fmt.Errorf("Failed to split shell (%q) into tokens: %w", e.Shell, err)
 	}
 
 	if len(shell) == 0 {

--- a/internal/job/integration/git.go
+++ b/internal/job/integration/git.go
@@ -73,7 +73,7 @@ func createTestGitRespository() (*gitRepository, error) {
 func newGitRepository() (*gitRepository, error) {
 	tempDirRaw, err := os.MkdirTemp("", "git-repo")
 	if err != nil {
-		return nil, fmt.Errorf("Error creating temp dir: %v", err)
+		return nil, fmt.Errorf("Error creating temp dir: %w", err)
 	}
 
 	// io.TempDir on Windows tilde-shortens (8.3 style?) long filenames in the path.
@@ -94,7 +94,7 @@ func newGitRepository() (*gitRepository, error) {
 	// EvalSymlinks seems best? Maybe there's a better way?
 	tempDir, err := filepath.EvalSymlinks(tempDirRaw)
 	if err != nil {
-		return nil, fmt.Errorf("EvalSymlinks for temp dir: %v", err)
+		return nil, fmt.Errorf("EvalSymlinks for temp dir: %w", err)
 	}
 
 	gr := &gitRepository{Path: tempDir}

--- a/internal/job/shell/shell.go
+++ b/internal/job/shell/shell.go
@@ -439,7 +439,7 @@ func (s *Shell) RunScript(ctx context.Context, path string, extra *env.Environme
 			s.Warningf("Couldn't find bash (%v). Attempting to fall back to sh. This may cause issues for hooks and plugins that assume Bash features.", err)
 			shPath, err = s.AbsolutePath("sh")
 			if err != nil {
-				return fmt.Errorf("error finding a shell, needed to run scripts: %v", err)
+				return fmt.Errorf("error finding a shell, needed to run scripts: %w", err)
 			}
 		}
 		command = shPath

--- a/internal/job/ssh.go
+++ b/internal/job/ssh.go
@@ -88,5 +88,5 @@ func findPathToSSHTools(ctx context.Context, sh *shell.Shell) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("Unable to find ssh-keyscan: %v", err)
+	return "", fmt.Errorf("Unable to find ssh-keyscan: %w", err)
 }

--- a/process/cat.go
+++ b/process/cat.go
@@ -12,7 +12,7 @@ import (
 func Cat(path string) (string, error) {
 	files, err := filepath.Glob(path)
 	if err != nil {
-		return "", fmt.Errorf("Failed to get a list of files: %v", err)
+		return "", fmt.Errorf("Failed to get a list of files: %w", err)
 	}
 
 	var buffer bytes.Buffer
@@ -20,7 +20,7 @@ func Cat(path string) (string, error) {
 	for _, file := range files {
 		data, err := os.ReadFile(file)
 		if err != nil {
-			return "", fmt.Errorf("Could not read file: %s (%T: %v)", file, err, err)
+			return "", fmt.Errorf("Could not read file: %s (%T: %w)", file, err, err)
 		}
 
 		buffer.WriteString(string(data))


### PR DESCRIPTION
### Description

The `%w` formatting verb has been available forever<sup>[citation needed]</sup> now, and it's frustrating to use `errors.Is`, expecting to find a wrapped error, only to find out that a call to `%v` in a `fmt.Errorf` call (instead of `%w`) has eaten all of the error decoration.

This PR casts a wide brush across the codebase, and attempts to replace many (most? all?) uses of `%v` for errors in calls to `fmt.Errorf` with `%w`, properly wrapping those errors

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
