### PR TITLE
fix enable http/2 by default as intended by flags

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -5,6 +5,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -47,6 +48,9 @@ type Config struct {
 
 	// The http client used, leave nil for the default
 	HTTPClient *http.Client
+
+	// optional TLS configuration primarily used for testing
+	TLSConfig *tls.Config
 }
 
 // A Client manages communication with the Buildkite Agent API.
@@ -85,6 +89,7 @@ func NewClient(l logger.Logger, conf Config) *Client {
 			IdleConnTimeout:     90 * time.Second,
 			TLSHandshakeTimeout: 30 * time.Second,
 			ForceAttemptHTTP2:   !conf.DisableHTTP2, // HTTP2 is enabled by default
+			TLSClientConfig:     conf.TLSConfig,
 		}
 
 		httpClient = &http.Client{

--- a/api/client.go
+++ b/api/client.go
@@ -86,7 +86,7 @@ func NewClient(l logger.Logger, conf Config) *Client {
 			tr.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
 			// The default TLSClientConfig has h2 in NextProtos, so the negotiated TLS connection will assume h2 support.
 			// see https://github.com/golang/go/issues/50571
-			tr.TLSClientConfig = nil
+			tr.TLSClientConfig.NextProtos = []string{"http/1.1"}
 		}
 
 		tr.TLSClientConfig = conf.TLSConfig

--- a/api/client.go
+++ b/api/client.go
@@ -5,7 +5,6 @@ package api
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -85,10 +84,7 @@ func NewClient(l logger.Logger, conf Config) *Client {
 			MaxIdleConns:        100,
 			IdleConnTimeout:     90 * time.Second,
 			TLSHandshakeTimeout: 30 * time.Second,
-		}
-
-		if conf.DisableHTTP2 {
-			t.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
+			ForceAttemptHTTP2:   !conf.DisableHTTP2, // HTTP2 is enabled by default
 		}
 
 		httpClient = &http.Client{


### PR DESCRIPTION
### Description

At some point the agent HTTP client configuration was updated however this resulted in it falling back to HTTP/1.1. Ideally we would take advantage of HTTP/2 to improve overall performance, especially for agents who are connecting from locations outside the US.

This will also lead to less TLS handshakes, and connections overall, which in turn should reduce the likelyhood of stalls uploading artifacts.

### Context

The defaulting to HTTP 1.1 was discovered while debugging higher than expected latency while uploading artifacts.

### Changes

Use the default transport to ensure that the `ForceAttemptHTTP2` is set and we use HTTP/2.0. Cloning the default transport is the simplest approach to ensure you get the most up to date configuration. 

See https://github.com/golang/go/issues/26013 for some background on the `Clone` method in the default transport.

From https://github.com/golang/go/blob/master/src/net/http/transport.go#L50.
```
	// ForceAttemptHTTP2 controls whether HTTP/2 is enabled when a non-zero
	// Dial, DialTLS, or DialContext func or TLSClientConfig is provided.
	// By default, use of any those fields conservatively disables HTTP/2.
	// To use a custom dialer or TLS config and still attempt HTTP/2
	// upgrades, set this to true.
	ForceAttemptHTTP2 bool
```

To disable HTTP/2.0 we need to update a few things, these are documented in this change as well.

### Testing

Before.

```
2024-07-30 13:25:03 DEBUG  POST https://agent.buildkite.com/v3/connect command=start agent_version=3.75.1+x..dirty
2024-07-30 13:25:04 DEBUG  ↳ POST https://agent.buildkite.com/v3/connect command=start proto=HTTP/1.1 status=200 Δ=743.567041ms agent_version=3.75.1+x..dirty
```

After.

```
2024-07-30 13:24:44 DEBUG  POST https://agent.buildkite.com/v3/connect command=start agent_version=3.75.1+x..dirty
2024-07-30 13:24:44 DEBUG  ↳ POST https://agent.buildkite.com/v3/connect command=start proto=HTTP/2.0 status=200 Δ=733.139667ms agent_version=3.75.1+x..dirty
```