### PR TITLE
Fix PR ref retry logic

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -400,7 +400,6 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string) (stri
 				Shell:      e.shell,
 				GitFlags:   fmt.Sprintf("--git-dir=%s", mirrorDir),
 				Repository: "origin",
-				Retry:      true,
 				RefSpecs:   []string{e.Branch},
 			}); err != nil {
 				return "", err
@@ -811,7 +810,6 @@ func gitFetchWithFallback(ctx context.Context, shell *shell.Shell, gitFetchFlags
 		Shell:         shell,
 		GitFetchFlags: gitFetchFlags,
 		Repository:    "origin",
-		Retry:         true,
 		RefSpecs:      []string{gitFetchRefspec, "+refs/tags/*:refs/tags/*"},
 	}); err != nil {
 		return fmt.Errorf("fetching refspecs %v: %w", refspecs, err)

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -75,7 +75,7 @@ func (e *Executor) removeCheckoutDir() error {
 		<-time.After(time.Second * 10)
 	}
 
-	return fmt.Errorf("Failed to remove %s", checkoutPath)
+	return fmt.Errorf("failed to remove %s", checkoutPath)
 }
 
 func (e *Executor) createCheckoutDir() error {
@@ -207,7 +207,7 @@ func (e *Executor) CheckoutPhase(ctx context.Context) error {
 					// keeps failing. This removes the checkout dir, which means the next checkout will be a lot slower (clone vs
 					// fetch), but hopefully will allow the agent to self-heal
 					if err := e.removeCheckoutDir(); err != nil {
-						e.shell.Printf("Failed to remove checkout dir while cleaning up after a checkout error.")
+						e.shell.Warningf("Failed to remove checkout dir while cleaning up after a checkout error: %v", err)
 					}
 
 					// Now make sure the build directory exists again before we try to checkout again, or proceed and run hooks
@@ -226,7 +226,7 @@ func (e *Executor) CheckoutPhase(ctx context.Context) error {
 
 				// If it's some kind of error that we don't know about, clean the checkout dir just to be safe
 				if err := e.removeCheckoutDir(); err != nil {
-					e.shell.Printf("Failed to remove checkout dir while cleaning up after a checkout error.")
+					e.shell.Warningf("Failed to remove checkout dir while cleaning up after a checkout error: %v", err)
 				}
 
 				// Now make sure the build directory exists again before we try to checkout again, or proceed and run hooks
@@ -397,7 +397,7 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string) (stri
 
 	if isMainRepository {
 		if e.PullRequest != "false" && strings.Contains(e.PipelineProvider, "github") {
-			e.shell.Commentf("Fetch and mirror pull request head from GitHub. This will be retried if it fails, as the pull request head might not be available yet — GitHub creates them asynchronously")
+			e.shell.Commentf("Fetching and mirroring pull request head from GitHub. This will be retried if it fails, as the pull request head might not be available yet — GitHub creates them asynchronously")
 			refspec := fmt.Sprintf("refs/pull/%s/head", e.PullRequest)
 
 			// Fetch the PR head from the upstream repository into the mirror.

--- a/internal/job/checkout_test.go
+++ b/internal/job/checkout_test.go
@@ -185,20 +185,17 @@ func TestDefaultCheckoutPhase_DelayedRefCreation(t *testing.T) {
 	tt.executor.Repository = s.RepoURL(tt.projectName)
 
 	checkoutDir, err := os.MkdirTemp("", "checkout-path-")
+	assert.NoError(err)
+	defer os.RemoveAll(checkoutDir)
 
 	// Concurrently sleep for 5 seconds to delay ref being created
 	go func() {
 		time.Sleep(5 * time.Second)
-
 		out, err = s.CreateRef(tt.projectName, tt.refSpec, commit)
 		if err != nil {
-			t.Fatalf("failed to create ref: %v output: %s", err, string(out))
+			t.Errorf("failed to create ref: %v output: %s", err, string(out))
 		}
-
 	}()
-
-	assert.NoError(err)
-	defer os.RemoveAll(checkoutDir)
 
 	shell.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", checkoutDir)
 

--- a/internal/job/git.go
+++ b/internal/job/git.go
@@ -35,9 +35,9 @@ const (
 )
 
 const (
-	gitErrStrbadObject             = "fatal: bad object"
-	gitErrStrbadReference          = "fatal: couldn't find remote ref"
-	gitErrStrbadReferencePreGit221 = "fatal: Couldn't find remote ref"
+	gitErrStrBadObject             = "fatal: bad object"
+	gitErrStrBadReference          = "fatal: couldn't find remote ref"
+	gitErrStrBadReferencePreGit221 = "fatal: Couldn't find remote ref"
 )
 
 var (
@@ -180,9 +180,9 @@ func gitFetch(ctx context.Context, args gitFetchArgs) error {
 	}
 
 	smelt := map[string]bool{
-		gitErrStrbadObject:             false,
-		gitErrStrbadReference:          false,
-		gitErrStrbadReferencePreGit221: false,
+		gitErrStrBadObject:             false,
+		gitErrStrBadReference:          false,
+		gitErrStrBadReferencePreGit221: false,
 	}
 
 	// The retry logic is used to handle rare cases where a commit ref is not yet available
@@ -207,7 +207,7 @@ func gitFetch(ctx context.Context, args gitFetchArgs) error {
 			// "fatal: [Cc]ouldn't find remote ref" happens when the remote ref does not exist (e.g. a branch that was deleted)
 			// Sometimes we want to wait for the remote ref to be created (eg in the case of the PR HEAD ref `refs/pulls/123/head
 			// that github creates asynchronously), so this case gets retried -- we don't call r.Break()
-			if smelt[gitErrStrbadReference] || smelt[gitErrStrbadReferencePreGit221] {
+			if smelt[gitErrStrBadReference] || smelt[gitErrStrBadReferencePreGit221] {
 				args.Shell.Commentf("%s", retrier)
 				return &gitError{error: err, Type: gitErrorFetchBadReference, WasRetried: args.Retry}
 			}
@@ -218,7 +218,7 @@ func gitFetch(ctx context.Context, args gitFetchArgs) error {
 			// reference to an object that it expects in the mirror, but the mirror
 			// no longer contains it (for whatever reason).
 			// See the NOTE under --shared at https://git-scm.com/docs/git-clone.
-			if smelt[gitErrStrbadObject] {
+			if smelt[gitErrStrBadObject] {
 				retrier.Break()
 				return &gitError{error: err, Type: gitErrorFetchBadObject}
 			}

--- a/internal/job/git_test.go
+++ b/internal/job/git_test.go
@@ -297,8 +297,13 @@ func TestGitFetch(t *testing.T) {
 		t.Fatalf("sh.AbsolutePath(git) = %v", err)
 	}
 
-	if err := gitFetch(ctx, sh, "", "--foo --bar", "repo", false, "ref1", "ref2"); err != nil {
-		t.Fatalf(`gitFetch(ctx, sh, "--foo --bar", "repo", "ref1", "ref2") = %v`, err)
+	if err := gitFetch(ctx, gitFetchArgs{
+		Shell:         sh,
+		GitFetchFlags: "--foo --bar",
+		Repository:    "repo",
+		RefSpecs:      []string{"ref1", "ref2"},
+	}); err != nil {
+		t.Fatalf(`gitFetch(ctx, gitFetchArgs{Shell: sh, GitFetchFlags: "--foo --bar", Remote: "repo", RefSpecs: []string{"ref1", "ref2"}} = %v`, err)
 	}
 
 	wantLog := [][]string{{absoluteGit, "fetch", "--foo", "--bar", "--", "repo", "ref1", "ref2"}}


### PR DESCRIPTION
### Description

In #3294, we introduced behaviour to retry `git fetch`es during the default checkout hook for checkouts using git mirrors. This is because during the checkout process for a PR build we fetch the `refs/pull/<some number>/head` ref that GitHub creates. The creation of this ref happens asynchronously to the PR being opened though, so in some cases a build will have started before the ref has been created. In this situation we're trying to fetch a ref that doesn't (yet) exist, which will fail the fetch, so we wait around and retry for a bit until either the ref exists, or we run out our retry loop, which tries 10 times over about 2 minutes.

However, #3294 also introduced a couple of bugs and oddities in this flow, primarily that:
1. The retry loop for fetching PR refs was nested inside [another retry loop](https://github.com/buildkite/agent/blob/main/internal/job/checkout.go#L160-L163) encapsulating the whole checkout phase. This meant that if there were a non-transient error in fetching the ref, both the inner (just retrying the fetch) and the outer (retrying the entire checkout phase) retry loop would run, meaning that the error would be retried 30 times instead of 10, and take ~7 minutes instead of ~2
1. Instead of just retrying the fetch for the PR head ref (`refs/pull/123/head`), all fetches in the git mirror update would be retried 30 times, not just the PR head ref. This means that if, for example, someone were to create a build against a branch that doesn't exist, the agent would try to check out that branch for 7 minutes before finally giving up, even though that branch is never going to exist

This PR fixes the above two issues, and makes a couple of cleanups along the way. It:
- Makes it so that only the PR ref fetch is retried, so bug/oddity number 2 doesn't happen. Fetches for refs that aren't the PR head won't have an inner retry loop, and will only retried as part of the outer (entire checkout phase) retry loop
- Makes it so that if the inner retry loop happens, the outer one is skipped -- so if fetching the PR head ref fails 10 times, it won't get kicked back out to the outer retry loop

All of this is to say that users will generally be waiting around on git fetches a whole bunch less now.

Additionally, I've made a couple of non-functional changes:
- The `job.gitFetch` function's signature was getting super long and hard to read, so I've updated it to use an args struct
- Make the error handling in the checkout phase a little more straightforward, with slightly fewer nested switches
- I've spruced up the logs for retrying PR head ref fetches a wee bit:
<details>
<summary>Before</summary>

![CleanShot 2025-06-13 at 15 05 04@2x](https://github.com/user-attachments/assets/63b57146-d313-4218-9fd4-dc927e19c9ce)
</details>

<details>
<summary>After</summary>

![CleanShot 2025-06-13 at 15 05 52@2x](https://github.com/user-attachments/assets/79ca8489-f9dc-44c9-8410-f216b76ed609)
</details>

### Context

[PS-755](https://linear.app/buildkite/issue/PS-755)

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
