### PR TITLE
Emit a better error if the job API token is missing

### DIFF
--- a/jobapi/client.go
+++ b/jobapi/client.go
@@ -14,7 +14,10 @@ const (
 	redactionsURL = "http://job/api/current-job/v0/redactions"
 )
 
-var errNoSocketEnv = errors.New("BUILDKITE_AGENT_JOB_API_SOCKET empty or undefined")
+var (
+	errNoJobAPISocketEnv = errors.New("BUILDKITE_AGENT_JOB_API_SOCKET empty or undefined")
+	errNoJobAPITokenEnv  = errors.New("BUILDKITE_AGENT_JOB_API_TOKEN empty or undefined")
+)
 
 // Client connects to the Job API.
 type Client struct {
@@ -36,12 +39,14 @@ func NewDefaultClient(ctx context.Context) (*Client, error) {
 func DefaultSocketPath() (path, token string, err error) {
 	path = os.Getenv("BUILDKITE_AGENT_JOB_API_SOCKET")
 	if path == "" {
-		return "", "", errNoSocketEnv
+		return "", "", errNoJobAPISocketEnv
 	}
+
 	token = os.Getenv("BUILDKITE_AGENT_JOB_API_TOKEN")
 	if token == "" {
-		return "", "", errNoSocketEnv
+		return "", "", errNoJobAPITokenEnv
 	}
+
 	return path, token, nil
 }
 

--- a/jobapi/client_test.go
+++ b/jobapi/client_test.go
@@ -124,13 +124,27 @@ func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestClient_NoSocket(t *testing.T) {
+	// t.Parallel() // Can't be parallelised, because it uses the t.Setenv() function
+
 	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(canc)
 
-	// This may be set if the test is being run by a buildkite agent!
-	os.Unsetenv("BUILDKITE_AGENT_JOB_API_SOCKET")
+	t.Setenv("BUILDKITE_AGENT_JOB_API_SOCKET", "") // This may be set if the test is being run by a buildkite agent!
 	_, err := NewDefaultClient(ctx)
-	assert.ErrorIs(t, err, errNoSocketEnv, "NewDefaultClient() error = %v, want %v", err, errNoSocketEnv)
+	assert.ErrorIs(t, err, errNoJobAPISocketEnv, "NewDefaultClient() error = %v, want %v", err, errNoJobAPISocketEnv)
+}
+
+func TestClient_NoToken(t *testing.T) {
+	// t.Parallel() // Can't be parallelised, because it uses the t.Setenv() function
+
+	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(canc)
+
+	t.Setenv("BUILDKITE_AGENT_JOB_API_SOCKET", "/tmp/fake-socket") // Just to make sure it's set
+	t.Setenv("BUILDKITE_AGENT_JOB_API_TOKEN", "")                  // This may be set if the test is being run by a buildkite agent!
+
+	_, err := NewDefaultClient(ctx)
+	assert.ErrorIs(t, err, errNoJobAPITokenEnv, "NewDefaultClient() error = %v, want %v", err, errNoJobAPITokenEnv)
 }
 
 func TestClientEnvGet(t *testing.T) {


### PR DESCRIPTION
### Description

At the moment, if the job api is missing a token, we emit an error about something completely different:
```
fatal: failed to create Job API client: BUILDKITE_AGENT_JOB_API_SOCKET empty or undefined
```

This PR changes it so that we emit an error that doesn't actively lead users astray:
```
fatal: failed to create Job API client: BUILDKITE_AGENT_JOB_API_TOKEN empty or undefined
```


### Context

[Slack convo](https://buildkite-corp.slack.com/archives/C05R3MTRK38/p1716339404757909)

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
