### PR TITLE
Explain verification-failure-behavior in more detail

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -677,7 +677,7 @@ var AgentStartCommand = cli.Command{
 		cli.StringFlag{
 			Name:   "verification-failure-behavior",
 			Value:  agent.VerificationBehaviourBlock,
-			Usage:  fmt.Sprintf("The behavior when a job is received without a signature. One of: %v. Defaults to %s", verificationFailureBehaviors, agent.VerificationBehaviourBlock),
+			Usage:  fmt.Sprintf("The behavior when a job is received without a valid verifiable signature (without a signature, with an invalid signature, or with a signature that fails verification). One of: %v. Defaults to %s", verificationFailureBehaviors, agent.VerificationBehaviourBlock),
 			EnvVar: "BUILDKITE_AGENT_JOB_VERIFICATION_NO_SIGNATURE_BEHAVIOR",
 		},
 		cli.StringSliceFlag{


### PR DESCRIPTION
### Description

Fix the usage string to list more cases where "warn" mode continues with the job.

### Context

Got side-tracked and ended up looking at what the behaviour actually was. 

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
