### PR TITLE
Publish Buildkite Packages — Fix Typo

### DIFF
--- a/.buildkite/steps/publish-buildkite-packages.sh
+++ b/.buildkite/steps/publish-buildkite-packages.sh
@@ -24,7 +24,7 @@ echo "--- Downloading built packages"
 buildkite-agent artifact download --build "${artifacts_build}" "${EXTENSION}/*.${EXTENSION}" "${EXTENSION}/"
 
 echo "--- Requesting OIDC token"
-TOKEN="$(buildkite-agent oidc request-token --audience "https://packages.buildkite.com/${REGISITRY}" --lifetime 300)"
+TOKEN="$(buildkite-agent oidc request-token --audience "https://packages.buildkite.com/${REGISTRY}" --lifetime 300)"
 
 echo "--- Pushing to Packagecloud"
 ORGANIZATION_SLUG="${REGISTRY%*/}"


### PR DESCRIPTION
Gotta love the push merge deploy cycle. This time [failed](https://buildkite.com/buildkite/agent-release-edge/builds/1278#01900b53-ec4a-4f7e-9a61-915e102aa4a4/194-195) because I have fat fingers.

<img width="1413" alt="image" src="https://github.com/buildkite/agent/assets/14028/e4f857b4-fe49-43c3-86a2-e572e3c4026b">

(Follow up to #2824.)