### PR TITLE
Revive "Dont sign initial steps with interpolations"

### DIFF
--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -1,6 +1,7 @@
 package clicommand
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"github.com/buildkite/go-pipeline/jwkutil"
 	"github.com/buildkite/go-pipeline/signature"
 	"github.com/buildkite/go-pipeline/warning"
+	"github.com/buildkite/interpolate"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/urfave/cli"
 	"gopkg.in/yaml.v3"
@@ -73,7 +75,28 @@ UI so that the agents running these steps can verify the signatures.
 
 If a token is provided using the ′graphql-token′ flag, the tool will attempt to retrieve the
 pipeline definition and repo using the Buildkite GraphQL API. If ′update′ is also set, it will
-update the pipeline definition with the signed version using the GraphQL API too.`,
+update the pipeline definition with the signed version using the GraphQL API too.
+
+Examples:
+
+Retrieving the pipeline from the GraphQL API and signing it:
+
+    $ buildkite-agent tool sign \
+        --graphql-token <graphql token> \
+        --organization-slug <your org slug> \
+        --pipeline-slug <slug of the pipeline whose steps you want to sign \
+        --jwks-file /path/to/private/key.json \
+        --update
+
+Signing a pipeline from a file:
+
+    $ buildkite-agent tool sign pipeline.yml \
+        --jwks-file /path/to/private/key.json \
+        --repo <repo url for your pipeline>
+    # or
+    $ cat pipeline.yml | buildkite-agent tool sign \
+        --jwks-file /path/to/private/key.json \
+        --repo <repo url for your pipeline>`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "graphql-token",
@@ -139,20 +162,41 @@ update the pipeline definition with the signed version using the GraphQL API too
 			return fmt.Errorf("couldn't read the signing key file: %w", err)
 		}
 
+		sign := signWithGraphQL
 		if cfg.GraphQLToken == "" {
-			return signOffline(c, l, key, &cfg)
+			sign = signOffline
 		}
 
-		return signWithGraphQL(ctx, c, l, key, &cfg)
+		err = sign(ctx, c, l, key, &cfg)
+		if err != nil {
+			return fmt.Errorf("Error signing pipeline: %w", err)
+		}
+
+		return nil
 	},
 }
 
-func signOffline(
-	c *cli.Context,
-	l logger.Logger,
-	key jwk.Key,
-	cfg *ToolSignConfig,
-) error {
+func validateNoInterpolations(pipelineString string) error {
+	expansions, err := interpolate.Identifiers(pipelineString)
+	if err != nil {
+		return fmt.Errorf("discovering interpolation expansions: %w", err)
+	}
+
+	if len(expansions) > 0 {
+		for i, e := range expansions {
+			// in interpolate, the identifiers of expansions don't have the $ prefix, and escaped expansions only have one
+			expansions[i] = "$" + e
+		}
+
+		return fmt.Errorf("pipeline contains environment interpolations, which are only supported when dynamically "+
+			"uploading a pipeline, and not when statically signing pipelines using this tool. "+
+			"Please remove the following interpolation directives: %s", strings.Join(expansions, ", "))
+	}
+
+	return nil
+}
+
+func signOffline(_ context.Context, c *cli.Context, l logger.Logger, key jwk.Key, cfg *ToolSignConfig) error {
 	if cfg.Repository == "" {
 		return ErrUseGraphQL
 	}
@@ -186,7 +230,17 @@ func signOffline(
 		return ErrNoPipeline
 	}
 
-	parsedPipeline, err := pipeline.Parse(input)
+	pipelineBytes, err := io.ReadAll(input)
+	if err != nil {
+		return fmt.Errorf("couldn't read pipeline: %w", err)
+	}
+
+	err = validateNoInterpolations(string(pipelineBytes))
+	if err != nil {
+		return err
+	}
+
+	parsedPipeline, err := pipeline.Parse(bytes.NewReader(pipelineBytes))
 	if w := warning.As(err); w != nil {
 		l.Warn("There were some issues with the pipeline input - signing will be attempted but might not succeed:\n%v", w)
 	} else if err != nil {
@@ -211,13 +265,7 @@ func signOffline(
 	return enc.Encode(parsedPipeline)
 }
 
-func signWithGraphQL(
-	ctx context.Context,
-	c *cli.Context,
-	l logger.Logger,
-	key jwk.Key,
-	cfg *ToolSignConfig,
-) error {
+func signWithGraphQL(ctx context.Context, c *cli.Context, l logger.Logger, key jwk.Key, cfg *ToolSignConfig) error {
 	orgPipelineSlug := fmt.Sprintf("%s/%s", cfg.OrganizationSlug, cfg.PipelineSlug)
 	debugL := l.WithFields(logger.StringField("orgPipelineSlug", orgPipelineSlug))
 
@@ -240,9 +288,14 @@ func signWithGraphQL(
 	}
 
 	debugL.Debug("Pipeline retrieved successfully: %#v", resp)
-	l.Info("Signing pipeline with the repository URL:\n%s", resp.Pipeline.Repository.Url)
 
-	parsedPipeline, err := pipeline.Parse(strings.NewReader(resp.Pipeline.Steps.Yaml))
+	pipelineString := resp.Pipeline.Steps.Yaml
+	err = validateNoInterpolations(pipelineString)
+	if err != nil {
+		return err
+	}
+
+	parsedPipeline, err := pipeline.Parse(strings.NewReader(pipelineString))
 	if w := warning.As(err); w != nil {
 		l.Warn("There were some issues with the pipeline input - signing will be attempted but might not succeed:\n%v", w)
 	} else if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 	github.com/buildkite/bintest/v3 v3.2.0
 	github.com/buildkite/go-pipeline v0.9.0
-	github.com/buildkite/interpolate v0.1.1
+	github.com/buildkite/interpolate v0.1.2
 	github.com/buildkite/roko v1.2.0
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/creack/pty v1.1.19

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 	github.com/buildkite/bintest/v3 v3.2.0
 	github.com/buildkite/go-pipeline v0.9.0
+	github.com/buildkite/interpolate v0.1.1
 	github.com/buildkite/roko v1.2.0
 	github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000
 	github.com/creack/pty v1.1.19
@@ -74,7 +75,6 @@ require (
 	github.com/alexflint/go-arg v1.4.2 // indirect
 	github.com/alexflint/go-scalar v1.0.0 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
-	github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/buildkite/bintest/v3 v3.2.0 h1:1GqUILGGni5UViGPH/PbSq0MxB9gzY3J/P7vNV
 github.com/buildkite/bintest/v3 v3.2.0/go.mod h1:+AdQZcVlzCiW2UyZWeG63xeH5z011XUBW6kWcRdaMtU=
 github.com/buildkite/go-pipeline v0.9.0 h1:2a2bibJ9dCCyyNReH73jkQVUYyUnhYAxISyf3+mrQNs=
 github.com/buildkite/go-pipeline v0.9.0/go.mod h1:4aqMzJ3iagc0wcI5h8NQpON9xfyq27QGDi4xfnKiCUs=
-github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
-github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
+github.com/buildkite/interpolate v0.1.1 h1:KP1WzuHTH0UxFUDS3FO2/DUEdloQ7Ksxw0mDU0oC45U=
+github.com/buildkite/interpolate v0.1.1/go.mod h1:UNVe6A+UfiBNKbhAySrBbZFZFxQ+DXr9nWen6WVt/A8=
 github.com/buildkite/roko v1.2.0 h1:hbNURz//dQqNl6Eo9awjQOVOZwSDJ8VEbBDxSfT9rGQ=
 github.com/buildkite/roko v1.2.0/go.mod h1:23R9e6nHxgedznkwwfmqZ6+0VJZJZ2Sg/uVcp2cP46I=
 github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000 h1:hiVSLk7s3yFKFOHF/huoShLqrj13RMguWX2yzfvy7es=

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/buildkite/go-pipeline v0.9.0 h1:2a2bibJ9dCCyyNReH73jkQVUYyUnhYAxISyf3
 github.com/buildkite/go-pipeline v0.9.0/go.mod h1:4aqMzJ3iagc0wcI5h8NQpON9xfyq27QGDi4xfnKiCUs=
 github.com/buildkite/interpolate v0.1.1 h1:KP1WzuHTH0UxFUDS3FO2/DUEdloQ7Ksxw0mDU0oC45U=
 github.com/buildkite/interpolate v0.1.1/go.mod h1:UNVe6A+UfiBNKbhAySrBbZFZFxQ+DXr9nWen6WVt/A8=
+github.com/buildkite/interpolate v0.1.2 h1:mVbMCphpu2MHUr1qLdjq9xc3NjNWYg/w/CbrGS5ckzg=
+github.com/buildkite/interpolate v0.1.2/go.mod h1:UNVe6A+UfiBNKbhAySrBbZFZFxQ+DXr9nWen6WVt/A8=
 github.com/buildkite/roko v1.2.0 h1:hbNURz//dQqNl6Eo9awjQOVOZwSDJ8VEbBDxSfT9rGQ=
 github.com/buildkite/roko v1.2.0/go.mod h1:23R9e6nHxgedznkwwfmqZ6+0VJZJZ2Sg/uVcp2cP46I=
 github.com/buildkite/shellwords v0.0.0-20180315084142-c3f497d1e000 h1:hiVSLk7s3yFKFOHF/huoShLqrj13RMguWX2yzfvy7es=

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,6 @@ github.com/buildkite/bintest/v3 v3.2.0 h1:1GqUILGGni5UViGPH/PbSq0MxB9gzY3J/P7vNV
 github.com/buildkite/bintest/v3 v3.2.0/go.mod h1:+AdQZcVlzCiW2UyZWeG63xeH5z011XUBW6kWcRdaMtU=
 github.com/buildkite/go-pipeline v0.9.0 h1:2a2bibJ9dCCyyNReH73jkQVUYyUnhYAxISyf3+mrQNs=
 github.com/buildkite/go-pipeline v0.9.0/go.mod h1:4aqMzJ3iagc0wcI5h8NQpON9xfyq27QGDi4xfnKiCUs=
-github.com/buildkite/interpolate v0.1.1 h1:KP1WzuHTH0UxFUDS3FO2/DUEdloQ7Ksxw0mDU0oC45U=
-github.com/buildkite/interpolate v0.1.1/go.mod h1:UNVe6A+UfiBNKbhAySrBbZFZFxQ+DXr9nWen6WVt/A8=
 github.com/buildkite/interpolate v0.1.2 h1:mVbMCphpu2MHUr1qLdjq9xc3NjNWYg/w/CbrGS5ckzg=
 github.com/buildkite/interpolate v0.1.2/go.mod h1:UNVe6A+UfiBNKbhAySrBbZFZFxQ+DXr9nWen6WVt/A8=
 github.com/buildkite/roko v1.2.0 h1:hbNURz//dQqNl6Eo9awjQOVOZwSDJ8VEbBDxSfT9rGQ=


### PR DESCRIPTION
Reverts buildkite/agent#2812

This is reviving a reverted PR #2807.

In addition to the original change, this PR upgrades the version of `buildkite/interpolate` to avoid the bug mentioned in the revert PR #2812.