### PR TITLE
[PIPE-1021] Propagate parent OTel trace/span from backend if provided

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -617,6 +617,10 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	if r.conf.AgentConfiguration.TracingBackend != "" {
 		env["BUILDKITE_TRACING_BACKEND"] = r.conf.AgentConfiguration.TracingBackend
 		env["BUILDKITE_TRACING_SERVICE_NAME"] = r.conf.AgentConfiguration.TracingServiceName
+
+		if r.conf.Job.TraceParent != "" {
+			env["BUILDKITE_TRACING_TRACEPARENT"] = r.conf.Job.TraceParent
+		}
 	}
 
 	env["BUILDKITE_AGENT_DISABLE_WARNINGS_FOR"] = strings.Join(r.conf.AgentConfiguration.DisableWarningsFor, ",")

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -25,6 +25,7 @@ type Job struct {
 	FinishedAt         string                     `json:"finished_at,omitempty"`
 	RunnableAt         string                     `json:"runnable_at,omitempty"`
 	ChunksFailedCount  int                        `json:"chunks_failed_count,omitempty"`
+	TraceParent        string                     `json:"traceparent"`
 }
 
 type JobState struct {

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -97,6 +97,7 @@ type BootstrapConfig struct {
 	RedactedVars                 []string `cli:"redacted-vars" normalize:"list"`
 	TracingBackend               string   `cli:"tracing-backend"`
 	TracingServiceName           string   `cli:"tracing-service-name"`
+	TracingTraceParent           string   `cli:"tracing-traceparent"`
 	TraceContextEncoding         string   `cli:"trace-context-encoding"`
 	NoJobAPI                     bool     `cli:"no-job-api"`
 	DisableWarningsFor           []string `cli:"disable-warnings-for" normalize:"list"`
@@ -358,6 +359,12 @@ var BootstrapCommand = cli.Command{
 			EnvVar: "BUILDKITE_TRACING_SERVICE_NAME",
 			Value:  "buildkite-agent",
 		},
+		cli.StringFlag{
+			Name:   "tracing-traceparent",
+			Usage:  "W3C Trace Parent for tracing",
+			EnvVar: "BUILDKITE_TRACING_TRACEPARENT",
+			Value:  "",
+		},
 		cli.BoolFlag{
 			Name:   "no-job-api",
 			Usage:  "Disables the Job API, which gives commands in jobs some abilities to introspect and mutate the state of the job.",
@@ -471,6 +478,7 @@ var BootstrapCommand = cli.Command{
 			TracingBackend:               cfg.TracingBackend,
 			TracingServiceName:           cfg.TracingServiceName,
 			TraceContextCodec:            traceContextCodec,
+			TracingTraceParent:           cfg.TracingTraceParent,
 			JobAPI:                       !cfg.NoJobAPI,
 			DisabledWarnings:             cfg.DisableWarningsFor,
 			KubernetesExec:               cfg.KubernetesExec,

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -169,6 +169,9 @@ type ExecutorConfig struct {
 	// Service name to use when reporting traces.
 	TracingServiceName string
 
+	// Traceing context information
+	TracingTraceParent string
+
 	// Encoding (within base64) for the trace context environment variable.
 	TraceContextCodec tracetools.Codec
 


### PR DESCRIPTION
### Description

As part of the OpenTelemetry Tracing Notification Service work, we provide the `traceparent` from the job acquire / accept endpoints. When present, and the user has opted-in, we set the root span for the job to use the provided trace/parent span id.

This is based on the W3C Tracecontext


### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
