### PR TITLE
Prefer $HOME on all platforms

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1383,7 +1383,7 @@ func agentLifecycleHook(hookName string, log logger.Logger, cfg AgentStartConfig
 }
 
 func defaultSocketsPath() string {
-	home, err := os.UserHomeDir()
+	home, err := osutil.UserHomeDir()
 	if err != nil {
 		return filepath.Join(os.TempDir(), "buildkite-sockets")
 	}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -30,7 +30,7 @@ import (
 	"github.com/buildkite/agent/v3/internal/experiments"
 	"github.com/buildkite/agent/v3/internal/job/hook"
 	"github.com/buildkite/agent/v3/internal/job/shell"
-	"github.com/buildkite/agent/v3/internal/utils"
+	"github.com/buildkite/agent/v3/internal/osutil"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/agent/v3/metrics"
 	"github.com/buildkite/agent/v3/process"
@@ -1133,7 +1133,7 @@ var AgentStartCommand = cli.Command{
 
 		// confirm the BuildPath is exists. The bootstrap is going to write to it when a job executes,
 		// so we may as well check that'll work now and fail early if it's a problem
-		if !utils.FileExists(agentConf.BuildPath) {
+		if !osutil.FileExists(agentConf.BuildPath) {
 			l.Info("Build Path doesn't exist, creating it (%s)", agentConf.BuildPath)
 			// Actual file permissions will be reduced by umask, and won't be 0777 unless the user has manually changed the umask to 000
 			if err := os.MkdirAll(agentConf.BuildPath, 0o777); err != nil {

--- a/cliconfig/file.go
+++ b/cliconfig/file.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/buildkite/agent/v3/internal/utils"
+	"github.com/buildkite/agent/v3/internal/osutil"
 )
 
 type File struct {
@@ -60,7 +60,7 @@ func (f *File) Load() error {
 }
 
 func (f File) AbsolutePath() (string, error) {
-	return utils.NormalizeFilePath(f.Path)
+	return osutil.NormalizeFilePath(f.Path)
 }
 
 func (f File) Exists() bool {

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/buildkite/agent/v3/internal/utils"
+	"github.com/buildkite/agent/v3/internal/osutil"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/oleiade/reflections"
 	"github.com/urfave/cli"
@@ -372,7 +372,7 @@ func (l Loader) normalizeField(fieldName string, normalization string) error {
 
 		// Normalize the field to be a filepath
 		if valueAsString, ok := value.(string); ok {
-			normalizedPath, err := utils.NormalizeFilePath(valueAsString)
+			normalizedPath, err := osutil.NormalizeFilePath(valueAsString)
 			if err != nil {
 				return err
 			}
@@ -392,7 +392,7 @@ func (l Loader) normalizeField(fieldName string, normalization string) error {
 
 		// Normalize the field to be a command
 		if valueAsString, ok := value.(string); ok {
-			normalizedCommandPath, err := utils.NormalizeCommand(valueAsString)
+			normalizedCommandPath, err := osutil.NormalizeCommand(valueAsString)
 			if err != nil {
 				return err
 			}

--- a/internal/job/hook/hook.go
+++ b/internal/job/hook/hook.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 
 	"github.com/buildkite/agent/v3/internal/job/shell"
-	"github.com/buildkite/agent/v3/internal/utils"
+	"github.com/buildkite/agent/v3/internal/osutil"
 )
 
 // Find returns the absolute path to the best matching hook file in a path, or
@@ -23,7 +23,7 @@ func Find(hookDir string, name string) (string, error) {
 		}
 	}
 	// otherwise chech for th default shell script
-	if p := filepath.Join(hookDir, name); utils.FileExists(p) {
+	if p := filepath.Join(hookDir, name); osutil.FileExists(p) {
 		return p, nil
 	}
 	// Don't wrap os.ErrNotExist without checking callers handle it.

--- a/internal/job/knownhosts.go
+++ b/internal/job/knownhosts.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/v3/internal/job/shell"
+	"github.com/buildkite/agent/v3/internal/osutil"
 	"golang.org/x/crypto/ssh/knownhosts"
 )
 
@@ -19,7 +20,7 @@ type knownHosts struct {
 }
 
 func findKnownHosts(sh *shell.Shell) (*knownHosts, error) {
-	userHomePath, err := os.UserHomeDir()
+	userHomePath, err := osutil.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("Could not find the current users home directory (%s)", err)
 	}

--- a/internal/job/plugin.go
+++ b/internal/job/plugin.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/buildkite/agent/v3/agent/plugin"
 	"github.com/buildkite/agent/v3/internal/job/hook"
-	"github.com/buildkite/agent/v3/internal/utils"
+	"github.com/buildkite/agent/v3/internal/osutil"
 	"github.com/buildkite/roko"
 )
 
@@ -162,7 +162,7 @@ func (e *Executor) VendoredPluginPhase(ctx context.Context) error {
 			return fmt.Errorf("Failed to resolve vendored plugin path for plugin %s: %w", p.Name(), err)
 		}
 
-		if !utils.FileExists(pluginLocation) {
+		if !osutil.FileExists(pluginLocation) {
 			return fmt.Errorf("Vendored plugin path %s doesn't exist", p.Location)
 		}
 
@@ -324,7 +324,7 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 	// that means a potentially slow and unnecessary clone on every build step.  Sigh.  I think the
 	// tradeoff is favourable for just blowing away an existing clone if we want least-hassle
 	// guarantee that the user will get the latest version of their plugin branch/tag/whatever.
-	if e.ExecutorConfig.PluginsAlwaysCloneFresh && utils.FileExists(pluginDirectory) {
+	if e.ExecutorConfig.PluginsAlwaysCloneFresh && osutil.FileExists(pluginDirectory) {
 		e.shell.Commentf("BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH is true; removing previous checkout of plugin %s", p.Label())
 		err = os.RemoveAll(pluginDirectory)
 		if err != nil {
@@ -333,7 +333,7 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 		}
 	}
 
-	if utils.FileExists(pluginGitDirectory) {
+	if osutil.FileExists(pluginGitDirectory) {
 		// It'd be nice to show the current commit of the plugin, so
 		// let's figure that out.
 		headCommit, err := gitRevParseInWorkingDirectory(ctx, e.shell, pluginDirectory, "--short=7", "HEAD")

--- a/internal/osutil/doc.go
+++ b/internal/osutil/doc.go
@@ -1,0 +1,2 @@
+// Package osutil provides some OS-level helper functions.
+package osutil

--- a/internal/osutil/file.go
+++ b/internal/osutil/file.go
@@ -1,4 +1,4 @@
-package utils
+package osutil
 
 import (
 	"fmt"

--- a/internal/osutil/homedir.go
+++ b/internal/osutil/homedir.go
@@ -1,0 +1,12 @@
+package osutil
+
+import "os"
+
+// UserHomeDir is similar to os.UserHomeDir, but prefers $HOME when available
+// over other options (such as USERPROFILE on Windows).
+func UserHomeDir() (string, error) {
+	if h := os.Getenv("HOME"); h != "" {
+		return h, nil
+	}
+	return os.UserHomeDir()
+}

--- a/internal/osutil/homedir_test.go
+++ b/internal/osutil/homedir_test.go
@@ -1,0 +1,50 @@
+package osutil
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestUserHomeDir(t *testing.T) {
+	// not parallel because it messes with env vars
+	origHome := os.Getenv("HOME")
+	origUserProfile := os.Getenv("USERPROFILE")
+	t.Cleanup(func() {
+		os.Setenv("HOME", origHome)
+		os.Setenv("USERPROFILE", origUserProfile)
+	})
+
+	type testCase struct {
+		home, userProfile, want string
+	}
+
+	tests := []testCase{
+		{
+			// Prefer $HOME on all platforms
+			home:        "home",
+			userProfile: "userProfile",
+			want:        "home",
+		},
+	}
+	if runtime.GOOS == "windows" {
+		// Windows can use %USERPROFILE% as a treat when $HOME is unavailable
+		tests = append(tests, testCase{
+			home:        "",
+			userProfile: "userProfile",
+			want:        "userProfile",
+		})
+	}
+
+	for _, test := range tests {
+		os.Setenv("HOME", test.home)
+		os.Setenv("USERPROFILE", test.userProfile)
+		got, err := UserHomeDir()
+		if err != nil {
+			t.Errorf("HOME=%q USERPROFILE=%q UserHomeDir() error = %v", test.home, test.userProfile, err)
+		}
+		if got != test.want {
+			t.Errorf("HOME=%q USERPROFILE=%q UserHomeDir() = %q, want %q", test.home, test.userProfile, got, test.want)
+		}
+	}
+}

--- a/internal/osutil/path.go
+++ b/internal/osutil/path.go
@@ -1,4 +1,4 @@
-package utils
+package osutil
 
 import (
 	"errors"

--- a/internal/osutil/path_test.go
+++ b/internal/osutil/path_test.go
@@ -1,4 +1,4 @@
-package utils
+package osutil
 
 import (
 	"os"

--- a/internal/osutil/path_windows_test.go
+++ b/internal/osutil/path_windows_test.go
@@ -1,7 +1,7 @@
 //go:build windows
 // +build windows
 
-package utils
+package osutil
 
 import (
 	"os"

--- a/internal/utils/doc.go
+++ b/internal/utils/doc.go
@@ -1,4 +1,0 @@
-// Package utils provides some file- and filepath-helper functions.
-//
-// TODO: `utils` is too vague. Find a better name for this package.
-package utils


### PR DESCRIPTION
### Description

#2990 is good, but is likely to be a breaking change on Windows particularly. For instance the Elastic CI Stack runs the agent with [`HOME=C:\buildkite-agent`](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/41363708a4231dd801e4c30d4ae2b4b5a6c8ff7c/packer/windows/conf/bin/bk-install-elastic-stack.ps1#L231).

Rather than revert #2990, in the spirit of Go Proverbs I propose we do [a little copying instead of a little dependency](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=9m28s).

### Changes

* Rename internal/utils to internal/osutil, which suits it a little better.
* Add `osutil.UserHomeDir`, which wraps `os.UserHomeDir` and prefers `$HOME` when available.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

