### PR TITLE
Multipart artifact upload

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -43,23 +43,24 @@ type AgentConfiguration struct {
 	VerificationJWKS             any    // The set of keys to verify jobs with
 	VerificationFailureBehaviour string // What to do if job verification fails (one of `block` or `warn`)
 
-	ANSITimestamps             bool
-	TimestampLines             bool
-	HealthCheckAddr            string
-	DisconnectAfterJob         bool
-	DisconnectAfterIdleTimeout int
-	CancelGracePeriod          int
-	SignalGracePeriod          time.Duration
-	EnableJobLogTmpfile        bool
-	JobLogPath                 string
-	WriteJobLogsToStdout       bool
-	LogFormat                  string
-	Shell                      string
-	Profile                    string
-	RedactedVars               []string
-	AcquireJob                 string
-	TracingBackend             string
-	TracingServiceName         string
-	TraceContextEncoding       string
-	DisableWarningsFor         []string
+	ANSITimestamps               bool
+	TimestampLines               bool
+	HealthCheckAddr              string
+	DisconnectAfterJob           bool
+	DisconnectAfterIdleTimeout   int
+	CancelGracePeriod            int
+	SignalGracePeriod            time.Duration
+	EnableJobLogTmpfile          bool
+	JobLogPath                   string
+	WriteJobLogsToStdout         bool
+	LogFormat                    string
+	Shell                        string
+	Profile                      string
+	RedactedVars                 []string
+	AcquireJob                   string
+	TracingBackend               string
+	TracingServiceName           string
+	TraceContextEncoding         string
+	DisableWarningsFor           []string
+	AllowMultipartArtifactUpload bool
 }

--- a/agent/api.go
+++ b/agent/api.go
@@ -37,7 +37,7 @@ type APIClient interface {
 	StartJob(context.Context, *api.Job) (*api.Response, error)
 	StepExport(context.Context, string, *api.StepExportRequest) (*api.StepExportResponse, *api.Response, error)
 	StepUpdate(context.Context, string, *api.StepUpdate) (*api.Response, error)
-	UpdateArtifacts(context.Context, string, map[string]string) (*api.Response, error)
+	UpdateArtifacts(context.Context, string, []api.ArtifactState) (*api.Response, error)
 	UploadChunk(context.Context, string, *api.Chunk) (*api.Response, error)
 	UploadPipeline(context.Context, string, *api.PipelineChange, ...api.Header) (*api.Response, error)
 }

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -534,6 +534,10 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 		env["BUILDKITE_KUBERNETES_EXEC"] = "true"
 	}
 
+	if !r.conf.AgentConfiguration.AllowMultipartArtifactUpload {
+		env["BUILDKITE_NO_MULTIPART_ARTIFACT_UPLOAD"] = "true"
+	}
+
 	// propagate CancelSignal to bootstrap, unless it's the default SIGTERM
 	if r.conf.CancelSignal != process.SIGTERM {
 		env["BUILDKITE_CANCEL_SIGNAL"] = r.conf.CancelSignal.String()

--- a/api/artifacts.go
+++ b/api/artifacts.go
@@ -51,27 +51,47 @@ type Artifact struct {
 }
 
 type ArtifactBatch struct {
-	ID                string      `json:"id"`
-	Artifacts         []*Artifact `json:"artifacts"`
-	UploadDestination string      `json:"upload_destination"`
+	ID                 string      `json:"id"`
+	Artifacts          []*Artifact `json:"artifacts"`
+	UploadDestination  string      `json:"upload_destination"`
+	MultipartSupported bool        `json:"multipart_supported,omitempty"`
 }
 
+// ArtifactUploadInstructions describes how to upload an artifact to Buildkite
+// artifact storage.
 type ArtifactUploadInstructions struct {
-	Data   map[string]string    `json:"data"`
+	// Used for a single-part upload.
 	Action ArtifactUploadAction `json:"action"`
+
+	// Used for a multi-part upload.
+	Actions []ArtifactUploadAction `json:"actions"`
+
+	// Contains other data necessary for interpreting instructions.
+	Data map[string]string `json:"data"`
 }
 
+// ArtifactUploadAction describes one action needed to upload an artifact or
+// part of an artifact to Buildkite artifact storage.
 type ArtifactUploadAction struct {
-	URL       string `json:"url,omitempty"`
-	Method    string `json:"method"`
-	Path      string `json:"path"`
-	FileInput string `json:"file_input"`
+	URL        string `json:"url,omitempty"`
+	Method     string `json:"method"`
+	Path       string `json:"path"`
+	FileInput  string `json:"file_input"`
+	PartNumber int    `json:"part_number,omitempty"`
 }
 
 type ArtifactBatchCreateResponse struct {
-	ID                 string                      `json:"id"`
-	ArtifactIDs        []string                    `json:"artifact_ids"`
-	UploadInstructions *ArtifactUploadInstructions `json:"upload_instructions"`
+	ID          string   `json:"id"`
+	ArtifactIDs []string `json:"artifact_ids"`
+
+	// These instructions apply to all artifacts. The template contains
+	// variable interpolations such as ${artifact:path}.
+	InstructionsTemplate *ArtifactUploadInstructions `json:"upload_instructions"`
+
+	// These instructions apply to specific artifacts, necessary for multipart
+	// uploads. It overrides InstructionTemplate and should not contain
+	// interpolations. Map: artifact ID -> instructions for that artifact.
+	PerArtifactInstructions map[string]*ArtifactUploadInstructions `json:"per_artifact_instructions"`
 }
 
 // ArtifactSearchOptions specifies the optional parameters to the
@@ -84,18 +104,29 @@ type ArtifactSearchOptions struct {
 	IncludeDuplicates  bool   `url:"include_duplicates,omitempty"`
 }
 
-type ArtifactBatchUpdateArtifact struct {
-	ID    string `json:"id"`
-	State string `json:"state"`
+// ArtifactState represents the state of a single artifact, when calling UpdateArtifacts.
+type ArtifactState struct {
+	ID        string `json:"id"`
+	State     string `json:"state"`
+	Multipart bool   `json:"multipart,omitempty"`
+	// If this artifact was a multipart upload and is complete, we need the
+	// the ETag from each uploaded part so that they can be joined together.
+	MultipartETags []ArtifactPartETag `json:"multipart_etags,omitempty"`
+}
+
+// ArtifactPartETag associates an ETag to a part number for a multipart upload.
+type ArtifactPartETag struct {
+	PartNumber int    `json:"part_number"`
+	ETag       string `json:"etag"`
 }
 
 type ArtifactBatchUpdateRequest struct {
-	Artifacts []*ArtifactBatchUpdateArtifact `json:"artifacts"`
+	Artifacts []ArtifactState `json:"artifacts"`
 }
 
 // CreateArtifacts takes a slice of artifacts, and creates them on Buildkite as a batch.
-func (c *Client) CreateArtifacts(ctx context.Context, jobId string, batch *ArtifactBatch) (*ArtifactBatchCreateResponse, *Response, error) {
-	u := fmt.Sprintf("jobs/%s/artifacts", railsPathEscape(jobId))
+func (c *Client) CreateArtifacts(ctx context.Context, jobID string, batch *ArtifactBatch) (*ArtifactBatchCreateResponse, *Response, error) {
+	u := fmt.Sprintf("jobs/%s/artifacts", railsPathEscape(jobID))
 
 	req, err := c.newRequest(ctx, "POST", u, batch)
 	if err != nil {
@@ -111,13 +142,11 @@ func (c *Client) CreateArtifacts(ctx context.Context, jobId string, batch *Artif
 	return createResponse, resp, err
 }
 
-// Updates a particular artifact
-func (c *Client) UpdateArtifacts(ctx context.Context, jobId string, artifactStates map[string]string) (*Response, error) {
-	u := fmt.Sprintf("jobs/%s/artifacts", railsPathEscape(jobId))
-	payload := ArtifactBatchUpdateRequest{}
-
-	for id, state := range artifactStates {
-		payload.Artifacts = append(payload.Artifacts, &ArtifactBatchUpdateArtifact{id, state})
+// UpdateArtifacts updates Buildkite with one or more artifact states.
+func (c *Client) UpdateArtifacts(ctx context.Context, jobID string, artifactStates []ArtifactState) (*Response, error) {
+	u := fmt.Sprintf("jobs/%s/artifacts", railsPathEscape(jobID))
+	payload := ArtifactBatchUpdateRequest{
+		Artifacts: artifactStates,
 	}
 
 	req, err := c.newRequest(ctx, "PUT", u, payload)
@@ -125,17 +154,12 @@ func (c *Client) UpdateArtifacts(ctx context.Context, jobId string, artifactStat
 		return nil, err
 	}
 
-	resp, err := c.doRequest(req, nil)
-	if err != nil {
-		return resp, err
-	}
-
-	return resp, err
+	return c.doRequest(req, nil)
 }
 
 // SearchArtifacts searches Buildkite for a set of artifacts
-func (c *Client) SearchArtifacts(ctx context.Context, buildId string, opt *ArtifactSearchOptions) ([]*Artifact, *Response, error) {
-	u := fmt.Sprintf("builds/%s/artifacts/search", railsPathEscape(buildId))
+func (c *Client) SearchArtifacts(ctx context.Context, buildID string, opt *ArtifactSearchOptions) ([]*Artifact, *Response, error) {
+	u := fmt.Sprintf("builds/%s/artifacts/search", railsPathEscape(buildID))
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err

--- a/api/artifacts.go
+++ b/api/artifacts.go
@@ -57,13 +57,15 @@ type ArtifactBatch struct {
 }
 
 type ArtifactUploadInstructions struct {
-	Data   map[string]string `json:"data"`
-	Action struct {
-		URL       string `json:"url,omitempty"`
-		Method    string `json:"method"`
-		Path      string `json:"path"`
-		FileInput string `json:"file_input"`
-	}
+	Data   map[string]string    `json:"data"`
+	Action ArtifactUploadAction `json:"action"`
+}
+
+type ArtifactUploadAction struct {
+	URL       string `json:"url,omitempty"`
+	Method    string `json:"method"`
+	Path      string `json:"path"`
+	FileInput string `json:"file_input"`
 }
 
 type ArtifactBatchCreateResponse struct {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -167,14 +167,15 @@ type AgentStartConfig struct {
 	TracingServiceName          string `cli:"tracing-service-name"`
 
 	// Global flags
-	Debug                bool     `cli:"debug"`
-	LogLevel             string   `cli:"log-level"`
-	NoColor              bool     `cli:"no-color"`
-	Experiments          []string `cli:"experiment" normalize:"list"`
-	Profile              string   `cli:"profile"`
-	StrictSingleHooks    bool     `cli:"strict-single-hooks"`
-	KubernetesExec       bool     `cli:"kubernetes-exec"`
-	TraceContextEncoding string   `cli:"trace-context-encoding"`
+	Debug                     bool     `cli:"debug"`
+	LogLevel                  string   `cli:"log-level"`
+	NoColor                   bool     `cli:"no-color"`
+	Experiments               []string `cli:"experiment" normalize:"list"`
+	Profile                   string   `cli:"profile"`
+	StrictSingleHooks         bool     `cli:"strict-single-hooks"`
+	KubernetesExec            bool     `cli:"kubernetes-exec"`
+	TraceContextEncoding      string   `cli:"trace-context-encoding"`
+	NoMultipartArtifactUpload bool     `cli:"no-multipart-artifact-upload"`
 
 	// API config
 	DebugHTTP bool   `cli:"debug-http"`
@@ -704,6 +705,7 @@ var AgentStartCommand = cli.Command{
 		StrictSingleHooksFlag,
 		KubernetesExecFlag,
 		TraceContextEncodingFlag,
+		NoMultipartArtifactUploadFlag,
 
 		// Deprecated flags which will be removed in v4
 		cli.StringSliceFlag{
@@ -994,7 +996,7 @@ var AgentStartCommand = cli.Command{
 			TracingBackend:               cfg.TracingBackend,
 			TracingServiceName:           cfg.TracingServiceName,
 			TraceContextEncoding:         cfg.TraceContextEncoding,
-			VerificationFailureBehaviour: cfg.VerificationFailureBehavior,
+			AllowMultipartArtifactUpload: !cfg.NoMultipartArtifactUpload,
 			KubernetesExec:               cfg.KubernetesExec,
 
 			SigningJWKSFile:  cfg.SigningJWKSFile,
@@ -1002,7 +1004,8 @@ var AgentStartCommand = cli.Command{
 			SigningAWSKMSKey: cfg.SigningAWSKMSKey,
 			DebugSigning:     cfg.DebugSigning,
 
-			VerificationJWKS: verificationJWKS,
+			VerificationJWKS:             verificationJWKS,
+			VerificationFailureBehaviour: cfg.VerificationFailureBehavior,
 
 			DisableWarningsFor: cfg.DisableWarningsFor,
 		}

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -88,6 +88,7 @@ type ArtifactUploadConfig struct {
 	// Uploader flags
 	GlobResolveFollowSymlinks bool `cli:"glob-resolve-follow-symlinks"`
 	UploadSkipSymlinks        bool `cli:"upload-skip-symlinks"`
+	NoMultipartUpload         bool `cli:"no-multipart-artifact-upload"`
 
 	// deprecated
 	FollowSymlinks bool `cli:"follow-symlinks" deprecated-and-renamed-to:"GlobResolveFollowSymlinks"`
@@ -138,6 +139,7 @@ var ArtifactUploadCommand = cli.Command{
 		LogLevelFlag,
 		ExperimentsFlag,
 		ProfileFlag,
+		NoMultipartArtifactUploadFlag,
 	},
 	Action: func(c *cli.Context) error {
 		ctx := context.Background()
@@ -154,6 +156,8 @@ var ArtifactUploadCommand = cli.Command{
 			Destination: cfg.Destination,
 			ContentType: cfg.ContentType,
 			DebugHTTP:   cfg.DebugHTTP,
+
+			AllowMultipart: !cfg.NoMultipartUpload,
 
 			// If the deprecated flag was set to true, pretend its replacement was set to true too
 			// this works as long as the user only sets one of the two flags

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -100,6 +100,12 @@ var (
 		EnvVar: "BUILDKITE_KUBERNETES_EXEC",
 	}
 
+	NoMultipartArtifactUploadFlag = cli.BoolFlag{
+		Name:   "no-multipart-artifact-upload",
+		Usage:  "For Buildkite-hosted artifacts, disables the use of multipart uploads. Has no effect on uploads to other destinations such as custom cloud buckets",
+		EnvVar: "BUILDKITE_NO_MULTIPART_ARTIFACT_UPLOAD",
+	}
+
 	ExperimentsFlag = cli.StringSliceFlag{
 		Name:   "experiment",
 		Value:  &cli.StringSlice{},

--- a/internal/artifact/api_client.go
+++ b/internal/artifact/api_client.go
@@ -10,5 +10,5 @@ import (
 type APIClient interface {
 	CreateArtifacts(context.Context, string, *api.ArtifactBatch) (*api.ArtifactBatchCreateResponse, *api.Response, error)
 	SearchArtifacts(context.Context, string, *api.ArtifactSearchOptions) ([]*api.Artifact, *api.Response, error)
-	UpdateArtifacts(context.Context, string, map[string]string) (*api.Response, error)
+	UpdateArtifacts(context.Context, string, []api.ArtifactState) (*api.Response, error)
 }

--- a/internal/artifact/artifactory_uploader.go
+++ b/internal/artifact/artifactory_uploader.go
@@ -99,36 +99,54 @@ func (u *ArtifactoryUploader) URL(artifact *api.Artifact) string {
 	return url.String()
 }
 
-func (u *ArtifactoryUploader) Upload(_ context.Context, artifact *api.Artifact) error {
+func (u *ArtifactoryUploader) CreateWork(artifact *api.Artifact) ([]workUnit, error) {
+	return []workUnit{&artifactoryUploaderWork{
+		ArtifactoryUploader: u,
+		artifact:            artifact,
+	}}, nil
+}
+
+type artifactoryUploaderWork struct {
+	*ArtifactoryUploader
+	artifact *api.Artifact
+}
+
+func (u *artifactoryUploaderWork) Artifact() *api.Artifact { return u.artifact }
+
+func (u *artifactoryUploaderWork) Description() string {
+	return singleUnitDescription(u.artifact)
+}
+
+func (u *artifactoryUploaderWork) DoWork(context.Context) error {
 	// Open file from filesystem
-	u.logger.Debug("Reading file \"%s\"", artifact.AbsolutePath)
-	f, err := os.Open(artifact.AbsolutePath)
+	u.logger.Debug("Reading file %q", u.artifact.AbsolutePath)
+	f, err := os.Open(u.artifact.AbsolutePath)
 	if err != nil {
-		return fmt.Errorf("failed to open file %q (%w)", artifact.AbsolutePath, err)
+		return fmt.Errorf("failed to open file %q (%w)", u.artifact.AbsolutePath, err)
 	}
 
 	// Upload the file to Artifactory.
-	u.logger.Debug("Uploading \"%s\" to `%s`", artifact.Path, u.URL(artifact))
+	u.logger.Debug("Uploading %q to %q", u.artifact.Path, u.URL(u.artifact))
 
-	req, err := http.NewRequest("PUT", u.URL(artifact), f)
+	req, err := http.NewRequest("PUT", u.URL(u.artifact), f)
 	req.SetBasicAuth(u.user, u.password)
 	if err != nil {
 		return err
 	}
 
-	md5Checksum, err := checksumFile(md5.New(), artifact.AbsolutePath)
+	md5Checksum, err := checksumFile(md5.New(), u.artifact.AbsolutePath)
 	if err != nil {
 		return err
 	}
 	req.Header.Add("X-Checksum-MD5", md5Checksum)
 
-	sha1Checksum, err := checksumFile(sha1.New(), artifact.AbsolutePath)
+	sha1Checksum, err := checksumFile(sha1.New(), u.artifact.AbsolutePath)
 	if err != nil {
 		return err
 	}
 	req.Header.Add("X-Checksum-SHA1", sha1Checksum)
 
-	sha256Checksum, err := checksumFile(sha256.New(), artifact.AbsolutePath)
+	sha256Checksum, err := checksumFile(sha256.New(), u.artifact.AbsolutePath)
 	if err != nil {
 		return err
 	}
@@ -138,11 +156,7 @@ func (u *ArtifactoryUploader) Upload(_ context.Context, artifact *api.Artifact) 
 	if err != nil {
 		return err
 	}
-	if err := checkResponse(res); err != nil {
-		return err
-	}
-
-	return nil
+	return checkResponse(res)
 }
 
 func checksumFile(hasher hash.Hash, path string) (string, error) {

--- a/internal/artifact/azure_blob_uploader.go
+++ b/internal/artifact/azure_blob_uploader.go
@@ -107,11 +107,11 @@ func (u *azureBlobUploaderWork) Description() string {
 }
 
 // DoWork uploads an artifact file.
-func (u *azureBlobUploaderWork) DoWork(ctx context.Context) error {
+func (u *azureBlobUploaderWork) DoWork(ctx context.Context) (*api.ArtifactPartETag, error) {
 	u.logger.Debug("Reading file %q", u.artifact.AbsolutePath)
 	f, err := os.Open(u.artifact.AbsolutePath)
 	if err != nil {
-		return fmt.Errorf("failed to open file %q (%w)", u.artifact.AbsolutePath, err)
+		return nil, fmt.Errorf("failed to open file %q (%w)", u.artifact.AbsolutePath, err)
 	}
 	defer f.Close()
 
@@ -121,5 +121,5 @@ func (u *azureBlobUploaderWork) DoWork(ctx context.Context) error {
 
 	bbc := u.client.NewContainerClient(u.loc.ContainerName).NewBlockBlobClient(blobName)
 	_, err = bbc.UploadFile(ctx, f, nil)
-	return err
+	return nil, err
 }

--- a/internal/artifact/batch_creator.go
+++ b/internal/artifact/batch_creator.go
@@ -60,9 +60,10 @@ func (a *BatchCreator) Create(ctx context.Context) ([]*api.Artifact, error) {
 		// twice, it'll just return the previous data and skip the
 		// upload)
 		batch := &api.ArtifactBatch{
-			ID:                api.NewUUID(),
-			Artifacts:         theseArtifacts,
-			UploadDestination: a.conf.UploadDestination,
+			ID:                 api.NewUUID(),
+			Artifacts:          theseArtifacts,
+			UploadDestination:  a.conf.UploadDestination,
+			MultipartSupported: true,
 		}
 
 		a.logger.Info("Creating (%d-%d)/%d artifacts", i, j, length)
@@ -111,11 +112,12 @@ func (a *BatchCreator) Create(ctx context.Context) ([]*api.Artifact, error) {
 		}
 
 		// Save the id and instructions to each artifact
-		index := 0
-		for _, id := range creation.ArtifactIDs {
+		for index, id := range creation.ArtifactIDs {
 			theseArtifacts[index].ID = id
-			theseArtifacts[index].UploadInstructions = creation.UploadInstructions
-			index += 1
+			theseArtifacts[index].UploadInstructions = creation.InstructionsTemplate
+			if specific := creation.PerArtifactInstructions[id]; specific != nil {
+				theseArtifacts[index].UploadInstructions = specific
+			}
 		}
 	}
 

--- a/internal/artifact/batch_creator.go
+++ b/internal/artifact/batch_creator.go
@@ -22,6 +22,9 @@ type BatchCreatorConfig struct {
 	// CreateArtifactsTimeout, sets a context.WithTimeout around the CreateArtifacts API.
 	// If it's zero, there's no context timeout and the default HTTP timeout will prevail.
 	CreateArtifactsTimeout time.Duration
+
+	// Whether to allow multipart uploads to the BK-hosted bucket.
+	AllowMultipart bool
 }
 
 type BatchCreator struct {
@@ -63,7 +66,7 @@ func (a *BatchCreator) Create(ctx context.Context) ([]*api.Artifact, error) {
 			ID:                 api.NewUUID(),
 			Artifacts:          theseArtifacts,
 			UploadDestination:  a.conf.UploadDestination,
-			MultipartSupported: true,
+			MultipartSupported: a.conf.AllowMultipart,
 		}
 
 		a.logger.Info("Creating (%d-%d)/%d artifacts", i, j, length)

--- a/internal/artifact/batch_creator.go
+++ b/internal/artifact/batch_creator.go
@@ -50,10 +50,7 @@ func (a *BatchCreator) Create(ctx context.Context) ([]*api.Artifact, error) {
 	// Split into the artifacts into chunks so we're not uploading a ton of
 	// files at once.
 	for i := 0; i < length; i += chunks {
-		j := i + chunks
-		if length < j {
-			j = length
-		}
+		j := min(i+chunks, length)
 
 		// The artifacts that will be uploaded in this chunk
 		theseArtifacts := a.conf.Artifacts[i:j]

--- a/internal/artifact/bk_uploader.go
+++ b/internal/artifact/bk_uploader.go
@@ -24,34 +24,36 @@ import (
 
 const artifactPathVariable = "${artifact:path}"
 
-// FormUploader uploads to S3 as a single signed POST, which have a hard limit of 5Gb.
+// BKUploader uploads to S3 as a single signed POST, which have a hard limit of 5Gb.
 const maxFormUploadedArtifactSize = int64(5368709120)
 
-type FormUploaderConfig struct {
+type BKUploaderConfig struct {
 	// Whether or not HTTP calls should be debugged
 	DebugHTTP bool
 }
 
-type FormUploader struct {
+// BKUploader uploads artifacts to Buildkite itself.
+type BKUploader struct {
 	// The configuration
-	conf FormUploaderConfig
+	conf BKUploaderConfig
 
 	// The logger instance to use
 	logger logger.Logger
 }
 
-func NewFormUploader(l logger.Logger, c FormUploaderConfig) *FormUploader {
-	return &FormUploader{
+// NewBKUploader creates a new Buildkite uploader.
+func NewBKUploader(l logger.Logger, c BKUploaderConfig) *BKUploader {
+	return &BKUploader{
 		logger: l,
 		conf:   c,
 	}
 }
 
-// The FormUploader doens't specify a URL, as one is provided by Buildkite
+// The BKUploader doens't specify a URL, as one is provided by Buildkite
 // after uploading
-func (u *FormUploader) URL(*api.Artifact) string { return "" }
+func (u *BKUploader) URL(*api.Artifact) string { return "" }
 
-func (u *FormUploader) Upload(ctx context.Context, artifact *api.Artifact) error {
+func (u *BKUploader) Upload(ctx context.Context, artifact *api.Artifact) error {
 	if artifact.FileSize > maxFormUploadedArtifactSize {
 		return errArtifactTooLarge{Size: artifact.FileSize}
 	}

--- a/internal/artifact/bk_uploader_test.go
+++ b/internal/artifact/bk_uploader_test.go
@@ -85,7 +85,7 @@ func TestFormUploading(t *testing.T) {
 		err = os.WriteFile(abspath, []byte("llamas"), 0700)
 		defer os.Remove(abspath)
 
-		uploader := NewFormUploader(logger.Discard, FormUploaderConfig{})
+		uploader := NewBKUploader(logger.Discard, BKUploaderConfig{})
 		artifact := &api.Artifact{
 			ID:           "xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx",
 			Path:         "llamas.txt",
@@ -129,7 +129,7 @@ func TestFormUploadFileMissing(t *testing.T) {
 
 	abspath := filepath.Join(temp, "llamas.txt")
 
-	uploader := NewFormUploader(logger.Discard, FormUploaderConfig{})
+	uploader := NewBKUploader(logger.Discard, BKUploaderConfig{})
 	artifact := &api.Artifact{
 		ID:           "xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx",
 		Path:         "llamas.txt",
@@ -155,7 +155,7 @@ func TestFormUploadFileMissing(t *testing.T) {
 
 func TestFormUploadTooBig(t *testing.T) {
 	ctx := context.Background()
-	uploader := NewFormUploader(logger.Discard, FormUploaderConfig{})
+	uploader := NewBKUploader(logger.Discard, BKUploaderConfig{})
 	const size = int64(6442450944) // 6Gb
 	artifact := &api.Artifact{
 		ID:                 "xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx",

--- a/internal/artifact/bk_uploader_test.go
+++ b/internal/artifact/bk_uploader_test.go
@@ -11,61 +11,63 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/logger"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestFormUploading(t *testing.T) {
 	ctx := context.Background()
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		switch req.URL.Path {
-		case "/buildkiteartifacts.com":
-			if req.ContentLength <= 0 {
-				http.Error(rw, "zero or unknown Content-Length", http.StatusBadRequest)
-				return
-			}
+		if req.Method != "POST" && req.URL.Path != "/buildkiteartifacts.com" {
+			http.Error(rw, fmt.Sprintf("not found; (method, path) = (%q, %q), want PUT /llamas3.txt", req.Method, req.URL.Path), http.StatusNotFound)
+			return
+		}
 
-			if err := req.ParseMultipartForm(5 * 1024 * 1024); err != nil {
-				http.Error(rw, fmt.Sprintf("req.ParseMultipartForm() = %v", err), http.StatusBadRequest)
-				return
-			}
+		if req.ContentLength <= 0 {
+			http.Error(rw, "zero or unknown Content-Length", http.StatusBadRequest)
+			return
+		}
 
-			// Check the ${artifact:path} interpolation is working
-			path := req.FormValue("path")
-			if got, want := path, "llamas.txt"; got != want {
-				http.Error(rw, fmt.Sprintf("path = %q, want %q", got, want), http.StatusBadRequest)
-				return
-			}
+		if err := req.ParseMultipartForm(5 * 1024 * 1024); err != nil {
+			http.Error(rw, fmt.Sprintf("req.ParseMultipartForm() = %v", err), http.StatusBadRequest)
+			return
+		}
 
-			file, fh, err := req.FormFile("file")
-			if err != nil {
-				http.Error(rw, fmt.Sprintf(`req.FormFile("file") error = %v`, err), http.StatusBadRequest)
-				return
-			}
-			defer file.Close()
+		// Check the ${artifact:path} interpolation is working
+		path := req.FormValue("path")
+		if got, want := path, "llamas.txt"; got != want {
+			http.Error(rw, fmt.Sprintf("path = %q, want %q", got, want), http.StatusBadRequest)
+			return
+		}
 
-			b := &bytes.Buffer{}
-			if _, err := io.Copy(b, file); err != nil {
-				http.Error(rw, fmt.Sprintf("io.Copy() error = %v", err), http.StatusInternalServerError)
-				return
-			}
+		file, fh, err := req.FormFile("file")
+		if err != nil {
+			http.Error(rw, fmt.Sprintf(`req.FormFile("file") error = %v`, err), http.StatusBadRequest)
+			return
+		}
+		defer file.Close()
 
-			// Check the file is attached correctly
-			if got, want := b.String(), "llamas"; got != want {
-				http.Error(rw, fmt.Sprintf("uploaded file content = %q, want %q", got, want), http.StatusBadRequest)
-				return
-			}
+		b := &bytes.Buffer{}
+		if _, err := io.Copy(b, file); err != nil {
+			http.Error(rw, fmt.Sprintf("io.Copy() error = %v", err), http.StatusInternalServerError)
+			return
+		}
 
-			if got, want := fh.Filename, "llamas.txt"; got != want {
-				http.Error(rw, fmt.Sprintf("uploaded file name = %q, want %q", got, want), http.StatusInternalServerError)
-				return
-			}
+		// Check the file is attached correctly
+		if got, want := b.String(), "llamas"; got != want {
+			http.Error(rw, fmt.Sprintf("uploaded file content = %q, want %q", got, want), http.StatusBadRequest)
+			return
+		}
 
-		default:
-			http.Error(rw, fmt.Sprintf("not found; method = %q, path = %q", req.Method, req.URL.Path), http.StatusNotFound)
+		if got, want := fh.Filename, "llamas.txt"; got != want {
+			http.Error(rw, fmt.Sprintf("uploaded file name = %q, want %q", got, want), http.StatusInternalServerError)
+			return
 		}
 	}))
 	defer server.Close()
@@ -113,9 +115,117 @@ func TestFormUploading(t *testing.T) {
 			}
 
 			for _, wu := range work {
-				if err := wu.DoWork(ctx); err != nil {
-					t.Errorf("bkUploaderWork.DoWork(artifact) = %v", err)
+				if _, err := wu.DoWork(ctx); err != nil {
+					t.Errorf("bkUploaderWork.DoWork(ctx) = %v", err)
 				}
+			}
+		})
+	}
+}
+
+func TestMultipartUploading(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.Method != "PUT" || req.URL.Path != "/llamas3.txt" {
+			http.Error(rw, fmt.Sprintf("not found; (method, path) = (%q, %q), want PUT /llamas3.txt", req.Method, req.URL.Path), http.StatusNotFound)
+			return
+		}
+		partNum, err := strconv.Atoi(req.URL.Query().Get("partNumber"))
+		if err != nil {
+			http.Error(rw, fmt.Sprintf("strconv.Atoi(req.URL.Query().Get(partNumber)) error = %v", err), http.StatusBadRequest)
+			return
+		}
+
+		if partNum < 1 || partNum > 3 {
+			http.Error(rw, fmt.Sprintf("partNumber %d out of range [1, 3]", partNum), http.StatusBadRequest)
+			return
+		}
+
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			http.Error(rw, fmt.Sprintf("io.ReadAll(req.Body) error = %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		if got, want := string(b), "llamas"; got != want {
+			http.Error(rw, fmt.Sprintf("req.Body = %q, want %q", got, want), http.StatusExpectationFailed)
+		}
+
+		rw.Header().Set("ETag", fmt.Sprintf(`"part number %d"`, partNum))
+		rw.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	temp, err := os.MkdirTemp("", "agent")
+	if err != nil {
+		t.Fatalf(`os.MkdirTemp("", "agent") error = %v`, err)
+	}
+	defer os.Remove(temp)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd() error = %v", err)
+	}
+
+	for _, wd := range []string{temp, cwd} {
+		t.Run(wd, func(t *testing.T) {
+			abspath := filepath.Join(wd, "llamas3.txt")
+			err = os.WriteFile(abspath, []byte("llamasllamasllamas"), 0700)
+			defer os.Remove(abspath)
+
+			uploader := NewBKUploader(logger.Discard, BKUploaderConfig{})
+			actions := []api.ArtifactUploadAction{
+				{URL: server.URL + "/llamas3.txt?partNumber=1", Method: "PUT", PartNumber: 1},
+				{URL: server.URL + "/llamas3.txt?partNumber=2", Method: "PUT", PartNumber: 2},
+				{URL: server.URL + "/llamas3.txt?partNumber=3", Method: "PUT", PartNumber: 3},
+			}
+			artifact := &api.Artifact{
+				ID:           "xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx",
+				Path:         "llamas3.txt",
+				AbsolutePath: abspath,
+				GlobPath:     "llamas3.txt",
+				FileSize:     18,
+				ContentType:  "text/plain",
+				UploadInstructions: &api.ArtifactUploadInstructions{
+					Actions: actions,
+				},
+			}
+
+			work, err := uploader.CreateWork(artifact)
+			if err != nil {
+				t.Fatalf("uploader.CreateWork(artifact) error = %v", err)
+			}
+
+			want := []workUnit{
+				&bkMultipartUpload{BKUploader: uploader, artifact: artifact, partCount: 3, action: &actions[0], offset: 0, size: 6},
+				&bkMultipartUpload{BKUploader: uploader, artifact: artifact, partCount: 3, action: &actions[1], offset: 6, size: 6},
+				&bkMultipartUpload{BKUploader: uploader, artifact: artifact, partCount: 3, action: &actions[2], offset: 12, size: 6},
+			}
+
+			if diff := cmp.Diff(work, want,
+				cmp.AllowUnexported(bkMultipartUpload{}),
+				cmpopts.EquateComparable(uploader),
+			); diff != "" {
+				t.Fatalf("CreateWork diff (-got +want):\n%s", diff)
+			}
+
+			var gotEtags []api.ArtifactPartETag
+			for _, wu := range work {
+				etag, err := wu.DoWork(ctx)
+				if err != nil {
+					t.Errorf("bkUploaderWork.DoWork(ctx) = %v", err)
+				}
+				gotEtags = append(gotEtags, *etag)
+			}
+
+			wantEtags := []api.ArtifactPartETag{
+				{PartNumber: 1, ETag: `"part number 1"`},
+				{PartNumber: 2, ETag: `"part number 2"`},
+				{PartNumber: 3, ETag: `"part number 3"`},
+			}
+			if diff := cmp.Diff(gotEtags, wantEtags); diff != "" {
+				t.Errorf("etags diff (-got +want):\n%s", diff)
 			}
 		})
 	}
@@ -161,8 +271,8 @@ func TestFormUploadFileMissing(t *testing.T) {
 	}
 
 	for _, wu := range work {
-		if err := wu.DoWork(ctx); !errors.Is(err, fs.ErrNotExist) {
-			t.Errorf("bkUploaderWork.DoWork(artifact) = %v, want %v", err, fs.ErrNotExist)
+		if _, err := wu.DoWork(ctx); !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("bkUploaderWork.DoWork(ctx) = %v, want %v", err, fs.ErrNotExist)
 		}
 	}
 }

--- a/internal/artifact/form_uploader_test.go
+++ b/internal/artifact/form_uploader_test.go
@@ -96,12 +96,7 @@ func TestFormUploading(t *testing.T) {
 				Data: map[string]string{
 					"path": "${artifact:path}",
 				},
-				Action: struct {
-					URL       string "json:\"url,omitempty\""
-					Method    string "json:\"method\""
-					Path      string "json:\"path\""
-					FileInput string "json:\"file_input\""
-				}{
+				Action: api.ArtifactUploadAction{
 					URL:       server.URL,
 					Method:    "POST",
 					Path:      "buildkiteartifacts.com",
@@ -145,12 +140,7 @@ func TestFormUploadFileMissing(t *testing.T) {
 			Data: map[string]string{
 				"path": "${artifact:path}",
 			},
-			Action: struct {
-				URL       string "json:\"url,omitempty\""
-				Method    string "json:\"method\""
-				Path      string "json:\"path\""
-				FileInput string "json:\"file_input\""
-			}{
+			Action: api.ArtifactUploadAction{
 				URL:       server.URL,
 				Method:    "POST",
 				Path:      "buildkiteartifacts.com",

--- a/internal/artifact/gs_uploader.go
+++ b/internal/artifact/gs_uploader.go
@@ -119,7 +119,25 @@ func (u *GSUploader) URL(artifact *api.Artifact) string {
 	return artifactURL.String()
 }
 
-func (u *GSUploader) Upload(_ context.Context, artifact *api.Artifact) error {
+func (u *GSUploader) CreateWork(artifact *api.Artifact) ([]workUnit, error) {
+	return []workUnit{&gsUploaderWork{
+		GSUploader: u,
+		artifact:   artifact,
+	}}, nil
+}
+
+type gsUploaderWork struct {
+	*GSUploader
+	artifact *api.Artifact
+}
+
+func (u *gsUploaderWork) Artifact() *api.Artifact { return u.artifact }
+
+func (u *gsUploaderWork) Description() string {
+	return singleUnitDescription(u.artifact)
+}
+
+func (u *gsUploaderWork) DoWork(_ context.Context) error {
 	permission := os.Getenv("BUILDKITE_GS_ACL")
 
 	// The dirtiest validation method ever...
@@ -134,19 +152,19 @@ func (u *GSUploader) Upload(_ context.Context, artifact *api.Artifact) error {
 
 	if permission == "" {
 		u.logger.Debug("Uploading \"%s\" to bucket \"%s\" with default permission",
-			u.artifactPath(artifact), u.BucketName)
+			u.artifactPath(u.artifact), u.BucketName)
 	} else {
 		u.logger.Debug("Uploading \"%s\" to bucket \"%s\" with permission \"%s\"",
-			u.artifactPath(artifact), u.BucketName, permission)
+			u.artifactPath(u.artifact), u.BucketName, permission)
 	}
 	object := &storage.Object{
-		Name:               u.artifactPath(artifact),
-		ContentType:        artifact.ContentType,
-		ContentDisposition: u.contentDisposition(artifact),
+		Name:               u.artifactPath(u.artifact),
+		ContentType:        u.artifact.ContentType,
+		ContentDisposition: u.contentDisposition(u.artifact),
 	}
-	file, err := os.Open(artifact.AbsolutePath)
+	file, err := os.Open(u.artifact.AbsolutePath)
 	if err != nil {
-		return errors.New(fmt.Sprintf("Failed to open file \"%q\" (%v)", artifact.AbsolutePath, err))
+		return errors.New(fmt.Sprintf("Failed to open file %q (%v)", u.artifact.AbsolutePath, err))
 	}
 	call := u.service.Objects.Insert(u.BucketName, object)
 	if permission != "" {
@@ -155,7 +173,7 @@ func (u *GSUploader) Upload(_ context.Context, artifact *api.Artifact) error {
 	if res, err := call.Media(file, googleapi.ContentType("")).Do(); err == nil {
 		u.logger.Debug("Created object %v at location %v\n\n", res.Name, res.SelfLink)
 	} else {
-		return errors.New(fmt.Sprintf("Failed to PUT file \"%s\" (%v)", u.artifactPath(artifact), err))
+		return errors.New(fmt.Sprintf("Failed to PUT file %q (%v)", u.artifactPath(u.artifact), err))
 	}
 
 	return nil

--- a/internal/artifact/s3_uploader.go
+++ b/internal/artifact/s3_uploader.go
@@ -99,10 +99,10 @@ func (u *s3UploaderWork) Description() string {
 	return singleUnitDescription(u.artifact)
 }
 
-func (u *s3UploaderWork) DoWork(context.Context) error {
+func (u *s3UploaderWork) DoWork(context.Context) (*api.ArtifactPartETag, error) {
 	permission, err := u.resolvePermission()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Create an uploader with the session and default options
@@ -112,7 +112,7 @@ func (u *s3UploaderWork) DoWork(context.Context) error {
 	u.logger.Debug("Reading file %q", u.artifact.AbsolutePath)
 	f, err := os.Open(u.artifact.AbsolutePath)
 	if err != nil {
-		return fmt.Errorf("failed to open file %q (%w)", u.artifact.AbsolutePath, err)
+		return nil, fmt.Errorf("failed to open file %q (%w)", u.artifact.AbsolutePath, err)
 	}
 
 	// Upload the file to S3.
@@ -131,8 +131,7 @@ func (u *s3UploaderWork) DoWork(context.Context) error {
 	}
 
 	_, err = uploader.Upload(params)
-
-	return err
+	return nil, err
 }
 
 func (u *S3Uploader) artifactPath(artifact *api.Artifact) string {

--- a/internal/artifact/s3_uploader.go
+++ b/internal/artifact/s3_uploader.go
@@ -81,8 +81,25 @@ func (u *S3Uploader) URL(artifact *api.Artifact) string {
 	return url.String()
 }
 
-func (u *S3Uploader) Upload(_ context.Context, artifact *api.Artifact) error {
+func (u *S3Uploader) CreateWork(artifact *api.Artifact) ([]workUnit, error) {
+	return []workUnit{&s3UploaderWork{
+		S3Uploader: u,
+		artifact:   artifact,
+	}}, nil
+}
 
+type s3UploaderWork struct {
+	*S3Uploader
+	artifact *api.Artifact
+}
+
+func (u *s3UploaderWork) Artifact() *api.Artifact { return u.artifact }
+
+func (u *s3UploaderWork) Description() string {
+	return singleUnitDescription(u.artifact)
+}
+
+func (u *s3UploaderWork) DoWork(context.Context) error {
 	permission, err := u.resolvePermission()
 	if err != nil {
 		return err
@@ -92,19 +109,19 @@ func (u *S3Uploader) Upload(_ context.Context, artifact *api.Artifact) error {
 	uploader := s3manager.NewUploaderWithClient(u.client)
 
 	// Open file from filesystem
-	u.logger.Debug("Reading file \"%s\"", artifact.AbsolutePath)
-	f, err := os.Open(artifact.AbsolutePath)
+	u.logger.Debug("Reading file %q", u.artifact.AbsolutePath)
+	f, err := os.Open(u.artifact.AbsolutePath)
 	if err != nil {
-		return fmt.Errorf("failed to open file %q (%w)", artifact.AbsolutePath, err)
+		return fmt.Errorf("failed to open file %q (%w)", u.artifact.AbsolutePath, err)
 	}
 
 	// Upload the file to S3.
-	u.logger.Debug("Uploading \"%s\" to bucket with permission `%s`", u.artifactPath(artifact), permission)
+	u.logger.Debug("Uploading %q to bucket with permission %q", u.artifactPath(u.artifact), permission)
 
 	params := &s3manager.UploadInput{
 		Bucket:      aws.String(u.BucketName),
-		Key:         aws.String(u.artifactPath(artifact)),
-		ContentType: aws.String(artifact.ContentType),
+		Key:         aws.String(u.artifactPath(u.artifact)),
+		ContentType: aws.String(u.artifact.ContentType),
 		ACL:         aws.String(permission),
 		Body:        f,
 	}

--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -370,7 +370,7 @@ func (a *Uploader) createUploader() (_ uploader, err error) {
 	switch {
 	case a.conf.Destination == "":
 		a.logger.Info("Uploading to default Buildkite artifact storage")
-		return NewFormUploader(a.logger, FormUploaderConfig{
+		return NewBKUploader(a.logger, BKUploaderConfig{
 			DebugHTTP: a.conf.DebugHTTP,
 		}), nil
 

--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -75,7 +75,7 @@ func NewUploader(l logger.Logger, ac APIClient, c UploaderConfig) *Uploader {
 
 func (a *Uploader) Upload(ctx context.Context) error {
 	// Create artifact structs for all the files we need to upload
-	artifacts, err := a.Collect(ctx)
+	artifacts, err := a.collect(ctx)
 	if err != nil {
 		return fmt.Errorf("collecting artifacts: %w", err)
 	}
@@ -109,7 +109,7 @@ func isDir(path string) bool {
 	return fi.IsDir()
 }
 
-func (a *Uploader) Collect(ctx context.Context) ([]*api.Artifact, error) {
+func (a *Uploader) collect(ctx context.Context) ([]*api.Artifact, error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("getting working directory: %w", err)

--- a/internal/artifact/uploader_test.go
+++ b/internal/artifact/uploader_test.go
@@ -97,13 +97,13 @@ func TestCollect(t *testing.T) {
 	ctxExpEnabled, _ := experiments.Enable(ctx, experiments.NormalisedUploadPaths)
 	ctxExpDisabled := experiments.Disable(ctx, experiments.NormalisedUploadPaths)
 
-	artifactsWithoutExperimentEnabled, err := uploader.Collect(ctxExpDisabled)
+	artifactsWithoutExperimentEnabled, err := uploader.collect(ctxExpDisabled)
 	if err != nil {
 		t.Fatalf("[normalised-upload-paths disabled] uploader.Collect() error = %v", err)
 	}
 	assert.Equal(t, 5, len(artifactsWithoutExperimentEnabled))
 
-	artifactsWithExperimentEnabled, err := uploader.Collect(ctxExpEnabled)
+	artifactsWithExperimentEnabled, err := uploader.collect(ctxExpEnabled)
 	if err != nil {
 		t.Fatalf("[normalised-upload-paths enabled] uploader.Collect() error = %v", err)
 	}
@@ -165,7 +165,7 @@ func TestCollectThatDoesntMatchAnyFiles(t *testing.T) {
 		}, ";"),
 	})
 
-	artifacts, err := uploader.Collect(ctx)
+	artifacts, err := uploader.collect(ctx)
 	if err != nil {
 		t.Fatalf("uploader.Collect() error = %v", err)
 	}
@@ -185,7 +185,7 @@ func TestCollectWithSomeGlobsThatDontMatchAnything(t *testing.T) {
 		}, ";"),
 	})
 
-	artifacts, err := uploader.Collect(ctx)
+	artifacts, err := uploader.collect(ctx)
 	if err != nil {
 		t.Fatalf("uploader.Collect() error = %v", err)
 	}
@@ -209,7 +209,7 @@ func TestCollectWithSomeGlobsThatDontMatchAnythingFollowingSymlinks(t *testing.T
 		GlobResolveFollowSymlinks: true,
 	})
 
-	artifacts, err := uploader.Collect(ctx)
+	artifacts, err := uploader.collect(ctx)
 	if err != nil {
 		t.Fatalf("uploader.Collect() error = %v", err)
 	}
@@ -230,7 +230,7 @@ func TestCollectWithDuplicateMatches(t *testing.T) {
 		}, ";"),
 	})
 
-	artifacts, err := uploader.Collect(ctx)
+	artifacts, err := uploader.collect(ctx)
 	if err != nil {
 		t.Fatalf("uploader.Collect() error = %v", err)
 	}
@@ -263,7 +263,7 @@ func TestCollectWithDuplicateMatchesFollowingSymlinks(t *testing.T) {
 		GlobResolveFollowSymlinks: true,
 	})
 
-	artifacts, err := uploader.Collect(ctx)
+	artifacts, err := uploader.collect(ctx)
 	if err != nil {
 		t.Fatalf("uploader.Collect() error = %v", err)
 	}
@@ -296,7 +296,7 @@ func TestCollectMatchesUploadSymlinks(t *testing.T) {
 		UploadSkipSymlinks: true,
 	})
 
-	artifacts, err := uploader.Collect(ctx)
+	artifacts, err := uploader.collect(ctx)
 	if err != nil {
 		t.Fatalf("uploader.Collect() error = %v", err)
 	}
@@ -389,13 +389,13 @@ func TestCollect_WithZZGlob(t *testing.T) {
 	ctxExpEnabled, _ := experiments.Enable(ctx, experiments.NormalisedUploadPaths)
 	ctxExpDisabled := experiments.Disable(ctx, experiments.NormalisedUploadPaths)
 
-	artifactsWithoutExperimentEnabled, err := uploader.Collect(ctxExpDisabled)
+	artifactsWithoutExperimentEnabled, err := uploader.collect(ctxExpDisabled)
 	if err != nil {
 		t.Fatalf("[normalised-upload-paths disabled] uploader.Collect() error = %v", err)
 	}
 	assert.Equal(t, 5, len(artifactsWithoutExperimentEnabled))
 
-	artifactsWithExperimentEnabled, err := uploader.Collect(ctxExpEnabled)
+	artifactsWithExperimentEnabled, err := uploader.collect(ctxExpEnabled)
 	if err != nil {
 		t.Fatalf("[normalised-upload-paths enabled] uploader.Collect() error = %v", err)
 	}
@@ -457,7 +457,7 @@ func TestCollectThatDoesntMatchAnyFiles_WithZZGlob(t *testing.T) {
 		}, ";"),
 	})
 
-	artifacts, err := uploader.Collect(ctx)
+	artifacts, err := uploader.collect(ctx)
 	if err != nil {
 		t.Fatalf("uploader.Collect() error = %v", err)
 	}
@@ -477,7 +477,7 @@ func TestCollectWithSomeGlobsThatDontMatchAnything_WithZZGlob(t *testing.T) {
 		}, ";"),
 	})
 
-	artifacts, err := uploader.Collect(ctx)
+	artifacts, err := uploader.collect(ctx)
 	if err != nil {
 		t.Fatalf("uploader.Collect() error = %v", err)
 	}
@@ -501,7 +501,7 @@ func TestCollectWithSomeGlobsThatDontMatchAnythingFollowingSymlinks_WithZZGlob(t
 		GlobResolveFollowSymlinks: true,
 	})
 
-	artifacts, err := uploader.Collect(ctx)
+	artifacts, err := uploader.collect(ctx)
 	if err != nil {
 		t.Fatalf("uploader.Collect() error = %v", err)
 	}
@@ -522,7 +522,7 @@ func TestCollectWithDuplicateMatches_WithZZGlob(t *testing.T) {
 		}, ";"),
 	})
 
-	artifacts, err := uploader.Collect(ctx)
+	artifacts, err := uploader.collect(ctx)
 	if err != nil {
 		t.Fatalf("uploader.Collect() error = %v", err)
 	}
@@ -555,7 +555,7 @@ func TestCollectWithDuplicateMatchesFollowingSymlinks_WithZZGlob(t *testing.T) {
 		GlobResolveFollowSymlinks: true,
 	})
 
-	artifacts, err := uploader.Collect(ctx)
+	artifacts, err := uploader.collect(ctx)
 	if err != nil {
 		t.Fatalf("uploader.Collect() error = %v", err)
 	}
@@ -588,7 +588,7 @@ func TestCollectMatchesUploadSymlinks_WithZZGlob(t *testing.T) {
 		UploadSkipSymlinks: true,
 	})
 
-	artifacts, err := uploader.Collect(ctx)
+	artifacts, err := uploader.collect(ctx)
 	if err != nil {
 		t.Fatalf("uploader.Collect() error = %v", err)
 	}


### PR DESCRIPTION
### Description

Add a multipart-upload mechanism for Buildkite-hosted artifacts, and upload parts in parallel (with each other, and with other artifacts).

### Context

https://linear.app/buildkite/issue/PIPE-180/implement-agent-half-of-multipart-uploads

### Changes

The changes to artifact uploading is substantial, but basically:

* Some tidyups to the existing code, such as context propagation, un-exporting the `Collect` method
* `FormUploader` is renamed to `BKUploader`, since it will manage both form uploads and multipart uploads to BK
* Changing all the existing uploaders to return one or more units of work, which are ultimately responsible for performing an upload
* Running work units concurrently on a pool of worker goroutines, and communicating between goroutines using channels
* Actually implementing multipart uploads:
  * Alter the batch artifact creation API to signal that multipart is supported and enabled
  * Alter the creation response to handle per-artifact instructions and multiple actions per instruction
  * Alter the batch update API to accept part number-ETag mappings
  * Implement multipart upload work units that are responsible for uploading a single part each

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
