### PR TITLE
Gracefully Handle Missing GitHub PR `refs/pull/%s/head` in Checkout

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -370,7 +370,7 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string) (stri
 			refspec := fmt.Sprintf("refs/pull/%s/head", e.PullRequest)
 			// Fetch the PR head from the upstream repository into the mirror.
 			if err := e.shell.Run(ctx, "git", "--git-dir", mirrorDir, "fetch", "origin", refspec); err != nil {
-				return "", err
+				e.shell.Warningf("Unable to fetch %q for mirror — continuing, will fetch commit %s directly", refspec, e.Commit)
 			}
 		} else {
 			// Fetch the build branch from the upstream repository into the mirror.


### PR DESCRIPTION
### Description

GitHub creates `refs/pull/%s/head` asynchronously, and we’ve seen cases where this ref isn't available yet when the Buildkite agent begins the checkout process. Currently, this causes the entire job to fail, even though the specific commit we want to build is still fetchable.

This PR updates the agent’s checkout logic to:
- Attempt to fetch refs/pull/%s/head (for GitHub PRs) as usual
- Log a warning instead of failing the job if the pull ref is missing
- Proceed to fetch the specific commit SHA via gitFetchCommitWithFallback(...)

This ensures that builds can proceed as long as the required commit exists, even if the PR ref is temporarily unavailable, which will improve reliability/flakey failures for Github PRs

This change also applies the same behavior to the mirror update logic in updateGitMirror. Previously, missing GitHub PR refs would cause builds to fail during mirrored checkouts. The mirror fetch will now continue with a warning if the ref is unavailable.

### Context

Issue raised:
https://github.com/buildkite/agent/issues/3254

### Changes

- tolerate missing refs/pull/%s/head during checkout
- extend the same handling to mirrored GitHub checkouts (#updateGitMirror)

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
  - [x] `go test -v github.com/buildkite/agent/v3/internal/job/integration`
- [ ] Code is formatted (with `go fmt ./...`)
