### PR TITLE
Add validate_dependencies flag to pipeline upload

### DIFF
--- a/api/pipelines.go
+++ b/api/pipelines.go
@@ -9,9 +9,10 @@ import (
 type PipelineChange struct {
 	// UUID identifies this pipeline change. We keep this constant during
 	// retry loops so that work is not repeated on the API server
-	UUID     string `json:"uuid"`
-	Pipeline any    `json:"pipeline"`
-	Replace  bool   `json:"replace,omitempty"`
+	UUID                 string `json:"uuid"`
+	Pipeline             any    `json:"pipeline"`
+	Replace              bool   `json:"replace,omitempty"`
+	ValidateDependencies bool   `json:"validate_dependencies,omitempty"`
 }
 
 type PipelineUploadStatus struct {

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -18,8 +18,9 @@ func TestSearchForSecrets(t *testing.T) {
 	t.Parallel()
 
 	cfg := &PipelineUploadConfig{
-		RedactedVars:  []string{"SEKRET", "SSH_KEY"},
-		RejectSecrets: true,
+		RedactedVars:         []string{"SEKRET", "SSH_KEY"},
+		RejectSecrets:        true,
+		ValidateDependencies: false,
 	}
 
 	plainPipeline := &pipeline.Pipeline{


### PR DESCRIPTION
### Description

Adds a `--validate-dependencies` flag to the pipeline upload command, which will fail the upload if any steps depend on keys that don't exist.

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

### Changes

```
❯ ./buildkite-agent-local pipeline upload --help
Usage:

    buildkite-agent pipeline upload [file] [options...]

<snip>

Options:

<snip>

  --validate-dependencies      When true, validates the dependencies of each step when uploading. [$BUILDKITE_PIPELINE_VALIDATE_DEPENDENCIES]

```

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
