### PR TITLE
Plt 2360 fix OIDC role name

### DIFF
--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -36,6 +36,10 @@ steps:
           login: true
           account-ids: "032379705303"
       - docker#v5.8.0:
+          environment:
+            - "AWS_ACCESS_KEY_ID"
+            - "AWS_SECRET_ACCESS_KEY"
+            - "AWS_SESSION_TOKEN"
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
           mount-buildkite-agent: true
@@ -73,6 +77,10 @@ steps:
       - aws-assume-role-with-web-identity:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
       - docker#v5.8.0:
+          environment:
+            - "AWS_ACCESS_KEY_ID"
+            - "AWS_SECRET_ACCESS_KEY"
+            - "AWS_SESSION_TOKEN"
           image: "public.ecr.aws/docker/library/ruby:3.0"
           entrypoint: bash
           propagate-environment: true
@@ -110,6 +118,10 @@ steps:
       - aws-assume-role-with-web-identity:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
       - docker#v5.8.0:
+          environment:
+            - "AWS_ACCESS_KEY_ID"
+            - "AWS_SECRET_ACCESS_KEY"
+            - "AWS_SESSION_TOKEN"
           image: "public.ecr.aws/docker/library/ruby:3.0"
           entrypoint: bash
           propagate-environment: true
@@ -141,6 +153,10 @@ steps:
           login: true
           account-ids: "032379705303"
       - docker#v5.8.0:
+          environment:
+            - "AWS_ACCESS_KEY_ID"
+            - "AWS_SECRET_ACCESS_KEY"
+            - "AWS_SESSION_TOKEN"
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
           mount-buildkite-agent: true

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -12,7 +12,7 @@ steps:
       CODENAME: "unstable"
     plugins:
       - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -31,7 +31,7 @@ steps:
       CODENAME: "unstable"
     plugins:
       - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -47,7 +47,7 @@ steps:
       RPM_S3_BUCKET: "yum.buildkite.com"
     plugins:
       - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
       - docker#v5.8.0:
           environment:
             - "AWS_ACCESS_KEY_ID"
@@ -71,7 +71,7 @@ steps:
       DISTRO_VERSION: rpm_any/rpm_any
     plugins:
       - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
       - docker#v5.8.0:
           image: "public.ecr.aws/docker/library/ruby:3.0"
           entrypoint: bash
@@ -88,7 +88,7 @@ steps:
       queue: "deploy"
     plugins:
       - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -110,7 +110,7 @@ steps:
       DISTRO_VERSION: any/any
     plugins:
       - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
       - docker#v5.8.0:
           image: "public.ecr.aws/docker/library/ruby:3.0"
           entrypoint: bash
@@ -124,7 +124,7 @@ steps:
       CODENAME: "unstable"
     plugins:
       - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
       - ecr#v2.7.0:
           login: true
           account-ids: "445615400570"
@@ -138,7 +138,7 @@ steps:
       CODENAME: "unstable"
     plugins:
       - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-unstable
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -36,6 +36,10 @@ steps:
           login: true
           account-ids: "032379705303"
       - docker#v5.8.0:
+          environment:
+            - "AWS_ACCESS_KEY_ID"
+            - "AWS_SECRET_ACCESS_KEY"
+            - "AWS_SESSION_TOKEN"
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
           mount-buildkite-agent: true
@@ -73,6 +77,10 @@ steps:
       - aws-assume-role-with-web-identity:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
       - docker#v5.8.0:
+          environment:
+            - "AWS_ACCESS_KEY_ID"
+            - "AWS_SECRET_ACCESS_KEY"
+            - "AWS_SESSION_TOKEN"
           image: "public.ecr.aws/docker/library/ruby:3.0"
           entrypoint: bash
           propagate-environment: true
@@ -84,8 +92,6 @@ steps:
     env:
       CODENAME: "unstable"
       DEB_S3_BUCKET: "apt.buildkite.com/buildkite-agent"
-    agents:
-      queue: "deploy"
     plugins:
       - aws-assume-role-with-web-identity:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
@@ -143,6 +149,10 @@ steps:
           login: true
           account-ids: "032379705303"
       - docker#v5.8.0:
+          environment:
+            - "AWS_ACCESS_KEY_ID"
+            - "AWS_SECRET_ACCESS_KEY"
+            - "AWS_SESSION_TOKEN"
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           propagate-environment: true
           mount-buildkite-agent: true


### PR DESCRIPTION
### Description

This PR updates the role name assumed in the unstable/beta release pipeline, and passes the AWS creds for that role through to docker containers.

### Context

A fix to changes introduced to the pipeline in #2755

