### PR TITLE
Fix poorly-timed timestamp insertions

### DIFF
--- a/process/ansi.go
+++ b/process/ansi.go
@@ -64,11 +64,12 @@ func init() {
 	// and any other byte is the "final byte" which terminates the sequence.
 	// Here's an ASCII-art state diagram:
 	//
-	//         0x30-0x3F             0x20-0x2F
-	//             ^|                    ^|
-	//             |v                    |v
-	// () --'['--> () --anything else--> () --anything else--> (nil)
-	//          parameter           intermediate               final
+	//         0x30-0x3F          0x20-0x2F
+	//             ^|                ^|
+	//             |v                |v
+	// () --'['--> () --0x20-0x2F--> () --anything else--> (nil)
+	//             |
+	//             +--anything else--> (nil)
 	//
 	csiIntermediate := ansiParserState{}
 	for b := byte(0x30); b <= 0x3F; b++ {

--- a/process/ansi.go
+++ b/process/ansi.go
@@ -1,0 +1,79 @@
+package process
+
+// ansiParser implements a tiny ANSI code parser. This is for the purposes of
+// telling whether or not we're in the middle of an ANSI sequence before
+// inserting data of our own.
+type ansiParser struct {
+	state ansiParserState
+}
+
+// feed passes more bytes through the parser.
+func (m *ansiParser) feed(data ...byte) {
+	for _, b := range data {
+		if m.state != nil {
+			m.state = m.state[b]
+			continue
+		}
+		if b == '\x1b' {
+			m.state = initialANSIState
+		}
+	}
+}
+
+// insideCode reports if the data is in the middle of an ANSI sequence.
+// The parser is mid-sequence if it's in any state other than nil ("normal").
+func (m *ansiParser) insideCode() bool { return m.state != nil }
+
+// ansiParserState is a possible state of the parser. It's just a map of next-
+// byte to next-state. Most next-states are nil.
+type ansiParserState map[byte]ansiParserState
+
+var (
+	// initialANSIState is the state the parser enters once it reads ESC.
+	initialANSIState = ansiParserState{
+		// Note that most bytes immediately following ESC terminate the sequence.
+		// The following require more processing:
+		'[': csiParameterState, // CSI
+		']': stTextState,       // OSC
+		'P': stTextState,       // DCS
+		'X': stTextState,       // SOS
+		'^': stTextState,       // PM
+		'_': stTextState,       // APC
+	}
+	// csiParameter state is the state the parser is in after ESC [
+	csiParameterState = ansiParserState{}
+
+	// stTextState is one of the ST-terminated text states (OSC, DCS, APC, etc)
+	stTextState = ansiParserState{}
+)
+
+// The "looping states" can't be built as struct literals since they refer to
+// themselves, so they are constructed in init.
+func init() {
+	// Control Sequence Introducers (CSI):
+	//   ESC '[' [0-9:;<=>?]* [ !"#$%&'()*+,-./]* [@A–Z[\]^_`a–z{|}~]
+	// or...
+	//   ESC '[' (0x30-0x3F)* (0x20-0x2F)* (0x40-0x7E)
+	// or...
+	//   ESC '[' (parameter byte)* (intermediate byte)* (final byte)
+	// So the "parameter bytes" and "intermediate bytes" need to loop,
+	// and any other byte is the "final byte".
+	csiIntermediate := ansiParserState{}
+	for b := byte(0x30); b <= 0x3F; b++ {
+		csiParameterState[b] = csiParameterState
+	}
+	for b := byte(0x20); b <= 0x2F; b++ {
+		csiParameterState[b] = csiIntermediate
+		csiIntermediate[b] = csiIntermediate
+	}
+
+	// OSC, APC, DCS, SOS, PM have the form:
+	//   ESC [PX]^_] (arbitrary text) (BEL | ESC '\')
+	// So all bytes need to loop except BEL and ESC \ (that's String Terminator)
+	// which terminate the sequence.
+	for b := range 256 {
+		stTextState[byte(b)] = stTextState
+	}
+	stTextState['\x07'] = nil
+	stTextState['\x1b'] = ansiParserState{'\\': nil}
+}

--- a/process/ansi_test.go
+++ b/process/ansi_test.go
@@ -40,6 +40,10 @@ func TestANSIParser(t *testing.T) {
 			input: "incomplete SOS: \x1bXasdfg",
 			want:  true,
 		},
+		{
+			input: "PM without ST: \x1b^asdf\x1b/more",
+			want:  true,
+		},
 	}
 
 	for _, test := range tests {

--- a/process/ansi_test.go
+++ b/process/ansi_test.go
@@ -1,0 +1,52 @@
+package process
+
+import "testing"
+
+func TestANSIParser(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{
+			input: "unadorned input",
+			want:  false,
+		},
+		{
+			input: "here's a CSI: \x1b[K and some regular text",
+			want:  false,
+		},
+		{
+			input: "some text followed by an incomplete CSI: \x1b[",
+			want:  true,
+		},
+		{
+			input: "a single escape byte: \x1b",
+			want:  true,
+		},
+		{
+			input: "complete BK timestamp: \x1b_bk;t=12345\x07",
+			want:  false,
+		},
+		{
+			input: "complete SOS: \x1bXasdfghjkl\x1b\\",
+			want:  false,
+		},
+		{
+			input: "incomplete BK timestamp: \x1b_bk;t=123",
+			want:  true,
+		},
+		{
+			input: "incomplete SOS: \x1bXasdfg",
+			want:  true,
+		},
+	}
+
+	for _, test := range tests {
+		var p ansiParser
+		p.feed([]byte(test.input)...)
+		if got := p.insideCode(); got != test.want {
+			t.Errorf("after p.feed(%q...): p.insideCode() = %t, want %t", test.input, got, test.want)
+		}
+	}
+}

--- a/process/timestamper_test.go
+++ b/process/timestamper_test.go
@@ -81,17 +81,18 @@ func TestTimestamper_WithTimeout(t *testing.T) {
 
 	// Another write on the same line immediately should _not_ trigger a new
 	// timestamp
-	if _, err := pw.Write([]byte("shiver with antici")); err != nil {
-		t.Fatalf("pw.Write(`shiver with antici`) error = %v", err)
+	if _, err := pw.Write([]byte("shiver with antici\x1b[")); err != nil {
+		t.Fatalf("pw.Write(`shiver with antici\x1b[`) error = %v", err)
 	}
 
 	// A write on the same line some time later should trigger a new timestamp
+	// but not in the middle of an ANSI sequence
 	time.Sleep(100 * time.Millisecond)
-	if _, err := pw.Write([]byte("pation")); err != nil {
-		t.Fatalf("pw.Write(`pation`) error = %v", err)
+	if _, err := pw.Write([]byte("1mpation")); err != nil {
+		t.Fatalf("pw.Write(`1mpation`) error = %v", err)
 	}
 
-	want := "...I see you shiver with antici...pation"
+	want := "...I see you shiver with antici\x1b[1m...pation"
 	if diff := cmp.Diff(out.String(), want); diff != "" {
 		t.Errorf("timestamper output diff (-got +want):\n%s", diff)
 	}


### PR DESCRIPTION
### Description

Prevent the insertion of BK timestamp APCs in the middle of other ANSI sequences.

### Context

https://github.com/buildkite/terminal-to-html/issues/143 among other examples

### The bug

Prior to #2447, BK APCs were only added immediately after new lines or "line clear" codes. In #2447 I made it insert extra timestamps, based on time-since-last timestamp. This made it possible to insert a timestamp within another ANSI sequence, but it seemed unlikely to happen, because a process typically outputs an entire ANSI sequence in one write call (or so I must have thought). This ignores buffers in the middle. If a process writes ANSI sequences into a buffer, and the buffer is written out in multiple write calls, then two write calls could occur on either side of the last-timestamp check. While this still seems unlikely, I've since spotted multiple cases of timestamps being inserted into existing ANSI sequences.

### Changes

- Add a minimal ANSI sequence parser
- Use it to ensure sequences are terminated before inserting a timestamp

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
