### PR TITLE
Let artifact phase and post-command run in grace period

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -843,27 +843,10 @@ var AgentStartCommand = cli.Command{
 			}
 		}
 
-		// Treat a negative signal grace period as relative to the cancel grace period
-		if cfg.SignalGracePeriodSeconds < 0 {
-			if cfg.CancelGracePeriod < -cfg.SignalGracePeriodSeconds {
-				return fmt.Errorf(
-					"cancel-grace-period (%d) must be at least as big as signal-grace-period-seconds (%d)",
-					cfg.CancelGracePeriod,
-					cfg.SignalGracePeriodSeconds,
-				)
-			}
-			cfg.SignalGracePeriodSeconds = cfg.CancelGracePeriod + cfg.SignalGracePeriodSeconds
+		signalGracePeriod, err := signalGracePeriod(cfg.CancelGracePeriod, cfg.SignalGracePeriodSeconds)
+		if err != nil {
+			return err
 		}
-
-		if cfg.CancelGracePeriod <= cfg.SignalGracePeriodSeconds {
-			return fmt.Errorf(
-				"cancel-grace-period (%d) must be greater than signal-grace-period-seconds (%d)",
-				cfg.CancelGracePeriod,
-				cfg.SignalGracePeriodSeconds,
-			)
-		}
-
-		signalGracePeriod := time.Duration(cfg.SignalGracePeriodSeconds) * time.Second
 
 		mc := metrics.NewCollector(l, metrics.CollectorConfig{
 			Datadog:              cfg.MetricsDatadog,

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -235,8 +235,10 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 			span.RecordError(commandErr)
 		}
 
-		// Only upload artifacts as part of the command phase
-		if err = e.artifactPhase(ctx); err != nil {
+		// Only upload artifacts as part of the command phase.
+		// The artifacts might be relevant for debugging job timeouts, so it can
+		// run during the grace period.
+		if err := e.artifactPhase(graceCtx); err != nil {
 			e.shell.Errorf("%v", err)
 
 			if commandErr != nil {

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -900,7 +900,9 @@ func (e *Executor) CommandPhase(ctx context.Context) (hookErr error, commandErr 
 		if preCommandErr != nil {
 			return
 		}
-		hookErr = e.runPostCommandHooks(ctx)
+		// Because post-command hooks are often used for post-job cleanup, they
+		// can run during the grace period.
+		hookErr = e.runPostCommandHooks(withGracePeriod(ctx, e.SignalGracePeriod))
 	}()
 
 	// Run pre-command hooks

--- a/internal/job/grace.go
+++ b/internal/job/grace.go
@@ -1,0 +1,22 @@
+package job
+
+import (
+	"context"
+	"time"
+)
+
+// withGracePeriod returns a context that is cancelled some time *after* the
+// parent context is cancelled. In general this is not a good pattern, since it
+// breaks the usual connection between context cancellations and requires an
+// extra goroutine. However, we need to enforce the signal grace period from
+// within the job executor for use-cases where the executor is _not_ forked from
+// something else that will enforce the grace period (with SIGKILL).
+func withGracePeriod(ctx context.Context, graceTimeout time.Duration) context.Context {
+	gctx, cancel := context.WithCancelCause(context.WithoutCancel(ctx))
+	go func() {
+		<-ctx.Done()
+		time.Sleep(graceTimeout)
+		cancel(context.DeadlineExceeded)
+	}()
+	return gctx
+}


### PR DESCRIPTION
### Description

Artifact phase (the built-in artifact upload performed by the agent) and post-command hooks are now allowed to run in the signal grace period (a configurable length of time after job cancellation).

The signal grace period is also now enforced within the job executor (as well as outside of it when run normally as a subprocess of the agent).

### Context

Artifacts uploaded this way can be relevant to user debugging job timeouts, so we should try a bit harder to upload them. 

A similar argument applies to post-command hooks, which can be used for post-job cleanup.

Both of these (and usual job teardown) are still subject to the executor being SIGKILL-ed by the agent parent process. However, some use-cases run `buildkite-agent bootstrap` separately to the agent ("standalone `bootstrap`", which happens for example in agent-stack-k8s). So the executor needs to be able to kill itself in case there's nothing else to do so, hence `graceCtx` instead of `nonCancelCtx`.

The executor (a.k.a. bootstrap) is also normally passed the (computed) signal grace period as a flag/env var from the parent agent process, but the flag shares the same definition as `agent start` (with default -1). If there is no parent agent process, the -1 signal grace period will cause `graceCtx` to be cancelled immediately after the main context is cancelled. An existing integration test shows this. So, for standalone `bootstrap`, the same flag computation that happens in `agent start` to obtain a positive `signalGracePeriod` should be done in `bootstrap` as well.

### Changes

* Add `withGracePeriod` helper method, to create a new context that is cancelled some period of time after another context is cancelled.
* Use `withGracePeriod` to replace the existing detached `nonCancelCtx` with a new `graceCtx`. The difference is that `graceCtx` will still be cancelled after the signal grace period.
* Use `graceCtx` for `tearDown`, `artifactPhase`, and create a grace context for `runPostCommandHooks`.
* Refactor the computation with cancel-grace-period and signal-grace-period-seconds from `agent start` into a function shared with `bootstrap`.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
