### PR TITLE
Annotate with lint findings

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,6 +17,7 @@ steps:
       - docker-compose#v4.14.0:
           config: .buildkite/docker-compose.yml
           cli-version: 2
+          mount-buildkite-agent: true
           run: lint
 
   - name: ":linux: Linux AMD64 Tests"

--- a/.buildkite/steps/check-code-committed.sh
+++ b/.buildkite/steps/check-code-committed.sh
@@ -34,9 +34,22 @@ if ! git diff --no-ext-diff --exit-code; then
   exit 1
 fi
 
-# While we're cleaning up things found by golangci-lint, don't fail if it finds
-# things.
 echo +++ :go: Running golangci-lint...
-golangci-lint run || true
+if ! lint_out="$(golangci-lint run --color=always)" ; then 
+  echo ^^^ +++
+  echo "golangci-lint found the following issues:"
+  echo ""
+  echo "${lint_out}"
+  buildkite-agent annotate --style=warning <<EOF
+golangci-lint found the following issues:
+
+\`\`\`term
+${lint_out}
+\`\`\`
+EOF
+  # While we're cleaning up things found by golangci-lint, don't fail if it
+  # finds things.
+  exit 0
+fi
 
 echo +++ Everything is clean and tidy! 🎉


### PR DESCRIPTION
### Description

Make the linter findings more obvious by putting them in an annotation.

### Context

https://github.com/buildkite/agent/pull/3399#pullrequestreview-3031410174

### Changes

- Mount `buildkite-agent` into the linter container
- Capture the linter output and pass it to `buildkite-agent annotate`

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

