### PR TITLE
Fix some common artifact download bugs

### DIFF
--- a/agent/download.go
+++ b/agent/download.go
@@ -189,18 +189,18 @@ func (d Download) try(ctx context.Context) error {
 		return fmt.Errorf("closing temp file (%T: %w)", err, err)
 	}
 
-	// Rename the temp file to its intended name within the same directory.
-	// On Unix-like platforms this is generally an "atomic replace".
-	// Caveats: https://pkg.go.dev/os#Rename
-	if err := os.Rename(temp.Name(), targetPath); err != nil {
-		return fmt.Errorf("renaming temp file to target (%T: %w)", err, err)
-	}
-
 	gotSHA256 := hex.EncodeToString(hash.Sum(nil))
 
 	// If the downloader was configured with a checksum to check, check it
 	if d.conf.WantSHA256 != "" && gotSHA256 != d.conf.WantSHA256 {
 		return fmt.Errorf("checksum of downloaded content %s != uploaded checksum %s", gotSHA256, d.conf.WantSHA256)
+	}
+
+	// Rename the temp file to its intended name within the same directory.
+	// On Unix-like platforms this is generally an "atomic replace".
+	// Caveats: https://pkg.go.dev/os#Rename
+	if err := os.Rename(temp.Name(), targetPath); err != nil {
+		return fmt.Errorf("renaming temp file to target (%T: %w)", err, err)
 	}
 
 	d.logger.Info("Successfully downloaded %q %s with SHA256 %s", d.conf.Path, humanize.IBytes(uint64(bytes)), gotSHA256)


### PR DESCRIPTION
### Description

While investigating the artifact download process a bit more, I discovered some fairly low-hanging fruit in the existing downloader.

### Context

Fixes #2774 by making one or another artifact the "winner", and printing a SHA256 sum of the content that it downloaded.

https://coda.io/d/_dHnUHNps1YO#View-3-of-Escalations-Table_tu3KF/r437&view=modal

### Changes

- Write to a temp file and move it to the destination name when ready
- Check the error return from Close
- Print a SHA256 sum of the content
- Add ability to verify SHA256 checksum (not yet used)
- Make error strings more Gothic

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
