### PR TITLE
Change healthHandler to log requests at debug level

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -136,7 +136,7 @@ func (ap *AgentPool) statusJSONHandler(l logger.Logger) http.HandlerFunc {
 
 func healthHandler(l logger.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		l.Info("%s %s", r.Method, r.URL.Path)
+		l.Debug("agent_pool.go/healthHandler: %s %s", r.Method, r.URL.Path)
 		if r.URL.Path != "/" {
 			http.NotFound(w, r)
 		} else {


### PR DESCRIPTION
### Description

An endless stream of "GET /" is not very useful unless you already know where it's coming from.

### Context

From trying to understand odd agent logs while investigating another issue.

The log itself is something I added in #1873, and must have forgotten to clean up at the time.

### Changes

`Info` -> `Debug` and add some missing context

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
