### PR TITLE
Pass cancel grace period to bootstrap

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math/rand/v2"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -590,7 +591,7 @@ func (a *AgentWorker) AcquireAndRunJob(ctx context.Context, jobId string) error 
 		aj, resp, err := a.apiClient.AcquireJob(
 			timeoutCtx, jobId,
 			api.Header{Name: "X-Buildkite-Lock-Acquire-Job", Value: "1"},
-			api.Header{Name: "X-Buildkite-Backoff-Sequence", Value: fmt.Sprintf("%d", r.AttemptCount())},
+			api.Header{Name: "X-Buildkite-Backoff-Sequence", Value: strconv.Itoa(r.AttemptCount())},
 		)
 		if err != nil {
 			if resp != nil {

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -455,7 +455,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	// Add agent environment variables
 	env["BUILDKITE_AGENT_DEBUG"] = fmt.Sprintf("%t", r.conf.Debug)
 	env["BUILDKITE_AGENT_DEBUG_HTTP"] = fmt.Sprintf("%t", r.conf.DebugHTTP)
-	env["BUILDKITE_AGENT_PID"] = fmt.Sprintf("%d", os.Getpid())
+	env["BUILDKITE_AGENT_PID"] = strconv.Itoa(os.Getpid())
 
 	// We know the BUILDKITE_BIN_PATH dir, because it's the path to the
 	// currently running file (there is only 1 binary)
@@ -487,13 +487,13 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	env["BUILDKITE_GIT_FETCH_FLAGS"] = r.conf.AgentConfiguration.GitFetchFlags
 	env["BUILDKITE_GIT_CLONE_MIRROR_FLAGS"] = r.conf.AgentConfiguration.GitCloneMirrorFlags
 	env["BUILDKITE_GIT_CLEAN_FLAGS"] = r.conf.AgentConfiguration.GitCleanFlags
-	env["BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT"] = fmt.Sprintf("%d", r.conf.AgentConfiguration.GitMirrorsLockTimeout)
+	env["BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT"] = strconv.Itoa(r.conf.AgentConfiguration.GitMirrorsLockTimeout)
 	env["BUILDKITE_SHELL"] = r.conf.AgentConfiguration.Shell
 	env["BUILDKITE_AGENT_EXPERIMENT"] = strings.Join(experiments.Enabled(ctx), ",")
 	env["BUILDKITE_REDACTED_VARS"] = strings.Join(r.conf.AgentConfiguration.RedactedVars, ",")
 	env["BUILDKITE_STRICT_SINGLE_HOOKS"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.StrictSingleHooks)
-	env["BUILDKITE_CANCEL_GRACE_PERIOD"] = fmt.Sprintf("%d", r.conf.AgentConfiguration.CancelGracePeriod)
-	env["BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS"] = fmt.Sprintf("%d", int(r.conf.AgentConfiguration.SignalGracePeriod/time.Second))
+	env["BUILDKITE_CANCEL_GRACE_PERIOD"] = strconv.Itoa(r.conf.AgentConfiguration.CancelGracePeriod)
+	env["BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS"] = strconv.Itoa(int(r.conf.AgentConfiguration.SignalGracePeriod / time.Second))
 
 	if r.conf.KubernetesExec {
 		env["BUILDKITE_KUBERNETES_EXEC"] = "true"

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -492,6 +492,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	env["BUILDKITE_AGENT_EXPERIMENT"] = strings.Join(experiments.Enabled(ctx), ",")
 	env["BUILDKITE_REDACTED_VARS"] = strings.Join(r.conf.AgentConfiguration.RedactedVars, ",")
 	env["BUILDKITE_STRICT_SINGLE_HOOKS"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.StrictSingleHooks)
+	env["BUILDKITE_CANCEL_GRACE_PERIOD"] = fmt.Sprintf("%d", r.conf.AgentConfiguration.CancelGracePeriod)
 	env["BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS"] = fmt.Sprintf("%d", int(r.conf.AgentConfiguration.SignalGracePeriod/time.Second))
 
 	if r.conf.KubernetesExec {

--- a/agent/pipeline_uploader.go
+++ b/agent/pipeline_uploader.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/buildkite/agent/v3/api"
@@ -125,7 +126,7 @@ func (u *PipelineUploader) pipelineUploadAsyncWithRetry(
 			u.Change,
 			api.Header{
 				Name:  "X-Buildkite-Backoff-Sequence",
-				Value: fmt.Sprintf("%d", r.AttemptCount()),
+				Value: strconv.Itoa(r.AttemptCount()),
 			},
 		)
 		if err != nil {
@@ -185,7 +186,7 @@ func (u *PipelineUploader) pollForPiplineUploadStatus(ctx context.Context, l log
 			u.Change.UUID,
 			api.Header{
 				Name:  "X-Buildkite-Backoff-Sequence",
-				Value: fmt.Sprintf("%d", r.AttemptCount()),
+				Value: strconv.Itoa(r.AttemptCount()),
 			},
 		)
 		if err != nil {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -983,7 +983,7 @@ var AgentStartCommand = cli.Command{
 			return fmt.Errorf("invalid log format %q. Only 'text' or 'json' are allowed.", cfg.LogFormat)
 		}
 
-		l.Notice("Starting buildkite-agent v%s with PID: %s", version.Version(), fmt.Sprintf("%d", os.Getpid()))
+		l.Notice("Starting buildkite-agent v%s with PID: %s", version.Version(), strconv.Itoa(os.Getpid()))
 		l.Notice("The agent source code can be found here: https://github.com/buildkite/agent")
 		l.Notice("For questions and support, email us at: hello@buildkite.com")
 

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -509,7 +509,7 @@ func (e *Executor) runWrappedShellScriptHook(ctx context.Context, hookName strin
 		return err
 	}); err != nil {
 		exitCode := shell.GetExitCode(err)
-		e.shell.Env.Set("BUILDKITE_LAST_HOOK_EXIT_STATUS", fmt.Sprintf("%d", exitCode))
+		e.shell.Env.Set("BUILDKITE_LAST_HOOK_EXIT_STATUS", strconv.Itoa(exitCode))
 
 		// If the hook exited with a non-zero exit code, then we should pass that back to the executor
 		// so it may inform the Buildkite API
@@ -910,7 +910,7 @@ func (e *Executor) CommandPhase(ctx context.Context) (hookErr error, commandErr 
 	// error this will be zero. It's used to set the exit code later, so it's important
 	e.shell.Env.Set(
 		"BUILDKITE_COMMAND_EXIT_STATUS",
-		fmt.Sprintf("%d", shell.GetExitCode(commandErr)),
+		strconv.Itoa(shell.GetExitCode(commandErr)),
 	)
 
 	// Exit early if there was no error

--- a/process/signal.go
+++ b/process/signal.go
@@ -4,7 +4,7 @@
 package process
 
 import (
-	"fmt"
+	"strconv"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -62,7 +62,7 @@ func GetPgid(pid int) (int, error) {
 func SignalString(s syscall.Signal) string {
 	name := unix.SignalName(s)
 	if name == "" {
-		return fmt.Sprintf("%d", int(s))
+		return strconv.Itoa(int(s))
 	}
 	return name
 }


### PR DESCRIPTION
### Description

The `buildkite-agent bootstrap` forked from `buildkite-agent start` needs both cancel-grace-period and signal-grace-period.

### Context

In #2899 the cancel grace period was added as a flag and env var read by the bootstrap subcommand, but I forgot to set it from the job runner.

### Changes

* Pass the value through an env var just like `BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS`
* Also a small cleanup across the whole agent codebase to replace `fmt.Sprintf("%d", ...)` with `strconv.Itoa(...)` (does the same thing, but it doesn't need the `fmt` package to parse a format string).

Note: the two env vars are different due to historical reasons. See https://github.com/buildkite/agent/blob/main/clicommand/cancel_signal.go

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
- [x] Manually checked that it works
