### PR TITLE
Update CLI cancel_signal arg description

### DIFF
--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -33,7 +33,7 @@ var (
 		Usage: "The number of seconds given to a subprocess to handle being sent ′cancel-signal′. " +
 			"After this period has elapsed, SIGKILL will be sent. " +
 			"Negative values are taken relative to ′cancel-grace-period′. " +
-			"The default value (-1) means that the effective signal grace period is equal to ′cancel-grace-period-seconds′ minus 1.",
+			"The default value (-1) means that the effective signal grace period is equal to ′cancel-grace-period′ minus 1.",
 		EnvVar: "BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS",
 	}
 )


### PR DESCRIPTION
### Description

Previous changes in https://github.com/buildkite/agent/pull/3197 updated `cancel-grace-period` to `cancel-grace-period-seconds` while improving the wording. Changing back to reference the correct CLI config.

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->
https://linear.app/buildkite/issue/SUP-3416/update-the-docs-for-signal-grace-period-seconds-value

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [X] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [X] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
