### PR TITLE
Introduce `riscv64` architecture

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -128,6 +128,7 @@ steps:
           - with: { os: linux, arch: ppc64le }
           - with: { os: linux, arch: mips64le }
           - with: { os: linux, arch: s390x }
+          - with: { os: linux, arch: riscv64 }
 
           - with: { os: netbsd, arch: amd64 }
 

--- a/.buildkite/steps/build-debian-packages.sh
+++ b/.buildkite/steps/build-debian-packages.sh
@@ -24,7 +24,7 @@ rm -rf deb
 
 # Build the packages into deb/
 PLATFORM="linux"
-for ARCH in "amd64" "386" "arm" "armhf" "arm64" "ppc64" "ppc64le"; do
+for ARCH in "amd64" "386" "arm" "armhf" "arm64" "ppc64" "ppc64le" "riscv64"; do
   echo "--- Building debian package ${PLATFORM}/${ARCH}"
 
   BINARY="pkg/buildkite-agent-${PLATFORM}-${ARCH}"

--- a/.buildkite/steps/build-rpm-packages.sh
+++ b/.buildkite/steps/build-rpm-packages.sh
@@ -24,7 +24,7 @@ rm -rf rpm
 
 # Build the packages into rpm/
 PLATFORM="linux"
-for ARCH in "amd64" "386" "arm64" "ppc64" "ppc64le"; do
+for ARCH in "amd64" "386" "arm64" "ppc64" "ppc64le" "riscv64"; do
   echo "--- Building rpm package ${PLATFORM}/${ARCH}"
 
   BINARY="pkg/buildkite-agent-${PLATFORM}-${ARCH}"

--- a/install.sh
+++ b/install.sh
@@ -65,6 +65,7 @@ else
     *aarch64*) ARCH="arm64"   ;;
     *mips64*) ARCH="mips64le" ;;
     *s390x*)   ARCH="s390x"   ;;
+    *riscv64*) ARCH="riscv64" ;;
     *)
       ARCH="386"
       echo -e "\n\033[36mWe don't recognise the $MACHINE architecture; falling back to $ARCH\033[0m"

--- a/scripts/build-debian-package.sh
+++ b/scripts/build-debian-package.sh
@@ -36,6 +36,8 @@ elif [ "$BUILD_ARCH" == "ppc64" ]; then
   ARCH="ppc64"
 elif [ "$BUILD_ARCH" == "ppc64le" ]; then
   ARCH="ppc64el"
+elif [ "$BUILD_ARCH" == "riscv64" ]; then
+  ARCH="riscv64"
 else
   echo "Unknown architecture: $BUILD_ARCH"
   exit 1

--- a/scripts/build-rpm-package.sh
+++ b/scripts/build-rpm-package.sh
@@ -32,6 +32,8 @@ elif [ "$BUILD_ARCH" == "ppc64" ]; then
   ARCH="ppc64"
 elif [ "$BUILD_ARCH" == "ppc64le" ]; then
   ARCH="ppc64le"
+elif [ "$BUILD_ARCH" == "riscv64" ]; then
+  ARCH="riscv64"
 else
   echo "Unknown architecture: $BUILD_ARCH"
   exit 1


### PR DESCRIPTION
Add `riscv64` DEB and RPM packaging logic.

Relate to: #2876 