### PR TITLE
dependabot: Group Dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,39 +1,17 @@
 version: 2
 updates:
   - package-ecosystem: docker
-    directory: /packaging/docker/alpine
-    schedule:
-      interval: weekly
-  - package-ecosystem: docker
-    directory: /packaging/docker/alpine-k8s
-    schedule:
-      interval: weekly
-  - package-ecosystem: docker
-    directory: /packaging/docker/sidecar
-    schedule:
-      interval: weekly
-  - package-ecosystem: docker
-    directory: /packaging/docker/ubuntu-18.04
+    directories:
+      - /packaging/docker/alpine
+      - /packaging/docker/alpine-k8s
+      - /packaging/docker/sidecar
+      - /packaging/docker/ubuntu-18.04
+      - /packaging/docker/ubuntu-20.04
+      - /packaging/docker/ubuntu-22.04
     schedule:
       interval: weekly
     ignore:
       - dependency-name: ubuntu
-  - package-ecosystem: docker
-    directory: /packaging/docker/ubuntu-20.04
-    schedule:
-      interval: weekly
-    ignore:
-      - dependency-name: ubuntu
-  - package-ecosystem: docker
-    directory: /packaging/docker/ubuntu-22.04
-    schedule:
-      interval: weekly
-    ignore:
-      - dependency-name: ubuntu
-  - package-ecosystem: docker
-    directory: /.buildkite
-    schedule:
-      interval: weekly
   - package-ecosystem: gomod
     directory: /
     schedule:


### PR DESCRIPTION
### Description

Docker rebuilds take a while, and Dependabot has been failing to pull images, so try to group updates.

### Context

Recent build times.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
