### PR TITLE
Jitter within ping, status, log loops

### DIFF
--- a/agent/integration/test_helpers.go
+++ b/agent/integration/test_helpers.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
@@ -69,6 +70,7 @@ func runJob(t *testing.T, ctx context.Context, cfg testRunJobConfig) error {
 		JWKS:               cfg.verificationJWKS,
 		AgentConfiguration: cfg.agentCfg,
 		MetricsScope:       scope,
+		JobStatusInterval:  1 * time.Second,
 	})
 
 	if err != nil {


### PR DESCRIPTION
### Description

More techniques to avoid thundering herds - introduce jittering inside fixed interval loops.

### Context

This is a change I've wanted to make for a while, but never really got around to it.

The job status checker loop (used to stop a job cancelled server-side) uses a sleep on a fixed interval between requests, meaning it is susceptible to spontaneous synchronisation between agents. 

The log processing loop is similar to the job status loop, with fixed 1 second wait. It's not directly connected to a network request, but the pipeline is tight.

The ping loop uses a ticker, which has internal mechanisms for keeping a fixed pace. But this therefore preserves initial synchronisation between agents (e.g. multiple machines come up at once due to, say, a power outage, and they proceed to start the agent at the same time).

### Changes

* Make the job status loop use a ticker
* Make the log processing loop use a ticker
* Make all three loops wait a random duration before continuing
* Tweak the implementation of the goroutine that waits for stopping within AcquireAndRunJob.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
