### PR TITLE
Upgrade math/rand to v2

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"sync"
 	"time"
@@ -608,7 +608,7 @@ func (a *AgentWorker) AcquireAndRunJob(ctx context.Context, jobId string) error 
 					a.logger.Warn("The job is waiting for a dependency (%s)", err)
 					duration, errParseDuration := time.ParseDuration(resp.Header.Get("Retry-After") + "s")
 					if errParseDuration != nil {
-						duration = time.Second + time.Duration(rand.Int63n(int64(time.Second)))
+						duration = time.Second + rand.N(time.Second)
 					}
 					r.SetNextInterval(duration)
 					return nil, err

--- a/agent/plugin/error_test.go
+++ b/agent/plugin/error_test.go
@@ -2,27 +2,27 @@ package plugin
 
 import (
 	"errors"
-	"math/rand"
+	"math/bits"
+	"math/rand/v2"
 	"testing"
 	"time"
 )
 
-func cyclicPermute[T any](arr []T) {
+func shuffle[T any](rnd *rand.Rand, arr []T) {
 	if len(arr) < 2 {
 		return
 	}
-
-	for i := len(arr) - 1; i > 0; i-- {
-		j := rand.Intn(i)
+	rnd.Shuffle(len(arr), func(i, j int) {
 		arr[i], arr[j] = arr[j], arr[i]
-	}
+	})
 }
 
 func TestDeprecatedNameErrorsOrder(t *testing.T) {
 	t.Parallel()
-	seed := time.Now().UnixNano() % ((1 << 31) - 1)
-	t.Logf("seed = %d", seed)
-	rand.Seed(seed)
+	seed1 := uint64(time.Now().UnixNano())
+	seed2 := bits.Reverse64(uint64(time.Now().UnixNano()))
+	t.Logf("seed1 = %d, seed2 = %d", seed1, seed2)
+	randSrc := rand.New(rand.NewPCG(seed1, seed2))
 
 	for _, test := range []struct {
 		name string
@@ -97,7 +97,7 @@ func TestDeprecatedNameErrorsOrder(t *testing.T) {
 			t.Parallel()
 			errs := make([]DeprecatedNameError, len(test.errs))
 			copy(errs, test.errs)
-			cyclicPermute(errs)
+			shuffle(randSrc, errs)
 
 			var err1, err2 *DeprecatedNameErrors
 			err1 = err1.Append(test.errs...)

--- a/jobapi/client_test.go
+++ b/jobapi/client_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"os"

--- a/jobapi/socket.go
+++ b/jobapi/socket.go
@@ -2,19 +2,14 @@ package jobapi
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
-	"time"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 // NewSocketPath generates a path to a socket file (without actually creating the file itself) that can be used with the
 // job api.
 func NewSocketPath(base string) (string, error) {
-	sockNum := rand.Int63() % 100_000
+	sockNum := rand.IntN(100_000)
 	return filepath.Join(base, "job-api", fmt.Sprintf("%d-%d.sock", os.Getpid(), sockNum)), nil
 }


### PR DESCRIPTION
### Description

I noticed a deprecated call to `rand.Seed`, and figured a quick upgrade to rand/v2 is in order.

### Context

Opportunistic drive-by improvement.

### Changes

* Remove deprecated `rand.Seed`
* Use new v2 package (many improvements)

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
