### PR TITLE
Exit 94 if a mirror lock times out

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -515,8 +515,8 @@ func (e *Executor) runWrappedShellScriptHook(ctx context.Context, hookName strin
 		// so it may inform the Buildkite API
 		if shell.IsExitError(err) {
 			return &shell.ExitError{
-				Code:    exitCode,
-				Message: fmt.Sprintf("The %s hook exited with status %d", hookName, exitCode),
+				Code: exitCode,
+				Err:  fmt.Errorf("The %s hook exited with status %d", hookName, exitCode),
 			}
 		}
 

--- a/internal/job/shell/shell.go
+++ b/internal/job/shell/shell.go
@@ -657,11 +657,11 @@ func IsExitError(err error) bool {
 
 // ExitError is an error that carries a shell exit code
 type ExitError struct {
-	Code    int
-	Message string
+	Code int
+	Err  error
 }
 
 // Error returns the string message and fulfils the error interface
-func (ee *ExitError) Error() string {
-	return ee.Message
-}
+func (ee *ExitError) Error() string { return ee.Err.Error() }
+
+func (ee *ExitError) Unwrap() error { return ee.Err }


### PR DESCRIPTION
### Description

Lockfiles (used for serialising access to git mirrors) aren't totally reliable in the face of agents dying without releasing them. As a stopgap, if a lockfile can't be acquired before the timeout, exit with a distinctive code (94, chosen randomly).

### Context

https://coda.io/d/_dHnUHNps1YO#Escalations-Pipelines_tuQbCBf6/r711

### Changes

* Create a new error type, `ErrTimedOutAcquiringLock`.
* Return it if the git mirror lockfiles fail for `context.DeadlineExceeded`
* Check for it in the checkout phase, and wrap it in a `shell.ExitError`
* Update the one other use of `shell.ExitError`

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
