### PR TITLE
Publish Buildkite Packages — Fix Urls

### DIFF
--- a/.buildkite/steps/publish-buildkite-packages.sh
+++ b/.buildkite/steps/publish-buildkite-packages.sh
@@ -30,7 +30,7 @@ echo "--- Pushing to Buildkite Packages"
 ORGANIZATION_SLUG="${REGISTRY%/*}"
 REGISTRY_SLUG="${REGISTRY#*/}"
 for FILE in "${EXTENSION}"/*."${EXTENSION}"; do
-  dry_run curl -X POST "https://api.buildkite.com/v2/packages/organizations/${ORGANIZATION_SLUG}/registries/${REGISTRY_SLUG}/packages" \
+  dry_run curl --fail -X POST "https://api.buildkite.com/v2/packages/organizations/${ORGANIZATION_SLUG}/registries/${REGISTRY_SLUG}/packages" \
     -H "Authorization: Bearer $TOKEN" \
     -F "file=@$FILE"
 done

--- a/.buildkite/steps/publish-buildkite-packages.sh
+++ b/.buildkite/steps/publish-buildkite-packages.sh
@@ -27,8 +27,8 @@ echo "--- Requesting OIDC token"
 TOKEN="$(buildkite-agent oidc request-token --audience "https://packages.buildkite.com/${REGISTRY}" --lifetime 300)"
 
 echo "--- Pushing to Buildkite Packages"
-ORGANIZATION_SLUG="${REGISTRY%*/}"
-REGISTRY_SLUG="${REGISTRY#/*}"
+ORGANIZATION_SLUG="${REGISTRY%/*}"
+REGISTRY_SLUG="${REGISTRY#*/}"
 for FILE in "${EXTENSION}"/*."${EXTENSION}"; do
   dry_run curl -X POST "https://api.buildkite.com/v2/packages/organizations/${ORGANIZATION_SLUG}/registries/${REGISTRY_SLUG}/packages" \
     -H "Authorization: Bearer $TOKEN" \

--- a/.buildkite/steps/publish-buildkite-packages.sh
+++ b/.buildkite/steps/publish-buildkite-packages.sh
@@ -26,7 +26,7 @@ buildkite-agent artifact download --build "${artifacts_build}" "${EXTENSION}/*.$
 echo "--- Requesting OIDC token"
 TOKEN="$(buildkite-agent oidc request-token --audience "https://packages.buildkite.com/${REGISTRY}" --lifetime 300)"
 
-echo "--- Pushing to Packagecloud"
+echo "--- Pushing to Buildkite Packages"
 ORGANIZATION_SLUG="${REGISTRY%*/}"
 REGISTRY_SLUG="${REGISTRY#/*}"
 for FILE in "${EXTENSION}"/*."${EXTENSION}"; do


### PR DESCRIPTION
Continuing from #2824, it's now failing with a "not found":

<img width="1474" alt="image" src="https://github.com/buildkite/agent/assets/14028/04194f87-96c6-49dc-a1c7-fcf5f6c66ff8">

I found the matching trace in Datadog APM:

https://app.datadoghq.com/apm/trace/1355574743850893837

which revealed the request path was:

    /v2/packages/organizations/buildkite/agent-rpm-experimental/registries/buildkite/agent-rpm-experimental/packages

The problem is the organization and registry slug weren't being split up quite right. The glob was the wrong way around 🤦

Given:

    REGISTRY="acme-inc/widgets"

Before:

    ORGANIZATION_SLUG="${REGISTRY%*/}"
    # => ORGANIZATION_SLUG=acme-inc/widgets
    
    REGISTRY_SLUG="${REGISTRY#/*}"
    # => REGISTRY_SLUG=acme-inc/widgets

After:

    ORGANIZATION_SLUG="${REGISTRY%/*}"
    # => ORGANIZATION_SLUG=acme-inc
    
    REGISTRY_SLUG="${REGISTRY#*/}"
    # => REGISTRY_SLUG=widgets

(I swear I tested these to check they were the right way around, but clearly have done something silly along the way.)

I've also adjusted the curl command to exit non-zero on HTTP error codes, so the step wouldn't have been green in this case or for any future errors.