### PR TITLE
Introduce a structure where coverage can increase on githttp checkout code

### DIFF
--- a/internal/job/checkout_test.go
+++ b/internal/job/checkout_test.go
@@ -1,0 +1,95 @@
+package job
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/buildkite/agent/v3/internal/job/githttptest"
+	"github.com/buildkite/agent/v3/internal/shell"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultCheckoutPhase(t *testing.T) {
+	assert := require.New(t)
+	ctx := context.Background()
+
+	shell, err := shell.New()
+	assert.NoError(err)
+
+	tests := []struct {
+		name        string
+		executor    *Executor
+		projectName string
+		checkoutDir string
+	}{
+		{
+			name: "Default checkout phase with HEAD commit",
+			executor: &Executor{
+				shell: shell,
+				ExecutorConfig: ExecutorConfig{
+					Commit:        "HEAD",
+					Branch:        "main",
+					CleanCheckout: false,
+					GitCleanFlags: "-f -d -x",
+				},
+			},
+			projectName: "project-name-head",
+		},
+		{
+			name: "Default checkout phase with custom refspec",
+			executor: &Executor{
+				shell: shell,
+				ExecutorConfig: ExecutorConfig{
+					Commit:        "HEAD",
+					Branch:        "main",
+					CleanCheckout: false,
+					GitCleanFlags: "-f -d -x",
+					RefSpec:       "refs/pull/124/head",
+				},
+			},
+			projectName: "project-name-refspec",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := require.New(t)
+
+			t.Setenv("GIT_CONFIG_GLOBAL", "~/.gitconfig.empty")
+
+			s := githttptest.NewServer()
+			s.Start()
+			defer s.Close()
+
+			err = s.CreateRepository(tt.projectName)
+			assert.NoError(err)
+
+			err = s.InitRepository(tt.projectName)
+			assert.NoError(err)
+
+			commit, err := s.PushBranch(tt.projectName, "feature-branch")
+			assert.NoError(err)
+
+			// create a custom ref to test
+			err = s.CreateRef(tt.projectName, "refs/pull/124/head", commit)
+			assert.NoError(err)
+
+			buildDir, err := os.MkdirTemp("", "build-path-")
+			assert.NoError(err)
+			defer os.RemoveAll(buildDir)
+
+			tt.executor.BuildPath = buildDir
+			tt.executor.Repository = s.RepoURL(tt.projectName)
+
+			checkoutDir, err := os.MkdirTemp("", "checkout-path-")
+			assert.NoError(err)
+			defer os.RemoveAll(checkoutDir)
+
+			shell.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", checkoutDir)
+
+			err = tt.executor.defaultCheckoutPhase(ctx)
+			assert.NoError(err)
+		})
+	}
+}

--- a/internal/job/checkout_test.go
+++ b/internal/job/checkout_test.go
@@ -23,7 +23,6 @@ func TestDefaultCheckoutPhase(t *testing.T) {
 		projectName string
 		checkoutDir string
 		refSpec     string
-		expectErr   bool
 	}{
 		{
 			name: "Default checkout phase with HEAD commit",

--- a/internal/job/checkout_test.go
+++ b/internal/job/checkout_test.go
@@ -84,7 +84,6 @@ func TestDefaultCheckoutPhase(t *testing.T) {
 			t.Setenv("GIT_COMMITTER_EMAIL", "agent@example.com")
 
 			s := githttptest.NewServer()
-			s.Start()
 			defer s.Close()
 
 			err = s.CreateRepository(tt.projectName)

--- a/internal/job/githttptest/githttptest.go
+++ b/internal/job/githttptest/githttptest.go
@@ -2,7 +2,6 @@ package githttptest
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -30,8 +29,6 @@ func NewServer() *Server {
 	if err != nil {
 		panic(fmt.Sprintf("githttptest: failed to create temp dir: %v", err))
 	}
-
-	log.Printf("githttptest: using %s as repositories root", repositories)
 
 	s := &Server{
 		repositories: repositories,
@@ -83,226 +80,149 @@ func (s *Server) CreateRepository(repoName string) error {
 		if err := initBareRepo(repoPath); err != nil {
 			return fmt.Errorf("failed to create repository: %w", err)
 		}
-		log.Printf("Created new repository: %s", repoPath)
 	}
 
 	return nil
 }
 
-func (s *Server) InitRepository(repoName string) error {
+func (s *Server) InitRepository(repoName string) ([]byte, error) {
 	tempDir, err := os.MkdirTemp("", "git-init-")
 	if err != nil {
-		return fmt.Errorf("failed to create temp dir: %w", err)
+		return nil, fmt.Errorf("failed to create temp dir: %w", err)
 	}
 	defer os.RemoveAll(tempDir)
 
-	// Initialize a normal repository in the temp directory
 	normalInitCmd := exec.Command("git", "init", tempDir)
-	if err := normalInitCmd.Run(); err != nil {
-		return fmt.Errorf("failed to initialize normal repository: %w", err)
+	if out, err := normalInitCmd.CombinedOutput(); err != nil {
+		return out, fmt.Errorf("failed to initialize normal repository: %w", err)
 	}
 
-	log.Printf("Initialized normal repository in %s", tempDir)
-
-	// Configure Git user for the commit
-	configNameCmd := exec.Command("git", "config", "user.name", "Git Server")
-	configNameCmd.Dir = tempDir
-	if err := configNameCmd.Run(); err != nil {
-		return fmt.Errorf("failed to configure user.name: %w", err)
-	}
-
-	configEmailCmd := exec.Command("git", "config", "user.email", "git@localhost")
-	configEmailCmd.Dir = tempDir
-	if err := configEmailCmd.Run(); err != nil {
-		return fmt.Errorf("failed to configure user.email: %w", err)
-	}
-
-	log.Printf("Configured Git user in %s", tempDir)
-
-	// Create a README file
 	readmePath := filepath.Join(tempDir, "README.md")
 	readmeContent := "# Git Repository\n\nThis repository was created by the Git HTTP server.\n"
 	if err := os.WriteFile(readmePath, []byte(readmeContent), 0644); err != nil {
-		return err
+		return nil, fmt.Errorf("failed to create README file: %w", err)
 	}
 
-	log.Printf("Created README file in %s", readmePath)
-
-	// Add and commit the README
 	addCmd := exec.Command("git", "add", "README.md")
 	addCmd.Dir = tempDir
-	if err := addCmd.Run(); err != nil {
-		return fmt.Errorf("failed to add README file: %w", err)
+	if out, err := addCmd.CombinedOutput(); err != nil {
+		return out, fmt.Errorf("failed to add README file: %w", err)
 	}
-
-	log.Printf("Added README file to staging area in %s", tempDir)
 
 	commitCmd := exec.Command("git", "commit", "-m", "Initial commit")
 	commitCmd.Dir = tempDir
-	if err := commitCmd.Run(); err != nil {
-		return fmt.Errorf("failed to commit README file: %w", err)
+	if out, err := commitCmd.CombinedOutput(); err != nil {
+		return out, fmt.Errorf("failed to commit README file: %w", err)
 	}
-
-	log.Printf("Committed README file in %s", tempDir)
 
 	url := fmt.Sprintf("%s/%s.git", s.URL, repoName)
 
-	// rename the master branch to main
 	renameCmd := exec.Command("git", "branch", "-m", "main")
 	renameCmd.Dir = tempDir
-	if err := renameCmd.Run(); err != nil {
-		return fmt.Errorf("failed to rename branch to main: %w", err)
+	if out, err := renameCmd.CombinedOutput(); err != nil {
+		return out, fmt.Errorf("failed to rename branch to main: %w", err)
 	}
 
-	// Push to the bare repository
 	remoteAddCmd := exec.Command("git", "remote", "add", "origin", url)
 	remoteAddCmd.Dir = tempDir
-	if err := remoteAddCmd.Run(); err != nil {
-		return fmt.Errorf("failed to add remote origin: %w", err)
+	if out, err := remoteAddCmd.CombinedOutput(); err != nil {
+		return out, fmt.Errorf("failed to add remote origin: %w", err)
 	}
-
-	log.Printf("Adding remote origin: %s", url)
 
 	pushCmd := exec.Command("git", "push", "-u", "origin", "main")
 	pushCmd.Dir = tempDir
-	err = pushCmd.Run()
-	if err != nil {
-		return fmt.Errorf("failed to push to repository: %w", err)
+	if out, err := pushCmd.CombinedOutput(); err != nil {
+		return out, fmt.Errorf("failed to push to repository: %w", err)
 	}
 
-	log.Printf("Pushed to repository at %s", url)
-
-	return nil
+	return nil, nil
 }
 
-func (s *Server) PushBranch(repoName, branchName string) (string, error) {
+func (s *Server) PushBranch(repoName, branchName string) (string, []byte, error) {
 	if branchName == "" || strings.ContainsAny(branchName, "\\/:*?\"<>|") {
-		return "", fmt.Errorf("invalid branch name: %s", branchName)
+		return "", nil, fmt.Errorf("invalid branch name: %s", branchName)
 	}
 
 	repoPath := filepath.Join(s.repositories, repoName)
 
-	// Check if repository exists
 	if _, err := os.Stat(repoPath); os.IsNotExist(err) {
-		return "", fmt.Errorf("repository '%s' not found at path: %s", repoName, repoPath)
+		return "", nil, fmt.Errorf("repository '%s' not found at path: %s", repoName, repoPath)
 	}
 
-	// clone the repository to a temporary directory
 	tempDir, err := os.MkdirTemp("", "git-push-")
 	if err != nil {
-		return "", fmt.Errorf("failed to create temp dir: %w", err)
+		return "", nil, fmt.Errorf("failed to create temp dir: %w", err)
 	}
 	defer os.RemoveAll(tempDir)
 
 	cloneCmd := exec.Command("git", "clone", s.RepoURL(repoName), tempDir)
 	if err := cloneCmd.Run(); err != nil {
-		return "", fmt.Errorf("failed to clone repository: %w", err)
+		return "", nil, fmt.Errorf("failed to clone repository: %w", err)
 	}
 
-	log.Printf("Cloned repository to %s", tempDir)
-
-	// Configure Git user for the commit
-	configNameCmd := exec.Command("git", "config", "user.name", "Git Server")
-	configNameCmd.Dir = tempDir
-	if err := configNameCmd.Run(); err != nil {
-		return "", fmt.Errorf("failed to configure user.name: %w", err)
-	}
-
-	configEmailCmd := exec.Command("git", "config", "user.email", "git@localhost")
-	configEmailCmd.Dir = tempDir
-	if err := configEmailCmd.Run(); err != nil {
-		return "", fmt.Errorf("failed to configure user.email: %w", err)
-	}
-
-	log.Printf("Configured Git user in %s", tempDir)
-
-	// create a new branch
 	branchCmd := exec.Command("git", "checkout", "-b", branchName)
 	branchCmd.Dir = tempDir
 	if err := branchCmd.Run(); err != nil {
-		return "", fmt.Errorf("failed to create branch %s: %w", branchName, err)
+		return "", nil, fmt.Errorf("failed to create branch %s: %w", branchName, err)
 	}
 
-	log.Printf("Created new branch: %s", branchName)
-
-	// create a new file in the repository
 	filePath := filepath.Join(tempDir, "newfile.txt")
 	if err := os.WriteFile(filePath, []byte("This is a new file."), 0644); err != nil {
-		return "", fmt.Errorf("failed to create new file: %w", err)
+		return "", nil, fmt.Errorf("failed to create new file: %w", err)
 	}
-	log.Printf("Created new file in repository: %s", filePath)
 
-	// commit the file
 	commitCmd := exec.Command("git", "add", "newfile.txt")
 	commitCmd.Dir = tempDir
-	if err := commitCmd.Run(); err != nil {
-		return "", fmt.Errorf("failed to add new file to staging area: %w", err)
+	if out, err := commitCmd.CombinedOutput(); err != nil {
+		return "", out, fmt.Errorf("failed to add new file to staging area: %w", err)
 	}
-	log.Printf("Added new file to staging area")
 
 	commitCmd = exec.Command("git", "commit", "-m", "Add new file")
 	commitCmd.Dir = tempDir
-	commitCmd.Stdout = os.Stdout
-	commitCmd.Stderr = os.Stderr
-	if err := commitCmd.Run(); err != nil {
+	if out, err := commitCmd.CombinedOutput(); err != nil {
 
-		return "", fmt.Errorf("failed to commit new file: %w", err)
+		return "", out, fmt.Errorf("failed to commit new file: %w", err)
 	}
 
-	log.Printf("Committed new file")
-
-	// set the remote URL
 	remoteCmd := exec.Command("git", "remote", "set-url", "origin", s.RepoURL(repoName))
 	remoteCmd.Dir = tempDir
-	if err := remoteCmd.Run(); err != nil {
-		return "", fmt.Errorf("failed to set remote URL: %w", err)
+	if out, err := remoteCmd.CombinedOutput(); err != nil {
+		return "", out, fmt.Errorf("failed to set remote URL: %w", err)
 	}
 
-	log.Printf("Set remote URL to %s", s.RepoURL(repoName))
-
-	// Push the specified branch to the remote
 	pushCmd := exec.Command("git", "push", "origin", branchName)
 	pushCmd.Dir = tempDir
-	if err := pushCmd.Run(); err != nil {
-		return "", fmt.Errorf("failed to push branch %s: %w", branchName, err)
+	if out, err := pushCmd.CombinedOutput(); err != nil {
+		return "", out, fmt.Errorf("failed to push branch %s: %w", branchName, err)
 	}
 
-	log.Printf("Pushed branch %s to repository at %s", branchName, repoPath)
-
-	// get the commit hash of the pushed branch
 	commitHashCmd := exec.Command("git", "rev-parse", branchName)
 	commitHashCmd.Dir = tempDir
 	commitHash, err := commitHashCmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to get commit hash: %w", err)
+		return "", nil, fmt.Errorf("failed to get commit hash: %w", err)
 	}
 
 	commitHashStr := strings.TrimSpace(string(commitHash))
-	log.Printf("Commit hash of pushed branch %s: %s", branchName, commitHashStr)
 
-	return commitHashStr, nil
+	return commitHashStr, nil, nil
 }
 
-func (s *Server) CreateRef(repoName, refName, commitHash string) error {
-	// if refName == "" || strings.ContainsAny(refName, "\\/:*?\"<>|") {
-	// 	return fmt.Errorf("invalid ref name: %s", refName)
-	// }
-
+func (s *Server) CreateRef(repoName, refName, commitHash string) (out []byte, err error) {
 	repoPath := filepath.Join(s.repositories, repoName)
 	// Check if repository exists
-	if _, err := os.Stat(repoPath); os.IsNotExist(err) {
-		return fmt.Errorf("repository '%s' not found at path: %s", repoName, repoPath)
+	if _, err = os.Stat(repoPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("repository '%s' not found at path: %s", repoName, repoPath)
 	}
 
 	// git update-ref refs/heads/branch-name commit-sha
 	updateRefCmd := exec.Command("git", "update-ref", refName, commitHash)
 	updateRefCmd.Dir = repoPath
-	if err := updateRefCmd.Run(); err != nil {
-		return fmt.Errorf("failed to create ref %s: %w", refName, err)
+	if out, err = updateRefCmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("failed to create ref %s: %w", refName, err)
 	}
-	log.Printf("Created ref %s in repository %s", refName, repoName)
 
-	return nil
+	return out, nil
 }
 
 func (s *Server) RepoURL(repoName string) string {
@@ -372,7 +292,6 @@ func (s *Server) handleGitUploadPack(w http.ResponseWriter, r *http.Request) {
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
-		log.Printf("Error executing git-upload-pack: %v", err)
 	}
 }
 
@@ -409,7 +328,6 @@ func (s *Server) handleGitReceivePack(w http.ResponseWriter, r *http.Request) {
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
-		log.Printf("Error executing git-receive-pack: %v", err)
 	}
 }
 
@@ -449,6 +367,5 @@ func (s *Server) handleGitInfoRefs(w http.ResponseWriter, r *http.Request) {
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
-		log.Printf("Error executing %s: %v", service, err)
 	}
 }

--- a/internal/job/githttptest/githttptest.go
+++ b/internal/job/githttptest/githttptest.go
@@ -268,9 +268,6 @@ func (s *Server) handleGitReceivePack(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if we're allowing pushes
-	// For a production server, you might want to add authentication here
-
 	buf := bytes.NewBuffer(nil)
 
 	cmd := exec.Command("git", "receive-pack", "--stateless-rpc", repoPath)


### PR DESCRIPTION
### Description

This PR introduces a githttptest package which provides a [Git smart http server](https://git-scm.com/book/en/v2/Git-on-the-Server-Smart-HTTP) used for testing, along with an array of utility methods to manipulate a git repository.

### Context

The checkout logic is a bit of a blind spot at the moment as there isn't any test coverage for this code. The goal of this PR is to change that by adding some tools which verify behavour, testing both the git command execution and the go code.

This will allow us to test some of the changes in #3294 

### Changes

This increases the test coverage for executor targeting the `defaultCheckoutPhase` method to start with.

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
