### PR TITLE
Work around golang/go#59690

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -5,11 +5,7 @@ import (
 	"net/http"
 )
 
-type canceler interface {
-	CancelRequest(*http.Request)
-}
-
-// authenticatedTransport manages injection of the API token
+// authenticatedTransport manages injection of the API token.
 type authenticatedTransport struct {
 	// The Token used for authentication. This can either the be
 	// organizations registration token, or the agents access token.
@@ -19,19 +15,59 @@ type authenticatedTransport struct {
 	Delegate http.RoundTripper
 }
 
-// RoundTrip invoked each time a request is made
+// RoundTrip invoked each time a request is made.
 func (t authenticatedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Per net/http#RoundTripper:
+	//
+	// "RoundTrip must always close the body, including on errors, ..."
+	reqBodyClosed := false
+	if req.Body != nil {
+		defer func() {
+			if !reqBodyClosed {
+				req.Body.Close()
+			}
+		}()
+	}
+
 	if t.Token == "" {
 		return nil, fmt.Errorf("Invalid token, empty string supplied")
 	}
 
+	// Per net/http#RoundTripper:
+	//
+	// "RoundTrip should not modify the request, except for
+	// consuming and closing the Request's Body. RoundTrip may
+	// read fields of the request in a separate goroutine. Callers
+	// should not mutate or reuse the request until the Response's
+	// Body has been closed."
+	//
+	// But we can pass a _different_ request to t.Delegate.RoundTrip.
+	// req.Clone does a sufficiently deep clone (including Header which we
+	// modify).
+	req = req.Clone(req.Context())
 	req.Header.Set("Authorization", fmt.Sprintf("Token %s", t.Token))
 
+	// req.Body is assumed to be closed by the delegate.
+	reqBodyClosed = true
 	return t.Delegate.RoundTrip(req)
 }
 
-// CancelRequest cancels an in-flight request by closing its connection.
+// CancelRequest forwards the call to t.Delegate, if it implements CancelRequest
+// itself.
 func (t *authenticatedTransport) CancelRequest(req *http.Request) {
-	cancelableTransport := t.Delegate.(canceler)
-	cancelableTransport.CancelRequest(req)
+	canceler, ok := t.Delegate.(interface{ CancelRequest(*http.Request) })
+	if !ok {
+		return
+	}
+	canceler.CancelRequest(req)
+}
+
+// CloseIdleConnections forwards the call to t.Delegate, if it implements
+// CloseIdleConnections itself.
+func (t *authenticatedTransport) CloseIdleConnections() {
+	closer, ok := t.Delegate.(interface{ CloseIdleConnections() })
+	if !ok {
+		return
+	}
+	closer.CloseIdleConnections()
 }

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.30.0
 	golang.org/x/crypto v0.27.0
 	golang.org/x/exp v0.0.0-20231108232855-2478ac86f678
+	golang.org/x/net v0.29.0
 	golang.org/x/oauth2 v0.23.0
 	golang.org/x/sys v0.25.0
 	golang.org/x/term v0.24.0
@@ -128,7 +129,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/net v0.29.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/text v0.18.0 // indirect
 	golang.org/x/time v0.6.0 // indirect


### PR DESCRIPTION
### Description

Work around a Go bug in HTTP/2 on Linux.

### Context

Various reports of connection failures.

Steps to reproduce:

1. Launch the agent on a linux machine
2. Obtain the source ports being used using `netstat -anp`
3. Block traffic destined for the agent source ports `iptables -I INPUT -p tcp --dport $PORT -j DROP`

**Expected behaviour:**
After the initial connection times out a new connection is established. The old connections no longer show as `ESTABLISHED` and communications to agent.buildkite.com are restored 

**Observed behaviour:**

The agent hangs for a long period of time (>3 minutes) and continuosly prints errors communicating with the agent backend:
```
2024-09-23 12:44:54 ERROR  HTTP Timing Trace uri=https://agent.buildkite.com/v3/ping method=GET hostPort=agent.buildkite.com:443 getConn=38.959µs gotConn=40.126µs reused=true idle=false idleTime=0s localAddr=198.19.249.69:42018 wroteHeaders=127.044µs wroteRequest=128.753µs
2024-09-23 12:44:54 WARN   ubuntu Failed to ping: Get "https://agent.buildkite.com/v3/ping": net/http: request canceled (Client.Timeout exceeded while awaiting headers) (Last successful was 13m0.810827775s ago)
```

### Changes

* Use `http2.ConfigureTransports` to gain access to `ReadIdleTimeout`, and set it to a nice low 30s, as documented in https://github.com/golang/go/issues/59690#issuecomment-1733619488.
* Make some related changes to `authenticatedTransport`. Getting rid of `authenticatedTransport` is too much hassle right now, but we can take inspiration from https://github.com/golang/oauth2/blob/master/transport.go#L20.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
