### PR TITLE
Update to use OIDC session tokens on AWS role assumption

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -249,8 +249,12 @@ steps:
       - name: ":docker: {{matrix}} image build"
         key: build-docker
         plugins:
-          - aws-assume-role-with-web-identity#v1.0.0:
+          - aws-assume-role-with-web-identity#v1.4.0:
               role_arn: "arn:aws:iam::${BUILD_AWS_ACCOUNT_ID}:role/${BUILD_AWS_ROLE_NAME}"
+              session-tags:
+                - organization_slug
+                - organization_id
+                - pipeline_slug
           - ecr#v2.9.0:
               login: true
               account_ids: "${BUILD_AWS_ACCOUNT_ID}"
@@ -280,8 +284,12 @@ steps:
           - build-docker
         command: .buildkite/steps/test-docker-image.sh {{matrix.variant}}
         plugins:
-          - aws-assume-role-with-web-identity#v1.0.0:
+          - aws-assume-role-with-web-identity#v1.4.0:
               role_arn: "arn:aws:iam::${BUILD_AWS_ACCOUNT_ID}:role/${BUILD_AWS_ROLE_NAME}"
+              session-tags:
+                - organization_slug
+                - organization_id
+                - pipeline_slug
           - ecr#v2.9.0:
               login: true
               account_ids: "${BUILD_AWS_ACCOUNT_ID}"
@@ -298,8 +306,12 @@ steps:
 
       - name: ":docker: {{matrix.variant}} arm64 image test"
         plugins:
-          - aws-assume-role-with-web-identity#v1.0.0:
+          - aws-assume-role-with-web-identity#v1.4.0:
               role_arn: "arn:aws:iam::${BUILD_AWS_ACCOUNT_ID}:role/${BUILD_AWS_ROLE_NAME}"
+              session-tags:
+                - organization_slug
+                - organization_id
+                - pipeline_slug
           - ecr#v2.9.0:
               login: true
               account_ids: "${BUILD_AWS_ACCOUNT_ID}"


### PR DESCRIPTION
### Description

Roll out using session tags for OIDC assumable IAM role trust policy. 
<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

### Context

Follow on from the work to support session tags in https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/pull/18

Requires matching update to the IAM role in PR: https://github.com/buildkite/aws-buildkite-dev/pull/474

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

### Changes

This is only changing the one pipeline, which uses an IAM role in `buildkite-dev` account. Additional pipelines defined in this repo will be updated when I move on to working on the `ops` repo roles. 
<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
