### PR TITLE
Add `force-grace-period-seconds` argument to `step cancel` command

### DIFF
--- a/api/steps.go
+++ b/api/steps.go
@@ -56,8 +56,9 @@ func (c *Client) StepUpdate(ctx context.Context, stepIdOrKey string, stepUpdate 
 }
 
 type StepCancel struct {
-	Build string `json:"build_id"`
-	Force bool   `json:"force,omitempty"`
+	Build                   string `json:"build_id"`
+	Force                   bool   `json:"force"`
+	ForceGracePeriodSeconds int64  `json:"force_grace_period"`
 }
 
 type StepCancelResponse struct {

--- a/clicommand/step_cancel_test.go
+++ b/clicommand/step_cancel_test.go
@@ -21,11 +21,12 @@ func TestStepCancel(t *testing.T) {
 		}))
 
 		cfg := StepCancelConfig{
-			Force:            true,
-			Build:            "1",
-			StepOrKey:        "some-random-key",
-			AgentAccessToken: "agentaccesstoken",
-			Endpoint:         server.URL,
+			ForceGracePeriodSeconds: 10,
+			Force:                   true,
+			Build:                   "1",
+			StepOrKey:               "some-random-key",
+			AgentAccessToken:        "agentaccesstoken",
+			Endpoint:                server.URL,
 		}
 
 		l := logger.NewBuffer()
@@ -40,10 +41,11 @@ func TestStepCancel(t *testing.T) {
 		}))
 
 		cfg := StepCancelConfig{
-			Force:            true,
-			StepOrKey:        "some-random-key",
-			AgentAccessToken: "agentaccesstoken",
-			Endpoint:         server.URL,
+			ForceGracePeriodSeconds: 10,
+			Force:                   true,
+			StepOrKey:               "some-random-key",
+			AgentAccessToken:        "agentaccesstoken",
+			Endpoint:                server.URL,
 		}
 
 		l := logger.NewBuffer()


### PR DESCRIPTION
### Description

We recently introduced a [`buildkite-agent step cancel` subcommand](https://github.com/buildkite/agent/pull/3070). The command can accept a flag `--force`, which will immediately cancel unfinished jobs **_in Buildkite_** (i.e. mark jobs as 'canceled') without waiting for the agents running the jobs to finish. Any subsequent artifact uploads to Buildkite by these agent running this job will begin to fail.

Now this `--force` flag might feel a little counter-intuitive when you think about how agents have a `cancel-grace-period` argument - you could _not_ use the `--force` flag, marking the jobs as 'canceling' and then rely on agents to SIGKILL their process once their `cancel-grace-period` has elapsed.

Imagine though that an agent isn't responding to Buildkite's request to cancel the job (and so we can't rely on `cancel-grace-period` within an agent). In this PR, we add an additional argument `--force-grace-period` to the subcommand to handle this. The value of `force-grace-period` will determine how long within Buildkite it will take for the job to move from a 'canceling' to a 'canceled' state (more information about job states can be read [here](https://buildkite.com/docs/apis/graphql/schemas/enum/jobstates)). Because jobs are then in a 'canceled' state, lost agents can be reaped much faster within Buildkite.

It's worth noting:
* Passing `--force-grace-period-seconds` without also supplying `--force` will not do anything. We rely on the `--force` flag to forecfully mark a job as 'canceled' within Buildkite.
* The value of `--force-grace-period-seconds` must be greater than or equal to zero. Negative values just don't make sense.
* The value of `--force-grace-period-seconds` is essentially overriding the value of `cancel-grace-period` for agents that are still connected to Buildkite. The default value of `--force-grace-period-seconds` if not supplied is the value of the current agent running the `buildkite-agent step cancel` command: if the agent running the `buildkite-agent step cancel` command has a `cancel-grace-period` value less than the agents having their jobs 'canceled', these agents will cleanup sooner than you might anticipate.

### Context

* Follow up to #3070

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)