### PR TITLE
Updated to support only ECC_NIST_P256 keyspec for initial release

### DIFF
--- a/internal/cryptosigner/aws/kms.go
+++ b/internal/cryptosigner/aws/kms.go
@@ -52,50 +52,27 @@ func NewKMS(client *kms.Client, kmsKeyID string) (*KMS, error) {
 		return nil, fmt.Errorf("invalid key usage. expected SIGN_VERIFY, got %q", keyDesc.KeyUsage)
 	}
 
-	// there should be at least one signing algorithm available, and for sign/verify keys there should only be one.
-	if len(keyDesc.SigningAlgorithms) != 1 {
-		return nil, fmt.Errorf("expected one signing algorithm for key %q got %q", kmsKeyID, keyDesc.SigningAlgorithms)
-	}
-
-	alg := keyDesc.SigningAlgorithms[0]
-
 	// Using the matching KMS keyset as per the following table, we select the
 	// appropriate jwa.KeyAlgorithm see https://datatracker.ietf.org/doc/html/rfc7518#section-3.1
 	// and https://docs.aws.amazon.com/kms/latest/developerguide/asymmetric-key-specs.html
 	//
-	// | "alg" Param Value | Digital Signature Algorithm | KMS KeySpec |
-	// | ----------------- | --------------------------- | ----------- |
-	// | ES256   | ECDSA using P-256 and SHA-256   | ECC_NIST_P256 |
-	// | ES384   | ECDSA using P-384 and SHA-384   | ECC_NIST_P384 |
-	// | ES512   | ECDSA using P-521 and SHA-512   | ECC_NIST_P521 |
-	// | RS256   | RSASSA-PKCS1-v1_5 using SHA-256 | RSASSA_PKCS1_V1_5_SHA_256 |
-	// | RS384   | RSASSA-PKCS1-v1_5 using SHA-384 | RSASSA_PKCS1_V1_5_SHA_384 |
-	// | RS512   | RSASSA-PKCS1-v1_5 using SHA-512 | RSASSA_PKCS1_V1_5_SHA_512 |
+	// | "alg" Param Value | Digital Signature Algorithm   | KMS KeySpec   |
+	// | ----------------- | ----------------------------- | ------------- |
+	// | ES256             | ECDSA using P-256 and SHA-256 | ECC_NIST_P256 |
 	//
-	var jwaAlg jwa.KeyAlgorithm
-	switch alg {
-	case types.SigningAlgorithmSpecEcdsaSha256:
-		jwaAlg = jwa.ES256
-	case types.SigningAlgorithmSpecEcdsaSha384:
-		jwaAlg = jwa.ES384
-	case types.SigningAlgorithmSpecEcdsaSha512:
-		jwaAlg = jwa.ES512
-	case types.SigningAlgorithmSpecRsassaPkcs1V15Sha256:
-		jwaAlg = jwa.RS256
-	case types.SigningAlgorithmSpecRsassaPkcs1V15Sha384:
-		jwaAlg = jwa.RS384
-	case types.SigningAlgorithmSpecRsassaPkcs1V15Sha512:
-		jwaAlg = jwa.RS512
+	// We only support ECC_NIST_P256 for now.
+	switch keyDesc.KeySpec {
+	case types.KeySpecEccNistP256:
+		return &KMS{
+			client: client,
+			kid:    kmsKeyID,
+			jwaAlg: jwa.ES256,
+			alg:    types.SigningAlgorithmSpecEcdsaSha256,
+		}, nil
 	default:
-		return nil, fmt.Errorf("unsupported signing algorithm %q", alg)
+		return nil, fmt.Errorf("unsupported key spec: %q, supported key specs are %q", keyDesc.KeySpec,
+			[]types.KeySpec{types.KeySpecEccNistP256})
 	}
-
-	return &KMS{
-		client: client,
-		jwaAlg: jwaAlg,
-		alg:    alg,
-		kid:    kmsKeyID,
-	}, nil
 }
 
 // Sign generates a signature from the given digest.


### PR DESCRIPTION
### Description

This reduces the support for key types to just `ECC_NIST_P256` for the initial release.

### Context

The reason I removed the other key types are:

1. The RSA types are more complex to configure and use as they support multiple signing algorythms, some of which have issues as identified in https://buildkite.com/docs/agent/v3/signed-pipelines regarding RSASSA-PKCS1 v1.5 signatures.
2. Currently the `ECC_NIST_P256` is the only ECDSA KMS key type tested for `crypto.Signing` with KMS in our JWS library, I will need to raise this upstream to figure out why.

So given the `ECC_NIST_P256` is widely used I think it is fine as a starting point for KMS signing support.