### PR TITLE
Tweak BUILDKITE_IGNORED_ENV handling

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -758,7 +758,7 @@ func (e *Executor) setUp(ctx context.Context) error {
 	// The job runner sets BUILDKITE_IGNORED_ENV with any keys that were ignored
 	// or overwritten. This shows a warning to the user so they don't get confused
 	// when their environment changes don't seem to do anything
-	if ignored, exists := e.shell.Env.Get("BUILDKITE_IGNORED_ENV"); exists {
+	if ignored, _ := e.shell.Env.Get("BUILDKITE_IGNORED_ENV"); ignored != "" {
 		e.shell.Headerf("Detected protected environment variables")
 		e.shell.Commentf("Your pipeline environment has protected environment variables set. " +
 			"These can only be set via hooks, plugins or the agent configuration.")


### PR DESCRIPTION
### Description

Make it so that, in certain places where env vars from the job might be passed through to the bootstrap incorrectly, the warning message can at least be suppressed.

### Context

https://coda.io/d/Escalations-Feedback_dHnUHNps1YO/Pipelines-Escalations_suQ4B7FT#Pipelines-Escalations-Board_tu66S__K/r638

### Changes

Change from printing the message if `BUILDKITE_IGNORED_ENV` merely exists, to printing the message if the var exists and is non-empty.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
