### PR TITLE
Remove the --debug-http flag from the git credential helper

### DIFF
--- a/clicommand/git_credentials_helper.go
+++ b/clicommand/git_credentials_helper.go
@@ -42,7 +42,7 @@ type GitCredentialsHelperConfig struct {
 	Profile     string   `cli:"profile"`
 
 	// API config
-	DebugHTTP        bool   `cli:"debug-http"`
+	// DebugHTTP bool // Not present due to the possibility of leaking code access tokens to logs
 	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
 	Endpoint         string `cli:"endpoint" validate:"required"`
 	NoHTTP2          bool   `cli:"no-http2"`
@@ -63,7 +63,7 @@ var GitCredentialsHelperCommand = cli.Command{
 		AgentAccessTokenFlag,
 		EndpointFlag,
 		NoHTTP2Flag,
-		DebugHTTPFlag,
+		// DebugHTTPFlag, // Not present due to the possibility of leaking code access tokens to logs
 
 		// Global flags
 		NoColorFlag,


### PR DESCRIPTION
### Description

one of the things that came up in a security chat the other day was the worry that when using buildkite hosted compute, using `--debug --debug-http` on the agent could get the agent’s git credential helper to print out the response body of the request asking for a code access token, and leak it into job logs. i’ve verified that this probably can’t happen right now, for a couple of reasons:
- first, buildkite's compute layer controls the agents, and doesn’t allow users to set specific flags on the agent. malicious (or negligent) users wouldn’t be able to set the two flags that could cause the response body to be leaked into job logs
- regardless of this, even when those options are set, the output of the git credential helper is eaten by git itself, and so wouldn’t be visible to users anyway. you can see an example of this in action in [this job](https://buildkite.com/bennos-super-secret-cool-time-org/private/builds/46#018f5197-b602-4dd4-9e64-eb879f8c9534) (private) - you can see that the HTTP request and response for a metadata exists call are printed, but the details of the code access token request are not

regardless of this, i’m still keen to remove the --debug-http option from the agent’s git credential helper. there’s already multiple layers of defence here, but output that has the opportunity for misuse is still being produced, and if we don’t produce it, it can’t be misused.

to wit, this PR does just that - removes the `--debug-http` flag from the git credential helper command.


<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

### Context

[slack chat](https://buildkite-corp.slack.com/archives/C071B119REG/p1715061684066239)

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
