### PR TITLE
Handle older version of remote ref error message

### DIFF
--- a/internal/job/git.go
+++ b/internal/job/git.go
@@ -151,9 +151,11 @@ func gitFetch(
 
 	const badObject = "fatal: bad object"
 	const badReference = "fatal: couldn't find remote ref"
+	const badReferencePreGit221 = "fatal: Couldn't find remote ref"
 	smelt := map[string]bool{
-		badObject:    false,
-		badReference: false,
+		badObject:             false,
+		badReference:          false,
+		badReferencePreGit221: false,
 	}
 
 	if err := sh.Command("git", commandArgs...).Run(ctx, shell.WithStringSearch(smelt)); err != nil {
@@ -167,8 +169,8 @@ func gitFetch(
 			return &gitError{error: err, Type: gitErrorFetchBadObject}
 		}
 
-		// "fatal: couldn't find remote ref" can happen when the just the short commit hash is given.
-		if smelt[badReference] {
+		// "fatal: [Cc]ouldn't find remote ref" can happen when just the short commit hash is given.
+		if smelt[badReference] || smelt[badReferencePreGit221] {
 			return &gitError{error: err, Type: gitErrorFetchBadReference}
 		}
 


### PR DESCRIPTION
### Description

We have code to handle the case where we can't fetch a short remote ref and fall back to fetching all tags. However the case of this error changed in git v2.21.0 (2019) and we only caught the new lowercase version. Handle the old title case version to support customers running old versions of git.

### Context

Linear PS-179

### Testing

- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
