### PR TITLE
Refactor the various agent HTTP clients

### DIFF
--- a/agent/tags.go
+++ b/agent/tags.go
@@ -49,7 +49,7 @@ func FetchTags(ctx context.Context, l logger.Logger, conf FetchTagsConfig) []str
 			return EC2Tags{}.Get()
 		},
 		ecsMetaDataDefault: func() (map[string]string, error) {
-			return ECSMetadata{}.Get()
+			return ECSMetadata{}.Get(ctx)
 		},
 		gcpMetaDataDefault: func() (map[string]string, error) {
 			return GCPMetaData{}.Get()

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -62,6 +62,7 @@ type ArtifactDownloadConfig struct {
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
+	TraceHTTP        bool   `cli:"trace-http"`
 	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
 	Endpoint         string `cli:"endpoint" validate:"required"`
 	NoHTTP2          bool   `cli:"no-http2"`
@@ -94,6 +95,7 @@ var ArtifactDownloadCommand = cli.Command{
 		EndpointFlag,
 		NoHTTP2Flag,
 		DebugHTTPFlag,
+		TraceHTTPFlag,
 
 		// Global flags
 		NoColorFlag,
@@ -118,6 +120,8 @@ var ArtifactDownloadCommand = cli.Command{
 			Step:               cfg.Step,
 			IncludeRetriedJobs: cfg.IncludeRetriedJobs,
 			DebugHTTP:          cfg.DebugHTTP,
+			TraceHTTP:          cfg.TraceHTTP,
+			DisableHTTP2:       cfg.NoHTTP2,
 		})
 
 		// Download the artifacts

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -81,6 +81,7 @@ type ArtifactUploadConfig struct {
 
 	// API config
 	DebugHTTP        bool   `cli:"debug-http"`
+	TraceHTTP        bool   `cli:"trace-http"`
 	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
 	Endpoint         string `cli:"endpoint" validate:"required"`
 	NoHTTP2          bool   `cli:"no-http2"`
@@ -132,6 +133,7 @@ var ArtifactUploadCommand = cli.Command{
 		EndpointFlag,
 		NoHTTP2Flag,
 		DebugHTTPFlag,
+		TraceHTTPFlag,
 
 		// Global flags
 		NoColorFlag,
@@ -151,11 +153,13 @@ var ArtifactUploadCommand = cli.Command{
 
 		// Setup the uploader
 		uploader := artifact.NewUploader(l, client, artifact.UploaderConfig{
-			JobID:       cfg.Job,
-			Paths:       cfg.UploadPaths,
-			Destination: cfg.Destination,
-			ContentType: cfg.ContentType,
-			DebugHTTP:   cfg.DebugHTTP,
+			JobID:        cfg.Job,
+			Paths:        cfg.UploadPaths,
+			Destination:  cfg.Destination,
+			ContentType:  cfg.ContentType,
+			DebugHTTP:    cfg.DebugHTTP,
+			TraceHTTP:    cfg.TraceHTTP,
+			DisableHTTP2: cfg.NoHTTP2,
 
 			AllowMultipart: !cfg.NoMultipartUpload,
 

--- a/internal/agenthttp/client.go
+++ b/internal/agenthttp/client.go
@@ -1,0 +1,136 @@
+// Package agenthttp creates standard Go [net/http.Client]s with common config
+// options.
+package agenthttp
+
+import (
+	"crypto/tls"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/net/http2"
+)
+
+// NewClient creates a HTTP client.
+func NewClient(opts ...ClientOption) *http.Client {
+	conf := clientConfig{
+		// This spells out the defaults, even if some of them are zero values.
+		Bearer:     "",
+		Token:      "",
+		AllowHTTP2: true,
+		Timeout:    60 * time.Second,
+		TLSConfig:  nil,
+	}
+	for _, opt := range opts {
+		opt(&conf)
+	}
+
+	cacheKey := transportCacheKey{
+		AllowHTTP2: conf.AllowHTTP2,
+		TLSConfig:  conf.TLSConfig,
+	}
+
+	transportCacheMu.Lock()
+	transport := transportCache[cacheKey]
+	if transport == nil {
+		transport = newTransport(&conf)
+		transportCache[cacheKey] = transport
+	}
+	transportCacheMu.Unlock()
+
+	if conf.Bearer == "" && conf.Token == "" {
+		// No credentials, no authenticatedTransport wrapper.
+		return &http.Client{
+			Timeout:   conf.Timeout,
+			Transport: transport,
+		}
+	}
+
+	// Wrap the transport in authenticatedTransport.
+	return &http.Client{
+		Timeout: conf.Timeout,
+		Transport: &authenticatedTransport{
+			Bearer:   conf.Bearer,
+			Token:    conf.Token,
+			Delegate: transport,
+		},
+	}
+}
+
+// Various NewClient options.
+func WithAuthBearer(b string) ClientOption     { return func(c *clientConfig) { c.Bearer = b } }
+func WithAuthToken(t string) ClientOption      { return func(c *clientConfig) { c.Token = t } }
+func WithAllowHTTP2(a bool) ClientOption       { return func(c *clientConfig) { c.AllowHTTP2 = a } }
+func WithTimeout(d time.Duration) ClientOption { return func(c *clientConfig) { c.Timeout = d } }
+func WithTLSConfig(t *tls.Config) ClientOption { return func(c *clientConfig) { c.TLSConfig = t } }
+
+type ClientOption = func(*clientConfig)
+
+func newTransport(conf *clientConfig) *http.Transport {
+	// Base any modifications on the default transport.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// Allow override of TLSConfig. This must be set prior to calling
+	// http2.ConfigureTransports.
+	if conf.TLSConfig != nil {
+		transport.TLSClientConfig = conf.TLSConfig
+	}
+
+	if conf.AllowHTTP2 {
+		// There is a bug in http2 on Linux regarding using dead connections.
+		// This is a workaround. See https://github.com/golang/go/issues/59690
+		//
+		// Note that http2.ConfigureTransports alters its argument in order to
+		// supply http2 functionality, and the http2.Transport does not support
+		// HTTP/1.1 as a protocol, so we get slightly odd-looking code where
+		// we use `transport` later on instead of the just-returned `tr2`.
+		// tr2 is needed merely to configure the http2 option.
+		tr2, err := http2.ConfigureTransports(transport)
+		if err != nil {
+			// ConfigureTransports is documented to only return an error if
+			// the transport arg was already HTTP2-enabled, which it should not
+			// have been...
+			panic("http2.ConfigureTransports: " + err.Error())
+		}
+		if tr2 != nil {
+			tr2.ReadIdleTimeout = 30 * time.Second
+		}
+	} else {
+		transport.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
+		// The default TLSClientConfig has h2 in NextProtos, so the
+		// negotiated TLS connection will assume h2 support.
+		// see https://github.com/golang/go/issues/50571
+		transport.TLSClientConfig.NextProtos = []string{"http/1.1"}
+	}
+
+	return transport
+}
+
+type clientConfig struct {
+	// The authentication token/ bearer credential to use
+	// For agent API usage, Token is usually an agent registration or access token
+	// For GraphQL usage, Bearer is usually a user token
+	Token  string
+	Bearer string
+
+	// If false, HTTP2 is disabled
+	AllowHTTP2 bool
+
+	// Timeout used as the client timeout.
+	Timeout time.Duration
+
+	// optional TLS configuration primarily used for testing
+	TLSConfig *tls.Config
+}
+
+// The underlying http.Transport is cached, mainly so that multiple clients with
+// the same options can reuse connections. The options that affect the transport
+// are also usually the same throughout the process.
+type transportCacheKey struct {
+	AllowHTTP2 bool
+	TLSConfig  *tls.Config
+}
+
+var (
+	transportCacheMu sync.Mutex
+	transportCache   = make(map[transportCacheKey]*http.Transport)
+)

--- a/internal/agenthttp/do.go
+++ b/internal/agenthttp/do.go
@@ -1,0 +1,186 @@
+package agenthttp
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/httptrace"
+	"net/http/httputil"
+	"net/textproto"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/buildkite/agent/v3/logger"
+)
+
+// Do wraps the http.Client's Do method with debug logging and tracing options.
+func Do(l logger.Logger, client *http.Client, req *http.Request, opts ...DoOption) (*http.Response, error) {
+	var cfg doConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	if cfg.debugHTTP {
+		// If the request is a multi-part form, then it's probably a
+		// file upload, in which case we don't want to spewing out the
+		// file contents into the debug log (especially if it's been
+		// gzipped)
+		dumpBody := !strings.Contains(req.Header.Get("Content-Type"), "multipart/form-data")
+		requestDump, err := httputil.DumpRequestOut(req, dumpBody)
+		if err != nil {
+			l.Debug("ERR: %s\n%s", err, string(requestDump))
+		} else {
+			l.Debug("%s", string(requestDump))
+		}
+	}
+
+	tracer := &tracer{Logger: l}
+	if cfg.traceHTTP {
+		// Inject a custom http tracer
+		req = traceHTTPRequest(req, tracer)
+		tracer.Start()
+	}
+
+	ts := time.Now()
+
+	l.Debug("%s %s", req.Method, req.URL)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		if cfg.traceHTTP {
+			tracer.EmitTraceToLog(logger.ERROR)
+		}
+		return nil, err
+	}
+
+	l.WithFields(
+		logger.StringField("proto", resp.Proto),
+		logger.IntField("status", resp.StatusCode),
+		logger.DurationField("Δ", time.Since(ts)),
+	).Debug("↳ %s %s", req.Method, req.URL)
+
+	if cfg.debugHTTP {
+		responseDump, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			l.Debug("\nERR: %s\n%s", err, string(responseDump))
+		} else {
+			l.Debug("\n%s", string(responseDump))
+		}
+	}
+	if cfg.traceHTTP {
+		tracer.EmitTraceToLog(logger.DEBUG)
+	}
+
+	return resp, err
+}
+
+type DoOption = func(*doConfig)
+
+type doConfig struct {
+	debugHTTP bool
+	traceHTTP bool
+}
+
+func WithDebugHTTP(d bool) DoOption { return func(c *doConfig) { c.debugHTTP = d } }
+func WithTraceHTTP(t bool) DoOption { return func(c *doConfig) { c.traceHTTP = t } }
+
+type traceEvent struct {
+	event string
+	since time.Duration
+}
+
+type tracer struct {
+	startTime time.Time
+	logger.Logger
+}
+
+func (t *tracer) Start() {
+	t.startTime = time.Now()
+}
+
+func (t *tracer) LogTiming(event string) {
+	t.Logger = t.Logger.WithFields(logger.DurationField(event, time.Since(t.startTime)))
+}
+
+func (t *tracer) LogField(key, value string) {
+	t.Logger = t.Logger.WithFields(logger.StringField(key, value))
+}
+
+func (t *tracer) LogDuration(event string, d time.Duration) {
+	t.Logger = t.Logger.WithFields(logger.DurationField(event, d))
+}
+
+// Currently logger.Logger doesn't give us a way to set the level we want to emit logs at dynamically
+func (t *tracer) EmitTraceToLog(level logger.Level) {
+	msg := "HTTP Timing Trace"
+	switch level {
+	case logger.DEBUG:
+		t.Debug(msg)
+	case logger.INFO:
+		t.Info(msg)
+	case logger.WARN:
+		t.Warn(msg)
+	case logger.ERROR:
+		t.Error(msg)
+	}
+}
+
+func traceHTTPRequest(req *http.Request, t *tracer) *http.Request {
+	trace := &httptrace.ClientTrace{
+		GetConn: func(hostPort string) {
+			t.LogField("hostPort", hostPort)
+			t.LogTiming("getConn")
+		},
+		GotConn: func(info httptrace.GotConnInfo) {
+			t.LogTiming("gotConn")
+			t.LogField("reused", strconv.FormatBool(info.Reused))
+			t.LogField("idle", strconv.FormatBool(info.WasIdle))
+			t.LogDuration("idleTime", info.IdleTime)
+			t.LogField("localAddr", info.Conn.LocalAddr().String())
+		},
+		PutIdleConn: func(err error) {
+			t.LogTiming("putIdleConn")
+			if err != nil {
+				t.LogField("putIdleConnectionError", err.Error())
+			}
+		},
+		GotFirstResponseByte: func() {
+			t.LogTiming("gotFirstResponseByte")
+		},
+		Got1xxResponse: func(code int, header textproto.MIMEHeader) error {
+			t.LogTiming("got1xxResponse")
+			return nil
+		},
+		DNSStart: func(_ httptrace.DNSStartInfo) {
+			t.LogTiming("dnsStart")
+		},
+		DNSDone: func(_ httptrace.DNSDoneInfo) {
+			t.LogTiming("dnsDone")
+		},
+		ConnectStart: func(network, addr string) {
+			t.LogTiming(fmt.Sprintf("connectStart.%s.%s", network, addr))
+		},
+		ConnectDone: func(network, addr string, _ error) {
+			t.LogTiming(fmt.Sprintf("connectDone.%s.%s", network, addr))
+		},
+		TLSHandshakeStart: func() {
+			t.LogTiming("tlsHandshakeStart")
+		},
+		TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
+			t.LogTiming("tlsHandshakeDone")
+		},
+		WroteHeaders: func() {
+			t.LogTiming("wroteHeaders")
+		},
+		WroteRequest: func(_ httptrace.WroteRequestInfo) {
+			t.LogTiming("wroteRequest")
+		},
+	}
+
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+
+	t.LogField("uri", req.URL.String())
+	t.LogField("method", req.Method)
+	return req
+}

--- a/internal/artifact/azure_blob_downloader.go
+++ b/internal/artifact/azure_blob_downloader.go
@@ -16,6 +16,7 @@ type AzureBlobDownloaderConfig struct {
 	Destination string
 	Retries     int
 	DebugHTTP   bool
+	TraceHTTP   bool
 }
 
 // AzureBlobDownloader downloads files from Azure Blob storage.

--- a/internal/artifact/gs_downloader.go
+++ b/internal/artifact/gs_downloader.go
@@ -26,6 +26,7 @@ type GSDownloaderConfig struct {
 
 	// If failed responses should be dumped to the log
 	DebugHTTP bool
+	TraceHTTP bool
 }
 
 type GSDownloader struct {
@@ -44,7 +45,7 @@ func NewGSDownloader(l logger.Logger, c GSDownloaderConfig) *GSDownloader {
 }
 
 func (d GSDownloader) Start(ctx context.Context) error {
-	client, err := newGoogleClient(storage.DevstorageReadOnlyScope)
+	client, err := newGoogleClient(ctx, storage.DevstorageReadOnlyScope)
 	if err != nil {
 		return errors.New(fmt.Sprintf("Error creating Google Cloud Storage client: %v", err))
 	}
@@ -58,6 +59,7 @@ func (d GSDownloader) Start(ctx context.Context) error {
 		Destination: d.conf.Destination,
 		Retries:     d.conf.Retries,
 		DebugHTTP:   d.conf.DebugHTTP,
+		TraceHTTP:   d.conf.TraceHTTP,
 	}).Start(ctx)
 }
 

--- a/internal/artifact/s3_uploader.go
+++ b/internal/artifact/s3_uploader.go
@@ -18,9 +18,6 @@ type S3UploaderConfig struct {
 	// The destination which includes the S3 bucket name and the path.
 	// For example, s3://my-bucket-name/foo/bar
 	Destination string
-
-	// Whether or not HTTP calls should be debugged
-	DebugHTTP bool
 }
 
 type S3Uploader struct {


### PR DESCRIPTION
### Description

It'd sure be be nice to do HTTP clients consistently the same way in the agent. Then we could reuse Pat's trace work, disable HTTP/2 consistently, ...

### Context

Noticed while working on artifacts, which create blank `&http.Client{}`s or use `http.DefaultClient`.

### Changes

* Moves client and transport creation into a new internal package with functional options
* Provide a single wrapper for `Do`, again with functional options
* Use it everywhere
* Some opportunistic removals of `context.Background` and a deprecated method
* Removed some unused `DebugHTTP` fields

Not changed:

* Some artifact upload/download code uses specific clients, e.g. `GSUploader` and `GSDownloader` make use of `google.DefaultClient`. These remain.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
