### PR TITLE
Add /.buildkite dir for Dockerfile updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: docker
     directories:
+      - /.buildkite
       - /packaging/docker/alpine
       - /packaging/docker/alpine-k8s
       - /packaging/docker/sidecar


### PR DESCRIPTION
### Description

`.buildkite` has Dockerfiles, but the directory was forgotten when rearranging the dependabot config.

### Context

Noticed that `.buildkite/Dockerfile-build` wasn't up to date.

