### PR TITLE
Default signal grace period to slightly less than cancel grace period

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -836,8 +836,8 @@ var AgentStartCommand = cli.Command{
 		}
 
 		// default signal grace period to slightly less than the cancel grace period
-		if cfg.SignalGracePeriodSeconds == -1 {
-			cfg.SignalGracePeriodSeconds = cfg.CancelGracePeriod - 1
+		if cfg.SignalGracePeriodSeconds < 0 {
+			cfg.SignalGracePeriodSeconds = cfg.CancelGracePeriod + cfg.SignalGracePeriodSeconds
 		}
 
 		if cfg.CancelGracePeriod <= cfg.SignalGracePeriodSeconds {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -837,11 +837,11 @@ var AgentStartCommand = cli.Command{
 
 		// Treat a negative signal grace period as relative to the cancel grace period
 		if cfg.SignalGracePeriodSeconds < 0 {
-			if cfg.SignalGracePeriodSeconds < cfg.CancelGracePeriod*-1 {
+			if cfg.CancelGracePeriod < -cfg.SignalGracePeriodSeconds {
 				return fmt.Errorf(
-					"signal-grace-period-seconds (%d) must be greater than the negative cancel-grace-period (%d)",
+					"cancel-grace-period (%d) must be at least as big as signal-grace-period-seconds (%d)",
+					cfg.CancelGracePeriod,
 					cfg.SignalGracePeriodSeconds,
-					cfg.CancelGracePeriod*-1,
 				)
 			}
 			cfg.SignalGracePeriodSeconds = cfg.CancelGracePeriod + cfg.SignalGracePeriodSeconds

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -835,8 +835,15 @@ var AgentStartCommand = cli.Command{
 			}
 		}
 
-		// default signal grace period to slightly less than the cancel grace period
+		// Treat a negative signal grace period as relative to the cancel grace period
 		if cfg.SignalGracePeriodSeconds < 0 {
+			if cfg.SignalGracePeriodSeconds < cfg.CancelGracePeriod*-1 {
+				return fmt.Errorf(
+					"signal-grace-period-seconds (%d) must be greater than the negative cancel-grace-period (%d)",
+					cfg.SignalGracePeriodSeconds,
+					cfg.CancelGracePeriod*-1,
+				)
+			}
 			cfg.SignalGracePeriodSeconds = cfg.CancelGracePeriod + cfg.SignalGracePeriodSeconds
 		}
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -835,6 +835,11 @@ var AgentStartCommand = cli.Command{
 			}
 		}
 
+		// default signal grace period to slightly less than the cancel grace period
+		if cfg.SignalGracePeriodSeconds == -1 {
+			cfg.SignalGracePeriodSeconds = cfg.CancelGracePeriod - 1
+		}
+
 		if cfg.CancelGracePeriod <= cfg.SignalGracePeriodSeconds {
 			return fmt.Errorf(
 				"cancel-grace-period (%d) must be greater than signal-grace-period-seconds (%d)",

--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -23,7 +23,9 @@ var (
 	signalGracePeriodSecondsFlag = cli.IntFlag{
 		Name: "signal-grace-period-seconds",
 		Usage: "The number of seconds given to a subprocess to handle being sent ′cancel-signal′. " +
-			"After this period has elapsed, SIGKILL will be sent.",
+			"After this period has elapsed, SIGKILL will be sent. " +
+			"Negative values are taken relative to ′cancel-grace-period′. " +
+			"The default is ′cancel-grace-period′ - 1.",
 		EnvVar: "BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS",
 		Value:  -1,
 	}

--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -4,13 +4,9 @@ import "github.com/urfave/cli"
 
 const (
 	defaultCancelGracePeriod = 10
-	defaultSignalGracePeriod = 9
 )
 
 var (
-	// cancel grace period must be strictly longer than signal grace period
-	_ uint = defaultCancelGracePeriod - defaultSignalGracePeriod - 1
-
 	cancelGracePeriodFlag = cli.IntFlag{
 		Name:  "cancel-grace-period",
 		Value: defaultCancelGracePeriod,
@@ -29,6 +25,6 @@ var (
 		Usage: "The number of seconds given to a subprocess to handle being sent ′cancel-signal′. " +
 			"After this period has elapsed, SIGKILL will be sent.",
 		EnvVar: "BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS",
-		Value:  defaultSignalGracePeriod,
+		Value:  -1,
 	}
 )


### PR DESCRIPTION
When a job is canceled, parent processes send a SIGTERM (by default) to child processes to try and gracefully fail. If a child doesn't finish after a period of time, we SIGKILL it. The grace periods are configured by two options:

* `--cancel-grace-period` - used by the `start` process when canceling the `bootstrap`
* `--signal-grace-period-seconds` - used by the `bootstrap` process when canceling its children (command/hooks/plugins etc)

In https://github.com/buildkite/agent/pull/2654, the signal grace period was extended to cover all job phases. Which means the effective grace period for a job changed from the cancel grace period to the minimum of the two periods.

In https://github.com/buildkite/agent/pull/2696, we changed the default signal grace period to be one second less than the default cancel grace period. But as reported in https://github.com/buildkite/agent/issues/2748, that doesn't help if you're trying to increase the cancel grace period.

This PR instead defaults `--signal-grace-period-seconds` to one less than `--cancel-grace-period`, whatever that happens to be set to. I've manually tested it and it works how you'd expect.

Fixes https://github.com/buildkite/agent/pull/2696.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
