### PR TITLE
Fix to reflect-exit-status flag

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1306,10 +1306,14 @@ var AgentStartCommand = cli.Command{
 			const acquisitionFailedExitCode = 27 // chosen by fair dice roll
 			return cli.NewExitError(err, acquisitionFailedExitCode)
 		}
-		if exit := new(core.ProcessExit); errors.As(err, exit) && cfg.ReflectExitStatus {
-			// If the agent acquired a job and it failed or was cancelled,
-			// then report its exit code as our own.
-			return cli.NewExitError(err, exit.Status)
+		if exit := new(core.ProcessExit); errors.As(err, exit) {
+			if cfg.ReflectExitStatus {
+				// If the agent acquired a job and it failed or was cancelled,
+				// then report its exit code as our own.
+				return cli.NewExitError(err, exit.Status)
+			}
+			// The job ran. Even though it failed, the agent did its job.
+			return nil
 		}
 
 		return err


### PR DESCRIPTION
### Description

Cherry-pick #3392 to v3.102 branch.

### Context

https://linear.app/buildkite/issue/PS-896

### Changes

- #3392

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

