### PR TITLE
Fix `redactor add --format json` help string

### DIFF
--- a/clicommand/redactor_add.go
+++ b/clicommand/redactor_add.go
@@ -68,10 +68,10 @@ To redact the string 'llamasecret' from future logs:
 		$ echo llamasecret | buildkite-agent redactor add
 
 To redact multiple secrets from future logs in one command, create a flat
-JSON object file (for example, 'my-secrets.json'), with multiple "key" values,
-one for each secret:
+JSON object file (for example, 'my-secrets.json'), with one entry per secret
+(the names of the keys have no effect on redaction):
 
-		$ echo '{"key":"secret1","key":"secret2"}' | buildkite-agent redactor add --format json
+		$ echo '{"key1":"secret1","key2":"secret2"}' | buildkite-agent redactor add --format json
 
 Or
 


### PR DESCRIPTION
### Description
The help string for `buildkite-agent redactor add --format json` has a bug; the example given uses the JSON object `{"key":"secret1","key":"secret2"}`, which is invalid because it contains duplicate keys. At runtime, this value is unmarshaled and the second value takes precedence over the first, which prevents redaction of all secrets but the last.

A test using version 3.88:
![image](https://github.com/user-attachments/assets/41de1801-a975-4ffe-9752-6d0ffc790d15)

The proper syntax is to use unique names for each key:
![image](https://github.com/user-attachments/assets/36617d87-b5d0-42a8-8530-dd90426a3764)


### Context
Current help string for `buildkite-agent redactor add --format json`

### Changes
Updated the help string with unique key names and specified that the key names have no effect on redaction based on https://github.com/buildkite/agent/blob/8f29ee7bf1e739a2664a7b887428c39d298a6fe3/clicommand/redactor_add.go#L150-L152 ignoring the key.

### Testing
This is a documentation-only change, the output when using the example in the help string in a test job is above.