### PR TITLE
Skip pushing the git commit metadata if BUILDKITE_COMMIT_RESOLVED=true

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -791,7 +791,7 @@ func (e *Executor) sendCommitToBuildkite(ctx context.Context) error {
 	commitResolved, _ := e.shell.Env.Get("BUILDKITE_COMMIT_RESOLVED")
 	if commitResolved == "true" {
 		// we can skip the metadata shenanigans here and push straight through
-		e.shell.Commentf("BUILDKITE_COMMIT is already resolved and meta-data populated, skipping...")
+		e.shell.Commentf("BUILDKITE_COMMIT is already resolved and meta-data populated, skipping")
 		return nil
 	}
 

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -780,12 +781,21 @@ func gitFetchCommitWithFallback(ctx context.Context, shell *shell.Shell, gitFetc
 
 const CommitMetadataKey = "buildkite:git:commit"
 
+var potentiallyValidGitSHA = regexp.MustCompile(`^[a-f0-9]{40}$`)
+
 // sendCommitToBuildkite sends commit information (commit, author, subject, body) to Buildkite, as the BK backend doesn't
 // have access to user's VCSes. To do this, we set a special meta-data key in the build, but only if it isn't already present
 // Functionally, this means that the first job in a build (usually a pipeline upload or similar) will push the commit info
 // to buildkite, which uses this info to display commit info in the UI eg in the title for the build
 // note that we bail early if the key already exists, as we don't want to overwrite it
 func (e *Executor) sendCommitToBuildkite(ctx context.Context) error {
+	commitRef, _ := e.shell.Env.Get("BUILDKITE_COMMIT")
+	if commitRef != "HEAD" && potentiallyValidGitSHA.MatchString(commitRef) {
+		// we can skip the metadata shenanigans here and push straight through
+		e.shell.Commentf("Skipping the meta-data git commit steps and assuming %q is correct...", commitRef)
+		return nil
+	}
+
 	e.shell.Commentf("Checking to see if git commit information needs to be sent to Buildkite...")
 	cmd := e.shell.Command("buildkite-agent", "meta-data", "exists", CommitMetadataKey)
 	if err := cmd.Run(ctx); err == nil {

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -781,7 +781,7 @@ func gitFetchCommitWithFallback(ctx context.Context, shell *shell.Shell, gitFetc
 
 const CommitMetadataKey = "buildkite:git:commit"
 
-var potentiallyValidGitSHA = regexp.MustCompile(`^[a-f0-9]{40}$`)
+var potentiallyValidGitSHA = regexp.MustCompile(`^[a-f0-9]{40}|[a-f0-9]{64}$`)
 
 // sendCommitToBuildkite sends commit information (commit, author, subject, body) to Buildkite, as the BK backend doesn't
 // have access to user's VCSes. To do this, we set a special meta-data key in the build, but only if it isn't already present

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -781,7 +781,7 @@ func gitFetchCommitWithFallback(ctx context.Context, shell *shell.Shell, gitFetc
 
 const CommitMetadataKey = "buildkite:git:commit"
 
-var potentiallyValidGitSHA = regexp.MustCompile(`^[a-f0-9]{40}|[a-f0-9]{64}$`)
+var potentiallyValidGitHashRE = regexp.MustCompile(`^[a-f0-9]{40}|[a-f0-9]{64}$`)
 
 // sendCommitToBuildkite sends commit information (commit, author, subject, body) to Buildkite, as the BK backend doesn't
 // have access to user's VCSes. To do this, we set a special meta-data key in the build, but only if it isn't already present
@@ -790,7 +790,7 @@ var potentiallyValidGitSHA = regexp.MustCompile(`^[a-f0-9]{40}|[a-f0-9]{64}$`)
 // note that we bail early if the key already exists, as we don't want to overwrite it
 func (e *Executor) sendCommitToBuildkite(ctx context.Context) error {
 	commitRef, _ := e.shell.Env.Get("BUILDKITE_COMMIT")
-	if commitRef != "HEAD" && potentiallyValidGitSHA.MatchString(commitRef) {
+	if potentiallyValidGitHashRE.MatchString(commitRef) {
 		// we can skip the metadata shenanigans here and push straight through
 		e.shell.Commentf("Skipping the meta-data git commit steps and assuming %q is correct...", commitRef)
 		return nil

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -93,14 +93,8 @@ func TestWithResolvingCommitExperiment_WithGitMirrors(t *testing.T) {
 		{"fetch", "-v", "--", "origin", "main"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
-		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 		{"rev-parse", "HEAD"},
 	})
-
-	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
-	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -950,6 +950,89 @@ func TestRepositorylessCheckout(t *testing.T) {
 	tester.RunAndCheck(t)
 }
 
+func TestGitCheckoutWithCommitResolved(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewExecutorTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewBootstrapTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	env := []string{"BUILDKITE_COMMIT_RESOLVED=true"}
+
+	git := tester.MustMock(t, "git").PassthroughToLocalCommand()
+
+	git.ExpectAll([][]any{
+		{"clone", "-v", "--", tester.Repo.Path, "."},
+		{"clean", "-ffxdq"},
+		{"fetch", "--", "origin", "main"},
+		{"checkout", "-f", "FETCH_HEAD"},
+		{"clean", "-ffxdq"},
+	})
+
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).Exactly(0)
+
+	tester.RunAndCheck(t, env...)
+}
+
+func TestGitCheckoutWithoutCommitResolved(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewExecutorTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewBootstrapTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	env := []string{"BUILDKITE_COMMIT_RESOLVED=false"}
+
+	git := tester.MustMock(t, "git").PassthroughToLocalCommand()
+
+	git.ExpectAll([][]any{
+		{"clone", "-v", "--", tester.Repo.Path, "."},
+		{"clean", "-ffxdq"},
+		{"fetch", "--", "origin", "main"},
+		{"checkout", "-f", "FETCH_HEAD"},
+		{"clean", "-ffxdq"},
+	})
+
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(0).Exactly(1)
+
+	tester.RunAndCheck(t, env...)
+}
+
+func TestGitCheckoutWithoutCommitResolvedAndNoMetaData(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewExecutorTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewBootstrapTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	env := []string{"BUILDKITE_COMMIT_RESOLVED=false"}
+
+	git := tester.MustMock(t, "git").PassthroughToLocalCommand()
+
+	git.ExpectAll([][]any{
+		{"clone", "-v", "--", tester.Repo.Path, "."},
+		{"clean", "-ffxdq"},
+		{"fetch", "--", "origin", "main"},
+		{"checkout", "-f", "FETCH_HEAD"},
+		{"clean", "-ffxdq"},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
+	})
+
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1).Exactly(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
+
+	tester.RunAndCheck(t, env...)
+}
+
 type subDirMatcher struct {
 	dir string
 }

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -59,14 +59,8 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 		{"fetch", "-v", "--", "origin", "main"},
 		{"checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
-		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 		{"rev-parse", "HEAD"},
 	})
-
-	// Mock out the meta-data calls to the agent after checkout
-	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
-	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
 }


### PR DESCRIPTION
### Description

During the checkout phase the agent will validate the `BUILDKITE_COMMIT` environment variable has been set knowingly within the build already, or push the data within this job. The first job in a build is likely to be the only time this needs to actually happen, as once it is and `BUILDKITE_COMMIT` has been set it will be available to remaining jobs within the build. We use the meta-data API to track this, which means we're making many API calls back to `buildkite.com` when really, we shouldn't need to do this by checking the value ourselves.

**Disclaimer:** This is quite naive in how the value of `BUILDKITE_COMMIT` is trusted, where we assume that if the value is 40 characters long and the characters match the accepted values of a SHA then we use it.

The value for `BUILDKITE_COMMIT` should only be **HEAD** or a git SHA, so we shouldn't have to worry too much. If there's a branch that was set as the value instead, it should fail the validation and then be set anyway (as in, the previous flow is preserved). In that event anyway, or in any where the validation fails, subsequent jobs will go via the happy path as the existing flow sets `BUILDKITE_COMMIT` to the determined value. I don't think there will be a problem by having this change made to shortcut the process.

### Screenshots

I did some additional testing to see if I could get some better data to back-up the intended claims from what this PR will accomplish. The idea is that only the first job in a build would need to go down the path of checking and setting the build metadata, if the `BUILDKITE_COMMIT` value is not _acceptable_, and in doing so sets the value so all remaining jobs in the build will skip that work. This tangibly means that we should see a performance improvement with job runs, as there are less calls back to Buildkite.

<img width="1250" alt="Screenshot 2025-01-09 at 14 40 49" src="https://github.com/user-attachments/assets/9eae34e3-e042-42ad-a9db-f8f2ab9e586a" />

This shows the log output for the first job, where the metadata pathway is getting triggered as the job sees `BUILDKITE_COMMIT=head` being the first to run.

<img width="1253" alt="Screenshot 2025-01-09 at 14 41 02" src="https://github.com/user-attachments/assets/b060a59e-fa7c-416b-87e1-9831f773e83f" />

This shows the log output for the second job, where the `BUILDKITE_COMMIT` value matches the regex and is _assumed_ to be a valid commit. This is highlighted by the comment in the output.

<img width="1107" alt="Screenshot 2025-01-09 at 14 41 10" src="https://github.com/user-attachments/assets/e918fe48-8bd8-4b6a-b7f2-3b3ab89dee61" />

This is a screenshot of the trace for the first job, highlighting the duration of the `checkout` phase consuming most of the time (as the command is super basic), and having a length of just under `7` seconds.

<img width="1104" alt="Screenshot 2025-01-09 at 14 41 16" src="https://github.com/user-attachments/assets/6ba7584e-b61b-4fa4-8aa1-7dcc7c09c34b" />

This is a screenshot of the trace for the second job, where the spans included are the same as the first except the timing is drastically reduced without the overhead of the metadata API call(s).

These traces show a _rough_ reduction of `2.5x` for the checkout alone.

### Testing

- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
