### PR TITLE
Fixes from the new modernize analyzer from the Go team

### DIFF
--- a/agent/integration/config_allowlisting_integration_test.go
+++ b/agent/integration/config_allowlisting_integration_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"maps"
 	"regexp"
 	"strings"
 	"testing"
@@ -122,9 +123,7 @@ func TestConfigAllowlisting(t *testing.T) {
 				Token: "bkaj_job-token",
 			}
 
-			for k, v := range tc.extraEnv {
-				job.Env[k] = v
-			}
+			maps.Copy(job.Env, tc.extraEnv)
 
 			e := createTestAgentEndpoint()
 			server := e.server()

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"math/rand/v2"
 	"os"
 	"path/filepath"
@@ -426,9 +427,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	// sent by Buildkite. The variables below should always take
 	// precedence.
 	env := make(map[string]string)
-	for key, value := range r.conf.Job.Env {
-		env[key] = value
-	}
+	maps.Copy(env, r.conf.Job.Env)
 
 	// The agent registration token should never make it into the job environment
 	delete(env, "BUILDKITE_AGENT_TOKEN")

--- a/api/oidc_test.go
+++ b/api/oidc_test.go
@@ -112,7 +112,7 @@ func TestOIDCToken(t *testing.T) {
 				Job:      jobID,
 				Audience: audience,
 			},
-			ExpectedBody: []byte(fmt.Sprintf(`{"audience":%q}`+"\n", audience)),
+			ExpectedBody: fmt.Appendf(nil, `{"audience":%q}`+"\n", audience),
 			OIDCToken:    &api.OIDCToken{Token: oidcToken},
 		},
 		{
@@ -121,7 +121,7 @@ func TestOIDCToken(t *testing.T) {
 				Job:      jobID,
 				Lifetime: lifetime,
 			},
-			ExpectedBody: []byte(fmt.Sprintf(`{"lifetime":%d}`+"\n", lifetime)),
+			ExpectedBody: fmt.Appendf(nil, `{"lifetime":%d}`+"\n", lifetime),
 			OIDCToken:    &api.OIDCToken{Token: oidcToken},
 		},
 		{

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -657,7 +658,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 		} else {
 			mirrorSubmodules := e.ExecutorConfig.GitMirrorsPath != ""
 			for _, repository := range submoduleRepos {
-				submoduleArgs := append([]string(nil), args...)
+				submoduleArgs := slices.Clone(args)
 				// submodules might need their fingerprints verified too
 				if e.SSHKeyscan {
 					addRepositoryHostToSSHKnownHosts(ctx, e.shell, repository)

--- a/internal/job/docker.go
+++ b/internal/job/docker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/buildkite/agent/v3/internal/shell"
@@ -19,12 +20,7 @@ var dockerEnv = []string{
 }
 
 func hasDeprecatedDockerIntegration(sh *shell.Shell) bool {
-	for _, k := range dockerEnv {
-		if sh.Env.Exists(k) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(dockerEnv, sh.Env.Exists)
 }
 
 func runDeprecatedDockerIntegration(ctx context.Context, sh *shell.Shell, cmd []string) error {

--- a/internal/job/tracing.go
+++ b/internal/job/tracing.go
@@ -3,7 +3,7 @@ package job
 import (
 	"context"
 	"fmt"
-	maps0 "maps"
+	"maps"
 	"os"
 	"slices"
 	"strconv"
@@ -253,15 +253,15 @@ func DDTracingExtras() map[string]any {
 	}
 }
 
-func Merge(maps ...map[string]any) map[string]any {
+func Merge(ms ...map[string]any) map[string]any {
 	fullCap := 0
-	for _, m := range maps {
+	for _, m := range ms {
 		fullCap += len(m)
 	}
 
 	merged := make(map[string]any, fullCap)
-	for _, m := range maps {
-		maps0.Copy(merged, m)
+	for _, m := range ms {
+		maps.Copy(merged, m)
 	}
 
 	return merged

--- a/internal/job/tracing.go
+++ b/internal/job/tracing.go
@@ -3,6 +3,7 @@ package job
 import (
 	"context"
 	"fmt"
+	maps0 "maps"
 	"os"
 	"slices"
 	"strconv"
@@ -260,9 +261,7 @@ func Merge(maps ...map[string]any) map[string]any {
 
 	merged := make(map[string]any, fullCap)
 	for _, m := range maps {
-		for key, val := range m {
-			merged[key] = val
-		}
+		maps0.Copy(merged, m)
 	}
 
 	return merged

--- a/internal/replacer/bm_redactor_test.go
+++ b/internal/replacer/bm_redactor_test.go
@@ -161,13 +161,7 @@ func (redactor *BoyerMooreRedactor) Write(input []byte) (int, error) {
 			// Everything in this input prior to the start of that needle can be
 			// confirmed, and that needle (if present) will be redacted in the next
 			// loop or next write.
-			confirmedTo := cursor - redactor.maxlen
-
-			// The maxlen needle (if any) is fully in future write calls, this whole
-			// input slice can be confirmed.
-			if confirmedTo > len(input) {
-				confirmedTo = len(input)
-			}
+			confirmedTo := min(cursor-redactor.maxlen, len(input))
 
 			// Save the confirmed input to outbuf ready for pushing down and advance
 			// doneTo to signal we have a confirmed series of bytes ready for pushing

--- a/internal/socket/middleware.go
+++ b/internal/socket/middleware.go
@@ -1,6 +1,7 @@
 package socket
 
 import (
+	"maps"
 	"net/http"
 	"strings"
 	"time"
@@ -24,9 +25,7 @@ func HeadersMiddleware(headers http.Header) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			h := w.Header()
-			for k, v := range headers {
-				h[k] = v
-			}
+			maps.Copy(h, headers)
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/status/status.go
+++ b/status/status.go
@@ -124,9 +124,7 @@ func (i *baseItem) delSubItem(title string) {
 func (i *baseItem) Items() map[string]item {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
-	icopy := make(map[string]item, len(i.items))
-	maps.Copy(icopy, i.items)
-	return icopy
+	return maps.Clone(i.items)
 }
 
 // SimpleItem is for untemplated status items that only report a simple non-HTML string.

--- a/status/status.go
+++ b/status/status.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"maps"
 	"net/http"
 	"os"
 	"os/user"
@@ -124,9 +125,7 @@ func (i *baseItem) Items() map[string]item {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	icopy := make(map[string]item, len(i.items))
-	for k, v := range i.items {
-		icopy[k] = v
-	}
+	maps.Copy(icopy, i.items)
 	return icopy
 }
 


### PR DESCRIPTION
### Description

Fixes from the new modernize analyzer from the Go team #3209 

https://github.com/golang/tools/releases/tag/gopls%2Fv0.18.0 for more details.

> [!NOTE]
> I had to fix all the imports manually.  

### Context

There are quite a few small optimisations which can be introduced to the codebase to "modernize" it.

### Changes

Just some linting fixes.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
