### PR TITLE
Enable configuration for no local hook or plugin failure behavours

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -36,6 +36,8 @@ type AgentConfiguration struct {
 	StrictSingleHooks           bool
 	RunInPty                    bool
 	KubernetesExec              bool
+	LocalHooksFailureBehavior   string
+	PluginsFailureBehavior      string
 
 	SigningJWKSFile  string // Where to find the key to sign pipeline uploads with (passed through to jobs, they might be uploading pipelines)
 	SigningJWKSKeyID string // The key ID to sign pipeline uploads with

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -46,6 +46,9 @@ const (
 
 	VerificationBehaviourWarn  = "warn"
 	VerificationBehaviourBlock = "block"
+
+	DisabledBehaviourWarn  = "warn"
+	DisabledBehaviourError = "error"
 )
 
 // Certain env can only be set by agent configuration.
@@ -490,6 +493,8 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	env["BUILDKITE_COMMAND_EVAL"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.CommandEval)
 	env["BUILDKITE_PLUGINS_ENABLED"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.PluginsEnabled)
 	env["BUILDKITE_LOCAL_HOOKS_ENABLED"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.LocalHooksEnabled)
+	env["BUILDKITE_LOCAL_HOOKS_FAILURE_BEHAVIOR"] = r.conf.AgentConfiguration.LocalHooksFailureBehavior
+	env["BUILDKITE_PLUGINS_FAILURE_BEHAVIOR"] = r.conf.AgentConfiguration.PluginsFailureBehavior
 	env["BUILDKITE_GIT_CHECKOUT_FLAGS"] = r.conf.AgentConfiguration.GitCheckoutFlags
 	env["BUILDKITE_GIT_CLONE_FLAGS"] = r.conf.AgentConfiguration.GitCloneFlags
 	env["BUILDKITE_GIT_FETCH_FLAGS"] = r.conf.AgentConfiguration.GitFetchFlags

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -81,6 +81,8 @@ type BootstrapConfig struct {
 	PluginValidation             bool     `cli:"plugin-validation"`
 	PluginsAlwaysCloneFresh      bool     `cli:"plugins-always-clone-fresh"`
 	LocalHooksEnabled            bool     `cli:"local-hooks-enabled"`
+	LocalHooksFailureBehavior    string   `cli:"local-hooks-failure-behavior"`
+	PluginsFailureBehavior       string   `cli:"plugins-failure-behavior"`
 	StrictSingleHooks            bool     `cli:"strict-single-hooks"`
 	PTY                          bool     `cli:"pty"`
 	LogLevel                     string   `cli:"log-level"`
@@ -315,6 +317,16 @@ var BootstrapCommand = cli.Command{
 			Usage:  "Allow local hooks to be run",
 			EnvVar: "BUILDKITE_LOCAL_HOOKS_ENABLED",
 		},
+		cli.StringFlag{
+			Name:   "local-hooks-failure-behavior",
+			Usage:  "The behavior when a job is not allowed to run local hooks.",
+			EnvVar: "BUILDKITE_LOCAL_HOOKS_FAILURE_BEHAVIOR",
+		},
+		cli.StringFlag{
+			Name:   "plugins-failure-behavior",
+			Usage:  "The behavior when a job is not allowed to run plugins.",
+			EnvVar: "BUILDKITE_PLUGINS_FAILURE_BEHAVIOR",
+		},
 		cli.BoolTFlag{
 			Name:   "ssh-keyscan",
 			Usage:  "Automatically run ssh-keyscan before checkout",
@@ -443,6 +455,8 @@ var BootstrapCommand = cli.Command{
 			HooksPath:                    cfg.HooksPath,
 			JobID:                        cfg.JobID,
 			LocalHooksEnabled:            cfg.LocalHooksEnabled,
+			LocalHooksFailureBehavior:    cfg.LocalHooksFailureBehavior,
+			PluginsFailureBehavior:       cfg.PluginsFailureBehavior,
 			OrganizationSlug:             cfg.OrganizationSlug,
 			Phases:                       cfg.Phases,
 			PipelineProvider:             cfg.PipelineProvider,

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -107,6 +107,12 @@ type ExecutorConfig struct {
 	// Are local hooks enabled?
 	LocalHooksEnabled bool
 
+	// What failure behaviour is configured for local hooks no being allowed to run
+	LocalHooksFailureBehavior string
+
+	// What failure behaviour is configured for plugins no being allowed to run
+	PluginsFailureBehavior string
+
 	// Should we enforce that only one checkout and one command hook are run?
 	StrictSingleHooks bool
 

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -20,6 +20,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/agent/plugin"
 	"github.com/buildkite/agent/v3/env"
 	"github.com/buildkite/agent/v3/internal/experiments"
@@ -693,7 +694,11 @@ func (e *Executor) executeLocalHook(ctx context.Context, name string) error {
 	}
 
 	if !localHooksEnabled {
-		return fmt.Errorf("Refusing to run %s, local hooks are disabled", localHookPath)
+		if e.ExecutorConfig.LocalHooksFailureBehavior == agent.DisabledBehaviourError {
+			return fmt.Errorf("Refusing to run %s, local hooks are disabled", localHookPath)
+		}
+
+		e.shell.Warningf("Refusing to run %s, local hooks are disabled", localHookPath)
 	}
 
 	return e.executeHook(ctx, HookConfig{

--- a/internal/job/plugin.go
+++ b/internal/job/plugin.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/agent/plugin"
 	"github.com/buildkite/agent/v3/internal/job/hook"
 	"github.com/buildkite/agent/v3/internal/utils"
@@ -42,11 +43,19 @@ func (e *Executor) preparePlugins() error {
 	// Check if we can run plugins (disabled via --no-plugins)
 	if !e.ExecutorConfig.PluginsEnabled {
 		if !e.ExecutorConfig.LocalHooksEnabled {
-			return fmt.Errorf("Plugins have been disabled on this agent with `--no-local-hooks`")
+			if e.ExecutorConfig.LocalHooksFailureBehavior == agent.DisabledBehaviourError {
+				return fmt.Errorf("Plugins have been disabled on this agent with `--no-local-hooks`")
+			}
+			e.shell.Logger.Warningf("Plugins have been disabled on this agent with `--no-local-hooks`")
+			return nil
 		} else if !e.ExecutorConfig.CommandEval {
 			return fmt.Errorf("Plugins have been disabled on this agent with `--no-command-eval`")
 		} else {
-			return fmt.Errorf("Plugins have been disabled on this agent with `--no-plugins`")
+			if e.ExecutorConfig.PluginsFailureBehavior == agent.DisabledBehaviourError {
+				return fmt.Errorf("Plugins have been disabled on this agent with `--no-plugins`")
+			}
+			e.shell.Logger.Warningf("Plugins have been disabled on this agent with `--no-plugins`")
+			return nil
 		}
 	}
 

--- a/internal/job/plugin_test.go
+++ b/internal/job/plugin_test.go
@@ -1,0 +1,129 @@
+package job
+
+import (
+	"testing"
+
+	"github.com/buildkite/agent/v3/internal/job/shell"
+)
+
+func Test_checkPluginsEnabled(t *testing.T) {
+	type args struct {
+		logger         shell.Logger
+		executorConfig ExecutorConfig
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "Plugins and local hooks are Enabled",
+			args: args{
+				logger: shell.DiscardLogger,
+				executorConfig: ExecutorConfig{
+					PluginsEnabled:    true,
+					LocalHooksEnabled: true,
+					CommandEval:       true,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Plugins are disabled",
+			args: args{
+				logger: shell.DiscardLogger,
+				executorConfig: ExecutorConfig{
+					PluginsEnabled:         false,
+					LocalHooksEnabled:      true,
+					CommandEval:            true,
+					PluginsFailureBehavior: "error",
+				},
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "Plugins are disabled, and failure behavior is warn",
+			args: args{
+				logger: shell.DiscardLogger,
+				executorConfig: ExecutorConfig{
+					PluginsEnabled:         false,
+					LocalHooksEnabled:      true,
+					CommandEval:            true,
+					PluginsFailureBehavior: "warn",
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Local hooks are disabled, and failure behavior is error",
+			args: args{
+				logger: shell.DiscardLogger,
+				executorConfig: ExecutorConfig{
+					PluginsEnabled:            true,
+					LocalHooksEnabled:         false,
+					LocalHooksFailureBehavior: "error",
+				},
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "Local hooks are disabled, and failure behavior is warn",
+			args: args{
+				logger: shell.DiscardLogger,
+				executorConfig: ExecutorConfig{
+					PluginsEnabled:            true,
+					LocalHooksEnabled:         false,
+					CommandEval:               true,
+					LocalHooksFailureBehavior: "warn",
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Local hooks are disabled, and failure behavior is warn",
+			args: args{
+				logger: shell.DiscardLogger,
+				executorConfig: ExecutorConfig{
+					PluginsEnabled:         false,
+					LocalHooksEnabled:      true,
+					CommandEval:            true,
+					PluginsFailureBehavior: "warn",
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "command eval is disabled",
+			args: args{
+				logger: shell.DiscardLogger,
+				executorConfig: ExecutorConfig{
+					PluginsEnabled:    true,
+					LocalHooksEnabled: true,
+					CommandEval:       false,
+				},
+			},
+			want:    false,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := checkPluginsEnabled(tt.args.logger, tt.args.executorConfig)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("checkPluginsEnabled() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+			if got != tt.want {
+				t.Errorf("checkPluginsEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
### Description

Currently if you block local hooks or plugins the build fails, however there are cases during migration where you may want to just print a warning for the developer while still not executing hooks or plugins.

### Context

This change enables teams to block local hooks without breaking the build.

### Changes

This change adds a couple of new flags which allow configuration of the failure behaviour to either "error" or "warn".

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
