### PR TITLE
Prefix fatal error message with 'buildkite-agent:'

### DIFF
--- a/clicommand/errors.go
+++ b/clicommand/errors.go
@@ -68,7 +68,7 @@ func (e *SilentExitError) Is(target error) bool {
 }
 
 // PrintMessageAndReturnExitCode prints the error message to stderr, preceded by
-// "fatal: " and returns the exit code for the given error. If `err` is a
+// "buildkite-agent: fatal: " and returns the exit code for the given error. If `err` is a
 // SilentExitError or ExitError, it will return the code from that. Otherwise
 // it will return 0 for nil errors and 1 for all other errors. Also, when `err`
 // is a SilentExitError, it will not print anything to stderr.
@@ -81,7 +81,7 @@ func PrintMessageAndReturnExitCode(err error) int {
 		return serr.Code()
 	}
 
-	fmt.Fprintf(os.Stderr, "fatal: %s\n", err)
+	fmt.Fprintf(os.Stderr, "buildkite-agent: fatal: %s\n", err)
 
 	if eerr := new(ExitError); errors.As(err, &eerr) {
 		return eerr.Code()


### PR DESCRIPTION
### Description
When the agent exits and prints an error message prefix the message with `buildkite-agent: ` to provide clarity as to where the error came from. Our buildkite-agent cli is often used in scripts and when it exits with an error it isn't always obvious to the user what printed the error. It is common practice for cli tools to prefix error messages with the tool name.

### Context
https://linear.app/buildkite/issue/PS-217/prefix-fatal-error-messages-with-buildkite-agent

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)