### PR TITLE
Publish Buildkite Packages without Docker

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -46,6 +46,11 @@ steps:
       REGISTRY: "buildkite/agent-rpm-experimental"
       EXTENSION: rpm
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
+      - ecr#v2.7.0:
+          login: true
+          account-ids: "032379705303"
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           entrypoint: bash
@@ -100,6 +105,11 @@ steps:
       REGISTRY: "buildkite/agent-deb-experimental"
       EXTENSION: deb
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
+      - ecr#v2.7.0:
+          login: true
+          account-ids: "032379705303"
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           entrypoint: bash

--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -45,17 +45,6 @@ steps:
     env:
       REGISTRY: "buildkite/agent-rpm-experimental"
       EXTENSION: rpm
-    plugins:
-      - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
-      - ecr#v2.7.0:
-          login: true
-          account-ids: "032379705303"
-      - docker#v5.8.0:
-          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
-          entrypoint: bash
-          propagate-environment: true
-          mount-buildkite-agent: true
     soft_fail: true
 
   - name: ":redhat: Publish Edge RPM Package to Packagecloud"
@@ -104,17 +93,6 @@ steps:
     env:
       REGISTRY: "buildkite/agent-deb-experimental"
       EXTENSION: deb
-    plugins:
-      - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
-      - ecr#v2.7.0:
-          login: true
-          account-ids: "032379705303"
-      - docker#v5.8.0:
-          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
-          entrypoint: bash
-          propagate-environment: true
-          mount-buildkite-agent: true
     soft_fail: true
 
   - name: ":debian: Publish Edge Debian Package to Packagecloud"

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -93,6 +93,11 @@ steps:
       REGISTRY: "buildkite/agent-rpm"
       EXTENSION: rpm
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
+      - ecr#v2.7.0:
+          login: true
+          account-ids: "032379705303"
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           entrypoint: bash
@@ -128,6 +133,11 @@ steps:
       REGISTRY: "buildkite/agent-deb"
       EXTENSION: deb
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
+      - ecr#v2.7.0:
+          login: true
+          account-ids: "032379705303"
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           entrypoint: bash

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -92,17 +92,6 @@ steps:
     env:
       REGISTRY: "buildkite/agent-rpm"
       EXTENSION: rpm
-    plugins:
-      - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
-      - ecr#v2.7.0:
-          login: true
-          account-ids: "032379705303"
-      - docker#v5.8.0:
-          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
-          entrypoint: bash
-          propagate-environment: true
-          mount-buildkite-agent: true
     soft_fail: true
 
   - name: ":debian: Publish Debian Package"
@@ -132,17 +121,6 @@ steps:
     env:
       REGISTRY: "buildkite/agent-deb"
       EXTENSION: deb
-    plugins:
-      - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
-      - ecr#v2.7.0:
-          login: true
-          account-ids: "032379705303"
-      - docker#v5.8.0:
-          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
-          entrypoint: bash
-          propagate-environment: true
-          mount-buildkite-agent: true
     soft_fail: true
 
   - name: ":debian: Publish Debian Package to Packagecloud"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -73,17 +73,6 @@ steps:
     env:
       REGISTRY: "buildkite/agent-rpm-unstable"
       EXTENSION: rpm
-    plugins:
-      - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
-      - ecr#v2.7.0:
-          login: true
-          account-ids: "032379705303"
-      - docker#v5.8.0:
-          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
-          entrypoint: bash
-          propagate-environment: true
-          mount-buildkite-agent: true
     soft_fail: true
 
   - name: ":redhat: Publish Unstable RPM Package to Packagecloud"
@@ -132,17 +121,6 @@ steps:
     env:
       REGISTRY: "buildkite/agent-deb-unstable"
       EXTENSION: deb
-    plugins:
-      - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
-      - ecr#v2.7.0:
-          login: true
-          account-ids: "032379705303"
-      - docker#v5.8.0:
-          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
-          entrypoint: bash
-          propagate-environment: true
-          mount-buildkite-agent: true
     soft_fail: true
 
   - name: ":debian: Publish Unstable Debian Package to Packagecloud"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -74,6 +74,11 @@ steps:
       REGISTRY: "buildkite/agent-rpm-unstable"
       EXTENSION: rpm
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
+      - ecr#v2.7.0:
+          login: true
+          account-ids: "032379705303"
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           entrypoint: bash
@@ -128,6 +133,11 @@ steps:
       REGISTRY: "buildkite/agent-deb-unstable"
       EXTENSION: deb
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
+      - ecr#v2.7.0:
+          login: true
+          account-ids: "032379705303"
       - docker#v5.8.0:
           image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
           entrypoint: bash


### PR DESCRIPTION
Following on from #2824 and #2824, it looks like the deploytools image is only available when authenticated to ECR:

<img width="1414" alt="image" src="https://github.com/buildkite/agent/assets/14028/56327815-7570-4be5-b8d8-3241ae5578b8">

I started by copy/pasting the auth gear from the other steps which use deploytools .. but then realised all these steps need are bash, buildkite-agent, and curl .. and those are all available on the host. So just remove all the docker plugin stuff and let it run on the host.