### PR TITLE
Only override TLSClientConfig if set

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -89,7 +89,9 @@ func NewClient(l logger.Logger, conf Config) *Client {
 			tr.TLSClientConfig.NextProtos = []string{"http/1.1"}
 		}
 
-		tr.TLSClientConfig = conf.TLSConfig
+		if conf.TLSConfig != nil {
+			tr.TLSClientConfig = conf.TLSConfig
+		}
 
 		httpClient = &http.Client{
 			Timeout: 60 * time.Second,


### PR DESCRIPTION
A hopefully minor bug: `TLSClientConfig` is overridden with `conf.TLSConfig` in all cases, when we should only really override it if it is set.

If `DisableHTTP2` is enabled, we want the default `TLSClientConfig` with `NextProtos` set in a particular way. But the unconditional override with `conf.TLSConfig` nukes it.