### PR TITLE
rm bazel-*, add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ packaging/docker/*/hooks/
 
 # Editor config boils down to personal preference
 .editorconfig
+
+# Bazel-generated symlinks to Bazel-generated output
+/bazel-agent
+/bazel-bin
+/bazel-out
+/bazel-testlogs

--- a/bazel-agent
+++ b/bazel-agent
@@ -1,1 +1,0 @@
-/private/var/tmp/_bazel_josh/d44041637b0a500cde67752126364286/execroot/_main

--- a/bazel-bin
+++ b/bazel-bin
@@ -1,1 +1,0 @@
-/private/var/tmp/_bazel_josh/d44041637b0a500cde67752126364286/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin

--- a/bazel-out
+++ b/bazel-out
@@ -1,1 +1,0 @@
-/private/var/tmp/_bazel_josh/d44041637b0a500cde67752126364286/execroot/_main/bazel-out

--- a/bazel-testlogs
+++ b/bazel-testlogs
@@ -1,1 +1,0 @@
-/private/var/tmp/_bazel_josh/d44041637b0a500cde67752126364286/execroot/_main/bazel-out/darwin_arm64-fastbuild/testlogs


### PR DESCRIPTION
### Description

Clean up Bazel cruft accidentally merged in #3172 


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
