### PR TITLE
fix: experiment missing from available

### DIFF
--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -53,6 +53,7 @@ var (
 		InterpolationPrefersRuntimeEnv: {},
 		NormalisedUploadPaths:          {},
 		OverrideZeroExitOnCancel:       {},
+		PTYRaw:                         {},
 		ResolveCommitAfterCheckout:     {},
 		UseZZGlob:                      {},
 	}


### PR DESCRIPTION
### Description

`PTYRaw` is in the "available" const block but not in the "available" map.

### Context
 
Found while working on other stuff


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
