### PR TITLE
Fix request headers for multipart

### DIFF
--- a/internal/artifact/bk_uploader.go
+++ b/internal/artifact/bk_uploader.go
@@ -145,10 +145,12 @@ func (u *bkMultipartUpload) DoWork(ctx context.Context) (*api.ArtifactPartETag, 
 		return nil, err
 	}
 
-	// Content-Range is mostly for debugging purposes.
-	// Note thatContent-Ranges are 0-indexed and inclusive
-	// example: Content-Range: bytes 200-1000/67589
-	req.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", u.offset, u.offset+u.size-1, u.artifact.FileSize))
+	// Content-Range would be useful for debugging purposes, but S3 will reject
+	// the request.
+	// Content-Length is needed to avoid Go adding Transfer-Encoding: chunked
+	// which would also cause S3 to reject the request (plus we know the part
+	// length in advance).
+	req.ContentLength = u.size
 	req.Header.Set("Content-Type", u.artifact.ContentType)
 
 	client := agenthttp.NewClient(


### PR DESCRIPTION
### Description

Set headers in the request that S3 is happy with.

`Content-Range` isn't necessary for the request (it was a flourish I added for debugging purposes), and `Transfer-Encoding` is added by Go when `ContentLength` isn't set.

### Context

Testing showed that AWS rejects `Content-Range` and `Transfer-Encoding` headers with 501 Not Implemented. 

### Changes

* Remove `Content-Range`
* Set `req.ContentLength`
* Update the comment

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)