### PR TITLE
Adding support for Additional Hooks Paths

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -12,6 +12,7 @@ type AgentConfiguration struct {
 	BootstrapScript             string
 	BuildPath                   string
 	HooksPath                   string
+	AdditionalHooksPaths        []string
 	SocketsPath                 string
 	GitMirrorsPath              string
 	GitMirrorsLockTimeout       int

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -512,6 +512,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	env["BUILDKITE_GIT_MIRRORS_PATH"] = r.conf.AgentConfiguration.GitMirrorsPath
 	env["BUILDKITE_GIT_MIRRORS_SKIP_UPDATE"] = fmt.Sprint(r.conf.AgentConfiguration.GitMirrorsSkipUpdate)
 	env["BUILDKITE_HOOKS_PATH"] = r.conf.AgentConfiguration.HooksPath
+	env["BUILDKITE_ADDITIONAL_HOOKS_PATHS"] = strings.Join(r.conf.AgentConfiguration.AdditionalHooksPaths, ",")
 	env["BUILDKITE_PLUGINS_PATH"] = r.conf.AgentConfiguration.PluginsPath
 	env["BUILDKITE_SSH_KEYSCAN"] = fmt.Sprint(r.conf.AgentConfiguration.SSHKeyscan)
 	env["BUILDKITE_GIT_SUBMODULES"] = fmt.Sprint(r.conf.AgentConfiguration.GitSubmodules)

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -75,6 +75,7 @@ type BootstrapConfig struct {
 	BinPath                      string   `cli:"bin-path" normalize:"filepath"`
 	BuildPath                    string   `cli:"build-path" normalize:"filepath"`
 	HooksPath                    string   `cli:"hooks-path" normalize:"filepath"`
+	AdditionalHooksPaths         []string `cli:"additional-hooks-paths" normalize:"list"`
 	SocketsPath                  string   `cli:"sockets-path" normalize:"filepath"`
 	PluginsPath                  string   `cli:"plugins-path" normalize:"filepath"`
 	CommandEval                  bool     `cli:"command-eval"`
@@ -280,6 +281,12 @@ var BootstrapCommand = cli.Command{
 			Usage:  "Directory where the hook scripts are found",
 			EnvVar: "BUILDKITE_HOOKS_PATH",
 		},
+		cli.StringSliceFlag{
+			Name:   "additional-hooks-paths",
+			Value:  &cli.StringSlice{},
+			Usage:  "Any additional directories to look for agent hooks",
+			EnvVar: "BUILDKITE_ADDITIONAL_HOOKS_PATHS",
+		},
 		cli.StringFlag{
 			Name:   "sockets-path",
 			Value:  defaultSocketsPath(),
@@ -449,6 +456,7 @@ var BootstrapCommand = cli.Command{
 			GitSubmodules:                cfg.GitSubmodules,
 			GitSubmoduleCloneConfig:      cfg.GitSubmoduleCloneConfig,
 			HooksPath:                    cfg.HooksPath,
+			AdditionalHooksPaths:         cfg.AdditionalHooksPaths,
 			JobID:                        cfg.JobID,
 			LocalHooksEnabled:            cfg.LocalHooksEnabled,
 			OrganizationSlug:             cfg.OrganizationSlug,

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -132,6 +132,9 @@ type ExecutorConfig struct {
 	// Path to the global hooks
 	HooksPath string
 
+	// Additional hooks directories that can be provided
+	AdditionalHooksPaths []string
+
 	// Path to the plugins directory
 	PluginsPath string
 

--- a/packaging/docker/alpine-k8s/buildkite-agent.cfg
+++ b/packaging/docker/alpine-k8s/buildkite-agent.cfg
@@ -36,6 +36,9 @@ build-path="/buildkite/builds"
 # Directory where the hook scripts are found
 hooks-path="/buildkite/hooks"
 
+# Any additional directories where hook scripts are found
+# additional-hooks-path="/hook/path/a,/hook/path/b"
+
 # Directory where plugins will be installed
 plugins-path="/buildkite/plugins"
 

--- a/packaging/docker/alpine/buildkite-agent.cfg
+++ b/packaging/docker/alpine/buildkite-agent.cfg
@@ -36,6 +36,9 @@ build-path="/buildkite/builds"
 # Directory where the hook scripts are found
 hooks-path="/buildkite/hooks"
 
+# Any additional directories where hook scripts are found
+# additional-hooks-path="/hook/path/a,/hook/path/b"
+
 # Directory where plugins will be installed
 plugins-path="/buildkite/plugins"
 

--- a/packaging/docker/sidecar/buildkite-agent.cfg
+++ b/packaging/docker/sidecar/buildkite-agent.cfg
@@ -36,6 +36,9 @@ build-path="/buildkite/builds"
 # Directory where the hook scripts are found
 hooks-path="/buildkite/hooks"
 
+# Any additional directories where hook scripts are found
+# additional-hooks-path="/hook/path/a,/hook/path/b"
+
 # Directory where plugins will be installed
 plugins-path="/buildkite/plugins"
 

--- a/packaging/docker/ubuntu-20.04/buildkite-agent.cfg
+++ b/packaging/docker/ubuntu-20.04/buildkite-agent.cfg
@@ -36,6 +36,9 @@ build-path="/buildkite/builds"
 # Directory where the hook scripts are found
 hooks-path="/buildkite/hooks"
 
+# Any additional directories where hook scripts are found
+# additional-hooks-path="/hook/path/a,/hook/path/b"
+
 # Directory where plugins will be installed
 plugins-path="/buildkite/plugins"
 

--- a/packaging/docker/ubuntu-22.04/buildkite-agent.cfg
+++ b/packaging/docker/ubuntu-22.04/buildkite-agent.cfg
@@ -36,6 +36,9 @@ build-path="/buildkite/builds"
 # Directory where the hook scripts are found
 hooks-path="/buildkite/hooks"
 
+# Any additional directories where hook scripts are found
+# additional-hooks-path="/hook/path/a,/hook/path/b"
+
 # Directory where plugins will be installed
 plugins-path="/buildkite/plugins"
 

--- a/packaging/docker/ubuntu-24.04/buildkite-agent.cfg
+++ b/packaging/docker/ubuntu-24.04/buildkite-agent.cfg
@@ -36,6 +36,9 @@ build-path="/buildkite/builds"
 # Directory where the hook scripts are found
 hooks-path="/buildkite/hooks"
 
+# Any additional directories where hook scripts are found
+# additional-hooks-path="/hook/path/a,/hook/path/b"
+
 # Directory where plugins will be installed
 plugins-path="/buildkite/plugins"
 

--- a/packaging/github/linux/buildkite-agent.cfg
+++ b/packaging/github/linux/buildkite-agent.cfg
@@ -36,6 +36,9 @@ build-path="$HOME/.buildkite-agent/builds"
 # Directory where the hook scripts are found
 hooks-path="$HOME/.buildkite-agent/hooks"
 
+# Any additional directories where hook scripts are found
+# additional-hooks-path="/hook/path/a,/hook/path/b"
+
 # Directory where plugins will be installed
 plugins-path="$HOME/.buildkite-agent/plugins"
 

--- a/packaging/github/windows/buildkite-agent.cfg
+++ b/packaging/github/windows/buildkite-agent.cfg
@@ -24,6 +24,9 @@ build-path="C:\buildkite-agent\builds"
 # Directory where the hook scripts are found
 hooks-path="C:\buildkite-agent\hooks"
 
+# Any additional directories where hook scripts are found
+# additional-hooks-paths="C:\hooks\a,C:\hooks\b"
+
 # Directory where plugins will be installed
 plugins-path="C:\buildkite-agent\plugins"
 

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -36,6 +36,9 @@ build-path="/var/lib/buildkite-agent/builds"
 # Directory where the hook scripts are found
 hooks-path="/etc/buildkite-agent/hooks"
 
+# Any additional directories where hook scripts are found
+# additional-hooks-path="/hook/path/a,/hook/path/b"
+
 # When plugins are installed they will be saved to this path
 plugins-path="/etc/buildkite-agent/plugins"
 


### PR DESCRIPTION
### Description

We would like to provide the ability to place hooks in multiple locations, meaning there can be multiple hooks of the same type, and they can be provided under different circumstances. These additional hooks are comma separated list, and ordered as they are provided in terms of how multiple hooks are executed. Those in `hooks-path` are always first, and then sequentially through `additional-hooks-paths`.

There are 2 places where we pull in these hooks:
1. During the agent startup phase
2. Through the job execution phases

We don't currently support the `pre-bootstrap` hook with additional paths.

#### Note

There is no change to any default behaviour included, nor is there any change in existing functionality when configuration is not changed. The only way to have any impact from this change is to set the new option with some value (which should be a comma separated list of paths).

A test is included here to validate the ordering of the hooks is predictable and preserved, however there is a weird timing issue during the test that prevents the additional hooks from being executed successfully. All manual usage of the changes has yielded expected results, so the test is left with `t.SkipNow()` to highlight that it _should_ be possible to test this, and perhaps there's something I've overlooked here.

#### Screenshots

**Before any additional hook paths are defined:**
<img width="1089" alt="Screenshot 2024-12-30 at 12 32 11" src="https://github.com/user-attachments/assets/1c379679-8632-4d6c-acf5-c7bea068325b" />

**Example trace showing additional hooks being run for a job:**
![image](https://github.com/user-attachments/assets/f676cd00-3dc5-40d8-8b67-36ea1423ac2d)

**Build output of the above within Buildkite**
![image](https://github.com/user-attachments/assets/ce767518-34bd-42f6-bcbd-a973c41e3013)

### Changes

- Adding `BUILDKITE_ADDITIONAL_HOOKS_PATHS` configuration option
- Find and run any hooks found _after_ `hooks-path`
  - For the `agent-startup` hook
  - For hooks within job execution

### Testing

- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
- [x] Additional tests covering new functionality (although `t.SkipNow()` is used)