### PR TITLE
Ensure all string slice args have whitespace cleaned off of each element

### DIFF
--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/buildkite/agent/v3/api"
@@ -109,10 +108,6 @@ var OIDCRequestTokenCommand = cli.Command{
 		// Note: if --lifetime is omitted, cfg.Lifetime = 0
 		if cfg.Lifetime < 0 {
 			return fmt.Errorf("lifetime %d must be a non-negative integer.", cfg.Lifetime)
-		}
-
-		for i, claim := range cfg.Claims {
-			cfg.Claims[i] = strings.TrimSpace(claim)
 		}
 
 		// Create the API client

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/buildkite/agent/v3/api"
@@ -108,6 +109,10 @@ var OIDCRequestTokenCommand = cli.Command{
 		// Note: if --lifetime is omitted, cfg.Lifetime = 0
 		if cfg.Lifetime < 0 {
 			return fmt.Errorf("lifetime %d must be a non-negative integer.", cfg.Lifetime)
+		}
+
+		for i, claim := range cfg.Claims {
+			cfg.Claims[i] = strings.TrimSpace(claim)
 		}
 
 		// Create the API client

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -421,6 +421,8 @@ func (l Loader) normalizeField(fieldName string, normalization string) error {
 						continue
 					}
 
+					normalized = strings.TrimSpace(normalized)
+
 					normalizedSlice = append(normalizedSlice, normalized)
 				}
 			}


### PR DESCRIPTION
This allows users to use:
```
buildkite-agent oidc request-token --claim 'this, that, the-other'
```
where previously, even if `that` and `the-other` were allowed optional claims, they'd be rejected, as they'd be sent to buildkite with their preceeding whitespace

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
