### PR TITLE
 Convey env vars between k8s containers

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -347,10 +347,10 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient APIClient, con
 			return nil, fmt.Errorf("failed to parse BUILDKITE_CONTAINER_COUNT: %w", err)
 		}
 		r.process = kubernetes.New(r.agentLogger, kubernetes.Config{
-			AccessToken: r.apiClient.Config().Token,
 			Stdout:      r.jobLogs,
 			Stderr:      r.jobLogs,
 			ClientCount: containerCount,
+			Env:         processEnv,
 		})
 	} else { // not Kubernetes
 		// The bootstrap-script gets parsed based on the operating system

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -394,16 +394,16 @@ var BootstrapCommand = cli.Command{
 		// directly, but because in k8s land we use containers to separate the
 		// agent and its executors, such vars won't be available unless we do
 		// this.
-		var k8sClient *kubernetes.Client
+		var k8sAgentSocket *kubernetes.Client
 		if c.Bool(KubernetesExecFlag.Name) {
-			k8sClient = &kubernetes.Client{ID: c.Int("kubernetes-container-id")}
+			k8sAgentSocket = &kubernetes.Client{ID: c.Int("kubernetes-container-id")}
 
 			rtr := roko.NewRetrier(
 				roko.WithMaxAttempts(7),
 				roko.WithStrategy(roko.Exponential(2*time.Second, 0)),
 			)
 			regResp, err := roko.DoFunc(ctx, rtr, func(rtr *roko.Retrier) (*kubernetes.RegisterResponse, error) {
-				return k8sClient.Connect(ctx)
+				return k8sAgentSocket.Connect(ctx)
 			})
 			if err != nil {
 				return fmt.Errorf("error connecting to kubernetes runner: %w", err)
@@ -493,7 +493,7 @@ var BootstrapCommand = cli.Command{
 			TracingServiceName:           cfg.TracingServiceName,
 			JobAPI:                       !cfg.NoJobAPI,
 			DisabledWarnings:             cfg.DisableWarningsFor,
-			KubernetesClient:             k8sClient,
+			K8sAgentSocket:               k8sAgentSocket,
 		})
 
 		cctx, cancel := context.WithCancel(ctx)

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/v3/env"
+	"github.com/buildkite/agent/v3/kubernetes"
 	"github.com/buildkite/agent/v3/process"
 )
 
@@ -168,8 +169,8 @@ type ExecutorConfig struct {
 	// Whether to start the JobAPI
 	JobAPI bool
 
-	// Whether to connect to the Kubernetes socket
-	KubernetesExec bool
+	// The connected Kubernetes socket, if needed
+	KubernetesClient *kubernetes.Client
 
 	// The warnings that have been disabled by the user
 	DisabledWarnings []string

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -170,7 +170,7 @@ type ExecutorConfig struct {
 	JobAPI bool
 
 	// The connected Kubernetes socket, if needed
-	KubernetesClient *kubernetes.Client
+	K8sAgentSocket *kubernetes.Client
 
 	// The warnings that have been disabled by the user
 	DisabledWarnings []string

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -101,14 +101,13 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 		e.shell.SignalGracePeriod = e.ExecutorConfig.SignalGracePeriod
 	}
 
-	if e.KubernetesExec {
-		kubernetesClient := &kubernetes.Client{}
-		if err := e.startKubernetesClient(ctx, kubernetesClient); err != nil {
+	if e.KubernetesClient != nil {
+		if err := e.kubernetesSetup(ctx, e.KubernetesClient); err != nil {
 			e.shell.Errorf("Failed to start kubernetes client: %v", err)
 			return 1
 		}
 		defer func() {
-			_ = kubernetesClient.Exit(exitCode)
+			_ = e.KubernetesClient.Exit(exitCode)
 		}()
 	}
 
@@ -1183,55 +1182,15 @@ func (e *Executor) setupRedactors() {
 	e.redactors.Add(valuesToRedact...)
 }
 
-func (e *Executor) startKubernetesClient(ctx context.Context, kubernetesClient *kubernetes.Client) error {
+func (e *Executor) kubernetesSetup(ctx context.Context, kubernetesClient *kubernetes.Client) error {
 	e.shell.Commentf("Using Kubernetes support")
 
-	id, err := strconv.Atoi(os.Getenv("BUILDKITE_CONTAINER_ID"))
-	if err != nil {
-		return fmt.Errorf("failed to parse BUILDKITE_CONTAINER_ID %q", os.Getenv("BUILDKITE_CONTAINER_ID"))
-	}
-	kubernetesClient.ID = id
-
-	rtr := roko.NewRetrier(
-		roko.WithMaxAttempts(7),
-		roko.WithStrategy(roko.Exponential(2*time.Second, 0)),
-	)
-	regResp, err := roko.DoFunc(ctx, rtr, func(rtr *roko.Retrier) (*kubernetes.RegisterResponse, error) {
-		return kubernetesClient.Connect(ctx)
-	})
-
-	if err != nil {
-		return fmt.Errorf("error connecting to kubernetes runner: %w", err)
-	}
-
-	// Merge the "server" container's process env into the shell env, and into
-	// our env too. This is the env that JobRunner would normally set when
-	// forking the executor, and includes BUILDKITE_AGENT_ACCESS_TOKEN,
-	// BUILDKITE_AGENT_ID, etc.
-	serverEnv := env.FromSlice(regResp.Env)
-	e.shell.Env.Merge(serverEnv)
-	for n, v := range serverEnv.Dump() {
-		if err := os.Setenv(n, v); err != nil {
-			return err
-		}
-	}
-
-	// TODO / food for thought:
-	// Maybe we should try to obtain the env from the "server" before
-	// setupLoggerAndConfig is called, since it sets subcommand config from
-	// env vars.
-	// This would more accurately emulate what happens in the non-k8s case
-	// (JobRunner passes processEnv when fork/exec-ing the executor directly,
-	// which configures the executor) and would make any env vars obtained from
-	// k8s socket that normally configure the executor (but currently don't,
-	// because they aren't available before setupLoggerAndConfig is called) be
-	// consistent with how it actually ends up configured (because they would
-	// configure them).
-
+	// Attach the log stream to the k8s client
 	writer := io.MultiWriter(os.Stdout, kubernetesClient)
 	e.shell.Writer = writer
 	e.shell.Logger = shell.NewWriterLogger(writer, true, e.DisabledWarnings)
 
+	// Proceed when ready
 	if err := kubernetesClient.Await(ctx, kubernetes.RunStateStart); err != nil {
 		return fmt.Errorf("error waiting for client to become ready: %w", err)
 	}


### PR DESCRIPTION
### Description

Pass environment vars through the k8s socket

### Context

https://linear.app/buildkite/issue/PS-72/make-buildkite-agent-id-available-within-k8s-stack-containers

### Changes

* In kubernetes/kubernetes.go: Replace `AccessToken string` with `Env []string`
* In agent/job_runner.go: Provide `processEnv` to the Kubernetes socket server
* In clicommand/bootstrap.go: Connect the socket as the very first thing it does, to get env vars in time for configuring the executor
* Some cleanup

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
