### PR TITLE
Temporarily pin kubectl version

### DIFF
--- a/packaging/docker/alpine-k8s/Dockerfile
+++ b/packaging/docker/alpine-k8s/Dockerfile
@@ -26,12 +26,12 @@ FROM public.ecr.aws/docker/library/alpine:3.20.1@sha256:b89d9c93e9ed3597455c90a0
 ARG TARGETOS
 ARG TARGETARCH
 
+ENV K8_VERSION=v1.31.0
+
 RUN <<EOF
 set -eu
-
-VERSION=$(wget -qO- https://dl.k8s.io/release/stable.txt)
 wget -qO kubectl \
-    "https://storage.googleapis.com/kubernetes-release/release/$VERSION/bin/linux/$TARGETARCH/kubectl"
+    "https://storage.googleapis.com/kubernetes-release/release/$K8_VERSION/bin/linux/$TARGETARCH/kubectl"
 chmod +x kubectl
 EOF
 


### PR DESCRIPTION
### Description

main build is failing

The latest k8s release hasn't been uploaded to the GCP bucket yet, which is causing our build to fail

### Changes

Pin the k8s version for now

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)
