### PR TITLE
Fix env loading order in kubernetes-bootstrap

### DIFF
--- a/clicommand/kubernetes_bootstrap.go
+++ b/clicommand/kubernetes_bootstrap.go
@@ -92,7 +92,11 @@ var KubernetesBootstrapCommand = cli.Command{
 			return fmt.Errorf("error connecting to kubernetes runner: %w", err)
 		}
 
-		regEnv := env.FromSlice(regResp.Env).Dump()
+		// Set the environment vars based on the registration response.
+		for n, v := range env.FromSlice(regResp.Env).Dump() {
+			// Copy it to environ
+			environ.Set(n, v)
+		}
 
 		// Capture parameters from the agent that affect how the subprocess
 		// should be run: build path, PTY, cancel signal, and signal grace period.
@@ -111,12 +115,6 @@ var KubernetesBootstrapCommand = cli.Command{
 		signalGracePeriod, err := signalGracePeriod(cgp, sgp)
 		if err != nil {
 			return err
-		}
-
-		// Set the environment vars based on the registration response.
-		for n, v := range regEnv {
-			// Copy it to environ
-			environ.Set(n, v)
 		}
 
 		// Set vars that should always be preserved from our env, and not be

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -798,7 +798,7 @@ func (e *Executor) setUp(ctx context.Context) error {
 	if e.BinPath != "" {
 		path, _ := e.shell.Env.Get("PATH")
 		// BinPath goes last so we don't disturb other tools
-		e.shell.Env.Set("PATH", fmt.Sprintf("%s%s%s", path, string(os.PathListSeparator), e.BinPath))
+		e.shell.Env.Set("PATH", fmt.Sprintf("%s%c%s", path, os.PathListSeparator, e.BinPath))
 	}
 
 	// Set a BUILDKITE_BUILD_CHECKOUT_PATH unless one exists already. We do this here


### PR DESCRIPTION
### Description

The registration response env vars are meant to be read to find out `BUILDKITE_PTY`, etc, but these were being added to `environ` after. 

### Context

Found during testing.

### Changes

- Merge the registration response vars into `environ` before reading them.
- A tiny simplification to `$PATH` computation found when trying to understand it.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
