### PR TITLE
Add retry around NewS3Client

### DIFF
--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -409,7 +409,7 @@ func (a *Uploader) createUploader(ctx context.Context) (_ workCreator, err error
 
 	case strings.HasPrefix(a.conf.Destination, "s3://"):
 		dest = "Amazon S3"
-		return NewS3Uploader(a.logger, S3UploaderConfig{
+		return NewS3Uploader(ctx, a.logger, S3UploaderConfig{
 			Destination: a.conf.Destination,
 		})
 


### PR DESCRIPTION
### Description

We received a report that during network flakiness, artifact uploads were failing. This PR adds retries around NewS3Client to mitigate this.

### Context

[PIPE-389]

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
