### PR TITLE
Fix redaction when no initial redactors are present

### DIFF
--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -339,13 +339,6 @@ var BootstrapCommand = cli.Command{
 			Usage:  "The specific phases to execute. The order they're defined is irrelevant.",
 			EnvVar: "BUILDKITE_BOOTSTRAP_PHASES",
 		},
-		cancelSignalFlag,
-		signalGracePeriodSecondsFlag,
-		cli.StringSliceFlag{
-			Name:   "redacted-vars",
-			Usage:  "Pattern of environment variable names containing sensitive values",
-			EnvVar: "BUILDKITE_REDACTED_VARS",
-		},
 		cli.StringFlag{
 			Name:   "tracing-backend",
 			Usage:  "The name of the tracing backend to use.",
@@ -368,10 +361,15 @@ var BootstrapCommand = cli.Command{
 			Usage:  "A list of warning IDs to disable",
 			EnvVar: "BUILDKITE_AGENT_DISABLE_WARNINGS_FOR",
 		},
+		cancelSignalFlag,
+		signalGracePeriodSecondsFlag,
+
+		// Global flags
 		DebugFlag,
 		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
+		RedactedVars,
 		StrictSingleHooksFlag,
 	},
 	Action: func(c *cli.Context) error {

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -1128,9 +1128,6 @@ func (e *Executor) writeBatchScript(cmd string) (string, error) {
 // The returned method will remove the redactors from the Executor and Flush them.
 func (e *Executor) setupRedactors() {
 	valuesToRedact := redact.Values(e.shell, e.ExecutorConfig.RedactedVars, e.shell.Env.Dump())
-	if len(valuesToRedact) == 0 {
-		return
-	}
 
 	if e.Debug {
 		e.shell.Commentf("Enabling output redaction for values from environment variables matching: %v", e.ExecutorConfig.RedactedVars)

--- a/internal/job/integration/artifact_integration_test.go
+++ b/internal/job/integration/artifact_integration_test.go
@@ -12,7 +12,7 @@ import (
 func TestArtifactsUploadAfterCommand(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -41,7 +41,7 @@ func TestArtifactsUploadAfterCommand(t *testing.T) {
 func TestArtifactsUploadAfterCommandFails(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -75,7 +75,7 @@ func TestArtifactsUploadAfterCommandFails(t *testing.T) {
 func TestArtifactsUploadAfterCommandHookFails(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -18,7 +18,7 @@ import (
 func TestCheckingOutGitHubPullRequests_WithGitMirrors(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -63,7 +63,7 @@ func TestWithResolvingCommitExperiment_WithGitMirrors(t *testing.T) {
 	t.Parallel()
 
 	ctx, _ := experiments.Enable(mainCtx, experiments.ResolveCommitAfterCheckout)
-	tester, err := NewBootstrapTester(ctx)
+	tester, err := NewExecutorTester(ctx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -108,7 +108,7 @@ func TestWithResolvingCommitExperiment_WithGitMirrors(t *testing.T) {
 func TestCheckingOutLocalGitProject_WithGitMirrors(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -157,7 +157,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules_WithGitMirrors(t *testing.T) {
 		t.Skip()
 	}
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -229,7 +229,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled_WithGitMirrors(t *test
 		t.Skip()
 	}
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -290,7 +290,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled_WithGitMirrors(t *test
 func TestCheckingOutShallowCloneOfLocalGitProject_WithGitMirrors(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -334,7 +334,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject_WithGitMirrors(t *testing.T) {
 func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite_WithGitMirrors(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -354,7 +354,7 @@ func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite_WithGitMirrors(t
 func TestCheckingOutWithSSHKeyscan_WithGitMirrors(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -386,7 +386,7 @@ func TestCheckingOutWithSSHKeyscan_WithGitMirrors(t *testing.T) {
 func TestCheckingOutWithoutSSHKeyscan_WithGitMirrors(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -411,7 +411,7 @@ func TestCheckingOutWithoutSSHKeyscan_WithGitMirrors(t *testing.T) {
 func TestCheckingOutWithSSHKeyscanAndUnscannableRepo_WithGitMirrors(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -444,7 +444,7 @@ func TestCleaningAnExistingCheckout_WithGitMirrors(t *testing.T) {
 
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -484,7 +484,7 @@ func TestCleaningAnExistingCheckout_WithGitMirrors(t *testing.T) {
 func TestForcingACleanCheckout_WithGitMirrors(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -510,7 +510,7 @@ func TestForcingACleanCheckout_WithGitMirrors(t *testing.T) {
 func TestCheckoutOnAnExistingRepositoryWithoutAGitFolder_WithGitMirrors(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -541,7 +541,7 @@ func TestCheckoutOnAnExistingRepositoryWithoutAGitFolder_WithGitMirrors(t *testi
 func TestCheckoutRetriesOnCleanFailure_WithGitMirrors(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -573,7 +573,7 @@ func TestCheckoutRetriesOnCleanFailure_WithGitMirrors(t *testing.T) {
 func TestCheckoutRetriesOnCloneFailure_WithGitMirrors(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -603,7 +603,7 @@ func TestCheckoutRetriesOnCloneFailure_WithGitMirrors(t *testing.T) {
 func TestCheckoutDoesNotRetryOnHookFailure_WithGitMirrors(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -640,7 +640,7 @@ func TestRepositorylessCheckout_WithGitMirrors(t *testing.T) {
 		t.Skip("Not supported on windows")
 	}
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -673,7 +673,7 @@ func TestRepositorylessCheckout_WithGitMirrors(t *testing.T) {
 func TestGitMirrorEnv(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -34,7 +34,7 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 	t.Parallel()
 
 	ctx, _ := experiments.Enable(mainCtx, experiments.ResolveCommitAfterCheckout)
-	tester, err := NewBootstrapTester(ctx)
+	tester, err := NewExecutorTester(ctx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -74,7 +74,7 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 func TestCheckingOutLocalGitProject(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -118,7 +118,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 		t.Skip()
 	}
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -184,7 +184,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 		t.Skip()
 	}
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -240,7 +240,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -279,7 +279,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 func TestCheckingOutLocalGitProjectWithShortCommitHash(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	assert.NilError(t, err)
 	defer tester.Close()
 
@@ -334,7 +334,7 @@ func TestCheckingOutLocalGitProjectWithShortCommitHash(t *testing.T) {
 func TestCheckingOutGitHubPullRequestWithCommitHash(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -363,7 +363,7 @@ func TestCheckingOutGitHubPullRequestWithCommitHash(t *testing.T) {
 func TestCheckingOutGitHubPullRequestAndCustomRefmap(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -398,7 +398,7 @@ func TestCheckingOutGitHubPullRequestAndCustomRefmap(t *testing.T) {
 func TestCheckingOutGitHubPullRequestWithCommitHashAfterForcePush(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -447,7 +447,7 @@ func TestCheckingOutGitHubPullRequestWithCommitHashAfterForcePush(t *testing.T) 
 func TestCheckingOutGitHubPullRequestWithShortCommitHash(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -477,7 +477,7 @@ func TestCheckingOutGitHubPullRequestWithShortCommitHash(t *testing.T) {
 func TestCheckingOutGitHubPullRequestAtHead(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -506,7 +506,7 @@ func TestCheckingOutGitHubPullRequestAtHead(t *testing.T) {
 func TestCheckingOutGitHubPullRequestAtHeadFromFork(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -539,7 +539,7 @@ func TestCheckingOutGitHubPullRequestAtHeadFromFork(t *testing.T) {
 func TestCheckoutErrorIsRetried(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -602,7 +602,7 @@ func TestCheckoutErrorIsRetried(t *testing.T) {
 func TestFetchErrorIsRetried(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -664,7 +664,7 @@ func TestFetchErrorIsRetried(t *testing.T) {
 func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -680,7 +680,7 @@ func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite(t *testing.T) {
 func TestCheckingOutWithSSHKeyscan(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -708,7 +708,7 @@ func TestCheckingOutWithSSHKeyscan(t *testing.T) {
 func TestCheckingOutWithoutSSHKeyscan(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -729,7 +729,7 @@ func TestCheckingOutWithoutSSHKeyscan(t *testing.T) {
 func TestCheckingOutWithSSHKeyscanAndUnscannableRepo(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -758,7 +758,7 @@ func TestCleaningAnExistingCheckout(t *testing.T) {
 
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -794,7 +794,7 @@ func TestCleaningAnExistingCheckout(t *testing.T) {
 func TestForcingACleanCheckout(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -816,7 +816,7 @@ func TestForcingACleanCheckout(t *testing.T) {
 func TestCheckoutOnAnExistingRepositoryWithoutAGitFolder(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -843,7 +843,7 @@ func TestCheckoutOnAnExistingRepositoryWithoutAGitFolder(t *testing.T) {
 func TestCheckoutRetriesOnCleanFailure(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -871,7 +871,7 @@ func TestCheckoutRetriesOnCleanFailure(t *testing.T) {
 func TestCheckoutRetriesOnCloneFailure(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -897,7 +897,7 @@ func TestCheckoutRetriesOnCloneFailure(t *testing.T) {
 func TestCheckoutDoesNotRetryOnHookFailure(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -930,7 +930,7 @@ func TestRepositorylessCheckout(t *testing.T) {
 		t.Skip("Not supported on windows")
 	}
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}

--- a/internal/job/integration/command_integration_test.go
+++ b/internal/job/integration/command_integration_test.go
@@ -15,7 +15,7 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 		t.Skip("batch test only applies to Windows")
 	}
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -45,7 +45,7 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}

--- a/internal/job/integration/docker_integration_test.go
+++ b/internal/job/integration/docker_integration_test.go
@@ -18,7 +18,7 @@ func argumentForCommand(cmd string) any {
 }
 
 func TestRunningCommandWithDocker(t *testing.T) {
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -51,7 +51,7 @@ func TestRunningCommandWithDocker(t *testing.T) {
 }
 
 func TestRunningCommandWithDockerAndCustomDockerfile(t *testing.T) {
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -85,7 +85,7 @@ func TestRunningCommandWithDockerAndCustomDockerfile(t *testing.T) {
 }
 
 func TestRunningFailingCommandWithDocker(t *testing.T) {
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -124,7 +124,7 @@ func TestRunningFailingCommandWithDocker(t *testing.T) {
 }
 
 func TestRunningCommandWithDockerCompose(t *testing.T) {
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -157,7 +157,7 @@ func TestRunningCommandWithDockerCompose(t *testing.T) {
 }
 
 func TestRunningFailingCommandWithDockerCompose(t *testing.T) {
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -197,7 +197,7 @@ func TestRunningFailingCommandWithDockerCompose(t *testing.T) {
 }
 
 func TestRunningCommandWithDockerComposeAndExtraConfig(t *testing.T) {
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -231,7 +231,7 @@ func TestRunningCommandWithDockerComposeAndExtraConfig(t *testing.T) {
 }
 
 func TestRunningCommandWithDockerComposeAndBuildAll(t *testing.T) {
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}

--- a/internal/job/integration/executor_tester.go
+++ b/internal/job/integration/executor_tester.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/buildkite/agent/v3/clicommand"
 	"github.com/buildkite/agent/v3/env"
 	"github.com/buildkite/agent/v3/internal/experiments"
 	"github.com/buildkite/agent/v3/internal/job"
@@ -109,7 +110,8 @@ func NewExecutorTester(ctx context.Context) (*ExecutorTester, error) {
 			"BUILDKITE_ARTIFACT_PATHS=",
 			"BUILDKITE_COMMAND=true",
 			"BUILDKITE_JOB_ID=1111-1111-1111-1111",
-			"BUILDKITE_AGENT_ACCESS_TOKEN=test",
+			"BUILDKITE_AGENT_ACCESS_TOKEN=test-token-please-ignore",
+			fmt.Sprintf("BUILDKITE_REDACTED_VARS=%s", strings.Join(*clicommand.RedactedVars.Value, ",")),
 		},
 		PathDir:    pathDir,
 		BuildDir:   buildDir,

--- a/internal/job/integration/executor_tester.go
+++ b/internal/job/integration/executor_tester.go
@@ -47,7 +47,7 @@ type ExecutorTester struct {
 	mocks    []*bintest.Mock
 }
 
-func NewBootstrapTester(ctx context.Context) (*ExecutorTester, error) {
+func NewExecutorTester(ctx context.Context) (*ExecutorTester, error) {
 	// The job API experiment adds a unix domain socket to a directory in the home directory
 	// UDS names are limited to 108 characters, so we need to use a shorter home directory
 	// Who knows what's going on in windowsland

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -21,7 +21,7 @@ import (
 func TestEnvironmentVariablesPassBetweenHooks(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -65,7 +65,7 @@ func TestEnvironmentVariablesPassBetweenHooks(t *testing.T) {
 func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -125,7 +125,7 @@ func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
 func TestDirectoryPassesBetweenHooks(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -159,7 +159,7 @@ func TestDirectoryPassesBetweenHooks(t *testing.T) {
 }
 
 func TestDirectoryPassesBetweenHooksIgnoredUnderExit(t *testing.T) {
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -196,7 +196,7 @@ func TestDirectoryPassesBetweenHooksIgnoredUnderExit(t *testing.T) {
 func TestCheckingOutFiresCorrectHooks(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -226,7 +226,7 @@ func TestCheckingOutFiresCorrectHooks(t *testing.T) {
 func TestReplacingCheckoutHook(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -255,7 +255,7 @@ func TestReplacingCheckoutHook(t *testing.T) {
 func TestReplacingGlobalCommandHook(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -280,7 +280,7 @@ func TestReplacingGlobalCommandHook(t *testing.T) {
 func TestReplacingLocalCommandHook(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -306,7 +306,7 @@ func TestReplacingLocalCommandHook(t *testing.T) {
 func TestPreExitHooksFireAfterCommandFailures(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -325,7 +325,7 @@ func TestPreExitHooksFireAfterCommandFailures(t *testing.T) {
 func TestPreExitHooksDoesNotFireWithoutCommandPhase(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -418,7 +418,7 @@ func TestPreExitHooksFireAfterHookFailures(t *testing.T) {
 		t.Run(tc.failingHook, func(t *testing.T) {
 			t.Parallel()
 
-			tester, err := NewBootstrapTester(ctx)
+			tester, err := NewExecutorTester(ctx)
 			if err != nil {
 				t.Fatalf("NewBootstrapTester() error = %v", err)
 			}
@@ -468,7 +468,7 @@ func TestPreExitHooksFireAfterHookFailures(t *testing.T) {
 func TestNoLocalHooksCalledWhenConfigSet(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -504,7 +504,7 @@ func TestExitCodesPropagateOutFromGlobalHooks(t *testing.T) {
 		// "post-artifact",
 	} {
 		t.Run(hook, func(t *testing.T) {
-			tester, err := NewBootstrapTester(ctx)
+			tester, err := NewExecutorTester(ctx)
 			if err != nil {
 				t.Fatalf("NewBootstrapTester() error = %v", err)
 			}
@@ -534,7 +534,7 @@ func TestPreExitHooksFireAfterCancel(t *testing.T) {
 		t.Skip()
 	}
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -581,7 +581,7 @@ func TestPolyglotScriptHooksCanBeRun(t *testing.T) {
 
 	ctx, _ := experiments.Enable(mainCtx, experiments.PolyglotHooks)
 
-	tester, err := NewBootstrapTester(ctx)
+	tester, err := NewExecutorTester(ctx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -610,7 +610,7 @@ func TestPolyglotBinaryHooksCanBeRun(t *testing.T) {
 	ctx := mainCtx
 	ctx, _ = experiments.Enable(ctx, experiments.PolyglotHooks)
 
-	tester, err := NewBootstrapTester(ctx)
+	tester, err := NewExecutorTester(ctx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}

--- a/internal/job/integration/job_api_integration_test.go
+++ b/internal/job/integration/job_api_integration_test.go
@@ -17,7 +17,7 @@ import (
 func TestBootstrapRunsJobAPI(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}

--- a/internal/job/integration/plugin_integration_test.go
+++ b/internal/job/integration/plugin_integration_test.go
@@ -18,7 +18,7 @@ import (
 func TestRunningPlugins(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -79,7 +79,7 @@ func TestRunningPlugins(t *testing.T) {
 func TestExitCodesPropagateOutFromPlugins(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -126,7 +126,7 @@ func TestExitCodesPropagateOutFromPlugins(t *testing.T) {
 func TestMalformedPluginNamesDontCrashBootstrap(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -150,7 +150,7 @@ func TestMalformedPluginNamesDontCrashBootstrap(t *testing.T) {
 func TestOverlappingPluginHooks(t *testing.T) {
 	t.Parallel()
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -214,7 +214,7 @@ func TestPluginCloneRetried(t *testing.T) {
 		t.Skip("Not passing on windows, needs investigation")
 	}
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -283,7 +283,7 @@ func TestModifiedPluginNoForcePull(t *testing.T) {
 
 	ctx := mainCtx
 
-	tester, err := NewBootstrapTester(ctx)
+	tester, err := NewExecutorTester(ctx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -350,7 +350,7 @@ func TestModifiedPluginNoForcePull(t *testing.T) {
 	tester.RunAndCheck(t, env...)
 
 	// Now, we want to "repeat" the test build, having modified the plugin's contents.
-	tester2, err := NewBootstrapTester(ctx)
+	tester2, err := NewExecutorTester(ctx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -396,7 +396,7 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 
 	ctx := mainCtx
 
-	tester, err := NewBootstrapTester(mainCtx)
+	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}
@@ -453,7 +453,7 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 
 	tester.RunAndCheck(t, env...)
 
-	tester2, err := NewBootstrapTester(ctx)
+	tester2, err := NewExecutorTester(ctx)
 	if err != nil {
 		t.Fatalf("NewBootstrapTester() error = %v", err)
 	}

--- a/internal/job/integration/redaction_integration_test.go
+++ b/internal/job/integration/redaction_integration_test.go
@@ -59,10 +59,7 @@ func TestRedactorDoesNotRedactAgentToken_WhenNotInRedactedVars(t *testing.T) {
 }
 
 func TestRedactorAdd_RedactsVarsAfterUse(t *testing.T) {
-	// when this test is run inside an agent (ie in CI), we don't want to connect to the job API of the executor running this test
-	// we want to instead connect to the job API of the executor process we're testing
-	t.Setenv("BUILDKITE_AGENT_JOB_API_TOKEN", "")
-	t.Setenv("BUILDKITE_AGENT_JOB_API_SOCKET", "")
+	t.Parallel()
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
@@ -70,7 +67,7 @@ func TestRedactorAdd_RedactsVarsAfterUse(t *testing.T) {
 	}
 	defer tester.Close()
 
-	secret := "huunter2" // secrets 6 chars or shorter don't get redacted, hence the extra u
+	secret := "hunter2"
 	tester.ExpectGlobalHook("command").AndCallFunc(redactionTestCommandHook(t, secret))
 
 	err = tester.Run(t)
@@ -93,10 +90,7 @@ func TestRedactorAdd_RedactsVarsAfterUse(t *testing.T) {
 // an empty list of redacted vars, it would not initialise the redactors at all, meaning that later redactions (ie with
 // the `buildkite-agent redactor add` command, or automatically when using `buildkite-agent secret get`) would not occur
 func TestRegression_TestRedactorAdd_StillWorksWhenNoInitialRedactedVarsAreProvided(t *testing.T) {
-	// when this test is run inside an agent (ie in CI), we don't want to connect to the job API of the executor running this test
-	// we want to instead connect to the job API of the executor process we're testing
-	t.Setenv("BUILDKITE_AGENT_JOB_API_SOCKET", "")
-	t.Setenv("BUILDKITE_AGENT_JOB_API_TOKEN", "")
+	t.Parallel()
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
@@ -104,7 +98,7 @@ func TestRegression_TestRedactorAdd_StillWorksWhenNoInitialRedactedVarsAreProvid
 	}
 	defer tester.Close()
 
-	secret := "huunter2" // secrets 6 chars or shorter don't get redacted, hence the extra u
+	secret := "hunter2"
 	tester.ExpectGlobalHook("command").AndCallFunc(redactionTestCommandHook(t, secret))
 
 	err = tester.Run(t, `BUILDKITE_REDACTED_VARS=""`)

--- a/internal/job/integration/redaction_integration_test.go
+++ b/internal/job/integration/redaction_integration_test.go
@@ -89,7 +89,10 @@ func TestRedactorAdd_RedactsVarsAfterUse(t *testing.T) {
 	}
 }
 
-func TestRedactorAdd_FailsWhenNoInitialRedactionStringsArePresent(t *testing.T) {
+// this is a regression test - prior to https://github.com/buildkite/agent/pull/2794, when the executor was provided with
+// an empty list of redacted vars, it would not initialise the redactors at all, meaning that later redactions (ie with
+// the `buildkite-agent redactor add` command, or automatically when using `buildkite-agent secret get`) would not occur
+func TestRegression_TestRedactorAdd_StillWorksWhenNoInitialRedactedVarsAreProvided(t *testing.T) {
 	// when this test is run inside an agent (ie in CI), we don't want to connect to the job API of the executor running this test
 	// we want to instead connect to the job API of the executor process we're testing
 	t.Setenv("BUILDKITE_AGENT_JOB_API_SOCKET", "")
@@ -115,7 +118,7 @@ func TestRedactorAdd_FailsWhenNoInitialRedactionStringsArePresent(t *testing.T) 
 	}
 
 	// now check that the string is still unredacted after the call to RedactionCreate
-	if !strings.Contains(tester.Output, fmt.Sprintf("There should be a redacted here: %s", secret)) {
+	if !strings.Contains(tester.Output, "There should be a redacted here: [REDACTED]") {
 		t.Fatalf("expected secret to be echoed without redaction after RedactionCreate, but it wasn't. Full output: %s", tester.Output)
 	}
 }


### PR DESCRIPTION
**This PR is best reviewed commit-by-commit**

### Problem

There's currently an edge case with with the agent's sensitive value redaction, where if the agent is started with an empty value for the `--redact-vars` flag (which in most cases has a sensible default), no redactions would happen. this is to be expected - it's what the user explicitly asked for, after all! however, doing this also prevents the user from dynamically adding values to redact using the `buildkite-agent redactor add` command, or automatically via the `buildkite-agent secret get` command. 

This behaviour was due to a bug where if upon startup, the job executor [found no values to redact](https://github.com/buildkite/agent/blob/0aa38aa4bd5e780296df293d220f78a796351958/internal/job/executor.go#L1130-L1133) - ie if the value of the `--redact-vars` flag was empty - it would not create any redactors. This behaviour was based on the assumption that vars to redact wouldn't change, but this is no longer the case since the introduction of the `buildkite-agent redactor add` command.

On its own this isn't much of an issue, as overriding the `--redact-vars` flag to not redact anything is a bit of a weird choice, but this bug interacted with the the [agent-stack-k8s](https://github.com/buildkite/agent-stack-k8s) in an interesting way.

In most modes of use, the `buildkite-agent start` process directly starts the `buildkite-agent bootstrap` process, which is the thing that actually runs the buildkite jobs. In these cases, the `start` process (the parent) will pass down the value of `--redact-vars` to its chile processes.

In the k8s-stack, however, the bootstrap container is started directly by the kubernetes controller, and only the command container (but not the checkout container) were given values for the `--redact-vars` flag.

All of this came together to mean that in jobs running on the kubernetes stack, in the command container, **no redaction at all would occur**.

### Solution

This PR fixes the above error in two ways:
- It fixes the underlying error of not creating redactors when there are initially no values to redact - values can be added by the `redactor add` command, so the job executor should be created with an empty redactor
- It updates the `buildkite-agent bootstrap` command to have the [same sensible default](https://github.com/buildkite/agent/blob/main/clicommand/global.go#L99-L109) as the `buildkite-agent start` command, such that if it's called by kubernetes, it will still have sensible defaults for redaction

### Context

[Support Escalation](https://coda.io/d/Escalations-Feedback_dHnUHNps1YO/Pipelines-Escalations_su7FT#Pipelines-Escalations-Board_tu__K/r453&view=modal)
[Slack convo w/ customer](https://buildkite.slack.com/archives/C074YF917A5/p1716424614877029)

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
