### PR TITLE
Include repo name in Packages image path

### DIFF
--- a/.buildkite/steps/publish-docker-image.sh
+++ b/.buildkite/steps/publish-docker-image.sh
@@ -37,11 +37,11 @@ parse_version() {
 release_image() {
   local tag="$1"
   echo "--- :docker: Copying ${target_image}:${tag} to Docker Hub"
-  dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://docker.io/${target_image}:${tag}"
+  dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://docker.io/buildkite/${target_image}:${tag}"
   echo "--- :github: Copying ${target_image}:${tag} to GHCR"
-  dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://ghcr.io/${target_image}:${tag}"
+  dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://ghcr.io/buildkite/${target_image}:${tag}"
   echo "--- :buildkite: Copying ${target_image}:${tag} to Buildkite Packages"
-  dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://packages.buildkite.com/${target_image}:${tag}"
+  dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://packages.buildkite.com/buildkite/agent-docker/${target_image}:${tag}"
 }
 
 variant="${1:-}"
@@ -50,7 +50,7 @@ codename="${3:-}"
 version="${4:-}"
 build="${5:-dev}"
 
-target_image="buildkite/agent"
+target_image="agent"
 variant_suffix=""
 
 if [[ "$variant" != "alpine" ]] ; then


### PR DESCRIPTION
### Description

Hopefully this will fix the deploys 🤞🏻

Fixes an issue from 0f9efccda and b8fd08133.

Dockerhub and Github use a container path of:

> registry/image

However, in Packages we use:

> org/registry/image

This PR fixes the path to support this.

### Context

PKG-7137

### Testing

Passes `shellcheck`.