### PR TITLE
PS-794: fix vendored plugin path ending with slash breaking envvar names

### DIFF
--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -141,6 +141,7 @@ func (p *Plugin) Name() string {
 	}
 	// for filepaths, we can get windows backslashes, so we normalize them
 	location := strings.Replace(p.Location, "\\", "/", -1)
+	location = strings.TrimRight(location, "/") // Trailing slash is useless and will confuse the subsequent parsing
 
 	// Grab the last part of the location
 	parts := strings.Split(location, "/")

--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -189,6 +189,14 @@ func TestPluginNameParsedFromLocation(t *testing.T) {
 			wantName: "vendored-with-a-space",
 		},
 		{
+			location: "vendor/src/vendored-with-a-slash/",
+			wantName: "vendored-with-a-slash",
+		},
+		{
+			location: "vendor/src/vendored-with-two-slash//",
+			wantName: "vendored-with-two-slash",
+		},
+		{
 			location: "./.buildkite/plugins/docker-compose",
 			wantName: "docker-compose",
 		},


### PR DESCRIPTION
### Description

Fixes an issue when vendored plugin path ending with `/`, the plugin parameter env var becomes: `BUILDKITE_PLUGINS__{var name}` instead of `BUILDKITE_PLUGINS_{plugin name}_{var name}`.

### Context

PS-794

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)