### PR TITLE
Update LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014-2018 Buildkite Pty Ltd
+Copyright (c) 2014 Buildkite Pty Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The MIT license specifies a single year[1] for the copyright notice, with this year being the first publication of the work.

[1] https://opensource.org/license/MIT