### PR TITLE
k8s: Unconditionally set BUILDKITE_AGENT_ACCESS_TOKEN

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -1244,6 +1244,16 @@ func (e *Executor) kubernetesSetup(ctx context.Context, k8sAgentSocket *kubernet
 		switch n {
 		case "BUILDKITE_COMMAND", "BUILDKITE_ARTIFACT_PATHS", "BUILDKITE_PLUGINS":
 			continue
+
+		case "BUILDKITE_AGENT_ACCESS_TOKEN":
+			// Just in case someone has tried to fiddle with this, set it
+			// unconditionally (to be compatible with pre-v3.74.1 / PR 2851
+			// behavior).
+			e.shell.Env.Set(n, v)
+			if err := os.Setenv(n, v); err != nil {
+				return err
+			}
+			continue
 		}
 		// Skip any that are already set.
 		if e.shell.Env.Exists(n) {


### PR DESCRIPTION
### Description

Unconditionally set `BUILDKITE_AGENT_ACCESS_TOKEN`, regardless of whether it is already set.
This matches pre-#2851 behaviour.

### Context

Manually setting `BUILDKITE_AGENT_ACCESS_TOKEN` within the command container was found to break uses of many agent subcommands (e.g. `meta-data set`) within jobs run on newer agents (v3.74.1 and later) in the k8s stack.

https://coda.io/d/Escalations-Feedback_dHnUHNps1YO/Pipelines-Escalations_su7FT#Pipelines-Escalations-Board_tu__K/r597&view=modal


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

