### PR TITLE
Introduce http client profile option for custom configuration

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -42,6 +42,9 @@ type Config struct {
 	// If true, only HTTP2 is disabled
 	DisableHTTP2 bool
 
+	// http client profile to use for the client
+	HTTPClientProfile string
+
 	// If true, requests and responses will be dumped and set to the logger
 	DebugHTTP bool
 
@@ -91,6 +94,7 @@ func NewClient(l logger.Logger, conf Config) *Client {
 			agenthttp.WithAuthToken(conf.Token),
 			agenthttp.WithAllowHTTP2(!conf.DisableHTTP2),
 			agenthttp.WithTLSConfig(conf.TLSConfig),
+			agenthttp.WithHTTPClientProfile(conf.HTTPClientProfile),
 		),
 		conf: conf,
 	}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -183,11 +183,12 @@ type AgentStartConfig struct {
 	NoMultipartArtifactUpload bool     `cli:"no-multipart-artifact-upload"`
 
 	// API config
-	DebugHTTP bool   `cli:"debug-http"`
-	TraceHTTP bool   `cli:"trace-http"`
-	Token     string `cli:"token" validate:"required"`
-	Endpoint  string `cli:"endpoint" validate:"required"`
-	NoHTTP2   bool   `cli:"no-http2"`
+	DebugHTTP         bool   `cli:"debug-http"`
+	TraceHTTP         bool   `cli:"trace-http"`
+	Token             string `cli:"token" validate:"required"`
+	Endpoint          string `cli:"endpoint" validate:"required"`
+	NoHTTP2           bool   `cli:"no-http2"`
+	HTTPClientProfile string `cli:"http-client-profile"`
 
 	// Deprecated
 	NoSSHFingerprintVerification bool     `cli:"no-automatic-ssh-fingerprint-verification" deprecated-and-renamed-to:"NoSSHKeyscan"`
@@ -721,6 +722,7 @@ var AgentStartCommand = cli.Command{
 		NoHTTP2Flag,
 		DebugHTTPFlag,
 		TraceHTTPFlag,
+		HTTPClientProfileFlag,
 
 		// Global flags
 		NoColorFlag,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -26,6 +26,7 @@ import (
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/core"
 	"github.com/buildkite/agent/v3/internal/agentapi"
+	"github.com/buildkite/agent/v3/internal/agenthttp"
 	"github.com/buildkite/agent/v3/internal/awslib"
 	awssigner "github.com/buildkite/agent/v3/internal/cryptosigner/aws"
 	"github.com/buildkite/agent/v3/internal/experiments"
@@ -1121,6 +1122,10 @@ var AgentStartCommand = cli.Command{
 		}
 
 		l.Info("Using http client profile: %s", cfg.HTTPClientProfile)
+
+		if !slices.Contains(agenthttp.ValidHTTPClientProfiles, cfg.HTTPClientProfile) {
+			l.Fatal("HTTP client profile %s is not in list of valid profiles: %v", cfg.HTTPClientProfile, agenthttp.ValidHTTPClientProfiles)
+		}
 
 		if len(cfg.AllowedRepositories) > 0 {
 			agentConf.AllowedRepositories = make([]*regexp.Regexp, 0, len(cfg.AllowedRepositories))

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1120,6 +1120,8 @@ var AgentStartCommand = cli.Command{
 			l.Info("Agents will disconnect after %d seconds of inactivity", agentConf.DisconnectAfterIdleTimeout)
 		}
 
+		l.Info("Using http client profile: %s", cfg.HTTPClientProfile)
+
 		if len(cfg.AllowedRepositories) > 0 {
 			agentConf.AllowedRepositories = make([]*regexp.Regexp, 0, len(cfg.AllowedRepositories))
 			for _, v := range cfg.AllowedRepositories {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1123,8 +1123,12 @@ var AgentStartCommand = cli.Command{
 
 		l.Info("Using http client profile: %s", cfg.HTTPClientProfile)
 
-		if !slices.Contains(agenthttp.ValidHTTPClientProfiles, cfg.HTTPClientProfile) {
-			l.Fatal("HTTP client profile %s is not in list of valid profiles: %v", cfg.HTTPClientProfile, agenthttp.ValidHTTPClientProfiles)
+		if !slices.Contains(agenthttp.ValidClientProfiles, cfg.HTTPClientProfile) {
+			l.Fatal("HTTP client profile %s is not in list of valid profiles: %v", cfg.HTTPClientProfile, agenthttp.ValidClientProfiles)
+		}
+
+		if cfg.HTTPClientProfile == agenthttp.ClientProfileStdlib && cfg.NoHTTP2 {
+			l.Fatal("NoHTTP2 is not supported with the standard library (%s) HTTP client profile, use GODEBUG see https://pkg.go.dev/net/http#hdr-HTTP_2", agenthttp.ClientProfileStdlib)
 		}
 
 		if len(cfg.AllowedRepositories) > 0 {

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -45,8 +45,8 @@ var (
 
 	HTTPClientProfileFlag = cli.StringFlag{
 		Name:   "http-client-profile",
-		Usage:  "Enable a http client profile, either standard, gcp or stdlib",
-		Value:  "standard",
+		Usage:  "Enable a http client profile, either default or stdlib",
+		Value:  "default",
 		EnvVar: "BUILDKITE_AGENT_HTTP_CLIENT_PROFILE",
 	}
 

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -43,6 +43,13 @@ var (
 		EnvVar: "BUILDKITE_AGENT_ENDPOINT",
 	}
 
+	HTTPClientProfileFlag = cli.StringFlag{
+		Name:   "http-client-profile",
+		Usage:  "Enable a http client profile, either standard, gcp or stdlib",
+		Value:  "standard",
+		EnvVar: "BUILDKITE_AGENT_HTTP_CLIENT_PROFILE",
+	}
+
 	NoHTTP2Flag = cli.BoolFlag{
 		Name:   "no-http2",
 		Usage:  "Disable HTTP2 when communicating with the Agent API.",
@@ -307,6 +314,11 @@ func loadAPIClientConfig(cfg any, tokenField string) api.Config {
 	noHTTP2, err := reflections.GetField(cfg, "NoHTTP2")
 	if err == nil {
 		conf.DisableHTTP2 = noHTTP2.(bool)
+	}
+
+	httpClientProfile, err := reflections.GetField(cfg, "HTTPClientProfile")
+	if err == nil {
+		conf.HTTPClientProfile = httpClientProfile.(string)
 	}
 
 	return conf

--- a/internal/agenthttp/client.go
+++ b/internal/agenthttp/client.go
@@ -12,6 +12,7 @@ import (
 )
 
 var (
+	// ValidHTTPClientProfiles lists accepted values for Config.HTTPClientProfile.
 	ValidHTTPClientProfiles = []string{"stdlib", "default"}
 )
 

--- a/internal/agenthttp/client.go
+++ b/internal/agenthttp/client.go
@@ -11,6 +11,10 @@ import (
 	"golang.org/x/net/http2"
 )
 
+var (
+	ValidHTTPClientProfiles = []string{"stdlib", "default"}
+)
+
 // NewClient creates a HTTP client. Note that the default timeout is 60 seconds;
 // for some use cases (e.g. artifact operations) use [WithNoTimeout].
 func NewClient(opts ...ClientOption) *http.Client {
@@ -46,6 +50,8 @@ func NewClient(opts ...ClientOption) *http.Client {
 			},
 		}
 	}
+
+	// fall back to the default http client profile
 
 	cacheKey := transportCacheKey{
 		AllowHTTP2: conf.AllowHTTP2,

--- a/internal/agenthttp/client.go
+++ b/internal/agenthttp/client.go
@@ -12,8 +12,11 @@ import (
 )
 
 var (
+	ClientProfileDefault = "default"
+	ClientProfileStdlib  = "stdlib"
+
 	// ValidHTTPClientProfiles lists accepted values for Config.HTTPClientProfile.
-	ValidHTTPClientProfiles = []string{"stdlib", "default"}
+	ValidClientProfiles = []string{ClientProfileDefault, ClientProfileStdlib}
 )
 
 // NewClient creates a HTTP client. Note that the default timeout is 60 seconds;
@@ -34,7 +37,7 @@ func NewClient(opts ...ClientOption) *http.Client {
 	// http client profile is used to switch between different http client implementations
 	// - stdlib: uses the standard library http client
 	switch conf.HTTPClientProfile {
-	case "stdlib":
+	case ClientProfileStdlib:
 		// Base any modifications on the default transport.
 		transport := http.DefaultTransport.(*http.Transport).Clone()
 

--- a/internal/agenthttp/client.go
+++ b/internal/agenthttp/client.go
@@ -26,14 +26,23 @@ func NewClient(opts ...ClientOption) *http.Client {
 		opt(&conf)
 	}
 
+	// http client profile is used to switch between different http client implementations
+	// - stdlib: uses the standard library http client
 	switch conf.HTTPClientProfile {
 	case "stdlib":
+		// Base any modifications on the default transport.
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+
+		if conf.TLSConfig != nil {
+			transport.TLSClientConfig = conf.TLSConfig
+		}
+
 		return &http.Client{
 			Timeout: conf.Timeout,
 			Transport: &authenticatedTransport{
 				Bearer:   conf.Bearer,
 				Token:    conf.Token,
-				Delegate: http.DefaultTransport,
+				Delegate: transport,
 			},
 		}
 	}


### PR DESCRIPTION
### Description

We have customers using the agent in a number of different environments, across different cloud services all over the world, so different configuration profiles for the HTTP client would be valueble.

### Context

The Go HTTP client has a log of configurable timeouts, passing all these through is not sustainable so we need a way to bless a subset of configuration and provide this with a generic name, hence the idea of configuration profiles.

On top of this different version of Go introduce new features, and new timeouts, so we also need a way to introduce new profiles as the HTTP Client evolves.

### Changes

This change introduces a flag which allows us to add HTTP client configurations which allows us to provide new profiles for customers, while also providing an unconfigured standard library profile to take advantage of the current defaults.

To get the ball rolling I have created a stdlib profile which applies the absolulte minimum configuration, this includes tlsconfig overrides, and the timeout value. Disabling H2 is not provided as this is avaliable via the `GODEBUG` environment variable supported by the Go Team. https://pkg.go.dev/net/http#hdr-HTTP_2

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
