### PR TITLE
Notify when host and bootstrap agent paths mismatch

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1278,17 +1278,28 @@ func checkBinaryPaths() error {
 		return fmt.Errorf("failed to locate bootstrap buildkite-agent: %w", err)
 	}
 
+	evalBootstrapPath, err := filepath.EvalSymlinks(bootstrapPath)
+	if err != nil {
+		return fmt.Errorf("failed to locate bootstrap buildkite-agent: %w", err)
+	}
+
 	hostPath, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("failed to determine host buildkite-agent executable: %w", err)
 	}
 
-	if hostPath != bootstrapPath {
+	evalHostPath, err := filepath.EvalSymlinks(hostPath)
+	if err != nil {
+		return fmt.Errorf("failed to determine host buildkite-agent executable: %w", err)
+	}
+
+	if evalHostPath != evalBootstrapPath {
 		return fmt.Errorf(
 			"mismatched buildkite-agent paths: host=%q bootstrap=%q",
-			hostPath, bootstrapPath,
+			evalHostPath, evalBootstrapPath,
 		)
 	}
+
 	return nil
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -38,6 +38,10 @@ func BuildNumber() string {
 	return buildNumber
 }
 
+func IsDevelopmentBuild() bool {
+	return buildNumber == "x"
+}
+
 // commitInfo returns a string consisting of the commit hash and whether the the build was made in a
 // `dirty` working directory or not. A dirty working directory is one that has uncommitted changes
 // to files that git would track.


### PR DESCRIPTION
### Description
During agent startup check if the bootstrap agent path matches the startup agent path. This is to avoid confusion during development when changes are made to the agent but the bootstrap agent still uses the default agent on the `$PATH`. Usually this results in changes being made to the agent, but then those changes not being observed when running the updated agent locally.

For example if I 

1. `go build -o buildkite-agent .` then
2. `./buildkite-agent start --spawn 2 --endpoint http://agent.buildkite.localhost/v3 --token buildkite`

By default the above will result in `./buildkite-agent` starting up and waiting for jobs, when a job is run, if that job uploads a pipeline it will use (in my case) `/opt/homebrew/bin/buildkite-agent`, not `./buildkite-agent`, so any changes I've made to `./buildkite-agent` will not be observed for the agent pipeline upload command.

This PR updates the agent to return a error `fatal: check binary paths: mismatched buildkite-agent paths: host="/Users/jordan/src/agent/buildkite-agent" bootstrap="/opt/homebrew/bin/buildkite-agent"` on boot. If the host agent is a development build then the error is fatal, otherwise it is just a warning.

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)