### PR TITLE
Lint fixes 2

### DIFF
--- a/agent/integration/config_allowlisting_integration_test.go
+++ b/agent/integration/config_allowlisting_integration_test.go
@@ -131,7 +131,7 @@ func TestConfigAllowlisting(t *testing.T) {
 
 			mb := mockBootstrap(t)
 			tc.mockBootstrapExpectation(mb)
-			defer mb.CheckAndClose(t)
+			defer mb.CheckAndClose(t) //nolint:errcheck // bintest logs to t
 
 			err := runJob(t, context.Background(), testRunJobConfig{
 				job:           job,

--- a/agent/integration/job_environment_integration_test.go
+++ b/agent/integration/job_environment_integration_test.go
@@ -27,7 +27,7 @@ func TestWhenCachePathsSetInJobStep_CachePathsEnvVarIsSet(t *testing.T) {
 	}
 
 	mb := mockBootstrap(t)
-	defer mb.CheckAndClose(t)
+	defer mb.CheckAndClose(t) //nolint:errcheck // bintest logs to t
 
 	mb.Expect().Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if got, want := c.GetEnv("BUILDKITE_AGENT_CACHE_PATHS"), "foo,bar"; got != want {
@@ -72,7 +72,7 @@ func TestBuildkiteRequestHeaders(t *testing.T) {
 	headers.Set("Buildkite-Hello", "world")
 
 	mb := mockBootstrap(t)
-	defer mb.CheckAndClose(t)
+	defer mb.CheckAndClose(t) //nolint:errcheck // bintest logs to t
 
 	// The main assertion: that the `Buildkite-Hello: world` server-specified request header is
 	// passed to the job environment as BUILDKITE_REQUEST_HEADER_BUILDKITE_HELLO=world. From there,

--- a/agent/integration/job_verification_integration_test.go
+++ b/agent/integration/job_verification_integration_test.go
@@ -591,7 +591,7 @@ func TestJobVerification(t *testing.T) {
 
 			mb := mockBootstrap(t)
 			tc.mockBootstrapExpectation(mb)
-			defer mb.CheckAndClose(t)
+			defer mb.CheckAndClose(t) //nolint:errcheck // bintest logs to t
 
 			stepWithInvariants := signature.CommandStepWithInvariants{
 				CommandStep:   tc.job.Step,

--- a/agent/integration/test_helpers.go
+++ b/agent/integration/test_helpers.go
@@ -86,11 +86,7 @@ func runJob(t *testing.T, ctx context.Context, cfg testRunJobConfig) error {
 		ignoreAgentInDispatches = ptr.To(true)
 	}
 
-	if err := jr.Run(context.Background(), ignoreAgentInDispatches); err != nil {
-		return err
-	}
-
-	return nil
+	return jr.Run(ctx, ignoreAgentInDispatches)
 }
 
 type testAgentEndpoint struct {
@@ -126,7 +122,7 @@ func (tae *testAgentEndpoint) finishesFor(t *testing.T, jobID string) []api.Job 
 	return finishes
 }
 
-func (tae *testAgentEndpoint) logsFor(t *testing.T, jobID string) string {
+func (tae *testAgentEndpoint) logsFor(t *testing.T, _ string) string {
 	t.Helper()
 	tae.mtx.Lock()
 	defer tae.mtx.Unlock()
@@ -225,16 +221,26 @@ func (t *testAgentEndpoint) server(extraRoutes ...route) *httptest.Server {
 
 	wrapRecordRequest := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			writeErr := func(status int, f string, v ...any) {
+				msg := fmt.Sprintf(f, v...)
+				fmt.Fprintln(os.Stderr, msg)
+				http.Error(rw, msg, status)
+			}
+
 			// wait a minute, what's going on here?
 			// well, we want to read the body of the request, but because HTTP response bodies are io.ReadClosers, they can only
 			// be read once. So we read the body, then write it back into the request body so that the next handler can read it.
-			b, _ := io.ReadAll(req.Body)
-			req.Body.Close()
+			b, err := io.ReadAll(req.Body)
+			if err != nil {
+				writeErr(http.StatusBadRequest, "incomplete body read: %v", err)
+				return
+			}
+			if err := req.Body.Close(); err != nil {
+				writeErr(http.StatusInternalServerError, "error from req.Body.Close: %v", err)
+				return
+			}
 
-			// bytes.NewBuffer takes ownership of the slice, so we need to copy it
-			newBodyBytes := make([]byte, len(b))
-			copy(newBodyBytes, b)
-			req.Body = io.NopCloser(bytes.NewBuffer(newBodyBytes))
+			req.Body = io.NopCloser(bytes.NewReader(b))
 
 			t.mtx.Lock()
 			t.calls[req.URL.Path] = append(t.calls[req.URL.Path], b)
@@ -243,9 +249,7 @@ func (t *testAgentEndpoint) server(extraRoutes ...route) *httptest.Server {
 			// We also require job tokens are used for authentication
 			authzHeader := req.Header.Get("Authorization")
 			if !strings.HasPrefix(authzHeader, "Token bkaj_") {
-				msg := fmt.Sprintf("Authorization header = %q, want job token prefix 'Token bkaj_'", authzHeader)
-				fmt.Fprintln(os.Stderr, msg)
-				http.Error(rw, msg, http.StatusUnauthorized)
+				writeErr(http.StatusUnauthorized, "Authorization header = %q, want job token prefix 'Token bkaj_'", authzHeader)
 				return
 			}
 

--- a/agent/log_streamer.go
+++ b/agent/log_streamer.go
@@ -16,7 +16,7 @@ import (
 const defaultLogMaxSize = 1024 * 1024 * 1024 // 1 GiB
 
 // Returned from Process after Stop has been called.
-var errStreamerStopped = errors.New("streamer stopped")
+var errStreamerStopped = errors.New("streamer was already stopped")
 
 // LogStreamerConfig contains configuration options for the log streamer.
 type LogStreamerConfig struct {

--- a/internal/artifact/download.go
+++ b/internal/artifact/download.go
@@ -170,8 +170,8 @@ func (d Download) try(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("creating temp file (%T: %w)", err, err)
 	}
-	defer os.Remove(temp.Name())
-	defer temp.Close() //nolint:errcheck // Best-effort cleanup - primary Close checked below.
+	defer os.Remove(temp.Name()) //nolint:errcheck // Best-effort cleanup
+	defer temp.Close()           //nolint:errcheck // Best-effort cleanup - primary Close checked below.
 
 	// Create a SHA256 to hash the download as we go.
 	hash := sha256.New()

--- a/internal/artifact/downloader_test.go
+++ b/internal/artifact/downloader_test.go
@@ -13,18 +13,21 @@ import (
 )
 
 func TestArtifactDownloaderConnectsToEndpoint(t *testing.T) {
-	defer os.Remove("llamas.txt")
+	t.Cleanup(func() {
+		os.Remove("llamas.txt") //nolint:errcheck // Best-effort cleanup.
+	})
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.RequestURI() {
 		case "/builds/my-build/artifacts/search?state=finished":
+			//nolint:errcheck // Test should fail with incomplete response.
 			fmt.Fprintf(rw, `[{
 				"id": "4600ac5c-5a13-4e92-bb83-f86f218f7b32",
 				"file_size": 3,
 				"absolute_path": "llamas.txt",
 				"path": "llamas.txt",
 				"url": "http://%s/download"
-			}]`, req.Host) //nolint:errcheck // Test should fail with incomplete response.
+			}]`, req.Host)
 		case "/download":
 			fmt.Fprintln(rw, "OK") //nolint:errcheck // YOLO?
 		default:

--- a/internal/artifact/searcher_test.go
+++ b/internal/artifact/searcher_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestArtifactSearcherConnectsToEndpoint(t *testing.T) {
-	defer os.Remove("llamas.txt")
+	t.Cleanup(func() {
+		os.Remove("llamas.txt") //nolint:errcheck // Best-effort cleanup.
+	})
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.RequestURI() {

--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -351,7 +351,7 @@ func (a *Uploader) build(path string, absolutePath string) (*api.Artifact, error
 	if err != nil {
 		return nil, fmt.Errorf("opening file %s: %w", absolutePath, err)
 	}
-	defer file.Close()
+	defer file.Close() //nolint:errcheck // File is only open for read.
 
 	// Generate a SHA-1 and SHA-256 checksums for the file.
 	// Writing to hashes never errors, but reading from the file might.

--- a/internal/job/ssh_test.go
+++ b/internal/job/ssh_test.go
@@ -39,7 +39,7 @@ func TestSSHKeyscanReturnsOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bintest.NewMock(ssh-keyscan) error = %v", err)
 	}
-	defer keyScan.CheckAndClose(t)
+	defer keyScan.CheckAndClose(t) //nolint:errcheck // bintest logs to t
 
 	sh.Env.Set("PATH", filepath.Dir(keyScan.Path))
 
@@ -63,7 +63,7 @@ func TestSSHKeyscanWithHostAndPortReturnsOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bintest.NewMock(ssh-keyscan) error = %v", err)
 	}
-	defer keyScan.CheckAndClose(t)
+	defer keyScan.CheckAndClose(t) //nolint:errcheck // bintest logs to t
 
 	sh.Env.Set("PATH", filepath.Dir(keyScan.Path))
 
@@ -87,7 +87,7 @@ func TestSSHKeyscanRetriesOnExit1(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bintest.NewMock(ssh-keyscan) error = %v", err)
 	}
-	defer keyScan.CheckAndClose(t)
+	defer keyScan.CheckAndClose(t) //nolint:errcheck // bintest logs to t
 
 	sh.Env.Set("PATH", filepath.Dir(keyScan.Path))
 
@@ -113,7 +113,7 @@ func TestSSHKeyscanRetriesOnBlankOutputAndExit0(t *testing.T) {
 		t.Fatalf("bintest.NewMock(ssh-keyscan) error = %v", err)
 	}
 	defer keyScan.CheckAndClose(t)
-
+	//nolint:errcheck // bintest logs to t
 	sh.Env.Set("PATH", filepath.Dir(keyScan.Path))
 
 	keyScan.

--- a/process/buffer.go
+++ b/process/buffer.go
@@ -6,7 +6,8 @@ import (
 	"sync"
 )
 
-var errAlreadyClosed = errors.New("already closed")
+// ErrAlreadyClosed is returned when a buffer has already been closed.
+var ErrAlreadyClosed = errors.New("already closed")
 
 // Buffer implements a concurrent-safe output buffer for processes.
 type Buffer struct {
@@ -32,7 +33,7 @@ func (l *Buffer) Close() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.closed {
-		return errAlreadyClosed
+		return ErrAlreadyClosed
 	}
 	l.closed = true
 	return nil

--- a/process/buffer_test.go
+++ b/process/buffer_test.go
@@ -48,7 +48,7 @@ func TestBufferClose(t *testing.T) {
 		t.Errorf("after b.Close(): b.Write() = (%d, %v), want (%d, %v)", gotN, gotErr, wantN, wantErr)
 	}
 
-	if err := b.Close(); err != errAlreadyClosed {
-		t.Errorf("double b.Close() = %v, want %v", err, errAlreadyClosed)
+	if err := b.Close(); err != ErrAlreadyClosed {
+		t.Errorf("double b.Close() = %v, want %v", err, ErrAlreadyClosed)
 	}
 }


### PR DESCRIPTION
### Description

Grind some more lints.

### Context

As reported by `golangci-lint run`.

### Changes

- Add / adjust some nolint:errchecks (about 100 to go)
- Actually handle some errors


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

