### PR TITLE
ANSI parser speedup

### DIFF
--- a/process/ansi.go
+++ b/process/ansi.go
@@ -11,8 +11,8 @@ type ansiParser struct {
 	state ansiParserState
 }
 
-// feed passes more bytes through the parser.
-func (m *ansiParser) feed(data ...byte) {
+// Write passes more bytes through the parser.
+func (m *ansiParser) Write(data []byte) (int, error) {
 	for _, b := range data {
 		if m.state != nil {
 			m.state = m.state[b]
@@ -22,6 +22,7 @@ func (m *ansiParser) feed(data ...byte) {
 			m.state = initialANSIState
 		}
 	}
+	return len(data), nil
 }
 
 // insideCode reports if the data is in the middle of an ANSI sequence.

--- a/process/ansi_test.go
+++ b/process/ansi_test.go
@@ -1,6 +1,9 @@
 package process
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func TestANSIParser(t *testing.T) {
 	t.Parallel()
@@ -48,9 +51,21 @@ func TestANSIParser(t *testing.T) {
 
 	for _, test := range tests {
 		var p ansiParser
-		p.feed([]byte(test.input)...)
+		p.Write([]byte(test.input))
 		if got := p.insideCode(); got != test.want {
 			t.Errorf("after p.feed(%q...): p.insideCode() = %t, want %t", test.input, got, test.want)
 		}
+	}
+}
+
+func BenchmarkANSIParser(b *testing.B) {
+	npm, err := os.ReadFile("fixtures/npm.sh.raw")
+	if err != nil {
+		b.Fatalf("os.ReadFile(fixtures/npm.sh.raw) error = %v", err)
+	}
+	b.ResetTimer()
+	for range b.N {
+		var p ansiParser
+		p.Write(npm)
 	}
 }

--- a/process/fixtures/npm.sh.raw
+++ b/process/fixtures/npm.sh.raw
@@ -1,0 +1,5000 @@
+[37m[40mnpm[0m [0m[32minfo[0m [0m[35mit worked if it ends with[0m ok
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcli[0m [ 'node', '/usr/local/bin/npm', 'install', 'webgl-workshop' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35musing[0m npm@2.1.6
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35musing[0m node@v0.10.33
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mnode symlink[0m /usr/local/bin/node
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mconfig[0m Skipping project config: /Users/mp/.npmrc. (matches userconfig)
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m coffee-trace@1.3.4 No repository field.
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec webgl-workshop
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m webgl-workshop@*
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name webgl-workshop
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/webgl-workshop
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/webgl-workshop not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /webgl-workshop
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /webgl-workshop
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /webgl-workshop
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './webgl-workshop' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/webgl-workshop
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:05:53
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest id[0m 5430219c4780059f
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "5QMBY1WKDWU2JK49GRQF08COQ"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/webgl-workshop
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/webgl-workshop from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m webgl-workshop@1.0.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddRemoteTarball[0m https://registry.npmjs.org/webgl-workshop/-/webgl-workshop-1.0.5.tgz not in flight; adding
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddRemoteTarball[0m [ 'https://registry.npmjs.org/webgl-workshop/-/webgl-workshop-1.0.5.tgz',
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddRemoteTarball[0m   'c9be1bb1357031897cdd558a159a047ac1115a65' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mretry[0m fetch attempt 1 at 13:05:54
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:05:54
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mfetch[0m GET https://registry.npmjs.org/webgl-workshop/-/webgl-workshop-1.0.5.tgz
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mfetch[0m 200 https://registry.npmjs.org/webgl-workshop/-/webgl-workshop-1.0.5.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddTmpTarball[0m /var/folders/q0/mqfk4sjd5b1g5n62dd43p5x40000gn/T/npm-5354-43f5bcfd/registry.npmjs.org/webgl-workshop/-/webgl-workshop-1.0.5.tgz not in flight; adding
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddTmpTarball[0m already have metadata; skipping unpack for webgl-workshop@1.0.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/webgl-workshop/1.0.5/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/webgl-workshop/1.0.5/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m webgl-workshop@1.0.5 into /Users/mp
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m webgl-workshop@1.0.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of webgl-workshop to /Users/mp not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/webgl-workshop-6920b95f59d20778.lock for /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/webgl-workshop/1.0.5/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m webgl-workshop@1.0.5
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/3d-clear-depth@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/3d-cull-face@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/3d-depth-buffer@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/3d-front-face@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/blend-basics@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/buffer-attributes@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/buffer-create@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/buffer-draw@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/buffer-elements@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/buffer-interleaved@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/challenge-0@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/challenge-1@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/drawing-color-mask@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/drawing-line-width@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/intro-clear-color@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/intro-hello-webgl@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/intro-scissor@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/intro-viewport@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/shader-attributes@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/shader-create@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/shader-uniforms@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/stencil-shadows@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/texture-create@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/texture-mipmaps@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/texture-parameters@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @exercise/texture-units@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @workshop/common@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @workshop/compare@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @workshop/envify-files@1.0.0 No description
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @workshop/envify-files@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @workshop/exercise@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @workshop/exercise-ui@1.0.0 No description
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @workshop/exercise-ui@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @workshop/menu@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @workshop/server@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @workshop/server-basic@1.0.0 No description
+[0m[37m[40mnpm[0m [0m[30m[43mWARN[0m [0m[35mpackage.json[0m @workshop/server-basic@1.0.0 No repository field.
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec cpr@^0.3.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec defaultcss@^1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec domify@^1.3.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec envify@^3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec escape-html@^1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec events@^1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec face-normals@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec findup@^0.1.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec findup-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec fresh-require@^1.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec fs-readdir-recursive@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec gl-api@^1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec gl-clear@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec gl-compare@^2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec gl-compare-sidebar@^1.1.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec gl-context@^0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec gl-geometry@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec gl-matrix@^2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec gl-reset@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec gl-shader-core@^2.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec glsldoc@0.0.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec glslify@^1.6.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec google-fonts@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec highlight.js@^8.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec inherits@^2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec inquirer@^0.5.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec linklocal@^2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec marked@^0.3.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec minimist@^1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec minstache@^1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec mkdirp@^0.5.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec mousetrap@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec myth@^1.2.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec normals@^0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec opener@^1.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec parse-obj@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec quotemeta@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec resolve@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec rework@^1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec rework-plugin-inline@^1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec sidenote@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec simplicial-complex@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec st@^0.5.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec teapot@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec unindex-mesh@^1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec watchify@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec wordwrap@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec xhr@^1.17.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec beefy@^2.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec bl@^0.9.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec brfs@^1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m cpr@>=0.3.2 <0.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name cpr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/cpr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/cpr not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m defaultcss@>=1.1.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name defaultcss
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/defaultcss
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/defaultcss not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m domify@>=1.3.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name domify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/domify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/domify not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m envify@>=3.0.0 <4.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name envify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/envify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/envify not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m escape-html@>=1.0.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name escape-html
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/escape-html
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/escape-html not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m events@>=1.0.2 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name events
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/events
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/events not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m face-normals@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name face-normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/face-normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/face-normals not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m findup@>=0.1.5 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name findup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/findup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/findup not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m findup-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name findup-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/findup-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/findup-element not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m fresh-require@>=1.0.3 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name fresh-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/fresh-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/fresh-require not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m fs-readdir-recursive@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/fs-readdir-recursive not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-api@>=1.0.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name gl-api
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/gl-api
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/gl-api not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-clear@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name gl-clear
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/gl-clear
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/gl-clear not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-compare@>=2.0.1 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name gl-compare
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/gl-compare
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/gl-compare not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-compare-sidebar@>=1.1.4 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name gl-compare-sidebar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/gl-compare-sidebar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/gl-compare-sidebar not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-context@>=0.1.1 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/gl-context not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-geometry@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name gl-geometry
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/gl-geometry
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/gl-geometry not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-matrix@>=2.1.0 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/gl-matrix not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-reset@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name gl-reset
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/gl-reset
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/gl-reset not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-shader-core@>=2.2.0 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name gl-shader-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/gl-shader-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/gl-shader-core not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m glsldoc@0.0.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name glsldoc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/glsldoc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/glsldoc not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m glslify@>=1.6.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name glslify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/glslify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/glslify not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m google-fonts@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name google-fonts
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/google-fonts
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/google-fonts not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m highlight.js@>=8.3.0 <9.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name highlight.js
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/highlight.js
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/highlight.js not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m inherits@>=2.0.1 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name inherits
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/inherits
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/inherits not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m inquirer@>=0.5.1 <0.6.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name inquirer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/inquirer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/inquirer not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m linklocal@>=2.0.1 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name linklocal
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/linklocal
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/linklocal not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m marked@>=0.3.2 <0.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/marked not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m minimist@>=1.1.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/minimist not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m minstache@>=1.2.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name minstache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/minstache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/minstache not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m mkdirp@>=0.5.0 <0.6.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/mkdirp not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m mousetrap@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name mousetrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/mousetrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/mousetrap not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m myth@>=1.2.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name myth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/myth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/myth not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m normals@>=0.1.0 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/normals not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m opener@>=1.4.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name opener
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/opener
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/opener not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m parse-obj@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name parse-obj
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/parse-obj
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/parse-obj not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m quotemeta@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name quotemeta
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/quotemeta
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/quotemeta not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m resolve@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/resolve not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rework@>=1.0.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name rework
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/rework
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/rework not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rework-plugin-inline@>=1.0.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name rework-plugin-inline
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/rework-plugin-inline
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/rework-plugin-inline not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m sidenote@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name sidenote
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/sidenote
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/sidenote not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m simplicial-complex@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name simplicial-complex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/simplicial-complex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/simplicial-complex not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m st@>=0.5.2 <0.6.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name st
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/st
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/st not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m teapot@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name teapot
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/teapot
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/teapot not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m unindex-mesh@>=1.0.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name unindex-mesh
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/unindex-mesh
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/unindex-mesh not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m watchify@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name watchify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/watchify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/watchify not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m wordwrap@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name wordwrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/wordwrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/wordwrap not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m xhr@>=1.17.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name xhr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/xhr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/xhr not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m beefy@>=2.1.1 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name beefy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/beefy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/beefy not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m bl@>=0.9.3 <0.10.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name bl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/bl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/bl not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec browser-menu@^1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec browserify@^6.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec brstar@^0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec bunny@^1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec canvas-fit@^1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec canvas-orbit-camera@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec canvas-pixels@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec chalk@^0.5.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec cheerio@^0.17.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m brfs@>=1.2.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name brfs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/brfs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/brfs not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m browser-menu@>=1.0.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name browser-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/browser-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/browser-menu not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m browserify@>=6.1.0 <7.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name browserify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/browserify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/browserify not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m brstar@>=0.1.0 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name brstar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/brstar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/brstar not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m bunny@>=1.0.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name bunny
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/bunny
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/bunny not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m canvas-fit@>=1.2.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name canvas-fit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/canvas-fit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/canvas-fit not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m canvas-orbit-camera@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/canvas-orbit-camera not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m canvas-pixels@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name canvas-pixels
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/canvas-pixels
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/canvas-pixels not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m chalk@>=0.5.1 <0.6.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name chalk
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/chalk
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/chalk not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m cheerio@>=0.17.0 <0.18.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name cheerio
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/cheerio
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/cheerio not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /cpr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /cpr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /cpr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './cpr' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/cpr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "EV3DSNSFYKNPHQH5MWLPDY2N9"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/cpr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /defaultcss
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /defaultcss
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /defaultcss
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './defaultcss' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/defaultcss
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "DB937ONO27JBS9MWXRSNO53UR"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/defaultcss
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /domify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /domify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /domify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './domify' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/domify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "850DCT52BSCDLNI071VLV06P"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/domify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /events
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /events
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /events
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './events' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/events
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "8JQ76SP9FLCNTEIII525OAY9I"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/events
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /envify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /envify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /envify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './envify' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/envify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "6A3O91M6P0K8LV18CXXL9FUTM"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/envify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /face-normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /face-normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /face-normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './face-normals' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/face-normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "5LTFUAWY5NI941TKHVAREF87X"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/face-normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /escape-html
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /escape-html
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /escape-html
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './escape-html' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/escape-html
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "56CSEOG59EVEEN5SJJK2EGQK9"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/escape-html
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /findup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /findup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /findup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './findup' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/findup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "7K6ZL1Y0QM4DNK3VQ1J9ZJ93K"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/findup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /findup-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /findup-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /findup-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './findup-element' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/findup-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "AGHXR1CXR6ML7YJ63SHM7B1O9"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/findup-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './fs-readdir-recursive' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "1FO0GUQ4T2JCZE9BTBO0UYX2E"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /fresh-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /fresh-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /fresh-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './fresh-require' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/fresh-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "JTH58AIDC1HY0CLD7615BWFV"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/fresh-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /gl-api
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /gl-api
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /gl-api
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './gl-api' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/gl-api
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "A4OYMW0UPLBXGE87VDPQWFYIJ"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/gl-api
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /gl-clear
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /gl-clear
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /gl-clear
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './gl-clear' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/gl-clear
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "3TOSHFONRRHBKDONQXLDMJT0U"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/gl-clear
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /gl-compare
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /gl-compare
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /gl-compare
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './gl-compare' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/gl-compare
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "47SE1C7NMUAB4XYH8IG9AI1QA"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/gl-compare
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './gl-context' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "1PU4BS87L19TYV3SPY71RAZFC"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /gl-compare-sidebar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /gl-compare-sidebar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /gl-compare-sidebar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './gl-compare-sidebar' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/gl-compare-sidebar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "C017J2OPGNFHZN0I6S3BI8K1E"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/gl-compare-sidebar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /gl-geometry
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /gl-geometry
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /gl-geometry
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './gl-geometry' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/gl-geometry
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "I8J2WP3SKT02DBINZ2HV09FV"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/gl-geometry
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './gl-matrix' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "D4UMUOWW2EQJVINFD6B9E190K"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /gl-shader-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /gl-shader-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /gl-shader-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './gl-shader-core' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/gl-shader-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "4L2GW55BZ38FSRXZMSAGY5WUB"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/gl-shader-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /gl-reset
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /gl-reset
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /gl-reset
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './gl-reset' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/gl-reset
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9BBFY68TV0SZ32BEOPD1SMAXB"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/gl-reset
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /glslify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /glslify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /glslify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './glslify' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/glslify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "D6W344A6NUVJ0DPDHXWKNWQ93"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/glslify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /glsldoc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /glsldoc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /glsldoc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './glsldoc' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/glsldoc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "HNMF48U9R0ZX15RN99E1OHTZ"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/glsldoc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /google-fonts
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /google-fonts
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /google-fonts
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './google-fonts' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/google-fonts
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "E8633RKZJ2WBCI0R0PI8OFTFB"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/google-fonts
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /inherits
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /inherits
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /inherits
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './inherits' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/inherits
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "4HKEWVWX7W0PKAF3UJZOADCGX"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/inherits
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /highlight.js
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /highlight.js
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /highlight.js
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './highlight.js' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/highlight.js
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "5SC4J8DXYJCLNVV7BR5ZMMQGR"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/highlight.js
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /linklocal
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /linklocal
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /linklocal
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './linklocal' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/linklocal
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "BWGYQ7CWC2WQO6Z9NHGVN70BK"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/linklocal
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /inquirer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /inquirer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /inquirer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './inquirer' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/inquirer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "E67YY28IQN84VLKLIDC9SUOH5"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/inquirer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './marked' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "8MKVLFR94LPG0CA82M7UHBIDL"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './minimist' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9VC6SEH15P2DPNUHRPLOEL1UV"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /minstache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /minstache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /minstache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './minstache' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/minstache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "8D9HQOHQO0N0J039O4JD5GIC0"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/minstache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './mkdirp' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "280CA9JAOPBHCLVQ3HD8AG8YS"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /mousetrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /mousetrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /mousetrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './mousetrap' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/mousetrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "2AG7GDGMVDY2HIU7ENH6NFAJA"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/mousetrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /myth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /myth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /myth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './myth' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/myth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "5TKM7XBKKXHU6VG2NIIZXU7CE"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/myth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './normals' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "62W2L73Q027QKLAR3LQC6TH9P"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /opener
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /opener
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /opener
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './opener' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/opener
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "3Y5T0NEGDZNC6L2FLBLSL1VS2"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/opener
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /parse-obj
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /parse-obj
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /parse-obj
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './parse-obj' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/parse-obj
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "1SNBEKRB9OXCZ0FQFTVTGV76E"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/parse-obj
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /quotemeta
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /quotemeta
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /quotemeta
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './quotemeta' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/quotemeta
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "4SKQAIR4XVML8JWV2UMPG0M5L"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/quotemeta
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './resolve' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "E8EO3VI6KDFATVHO865FSU1SZ"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /rework-plugin-inline
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /rework-plugin-inline
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /rework-plugin-inline
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './rework-plugin-inline' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/rework-plugin-inline
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9EH8PQEEASKT1YNI9BRR7V3BW"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/rework-plugin-inline
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /rework
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /rework
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /rework
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './rework' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/rework
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "6ZGHRXDR2MBBYP1R4JA8IS8AD"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/rework
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /sidenote
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /sidenote
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /sidenote
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './sidenote' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/sidenote
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "79FPTRYYHS0LS6JTOD7E2O82J"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/sidenote
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /teapot
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /teapot
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /teapot
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './teapot' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/teapot
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9OE92BXT4404UGVGVRS0QBH31"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/teapot
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /simplicial-complex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /simplicial-complex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /simplicial-complex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './simplicial-complex' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/simplicial-complex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "2D446MXO0XV0MMCIP41TD58IK"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/simplicial-complex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /unindex-mesh
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /unindex-mesh
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /unindex-mesh
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './unindex-mesh' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/unindex-mesh
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "DR9IE8XU0SK7QUYWRISH1O9OZ"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/unindex-mesh
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /st
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /st
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /st
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './st' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/st
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "6AW73XGWOPYRND46N3LWD5LL6"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/st
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /wordwrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /wordwrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /wordwrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './wordwrap' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/wordwrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "BWZBG6OAWP3BCANDD0T9BQOBO"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/wordwrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /watchify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /watchify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /watchify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './watchify' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/watchify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "BORPFN881XPA7M42T1DROSTZ8"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/watchify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /xhr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /xhr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /xhr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './xhr' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/xhr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "98BY4C87PKV6FF5JAM9EKPPV5"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/xhr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /beefy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /beefy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /beefy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './beefy' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/beefy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "DJGA6PQYAPQTAJIVF8TGM2H3"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/beefy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /bl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /bl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /bl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './bl' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/bl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "1P7ITS9KJLE5GFB5CZ6H5HE83"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/bl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /brfs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /brfs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /brfs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './brfs' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/brfs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "7E91NDN8JDOHY90B8Z1X60OZD"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/brfs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /browser-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /browser-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /browser-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './browser-menu' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/browser-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "2SX78ZF16U5K3J81XC8MN6E76"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/browser-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /brstar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /brstar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /brstar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './brstar' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/brstar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9UTS793YISDG48UHFLDKIFEY5"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/brstar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /bunny
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /bunny
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /bunny
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './bunny' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/bunny
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "BMAFZD4UF1GTAKDEIJZW17HED"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/bunny
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /canvas-pixels
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /canvas-pixels
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /canvas-pixels
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './canvas-pixels' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/canvas-pixels
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9K59R7Y2563CQEQHY8C1E3LOF"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/canvas-pixels
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /browserify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /browserify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /browserify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './browserify' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/browserify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "DQ500XN9IFH7IRQ5DU1BF5V66"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/browserify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /canvas-fit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /canvas-fit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /canvas-fit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './canvas-fit' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/canvas-fit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "DQ2SDLE8620R7MUBSH9T1XIKS"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/canvas-fit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './canvas-orbit-camera' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "7IJYVRWESSQSXUOBXJJIHYQE9"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /chalk
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /chalk
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /chalk
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './chalk' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/chalk
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "6ZTS04QFWCEG18AY1OIGTGPSZ"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/chalk
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /cheerio
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /cheerio
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /cheerio
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './cheerio' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/cheerio
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:01
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "ASMHX37O3HRYHTM88RQCKRD0D"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/cheerio
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/cpr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/cpr from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m cpr@0.3.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/cpr/0.3.2/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/cpr/0.3.2/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/domify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/domify from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m domify@1.3.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/domify/1.3.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/domify/1.3.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m200[0m https://registry.npmjs.org/envify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m envify@3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/envify/3.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/envify/3.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/escape-html
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/escape-html from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m escape-html@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/escape-html/1.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/escape-html/1.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/face-normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/face-normals from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/face-normals/0.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/face-normals/0.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/findup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/findup from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m findup@0.1.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/findup/0.1.5/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/findup/0.1.5/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/findup-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/findup-element from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/findup-element/0.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/findup-element/0.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m200[0m https://registry.npmjs.org/fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddRemoteTarball[0m https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.0.2.tgz not in flight; adding
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddRemoteTarball[0m [ 'https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.0.2.tgz',
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddRemoteTarball[0m   'a7863a54832b7af554febbc92d29662eb9f2797a' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mretry[0m fetch attempt 1 at 13:07:02
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:02
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mfetch[0m GET https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.0.2.tgz
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/gl-api
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/gl-api from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-api@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-api/1.0.2/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-api/1.0.2/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/events
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/events from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m events@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/events/1.0.2/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/events/1.0.2/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/defaultcss
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/defaultcss from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m defaultcss@1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/defaultcss/1.1.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/defaultcss/1.1.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/gl-clear
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/gl-clear from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-clear/0.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-clear/0.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/gl-compare
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/gl-compare from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-compare@2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-compare/2.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-compare/2.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/gl-geometry
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/gl-geometry from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-geometry@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-geometry/1.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-geometry/1.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/fresh-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/fresh-require from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m fresh-require@1.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/fresh-require/1.0.3/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/fresh-require/1.0.3/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/gl-matrix from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-matrix@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-matrix/2.1.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-matrix/2.1.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/gl-shader-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/gl-shader-core from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-shader-core@2.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-shader-core/2.2.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-shader-core/2.2.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/gl-reset
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/gl-reset from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-reset@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-reset/1.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-reset/1.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/glsldoc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/glsldoc from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/glsldoc/0.0.4/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/glsldoc/0.0.4/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/inherits
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/inherits from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m inherits@2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/inherits/2.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/inherits/2.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/google-fonts
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/google-fonts from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/google-fonts/0.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/google-fonts/0.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/gl-context from cache
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/gl-compare-sidebar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/gl-compare-sidebar from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-context@0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-compare-sidebar@1.1.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-context/0.1.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-compare-sidebar/1.1.4/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-compare-sidebar/1.1.4/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-context/0.1.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/inquirer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/inquirer from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m inquirer@0.5.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/inquirer/0.5.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/inquirer/0.5.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/highlight.js
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/highlight.js from cache
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m200[0m https://registry.npmjs.org/minimist
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/linklocal
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/linklocal from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m highlight.js@8.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m minimist@1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m linklocal@2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/highlight.js/8.3.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/minimist/1.1.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/linklocal/2.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/highlight.js/8.3.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/minimist/1.1.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/linklocal/2.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/glslify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/glslify from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m glslify@1.6.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/glslify/1.6.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m200[0m https://registry.npmjs.org/mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/glslify/1.6.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m mkdirp@0.5.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/mkdirp/0.5.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/mkdirp/0.5.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/marked from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m marked@0.3.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/marked/0.3.2/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/marked/0.3.2/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/opener
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/opener from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m opener@1.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/opener/1.4.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/opener/1.4.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/minstache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/minstache from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m minstache@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/minstache/1.2.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/minstache/1.2.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/mousetrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/mousetrap from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/mousetrap/0.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/mousetrap/0.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/resolve from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m resolve@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/resolve/1.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/resolve/1.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/myth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/myth from cache
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/normals from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m myth@1.2.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/myth/1.2.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m normals@0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/normals/0.1.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/myth/1.2.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/normals/0.1.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/parse-obj
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/parse-obj from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/parse-obj/0.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/parse-obj/0.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/rework
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/rework from cache
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/sidenote
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/sidenote from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m sidenote@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rework@1.0.1
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/rework-plugin-inline
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/rework-plugin-inline from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/sidenote/1.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/rework/1.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rework-plugin-inline@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/rework-plugin-inline/1.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/sidenote/1.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/rework/1.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/rework-plugin-inline/1.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/teapot
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/teapot from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m teapot@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/teapot/1.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/teapot/1.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/wordwrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/wordwrap from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/wordwrap/0.0.2/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/wordwrap/0.0.2/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/simplicial-complex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/simplicial-complex from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m simplicial-complex@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/simplicial-complex/1.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/simplicial-complex/1.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/unindex-mesh
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/unindex-mesh from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m unindex-mesh@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/unindex-mesh/1.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/st
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/st from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/unindex-mesh/1.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m st@0.5.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/st/0.5.2/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/st/0.5.2/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/bl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/bl from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m bl@0.9.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/bl/0.9.3/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/bl/0.9.3/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/quotemeta
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/quotemeta from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/quotemeta/0.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/quotemeta/0.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/xhr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/xhr from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m xhr@1.17.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/xhr/1.17.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/xhr/1.17.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m200[0m https://registry.npmjs.org/watchify
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/beefy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/beefy from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddRemoteTarball[0m https://registry.npmjs.org/watchify/-/watchify-2.1.0.tgz not in flight; adding
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddRemoteTarball[0m [ 'https://registry.npmjs.org/watchify/-/watchify-2.1.0.tgz',
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddRemoteTarball[0m   'ac4a442f9fb07c46bcb0136de220bc9974b1d6f0' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m beefy@2.1.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mretry[0m fetch attempt 1 at 13:07:05
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:05
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mfetch[0m GET https://registry.npmjs.org/watchify/-/watchify-2.1.0.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/beefy/2.1.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/beefy/2.1.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/brfs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/brfs from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m brfs@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/brfs/1.2.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/brfs/1.2.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/browser-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/browser-menu from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m browser-menu@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/browser-menu/1.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/browser-menu/1.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/brstar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/brstar from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m brstar@0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/brstar/0.1.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/brstar/0.1.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/bunny
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/bunny from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m bunny@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/bunny/1.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/bunny/1.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/canvas-pixels
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/canvas-pixels from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/canvas-pixels/0.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/canvas-pixels/0.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m200[0m https://registry.npmjs.org/chalk
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m chalk@0.5.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/chalk/0.5.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/chalk/0.5.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mfetch[0m 200 https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.0.2.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddTmpTarball[0m /var/folders/q0/mqfk4sjd5b1g5n62dd43p5x40000gn/T/npm-5354-43f5bcfd/registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.0.2.tgz not in flight; adding
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddTmpTarball[0m already have metadata; skipping unpack for fs-readdir-recursive@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/fs-readdir-recursive/0.0.2/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/fs-readdir-recursive/0.0.2/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/canvas-fit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/canvas-fit from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m canvas-fit@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/canvas-fit/1.2.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/canvas-fit/1.2.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/canvas-orbit-camera from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m canvas-orbit-camera@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/canvas-orbit-camera/1.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/canvas-orbit-camera/1.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m200[0m https://registry.npmjs.org/cheerio
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m cheerio@0.17.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/cheerio/0.17.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/cheerio/0.17.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mfetch[0m 200 https://registry.npmjs.org/watchify/-/watchify-2.1.0.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddTmpTarball[0m /var/folders/q0/mqfk4sjd5b1g5n62dd43p5x40000gn/T/npm-5354-43f5bcfd/registry.npmjs.org/watchify/-/watchify-2.1.0.tgz not in flight; adding
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddTmpTarball[0m already have metadata; skipping unpack for watchify@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/watchify/2.1.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/watchify/2.1.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m200[0m https://registry.npmjs.org/browserify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m browserify@6.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/browserify/6.2.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/browserify/6.2.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m cpr@0.3.2 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m domify@1.3.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m envify@3.0.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m escape-html@1.0.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m face-normals@0.0.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m findup@0.1.5 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m findup-element@0.0.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-api@1.0.2 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m events@1.0.2 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m defaultcss@1.1.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-clear@0.0.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-compare@2.0.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-geometry@1.0.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m fresh-require@1.0.3 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-matrix@2.1.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-shader-core@2.2.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-reset@1.0.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m glsldoc@0.0.4 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m inherits@2.0.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m google-fonts@0.0.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-compare-sidebar@1.1.4 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-context@0.1.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m inquirer@0.5.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m highlight.js@8.3.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m minimist@1.1.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m linklocal@2.0.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m glslify@1.6.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m mkdirp@0.5.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m marked@0.3.2 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m opener@1.4.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m minstache@1.2.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m mousetrap@0.0.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m resolve@1.0.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m myth@1.2.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m normals@0.1.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m parse-obj@0.0.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m sidenote@1.0.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m rework@1.0.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m rework-plugin-inline@1.0.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m teapot@1.0.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m wordwrap@0.0.2 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m simplicial-complex@1.0.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m unindex-mesh@1.0.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m st@0.5.2 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m bl@0.9.3 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m quotemeta@0.0.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m xhr@1.17.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m beefy@2.1.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m brfs@1.2.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m browser-menu@1.0.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m brstar@0.1.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m bunny@1.0.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m canvas-pixels@0.0.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m chalk@0.5.1 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m fs-readdir-recursive@0.0.2 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m canvas-fit@1.2.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m canvas-orbit-camera@1.0.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m cheerio@0.17.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m watchify@2.1.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m browserify@6.2.0 into /Users/mp/node_modules/webgl-workshop
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m cpr@0.3.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of cpr to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m domify@1.3.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of domify to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m envify@3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of envify to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m escape-html@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of escape-html to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m face-normals@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of face-normals to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m findup@0.1.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of findup to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m findup-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of findup-element to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m gl-api@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of gl-api to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m events@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of events to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m defaultcss@1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of defaultcss to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m gl-clear@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of gl-clear to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m gl-compare@2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of gl-compare to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m gl-geometry@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of gl-geometry to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m fresh-require@1.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of fresh-require to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m gl-matrix@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of gl-matrix to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m gl-shader-core@2.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of gl-shader-core to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m gl-reset@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of gl-reset to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m glsldoc@0.0.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of glsldoc to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m inherits@2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of inherits to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m google-fonts@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of google-fonts to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m gl-compare-sidebar@1.1.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of gl-compare-sidebar to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m gl-context@0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of gl-context to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m inquirer@0.5.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of inquirer to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m highlight.js@8.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of highlight.js to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m minimist@1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of minimist to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m linklocal@2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of linklocal to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m glslify@1.6.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of glslify to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m mkdirp@0.5.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of mkdirp to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m marked@0.3.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of marked to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m opener@1.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of opener to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m minstache@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of minstache to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m mousetrap@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of mousetrap to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m resolve@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of resolve to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m myth@1.2.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of myth to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m normals@0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of normals to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m parse-obj@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of parse-obj to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m sidenote@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of sidenote to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m rework@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of rework to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m rework-plugin-inline@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of rework-plugin-inline to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m teapot@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of teapot to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m wordwrap@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of wordwrap to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m simplicial-complex@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of simplicial-complex to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m unindex-mesh@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of unindex-mesh to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m st@0.5.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of st to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m bl@0.9.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of bl to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m quotemeta@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of quotemeta to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m xhr@1.17.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of xhr to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m beefy@2.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of beefy to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m brfs@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of brfs to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m browser-menu@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of browser-menu to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m brstar@0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of brstar to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m bunny@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of bunny to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m canvas-pixels@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of canvas-pixels to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m chalk@0.5.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of chalk to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m fs-readdir-recursive@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of fs-readdir-recursive to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m canvas-fit@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of canvas-fit to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m canvas-orbit-camera@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of canvas-orbit-camera to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m cheerio@0.17.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of cheerio to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m watchify@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of watchify to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m browserify@6.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of browserify to /Users/mp/node_modules/webgl-workshop not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/cpr-1236c9f75011dc35.lock for /Users/mp/node_modules/webgl-workshop/node_modules/cpr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/domify-7ba8d19bc60941bc.lock for /Users/mp/node_modules/webgl-workshop/node_modules/domify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/envify-f638ff676aa838dc.lock for /Users/mp/node_modules/webgl-workshop/node_modules/envify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/escape-html-1ab7ec8c6daaa3d1.lock for /Users/mp/node_modules/webgl-workshop/node_modules/escape-html
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/face-normals-67b497f841a7365b.lock for /Users/mp/node_modules/webgl-workshop/node_modules/face-normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/findup-c770bebfd52a0a7b.lock for /Users/mp/node_modules/webgl-workshop/node_modules/findup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/findup-element-06b31098a5ffa6e0.lock for /Users/mp/node_modules/webgl-workshop/node_modules/findup-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/gl-api-2fc91cc6909d9834.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-api
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/events-a836b6ab9d9cf3e6.lock for /Users/mp/node_modules/webgl-workshop/node_modules/events
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/defaultcss-d897499865f1bea8.lock for /Users/mp/node_modules/webgl-workshop/node_modules/defaultcss
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/gl-clear-195bb0d6f4923567.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/gl-compare-34b03f0ce5e2bfb2.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-compare
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/gl-geometry-ac90f579d986db10.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-geometry
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/fresh-require-2c070b865d6d5ada.lock for /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/gl-matrix-3a0db0f9470150dc.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/gl-shader-core-4bde8901c33a1b90.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-shader-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/gl-reset-fc0fe59905c893a0.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-reset
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/glsldoc-d437482c8be27e8f.lock for /Users/mp/node_modules/webgl-workshop/node_modules/glsldoc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/google-fonts-62b6476860b1aead.lock for /Users/mp/node_modules/webgl-workshop/node_modules/google-fonts
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/inherits-ea0de23a053292b4.lock for /Users/mp/node_modules/webgl-workshop/node_modules/inherits
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/gl-compare-sidebar-dd1d3d23b49e3780.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-compare-sidebar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/gl-context-b20e1808ab1f2a91.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/inquirer-58a9550b9889c4ad.lock for /Users/mp/node_modules/webgl-workshop/node_modules/inquirer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/linklocal-7f16fbbf682dce86.lock for /Users/mp/node_modules/webgl-workshop/node_modules/linklocal
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/highlight-js-0ccb0247d5999198.lock for /Users/mp/node_modules/webgl-workshop/node_modules/highlight.js
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/mkdirp-4ffd693370fdb91a.lock for /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/minimist-f1179efa99aff9e1.lock for /Users/mp/node_modules/webgl-workshop/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/glslify-282a42202596ae1d.lock for /Users/mp/node_modules/webgl-workshop/node_modules/glslify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/marked-f60c3e7e4961a494.lock for /Users/mp/node_modules/webgl-workshop/node_modules/marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/opener-6380f79e493c787c.lock for /Users/mp/node_modules/webgl-workshop/node_modules/opener
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/mousetrap-92231f750d762877.lock for /Users/mp/node_modules/webgl-workshop/node_modules/mousetrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/resolve-6c18ff843b0eb39c.lock for /Users/mp/node_modules/webgl-workshop/node_modules/resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/myth-9491bc35d2a90664.lock for /Users/mp/node_modules/webgl-workshop/node_modules/myth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/normals-11018487caaafc78.lock for /Users/mp/node_modules/webgl-workshop/node_modules/normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/parse-obj-d45063305f86d9e4.lock for /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/rework-plugin-inline-d0255bfbab1e49e9.lock for /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/teapot-bf121b71261fe2b7.lock for /Users/mp/node_modules/webgl-workshop/node_modules/teapot
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/wordwrap-2344455eef48c688.lock for /Users/mp/node_modules/webgl-workshop/node_modules/wordwrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/simplicial-complex-7ca3607c1039884c.lock for /Users/mp/node_modules/webgl-workshop/node_modules/simplicial-complex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/unindex-mesh-d02fe28e2defa38b.lock for /Users/mp/node_modules/webgl-workshop/node_modules/unindex-mesh
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/minstache-1b039a9efd5b7511.lock for /Users/mp/node_modules/webgl-workshop/node_modules/minstache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/rework-e101c639054b2db7.lock for /Users/mp/node_modules/webgl-workshop/node_modules/rework
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/st-b87f65b9109f9313.lock for /Users/mp/node_modules/webgl-workshop/node_modules/st
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/xhr-634e02a607fa97c2.lock for /Users/mp/node_modules/webgl-workshop/node_modules/xhr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/beefy-49900038464c7a3e.lock for /Users/mp/node_modules/webgl-workshop/node_modules/beefy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/quotemeta-05ac61c6d549f892.lock for /Users/mp/node_modules/webgl-workshop/node_modules/quotemeta
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/brfs-4956b07b7621d724.lock for /Users/mp/node_modules/webgl-workshop/node_modules/brfs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/browser-menu-191189737215db6e.lock for /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/brstar-beb246c02ce4b312.lock for /Users/mp/node_modules/webgl-workshop/node_modules/brstar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/bl-2bc9e1cdf5400f74.lock for /Users/mp/node_modules/webgl-workshop/node_modules/bl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/sidenote-a0070c632e8fce58.lock for /Users/mp/node_modules/webgl-workshop/node_modules/sidenote
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/bunny-e4f00c9aa663ce7f.lock for /Users/mp/node_modules/webgl-workshop/node_modules/bunny
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/chalk-415f116919307a6f.lock for /Users/mp/node_modules/webgl-workshop/node_modules/chalk
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/canvas-orbit-camera-b2dbe012ae25dae9.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/cheerio-15edb6a72fccde44.lock for /Users/mp/node_modules/webgl-workshop/node_modules/cheerio
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/watchify-c54f884f3f42beee.lock for /Users/mp/node_modules/webgl-workshop/node_modules/watchify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/fs-readdir-recursive-085e95b089ce5487.lock for /Users/mp/node_modules/webgl-workshop/node_modules/fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/cpr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/domify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/envify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/escape-html
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/face-normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/findup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/findup-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/gl-api
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/events
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/defaultcss
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/gl-clear
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/canvas-pixels-7f56926fb6dea3fa.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-pixels
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/gl-compare
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/gl-geometry
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/fresh-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/gl-shader-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/gl-reset
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/glsldoc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/google-fonts
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/inherits
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/gl-compare-sidebar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/inquirer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/linklocal
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/highlight.js
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/canvas-fit-03bc916d85cf0ad7.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/browserify-355ac75437d9c8c9.lock for /Users/mp/node_modules/webgl-workshop/node_modules/browserify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/glslify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/opener
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/mousetrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/myth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/parse-obj
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/rework-plugin-inline
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/teapot
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/wordwrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/simplicial-complex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/unindex-mesh
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/minstache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/rework
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/st
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/xhr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/beefy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/quotemeta
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/brfs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/browser-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/brstar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/bl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/sidenote
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/bunny
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/chalk
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/cheerio
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/canvas-pixels
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/canvas-fit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/browserify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/cpr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/domify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/envify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/escape-html
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/face-normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/findup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/findup-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-api
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/events
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/defaultcss
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-compare
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-geometry
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-shader-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-reset
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/glsldoc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/google-fonts
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/inherits
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-compare-sidebar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/inquirer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/linklocal
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/highlight.js
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/glslify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/opener
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/mousetrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/myth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/teapot
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/wordwrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/simplicial-complex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/unindex-mesh
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/minstache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/rework
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/st
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/xhr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/beefy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/quotemeta
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/brfs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/brstar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/bl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/sidenote
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/bunny
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/chalk
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/cheerio
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/cpr/0.3.2/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/cpr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/cpr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/domify/1.3.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/domify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/domify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/envify/3.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/envify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/envify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/escape-html/1.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/escape-html
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/escape-html
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/face-normals/0.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/face-normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/face-normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/findup/0.1.5/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/findup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/findup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/findup-element/0.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/findup-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/findup-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/gl-api/1.0.2/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/gl-api
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-api
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/events/1.0.2/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/events
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/events
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/defaultcss/1.1.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/defaultcss
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/defaultcss
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/gl-clear/0.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-pixels
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/gl-compare/2.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/gl-compare
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-compare
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/gl-geometry/1.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/gl-geometry
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-geometry
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/fresh-require/1.0.3/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/gl-matrix/2.1.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/gl-shader-core/2.2.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/gl-shader-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-shader-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/gl-reset/1.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/gl-reset
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-reset
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/glsldoc/0.0.4/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/glsldoc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/glsldoc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/google-fonts/0.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/google-fonts
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/google-fonts
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/inherits/2.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/inherits
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/inherits
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/gl-compare-sidebar/1.1.4/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/gl-compare-sidebar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-compare-sidebar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/gl-context/0.1.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/inquirer/0.5.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/inquirer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/inquirer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/linklocal/2.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/linklocal
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/linklocal
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/highlight.js/8.3.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/highlight.js
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/highlight.js
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/mkdirp/0.5.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/minimist/1.1.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/browserify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/glslify/1.6.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/glslify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/glslify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/marked/0.3.2/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/opener/1.4.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/opener
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/opener
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/mousetrap/0.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/mousetrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/mousetrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/resolve/1.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/myth/1.2.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/myth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/myth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/normals/0.1.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/parse-obj/0.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/rework-plugin-inline/1.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/teapot/1.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/teapot
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/teapot
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/wordwrap/0.0.2/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/wordwrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/wordwrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/simplicial-complex/1.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/simplicial-complex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/simplicial-complex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/unindex-mesh/1.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/unindex-mesh
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/unindex-mesh
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/minstache/1.2.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/minstache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/minstache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/rework/1.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/rework
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/rework
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/st/0.5.2/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/st
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/st
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/xhr/1.17.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/xhr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/xhr
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/beefy/2.1.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/beefy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/beefy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/quotemeta/0.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/quotemeta
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/quotemeta
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/brfs/1.2.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/brfs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/brfs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/browser-menu/1.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/brstar/0.1.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/brstar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/brstar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/bl/0.9.3/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/bl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/bl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/sidenote/1.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/sidenote
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/sidenote
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/bunny/1.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/bunny
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/bunny
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/chalk/0.5.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/chalk
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/chalk
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/canvas-orbit-camera/1.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/cheerio/0.17.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/cheerio
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/cheerio
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/canvas-pixels/0.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-pixels
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-pixels
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/canvas-fit/1.2.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/browserify/6.2.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/browserify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/browserify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/watchify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/watchify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/watchify/2.1.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/watchify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/watchify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/fs-readdir-recursive/0.0.2/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m rework@1.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m chalk@0.5.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m opener@1.4.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m normals@0.1.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m unindex-mesh@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec css@^2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec convert-source-map@^0.3.3
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m canvas-orbit-camera@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m css@>=2.0.0 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/css not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m convert-source-map@>=0.3.3 <0.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name convert-source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/convert-source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/convert-source-map not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/opener
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/opener
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m opener@1.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/normals
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m normals@0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/unindex-mesh
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/unindex-mesh
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m unindex-mesh@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec ansi-styles@^1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec escape-string-regexp@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec has-ansi@^0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec strip-ansi@^0.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec supports-color@^0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m opener@1.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlink bins[0m [ { opener: 'opener.js' },
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlink bins[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/.bin',
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlink bins[0m   false ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m opener@1.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m opener@1.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m normals@0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m normals@0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m normals@0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m ansi-styles@>=1.1.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name ansi-styles
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/ansi-styles
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/ansi-styles not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m escape-string-regexp@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name escape-string-regexp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/escape-string-regexp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/escape-string-regexp not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m has-ansi@>=0.1.0 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name has-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/has-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/has-ansi not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m strip-ansi@>=0.3.0 <0.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name strip-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/strip-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/strip-ansi not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m supports-color@>=0.2.0 <0.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name supports-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/supports-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/supports-color not in flight; fetching
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m sidenote@1.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m findup-element@0.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m gl-context@0.1.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m normals@0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m unindex-mesh@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m unindex-mesh@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m unindex-mesh@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec key-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec mouse-position@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec mouse-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec orbit-camera@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec scroll-speed@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './css' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:08
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "BIOF86NLUQVV4S27O6BQGQ52K"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /convert-source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /convert-source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /convert-source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './convert-source-map' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/convert-source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:08
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "40N4UMLV08VFRWSQ7RDU75KNX"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/convert-source-map
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m canvas-pixels@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/.bin/opener
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m canvas-fit@1.2.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m parse-obj@0.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m unindex-mesh@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m key-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name key-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/key-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/key-pressed not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m mouse-position@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name mouse-position
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/mouse-position
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/mouse-position not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m mouse-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name mouse-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/mouse-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/mouse-pressed not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m orbit-camera@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/orbit-camera not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m scroll-speed@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name scroll-speed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/scroll-speed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/scroll-speed not in flight; fetching
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m escape-html@1.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m normals@0.1.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m unindex-mesh@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/sidenote
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/sidenote
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m sidenote@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/findup-element
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/findup-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m findup-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /ansi-styles
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /ansi-styles
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /ansi-styles
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './ansi-styles' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/ansi-styles
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:08
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "89BTWDCZ6UUTTX6GL9L0IKRTG"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/ansi-styles
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /escape-string-regexp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /escape-string-regexp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /escape-string-regexp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './escape-string-regexp' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/escape-string-regexp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:08
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "EMIN7LOE22KESR5DOWJRB8ACW"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/escape-string-regexp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /has-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /has-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /has-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './has-ansi' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/has-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:08
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "2I8RDBNDGLCZT732CCHKVJUKJ"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/has-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /strip-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /strip-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /strip-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './strip-ansi' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/strip-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:08
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "75LHXYTAYHSVGUDAKW4Q6NTZR"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/strip-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /supports-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /supports-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /supports-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './supports-color' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/supports-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:08
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "8VB7BVKFWI2B74A3ZQ7EW2AZ1"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/supports-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-pixels
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-pixels
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m canvas-pixels@0.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m opener@1.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/normals-11018487caaafc78.lock for /Users/mp/node_modules/webgl-workshop/node_modules/normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec raf-component@^1.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m sidenote@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m sidenote@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m sidenote@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m findup-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m findup-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m findup-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/escape-html
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/escape-html
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m escape-html@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/unindex-mesh-d02fe28e2defa38b.lock for /Users/mp/node_modules/webgl-workshop/node_modules/unindex-mesh
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /key-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /key-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /key-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './key-pressed' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/key-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:08
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "6VLEZ2UWR3MTRZ7726AOXE3TO"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/key-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /mouse-position
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /mouse-position
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /mouse-position
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './mouse-position' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/mouse-position
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:08
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "96CFEEIKJOY8QFKLTJWZZX5J2"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/mouse-position
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /mouse-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /mouse-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /mouse-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './mouse-pressed' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/mouse-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:08
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "1QR3XVTIFSWEZQAJDVOT3WO9A"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/mouse-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './orbit-camera' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:08
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "A3S17MN11FKPYIWMYD1IELRXW"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m raf-component@>=1.1.2 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/raf-component not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec element-size@^1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec split@~0.2.10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /scroll-speed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /scroll-speed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /scroll-speed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './scroll-speed' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/scroll-speed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:08
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "ARDPU4NDJHPWK6T7JHCOV5F1Q"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/scroll-speed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m sidenote@1.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m findup-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m canvas-pixels@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m canvas-pixels@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m canvas-pixels@0.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m inherits@2.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m opener@1.4.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m rework-plugin-inline@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m element-size@>=1.1.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name element-size
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/element-size
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/element-size not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m split@>=0.2.10 <0.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name split
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/split
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/split not in flight; fetching
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m canvas-pixels@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m escape-html@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m escape-html@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m escape-html@1.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m sidenote@1.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m findup-element@0.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m escape-html@1.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m google-fonts@0.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m canvas-pixels@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/opener-6380f79e493c787c.lock for /Users/mp/node_modules/webgl-workshop/node_modules/opener
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m escape-html@1.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m defaultcss@1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/inherits
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/inherits
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m inherits@2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './raf-component' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "F2DSUETBMSDYFV4KGFADSS1HE"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/sidenote-a0070c632e8fce58.lock for /Users/mp/node_modules/webgl-workshop/node_modules/sidenote
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/findup-element-06b31098a5ffa6e0.lock for /Users/mp/node_modules/webgl-workshop/node_modules/findup-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec mime@1.2.11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec rework-plugin-function@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /split
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /split
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /split
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './split' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/split
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "7E86H9DTYSZP96PKQKZ85EG4Y"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/split
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /element-size
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /element-size
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /element-size
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './element-size' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/element-size
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "C4QCPWH6DB4320HLN1BHBIDAY"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/element-size
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m fs-readdir-recursive@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/canvas-pixels-7f56926fb6dea3fa.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-pixels
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m inherits@2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m inherits@2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m inherits@2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/google-fonts
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/google-fonts
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m google-fonts@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m mime@1.2.11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name mime
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/mime
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/mime not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rework-plugin-function@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name rework-plugin-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/rework-plugin-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/rework-plugin-function not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/escape-html-1ab7ec8c6daaa3d1.lock for /Users/mp/node_modules/webgl-workshop/node_modules/escape-html
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m inherits@2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/defaultcss
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/defaultcss
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m defaultcss@1.1.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m glsldoc@0.0.4
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m gl-reset@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m google-fonts@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m google-fonts@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m google-fonts@0.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m inherits@2.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m google-fonts@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m fs-readdir-recursive@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m defaultcss@1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m defaultcss@1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m defaultcss@1.1.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m defaultcss@1.1.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m google-fonts@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /mime
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /mime
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /mime
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './mime' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/mime
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9SQMRID0SFDWKUINX2BZ7BN44"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/mime
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m quotemeta@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /rework-plugin-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /rework-plugin-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /rework-plugin-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './rework-plugin-function' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/rework-plugin-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "7OZBM0Z6N77O9CNFWS28ZZ652"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/rework-plugin-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m fs-readdir-recursive@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m fs-readdir-recursive@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m fs-readdir-recursive@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/glsldoc
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/glsldoc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m glsldoc@0.0.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-reset
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-reset
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m gl-reset@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/inherits-ea0de23a053292b4.lock for /Users/mp/node_modules/webgl-workshop/node_modules/inherits
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m fs-readdir-recursive@0.0.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m defaultcss@1.1.1
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/convert-source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/convert-source-map from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m glsldoc@0.0.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m glsldoc@0.0.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m glsldoc@0.0.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m gl-reset@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m gl-reset@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m gl-reset@1.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m fresh-require@1.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/google-fonts-62b6476860b1aead.lock for /Users/mp/node_modules/webgl-workshop/node_modules/google-fonts
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m fs-readdir-recursive@0.0.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m glsldoc@0.0.4
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-reset@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/quotemeta
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/quotemeta
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m quotemeta@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/defaultcss-d897499865f1bea8.lock for /Users/mp/node_modules/webgl-workshop/node_modules/defaultcss
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/ansi-styles
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/ansi-styles from cache
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m glsldoc@0.0.4
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m gl-reset@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m quotemeta@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlink bins[0m [ {},
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlink bins[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/.bin',
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlink bins[0m   false ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m quotemeta@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m quotemeta@0.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m domify@1.3.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/fs-readdir-recursive-085e95b089ce5487.lock for /Users/mp/node_modules/webgl-workshop/node_modules/fs-readdir-recursive
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m gl-clear@0.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m quotemeta@0.0.0
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/escape-string-regexp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/escape-string-regexp from cache
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/strip-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/strip-ansi from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec escodegen@^1.4.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec is-require@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec shallow-copy@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec sleuth@^0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec through2@^0.6.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec acorn@^0.9.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec astw@^1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/glsldoc-d437482c8be27e8f.lock for /Users/mp/node_modules/webgl-workshop/node_modules/glsldoc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/gl-reset-fc0fe59905c893a0.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-reset
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m escodegen@>=1.4.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name escodegen
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/escodegen
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/escodegen not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m is-require@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name is-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/is-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/is-require not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m shallow-copy@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name shallow-copy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/shallow-copy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/shallow-copy not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m sleuth@>=0.1.1 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/sleuth not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through2@>=0.6.3 <0.7.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/through2 not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m acorn@>=0.9.0 <0.10.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name acorn
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/acorn
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/acorn not in flight; fetching
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/has-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/has-ansi from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m astw@>=1.2.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name astw
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/astw
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/astw not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m convert-source-map@0.3.5
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m quotemeta@0.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m face-normals@0.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m minstache@1.2.0
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/supports-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/supports-color from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/domify
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/domify
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m domify@1.3.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m gl-geometry@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec gl-context@^0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/quotemeta-05ac61c6d549f892.lock for /Users/mp/node_modules/webgl-workshop/node_modules/quotemeta
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m domify@1.3.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m domify@1.3.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m domify@1.3.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m ansi-styles@1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-context@>=0.0.0 <0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/gl-context not in flight; fetching
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m domify@1.3.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/face-normals
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/face-normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m face-normals@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /is-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /is-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /is-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './is-require' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/is-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "E5O249SG85CE8366WKE9X3U89"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/is-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './sleuth' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "BAFOFH1YGAYCW8U0PLF62YVJJ"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /shallow-copy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /shallow-copy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /shallow-copy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './shallow-copy' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/shallow-copy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "25NXNC005P2QNFDJ378T3HTUD"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/shallow-copy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './through2' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "23I8WVYJBB7WYZMVNO8P4XPLT"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /acorn
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /acorn
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /acorn
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './acorn' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/acorn
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "2RM3FWX17ZKWSC5CYDNNVC3MZ"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/acorn
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /escodegen
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /escodegen
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /escodegen
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './escodegen' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/escodegen
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "8W9RY3PVAE61NYXTVS0B19SH"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/escodegen
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /astw
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /astw
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /astw
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './astw' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/astw
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "1V531D4WCISEZTVLYDJKIM317"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/astw
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m envify@3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m escape-string-regexp@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec commander@1.0.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m strip-ansi@0.3.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m domify@1.3.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/convert-source-map/0.3.5/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m face-normals@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m face-normals@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m face-normals@0.0.0
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/css from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m commander@1.0.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name commander
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/commander
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/commander not in flight; fetching
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m face-normals@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m has-ansi@0.1.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m browser-menu@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec is-typedarray@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec isndarray@^0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec array-pack-2d@^0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec dtype@^0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec gl-buffer@^2.0.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec gl-vao@^1.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m supports-color@0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m is-typedarray@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name is-typedarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/is-typedarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/is-typedarray not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m isndarray@>=0.1.0 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name isndarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/isndarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/isndarray not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m array-pack-2d@>=0.1.0 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name array-pack-2d
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/array-pack-2d
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/array-pack-2d not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m dtype@>=0.1.0 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name dtype
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/dtype
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/dtype not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-buffer@>=2.0.6 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name gl-buffer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/gl-buffer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/gl-buffer not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-vao@>=1.1.2 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name gl-vao
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/gl-vao
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/gl-vao not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mregistry.get[0m https://registry.npmjs.org/gl-context not expired, no request
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-context@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/domify-7ba8d19bc60941bc.lock for /Users/mp/node_modules/webgl-workshop/node_modules/domify
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m face-normals@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/ansi-styles/1.1.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec xtend@~2.1.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m brstar@0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/escape-string-regexp/1.0.2/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec through@~2.3.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec esprima-fb@^4001.3001.0-dev-harmony-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec jstransform@^6.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/convert-source-map/0.3.5/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m xtend@>=2.1.2 <2.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/xtend not in flight; fetching
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m xhr@1.17.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/strip-ansi/0.3.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /commander
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /commander
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /commander
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './commander' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/commander
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9YUB2CD18S5US09MCKMF4EDMV"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/commander
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/face-normals-67b497f841a7365b.lock for /Users/mp/node_modules/webgl-workshop/node_modules/face-normals
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through@>=2.3.4 <2.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/through not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m esprima-fb@>=4001.3001.0-dev-harmony-fb <4002.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/esprima-fb not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m jstransform@>=6.1.0 <7.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name jstransform
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/jstransform
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/jstransform not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec remove-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec vkey@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec insert-css@^0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec xtend@^2.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec terminal-menu@^0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/has-ansi/0.1.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /is-typedarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /is-typedarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /is-typedarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './is-typedarray' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/is-typedarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "12CQM7RQ17P7OJM42MMMNKK6J"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/is-typedarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /isndarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /isndarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /isndarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './isndarray' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/isndarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "T5OEBFYXQV7BP97MS5LOYKDV"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/isndarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /array-pack-2d
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /array-pack-2d
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /array-pack-2d
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './array-pack-2d' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/array-pack-2d
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "DJM3EM825OD55JQBDKG570LSO"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/array-pack-2d
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /dtype
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /dtype
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /dtype
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './dtype' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/dtype
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "3OXA0YX1CRWFMSLAJR7P5Y1QS"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/dtype
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /gl-buffer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /gl-buffer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /gl-buffer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './gl-buffer' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/gl-buffer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "MWKRMD3DAHN75I2H59F1NY93"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/gl-buffer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m css@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m remove-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/remove-element not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m vkey@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/vkey not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m insert-css@>=0.1.1 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name insert-css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/insert-css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/insert-css not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m xtend@>=2.1.2 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/xtend already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m terminal-menu@>=0.2.0 <0.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name terminal-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/terminal-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/terminal-menu not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /gl-vao
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /gl-vao
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /gl-vao
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './gl-vao' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/gl-vao
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "8NI65CMDT3FLS2SJDQXFEMA5D"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/gl-vao
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/supports-color/0.2.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/ansi-styles/1.1.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-context/0.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec astw@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec resolve@^0.6.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec replace-method@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec ast-parents@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './xtend' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "ALDQI6BYCZ2GS2NIW19I322"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/escape-string-regexp/1.0.2/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m astw@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name astw
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/astw
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/astw already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m resolve@>=0.6.1 <0.7.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/resolve not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m replace-method@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name replace-method
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/replace-method
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/replace-method not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/strip-ansi/0.3.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec static-eval@^0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec escodegen@^1.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec global@~4.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec debug@^0.7.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec once@~1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec through@^2.3.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec parse-headers@^2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec sleuth@^0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec esprima@^1.0.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m ast-parents@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name ast-parents
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/ast-parents
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/ast-parents not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './through' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "4UPQ3JS8LBZWNNRDQXV2PMC2L"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './esprima-fb' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "6JC1FKHKF34MIFX7NWFOK5Y5R"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /jstransform
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /jstransform
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /jstransform
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './jstransform' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/jstransform
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "3LL5H88MCLOMTYFNB4I1SR3YQ"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/jstransform
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './remove-element' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "CO7V5E6DTDHX7IR62C6TWQ2B8"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './vkey' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9T3PLP3O8U90SK2F06XU8OYXI"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /insert-css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /insert-css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /insert-css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './insert-css' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/insert-css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "AFDLTP20JWUAEF5DZM5VKTY3Z"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/insert-css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/has-ansi/0.1.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m static-eval@>=0.1.0 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name static-eval
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/static-eval
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/static-eval not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m escodegen@>=1.3.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name escodegen
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/escodegen
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/escodegen already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m global@>=4.3.0 <4.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name global
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/global
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/global not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m debug@>=0.7.4 <0.8.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name debug
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/debug
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/debug not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m once@>=1.1.1 <1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name once
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/once
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/once not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through@>=2.3.4 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/through already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m parse-headers@>=2.0.0 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name parse-headers
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/parse-headers
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/parse-headers not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m sleuth@>=0.1.0 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/sleuth already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m esprima@>=1.0.4 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name esprima
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/esprima
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/esprima not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/supports-color/0.2.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m ansi-styles@1.1.0 into /Users/mp/node_modules/webgl-workshop/node_modules/chalk
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m escape-string-regexp@1.0.2 into /Users/mp/node_modules/webgl-workshop/node_modules/chalk
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m strip-ansi@0.3.0 into /Users/mp/node_modules/webgl-workshop/node_modules/chalk
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m has-ansi@0.1.0 into /Users/mp/node_modules/webgl-workshop/node_modules/chalk
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m supports-color@0.2.0 into /Users/mp/node_modules/webgl-workshop/node_modules/chalk
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m ansi-styles@1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of ansi-styles to /Users/mp/node_modules/webgl-workshop/node_modules/chalk not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m escape-string-regexp@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of escape-string-regexp to /Users/mp/node_modules/webgl-workshop/node_modules/chalk not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m strip-ansi@0.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of strip-ansi to /Users/mp/node_modules/webgl-workshop/node_modules/chalk not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m has-ansi@0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of has-ansi to /Users/mp/node_modules/webgl-workshop/node_modules/chalk not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m supports-color@0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of supports-color to /Users/mp/node_modules/webgl-workshop/node_modules/chalk not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /terminal-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /terminal-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /terminal-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './terminal-menu' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/terminal-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "5N05NMXB0H5ZGN0L0YRK3V2UX"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/terminal-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/css/2.1.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-context/0.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-context@0.0.0 into /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m gl-context@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of gl-context to /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear not in flight; installing
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/scroll-speed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/scroll-speed from cache
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m simplicial-complex@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mregistry.get[0m https://registry.npmjs.org/resolve not expired, no request
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m resolve@0.6.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /replace-method
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /replace-method
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /replace-method
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './replace-method' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/replace-method
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "CQWQ7SSM346P7I79646NE3O6P"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/replace-method
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /ast-parents
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /ast-parents
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /ast-parents
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './ast-parents' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/ast-parents
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "1AU4YUK9I5DF77HA6EEQT4CIP"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/ast-parents
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/ansi-styles-250ba003f43322cb.lock for /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/ansi-styles
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/escape-string-regexp-0950e1a968702cf8.lock for /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/escape-string-regexp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/strip-ansi-de6bd5761580abf5.lock for /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/strip-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/has-ansi-6bbdf848c01c7b1d.lock for /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/has-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/supports-color-2d77ab0ba6349a4b.lock for /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/supports-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /static-eval
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /static-eval
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /static-eval
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './static-eval' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/static-eval
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "7LD1E0FER5QYFWSJPG1AFVHUE"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/static-eval
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /global
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /global
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /global
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './global' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/global
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "1QAZXWOBYXAX7X0GWK6LVTX12"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/global
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /once
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /once
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /once
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './once' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/once
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9Q0UL0RJ1JGCFFZYPGF0YXBAV"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/once
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /debug
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /debug
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /debug
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './debug' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/debug
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "BWMD72JWBAIND5V8QRU6MMLCL"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/debug
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /parse-headers
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /parse-headers
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /parse-headers
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './parse-headers' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/parse-headers
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "5J5ZGJI53R08QVKRVRUDJYZES"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/parse-headers
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/gl-context-102a03f64a85f73b.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /esprima
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /esprima
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /esprima
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './esprima' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/esprima
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "14SRY426E3O3A5WDXDUOBH3ZM"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/esprima
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/chalk/node_modules/ansi-styles
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/chalk/node_modules/escape-string-regexp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/chalk/node_modules/strip-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/chalk/node_modules/has-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/chalk/node_modules/supports-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/css/2.1.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m convert-source-map@0.3.5 into /Users/mp/node_modules/webgl-workshop/node_modules/rework
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m css@2.1.0 into /Users/mp/node_modules/webgl-workshop/node_modules/rework
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m convert-source-map@0.3.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of convert-source-map to /Users/mp/node_modules/webgl-workshop/node_modules/rework not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m css@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of css to /Users/mp/node_modules/webgl-workshop/node_modules/rework not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/ansi-styles
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/escape-string-regexp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/strip-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/has-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/supports-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/ansi-styles/1.1.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/ansi-styles
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/ansi-styles
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/escape-string-regexp/1.0.2/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/escape-string-regexp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/escape-string-regexp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/strip-ansi/0.3.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/strip-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/strip-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/has-ansi/0.1.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/has-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/has-ansi
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/supports-color/0.2.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/supports-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/supports-color
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m gl-shader-core@2.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec bit-twiddle@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec union-find@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/gl-context/0.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/convert-source-map-c1f8fe4b013865eb.lock for /Users/mp/node_modules/webgl-workshop/node_modules/rework/node_modules/convert-source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/css-55200013e0e751cd.lock for /Users/mp/node_modules/webgl-workshop/node_modules/rework/node_modules/css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/resolve/0.6.3/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m bit-twiddle@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name bit-twiddle
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/bit-twiddle
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/bit-twiddle not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m union-find@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name union-find
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/union-find
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/union-find not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/rework/node_modules/convert-source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/rework/node_modules/css
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m gl-compare-sidebar@1.1.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/rework/node_modules/convert-source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/rework/node_modules/css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/convert-source-map/0.3.5/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/rework/node_modules/convert-source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/rework/node_modules/convert-source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/css/2.1.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/rework/node_modules/css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/rework/node_modules/css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec dup@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m dup@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name dup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/dup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/dup not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/scroll-speed/0.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /bit-twiddle
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /bit-twiddle
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /bit-twiddle
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './bit-twiddle' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/bit-twiddle
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "1S25AVR0VAAIC3A3GWL2KACX4"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/bit-twiddle
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /union-find
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /union-find
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /union-find
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './union-find' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/union-find
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "8106OMGLZ9D23M647V0UX7PXK"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/union-find
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/resolve/0.6.3/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec remove-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec insert-css@^0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec range-slider@^1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m remove-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/remove-element already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m insert-css@>=0.1.1 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name insert-css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/insert-css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/insert-css already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m range-slider@>=1.0.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name range-slider
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/range-slider
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/range-slider not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /dup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /dup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /dup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './dup' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/dup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "B33URSKRDBVDFC1JO4U54EW4C"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/dup
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/scroll-speed/0.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m cpr@0.3.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m glslify@1.6.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /range-slider
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /range-slider
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /range-slider
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './range-slider' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/range-slider
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "5CIL5PA3UURJ3ANHRORX86TGX"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/range-slider
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec mkdirp@~0.3.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec cssauron-glsl@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec concat-stream@^1.4.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec cssauron@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec emit-function@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec graceful-fs@~1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec esprima@^1.0.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec rimraf@~2.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec glsl-deparser@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec glsl-extract@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec glsl-min-stream@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec glslify-stream@^0.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec new-from@^0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec nopt@^2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec replace-method@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec resolve@^0.6.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec shortest@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec sleuth@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec static-eval@^0.2.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec through@^2.3.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m mkdirp@>=0.3.4 <0.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/mkdirp not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m cssauron-glsl@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name cssauron-glsl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/cssauron-glsl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/cssauron-glsl not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m concat-stream@>=1.4.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name concat-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/concat-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/concat-stream not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m cssauron@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name cssauron
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/cssauron
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/cssauron not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m emit-function@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name emit-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/emit-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/emit-function not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m graceful-fs@>=1.2.0 <1.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name graceful-fs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/graceful-fs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/graceful-fs not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m esprima@>=1.0.4 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name esprima
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/esprima
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/esprima already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rimraf@>=2.0.2 <2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name rimraf
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/rimraf
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/rimraf not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m glsl-deparser@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name glsl-deparser
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/glsl-deparser
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/glsl-deparser not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m glsl-extract@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name glsl-extract
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/glsl-extract
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/glsl-extract not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m glsl-min-stream@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name glsl-min-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/glsl-min-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/glsl-min-stream not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m glslify-stream@>=0.4.0 <0.5.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name glslify-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/glslify-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/glslify-stream not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m new-from@>=0.0.3 <0.0.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name new-from
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/new-from
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/new-from not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m nopt@>=2.0.0 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name nopt
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/nopt
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/nopt not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m replace-method@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name replace-method
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/replace-method
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/replace-method already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m resolve@>=0.6.1 <0.7.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/resolve not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m shortest@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name shortest
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/shortest
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/shortest not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m sleuth@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/sleuth already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m static-eval@>=0.2.2 <0.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name static-eval
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/static-eval
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/static-eval already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through@>=2.3.4 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/through already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mregistry.get[0m https://registry.npmjs.org/mkdirp not expired, no request
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m mkdirp@0.3.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /cssauron-glsl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /cssauron-glsl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /cssauron-glsl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './cssauron-glsl' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/cssauron-glsl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "7MHA5BPJHD63RKZ6P49M4SKMY"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/cssauron-glsl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /concat-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /concat-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /concat-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './concat-stream' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/concat-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "5WWRSX83NJOET2K9VDT6X4RSM"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/concat-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /cssauron
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /cssauron
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /cssauron
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './cssauron' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/cssauron
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "16AHG4J5FP6EPA6XOHVET75N4"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/cssauron
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /emit-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /emit-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /emit-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './emit-function' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/emit-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "13W3Y1EUUYA48ICEJTKZOU1FZ"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/emit-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /rimraf
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /rimraf
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /rimraf
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './rimraf' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/rimraf
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9Y5HY6JABQGHFY1D8KK9HBKAN"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/rimraf
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /graceful-fs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /graceful-fs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /graceful-fs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './graceful-fs' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/graceful-fs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9PV3CKHXC3191HOQIXV2QNLJO"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/graceful-fs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /glsl-deparser
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /glsl-deparser
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /glsl-deparser
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './glsl-deparser' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/glsl-deparser
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "ASX2IQ89R62UP4G2LYJ9MNTM5"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/glsl-deparser
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /glsl-extract
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /glsl-extract
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /glsl-extract
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './glsl-extract' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/glsl-extract
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "BRKW18R3186CGBQJDZCSCFMA7"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/glsl-extract
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /glsl-min-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /glsl-min-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /glsl-min-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './glsl-min-stream' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/glsl-min-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "DRKCA0SXK6RT9G4WOSMJ6913Y"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/glsl-min-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mregistry.get[0m https://registry.npmjs.org/resolve not expired, no request
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m resolve@0.6.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /new-from
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /new-from
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /new-from
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './new-from' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/new-from
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "BKMONQUR749O75WWVEMXBF3H5"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/new-from
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /glslify-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /glslify-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /glslify-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './glslify-stream' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/glslify-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "B1H01WJ7082WL2HXV08T303JA"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/glslify-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /nopt
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /nopt
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /nopt
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './nopt' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/nopt
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "2GWKPD9CYD6ZLDZ9J2A2BHFGO"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/nopt
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /shortest
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /shortest
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /shortest
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './shortest' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/shortest
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9TFIIP1M3U4IAXUFCMF52BNRN"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/shortest
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/resolve/0.6.3/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m findup@0.1.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/resolve/0.6.3/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/mkdirp/0.3.5/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec colors@~0.6.0-1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec commander@~2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m colors@>=0.6.0-1 <0.7.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name colors
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/colors
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/colors not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m commander@>=2.1.0 <2.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name commander
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/commander
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/commander already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/mkdirp/0.3.5/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m gl-compare@2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /colors
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /colors
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /colors
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './colors' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/colors
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:09
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "1MIFYNJ314H3TPP1WJ5ND608K"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/colors
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m wordwrap@0.0.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m bl@0.9.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec a-big-triangle@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec gl-fbo@^1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/wordwrap
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/wordwrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m wordwrap@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m a-big-triangle@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name a-big-triangle
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/a-big-triangle
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/a-big-triangle not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-fbo@>=1.1.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name gl-fbo
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/gl-fbo
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/gl-fbo not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m wordwrap@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m wordwrap@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m wordwrap@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec readable-stream@~1.0.26
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m wordwrap@0.0.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m escape-string-regexp@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m readable-stream@>=1.0.26 <1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name readable-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/readable-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/readable-stream not in flight; fetching
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m wordwrap@0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /a-big-triangle
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /a-big-triangle
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /a-big-triangle
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './a-big-triangle' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/a-big-triangle
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9J6JKVYZNQPT6427VSVMDTH4S"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/a-big-triangle
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /gl-fbo
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /gl-fbo
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /gl-fbo
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './gl-fbo' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/gl-fbo
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "8I1AK1ZEWUR1RFOBNLD5E7V43"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/gl-fbo
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m ansi-styles@1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/escape-string-regexp
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/escape-string-regexp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m escape-string-regexp@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/wordwrap-2344455eef48c688.lock for /Users/mp/node_modules/webgl-workshop/node_modules/wordwrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /readable-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /readable-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /readable-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './readable-stream' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/readable-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "EKXZ81XCOZBFB2OE9RM9RBPQ"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/readable-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/ansi-styles
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/ansi-styles
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m ansi-styles@1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m escape-string-regexp@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m escape-string-regexp@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m escape-string-regexp@1.0.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m escape-string-regexp@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m ansi-styles@1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m ansi-styles@1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m ansi-styles@1.1.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m ansi-styles@1.1.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m escape-string-regexp@1.0.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m strip-ansi@0.3.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m has-ansi@0.1.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m supports-color@0.2.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m ansi-styles@1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/escape-string-regexp-0950e1a968702cf8.lock for /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/escape-string-regexp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/supports-color
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/supports-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m supports-color@0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/ansi-styles-250ba003f43322cb.lock for /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/ansi-styles
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec ansi-regex@^0.2.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m ansi-regex@>=0.2.1 <0.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name ansi-regex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/ansi-regex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/ansi-regex not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec ansi-regex@^0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m supports-color@0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlink bins[0m [ { 'supports-color': 'cli.js' },
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlink bins[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/.bin',
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlink bins[0m   false ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m supports-color@0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m supports-color@0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m ansi-regex@>=0.2.0 <0.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name ansi-regex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/ansi-regex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/ansi-regex already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/.bin/supports-color
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m gl-context@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /ansi-regex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /ansi-regex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /ansi-regex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './ansi-regex' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/ansi-regex
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "1TB4RGXG7X6L6SJ5IOC34HPO9"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/ansi-regex
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m supports-color@0.2.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m supports-color@0.2.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m linklocal@2.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec raf-component@^1.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/supports-color-2d77ab0ba6349a4b.lock for /Users/mp/node_modules/webgl-workshop/node_modules/chalk/node_modules/supports-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m raf-component@>=1.1.2 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/raf-component already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec once@~1.3.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec rimraf@~2.2.8
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec commander@~2.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec debug@~2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m once@>=1.3.1 <1.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name once
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/once
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/once already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rimraf@>=2.2.8 <2.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name rimraf
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/rimraf
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/rimraf already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m commander@>=2.3.0 <2.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name commander
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/commander
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/commander already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m debug@>=2.0.0 <2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name debug
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/debug
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/debug already in flight; waiting
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m teapot@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/teapot
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/teapot
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m teapot@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m teapot@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m teapot@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m teapot@1.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m teapot@1.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m minimist@1.1.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m teapot@1.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m marked@0.3.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/teapot-bf121b71261fe2b7.lock for /Users/mp/node_modules/webgl-workshop/node_modules/teapot
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m minimist@1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m minimist@1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m minimist@1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m minimist@1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/marked
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m marked@0.3.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m minimist@1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m marked@0.3.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlink bins[0m [ { marked: './bin/marked' },
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlink bins[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/.bin',
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlink bins[0m   false ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m marked@0.3.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m marked@0.3.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m minimist@1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/.bin/marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/minimist-f1179efa99aff9e1.lock for /Users/mp/node_modules/webgl-workshop/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m marked@0.3.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m marked@0.3.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m watchify@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/marked-f60c3e7e4961a494.lock for /Users/mp/node_modules/webgl-workshop/node_modules/marked
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec chokidar@~0.8.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec through2@~0.5.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m chokidar@>=0.8.2 <0.9.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name chokidar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/chokidar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/chokidar not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through2@>=0.5.1 <0.6.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/through2 already in flight; waiting
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m mkdirp@0.5.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /chokidar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /chokidar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /chokidar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './chokidar' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/chokidar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "7UKPZPNMP8YYSFT571UEIQDIO"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/chokidar
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec minimist@0.0.8
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m minimist@0.0.8
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/minimist not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mregistry.get[0m https://registry.npmjs.org/minimist not expired, no request
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/minimist/0.0.8/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m bunny@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/minimist/0.0.8/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m minimist@0.0.8 into /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m minimist@0.0.8
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of minimist to /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m events@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/bunny
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/bunny
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m bunny@1.0.1
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/key-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/key-pressed from cache
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/mouse-position
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/mouse-position from cache
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/mouse-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/mouse-pressed from cache
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/orbit-camera from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m bunny@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m bunny@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m bunny@1.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m bunny@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/minimist-f31fa617e65e38de.lock for /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/events
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/events
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m events@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/mkdirp/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m bunny@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m events@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m events@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m events@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m events@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/minimist/0.0.8/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/bunny-e4f00c9aa663ce7f.lock for /Users/mp/node_modules/webgl-workshop/node_modules/bunny
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m events@1.0.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m css@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/events-a836b6ab9d9cf3e6.lock for /Users/mp/node_modules/webgl-workshop/node_modules/events
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/key-pressed/0.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/mouse-pressed/0.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/orbit-camera/0.0.3/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/mime
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/mime from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec source-map@^0.1.38
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec source-map-resolve@^0.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec urix@^0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/mouse-position/0.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m source-map@>=0.1.38 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/source-map not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m source-map-resolve@>=0.3.0 <0.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name source-map-resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/source-map-resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/source-map-resolve not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m urix@>=0.1.0 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name urix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/urix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/urix not in flight; fetching
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m inquirer@0.5.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/mouse-pressed/0.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/key-pressed/0.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /source-map-resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /source-map-resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /source-map-resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './source-map-resolve' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/source-map-resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9F5OWLR6ZFWP4ZT74XGOB48J1"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/source-map-resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './source-map' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9P1ON6ROD6YARE1NPRN6LCHQJ"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/mouse-position/0.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/orbit-camera/0.0.3/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m scroll-speed@0.0.0 into /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m mouse-pressed@0.0.1 into /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m key-pressed@0.0.1 into /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m mouse-position@0.0.1 into /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m orbit-camera@0.0.3 into /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m scroll-speed@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of scroll-speed to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m mouse-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of mouse-pressed to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m key-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of key-pressed to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m mouse-position@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of mouse-position to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m orbit-camera@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of orbit-camera to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /urix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /urix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /urix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './urix' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/urix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "B92WTHECPCE3GR0UKABQG40XK"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/urix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec lodash@~2.4.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec mute-stream@0.0.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec readline2@~0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec through@~2.3.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec chalk@~0.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec async@~0.8.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec cli-color@~0.3.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m lodash@>=2.4.1 <2.5.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name lodash
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/lodash
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/lodash not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m mute-stream@0.0.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name mute-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/mute-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/mute-stream not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m readline2@>=0.1.0 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name readline2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/readline2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/readline2 not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through@>=2.3.4 <2.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/through already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m chalk@>=0.4.0 <0.5.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name chalk
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/chalk
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/chalk not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m async@>=0.8.0 <0.9.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name async
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/async
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/async not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m cli-color@>=0.3.2 <0.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name cli-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/cli-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/cli-color not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/scroll-speed-f49f7501abe1147b.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/scroll-speed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/mouse-pressed-64c6c531334a4723.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/key-pressed-87c1f7f392f79a27.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/mouse-position-359c014a9ddbcf08.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-position
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/orbit-camera-b3d52245d3d1e8f3.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/scroll-speed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-position
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mregistry.get[0m https://registry.npmjs.org/chalk not expired, no request
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m chalk@0.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /readline2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /readline2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /readline2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './readline2' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/readline2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "8BWRSP68FP7FFC6XVDMJYFX2V"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/readline2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /lodash
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /lodash
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /lodash
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './lodash' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/lodash
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "CE0WT65V1BFEIC43DV11Y0P0D"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/lodash
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/scroll-speed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /mute-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /mute-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /mute-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './mute-stream' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/mute-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "43ATSFW1ZYC8BHL9M2WZERLP"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/mute-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /async
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /async
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /async
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './async' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/async
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "89MGFQ2Z6RY9VBTZ8TE2LCJ6U"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/async
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /cli-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /cli-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /cli-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './cli-color' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/cli-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "4XLCUAV98VTMCOJK021MPPDHR"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/cli-color
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-position
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/scroll-speed/0.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/scroll-speed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/scroll-speed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/mouse-pressed/0.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/key-pressed/0.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/mouse-position/0.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-position
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-position
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/orbit-camera/0.0.3/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/mime/1.2.11/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m convert-source-map@0.3.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/chalk/0.4.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/rework/node_modules/convert-source-map
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/rework/node_modules/convert-source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/rework/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m convert-source-map@0.3.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/mime/1.2.11/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m convert-source-map@0.3.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m convert-source-map@0.3.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m convert-source-map@0.3.5
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m st@0.5.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m convert-source-map@0.3.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/chalk/0.4.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m convert-source-map@0.3.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/convert-source-map-c1f8fe4b013865eb.lock for /Users/mp/node_modules/webgl-workshop/node_modules/rework/node_modules/convert-source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec fd@~0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m fd@>=0.0.2 <0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name fd
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/fd
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/fd not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec mime@~1.2.7
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec negotiator@~0.2.5
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec graceful-fs@~1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec async-cache@~0.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec bl@~0.8.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m mime@>=1.2.7 <1.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name mime
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/mime
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/mime not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m negotiator@>=0.2.5 <0.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name negotiator
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/negotiator
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/negotiator not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m graceful-fs@>=1.2.0 <1.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name graceful-fs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/graceful-fs
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/graceful-fs already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m async-cache@>=0.1.2 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name async-cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/async-cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/async-cache not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m bl@>=0.8.0 <0.9.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name bl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/bl
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/bl not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /fd
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /fd
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /fd
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './fd' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/fd
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "CC3LU83A46KKP3K6AXQQX9X8U"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/fd
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mregistry.get[0m https://registry.npmjs.org/mime not expired, no request
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m mime@1.2.11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mregistry.get[0m https://registry.npmjs.org/bl not expired, no request
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m bl@0.8.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /negotiator
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /negotiator
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /negotiator
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './negotiator' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/negotiator
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "107BOIN7NAG3S3KKEE8SX5CWI"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/negotiator
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /async-cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /async-cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /async-cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './async-cache' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/async-cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "D023LJPN8JRNRMYKMAQN6RW0D"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/async-cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/mime/1.2.11/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/raf-component from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/mime/1.2.11/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/bl/0.8.2/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/bl/0.8.2/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/raf-component/1.1.2/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/raf-component/1.1.2/package/package.json already in flight; not writing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m gl-api@1.0.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m mousetrap@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/raf-component/1.1.2/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m raf-component@1.1.2 into /Users/mp/node_modules/webgl-workshop/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of raf-component to /Users/mp/node_modules/webgl-workshop/node_modules/gl-context not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m raf-component@1.1.2 into /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of raf-component to /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-api
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-api
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m gl-api@1.0.2
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/rework-plugin-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/rework-plugin-function from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/mousetrap
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/mousetrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m mousetrap@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m gl-api@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m gl-api@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m gl-api@1.0.2
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m200[0m https://registry.npmjs.org/split
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/raf-component-8fb2ce92be6b766a.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/raf-component-7d9e0c8bad30a973.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-api@1.0.2
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/is-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/is-require from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m mousetrap@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m mousetrap@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m mousetrap@0.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m mousetrap@0.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m gl-api@1.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/raf-component/1.1.2/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/raf-component/1.1.2/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m mousetrap@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/gl-api-2fc91cc6909d9834.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-api
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rework-plugin-function@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/mousetrap-92231f750d762877.lock for /Users/mp/node_modules/webgl-workshop/node_modules/mousetrap
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m split@0.2.10
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/shallow-copy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/shallow-copy from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/rework-plugin-function/1.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/split/0.2.10/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/is-require/0.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m scroll-speed@0.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m key-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m mouse-position@0.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m mouse-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/rework-plugin-function/1.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m mime@1.2.11 into /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m rework-plugin-function@1.0.1 into /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m mime@1.2.11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of mime to /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m rework-plugin-function@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of rework-plugin-function to /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/split/0.2.10/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m split@0.2.10 into /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m split@0.2.10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of split to /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/is-require/0.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-position
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-position
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m mouse-position@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec wheel@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec vkey@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-pressed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m mouse-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m orbit-camera@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/shallow-copy/0.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/mime-7c39d2a38832a107.lock for /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline/node_modules/mime
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/rework-plugin-function-a7196d1891c7b7a6.lock for /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline/node_modules/rework-plugin-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m wheel@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name wheel
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/wheel
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/wheel not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m vkey@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/vkey already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m mouse-position@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m mouse-position@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m mouse-position@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/split-cf7824f332a56187.lock for /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/rework-plugin-inline/node_modules/mime
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/rework-plugin-inline/node_modules/rework-plugin-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m mouse-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m mouse-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m mouse-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m mouse-position@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m mouse-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline/node_modules/mime
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline/node_modules/rework-plugin-function
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m mouse-position@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/mime/1.2.11/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline/node_modules/mime
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline/node_modules/mime
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/rework-plugin-function/1.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline/node_modules/rework-plugin-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline/node_modules/rework-plugin-function
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m200[0m https://registry.npmjs.org/through2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m mouse-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/split/0.2.10/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/shallow-copy/0.0.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec gl-matrix@^2.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /wheel
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /wheel
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /wheel
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './wheel' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/wheel
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "4ILZZ8GEGUFSAZEDALOJ7IAST"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/wheel
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-matrix@>=2.2.0 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/gl-matrix not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/mouse-position-359c014a9ddbcf08.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-position
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/mouse-pressed-64c6c531334a4723.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/mouse-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through2@0.6.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through2@0.5.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mregistry.get[0m https://registry.npmjs.org/gl-matrix not expired, no request
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-matrix@2.2.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/through2/0.6.3/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/through2/0.5.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-matrix/2.2.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/through2/0.6.3/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/through2/0.5.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-matrix/2.2.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-matrix@2.2.1 into /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m gl-matrix@2.2.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of gl-matrix to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/gl-matrix-ce9a999d92a8a6bc.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/gl-matrix/2.2.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/escodegen
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/escodegen from cache
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m brfs@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m escodegen@1.4.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m escodegen@1.4.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/acorn
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/acorn from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec quote-stream@~0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec static-module@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec through2@~0.4.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m quote-stream@>=0.0.0 <0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name quote-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/quote-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/quote-stream not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m static-module@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name static-module
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/static-module
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/static-module not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through2@>=0.4.1 <0.5.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/through2 not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/gl-context/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m minimist@0.0.8
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/escodegen/1.4.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/escodegen/1.4.1/package/package.json already in flight; not writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m acorn@0.9.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mregistry.get[0m https://registry.npmjs.org/through2 not expired, no request
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through2@0.4.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /quote-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /quote-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /quote-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './quote-stream' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/quote-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "DLZ7ILVQ0JWJ789P5W9FF6ZZ"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/quote-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /static-module
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /static-module
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /static-module
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './static-module' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/static-module
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "7I5D4UNTQQWX51OXMQUM0AL0S"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/static-module
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/mkdirp/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m minimist@0.0.8
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m raf-component@1.1.2
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/astw
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/astw from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m minimist@0.0.8
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m minimist@0.0.8
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m minimist@0.0.8
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/escodegen/1.4.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m minimist@0.0.8
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/raf-component-8fb2ce92be6b766a.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m gl-context@0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/raf-component-7d9e0c8bad30a973.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context/node_modules/raf-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m gl-context@0.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m rework-plugin-function@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/acorn/0.9.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m minimist@0.0.8
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m gl-context@0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m gl-context@0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m gl-context@0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m gl-context@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m gl-context@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m gl-context@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/through2/0.4.2/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m [ 'raf-component' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-context@0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m [ 'raf-component' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-context@0.0.0
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m200[0m https://registry.npmjs.org/commander
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/minimist-f31fa617e65e38de.lock for /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp/node_modules/minimist
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m mkdirp@0.5.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m gl-context@0.1.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m gl-context@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec rework-visit@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m astw@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m astw@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rework-visit@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name rework-visit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/rework-visit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/rework-visit not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m mkdirp@0.5.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlink bins[0m [ { mkdirp: 'bin/cmd.js' },
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlink bins[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/.bin',
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlink bins[0m   false ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m mkdirp@0.5.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m mkdirp@0.5.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/acorn/0.9.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m [ 'minimist' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/gl-context-b20e1808ab1f2a91.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/.bin/mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/gl-context-102a03f64a85f73b.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear/node_modules/gl-context
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m gl-clear@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/through2/0.4.2/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m gl-clear@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m gl-clear@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m gl-clear@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddRemoteTarball[0m https://registry.npmjs.org/commander/-/commander-1.0.4.tgz not in flight; adding
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddRemoteTarball[0m [ 'https://registry.npmjs.org/commander/-/commander-1.0.4.tgz',
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddRemoteTarball[0m   '5edeb1aee23c4fb541a6b70d692abef19669a2d3' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m commander@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m commander@2.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /rework-visit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /rework-visit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /rework-visit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './rework-visit' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/rework-visit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "918MEJ97F7C6HOBZENWZWHJDK"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/rework-visit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m [ 'gl-context' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-clear@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/astw/1.2.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/astw/1.2.0/package/package.json already in flight; not writing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m mkdirp@0.5.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m gl-clear@0.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mretry[0m fetch attempt 1 at 13:07:11
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:11
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mfetch[0m GET https://registry.npmjs.org/commander/-/commander-1.0.4.tgz
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m mkdirp@0.5.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/gl-clear-195bb0d6f4923567.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-clear
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/commander/2.3.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/commander/2.1.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/astw/1.2.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/mkdirp-4ffd693370fdb91a.lock for /Users/mp/node_modules/webgl-workshop/node_modules/mkdirp
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/commander/2.3.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/commander/2.1.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m split@0.2.10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec through@2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through@>=2.0.0 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/through already in flight; waiting
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/is-typedarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/is-typedarray from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/is-typedarray/0.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/is-typedarray/0.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m mime@1.2.11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline/node_modules/mime
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline/node_modules/mime
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m mime@1.2.11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m mime@1.2.11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m mime@1.2.11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m mime@1.2.11
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m mime@1.2.11
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m mime@1.2.11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/mime-7c39d2a38832a107.lock for /Users/mp/node_modules/webgl-workshop/node_modules/rework-plugin-inline/node_modules/mime
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m resolve@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/resolve
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/resolve
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m resolve@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m resolve@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m resolve@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m resolve@1.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m resolve@1.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m resolve@1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/resolve-6c18ff843b0eb39c.lock for /Users/mp/node_modules/webgl-workshop/node_modules/resolve
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m cheerio@0.17.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec CSSselect@~0.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec entities@~1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec htmlparser2@~3.7.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec dom-serializer@~0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec lodash@~2.4.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m CSSselect@>=0.4.0 <0.5.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name CSSselect
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/CSSselect
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/CSSselect not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m entities@>=1.1.1 <1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name entities
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/entities
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/entities not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m htmlparser2@>=3.7.2 <3.8.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name htmlparser2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/htmlparser2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/htmlparser2 not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m dom-serializer@>=0.0.0 <0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name dom-serializer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/dom-serializer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/dom-serializer not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m lodash@>=2.4.1 <2.5.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name lodash
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/lodash
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/lodash already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /CSSselect
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /CSSselect
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /CSSselect
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './CSSselect' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/CSSselect
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "CB2X1UOJ03NRD9UYZWD858521"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/CSSselect
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /entities
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /entities
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /entities
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './entities' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/entities
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "DQ7G4X1XOUDQ7AH76XX2YUF8R"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/entities
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /dom-serializer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /dom-serializer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /dom-serializer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './dom-serializer' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/dom-serializer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "75BZWD534U7LYMF25ZLIYB5RW"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/dom-serializer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /htmlparser2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /htmlparser2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /htmlparser2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './htmlparser2' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/htmlparser2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "DD95J50IRS3WOQV2IHXN8O15T"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/htmlparser2
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/element-size
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/element-size from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m element-size@1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/element-size/1.1.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/element-size/1.1.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m element-size@1.1.1 into /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m element-size@1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of element-size to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/element-size-96a2c7b477eaf2bf.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit/node_modules/element-size
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/canvas-fit/node_modules/element-size
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit/node_modules/element-size
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/element-size/1.1.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit/node_modules/element-size
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit/node_modules/element-size
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/array-pack-2d
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/array-pack-2d from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m array-pack-2d@0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/array-pack-2d/0.1.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/array-pack-2d/0.1.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m element-size@1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit/node_modules/element-size
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit/node_modules/element-size
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m element-size@1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m element-size@1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m element-size@1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m element-size@1.1.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m element-size@1.1.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m element-size@1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/element-size-96a2c7b477eaf2bf.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit/node_modules/element-size
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m canvas-fit@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m canvas-fit@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m canvas-fit@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m canvas-fit@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m [ 'element-size' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m canvas-fit@1.2.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m canvas-fit@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/canvas-fit-03bc916d85cf0ad7.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-fit
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m gl-matrix@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m gl-matrix@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m gl-matrix@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m gl-matrix@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m gl-matrix@2.1.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-matrix@2.1.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m gl-matrix@2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/gl-matrix-3a0db0f9470150dc.lock for /Users/mp/node_modules/webgl-workshop/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/sleuth from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m sleuth@0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m sleuth@0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/sleuth/0.1.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/sleuth/0.1.1/package/package.json already in flight; not writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/sleuth/0.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/sleuth/0.1.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m is-require@0.0.1 into /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m shallow-copy@0.0.1 into /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m through2@0.6.3 into /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m escodegen@1.4.1 into /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m acorn@0.9.0 into /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m astw@1.2.0 into /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m sleuth@0.1.1 into /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m is-require@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of is-require to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m shallow-copy@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of shallow-copy to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m through2@0.6.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of through2 to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m escodegen@1.4.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of escodegen to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m acorn@0.9.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of acorn to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m astw@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of astw to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m sleuth@0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of sleuth to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/sleuth/0.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m200[0m https://registry.npmjs.org/gl-buffer
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/is-require-652b49aac58d13b9.lock for /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/is-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/shallow-copy-e7e1bfaf895d9b1c.lock for /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/shallow-copy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/through2-cf2488b3979471f6.lock for /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/escodegen-a29af576a100ccee.lock for /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/escodegen
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/acorn-ed81553a0113d45a.lock for /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/acorn
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/astw-82cc392714cbe3c3.lock for /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/astw
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/sleuth-a697fb8ef79731de.lock for /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/fresh-require/node_modules/is-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/fresh-require/node_modules/shallow-copy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/fresh-require/node_modules/through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/fresh-require/node_modules/escodegen
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/fresh-require/node_modules/acorn
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/fresh-require/node_modules/astw
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/fresh-require/node_modules/sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/is-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/shallow-copy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/escodegen
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/acorn
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/astw
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/is-require/0.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/is-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/is-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/shallow-copy/0.0.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/shallow-copy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/shallow-copy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/through2/0.6.3/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/through2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/escodegen/1.4.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/escodegen
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/escodegen
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/acorn/0.9.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/acorn
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/acorn
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/astw/1.2.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/astw
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/astw
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/sleuth/0.1.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/sleuth
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-buffer@2.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddRemoteTarball[0m https://registry.npmjs.org/gl-buffer/-/gl-buffer-2.1.1.tgz not in flight; adding
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddRemoteTarball[0m [ 'https://registry.npmjs.org/gl-buffer/-/gl-buffer-2.1.1.tgz',
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddRemoteTarball[0m   '76f19206aee78018842b1a8c88e3bd3b5d10d494' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mretry[0m fetch attempt 1 at 13:07:11
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:11
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mfetch[0m GET https://registry.npmjs.org/gl-buffer/-/gl-buffer-2.1.1.tgz
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m is-require@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/is-require
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/is-require
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m is-require@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m is-require@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m is-require@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m is-require@0.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m is-require@0.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m is-require@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/is-require-652b49aac58d13b9.lock for /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/is-require
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m sleuth@0.1.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m through2@0.6.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec static-eval@~0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m static-eval@>=0.1.0 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name static-eval
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/static-eval
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/static-eval already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec readable-stream@>=1.0.33-1 <1.1.0-0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec xtend@>=4.0.0 <4.1.0-0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m readable-stream@>=1.0.33-1 <1.1.0-0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name readable-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/readable-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/readable-stream already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m xtend@>=4.0.0 <4.1.0-0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/xtend already in flight; waiting
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m astw@1.2.0
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m200[0m https://registry.npmjs.org/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec esprima-fb@3001.1.0-dev-harmony-fb
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m shallow-copy@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m esprima-fb@3001.1.0-dev-harmony-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/esprima-fb already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/shallow-copy
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/shallow-copy
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m shallow-copy@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m xtend@2.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m xtend@2.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m xtend@4.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m shallow-copy@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m shallow-copy@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m shallow-copy@0.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m shallow-copy@0.0.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m shallow-copy@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/xtend/2.1.2/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/xtend/2.2.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/xtend/4.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/shallow-copy-e7e1bfaf895d9b1c.lock for /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/shallow-copy
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m200[0m https://registry.npmjs.org/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/xtend/4.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/xtend/2.2.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/xtend/2.1.2/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/through/2.3.6/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/through/2.3.6/package/package.json already in flight; not writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/through/2.3.6/package/package.json already in flight; not writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/through/2.3.6/package/package.json already in flight; not writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/through/2.3.6/package/package.json already in flight; not writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/through/2.3.6/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m through@2.3.6 into /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of through to /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/through-f646f64c94eb46b5.lock for /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split/node_modules/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split/node_modules/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split/node_modules/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/through/2.3.6/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split/node_modules/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split/node_modules/through
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m gl-matrix@2.2.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m gl-matrix@2.2.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m gl-matrix@2.2.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m gl-matrix@2.2.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m gl-matrix@2.2.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m gl-matrix@2.2.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m gl-matrix@2.2.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/gl-matrix-ce9a999d92a8a6bc.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera/node_modules/gl-matrix
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m orbit-camera@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m orbit-camera@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m orbit-camera@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m orbit-camera@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m [ 'gl-matrix' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m orbit-camera@0.0.3
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m orbit-camera@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/orbit-camera-b3d52245d3d1e8f3.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/orbit-camera
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split/node_modules/through
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split/node_modules/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/through-f646f64c94eb46b5.lock for /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split/node_modules/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m split@0.2.10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m split@0.2.10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m split@0.2.10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m split@0.2.10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m [ 'through' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m split@0.2.10
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m split@0.2.10
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/split-cf7824f332a56187.lock for /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj/node_modules/split
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m parse-obj@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m parse-obj@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m parse-obj@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m parse-obj@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m [ 'split' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m parse-obj@0.0.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m parse-obj@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/parse-obj-d45063305f86d9e4.lock for /Users/mp/node_modules/webgl-workshop/node_modules/parse-obj
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m escodegen@1.4.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec esutils@^1.1.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m esutils@>=1.1.4 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name esutils
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/esutils
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/esutils not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec esprima@^1.2.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec source-map@~0.1.37
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec estraverse@^1.5.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m esprima@>=1.2.2 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name esprima
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/esprima
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/esprima already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m source-map@>=0.1.37 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/source-map
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/source-map already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m estraverse@>=1.5.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name estraverse
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/estraverse
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/estraverse not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /esutils
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /esutils
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /esutils
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './esutils' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/esutils
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "AKNZRW4NX2LWYJY6EDZZF64PS"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/esutils
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /estraverse
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /estraverse
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /estraverse
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './estraverse' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/estraverse
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:11
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "18NAIQFRARLE74X8NETSNDHX6"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/estraverse
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/dtype
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/dtype from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m dtype@0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/dtype/0.1.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/dtype/0.1.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m myth@1.2.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec colors@~0.6.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m colors@>=0.6.2 <0.7.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name colors
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/colors
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/colors already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec commander@^2.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m commander@>=2.1.0 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name commander
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/commander
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/commander not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec is-browser@^2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec node-watch@~0.3.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec pad-component@~0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec read-file-stdin@^0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec rework-calc@^1.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec rework-color-function@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec rework-custom-media@~0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m is-browser@>=2.0.0 <3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name is-browser
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/is-browser
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/is-browser not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m node-watch@>=0.3.4 <0.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name node-watch
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/node-watch
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/node-watch not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m pad-component@>=0.0.1 <0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name pad-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/pad-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/pad-component not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m read-file-stdin@>=0.2.0 <0.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name read-file-stdin
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/read-file-stdin
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/read-file-stdin not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rework-calc@>=1.1.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name rework-calc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/rework-calc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/rework-calc not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rework-color-function@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name rework-color-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/rework-color-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/rework-color-function not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec rework-font-variant@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec rework-hex-alpha@^1.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec rework-import@^1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec rework-rebeccapurple@^1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec rework-vars@^3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec to-slug-case@~0.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec to-space-case@~0.1.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec write-file-stdout@~0.0.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec autoprefixer-core@^3.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec clone-component@~0.2.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rework-custom-media@>=0.1.1 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name rework-custom-media
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/rework-custom-media
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/rework-custom-media not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rework-font-variant@1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name rework-font-variant
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/rework-font-variant
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/rework-font-variant not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rework-hex-alpha@>=1.0.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name rework-hex-alpha
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/rework-hex-alpha
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/rework-hex-alpha not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rework-import@>=1.2.0 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name rework-import
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/rework-import
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/rework-import not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rework-rebeccapurple@>=1.0.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name rework-rebeccapurple
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/rework-rebeccapurple
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/rework-rebeccapurple not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m rework-vars@>=3.0.0 <4.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name rework-vars
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/rework-vars
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/rework-vars not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m to-slug-case@>=0.1.2 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name to-slug-case
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/to-slug-case
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/to-slug-case not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m to-space-case@>=0.1.3 <0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name to-space-case
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/to-space-case
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/to-space-case not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m write-file-stdout@>=0.0.2 <0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name write-file-stdout
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/write-file-stdout
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/write-file-stdout not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m autoprefixer-core@>=3.0.0 <4.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name autoprefixer-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/autoprefixer-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/autoprefixer-core not in flight; fetching
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/esprima-fb from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m clone-component@>=0.2.2 <0.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name clone-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/clone-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/clone-component not in flight; fetching
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/jstransform
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/jstransform from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mregistry.get[0m https://registry.npmjs.org/commander not expired, no request
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m commander@2.5.0
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/isndarray
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/isndarray from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /is-browser
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /is-browser
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /is-browser
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './is-browser' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/is-browser
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "7UUUY7M38NXM83ZW7OZEE3X6H"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/is-browser
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /pad-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /pad-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /pad-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './pad-component' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/pad-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "5DIFBZS9KVCVDJSD1YUUSK55Y"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/pad-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /node-watch
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /node-watch
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /node-watch
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './node-watch' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/node-watch
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "9IK9RR0SIPJFT38YH2U1GQ82O"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/node-watch
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /read-file-stdin
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /read-file-stdin
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /read-file-stdin
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './read-file-stdin' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/read-file-stdin
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "1C7Z1UEJQG6FBC9LYNOVCMSOP"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/read-file-stdin
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /rework-calc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /rework-calc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /rework-calc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './rework-calc' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/rework-calc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "K5GKEOQLZW3XECB2L590IBTK"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/rework-calc
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /rework-color-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /rework-color-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /rework-color-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './rework-color-function' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/rework-color-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "2VNM6F476KYBNHNXAI7I5S4EE"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/rework-color-function
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /rework-custom-media
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /rework-custom-media
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /rework-custom-media
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './rework-custom-media' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/rework-custom-media
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "6JZ5LNMF141QXA0VS2KZ7VR3N"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/rework-custom-media
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /rework-font-variant
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /rework-font-variant
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /rework-font-variant
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './rework-font-variant' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/rework-font-variant
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "491V751UBHF4HJ89E7ET6TXN8"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/rework-font-variant
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /rework-import
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /rework-import
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /rework-import
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './rework-import' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/rework-import
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "EZ16SMI30RXWEPX3XIRHGOBHA"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/rework-import
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /rework-rebeccapurple
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /rework-rebeccapurple
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /rework-rebeccapurple
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './rework-rebeccapurple' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/rework-rebeccapurple
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "HX0XG57NPUGVPFBOXTVX58QD"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/rework-rebeccapurple
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /rework-hex-alpha
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /rework-hex-alpha
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /rework-hex-alpha
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './rework-hex-alpha' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/rework-hex-alpha
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "B7XMZD2R2NQCXGDMCSFIDSLG9"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/rework-hex-alpha
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /to-slug-case
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /to-slug-case
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /to-slug-case
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './to-slug-case' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/to-slug-case
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "5RNZFUO3W87ZNZH0OBTE70POG"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/to-slug-case
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /rework-vars
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /rework-vars
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /rework-vars
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './rework-vars' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/rework-vars
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "3M0UEVRB835HAL4T0V07XYI7U"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/rework-vars
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /to-space-case
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /to-space-case
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /to-space-case
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './to-space-case' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/to-space-case
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "CRN74DVG9MJ16DVC9FR0KV82Y"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/to-space-case
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /write-file-stdout
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /write-file-stdout
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /write-file-stdout
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './write-file-stdout' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/write-file-stdout
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "2TF64AH951TI6HCZ5WYRKKDUS"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/write-file-stdout
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /autoprefixer-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /autoprefixer-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /autoprefixer-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './autoprefixer-core' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/autoprefixer-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "733LJWUZKIV68KTU92R7Z5JDK"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/autoprefixer-core
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /clone-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /clone-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /clone-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './clone-component' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/clone-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "6AXUAQC1PQL931UNY9A909VW8"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/clone-component
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m esprima-fb@4001.3001.0-dev-harmony-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m jstransform@6.3.2
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/gl-vao
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/gl-vao from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m isndarray@0.1.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/commander/2.5.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/esprima-fb/3001.1.0-dev-harmony-fb/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/esprima-fb/4001.3001.0-dev-harmony-fb/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/jstransform/6.3.2/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/commander/2.5.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/isndarray/0.1.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m gl-vao@1.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/esprima-fb/4001.3001.0-dev-harmony-fb/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/esprima-fb/3001.1.0-dev-harmony-fb/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m esprima-fb@3001.1.0-dev-harmony-fb into /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/astw
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m esprima-fb@3001.1.0-dev-harmony-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of esprima-fb to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/astw not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/jstransform/6.3.2/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m xtend@2.1.2 into /Users/mp/node_modules/webgl-workshop/node_modules/envify
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m through@2.3.6 into /Users/mp/node_modules/webgl-workshop/node_modules/envify
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m esprima-fb@4001.3001.0-dev-harmony-fb into /Users/mp/node_modules/webgl-workshop/node_modules/envify
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m jstransform@6.3.2 into /Users/mp/node_modules/webgl-workshop/node_modules/envify
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m xtend@2.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of xtend to /Users/mp/node_modules/webgl-workshop/node_modules/envify not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of through to /Users/mp/node_modules/webgl-workshop/node_modules/envify not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m esprima-fb@4001.3001.0-dev-harmony-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of esprima-fb to /Users/mp/node_modules/webgl-workshop/node_modules/envify not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m jstransform@6.3.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of jstransform to /Users/mp/node_modules/webgl-workshop/node_modules/envify not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/isndarray/0.1.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-vao/1.2.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/esprima-fb-1eef1ef701da733f.lock for /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/astw/node_modules/esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/xtend-850a623179f0ebf1.lock for /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/through-301149bbeb974fd1.lock for /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/esprima-fb-ef7106bb701941fa.lock for /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/fresh-require/node_modules/astw/node_modules/esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/jstransform-93e0df9feecd5cff.lock for /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/jstransform
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/envify/node_modules/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/envify/node_modules/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/envify/node_modules/esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/envify/node_modules/jstransform
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/remove-element from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/astw/node_modules/esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/gl-vao/1.2.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/esprima-fb/3001.1.0-dev-harmony-fb/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/astw/node_modules/esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/fresh-require/node_modules/astw/node_modules/esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/jstransform
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/xtend/2.1.2/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/through/2.3.6/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/esprima-fb/4001.3001.0-dev-harmony-fb/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/esprima-fb
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/jstransform/6.3.2/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/jstransform
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/jstransform
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/remove-element/0.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/remove-element/0.0.0/package/package.json already in flight; not writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/remove-element/0.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m xtend@2.1.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec object-keys@~0.4.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m object-keys@>=0.4.0 <0.5.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name object-keys
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/object-keys
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/object-keys not in flight; fetching
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/terminal-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/terminal-menu from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m on initialization, where is /object-keys
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 1, where is /object-keys
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m url raw /object-keys
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m resolving registry [ 'https://registry.npmjs.org/', './object-keys' ]
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m after pass 2, where is https://registry.npmjs.org/object-keys
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrequest[0m no auth needed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mattempt[0m registry request try #1 at 13:07:12
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m "ANF93L71TWRQ0X1UG132WPO0X"
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35mrequest[0m GET https://registry.npmjs.org/object-keys
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m terminal-menu@0.2.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/terminal-menu/0.2.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/through
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/through
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m through@2.3.6
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/terminal-menu/0.2.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/through-301149bbeb974fd1.lock for /Users/mp/node_modules/webgl-workshop/node_modules/envify/node_modules/through
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/vkey from cache
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/insert-css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/insert-css from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/vkey/0.0.3/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/vkey/0.0.3/package/package.json already in flight; not writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m insert-css@0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m insert-css@0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/vkey/0.0.3/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m vkey@0.0.3 into /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m vkey@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of vkey to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/vkey-1eee51ea1601944a.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed/node_modules/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/insert-css/0.1.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/insert-css/0.1.1/package/package.json already in flight; not writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed/node_modules/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed/node_modules/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/vkey/0.0.3/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed/node_modules/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed/node_modules/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/insert-css/0.1.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m xtend@2.2.0 into /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m remove-element@0.0.0 into /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m terminal-menu@0.2.0 into /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m vkey@0.0.3 into /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m insert-css@0.1.1 into /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m xtend@2.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of xtend to /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m remove-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of remove-element to /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m terminal-menu@0.2.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of terminal-menu to /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m vkey@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of vkey to /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu not in flight; installing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstallOne[0m insert-css@0.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35minstallOne[0m of insert-css to /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu not in flight; installing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/xtend-b95f567ac44f2f64.lock for /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/remove-element-1a000dc1f00c4d51.lock for /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/terminal-menu-978bd933fb325903.lock for /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/terminal-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/vkey-01fbcf01078b6dbd.lock for /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlock[0m using /Users/mp/.npm/_locks/insert-css-a8a45193b9207ab1.lock for /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/insert-css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/browser-menu/node_modules/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/browser-menu/node_modules/remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/browser-menu/node_modules/terminal-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/browser-menu/node_modules/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munbuild[0m node_modules/webgl-workshop/node_modules/browser-menu/node_modules/insert-css
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/once
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/once from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/terminal-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/insert-css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/xtend/2.2.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/xtend
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/remove-element/0.0.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/terminal-menu/0.2.0/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/terminal-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/terminal-menu
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/vkey/0.0.3/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpack /Users/mp/.npm/insert-css/0.1.1/package.tgz
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mtar[0m unpacking to /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/insert-css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mgentlyRm[0m vacuuming /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/insert-css
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m once@1.1.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m once@1.3.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/once/1.1.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/once/1.3.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m highlight.js@8.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/once/1.3.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/once/1.1.1/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/highlight.js
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/highlight.js
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m highlight.js@8.3.0
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/debug
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/debug from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m highlight.js@8.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m highlight.js@8.3.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m highlight.js@8.3.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m highlight.js@8.3.0
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m highlight.js@8.3.0
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/replace-method
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/replace-method from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/highlight-js-0ccb0247d5999198.lock for /Users/mp/node_modules/webgl-workshop/node_modules/highlight.js
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m debug@0.7.4
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m debug@2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/debug/2.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/debug/0.7.4/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/replace-method/0.0.0/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/replace-method/0.0.0/package/package.json already in flight; not writing
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/debug/0.7.4/package/package.json written
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/debug/2.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/ast-parents
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/ast-parents from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/replace-method/0.0.0/package/package.json written
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m vkey@0.0.3
+[0m[37m[40mnpm[0m [0m[32m[40mhttp[0m [0m[35m304[0m https://registry.npmjs.org/esprima
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35metag[0m https://registry.npmjs.org/esprima from cache
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed/node_modules/vkey
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed/node_modules/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m vkey@0.0.3
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m remove-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m vkey@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m vkey@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m vkey@0.0.3
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m vkey@0.0.3
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m beefy@2.1.1
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m vkey@0.0.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/remove-element
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules/remove-element
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/browser-menu/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m remove-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m remove-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m remove-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m remove-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35munlock[0m done using /Users/mp/.npm/_locks/vkey-1eee51ea1601944a.lock for /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed/node_modules/vkey
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mabout to build[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mbuild[0m /Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules/key-pressed
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m [ false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   false,
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkStuff[0m   '/Users/mp/node_modules/webgl-workshop/node_modules/canvas-orbit-camera/node_modules' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mlinkStuff[0m key-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mafterAdd[0m /Users/mp/.npm/ast-parents/0.0.1/package/package.json not in flight; writing
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpreinstall[0m vkey@0.0.3
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m remove-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkBins[0m key-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mlinkMans[0m key-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m key-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec concat-stream@^1.4.3
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec find-global-packages@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec ignorepatterns@^1.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec leftpad@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m esprima@1.2.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m esprima@1.2.2
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m esprima@1.2.2
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35mpostinstall[0m remove-element@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mrebuildBundles[0m [ 'vkey' ]
+[0m[37m[40mnpm[0m [0m[32minfo[0m [0m[35minstall[0m key-pressed@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m concat-stream@>=1.4.3 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name concat-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/concat-stream
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/concat-stream already in flight; waiting
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m find-global-packages@0.0.1
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name find-global-packages
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/find-global-packages
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/find-global-packages not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m ignorepatterns@>=1.0.1 <2.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name ignorepatterns
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/ignorepatterns
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameRange[0m registry:https://registry.npmjs.org/ignorepatterns not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNamed[0m leftpad@0.0.0
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m name leftpad
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mmapToRegistry[0m uri https://registry.npmjs.org/leftpad
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35maddNameVersion[0m registry:https://registry.npmjs.org/leftpad not in flight; fetching
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec mime@~1.2.9
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec minimist@0.0.8
+[0m[37m[40mnpm[0m [0m[34m[40mverb[0m [0m[35mcache add[0m spec open@0.0.3

--- a/process/timestamper.go
+++ b/process/timestamper.go
@@ -57,7 +57,7 @@ func (p *Timestamper) Write(data []byte) (n int, err error) {
 		var codeEnd []byte
 		for p.ansiParser.insideCode() && len(data) > len(codeEnd) {
 			fed := len(codeEnd)
-			p.ansiParser.feed(data[fed])
+			p.ansiParser.Write(data[fed : fed+1])
 			codeEnd = data[:fed+1]
 		}
 		if len(codeEnd) > 0 {
@@ -89,7 +89,7 @@ func (p *Timestamper) Write(data []byte) (n int, err error) {
 		if idx == nil {
 			// Write all remaining data. The line continues into the next Write
 			// call.
-			p.ansiParser.feed(data...)
+			p.ansiParser.Write(data)
 			n, err := p.out.Write(data)
 			written += n
 			return written, err
@@ -98,7 +98,7 @@ func (p *Timestamper) Write(data []byte) (n int, err error) {
 		// Write up to (and including) the newline / breaking sequence, ready to
 		// start a new line in the next iteration or Write.
 		chunk := data[:idx[1]]
-		p.ansiParser.feed(chunk...)
+		p.ansiParser.Write(chunk)
 		n, err = p.out.Write(chunk)
 		written += n
 		if err != nil {


### PR DESCRIPTION
### Description

Significant speed savings:

```
❯ benchstat ansi-parser-{maps,arrays}.txt
goos: darwin
goarch: arm64
pkg: github.com/buildkite/agent/v3/process
cpu: Apple M1 Max
              │ ansi-parser-maps.txt │       ansi-parser-arrays.txt        │
              │        sec/op        │   sec/op     vs base                │
ANSIParser-10           2322.3µ ± 0%   565.3µ ± 1%  -75.66% (p=0.000 n=30)
```

### Context

The secret redactor was sped up a bit by switching away from a map, and I remembered this used maps too.

### Changes

* Add a benchmark
* Rename `feed` to `Write` in case we want to e.g. `io.Copy` or `MultiWriter` into it
* Use `[256]*ansiParserState` instead of `map[byte]ansiParserState`

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

