### PR TITLE
Handle pause actions

### DIFF
--- a/agent/dummy_bootstrap.sh
+++ b/agent/dummy_bootstrap.sh
@@ -1,0 +1,1 @@
+# An empty script that exits 0

--- a/agent/idle_monitor.go
+++ b/agent/idle_monitor.go
@@ -1,0 +1,44 @@
+package agent
+
+import "sync"
+
+// This monitor has a 3rd implicit state we will call "initializing" that all agents start in
+// Agents can transition to busy and/or idle but always start in the "initializing" state
+/*
+//                -> Busy
+//              /     ^
+// Initializing       |
+//              \     v
+//                -> Idle
+*/
+// This (intentionally?) ensures the DisconnectAfterIdleTimeout doesn't fire before agents have had a chance to run a job
+type IdleMonitor struct {
+	sync.Mutex
+	totalAgents int
+	idle        map[string]struct{}
+}
+
+func NewIdleMonitor(totalAgents int) *IdleMonitor {
+	return &IdleMonitor{
+		totalAgents: totalAgents,
+		idle:        map[string]struct{}{},
+	}
+}
+
+func (i *IdleMonitor) Idle() bool {
+	i.Lock()
+	defer i.Unlock()
+	return len(i.idle) == i.totalAgents
+}
+
+func (i *IdleMonitor) MarkIdle(agentUUID string) {
+	i.Lock()
+	defer i.Unlock()
+	i.idle[agentUUID] = struct{}{}
+}
+
+func (i *IdleMonitor) MarkBusy(agentUUID string) {
+	i.Lock()
+	defer i.Unlock()
+	delete(i.idle, agentUUID)
+}

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/gofrs/flock v0.12.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-querystring v1.1.0
+	github.com/google/uuid v1.6.0
 	github.com/gowebpki/jcs v1.0.1
 	github.com/lestrrat-go/jwx/v2 v2.1.3
 	github.com/mattn/go-zglob v0.0.6
@@ -113,7 +114,6 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.25.1 // indirect

--- a/logger/log.go
+++ b/logger/log.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/buildkite/agent/v3/version"
@@ -265,4 +266,19 @@ var Discard = &ConsoleLogger{
 	printer: &TextPrinter{
 		Writer: io.Discard,
 	},
+}
+
+// TestPrinter is a log printer than calls the Logf method of a [testing.T]
+// or [testing.B].
+type TestPrinter struct {
+	tb testing.TB
+}
+
+func NewTestPrinter(tb testing.TB) TestPrinter {
+	return TestPrinter{tb: tb}
+}
+
+func (tp TestPrinter) Print(level Level, msg string, fields Fields) {
+	now := time.Now().Format(DateFormat)
+	tp.tb.Logf("%s %s %s %v", now, level, msg, fields)
 }


### PR DESCRIPTION
### Description

Handle "pause" as a ping action.

### Context

https://linear.app/buildkite/issue/PIPE-747/agent-prevent-paused-agent-terminating-in-one-shot-modes

### Changes

Important bits:
* Don't return early when using acquire-job, so that there's a ping loop after it, but exit from the ping loop instead
* Add "pause" as an action returned from ping, use it to `continue` the ping loop (avoiding either running a job or exiting the loop)

Refactoring/cleanup:
* Rearrange Ping so that it returns the action, and handle the action in the ping loop
* Move idle monitor to its own file
* Replace sync.Mutex+bool+channel with sync.Once+channel for tracking stopping

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

