### PR TITLE
refactor: rename `AgentRegisterResponse` local vars to `reg` consistently

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -164,11 +164,11 @@ func (e *errUnrecoverable) Unwrap() error {
 }
 
 // Creates the agent worker and initializes its API Client
-func NewAgentWorker(l logger.Logger, a *api.AgentRegisterResponse, m *metrics.Collector, apiClient APIClient, c AgentWorkerConfig) *AgentWorker {
-	apiClient = apiClient.FromAgentRegisterResponse(a)
+func NewAgentWorker(l logger.Logger, reg *api.AgentRegisterResponse, m *metrics.Collector, apiClient APIClient, c AgentWorkerConfig) *AgentWorker {
+	apiClient = apiClient.FromAgentRegisterResponse(reg)
 	return &AgentWorker{
 		logger:           l,
-		agent:            a,
+		agent:            reg,
 		metricsCollector: m,
 		apiClient:        apiClient,
 		client: &core.Client{

--- a/api/client.go
+++ b/api/client.go
@@ -103,15 +103,15 @@ func (c *Client) Config() Config {
 
 // FromAgentRegisterResponse returns a new instance using the access token and endpoint
 // from the registration response
-func (c *Client) FromAgentRegisterResponse(resp *AgentRegisterResponse) *Client {
+func (c *Client) FromAgentRegisterResponse(reg *AgentRegisterResponse) *Client {
 	conf := c.conf
 
 	// Override the registration token with the access token
-	conf.Token = resp.AccessToken
+	conf.Token = reg.AccessToken
 
 	// If Buildkite told us to use a new Endpoint, respect that
-	if resp.Endpoint != "" {
-		conf.Endpoint = resp.Endpoint
+	if reg.Endpoint != "" {
+		conf.Endpoint = reg.Endpoint
 	}
 
 	return NewClient(c.logger, conf)

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -52,16 +52,16 @@ func TestRegisteringAndConnectingClient(t *testing.T) {
 	})
 
 	// Check a register works
-	regResp, httpResp, err := c.Register(ctx, &api.AgentRegisterRequest{})
+	reg, httpResp, err := c.Register(ctx, &api.AgentRegisterRequest{})
 	if err != nil {
 		t.Fatalf("c.Register(&AgentRegisterRequest{}) error = %v", err)
 	}
 
-	if got, want := regResp.Name, "agent-1"; got != want {
+	if got, want := reg.Name, "agent-1"; got != want {
 		t.Errorf("regResp.Name = %q, want %q", got, want)
 	}
 
-	if got, want := regResp.AccessToken, "alpacas"; got != want {
+	if got, want := reg.AccessToken, "alpacas"; got != want {
 		t.Errorf("regResp.AccessToken = %q, want %q", got, want)
 	}
 
@@ -70,7 +70,7 @@ func TestRegisteringAndConnectingClient(t *testing.T) {
 	}
 
 	// New client with the access token
-	c2 := c.FromAgentRegisterResponse(regResp)
+	c2 := c.FromAgentRegisterResponse(reg)
 
 	// Check a connect works
 	if _, err := c2.Connect(ctx); err != nil {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1245,15 +1245,15 @@ var AgentStartCommand = cli.Command{
 			}
 
 			// Register the agent with the buildkite API
-			ag, err := client.Register(ctx, registerReq)
+			reg, err := client.Register(ctx, registerReq)
 			if err != nil {
 				return err
 			}
 
 			// Create an agent worker to run the agent
 			workers = append(workers, agent.NewAgentWorker(
-				l.WithFields(logger.StringField("agent", ag.Name)),
-				ag,
+				l.WithFields(logger.StringField("agent", reg.Name)),
+				reg,
 				mc,
 				apiClient,
 				agent.AgentWorkerConfig{

--- a/core/controller.go
+++ b/core/controller.go
@@ -54,7 +54,7 @@ func NewController(ctx context.Context, regToken, agentName string, tags []strin
 		},
 	}
 
-	regResp, err := controller.client.Register(ctx, api.AgentRegisterRequest{
+	reg, err := controller.client.Register(ctx, api.AgentRegisterRequest{
 		Name:               agentName,
 		IgnoreInDispatches: true, // TODO: implement a regular agent mode? (ping loop, accept job, etc)
 		ScriptEvalEnabled:  cfg.scriptEvalEnabled,
@@ -65,7 +65,7 @@ func NewController(ctx context.Context, regToken, agentName string, tags []strin
 	if err != nil {
 		return nil, err
 	}
-	controller.client.APIClient = apiClient.FromAgentRegisterResponse(regResp)
+	controller.client.APIClient = apiClient.FromAgentRegisterResponse(reg)
 
 	if err := controller.client.Connect(ctx); err != nil {
 		return nil, err


### PR DESCRIPTION
These local vars were previously named `a`, `ag`, `resp`, and `regResp` in different places.

I was anticipating some upcoming work on agent registration responses, and renamed these while exploring the code. That work doesn't need to happen after all, so this is just a tiny stand-alone refactor.