### PR TITLE
install.sh tidyups

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This is the installer for the Buildkite Agent.
 #
 # For more information, see: https://github.com/buildkite/agent
 
-set -e
+set -eu
 
-COMMAND="bash -c \"\`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh\`\""
+COMMAND="bash -c \"\`curl -sL https://raw.githubusercontent.com/buildkite/agent/main/install.sh\`\""
 
 echo -e "\033[33m
   _           _ _     _ _    _ _                                _
@@ -20,22 +20,22 @@ echo -e "\033[33m
 
 echo -e "Finding latest release..."
 
-SYSTEM=$(uname -s | awk '{print tolower($0)}')
-MACHINE=$(uname -m | awk '{print tolower($0)}')
+SYSTEM="$(uname -s | awk '{print tolower($0)}')"
+MACHINE="$(uname -m | awk '{print tolower($0)}')"
 
-if [[ ($SYSTEM == *"mac os x"*) || ($SYSTEM == *darwin*) ]]; then
+if [[ ("${SYSTEM}" == *"mac os x"*) || ("${SYSTEM}" == *darwin*) ]]; then
   PLATFORM="darwin"
-elif [[ ($SYSTEM == *"freebsd"*) ]]; then
+elif [[ ("${SYSTEM}" == *"freebsd"*) ]]; then
   PLATFORM="freebsd"
 else
   PLATFORM="linux"
 fi
 
-if [ -n "$BUILDKITE_INSTALL_ARCH" ]; then
-  ARCH="$BUILDKITE_INSTALL_ARCH"
-  echo "Using explicit arch '$ARCH'"
+if [ -n "${BUILDKITE_INSTALL_ARCH:-}" ]; then
+  ARCH="${BUILDKITE_INSTALL_ARCH}"
+  echo "Using explicit arch '${ARCH}'"
 else
-  case $MACHINE in
+  case "${MACHINE}" in
     *amd64*)   ARCH="amd64"   ;;
     *x86_64*)
       ARCH="amd64"
@@ -43,13 +43,13 @@ else
       # On Apple Silicon Macs, the architecture reported by `uname` depends on
       # the architecture of the shell, which is in turn influenced by the
       # *terminal*, as *child processes prefer their parents' architecture*.
-      # 
+      #
       # This means that for Terminal.app with the default shell it will be
       # arm64, but x86_64 for people using (pre-3.4.0 builds of) iTerm2 or
       # x86_64 shells.
       #
       # Based on logic in Homebrew: https://github.com/Homebrew/brew/pull/7995
-      if [[ "$PLATFORM" == "darwin" && "$(/usr/sbin/sysctl -n hw.optional.arm64 2> /dev/null)" == "1" ]]; then
+      if [[ "${PLATFORM}" == "darwin" && "$(/usr/sbin/sysctl -n hw.optional.arm64 2> /dev/null)" == "1" ]]; then
         ARCH="arm64"
       fi
       ;;
@@ -68,128 +68,152 @@ else
     *riscv64*) ARCH="riscv64" ;;
     *)
       ARCH="386"
-      echo -e "\n\033[36mWe don't recognise the $MACHINE architecture; falling back to $ARCH\033[0m"
+      echo -e "\n\033[36mWe don't recognise the ${MACHINE} architecture; falling back to ${ARCH}\033[0m"
       ;;
   esac
 fi
 
-if [[ "$BETA" == "true" ]]; then
-  RELEASE_INFO_URL="https://buildkite.com/agent/releases/latest?platform=$PLATFORM&arch=$ARCH&prerelease=true&system=$SYSTEM&machine=$MACHINE"
-else
-  RELEASE_INFO_URL="https://buildkite.com/agent/releases/latest?platform=$PLATFORM&arch=$ARCH&system=$SYSTEM&machine=$MACHINE"
+RELEASE_INFO_URL="https://buildkite.com/agent/releases/latest?platform=${PLATFORM}&arch=${ARCH}&system=${SYSTEM}&machine=${MACHINE}"
+if [[ "${BETA:-}" == "true" ]]; then
+  RELEASE_INFO_URL="${RELEASE_INFO_URL}&prerelease=true"
 fi
 
-if command -v wget >/dev/null; then
-  LATEST_RELEASE=$(wget -qO- "$RELEASE_INFO_URL")
+if command -v curl >/dev/null 2>&1 ; then
+  HTTP_GET="curl -LsS"
+elif command -v wget >/dev/null 2>&1 ; then
+  HTTP_GET="wget -qO-"
 else
-  LATEST_RELEASE=$(curl -s "$RELEASE_INFO_URL")
+  echo -e "\033[31mCouldn't find either curl or wget on the system\!\033[0m\n"
+  echo -e "\033[31mMake sure either curl or wget is installed and findable within \$PATH\!\033[0m\n"
+  exit 1
 fi
 
-VERSION=$(echo "$LATEST_RELEASE"      | awk -F= '/version=/  { print $2 }')
-DOWNLOAD_FILENAME=$(echo "$LATEST_RELEASE"     | awk -F= '/filename=/ { print $2 }')
-DOWNLOAD_URL=$(echo "$LATEST_RELEASE" | awk -F= '/url=/      { print $2 }')
+LATEST_RELEASE="$(eval "${HTTP_GET} '${RELEASE_INFO_URL}'")"
 
-function buildkite-download {
-  BUILDKITE_DOWNLOAD_TMP_FILE="/tmp/buildkite-download-$$.txt"
+VERSION="$(          echo "${LATEST_RELEASE}" | awk -F= '/version=/  { print $2 }')"
+DOWNLOAD_FILENAME="$(echo "${LATEST_RELEASE}" | awk -F= '/filename=/ { print $2 }')"
+DOWNLOAD_URL="$(     echo "${LATEST_RELEASE}" | awk -F= '/url=/      { print $2 }')"
 
-  if command -v wget >/dev/null
-  then
-    wget "$1" -O "$2" 2> $BUILDKITE_DOWNLOAD_TMP_FILE || BUILDKITE_DOWNLOAD_EXIT_STATUS=$?
+if [[ "${DISABLE_CHECKSUM_VERIFICATION:-}" != "true" ]]; then
+  if command -v openssl >/dev/null 2>&1 ; then
+    SHA256SUM="openssl dgst -r"
+  elif command -v sha256sum >/dev/null 2>&1 ; then
+    SHA256SUM="sha256sum"
   else
-    curl -L -o "$2" "$1" 2> $BUILDKITE_DOWNLOAD_TMP_FILE || BUILDKITE_DOWNLOAD_EXIT_STATUS=$?
+    echo -e "\033[31mCouldn't find either openssl or sha256sum on the system\!\033[0m\n"
+    echo -e "\033[31mMake sure either openssl or sha256sum is installed and findable within \$PATH\!\033[0m\n"
+    echo -e "\033[31mOr, set DISABLE_CHECKSUM_VERIFICATION=true to disable verification.\033[0m\n"
+    exit 1
   fi
 
-  if [[ $BUILDKITE_DOWNLOAD_EXIT_STATUS -ne 0 ]]; then
-    echo -e "\033[31mFailed to download file: $1\033[0m\n"
+  SHASUMS_FILE="buildkite-agent-${VERSION}.SHA256SUMS"
+  SHASUMS_URL="${DOWNLOAD_URL%"${DOWNLOAD_FILENAME}"}${SHASUMS_FILE}"
+  WANT_SHASUM="$(eval "${HTTP_GET} '${SHASUMS_URL}' | awk '/${DOWNLOAD_FILENAME}/ { print \$1 }'")"
 
-    cat $BUILDKITE_DOWNLOAD_TMP_FILE
-    exit $BUILDKITE_DOWNLOAD_EXIT_STATUS
+  if [[ "${WANT_SHASUM}" == "" ]]; then
+    echo -e "\033[31mA SHA256 checksum for ${DOWNLOAD_FILENAME} could not be fetched\!\033[0m\n"
+    echo -e "\033[31mPlease retry, and reach out to support@buildkite.com if this error persists.\033[0m\n"
+    echo -e "\033[31mIf you want to skip checksum verification, set DISABLE_CHECKSUM_VERIFICATION=true when re-running.\033[0m\n"
+    exit 1
   fi
-}
+fi
 
-echo -e "Installing Version: \033[35mv$VERSION\033[0m"
+echo -e "Installing Version: \033[35mv${VERSION}\033[0m"
 
 # Default the destination folder
-: ${DESTINATION:="$HOME/.buildkite-agent"}
+: "${DESTINATION:="${HOME}/.buildkite-agent"}"
 
 # If they have a $HOME/.buildkite folder, rename it to `buildkite-agent` and
 # symlink back to the old one. Since we changed the name of the folder, we
 # don't want any scripts that the user has written that may reference
 # ~/.buildkite to break.
-if [[ -d "$HOME/.buildkite" && ! -d "$HOME/.buildkite-agent" ]]; then
-  mv "$HOME/.buildkite" "$HOME/.buildkite-agent"
-  ln -s "$HOME/.buildkite-agent" "$HOME/.buildkite"
+if [[ -d "${HOME}/.buildkite" && ! -d "${HOME}/.buildkite-agent" ]]; then
+  mv "${HOME}/.buildkite" "${HOME}/.buildkite-agent"
+  ln -s "${HOME}/.buildkite-agent" "${HOME}/.buildkite"
 
-  echo ""
-  echo "======================= IMPORTANT UPGRADE NOTICE =========================="
-  echo ""
-  echo "Hey!"
-  echo ""
-  echo "Sorry to be a pain, but we've renamed ~/.buildkite to ~/.buildkite-agent"
-  echo ""
-  echo "I've renamed your .buildkite folder to .buildkite-agent, and created a symlink"
-  echo "from the old location to the new location, just in case you had any scripts that"
-  echo "referenced the previous location."
-  echo ""
-  echo "If you have any questions, feel free to email me at: keith@buildkite.com"
-  echo ""
-  echo "~ Keith"
-  echo ""
-  echo "=========================================================================="
-  echo ""
+  cat <<EON
+======================= IMPORTANT UPGRADE NOTICE ==========================
+
+Hey!
+
+Sorry to be a pain, but we've renamed ~/.buildkite to ~/.buildkite-agent
+
+I've renamed your .buildkite folder to .buildkite-agent, and created a symlink
+from the old location to the new location, just in case you had any scripts that
+referenced the previous location.
+
+If you have any questions, feel free to email me at: keith@buildkite.com
+
+~ Keith
+
+==========================================================================
+EON
 fi
 
-mkdir -p "$DESTINATION"
+# Set up destination paths
+mkdir -p "${DESTINATION}"
 
-if [[ ! -w "$DESTINATION" ]]; then
-  echo -e "\n\033[31mUnable to write to destination \`$DESTINATION\`\n\nYou can change the destination by running:\n\nDESTINATION=/my/path $COMMAND\033[0m\n"
+if [[ ! -w "${DESTINATION}" ]]; then
+  echo -e "\n\033[31mUnable to write to destination \`${DESTINATION}\`\n\nYou can change the destination by running:\n\nDESTINATION=/my/path ${COMMAND}\033[0m\n"
   exit 1
 fi
 
-echo -e "Destination: \033[35m$DESTINATION\033[0m"
+mkdir -p "${DESTINATION}/bin"   # for the binary
+mkdir -p "${DESTINATION}/hooks" # for hooks
+INSTALL_TMP="$(mktemp -d -p "${DESTINATION}")" # for tarball extraction
+trap 'rm -fr ${INSTALL_TMP}' EXIT
 
-echo -e "Downloading $DOWNLOAD_URL"
+echo -e "Destination: \033[35m${DESTINATION}\033[0m"
 
-# Create a temporary folder to download the binary to
-INSTALL_TMP=/tmp/buildkite-agent-install-$$
-mkdir -p $INSTALL_TMP
+echo -e "Downloading ${DOWNLOAD_URL}"
 
 # If the file already exists in a folder called releases. This is useful for
 # local testing of this file.
-if [[ -e releases/$DOWNLOAD ]]; then
-  echo "Using existing release: releases/$DOWNLOAD_FILENAME"
-  cp releases/"$DOWNLOAD_FILENAME" $INSTALL_TMP
+if [[ -e "releases/${DOWNLOAD_FILENAME}" ]]; then
+  echo "Using existing release: releases/${DOWNLOAD_FILENAME}"
+  cp "releases/${DOWNLOAD_FILENAME}" "${INSTALL_TMP}/${DOWNLOAD_FILENAME}"
 else
-  buildkite-download "$DOWNLOAD_URL" "$INSTALL_TMP/$DOWNLOAD_FILENAME"
+  if ! eval "${HTTP_GET} '${DOWNLOAD_URL}'" > "${INSTALL_TMP}/${DOWNLOAD_FILENAME}" ; then
+    echo -e "\033[31mFailed to download file: ${DOWNLOAD_FILENAME}\033[0m\n"
+    exit 1
+  fi
+fi
+
+if [[ "${DISABLE_CHECKSUM_VERIFICATION:-}" != "true" ]]; then
+  if ! eval "${SHA256SUM} ${INSTALL_TMP}/${DOWNLOAD_FILENAME} | grep -q '${WANT_SHASUM}'" ; then
+    echo -e "\033[31m${DOWNLOAD_FILENAME} downloaded, but was corrupted (has the wrong checksum)\033[0m\n"
+    echo -e "\033[31mYou might be able to resolve this by retrying.\033[0m\n"
+    echo -e "\033[31mTo skip checksum verification, set DISABLE_CHECKSUM_VERIFICATION=true when re-running.\033[0m\n"
+    exit 1
+  fi
 fi
 
 # Extract the download to a tmp folder inside the $DESTINATION
 # folder
-tar -C "$INSTALL_TMP" -zxf "$INSTALL_TMP"/"$DOWNLOAD_FILENAME"
+tar -C "${INSTALL_TMP}" -zxf "${INSTALL_TMP}/${DOWNLOAD_FILENAME}"
 
 # Move the buildkite binary into a bin folder
-mkdir -p "$DESTINATION"/bin
-mv $INSTALL_TMP/buildkite-agent "$DESTINATION"/bin
-chmod +x "$DESTINATION"/bin/buildkite-agent
+mv "${INSTALL_TMP}/buildkite-agent" "${DESTINATION}/bin"
+chmod +x "${DESTINATION}/bin/buildkite-agent"
 
 # Copy the latest config file as dist
-mv "$INSTALL_TMP"/buildkite-agent.cfg "$DESTINATION"/buildkite-agent.dist.cfg
+mv "${INSTALL_TMP}/buildkite-agent.cfg" "${DESTINATION}/buildkite-agent.dist.cfg"
 
 # Copy the config file if it doesn't exist
-if [[ -f $DESTINATION/buildkite-agent.cfg ]]; then
+if [[ -f "${DESTINATION}/buildkite-agent.cfg" ]]; then
   echo -e "\n\033[36mIgnoring existing buildkite-agent.cfg (see buildkite-agent.dist.cfg for the latest version)\033[0m"
 else
-  echo -e "\n\033[36mA default buildkite-agent.cfg has been created for you in $DESTINATION\033[0m"
+  echo -e "\n\033[36mA default buildkite-agent.cfg has been created for you in ${DESTINATION}\033[0m"
 
-  cp "$DESTINATION"/buildkite-agent.dist.cfg "$DESTINATION"/buildkite-agent.cfg
+  cp "${DESTINATION}/buildkite-agent.dist.cfg" "${DESTINATION}/buildkite-agent.cfg"
 
   # Set their token for them
-  if [[ -n $TOKEN ]]; then
+  if [[ -n "${TOKEN:-}" ]]; then
     # Need "-i ''" for macOS X and FreeBSD
-    if [[ $(uname) == 'Darwin' ]] || [[ $(uname) == 'FreeBSD' ]]; then
-      sed -i '' "s/token=\"xxx\"/token=\"$TOKEN\"/g" "$DESTINATION"/buildkite-agent.cfg
+    if [[ "$(uname)" == 'Darwin' ]] || [[ "$(uname)" == 'FreeBSD' ]]; then
+      sed -i '' "s/token=\"xxx\"/token=\"${TOKEN}\"/g" "${DESTINATION}/buildkite-agent.cfg"
     else
-      sed -i "s/token=\"xxx\"/token=\"$TOKEN\"/g" "$DESTINATION"/buildkite-agent.cfg
+      sed -i "s/token=\"xxx\"/token=\"${TOKEN}\"/g" "${DESTINATION}/buildkite-agent.cfg"
     fi
   else
     echo -e "\n\033[36mDon't forget to update the config with your agent token! You can find it token on your \"Agents\" page in Buildkite\033[0m"
@@ -197,19 +221,18 @@ else
 fi
 
 # Copy the hook samples
-mkdir -p "$DESTINATION"/hooks
-mv $INSTALL_TMP/hooks/*.sample "$DESTINATION"/hooks
+mv "${INSTALL_TMP}/hooks/"*.sample "${DESTINATION}/hooks"
 
-if [[ -f "$INSTALL_TMP/bootstrap.sh" ]]; then
-  mv "$INSTALL_TMP/bootstrap.sh" "$DESTINATION"
-  chmod +x "$DESTINATION/bootstrap.sh"
+if [[ -f "${INSTALL_TMP}/bootstrap.sh" ]]; then
+  mv "${INSTALL_TMP}/bootstrap.sh" "${DESTINATION}"
+  chmod +x "${DESTINATION}/bootstrap.sh"
 fi
 
-echo -e "\n\033[32mSuccessfully installed to $DESTINATION\033[0m
+echo -e "\n\033[32mSuccessfully installed to ${DESTINATION}\033[0m
 
 You can now start the agent!
 
-  $DESTINATION/bin/buildkite-agent start
+  ${DESTINATION}/bin/buildkite-agent start
 
 For docs, help and support:
 


### PR DESCRIPTION
### Description

install.sh is in need of some love. I borrowed some ideas from https://getmic.ro

### Context

https://coda.io/d/Escalations-Feedback_dHnUHNps1YO/Pipelines-In-Progress-Board_suIFKYEb#Escalations-Pipelines_tuQbCBf6/r732&view=modal

### Changes

* More quotes and handlebars
* Refactor picking the HTTP client program (wget/curl)
* Use `mktemp -d`, and a cleanup trap
* Heredoc
* Use the new-ish SHA256SUMS file to checksum the file, with an escape hatch

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
- [x] Works on macOS
- [x] Works on Ubuntu