### PR TITLE
Expand buildkite-agent secret command with a more useful description.

### DIFF
--- a/clicommand/secret_get.go
+++ b/clicommand/secret_get.go
@@ -29,9 +29,23 @@ type SecretGetConfig struct {
 }
 
 var SecretGetCommand = cli.Command{
-	Name:        "get",
-	Usage:       "Get a secret by its key",
-	Description: "Get a secret by key from Buildkite Pipelines Secrets and print it to stdout.",
+	Name:  "get",
+	Usage: "Get a secret by its key",
+	Description: `Usage:
+
+    buildkite-agent secret get [key] [options...]
+
+Description:
+
+Gets a secret from Buildkite secrets and prints it to stdout. The ′key′
+specified in this command is key's name defined for the secret in its cluster.
+The key's name is case-insensitive in this command, and the key's value is
+automatically redacted in the build logs.
+
+Example:
+
+    $ buildkite-agent secret get deploy_key
+	`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "job",

--- a/clicommand/secret_get.go
+++ b/clicommand/secret_get.go
@@ -30,7 +30,7 @@ type SecretGetConfig struct {
 
 var SecretGetCommand = cli.Command{
 	Name:  "get",
-	Usage: "Get a secret by its key",
+	Usage: "Get a secret by its key and print it to stdout",
 	Description: `Usage:
 
     buildkite-agent secret get [key] [options...]

--- a/clicommand/secret_get.go
+++ b/clicommand/secret_get.go
@@ -38,13 +38,16 @@ var SecretGetCommand = cli.Command{
 Description:
 
 Gets a secret from Buildkite secrets and prints it to stdout. The ′key′
-specified in this command is key's name defined for the secret in its cluster.
-The key's name is case-insensitive in this command, and the key's value is
-automatically redacted in the build logs.
+specified in this command is the key's name defined for the secret in its
+cluster. The key's name is case insensitive in this command, and the
+key's value is automatically redacted in the build logs.
 
-Example:
+Examples:
+
+The following examples reference the same Buildkite secret ′key′:
 
     $ buildkite-agent secret get deploy_key
+		$ buildkite-agent secret get DEPLOY_KEY
 	`,
 	Flags: []cli.Flag{
 		cli.StringFlag{

--- a/clicommand/secret_get.go
+++ b/clicommand/secret_get.go
@@ -47,8 +47,7 @@ Examples:
 The following examples reference the same Buildkite secret ′key′:
 
     $ buildkite-agent secret get deploy_key
-		$ buildkite-agent secret get DEPLOY_KEY
-	`,
+		$ buildkite-agent secret get DEPLOY_KEY`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "job",


### PR DESCRIPTION
### Description

This PR expands the `buildkite-agent secret get` command with a more useful description for both the output and the docs.

### Context

The aim is to flesh out this description so that the current extremely brief one we have here:
https://buildkite.com/docs/agent/v3/cli-secret

Contains more info (i.e. separate **Usage**, **Description** and **Example** sections) like the one here:
https://buildkite.com/docs/agent/v3/cli-step#updating-a-step

This edited description (in this PR) affects the wording on https://buildkite.com/docs/agent/v3/cli-secret, which is auto-generated from this content.

### Changes

Just the description, which will be surfaced through the CLI command: 
`buildkite-agent secret get --help`.

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

I have tested the output locally with the command:
`go run *.go secret get --help --debug`
and the output is as intended.