### PR TITLE
Fix image name when pushing to Buildkite packages

### DIFF
--- a/.buildkite/steps/publish-docker-image.sh
+++ b/.buildkite/steps/publish-docker-image.sh
@@ -41,7 +41,7 @@ release_image() {
   echo "--- :github: Copying ${target_image}:${tag} to GHCR"
   dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://ghcr.io/${target_image}:${tag}"
   echo "--- :buildkite: Copying ${target_image}:${tag} to Buildkite Packages"
-  dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://packages.buildkite.com/buildkite/agent-docker/agent/${target_image}:${tag}"
+  dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://packages.buildkite.com/${target_image}:${tag}"
 }
 
 variant="${1:-}"

--- a/.buildkite/steps/publish-docker-images.sh
+++ b/.buildkite/steps/publish-docker-images.sh
@@ -47,9 +47,9 @@ aws ssm get-parameter \
 echo "--- docker login to Buildkite Packages"
 
 buildkite-agent oidc request-token \
-  --audience "https://packages.buildkite.com/buildkite/agent-docker" \
+  --audience "https://packages.buildkite.com/buildkite/agent" \
   --lifetime 300 \
-  | docker login packages.buildkite.com/buildkite/agent-docker --username=buildkite --password-stdin
+  | docker login packages.buildkite.com/buildkite/agent --username=buildkite --password-stdin
 
 version=$(buildkite-agent meta-data get "agent-version")
 build=$(buildkite-agent meta-data get "agent-version-build")


### PR DESCRIPTION
The target repo but be named "buildkite/agent" as this is used for all images.

I've renamed the repo to match.

PKG-7137