### PR TITLE
Exit with code 28 when job acquisition is locked

### DIFF
--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -194,8 +194,8 @@ func TestAcquireAndRunJobWaiting(t *testing.T) {
 	err := worker.AcquireAndRunJob(ctx, "waitinguuid")
 	assert.ErrorContains(t, err, "423")
 
-	if errors.Is(err, ErrJobAcquisitionFailure) {
-		t.Fatalf("expected worker.AcquireAndRunJob(%q) not to be a ErrJobAcquisitionFailure, but it was: %v", "waitinguuid", err)
+	if !errors.Is(err, ErrJobNotYetAcquirable) {
+		t.Fatalf("expected worker.AcquireAndRunJob(%q) to be an ErrJobNotYetAcquirable, but it was: %v", "waitinguuid", err)
 	}
 
 	// the last Retry-After is not recorded as the retries loop exits before using it


### PR DESCRIPTION
### Description

In https://github.com/buildkite/agent/pull/2762, we made it so that failed job acquisitions would return an exit code `27`, so that consumers could know that acquiring that job would never be viable.

This PR adds similar handling for jobs that are waiting on dependencies to run, and returns an exit code `28` when this is the case. The reason that this exit code differs is that jobs that are waiting on dependencies will eventually (probably, some jobs depend on things that don't exist) become available for acquisition

### Context

[Slack convo](https://buildkite-corp.slack.com/archives/C05MQ1W710X/p1715093549414119)
COMP-400

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
