### PR TITLE
Add kubernetes-bootstrap

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -535,12 +535,7 @@ var AgentStartCommand = cli.Command{
 			Usage:  "Additional directories to look for agent hooks",
 			EnvVar: "BUILDKITE_ADDITIONAL_HOOKS_PATHS",
 		},
-		cli.StringFlag{
-			Name:   "sockets-path",
-			Value:  defaultSocketsPath(),
-			Usage:  "Directory where the agent will place sockets",
-			EnvVar: "BUILDKITE_SOCKETS_PATH",
-		},
+		SocketsPathFlag,
 		cli.StringFlag{
 			Name:   "plugins-path",
 			Value:  "",

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -287,12 +287,7 @@ var BootstrapCommand = cli.Command{
 			Usage:  "Any additional directories to look for agent hooks",
 			EnvVar: "BUILDKITE_ADDITIONAL_HOOKS_PATHS",
 		},
-		cli.StringFlag{
-			Name:   "sockets-path",
-			Value:  defaultSocketsPath(),
-			Usage:  "Directory where the agent will place sockets",
-			EnvVar: "BUILDKITE_SOCKETS_PATH",
-		},
+		SocketsPathFlag,
 		cli.StringFlag{
 			Name:   "plugins-path",
 			Value:  "",
@@ -372,13 +367,7 @@ var BootstrapCommand = cli.Command{
 			Usage:  "A list of warning IDs to disable",
 			EnvVar: "BUILDKITE_AGENT_DISABLE_WARNINGS_FOR",
 		},
-		cli.IntFlag{
-			Name: "kubernetes-container-id",
-			Usage: "This is intended to be used only by the Buildkite k8s stack " +
-				"(github.com/buildkite/agent-stack-k8s); it sets an ID number " +
-				"used to identify this container within the pod",
-			EnvVar: "BUILDKITE_CONTAINER_ID",
-		},
+		KubernetesContainerIDFlag,
 		cancelSignalFlag,
 		cancelGracePeriodFlag,
 		signalGracePeriodSecondsFlag,

--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -10,7 +10,7 @@ import (
 const (
 	defaultCancelGracePeriodSecs = 10
 	defaultSignalGracePeriodSecs = -1
-	defaultSignalGracePeriod     = (defaultCancelGracePeriodSecs + defaultCancelGracePeriodSecs) * time.Second
+	defaultSignalGracePeriod     = (defaultCancelGracePeriodSecs + defaultSignalGracePeriodSecs) * time.Second
 )
 
 var (

--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -8,31 +8,33 @@ import (
 )
 
 const (
-	defaultCancelGracePeriod = 10
+	defaultCancelGracePeriodSecs = 10
+	defaultSignalGracePeriodSecs = -1
+	defaultSignalGracePeriod     = (defaultCancelGracePeriodSecs + defaultCancelGracePeriodSecs) * time.Second
 )
 
 var (
 	cancelGracePeriodFlag = cli.IntFlag{
 		Name:  "cancel-grace-period",
-		Value: defaultCancelGracePeriod,
+		Value: defaultCancelGracePeriodSecs,
 		Usage: "The number of seconds a canceled or timed out job is given " +
 			"to gracefully terminate and upload its artifacts",
 		EnvVar: "BUILDKITE_CANCEL_GRACE_PERIOD",
 	}
 	cancelSignalFlag = cli.StringFlag{
 		Name:   "cancel-signal",
+		Value:  "SIGTERM",
 		Usage:  "The signal to use for cancellation",
 		EnvVar: "BUILDKITE_CANCEL_SIGNAL",
-		Value:  "SIGTERM",
 	}
 	signalGracePeriodSecondsFlag = cli.IntFlag{
-		Name: "signal-grace-period-seconds",
+		Name:  "signal-grace-period-seconds",
+		Value: defaultSignalGracePeriodSecs,
 		Usage: "The number of seconds given to a subprocess to handle being sent ′cancel-signal′. " +
 			"After this period has elapsed, SIGKILL will be sent. " +
 			"Negative values are taken relative to ′cancel-grace-period′. " +
 			"The default value (-1) means that the effective signal grace period is equal to ′cancel-grace-period-seconds′ minus 1.",
 		EnvVar: "BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS",
-		Value:  -1,
 	}
 )
 
@@ -42,11 +44,14 @@ var (
 //     cancelGracePeriodSecs.
 //   - If cancelGracePeriodSecs is less than signalGracePeriodSecs that is an
 //     error.
+//
+// If the combination is invalid, both the defaultSignalGracePeriod and an error
+// is returned.
 func signalGracePeriod(cancelGracePeriodSecs, signalGracePeriodSecs int) (time.Duration, error) {
 	// Treat a negative signal grace period as relative to the cancel grace period
 	if signalGracePeriodSecs < 0 {
 		if cancelGracePeriodSecs < -signalGracePeriodSecs {
-			return 0, fmt.Errorf(
+			return defaultSignalGracePeriod, fmt.Errorf(
 				"cancel-grace-period (%d) must be at least as big as signal-grace-period-seconds (%d)",
 				cancelGracePeriodSecs,
 				signalGracePeriodSecs,
@@ -56,7 +61,7 @@ func signalGracePeriod(cancelGracePeriodSecs, signalGracePeriodSecs int) (time.D
 	}
 
 	if cancelGracePeriodSecs <= signalGracePeriodSecs {
-		return 0, fmt.Errorf(
+		return defaultSignalGracePeriod, fmt.Errorf(
 			"cancel-grace-period (%d) must be greater than signal-grace-period-seconds (%d)",
 			cancelGracePeriodSecs,
 			signalGracePeriodSecs,

--- a/clicommand/commands.go
+++ b/clicommand/commands.go
@@ -45,6 +45,7 @@ var BuildkiteAgentCommands = []cli.Command{
 		},
 	},
 	GitCredentialsHelperCommand,
+	KubernetesBootstrapCommand,
 	{
 		Name:  "lock",
 		Usage: "Process lock subcommands",

--- a/clicommand/config_completeness_test.go
+++ b/clicommand/config_completeness_test.go
@@ -32,6 +32,7 @@ var commandConfigPairs = []configCommandPair{
 	{Config: EnvSetConfig{}, Command: EnvSetCommand},
 	{Config: EnvUnsetConfig{}, Command: EnvUnsetCommand},
 	{Config: GitCredentialsHelperConfig{}, Command: GitCredentialsHelperCommand},
+	{Config: KubernetesBootstrapConfig{}, Command: KubernetesBootstrapCommand},
 	{Config: LockAcquireConfig{}, Command: LockAcquireCommand},
 	{Config: LockDoConfig{}, Command: LockDoCommand},
 	{Config: LockDoneConfig{}, Command: LockDoneCommand},

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -92,12 +92,27 @@ var (
 		EnvVar: "BUILDKITE_STRICT_SINGLE_HOOKS",
 	}
 
+	SocketsPathFlag = cli.StringFlag{
+		Name:   "sockets-path",
+		Value:  defaultSocketsPath(),
+		Usage:  "Directory where the agent will place sockets",
+		EnvVar: "BUILDKITE_SOCKETS_PATH",
+	}
+
 	KubernetesExecFlag = cli.BoolFlag{
 		Name: "kubernetes-exec",
 		Usage: "This is intended to be used only by the Buildkite k8s stack " +
 			"(github.com/buildkite/agent-stack-k8s); it enables a Unix socket for transporting " +
 			"logs and exit statuses between containers in a pod",
 		EnvVar: "BUILDKITE_KUBERNETES_EXEC",
+	}
+
+	KubernetesContainerIDFlag = cli.IntFlag{
+		Name: "kubernetes-container-id",
+		Usage: "This is intended to be used only by the Buildkite k8s stack " +
+			"(github.com/buildkite/agent-stack-k8s); it sets an ID number " +
+			"used to identify this container within the pod",
+		EnvVar: "BUILDKITE_CONTAINER_ID",
 	}
 
 	NoMultipartArtifactUploadFlag = cli.BoolFlag{

--- a/clicommand/kubernetes_bootstrap.go
+++ b/clicommand/kubernetes_bootstrap.go
@@ -1,0 +1,213 @@
+package clicommand
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/buildkite/agent/v3/env"
+	"github.com/buildkite/agent/v3/kubernetes"
+	"github.com/buildkite/agent/v3/process"
+	"github.com/buildkite/roko"
+	"github.com/urfave/cli"
+)
+
+const kubernetesBootstrapHelpDescription = `Usage:
+
+     buildkite-agent kubernetes-bootstrap [options...]
+
+Description:
+
+This command is used internally by Buildkite Kubernetes jobs. It is not
+intended to be used directly.`
+
+type KubernetesBootstrapConfig struct {
+	// Supplied specifically by agent-stack-k8s
+	Command               string   `cli:"command"`
+	Phases                []string `cli:"phases" normalize:"list"`
+	KubernetesContainerID int      `cli:"kubernetes-container-id"`
+
+	// Global flags for debugging, etc
+	LogLevel    string   `cli:"log-level"`
+	Debug       bool     `cli:"debug"`
+	Experiments []string `cli:"experiment" normalize:"list"`
+	Profile     string   `cli:"profile"`
+}
+
+var KubernetesBootstrapCommand = cli.Command{
+	Name:        "kubernetes-bootstrap",
+	Usage:       "Rebootstraps the command after connecting to the Kubernetes socket",
+	Description: bootstrapHelpDescription,
+	Flags: []cli.Flag{
+		// Supplied specifically by agent-stack-k8s
+		cli.StringFlag{
+			Name:   "command",
+			Usage:  "The command to run",
+			EnvVar: "BUILDKITE_COMMAND",
+		},
+		cli.StringSliceFlag{
+			Name:   "phases",
+			Usage:  "The specific phases to execute. The order they're defined is irrelevant.",
+			EnvVar: "BUILDKITE_BOOTSTRAP_PHASES",
+		},
+		KubernetesContainerIDFlag,
+
+		// Global flags for debugging, etc
+		DebugFlag,
+		LogLevelFlag,
+		ExperimentsFlag,
+		ProfileFlag,
+	},
+	Action: func(c *cli.Context) error {
+		ctx := context.Background()
+		ctx, cfg, l, _, done := setupLoggerAndConfig[KubernetesBootstrapConfig](ctx, c)
+		defer done()
+
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		// Start with our env, then override bits of it.
+		environ := env.FromSlice(os.Environ())
+
+		// Connect the socket.
+		socket := &kubernetes.Client{ID: cfg.KubernetesContainerID}
+
+		// Registration passes down the env vars the agent normally sets on the
+		// subprocess, but in this case the bootstrap is in a separate
+		// container.
+		rtr := roko.NewRetrier(
+			roko.WithMaxAttempts(7),
+			roko.WithStrategy(roko.Exponential(2*time.Second, 0)),
+		)
+		regResp, err := roko.DoFunc(ctx, rtr, func(rtr *roko.Retrier) (*kubernetes.RegisterResponse, error) {
+			return socket.Connect(ctx)
+		})
+		if err != nil {
+			return fmt.Errorf("error connecting to kubernetes runner: %w", err)
+		}
+
+		regEnv := env.FromSlice(regResp.Env).Dump()
+
+		// Capture parameters from the agent that affect how the subprocess
+		// should be run: build path, PTY, cancel signal, and signal grace period.
+		buildPath := environ.GetString("BUILDKITE_BUILD_PATH", "/workspace/build")
+		runInPTY := environ.GetBool("BUILDKITE_PTY", true)
+		cancelSignal := process.SIGTERM
+		if sig, has := environ.Get("BUILDKITE_CANCEL_SIGNAL"); has {
+			cs, err := process.ParseSignal(sig)
+			if err != nil {
+				return err
+			}
+			cancelSignal = cs
+		}
+		cgp := environ.GetInt("BUILDKITE_CANCEL_GRACE_PERIOD", defaultCancelGracePeriodSecs)
+		sgp := environ.GetInt("BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS", defaultSignalGracePeriodSecs)
+		signalGracePeriod, err := signalGracePeriod(cgp, sgp)
+		if err != nil {
+			return err
+		}
+
+		// Set the environment vars based on the registration response.
+		for n, v := range regEnv {
+			// Copy it to environ
+			environ.Set(n, v)
+		}
+
+		// Set vars that should always be preserved from our env, and not be
+		// possible to fiddle with via job env.
+		// agent-stack-k8s interprets the job definition itself, and sets
+		// BUILDKITE_COMMAND to one that could be radically different to the
+		// one the agent normally sets.
+		// Similarly bootstrap phases varies depending on whether this is a
+		// checkout or command container.
+		// Container ID should be preserved in case of Hyrum's Law.
+		environ.Set("BUILDKITE_COMMAND", cfg.Command)
+		environ.Set("BUILDKITE_BOOTSTRAP_PHASES", strings.Join(cfg.Phases, ","))
+		environ.Set("BUILDKITE_CONTAINER_ID", strconv.Itoa(cfg.KubernetesContainerID))
+
+		// Ensure the Kubernetes socket setup is disabled in the subprocess
+		// (we're doing all that here).
+		environ.Set("BUILDKITE_KUBERNETES_EXEC", "false")
+
+		// So that the agent doesn't exit early thinking the client is lost, we want
+		// to continue talking to the agent container for as long as possible (after
+		// Interrupt). Hence detach the StatusLoop context from cancellation using
+		// [context.WithoutCancel]. The goroutine will exit with the process.
+		// (Why even have a context arg? Testing and possible future value-passing)
+		if err := socket.StatusLoop(context.WithoutCancel(ctx), func(err error) {
+			// If the k8s client is interrupted for any reason (either the server
+			// is in state interrupted or the connection died or ...), we should
+			// cancel the job.
+			if err != nil {
+				l.Error("Error waiting for client interrupt: %v", err)
+			}
+			cancel()
+		}); err != nil {
+			return fmt.Errorf("connecting to k8s socket: %w", err)
+		}
+
+		var exitCode int
+		defer func() {
+			_ = socket.Exit(exitCode)
+		}()
+
+		// TODO: support custom bootstrap scripts?
+		self, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("finding absolute path to executable: %w", err)
+		}
+
+		// Now we can run the real `buildkite-agent bootstrap`.
+		// Compare with the setup in [agent.NewJobRunner].
+		// Tee both stdout and stderr to the k8s socket client, so that the
+		// logs are shipped to the agent container and then to Buildkite, but
+		// are also visible as container logs.
+		proc := process.New(l, process.Config{
+			Path:              self,
+			Args:              []string{"bootstrap"},
+			Env:               environ.ToSlice(),
+			Stdout:            io.MultiWriter(os.Stdout, socket),
+			Stderr:            io.MultiWriter(os.Stderr, socket),
+			Dir:               buildPath,
+			PTY:               runInPTY,
+			InterruptSignal:   cancelSignal,
+			SignalGracePeriod: signalGracePeriod,
+		})
+
+		if err := proc.Run(ctx); err != nil {
+			return fmt.Errorf("couldn't run subprocess: %w", err)
+		}
+
+		// We aren't expecting the user to Ctrl-C the process (we're in a k8s
+		// pod), but Kubernetes might send signals.
+		// Forward them to the subprocess.
+		signals := make(chan os.Signal, 1)
+		signal.Notify(signals, os.Interrupt,
+			syscall.SIGHUP,
+			syscall.SIGTERM,
+			syscall.SIGINT,
+			syscall.SIGQUIT)
+		defer signal.Stop(signals)
+
+		// Block until done, but also pass along signals.
+	signalLoop:
+		for {
+			select {
+			case <-proc.Done():
+				break signalLoop
+			case <-signals:
+				proc.Interrupt()
+			}
+		}
+
+		exitCode = proc.WaitStatus().ExitStatus()
+
+		return &SilentExitError{code: exitCode}
+	},
+}

--- a/clicommand/lock_common.go
+++ b/clicommand/lock_common.go
@@ -16,12 +16,7 @@ func lockCommonFlags() []cli.Flag {
 			Usage:  "The scope for locks used in this operation. Currently only 'machine' scope is supported",
 			EnvVar: "BUILDKITE_LOCK_SCOPE",
 		},
-		cli.StringFlag{
-			Name:   "sockets-path",
-			Value:  defaultSocketsPath(),
-			Usage:  "Directory where the agent will place sockets",
-			EnvVar: "BUILDKITE_SOCKETS_PATH",
-		},
+		SocketsPathFlag,
 	)
 }
 

--- a/clicommand/step_cancel.go
+++ b/clicommand/step_cancel.go
@@ -63,7 +63,7 @@ var StepCancelCommand = cli.Command{
 
 		cli.Int64Flag{
 			Name:   "force-grace-period-seconds",
-			Value:  defaultCancelGracePeriod,
+			Value:  defaultCancelGracePeriodSecs,
 			Usage:  "The number of seconds to wait for agents to finish uploading artifacts before transitioning unfinished jobs to a canceled state. ′--force′ must also be supplied for this to take affect",
 			EnvVar: "BUILDKITE_STEP_CANCEL_FORCE_GRACE_PERIOD_SECONDS,BUILDKITE_CANCEL_GRACE_PERIOD",
 		},

--- a/env/environment.go
+++ b/env/environment.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/puzpuzpuz/xsync/v2"
@@ -112,6 +113,30 @@ func (e *Environment) GetBool(key string, defaultValue bool) bool {
 	default:
 		return defaultValue
 	}
+}
+
+// GetInt gets an int value from environment, with a default for unset, empty,
+// or invalid values.
+func (e *Environment) GetInt(key string, defaultValue int) int {
+	v, has := e.Get(key)
+	if !has || v == "" {
+		return defaultValue
+	}
+	x, err := strconv.Atoi(v)
+	if err != nil {
+		return defaultValue
+	}
+	return x
+}
+
+// GetString gets a string value from environment, with a default for unset or
+// empty values.
+func (e *Environment) GetString(key, defaultValue string) string {
+	v, has := e.Get(key)
+	if !has || v == "" {
+		return defaultValue
+	}
+	return v
 }
 
 // Exists returns true/false depending on whether or not the key exists in the env


### PR DESCRIPTION
### Description

Reduce Kubernetes resource size (when using agent-stack-k8s) by applying more environment variables from the socket.

### Context

A customer had feedback that having a lot of env vars repeated across containers in the pod spec can consume a lot of space in etcd.

### Changes

- Add a `kubernetes-bootstrap` subcommand. This allows fetching the env vars from the socket before the `bootstrap` subcommand runs, which was the fatal flaw in commit 36940e5
- Filter out the kubernetes plugin when creating the bootstrap env
- Some small-scale refactoring of flags and env helpers

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
