### PR TITLE
Set job log tempfile permissions to 644 (was 600)

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -265,6 +265,12 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient APIClient, con
 		if err != nil {
 			return nil, err
 		}
+
+		err := os.Chmod(tmpFile.Name(), 0o644) // Make it world-readable - useful for log collection etc
+		if err != nil {
+			return nil, fmt.Errorf("failed to set permissions on job log tmpfile %s: %w", tmpFile.Name(), err)
+		}
+
 		os.Setenv("BUILDKITE_JOB_LOG_TMPFILE", tmpFile.Name())
 		outputWriter = io.MultiWriter(outputWriter, tmpFile)
 	}

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -218,8 +218,8 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient APIClient, con
 	// TempDir is not guaranteed to exist
 	tempDir := os.TempDir()
 	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
-		// Actual file permissions will be reduced by umask, and won't be 0777 unless the user has manually changed the umask to 000
-		if err = os.MkdirAll(tempDir, 0777); err != nil {
+		// Actual file permissions will be reduced by umask, and won't be 0o777 unless the user has manually changed the umask to 000
+		if err = os.MkdirAll(tempDir, 0o777); err != nil {
 			return nil, err
 		}
 	}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1172,7 +1172,7 @@ var AgentStartCommand = cli.Command{
 		// so we may as well check that'll work now and fail early if it's a problem
 		if !osutil.FileExists(agentConf.BuildPath) {
 			l.Info("Build Path doesn't exist, creating it (%s)", agentConf.BuildPath)
-			// Actual file permissions will be reduced by umask, and won't be 0777 unless the user has manually changed the umask to 000
+			// Actual file permissions will be reduced by umask, and won't be 0o777 unless the user has manually changed the umask to 000
 			if err := os.MkdirAll(agentConf.BuildPath, 0o777); err != nil {
 				return fmt.Errorf("failed to create builds path: %w", err)
 			}

--- a/internal/artifact/bk_uploader_test.go
+++ b/internal/artifact/bk_uploader_test.go
@@ -86,7 +86,7 @@ func TestFormUploading(t *testing.T) {
 	for _, wd := range []string{temp, cwd} {
 		t.Run(wd, func(t *testing.T) {
 			abspath := filepath.Join(wd, "llamas.txt")
-			err = os.WriteFile(abspath, []byte("llamas"), 0700)
+			err = os.WriteFile(abspath, []byte("llamas"), 0o700)
 			defer os.Remove(abspath)
 
 			uploader := NewBKUploader(logger.Discard, BKUploaderConfig{})
@@ -171,7 +171,7 @@ func TestMultipartUploading(t *testing.T) {
 	for _, wd := range []string{temp, cwd} {
 		t.Run(wd, func(t *testing.T) {
 			abspath := filepath.Join(wd, "llamas3.txt")
-			err = os.WriteFile(abspath, []byte("llamasllamasllamas"), 0700)
+			err = os.WriteFile(abspath, []byte("llamasllamasllamas"), 0o700)
 			defer os.Remove(abspath)
 
 			uploader := NewBKUploader(logger.Discard, BKUploaderConfig{})

--- a/internal/artifact/download.go
+++ b/internal/artifact/download.go
@@ -160,8 +160,8 @@ func (d Download) try(ctx context.Context) error {
 	}
 
 	// Now make the folder for our file
-	// Actual file permissions will be reduced by umask, and won't be 0777 unless the user has manually changed the umask to 000
-	if err := os.MkdirAll(targetDirectory, 0777); err != nil {
+	// Actual file permissions will be reduced by umask, and won't be 0o777 unless the user has manually changed the umask to 000
+	if err := os.MkdirAll(targetDirectory, 0o777); err != nil {
 		return fmt.Errorf("creating directory for %s (%T: %w)", targetPath, err, err)
 	}
 

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -83,8 +83,8 @@ func (e *Executor) createCheckoutDir() error {
 
 	if !osutil.FileExists(checkoutPath) {
 		e.shell.Commentf("Creating \"%s\"", checkoutPath)
-		// Actual file permissions will be reduced by umask, and won't be 0777 unless the user has manually changed the umask to 000
-		if err := os.MkdirAll(checkoutPath, 0777); err != nil {
+		// Actual file permissions will be reduced by umask, and won't be 0o777 unless the user has manually changed the umask to 000
+		if err := os.MkdirAll(checkoutPath, 0o777); err != nil {
 			return err
 		}
 	}
@@ -293,8 +293,8 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string) (stri
 	// Create the mirrors path if it doesn't exist
 	if baseDir := filepath.Dir(mirrorDir); !osutil.FileExists(baseDir) {
 		e.shell.Commentf("Creating \"%s\"", baseDir)
-		// Actual file permissions will be reduced by umask, and won't be 0777 unless the user has manually changed the umask to 000
-		if err := os.MkdirAll(baseDir, 0777); err != nil {
+		// Actual file permissions will be reduced by umask, and won't be 0o777 unless the user has manually changed the umask to 000
+		if err := os.MkdirAll(baseDir, 0o777); err != nil {
 			return "", err
 		}
 	}

--- a/internal/job/githttptest/githttptest.go
+++ b/internal/job/githttptest/githttptest.go
@@ -72,7 +72,7 @@ func (s *Server) InitRepository(repoName string) ([]byte, error) {
 
 	readmePath := filepath.Join(tempDir, "README.md")
 	readmeContent := "# Git Repository\n\nThis repository was created by the Git HTTP server.\n"
-	if err := os.WriteFile(readmePath, []byte(readmeContent), 0644); err != nil {
+	if err := os.WriteFile(readmePath, []byte(readmeContent), 0o644); err != nil {
 		return nil, fmt.Errorf("failed to create README file: %w", err)
 	}
 
@@ -140,7 +140,7 @@ func (s *Server) PushBranch(repoName, branchName string) (string, []byte, error)
 	}
 
 	filePath := filepath.Join(tempDir, "newfile.txt")
-	if err := os.WriteFile(filePath, []byte("This is a new file."), 0644); err != nil {
+	if err := os.WriteFile(filePath, []byte("This is a new file."), 0o644); err != nil {
 		return "", nil, fmt.Errorf("failed to create new file: %w", err)
 	}
 

--- a/internal/job/integration/artifact_integration_test.go
+++ b/internal/job/integration/artifact_integration_test.go
@@ -20,8 +20,8 @@ func TestArtifactsUploadAfterCommand(t *testing.T) {
 
 	// Write a file in the command hook
 	tester.ExpectGlobalHook("command").Once().AndCallFunc(func(c *bintest.Call) {
-		if err := os.WriteFile(filepath.Join(c.Dir, "test.txt"), []byte("llamas"), 0700); err != nil {
-			t.Fatalf("os.WriteFile(test.txt, llamas, 0700) = %v", err)
+		if err := os.WriteFile(filepath.Join(c.Dir, "test.txt"), []byte("llamas"), 0o700); err != nil {
+			t.Fatalf("os.WriteFile(test.txt, llamas, 0o700) = %v", err)
 		}
 		c.Exit(0)
 	})
@@ -48,9 +48,9 @@ func TestArtifactsUploadAfterCommandFails(t *testing.T) {
 	defer tester.Close()
 
 	tester.MustMock(t, "my-command").Expect().AndCallFunc(func(c *bintest.Call) {
-		err := os.WriteFile(filepath.Join(c.Dir, "test.txt"), []byte("llamas"), 0700)
+		err := os.WriteFile(filepath.Join(c.Dir, "test.txt"), []byte("llamas"), 0o700)
 		if err != nil {
-			t.Fatalf("os.WriteFile(test.txt, llamas, 0700) = %v", err)
+			t.Fatalf("os.WriteFile(test.txt, llamas, 0o700) = %v", err)
 		}
 		c.Exit(1)
 	})
@@ -83,9 +83,9 @@ func TestArtifactsUploadAfterCommandHookFails(t *testing.T) {
 
 	// Write a file in the command hook
 	tester.ExpectGlobalHook("command").Once().AndCallFunc(func(c *bintest.Call) {
-		err := os.WriteFile(filepath.Join(c.Dir, "test.txt"), []byte("llamas"), 0700)
+		err := os.WriteFile(filepath.Join(c.Dir, "test.txt"), []byte("llamas"), 0o700)
 		if err != nil {
-			t.Fatalf("os.WriteFile(test.txt, llamas, 0700) = %v", err)
+			t.Fatalf("os.WriteFile(test.txt, llamas, 0o700) = %v", err)
 		}
 		c.Exit(1)
 	})

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -454,8 +454,8 @@ func TestCleaningAnExistingCheckout_WithGitMirrors(t *testing.T) {
 		t.Fatalf(`tester.Repo.Execute(clone, -v, --, %q, %q) error = %v\nout = %s`, tester.Repo.Path, tester.CheckoutDir(), err, out)
 	}
 	testpath := filepath.Join(tester.CheckoutDir(), "test.txt")
-	if err := os.WriteFile(testpath, []byte("llamas"), 0700); err != nil {
-		t.Fatalf("os.WriteFile(test.txt, llamas, 0700) = %v", err)
+	if err := os.WriteFile(testpath, []byte("llamas"), 0o700); err != nil {
+		t.Fatalf("os.WriteFile(test.txt, llamas, 0o700) = %v", err)
 	}
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -649,8 +649,8 @@ func TestRepositorylessCheckout_WithGitMirrors(t *testing.T) {
 		"export BUILDKITE_REPO=",
 	}
 
-	if err := os.WriteFile(filepath.Join(tester.HooksDir, "environment"), []byte(strings.Join(script, "\n")), 0700); err != nil {
-		t.Fatalf("os.WriteFile(environment, script, 0700) = %v", err)
+	if err := os.WriteFile(filepath.Join(tester.HooksDir, "environment"), []byte(strings.Join(script, "\n")), 0o700); err != nil {
+		t.Fatalf("os.WriteFile(environment, script, 0o700) = %v", err)
 	}
 
 	tester.MustMock(t, "git").Expect().NotCalled()

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -546,7 +546,7 @@ func TestCheckoutErrorIsRetried(t *testing.T) {
 	}
 
 	// Simulate state from a previous checkout
-	if err := os.MkdirAll(tester.CheckoutDir(), 0755); err != nil {
+	if err := os.MkdirAll(tester.CheckoutDir(), 0o755); err != nil {
 		t.Fatalf("error creating dir to clone from: %s", err)
 	}
 	cmd := exec.Command("git", "clone", "-v", "--", tester.Repo.Path, ".")
@@ -609,7 +609,7 @@ func TestFetchErrorIsRetried(t *testing.T) {
 	}
 
 	// Simulate state from a previous checkout
-	if err := os.MkdirAll(tester.CheckoutDir(), 0755); err != nil {
+	if err := os.MkdirAll(tester.CheckoutDir(), 0o755); err != nil {
 		t.Fatalf("error creating dir to clone from: %s", err)
 	}
 	cmd := exec.Command("git", "clone", "-v", "--", tester.Repo.Path, ".")
@@ -764,8 +764,8 @@ func TestCleaningAnExistingCheckout(t *testing.T) {
 		t.Fatalf(`tester.Repo.Execute(clone, -v, --, %q, %q) error = %v\nout = %s`, tester.Repo.Path, tester.CheckoutDir(), err, out)
 	}
 	testpath := filepath.Join(tester.CheckoutDir(), "test.txt")
-	if err := os.WriteFile(testpath, []byte("llamas"), 0700); err != nil {
-		t.Fatalf("os.WriteFile(test.txt, llamas, 0700) = %v", err)
+	if err := os.WriteFile(testpath, []byte("llamas"), 0o700); err != nil {
+		t.Fatalf("os.WriteFile(test.txt, llamas, 0o700) = %v", err)
 	}
 
 	// Mock out the meta-data calls to the agent after checkout
@@ -935,8 +935,8 @@ func TestRepositorylessCheckout(t *testing.T) {
 		"export BUILDKITE_REPO=",
 	}
 
-	if err := os.WriteFile(filepath.Join(tester.HooksDir, "environment"), []byte(strings.Join(script, "\n")), 0700); err != nil {
-		t.Fatalf("os.WriteFile(environment, script, 0700) = %v", err)
+	if err := os.WriteFile(filepath.Join(tester.HooksDir, "environment"), []byte(strings.Join(script, "\n")), 0o700); err != nil {
+		t.Fatalf("os.WriteFile(environment, script, 0o700) = %v", err)
 	}
 
 	tester.MustMock(t, "git").Expect().NotCalled()

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -38,8 +38,8 @@ func TestEnvironmentVariablesPassBetweenHooks(t *testing.T) {
 		}
 	}
 
-	if err := os.WriteFile(filepath.Join(tester.HooksDir, filename), []byte(strings.Join(script, "\n")), 0700); err != nil {
-		t.Fatalf("os.WriteFile(%q, script, 0700) = %v", filename, err)
+	if err := os.WriteFile(filepath.Join(tester.HooksDir, filename), []byte(strings.Join(script, "\n")), 0o700); err != nil {
+		t.Fatalf("os.WriteFile(%q, script, 0o700) = %v", filename, err)
 	}
 
 	git := tester.MustMock(t, "git").PassthroughToLocalCommand().Before(func(i bintest.Invocation) error {
@@ -91,12 +91,12 @@ func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
 		}
 	}
 
-	if err := os.WriteFile(filepath.Join(tester.HooksDir, preCmdFile), []byte(strings.Join(preCommand, "\n")), 0700); err != nil {
-		t.Fatalf("os.WriteFile(%q, preCommand, 0700) = %v", preCmdFile, err)
+	if err := os.WriteFile(filepath.Join(tester.HooksDir, preCmdFile), []byte(strings.Join(preCommand, "\n")), 0o700); err != nil {
+		t.Fatalf("os.WriteFile(%q, preCommand, 0o700) = %v", preCmdFile, err)
 	}
 
-	if err := os.WriteFile(filepath.Join(tester.HooksDir, postCmdFile), []byte(strings.Join(postCommand, "\n")), 0700); err != nil {
-		t.Fatalf("os.WriteFile(%q, postCommand, 0700) = %v", postCmdFile, err)
+	if err := os.WriteFile(filepath.Join(tester.HooksDir, postCmdFile), []byte(strings.Join(postCommand, "\n")), 0o700); err != nil {
+		t.Fatalf("os.WriteFile(%q, postCommand, 0o700) = %v", postCmdFile, err)
 	}
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
@@ -140,8 +140,8 @@ func TestDirectoryPassesBetweenHooks(t *testing.T) {
 		"cd ./mysubdir",
 	}
 
-	if err := os.WriteFile(filepath.Join(tester.HooksDir, "pre-command"), []byte(strings.Join(script, "\n")), 0700); err != nil {
-		t.Fatalf("os.WriteFile(pre-command, script, 0700) = %v", err)
+	if err := os.WriteFile(filepath.Join(tester.HooksDir, "pre-command"), []byte(strings.Join(script, "\n")), 0o700); err != nil {
+		t.Fatalf("os.WriteFile(pre-command, script, 0o700) = %v", err)
 	}
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
@@ -175,8 +175,8 @@ func TestDirectoryPassesBetweenHooksIgnoredUnderExit(t *testing.T) {
 		"exit 0",
 	}
 
-	if err := os.WriteFile(filepath.Join(tester.HooksDir, "pre-command"), []byte(strings.Join(script, "\n")), 0700); err != nil {
-		t.Fatalf("os.WriteFile(pre-command, script, 0700) = %v", err)
+	if err := os.WriteFile(filepath.Join(tester.HooksDir, "pre-command"), []byte(strings.Join(script, "\n")), 0o700); err != nil {
+		t.Fatalf("os.WriteFile(pre-command, script, 0o700) = %v", err)
 	}
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
@@ -591,8 +591,8 @@ func TestPolyglotScriptHooksCanBeRun(t *testing.T) {
 		`puts "ohai, it's ruby!"`,
 	}
 
-	if err := os.WriteFile(filepath.Join(tester.HooksDir, filename), []byte(strings.Join(script, "\n")), 0755); err != nil {
-		t.Fatalf("os.WriteFile(%q, script, 0755) = %v", filename, err)
+	if err := os.WriteFile(filepath.Join(tester.HooksDir, filename), []byte(strings.Join(script, "\n")), 0o755); err != nil {
+		t.Fatalf("os.WriteFile(%q, script, 0o755) = %v", filename, err)
 	}
 
 	tester.RunAndCheck(t)

--- a/internal/job/integration/plugin_integration_test.go
+++ b/internal/job/integration/plugin_integration_test.go
@@ -510,14 +510,14 @@ func createTestPlugin(t *testing.T, hooks map[string][]string) *testPlugin {
 		t.Fatalf("newGitRepository() error = %v", err)
 	}
 
-	if err := os.MkdirAll(filepath.Join(repo.Path, "hooks"), 0700); err != nil {
-		t.Fatalf("os.MkdirAll(hooks, 0700) = %v", err)
+	if err := os.MkdirAll(filepath.Join(repo.Path, "hooks"), 0o700); err != nil {
+		t.Fatalf("os.MkdirAll(hooks, 0o700) = %v", err)
 	}
 
 	for hook, lines := range hooks {
 		data := []byte(strings.Join(lines, "\n"))
-		if err := os.WriteFile(filepath.Join(repo.Path, "hooks", hook), data, 0600); err != nil {
-			t.Fatalf("os.WriteFile(hooks/%s, data, 0600) = %v", hook, err)
+		if err := os.WriteFile(filepath.Join(repo.Path, "hooks", hook), data, 0o600); err != nil {
+			t.Fatalf("os.WriteFile(hooks/%s, data, 0o600) = %v", hook, err)
 		}
 	}
 
@@ -545,8 +545,8 @@ func modifyTestPlugin(t *testing.T, hooks map[string][]string, testPlugin *testP
 
 	for hook, lines := range hooks {
 		data := []byte(strings.Join(lines, "\n"))
-		if err := os.WriteFile(filepath.Join(repo.Path, "hooks", hook), data, 0600); err != nil {
-			t.Fatalf("os.WriteFile(hooks/%s, data, 0600) = %v", hook, err)
+		if err := os.WriteFile(filepath.Join(repo.Path, "hooks", hook), data, 0o600); err != nil {
+			t.Fatalf("os.WriteFile(hooks/%s, data, 0o600) = %v", hook, err)
 		}
 	}
 

--- a/internal/job/knownhosts.go
+++ b/internal/job/knownhosts.go
@@ -30,13 +30,13 @@ func findKnownHosts(sh *shell.Shell) (*knownHosts, error) {
 	knownHostPath := filepath.Join(sshDirectory, "known_hosts")
 
 	// Ensure ssh directory exists
-	if err := os.MkdirAll(sshDirectory, 0700); err != nil {
+	if err := os.MkdirAll(sshDirectory, 0o700); err != nil {
 		return nil, err
 	}
 
 	// Ensure file exists
 	if _, err := os.Stat(knownHostPath); err != nil {
-		f, err := os.OpenFile(knownHostPath, os.O_CREATE|os.O_WRONLY, 0600)
+		f, err := os.OpenFile(knownHostPath, os.O_CREATE|os.O_WRONLY, 0o600)
 		if err != nil {
 			return nil, fmt.Errorf("create %q: %w", knownHostPath, err)
 		}
@@ -118,7 +118,7 @@ func (kh *knownHosts) Add(ctx context.Context, host string) error {
 	kh.Shell.Commentf("Added host %q to known hosts at \"%s\"", host, kh.Path)
 
 	// Try and open the existing hostfile in (append_only) mode
-	f, err := os.OpenFile(kh.Path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0700)
+	f, err := os.OpenFile(kh.Path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o700)
 	if err != nil {
 		return fmt.Errorf("Could not open %q for appending: %w", kh.Path, err)
 	}

--- a/internal/osutil/file.go
+++ b/internal/osutil/file.go
@@ -11,8 +11,8 @@ func ChmodExecutable(filename string) error {
 	if err != nil {
 		return fmt.Errorf("Failed to retrieve file information of \"%s\" (%s)", filename, err)
 	}
-	if s.Mode()&0100 == 0 {
-		err = os.Chmod(filename, s.Mode()|0100)
+	if s.Mode()&0o100 == 0 {
+		err = os.Chmod(filename, s.Mode()|0o100)
 		if err != nil {
 			return fmt.Errorf("Failed to mark \"%s\" as executable (%s)", filename, err)
 		}

--- a/internal/shell/lookpath.go
+++ b/internal/shell/lookpath.go
@@ -23,7 +23,7 @@ func findExecutable(file string) error {
 	if err != nil {
 		return err
 	}
-	if m := d.Mode(); !m.IsDir() && m&0111 != 0 {
+	if m := d.Mode(); !m.IsDir() && m&0o111 != 0 {
 		return nil
 	}
 	return os.ErrPermission

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -250,8 +250,8 @@ func TestWorkingDir(t *testing.T) {
 
 	dirs := []string{tempDir, "my", "test", "dirs"}
 
-	if err := os.MkdirAll(filepath.Join(dirs...), 0700); err != nil {
-		t.Fatalf("os.MkdirAll(dirs, 0700) = %v", err)
+	if err := os.MkdirAll(filepath.Join(dirs...), 0o700); err != nil {
+		t.Fatalf("os.MkdirAll(dirs, 0o700) = %v", err)
 	}
 
 	currentWd, err := os.Getwd()

--- a/internal/socket/server.go
+++ b/internal/socket/server.go
@@ -24,7 +24,7 @@ func NewServer(socketPath string, handler http.Handler) (*Server, error) {
 		return nil, fmt.Errorf("socket path %s is too long (path length: %d, max %d characters). This is a limitation of your host OS", socketPath, len(socketPath), socketPathLength())
 	}
 
-	if err := os.MkdirAll(filepath.Dir(socketPath), os.FileMode(0700)); err != nil {
+	if err := os.MkdirAll(filepath.Dir(socketPath), os.FileMode(0o700)); err != nil {
 		return nil, fmt.Errorf("creating socket directory: %w", err)
 	}
 

--- a/kubernetes/runner.go
+++ b/kubernetes/runner.go
@@ -84,7 +84,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	r.server.Register(r)
 	r.mux.Handle(rpc.DefaultRPCPath, r.server)
 
-	oldUmask, err := Umask(0) // set umask of socket file to 0777 (world read-write-executable)
+	oldUmask, err := Umask(0) // set umask of socket file to 0o777 (world read-write-executable)
 	if err != nil {
 		return fmt.Errorf("failed to set socket umask: %w", err)
 	}


### PR DESCRIPTION
- **Make job log tempfile world-readable**

### Description

Currently, when users use the `--job-log-tempfile` flag on the agent, the tempfile is created with `600` permissions (ie, readable and writable by the current user, unavailable to everyone else). This can be frustrating, as a primary use case for this file is ingestion by a log ingestion framework a la Cloudwatch/Stackdriver/Loki, which often run as different users.

To fix this, this PR sets the permissions on the job log tempfile to `644` (readable and writable by us, readable by everyone else). This is relatively in line with the unix permissions policy for files created by the agent, which are generally created with relatively permissive permissions (usually 777), to be reduced by the umask. Given that job logs can be somewhat sensitive, I've chosen to have an explicitly lower permission set than usual for this specific file.

### Context

[PS-276](https://linear.app/buildkite/issue/PS-726/2-zipline-logfile-permission-needs-update-from-600-to-644#comment-5b396b68)

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
