### PR TITLE
[ci] Update agent release stable pipeline explicit dependencies

### DIFF
--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -1,12 +1,13 @@
-steps:
-  - wait
+steps
 
   - name: ":spiral_note_pad: Check Changelog"
     command: ".buildkite/steps/check-changelog.sh"
-
-  - wait
+    key: "check_changelog"
 
   - name: ":s3: Upload Binaries to S3"
+    key: "upload_binaries_to_s3"
+    depends_on:
+      - "check_changelog"
     command: ".buildkite/steps/publish-to-s3.sh"
     env:
       CODENAME: "stable"
@@ -26,6 +27,9 @@ steps:
           mount-buildkite-agent: true
 
   - name: ":octocat: :rocket: Create Github Release (if necessary)"
+    key: "create_github_release_if_necessary"
+    depends_on:
+      - "check_changelog"
     command: ".buildkite/steps/github-release.sh"
     env:
       CODENAME: "stable"
@@ -45,6 +49,9 @@ steps:
           mount-buildkite-agent: true
 
   - name: ":redhat: Publish RPM Package"
+    key: "publish_rpm_package"
+    depends_on:
+      - "check_changelog"
     command: ".buildkite/steps/publish-rpm-package.sh"
     env:
       CODENAME: "stable"
@@ -69,6 +76,9 @@ steps:
           limit: 3
 
   - group: ":redhat: Publish RPM Package to Buildkite Packages"
+    key: "publish_rpm_package_to_buildkite_packages"
+    depends_on:
+      - "check_changelog"
     steps:
       - name: ":redhat: Publish {{matrix.pkg_arch}} RPM Package to Buildkite Packages"
         plugins:
@@ -102,6 +112,9 @@ steps:
               skip: true
 
   - name: ":debian: Publish Debian Package"
+    key: "publish_debian_package"
+    depends_on:
+      - "check_changelog"
     command: ".buildkite/steps/publish-debian-package.sh"
     env:
       CODENAME: "stable"
@@ -124,6 +137,9 @@ steps:
             - "/root/.gnupg"
 
   - group: ":debian: Publish Debian Package to Buildkite Packages"
+    key: "publish_debian_package_to_buildkite_packages"
+    depends_on:
+      - "check_changelog"
     steps:
       - name: ":debian: Publish {{matrix.pkg_arch}} Debian Package to Buildkite Packages"
         plugins:
@@ -161,6 +177,9 @@ steps:
               skip: true
 
   - group: ":docker: Publish Docker Images"
+    key: "publish_docker_images"
+    depends_on:
+      - "check_changelog"
     steps:
       - name: ":docker: Publish Docker Images to {{matrix.registry}}"
         command: ".buildkite/steps/publish-docker-images.sh"
@@ -180,9 +199,15 @@ steps:
               - ghcr.io
               - packages.buildkite.com
 
-  - wait
-
   - name: ":beer: Publish Homebrew Package"
+    depends_on:
+      - "upload_binaries_to_s3"
+      - "create_github_release_if_necessary"
+      - "publish_rpm_package"
+      - "publish_rpm_package_to_buildkite_packages"
+      - "publish_debian_package"
+      - "publish_debian_package_to_buildkite_packages"
+      - "publish_docker_images"
     command: ".buildkite/steps/release-homebrew.sh"
     artifact_paths: "pkg/*.rb;pkg/*.json"
     env:

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -1,5 +1,4 @@
-steps
-
+steps:
   - name: ":spiral_note_pad: Check Changelog"
     command: ".buildkite/steps/check-changelog.sh"
     key: "check_changelog"
@@ -207,7 +206,6 @@ steps
       - "publish_rpm_package_to_buildkite_packages"
       - "publish_debian_package"
       - "publish_debian_package_to_buildkite_packages"
-      - "publish_docker_images"
     command: ".buildkite/steps/release-homebrew.sh"
     artifact_paths: "pkg/*.rb;pkg/*.json"
     env:


### PR DESCRIPTION
### Description

Use `depends_on` to specify dependencies between steps rather than relying on implicit `wait` step.

### Testing

CI only!