### PR TITLE
Exit with a specific code when the Job being Acquired is Locked

### DIFF
--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -236,8 +236,8 @@ func TestAcquireAndRunJobWaiting(t *testing.T) {
 	err := worker.AcquireAndRunJob(ctx, "waitinguuid")
 	assert.ErrorContains(t, err, "423")
 
-	if errors.Is(err, core.ErrJobAcquisitionRejected) {
-		t.Fatalf("expected worker.AcquireAndRunJob(%q) not to be core.ErrJobAcquisitionRejected, but it was: %v", "waitinguuid", err)
+	if !errors.Is(err, core.ErrJobLocked) {
+		t.Fatalf("expected worker.AcquireAndRunJob(%q) = core.ErrJobLocked, got %v", "waitinguuid", err)
 	}
 
 	// the last Retry-After is not recorded as the retries loop exits before using it

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1307,6 +1307,13 @@ var AgentStartCommand = cli.Command{
 			const acquisitionFailedExitCode = 27 // chosen by fair dice roll
 			return cli.NewExitError(err, acquisitionFailedExitCode)
 		}
+		if errors.Is(err, core.ErrJobLocked) {
+			// If the agent tried to acquire a job, but it couldn't because the job is locked (waiting for dependencies),
+			// we should exit with a specific exit code so that the caller can know that this job is locked.
+
+			const jobLockedExitCode = 28
+			return cli.NewExitError(err, jobLockedExitCode)
+		}
 		if exit := new(core.ProcessExit); errors.As(err, exit) {
 			if cfg.ReflectExitStatus {
 				// If the agent acquired a job and it failed or was cancelled,

--- a/core/client.go
+++ b/core/client.go
@@ -159,7 +159,7 @@ func handleRetriableJobAcquisitionError(warning string, resp *api.Response, r *r
 	r.SetNextInterval(duration)
 }
 
-// Connect the agent to the Buildkite Agent API, retrying up to 10 times with 5
+// Connect connects the agent to the Buildkite Agent API, retrying up to 10 times with 5
 // seconds delay if it fails.
 func (c *Client) Connect(ctx context.Context) error {
 	c.Logger.Info("Connecting to Buildkite...")


### PR DESCRIPTION
### Description

When a Job fails to be Acquired, if that Job is locked due to dependencies then retry for a short time. If this wait continues for too long, exit with a unique code that will allow a scheduler to take specific behaviour for that scenario. There will be another webhook once the Job has moved back to Scheduled so the Job won't be lost.

### Context

At present a scheduler is given no indication on whether the failed acquisition was for any particular purpose, and in this scenario where the job is locked the behaviour can be better handled with a new code.

### Changes

- Exit with a unique code (`28`) when the Job being Acquired is Locked.
- Pepper the error message generated with the Locked detail to surface this in the Job log.
- Add test cases to handle the expected error codes for different Job statuses.

### Testing

- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)