### PR TITLE
Fix downloaded artifact permissions

### DIFF
--- a/agent/download_unix.go
+++ b/agent/download_unix.go
@@ -1,0 +1,15 @@
+//go:build unix
+
+package agent
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func init() {
+	// Can't read the current umask(2) without changing it.
+	umask = os.FileMode(unix.Umask(int(umask)))
+	unix.Umask(int(umask))
+}


### PR DESCRIPTION
### Description

The change from `os.Create` to `os.CreateTemp` changed the file permissions of the created file (from 0o666 to 0o600). This was unintentional. 

### Context

#2878 


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

