### PR TITLE
Revert "Ensure the log streamer respects forced shutdown of the agent"

### DIFF
--- a/agent/log_streamer.go
+++ b/agent/log_streamer.go
@@ -66,9 +66,6 @@ type LogStreamer struct {
 
 	// Have we stopped?
 	stopped bool
-
-	// have we been asked to exit immediately?
-	exitImmediately bool
 }
 
 // NewLogStreamer creates a new instance of the log streamer.
@@ -164,7 +161,7 @@ func (ls *LogStreamer) Process(ctx context.Context, output []byte) error {
 }
 
 // Stop stops the streamer.
-func (ls *LogStreamer) Stop(graceful bool) {
+func (ls *LogStreamer) Stop() {
 	ls.processMutex.Lock()
 	if ls.stopped {
 		ls.processMutex.Unlock()
@@ -174,13 +171,8 @@ func (ls *LogStreamer) Stop(graceful bool) {
 	close(ls.queue)
 	ls.processMutex.Unlock()
 
-	if graceful {
-		ls.workerWG.Wait()
-		ls.logger.Info("[LogStreamer] Waiting for workers to shut down and outstanding chunks to be uploaded")
-	} else {
-		ls.exitImmediately = true
-		ls.logger.Warn("[LogStreamer] NOT waiting for outstanding chunks to be uploaded")
-	}
+	ls.logger.Debug("[LogStreamer] Waiting for workers to shut down")
+	ls.workerWG.Wait()
 }
 
 // The actual log streamer worker
@@ -197,15 +189,6 @@ func (ls *LogStreamer) worker(ctx context.Context, id int) {
 	for {
 		setStat("⌚️ Waiting for a chunk")
 
-		if len(ls.queue) > 0 {
-			ls.logger.Debug("[LogStreamer/Worker#%d] Queue length: %d", id, len(ls.queue))
-		}
-
-		if ls.exitImmediately {
-			ls.logger.Warn("[LogStreamer/Worker#%d] Worker is shutting down immediately, Outstanding Queue length: %d", id, len(ls.queue))
-			return
-		}
-
 		// Get the next chunk (pointer) from the queue. This will block
 		// until something is returned.
 		var chunk *api.Chunk
@@ -217,9 +200,6 @@ func (ls *LogStreamer) worker(ctx context.Context, id int) {
 		case <-ctx.Done(): // pack it up
 			return
 		}
-
-		// used to simulate a slow upload
-		// time.Sleep(30 * time.Second)
 
 		setStat("📨 Uploading chunk")
 

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -355,7 +355,7 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 	r.logStreamer.Process(ctx, r.output.ReadAndTruncate())
 
 	// Stop the log streamer. This will block until all the chunks have been uploaded
-	r.logStreamer.Stop(true)
+	r.logStreamer.Stop()
 
 	// Stop the header time streamer. This will block until all the chunks have been uploaded
 	r.headerTimesStreamer.Stop()
@@ -471,7 +471,6 @@ func (r *JobRunner) CancelAndStop() error {
 	r.cancelLock.Lock()
 	r.stopped = true
 	r.cancelLock.Unlock()
-	r.logStreamer.Stop(false)
 	return r.Cancel()
 }
 


### PR DESCRIPTION
Reverts buildkite/agent#3180

This is being reverted because log output is being truncated by this change.