### PR TITLE
Use Ubuntu codename labels for base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
       - /packaging/docker/ubuntu-24.04
     schedule:
       interval: weekly
+    groups:
+      container-images:
+        patterns:
+          - "*"
+
   - package-ecosystem: gomod
     directory: /
     schedule:

--- a/packaging/docker/ubuntu-20.04/Dockerfile
+++ b/packaging/docker/ubuntu-20.04/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM public.ecr.aws/buildkite/agent-base:ubuntu-20.04@sha256:6bcb19149500f017fa4fa75fc2a3c082d3f35df94784594737beaf62568e2613
+FROM public.ecr.aws/buildkite/agent-base:ubuntu-focal@sha256:c6b96cbb8500f371a30e1cbb830239eaff4ab3a692c10a90c36ce27815eec08c
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/packaging/docker/ubuntu-22.04/Dockerfile
+++ b/packaging/docker/ubuntu-22.04/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM public.ecr.aws/buildkite/agent-base:ubuntu-22.04@sha256:ca90fbc56ff1813f486bc3d3787c4d2802f31eede330baf1dde3d6923ee89ea6
+FROM public.ecr.aws/buildkite/agent-base:ubuntu-jammy@sha256:5971531b64dcb926395b5c8b7a20b02b7d15dd4724ccae9ad330633c7438ba9b
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/packaging/docker/ubuntu-24.04/Dockerfile
+++ b/packaging/docker/ubuntu-24.04/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM public.ecr.aws/buildkite/agent-base:ubuntu-24.04@sha256:56b7751485d03ed3dce567e37cfc879db94b25ec827ee016615e36bc3e266516
+FROM public.ecr.aws/buildkite/agent-base:ubuntu-noble@sha256:89f0eda84bf61f0cff8dcf54d224fbd6c4d6355db0caf04accc1c3e325735e7f
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
### Description

Stop Dependabot attempting upgrades of Ubuntu images to the latest LTS. 

### Context

See #3099, #3100

### Changes

* Use new image tags added in buildkite/agent-base-images#1
* Use a group in Dependabot to make it do one PR for all images

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
