### PR TITLE
Rename env var to `BUILDKITE_STEP_CANCEL_FORCE_GRACE_PERIOD_SECONDS`

### DIFF
--- a/clicommand/step_cancel.go
+++ b/clicommand/step_cancel.go
@@ -74,7 +74,7 @@ var StepCancelCommand = cli.Command{
 			Name:   "force-grace-period-seconds",
 			Value:  defaultCancelGracePeriod,
 			Usage:  "The number of seconds to wait for agents to finish uploading artifacts before transitioning unfinished jobs to a canceled state. ′--force′ must also be supplied for this to take affect",
-			EnvVar: "BUILDKITE_FORCE_GRACE_PERIOD_SECONDS,BUILDKITE_CANCEL_GRACE_PERIOD",
+			EnvVar: "BUILDKITE_STEP_CANCEL_FORCE_GRACE_PERIOD_SECONDS,BUILDKITE_CANCEL_GRACE_PERIOD",
 		},
 
 		// API Flags


### PR DESCRIPTION
### Description

Meant to include  https://github.com/buildkite/agent/commit/a3b8339605d826de15f8ca5ce85e148c6c313b19 in https://github.com/buildkite/agent/pull/3084 but messed up the rebase. `BUILDKITE_STEP_CANCEL_FORCE_GRACE_PERIOD_SECONDS ` feels like a better name for this env variable.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
