### PR TITLE
`api.Client` sends request headers specified by server in register/ping

### DIFF
--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -331,15 +332,7 @@ func TestAgentWorker_Start_AcquireJob_Pause_Unpause(t *testing.T) {
 			}
 
 		case "/heartbeat":
-			var hb api.Heartbeat
-			if err := json.NewDecoder(req.Body).Decode(&hb); err != nil {
-				http.Error(rw, fmt.Sprintf(`{"message":%q}`, err), http.StatusBadRequest)
-				return
-			}
-			hb.ReceivedAt = time.Now().Format(time.RFC3339)
-			if err := json.NewEncoder(rw).Encode(hb); err != nil {
-				t.Errorf("json.NewEncoder(http.ResponseWriter).Encode(%v) = %v", hb, err)
-			}
+			heartbeatHandler(t, rw, req)
 
 		default:
 			http.Error(rw, "Not found", http.StatusNotFound)
@@ -499,15 +492,7 @@ func TestAgentWorker_DisconnectAfterJob_Start_Pause_Unpause(t *testing.T) {
 			}
 
 		case "/heartbeat":
-			var hb api.Heartbeat
-			if err := json.NewDecoder(req.Body).Decode(&hb); err != nil {
-				http.Error(rw, fmt.Sprintf(`{"message":%q}`, err), http.StatusBadRequest)
-				return
-			}
-			hb.ReceivedAt = time.Now().Format(time.RFC3339)
-			if err := json.NewEncoder(rw).Encode(hb); err != nil {
-				t.Errorf("json.NewEncoder(http.ResponseWriter).Encode(%v) = %v", hb, err)
-			}
+			heartbeatHandler(t, rw, req)
 
 		default:
 			http.Error(rw, "Not found", http.StatusNotFound)
@@ -567,5 +552,477 @@ func TestAgentWorker_DisconnectAfterJob_Start_Pause_Unpause(t *testing.T) {
 	}
 	if !jobFinished {
 		t.Errorf("jobFinished = %t, want true", jobFinished)
+	}
+}
+
+func TestAgentWorker_SetRequestHeadersDuringRegistration(t *testing.T) {
+	// The registration request is made in clicommand.AgentStartCommand, and the response
+	// is passed into agent.NewAgentWorker(...), so we'll just test the response handling.
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	pingCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v3/ping":
+			var resp api.Ping
+			switch pingCount {
+			case 0:
+				if want, got := "world", req.Header.Get("Buildkite-Hello"); want != got {
+					t.Errorf("Expected Buildkite-Hello: %q, got %q", want, got)
+				}
+				t.Log("server ping: disconnect")
+				resp = api.Ping{Action: "disconnect"}
+			default:
+				http.Error(rw, fmt.Sprintf(`{"message":"unexpected ping #%d"}`, pingCount), http.StatusUnprocessableEntity)
+				return
+			}
+			pingCount++
+			if err := json.NewEncoder(rw).Encode(resp); err != nil {
+				t.Errorf("json.NewEncoder(http.ResponseWriter).Encode(%v) = %v", resp, err)
+			}
+
+		case "/v3/heartbeat":
+			heartbeatHandler(t, rw, req)
+
+		default:
+			http.Error(rw, "Not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	endpoint := server.URL + "/v3"
+
+	// Create API client with the _old_ endpoint that it would have used for registration,
+	// but that it should not connect to again.
+	apiClient := api.NewClient(logger.Discard, api.Config{
+		Endpoint: endpoint,
+		Token:    "llamas",
+	})
+
+	l := logger.NewConsoleLogger(logger.NewTestPrinter(t), func(int) {})
+
+	worker := NewAgentWorker(
+		l,
+		&api.AgentRegisterResponse{
+			UUID:              uuid.New().String(),
+			Name:              "agent-1",
+			AccessToken:       "alpacas",
+			Endpoint:          endpoint,
+			PingInterval:      1,
+			JobStatusInterval: 5,
+			HeartbeatInterval: 60,
+			RequestHeaders:    map[string]string{"Buildkite-Hello": "world"},
+		},
+		metrics.NewCollector(logger.Discard, metrics.CollectorConfig{}),
+		apiClient,
+		AgentWorkerConfig{},
+	)
+	// turbo testing
+	worker.noWaitBetweenPingsForTesting = true
+
+	if err := worker.Start(ctx, NewIdleMonitor(1)); err != nil {
+		t.Errorf("worker.Start() = %v", err)
+	}
+
+	if got, want := pingCount, 1; got != want {
+		t.Errorf("pingCount = %d, want %d", got, want)
+	}
+}
+
+func TestAgentWorker_SetEndpointDuringRegistration(t *testing.T) {
+	// The registration request is made in clicommand.AgentStartCommand, and the response
+	// is passed into agent.NewAgentWorker(...), so we'll just test the response handling.
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	pingCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v3/ping":
+			var resp api.Ping
+			switch pingCount {
+			case 0:
+				t.Log("server ping: disconnect")
+				resp = api.Ping{Action: "disconnect"}
+			default:
+				http.Error(rw, fmt.Sprintf(`{"message":"unexpected ping #%d"}`, pingCount), http.StatusUnprocessableEntity)
+				return
+			}
+			pingCount++
+			if err := json.NewEncoder(rw).Encode(resp); err != nil {
+				t.Errorf("json.NewEncoder(http.ResponseWriter).Encode(%v) = %v", resp, err)
+			}
+
+		case "/v3/heartbeat":
+			heartbeatHandler(t, rw, req)
+
+		default:
+			http.Error(rw, "Not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	targetEndpoint := server.URL + "/v3"
+
+	// Create a listener without an HTTP server; hitting this would cause a network error/timeout.
+	// This is a bit neater than using a random host/port and hoping nothing is listening on it.
+	registrationServer, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("creating broken endpoint listener: %v", err)
+	}
+	defer registrationServer.Close()
+	registrationEndpoint := fmt.Sprintf("http://%s/v3", registrationServer.Addr().String())
+
+	// Create API client with the _old_ endpoint that it would have used for registration,
+	// but that it should not connect to again.
+	apiClient := api.NewClient(logger.Discard, api.Config{
+		Endpoint: registrationEndpoint, // should not be connected to again
+		Token:    "llamas",
+	})
+
+	l := logger.NewConsoleLogger(logger.NewTestPrinter(t), func(int) {})
+
+	worker := NewAgentWorker(
+		l,
+		&api.AgentRegisterResponse{
+			UUID:              uuid.New().String(),
+			Name:              "agent-1",
+			AccessToken:       "alpacas",
+			Endpoint:          targetEndpoint, // should be used from now on
+			PingInterval:      1,
+			JobStatusInterval: 5,
+			HeartbeatInterval: 60,
+		},
+		metrics.NewCollector(logger.Discard, metrics.CollectorConfig{}),
+		apiClient,
+		AgentWorkerConfig{},
+	)
+	// turbo testing
+	worker.noWaitBetweenPingsForTesting = true
+
+	if err := worker.Start(ctx, NewIdleMonitor(1)); err != nil {
+		t.Errorf("worker.Start() = %v", err)
+	}
+
+	if got, want := pingCount, 1; got != want {
+		t.Errorf("pingCount = %d, want %d", got, want)
+	}
+}
+
+func TestAgentWorker_UpdateRequestHeadersDuringPing(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	pingCount := 0
+
+	header := "Buildkite-Hello"
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/ping":
+			var resp api.Ping
+			switch pingCount {
+			case 0: // no action
+				if len(req.Header.Values(header)) != 0 {
+					t.Errorf("unexpected header: %s: %q", header, req.Header.Get(header))
+				}
+				t.Log("server ping: idle")
+				resp = api.Ping{Action: "idle"}
+			case 1:
+				if len(req.Header.Values(header)) != 0 {
+					t.Errorf("unexpected header: %s: %q", header, req.Header.Get(header))
+				}
+				t.Log("server ping: idle, set RequestHeaders")
+				resp = api.Ping{
+					Action:         "idle",
+					RequestHeaders: map[string]string{header: "world"},
+				}
+			case 2:
+				if want, got := "world", req.Header.Get(header); want != got {
+					t.Errorf("expected %s: %q, got %q", header, want, got)
+				}
+				t.Log("server ping: idle")
+				resp = api.Ping{Action: "idle"}
+			case 3:
+				if want, got := "world", req.Header.Get(header); want != got {
+					t.Errorf("expected %s: %q, got %q", header, want, got)
+				}
+				t.Log("server ping: idle, set empty RequestHeaders")
+				resp = api.Ping{Action: "idle", RequestHeaders: map[string]string{}}
+			case 4:
+				if len(req.Header.Values(header)) != 0 {
+					t.Errorf("unexpected header: %s: %q", header, req.Header.Get(header))
+				}
+				t.Log("server ping: disconnect")
+				resp = api.Ping{Action: "disconnect"}
+			default:
+				http.Error(rw, `{"message":"too many pings"}`, http.StatusUnprocessableEntity)
+				return
+			}
+
+			pingCount++
+
+			if err := json.NewEncoder(rw).Encode(resp); err != nil {
+				t.Errorf("json.NewEncoder(http.ResponseWriter).Encode(%v) = %v", resp, err)
+			}
+
+		case "/heartbeat":
+			heartbeatHandler(t, rw, req)
+
+		default:
+			http.Error(rw, "Not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	apiClient := api.NewClient(logger.Discard, api.Config{
+		Endpoint: server.URL,
+		Token:    "llamas",
+	})
+
+	l := logger.NewConsoleLogger(logger.NewTestPrinter(t), func(int) {})
+
+	worker := NewAgentWorker(
+		l,
+		&api.AgentRegisterResponse{
+			UUID:              uuid.New().String(),
+			Name:              "agent-1",
+			AccessToken:       "alpacas",
+			Endpoint:          server.URL,
+			PingInterval:      1,
+			JobStatusInterval: 5,
+			HeartbeatInterval: 60,
+		},
+		metrics.NewCollector(logger.Discard, metrics.CollectorConfig{}),
+		apiClient,
+		AgentWorkerConfig{},
+	)
+	// turbo testing
+	worker.noWaitBetweenPingsForTesting = true
+
+	if err := worker.Start(ctx, NewIdleMonitor(1)); err != nil {
+		t.Errorf("worker.Start() = %v", err)
+	}
+
+	if got, want := pingCount, 5; got != want {
+		t.Errorf("pingCount = %d, want %d", got, want)
+	}
+}
+
+func TestAgentWorker_UpdateEndpointDuringPing(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	pingCount := 0
+
+	// the second endpoint, to be redirected to (we need its address first...)
+	endpointB := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v3/ping":
+			var resp api.Ping
+			switch pingCount {
+			case 2:
+				t.Log("endpointB ping: idle")
+				resp = api.Ping{Action: "idle"}
+			case 3:
+				t.Log("endpointB ping: disconnect")
+				resp = api.Ping{Action: "disconnect"}
+			default:
+				http.Error(rw, fmt.Sprintf(`{"message":"endpointB unexpected ping #%d"}`, pingCount), http.StatusUnprocessableEntity)
+				return
+			}
+
+			pingCount++
+
+			if err := json.NewEncoder(rw).Encode(resp); err != nil {
+				t.Errorf("json.NewEncoder(http.ResponseWriter).Encode(%v) = %v", resp, err)
+			}
+
+		case "/v3/heartbeat":
+			heartbeatHandler(t, rw, req)
+
+		default:
+			http.Error(rw, "Not found", http.StatusNotFound)
+		}
+	}))
+	defer endpointB.Close()
+
+	endpointA := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v3/ping":
+			var resp api.Ping
+			switch pingCount {
+			case 0:
+				t.Log("endpointA ping: idle")
+				resp = api.Ping{Action: "idle"}
+			case 1:
+				endpoint := endpointB.URL + "/v3"
+				t.Logf("endpointA ping: idle, Endpoint: %s (endpointB)", endpoint)
+				resp = api.Ping{Action: "idle", Endpoint: endpoint}
+			default:
+				http.Error(rw, fmt.Sprintf(`{"message":"endpointA unexpected ping #%d"}`, pingCount), http.StatusUnprocessableEntity)
+				return
+			}
+
+			pingCount++
+
+			if err := json.NewEncoder(rw).Encode(resp); err != nil {
+				t.Errorf("json.NewEncoder(http.ResponseWriter).Encode(%v) = %v", resp, err)
+			}
+
+		case "/v3/heartbeat":
+			heartbeatHandler(t, rw, req)
+
+		default:
+			http.Error(rw, "Not found", http.StatusNotFound)
+		}
+	}))
+	defer endpointA.Close()
+
+	// start on endpointA, expect to be redirected to endpointB
+	endpoint := endpointA.URL + "/v3"
+
+	apiClient := api.NewClient(logger.Discard, api.Config{
+		Endpoint: endpoint,
+		Token:    "llamas",
+	})
+
+	l := logger.NewConsoleLogger(logger.NewTestPrinter(t), func(int) {})
+
+	worker := NewAgentWorker(
+		l,
+		&api.AgentRegisterResponse{
+			UUID:              uuid.New().String(),
+			Name:              "agent-1",
+			AccessToken:       "alpacas",
+			Endpoint:          endpoint,
+			PingInterval:      1,
+			JobStatusInterval: 5,
+			HeartbeatInterval: 60,
+		},
+		metrics.NewCollector(logger.Discard, metrics.CollectorConfig{}),
+		apiClient,
+		AgentWorkerConfig{},
+	)
+	// turbo testing
+	worker.noWaitBetweenPingsForTesting = true
+
+	if err := worker.Start(ctx, NewIdleMonitor(1)); err != nil {
+		t.Errorf("worker.Start() = %v", err)
+	}
+
+	if got, want := pingCount, 4; got != want {
+		t.Errorf("pingCount = %d, want %d", got, want)
+	}
+}
+
+func TestAgentWorker_UpdateEndpointDuringPing_FailAndRevert(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	pingCount := 0
+
+	// Create a listener without an HTTP server, to guarantee a network error/timeout
+	endpointB, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("creating broken endpoint listener: %v", err)
+	}
+	defer endpointB.Close()
+
+	endpointA := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v3/ping":
+			var resp api.Ping
+			switch pingCount {
+			case 0:
+				t.Log("endpointA ping: idle")
+				resp = api.Ping{Action: "idle"}
+			case 1:
+				endpoint := fmt.Sprintf("http://%s/v3", endpointB.Addr().String())
+				t.Logf("endpointA ping: idle, Endpoint: %s (endpointB; broken)", endpoint)
+				resp = api.Ping{Action: "idle", Endpoint: endpoint}
+			case 2:
+				t.Log("endpointA ping: idle")
+				resp = api.Ping{Action: "idle"}
+			case 3:
+				t.Log("endpointA ping: disconnect")
+				resp = api.Ping{Action: "disconnect"}
+			default:
+				http.Error(rw, fmt.Sprintf(`{"message":"endpointA unexpected ping #%d"}`, pingCount), http.StatusUnprocessableEntity)
+				return
+			}
+
+			pingCount++
+
+			if err := json.NewEncoder(rw).Encode(resp); err != nil {
+				t.Errorf("json.NewEncoder(http.ResponseWriter).Encode(%v) = %v", resp, err)
+			}
+
+		case "/v3/heartbeat":
+			heartbeatHandler(t, rw, req)
+
+		default:
+			http.Error(rw, "Not found", http.StatusNotFound)
+		}
+	}))
+	defer endpointA.Close()
+
+	// start on endpointA, expect to be redirected to endpointB
+	endpoint := endpointA.URL + "/v3"
+
+	apiClient := api.NewClient(logger.Discard, api.Config{
+		Endpoint: endpoint,
+		Token:    "llamas",
+		Timeout:  100 * time.Millisecond,
+	})
+
+	l := logger.NewConsoleLogger(logger.NewTestPrinter(t), func(int) {})
+
+	worker := NewAgentWorker(
+		l,
+		&api.AgentRegisterResponse{
+			UUID:              uuid.New().String(),
+			Name:              "agent-1",
+			AccessToken:       "alpacas",
+			Endpoint:          endpoint,
+			PingInterval:      1,
+			JobStatusInterval: 5,
+			HeartbeatInterval: 60,
+		},
+		metrics.NewCollector(logger.Discard, metrics.CollectorConfig{}),
+		apiClient,
+		AgentWorkerConfig{},
+	)
+	// turbo testing
+	worker.noWaitBetweenPingsForTesting = true
+
+	if err := worker.Start(ctx, NewIdleMonitor(1)); err != nil {
+		t.Errorf("worker.Start() = %v", err)
+	}
+
+	if got, want := pingCount, 4; got != want {
+		t.Errorf("pingCount = %d, want %d", got, want)
+	}
+}
+
+var heartbeatHandler = func(t *testing.T, rw http.ResponseWriter, req *http.Request) {
+	var hb api.Heartbeat
+	if err := json.NewDecoder(req.Body).Decode(&hb); err != nil {
+		http.Error(rw, fmt.Sprintf(`{"message":%q}`, err), http.StatusBadRequest)
+		return
+	}
+	hb.ReceivedAt = time.Now().Format(time.RFC3339)
+	if err := json.NewEncoder(rw).Encode(hb); err != nil {
+		t.Errorf("json.NewEncoder(http.ResponseWriter).Encode(%v) = %v", hb, err)
 	}
 }

--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -1015,7 +1015,8 @@ func TestAgentWorker_UpdateEndpointDuringPing_FailAndRevert(t *testing.T) {
 	}
 }
 
-var heartbeatHandler = func(t *testing.T, rw http.ResponseWriter, req *http.Request) {
+// A generic fake heartbeat handler used by various httptest servers.
+func heartbeatHandler(t *testing.T, rw http.ResponseWriter, req *http.Request) {
 	var hb api.Heartbeat
 	if err := json.NewDecoder(req.Body).Decode(&hb); err != nil {
 		http.Error(rw, fmt.Sprintf(`{"message":%q}`, err), http.StatusBadRequest)

--- a/api/agents.go
+++ b/api/agents.go
@@ -21,14 +21,15 @@ type AgentRegisterRequest struct {
 
 // AgentRegisterResponse is the response from the Buildkite Agent API
 type AgentRegisterResponse struct {
-	UUID              string   `json:"id"`
-	Name              string   `json:"name"`
-	AccessToken       string   `json:"access_token"`
-	Endpoint          string   `json:"endpoint"`
-	PingInterval      int      `json:"ping_interval"`
-	JobStatusInterval int      `json:"job_status_interval"`
-	HeartbeatInterval int      `json:"heartbeat_interval"`
-	Tags              []string `json:"meta_data"`
+	UUID              string            `json:"id"`
+	Name              string            `json:"name"`
+	AccessToken       string            `json:"access_token"`
+	Endpoint          string            `json:"endpoint"`
+	PingInterval      int               `json:"ping_interval"`
+	JobStatusInterval int               `json:"job_status_interval"`
+	HeartbeatInterval int               `json:"heartbeat_interval"`
+	Tags              []string          `json:"meta_data"`
+	RequestHeaders    map[string]string `json:"request_headers"`
 }
 
 // Registers the agent against the Buildkite Agent API. The client for this

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -78,6 +78,39 @@ func TestRegisteringAndConnectingClient(t *testing.T) {
 	}
 }
 
+func TestFromPing_WithNoChange(t *testing.T) {
+	client := api.NewClient(logger.Discard, api.Config{
+		Endpoint: "http://localhost:12314",
+		Token:    "llamas",
+	})
+
+	if client.FromPing(&api.Ping{}) != client {
+		t.Errorf("expected unchanged client after ping with no Endpoint or RequestHeaders")
+	}
+}
+
+func TestFromPing_WithHeaderChange(t *testing.T) {
+	client := api.NewClient(logger.Discard, api.Config{
+		Endpoint: "http://localhost:12314",
+		Token:    "llamas",
+	})
+
+	if client.FromPing(&api.Ping{RequestHeaders: map[string]string{"Buildkite-A": "b"}}) == client {
+		t.Errorf("expected new client after ping with RequestHeaders")
+	}
+}
+
+func TestFromPing_WithEndpointChange(t *testing.T) {
+	client := api.NewClient(logger.Discard, api.Config{
+		Endpoint: "https://agent.buildkite.com/v3",
+		Token:    "llamas",
+	})
+
+	if client.FromPing(&api.Ping{Endpoint: "https://shard-0.agent.buildkite.com/v3"}) == client {
+		t.Errorf("expected new client after ping with RequestHeaders")
+	}
+}
+
 func authToken(req *http.Request) string {
 	return strings.TrimPrefix(req.Header.Get("Authorization"), "Token ")
 }

--- a/api/pings.go
+++ b/api/pings.go
@@ -4,10 +4,11 @@ import "context"
 
 // Ping represents a Buildkite Agent API Ping
 type Ping struct {
-	Action   string `json:"action,omitempty"`
-	Message  string `json:"message,omitempty"`
-	Job      *Job   `json:"job,omitempty"`
-	Endpoint string `json:"endpoint,omitempty"`
+	Action         string            `json:"action,omitempty"`
+	Message        string            `json:"message,omitempty"`
+	Job            *Job              `json:"job,omitempty"`
+	Endpoint       string            `json:"endpoint,omitempty"`
+	RequestHeaders map[string]string `json:"request_headers,omitzero"` // omit nil, keep empty map
 }
 
 // Pings the API and returns any work the client needs to perform


### PR DESCRIPTION
_Update: superseded by https://github.com/buildkite/agent/pull/3268_

This allows Buildkite server to add `Buildkite-*` request headers to an agent's session, and then use those subsequent request headers to e.g. improve routing, performance, and reliability of requests. Specifically, we intend to use these headers to extend the resilience of our [sharded architecture](https://buildkite.com/docs/pipelines/announcements/database-migration).

The request headers would be included in an optional `request_headers` field of `/v3/register` and `/v3/ping` responses:

```json
{
  "…": "…",
  "request_headers": {
    "Buildkite-Hello": "world!"
  }
}
```

Summary of the primary change:

- The API client has a new internal map of server-specified headers to include in every request (`Client.requestHeaders`).
- Only headers beginning with `Buildkite-` are accepted by the agent, so HTTP transport behaviour cannot be impacted.
- The presence of `request_headers` in register/ping _replaces_ the client's request headers.
- Thus, the presence of an _empty_ object i.e. `"request_headers": {}` clears `Client.requestHeaders` and stops sending any server-specified headers.
- Whereas the absence of that field, or a value of `null`, is a no-op; the client is not updated and any existing headers continue to be sent. This allows the majority of ping responses to omit the `request_headers` data.

Test coverage added:
- `TestAgentWorker_SetRequestHeadersDuringRegistration`
- `TestAgentWorker_SetEndpointDuringRegistration`
- `TestAgentWorker_UpdateRequestHeadersDuringPing`
- `TestAgentWorker_UpdateEndpointDuringPing`
- `TestAgentWorker_UpdateEndpointDuringPing_FailAndRevert`
- `TestFromPing_WithNoChange`
- `TestFromPing_WithHeaderChange`
- `TestFromPing_WithEndpointChange`


Implementation notes:

Note that this is implemented alongside the long-standing ability for the server to redirect to an alternate endpoint; I've added test coverage to that functionality while I'm here, but have done my best not to change that behaviour.

I had hoped to implement this orthogonally to the existing endpoint switching functionality, but it's quite closely related, and that proved tricky. So I let that existing implementation somewhat guide how and where this is implemented. This is why the entire `api.Client` is _replaced_ when headers (or endpoint) change, rather than just mutating the existing client. I'm not sure I love that, but I think it's a two-way door that we could change in future.

I noticed that the endpoint-switching re-ping could in some cases return the `action` from the original ping (e.g. `idle`) alongside a `Job` from a non-idle re-ping. I couldn't see any impact of that, but I've fixed it anyway.

It would have been a slightly simpler/smaller change to add these request headers to `api.Config` rather than as internal state of `api.Client`, however they're not really _configuration_.