### PR TITLE
Exit with same code in acquire-job mode

### DIFF
--- a/agent/dummy_bootstrap.sh
+++ b/agent/dummy_bootstrap.sh
@@ -1,1 +1,0 @@
-# An empty script that exits 0

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1300,6 +1300,11 @@ var AgentStartCommand = cli.Command{
 			const acquisitionFailedExitCode = 27 // chosen by fair dice roll
 			return cli.NewExitError(err, acquisitionFailedExitCode)
 		}
+		if exit := new(core.ProcessExit); errors.As(err, exit) {
+			// If the agent acquired a job and it failed or was cancelled,
+			// then report its exit code as our own.
+			return cli.NewExitError(err, exit.Status)
+		}
 
 		return err
 	},

--- a/core/process_exit.go
+++ b/core/process_exit.go
@@ -1,9 +1,29 @@
 package core
 
+import (
+	"fmt"
+	"strings"
+)
+
 // ProcessExit describes how a process exited: if it was signaled, what its
 // exit code was
 type ProcessExit struct {
 	Status       int
 	Signal       string
 	SignalReason string
+}
+
+// Error allows ProcessExit to be passed through error returns.
+func (e ProcessExit) Error() string {
+	if e.Status == 0 {
+		return "process exited normally"
+	}
+	bits := []string{fmt.Sprintf("status=%d", e.Status)}
+	if e.Signal != "" {
+		bits = append(bits, "signal="+e.Signal)
+	}
+	if e.SignalReason != "" {
+		bits = append(bits, "reason="+e.SignalReason)
+	}
+	return "process exited with " + strings.Join(bits, ", ")
 }

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -982,17 +982,13 @@ func (e *Executor) CommandPhase(ctx context.Context) (hookErr error, commandErr 
 
 	switch {
 	case isExitError && isExitSignaled:
-		// The recursive trap created a segfault that we were previously inadvertently suppressing
-		// in the next branch. Once the experiment is promoted, we should keep this branch in case
-		// to show the error to users.
 		e.shell.Errorf("The command was interrupted by a signal: %v", commandErr)
+		return nil, commandErr
 
-		// although error is an exit error, it's not returned. (seems like a bug)
-		// TODO: investigate phasing this out under a experiment
-		return nil, nil
 	case isExitError && !isExitSignaled:
 		e.shell.Errorf("The command exited with status %d", shell.ExitCode(commandErr))
 		return nil, commandErr
+
 	default:
 		e.shell.Errorf("%s", commandErr)
 


### PR DESCRIPTION
### Description

For acquire-job cases, making the agent reflect the exit code makes it easier to integrate the agent into more things.

### Context

Fixes #3369

- [x] TODO: check this fixes the issue
- [x] TODO: convince ourselves this doesn't introduce significant problems

### Changes

- Make `core.ProcessExit` a kind of `error`, so that it can be returned easily. 
- If a `core.ProcessExit` lands in the `start` command, exit with the same status.
- Return the `core.ProcessExit` from the job runner if the agent is set to acquire job and the exit status was non-zero.
- Fix the "seems like a bug" issue where the exit code of a process within the bootstrap would be swallowed following being signaled.
- Remove "dummy_bootstrap.sh" in favour of a small (OS-dependent) no-op command, and ensure the build and hooks subdirs exist. Turns out the "dummy_bootstrap.sh" approach didn't actually work, and now that the process error is propagating in some scenarios, the test broke.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

