### PR TITLE
Use job tokens for log chunk uploads

### DIFF
--- a/agent/integration/config_allowlisting_integration_test.go
+++ b/agent/integration/config_allowlisting_integration_test.go
@@ -119,6 +119,7 @@ func TestConfigAllowlisting(t *testing.T) {
 					"BUILDKITE":         "true",
 					"BUILDKITE_COMMAND": "echo hello",
 				},
+				Token: "bkaj_job-token",
 			}
 
 			for k, v := range tc.extraEnv {

--- a/agent/integration/job_environment_integration_test.go
+++ b/agent/integration/job_environment_integration_test.go
@@ -22,6 +22,7 @@ func TestWhenCachePathsSetInJobStep_CachePathsEnvVarIsSet(t *testing.T) {
 				Paths: []string{"foo", "bar"},
 			},
 		},
+		Token: "bkaj_job-token",
 	}
 
 	mb := mockBootstrap(t)

--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -103,6 +103,7 @@ func TestPreBootstrapHookScripts(t *testing.T) {
 				Env: map[string]string{
 					"BUILDKITE_COMMAND": "echo hello world",
 				},
+				Token: "bkaj_job-token",
 			}
 
 			mb := mockBootstrap(t)
@@ -150,6 +151,7 @@ func TestPreBootstrapHookRefusesJob(t *testing.T) {
 		Env: map[string]string{
 			"BUILDKITE_COMMAND": "echo hello world",
 		},
+		Token: "bkaj_job-token",
 	}
 
 	// create a mock agent API
@@ -197,6 +199,7 @@ func TestJobRunner_WhenBootstrapExits_ItSendsTheExitStatusToTheAPI(t *testing.T)
 				Env: map[string]string{
 					"BUILDKITE_COMMAND": "echo hello world",
 				},
+				Token: "bkaj_job-token",
 			}
 
 			mb := mockBootstrap(t)
@@ -231,7 +234,7 @@ func TestJobRunner_WhenJobHasToken_ItOverridesAccessToken(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	jobToken := "actually-llamas-are-only-okay"
+	jobToken := "bkaj_actually-llamas-are-only-okay"
 
 	j := &api.Job{
 		ID:                 "my-job-id",
@@ -280,13 +283,14 @@ func TestJobRunnerPassesAccessTokenToBootstrap(t *testing.T) {
 		Env: map[string]string{
 			"BUILDKITE_COMMAND": "echo hello world",
 		},
+		Token: "bkaj_job-token",
 	}
 
 	mb := mockBootstrap(t)
 	defer mb.CheckAndClose(t)
 
 	mb.Expect().Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
-		if got, want := c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN"), "llamasrock"; got != want {
+		if got, want := c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN"), "bkaj_job-token"; got != want {
 			t.Errorf("c.GetEnv(BUILDKITE_AGENT_ACCESS_TOKEN) = %q, want %q", got, want)
 		}
 		c.Exit(0)
@@ -319,6 +323,7 @@ func TestJobRunnerIgnoresPipelineChangesToProtectedVars(t *testing.T) {
 			"BUILDKITE_COMMAND":      "echo hello world",
 			"BUILDKITE_COMMAND_EVAL": "false",
 		},
+		Token: "bkaj_job-token",
 	}
 
 	mb := mockBootstrap(t)

--- a/agent/integration/job_verification_integration_test.go
+++ b/agent/integration/job_verification_integration_test.go
@@ -46,6 +46,7 @@ var (
 			"BUILDKITE_REPO":    defaultRepositoryURL,
 			"DEPLOY":            "1", // step env overrides pipeline env
 		},
+		Token: "bkaj_job-token",
 	}
 
 	jobWithNoPluginConfig = api.Job{
@@ -67,6 +68,7 @@ var (
 			"BUILDKITE_REPO":    defaultRepositoryURL,
 			"DEPLOY":            "1", // step env overrides pipeline env
 		},
+		Token: "bkaj_job-token",
 	}
 
 	jobWithNoPlugins = api.Job{
@@ -82,6 +84,7 @@ var (
 			"BUILDKITE_REPO":    defaultRepositoryURL,
 			"DEPLOY":            "0",
 		},
+		Token: "bkaj_job-token",
 	}
 
 	jobWithNullPlugins = api.Job{
@@ -97,6 +100,7 @@ var (
 			"BUILDKITE_REPO":    defaultRepositoryURL,
 			"DEPLOY":            "0",
 		},
+		Token: "bkaj_job-token",
 	}
 
 	jobWithMismatchedStepAndJob = api.Job{
@@ -110,6 +114,7 @@ var (
 			"BUILDKITE_REPO":    defaultRepositoryURL,
 			"DEPLOY":            "0",
 		},
+		Token: "bkaj_job-token",
 	}
 
 	jobWithMismatchedPlugins = api.Job{
@@ -130,6 +135,7 @@ var (
 			"BUILDKITE_REPO":    defaultRepositoryURL,
 			"DEPLOY":            "0",
 		},
+		Token: "bkaj_job-token",
 	}
 
 	jobWithMissingPlugins = api.Job{
@@ -150,6 +156,7 @@ var (
 			"BUILDKITE_REPO":    defaultRepositoryURL,
 			"DEPLOY":            "0",
 		},
+		Token: "bkaj_job-token",
 	}
 
 	jobWithMismatchedEnv = api.Job{
@@ -163,6 +170,7 @@ var (
 			"BUILDKITE_REPO":    defaultRepositoryURL,
 			"DEPLOY":            "crimes",
 		},
+		Token: "bkaj_job-token",
 	}
 
 	jobWithStepEnvButNoCorrespondingJobEnv = api.Job{
@@ -177,6 +185,7 @@ var (
 			"BUILDKITE_REPO":    defaultRepositoryURL,
 			"DEPLOY":            "0",
 		},
+		Token: "bkaj_job-token",
 	}
 
 	jobWithPipelineEnvButNoCorrespondingJobEnv = api.Job{
@@ -189,6 +198,7 @@ var (
 			"BUILDKITE_COMMAND": "echo hello world",
 			"BUILDKITE_REPO":    defaultRepositoryURL,
 		},
+		Token: "bkaj_job-token",
 	}
 
 	jobWithMatrix = api.Job{
@@ -206,6 +216,7 @@ var (
 			"greeting": "hello",
 			"object":   "world",
 		},
+		Token: "bkaj_job-token",
 	}
 
 	jobWithInvalidMatrixPermutation = api.Job{
@@ -223,6 +234,7 @@ var (
 			"greeting": "goodbye",
 			"object":   "mister anderson",
 		},
+		Token: "bkaj_job-token",
 	}
 
 	jobWithMatrixMismatch = api.Job{
@@ -240,6 +252,7 @@ var (
 			"greeting": "hello",
 			"object":   "world",
 		},
+		Token: "bkaj_job-token",
 	}
 
 	jobWithPipelineInvariantsInEnv = api.Job{
@@ -253,6 +266,7 @@ var (
 			"BUILDKITE_REPO":    defaultRepositoryURL,
 			"DEPLOY":            "0",
 		},
+		Token: "bkaj_job-token",
 	}
 
 	jobWithInvalidPipelineInvariantsInEnv = api.Job{
@@ -266,6 +280,7 @@ var (
 			"BUILDKITE_REPO":    "https://github.com/haxors/agent.git",
 			"DEPLOY":            "0",
 		},
+		Token: "bkaj_job-token",
 	}
 )
 

--- a/agent/integration/test_helpers.go
+++ b/agent/integration/test_helpers.go
@@ -230,9 +230,11 @@ func (t *testAgentEndpoint) server(extraRoutes ...route) *httptest.Server {
 			t.mtx.Unlock()
 
 			// We also require job tokens are used for authentication
-			if !strings.HasPrefix(req.Header["Authorization"][0], "Token bkaj_") {
-				fmt.Printf("Invalid authorization header, expected job token, got: %q\n", req.Header["Authorization"][0])
-				rw.WriteHeader(http.StatusUnauthorized)
+			authzHeader := req.Header.Get("Authorization")
+			if !strings.HasPrefix(authzHeader, "Token bkaj_") {
+				msg := fmt.Sprintf("Authorization header = %q, want job token prefix 'Token bkaj_'", authzHeader)
+				fmt.Fprintln(os.Stderr, msg)
+				http.Error(rw, msg, http.StatusUnauthorized)
 				return
 			}
 

--- a/agent/integration/test_helpers.go
+++ b/agent/integration/test_helpers.go
@@ -229,6 +229,13 @@ func (t *testAgentEndpoint) server(extraRoutes ...route) *httptest.Server {
 			t.calls[req.URL.Path] = append(t.calls[req.URL.Path], b)
 			t.mtx.Unlock()
 
+			// We also require job tokens are used for authentication
+			if !strings.HasPrefix(req.Header["Authorization"][0], "Token bkaj_") {
+				fmt.Printf("Invalid authorization header, expected job token, got: %q\n", req.Header["Authorization"][0])
+				rw.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
 			next.ServeHTTP(rw, req)
 		})
 	}

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -179,7 +179,6 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient APIClient, con
 		agentLogger: l,
 		conf:        conf,
 		apiClient:   apiClient,
-		client:      &core.Client{APIClient: apiClient, Logger: l},
 	}
 
 	var err error
@@ -199,6 +198,7 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient APIClient, con
 		clientConf.Token = r.conf.Job.Token
 		r.apiClient = api.NewClient(r.agentLogger, clientConf)
 	}
+	r.client = &core.Client{APIClient: r.apiClient, Logger: l}
 
 	// Create our header times struct
 	r.headerTimesStreamer = newHeaderTimesStreamer(r.agentLogger, r.onUploadHeaderTime)


### PR DESCRIPTION
In https://github.com/buildkite/agent/pull/2915 we refactored a bunch of this code. In the process, we now take a copy of the `apiClient` object in `NewJobRunner` _before_ we replace the `apiClient` with a new one that uses the job token rather than the session token. We then use the copy for log streaming. This means agents since v3.77.0 use session tokens rather than job tokens for chunk uploads.

~I've tested it locally and this change fixes the problem. I'm not sure how to add regression tests for this though.~ This is tested by updating the fake bk server in the integration tests to require job tokens for everything.