### PR TITLE
Redact Job API token like other env vars

### DIFF
--- a/internal/job/api.go
+++ b/internal/job/api.go
@@ -3,6 +3,7 @@ package job
 import (
 	"fmt"
 
+	"github.com/buildkite/agent/v3/internal/redact"
 	"github.com/buildkite/agent/v3/internal/socket"
 	"github.com/buildkite/agent/v3/jobapi"
 )
@@ -36,6 +37,21 @@ We'll continue to run your job, but you won't be able to use the Job API`)
 
 	e.shell.Env.Set("BUILDKITE_AGENT_JOB_API_SOCKET", socketPath)
 	e.shell.Env.Set("BUILDKITE_AGENT_JOB_API_TOKEN", token)
+
+	if redact.Match(e.shell.Logger, e.RedactedVars, "BUILDKITE_AGENT_JOB_API_TOKEN") {
+		// The Job API token lets the job talk to this executor. When the job ends,
+		// the socket should be closed and the token becomes meaningless. Also, the
+		// socket should only be accessible to the user running the agent on the
+		// local host.
+		// So it shouldn't matter if the token is leaked in the logs - in order
+		// to make any use of it, someone would have to be on the same host as the
+		// same local user at the same time the job is running.
+		// However, it looks confusing when an environment variable that looks like
+		// an access token with a name ending in _TOKEN is *not* redacted.
+		// Conclusion: if the name matches, redact the Job API token.
+		// This depends on startJobAPI being called after setupRedactors.
+		e.redactors.Add(token)
+	}
 
 	if err := srv.Start(); err != nil {
 		return cleanup, fmt.Errorf("starting Job API server: %w", err)

--- a/internal/job/executor_test.go
+++ b/internal/job/executor_test.go
@@ -5,9 +5,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/agent/v3/internal/job/shell"
-	"github.com/buildkite/agent/v3/internal/redact"
 	"github.com/buildkite/agent/v3/tracetools"
-	"github.com/google/go-cmp/cmp"
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"
@@ -43,43 +41,6 @@ func TestDirForRepository(t *testing.T) {
 
 	for _, test := range repositoryNameTests {
 		assert.Equal(t, test.expected, dirForRepository(test.repositoryName))
-	}
-}
-
-func TestValuesToRedact(t *testing.T) {
-	t.Parallel()
-
-	redactConfig := []string{
-		"*_PASSWORD",
-		"*_TOKEN",
-	}
-	environment := map[string]string{
-		"BUILDKITE_PIPELINE": "unit-test",
-		// These are example values, and are not leaked credentials
-		"DATABASE_USERNAME": "AzureDiamond",
-		"DATABASE_PASSWORD": "hunter2",
-	}
-
-	got := redact.Values(shell.DiscardLogger, redactConfig, environment)
-	want := []string{"hunter2"}
-
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("redact.Values(%q, %q) diff (-got +want)\n%s", redactConfig, environment, diff)
-	}
-}
-
-func TestValuesToRedactEmpty(t *testing.T) {
-	t.Parallel()
-
-	redactConfig := []string{}
-	environment := map[string]string{
-		"FOO":                "BAR",
-		"BUILDKITE_PIPELINE": "unit-test",
-	}
-
-	got := redact.Values(shell.DiscardLogger, redactConfig, environment)
-	if len(got) != 0 {
-		t.Errorf("redact.Values(%q, %q) = %q, want empty slice", redactConfig, environment, got)
 	}
 }
 

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,45 @@
+package redact
+
+import (
+	"testing"
+
+	"github.com/buildkite/agent/v3/internal/job/shell"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestValuesToRedact(t *testing.T) {
+	t.Parallel()
+
+	redactConfig := []string{
+		"*_PASSWORD",
+		"*_TOKEN",
+	}
+	environment := map[string]string{
+		"BUILDKITE_PIPELINE": "unit-test",
+		// These are example values, and are not leaked credentials
+		"DATABASE_USERNAME": "AzureDiamond",
+		"DATABASE_PASSWORD": "hunter2",
+	}
+
+	got := Values(shell.DiscardLogger, redactConfig, environment)
+	want := []string{"hunter2"}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Values(%q, %q) diff (-got +want)\n%s", redactConfig, environment, diff)
+	}
+}
+
+func TestValuesToRedactEmpty(t *testing.T) {
+	t.Parallel()
+
+	redactConfig := []string{}
+	environment := map[string]string{
+		"FOO":                "BAR",
+		"BUILDKITE_PIPELINE": "unit-test",
+	}
+
+	got := Values(shell.DiscardLogger, redactConfig, environment)
+	if len(got) != 0 {
+		t.Errorf("Values(%q, %q) = %q, want empty slice", redactConfig, environment, got)
+	}
+}


### PR DESCRIPTION
### Description

Reduce confusion around having a `_TOKEN` env var around that should be redacted as configured, even though the risks associated with it leaking should be minimal.

### Context

https://linear.app/buildkite/issue/PS-71/job-api-token-not-redacted-is-confusing-customers

### Changes

* Add the Job API token to the redactors if the name would have matched the configured redacted vars patterns
* Move tests

### Testing
- [X] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [X] Code is formatted (with `go fmt ./...`)

