### PR TITLE
Fix duplicated output when debug is enabled

### DIFF
--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -566,14 +566,18 @@ func (s *Shell) executeCommand(ctx context.Context, cmdCfg process.Config, stdou
 	}
 
 	if s.debug {
-		// Tee output streams to debug logger.
-		stdOutStreamer := NewLoggerStreamer(s.Logger)
-		defer stdOutStreamer.Close()
-		cmdCfg.Stdout = io.MultiWriter(cmdCfg.Stdout, stdOutStreamer)
+		// Display normally-hidden output streams using log streamer.
+		if cmdCfg.Stdout == io.Discard {
+			stdOutStreamer := NewLoggerStreamer(s.Logger)
+			defer stdOutStreamer.Close()
+			cmdCfg.Stdout = stdOutStreamer
+		}
 
-		stdErrStreamer := NewLoggerStreamer(s.Logger)
-		defer stdErrStreamer.Close()
-		cmdCfg.Stderr = io.MultiWriter(cmdCfg.Stderr, stdErrStreamer)
+		if cmdCfg.Stderr == io.Discard {
+			stdErrStreamer := NewLoggerStreamer(s.Logger)
+			defer stdErrStreamer.Close()
+			cmdCfg.Stderr = stdErrStreamer
+		}
 	}
 
 	if s.commandLog != nil {


### PR DESCRIPTION
### Description

Fix duplicate command output when debug mode is enabled.

Fixes #3107

### Context

https://linear.app/buildkite/issue/PS-200/duplicate-logs-in-agent-with-debug-mode-enabled

The bug was added in #3068 - at the time, I didn't think through all the consequences of changing to "tee-ing" command output.

### Changes

* Instead of tee-ing output to the log streamer when debug is enabled, substitute stdout or stderr (or both) if set to `io.Discard`.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
