### PR TITLE
Clone if git mirror directory is empty

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -318,8 +318,9 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string) (stri
 	}
 	defer mirrorCloneLock.Unlock()
 
-	// If we don't have a mirror, we need to clone it
-	if !osutil.FileExists(mirrorDir) {
+	// If we don't have a mirror, or it's empty for some reason, we need to
+	// clone it
+	if !osutil.FileExists(mirrorDir) || osutil.IsEmptyDir(mirrorDir) {
 		e.shell.Commentf("Cloning a mirror of the repository to %q", mirrorDir)
 		flags := "--mirror " + e.GitCloneMirrorFlags
 		if err := gitClone(ctx, e.shell, flags, repository, mirrorDir); err != nil {

--- a/internal/osutil/file.go
+++ b/internal/osutil/file.go
@@ -29,3 +29,10 @@ func FileExists(filename string) bool {
 	_, err := os.Stat(filename)
 	return err == nil
 }
+
+// IsEmptyDir reports whether the path is an empty directory. Any error returned
+// by [os.ReadDir] causes the result to be false.
+func IsEmptyDir(path string) bool {
+	ents, err := os.ReadDir(path)
+	return err == nil && len(ents) == 0
+}


### PR DESCRIPTION
### Description

If the git mirror directory is present, but empty for some reason, then clone it.

### Context

Possible cause for https://coda.io/d/Escalations-Feedback_dHnUHNps1YO/Pipelines-Escalations_suQ4B7FT#Pipelines-Escalations-Board_tu66S__K/r789&view=modal

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
