### PR TITLE
Add reflect-exit-status flag to control exiting with job status

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -107,6 +107,7 @@ type AgentStartConfig struct {
 	DisconnectAfterUptime      int    `cli:"disconnect-after-uptime"`
 	CancelGracePeriod          int    `cli:"cancel-grace-period"`
 	SignalGracePeriodSeconds   int    `cli:"signal-grace-period-seconds"`
+	ReflectExitStatus          bool   `cli:"reflect-exit-status"`
 
 	EnableJobLogTmpfile bool   `cli:"enable-job-log-tmpfile"`
 	JobLogPath          string `cli:"job-log-path" normalize:"filepath"`
@@ -356,6 +357,11 @@ var AgentStartCommand = cli.Command{
 			Value:  "",
 			Usage:  "Start this agent and only run the specified job, disconnecting after it's finished",
 			EnvVar: "BUILDKITE_AGENT_ACQUIRE_JOB",
+		},
+		cli.BoolFlag{
+			Name:   "reflect-exit-status",
+			Usage:  "When used with --acquire-job, causes the agent to exit with the same exit status as the job",
+			EnvVar: "BUILDKITE_AGENT_REFLECT_EXIT_STATUS",
 		},
 		cli.BoolFlag{
 			Name:   "disconnect-after-job",
@@ -1301,7 +1307,7 @@ var AgentStartCommand = cli.Command{
 			const acquisitionFailedExitCode = 27 // chosen by fair dice roll
 			return cli.NewExitError(err, acquisitionFailedExitCode)
 		}
-		if exit := new(core.ProcessExit); errors.As(err, exit) {
+		if exit := new(core.ProcessExit); errors.As(err, exit) && cfg.ReflectExitStatus {
 			// If the agent acquired a job and it failed or was cancelled,
 			// then report its exit code as our own.
 			return cli.NewExitError(err, exit.Status)


### PR DESCRIPTION
### Description

It was pointed out that #3376 was a breaking change, and particularly, it changed some behaviour people were relying on. 

Make the new behaviour opt-in via flag.

### Context

https://linear.app/buildkite/issue/PS-896

### Changes

- Introduce a new flag, `reflect-exit-status`
- Exit with the job exit status only if the new flag is enabled.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

