### PR TITLE
Add tini-static to alpine images

### DIFF
--- a/packaging/docker/alpine-k8s/Dockerfile
+++ b/packaging/docker/alpine-k8s/Dockerfile
@@ -18,6 +18,7 @@ RUN apk update && apk add --no-cache \
     run-parts \
     su-exec \
     tini \
+    tini-static \
     tzdata
 
 COPY docker-compose /usr/local/bin/docker-compose

--- a/packaging/docker/alpine/Dockerfile
+++ b/packaging/docker/alpine/Dockerfile
@@ -19,6 +19,7 @@ RUN apk add --no-cache \
     run-parts \
     su-exec \
     tini \
+    tini-static \
     tzdata
 
 COPY docker-compose /usr/local/bin/docker-compose


### PR DESCRIPTION
### Description

Install both `tini` and `tini-static` in `alpine` and `alpine-k8s`.

### Context

This is the easiest way to make `tini-static` available to `agent-stack-k8s`, which will be needed for defunct-process-reaping within arbitrary container images. `agent-stack-k8s` by default uses the agent `alpine` image, not `alpine-k8s`, but I think they should be somewhat consistent.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
