### PR TITLE
Ignore empty submodule clone configs

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -641,6 +641,12 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 
 		args := []string{}
 		for _, config := range e.GitSubmoduleCloneConfig {
+			// -c foo=bar is valid, -c foo= is valid, -c foo is valid, but...
+			// -c (nothing) is invalid.
+			// This could happen because the env var was set to an empty value.
+			if config == "" {
+				continue
+			}
 			args = append(args, "-c", config)
 		}
 


### PR DESCRIPTION
### Description

A small bit of hardening - if `BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG` is set but empty, then `GitSubmoduleCloneConfig` can be a slice with one element `""`, causing an invalid Git flag to be appended.

### Context

https://coda.io/d/_dHnUHNps1YO#Escalations-by-Assignee_tugT4T3x/r883&view=center

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
