### PR TITLE
k8s exec: Perform liveness check of clients

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -362,7 +362,7 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient APIClient, con
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse BUILDKITE_CONTAINER_COUNT: %w", err)
 		}
-		r.process = kubernetes.New(r.agentLogger, kubernetes.Config{
+		r.process = kubernetes.NewRunner(r.agentLogger, kubernetes.RunnerConfig{
 			Stdout:      r.jobLogs,
 			Stderr:      r.jobLogs,
 			ClientCount: containerCount,

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -363,10 +363,11 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient APIClient, con
 			return nil, fmt.Errorf("failed to parse BUILDKITE_CONTAINER_COUNT: %w", err)
 		}
 		r.process = kubernetes.NewRunner(r.agentLogger, kubernetes.RunnerConfig{
-			Stdout:      r.jobLogs,
-			Stderr:      r.jobLogs,
-			ClientCount: containerCount,
-			Env:         processEnv,
+			Stdout:            r.jobLogs,
+			Stderr:            r.jobLogs,
+			ClientCount:       containerCount,
+			Env:               processEnv,
+			ClientLostTimeout: 30 * time.Second,
 		})
 	} else { // not Kubernetes
 		// The bootstrap-script gets parsed based on the operating system

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -291,9 +291,9 @@ func (r *JobRunner) runJob(ctx context.Context) core.ProcessExit {
 	// start. Normally such errors are hidden in the Kubernetes events. Let's feed them up
 	// to the user as they may be the caused by errors in the pipeline definition.
 	k8sProcess, ok := r.process.(*kubernetes.Runner)
-	if ok && r.cancelled && !r.stopped && k8sProcess.ClientStateUnknown() {
+	if ok && r.cancelled && !r.stopped && k8sProcess.AnyClientNotConnectedYet() {
 		fmt.Fprintln(r.jobLogs, "+++ Unknown container exit status")
-		fmt.Fprintln(r.jobLogs, "Some containers had unknown exit statuses. Perhaps the container image specified in your podSpec could not be pulled (ImagePullBackOff)")
+		fmt.Fprintln(r.jobLogs, "Some containers never connected to the agent. Perhaps the container image specified in your podSpec could not be pulled (ImagePullBackOff)")
 	}
 
 	// Collect the finished process' exit status

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -290,10 +290,19 @@ func (r *JobRunner) runJob(ctx context.Context) core.ProcessExit {
 	// Intended to capture situations where the job-exec (aka bootstrap) container did not
 	// start. Normally such errors are hidden in the Kubernetes events. Let's feed them up
 	// to the user as they may be the caused by errors in the pipeline definition.
-	k8sProcess, ok := r.process.(*kubernetes.Runner)
-	if ok && r.cancelled && !r.stopped && k8sProcess.AnyClientNotConnectedYet() {
-		fmt.Fprintln(r.jobLogs, "+++ Unknown container exit status")
-		fmt.Fprintln(r.jobLogs, "Some containers never connected to the agent. Perhaps the container image specified in your podSpec could not be pulled (ImagePullBackOff)")
+	k8sProcess, isK8s := r.process.(*kubernetes.Runner)
+	if isK8s && !r.stopped {
+		switch {
+		case r.cancelled && k8sProcess.AnyClientIn(kubernetes.StateNotYetConnected):
+			fmt.Fprint(r.jobLogs, `+++ Unknown container exit status
+One or more containers never connected to the agent. Perhaps the container image specified in your podSpec could not be pulled (ImagePullBackOff)?
+`)
+		case k8sProcess.AnyClientIn(kubernetes.StateLost):
+			fmt.Fprint(r.jobLogs, `+++ Unknown container exit status
+One or more containers connected to the agent, but then stopped communicating without exiting normally. Perhaps the container was OOM-killed?
+`)
+		}
+
 	}
 
 	// Collect the finished process' exit status

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -1,0 +1,97 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"net/rpc"
+	"time"
+
+	"github.com/buildkite/roko"
+)
+
+type Client struct {
+	ID         int
+	SocketPath string
+
+	client *rpc.Client
+}
+
+var errNotConnected = errors.New("client not connected")
+
+func (c *Client) Connect(ctx context.Context) (*RegisterResponse, error) {
+	if c.SocketPath == "" {
+		c.SocketPath = defaultSocketPath
+	}
+
+	// Because k8s might run the containers "out of order", the server socket
+	// might not exist yet. Try to connect several times.
+	r := roko.NewRetrier(
+		roko.WithMaxAttempts(30),
+		roko.WithStrategy(roko.Constant(time.Second)),
+	)
+	client, err := roko.DoFunc(ctx, r, func(*roko.Retrier) (*rpc.Client, error) {
+		return rpc.DialHTTP("unix", c.SocketPath)
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.client = client
+	var resp RegisterResponse
+	if err := c.client.Call("Runner.Register", c.ID, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *Client) Exit(exitStatus int) error {
+	if c.client == nil {
+		return errNotConnected
+	}
+	return c.client.Call("Runner.Exit", ExitCode{
+		ID:         c.ID,
+		ExitStatus: exitStatus,
+	}, nil)
+}
+
+// Write implements io.Writer
+func (c *Client) Write(p []byte) (int, error) {
+	if c.client == nil {
+		return 0, errNotConnected
+	}
+	n := len(p)
+	err := c.client.Call("Runner.WriteLogs", Logs{
+		Data: p,
+	}, nil)
+	return n, err
+}
+
+var ErrInterrupt = errors.New("interrupt signal received")
+
+func (c *Client) Await(ctx context.Context, desiredState RunState) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			var current RunState
+			if err := c.client.Call("Runner.Status", c.ID, &current); err != nil {
+				return err
+			}
+			if current == desiredState {
+				return nil
+			}
+			if current == RunStateInterrupt {
+				return ErrInterrupt
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Second):
+			}
+		}
+	}
+}
+
+func (c *Client) Close() {
+	c.client.Close()
+}

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -24,13 +24,6 @@ func TestOrderedClients(t *testing.T) {
 	client2 := &Client{ID: 2}
 	clients := []*Client{client0, client1, client2}
 
-	// wait for runner to listen
-	require.Eventually(t, func() bool {
-		_, err := os.Lstat(socketPath)
-		return err == nil
-
-	}, time.Second*10, time.Millisecond, "expected socket file to exist")
-
 	for _, client := range clients {
 		client.SocketPath = socketPath
 		require.NoError(t, connect(client))
@@ -60,19 +53,39 @@ func TestOrderedClients(t *testing.T) {
 	}
 }
 
+func TestLivenessCheck(t *testing.T) {
+	runner := newRunner(t, 2)
+	socketPath := runner.conf.SocketPath
+
+	client0 := &Client{ID: 0}
+	client1 := &Client{ID: 1}
+	clients := []*Client{client0, client1}
+
+	for _, client := range clients {
+		client.SocketPath = socketPath
+		require.NoError(t, connect(client))
+		t.Cleanup(client.Close)
+	}
+	ctx := context.Background()
+	require.NoError(t, client0.Await(ctx, RunStateStart))
+	require.NoError(t, client1.Await(ctx, RunStateWait))
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	select {
+	case <-runner.Done():
+		break
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for client0 to be declared lost and job terminated")
+	}
+}
+
 func TestDuplicateClients(t *testing.T) {
 	runner := newRunner(t, 2)
 	socketPath := runner.conf.SocketPath
 
 	client0 := &Client{ID: 0, SocketPath: socketPath}
 	client1 := &Client{ID: 0, SocketPath: socketPath}
-
-	// wait for runner to listen
-	require.Eventually(t, func() bool {
-		_, err := os.Lstat(socketPath)
-		return err == nil
-
-	}, time.Second*10, time.Millisecond, "expected socket file to exist")
 
 	require.NoError(t, connect(client0))
 	require.Error(t, connect(client1), "expected an error when connecting a client with a duplicate ID")
@@ -136,8 +149,9 @@ func newRunner(t *testing.T, clientCount int) *Runner {
 		os.RemoveAll(tempDir)
 	})
 	runner := NewRunner(logger.Discard, RunnerConfig{
-		SocketPath:  socketPath,
-		ClientCount: clientCount,
+		SocketPath:        socketPath,
+		ClientCount:       clientCount,
+		ClientLostTimeout: 2 * time.Second,
 	})
 	runnerCtx, cancelRunner := context.WithCancel(context.Background())
 	go runner.Run(runnerCtx)

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -135,7 +135,7 @@ func newRunner(t *testing.T, clientCount int) *Runner {
 	t.Cleanup(func() {
 		os.RemoveAll(tempDir)
 	})
-	runner := New(logger.Discard, Config{
+	runner := NewRunner(logger.Discard, RunnerConfig{
 		SocketPath:  socketPath,
 		ClientCount: clientCount,
 	})


### PR DESCRIPTION
### Description

Add a mechanism for terminating if a client stops communicating.

### Context

Sometimes, a container will just die (e.g. it is OOM-killed). If that happens, the agent can sit around happily until the heat death of the universe waiting for `Exit` to be called by something that isn't running any more.

### Changes

* Some code rearrangement
* Store clients in a slice instead of a map, since they're keyed by sequential int
* Finer-grained locking
  * Locking around channel close inside a `sync.Once.Do` is pointless, given nothing else writes to the channels. The existing locking only prevented data races on the clients, and the clients map/slice never changes, so the mutexes can be made client-specific.
* Add a goroutine that inspects client states and terminates the job if a client that should be connected goes silent for too long.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
