### PR TITLE
Reduce git fetch from twice to once for typical Github PR build

### DIFF
--- a/internal/job/git.go
+++ b/internal/job/git.go
@@ -22,8 +22,11 @@ const (
 	gitErrorCheckoutRetryClean
 	gitErrorClone
 	gitErrorFetch
+	// exit code 128: broad error, most likely not recoverable.
 	gitErrorFetchRetryClean
+	// local repo corruption, unrecoverable.
 	gitErrorFetchBadObject
+	// can happen when just the short commit hash is given.
 	gitErrorFetchBadReference
 	gitErrorClean
 	gitErrorCleanSubmodules


### PR DESCRIPTION
### Description

Currently, when a PR triggers a build, we trigger two `git fetch`. This PR merges these two `git fetch` into one.

### Context

PS-624

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
