### PR TITLE
Kill exp/maps and replace with stdlib maps

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -42,7 +43,6 @@ import (
 	"github.com/buildkite/shellwords"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/urfave/cli"
-	"golang.org/x/exp/maps"
 )
 
 const startDescription = `Usage:
@@ -926,7 +926,7 @@ var AgentStartCommand = cli.Command{
 			return fmt.Errorf(
 				"the given tracing backend %q is not supported. Valid backends are: %q",
 				cfg.TracingBackend,
-				maps.Keys(tracetools.ValidTracingBackends),
+				slices.Collect(maps.Keys(tracetools.ValidTracingBackends)),
 			)
 		}
 

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/exec"
 	"path"
@@ -33,7 +34,6 @@ import (
 	"github.com/buildkite/go-pipeline/warning"
 	"github.com/buildkite/interpolate"
 	"github.com/urfave/cli"
-	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 )
 
@@ -522,13 +522,13 @@ func searchForSecrets(
 	}
 
 	if len(shortValues) > 0 {
-		vars := maps.Keys(shortValues)
+		vars := slices.Collect(maps.Keys(shortValues))
 		slices.Sort(vars)
 		l.Warn("Some variables have values below minimum length (%d bytes) and will not be redacted: %s", redact.LengthMin, strings.Join(vars, ", "))
 	}
 
 	if len(secretsFound) > 0 {
-		secretsFound := maps.Keys(secretsFound)
+		secretsFound := slices.Collect(maps.Keys(secretsFound))
 		slices.Sort(secretsFound)
 
 		if cfg.RejectSecrets {

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
 	golang.org/x/crypto v0.35.0
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/net v0.35.0
 	golang.org/x/oauth2 v0.27.0
 	golang.org/x/sys v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,6 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
 golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
-golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
-golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=

--- a/jobapi/env.go
+++ b/jobapi/env.go
@@ -3,11 +3,12 @@ package jobapi
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
 
 	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/internal/socket"
-	"golang.org/x/exp/maps"
 )
 
 func (s *Server) getEnv(w http.ResponseWriter, _ *http.Request) {
@@ -35,7 +36,7 @@ func (s *Server) patchEnv(w http.ResponseWriter, r *http.Request) {
 
 	added := make([]string, 0, len(req.Env))
 	updated := make([]string, 0, len(req.Env))
-	protected := checkProtected(maps.Keys(req.Env))
+	protected := checkProtected(slices.Collect(maps.Keys(req.Env)))
 
 	if len(protected) > 0 {
 		err := socket.WriteError(

--- a/tracetools/propagate_test.go
+++ b/tracetools/propagate_test.go
@@ -6,13 +6,13 @@ import (
 	"encoding/base64"
 	"encoding/gob"
 	"errors"
+	"maps"
 	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
-	"golang.org/x/exp/maps"
 )
 
 // nullLogger is meant to make Datadog tracing logs go nowhere during tests.
@@ -142,9 +142,10 @@ func TestEncodeTraceContext(t *testing.T) {
 			}
 			// The content of the trace context will vary, but the keys should
 			// remain the same.
-			gotKeys := maps.Keys(textmap)
+			gotKeys := slices.Collect(maps.Keys(textmap))
 			slices.Sort(gotKeys)
-			wantKeys := maps.Keys(test.want)
+
+			wantKeys := slices.Collect(maps.Keys(test.want))
 			slices.Sort(wantKeys)
 			if diff := cmp.Diff(gotKeys, wantKeys); diff != "" {
 				t.Errorf("decoded textmap keys diff (-got +want):\n%s", diff)


### PR DESCRIPTION
### Description

I, a bad and evil person, introduced the `exp/maps` library into this project before it was introduced to the stdlib. As penance, i give to you this gift: `exp` has been excised from this repo and cast into the fires that birthed it.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
