### PR TITLE
Speed up needlessly slow tests

### DIFF
--- a/clicommand/step_cancel_test.go
+++ b/clicommand/step_cancel_test.go
@@ -37,7 +37,7 @@ func TestStepCancel(t *testing.T) {
 
 	t.Run("failed", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			rw.WriteHeader(http.StatusInternalServerError)
+			rw.WriteHeader(http.StatusBadRequest)
 		}))
 
 		cfg := StepCancelConfig{

--- a/tracetools/propagate_example_test.go
+++ b/tracetools/propagate_example_test.go
@@ -5,19 +5,15 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"
+	"github.com/opentracing/opentracing-go/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 func ExampleEncodeTraceContext() {
 	// Start and configure the tracer to use the propagator.
-	t := opentracer.New(
-		// These args are just to ensure nothing actually gets sent if the test
-		// platform actually has a DD agent running locally.
-		// This is an unlikely, local, non-default agent address.
-		tracer.WithAgentAddr("10.0.0.1:65534"),
-		tracer.WithLogger(&nullLogger{}),
-	)
+	// A more realistic example would connect to, say, a real DataDog agent
+	// instead of using mocktracer.
+	t := mocktracer.New()
 	opentracing.SetGlobalTracer(t)
 	defer tracer.Stop()
 


### PR DESCRIPTION
### Description

These two tests take 40 - 50 seconds each. They can be short-circuited a bit (without affecting their fidelity).

### Context

Noticed by @pda here: https://buildkite-corp.slack.com/archives/C061U5PG9K5/p1738728903252739

### Changes

* Instead of trying to send traces to a non-existent DD agent (and timing out), use `mocktracer`.
* Instead of trying to cancel a job against a fake server that always returns HTTP 500, return HTTP 400 which aborts the retry quickly.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
