### PR TITLE
Better helptext

### DIFF
--- a/clicommand/agent_pause.go
+++ b/clicommand/agent_pause.go
@@ -39,6 +39,7 @@ type AgentPauseConfig struct {
 
 var AgentPauseCommand = cli.Command{
 	Name:        "pause",
+	Category:    categoryJobCommands,
 	Usage:       "Pause the agent",
 	Description: pauseDescription,
 	Flags: slices.Concat(globalFlags(), apiFlags(), []cli.Flag{

--- a/clicommand/agent_resume.go
+++ b/clicommand/agent_resume.go
@@ -32,6 +32,7 @@ type AgentResumeConfig struct {
 
 var AgentResumeCommand = cli.Command{
 	Name:        "resume",
+	Category:    categoryJobCommands,
 	Usage:       "Resume the agent",
 	Description: resumeDescription,
 	Flags:       slices.Concat(globalFlags(), apiFlags()),

--- a/clicommand/agent_stop.go
+++ b/clicommand/agent_stop.go
@@ -38,6 +38,7 @@ type AgentStopConfig struct {
 
 var AgentStopCommand = cli.Command{
 	Name:        "stop",
+	Category:    categoryJobCommands,
 	Usage:       "Stop the agent",
 	Description: stopDescription,
 	Flags: slices.Concat(globalFlags(), apiFlags(), []cli.Flag{

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -71,7 +71,7 @@ type AnnotateConfig struct {
 var AnnotateCommand = cli.Command{
 	Name:        "annotate",
 	Category:    categoryJobCommands,
-	Usage:       "Annotate the build page within the Buildkite UI with text from within a Buildkite job",
+	Usage:       "Annotate the build page in the Buildkite UI with information from within a Buildkite job",
 	Description: annotateHelpDescription,
 	Flags: slices.Concat(globalFlags(), apiFlags(), []cli.Flag{
 		cli.StringFlag{

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -70,6 +70,7 @@ type AnnotateConfig struct {
 
 var AnnotateCommand = cli.Command{
 	Name:        "annotate",
+	Category:    categoryJobCommands,
 	Usage:       "Annotate the build page within the Buildkite UI with text from within a Buildkite job",
 	Description: annotateHelpDescription,
 	Flags: slices.Concat(globalFlags(), apiFlags(), []cli.Flag{

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -107,6 +107,7 @@ type BootstrapConfig struct {
 var BootstrapCommand = cli.Command{
 	Name:        "bootstrap",
 	Usage:       "Run a Buildkite job locally",
+	Hidden:      true, // This command is not intended to be run directly by users, but rather as a sub-process of the agent.
 	Description: bootstrapHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -106,8 +106,8 @@ type BootstrapConfig struct {
 
 var BootstrapCommand = cli.Command{
 	Name:        "bootstrap",
-	Usage:       "Run a Buildkite job locally",
-	Hidden:      true, // This command is not intended to be run directly by users, but rather as a sub-process of the agent.
+	Usage:       "Harness used internally by the agent to run jobs as subprocesses",
+	Category:    categoryInternal,
 	Description: bootstrapHelpDescription,
 	Flags: []cli.Flag{
 		cli.StringFlag{

--- a/clicommand/commands.go
+++ b/clicommand/commands.go
@@ -10,6 +10,7 @@ var BuildkiteAgentCommands = []cli.Command{
 	// These commands are special. The have a different lifecycle to the others
 	AgentStartCommand,
 	BootstrapCommand,
+	KubernetesBootstrapCommand,
 
 	// These are in alphabetical order
 	AcknowledgementsCommand,
@@ -53,7 +54,6 @@ var BuildkiteAgentCommands = []cli.Command{
 		},
 	},
 	GitCredentialsHelperCommand,
-	KubernetesBootstrapCommand,
 	{
 		Name:     "lock",
 		Category: categoryJobCommands,

--- a/clicommand/commands.go
+++ b/clicommand/commands.go
@@ -19,7 +19,7 @@ var BuildkiteAgentCommands = []cli.Command{
 	{
 		Name:     "annotation",
 		Category: categoryJobCommands,
-		Usage:    "Make changes to an annotation on the currently running build",
+		Usage:    "Make changes to annotations on the currently running build",
 		Subcommands: []cli.Command{
 			AnnotationRemoveCommand,
 		},
@@ -46,7 +46,7 @@ var BuildkiteAgentCommands = []cli.Command{
 	{
 		Name:     "env",
 		Category: categoryJobCommands,
-		Usage:    "Process environment subcommands",
+		Usage:    "Interact with the environment of the currently running build",
 		Subcommands: []cli.Command{
 			EnvDumpCommand,
 			EnvGetCommand,
@@ -58,7 +58,7 @@ var BuildkiteAgentCommands = []cli.Command{
 	{
 		Name:     "lock",
 		Category: categoryJobCommands,
-		Usage:    "Process lock subcommands",
+		Usage:    "Lock or unlock resources for the currently running build",
 		Subcommands: []cli.Command{
 			LockAcquireCommand,
 			LockDoCommand,
@@ -78,7 +78,7 @@ var BuildkiteAgentCommands = []cli.Command{
 	{
 		Name:     "meta-data",
 		Category: categoryJobCommands,
-		Usage:    "Get/set data from Buildkite jobs",
+		Usage:    "Get/set metadata from Buildkite jobs",
 		Subcommands: []cli.Command{
 			MetaDataSetCommand,
 			MetaDataGetCommand,
@@ -125,7 +125,7 @@ var BuildkiteAgentCommands = []cli.Command{
 	AgentStopCommand,
 	{
 		Name:  "tool",
-		Usage: "Utility commands, intended for users and operators of the agent to run directly on their machines, and not as part of a Buildkite job",
+		Usage: "Utilities for working with the Buildkite Agent",
 		Subcommands: []cli.Command{
 			ToolKeygenCommand,
 			ToolSignCommand,

--- a/clicommand/commands.go
+++ b/clicommand/commands.go
@@ -4,6 +4,7 @@ import "github.com/urfave/cli"
 
 const (
 	categoryJobCommands = "Commands that can be run within a Buildkite job"
+	categoryInternal    = "Internal commands, not intended to be run by users"
 )
 
 var BuildkiteAgentCommands = []cli.Command{

--- a/clicommand/commands.go
+++ b/clicommand/commands.go
@@ -2,6 +2,10 @@ package clicommand
 
 import "github.com/urfave/cli"
 
+const (
+	categoryJobCommands = "Commands that can be run within a Buildkite job"
+)
+
 var BuildkiteAgentCommands = []cli.Command{
 	// These commands are special. The have a different lifecycle to the others
 	AgentStartCommand,
@@ -11,15 +15,17 @@ var BuildkiteAgentCommands = []cli.Command{
 	AcknowledgementsCommand,
 	AnnotateCommand,
 	{
-		Name:  "annotation",
-		Usage: "Make changes to an annotation on the currently running build",
+		Name:     "annotation",
+		Category: categoryJobCommands,
+		Usage:    "Make changes to an annotation on the currently running build",
 		Subcommands: []cli.Command{
 			AnnotationRemoveCommand,
 		},
 	},
 	{
-		Name:  "artifact",
-		Usage: "Upload/download artifacts from Buildkite jobs",
+		Name:     "artifact",
+		Category: categoryJobCommands,
+		Usage:    "Upload/download artifacts from Buildkite jobs",
 		Subcommands: []cli.Command{
 			ArtifactUploadCommand,
 			ArtifactDownloadCommand,
@@ -28,15 +34,17 @@ var BuildkiteAgentCommands = []cli.Command{
 		},
 	},
 	{
-		Name:  "build",
-		Usage: "Interact with a Buildkite build",
+		Name:     "build",
+		Category: categoryJobCommands,
+		Usage:    "Interact with a Buildkite build",
 		Subcommands: []cli.Command{
 			BuildCancelCommand,
 		},
 	},
 	{
-		Name:  "env",
-		Usage: "Process environment subcommands",
+		Name:     "env",
+		Category: categoryJobCommands,
+		Usage:    "Process environment subcommands",
 		Subcommands: []cli.Command{
 			EnvDumpCommand,
 			EnvGetCommand,
@@ -47,8 +55,9 @@ var BuildkiteAgentCommands = []cli.Command{
 	GitCredentialsHelperCommand,
 	KubernetesBootstrapCommand,
 	{
-		Name:  "lock",
-		Usage: "Process lock subcommands",
+		Name:     "lock",
+		Category: categoryJobCommands,
+		Usage:    "Process lock subcommands",
 		Subcommands: []cli.Command{
 			LockAcquireCommand,
 			LockDoCommand,
@@ -58,15 +67,17 @@ var BuildkiteAgentCommands = []cli.Command{
 		},
 	},
 	{
-		Name:  "redactor",
-		Usage: "Redact sensitive information from logs",
+		Name:     "redactor",
+		Category: categoryJobCommands,
+		Usage:    "Redact sensitive information from logs",
 		Subcommands: []cli.Command{
 			RedactorAddCommand,
 		},
 	},
 	{
-		Name:  "meta-data",
-		Usage: "Get/set data from Buildkite jobs",
+		Name:     "meta-data",
+		Category: categoryJobCommands,
+		Usage:    "Get/set data from Buildkite jobs",
 		Subcommands: []cli.Command{
 			MetaDataSetCommand,
 			MetaDataGetCommand,
@@ -75,31 +86,35 @@ var BuildkiteAgentCommands = []cli.Command{
 		},
 	},
 	{
-		Name:  "oidc",
-		Usage: "Interact with Buildkite OpenID Connect (OIDC)",
+		Name:     "oidc",
+		Category: categoryJobCommands,
+		Usage:    "Interact with Buildkite OpenID Connect (OIDC)",
 		Subcommands: []cli.Command{
 			OIDCRequestTokenCommand,
 		},
 	},
 	AgentPauseCommand,
 	{
-		Name:  "pipeline",
-		Usage: "Make changes to the pipeline of the currently running build",
+		Name:     "pipeline",
+		Category: categoryJobCommands,
+		Usage:    "Make changes to the pipeline of the currently running build",
 		Subcommands: []cli.Command{
 			PipelineUploadCommand,
 		},
 	},
 	AgentResumeCommand,
 	{
-		Name:  "secret",
-		Usage: "Interact with Pipelines Secrets",
+		Name:     "secret",
+		Category: categoryJobCommands,
+		Usage:    "Interact with Pipelines Secrets",
 		Subcommands: []cli.Command{
 			SecretGetCommand,
 		},
 	},
 	{
-		Name:  "step",
-		Usage: "Get or update an attribute of a build step, or cancel unfinished jobs for a step",
+		Name:     "step",
+		Category: categoryJobCommands,
+		Usage:    "Get or update an attribute of a build step, or cancel unfinished jobs for a step",
 		Subcommands: []cli.Command{
 			StepGetCommand,
 			StepUpdateCommand,

--- a/clicommand/git_credentials_helper.go
+++ b/clicommand/git_credentials_helper.go
@@ -20,8 +20,6 @@ const gitCredentialsHelperHelpDescription = `Usage:
 
 Description:
 
-[EXPERIMENTAL]
-
 Ask buildkite for credentials to use to authenticate with Github when cloning via HTTPS.
 The credentials are returned in the git-credential format.
 

--- a/clicommand/git_credentials_helper.go
+++ b/clicommand/git_credentials_helper.go
@@ -46,6 +46,7 @@ type GitCredentialsHelperConfig struct {
 var GitCredentialsHelperCommand = cli.Command{
 	Name:        "git-credentials-helper",
 	Usage:       "Ask buildkite for credentials to use to authenticate with Github when cloning",
+	Hidden:      true, // This command is not intended to be used directly by users, and is configured to be run by hosted compute jobs
 	Description: gitCredentialsHelperHelpDescription,
 	Flags: append(globalFlags(),
 		cli.StringFlag{

--- a/clicommand/git_credentials_helper.go
+++ b/clicommand/git_credentials_helper.go
@@ -43,8 +43,8 @@ type GitCredentialsHelperConfig struct {
 
 var GitCredentialsHelperCommand = cli.Command{
 	Name:        "git-credentials-helper",
-	Usage:       "Ask buildkite for credentials to use to authenticate with Github when cloning",
-	Hidden:      true, // This command is not intended to be used directly by users, and is configured to be run by hosted compute jobs
+	Usage:       "Internal process used by hosted compute jobs to authenticate with Github",
+	Category:    categoryInternal,
 	Description: gitCredentialsHelperHelpDescription,
 	Flags: append(globalFlags(),
 		cli.StringFlag{

--- a/clicommand/kubernetes_bootstrap.go
+++ b/clicommand/kubernetes_bootstrap.go
@@ -40,6 +40,7 @@ type KubernetesBootstrapConfig struct {
 var KubernetesBootstrapCommand = cli.Command{
 	Name:        "kubernetes-bootstrap",
 	Usage:       "Rebootstraps the command after connecting to the Kubernetes socket",
+	Hidden:      true, // This command is not intended to be used directly by users, and is instead run by the agent-stack-k8s container
 	Description: bootstrapHelpDescription,
 	Flags: []cli.Flag{
 		KubernetesContainerIDFlag,

--- a/clicommand/kubernetes_bootstrap.go
+++ b/clicommand/kubernetes_bootstrap.go
@@ -39,8 +39,8 @@ type KubernetesBootstrapConfig struct {
 
 var KubernetesBootstrapCommand = cli.Command{
 	Name:        "kubernetes-bootstrap",
-	Usage:       "Rebootstraps the command after connecting to the Kubernetes socket",
-	Hidden:      true, // This command is not intended to be used directly by users, and is instead run by the agent-stack-k8s container
+	Usage:       "Harness used internally by the agent to run jobs on Kubernetes",
+	Category:    categoryInternal,
 	Description: bootstrapHelpDescription,
 	Flags: []cli.Flag{
 		KubernetesContainerIDFlag,

--- a/main.go
+++ b/main.go
@@ -16,7 +16,6 @@ import (
 )
 
 const appHelpTemplate = `Usage:
-
   {{.Name}} <command> [options...]
 
 Available commands are: {{range .VisibleCategories}}{{if .Name}}

--- a/main.go
+++ b/main.go
@@ -19,10 +19,10 @@ const appHelpTemplate = `Usage:
 
   {{.Name}} <command> [options...]
 
-Available commands are:
-
-  {{range .Commands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
-  {{end}}
+Available commands are: {{range .VisibleCategories}}{{if .Name}}
+{{.Name}}:{{range .VisibleCommands}}
+  {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{"\n"}}{{else}}{{range .VisibleCommands}}
+  {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{"\n"}}{{end}}{{end}}
 Use "{{.Name}} <command> --help" for more information about a command.
 `
 

--- a/main.go
+++ b/main.go
@@ -65,15 +65,10 @@ func main() {
 	app.Commands = clicommand.BuildkiteAgentCommands
 	app.ErrWriter = os.Stderr
 
-	// When no sub command is used
-	app.Action = func(c *cli.Context) {
-		_ = cli.ShowAppHelp(c)
-		os.Exit(1)
-	}
-
 	// When a sub command can't be found
 	app.CommandNotFound = func(c *cli.Context, command string) {
-		_ = cli.ShowAppHelp(c)
+		fmt.Fprintf(app.ErrWriter, "buildkite-agent: unknown subcommand %q\n", command)
+		fmt.Fprintf(app.ErrWriter, "Run '%s --help' for usage.\n", c.App.Name)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
### Description

#### TL;DR
<details>
<summary>Before</summary>

```
$ buildkite-agent --help
Usage:

  buildkite-agent <command> [options...]

Available commands are:

  start                   Starts a Buildkite agent
  bootstrap               Run a Buildkite job locally
  acknowledgements        Prints the licenses and notices of open source software incorporated into this software.
  annotate                Annotate the build page within the Buildkite UI with text from within a Buildkite job
  annotation              Make changes to an annotation on the currently running build
  artifact                Upload/download artifacts from Buildkite jobs
  build                   Interact with a Buildkite build
  env                     Process environment subcommands
  git-credentials-helper  Ask buildkite for credentials to use to authenticate with Github when cloning
  kubernetes-bootstrap    Rebootstraps the command after connecting to the Kubernetes socket
  lock                    Process lock subcommands
  redactor                Redact sensitive information from logs
  meta-data               Get/set data from Buildkite jobs
  oidc                    Interact with Buildkite OpenID Connect (OIDC)
  pause                   Pause the agent
  pipeline                Make changes to the pipeline of the currently running build
  resume                  Resume the agent
  secret                  Interact with Pipelines Secrets
  step                    Get or update an attribute of a build step, or cancel unfinished jobs for a step
  stop                    Stop the agent
  tool                    Utility commands, intended for users and operators of the agent to run directly on their machines, and not as part of a Buildkite job
  help                    Shows a list of commands or help for one command
```

```
$ buildkite-agent some-command-that-doesnt-exist
# ... the whole helptext in full, with no error message
```
</details>

<details>
<summary>After</summary>

```
Usage:
  buildkite-agent <command> [options...]

Available commands are:
  start             Starts a Buildkite agent
  acknowledgements  Prints the licenses and notices of open source software incorporated into this software.
  tool              Utilities for working with the Buildkite Agent
  help, h           Shows a list of commands or help for one command

Commands that can be run within a Buildkite job:
  annotate    Annotate the build page within the Buildkite UI with text from within a Buildkite job
  annotation  Make changes to annotations on the currently running build
  artifact    Upload/download artifacts from Buildkite jobs
  build       Interact with a Buildkite build
  env         Interact with the environment of the currently running build
  lock        Lock or unlock resources for the currently running build
  redactor    Redact sensitive information from logs
  meta-data   Get/set metadata from Buildkite jobs
  oidc        Interact with Buildkite OpenID Connect (OIDC)
  pause       Pause the agent
  pipeline    Make changes to the pipeline of the currently running build
  resume      Resume the agent
  secret      Interact with Pipelines Secrets
  step        Get or update an attribute of a build step, or cancel unfinished jobs for a step
  stop        Stop the agent

Internal commands, not intended to be run by users:
  bootstrap               Harness used internally by the agent to run jobs as subprocesses
  kubernetes-bootstrap    Harness used internally by the agent to run jobs on Kubernetes
  git-credentials-helper  Internal process used by hosted compute jobs to authenticate with Github

Use "buildkite-agent <command> --help" for more information about a command.
```

```
$ buildkite-agent some-command-that-doesnt-exist 
buildkite-agent: unknown subcommand "some-command-that-doesnt-exist"
Run 'buildkite-agent --help' for usage.
```
</details>

As I see it, the output of `buildkite-agent --help` as it stands has a couple of key issues:
- Commands that are not intended for use by end users (`bootstrap`, `kubernetes-bootstrap`, `git-credentials-helper`) are included in the help output
- Commands that the user can run, like `start`, are mixed in with ones they can't outside of a job, like `artifact upload`
- When an unknown subcommand is used, the agent just prints its helptext without giving any useful error message

This PR addresses each of these issues by:
- Hiding `bootstrap`, `kubernetes-bootstrap`, and `git-credentials-helper` in the help output
- Categorising the available commands section of the output of `buildkite-agent --help` into "things you could theoretically run in your terminal" and "things you can only run inside a job"
- Change the subcommand not found output to be of the form
```
buildkite-agent: unknown subcommand "some-command-that-doesnt-exist"
Run 'buildkite-agent --help' for usage.
```

Note that as part of this PR, the exit code when a user runs `buildkite-agent` (with no subcommand) has changed from 1 to 0.

For a preview of what the new output looks like, check out the "After" details block above.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)