### PR TITLE
Fix the Packages registry name

### DIFF
--- a/.buildkite/steps/publish-docker-images.sh
+++ b/.buildkite/steps/publish-docker-images.sh
@@ -49,7 +49,7 @@ echo "--- docker login to Buildkite Packages"
 buildkite-agent oidc request-token \
   --audience "https://packages.buildkite.com/buildkite/agent" \
   --lifetime 300 \
-  | docker login packages.buildkite.com/buildkite/agent --username=buildkite --password-stdin
+  | docker login packages.buildkite.com/buildkite/agent-docker --username=buildkite --password-stdin
 
 version=$(buildkite-agent meta-data get "agent-version")
 build=$(buildkite-agent meta-data get "agent-version-build")


### PR DESCRIPTION
In 48df9f77659545a8a77307393daa92404c9656f1 I renamed the registry from "agent" to "agent-docker" but forgot to update the login command.