### PR TITLE
Update cancel_signal.go

### DIFF
--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -30,7 +30,7 @@ var (
 		Usage: "The number of seconds given to a subprocess to handle being sent ′cancel-signal′. " +
 			"After this period has elapsed, SIGKILL will be sent. " +
 			"Negative values are taken relative to ′cancel-grace-period′. " +
-			"The default is ′signal-grace-period-seconds′ - 1.",
+			"The default value (-1) means that the effective signal grace period is equal to ′cancel-grace-period-seconds′ minus 1.",
 		EnvVar: "BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS",
 		Value:  -1,
 	}

--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -30,7 +30,7 @@ var (
 		Usage: "The number of seconds given to a subprocess to handle being sent ′cancel-signal′. " +
 			"After this period has elapsed, SIGKILL will be sent. " +
 			"Negative values are taken relative to ′cancel-grace-period′. " +
-			"The default is ′cancel-grace-period-seconds′ - 1.",
+			"The default is ′signal-grace-period-seconds′ - 1.",
 		EnvVar: "BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS",
 		Value:  -1,
 	}

--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -30,7 +30,7 @@ var (
 		Usage: "The number of seconds given to a subprocess to handle being sent ′cancel-signal′. " +
 			"After this period has elapsed, SIGKILL will be sent. " +
 			"Negative values are taken relative to ′cancel-grace-period′. " +
-			"The default is ′cancel-grace-period′ - 1.",
+			"The default is ′cancel-grace-period-seconds′ - 1.",
 		EnvVar: "BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS",
 		Value:  -1,
 	}


### PR DESCRIPTION
Update to fix an error in the description to fix an error in the Buildkite Docs.

### Description

Fixes an error in https://buildkite.com/docs/agent/v3/cli-bootstrap#signal-grace-period-seconds as this page in the Buildkite Docs is being generated from a script and the script is dependent on the content of this file the PR is updating in https://github.com/buildkite/agent

### Context

https://linear.app/buildkite/issue/SUP-3416/update-the-docs-for-signal-grace-period-seconds-value

### Changes

A two-word change, please see the diff.

### Testing
The change does not touch any functionality, only a description.