### PR TITLE
coda-content-type pass content-type to the server when specified

### DIFF
--- a/api/artifacts.go
+++ b/api/artifacts.go
@@ -47,7 +47,7 @@ type Artifact struct {
 	UploadInstructions *ArtifactUploadInstructions `json:"-"`
 
 	// A specific Content-Type to use on upload
-	ContentType string `json:"-"`
+	ContentType string `json:"content_type,omitempty"`
 }
 
 type ArtifactBatch struct {


### PR DESCRIPTION
### Description

Currently when the content_type isn't getting passed to the server. This PR is a fix for that. 

With this change when the content type is passed in via 
```
command: "echo hi > tmp.txt; buildkite-agent artifact upload --debug --debug-http --content-type 'text/html' tmp.txt"
```
content type is now being passed to the server (bk/bk)
ps you can see the content_type at the end of the line
```
{"id":"f569d9cf-391c-4014-b6a7-91e3b246ae23","artifacts":[{"id":"","path":"tmp.txt","absolute_path":"/tmp/buildkite-builds/Sorchas-MacBook-Pro-local-1/test/trigger-repo1/tmp.txt","glob_path":"","file_size":3,"sha1sum":"55ca6286e3e4f4fba5d0448333fa99fc5a404a73","sha256sum":"98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4","job_id":"","created_at":"0001-01-01T00:00:00Z","content_type":"text/html"}],"upload_destination":""}
--
```

### Context
Customer raised this a while ago https://buildkite.slack.com/archives/C90EU6HPD/p1723076236603279


### Changes
v small change made to artifacts struct. 


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
