### PR TITLE
chore: Use golangci-lint for code checks

### DIFF
--- a/.buildkite/Dockerfile-lint
+++ b/.buildkite/Dockerfile-lint
@@ -1,0 +1,1 @@
+FROM golangci/golangci-lint:v2.0-alpine@sha256:53416810ed467f3ef6e63007bd5992cef833883f62ad0109c6a475f1f210dec4

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -1,6 +1,19 @@
 version: '3.5'
 
 services:
+  lint:
+    build:
+      context: .
+      dockerfile: Dockerfile-lint
+    volumes:
+      - ../:/work:cached
+      - ~/gocache:/gocache
+      - ~/gomodcache:/gomodcache
+    working_dir: /work
+    environment:
+      - GOCACHE=/gocache
+      - GOMODCACHE=/gomodcache
+  
   agent:
     build:
       context: .

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,14 +10,14 @@ agents:
   queue: "$AGENT_RUNNERS_LINUX_QUEUE"
 
 steps:
-  - name: ":go::robot_face: Check Code Committed"
+  - name: ":go::robot_face: Lint"
     key: check-code-committed
     command: .buildkite/steps/check-code-committed.sh
     plugins:
       - docker-compose#v4.14.0:
           config: .buildkite/docker-compose.yml
           cli-version: 2
-          run: agent
+          run: lint
 
   - name: ":linux: Linux AMD64 Tests"
     key: test-linux-amd64

--- a/.buildkite/steps/check-code-committed.sh
+++ b/.buildkite/steps/check-code-committed.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-set -Eeufo pipefail
+set -euf
 
 echo --- :go: Checking go mod tidyness
 go mod tidy
@@ -33,5 +33,10 @@ if ! git diff --no-ext-diff --exit-code; then
 
   exit 1
 fi
+
+# While we're cleaning up things found by golangci-lint, don't fail if it finds
+# things.
+echo +++ :go: Running golangci-lint...
+golangci-lint run || true
 
 echo +++ Everything is clean and tidy! 🎉


### PR DESCRIPTION
### Description

Use a more powerful lint tool to find issues.
Since it finds numerous violations in the existing codebase, ignore its exit code (for now).

### Context

Noticed during #3273 

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

