### PR TITLE
Fix default endpoint string

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	defaultEndpoint  = "https://agent.buildkite.com/"
+	defaultEndpoint  = "https://agent.buildkite.com/v3"
 	defaultUserAgent = "buildkite-agent/api"
 )
 

--- a/core/controller.go
+++ b/core/controller.go
@@ -25,7 +25,7 @@ func NewController(ctx context.Context, regToken, agentName string, tags []strin
 	cfg := &controllerConfig{
 		logger:            logger.Discard,
 		retrySleepFunc:    nil,
-		endpoint:          "https://agent.buildkite.com/",
+		endpoint:          "https://agent.buildkite.com/v3",
 		userAgent:         version.UserAgent(),
 		debugHTTP:         false,
 		allowHTTP2:        true,

--- a/core/doc.go
+++ b/core/doc.go
@@ -1,4 +1,4 @@
-// Package core implements core agent routines in a tasty library form.
+// Package core implements core functions wrapped up in a tasty library package.
 // This package is intended to be imported and used elsewhere, but the API
 // should NOT yet be considered stable. Use at own risk!
 package core

--- a/core/options.go
+++ b/core/options.go
@@ -39,7 +39,7 @@ func WithRetrySleepFunc(f func(time.Duration)) ControllerOption {
 }
 
 // WithEndpoint allows overriding the API endpoint (base URL).
-// Defaults to "https://agent.buildkite.com/".
+// Defaults to "https://agent.buildkite.com/v3".
 func WithEndpoint(endpoint string) ControllerOption {
 	return func(c *controllerConfig) {
 		c.endpoint = endpoint


### PR DESCRIPTION
### Description

The default endpoint string was missing `v3`. `v3` is visible in `clicommand/global.go`, which has the proper default value.

### Changes

Add `v3` to the end of the endpoint strings used as defaults.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
