### PR TITLE
Fix nil pointer deref on executor.go:103

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -100,7 +100,7 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 
 		socket := &kubernetes.Client{ID: e.KubernetesContainerID}
 		if err := e.kubernetesSetup(ctx, environ, socket); err != nil {
-			e.shell.Errorf("Failed to start kubernetes socket client: %v", err)
+			tempLog.Errorf("Failed to start kubernetes socket client: %v", err)
 			return 1
 		}
 


### PR DESCRIPTION
### Description

`e.shell` isn't set yet.

### Context

#3149 

### Changes

Use `tempLog` instead of `e.shell` to log the error.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

