### PR TITLE
[PKG-7587] Generate build provenance on binary-build and packaging steps in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -101,7 +101,7 @@ steps:
               config: .buildkite/docker-compose.yml
               cli-version: 2
               run: agent
-          - buildkite-plugins/generate-build-provenance#isaacsu/check-globbing:
+          - generate-build-provenance#v1.0.0:
               artifacts: "pkg/*"
               provenance_filename: "buildkite-agent-{{matrix.os}}-{{matrix.arch}}.provenance.json"
         matrix:
@@ -226,7 +226,7 @@ steps:
     command: ".buildkite/steps/build-debian-packages.sh"
     artifact_paths: "deb/**/*"
     plugins:
-      - buildkite-plugins/generate-build-provenance#isaacsu/check-globbing:
+      - generate-build-provenance#v1.0.0:
           artifacts: "deb/*"
           provenance_filename: "buildkite-agent-debian-packages.provenance.json"
 
@@ -238,7 +238,7 @@ steps:
     command: ".buildkite/steps/build-rpm-packages.sh"
     artifact_paths: "rpm/**/*"
     plugins:
-      - buildkite-plugins/generate-build-provenance#isaacsu/check-globbing:
+      - generate-build-provenance#v1.0.0:
           artifacts: "rpm/*"
           provenance_filename: "buildkite-agent-rpm-packages.provenance.json"
 
@@ -253,7 +253,7 @@ steps:
       - docker-compose#v4.14.0:
           config: .buildkite/docker-compose.release.yml
           run: github-release
-      - buildkite-plugins/generate-build-provenance#isaacsu/check-globbing:
+      - generate-build-provenance#v1.0.0:
           artifacts: "releases/*.tar.gz;releases/*.zip"
           provenance_filename: "buildkite-agent-github-releases.provenance.json"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -125,13 +125,13 @@ steps:
             # - with: { os: freebsd, arch: arm64 }
             #   skip: "arm64 FreeBSD is not currently supported"
 
-            # - with: { os: linux, arch: arm }
-            # - with: { os: linux, arch: armhf }
-            # - with: { os: linux, arch: ppc64 }
-            # - with: { os: linux, arch: ppc64le }
-            # - with: { os: linux, arch: mips64le }
-            # - with: { os: linux, arch: s390x }
-            # - with: { os: linux, arch: riscv64 }
+            - with: { os: linux, arch: arm }
+            - with: { os: linux, arch: armhf }
+            - with: { os: linux, arch: ppc64 }
+            - with: { os: linux, arch: ppc64le }
+            - with: { os: linux, arch: mips64le }
+            - with: { os: linux, arch: s390x }
+            - with: { os: linux, arch: riscv64 }
 
             # - with: { os: netbsd, arch: amd64 }
 
@@ -159,9 +159,9 @@ steps:
   #       volumes:
   #         - "/usr/bin/buildkite-agent:/usr/bin/buildkite-agent"
 
-  # - name: ":mag: Extract Agent Version Metadata"
-  #   key: set-metadata
-  #   command: ".buildkite/steps/extract-agent-version-metadata.sh"
+  - name: ":mag: Extract Agent Version Metadata"
+    key: set-metadata
+    command: ".buildkite/steps/extract-agent-version-metadata.sh"
 
   # - group: ":docker: Docker Image Builds"
   #   steps:
@@ -218,21 +218,29 @@ steps:
   #             - ubuntu-22.04
   #             - sidecar
 
-  # - name: ":debian: Debian package build"
-  #   key: build-debian-packages
-  #   depends_on:
-  #     - build-binary
-  #     - set-metadata
-  #   command: ".buildkite/steps/build-debian-packages.sh"
-  #   artifact_paths: "deb/**/*"
+  - name: ":debian: Debian package build"
+    key: build-debian-packages
+    depends_on:
+      - build-binary
+      - set-metadata
+    command: ".buildkite/steps/build-debian-packages.sh"
+    artifact_paths: "deb/**/*"
+    plugins:
+      - buildkite-plugins/generate-build-provenance#main:
+          artifacts: "deb/*"
+          provenance_filename: "buildkite-agent-debian-packages.provenance.json"
 
-  # - name: ":redhat: RPM Package build"
-  #   key: build-rpm-packages
-  #   depends_on:
-  #     - build-binary
-  #     - set-metadata
-  #   command: ".buildkite/steps/build-rpm-packages.sh"
-  #   artifact_paths: "rpm/**/*"
+  - name: ":redhat: RPM Package build"
+    key: build-rpm-packages
+    depends_on:
+      - build-binary
+      - set-metadata
+    command: ".buildkite/steps/build-rpm-packages.sh"
+    artifact_paths: "rpm/**/*"
+    plugins:
+      - buildkite-plugins/generate-build-provenance#main:
+          artifacts: "rpm/*"
+          provenance_filename: "buildkite-agent-rpm-packages.provenance.json"
 
   # - name: ":github: Build Github Release"
   #   key: build-github-release

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -101,7 +101,7 @@ steps:
               config: .buildkite/docker-compose.yml
               cli-version: 2
               run: agent
-          - generate-build-provenance#v1.0.0:
+          - generate-build-provenance#v1.0.1:
               artifacts: "pkg/*"
               provenance_filename: "buildkite-agent-{{matrix.os}}-{{matrix.arch}}.provenance.json"
         matrix:
@@ -226,7 +226,7 @@ steps:
     command: ".buildkite/steps/build-debian-packages.sh"
     artifact_paths: "deb/**/*"
     plugins:
-      - generate-build-provenance#v1.0.0:
+      - generate-build-provenance#v1.0.1:
           artifacts: "deb/*"
           provenance_filename: "buildkite-agent-debian-packages.provenance.json"
 
@@ -238,7 +238,7 @@ steps:
     command: ".buildkite/steps/build-rpm-packages.sh"
     artifact_paths: "rpm/**/*"
     plugins:
-      - generate-build-provenance#v1.0.0:
+      - generate-build-provenance#v1.0.1:
           artifacts: "rpm/*"
           provenance_filename: "buildkite-agent-rpm-packages.provenance.json"
 
@@ -253,7 +253,7 @@ steps:
       - docker-compose#v4.14.0:
           config: .buildkite/docker-compose.release.yml
           run: github-release
-      - generate-build-provenance#v1.0.0:
+      - generate-build-provenance#v1.0.1:
           artifacts: "releases/*.tar.gz;releases/*.zip"
           provenance_filename: "buildkite-agent-github-releases.provenance.json"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -101,7 +101,7 @@ steps:
               config: .buildkite/docker-compose.yml
               cli-version: 2
               run: agent
-          - buildkite-plugins/generate-build-provenance#main:
+          - buildkite-plugins/generate-build-provenance#isaacsu/check-globbing:
               artifacts: "pkg/*"
               provenance_filename: "buildkite-agent-{{matrix.os}}-{{matrix.arch}}.provenance.json"
         matrix:
@@ -226,7 +226,7 @@ steps:
     command: ".buildkite/steps/build-debian-packages.sh"
     artifact_paths: "deb/**/*"
     plugins:
-      - buildkite-plugins/generate-build-provenance#main:
+      - buildkite-plugins/generate-build-provenance#isaacsu/check-globbing:
           artifacts: "deb/*"
           provenance_filename: "buildkite-agent-debian-packages.provenance.json"
 
@@ -238,7 +238,7 @@ steps:
     command: ".buildkite/steps/build-rpm-packages.sh"
     artifact_paths: "rpm/**/*"
     plugins:
-      - buildkite-plugins/generate-build-provenance#main:
+      - buildkite-plugins/generate-build-provenance#isaacsu/check-globbing:
           artifacts: "rpm/*"
           provenance_filename: "buildkite-agent-rpm-packages.provenance.json"
 
@@ -253,8 +253,8 @@ steps:
       - docker-compose#v4.14.0:
           config: .buildkite/docker-compose.release.yml
           run: github-release
-      - buildkite-plugins/generate-build-provenance#main:
-          artifacts: "releases/*.tar.gz"
+      - buildkite-plugins/generate-build-provenance#isaacsu/check-globbing:
+          artifacts: "releases/*.tar.gz;releases/*.zip"
           provenance_filename: "buildkite-agent-github-releases.provenance.json"
 
   - name: ":pipeline: Upload Release Pipeline"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,247 +13,250 @@ steps:
           cli-version: 2
           run: agent
 
-  - name: ":linux: Linux AMD64 Tests"
-    key: test-linux-amd64
-    command: ".buildkite/steps/tests.sh"
-    artifact_paths: junit-*.xml
-    plugins:
-      - docker-compose#v4.14.0:
-          config: .buildkite/docker-compose.yml
-          cli-version: 2
-          run: agent
-      - test-collector#v1.2.0:
-          files: "junit-*.xml"
-          format: "junit"
-      - artifacts#v1.9.0:
-          upload: "cover.{html,out}"
+  # - name: ":linux: Linux AMD64 Tests"
+  #   key: test-linux-amd64
+  #   command: ".buildkite/steps/tests.sh"
+  #   artifact_paths: junit-*.xml
+  #   plugins:
+  #     - docker-compose#v4.14.0:
+  #         config: .buildkite/docker-compose.yml
+  #         cli-version: 2
+  #         run: agent
+  #     - test-collector#v1.2.0:
+  #         files: "junit-*.xml"
+  #         format: "junit"
+  #     - artifacts#v1.9.0:
+  #         upload: "cover.{html,out}"
 
-  - name: ":linux: Linux ARM64 Tests"
-    key: test-linux-arm64
-    command: ".buildkite/steps/tests.sh"
-    artifact_paths: junit-*.xml
-    agents:
-      queue: agent-runners-linux-arm64
-    plugins:
-      - docker-compose#v4.14.0:
-          config: .buildkite/docker-compose.yml
-          cli-version: 2
-          run: agent
-      - test-collector#v1.2.0:
-          files: "junit-*.xml"
-          format: "junit"
-      - artifacts#v1.9.0:
-          upload: "cover.{html,out}"
+  # - name: ":linux: Linux ARM64 Tests"
+  #   key: test-linux-arm64
+  #   command: ".buildkite/steps/tests.sh"
+  #   artifact_paths: junit-*.xml
+  #   agents:
+  #     queue: agent-runners-linux-arm64
+  #   plugins:
+  #     - docker-compose#v4.14.0:
+  #         config: .buildkite/docker-compose.yml
+  #         cli-version: 2
+  #         run: agent
+  #     - test-collector#v1.2.0:
+  #         files: "junit-*.xml"
+  #         format: "junit"
+  #     - artifacts#v1.9.0:
+  #         upload: "cover.{html,out}"
 
-  - name: ":satellite: Detect Data Races"
-    key: test-race-linux-arm64
-    command: ".buildkite/steps/tests.sh -race"
-    artifact_paths: junit-*.xml
-    agents:
-      queue: agent-runners-linux-arm64
-    plugins:
-      - docker-compose#v4.14.0:
-          config: .buildkite/docker-compose.yml
-          cli-version: 2
-          run: agent
-      - test-collector#v1.2.0:
-          files: "junit-*.xml"
-          format: "junit"
-      - artifacts#v1.9.0:
-          upload: "cover.{html,out}"
+  # - name: ":satellite: Detect Data Races"
+  #   key: test-race-linux-arm64
+  #   command: ".buildkite/steps/tests.sh -race"
+  #   artifact_paths: junit-*.xml
+  #   agents:
+  #     queue: agent-runners-linux-arm64
+  #   plugins:
+  #     - docker-compose#v4.14.0:
+  #         config: .buildkite/docker-compose.yml
+  #         cli-version: 2
+  #         run: agent
+  #     - test-collector#v1.2.0:
+  #         files: "junit-*.xml"
+  #         format: "junit"
+  #     - artifacts#v1.9.0:
+  #         upload: "cover.{html,out}"
 
-  - name: ":windows: Windows AMD64 Tests"
-    key: test-windows
-    command: "bash .buildkite\\steps\\tests.sh"
-    artifact_paths: junit-*.xml
-    agents:
-      queue: agent-runners-windows-amd64
-    plugins:
-      - test-collector#v1.2.0:
-          files: "junit-*.xml"
-          format: "junit"
-      - artifacts#v1.9.0:
-          upload: "cover.{html,out}"
+  # - name: ":windows: Windows AMD64 Tests"
+  #   key: test-windows
+  #   command: "bash .buildkite\\steps\\tests.sh"
+  #   artifact_paths: junit-*.xml
+  #   agents:
+  #     queue: agent-runners-windows-amd64
+  #   plugins:
+  #     - test-collector#v1.2.0:
+  #         files: "junit-*.xml"
+  #         format: "junit"
+  #     - artifacts#v1.9.0:
+  #         upload: "cover.{html,out}"
 
-  - label: ":writing_hand: Annotate with Test Failures"
-    depends_on:
-      - test-linux-amd64
-      - test-race-linux-arm64
-      - test-linux-arm64
-      - test-windows
-    allow_dependency_failure: true
-    plugins:
-      - junit-annotate#v1.6.0:
-          artifacts: junit-*.xml
+  # - label: ":writing_hand: Annotate with Test Failures"
+  #   depends_on:
+  #     - test-linux-amd64
+  #     - test-race-linux-arm64
+  #     - test-linux-arm64
+  #     - test-windows
+  #   allow_dependency_failure: true
+  #   plugins:
+  #     - junit-annotate#v1.6.0:
+  #         artifacts: junit-*.xml
 
   - group: ":hammer_and_wrench: Binary builds"
     steps:
-    - name: ":{{matrix.os}}: Build {{matrix.os}} {{matrix.arch}} binary"
-      command: ".buildkite/steps/build-binary.sh {{matrix.os}} {{matrix.arch}}"
-      key: build-binary
-      depends_on:
-        # don't wait for slower windows tests
-        - test-linux-amd64
-        - test-linux-arm64
-      artifact_paths: "pkg/*"
-      plugins:
-        docker-compose#v4.14.0:
-          config: .buildkite/docker-compose.yml
-          cli-version: 2
-          run: agent
-      matrix:
-        setup:
-          os:
-            - darwin
-            - freebsd
-            - linux
-            - openbsd
-            - windows
-          arch:
-            - "386"
-            - amd64
-            - arm64
-        adjustments:
-          - with: { os: darwin, arch: "386" }
-            skip: "macOS no longer supports x86 binaries"
-
-          - with: { os: dragonflybsd, arch: amd64 }
-
-          - with: { os: freebsd, arch: arm64 }
-            skip: "arm64 FreeBSD is not currently supported"
-
-          - with: { os: linux, arch: arm }
-          - with: { os: linux, arch: armhf }
-          - with: { os: linux, arch: ppc64 }
-          - with: { os: linux, arch: ppc64le }
-          - with: { os: linux, arch: mips64le }
-          - with: { os: linux, arch: s390x }
-          - with: { os: linux, arch: riscv64 }
-
-          - with: { os: netbsd, arch: amd64 }
-
-          - with: { os: openbsd, arch: arm64 }
-            skip: "arm64 OpenBSD is not currently supported"
-
-  - label: ":bathtub: Check version string is clean"
-    key: check-version-string
-    depends_on: build-binary
-    command: .buildkite/steps/check-version-string.sh
-
-  - name: ":technologist: Test bk cli + Agent cli"
-    key: test-bk-cli
-    depends_on: build-binary
-    command: ".buildkite/steps/test-bk.sh"
-    plugins:
-      docker-compose#v4.14.0:
-        config: .buildkite/docker-compose.yml
-        cli-version: 2
-        run: agent
-        env:
-          - BUILDKITE_AGENT_ACCESS_TOKEN
-          - BUILDKITE_BUILD_ID
-          - BUILDKITE_JOB_ID
-        volumes:
-          - "/usr/bin/buildkite-agent:/usr/bin/buildkite-agent"
-
-  - name: ":mag: Extract Agent Version Metadata"
-    key: set-metadata
-    command: ".buildkite/steps/extract-agent-version-metadata.sh"
-
-  - group: ":docker: Docker Image Builds"
-    steps:
-      - name: ":docker: {{matrix}} image build"
-        key: build-docker
-        agents:
-          queue: elastic-builders
+      - name: ":{{matrix.os}}: Build {{matrix.os}} {{matrix.arch}} binary"
+        command: ".buildkite/steps/build-binary.sh {{matrix.os}} {{matrix.arch}}"
+        key: build-binary
         depends_on:
-          - build-binary
-          - set-metadata
-        command: ".buildkite/steps/build-docker-image.sh {{matrix}}"
+          # don't wait for slower windows tests
+          # - test-linux-amd64
+          # - test-linux-arm64
+        artifact_paths: "pkg/*"
+        plugins:
+          - docker-compose#v4.14.0:
+              config: .buildkite/docker-compose.yml
+              cli-version: 2
+              run: agent
+          - buildkite-plugins/generate-build-provenance#main:
+              artifacts: "pkg/*"
+              provenance_filename: "buildkite-agent-{{matrix.os}}-{{matrix.arch}}.provenance.json"
         matrix:
           setup:
-            - "alpine"
-            - "alpine-k8s"
-            - "ubuntu-18.04"
-            - "ubuntu-20.04"
-            - "ubuntu-22.04"
-            - "sidecar"
+            os:
+              - darwin
+              # - freebsd
+              - linux
+              # - openbsd
+              # - windows
+            arch:
+              - "386"
+              - amd64
+              - arm64
+          adjustments:
+            - with: { os: darwin, arch: "386" }
+              skip: "macOS no longer supports x86 binaries"
 
-  - group: ":docker: Docker Image Tests"
-    steps:
-      - name: ":docker: {{matrix.variant}} amd64 image test"
-        key: test-docker-amd64
-        agents:
-          queue: elastic-builders
-        depends_on:
-          - build-docker
-        command: .buildkite/steps/test-docker-image.sh {{matrix.variant}}
-        matrix:
-          setup:
-            variant:
-              - alpine
-              - alpine-k8s
-              - ubuntu-18.04
-              - ubuntu-20.04
-              - ubuntu-22.04
-              - sidecar
+            # - with: { os: dragonflybsd, arch: amd64 }
 
-      - name: ":docker: {{matrix.variant}} arm64 image test"
-        key: test-docker-arm64
-        agents:
-          queue: elastic-builders-arm64
-        depends_on:
-          - build-docker
-        command: .buildkite/steps/test-docker-image.sh {{matrix.variant}}
-        matrix:
-          setup:
-            variant:
-              - alpine
-              - alpine-k8s
-              - ubuntu-18.04
-              - ubuntu-20.04
-              - ubuntu-22.04
-              - sidecar
+            # - with: { os: freebsd, arch: arm64 }
+            #   skip: "arm64 FreeBSD is not currently supported"
 
-  - name: ":debian: Debian package build"
-    key: build-debian-packages
-    depends_on:
-      - build-binary
-      - set-metadata
-    command: ".buildkite/steps/build-debian-packages.sh"
-    artifact_paths: "deb/**/*"
+            # - with: { os: linux, arch: arm }
+            # - with: { os: linux, arch: armhf }
+            # - with: { os: linux, arch: ppc64 }
+            # - with: { os: linux, arch: ppc64le }
+            # - with: { os: linux, arch: mips64le }
+            # - with: { os: linux, arch: s390x }
+            # - with: { os: linux, arch: riscv64 }
 
-  - name: ":redhat: RPM Package build"
-    key: build-rpm-packages
-    depends_on:
-      - build-binary
-      - set-metadata
-    command: ".buildkite/steps/build-rpm-packages.sh"
-    artifact_paths: "rpm/**/*"
+            # - with: { os: netbsd, arch: amd64 }
 
-  - name: ":github: Build Github Release"
-    key: build-github-release
-    depends_on:
-      - build-binary
-      - set-metadata
-    command: ".buildkite/steps/build-github-release.sh"
-    artifact_paths: "releases/**/*"
-    plugins:
-      docker-compose#v4.14.0:
-        config: .buildkite/docker-compose.release.yml
-        run: github-release
+            # - with: { os: openbsd, arch: arm64 }
+            #   skip: "arm64 OpenBSD is not currently supported"
 
-  - name: ":pipeline: Upload Release Pipeline"
-    key: upload-release-steps
-    depends_on:
-      - check-code-committed
-      - check-version-string
-      - test-windows
-      - test-bk-cli
-      - test-docker-amd64
-      - test-docker-arm64
-      - build-rpm-packages
-      - build-debian-packages
-      - build-github-release
-    command: ".buildkite/steps/upload-release-steps.sh"
-    if: build.env("DRY_RUN") == "true" || build.branch =~ /^(main|.*-.*-stable)$$/
+  # - label: ":bathtub: Check version string is clean"
+  #   key: check-version-string
+  #   depends_on: build-binary
+  #   command: .buildkite/steps/check-version-string.sh
+
+  # - name: ":technologist: Test bk cli + Agent cli"
+  #   key: test-bk-cli
+  #   depends_on: build-binary
+  #   command: ".buildkite/steps/test-bk.sh"
+  #   plugins:
+  #     docker-compose#v4.14.0:
+  #       config: .buildkite/docker-compose.yml
+  #       cli-version: 2
+  #       run: agent
+  #       env:
+  #         - BUILDKITE_AGENT_ACCESS_TOKEN
+  #         - BUILDKITE_BUILD_ID
+  #         - BUILDKITE_JOB_ID
+  #       volumes:
+  #         - "/usr/bin/buildkite-agent:/usr/bin/buildkite-agent"
+
+  # - name: ":mag: Extract Agent Version Metadata"
+  #   key: set-metadata
+  #   command: ".buildkite/steps/extract-agent-version-metadata.sh"
+
+  # - group: ":docker: Docker Image Builds"
+  #   steps:
+  #     - name: ":docker: {{matrix}} image build"
+  #       key: build-docker
+  #       agents:
+  #         queue: elastic-builders
+  #       depends_on:
+  #         - build-binary
+  #         - set-metadata
+  #       command: ".buildkite/steps/build-docker-image.sh {{matrix}}"
+  #       matrix:
+  #         setup:
+  #           - "alpine"
+  #           - "alpine-k8s"
+  #           - "ubuntu-18.04"
+  #           - "ubuntu-20.04"
+  #           - "ubuntu-22.04"
+  #           - "sidecar"
+
+  # - group: ":docker: Docker Image Tests"
+  #   steps:
+  #     - name: ":docker: {{matrix.variant}} amd64 image test"
+  #       key: test-docker-amd64
+  #       agents:
+  #         queue: elastic-builders
+  #       depends_on:
+  #         - build-docker
+  #       command: .buildkite/steps/test-docker-image.sh {{matrix.variant}}
+  #       matrix:
+  #         setup:
+  #           variant:
+  #             - alpine
+  #             - alpine-k8s
+  #             - ubuntu-18.04
+  #             - ubuntu-20.04
+  #             - ubuntu-22.04
+  #             - sidecar
+
+  #     - name: ":docker: {{matrix.variant}} arm64 image test"
+  #       key: test-docker-arm64
+  #       agents:
+  #         queue: elastic-builders-arm64
+  #       depends_on:
+  #         - build-docker
+  #       command: .buildkite/steps/test-docker-image.sh {{matrix.variant}}
+  #       matrix:
+  #         setup:
+  #           variant:
+  #             - alpine
+  #             - alpine-k8s
+  #             - ubuntu-18.04
+  #             - ubuntu-20.04
+  #             - ubuntu-22.04
+  #             - sidecar
+
+  # - name: ":debian: Debian package build"
+  #   key: build-debian-packages
+  #   depends_on:
+  #     - build-binary
+  #     - set-metadata
+  #   command: ".buildkite/steps/build-debian-packages.sh"
+  #   artifact_paths: "deb/**/*"
+
+  # - name: ":redhat: RPM Package build"
+  #   key: build-rpm-packages
+  #   depends_on:
+  #     - build-binary
+  #     - set-metadata
+  #   command: ".buildkite/steps/build-rpm-packages.sh"
+  #   artifact_paths: "rpm/**/*"
+
+  # - name: ":github: Build Github Release"
+  #   key: build-github-release
+  #   depends_on:
+  #     - build-binary
+  #     - set-metadata
+  #   command: ".buildkite/steps/build-github-release.sh"
+  #   artifact_paths: "releases/**/*"
+  #   plugins:
+  #     docker-compose#v4.14.0:
+  #       config: .buildkite/docker-compose.release.yml
+  #       run: github-release
+
+  # - name: ":pipeline: Upload Release Pipeline"
+  #   key: upload-release-steps
+  #   depends_on:
+  #     - check-code-committed
+  #     - check-version-string
+  #     - test-windows
+  #     - test-bk-cli
+  #     - test-docker-amd64
+  #     - test-docker-arm64
+  #     - build-rpm-packages
+  #     - build-debian-packages
+  #     - build-github-release
+  #   command: ".buildkite/steps/upload-release-steps.sh"
+  #   if: build.env("DRY_RUN") == "true" || build.branch =~ /^(main|.*-.*-stable)$$/

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,78 +13,78 @@ steps:
           cli-version: 2
           run: agent
 
-  # - name: ":linux: Linux AMD64 Tests"
-  #   key: test-linux-amd64
-  #   command: ".buildkite/steps/tests.sh"
-  #   artifact_paths: junit-*.xml
-  #   plugins:
-  #     - docker-compose#v4.14.0:
-  #         config: .buildkite/docker-compose.yml
-  #         cli-version: 2
-  #         run: agent
-  #     - test-collector#v1.2.0:
-  #         files: "junit-*.xml"
-  #         format: "junit"
-  #     - artifacts#v1.9.0:
-  #         upload: "cover.{html,out}"
+  - name: ":linux: Linux AMD64 Tests"
+    key: test-linux-amd64
+    command: ".buildkite/steps/tests.sh"
+    artifact_paths: junit-*.xml
+    plugins:
+      - docker-compose#v4.14.0:
+          config: .buildkite/docker-compose.yml
+          cli-version: 2
+          run: agent
+      - test-collector#v1.2.0:
+          files: "junit-*.xml"
+          format: "junit"
+      - artifacts#v1.9.0:
+          upload: "cover.{html,out}"
 
-  # - name: ":linux: Linux ARM64 Tests"
-  #   key: test-linux-arm64
-  #   command: ".buildkite/steps/tests.sh"
-  #   artifact_paths: junit-*.xml
-  #   agents:
-  #     queue: agent-runners-linux-arm64
-  #   plugins:
-  #     - docker-compose#v4.14.0:
-  #         config: .buildkite/docker-compose.yml
-  #         cli-version: 2
-  #         run: agent
-  #     - test-collector#v1.2.0:
-  #         files: "junit-*.xml"
-  #         format: "junit"
-  #     - artifacts#v1.9.0:
-  #         upload: "cover.{html,out}"
+  - name: ":linux: Linux ARM64 Tests"
+    key: test-linux-arm64
+    command: ".buildkite/steps/tests.sh"
+    artifact_paths: junit-*.xml
+    agents:
+      queue: agent-runners-linux-arm64
+    plugins:
+      - docker-compose#v4.14.0:
+          config: .buildkite/docker-compose.yml
+          cli-version: 2
+          run: agent
+      - test-collector#v1.2.0:
+          files: "junit-*.xml"
+          format: "junit"
+      - artifacts#v1.9.0:
+          upload: "cover.{html,out}"
 
-  # - name: ":satellite: Detect Data Races"
-  #   key: test-race-linux-arm64
-  #   command: ".buildkite/steps/tests.sh -race"
-  #   artifact_paths: junit-*.xml
-  #   agents:
-  #     queue: agent-runners-linux-arm64
-  #   plugins:
-  #     - docker-compose#v4.14.0:
-  #         config: .buildkite/docker-compose.yml
-  #         cli-version: 2
-  #         run: agent
-  #     - test-collector#v1.2.0:
-  #         files: "junit-*.xml"
-  #         format: "junit"
-  #     - artifacts#v1.9.0:
-  #         upload: "cover.{html,out}"
+  - name: ":satellite: Detect Data Races"
+    key: test-race-linux-arm64
+    command: ".buildkite/steps/tests.sh -race"
+    artifact_paths: junit-*.xml
+    agents:
+      queue: agent-runners-linux-arm64
+    plugins:
+      - docker-compose#v4.14.0:
+          config: .buildkite/docker-compose.yml
+          cli-version: 2
+          run: agent
+      - test-collector#v1.2.0:
+          files: "junit-*.xml"
+          format: "junit"
+      - artifacts#v1.9.0:
+          upload: "cover.{html,out}"
 
-  # - name: ":windows: Windows AMD64 Tests"
-  #   key: test-windows
-  #   command: "bash .buildkite\\steps\\tests.sh"
-  #   artifact_paths: junit-*.xml
-  #   agents:
-  #     queue: agent-runners-windows-amd64
-  #   plugins:
-  #     - test-collector#v1.2.0:
-  #         files: "junit-*.xml"
-  #         format: "junit"
-  #     - artifacts#v1.9.0:
-  #         upload: "cover.{html,out}"
+  - name: ":windows: Windows AMD64 Tests"
+    key: test-windows
+    command: "bash .buildkite\\steps\\tests.sh"
+    artifact_paths: junit-*.xml
+    agents:
+      queue: agent-runners-windows-amd64
+    plugins:
+      - test-collector#v1.2.0:
+          files: "junit-*.xml"
+          format: "junit"
+      - artifacts#v1.9.0:
+          upload: "cover.{html,out}"
 
-  # - label: ":writing_hand: Annotate with Test Failures"
-  #   depends_on:
-  #     - test-linux-amd64
-  #     - test-race-linux-arm64
-  #     - test-linux-arm64
-  #     - test-windows
-  #   allow_dependency_failure: true
-  #   plugins:
-  #     - junit-annotate#v1.6.0:
-  #         artifacts: junit-*.xml
+  - label: ":writing_hand: Annotate with Test Failures"
+    depends_on:
+      - test-linux-amd64
+      - test-race-linux-arm64
+      - test-linux-arm64
+      - test-windows
+    allow_dependency_failure: true
+    plugins:
+      - junit-annotate#v1.6.0:
+          artifacts: junit-*.xml
 
   - group: ":hammer_and_wrench: Binary builds"
     steps:
@@ -93,8 +93,8 @@ steps:
         key: build-binary
         depends_on:
           # don't wait for slower windows tests
-          # - test-linux-amd64
-          # - test-linux-arm64
+          - test-linux-amd64
+          - test-linux-arm64
         artifact_paths: "pkg/*"
         plugins:
           - docker-compose#v4.14.0:
@@ -108,10 +108,10 @@ steps:
           setup:
             os:
               - darwin
-              # - freebsd
+              - freebsd
               - linux
-              # - openbsd
-              # - windows
+              - openbsd
+              - windows
             arch:
               - "386"
               - amd64
@@ -120,10 +120,10 @@ steps:
             - with: { os: darwin, arch: "386" }
               skip: "macOS no longer supports x86 binaries"
 
-            # - with: { os: dragonflybsd, arch: amd64 }
+            - with: { os: dragonflybsd, arch: amd64 }
 
-            # - with: { os: freebsd, arch: arm64 }
-            #   skip: "arm64 FreeBSD is not currently supported"
+            - with: { os: freebsd, arch: arm64 }
+              skip: "arm64 FreeBSD is not currently supported"
 
             - with: { os: linux, arch: arm }
             - with: { os: linux, arch: armhf }
@@ -133,90 +133,90 @@ steps:
             - with: { os: linux, arch: s390x }
             - with: { os: linux, arch: riscv64 }
 
-            # - with: { os: netbsd, arch: amd64 }
+            - with: { os: netbsd, arch: amd64 }
 
-            # - with: { os: openbsd, arch: arm64 }
-            #   skip: "arm64 OpenBSD is not currently supported"
+            - with: { os: openbsd, arch: arm64 }
+              skip: "arm64 OpenBSD is not currently supported"
 
-  # - label: ":bathtub: Check version string is clean"
-  #   key: check-version-string
-  #   depends_on: build-binary
-  #   command: .buildkite/steps/check-version-string.sh
+  - label: ":bathtub: Check version string is clean"
+    key: check-version-string
+    depends_on: build-binary
+    command: .buildkite/steps/check-version-string.sh
 
-  # - name: ":technologist: Test bk cli + Agent cli"
-  #   key: test-bk-cli
-  #   depends_on: build-binary
-  #   command: ".buildkite/steps/test-bk.sh"
-  #   plugins:
-  #     docker-compose#v4.14.0:
-  #       config: .buildkite/docker-compose.yml
-  #       cli-version: 2
-  #       run: agent
-  #       env:
-  #         - BUILDKITE_AGENT_ACCESS_TOKEN
-  #         - BUILDKITE_BUILD_ID
-  #         - BUILDKITE_JOB_ID
-  #       volumes:
-  #         - "/usr/bin/buildkite-agent:/usr/bin/buildkite-agent"
+  - name: ":technologist: Test bk cli + Agent cli"
+    key: test-bk-cli
+    depends_on: build-binary
+    command: ".buildkite/steps/test-bk.sh"
+    plugins:
+      - docker-compose#v4.14.0:
+          config: .buildkite/docker-compose.yml
+          cli-version: 2
+          run: agent
+          env:
+            - BUILDKITE_AGENT_ACCESS_TOKEN
+            - BUILDKITE_BUILD_ID
+            - BUILDKITE_JOB_ID
+          volumes:
+            - "/usr/bin/buildkite-agent:/usr/bin/buildkite-agent"
 
   - name: ":mag: Extract Agent Version Metadata"
     key: set-metadata
     command: ".buildkite/steps/extract-agent-version-metadata.sh"
 
-  # - group: ":docker: Docker Image Builds"
-  #   steps:
-  #     - name: ":docker: {{matrix}} image build"
-  #       key: build-docker
-  #       agents:
-  #         queue: elastic-builders
-  #       depends_on:
-  #         - build-binary
-  #         - set-metadata
-  #       command: ".buildkite/steps/build-docker-image.sh {{matrix}}"
-  #       matrix:
-  #         setup:
-  #           - "alpine"
-  #           - "alpine-k8s"
-  #           - "ubuntu-18.04"
-  #           - "ubuntu-20.04"
-  #           - "ubuntu-22.04"
-  #           - "sidecar"
+  - group: ":docker: Docker Image Builds"
+    steps:
+      - name: ":docker: {{matrix}} image build"
+        key: build-docker
+        agents:
+          queue: elastic-builders
+        depends_on:
+          - build-binary
+          - set-metadata
+        command: ".buildkite/steps/build-docker-image.sh {{matrix}}"
+        matrix:
+          setup:
+            - "alpine"
+            - "alpine-k8s"
+            - "ubuntu-18.04"
+            - "ubuntu-20.04"
+            - "ubuntu-22.04"
+            - "sidecar"
 
-  # - group: ":docker: Docker Image Tests"
-  #   steps:
-  #     - name: ":docker: {{matrix.variant}} amd64 image test"
-  #       key: test-docker-amd64
-  #       agents:
-  #         queue: elastic-builders
-  #       depends_on:
-  #         - build-docker
-  #       command: .buildkite/steps/test-docker-image.sh {{matrix.variant}}
-  #       matrix:
-  #         setup:
-  #           variant:
-  #             - alpine
-  #             - alpine-k8s
-  #             - ubuntu-18.04
-  #             - ubuntu-20.04
-  #             - ubuntu-22.04
-  #             - sidecar
+  - group: ":docker: Docker Image Tests"
+    steps:
+      - name: ":docker: {{matrix.variant}} amd64 image test"
+        key: test-docker-amd64
+        agents:
+          queue: elastic-builders
+        depends_on:
+          - build-docker
+        command: .buildkite/steps/test-docker-image.sh {{matrix.variant}}
+        matrix:
+          setup:
+            variant:
+              - alpine
+              - alpine-k8s
+              - ubuntu-18.04
+              - ubuntu-20.04
+              - ubuntu-22.04
+              - sidecar
 
-  #     - name: ":docker: {{matrix.variant}} arm64 image test"
-  #       key: test-docker-arm64
-  #       agents:
-  #         queue: elastic-builders-arm64
-  #       depends_on:
-  #         - build-docker
-  #       command: .buildkite/steps/test-docker-image.sh {{matrix.variant}}
-  #       matrix:
-  #         setup:
-  #           variant:
-  #             - alpine
-  #             - alpine-k8s
-  #             - ubuntu-18.04
-  #             - ubuntu-20.04
-  #             - ubuntu-22.04
-  #             - sidecar
+      - name: ":docker: {{matrix.variant}} arm64 image test"
+        key: test-docker-arm64
+        agents:
+          queue: elastic-builders-arm64
+        depends_on:
+          - build-docker
+        command: .buildkite/steps/test-docker-image.sh {{matrix.variant}}
+        matrix:
+          setup:
+            variant:
+              - alpine
+              - alpine-k8s
+              - ubuntu-18.04
+              - ubuntu-20.04
+              - ubuntu-22.04
+              - sidecar
 
   - name: ":debian: Debian package build"
     key: build-debian-packages
@@ -242,29 +242,32 @@ steps:
           artifacts: "rpm/*"
           provenance_filename: "buildkite-agent-rpm-packages.provenance.json"
 
-  # - name: ":github: Build Github Release"
-  #   key: build-github-release
-  #   depends_on:
-  #     - build-binary
-  #     - set-metadata
-  #   command: ".buildkite/steps/build-github-release.sh"
-  #   artifact_paths: "releases/**/*"
-  #   plugins:
-  #     docker-compose#v4.14.0:
-  #       config: .buildkite/docker-compose.release.yml
-  #       run: github-release
+  - name: ":github: Build Github Release"
+    key: build-github-release
+    depends_on:
+      - build-binary
+      - set-metadata
+    command: ".buildkite/steps/build-github-release.sh"
+    artifact_paths: "releases/**/*"
+    plugins:
+      - docker-compose#v4.14.0:
+          config: .buildkite/docker-compose.release.yml
+          run: github-release
+      - buildkite-plugins/generate-build-provenance#main:
+          artifacts: "releases/*.tar.gz"
+          provenance_filename: "buildkite-agent-github-releases.provenance.json"
 
-  # - name: ":pipeline: Upload Release Pipeline"
-  #   key: upload-release-steps
-  #   depends_on:
-  #     - check-code-committed
-  #     - check-version-string
-  #     - test-windows
-  #     - test-bk-cli
-  #     - test-docker-amd64
-  #     - test-docker-arm64
-  #     - build-rpm-packages
-  #     - build-debian-packages
-  #     - build-github-release
-  #   command: ".buildkite/steps/upload-release-steps.sh"
-  #   if: build.env("DRY_RUN") == "true" || build.branch =~ /^(main|.*-.*-stable)$$/
+  - name: ":pipeline: Upload Release Pipeline"
+    key: upload-release-steps
+    depends_on:
+      - check-code-committed
+      - check-version-string
+      - test-windows
+      - test-bk-cli
+      - test-docker-amd64
+      - test-docker-arm64
+      - build-rpm-packages
+      - build-debian-packages
+      - build-github-release
+    command: ".buildkite/steps/upload-release-steps.sh"
+    if: build.env("DRY_RUN") == "true" || build.branch =~ /^(main|.*-.*-stable)$$/


### PR DESCRIPTION
> Best reviewed with whitespace hidden: https://github.com/buildkite/agent/pull/2976/files?w=1

### Description

Using the new [Generate Build Provenance](https://github.com/buildkite-plugins/generate-build-provenance-buildkite-plugin) plugin to generate [SLSA Build Provenance documents](https://slsa.dev/spec/v1.0/provenance) on the following steps in CI:

- Build binaries matrix
- Debian package build step
- RPM package build step
- Github release step

The Build Provenance documents are not immediately used anywhere - this will be followed up later.

### Context

Buildkite has released an [exciting new plugin](https://github.com/buildkite-plugins/generate-build-provenance-buildkite-plugin) that generates SLSA Build Provenance documents for pipeline steps. We'd really like to give it a go in the Agent CI pipelines.

### Changes

- No changes to the actual agent binary.

### Testing
- Tested in Agent CI pipelines.