### PR TITLE
Fix unusable `BUILDKITE_AGENT_TAGS_FROM_EC2_TAGS` env var

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -744,7 +744,7 @@ var AgentStartCommand = cli.Command{
 		cli.BoolFlag{
 			Name:   "meta-data-ec2-tags",
 			Hidden: true,
-			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_EC2_TAGS",
+			EnvVar: "BUILDKITE_AGENT_META_DATA_EC2_TAGS",
 		},
 		cli.BoolFlag{
 			Name:   "meta-data-gcp",


### PR DESCRIPTION
The `BUILDKITE_AGENT_TAGS_FROM_EC2_TAGS` env var is assigned to set both `tags-from-ec2-tags` and its deprecated duplicate `meta-data-ec2-tags`. The agent [errors][1] when both the deprecated and new version of an option are set, which makes `BUILDKITE_AGENT_TAGS_FROM_EC2_TAGS` unusable.

Following the naming of other deprecated `meta-data-*` it seems `BUILDKITE_AGENT_META_DATA_EC2_TAGS` was meant to be used for `meta-data-ec2-tags`.

[1]: https://github.com/buildkite/agent/blob/fd239e03db6abffdb562ef0963459ab90203b763/cliconfig/loader.go#L120
