### PR TITLE
Fix typo in 'buildkite-agent redactor add' description.

### DIFF
--- a/clicommand/redactor_add.go
+++ b/clicommand/redactor_add.go
@@ -54,7 +54,7 @@ type RedactorAddConfig struct {
 var RedactorAddCommand = cli.Command{
 	Name:        "add",
 	Usage:       "Add values to redact from a job's log output",
-	Description: "This may be used to parse a file for values to redact from a running job's log output. If you dynamically fetch secrets during a job, it is recommended that you use this command to ensure they will be redacted from subsequent logs. Secrects fetched with the builtin ′secret get′ command do not require the use of this command, they will be redacted automatically.",
+	Description: "This may be used to parse a file for values to redact from a running job's log output. If you dynamically fetch secrets during a job, it is recommended that you use this command to ensure they will be redacted from subsequent logs. Secrets fetched with the builtin ′secret get′ command do not require the use of this command, they will be redacted automatically.",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "format",


### PR DESCRIPTION
Just fixes a minor typo in the help output for the `buildkite-agent redactor add` command, which is also propagated across to the docs.

I have a plan to reformat the description, similar to https://github.com/buildkite/agent/pull/2775, but this is a lower priority thing I'll do once I have more time.