### PR TITLE
Dont sign initial steps with interpolations

### DIFF
--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -75,7 +75,28 @@ UI so that the agents running these steps can verify the signatures.
 
 If a token is provided using the ′graphql-token′ flag, the tool will attempt to retrieve the
 pipeline definition and repo using the Buildkite GraphQL API. If ′update′ is also set, it will
-update the pipeline definition with the signed version using the GraphQL API too.`,
+update the pipeline definition with the signed version using the GraphQL API too.
+
+Examples:
+
+Retrieving the pipeline from the GraphQL API and signing it:
+
+    $ buildkite-agent tool sign \
+        --graphql-token <graphql token> \
+        --organization-slug <your org slug> \
+        --pipeline-slug <slug of the pipeline whose steps you want to sign \
+        --jwks-file /path/to/private/key.json \
+        --update
+
+Signing a pipeline from a file:
+
+    $ buildkite-agent tool sign pipeline.yml \
+        --jwks-file /path/to/private/key.json \
+        --repo <repo url for your pipeline>
+    # or
+    $ cat pipeline.yml | buildkite-agent tool sign \
+        --jwks-file /path/to/private/key.json \
+        --repo <repo url for your pipeline>`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "graphql-token",

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 	github.com/buildkite/bintest/v3 v3.2.0
 	github.com/buildkite/go-pipeline v0.9.0
+	github.com/buildkite/interpolate v0.1.1
 	github.com/buildkite/roko v1.2.0
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/creack/pty v1.1.19
@@ -74,7 +75,6 @@ require (
 	github.com/alexflint/go-arg v1.4.2 // indirect
 	github.com/alexflint/go-scalar v1.0.0 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
-	github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/buildkite/bintest/v3 v3.2.0 h1:1GqUILGGni5UViGPH/PbSq0MxB9gzY3J/P7vNV
 github.com/buildkite/bintest/v3 v3.2.0/go.mod h1:+AdQZcVlzCiW2UyZWeG63xeH5z011XUBW6kWcRdaMtU=
 github.com/buildkite/go-pipeline v0.9.0 h1:2a2bibJ9dCCyyNReH73jkQVUYyUnhYAxISyf3+mrQNs=
 github.com/buildkite/go-pipeline v0.9.0/go.mod h1:4aqMzJ3iagc0wcI5h8NQpON9xfyq27QGDi4xfnKiCUs=
-github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
-github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
+github.com/buildkite/interpolate v0.1.1 h1:KP1WzuHTH0UxFUDS3FO2/DUEdloQ7Ksxw0mDU0oC45U=
+github.com/buildkite/interpolate v0.1.1/go.mod h1:UNVe6A+UfiBNKbhAySrBbZFZFxQ+DXr9nWen6WVt/A8=
 github.com/buildkite/roko v1.2.0 h1:hbNURz//dQqNl6Eo9awjQOVOZwSDJ8VEbBDxSfT9rGQ=
 github.com/buildkite/roko v1.2.0/go.mod h1:23R9e6nHxgedznkwwfmqZ6+0VJZJZ2Sg/uVcp2cP46I=
 github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000 h1:hiVSLk7s3yFKFOHF/huoShLqrj13RMguWX2yzfvy7es=


### PR DESCRIPTION
### Description

There are two types of signed pipelines supported by the agent:
- "Dynamic" signing of pipelines uploaded by the agent
- "Static" signing of initial steps of a project, stored in buildkite. This signing is done by either the `buildkite-agent tool sign` tool, or by the [terraform provider](https://registry.terraform.io/providers/buildkite/buildkite/latest/docs/data-sources/signed_pipeline_steps)

Due to limitations in the Buildkite backend, the second type of signed pipelines cannot contain variable interpolations - the backend attempts to perform these interpolations, and in so doing, changes the content of the steps, causing any signature verifications to fail.

This PR updates the `buildkite-agent tool sign` command to reject signing any pipelines that have variable interpolations in them - these pipelines will always fail verification, even if we didn't refuse to sign them.

This PR includes [recent changes](https://github.com/buildkite/interpolate/pull/10) to the [`interpolate`](https://github.com/buildkite/interpolate/) library - previously, it wouldn't report escaped interpolations (which we also don't support for static signing), but now it does!

### Context

[interpolate #10](https://github.com/buildkite/interpolate/pull/10)
[Customer escalation](https://coda.io/d/Escalations-Feedback_dHnUHNps1YO/Pipelines-Escalations_su7FT#Pipelines-Escalations-Board_tu__K/r436&view=modal)


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
