### PR TITLE
Log in to buildkite packages right before pushing images

### DIFF
--- a/.buildkite/steps/publish-docker-image.sh
+++ b/.buildkite/steps/publish-docker-image.sh
@@ -40,6 +40,13 @@ release_image() {
   dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://docker.io/buildkite/${target_image}:${tag}"
   echo "--- :github: Copying ${target_image}:${tag} to GHCR"
   dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://ghcr.io/buildkite/${target_image}:${tag}"
+
+  # OIDC tokens only last 5 minutes, and issuing them is cheap, so log in as close as possible to the push
+  buildkite-agent oidc request-token \
+    --audience "https://packages.buildkite.com/buildkite/agent-docker" \
+    --lifetime 300 \
+    | docker login packages.buildkite.com/buildkite/agent-docker --username=buildkite --password-stdin
+
   echo "--- :buildkite: Copying ${target_image}:${tag} to Buildkite Packages"
   dry_run skopeo copy --multi-arch all "docker://${source_image}" "docker://packages.buildkite.com/buildkite/agent-docker/${target_image}:${tag}"
 }

--- a/.buildkite/steps/publish-docker-images.sh
+++ b/.buildkite/steps/publish-docker-images.sh
@@ -46,11 +46,6 @@ aws ssm get-parameter \
 
 echo "--- docker login to Buildkite Packages"
 
-buildkite-agent oidc request-token \
-  --audience "https://packages.buildkite.com/buildkite/agent-docker" \
-  --lifetime 300 \
-  | docker login packages.buildkite.com/buildkite/agent-docker --username=buildkite --password-stdin
-
 version=$(buildkite-agent meta-data get "agent-version")
 build=$(buildkite-agent meta-data get "agent-version-build")
 


### PR DESCRIPTION
### Description

Currently, we `docker login` to the buildkite packages container registry in the same place as all the other docker logins, in [`.buildkite/steps/publish_docker_images.sh`](https://github.com/buildkite/agent/blob/main/.buildkite/steps/publish-docker-images.sh). However, because this docker login is done using an OIDC token, it's timed, and only lasts five minutes.

If pushing the docker images to registries before BK packages takes longer than five minutes, the push to BK packages will fail, as the token will expire - see [here](https://buildkite.com/buildkite/agent-release-edge/builds/1315#0190c3aa-4ada-4828-ba5e-46765578cb1b).

This PR updates the docker push process so that we log in to buildkite packages as close as possible to push-time.

