### PR TITLE
Support ignoring env vars in job signatures

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -36,13 +36,15 @@ type AgentConfiguration struct {
 	RunInPty                    bool
 	KubernetesExec              bool
 
-	SigningJWKSFile  string // Where to find the key to sign pipeline uploads with (passed through to jobs, they might be uploading pipelines)
-	SigningJWKSKeyID string // The key ID to sign pipeline uploads with
-	SigningAWSKMSKey string // The KMS key ID to sign pipeline uploads with
-	DebugSigning     bool   // Whether to print step payloads when signing them
+	SigningJWKSFile       string   // Where to find the key to sign pipeline uploads with (passed through to jobs, they might be uploading pipelines)
+	SigningJWKSKeyID      string   // The key ID to sign pipeline uploads with
+	SigningAWSKMSKey      string   // The KMS key ID to sign pipeline uploads with
+	DebugSigning          bool     // Whether to print step payloads when signing them
+	SigningIgnoredEnvVars []string // A list of environment variable names to ignore when signing the pipeline. These variables (and their values) will not be included in the signature. For signatures to match, the corresponding flag must be set on the agent that signed the pipeline
 
-	VerificationJWKS             any    // The set of keys to verify jobs with
-	VerificationFailureBehaviour string // What to do if job verification fails (one of `block` or `warn`)
+	VerificationJWKS             any      // The set of keys to verify jobs with
+	VerificationFailureBehaviour string   // What to do if job verification fails (one of `block` or `warn`)
+	VerificationIgnoredEnvVars   []string // A list of environment variable names to ignore when verifying the pipeline. These variables (and their values) will not be included in the signature verification. For signatures to match, the corresponding flag must be set on the agent that signed the pipeline
 
 	ANSITimestamps               bool
 	TimestampLines               bool

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -605,6 +605,14 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 		env["BUILDKITE_AGENT_DEBUG_SIGNING"] = "true"
 	}
 
+	if r.conf.AgentConfiguration.SigningIgnoredEnvVars != nil {
+		env["BUILDKITE_AGENT_SIGNING_IGNORED_ENV_VARS"] = strings.Join(r.conf.AgentConfiguration.SigningIgnoredEnvVars, ",")
+	}
+
+	if r.conf.AgentConfiguration.VerificationIgnoredEnvVars != nil {
+		env["BUILDKITE_AGENT_VERIFICATION_IGNORED_ENV_VARS"] = strings.Join(r.conf.AgentConfiguration.VerificationIgnoredEnvVars, ",")
+	}
+
 	enablePluginValidation := r.conf.AgentConfiguration.PluginValidation
 	// Allow BUILDKITE_PLUGIN_VALIDATION to be enabled from env for easier
 	// per-pipeline testing

--- a/agent/verify_job.go
+++ b/agent/verify_job.go
@@ -56,6 +56,7 @@ func (r *JobRunner) verifyJob(ctx context.Context, keySet any) error {
 		signature.WithEnv(r.conf.Job.Env),
 		signature.WithLogger(r.agentLogger),
 		signature.WithDebugSigning(r.conf.AgentConfiguration.DebugSigning),
+		signature.IgnoringEnvVars(r.conf.AgentConfiguration.VerificationIgnoredEnvVars...),
 	)
 	if err != nil {
 		r.agentLogger.Debug("failed to verifyJob: step.Signature.Verify(Job.Env, stepWithInvariants, JWKS) = %v", err)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -94,12 +94,14 @@ type AgentStartConfig struct {
 
 	SigningJWKSKeyID string `cli:"signing-jwks-key-id"`
 
-	SigningJWKSFile  string `cli:"signing-jwks-file" normalize:"filepath"`
-	SigningAWSKMSKey string `cli:"signing-aws-kms-key"`
-	DebugSigning     bool   `cli:"debug-signing"`
+	SigningJWKSFile       string   `cli:"signing-jwks-file" normalize:"filepath"`
+	SigningAWSKMSKey      string   `cli:"signing-aws-kms-key"`
+	DebugSigning          bool     `cli:"debug-signing"`
+	SigningIgnoredEnvVars []string `cli:"signing-ignored-env-vars" normalize:"list"`
 
-	VerificationJWKSFile        string `cli:"verification-jwks-file" normalize:"filepath"`
-	VerificationFailureBehavior string `cli:"verification-failure-behavior"`
+	VerificationIgnoredEnvVars  []string `cli:"verification-ignored-env-vars" normalize:"list"`
+	VerificationJWKSFile        string   `cli:"verification-jwks-file" normalize:"filepath"`
+	VerificationFailureBehavior string   `cli:"verification-failure-behavior"`
 
 	AcquireJob                 string `cli:"acquire-job"`
 	DisconnectAfterJob         bool   `cli:"disconnect-after-job"`
@@ -724,6 +726,16 @@ var AgentStartCommand = cli.Command{
 			Usage:  "Enable debug logging for pipeline signing. This can potentially leak secrets to the logs as it prints each step in full before signing. Requires debug logging to be enabled",
 			EnvVar: "BUILDKITE_AGENT_DEBUG_SIGNING",
 		},
+		cli.StringSliceFlag{
+			Name:   "signing-ignored-env-vars",
+			Usage:  "A list of environment variable names to ignore when signing the pipeline. These variables (and their values) will not be included in the signature. For signatures to match, the corresponding flag must be set on the agent that verifies the signature and runs the job",
+			EnvVar: "BUILDKITE_AGENT_SIGNING_IGNORED_ENV_VARS",
+		},
+		cli.StringSliceFlag{
+			Name:   "verification-ignored-env-vars",
+			Usage:  "A list of environment variable names to ignore when signing the pipeline. These variables (and their values) will not be included in the signature. For signatures to match, the corresponding flag must be set on the agent that verifies the signature and runs the job",
+			EnvVar: "BUILDKITE_AGENT_VERIFICATION_IGNORED_ENV_VARS",
+		},
 		cli.StringFlag{
 			Name:   "verification-failure-behavior",
 			Value:  agent.VerificationBehaviourBlock,
@@ -1049,13 +1061,15 @@ var AgentStartCommand = cli.Command{
 			AllowMultipartArtifactUpload: !cfg.NoMultipartArtifactUpload,
 			KubernetesExec:               cfg.KubernetesExec,
 
-			SigningJWKSFile:  cfg.SigningJWKSFile,
-			SigningJWKSKeyID: cfg.SigningJWKSKeyID,
-			SigningAWSKMSKey: cfg.SigningAWSKMSKey,
-			DebugSigning:     cfg.DebugSigning,
+			SigningJWKSFile:       cfg.SigningJWKSFile,
+			SigningJWKSKeyID:      cfg.SigningJWKSKeyID,
+			SigningAWSKMSKey:      cfg.SigningAWSKMSKey,
+			DebugSigning:          cfg.DebugSigning,
+			SigningIgnoredEnvVars: cfg.SigningIgnoredEnvVars,
 
 			VerificationJWKS:             verificationJWKS,
 			VerificationFailureBehaviour: cfg.VerificationFailureBehavior,
+			VerificationIgnoredEnvVars:   cfg.VerificationIgnoredEnvVars,
 
 			DisableWarningsFor: cfg.DisableWarningsFor,
 		}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kms v1.41.2
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 	github.com/buildkite/bintest/v3 v3.3.0
-	github.com/buildkite/go-pipeline v0.14.0
+	github.com/buildkite/go-pipeline v0.14.1-0.20250718044939-1ded6233e93a
 	github.com/buildkite/interpolate v0.1.5
 	github.com/buildkite/roko v1.3.1
 	github.com/buildkite/shellwords v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf
 github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20220812150832-b6b31c6eeeaf/go.mod h1:CeKhh8xSs3WZAc50xABMxu+FlfAAd5PNumo7NfOv7EE=
 github.com/buildkite/bintest/v3 v3.3.0 h1:RTWcSaJRlOT6t/K311ejPf+0J3LE/QEODzVG3vlLnWo=
 github.com/buildkite/bintest/v3 v3.3.0/go.mod h1:btqpTsVODiJcb0NMdkkmtMQ6xoFc2W/nY5yy+3I0zcs=
-github.com/buildkite/go-pipeline v0.14.0 h1:TMkFalrkniy2l5wEfmGyckT5kf21akWOY07i4esosAI=
-github.com/buildkite/go-pipeline v0.14.0/go.mod h1:VE37qY3X5pmAKKUMoDZvPsHOQuyakB9cmXj9Qn6QasA=
+github.com/buildkite/go-pipeline v0.14.1-0.20250718044939-1ded6233e93a h1:chBy8GDueYJ9VAHTETJcO+SX4lfFTwx4CzfOdJNT1CE=
+github.com/buildkite/go-pipeline v0.14.1-0.20250718044939-1ded6233e93a/go.mod h1:VE37qY3X5pmAKKUMoDZvPsHOQuyakB9cmXj9Qn6QasA=
 github.com/buildkite/interpolate v0.1.5 h1:v2Ji3voik69UZlbfoqzx+qfcsOKLA61nHdU79VV+tPU=
 github.com/buildkite/interpolate v0.1.5/go.mod h1:dHnrwHew5O8VNOAgMDpwRlFnhL5VSN6M1bHVmRZ9Ccc=
 github.com/buildkite/roko v1.3.1 h1:t7K30ceLLYn6k7hQP4oq1c7dVlhgD5nRcuSRDEEnY1s=


### PR DESCRIPTION
### Description

In some cases, when using signed pipelines, the values of some environment variables can't necessarily be controlled by the user to the degree that steps will always pass verification -- for example, successive pipeline uploads can change build-level environment such that steps will fail to verify.

To allow users to still use pipeline signing in these situations, we've added a pair of flags to the agent `--signing-ignored-env-vars` and `--verification-ignored-env-vars`. As their names imply, they remove environment variables from the step payloads that we sign and verify. 

This means that if we knew that environment variables called `MOUNTAIN` and `RIVER` were going to change between signing and verification, we could start the signing agents with `--signing-ignored-env-vars="MOUNTAIN,RIVER"` and the verifying agents with `--verification-ignored-env-vars="MOUNTAIN,RIVER"`. 

Setting these flags reduces the integrity of the signature, and thus weakens the security guarantees that signed pipelines provides. As such, when in use, signing pipelines with ignored env vars will always emit a warning. The intent is that the use of these flags will be a stopgap until agent environments can be better controlled.

This PR relies on the associated one in [go-pipeline](https://github.com/buildkite/go-pipeline/pull/67).

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
