### PR TITLE
Update description for the 'priority' option for the 'buildkite-agent annotate' command.

### DIFF
--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -99,6 +99,7 @@ var AnnotateCommand = cli.Command{
 			Name:   "priority",
 			Usage:  "The priority of the annotation (′1′ to ′10′). Annotations with a priority of ′10′ are shown first, while annotations with a priority of ′1′ are shown last. When this option is not specified, annotations have a default priority of ′3′.",
 			EnvVar: "BUILDKITE_ANNOTATION_PRIORITY",
+			Value:  3,
 		},
 		cli.StringFlag{
 			Name:   "job",

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -97,7 +97,7 @@ var AnnotateCommand = cli.Command{
 		},
 		cli.IntFlag{
 			Name:   "priority",
-			Usage:  "The priority of the annotation (′1′ to ′10′). Annotations with a priority of ′10′ are shown first, while annotations with a priority of ′1′ are shown last. When this option is not specified, annotations have a default priority of ′3′.",
+			Usage:  "The priority of the annotation (′1′ to ′10′). Annotations with a priority of ′10′ are shown first, while annotations with a priority of ′1′ are shown last.",
 			EnvVar: "BUILDKITE_ANNOTATION_PRIORITY",
 			Value:  3,
 		},

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -97,7 +97,7 @@ var AnnotateCommand = cli.Command{
 		},
 		cli.IntFlag{
 			Name:   "priority",
-			Usage:  "Priority of the annotation (1 to 10). By default annotations have a priority of 3. Annotations with a priority of 10 will be shown first, and annotations with a priority of 1 will be shown last.",
+			Usage:  "The priority of the annotation (′1′ to ′10′). Annotations with a priority of ′10′ are shown first, while annotations with a priority of ′1′ are shown last. When this option is not specified, annotations have a default priority of ′3′.",
 			EnvVar: "BUILDKITE_ANNOTATION_PRIORITY",
 		},
 		cli.StringFlag{


### PR DESCRIPTION
### Description

Update the description for the `--priority` option for the `buildkite-agent annotate` command.

### Context

Minor wording tweak to be surfaced through the Buildkite Docs based on https://github.com/buildkite/docs/pull/2934.

### Changes

An option description for the `buildkite-agent annotate` command.
Also, set the agent's client-side default to `3`.

### Testing

Not done.
