### PR TITLE
`api.Client` sends request headers specified by server in register & ping

### DIFF
--- a/agent/api.go
+++ b/agent/api.go
@@ -27,7 +27,6 @@ type APIClient interface {
 	GetJobState(context.Context, string) (*api.JobState, *api.Response, error)
 	GetMetaData(context.Context, string, string, string) (*api.MetaData, *api.Response, error)
 	GetSecret(context.Context, *api.GetSecretRequest) (*api.Secret, *api.Response, error)
-	GetServerSpecifiedRequestHeaders() http.Header
 	Heartbeat(context.Context) (*api.Heartbeat, *api.Response, error)
 	MetaDataKeys(context.Context, string, string) ([]string, *api.Response, error)
 	New(api.Config) *api.Client
@@ -37,6 +36,7 @@ type APIClient interface {
 	Register(context.Context, *api.AgentRegisterRequest) (*api.AgentRegisterResponse, *api.Response, error)
 	SaveHeaderTimes(context.Context, string, *api.HeaderTimes) (*api.Response, error)
 	SearchArtifacts(context.Context, string, *api.ArtifactSearchOptions) ([]*api.Artifact, *api.Response, error)
+	ServerSpecifiedRequestHeaders() http.Header
 	SetMetaData(context.Context, string, *api.MetaData) (*api.Response, error)
 	StartJob(context.Context, *api.Job) (*api.Response, error)
 	StepCancel(context.Context, string, *api.StepCancel) (*api.StepCancelResponse, *api.Response, error)

--- a/agent/api.go
+++ b/agent/api.go
@@ -5,6 +5,7 @@ package agent
 import (
 	"context"
 	"github.com/buildkite/agent/v3/api"
+	"net/http"
 )
 
 // APIClient is an interface generated for "github.com/buildkite/agent/v3/api.Client".
@@ -26,8 +27,10 @@ type APIClient interface {
 	GetJobState(context.Context, string) (*api.JobState, *api.Response, error)
 	GetMetaData(context.Context, string, string, string) (*api.MetaData, *api.Response, error)
 	GetSecret(context.Context, *api.GetSecretRequest) (*api.Secret, *api.Response, error)
+	GetServerSpecifiedRequestHeaders() http.Header
 	Heartbeat(context.Context) (*api.Heartbeat, *api.Response, error)
 	MetaDataKeys(context.Context, string, string) ([]string, *api.Response, error)
+	New(api.Config) *api.Client
 	OIDCToken(context.Context, *api.OIDCTokenRequest) (*api.OIDCToken, *api.Response, error)
 	Ping(context.Context) (*api.Ping, *api.Response, error)
 	PipelineUploadStatus(context.Context, string, string, ...api.Header) (*api.PipelineUploadStatus, *api.Response, error)

--- a/agent/integration/job_environment_integration_test.go
+++ b/agent/integration/job_environment_integration_test.go
@@ -67,7 +67,7 @@ func TestBuildkiteRequestHeaders(t *testing.T) {
 		Token:     "llamasrock",
 		DebugHTTP: true,
 	})
-	headers := client.GetServerSpecifiedRequestHeaders()
+	headers := client.ServerSpecifiedRequestHeaders()
 	// That getter isn't designed to modify the headers, but all's fair in test setup code and war.
 	headers.Set("Buildkite-Hello", "world")
 

--- a/agent/integration/job_environment_integration_test.go
+++ b/agent/integration/job_environment_integration_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/bintest/v3"
 	"github.com/buildkite/go-pipeline"
 )
@@ -45,6 +46,55 @@ func TestWhenCachePathsSetInJobStep_CachePathsEnvVarIsSet(t *testing.T) {
 		server:        server,
 		agentCfg:      agent.AgentConfiguration{},
 		mockBootstrap: mb,
+	})
+	if err != nil {
+		t.Fatalf("runJob() error = %v", err)
+	}
+}
+
+func TestBuildkiteRequestHeaders(t *testing.T) {
+	t.Parallel()
+
+	// create a mock agent API
+	e := createTestAgentEndpoint()
+	server := e.server()
+	defer server.Close()
+
+	// create a client with server-specified headers
+	l := logger.NewConsoleLogger(logger.NewTestPrinter(t), func(int) {})
+	client := api.NewClient(l, api.Config{
+		Endpoint:  server.URL,
+		Token:     "llamasrock",
+		DebugHTTP: true,
+	})
+	headers := client.GetServerSpecifiedRequestHeaders()
+	// That getter isn't designed to modify the headers, but all's fair in test setup code and war.
+	headers.Set("Buildkite-Hello", "world")
+
+	mb := mockBootstrap(t)
+	defer mb.CheckAndClose(t)
+
+	// The main assertion: that the `Buildkite-Hello: world` server-specified request header is
+	// passed to the job environment as BUILDKITE_REQUEST_HEADER_BUILDKITE_HELLO=world. From there,
+	// it'll be picked up by api.NewClient() in sub-processes like `buildkite-agent annotate` etc.
+	mb.Expect().Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
+		if got, want := c.GetEnv("BUILDKITE_REQUEST_HEADER_BUILDKITE_HELLO"), "world"; got != want {
+			t.Errorf("c.GetEnv(BUILDKITE_REQUEST_HEADER_BUILDKITE_HELLO) = %q, want %q", got, want)
+		}
+		c.Exit(0)
+	})
+
+	err := runJob(t, context.Background(), testRunJobConfig{
+		job: &api.Job{
+			ID:                 "00000000-0000-0000-0000-000000000123",
+			ChunksMaxSizeBytes: 1024,
+			Step:               pipeline.CommandStep{},
+			Token:              "bkaj_job-token",
+		},
+		server:        server,
+		agentCfg:      agent.AgentConfiguration{},
+		mockBootstrap: mb,
+		client:        client,
 	})
 	if err != nil {
 		t.Fatalf("runJob() error = %v", err)

--- a/agent/integration/test_helpers.go
+++ b/agent/integration/test_helpers.go
@@ -46,6 +46,7 @@ type testRunJobConfig struct {
 	agentCfg         agent.AgentConfiguration
 	mockBootstrap    *bintest.Mock
 	verificationJWKS jwk.Set
+	client           *api.Client
 }
 
 func runJob(t *testing.T, ctx context.Context, cfg testRunJobConfig) error {
@@ -60,12 +61,14 @@ func runJob(t *testing.T, ctx context.Context, cfg testRunJobConfig) error {
 	// set the bootstrap into the config
 	cfg.agentCfg.BootstrapScript = cfg.mockBootstrap.Path
 
-	client := api.NewClient(l, api.Config{
-		Endpoint: cfg.server.URL,
-		Token:    "llamasrock",
-	})
+	if cfg.client == nil {
+		cfg.client = api.NewClient(l, api.Config{
+			Endpoint: cfg.server.URL,
+			Token:    "llamasrock",
+		})
+	}
 
-	jr, err := agent.NewJobRunner(ctx, l, client, agent.JobRunnerConfig{
+	jr, err := agent.NewJobRunner(ctx, l, cfg.client, agent.JobRunnerConfig{
 		Job:                cfg.job,
 		JWKS:               cfg.verificationJWKS,
 		AgentConfiguration: cfg.agentCfg,

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -491,7 +491,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 
 	// ... including any server-specified request headers, so that sub-processes such as
 	// buildkite-agent annotate etc can respect them.
-	for header, values := range r.apiClient.GetServerSpecifiedRequestHeaders() {
+	for header, values := range r.apiClient.ServerSpecifiedRequestHeaders() {
 		k := fmt.Sprintf(
 			"BUILDKITE_REQUEST_HEADER_%s",
 			strings.ToUpper(strings.ReplaceAll(header, "-", "_")),

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -178,10 +178,19 @@ var _ jobRunner = (*JobRunner)(nil)
 
 // Initializes the job runner
 func NewJobRunner(ctx context.Context, l logger.Logger, apiClient APIClient, conf JobRunnerConfig) (jobRunner, error) {
+	// If the accept response has a token attached, we should use that instead of the Agent Access Token that
+	// our current apiClient is using
+	if conf.Job.Token != "" {
+		clientConf := apiClient.Config()
+		clientConf.Token = conf.Job.Token
+		apiClient = apiClient.New(clientConf)
+	}
+
 	r := &JobRunner{
 		agentLogger: l,
 		conf:        conf,
 		apiClient:   apiClient,
+		client:      &core.Client{APIClient: apiClient, Logger: l},
 	}
 
 	var err error
@@ -193,15 +202,6 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient APIClient, con
 	if conf.JobStatusInterval == 0 {
 		conf.JobStatusInterval = 1 * time.Second
 	}
-
-	// If the accept response has a token attached, we should use that instead of the Agent Access Token that
-	// our current apiClient is using
-	if r.conf.Job.Token != "" {
-		clientConf := r.apiClient.Config()
-		clientConf.Token = r.conf.Job.Token
-		r.apiClient = api.NewClient(r.agentLogger, clientConf)
-	}
-	r.client = &core.Client{APIClient: r.apiClient, Logger: l}
 
 	// Create our header times struct
 	r.headerTimesStreamer = newHeaderTimesStreamer(r.agentLogger, r.onUploadHeaderTime)
@@ -488,6 +488,18 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	env["BUILDKITE_AGENT_ENDPOINT"] = apiConfig.Endpoint
 	env["BUILDKITE_AGENT_ACCESS_TOKEN"] = apiConfig.Token
 	env["BUILDKITE_NO_HTTP2"] = fmt.Sprint(apiConfig.DisableHTTP2)
+
+	// ... including any server-specified request headers, so that sub-processes such as
+	// buildkite-agent annotate etc can respect them.
+	for header, values := range r.apiClient.GetServerSpecifiedRequestHeaders() {
+		k := fmt.Sprintf(
+			"BUILDKITE_REQUEST_HEADER_%s",
+			strings.ToUpper(strings.ReplaceAll(header, "-", "_")),
+		)
+		for _, v := range values {
+			env[k] = v
+		}
+	}
 
 	// Add agent environment variables
 	env["BUILDKITE_AGENT_DEBUG"] = fmt.Sprint(r.conf.Debug)

--- a/api/agents.go
+++ b/api/agents.go
@@ -47,7 +47,7 @@ func (c *Client) Register(ctx context.Context, regReq *AgentRegisterRequest) (*A
 	}
 
 	// If Buildkite told us to use Buildkite-* request headers, store those
-	c.setRequestHeadersFromMap(a.RequestHeaders)
+	c.setRequestHeaders(a.RequestHeaders)
 
 	return a, resp, err
 }

--- a/api/agents.go
+++ b/api/agents.go
@@ -21,14 +21,15 @@ type AgentRegisterRequest struct {
 
 // AgentRegisterResponse is the response from the Buildkite Agent API
 type AgentRegisterResponse struct {
-	UUID              string   `json:"id"`
-	Name              string   `json:"name"`
-	AccessToken       string   `json:"access_token"`
-	Endpoint          string   `json:"endpoint"`
-	PingInterval      int      `json:"ping_interval"`
-	JobStatusInterval int      `json:"job_status_interval"`
-	HeartbeatInterval int      `json:"heartbeat_interval"`
-	Tags              []string `json:"meta_data"`
+	UUID              string            `json:"id"`
+	Name              string            `json:"name"`
+	AccessToken       string            `json:"access_token"`
+	Endpoint          string            `json:"endpoint"`
+	RequestHeaders    map[string]string `json:"request_headers"`
+	PingInterval      int               `json:"ping_interval"`
+	JobStatusInterval int               `json:"job_status_interval"`
+	HeartbeatInterval int               `json:"heartbeat_interval"`
+	Tags              []string          `json:"meta_data"`
 }
 
 // Registers the agent against the Buildkite Agent API. The client for this
@@ -44,6 +45,9 @@ func (c *Client) Register(ctx context.Context, regReq *AgentRegisterRequest) (*A
 	if err != nil {
 		return nil, resp, err
 	}
+
+	// If Buildkite told us to use Buildkite-* request headers, store those
+	c.setRequestHeadersFromMap(a.RequestHeaders)
 
 	return a, resp, err
 }

--- a/api/client.go
+++ b/api/client.go
@@ -171,7 +171,7 @@ func (c *Client) FromAgentRegisterResponse(reg *AgentRegisterResponse) *Client {
 	return c.New(conf)
 }
 
-func (c *Client) setRequestHeadersFromMap(headers map[string]string) {
+func (c *Client) setRequestHeaders(headers map[string]string) {
 	if headers == nil {
 		return
 	}

--- a/api/client.go
+++ b/api/client.go
@@ -149,9 +149,9 @@ func (c *Client) Config() Config {
 	return c.conf
 }
 
-// GetServerSpecifiedRequestHeaders returns the HTTP headers that the Buildkite register/ping
+// ServerSpecifiedRequestHeaders returns the HTTP headers that the Buildkite register/ping
 // APIs have advised the client to send in all requests.
-func (c *Client) GetServerSpecifiedRequestHeaders() http.Header {
+func (c *Client) ServerSpecifiedRequestHeaders() http.Header {
 	return c.requestHeaders
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -183,6 +183,14 @@ func (c *Client) setRequestHeaders(headers map[string]string) {
 		}
 		c.requestHeaders.Set(k, v)
 	}
+
+	if c.logger.Level() <= logger.DEBUG {
+		for k, values := range c.requestHeaders {
+			for _, v := range values {
+				c.logger.Debug("Server-specified request header: %s: %s", k, v)
+			}
+		}
+	}
 }
 
 // FromPing returns a new instance using a new endpoint from a ping response

--- a/api/client_private_test.go
+++ b/api/client_private_test.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRequestHeadersFromEnv(t *testing.T) {
+	environ := []string{
+		"HOME=/where/the/heart/is",
+		"BUILDKITE_REQUEST_HEADER_BUILDKITE_FOO=bar",
+		"BUILDKITE_REQUEST_HEADER_BUILDKITE_ANOTHER_THING=something else",
+		"BUILDKITE_REQUEST_HEADER_CONTENT_TYPE=reject/this",
+	}
+	want := http.Header{
+		"Buildkite-Foo":           []string{"bar"},
+		"Buildkite-Another-Thing": []string{"something else"},
+	}
+	got := requestHeadersFromEnv(environ)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("requestHeadersFromEnv -want +got:\n%s", diff)
+	}
+}

--- a/api/pings.go
+++ b/api/pings.go
@@ -4,10 +4,11 @@ import "context"
 
 // Ping represents a Buildkite Agent API Ping
 type Ping struct {
-	Action   string `json:"action,omitempty"`
-	Message  string `json:"message,omitempty"`
-	Job      *Job   `json:"job,omitempty"`
-	Endpoint string `json:"endpoint,omitempty"`
+	Action         string            `json:"action,omitempty"`
+	Message        string            `json:"message,omitempty"`
+	Job            *Job              `json:"job,omitempty"`
+	Endpoint       string            `json:"endpoint,omitempty"`
+	RequestHeaders map[string]string `json:"request_headers,omitzero"` // omit nil, keep empty map
 }
 
 // Pings the API and returns any work the client needs to perform
@@ -22,6 +23,9 @@ func (c *Client) Ping(ctx context.Context) (*Ping, *Response, error) {
 	if err != nil {
 		return nil, resp, err
 	}
+
+	// If Buildkite told us to use Buildkite-* request headers, store those
+	c.setRequestHeadersFromMap(ping.RequestHeaders)
 
 	return ping, resp, err
 }

--- a/api/pings.go
+++ b/api/pings.go
@@ -25,7 +25,7 @@ func (c *Client) Ping(ctx context.Context) (*Ping, *Response, error) {
 	}
 
 	// If Buildkite told us to use Buildkite-* request headers, store those
-	c.setRequestHeadersFromMap(ping.RequestHeaders)
+	c.setRequestHeaders(ping.RequestHeaders)
 
 	return ping, resp, err
 }


### PR DESCRIPTION
Allow Buildkite server to add `Buildkite-*` request headers to an agent's session, and then use those subsequent request headers to e.g. improve routing, performance, and reliability of requests. Specifically, we intend to use these headers to extend the resilience of our sharded architecture.

The request headers would be included in an optional `request_headers` field of /v3/register and /v3/ping responses:

    {
      "…": "…",
      "request_headers": {
        "Buildkite-Hello": "world!"
      }
    }

## Summary of changes:

- The API client has a new internal map of server-specified headers to include in every request (`api.Client.requestHeaders`).
- Only headers beginning with `Buildkite-` are accepted by the agent, so general HTTP behaviour cannot be impacted by this mechanism.
- The presence of `request_headers` in register/ping _replaces_ the client's request headers.
- Thus, the presence of an _empty_ object i.e. `"request_headers": {}` clears `Client.requestHeaders` and stops sending any server-specified headers.
- Whereas the absence of that field, or a value of `null`, is a no-op; the client is not updated and any existing headers continue to be sent. This allows the majority of ping responses to omit the `request_headers` data.


## Header Propagation

To include these server-specified headers in all subsequent Agent API requests, there's a few scenarios:

### Requests from the same `api.Client`

This is straightforward; the server-specified headers from ping & register responses are stored in a private field of the `api.Client` struct, and added to subsequent requests.

### Requests from new/reconfigured `api.Client`

There's a few places where an existing `api.Client` is exchanged for a reconfigured one.
- [`(*api.Client).FromAgentRegisterResponse()`](https://github.com/buildkite/agent/blob/88969df5795566d13d2caeb5e1bc17078698a754/api/client.go#L117) (after register, before ping/heartbeat/etc)
- [`(*api.Client).FromPing()`](https://github.com/buildkite/agent/blob/88969df5795566d13d2caeb5e1bc17078698a754/api/client.go#L129) (after a ping _only_ if the endpoint has changed)
- [`agent.NewJobRunner()`](https://github.com/buildkite/agent/blob/88969df5795566d13d2caeb5e1bc17078698a754/agent/job_runner.go#L202) (if the accept response has a _job token_)

These scenarios previously used `api.NewClient(logger, modifiedCopyOfConfig)` which lost any internal state from the client. I've instead introduced `(*api.Client).New(config)` which passes non-config state (currently: `logger` & `requestHeaders`) from the old to the new client.

### Requests from `buildkite-agent …` calls inside jobs

Commands like `buildkite-agent annotate …` and `buildkite-agent artifact …` are generally run from scripts running inside the command of a job running in the “bootstrap” (`job.Executor`), so they're several layers of process removed from the process with the `api.Client` that has the request headers.

As with all other information passed to the bootstrap / job command, this PR maps the necessary request headers to environment variables with `BUILDKITE_REQUEST_HEADER_` prefix, e.g. `Buildkite-Hello: world` becomes `BUILDKITE_REQUEST_HEADER_BUILDKITE_HELLO=world`.

Inside the `buildkite-agent …` sub-process within the job command, the `api.NewClient()` method discovers these environment variables and maps them back to its internal store of request headers (but only for headers beginning with `Buildkite-`).

Related:
- Closes #3263; this is an alternative (and more complete) implementation approach.
- extracted https://github.com/buildkite/agent/pull/3269 from this PR, which will make this PR a bit smaller and more focused.