### PR TITLE
[PKG-7596] Bump publish-to-packages plugin to v2.0.0

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -42,7 +42,7 @@ steps:
 
   - name: ":redhat: Publish Edge RPM Package to Buildkite Packages"
     plugins:
-      - publish-to-packages#isaacsu/pkg-7533-upload-build-provenance:
+      - publish-to-packages#v2.0.0:
           artifacts: "rpm/*.rpm"
           registry: "buildkite/agent-rpm-experimental"
           artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
@@ -76,7 +76,7 @@ steps:
 
   - name: ":debian: Publish Edge Debian Package to Buildkite Packages"
     plugins:
-      - publish-to-packages#isaacsu/pkg-7533-upload-build-provenance:
+      - publish-to-packages#v2.0.0:
           artifacts: "deb/*.deb"
           registry: "buildkite/agent-deb-experimental"
           artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"

--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -42,7 +42,7 @@ steps:
 
   - name: ":redhat: Publish Edge RPM Package to Buildkite Packages"
     plugins:
-      - publish-to-packages#v1.0.0:
+      - publish-to-packages#isaacsu/pkg-7533-upload-build-provenance:
           artifacts: "rpm/*.rpm"
           registry: "buildkite/agent-rpm-experimental"
           artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
@@ -76,7 +76,7 @@ steps:
 
   - name: ":debian: Publish Edge Debian Package to Buildkite Packages"
     plugins:
-      - publish-to-packages#v1.0.0:
+      - publish-to-packages#isaacsu/pkg-7533-upload-build-provenance:
           artifacts: "deb/*.deb"
           registry: "buildkite/agent-deb-experimental"
           artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -70,7 +70,7 @@ steps:
 
   - name: ":redhat: Publish RPM Package to Buildkite Packages"
     plugins:
-      - publish-to-packages#v1.0.0:
+      - publish-to-packages#v2.0.0:
           artifacts: "rpm/*.rpm"
           registry: "buildkite/agent-rpm"
           artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
@@ -100,7 +100,7 @@ steps:
 
   - name: ":debian: Publish Debian Package to Buildkite Packages"
     plugins:
-      - publish-to-packages#v1.0.0:
+      - publish-to-packages#v2.0.0:
           artifacts: "deb/*.deb"
           registry: "buildkite/agent-deb"
           artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -70,7 +70,7 @@ steps:
 
   - name: ":redhat: Publish Unstable RPM Package to Buildkite Packages"
     plugins:
-      - publish-to-packages#v1.0.0:
+      - publish-to-packages#v2.0.0:
           artifacts: "rpm/*.rpm"
           registry: "buildkite/agent-rpm-unstable"
           artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
@@ -100,7 +100,7 @@ steps:
 
   - name: ":debian: Publish Unstable Debian Package to Buildkite Packages"
     plugins:
-      - publish-to-packages#v1.0.0:
+      - publish-to-packages#v2.0.0:
           artifacts: "deb/*.deb"
           registry: "buildkite/agent-deb-unstable"
           artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  DRY_RUN: false # set to true to disable publishing releases
+  DRY_RUN: true # set to true to disable publishing releases
 agents:
   queue: agent-runners-linux-amd64
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  DRY_RUN: true # set to true to disable publishing releases
+  DRY_RUN: false # set to true to disable publishing releases
 agents:
   queue: agent-runners-linux-amd64
 


### PR DESCRIPTION
Bump publish-to-packages plugin to version v2.0.0 to get all the cool new features introduced here: https://github.com/buildkite-plugins/publish-to-packages-buildkite-plugin/pull/4