### PR TITLE
agent_worker_test: tests for endpoint switching during register/ping

### DIFF
--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -433,7 +433,7 @@ func TestAgentWorker_SetEndpointDuringRegistration(t *testing.T) {
 		t.Fatalf("creating broken endpoint listener: %v", err)
 	}
 	defer registrationServer.Close()
-	registrationEndpoint := fmt.Sprintf("http://%s/", registrationServer.Addr().String())
+	registrationEndpoint := fmt.Sprintf("http://%s/", registrationServer.Addr())
 
 	// Create API client with the _old_ endpoint that it would have used for registration,
 	// but that it should not connect to again.


### PR DESCRIPTION
This functionality has existed for a long time, but hasn't had test coverage.

Uses the nice new `FakeAPIServer` from https://github.com/buildkite/agent/pull/3264

This also introduces `(api.Config).Timeout time.Duration` so that the timeout on a known-broken endpoint in tests can be reduced to milliseconds instead of the default 60 seconds.

These tests are extracted and adapted from ~#3263~ #3268, so that/those PRs can be rebased after this is merged to shrink them to their actual intent.