### PR TITLE
Revert "Dont sign initial steps with interpolations"

### DIFF
--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -1,7 +1,6 @@
 package clicommand
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -16,7 +15,6 @@ import (
 	"github.com/buildkite/go-pipeline/jwkutil"
 	"github.com/buildkite/go-pipeline/signature"
 	"github.com/buildkite/go-pipeline/warning"
-	"github.com/buildkite/interpolate"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/urfave/cli"
 	"gopkg.in/yaml.v3"
@@ -75,28 +73,7 @@ UI so that the agents running these steps can verify the signatures.
 
 If a token is provided using the ′graphql-token′ flag, the tool will attempt to retrieve the
 pipeline definition and repo using the Buildkite GraphQL API. If ′update′ is also set, it will
-update the pipeline definition with the signed version using the GraphQL API too.
-
-Examples:
-
-Retrieving the pipeline from the GraphQL API and signing it:
-
-    $ buildkite-agent tool sign \
-        --graphql-token <graphql token> \
-        --organization-slug <your org slug> \
-        --pipeline-slug <slug of the pipeline whose steps you want to sign \
-        --jwks-file /path/to/private/key.json \
-        --update
-
-Signing a pipeline from a file:
-
-    $ buildkite-agent tool sign pipeline.yml \
-        --jwks-file /path/to/private/key.json \
-        --repo <repo url for your pipeline>
-    # or
-    $ cat pipeline.yml | buildkite-agent tool sign \
-        --jwks-file /path/to/private/key.json \
-        --repo <repo url for your pipeline>`,
+update the pipeline definition with the signed version using the GraphQL API too.`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "graphql-token",
@@ -162,41 +139,20 @@ Signing a pipeline from a file:
 			return fmt.Errorf("couldn't read the signing key file: %w", err)
 		}
 
-		sign := signWithGraphQL
 		if cfg.GraphQLToken == "" {
-			sign = signOffline
+			return signOffline(c, l, key, &cfg)
 		}
 
-		err = sign(ctx, c, l, key, &cfg)
-		if err != nil {
-			return fmt.Errorf("Error signing pipeline: %w", err)
-		}
-
-		return nil
+		return signWithGraphQL(ctx, c, l, key, &cfg)
 	},
 }
 
-func validateNoInterpolations(pipelineString string) error {
-	expansions, err := interpolate.Identifiers(pipelineString)
-	if err != nil {
-		return fmt.Errorf("discovering interpolation expansions: %w", err)
-	}
-
-	if len(expansions) > 0 {
-		for i, e := range expansions {
-			// in interpolate, the identifiers of expansions don't have the $ prefix, and escaped expansions only have one
-			expansions[i] = "$" + e
-		}
-
-		return fmt.Errorf("pipeline contains environment interpolations, which are only supported when dynamically "+
-			"uploading a pipeline, and not when statically signing pipelines using this tool. "+
-			"Please remove the following interpolation directives: %s", strings.Join(expansions, ", "))
-	}
-
-	return nil
-}
-
-func signOffline(_ context.Context, c *cli.Context, l logger.Logger, key jwk.Key, cfg *ToolSignConfig) error {
+func signOffline(
+	c *cli.Context,
+	l logger.Logger,
+	key jwk.Key,
+	cfg *ToolSignConfig,
+) error {
 	if cfg.Repository == "" {
 		return ErrUseGraphQL
 	}
@@ -230,17 +186,7 @@ func signOffline(_ context.Context, c *cli.Context, l logger.Logger, key jwk.Key
 		return ErrNoPipeline
 	}
 
-	pipelineBytes, err := io.ReadAll(input)
-	if err != nil {
-		return fmt.Errorf("couldn't read pipeline: %w", err)
-	}
-
-	err = validateNoInterpolations(string(pipelineBytes))
-	if err != nil {
-		return err
-	}
-
-	parsedPipeline, err := pipeline.Parse(bytes.NewReader(pipelineBytes))
+	parsedPipeline, err := pipeline.Parse(input)
 	if w := warning.As(err); w != nil {
 		l.Warn("There were some issues with the pipeline input - signing will be attempted but might not succeed:\n%v", w)
 	} else if err != nil {
@@ -265,7 +211,13 @@ func signOffline(_ context.Context, c *cli.Context, l logger.Logger, key jwk.Key
 	return enc.Encode(parsedPipeline)
 }
 
-func signWithGraphQL(ctx context.Context, c *cli.Context, l logger.Logger, key jwk.Key, cfg *ToolSignConfig) error {
+func signWithGraphQL(
+	ctx context.Context,
+	c *cli.Context,
+	l logger.Logger,
+	key jwk.Key,
+	cfg *ToolSignConfig,
+) error {
 	orgPipelineSlug := fmt.Sprintf("%s/%s", cfg.OrganizationSlug, cfg.PipelineSlug)
 	debugL := l.WithFields(logger.StringField("orgPipelineSlug", orgPipelineSlug))
 
@@ -288,14 +240,9 @@ func signWithGraphQL(ctx context.Context, c *cli.Context, l logger.Logger, key j
 	}
 
 	debugL.Debug("Pipeline retrieved successfully: %#v", resp)
+	l.Info("Signing pipeline with the repository URL:\n%s", resp.Pipeline.Repository.Url)
 
-	pipelineString := resp.Pipeline.Steps.Yaml
-	err = validateNoInterpolations(pipelineString)
-	if err != nil {
-		return err
-	}
-
-	parsedPipeline, err := pipeline.Parse(strings.NewReader(pipelineString))
+	parsedPipeline, err := pipeline.Parse(strings.NewReader(resp.Pipeline.Steps.Yaml))
 	if w := warning.As(err); w != nil {
 		l.Warn("There were some issues with the pipeline input - signing will be attempted but might not succeed:\n%v", w)
 	} else if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 	github.com/buildkite/bintest/v3 v3.2.0
 	github.com/buildkite/go-pipeline v0.9.0
-	github.com/buildkite/interpolate v0.1.1
 	github.com/buildkite/roko v1.2.0
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/creack/pty v1.1.19
@@ -75,6 +74,7 @@ require (
 	github.com/alexflint/go-arg v1.4.2 // indirect
 	github.com/alexflint/go-scalar v1.0.0 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
+	github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/buildkite/bintest/v3 v3.2.0 h1:1GqUILGGni5UViGPH/PbSq0MxB9gzY3J/P7vNV
 github.com/buildkite/bintest/v3 v3.2.0/go.mod h1:+AdQZcVlzCiW2UyZWeG63xeH5z011XUBW6kWcRdaMtU=
 github.com/buildkite/go-pipeline v0.9.0 h1:2a2bibJ9dCCyyNReH73jkQVUYyUnhYAxISyf3+mrQNs=
 github.com/buildkite/go-pipeline v0.9.0/go.mod h1:4aqMzJ3iagc0wcI5h8NQpON9xfyq27QGDi4xfnKiCUs=
-github.com/buildkite/interpolate v0.1.1 h1:KP1WzuHTH0UxFUDS3FO2/DUEdloQ7Ksxw0mDU0oC45U=
-github.com/buildkite/interpolate v0.1.1/go.mod h1:UNVe6A+UfiBNKbhAySrBbZFZFxQ+DXr9nWen6WVt/A8=
+github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
+github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/buildkite/roko v1.2.0 h1:hbNURz//dQqNl6Eo9awjQOVOZwSDJ8VEbBDxSfT9rGQ=
 github.com/buildkite/roko v1.2.0/go.mod h1:23R9e6nHxgedznkwwfmqZ6+0VJZJZ2Sg/uVcp2cP46I=
 github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000 h1:hiVSLk7s3yFKFOHF/huoShLqrj13RMguWX2yzfvy7es=


### PR DESCRIPTION
Reverts buildkite/agent#2807

This PR had an issue where escaped dollar signs that aren't interpolations (now i know that those exist! 🫠) would fail to parse as pipeline uploads, as interpolate would try to parse them as an expansion, which they were not.

we were alerted to this by the agent pipeline, which contains as its final line:
```
if: build.env("DRY_RUN") == "true" || build.branch =~ /^(main|.*-.*-stable)$$/
```

there's a double-dollar there being used as an escaped literal dollar sign for the end of a regex, but the change to the interpolate library was attempting to parse it as an expansion `$$/`, but `/` is not a valid identifier, so the interpolate library was getting confused. the initial error message can be found [here](https://buildkite.com/buildkite/agent/builds/8536#018fe212-fba5-4c36-8c62-f551438be49a):
```
$ buildkite-agent pipeline upload
2024-06-04 07:07:29 INFO   Searching for pipeline config...
2024-06-04 07:07:29 INFO   Found config file ".buildkite/pipeline.yml"
2024-06-04 07:07:29 INFO   Updating BUILDKITE_COMMIT to "d36f21b28f507cb9e36c6fdb25ed449b0343867f"
fatal: pipeline interpolation of "pipeline.yml" failed: interpolating remaining fields: Expected identifier to start with a letter, got /
```