### PR TITLE
Fix to reflect-exit-status flag

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1307,10 +1307,14 @@ var AgentStartCommand = cli.Command{
 			const acquisitionFailedExitCode = 27 // chosen by fair dice roll
 			return cli.NewExitError(err, acquisitionFailedExitCode)
 		}
-		if exit := new(core.ProcessExit); errors.As(err, exit) && cfg.ReflectExitStatus {
-			// If the agent acquired a job and it failed or was cancelled,
-			// then report its exit code as our own.
-			return cli.NewExitError(err, exit.Status)
+		if exit := new(core.ProcessExit); errors.As(err, exit) {
+			if cfg.ReflectExitStatus {
+				// If the agent acquired a job and it failed or was cancelled,
+				// then report its exit code as our own.
+				return cli.NewExitError(err, exit.Status)
+			}
+			// The job ran. Even though it failed, the agent did its job.
+			return nil
 		}
 
 		return err


### PR DESCRIPTION
### Description

If `--reflect-exit-status` is not enabled (the default), and acquire-job returned an exit status, then don't return the exit status up to main.

### Context

https://linear.app/buildkite/issue/PS-896

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`
- [x] Manually tested with and without `--reflect-exit-status`.

```shell
$ buildkite-agent start --acquire-job 01980b59-5760-4753-8a03-204d42db2a06
...
2025-07-15 09:51:16 ERROR  WorkBook.local-1 Failed to acquire and run job: Failed to run job: process exited with status=17 
2025-07-15 09:51:16 INFO   WorkBook.local-1 Waiting for instructions... 
2025-07-15 09:51:17 INFO   WorkBook.local-1 Disconnecting... 
2025-07-15 09:51:17 INFO   WorkBook.local-1 Disconnected 
$ echo $?
0
$ buildkite-agent start --acquire-job 01980b59-c30f-4f1e-b714-34a7618166dc --reflect-exit-status
...
2025-07-15 09:54:07 ERROR  WorkBook.local-1 Failed to acquire and run job: Failed to run job: process exited with status=17 
2025-07-15 09:54:07 INFO   WorkBook.local-1 Waiting for instructions... 
2025-07-15 09:54:09 INFO   WorkBook.local-1 Disconnecting... 
2025-07-15 09:54:09 INFO   WorkBook.local-1 Disconnected 
Failed to run job: process exited with status=17
$ echo $?
17
```