### PR TITLE
Don't surface expected stderr output from git rev-parse

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -270,7 +270,7 @@ func hasGitSubmodules(sh *shell.Shell) bool {
 
 func hasGitCommit(ctx context.Context, sh *shell.Shell, gitDir string, commit string) bool {
 	// Resolve commit to an actual commit object
-	output, err := sh.Command("git", "--git-dir", gitDir, "rev-parse", commit+"^{commit}").RunAndCaptureStdout(ctx)
+	output, err := sh.Command("git", "--git-dir", gitDir, "rev-parse", commit+"^{commit}").RunAndCaptureStdout(ctx, shell.ShowStderr(false))
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
### Description

When using git-mirrors, a rev-parse call is made to look for the commit within the current mirror, which will fatal if not found. As this is expected behaviour, capturing and displaying this error is misleading and not helpful. We can instead ignore it, as the mirror will be updated in this circumstance.

### Context

https://coda.io/d/Escalations-Feedback_dHnUHNps1YO/Pipelines-In-Progress-Board_suIFKYEb#Escalations-Pipelines_tuQbCBf6/r850&view=modal

### Changes

When doing the rev-parse check for the commit, include a `ShowStderr(false)` to the shell call.

### Testing

- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
