### PR TITLE
Set ignore_agent_in_dispatches when finishing with disconnect-after-job

### DIFF
--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -397,6 +397,9 @@ func TestAgentWorker_DisconnectAfterJob_Start_Pause_Unpause(t *testing.T) {
 	if got, want := agent.Pings, 3; got != want {
 		t.Errorf("agent.Pings = %d, want %d", got, want)
 	}
+	if got, want := agent.IgnoreInDispatches, true; got != want {
+		t.Errorf("agent.IgnoreInDispatches = %t, want %t", got, want)
+	}
 	if got, want := job.State, JobStateFinished; got != want {
 		t.Errorf("job.State = %q, want %q", got, want)
 	}

--- a/agent/api.go
+++ b/agent/api.go
@@ -20,7 +20,7 @@ type APIClient interface {
 	CreateArtifacts(context.Context, string, *api.ArtifactBatch) (*api.ArtifactBatchCreateResponse, *api.Response, error)
 	Disconnect(context.Context) (*api.Response, error)
 	ExistsMetaData(context.Context, string, string, string) (*api.MetaDataExists, *api.Response, error)
-	FinishJob(context.Context, *api.Job) (*api.Response, error)
+	FinishJob(context.Context, *api.Job, *bool) (*api.Response, error)
 	FromAgentRegisterResponse(*api.AgentRegisterResponse) *api.Client
 	FromPing(*api.Ping) *api.Client
 	GenerateGithubCodeAccessToken(context.Context, string, string) (string, *api.Response, error)

--- a/agent/integration/test_helpers.go
+++ b/agent/integration/test_helpers.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/internal/ptr"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/agent/v3/metrics"
 	"github.com/buildkite/bintest/v3"
@@ -80,7 +81,12 @@ func runJob(t *testing.T, ctx context.Context, cfg testRunJobConfig) error {
 		t.Fatalf("agent.NewJobRunner() error = %v", err)
 	}
 
-	if err := jr.Run(context.Background()); err != nil {
+	var ignoreAgentInDispatches *bool
+	if cfg.agentCfg.DisconnectAfterJob {
+		ignoreAgentInDispatches = ptr.To(true)
+	}
+
+	if err := jr.Run(context.Background(), ignoreAgentInDispatches); err != nil {
 		return err
 	}
 

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -35,12 +35,13 @@ type jobStartRequest struct {
 	StartedAt string `json:"started_at,omitempty"`
 }
 
-type jobFinishRequest struct {
-	ExitStatus        string `json:"exit_status,omitempty"`
-	Signal            string `json:"signal,omitempty"`
-	SignalReason      string `json:"signal_reason,omitempty"`
-	FinishedAt        string `json:"finished_at,omitempty"`
-	ChunksFailedCount int    `json:"chunks_failed_count"`
+type JobFinishRequest struct {
+	ExitStatus              string `json:"exit_status,omitempty"`
+	Signal                  string `json:"signal,omitempty"`
+	SignalReason            string `json:"signal_reason,omitempty"`
+	FinishedAt              string `json:"finished_at,omitempty"`
+	ChunksFailedCount       int    `json:"chunks_failed_count"`
+	IgnoreAgentInDispatches *bool  `json:"ignore_agent_in_dispatches,omitempty"`
 }
 
 // GetJobState returns the state of a given job
@@ -114,15 +115,16 @@ func (c *Client) StartJob(ctx context.Context, job *Job) (*Response, error) {
 }
 
 // FinishJob finishes the passed in job
-func (c *Client) FinishJob(ctx context.Context, job *Job) (*Response, error) {
+func (c *Client) FinishJob(ctx context.Context, job *Job, ignoreAgentInDispatches *bool) (*Response, error) {
 	u := fmt.Sprintf("jobs/%s/finish", railsPathEscape(job.ID))
 
-	req, err := c.newRequest(ctx, "PUT", u, &jobFinishRequest{
-		FinishedAt:        job.FinishedAt,
-		ExitStatus:        job.ExitStatus,
-		Signal:            job.Signal,
-		SignalReason:      job.SignalReason,
-		ChunksFailedCount: job.ChunksFailedCount,
+	req, err := c.newRequest(ctx, "PUT", u, &JobFinishRequest{
+		FinishedAt:              job.FinishedAt,
+		ExitStatus:              job.ExitStatus,
+		Signal:                  job.Signal,
+		SignalReason:            job.SignalReason,
+		ChunksFailedCount:       job.ChunksFailedCount,
+		IgnoreAgentInDispatches: ignoreAgentInDispatches,
 	})
 	if err != nil {
 		return nil, err

--- a/core/api_client.go
+++ b/core/api_client.go
@@ -11,7 +11,7 @@ type APIClient interface {
 	AcquireJob(context.Context, string, ...api.Header) (*api.Job, *api.Response, error)
 	Connect(context.Context) (*api.Response, error)
 	Disconnect(context.Context) (*api.Response, error)
-	FinishJob(context.Context, *api.Job) (*api.Response, error)
+	FinishJob(context.Context, *api.Job, *bool) (*api.Response, error)
 	Register(context.Context, *api.AgentRegisterRequest) (*api.AgentRegisterResponse, *api.Response, error)
 	StartJob(context.Context, *api.Job) (*api.Response, error)
 	UploadChunk(context.Context, string, *api.Chunk) (*api.Response, error)

--- a/core/job_controller.go
+++ b/core/job_controller.go
@@ -59,8 +59,8 @@ func (c *JobController) Start(ctx context.Context) error {
 }
 
 // Finish marks the job as finished in Buildkite.
-func (c *JobController) Finish(ctx context.Context, exit ProcessExit) error {
-	return c.client.FinishJob(ctx, c.job, time.Now(), exit, 0)
+func (c *JobController) Finish(ctx context.Context, exit ProcessExit, ignoreAgentInDispatches *bool) error {
+	return c.client.FinishJob(ctx, c.job, time.Now(), exit, 0, ignoreAgentInDispatches)
 }
 
 // BKTimestamp formats a time as a Buildkite timestamp code.

--- a/internal/ptr/to.go
+++ b/internal/ptr/to.go
@@ -1,0 +1,8 @@
+package ptr
+
+// Go Proverbs: "A little copying is better than a little dependency."
+//
+// This file is basically the one function from k8s.io/utils/ptr.
+
+// To returns a pointer to a variable containing the value.
+func To[T any](t T) *T { return &t }

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildkite/agent/v3/internal/ptr"
 	"github.com/buildkite/agent/v3/logger"
 )
 
@@ -304,11 +305,9 @@ func newRunner(t *testing.T, clientCount int) *Runner {
 }
 
 var (
-	one = 1
-
 	waitStatusSuccess  = waitStatus{Code: 0}
 	waitStatusFailure  = waitStatus{Code: 1}
-	waitStatusSignaled = waitStatus{Code: 0, SignalCode: &one}
+	waitStatusSignaled = waitStatus{Code: 0, SignalCode: ptr.To(1)}
 )
 
 func init() {


### PR DESCRIPTION
### Description

Prevent jobs being dispatched to agents that are finishing up by passing a newly-available flag in the finish call.

### Context

https://linear.app/buildkite/issue/PS-554

### Changes

- Thread the new flag through the call stack
- Pass it when disconnect-after-job is enabled

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)