### PR TITLE
Use sha256 in the checksum verification

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -96,7 +96,7 @@ DOWNLOAD_URL="$(     echo "${LATEST_RELEASE}" | awk -F= '/url=/      { print $2 
 
 if [[ "${DISABLE_CHECKSUM_VERIFICATION:-}" != "true" ]]; then
   if command -v openssl >/dev/null 2>&1 ; then
-    SHA256SUM="openssl dgst -r"
+    SHA256SUM="openssl dgst -sha256 -r"
   elif command -v sha256sum >/dev/null 2>&1 ; then
     SHA256SUM="sha256sum"
   else


### PR DESCRIPTION
### Description

Older version of openssl (e.g. 1.0.2) don't use sha256 as default
option for the openssl dgst so make it explicit.

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

