### PR TITLE
Promote polyglot-hooks experiment to default

### DIFF
--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -30,7 +30,6 @@ const (
 	NormalisedUploadPaths          = "normalised-upload-paths"
 	OverrideZeroExitOnCancel       = "override-zero-exit-on-cancel"
 	PTYRaw                         = "pty-raw"
-	PolyglotHooks                  = "polyglot-hooks"
 	ResolveCommitAfterCheckout     = "resolve-commit-after-checkout"
 	UseZZGlob                      = "use-zzglob"
 
@@ -43,6 +42,7 @@ const (
 	IsolatedPluginCheckout = "isolated-plugin-checkout"
 	JobAPI                 = "job-api"
 	KubernetesExec         = "kubernetes-exec"
+	PolyglotHooks          = "polyglot-hooks"
 )
 
 var (
@@ -53,7 +53,6 @@ var (
 		InterpolationPrefersRuntimeEnv: {},
 		NormalisedUploadPaths:          {},
 		OverrideZeroExitOnCancel:       {},
-		PolyglotHooks:                  {},
 		ResolveCommitAfterCheckout:     {},
 		UseZZGlob:                      {},
 	}
@@ -67,6 +66,7 @@ var (
 		IsolatedPluginCheckout: standardPromotionMsg(IsolatedPluginCheckout, "v3.67.0"),
 		JobAPI:                 standardPromotionMsg(JobAPI, "v3.64.0"),
 		KubernetesExec:         "The kubernetes-exec experiment has been replaced with the --kubernetes-exec flag as of agent v3.74.0",
+		PolyglotHooks:          standardPromotionMsg(PolyglotHooks, "v3.85.0"),
 	}
 
 	// Used to track experiments possibly in use.

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/buildkite/agent/v3/agent/plugin"
 	"github.com/buildkite/agent/v3/env"
-	"github.com/buildkite/agent/v3/internal/experiments"
 	"github.com/buildkite/agent/v3/internal/file"
 	"github.com/buildkite/agent/v3/internal/job/hook"
 	"github.com/buildkite/agent/v3/internal/job/shell"
@@ -346,10 +345,6 @@ func (e *Executor) executeHook(ctx context.Context, hookCfg HookConfig) error {
 	}
 
 	e.shell.Headerf("Running %s hook", hookName)
-
-	if !experiments.IsEnabled(ctx, experiments.PolyglotHooks) {
-		return e.runWrappedShellScriptHook(ctx, hookName, hookCfg)
-	}
 
 	hookType, err := hook.Type(hookCfg.Path)
 	if err != nil {

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buildkite/agent/v3/internal/experiments"
 	"github.com/buildkite/agent/v3/internal/job"
 
 	"github.com/buildkite/agent/v3/internal/job/shell"
@@ -579,7 +578,7 @@ func TestPolyglotScriptHooksCanBeRun(t *testing.T) {
 		t.Fatal("ruby not found in $PATH. This test requires ruby to be installed on the host")
 	}
 
-	ctx, _ := experiments.Enable(mainCtx, experiments.PolyglotHooks)
+	ctx := mainCtx
 
 	tester, err := NewExecutorTester(ctx)
 	if err != nil {
@@ -608,7 +607,6 @@ func TestPolyglotBinaryHooksCanBeRun(t *testing.T) {
 	t.Parallel()
 
 	ctx := mainCtx
-	ctx, _ = experiments.Enable(ctx, experiments.PolyglotHooks)
 
 	tester, err := NewExecutorTester(ctx)
 	if err != nil {


### PR DESCRIPTION
### Description

Promote polyglot-hooks 🎉 

### Context

Polyglot hooks was [added as an experiment in May 2023](https://github.com/buildkite/agent/pull/2040). It's high time this was just made default.

### Changes

* Move the experiment into "promoted"
* Remove the conditional
* Remove the experiment setup in tests

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
