### PR TITLE
Timeout waiting for client containers

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -365,11 +365,12 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient APIClient, con
 			return nil, fmt.Errorf("failed to parse BUILDKITE_CONTAINER_COUNT: %w", err)
 		}
 		r.process = kubernetes.NewRunner(r.agentLogger, kubernetes.RunnerConfig{
-			Stdout:            r.jobLogs,
-			Stderr:            r.jobLogs,
-			ClientCount:       containerCount,
-			Env:               processEnv,
-			ClientLostTimeout: 30 * time.Second,
+			Stdout:             r.jobLogs,
+			Stderr:             r.jobLogs,
+			ClientCount:        containerCount,
+			Env:                processEnv,
+			ClientStartTimeout: 5 * time.Minute,
+			ClientLostTimeout:  30 * time.Second,
 		})
 	} else { // not Kubernetes
 		// The bootstrap-script gets parsed based on the operating system

--- a/bazel-agent
+++ b/bazel-agent
@@ -1,0 +1,1 @@
+/private/var/tmp/_bazel_josh/d44041637b0a500cde67752126364286/execroot/_main

--- a/bazel-bin
+++ b/bazel-bin
@@ -1,0 +1,1 @@
+/private/var/tmp/_bazel_josh/d44041637b0a500cde67752126364286/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin

--- a/bazel-out
+++ b/bazel-out
@@ -1,0 +1,1 @@
+/private/var/tmp/_bazel_josh/d44041637b0a500cde67752126364286/execroot/_main/bazel-out

--- a/bazel-testlogs
+++ b/bazel-testlogs
@@ -1,0 +1,1 @@
+/private/var/tmp/_bazel_josh/d44041637b0a500cde67752126364286/execroot/_main/bazel-out/darwin_arm64-fastbuild/testlogs

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -149,9 +149,10 @@ func newRunner(t *testing.T, clientCount int) *Runner {
 		os.RemoveAll(tempDir)
 	})
 	runner := NewRunner(logger.Discard, RunnerConfig{
-		SocketPath:        socketPath,
-		ClientCount:       clientCount,
-		ClientLostTimeout: 2 * time.Second,
+		SocketPath:         socketPath,
+		ClientCount:        clientCount,
+		ClientStartTimeout: 10 * time.Minute,
+		ClientLostTimeout:  2 * time.Second,
 	})
 	runnerCtx, cancelRunner := context.WithCancel(context.Background())
 	go runner.Run(runnerCtx)

--- a/kubernetes/runner.go
+++ b/kubernetes/runner.go
@@ -25,11 +25,12 @@ func init() {
 const defaultSocketPath = "/workspace/buildkite.sock"
 
 type RunnerConfig struct {
-	SocketPath        string
-	ClientCount       int
-	Stdout, Stderr    io.Writer
-	Env               []string
-	ClientLostTimeout time.Duration
+	SocketPath         string
+	ClientCount        int
+	Stdout, Stderr     io.Writer
+	Env                []string
+	ClientStartTimeout time.Duration
+	ClientLostTimeout  time.Duration
 }
 
 // NewRunner returns a runner, implementing the agent's jobRunner interface.
@@ -50,6 +51,9 @@ func NewRunner(l logger.Logger, c RunnerConfig) *Runner {
 		done:      make(chan struct{}),
 		started:   make(chan struct{}),
 		interrupt: make(chan struct{}),
+
+		// Buffered in case startupCheck is disabled
+		startCounter: make(chan struct{}, c.ClientCount),
 	}
 }
 
@@ -64,8 +68,11 @@ type Runner struct {
 	// Channels that are closed at certain points in the job lifecycle
 	started, done, interrupt chan struct{}
 
-	// Guards the closing of the channels to ensure they are only closed once
+	// Guards the closing of the above channels to ensure they are only closed once
 	startedOnce, doneOnce, interruptOnce sync.Once
+
+	// Used to count clients as they connect
+	startCounter chan struct{}
 
 	server  *rpc.Server
 	mux     *http.ServeMux
@@ -96,7 +103,37 @@ func (r *Runner) Run(ctx context.Context) error {
 		go r.livenessCheck(ctx)
 	}
 
+	if err := r.startupCheck(ctx); err != nil {
+		return err
+	}
+
 	<-r.done
+	return nil
+}
+
+// startupCheck blocks until all containers have connected, or times out.
+func (r *Runner) startupCheck(ctx context.Context) error {
+	if r.conf.ClientStartTimeout <= 0 { // check is disabled
+		return nil
+	}
+
+	// wait for a value on startCounter once per client
+	timeout := time.After(r.conf.ClientStartTimeout)
+	for range r.clients {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-timeout:
+			return fmt.Errorf("timed out waiting %v for all containers to connect", r.conf.ClientStartTimeout)
+
+		case <-r.done:
+			return nil
+
+		case <-r.startCounter:
+			// Another client has started!
+		}
+	}
 	return nil
 }
 
@@ -137,6 +174,7 @@ func (r *Runner) livenessCheck(ctx context.Context) {
 }
 
 // Started returns a channel that is closed when the job has started running.
+// (At least one client container has connected.)
 func (r *Runner) Started() <-chan struct{} { return r.started }
 
 func (r *Runner) markStarted() { r.startedOnce.Do(func() { close(r.started) }) }
@@ -150,7 +188,7 @@ func (r *Runner) Interrupt() error {
 	return nil
 }
 
-// Terminate stops the RPC server, allowing Run to return immediately.
+// Terminate allows Run to return immediately, halting the RPC server.
 func (r *Runner) Terminate() error {
 	r.doneOnce.Do(func() { close(r.done) })
 	return nil
@@ -258,6 +296,7 @@ func (r *Runner) Register(id int, reply *RegisterResponse) error {
 	}
 
 	r.markStarted()
+	r.startCounter <- struct{}{}
 
 	client := r.clients[id]
 	client.mu.Lock()


### PR DESCRIPTION
### Description

Ensure the agent process does not wait forever for the client containers to connect.

### Context

Addresses one cause of agent containers continuing to run, as reported in buildkite/agent-stack-k8s#479

### Changes

Adds a `startupCheck` that waits for all client containers to connect. If one or more fail to connect within a timeout, an error is returned.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

