### PR TITLE
Fix data race on exitImmediately

### DIFF
--- a/agent/log_streamer.go
+++ b/agent/log_streamer.go
@@ -41,7 +41,7 @@ type LogStreamer struct {
 	logger logger.Logger
 
 	// A counter of how many chunks failed to upload
-	chunksFailedCount int32
+	chunksFailedCount atomic.Int32
 
 	// The callback called when a chunk is ready for upload
 	callback func(context.Context, *api.Chunk) error
@@ -68,7 +68,7 @@ type LogStreamer struct {
 	stopped bool
 
 	// have we been asked to exit immediately?
-	exitImmediately bool
+	exitImmediately atomic.Bool
 }
 
 // NewLogStreamer creates a new instance of the log streamer.
@@ -104,7 +104,7 @@ func (ls *LogStreamer) Start(ctx context.Context) error {
 }
 
 func (ls *LogStreamer) FailedChunks() int {
-	return int(atomic.LoadInt32(&ls.chunksFailedCount))
+	return int(ls.chunksFailedCount.Load())
 }
 
 // Process streams the output. It returns an error if the output data cannot be
@@ -178,7 +178,7 @@ func (ls *LogStreamer) Stop(graceful bool) {
 		ls.workerWG.Wait()
 		ls.logger.Info("[LogStreamer] Waiting for workers to shut down and outstanding chunks to be uploaded")
 	} else {
-		ls.exitImmediately = true
+		ls.exitImmediately.Store(true)
 		ls.logger.Warn("[LogStreamer] NOT waiting for outstanding chunks to be uploaded")
 	}
 }
@@ -201,7 +201,7 @@ func (ls *LogStreamer) worker(ctx context.Context, id int) {
 			ls.logger.Debug("[LogStreamer/Worker#%d] Queue length: %d", id, len(ls.queue))
 		}
 
-		if ls.exitImmediately {
+		if ls.exitImmediately.Load() {
 			ls.logger.Warn("[LogStreamer/Worker#%d] Worker is shutting down immediately, Outstanding Queue length: %d", id, len(ls.queue))
 			return
 		}
@@ -226,7 +226,7 @@ func (ls *LogStreamer) worker(ctx context.Context, id int) {
 		// Upload the chunk
 		err := ls.callback(ctx, chunk)
 		if err != nil {
-			atomic.AddInt32(&ls.chunksFailedCount, 1)
+			ls.chunksFailedCount.Add(1)
 
 			ls.logger.Error("Giving up on uploading chunk %d, this will result in only a partial build log on Buildkite", chunk.Sequence)
 		}

--- a/agent/log_streamer_test.go
+++ b/agent/log_streamer_test.go
@@ -130,7 +130,7 @@ func TestLogStreamerExitImmediately(t *testing.T) {
 
 	ls.Stop(false)
 
-	if !ls.exitImmediately {
+	if !ls.exitImmediately.Load() {
 		t.Errorf("LogStreamer.Stop(false) did not set exitImmediately")
 	}
 

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -354,7 +354,7 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 	// were left behind because the uploader goroutine exited before it could flush them.
 	r.logStreamer.Process(ctx, r.output.ReadAndTruncate())
 
-	// Stop the log streamer. This will block until all the chunks have been uploaded
+	// Stop the log streamer gracefully. This will block until all the chunks have been uploaded
 	r.logStreamer.Stop(true)
 
 	// Stop the header time streamer. This will block until all the chunks have been uploaded


### PR DESCRIPTION
### Description

* What it says on the title
* Also switches to `atomic.Int32` for `chunksFailedCount`.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
