### PR TITLE
Add logs to allowed-[repositories|plugins]

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1032,6 +1032,7 @@ var AgentStartCommand = cli.Command{
 		}
 
 		if len(cfg.AllowedRepositories) > 0 {
+			l.Info("Evaluating allowed repositories has been enabled")
 			agentConf.AllowedRepositories = make([]*regexp.Regexp, 0, len(cfg.AllowedRepositories))
 			for _, v := range cfg.AllowedRepositories {
 				r, err := regexp.Compile(v)
@@ -1043,6 +1044,7 @@ var AgentStartCommand = cli.Command{
 		}
 
 		if len(cfg.AllowedPlugins) > 0 {
+			l.Info("Evaluating allowed plugins has been enabled")
 			agentConf.AllowedPlugins = make([]*regexp.Regexp, 0, len(cfg.AllowedPlugins))
 			for _, v := range cfg.AllowedPlugins {
 				r, err := regexp.Compile(v)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1032,7 +1032,6 @@ var AgentStartCommand = cli.Command{
 		}
 
 		if len(cfg.AllowedRepositories) > 0 {
-			l.Info("Evaluating allowed repositories has been enabled")
 			agentConf.AllowedRepositories = make([]*regexp.Regexp, 0, len(cfg.AllowedRepositories))
 			for _, v := range cfg.AllowedRepositories {
 				r, err := regexp.Compile(v)
@@ -1041,10 +1040,10 @@ var AgentStartCommand = cli.Command{
 				}
 				agentConf.AllowedRepositories = append(agentConf.AllowedRepositories, r)
 			}
+			l.Info("Allowed repositories patterns: %q", agentConf.AllowedRepositories)
 		}
 
 		if len(cfg.AllowedPlugins) > 0 {
-			l.Info("Evaluating allowed plugins has been enabled")
 			agentConf.AllowedPlugins = make([]*regexp.Regexp, 0, len(cfg.AllowedPlugins))
 			for _, v := range cfg.AllowedPlugins {
 				r, err := regexp.Compile(v)
@@ -1053,6 +1052,7 @@ var AgentStartCommand = cli.Command{
 				}
 				agentConf.AllowedPlugins = append(agentConf.AllowedPlugins, r)
 			}
+			l.Info("Allowed plugins patterns: %q", agentConf.AllowedPlugins)
 		}
 
 		cancelSig, err := process.ParseSignal(cfg.CancelSignal)


### PR DESCRIPTION
### Description

A handy log line, which supports a process of enabling allowed repo and plugins on buildkite-agent.

### Context

My first attempt of enabling buildkite allowed-repo and allowed-plugins failed. I'm not entirely sure if I'm propagating the variables correctly, so this log line would be pretty useful in debugging.

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [X] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [X] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
