### PR TITLE
Self-execute the path from os.Executable in more places

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"maps"
 	"os"
-	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"regexp"
@@ -788,18 +787,6 @@ var AgentStartCommand = cli.Command{
 		// used later to force the shutdown of the agent
 		ctx, cancel := context.WithCancel(ctx)
 
-		// Verify that the bootstrap buildkite-agent executable matches the current host agent
-		// executable. In development builds, it exits on mismatch; otherwise it only logs a warning.
-		// This is to avoid confusion when making changes to the buildkite-agent but forgetting to
-		// update the buildkite-agent binary available from $PATH
-		if err := checkBinaryPaths(); err != nil {
-			if version.IsDevelopmentBuild() {
-				return fmt.Errorf("check binary paths: %s", err)
-			} else {
-				l.Warn("check binary paths: %s", err)
-			}
-		}
-
 		// Remove any config env from the environment to prevent them propagating to bootstrap
 		if err := UnsetConfigFromEnvironment(c); err != nil {
 			return fmt.Errorf("failed to unset config from environment: %w", err)
@@ -1300,39 +1287,6 @@ var AgentStartCommand = cli.Command{
 
 		return err
 	},
-}
-
-// checkBinaryPaths looks up both the bootstrap and host buildkite-agent paths,
-// and returns an error if they do not match or if either cannot be determined.
-func checkBinaryPaths() error {
-	bootstrapPath, err := exec.LookPath("buildkite-agent")
-	if err != nil {
-		return fmt.Errorf("failed to locate bootstrap buildkite-agent: %w", err)
-	}
-
-	evalBootstrapPath, err := filepath.EvalSymlinks(bootstrapPath)
-	if err != nil {
-		return fmt.Errorf("failed to locate bootstrap buildkite-agent: %w", err)
-	}
-
-	hostPath, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("failed to determine host buildkite-agent executable: %w", err)
-	}
-
-	evalHostPath, err := filepath.EvalSymlinks(hostPath)
-	if err != nil {
-		return fmt.Errorf("failed to determine host buildkite-agent executable: %w", err)
-	}
-
-	if evalHostPath != evalBootstrapPath {
-		return fmt.Errorf(
-			"mismatched buildkite-agent paths: host=%q bootstrap=%q",
-			evalHostPath, evalBootstrapPath,
-		)
-	}
-
-	return nil
 }
 
 func parseAndValidateJWKS(ctx context.Context, keysetType, path string) (jwk.Set, error) {

--- a/internal/job/artifacts.go
+++ b/internal/job/artifacts.go
@@ -3,6 +3,7 @@ package job
 import (
 	"context"
 
+	"github.com/buildkite/agent/v3/internal/self"
 	"github.com/buildkite/agent/v3/tracetools"
 )
 
@@ -69,7 +70,7 @@ func (e *Executor) uploadArtifacts(ctx context.Context) error {
 		args = append(args, e.ArtifactUploadDestination)
 	}
 
-	if err = e.shell.Command("buildkite-agent", args...).Run(ctx); err != nil {
+	if err = e.shell.Command(self.Path(ctx), args...).Run(ctx); err != nil {
 		return err
 	}
 

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/buildkite/agent/v3/internal/experiments"
 	"github.com/buildkite/agent/v3/internal/osutil"
+	"github.com/buildkite/agent/v3/internal/self"
 	"github.com/buildkite/agent/v3/internal/shell"
 	"github.com/buildkite/agent/v3/tracetools"
 	"github.com/buildkite/roko"
@@ -32,12 +33,7 @@ func (e *Executor) configureGitCredentialHelper(ctx context.Context) error {
 		return fmt.Errorf("enabling git credential.useHttpPath: %w", err)
 	}
 
-	buildkiteAgent, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("getting executable path: %w", err)
-	}
-
-	helper := fmt.Sprintf(`%s git-credentials-helper`, buildkiteAgent)
+	helper := fmt.Sprintf(`%s git-credentials-helper`, self.Path(ctx))
 	err = e.shell.Command("git", "config", "--global", "credential.helper", helper).Run(ctx, shell.ShowPrompt(false))
 	if err != nil {
 		return fmt.Errorf("configuring git credential.helper: %w", err)
@@ -853,7 +849,7 @@ func (e *Executor) sendCommitToBuildkite(ctx context.Context) error {
 		return nil
 	}
 
-	cmd := e.shell.Command("buildkite-agent", "meta-data", "exists", CommitMetadataKey)
+	cmd := e.shell.Command(self.Path(ctx), "meta-data", "exists", CommitMetadataKey)
 	if err := cmd.Run(ctx); err == nil {
 		// Command exited 0, ie the key exists, so we don't need to send it again
 		e.shell.Commentf("Git commit information has already been sent to Buildkite")
@@ -886,7 +882,7 @@ func (e *Executor) sendCommitToBuildkite(ctx context.Context) error {
 	}
 
 	stdin := strings.NewReader(out)
-	cmd = e.shell.CloneWithStdin(stdin).Command("buildkite-agent", "meta-data", "set", CommitMetadataKey)
+	cmd = e.shell.CloneWithStdin(stdin).Command(self.Path(ctx), "meta-data", "set", CommitMetadataKey)
 	if err := cmd.Run(ctx); err != nil {
 		return fmt.Errorf("sending git commit information to Buildkite: %w", err)
 	}

--- a/internal/job/integration/artifact_integration_test.go
+++ b/internal/job/integration/artifact_integration_test.go
@@ -14,7 +14,7 @@ func TestArtifactsUploadAfterCommand(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -43,7 +43,7 @@ func TestArtifactsUploadAfterCommandFails(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -77,7 +77,7 @@ func TestArtifactsUploadAfterCommandHookFails(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -20,7 +20,7 @@ func TestCheckingOutGitHubPullRequests_WithGitMirrors(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -65,7 +65,7 @@ func TestWithResolvingCommitExperiment_WithGitMirrors(t *testing.T) {
 	ctx, _ := experiments.Enable(mainCtx, experiments.ResolveCommitAfterCheckout)
 	tester, err := NewExecutorTester(ctx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -104,7 +104,7 @@ func TestCheckingOutLocalGitProject_WithGitMirrors(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -153,7 +153,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules_WithGitMirrors(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -225,7 +225,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled_WithGitMirrors(t *test
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -286,7 +286,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject_WithGitMirrors(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -330,7 +330,7 @@ func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite_WithGitMirrors(t
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -350,7 +350,7 @@ func TestCheckingOutWithSSHKeyscan_WithGitMirrors(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -382,7 +382,7 @@ func TestCheckingOutWithoutSSHKeyscan_WithGitMirrors(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -407,7 +407,7 @@ func TestCheckingOutWithSSHKeyscanAndUnscannableRepo_WithGitMirrors(t *testing.T
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -440,7 +440,7 @@ func TestCleaningAnExistingCheckout_WithGitMirrors(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -480,7 +480,7 @@ func TestForcingACleanCheckout_WithGitMirrors(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -506,7 +506,7 @@ func TestCheckoutOnAnExistingRepositoryWithoutAGitFolder_WithGitMirrors(t *testi
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -537,7 +537,7 @@ func TestCheckoutRetriesOnCleanFailure_WithGitMirrors(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -569,7 +569,7 @@ func TestCheckoutRetriesOnCloneFailure_WithGitMirrors(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -599,7 +599,7 @@ func TestCheckoutDoesNotRetryOnHookFailure_WithGitMirrors(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -636,7 +636,7 @@ func TestRepositorylessCheckout_WithGitMirrors(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -669,7 +669,7 @@ func TestGitMirrorEnv(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -36,7 +36,7 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 	ctx, _ := experiments.Enable(mainCtx, experiments.ResolveCommitAfterCheckout)
 	tester, err := NewExecutorTester(ctx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -70,7 +70,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -114,7 +114,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -180,7 +180,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -236,7 +236,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -330,7 +330,7 @@ func TestCheckingOutGitHubPullRequestWithCommitHash(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -359,7 +359,7 @@ func TestCheckingOutGitHubPullRequestAndCustomRefmap(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -394,7 +394,7 @@ func TestCheckingOutGitHubPullRequestWithCommitHashAfterForcePush(t *testing.T) 
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -443,7 +443,7 @@ func TestCheckingOutGitHubPullRequestWithShortCommitHash(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -473,7 +473,7 @@ func TestCheckingOutGitHubPullRequestAtHead(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -502,7 +502,7 @@ func TestCheckingOutGitHubPullRequestAtHeadFromFork(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -535,7 +535,7 @@ func TestCheckoutErrorIsRetried(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -598,7 +598,7 @@ func TestFetchErrorIsRetried(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -660,7 +660,7 @@ func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -676,7 +676,7 @@ func TestCheckingOutWithSSHKeyscan(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -704,7 +704,7 @@ func TestCheckingOutWithoutSSHKeyscan(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -725,7 +725,7 @@ func TestCheckingOutWithSSHKeyscanAndUnscannableRepo(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -754,7 +754,7 @@ func TestCleaningAnExistingCheckout(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -790,7 +790,7 @@ func TestForcingACleanCheckout(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -812,7 +812,7 @@ func TestCheckoutOnAnExistingRepositoryWithoutAGitFolder(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -839,7 +839,7 @@ func TestCheckoutRetriesOnCleanFailure(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -867,7 +867,7 @@ func TestCheckoutRetriesOnCloneFailure(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -893,7 +893,7 @@ func TestCheckoutDoesNotRetryOnHookFailure(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -926,7 +926,7 @@ func TestRepositorylessCheckout(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -955,7 +955,7 @@ func TestGitCheckoutWithCommitResolved(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -982,7 +982,7 @@ func TestGitCheckoutWithoutCommitResolved(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -1009,7 +1009,7 @@ func TestGitCheckoutWithoutCommitResolvedAndNoMetaData(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 

--- a/internal/job/integration/command_integration_test.go
+++ b/internal/job/integration/command_integration_test.go
@@ -17,7 +17,7 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -47,7 +47,7 @@ func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 

--- a/internal/job/integration/docker_integration_test.go
+++ b/internal/job/integration/docker_integration_test.go
@@ -20,7 +20,7 @@ func argumentForCommand(cmd string) any {
 func TestRunningCommandWithDocker(t *testing.T) {
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -53,7 +53,7 @@ func TestRunningCommandWithDocker(t *testing.T) {
 func TestRunningCommandWithDockerAndCustomDockerfile(t *testing.T) {
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -87,7 +87,7 @@ func TestRunningCommandWithDockerAndCustomDockerfile(t *testing.T) {
 func TestRunningFailingCommandWithDocker(t *testing.T) {
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -126,7 +126,7 @@ func TestRunningFailingCommandWithDocker(t *testing.T) {
 func TestRunningCommandWithDockerCompose(t *testing.T) {
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -159,7 +159,7 @@ func TestRunningCommandWithDockerCompose(t *testing.T) {
 func TestRunningFailingCommandWithDockerCompose(t *testing.T) {
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -199,7 +199,7 @@ func TestRunningFailingCommandWithDockerCompose(t *testing.T) {
 func TestRunningCommandWithDockerComposeAndExtraConfig(t *testing.T) {
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -233,7 +233,7 @@ func TestRunningCommandWithDockerComposeAndExtraConfig(t *testing.T) {
 func TestRunningCommandWithDockerComposeAndBuildAll(t *testing.T) {
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 

--- a/internal/job/integration/executor_tester.go
+++ b/internal/job/integration/executor_tester.go
@@ -112,6 +112,11 @@ func NewExecutorTester(ctx context.Context) (*ExecutorTester, error) {
 			"BUILDKITE_JOB_ID=1111-1111-1111-1111",
 			"BUILDKITE_AGENT_ACCESS_TOKEN=test-token-please-ignore",
 			fmt.Sprintf("BUILDKITE_REDACTED_VARS=%s", strings.Join(*clicommand.RedactedVars.Value, ",")),
+			// Normally the executor will use the self-path to self-execute
+			// other subcommands such as 'artifact upload'.
+			// Because we've mocked buildkite-agent using bintest, we want it to
+			// use the mock instead.
+			"BUILDKITE_OVERRIDE_SELF=buildkite-agent",
 		},
 		PathDir:    pathDir,
 		BuildDir:   buildDir,

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -21,7 +21,7 @@ func TestEnvironmentVariablesPassBetweenHooks(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -65,7 +65,7 @@ func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -125,7 +125,7 @@ func TestDirectoryPassesBetweenHooks(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -159,7 +159,7 @@ func TestDirectoryPassesBetweenHooks(t *testing.T) {
 func TestDirectoryPassesBetweenHooksIgnoredUnderExit(t *testing.T) {
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -196,7 +196,7 @@ func TestCheckingOutFiresCorrectHooks(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -226,7 +226,7 @@ func TestReplacingCheckoutHook(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -255,7 +255,7 @@ func TestReplacingGlobalCommandHook(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -280,7 +280,7 @@ func TestReplacingLocalCommandHook(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -306,7 +306,7 @@ func TestPreExitHooksFireAfterCommandFailures(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -325,7 +325,7 @@ func TestPreExitHooksDoesNotFireWithoutCommandPhase(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -418,7 +418,7 @@ func TestPreExitHooksFireAfterHookFailures(t *testing.T) {
 
 			tester, err := NewExecutorTester(ctx)
 			if err != nil {
-				t.Fatalf("NewBootstrapTester() error = %v", err)
+				t.Fatalf("NewExecutorTester() error = %v", err)
 			}
 			defer tester.Close()
 
@@ -468,7 +468,7 @@ func TestNoLocalHooksCalledWhenConfigSet(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -504,7 +504,7 @@ func TestExitCodesPropagateOutFromGlobalHooks(t *testing.T) {
 		t.Run(hook, func(t *testing.T) {
 			tester, err := NewExecutorTester(ctx)
 			if err != nil {
-				t.Fatalf("NewBootstrapTester() error = %v", err)
+				t.Fatalf("NewExecutorTester() error = %v", err)
 			}
 			defer tester.Close()
 
@@ -534,7 +534,7 @@ func TestPreExitHooksFireAfterCancel(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -581,7 +581,7 @@ func TestPolyglotScriptHooksCanBeRun(t *testing.T) {
 
 	tester, err := NewExecutorTester(ctx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -609,7 +609,7 @@ func TestPolyglotBinaryHooksCanBeRun(t *testing.T) {
 
 	tester, err := NewExecutorTester(ctx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 

--- a/internal/job/integration/job_api_integration_test.go
+++ b/internal/job/integration/job_api_integration_test.go
@@ -19,7 +19,7 @@ func TestBootstrapRunsJobAPI(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 

--- a/internal/job/integration/plugin_integration_test.go
+++ b/internal/job/integration/plugin_integration_test.go
@@ -20,7 +20,7 @@ func TestRunningPlugins(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -81,7 +81,7 @@ func TestExitCodesPropagateOutFromPlugins(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -128,7 +128,7 @@ func TestMalformedPluginNamesDontCrashBootstrap(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -152,7 +152,7 @@ func TestOverlappingPluginHooks(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -216,7 +216,7 @@ func TestPluginCloneRetried(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -285,11 +285,11 @@ func TestModifiedPluginNoForcePull(t *testing.T) {
 
 	tester, err := NewExecutorTester(ctx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
-	// Let's set a fixed location for plugins, otherwise NewBootstrapTester() gives us a random new
+	// Let's set a fixed location for plugins, otherwise NewExecutorTester() gives us a random new
 	// tempdir every time, which defeats our test.  Later we'll use this pluginsDir for the second
 	// test run, too.
 	pluginsDir, err := os.MkdirTemp("", "bootstrap-plugins")
@@ -299,7 +299,7 @@ func TestModifiedPluginNoForcePull(t *testing.T) {
 	tester.PluginsDir = pluginsDir
 
 	// There's a bit of machinery in replacePluginPathInEnv to modify only the
-	// BUILDKITE_PLUGINS_PATH, leaving the rest of the environment variables NewBootstrapTester()
+	// BUILDKITE_PLUGINS_PATH, leaving the rest of the environment variables NewExecutorTester()
 	// gave us as-is.
 	tester.Env = replacePluginPathInEnv(tester.Env, pluginsDir)
 
@@ -352,7 +352,7 @@ func TestModifiedPluginNoForcePull(t *testing.T) {
 	// Now, we want to "repeat" the test build, having modified the plugin's contents.
 	tester2, err := NewExecutorTester(ctx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester2.Close()
 
@@ -398,7 +398,7 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester.Close()
 
@@ -455,7 +455,7 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 
 	tester2, err := NewExecutorTester(ctx)
 	if err != nil {
-		t.Fatalf("NewBootstrapTester() error = %v", err)
+		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
 	defer tester2.Close()
 
@@ -588,7 +588,7 @@ func (tp *testPlugin) MarshalJSON() ([]byte, error) {
 }
 
 // replacePluginPathInEnv is useful for modifying the Env blob of a tester created with
-// NewBootstrapTester().  We need to do that because the tester relies on BUILDKITE_PLUGINS_PATH,
+// NewExecutorTester().  We need to do that because the tester relies on BUILDKITE_PLUGINS_PATH,
 // not on the .PluginsDir field as one might expect.
 func replacePluginPathInEnv(originalEnv []string, pluginsDir string) (newEnv []string) {
 	newEnv = []string{}

--- a/internal/self/self.go
+++ b/internal/self/self.go
@@ -1,0 +1,37 @@
+// Package self implements helpers for self-interaction.
+package self
+
+import (
+	"context"
+	"os"
+)
+
+// Overwritten by init.
+var pathToSelf = "buildkite-agent"
+
+func init() {
+	p, err := os.Executable()
+	if err != nil {
+		return
+	}
+	pathToSelf = p
+}
+
+type ctxKey struct{}
+
+// Path returns an absolute file path to buildkite-agent. If an absolute
+// path cannot be found, it defaults to "buildkite-agent" on the assumption it
+// is in $PATH. Self-executing with this path can still fail if someone is
+// playing games (e.g. unlinking the binary after starting it).
+func Path(ctx context.Context) string {
+	if val := ctx.Value(ctxKey{}); val != nil {
+		return val.(string)
+	}
+	return pathToSelf
+}
+
+// OverridePath changes the self-path used within a context. This is usually
+// only used for testing purposes (creating a mock of buildkite-agent.)
+func OverridePath(parent context.Context, path string) context.Context {
+	return context.WithValue(parent, ctxKey{}, path)
+}

--- a/version/version.go
+++ b/version/version.go
@@ -38,10 +38,6 @@ func BuildNumber() string {
 	return buildNumber
 }
 
-func IsDevelopmentBuild() bool {
-	return buildNumber == "x"
-}
-
 // commitInfo returns a string consisting of the commit hash and whether the the build was made in a
 // `dirty` working directory or not. A dirty working directory is one that has uncommitted changes
 // to files that git would track.


### PR DESCRIPTION
### Description

Remove `checkBinaryPaths`, and self-execute using the result from `os.Executable` in more places.

Unfortunately we can't yet totally solve the sorry-Mario-your-`buildkite-agent`-is-in-another-castle problem (`buildkite-agent` within a command or script run as part of a step can still be a separate binary). 

### Context

`checkBinaryPaths` creates the need for some ugly workarounds elsewhere for those who build the agent themselves.

https://linear.app/buildkite/issue/PS-732

### Changes

- Revert #3123 
- Add a `self` internal package for managing path to self, and provide a way to override during tests
- Use `self.Path` for artifact phase, setting metadata, and the credential helper.
- Use `self.OverridePath` within the bootstrap subcommand, if a magic combination of undocumented env vars is present


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

