### PR TITLE
Add JSON-format env file, allow annotations from pre-bootstrap

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -484,10 +484,11 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	apiConfig := r.apiClient.Config()
 	env["BUILDKITE_AGENT_ENDPOINT"] = apiConfig.Endpoint
 	env["BUILDKITE_AGENT_ACCESS_TOKEN"] = apiConfig.Token
+	env["BUILDKITE_NO_HTTP2"] = fmt.Sprint(apiConfig.DisableHTTP2)
 
 	// Add agent environment variables
-	env["BUILDKITE_AGENT_DEBUG"] = fmt.Sprintf("%t", r.conf.Debug)
-	env["BUILDKITE_AGENT_DEBUG_HTTP"] = fmt.Sprintf("%t", r.conf.DebugHTTP)
+	env["BUILDKITE_AGENT_DEBUG"] = fmt.Sprint(r.conf.Debug)
+	env["BUILDKITE_AGENT_DEBUG_HTTP"] = fmt.Sprint(r.conf.DebugHTTP)
 	env["BUILDKITE_AGENT_PID"] = strconv.Itoa(os.Getpid())
 
 	// We know the BUILDKITE_BIN_PATH dir, because it's the path to the
@@ -507,14 +508,14 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	env["BUILDKITE_BUILD_PATH"] = r.conf.AgentConfiguration.BuildPath
 	env["BUILDKITE_SOCKETS_PATH"] = r.conf.AgentConfiguration.SocketsPath
 	env["BUILDKITE_GIT_MIRRORS_PATH"] = r.conf.AgentConfiguration.GitMirrorsPath
-	env["BUILDKITE_GIT_MIRRORS_SKIP_UPDATE"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.GitMirrorsSkipUpdate)
+	env["BUILDKITE_GIT_MIRRORS_SKIP_UPDATE"] = fmt.Sprint(r.conf.AgentConfiguration.GitMirrorsSkipUpdate)
 	env["BUILDKITE_HOOKS_PATH"] = r.conf.AgentConfiguration.HooksPath
 	env["BUILDKITE_PLUGINS_PATH"] = r.conf.AgentConfiguration.PluginsPath
-	env["BUILDKITE_SSH_KEYSCAN"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.SSHKeyscan)
-	env["BUILDKITE_GIT_SUBMODULES"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.GitSubmodules)
-	env["BUILDKITE_COMMAND_EVAL"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.CommandEval)
-	env["BUILDKITE_PLUGINS_ENABLED"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.PluginsEnabled)
-	env["BUILDKITE_LOCAL_HOOKS_ENABLED"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.LocalHooksEnabled)
+	env["BUILDKITE_SSH_KEYSCAN"] = fmt.Sprint(r.conf.AgentConfiguration.SSHKeyscan)
+	env["BUILDKITE_GIT_SUBMODULES"] = fmt.Sprint(r.conf.AgentConfiguration.GitSubmodules)
+	env["BUILDKITE_COMMAND_EVAL"] = fmt.Sprint(r.conf.AgentConfiguration.CommandEval)
+	env["BUILDKITE_PLUGINS_ENABLED"] = fmt.Sprint(r.conf.AgentConfiguration.PluginsEnabled)
+	env["BUILDKITE_LOCAL_HOOKS_ENABLED"] = fmt.Sprint(r.conf.AgentConfiguration.LocalHooksEnabled)
 	env["BUILDKITE_GIT_CHECKOUT_FLAGS"] = r.conf.AgentConfiguration.GitCheckoutFlags
 	env["BUILDKITE_GIT_CLONE_FLAGS"] = r.conf.AgentConfiguration.GitCloneFlags
 	env["BUILDKITE_GIT_FETCH_FLAGS"] = r.conf.AgentConfiguration.GitFetchFlags
@@ -524,7 +525,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	env["BUILDKITE_SHELL"] = r.conf.AgentConfiguration.Shell
 	env["BUILDKITE_AGENT_EXPERIMENT"] = strings.Join(experiments.Enabled(ctx), ",")
 	env["BUILDKITE_REDACTED_VARS"] = strings.Join(r.conf.AgentConfiguration.RedactedVars, ",")
-	env["BUILDKITE_STRICT_SINGLE_HOOKS"] = fmt.Sprintf("%t", r.conf.AgentConfiguration.StrictSingleHooks)
+	env["BUILDKITE_STRICT_SINGLE_HOOKS"] = fmt.Sprint(r.conf.AgentConfiguration.StrictSingleHooks)
 	env["BUILDKITE_CANCEL_GRACE_PERIOD"] = strconv.Itoa(r.conf.AgentConfiguration.CancelGracePeriod)
 	env["BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS"] = strconv.Itoa(int(r.conf.AgentConfiguration.SignalGracePeriod / time.Second))
 	env["BUILDKITE_TRACE_CONTEXT_ENCODING"] = r.conf.AgentConfiguration.TraceContextEncoding
@@ -576,7 +577,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 			enablePluginValidation = true
 		}
 	}
-	env["BUILDKITE_PLUGIN_VALIDATION"] = fmt.Sprintf("%t", enablePluginValidation)
+	env["BUILDKITE_PLUGIN_VALIDATION"] = fmt.Sprint(enablePluginValidation)
 
 	if r.conf.AgentConfiguration.TracingBackend != "" {
 		env["BUILDKITE_TRACING_BACKEND"] = r.conf.AgentConfiguration.TracingBackend

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -639,8 +639,18 @@ func (r *JobRunner) executePreBootstrapHook(ctx context.Context, hook string) (b
 
 	// This (plus inherited) is the only ENV that should be exposed
 	// to the pre-bootstrap hook.
+	// - Env files are designed to be validated by the pre-bootstrap hook
+	// - The pre-bootstrap hook may want to create annotations, so it can also
+	//   have a few necessary and global args as env vars.
 	sh.Env.Set("BUILDKITE_ENV_FILE", r.envShellFile.Name())
 	sh.Env.Set("BUILDKITE_ENV_JSON_FILE", r.envJSONFile.Name())
+	apiConfig := r.apiClient.Config()
+	sh.Env.Set("BUILDKITE_JOB_ID", r.conf.Job.ID)
+	sh.Env.Set("BUILDKITE_AGENT_ACCESS_TOKEN", apiConfig.Token)
+	sh.Env.Set("BUILDKITE_AGENT_ENDPOINT", apiConfig.Endpoint)
+	sh.Env.Set("BUILDKITE_NO_HTTP2", fmt.Sprint(apiConfig.DisableHTTP2))
+	sh.Env.Set("BUILDKITE_AGENT_DEBUG", fmt.Sprint(r.conf.Debug))
+	sh.Env.Set("BUILDKITE_AGENT_DEBUG_HTTP", fmt.Sprint(r.conf.DebugHTTP))
 
 	sh.Writer = LogWriter{
 		l: r.agentLogger,

--- a/agent/job_runner_test.go
+++ b/agent/job_runner_test.go
@@ -7,43 +7,51 @@ import (
 	"testing"
 
 	"github.com/buildkite/agent/v3/logger"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTruncateEnv(t *testing.T) {
 	l := logger.NewBuffer()
-	env := map[string]string{"FOO": strings.Repeat("a", 100)}
-	err := truncateEnv(l, env, "FOO", 64)
-	require.NoError(t, err)
-	assert.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaa[value truncated 100 -> 59 bytes]", env["FOO"])
-	assert.Equal(t, 64, len(fmt.Sprintf("FOO=%s\000", env["FOO"])))
+	key := "FOO"
+	env := map[string]string{key: strings.Repeat("a", 100)}
+	limit := 64
+	if err := truncateEnv(l, env, key, limit); err != nil {
+		t.Fatalf("truncateEnv(logger, %v, %q, %d) = %v", env, key, limit, err)
+	}
+	if got, want := env["FOO"], "aaaaaaaaaaaaaaaaaaaaaaaaaa[value truncated 100 -> 59 bytes]"; got != want {
+		t.Errorf("after truncateEnv(logger, %v, %q, %d): env[%q] = %q, want %q", env, key, limit, key, got, want)
+	}
+	format := "FOO=%s\000"
+	if got, want := len(fmt.Sprintf(format, env["FOO"])), limit; got != want {
+		t.Errorf("after truncateEnv(logger, %v, %q, %d): len(fmt.Sprintf(%q, env[%q])) = %d, want %d", env, key, limit, format, key, got, want)
+	}
 }
 
 func TestValidateJobValue(t *testing.T) {
 	bkTarget := "github.com/buildkite/test"
-	bkTargetRe := regexp.MustCompile("^github.com/buildkite/.*")
-	ghTargetRe := regexp.MustCompile("^github.com/nope/.*")
+	bkTargetRE := regexp.MustCompile(`^github\.com/buildkite/.*`)
+	ghTargetRE := regexp.MustCompile(`^github\.com/nope/.*`)
 
 	tests := []struct {
 		name           string
 		allowedTargets []*regexp.Regexp
 		pipelineTarget string
 		wantErr        bool
-	}{{
-		name:           "No error. Allowed targets no configured.",
-		allowedTargets: []*regexp.Regexp{},
-		pipelineTarget: bkTarget,
-	}, {
-		name:           "No pipeline target match",
-		allowedTargets: []*regexp.Regexp{ghTargetRe},
-		pipelineTarget: bkTarget,
-		wantErr:        true,
-	}, {
-		name:           "Pipeline target match",
-		allowedTargets: []*regexp.Regexp{ghTargetRe, bkTargetRe},
-		pipelineTarget: bkTarget,
-	}}
+	}{
+		{
+			name:           "No error. Allowed targets no configured.",
+			allowedTargets: []*regexp.Regexp{},
+			pipelineTarget: bkTarget,
+		}, {
+			name:           "No pipeline target match",
+			allowedTargets: []*regexp.Regexp{ghTargetRE},
+			pipelineTarget: bkTarget,
+			wantErr:        true,
+		}, {
+			name:           "Pipeline target match",
+			allowedTargets: []*regexp.Regexp{ghTargetRE, bkTargetRE},
+			pipelineTarget: bkTarget,
+		},
+	}
 
 	for _, tc := range tests {
 		err := validateJobValue(tc.allowedTargets, tc.pipelineTarget)

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -349,11 +349,15 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 	wg.Wait()
 
 	// Remove the env file, if any
-	if r.envFile != nil {
-		if err := os.Remove(r.envFile.Name()); err != nil {
-			r.agentLogger.Warn("[JobRunner] Error cleaning up env file: %s", err)
+	for _, f := range []*os.File{r.envShellFile, r.envJSONFile} {
+		if f == nil {
+			continue
 		}
-		r.agentLogger.Debug("[JobRunner] Deleted env file: %s", r.envFile.Name())
+		if err := os.Remove(f.Name()); err != nil {
+			r.agentLogger.Warn("[JobRunner] Error cleaning up env file: %s", err)
+			continue
+		}
+		r.agentLogger.Debug("[JobRunner] Deleted env file: %s", f.Name())
 	}
 
 	// Write some metrics about the job run

--- a/internal/mime/mime.go
+++ b/internal/mime/mime.go
@@ -388,6 +388,7 @@ var types = map[string]string{
 	".js":          "application/javascript",
 	".json":        "application/json",
 	".jsonml":      "application/jsonml+json",
+	".jxl":         "image/jxl",
 	".kar":         "audio/midi",
 	".karbon":      "application/vnd.kde.karbon",
 	".kfo":         "application/vnd.kde.kformula",


### PR DESCRIPTION
### Description

Two changes, since they touch similar code, done in one:
- Alongside `BUILDKITE_ENV_FILE`, write a `BUILDKITE_ENV_JSON_FILE` which has better-understood escaping and canonicalisation qualities.
- Set enough environment variables in `pre-bootstrap` hook to enable `buildkite-agent annotate` to work.

Opportunistic fixes:

- Turns out `BUILDKITE_NO_HTTP2` wasn't being passed to the bootstrap subcommand. That's fixed too.
- Globally replace `fmt.Sprintf("%t", someBool)` with the equivalent `fmt.Sprint(someBool)`.
- Tweaks to `job_runner_test.go`, including regexes and getting rid of assert/require.

### Context

Fixes #2962
Fixes #2966


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

I've also manually tested with a pre-bootstrap hook that reads `$BUILDKITE_ENV_JSON_FILE` with `jq .`, and annotates the build with it. :+1:
