### PR TITLE
Redact annotations

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -1226,9 +1226,9 @@ func (e *Executor) setupRedactors(log shell.Logger, environ *env.Environment, st
 		needles = append(needles, pair.Value)
 	}
 
-	stdoutRedactor := replacer.New(stdout, needles, redact.Redact)
+	stdoutRedactor := replacer.New(stdout, needles, redact.Redacted)
 	e.redactors.Append(stdoutRedactor)
-	loggerRedactor := replacer.New(stderr, needles, redact.Redact)
+	loggerRedactor := replacer.New(stderr, needles, redact.Redacted)
 	e.redactors.Append(loggerRedactor)
 
 	logger := shell.NewWriterLogger(loggerRedactor, true, e.DisabledWarnings)

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -3,10 +3,15 @@ package redact
 
 import (
 	"fmt"
+	"io"
+	"maps"
+	"os"
 	"path"
 	"slices"
+	"strings"
 
 	"github.com/buildkite/agent/v3/env"
+	"github.com/buildkite/agent/v3/internal/replacer"
 )
 
 // LengthMin is the shortest string length that will be considered a
@@ -16,11 +21,40 @@ import (
 // from being redacted from useful log output.
 const LengthMin = 6
 
-var redacted = []byte("[REDACTED]")
+// Redacted ignores its input and returns "[REDACTED]".
+func Redacted([]byte) []byte { return []byte("[REDACTED]") }
 
-// Redact ignores its input and returns "[REDACTED]".
-func Redact([]byte) []byte {
-	return redacted
+// String is a convenience wrapper for redacting small strings.
+// This is fine to call repeatedly with many separate strings, but avoid using
+// this to redact large streams - it requires buffering the whole input and
+// output.
+func String(input string, needles []string) string {
+	var sb strings.Builder
+	// strings.Builder.Write doesn't return an error, so neither should a
+	// Replacer that writes to it.
+	New(&sb, needles).Write([]byte(input))
+	return sb.String()
+}
+
+// NeedlesFromEnv matches the patterns against [os.Environ]. It returns values
+// to redact and the names of env vars with "short" values.
+func NeedlesFromEnv(patterns []string) (values, short []string, err error) {
+	environ := env.FromSlice(os.Environ()).DumpPairs()
+	toRedact, short, err := Vars(patterns, environ)
+	if err != nil {
+		return nil, nil, fmt.Errorf("finding env vars to redact: %w", err)
+	}
+	// Make the values unique.
+	needles := make(map[string]struct{})
+	for _, v := range toRedact {
+		needles[v.Value] = struct{}{}
+	}
+	return slices.Collect(maps.Keys(needles)), short, nil
+}
+
+// New returns a replacer configured to write to dst, and redact all needles.
+func New(dst io.Writer, needles []string) *replacer.Replacer {
+	return replacer.New(dst, needles, Redacted)
 }
 
 // MatchAny reports if the name matches any of the patterns.

--- a/internal/replacer/replacer_test.go
+++ b/internal/replacer/replacer_test.go
@@ -100,7 +100,7 @@ func TestReplacerLoremIpsum(t *testing.T) {
 			t.Parallel()
 
 			var buf strings.Builder
-			replacer := replacer.New(&buf, test.needles, redact.Redact)
+			replacer := replacer.New(&buf, test.needles, redact.Redacted)
 			fmt.Fprint(replacer, lipsum)
 			replacer.Flush()
 
@@ -114,7 +114,7 @@ func TestReplacerLoremIpsum(t *testing.T) {
 			t.Parallel()
 
 			var buf strings.Builder
-			replacer := replacer.New(&buf, test.needles, redact.Redact)
+			replacer := replacer.New(&buf, test.needles, redact.Redacted)
 			for _, c := range []byte(lipsum) {
 				replacer.Write([]byte{c})
 			}
@@ -164,7 +164,7 @@ func TestReplacerWriteBoundaries(t *testing.T) {
 			t.Parallel()
 			var buf strings.Builder
 
-			replacer := replacer.New(&buf, test.needles, redact.Redact)
+			replacer := replacer.New(&buf, test.needles, redact.Redacted)
 
 			for _, input := range test.inputs {
 				fmt.Fprint(replacer, input)
@@ -182,7 +182,7 @@ func TestReplacerResetMidStream(t *testing.T) {
 	t.Parallel()
 
 	var buf strings.Builder
-	replacer := replacer.New(&buf, []string{"secret1111"}, redact.Redact)
+	replacer := replacer.New(&buf, []string{"secret1111"}, redact.Redacted)
 
 	// start writing to the stream (no trailing newline, to be extra tricky)
 	replacer.Write([]byte("redact secret1111 but don't redact secret2222 until"))
@@ -204,7 +204,7 @@ func TestReplacerMultibyte(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	replacer := replacer.New(&buf, []string{"ÿ"}, redact.Redact)
+	replacer := replacer.New(&buf, []string{"ÿ"}, redact.Redacted)
 
 	replacer.Write([]byte("fooÿbar"))
 	replacer.Flush()
@@ -285,7 +285,7 @@ func TestReplacerMultiLine(t *testing.T) {
 			t.Parallel()
 
 			var buf strings.Builder
-			r := replacer.New(&buf, []string{secret}, redact.Redact)
+			r := replacer.New(&buf, []string{secret}, redact.Redacted)
 
 			for _, line := range test.input {
 				fmt.Fprint(r, line)
@@ -306,7 +306,7 @@ func TestAddingNeedles(t *testing.T) {
 	afterAddExpectedNeedles := []string{"secret1111", "secret2222", "pre-secret3333"}
 
 	var buf strings.Builder
-	replacer := replacer.New(&buf, needles, redact.Redact)
+	replacer := replacer.New(&buf, needles, redact.Redacted)
 	actualNeedles := replacer.Needles()
 
 	slices.Sort(needles)
@@ -331,7 +331,7 @@ func TestAddingNeedles(t *testing.T) {
 
 func BenchmarkReplacer(b *testing.B) {
 	b.ResetTimer()
-	r := replacer.New(io.Discard, bigLipsumSecrets, redact.Redact)
+	r := replacer.New(io.Discard, bigLipsumSecrets, redact.Redacted)
 	for range b.N {
 		fmt.Fprintln(r, bigLipsum)
 	}
@@ -363,7 +363,7 @@ func FuzzReplacer(f *testing.F) {
 		}
 
 		var sb strings.Builder
-		replacer := replacer.New(&sb, secrets, redact.Redact)
+		replacer := replacer.New(&sb, secrets, redact.Redacted)
 		if split < 0 || split >= len(plaintext) {
 			fmt.Fprint(replacer, plaintext)
 		} else {

--- a/jobapi/server_test.go
+++ b/jobapi/server_test.go
@@ -410,7 +410,7 @@ func TestCreateRedaction(t *testing.T) {
 	)
 
 	writeBuf := &bytes.Buffer{}
-	rdc := replacer.New(writeBuf, []string{alreadyRedacted}, redact.Redact)
+	rdc := replacer.New(writeBuf, []string{alreadyRedacted}, redact.Redacted)
 	mux := replacer.NewMux(rdc)
 
 	env := testEnviron()


### PR DESCRIPTION
### Description

Annotations are as visible as job logs, and can just as easily have secrets leaked into them accidentally, so apply redaction to them.

### Context

https://3.basecamp.com/3453178/buckets/23112918/messages/8443739637

### Changes

* internal/redact: Some helper refactoring 
* clicommand: Pass the annotation body through `redact.String`.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

