### PR TITLE
BUG FIX: Ensure Build Title Is Correct When Checkout Is Skipped

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -774,7 +774,7 @@ func (e *Executor) sendCommitToBuildkite(ctx context.Context) error {
 		"--no-pager",
 		"log",
 		"-1",
-		"HEAD",
+		e.Commit,
 		"-s", // --no-patch was introduced in v1.8.4 in 2013, but e.g. CentOS 7 isn't there yet
 		"--no-color",
 		"--format=commit %H%nabbrev-commit %h%nAuthor: %an <%ae>%n%n%w(0,4,4)%B",

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -301,7 +301,7 @@ func TestCheckingOutLocalGitProjectWithShortCommitHash(t *testing.T) {
 		PassthroughToLocalCommand()
 
 	// Git should attempt to fetch the shortHash, but fail. Then fallback to fetching
-	// all the heads and tags and checking out the short hash.
+	// all the heads and tags and checking out the short commit hash.
 	git.ExpectAll([][]any{
 		{"remote", "get-url", "origin"},
 		{"clean", "-ffxdq"},
@@ -310,7 +310,7 @@ func TestCheckingOutLocalGitProjectWithShortCommitHash(t *testing.T) {
 		{"fetch", "--", "origin", "+refs/heads/*:refs/remotes/origin/*", "+refs/tags/*:refs/tags/*"},
 		{"checkout", "-f", shortCommitHash},
 		{"clean", "-ffxdq"},
-		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
+		{"--no-pager", "log", "-1", shortCommitHash, "-s", "--no-color", gitShowFormatArg},
 	})
 
 	// Mock out the meta-data calls to the agent after checkout


### PR DESCRIPTION
### Description
Bug: When using skip-checkout plugin, the build title and commit details will match the previously checked out commit details (rather than taking it from the webhook details). 

See video below. I trigger a build via webhook (with skip checkout). It starts off with the correct details, but changes to to the details of `HEAD`

https://github.com/user-attachments/assets/db0f159c-433f-436f-a22c-ca8d98f82f58

### Changes
Ensure agent gets correct commit message associated with webhook-triggered build, rather than reading it from git repo's `HEAD`. 

Modified function `sendCommitToBuildkite` in `internal/job/checkout.go` to extract the message from `e.Commit` rather than `HEAD`

### Testing / Reproduction
**To reproduce bug**
- Set up a pipeline (or use an existing one). 
- Ensure a webhook triggers the build on push events (when you push to a branch, it triggers a build).
- Run a build that performs a checkout so there is a working directory with older commit details. 
- Now add a step to your `pipeline.yml` to use the skip-checkout plugin. For example:
```
steps:
  - label: "Skip checkout step"
    command: "echo 'Skipping checkout and returning true'"
    plugins:
      - thedyrt/skip-checkout#v0.1.1: ~
```
- Push a new commit and trigger the build via the webhook.
- Observe the build logs. You'll notice the build takes commit details from the old commit (due to skipping checkout) instead of the new one.


- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)


