### PR TITLE
Add sha256 checksum output to the formatting options

### DIFF
--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -64,7 +64,7 @@ Format specifiers:
 
   %S    SHA1 checksum of the artifact
 
-	%t    SHA256 checksum of the artifact
+  %T    SHA256 checksum of the artifact
 
   %u    Download URL for the artifact, though consider using 'buildkite-agent artifact download' instead`
 
@@ -164,7 +164,7 @@ var ArtifactSearchCommand = cli.Command{
 				"%j", artifact.JobID,
 				"%s", strconv.FormatInt(artifact.FileSize, 10),
 				"%S", artifact.Sha1Sum,
-				"%t", artifact.Sha256Sum,
+				"%T", artifact.Sha256Sum,
 				"%u", artifact.URL,
 				"%i", artifact.ID,
 			)

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -64,6 +64,8 @@ Format specifiers:
 
   %S    SHA1 checksum of the artifact
 
+	%t    SHA256 checksum of the artifact
+
   %u    Download URL for the artifact, though consider using 'buildkite-agent artifact download' instead`
 
 type ArtifactSearchConfig struct {
@@ -162,6 +164,7 @@ var ArtifactSearchCommand = cli.Command{
 				"%j", artifact.JobID,
 				"%s", strconv.FormatInt(artifact.FileSize, 10),
 				"%S", artifact.Sha1Sum,
+				"%t", artifact.Sha256Sum,
 				"%u", artifact.URL,
 				"%i", artifact.ID,
 			)


### PR DESCRIPTION
### Description

When running `artifact shasum` you can optionally print the SHA256 checksum for a single artifact.
But if you're trying to list multiple artifacts using the `search` subcommand, we only support printing the SHA1 checksum

### Changes

Add new formatting option, `%T`, for SHA256. I chose t because it's the next letter in the alphabet and both `%s` and `%S` are taken. Open to suggestions!

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)


![image](https://github.com/user-attachments/assets/dc8c7b7b-232e-4e78-bceb-9579a01a1f3d)
