### PR TITLE
Don't try to early-set env vars

### DIFF
--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/v3/env"
-	"github.com/buildkite/agent/v3/kubernetes"
 	"github.com/buildkite/agent/v3/process"
 )
 
@@ -169,8 +168,9 @@ type ExecutorConfig struct {
 	// Whether to start the JobAPI
 	JobAPI bool
 
-	// The connected Kubernetes socket, if needed
-	K8sAgentSocket *kubernetes.Client
+	// Whether to enable Kubernetes support, and which container we're running in
+	KubernetesExec        bool
+	KubernetesContainerID int
 
 	// The warnings that have been disabled by the user
 	DisabledWarnings []string


### PR DESCRIPTION
### Description

After some testing, I discovered that the env vars can't be set early enough to affect the bootstrap config, so this moves back to doing most of the socket setup in executor.go

### Changes

* Undo most of 36940e5

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

