### PR TITLE
Reject more secrets

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/buildkite/go-pipeline/signature"
 	"github.com/buildkite/go-pipeline/warning"
 	"github.com/urfave/cli"
+	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 )
 
@@ -270,7 +272,7 @@ var PipelineUploadCommand = cli.Command{
 		if len(cfg.RedactedVars) > 0 {
 			// Secret detection uses the original environment, since
 			// Interpolate merges the pipeline's env block into `environ`.
-			searchForSecrets(l, &cfg, environ.Dump(), result, src)
+			searchForSecrets(l, &cfg, environ, result, src)
 		}
 
 		if cfg.JWKSFile != "" {
@@ -366,40 +368,87 @@ func resolveCommit(l logger.Logger, environ *env.Environment) {
 	environ.Set("BUILDKITE_COMMIT", trimmedCmdOut)
 }
 
+// allEnvVars recursively iterates env vars from any object that contains them:
+// the pipeline itself, or command steps (which may be nested inside group
+// steps).
+func allEnvVars(o any, f func(p env.Pair)) {
+	switch x := o.(type) {
+	case *pipeline.Pipeline:
+		// First iterate through all pipeline env vars.
+		x.Env.Range(func(k, v string) error {
+			f(env.Pair{Name: k, Value: v})
+			return nil
+		})
+		// Recurse through each step.
+		for _, s := range x.Steps {
+			allEnvVars(s, f)
+		}
+
+	case *pipeline.CommandStep:
+		// Iterate through the step env vars.
+		for n, v := range x.Env {
+			f(env.Pair{Name: n, Value: v})
+		}
+
+	case *pipeline.GroupStep:
+		// Recurse through each step.
+		for _, s := range x.Steps {
+			allEnvVars(s, f)
+		}
+	}
+}
+
 func searchForSecrets(
 	l logger.Logger,
 	cfg *PipelineUploadConfig,
-	environ map[string]string,
-	result *pipeline.Pipeline,
+	environ *env.Environment,
+	pp *pipeline.Pipeline,
 	src string,
 ) error {
-	// Get vars to redact, as both a map and a slice.
-	vars := redact.Vars(shell.StderrLogger, cfg.RedactedVars, environ)
+	// In other parts of the agent, only the process environment is considered
+	// as potentially containing secrets (to redact from logs).
+	// The process environment here can definitely contain secrets, but the
+	// pipeline being uploaded can also contain secret-shaped environment
+	// variables in the env maps strewn throughout the pipeline (pipeline env
+	// and step env).
+	// Just because it's a variable written in the pipeline YAML, doesn't mean
+	// it's not a secret that needs rejecting from the upload!
+	// Therefore, gather all environment variables from the pipeline.
+	allVars := environ.DumpPairs()
+	allEnvVars(pp, func(pair env.Pair) {
+		allVars = append(allVars, pair)
+	})
+
+	// Filter down to vars to redact, and a slice with just their values.
+	vars := redact.Vars(shell.StderrLogger, cfg.RedactedVars, allVars)
 	needles := make([]string, 0, len(vars))
-	for _, needle := range vars {
-		needles = append(needles, needle)
+	for _, pair := range vars {
+		needles = append(needles, pair.Value)
 	}
 
 	// Use a streaming replacer as a string searcher.
-	secretsFound := make([]string, 0, len(needles))
+	secretsFound := make(map[string]struct{})
 	searcher := replacer.New(io.Discard, needles, func(found []byte) []byte {
 		// It matched some of the needles, but which ones?
 		// (This information could be plumbed through the replacer, if
 		// we wanted to make it even more complicated.)
-		for needleKey, needle := range vars {
-			if strings.Contains(string(found), needle) {
-				secretsFound = append(secretsFound, needleKey)
+		for _, pair := range vars {
+			if strings.Contains(string(found), pair.Value) {
+				secretsFound[pair.Name] = struct{}{}
 			}
 		}
 		return nil
 	})
 
 	// Encode the pipeline as JSON into the searcher.
-	if err := json.NewEncoder(searcher).Encode(result); err != nil {
+	if err := json.NewEncoder(searcher).Encode(pp); err != nil {
 		return fmt.Errorf("couldn’t scan the %q pipeline for redacted variables. This parsed pipeline could not be serialized, ensure the pipeline YAML is valid, or ignore interpolated secrets for this upload by passing --redacted-vars=''. (%w)", src, err)
 	}
 
 	if len(secretsFound) > 0 {
+		secretsFound := maps.Keys(secretsFound)
+		slices.Sort(secretsFound)
+
 		if cfg.RejectSecrets {
 			return fmt.Errorf("pipeline %q contains values interpolated from the following secret environment variables: %v, and cannot be uploaded to Buildkite", src, secretsFound)
 		}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -270,10 +270,12 @@ var PipelineUploadCommand = cli.Command{
 		}
 
 		result, err := cfg.parseAndInterpolate(ctx, src, input, environ)
-		if w := warning.As(err); w != nil {
+		if err != nil {
+			w := warning.As(err)
+			if w == nil {
+				return err
+			}
 			l.Warn("There were some issues with the pipeline input - pipeline upload will proceed, but might not succeed:\n%v", w)
-		} else if err != nil {
-			return err
 		}
 
 		if len(cfg.RedactedVars) > 0 {

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -101,6 +101,35 @@ func TestSearchForSecrets(t *testing.T) {
 			},
 			wantLog: `pipeline "cat-o-matic.yaml" contains values interpolated from the following secret environment variables: [SEKRET], and cannot be uploaded to Buildkite`,
 		},
+		{
+			desc:    "step env 'secret' that is actually runtime env interpolation",
+			environ: nil,
+			pipeline: &pipeline.Pipeline{
+				Steps: pipeline.Steps{
+					&pipeline.CommandStep{
+						Command: "secret llamas and alpacas",
+						Env:     map[string]string{"SEKRET": "$SQUIRREL", "UNRELATED": "horses"},
+					},
+				},
+			},
+			wantLog: "",
+		},
+		{
+			desc:    "pipeline env 'secret' that is actually runtime env interpolation",
+			environ: nil,
+			pipeline: &pipeline.Pipeline{
+				Env: ordered.MapFromItems(
+					ordered.TupleSS{Key: "SEKRET", Value: "${SQUIRREL}"},
+					ordered.TupleSS{Key: "UNRELATED", Value: "horses"},
+				),
+				Steps: pipeline.Steps{
+					&pipeline.CommandStep{
+						Command: "secret llamas and alpacas",
+					},
+				},
+			},
+			wantLog: "",
+		},
 	}
 
 	for _, test := range tests {

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -61,7 +61,7 @@ func TestSearchForSecrets(t *testing.T) {
 			pipeline: &pipeline.Pipeline{
 				Steps: pipeline.Steps{
 					&pipeline.CommandStep{
-						Command: "secret squirrels and alpacas",
+						Command: "secret llamas and alpacas",
 						Env:     map[string]string{"SEKRET": "squirrels", "UNRELATED": "horses"},
 					},
 				},
@@ -76,7 +76,7 @@ func TestSearchForSecrets(t *testing.T) {
 					&pipeline.GroupStep{
 						Steps: pipeline.Steps{
 							&pipeline.CommandStep{
-								Command: "secret squirrels and alpacas",
+								Command: "secret llamas and alpacas",
 								Env:     map[string]string{"SEKRET": "squirrels", "UNRELATED": "horses"},
 							},
 						},
@@ -95,7 +95,7 @@ func TestSearchForSecrets(t *testing.T) {
 				),
 				Steps: pipeline.Steps{
 					&pipeline.CommandStep{
-						Command: "secret squirrels and alpacas",
+						Command: "secret llamas and alpacas",
 					},
 				},
 			},

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -254,10 +254,12 @@ func signOffline(ctx context.Context, c *cli.Context, l logger.Logger, key jwk.K
 	}
 
 	parsedPipeline, err := pipeline.Parse(bytes.NewReader(pipelineBytes))
-	if w := warning.As(err); w != nil {
+	if err != nil {
+		w := warning.As(err)
+		if w == nil {
+			return fmt.Errorf("pipeline parsing of %q failed: %w", filename, err)
+		}
 		l.Warn("There were some issues with the pipeline input - signing will be attempted but might not succeed:\n%v", w)
-	} else if err != nil {
-		return fmt.Errorf("pipeline parsing of %q failed: %w", filename, err)
 	}
 
 	if cfg.Debug {
@@ -318,10 +320,12 @@ func signWithGraphQL(ctx context.Context, c *cli.Context, l logger.Logger, key j
 	}
 
 	parsedPipeline, err := pipeline.Parse(strings.NewReader(pipelineString))
-	if w := warning.As(err); w != nil {
+	if err != nil {
+		w := warning.As(err)
+		if w == nil {
+			return fmt.Errorf("pipeline parsing failed: %w", err)
+		}
 		l.Warn("There were some issues with the pipeline input - signing will be attempted but might not succeed:\n%v", w)
-	} else if err != nil {
-		return fmt.Errorf("pipeline parsing failed: %w", err)
 	}
 
 	if cfg.Debug {

--- a/env/environment.go
+++ b/env/environment.go
@@ -67,6 +67,22 @@ func FromSlice(s []string) *Environment {
 	return env
 }
 
+// Pair is an environment variable name/value pair.
+type Pair struct{ Name, Value string }
+
+// DumpPairs returns a copy of the environment with all keys normalised.
+func (e *Environment) DumpPairs() []Pair {
+	d := make([]Pair, 0, e.underlying.Size())
+	e.underlying.Range(func(k, v string) bool {
+		d = append(d, Pair{
+			Name:  normalizeKeyName(k),
+			Value: v,
+		})
+		return true
+	})
+	return d
+}
+
 // Dump returns a copy of the environment with all keys normalized
 func (e *Environment) Dump() map[string]string {
 	d := make(map[string]string, e.underlying.Size())

--- a/internal/job/api.go
+++ b/internal/job/api.go
@@ -38,7 +38,11 @@ We'll continue to run your job, but you won't be able to use the Job API`)
 	e.shell.Env.Set("BUILDKITE_AGENT_JOB_API_SOCKET", socketPath)
 	e.shell.Env.Set("BUILDKITE_AGENT_JOB_API_TOKEN", token)
 
-	if redact.Match(e.shell.Logger, e.RedactedVars, "BUILDKITE_AGENT_JOB_API_TOKEN") {
+	matched, err := redact.MatchAny(e.RedactedVars, "BUILDKITE_AGENT_JOB_API_TOKEN")
+	if err != nil {
+		e.shell.OptionalWarningf("bad-redacted-vars", "Couldn't match environment variable names against -redacted-vars: %v", err)
+	}
+	if matched {
 		// The Job API token lets the job talk to this executor. When the job ends,
 		// the socket should be closed and the token becomes meaningless. Also, the
 		// socket should only be accessible to the user running the agent on the

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -578,7 +578,7 @@ func (e *Executor) applyEnvironmentChanges(changes hook.EnvChanges) {
 	e.shell.Env.Apply(changes.Diff)
 
 	// reset output redactors based on new environment variable values
-	e.redactors.Add(redact.Values(e.shell, e.ExecutorConfig.RedactedVars, e.shell.Env.Dump())...)
+	e.redactors.Add(redact.Values(e.shell, e.ExecutorConfig.RedactedVars, e.shell.Env.DumpPairs())...)
 
 	// First, let see any of the environment variables are supposed
 	// to change the job configuration at run time.
@@ -1140,7 +1140,7 @@ func (e *Executor) writeBatchScript(cmd string) (string, error) {
 //
 // The returned method will remove the redactors from the Executor and Flush them.
 func (e *Executor) setupRedactors() {
-	valuesToRedact := redact.Values(e.shell, e.ExecutorConfig.RedactedVars, e.shell.Env.Dump())
+	valuesToRedact := redact.Values(e.shell, e.ExecutorConfig.RedactedVars, e.shell.Env.DumpPairs())
 
 	if e.Debug {
 		e.shell.Commentf("Enabling output redaction for values from environment variables matching: %v", e.ExecutorConfig.RedactedVars)

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -2,13 +2,11 @@
 package redact
 
 import (
+	"fmt"
 	"path"
-	"sort"
-	"strings"
+	"slices"
 
 	"github.com/buildkite/agent/v3/env"
-	"github.com/buildkite/agent/v3/internal/job/shell"
-	"golang.org/x/exp/maps"
 )
 
 // LengthMin is the shortest string length that will be considered a
@@ -25,67 +23,56 @@ func Redact([]byte) []byte {
 	return redacted
 }
 
-// Match reports if the name matches any of the patterns.
-func Match(logger shell.Logger, patterns []string, name string) bool {
+// MatchAny reports if the name matches any of the patterns.
+func MatchAny(patterns []string, name string) (matched bool, err error) {
+	// Track patterns that couldn't be parsed by path.Match, and report them
+	// in a single error.
+	var badPatterns []string
+	defer func() {
+		if len(badPatterns) > 0 {
+			slices.Sort(badPatterns)
+			err = fmt.Errorf("bad patterns: %q", badPatterns)
+		}
+	}()
+
 	for _, pattern := range patterns {
 		matched, err := path.Match(pattern, name)
 		if err != nil {
-			// path.ErrBadPattern is the only error returned by path.Match
-			logger.Warningf("Bad redacted vars pattern: %s", pattern)
+			badPatterns = append(badPatterns, pattern)
 			continue
 		}
 
 		if matched {
-			return true
+			return true, nil
 		}
 	}
-	return false
-}
-
-// Values returns the variable Values to be redacted, given a
-// redaction config string and an environment map.
-func Values(logger shell.Logger, patterns []string, environment []env.Pair) []string {
-	vars := Vars(logger, patterns, environment)
-	if len(vars) == 0 {
-		return nil
-	}
-
-	vals := make([]string, 0, len(vars))
-	for _, pair := range vars {
-		vals = append(vals, pair.Value)
-	}
-
-	return vals
+	return false, nil
 }
 
 // Vars returns the variable names and values to be redacted, given a
-// redaction config string and an environment map.
-func Vars(logger shell.Logger, patterns []string, environment []env.Pair) []env.Pair {
-	var vars []env.Pair
-	shortVars := make(map[string]struct{})
-
+// redaction config string and an environment map. It also returned variables
+// whose names match the redacted-vars config, but whose values were too short.
+func Vars(patterns []string, environment []env.Pair) (matched []env.Pair, short []string, err error) {
 	for _, pair := range environment {
 		// Does the name match any of the patterns?
-		if !Match(logger, patterns, pair.Name) {
+		m, err := MatchAny(patterns, pair.Name)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !m {
 			continue
 		}
 
 		// The name matched, now test the length of the value.
 		if len(pair.Value) < LengthMin {
 			if len(pair.Value) > 0 {
-				shortVars[pair.Name] = struct{}{}
+				short = append(short, pair.Name)
 			}
 			continue
 		}
 
-		vars = append(vars, pair)
+		matched = append(matched, pair)
 	}
 
-	if len(shortVars) > 0 {
-		// TODO: Use stdlib maps when it gets a Keys function (Go 1.22?)
-		vars := maps.Keys(shortVars)
-		sort.Strings(vars)
-		logger.Warningf("Some variables have values below minimum length (%d bytes) and will not be redacted: %s", LengthMin, strings.Join(vars, ", "))
-	}
-	return vars
+	return matched, short, nil
 }

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -3,6 +3,7 @@ package redact
 import (
 	"testing"
 
+	"github.com/buildkite/agent/v3/env"
 	"github.com/buildkite/agent/v3/internal/job/shell"
 	"github.com/google/go-cmp/cmp"
 )
@@ -14,11 +15,11 @@ func TestValuesToRedact(t *testing.T) {
 		"*_PASSWORD",
 		"*_TOKEN",
 	}
-	environment := map[string]string{
-		"BUILDKITE_PIPELINE": "unit-test",
+	environment := []env.Pair{
+		{Name: "BUILDKITE_PIPELINE", Value: "unit-test"},
 		// These are example values, and are not leaked credentials
-		"DATABASE_USERNAME": "AzureDiamond",
-		"DATABASE_PASSWORD": "hunter2",
+		{Name: "DATABASE_USERNAME", Value: "AzureDiamond"},
+		{Name: "DATABASE_PASSWORD", Value: "hunter2"},
 	}
 
 	got := Values(shell.DiscardLogger, redactConfig, environment)
@@ -33,9 +34,9 @@ func TestValuesToRedactEmpty(t *testing.T) {
 	t.Parallel()
 
 	redactConfig := []string{}
-	environment := map[string]string{
-		"FOO":                "BAR",
-		"BUILDKITE_PIPELINE": "unit-test",
+	environment := []env.Pair{
+		{Name: "FOO", Value: "BAR"},
+		{Name: "BUILDKITE_PIPELINE", Value: "unit-test"},
 	}
 
 	got := Values(shell.DiscardLogger, redactConfig, environment)

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -4,11 +4,10 @@ import (
 	"testing"
 
 	"github.com/buildkite/agent/v3/env"
-	"github.com/buildkite/agent/v3/internal/job/shell"
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestValuesToRedact(t *testing.T) {
+func TestVars(t *testing.T) {
 	t.Parallel()
 
 	redactConfig := []string{
@@ -22,11 +21,17 @@ func TestValuesToRedact(t *testing.T) {
 		{Name: "DATABASE_PASSWORD", Value: "hunter2"},
 	}
 
-	got := Values(shell.DiscardLogger, redactConfig, environment)
-	want := []string{"hunter2"}
+	got, short, err := Vars(redactConfig, environment)
+	if err != nil {
+		t.Errorf("Vars(%q, %q) error = %v", redactConfig, environment, err)
+	}
+	if len(short) > 0 {
+		t.Errorf("Vars(%q, %q) short = %q", redactConfig, environment, short)
+	}
+	want := []env.Pair{{Name: "DATABASE_PASSWORD", Value: "hunter2"}}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Values(%q, %q) diff (-got +want)\n%s", redactConfig, environment, diff)
+		t.Errorf("Vars(%q, %q) diff (-got +want)\n%s", redactConfig, environment, diff)
 	}
 }
 
@@ -39,8 +44,14 @@ func TestValuesToRedactEmpty(t *testing.T) {
 		{Name: "BUILDKITE_PIPELINE", Value: "unit-test"},
 	}
 
-	got := Values(shell.DiscardLogger, redactConfig, environment)
+	got, short, err := Vars(redactConfig, environment)
+	if err != nil {
+		t.Errorf("Vars(%q, %q) error = %v", redactConfig, environment, err)
+	}
+	if len(short) > 0 {
+		t.Errorf("Vars(%q, %q) short = %q", redactConfig, environment, short)
+	}
 	if len(got) != 0 {
-		t.Errorf("Values(%q, %q) = %q, want empty slice", redactConfig, environment, got)
+		t.Errorf("Vars(%q, %q) = %q, want empty slice", redactConfig, environment, got)
 	}
 }


### PR DESCRIPTION
### Description

Reject secrets originating from more places (e.g. within the pipeline YAML being uploaded)

### Context

With the flag enabled, env vars containing secrets are already rejected, but only if they are in the process env of the agent uploading a pipeline.

A pipeline generator might accidentally insert secrets as env vars within the pipeline env block or a step env block. These are still secrets, so they should be found and rejected.

### Changes

Each commit should be fairly self contained. 

Main changes that ought to be reasoned about:

- Considering all env maps for secrets. This is the main change, and involves recursively inspecting the pipeline for things with `env` blocks (pipeline or command), then adding the vars and values found to the input to `redact.Vars`.
- Not scanning for pipeline / step env vars. By definition pipeline and step env vars are already in the pipeline. So we don't have to scan the JSON version of the pipeline for them.
- Skipping pure variable substitutions. Some secrets aren't actually secrets until runtime interpolation happens, so any env var that consists entirely of one or more variable substitutions without defaults can be skipped from consideration as a secret.

Refactors / tidyups:

- Preferring `if err != nil { /* check for warning */ }` over `if warning { } else if err != nil { }`
- Moving the resolution of git commit to its own function
- Making the redact package not responsible for logging (about malformed patterns or short variables), and simplifying away `Values`.
- Adding `env.Pair` and `(*env.Environment).DumpPairs` as an alternative to dumping as a map.  Representing env vars as a slice of pairs is necessary in case a user defines the same env var with different values in multiple `env` blocks.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
