### PR TITLE
Release Docker images on Buildkite Packages

### DIFF
--- a/.buildkite/steps/publish-docker-image.sh
+++ b/.buildkite/steps/publish-docker-image.sh
@@ -41,8 +41,7 @@ release_image() {
   echo "--- :github: Copying ${target_image}:${tag} to GHCR"
   dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://ghcr.io/${target_image}:${tag}"
   echo "--- :buildkite: Copying ${target_image}:${tag} to Buildkite Packages"
-  dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://packages.buildkite.com/buildkite/agent-docker/agent/${target_image}:${tag}" \
-    || true # Soft fail if we can't upload to Packages
+  dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://packages.buildkite.com/buildkite/agent-docker/agent/${target_image}:${tag}"
 }
 
 variant="${1:-}"

--- a/.buildkite/steps/publish-docker-image.sh
+++ b/.buildkite/steps/publish-docker-image.sh
@@ -40,6 +40,9 @@ release_image() {
   dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://docker.io/${target_image}:${tag}"
   echo "--- :github: Copying ${target_image}:${tag} to GHCR"
   dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://ghcr.io/${target_image}:${tag}"
+  echo "--- :buildkite: Copying ${target_image}:${tag} to Buildkite Packages"
+  dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://packages.buildkite.com/buildkite/agent-docker/agent/${target_image}:${tag}" \
+    || true # Soft fail if we can't upload to Packages
 }
 
 variant="${1:-}"

--- a/.buildkite/steps/publish-docker-images.sh
+++ b/.buildkite/steps/publish-docker-images.sh
@@ -44,6 +44,13 @@ aws ssm get-parameter \
   --region us-east-1 \
   | docker login ghcr.io --username="${ghcr_user}" --password-stdin
 
+echo "--- docker login to Buildkite Packages"
+
+buildkite-agent oidc request-token \
+  --audience "https://packages.buildkite.com/buildkite/agent-docker" \
+  --lifetime 300 \
+  | docker login packages.buildkite.com/buildkite/agent-docker --username=buildkite --password-stdin
+
 version=$(buildkite-agent meta-data get "agent-version")
 build=$(buildkite-agent meta-data get "agent-version-build")
 


### PR DESCRIPTION
### Description

Pushing our images to Buildkite Packages to a great example of dogfooding out own product. However, while we're building confidence that everything works correctly we don't want the entire build to fail if there is an issue with Buildkite Packages so I've set it to soft fail.

### Context

[PKG-7137](https://github.com/buildkite/agent/pull/2837)

### Testing

I ran `checkshell` locally. The only error was unrelated to these changes.