### PR TITLE
Make the graphql endpoint for `buildkite-agent tool sign` configurable

### DIFF
--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -37,6 +37,7 @@ type ToolSignConfig struct {
 	// Needed for to use GraphQL API
 	OrganizationSlug string `cli:"organization-slug"`
 	PipelineSlug     string `cli:"pipeline-slug"`
+	GraphQLEndpoint  string `cli:"graphql-endpoint"`
 
 	// Added to signature
 	Repository string `cli:"repo"`
@@ -136,6 +137,12 @@ Signing a pipeline from a file:
 			Name:   "pipeline-slug",
 			Usage:  "The pipeline slug. Required to connect to the GraphQL API.",
 			EnvVar: "BUILDKITE_PIPELINE_SLUG",
+		},
+		cli.StringFlag{
+			Name:   "graphql-endpoint",
+			Usage:  "The endpoint for the Buildkite GraphQL API. This is only needed if you are using the the graphql-token flag, and is mostly useful for development purposes",
+			Value:  bkgql.DefaultEndpoint,
+			EnvVar: "BUILDKITE_GRAPHQL_ENDPOINT",
 		},
 
 		// Added to signature
@@ -271,7 +278,7 @@ func signWithGraphQL(ctx context.Context, c *cli.Context, l logger.Logger, key j
 
 	l.Info("Retrieving pipeline from the GraphQL API")
 
-	client := bkgql.NewClient(cfg.GraphQLToken)
+	client := bkgql.NewClient(cfg.GraphQLEndpoint, cfg.GraphQLToken)
 
 	resp, err := bkgql.GetPipeline(ctx, client, orgPipelineSlug)
 	if err != nil {

--- a/internal/bkgql/client.go
+++ b/internal/bkgql/client.go
@@ -12,12 +12,12 @@ import (
 )
 
 const (
-	graphQLEndpoint = "https://graphql.buildkite.com/v1"
+	DefaultEndpoint = "https://graphql.buildkite.com/v1"
 	graphQLTimeout  = 60 * time.Second
 )
 
-func NewClient(token string) graphql.Client {
-	return graphql.NewClient("https://graphql.buildkite.com/v1", &http.Client{
+func NewClient(endpoint, token string) graphql.Client {
+	return graphql.NewClient(endpoint, &http.Client{
 		Timeout:   graphQLTimeout,
 		Transport: &authedTransport{token: token, wrapped: http.DefaultTransport},
 	})


### PR DESCRIPTION
### Description

Currently, the `tool sign` command, when being used with graphQL, can't be used against a local development setup.

This PR adds a flag `--graphql-endpoint` to that command, allowing the graphql endpoint that it uses to get and update pipeline definitions to be user-defined

### Context

https://buildkite-corp.slack.com/archives/C061U5PG9K5/p1718679622959369

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
