### PR TITLE
Change the signal handler to ensure the agent quits after the grace period

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -29,6 +29,7 @@ import (
 	"github.com/buildkite/agent/v3/internal/awslib"
 	awssigner "github.com/buildkite/agent/v3/internal/cryptosigner/aws"
 	"github.com/buildkite/agent/v3/internal/experiments"
+	"github.com/buildkite/agent/v3/internal/job"
 	"github.com/buildkite/agent/v3/internal/job/hook"
 	"github.com/buildkite/agent/v3/internal/osutil"
 	"github.com/buildkite/agent/v3/internal/shell"
@@ -785,6 +786,9 @@ var AgentStartCommand = cli.Command{
 		))
 		defer done()
 
+		// used later to force the shutdown of the agent
+		ctx, cancel := context.WithCancel(ctx)
+
 		// Verify that the bootstrap buildkite-agent executable matches the current host agent
 		// executable. In development builds, it exits on mismatch; otherwise it only logs a warning.
 		// This is to avoid confusion when making changes to the buildkite-agent but forgetting to
@@ -1274,7 +1278,7 @@ var AgentStartCommand = cli.Command{
 		}
 
 		// Handle process signals
-		signals := handlePoolSignals(ctx, l, pool)
+		signals := handlePoolSignals(ctx, l, pool, cancel, cfg.CancelGracePeriod)
 		defer close(signals)
 
 		l.Info("Starting %d Agent(s)", cfg.Spawn)
@@ -1362,7 +1366,7 @@ func parseAndValidateJWKS(ctx context.Context, keysetType, path string) (jwk.Set
 	return jwks, nil
 }
 
-func handlePoolSignals(ctx context.Context, l logger.Logger, pool *agent.AgentPool) chan os.Signal {
+func handlePoolSignals(ctx context.Context, l logger.Logger, pool *agent.AgentPool, cancel context.CancelFunc, cancelGracePeriod int) chan os.Signal {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt,
 		syscall.SIGHUP,
@@ -1392,8 +1396,26 @@ func handlePoolSignals(ctx context.Context, l logger.Logger, pool *agent.AgentPo
 					l.Info("Received CTRL-C, send again to forcefully kill the agent(s)")
 					pool.Stop(true)
 				} else {
-					l.Info("Forcefully stopping running jobs and stopping the agent(s)")
-					pool.Stop(false)
+					l.Info("Forcefully stopping running jobs and stopping the agent(s) in %d seconds", cancelGracePeriod)
+
+					gracefulContext, _ := job.WithGracePeriod(ctx, cancelGracePeriodDuration(cancelGracePeriod)*time.Second)
+
+					go func() {
+						l.Info("Forced agent(s) to stop")
+						pool.Stop(false) // one last chance to stop
+
+						time.Sleep(cancelGracePeriodDuration(cancelGracePeriod/2) * time.Second)
+
+						l.Info("Cancelling all internal tasks and API requests")
+						cancel() // cancel the context to stop all network operations
+					}()
+
+					<-gracefulContext.Done()
+					l.Info("exiting with status 1")
+
+					// this should only be called if the context cancellation and forceful stop fails
+					os.Exit(1)
+
 				}
 			default:
 				l.Debug("Ignoring signal `%s`", sig.String())
@@ -1565,4 +1587,12 @@ func envHasKey(key string) bool {
 	_, ok := os.LookupEnv(key)
 	return ok
 
+}
+
+func cancelGracePeriodDuration(cancelGracePeriod int) time.Duration {
+	if cancelGracePeriod < 10 {
+		return 10 // minimum 10 seconds for forceful shutdown
+	}
+
+	return time.Duration(cancelGracePeriod)
 }

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -145,7 +145,7 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 
 	// Listen for cancellation. Once ctx is cancelled, some tasks can run
 	// afterwards during the signal grace period. These use graceCtx.
-	graceCtx, graceCancel := withGracePeriod(ctx, e.SignalGracePeriod)
+	graceCtx, graceCancel := WithGracePeriod(ctx, e.SignalGracePeriod)
 	defer graceCancel()
 	go func() {
 		<-e.cancelCh
@@ -948,7 +948,7 @@ func (e *Executor) CommandPhase(ctx context.Context) (hookErr error, commandErr 
 		}
 		// Because post-command hooks are often used for post-job cleanup, they
 		// can run during the grace period.
-		graceCtx, cancel := withGracePeriod(ctx, e.SignalGracePeriod)
+		graceCtx, cancel := WithGracePeriod(ctx, e.SignalGracePeriod)
 		defer cancel()
 		hookErr = e.runPostCommandHooks(graceCtx)
 	}()

--- a/internal/job/grace.go
+++ b/internal/job/grace.go
@@ -5,13 +5,13 @@ import (
 	"time"
 )
 
-// withGracePeriod returns a context that is cancelled some time *after* the
+// WithGracePeriod returns a context that is cancelled some time *after* the
 // parent context is cancelled. In general this is not a good pattern, since it
 // breaks the usual connection between context cancellations and requires an
 // extra goroutine. However, we need to enforce the signal grace period from
 // within the job executor for use-cases where the executor is _not_ forked from
 // something else that will enforce the grace period (with SIGKILL).
-func withGracePeriod(ctx context.Context, graceTimeout time.Duration) (context.Context, context.CancelFunc) {
+func WithGracePeriod(ctx context.Context, graceTimeout time.Duration) (context.Context, context.CancelFunc) {
 	gctx, cancel := context.WithCancelCause(context.WithoutCancel(ctx))
 	go func() {
 		<-ctx.Done()


### PR DESCRIPTION
### Description

This uses two new calls to which are only triggered after the second quit attempt to ensure the agent exits:

1. After half the cancel grace period (defaults to at least 10s) the agent will cancel the context.
2. At the end of the cancel grace period, if the agent is stuck it will call os.Exit(1).

The pool stop with graceful false should, if at all possible, trigger disconnect calls for all the agents. 

> [!NOTE]
> This code logic is only invoked after a second exit signal.

### Context

If the agent is unable to commicate with the agent API it can take almost an hour to stop.

### Changes

Adds more logic to the signal handler to ensure the agent exits.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

To test this logic I used https://github.com/smarty/cproxy as a HTTP proxy with the agent configured to use it, then once a job was started and the process was running I killed the proxy, interupted the agent twice and waited for the service to exit.

<!--
Note: if the tests fail to run locally, please let us know!
-->
