### PR TITLE
TE-3708: use bktec on agent

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     environment:
       - GOCACHE=/gocache
       - GOMODCACHE=/gomodcache
-  
+
   agent:
     build:
       context: .
@@ -30,6 +30,7 @@ services:
       - "BUILDKITE_BUILD_PATH=/buildkite"
       - GOCACHE=/gocache
       - GOMODCACHE=/gomodcache
+      - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
 
   ruby:
     image: ruby:2.7.6

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,11 +22,13 @@ steps:
   - name: ":linux: Linux AMD64 Tests"
     key: test-linux-amd64
     command: ".buildkite/steps/tests.sh"
+    parallelism: 2
     artifact_paths: junit-*.xml
     plugins:
       - docker-compose#v4.14.0:
           config: .buildkite/docker-compose.yml
           cli-version: 2
+          propagate-environment: true
           run: agent
       - test-collector#v1.2.0:
           files: "junit-*.xml"
@@ -37,6 +39,7 @@ steps:
   - name: ":linux: Linux ARM64 Tests"
     key: test-linux-arm64
     command: ".buildkite/steps/tests.sh"
+    parallelism: 2
     artifact_paths: junit-*.xml
     agents:
       queue: $AGENT_RUNNERS_LINUX_ARM64_QUEUE
@@ -44,6 +47,7 @@ steps:
       - docker-compose#v4.14.0:
           config: .buildkite/docker-compose.yml
           cli-version: 2
+          propagate-environment: true
           run: agent
       - test-collector#v1.2.0:
           files: "junit-*.xml"
@@ -54,6 +58,8 @@ steps:
   - name: ":satellite: Detect Data Races"
     key: test-race-linux-arm64
     command: ".buildkite/steps/tests.sh -race"
+    # Extra parallelism because this data race test is slow
+    parallelism: 3
     artifact_paths: junit-*.xml
     agents:
       queue: $AGENT_RUNNERS_LINUX_ARM64_QUEUE
@@ -61,6 +67,7 @@ steps:
       - docker-compose#v4.14.0:
           config: .buildkite/docker-compose.yml
           cli-version: 2
+          propagate-environment: true
           run: agent
       - test-collector#v1.2.0:
           files: "junit-*.xml"
@@ -71,6 +78,7 @@ steps:
   - name: ":windows: Windows AMD64 Tests"
     key: test-windows
     command: "bash .buildkite\\steps\\tests.sh"
+    parallelism: 2
     artifact_paths: junit-*.xml
     agents:
       queue: $AGENT_RUNNERS_WINDOWS_QUEUE

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -6,8 +6,16 @@ echo arch is "$(uname -m)"
 
 go install gotest.tools/gotestsum@v1.8.0
 
+go install github.com/buildkite/test-engine-client@v1.5.0-rc.3
+
 echo '+++ Running tests'
-gotestsum --junitfile "junit-${BUILDKITE_JOB_ID}.xml" -- -count=1 -coverprofile=cover.out -failfast "$@" ./...
+export BUILDKITE_TEST_ENGINE_SUITE_SLUG=buildkite-agent
+export BUILDKITE_TEST_ENGINE_TEST_RUNNER=gotest
+export BUILDKITE_TEST_ENGINE_RESULT_PATH="junit-${BUILDKITE_JOB_ID}.xml"
+export BUILDKITE_TEST_ENGINE_RETRY_COUNT=1
+export BUILDKITE_TEST_ENGINE_TEST_CMD="gotestsum --junitfile={{resultPath}} -- -count=1 -coverprofile=cover.out $@ {{packages}}"
+
+test-engine-client
 
 echo 'Producing coverage report'
 go tool cover -html cover.out -o cover.html


### PR DESCRIPTION
### Description

Use bktec to run go test for agent, this bring following benefits: 

* auto package level splitting: slightly reducing test duration -> not too obvious though. 
* auto retry. 
* Automatic test state management, flaky test will get muted automatically. You can also manually control test state via buildkite UI. 
* Dogfooding helping Test Engine 😉 

### Context

TE-3708