### PR TITLE
Support installing specific versions via script

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -41,20 +41,24 @@ if ([string]::IsNullOrEmpty($url)) {
     if($null -eq $version){
       $version = "latest"
     }
-    $releaseInfoUrl = "https://buildkite.com/agent/releases/$($version)?platform=windows&arch=$arch"
-    if($beta) {
-        $releaseInfoUrl = $releaseInfoUrl + "&prerelease=true"
+    if ($version -eq "latest") {
+      $releaseInfoUrl = "https://buildkite.com/agent/releases/$($version)?platform=windows&arch=$arch"
+      if($beta) {
+          $releaseInfoUrl = $releaseInfoUrl + "&prerelease=true"
+      }
+      Write-Host "Finding latest release"
+  
+      $resp = Invoke-WebRequest -Uri "$releaseInfoUrl" -UseBasicParsing -Method GET
+  
+      $releaseInfo = @{}
+      foreach ($line in $resp.Content.Split("`n")) {
+          $info = $line -split "="
+          $releaseInfo.add($info[0],$info[1])
+      }
+      $url = $releaseInfo.url
+    } else {
+      $url = "https://github.com/buildkite/agent/releases/download/v$($version)/buildkite-agent-windows-$arch-$($version).zip"
     }
-    Write-Host "Finding latest release"
-
-    $resp = Invoke-WebRequest -Uri "$releaseInfoUrl" -UseBasicParsing -Method GET
-
-    $releaseInfo = @{}
-    foreach ($line in $resp.Content.Split("`n")) {
-        $info = $line -split "="
-        $releaseInfo.add($info[0],$info[1])
-    }
-    $url = $releaseInfo.url
 }
 
 # Github requires TLS1.2

--- a/install.sh
+++ b/install.sh
@@ -81,7 +81,7 @@ else
   exit 1
 fi
 
-if [[ "${BUILDKITE_AGENT_VERSION:-"latest"}" == "latest" ]]; then
+if [[ "${BUILDKITE_AGENT_VERSION:-latest}" == "latest" ]]; then
     echo -e "Finding latest release..."
 
     RELEASE_INFO_URL="https://buildkite.com/agent/releases/latest?platform=${PLATFORM}&arch=${ARCH}&system=${SYSTEM}&machine=${MACHINE}"
@@ -95,7 +95,7 @@ if [[ "${BUILDKITE_AGENT_VERSION:-"latest"}" == "latest" ]]; then
     DOWNLOAD_FILENAME="$(echo "${LATEST_RELEASE}" | awk -F= '/filename=/ { print $2 }')"
     DOWNLOAD_URL="$(     echo "${LATEST_RELEASE}" | awk -F= '/url=/      { print $2 }')"
 else
-    VERSION=$BUILDKITE_AGENT_VERSION
+    VERSION="${BUILDKITE_AGENT_VERSION}"
     DOWNLOAD_FILENAME="buildkite-agent-${PLATFORM}-${ARCH}-${VERSION}.tar.gz"
     DOWNLOAD_URL="https://github.com/buildkite/agent/releases/download/v${VERSION}/${DOWNLOAD_FILENAME}"
 fi


### PR DESCRIPTION
### Description
Add support for specifying agent version when installing via `install.sh` or `install.ps1`. Pulled upstream from https://github.com/elastic/buildkite-agent thanks to @esenmarti!

To set the agent version use the following before running the install script.
- Windows
  - `$env:buildkiteAgentVersion = "3.84.0"`
- Linux
  - `BUILDKITE_AGENT_VERSION = "3.84.0"`
  
### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] ~~Code is formatted (with `go fmt ./...`)~~