### PR TITLE
shell logger: Use fmt functions once

### DIFF
--- a/internal/job/shell/logger.go
+++ b/internal/job/shell/logger.go
@@ -69,39 +69,35 @@ func (wl *WriterLogger) Write(b []byte) (int, error) {
 }
 
 func (wl *WriterLogger) Printf(format string, v ...any) {
-	fmt.Fprintf(wl.Writer, "%s", fmt.Sprintf(format, v...))
-	fmt.Fprintln(wl.Writer)
+	fmt.Fprintf(wl.Writer, format+"\n", v...)
 }
 
 func (wl *WriterLogger) Headerf(format string, v ...any) {
-	fmt.Fprintf(wl.Writer, "~~~ %s", fmt.Sprintf(format, v...))
-	fmt.Fprintln(wl.Writer)
+	fmt.Fprintf(wl.Writer, "~~~ "+format+"\n", v...)
 }
 
 func (wl *WriterLogger) Commentf(format string, v ...any) {
 	if wl.Ansi {
-		wl.Printf(ansiColor("# %s", "90"), fmt.Sprintf(format, v...))
+		wl.Printf(ansiColor("# "+format, "90"), v...)
 	} else {
-		wl.Printf("# %s", fmt.Sprintf(format, v...))
+		wl.Printf("# "+format, v...)
 	}
 }
 
 func (wl *WriterLogger) Errorf(format string, v ...any) {
 	if wl.Ansi {
-		wl.Printf(ansiColor("🚨 Error: %s", "31"), fmt.Sprintf(format, v...))
+		wl.Printf(ansiColor("🚨 Error: "+format+"\n^^^ +++", "31"), v...)
 	} else {
-		wl.Printf("🚨 Error: %s", fmt.Sprintf(format, v...))
+		wl.Printf("🚨 Error: "+format+"\n^^^ +++", v...)
 	}
-	wl.Printf("^^^ +++")
 }
 
 func (wl *WriterLogger) Warningf(format string, v ...any) {
 	if wl.Ansi {
-		wl.Printf(ansiColor("⚠️ Warning: %s", "33"), fmt.Sprintf(format, v...))
+		wl.Printf(ansiColor("⚠️ Warning: "+format+"\n^^^ +++", "33"), v...)
 	} else {
-		wl.Printf("⚠️ Warning: %s", fmt.Sprintf(format, v...))
+		wl.Printf("⚠️ Warning: "+format+"\n^^^ +++", v...)
 	}
-	wl.Printf("^^^ +++")
 }
 
 func (wl *WriterLogger) OptionalWarningf(id, format string, v ...any) {
@@ -120,9 +116,9 @@ func (wl *WriterLogger) Promptf(format string, v ...any) {
 		prompt = ">"
 	}
 	if wl.Ansi {
-		wl.Printf(ansiColor(prompt, "90")+" %s", fmt.Sprintf(format, v...))
+		wl.Printf(ansiColor(prompt, "90")+" "+format, v...)
 	} else {
-		wl.Printf(prompt+" %s", fmt.Sprintf(format, v...))
+		wl.Printf(prompt+" "+format, v...)
 	}
 }
 
@@ -148,15 +144,15 @@ func (tl TestingLogger) Headerf(format string, v ...any) {
 }
 
 func (tl TestingLogger) Commentf(format string, v ...any) {
-	tl.Logf("# %s", fmt.Sprintf(format, v...))
+	tl.Logf("# "+format, v...)
 }
 
 func (tl TestingLogger) Errorf(format string, v ...any) {
-	tl.Logf("🚨 Error: %s", fmt.Sprintf(format, v...))
+	tl.Logf("🚨 Error: "+format, v...)
 }
 
 func (tl TestingLogger) Warningf(format string, v ...any) {
-	tl.Logf("⚠️ Warning: %s", fmt.Sprintf(format, v...))
+	tl.Logf("⚠️ Warning: "+format, v...)
 }
 
 func (tl TestingLogger) OptionalWarningf(_id, format string, v ...any) {
@@ -169,7 +165,7 @@ func (tl TestingLogger) Promptf(format string, v ...any) {
 	if runtime.GOOS == "windows" {
 		prompt = ">"
 	}
-	tl.Logf(prompt+" %s", fmt.Sprintf(format, v...))
+	tl.Logf(prompt+" "+format, v...)
 }
 
 type LoggerStreamer struct {
@@ -185,7 +181,7 @@ var lineRegexp = regexp.MustCompile(`(?m:^(.*)\r?\n)`)
 func NewLoggerStreamer(logger Logger) *LoggerStreamer {
 	return &LoggerStreamer{
 		Logger: logger,
-		buf:    bytes.NewBuffer([]byte("")),
+		buf:    bytes.NewBuffer(nil),
 	}
 }
 
@@ -206,7 +202,7 @@ func (l *LoggerStreamer) Close() error {
 	if remaining := l.buf.String()[l.offset:]; len(remaining) > 0 {
 		l.Logger.Printf("%s%s", l.Prefix, remaining)
 	}
-	l.buf = bytes.NewBuffer([]byte(""))
+	l.buf = bytes.NewBuffer(nil)
 	return nil
 }
 

--- a/internal/job/shell/logger_test.go
+++ b/internal/job/shell/logger_test.go
@@ -3,6 +3,7 @@ package shell_test
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"runtime"
 	"testing"
 
@@ -67,5 +68,24 @@ func TestLoggerStreamer(t *testing.T) {
 
 	if diff := cmp.Diff(got.String(), want.String()); diff != "" {
 		t.Fatalf("shell.WriterLogger output buffer diff (-got +want):\n%s", diff)
+	}
+}
+
+func BenchmarkDoubleFmt(b *testing.B) {
+	logf := func(format string, v ...any) {
+		fmt.Fprintf(io.Discard, "%s", fmt.Sprintf(format, v...))
+		fmt.Fprintln(io.Discard)
+	}
+	for range b.N {
+		logf("asdfghjkl %s %d %t", "hi", 42, true)
+	}
+}
+
+func BenchmarkFmtConcat(b *testing.B) {
+	logf := func(format string, v ...any) {
+		fmt.Fprintf(io.Discard, format+"\n", v...)
+	}
+	for range b.N {
+		logf("asdfghjkl %s %d %t", "hi", 42, true)
 	}
 }


### PR DESCRIPTION
### Description

`fmt.Fprintf(w, "%s", fmt.Sprintf(format, v...))` seems silly - and following it with `fmt.Fprintln(w)` also seems silly.

`fmt.Fprintf(w, format+"\n", v...)` is faster and does less allocations:

```plain
goos: darwin
goarch: arm64
pkg: github.com/buildkite/agent/v3/internal/job/shell
          │ doublefmt.txt │            fmtconcat.txt            │
          │    sec/op     │   sec/op     vs base                │
Printf-10    140.80n ± 0%   87.05n ± 0%  -38.17% (p=0.000 n=30)

          │ doublefmt.txt │           fmtconcat.txt            │
          │     B/op      │   B/op     vs base                 │
Printf-10      40.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=30)

          │ doublefmt.txt │            fmtconcat.txt            │
          │   allocs/op   │ allocs/op   vs base                 │
Printf-10      2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=30)
```

### Context

I was wondering why two error messages (from different goroutines) collided this way in a job log:

<img width="846" alt="Screenshot 2024-05-28 at 5 09 09 PM" src="https://github.com/buildkite/agent/assets/2398124/24d969c5-4bf1-40e1-8e77-0a1ede2aa555">

and tracked it to the separate `fmt.Fprintln` call.

### Changes

- Change how format strings are handled in the shell loggers
- Add benchmarks

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
