### PR TITLE
Set env when job cancelled for hooks

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -309,6 +309,7 @@ func (e *Executor) Cancel() error {
 		return errors.New("already cancelled")
 	}
 	e.cancelled = true
+	e.shell.Env.Set("BUILDKITE_JOB_CANCELLED", "true")
 	close(e.cancelCh)
 	return nil
 }


### PR DESCRIPTION
So that hook behaviour can change when the job has cancelled, either from the platform or because the agent is being stopped, and so its result is likely inconsequential. We have some customers who would like to use this to avoid sending a notification to a system about a result that doesn't matter because it is either incomplete or will be retried.

Alternative to #3201 / PIPE-481.

### Testing

- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

This could use an additional automated test but I'm not sure how complicated that'll be. But this seems a pretty low-risk change in any case.

I manually tested by adding a post-command hook like this:

```bash
if [[ "$BUILDKITE_JOB_CANCELLED" == "true" ]]; then
  echo "Job was cancelled, skipping notifications!"
  exit
fi

echo "Sending notifications ..."
```

and it worked a treat:

<img width="1170" alt="image" src="https://github.com/user-attachments/assets/b4ddd54e-c164-480f-8850-b12510b91ab3" />

That should also cover when the agent is stopped forcefully which also cancels the job.