### PR TITLE
[PKG-7630] Publish packages with attestations to Buildkite Packages

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -40,13 +40,38 @@ steps:
           volumes:
             - "/yum.buildkite.com"
 
-  - name: ":redhat: Publish Edge RPM Package to Buildkite Packages"
-    plugins:
-      - publish-to-packages#v2.0.0:
-          artifacts: "rpm/*.rpm"
-          registry: "buildkite/agent-rpm-experimental"
-          artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
-    soft_fail: true
+  - group: ":redhat: Publish Edge RPM Package to Buildkite Packages"
+    steps:
+      - name: ":redhat: Publish Edge {{matrix.pkg_arch}} RPM Package to Buildkite Packages"
+        plugins:
+          - publish-to-packages#v2.2.0:
+              artifacts: "rpm/buildkite-agent_*_{{matrix.pkg_arch}}.rpm"
+              registry: "buildkite/agent-rpm-experimental"
+              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
+              attestations:
+                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
+                - "buildkite-agent-rpm-packages.package-attestation.json"
+        soft_fail: true
+        matrix:
+          setup:
+            go_arch:
+              - "amd64"
+              - "386"
+              - "arm64"
+              - "ppc64"
+              - "ppc64le"
+              - "riscv64"
+            pkg_arch:
+              - "SKIP_FAKE_ARCH"
+          adjustments:
+            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
+            - with: { go_arch: "386", pkg_arch: "i386" }
+            - with: { go_arch: "arm64", pkg_arch: "aarch64" }
+            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
+            - with: { go_arch: "ppc64le", pkg_arch: "ppc64le" }
+            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
+            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
+              skip: true
 
   - name: ":debian: Publish Edge Debian Package"
     command: ".buildkite/steps/publish-debian-package.sh"
@@ -74,13 +99,42 @@ steps:
         - exit_status: 1
           limit: 3
 
-  - name: ":debian: Publish Edge Debian Package to Buildkite Packages"
-    plugins:
-      - publish-to-packages#v2.0.0:
-          artifacts: "deb/*.deb"
-          registry: "buildkite/agent-deb-experimental"
-          artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
-    soft_fail: true
+  - group: ":debian: Publish Edge Debian Package to Buildkite Packages"
+    steps:
+      - name: ":debian: Publish Edge {{matrix.pkg_arch}} Debian Package to Buildkite Packages"
+        plugins:
+          - publish-to-packages#v2.2.0:
+              artifacts: "deb/buildkite-agent_*_{{matrix.pkg_arch}}.deb"
+              registry: "buildkite/agent-deb-experimental"
+              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
+              attestations:
+                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
+                - "buildkite-agent-debian-packages.package-attestation.json"
+        soft_fail: true
+        matrix:
+          setup:
+            go_arch:
+              - "amd64"
+              - "386"
+              - "arm"
+              - "armhf"
+              - "arm64"
+              - "ppc64"
+              - "ppc64le"
+              - "riscv64"
+            pkg_arch:
+              - "SKIP_FAKE_ARCH"
+          adjustments:
+            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
+            - with: { go_arch: "386", pkg_arch: "i386" }
+            - with: { go_arch: "arm", pkg_arch: "arm" }
+            - with: { go_arch: "armhf", pkg_arch: "armhf" }
+            - with: { go_arch: "arm64", pkg_arch: "arm64" }
+            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
+            - with: { go_arch: "ppc64le", pkg_arch: "ppc64el" }
+            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
+            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
+              skip: true
 
   - name: ":docker: Publish Edge Docker Images"
     command: ".buildkite/steps/publish-docker-images.sh"

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -68,13 +68,38 @@ steps:
         - exit_status: 1
           limit: 3
 
-  - name: ":redhat: Publish RPM Package to Buildkite Packages"
-    plugins:
-      - publish-to-packages#v2.0.0:
-          artifacts: "rpm/*.rpm"
-          registry: "buildkite/agent-rpm"
-          artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
-    soft_fail: true
+  - group: ":redhat: Publish RPM Package to Buildkite Packages"
+    steps:
+      - name: ":redhat: Publish {{matrix.pkg_arch}} RPM Package to Buildkite Packages"
+        plugins:
+          - publish-to-packages#v2.2.0:
+              artifacts: "rpm/buildkite-agent_*_{{matrix.pkg_arch}}.rpm"
+              registry: "buildkite/agent-rpm"
+              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
+              attestations:
+                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
+                - "buildkite-agent-rpm-packages.package-attestation.json"
+        soft_fail: true
+        matrix:
+          setup:
+            go_arch:
+              - "amd64"
+              - "386"
+              - "arm64"
+              - "ppc64"
+              - "ppc64le"
+              - "riscv64"
+            pkg_arch:
+              - "SKIP_FAKE_ARCH"
+          adjustments:
+            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
+            - with: { go_arch: "386", pkg_arch: "i386" }
+            - with: { go_arch: "arm64", pkg_arch: "aarch64" }
+            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
+            - with: { go_arch: "ppc64le", pkg_arch: "ppc64le" }
+            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
+            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
+              skip: true
 
   - name: ":debian: Publish Debian Package"
     command: ".buildkite/steps/publish-debian-package.sh"
@@ -98,13 +123,42 @@ steps:
           tmpfs:
             - "/root/.gnupg"
 
-  - name: ":debian: Publish Debian Package to Buildkite Packages"
-    plugins:
-      - publish-to-packages#v2.0.0:
-          artifacts: "deb/*.deb"
-          registry: "buildkite/agent-deb"
-          artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
-    soft_fail: true
+  - group: ":debian: Publish Debian Package to Buildkite Packages"
+    steps:
+      - name: ":debian: Publish {{matrix.pkg_arch}} Debian Package to Buildkite Packages"
+        plugins:
+          - publish-to-packages#v2.2.0:
+              artifacts: "deb/buildkite-agent_*_{{matrix.pkg_arch}}.deb"
+              registry: "buildkite/agent-deb"
+              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
+              attestations:
+                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
+                - "buildkite-agent-debian-packages.package-attestation.json"
+        soft_fail: true
+        matrix:
+          setup:
+            go_arch:
+              - "amd64"
+              - "386"
+              - "arm"
+              - "armhf"
+              - "arm64"
+              - "ppc64"
+              - "ppc64le"
+              - "riscv64"
+            pkg_arch:
+              - "SKIP_FAKE_ARCH"
+          adjustments:
+            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
+            - with: { go_arch: "386", pkg_arch: "i386" }
+            - with: { go_arch: "arm", pkg_arch: "arm" }
+            - with: { go_arch: "armhf", pkg_arch: "armhf" }
+            - with: { go_arch: "arm64", pkg_arch: "arm64" }
+            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
+            - with: { go_arch: "ppc64le", pkg_arch: "ppc64el" }
+            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
+            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
+              skip: true
 
   - name: ":docker: Publish Docker Images"
     command: ".buildkite/steps/publish-docker-images.sh"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -68,13 +68,38 @@ steps:
         - exit_status: 1
           limit: 3
 
-  - name: ":redhat: Publish Unstable RPM Package to Buildkite Packages"
-    plugins:
-      - publish-to-packages#v2.0.0:
-          artifacts: "rpm/*.rpm"
-          registry: "buildkite/agent-rpm-unstable"
-          artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
-    soft_fail: true
+  - group: ":redhat: Publish Unstable RPM Package to Buildkite Packages"
+    steps:
+      - name: ":redhat: Publish Unstable {{matrix.pkg_arch}} RPM Package to Buildkite Packages"
+        plugins:
+          - publish-to-packages#v2.2.0:
+              artifacts: "rpm/buildkite-agent_*_{{matrix.pkg_arch}}.rpm"
+              registry: "buildkite/agent-rpm-unstable"
+              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
+              attestations:
+                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
+                - "buildkite-agent-rpm-packages.package-attestation.json"
+        soft_fail: true
+        matrix:
+          setup:
+            go_arch:
+              - "amd64"
+              - "386"
+              - "arm64"
+              - "ppc64"
+              - "ppc64le"
+              - "riscv64"
+            pkg_arch:
+              - "SKIP_FAKE_ARCH"
+          adjustments:
+            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
+            - with: { go_arch: "386", pkg_arch: "i386" }
+            - with: { go_arch: "arm64", pkg_arch: "aarch64" }
+            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
+            - with: { go_arch: "ppc64le", pkg_arch: "ppc64le" }
+            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
+            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
+              skip: true
 
   - name: ":debian: Publish Unstable Debian Package"
     command: ".buildkite/steps/publish-debian-package.sh"
@@ -98,13 +123,42 @@ steps:
           tmpfs:
             - "/root/.gnupg"
 
-  - name: ":debian: Publish Unstable Debian Package to Buildkite Packages"
-    plugins:
-      - publish-to-packages#v2.0.0:
-          artifacts: "deb/*.deb"
-          registry: "buildkite/agent-deb-unstable"
-          artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
-    soft_fail: true
+  - group: ":debian: Publish Unstable Debian Package to Buildkite Packages"
+    steps:
+      - name: ":debian: Publish Unstable {{matrix.pkg_arch}} Debian Package to Buildkite Packages"
+        plugins:
+          - publish-to-packages#v2.2.0:
+              artifacts: "deb/buildkite-agent_*_{{matrix.pkg_arch}}.deb"
+              registry: "buildkite/agent-deb-unstable"
+              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
+              attestations:
+                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
+                - "buildkite-agent-debian-packages.package-attestation.json"
+        soft_fail: true
+        matrix:
+          setup:
+            go_arch:
+              - "amd64"
+              - "386"
+              - "arm"
+              - "armhf"
+              - "arm64"
+              - "ppc64"
+              - "ppc64le"
+              - "riscv64"
+            pkg_arch:
+              - "SKIP_FAKE_ARCH"
+          adjustments:
+            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
+            - with: { go_arch: "386", pkg_arch: "i386" }
+            - with: { go_arch: "arm", pkg_arch: "arm" }
+            - with: { go_arch: "armhf", pkg_arch: "armhf" }
+            - with: { go_arch: "arm64", pkg_arch: "arm64" }
+            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
+            - with: { go_arch: "ppc64le", pkg_arch: "ppc64el" }
+            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
+            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
+              skip: true
 
   - name: ":docker: Publish Unstable Docker Images"
     command: ".buildkite/steps/publish-docker-images.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -107,7 +107,7 @@ steps:
               config: .buildkite/docker-compose.yml
               cli-version: 2
               run: agent
-          - generate-provenance-attestation#v1.0.0:
+          - generate-provenance-attestation#v1.1.0:
               artifacts: "pkg/*"
               attestation_name: "buildkite-agent-{{matrix.os}}-{{matrix.arch}}.build-attestation.json"
         matrix:
@@ -253,7 +253,7 @@ steps:
     command: ".buildkite/steps/build-debian-packages.sh"
     artifact_paths: "deb/**/*"
     plugins:
-      - generate-provenance-attestation#v1.0.0:
+      - generate-provenance-attestation#v1.1.0:
           artifacts: "deb/*"
           attestation_name: "buildkite-agent-debian-packages.package-attestation.json"
 
@@ -265,7 +265,7 @@ steps:
     command: ".buildkite/steps/build-rpm-packages.sh"
     artifact_paths: "rpm/**/*"
     plugins:
-      - generate-provenance-attestation#v1.0.0:
+      - generate-provenance-attestation#v1.1.0:
           artifacts: "rpm/*"
           attestation_name: "buildkite-agent-rpm-packages.package-attestation.json"
 
@@ -280,7 +280,7 @@ steps:
       - docker-compose#v4.14.0:
           config: .buildkite/docker-compose.release.yml
           run: github-release
-      - generate-provenance-attestation#v1.0.0:
+      - generate-provenance-attestation#v1.1.0:
           artifacts: "releases/*.tar.gz;releases/*.zip"
           attestation_name: "buildkite-agent-github-releases.attestation.json"
 


### PR DESCRIPTION
### Description

This PR updates the release pipelines to upload SLSA Provenance attestations when publishing packages to Buildkite Packages.

The actual release steps have been broken out into a matrixed group of steps so that each package can be uploaded with the relevant attestation per architecture.

### Changes
- **Publish to Buildkite Packages** steps in the release pipelines have been reimplemented as groups of matrixed steps per-arch, and are now uploading relevant attestations along with the packages.
- Upgrade [Publish to Packages](https://github.com/buildkite-plugins/publish-to-packages-buildkite-plugin/) plugin to v2.2.0 for new `attestations:` functionality.
- Upgrade [Generate Provenance Attestation](https://github.com/buildkite-plugins/generate-provenance-attestation-buildkite-plugin) plugin.