### PR TITLE
Set BUILDKITE_SIGNAL_REASON in time for post-command hook

### DIFF
--- a/internal/job/stdin.go
+++ b/internal/job/stdin.go
@@ -1,0 +1,27 @@
+package job
+
+import (
+	"bufio"
+	"io"
+
+	"github.com/buildkite/agent/v3/env"
+	"github.com/buildkite/agent/v3/internal/shell"
+)
+
+func readVarsFromStdin(shell *shell.Shell, stdin io.Reader) error {
+	if stdin == nil {
+		return nil
+	}
+
+	sc := bufio.NewScanner(stdin)
+	for sc.Scan() {
+		line := sc.Text()
+		name, val, ok := env.Split(line)
+		if !ok {
+			continue
+		}
+		shell.Logger.Commentf("Agent process setting %s=%s", name, val)
+		shell.Env.Set(name, val)
+	}
+	return sc.Err()
+}

--- a/kubernetes/runner.go
+++ b/kubernetes/runner.go
@@ -27,6 +27,7 @@ const defaultSocketPath = "/workspace/buildkite.sock"
 type RunnerConfig struct {
 	SocketPath         string
 	ClientCount        int
+	Stdin              io.Reader // TODO: use this
 	Stdout, Stderr     io.Writer
 	Env                []string
 	ClientStartTimeout time.Duration

--- a/process/process.go
+++ b/process/process.go
@@ -204,6 +204,11 @@ func (p *Process) Run(ctx context.Context) error {
 		go func() {
 			p.logger.Debug("[Process] Starting to copy PTY to the buffer")
 
+			// Concurrently copy stdin to the pty ("best effort" basis).
+			if p.conf.Stdin != nil {
+				go io.Copy(pty, p.conf.Stdin)
+			}
+
 			// Copy the pty to our writer. This will block until it EOFs or something breaks.
 			_, err = io.Copy(p.conf.Stdout, pty)
 			switch {


### PR DESCRIPTION
### Description

Make the signal reason available to post-command hooks.

### Context

https://linear.app/buildkite/issue/PIPE-481/add-signal-reason-to-the-post-command-hook

### TODO

Most of the Kubernetes side (establish an RPC method to poll for stdin? or something tailored for env vars specifically?)

### Changes

* process: Copy data from stdin to the pty
* agent: Set up a pipe for the process to read and Cancel to write
* agent: On cancellation, write an environment variable into stdin indicating either that the job is cancelled or the agent is stopping
* internal/job: Read stdin for env vars to set

### Why stdin 🤔 

The "bootstrap" has a Job API, and even has methods for manipulating env vars. Accessing this needs the socket path and token, which are only available to the bootstrap process and its subprocesses. I guess we could sneak that info back to the agent through the bootstrap's stdout or stderr...

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
