### PR TITLE
Add support for oidc aws session tags

### DIFF
--- a/api/oidc.go
+++ b/api/oidc.go
@@ -10,21 +10,24 @@ type OIDCToken struct {
 }
 
 type OIDCTokenRequest struct {
-	Job      string
-	Audience string
-	Lifetime int
-	Claims   []string
+	Job            string
+	Audience       string
+	Lifetime       int
+	Claims         []string
+	AwsSessionTags []string
 }
 
 func (c *Client) OIDCToken(ctx context.Context, methodReq *OIDCTokenRequest) (*OIDCToken, *Response, error) {
 	m := &struct {
-		Audience string   `json:"audience,omitempty"`
-		Lifetime int      `json:"lifetime,omitempty"`
-		Claims   []string `json:"claims,omitempty"`
+		Audience       string   `json:"audience,omitempty"`
+		Lifetime       int      `json:"lifetime,omitempty"`
+		Claims         []string `json:"claims,omitempty"`
+		AwsSessionTags []string `json:"aws_session_tags,omitempty"`
 	}{
-		Audience: methodReq.Audience,
-		Lifetime: methodReq.Lifetime,
-		Claims:   methodReq.Claims,
+		Audience:       methodReq.Audience,
+		Lifetime:       methodReq.Lifetime,
+		Claims:         methodReq.Claims,
+		AwsSessionTags: methodReq.AwsSessionTags,
 	}
 
 	u := fmt.Sprintf("jobs/%s/oidc/tokens", railsPathEscape(methodReq.Job))

--- a/api/oidc.go
+++ b/api/oidc.go
@@ -14,7 +14,7 @@ type OIDCTokenRequest struct {
 	Audience       string
 	Lifetime       int
 	Claims         []string
-	AwsSessionTags []string
+	AWSSessionTags []string
 }
 
 func (c *Client) OIDCToken(ctx context.Context, methodReq *OIDCTokenRequest) (*OIDCToken, *Response, error) {
@@ -22,12 +22,12 @@ func (c *Client) OIDCToken(ctx context.Context, methodReq *OIDCTokenRequest) (*O
 		Audience       string   `json:"audience,omitempty"`
 		Lifetime       int      `json:"lifetime,omitempty"`
 		Claims         []string `json:"claims,omitempty"`
-		AwsSessionTags []string `json:"aws_session_tags,omitempty"`
+		AWSSessionTags []string `json:"aws_session_tags,omitempty"`
 	}{
 		Audience:       methodReq.Audience,
 		Lifetime:       methodReq.Lifetime,
 		Claims:         methodReq.Claims,
-		AwsSessionTags: methodReq.AwsSessionTags,
+		AWSSessionTags: methodReq.AWSSessionTags,
 	}
 
 	u := fmt.Sprintf("jobs/%s/oidc/tokens", railsPathEscape(methodReq.Job))

--- a/api/oidc_test.go
+++ b/api/oidc_test.go
@@ -124,6 +124,24 @@ func TestOIDCToken(t *testing.T) {
 			ExpectedBody: []byte(fmt.Sprintf(`{"lifetime":%d}`+"\n", lifetime)),
 			OIDCToken:    &api.OIDCToken{Token: oidcToken},
 		},
+		{
+			AccessToken: accessToken,
+			OIDCTokenRequest: &api.OIDCTokenRequest{
+				Job:    jobID,
+				Claims: []string{"organization_id", "pipeline_id"},
+			},
+			ExpectedBody: []byte(`{"claims":["organization_id","pipeline_id"]}` + "\n"),
+			OIDCToken:    &api.OIDCToken{Token: oidcToken},
+		},
+		{
+			AccessToken: accessToken,
+			OIDCTokenRequest: &api.OIDCTokenRequest{
+				Job:            jobID,
+				AwsSessionTags: []string{"organization_id", "pipeline_id"},
+			},
+			ExpectedBody: []byte(`{"aws_session_tags":["organization_id","pipeline_id"]}` + "\n"),
+			OIDCToken:    &api.OIDCToken{Token: oidcToken},
+		},
 	}
 
 	for _, test := range tests {

--- a/api/oidc_test.go
+++ b/api/oidc_test.go
@@ -137,7 +137,7 @@ func TestOIDCToken(t *testing.T) {
 			AccessToken: accessToken,
 			OIDCTokenRequest: &api.OIDCTokenRequest{
 				Job:            jobID,
-				AwsSessionTags: []string{"organization_id", "pipeline_id"},
+				AWSSessionTags: []string{"organization_id", "pipeline_id"},
 			},
 			ExpectedBody: []byte(`{"aws_session_tags":["organization_id","pipeline_id"]}` + "\n"),
 			OIDCToken:    &api.OIDCToken{Token: oidcToken},

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -16,7 +16,8 @@ type OIDCTokenConfig struct {
 	Lifetime int    `cli:"lifetime"`
 	Job      string `cli:"job"      validate:"required"`
 	// TODO: enumerate possible values, perhaps by adding a link to the documentation
-	Claims []string `cli:"claim"    normalize:"list"`
+	Claims         []string `cli:"claim"           normalize:"list"`
+	AwsSessionTags []string `cli:"aws-session-tag" normalize:"list"`
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
@@ -79,6 +80,13 @@ var OIDCRequestTokenCommand = cli.Command{
 			EnvVar: "BUILDKITE_OIDC_TOKEN_CLAIMS",
 		},
 
+		cli.StringSliceFlag{
+			Name:   "aws-session-tag",
+			Value:  &cli.StringSlice{},
+			Usage:  "Add claims as AWS Session Tags",
+			EnvVar: "BUILDKITE_OIDC_TOKEN_AWS_SESSION_TAGS",
+		},
+
 		// API Flags
 		AgentAccessTokenFlag,
 		EndpointFlag,
@@ -112,10 +120,11 @@ var OIDCRequestTokenCommand = cli.Command{
 		)
 		token, err := roko.DoFunc(ctx, r, func(r *roko.Retrier) (*api.OIDCToken, error) {
 			req := &api.OIDCTokenRequest{
-				Job:      cfg.Job,
-				Audience: cfg.Audience,
-				Lifetime: cfg.Lifetime,
-				Claims:   cfg.Claims,
+				Job:            cfg.Job,
+				Audience:       cfg.Audience,
+				Lifetime:       cfg.Lifetime,
+				Claims:         cfg.Claims,
+				AwsSessionTags: cfg.AwsSessionTags,
 			}
 
 			token, resp, err := client.OIDCToken(ctx, req)

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -17,7 +17,7 @@ type OIDCTokenConfig struct {
 	Job      string `cli:"job"      validate:"required"`
 	// TODO: enumerate possible values, perhaps by adding a link to the documentation
 	Claims         []string `cli:"claim"           normalize:"list"`
-	AwsSessionTags []string `cli:"aws-session-tag" normalize:"list"`
+	AWSSessionTags []string `cli:"aws-session-tag" normalize:"list"`
 
 	// Global flags
 	Debug       bool     `cli:"debug"`
@@ -124,7 +124,7 @@ var OIDCRequestTokenCommand = cli.Command{
 				Audience:       cfg.Audience,
 				Lifetime:       cfg.Lifetime,
 				Claims:         cfg.Claims,
-				AwsSessionTags: cfg.AwsSessionTags,
+				AWSSessionTags: cfg.AWSSessionTags,
 			}
 
 			token, resp, err := client.OIDCToken(ctx, req)


### PR DESCRIPTION
### Description

Teach the agent how to request OIDC tokens including aws session tags:

```
buildkite-agent oidc request-token --audience sts.amazonaws.com --aws-session-tag pipeline_id
```

Claims are then added to the returned token as aws session tags using their prescribed format:

https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_adding-assume-role-idp

which can then be used to grant permission to aws resources using attribute based access control (ABAC):

https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html

This is a finer grained control than the subject condition based option currently available:

https://buildkite.com/docs/pipelines/security/oidc/aws#step-2-create-a-new-or-update-an-existing-iam-role-to-use-with-your-pipelines

The Buildkite Agent API already supports this parameter.

### Changes

Mostly copy/pasta of how `--claim` works. I also added an api test for `claims` alongside `aws_session_tags`.

### Testing

- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

```
go run . oidc request-token --endpoint http://agent.buildkite.localhost --agent-access-token test --job abc123 --debug --debug-http --aws-session-tag organization_id
2024-09-24 13:43:44 DEBUG  Loaded config command=oidc request-token agent_version=3.78.0+x..dirty
2024-09-24 13:43:44 DEBUG  POST /jobs/abc123/oidc/tokens HTTP/1.1
Host: agent.buildkite.localhost
User-Agent: buildkite-agent/3.78.0.x (darwin; arm64)
Content-Length: 41
Content-Type: application/json
Accept-Encoding: gzip

{"aws_session_tags":["organization_id"]}
```

That will do the job.