### PR TITLE
Reduce timeout for these two operations to avoid holding up compute

### DIFF
--- a/core/client.go
+++ b/core/client.go
@@ -219,7 +219,7 @@ func (c *Client) FinishJob(ctx context.Context, job *api.Job, finishedAt time.Ti
 	return roko.NewRetrier(
 		// retry for ~a day with exponential backoff
 		roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
-		roko.WithMaxAttempts(20),
+		roko.WithMaxAttempts(12), // 12 attempts will take 26 minutes
 		roko.WithJitter(),
 		roko.WithSleepFunc(c.RetrySleepFunc),
 	).DoWithContext(ctx, func(retrier *roko.Retrier) error {
@@ -354,7 +354,7 @@ func (c *Client) UploadChunk(ctx context.Context, jobID string, chunk *api.Chunk
 	return roko.NewRetrier(
 		// retry for ~a day with exponential backoff
 		roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
-		roko.WithMaxAttempts(20),
+		roko.WithMaxAttempts(12), // 12 attempts will take 26 minutes
 		roko.WithJitter(),
 		roko.WithSleepFunc(c.RetrySleepFunc),
 	).DoWithContext(ctx, func(retrier *roko.Retrier) error {

--- a/core/client.go
+++ b/core/client.go
@@ -213,7 +213,7 @@ func (c *Client) FinishJob(ctx context.Context, job *api.Job, finishedAt time.Ti
 	c.Logger.Debug("[JobRunner] Finishing job with exit_status=%s, signal=%s and signal_reason=%s",
 		job.ExitStatus, job.Signal, job.SignalReason)
 
-	ctx, cancel := context.WithTimeout(ctx, 48*time.Hour)
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Hour)
 	defer cancel()
 
 	return roko.NewRetrier(
@@ -348,7 +348,7 @@ func (c *Client) UploadChunk(ctx context.Context, jobID string, chunk *api.Chunk
 	// This code will retry for a long time until we get back a successful
 	// response from Buildkite that it's considered the chunk (a 4xx will be
 	// returned if the chunk is invalid, and we shouldn't retry on that)
-	ctx, cancel := context.WithTimeout(ctx, 48*time.Hour)
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Hour)
 	defer cancel()
 
 	return roko.NewRetrier(


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

When there is a failure between a customer and buildkite we "could" hold onto compute for up to 48 hours.

I am starting with these two calls as they are important calls which can block agent shutting down.

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

If the buildkite API, or intermediate network devices, such as nat GW trigger drop outs and timeouts of requests over an extended period of time we can tie up compute resources, this isn't ideal as it can hold onto expensive resources.

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

Reducing these two values avoids surprising outcomes for customers when things go wrong.

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
