### PR TITLE
Normalise indentation in redactor add usage

### DIFF
--- a/clicommand/redactor_add.go
+++ b/clicommand/redactor_add.go
@@ -61,23 +61,23 @@ Examples:
 
 To redact the verbatim contents of the file 'id_ed25519' from future logs:
 
-	$ buildkite-agent redactor add id_ed25519
+    $ buildkite-agent redactor add id_ed25519
 
 To redact the string 'llamasecret' from future logs:
 
-	$ echo llamasecret | buildkite-agent redactor add
+    $ echo llamasecret | buildkite-agent redactor add
 
 Pass a flat JSON object whose keys are unique and whose values are your secrets:
 
-	$ echo '{"db_password":"secret1","api_token":"secret2","ssh_key":"secret3"}' | buildkite-agent redactor add --format json
+    $ echo '{"db_password":"secret1","api_token":"secret2","ssh_key":"secret3"}' | buildkite-agent redactor add --format json
 
 Or
 
-	$ buildkite-agent redactor add --format json my-secrets.json
+    $ buildkite-agent redactor add --format json my-secrets.json
 
 JSON does not allow duplicate keys. If you repeat the same key ("key"), the JSON parser keeps only the final entry, so only that single value is added to the redactor:
 
-        $ echo '{"key":"value1","key":"value2","key":"value3"}' | buildkite-agent redactor add --format json`,
+    $ echo '{"key":"value1","key":"value2","key":"value3"}' | buildkite-agent redactor add --format json`,
 	Flags: slices.Concat(globalFlags(), apiFlags(), []cli.Flag{
 		cli.StringFlag{
 			Name:   "format",


### PR DESCRIPTION
### Description

The documentation update script expects 4 space indents for shell examples.

### Context

I noticed this while updating the docs.

### Changes

Make the indentation consistently 4 spaces.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
