### PR TITLE
Adding a reference  in our docs the limit of an annotation's contexts

### DIFF
--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -84,7 +84,7 @@ var AnnotateCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "context",
-			Usage:  "The context of the annotation used to differentiate this annotation from others. The value has a limit of 100 characters",
+			Usage:  "The context of the annotation used to differentiate this annotation from others. This value has a limit of 100 characters.",
 			EnvVar: "BUILDKITE_ANNOTATION_CONTEXT",
 		},
 		cli.StringFlag{

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -84,7 +84,7 @@ var AnnotateCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:   "context",
-			Usage:  "The context of the annotation used to differentiate this annotation from others",
+			Usage:  "The context of the annotation used to differentiate this annotation from others. The value has a limit of 100 characters",
 			EnvVar: "BUILDKITE_ANNOTATION_CONTEXT",
 		},
 		cli.StringFlag{


### PR DESCRIPTION
### Description

We had a customer hitting the limit of the annotation's context. So adding the limit in our docs would help future travellers be aware that such limit exits.

### Context

### Changes

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

