### PR TITLE
[PROTOTYPE] Inform agent-shutdown hook of reason for agent shutdown.

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math/rand/v2"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -424,6 +425,7 @@ func (a *AgentWorker) runPingLoop(ctx context.Context, idleMonitor *IdleMonitor)
 				// But only terminate if everyone else is also idle
 				if idleMonitor.Idle() {
 					a.logger.Info("All agents have been idle for %v. Disconnecting...", disconnectAfterIdleTimeout)
+					os.Setenv("BUILDKITE_AGENT_SHUTDOWN_REASON", "IDLE")
 					return nil
 				}
 				a.logger.Debug("Agent has been idle for %.f seconds, but other agents haven't",

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1377,9 +1377,17 @@ func handlePoolSignals(ctx context.Context, l logger.Logger, pool *agent.AgentPo
 			switch sig {
 			case syscall.SIGQUIT:
 				l.Debug("Received signal `%s`", sig.String())
+				os.Setenv("BUILDKITE_AGENT_SHUTDOWN_REASON", "SIGNAL")
+				os.Setenv("BUILDKITE_AGENT_SHUTDOWN_SIGNAL", "SIGQUIT")
 				pool.Stop(false)
 			case syscall.SIGTERM, syscall.SIGINT:
 				l.Debug("Received signal `%s`", sig.String())
+				os.Setenv("BUILDKITE_AGENT_SHUTDOWN_REASON", "SIGNAL")
+				if sig == syscall.SIGTERM {
+					os.Setenv("BUILDKITE_AGENT_SHUTDOWN_SIGNAL", "SIGTERM")
+				} else {
+					os.Setenv("BUILDKITE_AGENT_SHUTDOWN_SIGNAL", "SIGINT")
+				}
 				if interruptCount == 0 {
 					interruptCount++
 					l.Info("Received CTRL-C, send again to forcefully kill the agent(s)")


### PR DESCRIPTION
When running the agent-shutdown hook, the following environment variables may be set:

 - BUILDKITE_AGENT_SHUTDOWN_REASON: The reason the buildkite-agent process is shutting down, "IDLE" for the idle timeout expiring or "SIGNAL" for SIGINT/SIGTERM/etc.

 - BUILDKITE_AGENT_SHUTDOWN_SIGNAL: The signal which caused the agent to shut down (e.g. "SIGINT").

My use case for this is triggering a system shutdown from the agent shutdown hook when the agent has shut down due to inactivity, I can imagine it getting used for other cluster orchestration things too.

See also: https://forum.buildkite.community/t/provide-termination-reason-to-agent-shutdown-hook/4364