### PR TITLE
Ignore the ping interval if agent will disconnect after job

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -436,6 +436,8 @@ func (a *AgentWorker) runPingLoop(ctx context.Context, idleMonitor *IdleMonitor)
 		ranJob = true
 		if a.agentConfiguration.DisconnectAfterJob {
 			// Unless paused, this agent disconnects after the next ping.
+			// Do the ping immediately so we reduce the chances our agent is assigned a job
+			pingTicker.Reset(pingInterval)
 			continue
 		}
 		lastActionTime = time.Now()


### PR DESCRIPTION
### Description

Since a change in 3.95.0 (#3238) to ping after a job is finished we've had reports that jobs are assigned to agents that are about to be disconnected. While this could happen before this change, we believe waiting for the ping interval has made it more frequent and it's likely to happen multiple times for the same job.

This change ensures we don't wait up to 10s before disconnecting, making it as likely as before

### Changes

Reset the ping interval if disconnectAfterJob is set.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)