### PR TITLE
`AgentWorker` has `noWaitBetweenPingsForTesting` field

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -104,6 +104,9 @@ type AgentWorker struct {
 	stateMtx     sync.Mutex
 	state        agentWorkerState
 	currentJobID string
+
+	// force a sub-second ping interval for testing
+	pingIntervalForTesting time.Duration
 }
 
 type agentWorkerState string
@@ -291,6 +294,9 @@ func (a *AgentWorker) runPingLoop(ctx context.Context, idleMonitor *IdleMonitor)
 
 	// Create the ticker
 	pingInterval := time.Second * time.Duration(a.agent.PingInterval)
+	if a.pingIntervalForTesting != 0 {
+		pingInterval = a.pingIntervalForTesting
+	}
 	pingTicker := time.NewTicker(pingInterval)
 	defer pingTicker.Stop()
 

--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -377,6 +377,7 @@ func TestAgentWorker_Start_AcquireJob_Pause_Unpause(t *testing.T) {
 			},
 		},
 	)
+	worker.pingIntervalForTesting = 1 * time.Millisecond
 
 	idleMonitor := NewIdleMonitor(1)
 
@@ -544,6 +545,7 @@ func TestAgentWorker_DisconnectAfterJob_Start_Pause_Unpause(t *testing.T) {
 			},
 		},
 	)
+	worker.pingIntervalForTesting = 1 * time.Millisecond
 
 	idleMonitor := NewIdleMonitor(1)
 

--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -377,7 +377,7 @@ func TestAgentWorker_Start_AcquireJob_Pause_Unpause(t *testing.T) {
 			},
 		},
 	)
-	worker.pingIntervalForTesting = 1 * time.Millisecond
+	worker.noWaitBetweenPingsForTesting = true
 
 	idleMonitor := NewIdleMonitor(1)
 
@@ -545,7 +545,7 @@ func TestAgentWorker_DisconnectAfterJob_Start_Pause_Unpause(t *testing.T) {
 			},
 		},
 	)
-	worker.pingIntervalForTesting = 1 * time.Millisecond
+	worker.noWaitBetweenPingsForTesting = true
 
 	idleMonitor := NewIdleMonitor(1)
 


### PR DESCRIPTION
The minimum valid server-specified ping interval is 1 second, which means tests that run the ping loop through multiple pings spend multiple seconds waiting.

This introduces a private `AgentWorker.noWaitBetweenPingsForTesting bool` field that tests within package agent can set, which will skip the delay between pings by immediately returning from the `select { … }` due to a closed channel.

This speeds up the existing agent tests by ~5 seconds when run with single parallelism. The benefits are presumably less when running the entire suite in parallel, but this remains useful when iterating on a single test (milliseconds instead of seconds).

Context: I'm working on [some changes](https://github.com/buildkite/agent/pull/3263) that introduce new tests which use the ping loop.