### PR TITLE
Wrap S3 client test request in retry

### DIFF
--- a/internal/artifact/downloader.go
+++ b/internal/artifact/downloader.go
@@ -85,7 +85,7 @@ func (a *Downloader) Download(ctx context.Context) error {
 
 	p := pool.New(pool.MaxConcurrencyLimit)
 	errors := []error{}
-	s3Clients, err := a.generateS3Clients(artifacts)
+	s3Clients, err := a.generateS3Clients(ctx, artifacts)
 	if err != nil {
 		return fmt.Errorf("failed to generate S3 clients for artifact upload: %w", err)
 	}
@@ -126,7 +126,7 @@ func (a *Downloader) Download(ctx context.Context) error {
 // We want to have as few S3 clients as possible, as creating them is kind of an expensive operation
 // But it's also theoretically possible that we'll have multiple artifacts with different S3 buckets, and each
 // S3Client only applies to one bucket, so we need to store the S3 clients in a map, one for each bucket
-func (a *Downloader) generateS3Clients(artifacts []*api.Artifact) (map[string]*s3.S3, error) {
+func (a *Downloader) generateS3Clients(ctx context.Context, artifacts []*api.Artifact) (map[string]*s3.S3, error) {
 	s3Clients := map[string]*s3.S3{}
 
 	for _, artifact := range artifacts {
@@ -136,7 +136,7 @@ func (a *Downloader) generateS3Clients(artifacts []*api.Artifact) (map[string]*s
 
 		bucketName, _ := ParseS3Destination(artifact.UploadDestination)
 		if _, has := s3Clients[bucketName]; !has {
-			client, err := NewS3Client(a.logger, bucketName)
+			client, err := NewS3Client(ctx, a.logger, bucketName)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create S3 client for bucket %s: %w", bucketName, err)
 			}

--- a/internal/artifact/s3_uploader.go
+++ b/internal/artifact/s3_uploader.go
@@ -37,11 +37,11 @@ type S3Uploader struct {
 	logger logger.Logger
 }
 
-func NewS3Uploader(l logger.Logger, c S3UploaderConfig) (*S3Uploader, error) {
+func NewS3Uploader(ctx context.Context, l logger.Logger, c S3UploaderConfig) (*S3Uploader, error) {
 	bucketName, bucketPath := ParseS3Destination(c.Destination)
 
 	// Initialize the s3 client, and authenticate it
-	s3Client, err := NewS3Client(l, bucketName)
+	s3Client, err := NewS3Client(ctx, l, bucketName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -409,7 +409,7 @@ func (a *Uploader) createUploader(ctx context.Context) (_ workCreator, err error
 
 	case strings.HasPrefix(a.conf.Destination, "s3://"):
 		dest = "Amazon S3"
-		return NewS3Uploader(a.logger, S3UploaderConfig{
+		return NewS3Uploader(ctx, a.logger, S3UploaderConfig{
 			Destination: a.conf.Destination,
 		})
 


### PR DESCRIPTION
### Description
Test the hypothesis that the S3 client test request can fail with `ErrNoValidProvidersFoundInChain` because of transient network issues, by wrapping in a retry.

Also: update a deprecated call.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
