### PR TITLE
Publish buildkite packages from regular queue

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -45,8 +45,6 @@ steps:
     env:
       REGISTRY: "buildkite/agent-rpm-experimental"
       EXTENSION: rpm
-    agents:
-      queue: "deploy"
     plugins:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
@@ -101,8 +99,6 @@ steps:
     env:
       REGISTRY: "buildkite/agent-deb-experimental"
       EXTENSION: deb
-    agents:
-      queue: "deploy"
     plugins:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -92,8 +92,6 @@ steps:
     env:
       REGISTRY: "buildkite/agent-rpm"
       EXTENSION: rpm
-    agents:
-      queue: "deploy"
     plugins:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
@@ -129,8 +127,6 @@ steps:
     env:
       REGISTRY: "buildkite/agent-deb"
       EXTENSION: deb
-    agents:
-      queue: "deploy"
     plugins:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -73,8 +73,6 @@ steps:
     env:
       REGISTRY: "buildkite/agent-rpm-unstable"
       EXTENSION: rpm
-    agents:
-      queue: "deploy"
     plugins:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
@@ -129,8 +127,6 @@ steps:
     env:
       REGISTRY: "buildkite/agent-deb-unstable"
       EXTENSION: deb
-    agents:
-      queue: "deploy"
     plugins:
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"


### PR DESCRIPTION
The new steps introduced in #2824 are failing because they're running on the deploy queue. Looks like I copy pasta'd the wrong queues across branches. The deploy queue isn't allowed to run jobs from the agent repository. But these jobs should run fine on regular elastic runners.