### PR TITLE
Soft fail upload of packages docker images

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -155,3 +155,6 @@ steps:
               - docker.io
               - ghcr.io
               - packages.buildkite.com
+          adjustments:
+            - with: { registry: "packages.buildkite.com" }
+              soft_fail: true

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -179,6 +179,9 @@ steps:
               - docker.io
               - ghcr.io
               - packages.buildkite.com
+          adjustments:
+            - with: { registry: "packages.buildkite.com" }
+              soft_fail: true
 
   - wait
 

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -179,6 +179,9 @@ steps:
               - docker.io
               - ghcr.io
               - packages.buildkite.com
+          adjustments:
+            - with: { registry: "packages.buildkite.com" }
+              soft_fail: true
 
   - wait
 


### PR DESCRIPTION
### Description

Packages upload of docker images isn't on the critical path until we build custom domains, if any errors occur we shouldn't block agent deploys. When agents are served by buildkite packages soft_fail should be removed. Other steps are already soft fail but this needs an update on the docker to packages specific variation on the matrix.

When this build failed https://buildkite.com/buildkite/agent-release-stable/builds/149#01930ac6-f742-4aca-a10e-74aeb7456373 - it was on the upload to docker step for packages and actively blocked a critical release for Shopify.

![CleanShot 2024-11-15 at 15 27 25@2x](https://github.com/user-attachments/assets/730e5ba3-e45c-49e9-9ce5-2847054ae5f4)


### Context

https://linear.app/buildkite/issue/PKG-7830/change-agent-pipeline-to-soft-fail-on-packages-uploads

### Changes

Changes docker deploy step to make packages.buildkite.com step to be `soft_fail`

Pretty sure this is the right way to do it, but I've not done anything with matrix step before: 

https://buildkite.com/docs/pipelines/build-matrix#adding-combinations-to-the-build-matrix

