### PR TITLE
Remove .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,0 @@
-[*.go]
-indent_size=2

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ packaging/docker/*/hooks/
 
 .idea
 .vscode
+
+# Editor config boils down to personal preference
+.editorconfig


### PR DESCRIPTION
### Description

I think that Go code should _not_ use 2 space tabs, especially if it's just to be consistent with Ruby backend code. Personally I am used to 4 or 8 space tabs. But I also think that `.editorconfig` is a matter of personal preference: if you want to use 2 space tabs you go ahead and configure your editor that way. We shouldn't be supplying an `.editorconfig` for you.

### Context

The editor I've been using started respecting this file ahead of my other config, so I'm inclined to remove the file.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
