### PR TITLE
Remove mitchellh/go-homedir; it's archived

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -39,7 +39,6 @@ import (
 	"github.com/buildkite/agent/v3/version"
 	"github.com/buildkite/shellwords"
 	"github.com/lestrrat-go/jwx/v2/jwk"
-	"github.com/mitchellh/go-homedir"
 	"github.com/urfave/cli"
 	"golang.org/x/exp/maps"
 )
@@ -1382,7 +1381,7 @@ func agentLifecycleHook(hookName string, log logger.Logger, cfg AgentStartConfig
 }
 
 func defaultSocketsPath() string {
-	home, err := homedir.Dir()
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return filepath.Join(os.TempDir(), "buildkite-sockets")
 	}

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/gowebpki/jcs v1.0.1
 	github.com/lestrrat-go/jwx/v2 v2.1.1
 	github.com/mattn/go-zglob v0.0.6
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/oleiade/reflections v1.1.0
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pborman/uuid v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-zglob v0.0.6 h1:mP8RnmCgho4oaUYDIDn6GNxYk+qJGUs8fJLn+twYj2A=
 github.com/mattn/go-zglob v0.0.6/go.mod h1:MxxjyoXXnMxfIpxTK2GAkw1w8glPsQILx3N5wrKakiY=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/oleiade/reflections v1.1.0 h1:D+I/UsXQB4esMathlt0kkZRJZdUDmhv5zGi/HOwYTWo=

--- a/internal/job/integration/executor_tester.go
+++ b/internal/job/integration/executor_tester.go
@@ -135,6 +135,7 @@ func NewExecutorTester(ctx context.Context) (*ExecutorTester, error) {
 			"PATHEXT="+os.Getenv("PATHEXT"),
 			"TMP="+os.Getenv("TMP"),
 			"TEMP="+os.Getenv("TEMP"),
+			"USERPROFILE="+os.Getenv("USERPROFILE"),
 		)
 	} else {
 		bt.Env = append(bt.Env, "PATH="+pathDir+":"+os.Getenv("PATH"))

--- a/internal/job/integration/executor_tester.go
+++ b/internal/job/integration/executor_tester.go
@@ -135,7 +135,7 @@ func NewExecutorTester(ctx context.Context) (*ExecutorTester, error) {
 			"PATHEXT="+os.Getenv("PATHEXT"),
 			"TMP="+os.Getenv("TMP"),
 			"TEMP="+os.Getenv("TEMP"),
-			"USERPROFILE="+os.Getenv("USERPROFILE"),
+			"USERPROFILE="+homeDir,
 		)
 	} else {
 		bt.Env = append(bt.Env, "PATH="+pathDir+":"+os.Getenv("PATH"))

--- a/internal/job/knownhosts.go
+++ b/internal/job/knownhosts.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/v3/internal/job/shell"
-	homedir "github.com/mitchellh/go-homedir"
 	"golang.org/x/crypto/ssh/knownhosts"
 )
 
@@ -20,7 +19,7 @@ type knownHosts struct {
 }
 
 func findKnownHosts(sh *shell.Shell) (*knownHosts, error) {
-	userHomePath, err := homedir.Dir()
+	userHomePath, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("Could not find the current users home directory (%s)", err)
 	}

--- a/internal/job/shell/test.go
+++ b/internal/job/shell/test.go
@@ -37,6 +37,7 @@ func NewTestShell(t *testing.T) *Shell {
 			"TMP":         os.Getenv("TMP"),
 			"TEMP":        os.Getenv("TEMP"),
 			"ProgramData": os.Getenv("ProgramData"),
+			"USERPROFILE": os.Getenv("USERPROFILE"),
 		})
 	} else {
 		sh.Env = env.FromMap(map[string]string{


### PR DESCRIPTION
### Description

[Go has caught up to the functionality](https://github.com/mitchellh/go-homedir/issues/34#issuecomment-2011915588) of [mitchellh/go-homedir](https://github.com/mitchellh/go-homedir) since 1.20, and go-homedir has been archived since June. No time like the present to drop a dependency!

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
