### PR TITLE
Fix AquireJob to return early and trigger a sentinal error for rejection

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -243,6 +243,12 @@ func (a *AgentWorker) Start(ctx context.Context, idleMonitor *IdleMonitor) error
 		idleMonitor.MarkBusy(a.agent.UUID)
 
 		if err := a.AcquireAndRunJob(ctx, a.agentConfiguration.AcquireJob); err != nil {
+			// If the job acquisition was rejected, we can exit with an error
+			// so that supervisor knows that the job was not acquired due to the job being rejected.
+			if errors.Is(err, core.ErrJobAcquisitionRejected) {
+				return fmt.Errorf("Failed to acquire job %q: %w", a.agentConfiguration.AcquireJob, err)
+			}
+
 			a.logger.Error("Failed to acquire and run job: %v", err)
 		}
 	}


### PR DESCRIPTION
### Description

This change https://github.com/buildkite/agent/commit/77fc7dc04462183d29d44217a18d13fa710fabd7 introduced a regression which resulted in acquire job not triggering a exit code 27 for jobs when acquire job API calls are rejected by buildkite.

### Context

https://linear.app/buildkite/issue/MDC-493/regression-in-agent-behavior-not-reporting-non-eligible-jobs

### Changes

Do the same sentinel error check on the return from AcquireAndRunJob and returning early to restore the previous exit code behaviour.

> [!WARNING]  
> This change resolves a regression, if you encounter issues with this release rollback raise an issue or contact support@buildkite.com

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
