### PR TITLE
Ensure the log streamer respects forced shutdown of the agent

### DIFF
--- a/agent/log_streamer_test.go
+++ b/agent/log_streamer_test.go
@@ -46,7 +46,7 @@ func TestLogStreamer(t *testing.T) {
 		t.Errorf("LogStreamer.Process(ctx, %q) = %v", input, err)
 	}
 
-	ls.Stop()
+	ls.Stop(true)
 
 	want := []*api.Chunk{
 		{
@@ -92,5 +92,49 @@ func TestLogStreamer(t *testing.T) {
 	input = "¿more log after stop?"
 	if err := ls.Process(ctx, []byte(input)); !errors.Is(err, errStreamerStopped) {
 		t.Errorf("after Stop: LogStreamer.Process(ctx, %q) err = %v, want %v", input, err, errStreamerStopped)
+	}
+}
+
+func TestLogStreamerExitImmediately(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	logger := logger.NewConsoleLogger(
+		logger.NewTextPrinter(os.Stderr),
+		func(c int) { t.Errorf("exit(%d)", c) },
+	)
+
+	var mu sync.Mutex
+	var got []*api.Chunk
+	callback := func(ctx context.Context, chunk *api.Chunk) error {
+		mu.Lock()
+		got = append(got, chunk)
+		mu.Unlock()
+		return nil
+	}
+
+	ls := NewLogStreamer(logger, callback, LogStreamerConfig{
+		Concurrency:       3,
+		MaxChunkSizeBytes: 10,
+		MaxSizeBytes:      30,
+	})
+
+	if err := ls.Start(ctx); err != nil {
+		t.Fatalf("LogStreamer.Start(ctx) = %v", err)
+	}
+
+	input := "0123456789abcdefghijklmnopqrstuvwxyz!@#$%^&*()" // 46 bytes
+	if err := ls.Process(ctx, []byte(input)); err != nil {
+		t.Errorf("LogStreamer.Process(ctx, %q) = %v", input, err)
+	}
+
+	ls.Stop(false)
+
+	if !ls.exitImmediately {
+		t.Errorf("LogStreamer.Stop(false) did not set exitImmediately")
+	}
+
+	if len(got) > 0 {
+		t.Errorf("LogStreamer.Stop(false) did not exit immediately")
 	}
 }

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -355,7 +355,7 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 	r.logStreamer.Process(ctx, r.output.ReadAndTruncate())
 
 	// Stop the log streamer. This will block until all the chunks have been uploaded
-	r.logStreamer.Stop()
+	r.logStreamer.Stop(true)
 
 	// Stop the header time streamer. This will block until all the chunks have been uploaded
 	r.headerTimesStreamer.Stop()
@@ -471,6 +471,7 @@ func (r *JobRunner) CancelAndStop() error {
 	r.cancelLock.Lock()
 	r.stopped = true
 	r.cancelLock.Unlock()
+	r.logStreamer.Stop(false)
 	return r.Cancel()
 }
 


### PR DESCRIPTION
Currently if the agent is sent a sigterm the log streamer will wait for all chunks to be uploaded, and even if a second sigterm is sent we still wait.

Other components of the agent honor the a graceful=false flag which allows operators to force the agent to stop.

This change adds that graceful option to the log streamer stop.

### Description

This change introduces immediate cancellation to the log streamer when the agent is forced to stop.

### Context

If customers egress is overloaded, or there is a large backlog of chunks to upload, and that is blocked due to internet connectivity issues, the agent can block for extended periods waiting to upload chuncks even if has been "forced" to quit.

### Changes

Adds a simple way to signal to the uploader workers to stop work and quite immediately when the agent has been told to exit and cancel.

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
