### PR TITLE
Revert "Fix data race on exitImmediately"

### DIFF
--- a/agent/log_streamer_test.go
+++ b/agent/log_streamer_test.go
@@ -130,7 +130,7 @@ func TestLogStreamerExitImmediately(t *testing.T) {
 
 	ls.Stop(false)
 
-	if !ls.exitImmediately.Load() {
+	if !ls.exitImmediately {
 		t.Errorf("LogStreamer.Stop(false) did not set exitImmediately")
 	}
 

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -354,7 +354,7 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 	// were left behind because the uploader goroutine exited before it could flush them.
 	r.logStreamer.Process(ctx, r.output.ReadAndTruncate())
 
-	// Stop the log streamer gracefully. This will block until all the chunks have been uploaded
+	// Stop the log streamer. This will block until all the chunks have been uploaded
 	r.logStreamer.Stop(true)
 
 	// Stop the header time streamer. This will block until all the chunks have been uploaded


### PR DESCRIPTION
Reverts buildkite/agent#3187

This is being reverted because log output is being truncated by this change on #3180