### PR TITLE
Allow token to be empty if graphql-token is provided

### DIFF
--- a/internal/agenthttp/auth.go
+++ b/internal/agenthttp/auth.go
@@ -36,7 +36,7 @@ func (t authenticatedTransport) RoundTrip(req *http.Request) (*http.Response, er
 		}()
 	}
 
-	if t.Token == "" {
+	if t.Token == "" && t.Bearer == "" {
 		return nil, fmt.Errorf("Invalid token, empty string supplied")
 	}
 


### PR DESCRIPTION
### Description
Fixes `tool sign` when using `--graphql-token`.

### Context
Running `tool sign --graphql-endpoint http://graphql.buildkite.localhost/v1 --graphql-token this_is_not_the_actual_token` kept returning an error `fatal: Error signing pipeline: couldn't retrieve pipeline: Post "http://graphql.buildkite.localhost/v1": Invalid token, empty string supplied`

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)