### PR TITLE
Add agent stop command

### DIFF
--- a/agent/api.go
+++ b/agent/api.go
@@ -39,6 +39,7 @@ type APIClient interface {
 	StepCancel(context.Context, string, *api.StepCancel) (*api.StepCancelResponse, *api.Response, error)
 	StepExport(context.Context, string, *api.StepExportRequest) (*api.StepExportResponse, *api.Response, error)
 	StepUpdate(context.Context, string, *api.StepUpdate) (*api.Response, error)
+	Stop(context.Context, *api.AgentStopRequest) (*api.Response, error)
 	UpdateArtifacts(context.Context, string, []api.ArtifactState) (*api.Response, error)
 	UploadChunk(context.Context, string, *api.Chunk) (*api.Response, error)
 	UploadPipeline(context.Context, string, *api.PipelineChange, ...api.Header) (*api.Response, error)

--- a/api/agents.go
+++ b/api/agents.go
@@ -67,3 +67,18 @@ func (c *Client) Disconnect(ctx context.Context) (*Response, error) {
 
 	return c.doRequest(req, nil)
 }
+
+// AgentStopRequest is a call to stop the agent via the Buildkite Agent API
+type AgentStopRequest struct {
+	Force bool `json:"force",omitempty`
+}
+
+// Stops the agent via the Buildkite Agent API
+func (c *Client) Stop(ctx context.Context, stopReq *AgentStopRequest) (*Response, error) {
+	req, err := c.newRequest(ctx, "POST", "stop", stopReq)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.doRequest(req, nil)
+}

--- a/clicommand/agent_stop.go
+++ b/clicommand/agent_stop.go
@@ -1,0 +1,114 @@
+package clicommand
+
+import (
+	"context"
+	"fmt"
+
+	"time"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/buildkite/roko"
+	"github.com/urfave/cli"
+)
+
+const stopDescription = `Usage:
+
+    buildkite-agent stop [options...]
+
+Description:
+
+Stop the current agent.
+
+Example:
+
+    # Stops the agent gracefully after any currently running job completes
+    $ buildkite-agent stop
+
+    # Stops the agent, cancelling any currently running job
+    $ buildkite-agent stop --force`
+
+type AgentStopConfig struct {
+	Force bool `cli:"force"`
+
+	// Global flags
+	Debug       bool     `cli:"debug"`
+	LogLevel    string   `cli:"log-level"`
+	NoColor     bool     `cli:"no-color"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile     string   `cli:"profile"`
+
+	// API config
+	DebugHTTP        bool   `cli:"debug-http"`
+	AgentAccessToken string `cli:"agent-access-token" validate:"required"`
+	Endpoint         string `cli:"endpoint" validate:"required"`
+	NoHTTP2          bool   `cli:"no-http2"`
+}
+
+var AgentStopCommand = cli.Command{
+	Name:        "stop",
+	Usage:       "Stop the agent",
+	Description: stopDescription,
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "force",
+			Usage: "Cancel any currently running job",
+		},
+
+		// API Flags
+		AgentAccessTokenFlag,
+		EndpointFlag,
+		NoHTTP2Flag,
+		DebugHTTPFlag,
+
+		// Global flags
+		NoColorFlag,
+		DebugFlag,
+		LogLevelFlag,
+		ExperimentsFlag,
+		ProfileFlag,
+	},
+	Action: func(c *cli.Context) error {
+		ctx := context.Background()
+		ctx, cfg, l, _, done := setupLoggerAndConfig[AgentStopConfig](ctx, c)
+		defer done()
+
+		return stop(ctx, cfg, l)
+	},
+}
+
+func stop(ctx context.Context, cfg AgentStopConfig, l logger.Logger) error {
+	// Create the API client
+	client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
+
+	// Retry the build cancellation a few times before giving up
+	if err := roko.NewRetrier(
+		roko.WithMaxAttempts(5),
+		roko.WithStrategy(roko.Constant(1*time.Second)),
+		roko.WithJitter(),
+	).DoWithContext(ctx, func(r *roko.Retrier) error {
+		// Attempt to cancel the build
+		resp, err := client.Stop(ctx, &api.AgentStopRequest{
+			Force: cfg.Force,
+		})
+
+		// Don't bother retrying if the response was one of these statuses
+		if resp != nil && (resp.StatusCode == 422) {
+			r.Break()
+			return err
+		}
+
+		// Show the unexpected error
+		if err != nil {
+			l.Warn("%s (%s)", err, r)
+			return err
+		}
+
+		l.Info("Successfully stopped agent")
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to stop agent: %w", err)
+	}
+
+	return nil
+}

--- a/clicommand/agent_stop_test.go
+++ b/clicommand/agent_stop_test.go
@@ -1,0 +1,38 @@
+package clicommand
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func newAgentStopTestServer(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.RequestURI() {
+		case "/stop":
+			rw.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected HTTP request: %s %v", req.Method, req.URL.RequestURI())
+		}
+	}))
+}
+
+func TestAgentStop(t *testing.T) {
+	server := newAgentStopTestServer(t)
+	defer server.Close()
+
+	ctx := context.Background()
+	cfg := AgentStopConfig{
+		AgentAccessToken: "agentaccesstoken",
+		Endpoint:         server.URL,
+	}
+	l := logger.NewBuffer()
+
+	err := stop(ctx, cfg, l)
+	assert.NoError(t, err)
+	assert.Contains(t, l.Messages, "[info] Successfully stopped agent")
+}

--- a/clicommand/commands.go
+++ b/clicommand/commands.go
@@ -103,6 +103,7 @@ var BuildkiteAgentCommands = []cli.Command{
 			StepCancelCommand,
 		},
 	},
+	AgentStopCommand,
 	{
 		Name:  "tool",
 		Usage: "Utility commands, intended for users and operators of the agent to run directly on their machines, and not as part of a Buildkite job",

--- a/clicommand/config_completeness_test.go
+++ b/clicommand/config_completeness_test.go
@@ -16,6 +16,7 @@ type configCommandPair struct {
 var commandConfigPairs = []configCommandPair{
 	{Config: AcknowledgementsConfig{}, Command: AcknowledgementsCommand},
 	{Config: AgentStartConfig{}, Command: AgentStartCommand},
+	{Config: AgentStopConfig{}, Command: AgentStopCommand},
 	{Config: AnnotateConfig{}, Command: AnnotateCommand},
 	{Config: AnnotationRemoveConfig{}, Command: AnnotationRemoveCommand},
 	{Config: ArtifactDownloadConfig{}, Command: ArtifactDownloadCommand},


### PR DESCRIPTION
Add a `buildkite-agent stop [--force]` command.

The main use case is to allow customers to write "health checks" in agent and job hooks which can tell the agent to stop before or after the current job. For example, a `pre-command` agent hook could detect a spot instance has been asked to terminate and forcefully stop the agent, and allowing the use of an `AGENT_STOP` signal reason to automatically retry in that case. Or a `post-command` agent hook could detect a 95% full disk and tell the agent to stop after the current job completes.

Implementation is mostly extrapolated from what exists, I'm not here to set up new patterns 🙈

This PR only adds a basic test to make sure the plumbing works. There's not a lot of maturity in the testing, so this felt like a nice add without going full ham on figuring out how to do more comprehensive testing. We could also test the error response (a 422) and the force parameter, but manual testing shows they work.