### PR TITLE
PTY rows/cols increased

### DIFF
--- a/process/pty.go
+++ b/process/pty.go
@@ -11,5 +11,10 @@ import (
 )
 
 func StartPTY(c *exec.Cmd) (*os.File, error) {
-	return pty.Start(c)
+	return pty.StartWithSize(c, &pty.Winsize{
+		Rows: 100,
+		Cols: 160,
+		X:    0, // unused
+		Y:    0, // unused
+	})
 }


### PR DESCRIPTION
The size of the fake PTY allocated to build jobs was previously unspecified, which generally led to a default of 80x24. That meant programs which checked the size of the terminal would assume it was very small, and that programs which default to using a pager (e.g. less/more) for long output, lines would be truncated at 80 characters, and showing more than ~24 lines of text would often result in a blocking prompt to show more.

Increasing the cols by 2x and rows/lines by ~4x seems reasonable, it comes _closer_ to matching actual modern terminal window sizes, shows longer lines, and is less likely to trigger a blocking pager. Perhaps larger values would be good, especially for Rows. Maybe there's no harm and some upside to e.g. 1,000 rows?

This doesn't fundamentally solve the issue, but perhaps reduces the likelihood and impact of pager interference.

Before & after:

<img width="953" alt="image" src="https://github.com/buildkite/agent/assets/15759/7cfcdc94-c02b-4249-a76f-15971cafac3f">
