### PR TITLE
Redact meta-data values and step attribute updates with warnings

### DIFF
--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -160,7 +160,10 @@ func annotate(ctx context.Context, cfg AnnotateConfig, l logger.Logger) error {
 	if err != nil {
 		return err
 	}
-	body = redact.String(body, needles)
+	if redactedBody := redact.String(body, needles); redactedBody != body {
+		l.Warn("Annotation body contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret")
+		body = redactedBody
+	}
 
 	if bodySize := len(body); bodySize > maxBodySize {
 		return fmt.Errorf("annotation body size (%dB) exceeds maximum (%dB)", bodySize, maxBodySize)


### PR DESCRIPTION
### Description

Apply redaction to meta-data and step updates. 
When redaction happens in these cases, log a warning (also for annotations).

### Context

https://3.basecamp.com/3453178/buckets/23112918/messages/8443739637

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
