### PR TITLE
Fix data race on worker stop

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -86,9 +86,9 @@ type AgentWorker struct {
 	cancelSig process.Signal
 
 	// Stop controls
+	stopMutex sync.Mutex
 	stop      chan struct{}
 	stopping  bool
-	stopMutex sync.Mutex
 
 	// The index of this agent worker
 	spawnIndex int
@@ -296,7 +296,10 @@ func (a *AgentWorker) runPingLoop(ctx context.Context, idleMonitor *IdleMonitor)
 
 	// Continue this loop until the closing of the stop channel signals termination
 	for {
-		if !a.stopping {
+		a.stopMutex.Lock()
+		stopping := a.stopping
+		a.stopMutex.Unlock()
+		if !stopping {
 			setStat("📡 Pinging Buildkite for work")
 			job, err := a.Ping(ctx)
 			if err != nil {


### PR DESCRIPTION
### Description
Fix a data race on `AgentWorker.stopping` by guarding the read with the same mutex that already guards the write.

### Context
Noticed when running an agent build with `-race` enabled.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
