### PR TITLE
Support for multiple trace context encodings

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -61,5 +61,6 @@ type AgentConfiguration struct {
 	AcquireJob                 string
 	TracingBackend             string
 	TracingServiceName         string
+	TraceContextEncoding       string
 	DisableWarningsFor         []string
 }

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -502,6 +502,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	env["BUILDKITE_STRICT_SINGLE_HOOKS"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.StrictSingleHooks)
 	env["BUILDKITE_CANCEL_GRACE_PERIOD"] = strconv.Itoa(r.conf.AgentConfiguration.CancelGracePeriod)
 	env["BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS"] = strconv.Itoa(int(r.conf.AgentConfiguration.SignalGracePeriod / time.Second))
+	env["BUILDKITE_TRACE_CONTEXT_ENCODING"] = r.conf.AgentConfiguration.TraceContextEncoding
 
 	if r.conf.KubernetesExec {
 		env["BUILDKITE_KUBERNETES_EXEC"] = "true"

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -161,13 +161,14 @@ type AgentStartConfig struct {
 	TracingServiceName          string `cli:"tracing-service-name"`
 
 	// Global flags
-	Debug             bool     `cli:"debug"`
-	LogLevel          string   `cli:"log-level"`
-	NoColor           bool     `cli:"no-color"`
-	Experiments       []string `cli:"experiment" normalize:"list"`
-	Profile           string   `cli:"profile"`
-	StrictSingleHooks bool     `cli:"strict-single-hooks"`
-	KubernetesExec    bool     `cli:"kubernetes-exec"`
+	Debug                bool     `cli:"debug"`
+	LogLevel             string   `cli:"log-level"`
+	NoColor              bool     `cli:"no-color"`
+	Experiments          []string `cli:"experiment" normalize:"list"`
+	Profile              string   `cli:"profile"`
+	StrictSingleHooks    bool     `cli:"strict-single-hooks"`
+	KubernetesExec       bool     `cli:"kubernetes-exec"`
+	TraceContextEncoding string   `cli:"trace-context-encoding"`
 
 	// API config
 	DebugHTTP bool   `cli:"debug-http"`
@@ -689,6 +690,7 @@ var AgentStartCommand = cli.Command{
 		RedactedVars,
 		StrictSingleHooksFlag,
 		KubernetesExecFlag,
+		TraceContextEncodingFlag,
 
 		// Deprecated flags which will be removed in v4
 		cli.StringSliceFlag{
@@ -849,6 +851,10 @@ var AgentStartCommand = cli.Command{
 			return err
 		}
 
+		if _, err := tracetools.ParseEncoding(cfg.TraceContextEncoding); err != nil {
+			return fmt.Errorf("while parsing trace context encoding: %v", err)
+		}
+
 		mc := metrics.NewCollector(l, metrics.CollectorConfig{
 			Datadog:              cfg.MetricsDatadog,
 			DatadogHost:          cfg.MetricsDatadogHost,
@@ -946,6 +952,7 @@ var AgentStartCommand = cli.Command{
 			AcquireJob:                   cfg.AcquireJob,
 			TracingBackend:               cfg.TracingBackend,
 			TracingServiceName:           cfg.TracingServiceName,
+			TraceContextEncoding:         cfg.TraceContextEncoding,
 			VerificationFailureBehaviour: cfg.VerificationFailureBehavior,
 			KubernetesExec:               cfg.KubernetesExec,
 

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -117,6 +117,13 @@ var (
 			"*_CONNECTION_STRING",
 		},
 	}
+
+	TraceContextEncodingFlag = cli.StringFlag{
+		Name:   "trace-context-encoding",
+		Usage:  "Sets the inner encoding for BUILDKITE_TRACE_CONTEXT. Must be either json or gob",
+		Value:  "gob",
+		EnvVar: "BUILDKITE_TRACE_CONTEXT_ENCODING",
+	}
 )
 
 func globalFlags() []cli.Flag {

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/buildkite/agent/v3/env"
 	"github.com/buildkite/agent/v3/process"
+	"github.com/buildkite/agent/v3/tracetools"
 )
 
 // Config provides the configuration for the job executor. Some of the keys are
@@ -164,6 +165,9 @@ type ExecutorConfig struct {
 
 	// Service name to use when reporting traces.
 	TracingServiceName string
+
+	// Encoding (within base64) for the trace context environment variable.
+	TraceContextCodec tracetools.Codec
 
 	// Whether to start the JobAPI
 	JobAPI bool

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -89,7 +89,7 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 		var err error
 		logger := shell.StderrLogger
 		logger.DisabledWarningIDs = e.DisabledWarnings
-		e.shell, err = shell.New(shell.WithLogger(logger))
+		e.shell, err = shell.New(shell.WithLogger(logger), shell.WithTraceContextCodec(e.TraceContextCodec))
 		if err != nil {
 			fmt.Printf("Error creating shell: %v", err)
 			return 1

--- a/internal/job/tracing.go
+++ b/internal/job/tracing.go
@@ -100,7 +100,7 @@ func (e *Executor) startTracingDatadog(ctx context.Context) (tracetools.Span, co
 // extractTraceCtx pulls encoded distributed tracing information from the env vars.
 // Note: This should match the injectTraceCtx code in shell.
 func (e *Executor) extractDDTraceCtx() opentracing.SpanContext {
-	sctx, err := tracetools.DecodeTraceContext(e.shell.Env.Dump())
+	sctx, err := tracetools.DecodeTraceContext(e.shell.Env.Dump(), e.ExecutorConfig.TraceContextCodec)
 	if err != nil {
 		// Return nil so a new span will be created
 		return nil

--- a/tracetools/propagate_example_test.go
+++ b/tracetools/propagate_example_test.go
@@ -35,7 +35,7 @@ func ExampleEncodeTraceContext() {
 
 		// Now say we want to launch a child process.
 		// Prepare it's env vars. This will be the carrier for the tracing data.
-		if err := EncodeTraceContext(span, childEnv); err != nil {
+		if err := EncodeTraceContext(span, childEnv, CodecGob{}); err != nil {
 			fmt.Println("oops an error for parent process trace injection")
 		}
 		// Now childEnv will contain the encoded data set with the env var key.
@@ -58,7 +58,7 @@ func ExampleEncodeTraceContext() {
 		// Make sure tracing is setup the same way (same env var key)
 		// Normally you'd use os.Environ or similar here (the list of strings is
 		// supported). We're just reusing childEnv for test simplicity.
-		sctx, err := DecodeTraceContext(childEnv)
+		sctx, err := DecodeTraceContext(childEnv, CodecGob{})
 		if err != nil {
 			fmt.Println("oops an error for child process trace extraction")
 		} else {

--- a/tracetools/propagate_test.go
+++ b/tracetools/propagate_test.go
@@ -2,12 +2,17 @@ package tracetools
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/gob"
+	"errors"
+	"slices"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/opentracing/opentracing-go"
-	"github.com/stretchr/testify/assert"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"golang.org/x/exp/maps"
 )
 
 // nullLogger is meant to make Datadog tracing logs go nowhere during tests.
@@ -15,32 +20,135 @@ type nullLogger struct{}
 
 func (n nullLogger) Log(_ string) {}
 
+func stubGlobalTracer() func() {
+	oriTracer := opentracing.GlobalTracer()
+	opentracing.SetGlobalTracer(mocktracer.New())
+	return func() {
+		opentracing.SetGlobalTracer(oriTracer)
+	}
+}
+
 func TestDecodeTraceContext(t *testing.T) {
+	t.Cleanup(stubGlobalTracer())
+
 	t.Run("No context info", func(t *testing.T) {
-		sctx, err := DecodeTraceContext(map[string]string{})
-		assert.Nil(t, sctx)
-		assert.Equal(t, opentracing.ErrSpanContextNotFound, err)
+		sctx, err := DecodeTraceContext(map[string]string{}, CodecGob{})
+		if sctx != nil {
+			t.Errorf("DecodeTraceContext({}, gob) = %v, want nil", sctx)
+		}
+		if want := opentracing.ErrSpanContextNotFound; !errors.Is(err, want) {
+			t.Errorf("DecodeTraceContext({}, gob) error = %v, want %v", err, want)
+		}
 	})
 
 	t.Run("Invalid bsae64 context string", func(t *testing.T) {
 		sctx, err := DecodeTraceContext(map[string]string{
 			EnvVarTraceContextKey: "asd",
-		})
-		assert.Nil(t, sctx)
-		assert.Equal(t, base64.CorruptInputError(0), err)
+		}, CodecGob{})
+		if sctx != nil {
+			t.Errorf("DecodeTraceContext({}, gob) = %v, want nil", sctx)
+		}
+		if want := base64.CorruptInputError(0); !errors.Is(err, want) {
+			t.Errorf("DecodeTraceContext({}, gob) error = %v, want %v", err, want)
+		}
 	})
 
 	t.Run("Invalid context data", func(t *testing.T) {
 		buf := bytes.NewBuffer([]byte{})
 		err := gob.NewEncoder(buf).Encode("asd")
 		if err != nil {
-			assert.FailNow(t, "unexpected encode error: %v", err)
+			t.Fatalf("gob.NewEncoder(buf).Encode(\"asd\") error = %v", err)
 		}
 		s := base64.URLEncoding.EncodeToString(buf.Bytes())
-		sctx, err := DecodeTraceContext(map[string]string{
-			EnvVarTraceContextKey: s,
-		})
-		assert.Nil(t, sctx)
-		assert.Error(t, err)
+		input := map[string]string{EnvVarTraceContextKey: s}
+		sctx, err := DecodeTraceContext(input, CodecGob{})
+		if sctx != nil {
+			t.Errorf("DecodeTraceContext(%v, gob) = %v, want nil", input, sctx)
+		}
+		if err == nil { // gob returns string errors, not typed errors...
+			t.Errorf("DecodeTraceContext(%v, gob) error = %v, want gob decoding error", input, err)
+		}
 	})
+
+	for _, encoding := range []string{"", "gob", "json"} {
+		t.Run(encoding, func(t *testing.T) {
+			codec, err := ParseEncoding(encoding)
+			if err != nil {
+				t.Fatalf("ParseEncoding(%q) error = %v", encoding, err)
+			}
+
+			span := opentracing.StartSpan("job.run")
+			env := map[string]string{}
+			if err := EncodeTraceContext(span, env, codec); err != nil {
+				t.Fatalf("EncodeTraceContext(span, %v, %v) error = %v", env, codec, err)
+			}
+
+			sctx, err := DecodeTraceContext(env, codec)
+			if err != nil {
+				t.Fatalf("DecodeTraceContext(%v, %v) error = %v", env, codec, err)
+			}
+			if sctx == nil {
+				t.Errorf("DecodeTraceContext(%v, %v) = %v, want non-nil span context", env, codec, sctx)
+			}
+		})
+	}
+}
+
+func TestEncodeTraceContext(t *testing.T) {
+	t.Cleanup(stubGlobalTracer())
+
+	testCases := []struct {
+		encoding string
+		want     opentracing.TextMapCarrier
+	}{
+		{
+			encoding: "json",
+			want:     opentracing.TextMapCarrier{"mockpfx-ids-sampled": "true", "mockpfx-ids-spanid": "46", "mockpfx-ids-traceid": "43"},
+		},
+		{
+			encoding: "gob",
+			want:     opentracing.TextMapCarrier{"mockpfx-ids-sampled": "true", "mockpfx-ids-spanid": "50", "mockpfx-ids-traceid": "47"},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.encoding, func(t *testing.T) {
+			codec, err := ParseEncoding(test.encoding)
+			if err != nil {
+				t.Fatalf("ParseEncoding(%q) error = %v", test.encoding, err)
+			}
+
+			ctx := context.Background()
+			parent := opentracing.StartSpan("job.parent")
+			ctx = opentracing.ContextWithSpan(ctx, parent)
+
+			span, ctx := opentracing.StartSpanFromContext(ctx, "job.run")
+			env := map[string]string{}
+			if err := EncodeTraceContext(span, env, codec); err != nil {
+				t.Fatalf("EncodeTraceContext(span, %v, %v) error = %v", env, codec, err)
+			}
+			if got := env[EnvVarTraceContextKey]; got == "" {
+				t.Errorf("after EncodeTraceContext(span, env, %v): env[%q] = %q, want non-empty encoded trace context", codec, EnvVarTraceContextKey, got)
+			}
+
+			contextBytes, err := base64.URLEncoding.DecodeString(env[EnvVarTraceContextKey])
+			if err != nil {
+				t.Fatalf("base64.URLEncoding.DecodeString(%q) error = %v", env[EnvVarTraceContextKey], err)
+			}
+
+			dec := codec.NewDecoder(bytes.NewReader(contextBytes))
+			textmap := opentracing.TextMapCarrier{}
+			if err := dec.Decode(&textmap); err != nil {
+				t.Fatalf("Codec(%v).NewDecoder(%q).Decode(&opentracing.TextMapCarrier{}) error = %v", codec, contextBytes, err)
+			}
+			// The content of the trace context will vary, but the keys should
+			// remain the same.
+			gotKeys := maps.Keys(textmap)
+			slices.Sort(gotKeys)
+			wantKeys := maps.Keys(test.want)
+			slices.Sort(wantKeys)
+			if diff := cmp.Diff(gotKeys, wantKeys); diff != "" {
+				t.Errorf("decoded textmap keys diff (-got +want):\n%s", diff)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### Description

This is part merge-conflict-resolution, part refinement of #1775. The main differences to #1775 are: specifying the encoding with a string flag rather than bool, represented internally with a `Codec` interface, and some tweaks to the tests.

### Context

Closes #1775

###

* Add `--trace-context-encoding` flag and `BUILDKITE_TRACE_CONTEXT_ENCODING` env var, accepting the values `gob` and `json`, defaulting to `gob`.
* Parse the new flag/var and plumb the resulting codec through agent start, job runner, and bootstrap.
* Use the codec to perform encoding/decoding of the trace context.
* Add tests.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
