### PR TITLE
fix for layout issues with log messages

### DIFF
--- a/internal/job/shell/logger.go
+++ b/internal/job/shell/logger.go
@@ -86,7 +86,7 @@ func (wl *WriterLogger) Commentf(format string, v ...any) {
 
 func (wl *WriterLogger) Errorf(format string, v ...any) {
 	if wl.Ansi {
-		wl.Printf(ansiColor("🚨 Error: "+format+"\n^^^ +++", "31"), v...)
+		wl.Printf(ansiColor("🚨 Error: "+format, "31")+"\n^^^ +++", v...)
 	} else {
 		wl.Printf("🚨 Error: "+format+"\n^^^ +++", v...)
 	}
@@ -94,7 +94,7 @@ func (wl *WriterLogger) Errorf(format string, v ...any) {
 
 func (wl *WriterLogger) Warningf(format string, v ...any) {
 	if wl.Ansi {
-		wl.Printf(ansiColor("⚠️ Warning: "+format+"\n^^^ +++", "33"), v...)
+		wl.Printf(ansiColor("⚠️ Warning: "+format, "33")+"\n^^^ +++", v...)
 	} else {
 		wl.Printf("⚠️ Warning: "+format+"\n^^^ +++", v...)
 	}

--- a/internal/job/shell/logger_test.go
+++ b/internal/job/shell/logger_test.go
@@ -43,6 +43,38 @@ func TestAnsiLogger(t *testing.T) {
 	}
 }
 
+func TestAnsiWithColorsLogger(t *testing.T) {
+	got := &bytes.Buffer{}
+	l := shell.NewWriterLogger(got, true, nil)
+
+	l.Headerf("Testing header: %q", "llamas")
+	l.Printf("Testing print: %q", "llamas")
+	l.Commentf("Testing comment: %q", "llamas")
+	l.Errorf("Testing error: %q", "llamas")
+	l.Warningf("Testing warning: %q", "llamas")
+	l.Promptf("Testing prompt: %q", "llamas")
+
+	want := &bytes.Buffer{}
+
+	fmt.Fprintln(want, `~~~ Testing header: "llamas"`)
+	fmt.Fprintln(want, `Testing print: "llamas"`)
+	fmt.Fprintln(want, `[90m# Testing comment: "llamas"[0m`)
+	fmt.Fprintln(want, `[31m🚨 Error: Testing error: "llamas"[0m`)
+	fmt.Fprintln(want, "^^^ +++")
+	fmt.Fprintln(want, `[33m⚠️ Warning: Testing warning: "llamas"[0m`)
+	fmt.Fprintln(want, "^^^ +++")
+
+	if runtime.GOOS == "windows" {
+		fmt.Fprintln(want, `[90m>[0m Testing prompt: "llamas"`)
+	} else {
+		fmt.Fprintln(want, `[90m$[0m Testing prompt: "llamas"`)
+	}
+
+	if diff := cmp.Diff(got.String(), want.String()); diff != "" {
+		t.Fatalf("shell.WriterLogger output buffer diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestLoggerStreamer(t *testing.T) {
 	got := &bytes.Buffer{}
 	l := shell.NewWriterLogger(got, false, nil)


### PR DESCRIPTION
### Description

When the group expansion characters are printed `^^^ +++`  whilst also using ansi colours, our log rendering in the UI does not expand the group, so the message is hidden.

### Context

Changes in https://github.com/buildkite/agent/pull/2805 a while back adjusted the structure of the messages slightly when using ansi color, this resulted in some formatting issues.

With @tessereth expert guidance we found the issue and added a test to validate it.

### Changes

Just moved the `^^^ +++` sequence out of the ansi formatting.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
