### PR TITLE
Rename local -> repository hooks, global -> agent hooks

### DIFF
--- a/internal/job/plugin.go
+++ b/internal/job/plugin.go
@@ -250,7 +250,7 @@ func (e *Executor) executePluginHook(ctx context.Context, name string, checkouts
 		}
 
 		if err := e.executeHook(ctx, HookConfig{
-			Scope:      "plugin",
+			Scope:      HookScopePlugin,
 			Name:       name,
 			Path:       hookPath,
 			Env:        envMap,


### PR DESCRIPTION
### Description

In the docs, we say:
<img width="1404" height="384" alt="image" src="https://github.com/user-attachments/assets/c4078864-4165-4ec7-be28-9d9419e5628c" />

but then in job logs, we say:
<img width="682" height="242" alt="image" src="https://github.com/user-attachments/assets/347ca38f-dc12-453a-b9af-6d25a822681f" />

also, `local` and `global` as names are pretty meaningless. `agent` and `repository` are much clearer, so this PR updates the the hook scopes to be formally named `agent` and `repository`.

There's a wee punchout for the datadog tracing implementation, which expects hook scopes to be called the old names in span attributes, so we've retained them there and there only.

**Before:**
<img width="1218" height="328" alt="CleanShot 2025-07-18 at 11 22 18@2x" src="https://github.com/user-attachments/assets/a747d757-3241-4e53-ac51-372f8ed6d90e" />


**After**
<img width="1308" height="328" alt="CleanShot 2025-07-18 at 11 22 45@2x" src="https://github.com/user-attachments/assets/64d300bc-a3ec-40a1-af66-900627ef123b" />


### Context

https://buildkite-corp.slack.com/archives/C07LSRYCPSR/p1752753127654479


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)