### PR TITLE
Don't fail if the interrupt fails when the PID is already exited

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -361,6 +361,12 @@ func (p *Process) Interrupt() error {
 
 	// interrupt the process (ctrl-c or SIGINT)
 	if err := p.interruptProcessGroup(); err != nil {
+		//  No process or process group can be found corresponding to that specified by pid.
+		if errors.Is(err, syscall.ESRCH) {
+			p.logger.Warn("[Process] Process %d has already exited", p.pid)
+			return nil
+		}
+
 		p.logger.Error("[Process] Failed to interrupt process %d: %v", p.pid, err)
 
 		// Fallback to terminating if we get an error

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -306,6 +306,30 @@ func TestProcessInterrupts(t *testing.T) {
 	assertProcessDoesntExist(t, p)
 }
 
+func TestProcessInterruptsAfterDone(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Process groups not supported on windows")
+		return
+	}
+
+	p := process.New(logger.Discard, process.Config{
+		Path: os.Args[0],
+		Env:  []string{"TEST_MAIN=tester-pgid"},
+	})
+
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("p.Run() = %v", err)
+	}
+
+	<-p.Done()
+
+	if err := p.Interrupt(); err != nil {
+		t.Fatalf("p.Interrupt() = %v", err)
+	}
+}
+
 func TestProcessInterruptsWithCustomSignal(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
While testing a number of failure scenarios which simulate network failures I can across this error, which occurs if an agent is sent a `SIGTERM` and tries to kill a process which is already exited.

This sort of race condition is caused by outages of the buildkite api, or network interuptions.

One open question I have is the switch linked below in the correct order? Given the error being raised skips the timeout, and the done check being after this timeout which seems odd.

https://github.com/buildkite/agent/blob/fix_dont_fail_interrupt_if_pid_exited/agent/run_job.go#L504-L520 