### PR TITLE
Parallel container image uploads

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -136,13 +136,22 @@ steps:
             - with: { pkg_arch: "SKIP_FAKE_ARCH" }
               skip: true
 
-  - name: ":docker: Publish Edge Docker Images"
-    command: ".buildkite/steps/publish-docker-images.sh"
-    env:
-      CODENAME: "experimental"
-    plugins:
-      - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
-      - ecr#v2.7.0:
-          login: true
-          account-ids: "445615400570"
+  - group: ":docker: Publish Edge Docker Images"
+    steps:
+      - name: ":docker: Publish Edge Images to {{matrix.registry}}"
+        command: ".buildkite/steps/publish-docker-images.sh"
+        env:
+          CODENAME: "experimental"
+          REGISTRY: "{{matrix.registry}}"
+        plugins:
+          - aws-assume-role-with-web-identity:
+              role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
+          - ecr#v2.7.0:
+              login: true
+              account-ids: "445615400570"
+        matrix:
+          setup:
+            registry:
+              - docker.io
+              - ghcr.io
+              - packages.buildkite.com

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -160,16 +160,25 @@ steps:
             - with: { pkg_arch: "SKIP_FAKE_ARCH" }
               skip: true
 
-  - name: ":docker: Publish Docker Images"
-    command: ".buildkite/steps/publish-docker-images.sh"
-    env:
-      CODENAME: "stable"
-    plugins:
-      - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
-      - ecr#v2.7.0:
-          login: true
-          account-ids: "445615400570"
+  - group: ":docker: Publish Docker Images"
+    steps:
+      - name: ":docker: Publish Docker Images to {{matrix.registry}}"
+        command: ".buildkite/steps/publish-docker-images.sh"
+        env:
+          CODENAME: "stable"
+          REGISTRY: "{{matrix.registry}}"
+        plugins:
+          - aws-assume-role-with-web-identity:
+              role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
+          - ecr#v2.7.0:
+              login: true
+              account-ids: "445615400570"
+        matrix:
+          setup:
+            registry:
+              - docker.io
+              - ghcr.io
+              - packages.buildkite.com
 
   - wait
 

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -160,16 +160,25 @@ steps:
             - with: { pkg_arch: "SKIP_FAKE_ARCH" }
               skip: true
 
-  - name: ":docker: Publish Unstable Docker Images"
-    command: ".buildkite/steps/publish-docker-images.sh"
-    env:
-      CODENAME: "unstable"
-    plugins:
-      - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
-      - ecr#v2.7.0:
-          login: true
-          account-ids: "445615400570"
+  - group: ":docker: Publish Unstable Docker Images"
+    steps:
+      - name: ":docker: Publish Unstable Images to {{matrix.registry}}"
+        command: ".buildkite/steps/publish-docker-images.sh"
+        env:
+          CODENAME: "unstable"
+          REGISTRY: "{{matrix.registry}}"
+        plugins:
+          - aws-assume-role-with-web-identity:
+              role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
+          - ecr#v2.7.0:
+              login: true
+              account-ids: "445615400570"
+        matrix:
+          setup:
+            registry:
+              - docker.io
+              - ghcr.io
+              - packages.buildkite.com
 
   - wait
 

--- a/.buildkite/steps/publish-docker-images.sh
+++ b/.buildkite/steps/publish-docker-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 dry_run() {
@@ -9,51 +9,64 @@ dry_run() {
   fi
 }
 
-if [[ "$CODENAME" == "" ]]; then
+if [[ "${CODENAME:-}" == "" ]]; then
   echo "Error: Missing \$CODENAME (stable, experimental or unstable)"
   exit 1
 fi
 
-echo "--- docker login to Docker Hub"
+if [[ "${REGISTRY:-}" == "" ]]; then
+    echo "Error: Missing \$REGISTRY (docker.io, ghcr.io, or packages.buildkite.com)"
+    exit 1
+fi
 
-dockerhub_user="$(aws ssm get-parameter \
-  --name /pipelines/agent/DOCKER_HUB_USER \
-  --with-decryption \
-  --output text \
-  --query Parameter.Value \
-  --region us-east-1\
-)"
+case "${REGISTRY}" in
+docker.io)
+  echo "--- docker login to Docker Hub"
+  dockerhub_user="$(aws ssm get-parameter \
+    --name /pipelines/agent/DOCKER_HUB_USER \
+    --with-decryption \
+    --output text \
+    --query Parameter.Value \
+    --region us-east-1\
+  )"
+  aws ssm get-parameter \
+    --name /pipelines/agent/DOCKER_HUB_PASSWORD \
+    --with-decryption \
+    --output text \
+    --query Parameter.Value \
+    --region us-east-1 \
+    | docker login --username="${dockerhub_user}" --password-stdin
+  ;;
+ghcr.io)
+  echo "--- docker login to GitHub"
 
-aws ssm get-parameter \
-  --name /pipelines/agent/DOCKER_HUB_PASSWORD \
-  --with-decryption \
-  --output text \
-  --query Parameter.Value \
-  --region us-east-1 \
-  | docker login --username="${dockerhub_user}" --password-stdin
+  ghcr_user=buildkite-agent-releaser
+  aws ssm get-parameter \
+    --name /pipelines/agent/GITHUB_RELEASE_ACCESS_TOKEN \
+    --with-decryption \
+    --output text \
+    --query Parameter.Value \
+    --region us-east-1 \
+    | docker login ghcr.io --username="${ghcr_user}" --password-stdin
 
+  ;;
+packages.buildkite.com)
+  echo "--- Uploading images to Buildkite Packages"
+  ;;
+*)
+  echo "+++ Registry '${REGISTRY}' is not supported\!"
+  exit 1
+  ;;
+esac
 
-echo "--- docker login to GitHub"
-
-ghcr_user=buildkite-agent-releaser
-aws ssm get-parameter \
-  --name /pipelines/agent/GITHUB_RELEASE_ACCESS_TOKEN \
-  --with-decryption \
-  --output text \
-  --query Parameter.Value \
-  --region us-east-1 \
-  | docker login ghcr.io --username="${ghcr_user}" --password-stdin
-
-echo "--- docker login to Buildkite Packages"
-
-version=$(buildkite-agent meta-data get "agent-version")
-build=$(buildkite-agent meta-data get "agent-version-build")
+version="$(buildkite-agent meta-data get "agent-version")"
+build="$(buildkite-agent meta-data get "agent-version-build")"
 
 for variant in "alpine" "alpine-k8s" "ubuntu-18.04" "ubuntu-20.04" "ubuntu-22.04" "sidecar" ; do
   echo "--- Getting docker image tag for $variant from build meta data"
-  source_image=$(buildkite-agent meta-data get "agent-docker-image-$variant")
-  echo "Docker Image Tag for $variant: $source_image"
+  source_image="$(buildkite-agent meta-data get "agent-docker-image-${variant}")"
+  echo "Docker Image Tag for ${variant}: ${source_image}"
 
-  echo "--- :docker: Publishing images for $variant"
-  .buildkite/steps/publish-docker-image.sh "$variant" "$source_image" "$CODENAME" "$version" "$build"
+  echo "--- :docker: Publishing images for ${variant}"
+  .buildkite/steps/publish-docker-image.sh "${REGISTRY}" "${variant}" "${source_image}" "${CODENAME}" "${version}" "${build}"
 done


### PR DESCRIPTION
### Description

Push container images to each registry in a separate job (using matrices).

### Context

We keep getting 500 errors from the different registries, possibly because the process takes over 5 minutes. Maybe this will help?

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
