### PR TITLE
Add disconnect-after-uptime flag to set a max lifetime for agents

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -49,6 +49,7 @@ type AgentConfiguration struct {
 	HealthCheckAddr              string
 	DisconnectAfterJob           bool
 	DisconnectAfterIdleTimeout   int
+	DisconnectAfterUptime        int
 	CancelGracePeriod            int
 	SignalGracePeriod            time.Duration
 	EnableJobLogTmpfile          bool


### PR DESCRIPTION
### Description

We want our buildkite agent fleet to regularly cycle out machines, but we always have at least some jobs running in our cluster which leads to some agents staying up for a long period of time, even with disconnect-after-idle-timeout set. This PR adds an additional config option to set a max lifetime for the buildkite agent, after which time it will shut itself down.

I am not super familiar with Golang, but I modeled this after the existing disconnect-after-timeout flag. I tested this locally and it seems to perform as desired.

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

* Added new config option disconnect-after-uptime
* Added a test for the new functionality

```
  --disconnect-after-uptime value          The maximum uptime in seconds before the agent stops accepting ne
w jobs and shuts down after any running jobs complete. The default of 0 means no timeout (default: 0) [$BUIL
DKITE_AGENT_DISCONNECT_AFTER_UPTIME]
```

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
