### PR TITLE
SUP-2343: remove "retry" example from "buildkite-agent step get" as not valid

### DIFF
--- a/clicommand/step_get.go
+++ b/clicommand/step_get.go
@@ -27,7 +27,6 @@ Example:
 
     $ buildkite-agent step get "label" --step "key"
     $ buildkite-agent step get --format json
-    $ buildkite-agent step get "retry" --format json
     $ buildkite-agent step get "state" --step "my-other-step"`
 
 type StepGetConfig struct {


### PR DESCRIPTION
### Description

The "retry" attribute is not a valid for using with `buildkite-agent step get` command.

### Context

Updating the docs on the `buildkite-agent step` commands to provide a list of valid attributes - see https://github.com/buildkite/docs/pull/2872 - and ran the following, so see that "retry" is not a valid attribute for a Step:

```bash
$ buildkite-agent step get --format json
{
  "label": "label",
  "type": "command",
  "if": null,
  "state": "running",
  "key": "key",
  "outcome": null,
  "notify": [

  ],
  "command": "buildkite-agent step get --format json",
  "parallelism": null,
  "env": null,
  "timeout": 1,
  "concurrency_limit": null,
  "concurrency_key": null,
  "agents": null,
  "depends_on": [

  ]
}
```

and when running the following Pipeline:

```yaml
steps:
  - label: "label"
    key: "key"
    command: buildkite-agent step get "retry" --format json
    retry: 
      automatic:
        signal_reason: "*"
        limit: 2
```

results in the following:

```bash
$ buildkite-agent step get "retry" --format json
2024-07-08 11:03:57 WARN   POST https://agent.buildkite.com/v3/steps/{STEP ID}/export: 400 Bad Request: `retry` is currently not supported. Please contact help@buildkite.com if you'd like it added! (Attempt 1/10 Retrying in 5s)
fatal: failed to get step: POST https://agent.buildkite.com/v3/steps/{STEP ID}/export: 400 Bad Request: `retry` is currently not supported. Please contact help@buildkite.com if you'd like it added!
🚨 Error: The command exited with status 1
```

### Changes

Output changes
```bash
$ buildkite-agent step get --help                         
Usage:

    buildkite-agent step get <attribute> [options...]

Description:

Retrieve the value of an attribute in a step. If no attribute is passed, the
entire step will be returned.

In the event a complex object is returned (an object or an array),
you'll need to supply the --format option to tell the agent how it should
output the data (currently only JSON is supported).

Example:

    $ buildkite-agent step get "label" --step "key"
    $ buildkite-agent step get --format json
    $ buildkite-agent step get "state" --step "my-other-step"

Options:
...
```

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)


<!--
Note: if the tests fail to run locally, please let us know!
-->
