### PR TITLE
Print valid json

### DIFF
--- a/logger/log.go
+++ b/logger/log.go
@@ -6,6 +6,7 @@
 package logger
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -250,7 +251,13 @@ func (p *JSONPrinter) Print(level Level, msg string, fields Fields) {
 
 	b.WriteString(fmt.Sprintf(`"ts":%q,`, time.Now().Format(time.RFC3339)))
 	b.WriteString(fmt.Sprintf(`"level":%q,`, level.String()))
-	b.WriteString(fmt.Sprintf(`"msg":%q,`, msg))
+
+	// Serialize msg to JSON so we're not producing invalid JSON
+	jsonMsg, err := json.Marshal(msg)
+	if err != nil {
+		jsonMsg = []byte(`"error marshaling message"`)
+	}
+	b.WriteString(fmt.Sprintf(`"msg":%s,`, jsonMsg))
 
 	for _, field := range fields {
 		b.WriteString(fmt.Sprintf("%q:%q,", field.Key(), field.String()))

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -95,3 +95,16 @@ func TestJSONPrinter(t *testing.T) {
 		t.Fatalf("bad level, got %v", val)
 	}
 }
+
+func TestJSONPrinterSpecialCharacters(t *testing.T) {
+	b := &bytes.Buffer{}
+
+	printer := logger.NewJSONPrinter(b)
+	printer.Print(logger.INFO, "\x1b", logger.Fields{logger.StringField("key", "val")})
+
+	var results map[string]any
+	err := json.Unmarshal(b.Bytes(), &results)
+	if err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+}


### PR DESCRIPTION
### Description

When setting the agent log output to JSON, the output is sometimes not valid JSON. For instance, when using ANSI links or colours (`"\e]1339;url=#{url};content=#{caption}\a"` or `"\e[#{color_code}m#{text}\e[0m"`).