### PR TITLE
Capture some HTTP client details from registering agents

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -236,6 +236,10 @@ func (asc AgentStartConfig) Features(ctx context.Context) []string {
 		features = append(features, "no-script-eval")
 	}
 
+	if asc.NoHTTP2 {
+		features = append(features, "no-http2")
+	}
+
 	if len(asc.AllowedRepositories) > 0 {
 		features = append(features, "allowed-repositories")
 	}
@@ -246,6 +250,14 @@ func (asc AgentStartConfig) Features(ctx context.Context) []string {
 
 	for _, exp := range experiments.Enabled(ctx) {
 		features = append(features, fmt.Sprintf("experiment-%s", exp))
+	}
+
+	if envHasKey("HTTP_PROXY") || envHasKey("http_proxy") {
+		features = append(features, "env-http-proxy")
+	}
+
+	if envHasKey("GODEBUG") {
+		features = append(features, "env-godebug")
 	}
 
 	return features
@@ -1540,4 +1552,10 @@ func leaderPinger(ctx context.Context, l logger.Logger, path, leaderPath string)
 			os.Symlink(path, leaderPath)
 		}
 	}
+}
+
+func envHasKey(key string) bool {
+	_, ok := os.LookupEnv(key)
+	return ok
+
 }


### PR DESCRIPTION
Agent registration requests include an array of "features" that are enabled on the agent. To assist with debugging, it would be helpful to know if a particular agent:

* has opted into HTTP 1.1 only
* is using a HTTP proxy
* has set GODEBUG, which [can be used to change the behaviour of net/http](https://pkg.go.dev/net/http)

We're submitting a boolean only, to indicate the feature is active. We don't submit values, such as the address of the HTTP proxy.

It would also be quite helpful to have the agent log out the state of its connection pool to agent.buildkite.com, but that's quite a different change to this so I've left it out and kept this PR simple.
