### PR TITLE
Fix incomplete processing in newly-redacted operations

### DIFF
--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -32,7 +32,9 @@ func String(input string, needles []string) string {
 	var sb strings.Builder
 	// strings.Builder.Write doesn't return an error, so neither should a
 	// Replacer that writes to it.
-	New(&sb, needles).Write([]byte(input))
+	repl := New(&sb, needles)
+	repl.Write([]byte(input))
+	repl.Flush()
 	return sb.String()
 }
 

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -55,3 +55,43 @@ func TestValuesToRedactEmpty(t *testing.T) {
 		t.Errorf("Vars(%q, %q) = %q, want empty slice", redactConfig, environment, got)
 	}
 }
+
+func TestRedactString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		needles []string
+		input   string
+		want    string
+	}{
+		{
+			name:    "no needles",
+			needles: nil,
+			input:   "secret 1 secret 2 secret 3 s",
+			want:    "secret 1 secret 2 secret 3 s",
+		},
+		{
+			name:    "one needle",
+			needles: []string{"secret 2"},
+			input:   "secret 1 secret 2 secret 3 s",
+			want:    "secret 1 [REDACTED] secret 3 s",
+		},
+		{
+			name:    "three needles",
+			needles: []string{"secret 1", "secret 2", "secret 3"},
+			input:   "secret 1 secret 2 secret 3 s",
+			want:    "[REDACTED] [REDACTED] [REDACTED] s",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := String(test.input, test.needles); got != test.want {
+				t.Errorf("String(%q, %q) = %q, want %q", test.input, test.needles, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

Fixes the operations that recently had redaction added (annotate, meta-data set, step update) where the final character(s) would be missing.

The cause was a missing call to `Flush` on the string replacer, combined with one or more secrets that started with the missing character.

### Context

https://linear.app/buildkite/issue/PS-485

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
