### PR TITLE
PS-111-mirrors use withTimeout that will cancel after expiry

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -484,10 +484,14 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 
 	var mirrorDir string
 
+	lockTimeout := time.Second * time.Duration(e.GitMirrorsLockTimeout)
+	getCtx, canc := context.WithTimeout(ctx, lockTimeout)
+	defer canc()
+
 	// If we can, get a mirror of the git repository to use for reference later
 	if e.ExecutorConfig.GitMirrorsPath != "" && e.ExecutorConfig.Repository != "" {
 		span.AddAttributes(map[string]string{"checkout.is_using_git_mirrors": "true"})
-		mirrorDir, err = e.getOrUpdateMirrorDir(ctx, e.Repository)
+		mirrorDir, err = e.getOrUpdateMirrorDir(getCtx, e.Repository)
 		if err != nil {
 			return fmt.Errorf("getting/updating git mirror: %w", err)
 		}


### PR DESCRIPTION
### Description
There is an error (intermittently) mirror fails when a node trying to acquire the lock and checkout 
https://github.com/buildkite/agent/blob/dd959ad66251fdb9d56159f72aaae187b30106c9/internal/job/checkout.go#L491-L493

Ideally the customer wants a new exit code for the git mirror failure so they can retry on that 
or
any time element so the lock would get auto-released after a certain period

This PR attempts the latter but I could be way off


### Context

Plain: https://app.plain.com/workspace/w_01J0T5SBKJHGBT6FZZHAMH3GRB/thread/th_01J80NPYZRCDEGXAVPNYRD5NT1/
Coda:
https://coda.io/d/Escalations-Feedback_dHnUHNps1YO/Pipelines-Escalations_suQ4B7FT#Pipelines-Escalations-Board_tu66S__K/r711&view=modal

Linear
https://linear.app/buildkite/issue/PS-111/new-exit-code-when-lock-for-git-mirrors

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
