### PR TITLE
kubernetes-exec is now a flag

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -37,16 +37,6 @@ After repository checkout, resolve `BUILDKITE_COMMIT` to a commit hash. This mak
 
 **Status**: broadly useful, we'd like this to be the standard behaviour in 4.0. 👍👍
 
-### `kubernetes-exec`
-
-Modifies `start` and `bootstrap` in such a way that they can run in separate Kubernetes containers in the same pod.
-
-Currently, this experiment is being used by [agent-stack-k8s](https://github.com/buildkite/agent-stack-k8s).
-
-This will result in errors unless orchestrated in a similar manner to that project. Please see the [README](https://github.com/buildkite/agent-stack-k8s/blob/main/README.md) of that repository for more details.
-
-**Status**: Being used in a preview release of agent-stack-k8s. As it has little applicability outside of Kubernetes, this will not be the default behaviour.
-
 ### `polyglot-hooks`
 
 Allows the agent to run hooks written in languages other than bash. This enables the agent to run hooks written in any language, as long as the language has a runtime available on the agent. Polyglot hooks can be in interpreted languages, so long as they have a valid shebang, and the interpreter specified in the shebang is installed on the agent.

--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -35,6 +35,7 @@ type AgentConfiguration struct {
 	LocalHooksEnabled           bool
 	StrictSingleHooks           bool
 	RunInPty                    bool
+	KubernetesExec              bool
 
 	SigningJWKSFile  string // Where to find the key to sign pipeline uploads with (passed through to jobs, they might be uploading pipelines)
 	SigningJWKSKeyID string // The key ID to sign pipeline uploads with

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -687,6 +687,7 @@ func (a *AgentWorker) RunJob(ctx context.Context, acceptResponse *api.Job) error
 		JobStatusInterval:  time.Duration(a.agent.JobStatusInterval) * time.Second,
 		AgentConfiguration: a.agentConfiguration,
 		AgentStdout:        a.agentStdout,
+		KubernetesExec:     a.agentConfiguration.KubernetesExec,
 	})
 	if err != nil {
 		return fmt.Errorf("Failed to initialize job: %w", err)

--- a/agent/tags.go
+++ b/agent/tags.go
@@ -18,6 +18,7 @@ import (
 type FetchTagsConfig struct {
 	Tags []string
 
+	TagsFromK8s               bool
 	TagsFromEC2MetaData       bool
 	TagsFromEC2MetaDataPaths  []string
 	TagsFromEC2Tags           bool
@@ -77,7 +78,7 @@ type tagFetcher struct {
 func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsConfig) []string {
 	tags := conf.Tags
 
-	if t.k8s != nil {
+	if conf.TagsFromK8s {
 		k8sTags, err := t.k8s()
 		if err != nil {
 			l.Warn("Could not fetch tags from k8s: %s", err)

--- a/agent/tags.go
+++ b/agent/tags.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/buildkite/agent/v3/internal/experiments"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/roko"
 	"github.com/denisbrodbeck/machineid"
@@ -78,7 +77,7 @@ type tagFetcher struct {
 func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsConfig) []string {
 	tags := conf.Tags
 
-	if experiments.IsEnabled(ctx, experiments.KubernetesExec) {
+	if t.k8s != nil {
 		k8sTags, err := t.k8s()
 		if err != nil {
 			l.Warn("Could not fetch tags from k8s: %s", err)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -165,6 +165,7 @@ type AgentStartConfig struct {
 	Experiments       []string `cli:"experiment" normalize:"list"`
 	Profile           string   `cli:"profile"`
 	StrictSingleHooks bool     `cli:"strict-single-hooks"`
+	KuberentesExec    bool     `cli:"kubernetes-exec"`
 
 	// API config
 	DebugHTTP bool   `cli:"debug-http"`
@@ -680,6 +681,7 @@ var AgentStartCommand = cli.Command{
 		ProfileFlag,
 		RedactedVars,
 		StrictSingleHooksFlag,
+		KubernetesExecFlag,
 
 		// Deprecated flags which will be removed in v4
 		cli.StringSliceFlag{
@@ -955,6 +957,7 @@ var AgentStartCommand = cli.Command{
 			TracingBackend:               cfg.TracingBackend,
 			TracingServiceName:           cfg.TracingServiceName,
 			VerificationFailureBehaviour: cfg.VerificationFailureBehavior,
+			KubernetesExec:               cfg.KuberentesExec,
 
 			SigningJWKSFile:  cfg.SigningJWKSFile,
 			SigningJWKSKeyID: cfg.SigningJWKSKeyID,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1065,6 +1065,7 @@ var AgentStartCommand = cli.Command{
 
 		tags := agent.FetchTags(ctx, l, agent.FetchTagsConfig{
 			Tags:                      cfg.Tags,
+			TagsFromK8s:               cfg.KuberentesExec,
 			TagsFromEC2MetaData:       (cfg.TagsFromEC2MetaData || cfg.TagsFromEC2),
 			TagsFromEC2MetaDataPaths:  cfg.TagsFromEC2MetaDataPaths,
 			TagsFromEC2Tags:           cfg.TagsFromEC2Tags,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -97,6 +97,7 @@ type BootstrapConfig struct {
 	TracingServiceName           string   `cli:"tracing-service-name"`
 	NoJobAPI                     bool     `cli:"no-job-api"`
 	DisableWarningsFor           []string `cli:"disable-warnings-for" normalize:"list"`
+	KubernetesExec               bool     `cli:"kubernetes-exec"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -371,6 +372,7 @@ var BootstrapCommand = cli.Command{
 		ProfileFlag,
 		RedactedVars,
 		StrictSingleHooksFlag,
+		KubernetesExecFlag,
 	},
 	Action: func(c *cli.Context) error {
 		ctx := context.Background()
@@ -452,6 +454,7 @@ var BootstrapCommand = cli.Command{
 			TracingServiceName:           cfg.TracingServiceName,
 			JobAPI:                       !cfg.NoJobAPI,
 			DisabledWarnings:             cfg.DisableWarningsFor,
+			KubernetesExec:               cfg.KubernetesExec,
 		})
 
 		cctx, cancel := context.WithCancel(ctx)

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -21,93 +21,103 @@ const (
 	DefaultEndpoint = "https://agent.buildkite.com/v3"
 )
 
-var AgentAccessTokenFlag = cli.StringFlag{
-	Name:   "agent-access-token",
-	Value:  "",
-	Usage:  "The access token used to identify the agent",
-	EnvVar: "BUILDKITE_AGENT_ACCESS_TOKEN",
-}
+var (
+	AgentAccessTokenFlag = cli.StringFlag{
+		Name:   "agent-access-token",
+		Value:  "",
+		Usage:  "The access token used to identify the agent",
+		EnvVar: "BUILDKITE_AGENT_ACCESS_TOKEN",
+	}
 
-var AgentRegisterTokenFlag = cli.StringFlag{
-	Name:   "token",
-	Value:  "",
-	Usage:  "Your account agent token",
-	EnvVar: "BUILDKITE_AGENT_TOKEN",
-}
+	AgentRegisterTokenFlag = cli.StringFlag{
+		Name:   "token",
+		Value:  "",
+		Usage:  "Your account agent token",
+		EnvVar: "BUILDKITE_AGENT_TOKEN",
+	}
 
-var EndpointFlag = cli.StringFlag{
-	Name:   "endpoint",
-	Value:  DefaultEndpoint,
-	Usage:  "The Agent API endpoint",
-	EnvVar: "BUILDKITE_AGENT_ENDPOINT",
-}
+	EndpointFlag = cli.StringFlag{
+		Name:   "endpoint",
+		Value:  DefaultEndpoint,
+		Usage:  "The Agent API endpoint",
+		EnvVar: "BUILDKITE_AGENT_ENDPOINT",
+	}
 
-var NoHTTP2Flag = cli.BoolFlag{
-	Name:   "no-http2",
-	Usage:  "Disable HTTP2 when communicating with the Agent API.",
-	EnvVar: "BUILDKITE_NO_HTTP2",
-}
+	NoHTTP2Flag = cli.BoolFlag{
+		Name:   "no-http2",
+		Usage:  "Disable HTTP2 when communicating with the Agent API.",
+		EnvVar: "BUILDKITE_NO_HTTP2",
+	}
 
-var DebugFlag = cli.BoolFlag{
-	Name:   "debug",
-	Usage:  "Enable debug mode. Synonym for ′--log-level debug′. Takes precedence over ′--log-level′",
-	EnvVar: "BUILDKITE_AGENT_DEBUG",
-}
+	DebugFlag = cli.BoolFlag{
+		Name:   "debug",
+		Usage:  "Enable debug mode. Synonym for ′--log-level debug′. Takes precedence over ′--log-level′",
+		EnvVar: "BUILDKITE_AGENT_DEBUG",
+	}
 
-var LogLevelFlag = cli.StringFlag{
-	Name:   "log-level",
-	Value:  "notice",
-	Usage:  "Set the log level for the agent, making logging more or less verbose. Defaults to notice. Allowed values are: debug, info, error, warn, fatal",
-	EnvVar: "BUILDKITE_AGENT_LOG_LEVEL",
-}
+	LogLevelFlag = cli.StringFlag{
+		Name:   "log-level",
+		Value:  "notice",
+		Usage:  "Set the log level for the agent, making logging more or less verbose. Defaults to notice. Allowed values are: debug, info, error, warn, fatal",
+		EnvVar: "BUILDKITE_AGENT_LOG_LEVEL",
+	}
 
-var ProfileFlag = cli.StringFlag{
-	Name:   "profile",
-	Usage:  "Enable a profiling mode, either cpu, memory, mutex or block",
-	EnvVar: "BUILDKITE_AGENT_PROFILE",
-}
+	ProfileFlag = cli.StringFlag{
+		Name:   "profile",
+		Usage:  "Enable a profiling mode, either cpu, memory, mutex or block",
+		EnvVar: "BUILDKITE_AGENT_PROFILE",
+	}
 
-var DebugHTTPFlag = cli.BoolFlag{
-	Name:   "debug-http",
-	Usage:  "Enable HTTP debug mode, which dumps all request and response bodies to the log",
-	EnvVar: "BUILDKITE_AGENT_DEBUG_HTTP",
-}
+	DebugHTTPFlag = cli.BoolFlag{
+		Name:   "debug-http",
+		Usage:  "Enable HTTP debug mode, which dumps all request and response bodies to the log",
+		EnvVar: "BUILDKITE_AGENT_DEBUG_HTTP",
+	}
 
-var NoColorFlag = cli.BoolFlag{
-	Name:   "no-color",
-	Usage:  "Don't show colors in logging",
-	EnvVar: "BUILDKITE_AGENT_NO_COLOR",
-}
+	NoColorFlag = cli.BoolFlag{
+		Name:   "no-color",
+		Usage:  "Don't show colors in logging",
+		EnvVar: "BUILDKITE_AGENT_NO_COLOR",
+	}
 
-var StrictSingleHooksFlag = cli.BoolFlag{
-	Name:   "strict-single-hooks",
-	Usage:  "Enforces that only one checkout hook, and only one command hook, can be run",
-	EnvVar: "BUILDKITE_STRICT_SINGLE_HOOKS",
-}
+	StrictSingleHooksFlag = cli.BoolFlag{
+		Name:   "strict-single-hooks",
+		Usage:  "Enforces that only one checkout hook, and only one command hook, can be run",
+		EnvVar: "BUILDKITE_STRICT_SINGLE_HOOKS",
+	}
 
-var ExperimentsFlag = cli.StringSliceFlag{
-	Name:   "experiment",
-	Value:  &cli.StringSlice{},
-	Usage:  "Enable experimental features within the buildkite-agent",
-	EnvVar: "BUILDKITE_AGENT_EXPERIMENT",
-}
+	KubernetesExecFlag = cli.BoolFlag{
+		Name: "kubernetes-exec",
+		Usage: "This is intended to be used only by the Buildkite k8s stack " +
+			"(github.com/buildkite/agent-stack-k8s); it enables a Unix socket for transporting " +
+			"logs and exit statuses between containers in a pod",
+		EnvVar: "BUILDKITE_KUBERNETES_EXEC",
+	}
 
-var RedactedVars = cli.StringSliceFlag{
-	Name:   "redacted-vars",
-	Usage:  "Pattern of environment variable names containing sensitive values",
-	EnvVar: "BUILDKITE_REDACTED_VARS",
-	Value: &cli.StringSlice{
-		"*_PASSWORD",
-		"*_SECRET",
-		"*_TOKEN",
-		"*_PRIVATE_KEY",
-		"*_ACCESS_KEY",
-		"*_SECRET_KEY",
-		// Connection strings frequently contain passwords, e.g.
-		// https://user:pass@host/ or Server=foo;Database=my-db;User Id=user;Password=pass;
-		"*_CONNECTION_STRING",
-	},
-}
+	ExperimentsFlag = cli.StringSliceFlag{
+		Name:   "experiment",
+		Value:  &cli.StringSlice{},
+		Usage:  "Enable experimental features within the buildkite-agent",
+		EnvVar: "BUILDKITE_AGENT_EXPERIMENT",
+	}
+
+	RedactedVars = cli.StringSliceFlag{
+		Name:   "redacted-vars",
+		Usage:  "Pattern of environment variable names containing sensitive values",
+		EnvVar: "BUILDKITE_REDACTED_VARS",
+		Value: &cli.StringSlice{
+			"*_PASSWORD",
+			"*_SECRET",
+			"*_TOKEN",
+			"*_PRIVATE_KEY",
+			"*_ACCESS_KEY",
+			"*_SECRET_KEY",
+			// Connection strings frequently contain passwords, e.g.
+			// https://user:pass@host/ or Server=foo;Database=my-db;User Id=user;Password=pass;
+			"*_CONNECTION_STRING",
+		},
+	}
+)
 
 func globalFlags() []cli.Flag {
 	return []cli.Flag{

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -26,7 +26,6 @@ const (
 	AgentAPI                       = "agent-api"
 	DescendingSpawnPriority        = "descending-spawn-priority"
 	InterpolationPrefersRuntimeEnv = "interpolation-prefers-runtime-env"
-	KubernetesExec                 = "kubernetes-exec"
 	NormalisedUploadPaths          = "normalised-upload-paths"
 	OverrideZeroExitOnCancel       = "override-zero-exit-on-cancel"
 	PTYRaw                         = "pty-raw"
@@ -42,6 +41,7 @@ const (
 	InbuiltStatusPage      = "inbuilt-status-page"
 	IsolatedPluginCheckout = "isolated-plugin-checkout"
 	JobAPI                 = "job-api"
+	KubernetesExec         = "kubernetes-exec"
 )
 
 var (
@@ -49,7 +49,6 @@ var (
 		AgentAPI:                       {},
 		DescendingSpawnPriority:        {},
 		InterpolationPrefersRuntimeEnv: {},
-		KubernetesExec:                 {},
 		NormalisedUploadPaths:          {},
 		OverrideZeroExitOnCancel:       {},
 		PolyglotHooks:                  {},
@@ -65,6 +64,7 @@ var (
 		InbuiltStatusPage:      standardPromotionMsg(InbuiltStatusPage, "v3.48.0"),
 		IsolatedPluginCheckout: standardPromotionMsg(IsolatedPluginCheckout, "v3.67.0"),
 		JobAPI:                 standardPromotionMsg(JobAPI, "v3.64.0"),
+		KubernetesExec:         "The kubernetes-exec experiment has been replaced with the --kubernetes-exec flag as of agent v3.74.0",
 	}
 
 	// Used to track experiments possibly in use.

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -168,6 +168,9 @@ type ExecutorConfig struct {
 	// Whether to start the JobAPI
 	JobAPI bool
 
+	// Whether to connect to the Kubernetes socket
+	KubernetesExec bool
+
 	// The warnings that have been disabled by the user
 	DisabledWarnings []string
 }

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -100,7 +100,7 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 		e.shell.InterruptSignal = e.ExecutorConfig.CancelSignal
 		e.shell.SignalGracePeriod = e.ExecutorConfig.SignalGracePeriod
 	}
-	if experiments.IsEnabled(ctx, experiments.KubernetesExec) {
+	if e.KubernetesExec {
 		kubernetesClient := &kubernetes.Client{}
 		if err := e.startKubernetesClient(ctx, kubernetesClient); err != nil {
 			e.shell.Errorf("Failed to start kubernetes client: %v", err)


### PR DESCRIPTION
### Description

Replaces the `kubernetes-exec` "experiment" with a proper flag, environment variable, etc.

### Context

The `kubernetes-exec` "experiment" was not really an experiment, but rather misused the experiments system as a way to pass a Boolean flag into various parts of the agent without setting up a flag, environment variable, etc.


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

