### PR TITLE
Write "unknown exit status" in expanded section

### DIFF
--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -295,7 +295,7 @@ func (r *JobRunner) runJob(ctx context.Context) processExit {
 	k8sProcess, ok := r.process.(*kubernetes.Runner)
 	if ok && r.cancelled && !r.stopped && k8sProcess.ClientStateUnknown() {
 		fmt.Fprintln(r.jobLogs, "+++ Unknown container exit status")
-		fmt.Fprintln(r.jobLogs, "Some containers had unknown exit statuses. Perhaps they were in ImagePullBackOff.")
+		fmt.Fprintln(r.jobLogs, "Some containers had unknown exit statuses. Perhaps the container image specified in your podSpec could not be pulled (ImagePullBackOff)")
 	}
 
 	// Collect the finished process' exit status

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -294,10 +294,8 @@ func (r *JobRunner) runJob(ctx context.Context) processExit {
 	// to the user as they may be the caused by errors in the pipeline definition.
 	k8sProcess, ok := r.process.(*kubernetes.Runner)
 	if ok && r.cancelled && !r.stopped && k8sProcess.ClientStateUnknown() {
-		fmt.Fprintln(
-			r.jobLogs,
-			"Some containers had unknown exit statuses. Perhaps they were in ImagePullBackOff.",
-		)
+		fmt.Fprintln(r.jobLogs, "+++ Unknown container exit status")
+		fmt.Fprintln(r.jobLogs, "Some containers had unknown exit statuses. Perhaps they were in ImagePullBackOff.")
 	}
 
 	// Collect the finished process' exit status

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -1181,7 +1181,7 @@ func (e *Executor) startKubernetesClient(ctx context.Context, kubernetesClient *
 	).Do(func(rtr *roko.Retrier) error {
 		id, err := strconv.Atoi(os.Getenv("BUILDKITE_CONTAINER_ID"))
 		if err != nil {
-			return fmt.Errorf("failed to parse container id, %s", os.Getenv("BUILDKITE_CONTAINER_ID"))
+			return fmt.Errorf("failed to parse BUILDKITE_CONTAINER_ID %q", os.Getenv("BUILDKITE_CONTAINER_ID"))
 		}
 		kubernetesClient.ID = id
 		connect, err := kubernetesClient.Connect(ctx)

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -362,10 +362,15 @@ func (c *Client) Await(ctx context.Context, desiredState RunState) error {
 			}
 			if current == desiredState {
 				return nil
-			} else if current == RunStateInterrupt {
+			}
+			if current == RunStateInterrupt {
 				return ErrInterrupt
 			}
-			time.Sleep(time.Second)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Second):
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description

Improve the messaging when running in the Kubernetes stack when one of the other containers never connect to the "server" container socket.

### Context

https://linear.app/buildkite/issue/PENT-50/investigate-the-difficulty-of-showing-more-descriptive-error-messages

### Changes

* Put the existing error message in a new pre-expanded section, so it's not hidden inside another section accidentally
* Tweak the wording (ImagePullBackoff = container image couldn't be pulled)
* Drive-by improvement to the Await loop to make the sleep context-aware
* Drive-by improvement to an error string (`%q`)

### Testing
- [X] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [X] Code is formatted (with `go fmt ./...`)
