### PR TITLE
Emit HTTP timings

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -397,11 +397,11 @@ func traceHTTPRequest(req *http.Request, t *tracer) *http.Request {
 		DNSDone: func(_ httptrace.DNSDoneInfo) {
 			t.LogTiming("dnsDone")
 		},
-		ConnectStart: func(_, _ string) {
-			t.LogTiming("connectStart")
+		ConnectStart: func(network, addr string) {
+			t.LogTiming(fmt.Sprintf("connectStart.%s.%s", network, addr))
 		},
-		ConnectDone: func(_, _ string, _ error) {
-			t.LogTiming("connectDone")
+		ConnectDone: func(network, addr string, _ error) {
+			t.LogTiming(fmt.Sprintf("connectDone.%s.%s", network, addr))
 		},
 		TLSHandshakeStart: func() {
 			t.LogTiming("tlsHandshakeStart")

--- a/api/client.go
+++ b/api/client.go
@@ -11,7 +11,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptrace"
 	"net/http/httputil"
+	"net/textproto"
 	"net/url"
 	"reflect"
 	"strconv"
@@ -44,6 +46,9 @@ type Config struct {
 
 	// If true, requests and responses will be dumped and set to the logger
 	DebugHTTP bool
+
+	// If true timings for each request will be logged
+	TraceHTTP bool
 
 	// The http client used, leave nil for the default
 	HTTPClient *http.Client
@@ -253,12 +258,22 @@ func (c *Client) doRequest(req *http.Request, v any) (*Response, error) {
 		}
 	}
 
+	tracer := &tracer{Logger: c.logger}
+	if c.conf.TraceHTTP {
+		// Inject a custom http tracer
+		req = traceHTTPRequest(req, tracer)
+		tracer.Start()
+	}
+
 	ts := time.Now()
 
 	c.logger.Debug("%s %s", req.Method, req.URL)
 
 	resp, err := c.client.Do(req)
 	if err != nil {
+		if c.conf.TraceHTTP {
+			tracer.EmitTraceToLog(logger.ERROR)
+		}
 		return nil, err
 	}
 
@@ -280,6 +295,10 @@ func (c *Client) doRequest(req *http.Request, v any) (*Response, error) {
 		} else {
 			c.logger.Debug("\n%s", string(responseDump))
 		}
+	}
+
+	if c.conf.TraceHTTP {
+		tracer.EmitTraceToLog(logger.DEBUG)
 	}
 
 	err = checkResponse(resp)
@@ -304,6 +323,105 @@ func (c *Client) doRequest(req *http.Request, v any) (*Response, error) {
 	}
 
 	return response, err
+}
+
+type traceEvent struct {
+	event string
+	since time.Duration
+}
+
+type tracer struct {
+	startTime time.Time
+	logger.Logger
+}
+
+func (t *tracer) Start() {
+	t.startTime = time.Now()
+}
+
+func (t *tracer) LogTiming(event string) {
+	t.Logger = t.Logger.WithFields(logger.DurationField(event, time.Since(t.startTime)))
+}
+
+func (t *tracer) LogField(key, value string) {
+	t.Logger = t.Logger.WithFields(logger.StringField(key, value))
+}
+
+func (t *tracer) LogDuration(event string, d time.Duration) {
+	t.Logger = t.Logger.WithFields(logger.DurationField(event, d))
+}
+
+// Currently logger.Logger doesn't give us a way to set the level we want to emit logs at dynamically
+func (t *tracer) EmitTraceToLog(level logger.Level) {
+	msg := "HTTP Timing Trace"
+	switch level {
+	case logger.DEBUG:
+		t.Debug(msg)
+	case logger.INFO:
+		t.Info(msg)
+	case logger.WARN:
+		t.Warn(msg)
+	case logger.ERROR:
+		t.Error(msg)
+	}
+}
+
+func traceHTTPRequest(req *http.Request, t *tracer) *http.Request {
+	trace := &httptrace.ClientTrace{
+		GetConn: func(hostPort string) {
+			t.LogField("hostPort", hostPort)
+			t.LogTiming("getConn")
+		},
+		GotConn: func(info httptrace.GotConnInfo) {
+			t.LogTiming("gotConn")
+			t.LogField("reused", strconv.FormatBool(info.Reused))
+			t.LogField("idle", strconv.FormatBool(info.WasIdle))
+			t.LogDuration("idleTime", info.IdleTime)
+		},
+		PutIdleConn: func(err error) {
+			t.LogTiming("putIdleConn")
+			if err != nil {
+				t.LogField("putIdleConnectionError", err.Error())
+			}
+		},
+		GotFirstResponseByte: func() {
+			t.LogTiming("gotFirstResponseByte")
+		},
+		Got1xxResponse: func(code int, header textproto.MIMEHeader) error {
+			t.LogTiming("got1xxResponse")
+			return nil
+		},
+		DNSStart: func(_ httptrace.DNSStartInfo) {
+			t.LogTiming("dnsStart")
+		},
+		DNSDone: func(_ httptrace.DNSDoneInfo) {
+			t.LogTiming("dnsDone")
+		},
+		ConnectStart: func(_, _ string) {
+			t.LogTiming("connectStart")
+		},
+		ConnectDone: func(_, _ string, _ error) {
+			t.LogTiming("connectDone")
+		},
+		TLSHandshakeStart: func() {
+			t.LogTiming("tlsHandshakeStart")
+		},
+		TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
+			t.LogTiming("tlsHandshakeDone")
+		},
+		WroteHeaders: func() {
+			t.LogTiming("wroteHeaders")
+		},
+		WroteRequest: func(_ httptrace.WroteRequestInfo) {
+			t.LogTiming("wroteRequest")
+		},
+	}
+
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+
+	t.LogField("uri", req.URL.String())
+	t.LogField("method", req.Method)
+	return req
 }
 
 // ErrorResponse provides a message.

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -179,6 +179,7 @@ type AgentStartConfig struct {
 
 	// API config
 	DebugHTTP bool   `cli:"debug-http"`
+	TraceHTTP bool   `cli:"trace-http"`
 	Token     string `cli:"token" validate:"required"`
 	Endpoint  string `cli:"endpoint" validate:"required"`
 	NoHTTP2   bool   `cli:"no-http2"`
@@ -692,6 +693,7 @@ var AgentStartCommand = cli.Command{
 		EndpointFlag,
 		NoHTTP2Flag,
 		DebugHTTPFlag,
+		TraceHTTPFlag,
 
 		// Global flags
 		NoColorFlag,

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -74,6 +74,12 @@ var (
 		EnvVar: "BUILDKITE_AGENT_DEBUG_HTTP",
 	}
 
+	TraceHTTPFlag = cli.BoolFlag{
+		Name:   "trace-http",
+		Usage:  "Enable HTTP trace mode, which logs timings for each HTTP request. Timings are logged at the debug level unless a request fails at the network level in which case they are logged at the error level",
+		EnvVar: "BUILDKITE_AGENT_TRACE_HTTP",
+	}
+
 	NoColorFlag = cli.BoolFlag{
 		Name:   "no-color",
 		Usage:  "Don't show colors in logging",

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -283,6 +283,11 @@ func loadAPIClientConfig(cfg any, tokenField string) api.Config {
 		conf.DebugHTTP = true
 	}
 
+	traceHTTP, err := reflections.GetField(cfg, "TraceHTTP")
+	if traceHTTP == true && err == nil {
+		conf.TraceHTTP = true
+	}
+
 	endpoint, err := reflections.GetField(cfg, "Endpoint")
 	if endpoint != "" && err == nil {
 		conf.Endpoint = endpoint.(string)

--- a/internal/mime/mime.go
+++ b/internal/mime/mime.go
@@ -388,6 +388,7 @@ var types = map[string]string{
 	".js":          "application/javascript",
 	".json":        "application/json",
 	".jsonml":      "application/jsonml+json",
+	".jxl":         "image/jxl",
 	".kar":         "audio/midi",
 	".karbon":      "application/vnd.kde.karbon",
 	".kfo":         "application/vnd.kde.kformula",


### PR DESCRIPTION
### Description

When debugging network timeouts it can be useful to have detailed timings to know where specifically the time being consumed.

### Changes

Add a TraceHTTP flag (only on agent start for now).
Use http trace to capture timings between each network event In the case of a network error emit this to error log. Otherwise emit it to the debug logs.

Example:
```
2024-09-17 09:31:11 DEBUG  HTTP Timing Trace uri=https://agent.buildkite.com/v3/ping method=GET hostPort=agent.buildkite.com:443 getConn=746.458µs dnsStart=773.625µs dnsDone=5.492208ms connectStart.tcp.3.168.86.46:443=5.502791ms connectDone.tcp.3.168.86.46:443=169.197333ms tlsHandshakeStart=169.207541ms tlsHandshakeDone=337.926125ms gotConn=337.964208ms reused=false idle=false idleTime=0s wroteHeaders=337.995208ms wroteRequest=337.995791ms gotFirstResponseByte=665.737916ms agent_version=3.81.0+x..dirty
```

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)
