### PR TITLE
kubernetes-bootstrap refinements

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -520,15 +520,12 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 
 	// We know the BUILDKITE_BIN_PATH dir, because it's the path to the
 	// currently running file (there is only 1 binary)
+	// Note that [os.Executable] returns an absolute path.
 	exePath, err := os.Executable()
 	if err != nil {
 		return nil, err
 	}
-	dir, err := filepath.Abs(filepath.Dir(exePath))
-	if err != nil {
-		return nil, err
-	}
-	env["BUILDKITE_BIN_PATH"] = dir
+	env["BUILDKITE_BIN_PATH"] = filepath.Dir(exePath)
 
 	// Add options from the agent configuration
 	env["BUILDKITE_CONFIG_PATH"] = r.conf.AgentConfiguration.ConfigPath

--- a/process/process.go
+++ b/process/process.go
@@ -75,7 +75,6 @@ func ParseSignal(sig string) (Signal, error) {
 // Configuration for a Process
 type Config struct {
 	PTY               bool
-	Timestamp         bool
 	Path              string
 	Args              []string
 	Env               []string


### PR DESCRIPTION
### Description

Refine `kubernetes-bootstrap` based on things learned during testing.

### Context

buildkite/agent-stack-k8s#595

### Changes

- Reorder the construction of `environ` so `os.Environ()` takes precedence over the registration env, which eliminates some of the previous hand-holding via config.
- Replace `BUILDKITE_BIN_PATH` with the directory of `os.Executable`
- Enforce `BUILDKITE_SOCKETS_PATH` based on what agent-stack-k8s provides
- Remove redundant call to `filepath.Abs` (in job_runner.go)
- Remove unused `Timestamp` field (in process.go)

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)