### PR TITLE
Record build URL in the buildkite-agent log for easier traceability

### DIFF
--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -54,7 +54,7 @@ func (e *missingKeyError) Error() string {
 
 // Runs the job
 func (r *JobRunner) Run(ctx context.Context) error {
-	r.agentLogger.Info("Starting job %s", r.conf.Job.ID)
+	r.agentLogger.Info("Starting job %s for build at %s", r.conf.Job.ID, r.conf.Job.Env["BUILDKITE_BUILD_URL"])
 
 	ctx, done := status.AddItem(ctx, "Job Runner", "", nil)
 	defer done()
@@ -396,7 +396,7 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 	// Once we tell the API we're finished it might assign us new work, so make sure everything else is done first.
 	r.client.FinishJob(ctx, r.conf.Job, finishedAt, exit, r.logStreamer.FailedChunks())
 
-	r.agentLogger.Info("Finished job %s", r.conf.Job.ID)
+	r.agentLogger.Info("Finished job %s for build at %s", r.conf.Job.ID, r.conf.Job.Env["BUILDKITE_BUILD_URL"])
 }
 
 // streamJobLogsAfterProcessStart waits for the process to start, then grabs the job output


### PR DESCRIPTION
### Description

As Developer Productivity engineers, we are sometimes tasked with troubleshooting misbehaving agents. To do this, we collect agent metrics and the logs in our o11y platform. This PR is a QoL improvement to record build URL in the buildkite-agent log in addition to the job ID. If the agent has been around for a while and has executed several jobs, it would be great to have easier traceability to see what has been executed on the agent. Having the build URL will allow to quickly locate the executed job in Buildkite UI.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
