### PR TITLE
Only run tests if code has changed

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,6 +13,7 @@ steps:
   - name: ":go::robot_face: Lint"
     key: check-code-committed
     command: .buildkite/steps/check-code-committed.sh
+    if_changed: "{go.mod,go.sum,**.go,.buildkite/steps/check-code-committed.sh}"
     plugins:
       - docker-compose#v4.14.0:
           config: .buildkite/docker-compose.yml
@@ -20,153 +21,158 @@ steps:
           mount-buildkite-agent: true
           run: lint
 
-  - name: ":linux: Linux AMD64 Tests"
-    key: test-linux-amd64
-    command: ".buildkite/steps/tests.sh"
-    parallelism: 2
-    artifact_paths:
-      - junit-*.xml
-      - "coverage/**/*"
-    plugins:
-      - docker-compose#v4.14.0:
-          config: .buildkite/docker-compose.yml
-          cli-version: 2
-          propagate-environment: true
-          run: agent
-      - test-collector#v1.11.0:
-          files: "junit-*.xml"
-          format: "junit"
-          tags:
-            - "os=linux"
-            - "arch=amd64"
-            - "race=false"
-
-  - name: ":linux: Linux ARM64 Tests"
-    key: test-linux-arm64
-    command: ".buildkite/steps/tests.sh"
-    parallelism: 2
-    artifact_paths:
-      - junit-*.xml
-      - "coverage/**/*"
-    agents:
-      queue: $AGENT_RUNNERS_LINUX_ARM64_QUEUE
-    plugins:
-      - docker-compose#v4.14.0:
-          config: .buildkite/docker-compose.yml
-          cli-version: 2
-          propagate-environment: true
-          run: agent
-      - test-collector#v1.11.0:
-          files: "junit-*.xml"
-          format: "junit"
-          tags:
-            - "os=linux"
-            - "arch=arm64"
-            - "race=false"
-
-  - name: ":satellite: Detect Data Races"
-    key: test-race-linux-arm64
-    command: ".buildkite/steps/tests.sh -race"
-    # Extra parallelism because this data race test is slow
-    parallelism: 3
-    artifact_paths:
-      - junit-*.xml
-      - "coverage/**/*"
-    agents:
-      queue: $AGENT_RUNNERS_LINUX_ARM64_QUEUE
-    plugins:
-      - docker-compose#v4.14.0:
-          config: .buildkite/docker-compose.yml
-          cli-version: 2
-          propagate-environment: true
-          run: agent
-      - test-collector#v1.11.0:
-          files: "junit-*.xml"
-          format: "junit"
-          tags:
-            - "os=linux"
-            - "arch=arm64"
-            - "race=true"
-
-  - name: ":windows: Windows AMD64 Tests"
-    key: test-windows
-    command: "bash .buildkite\\steps\\tests.sh"
-    parallelism: 2
-    artifact_paths:
-      - junit-*.xml
-      - "coverage/**/*"
-    agents:
-      queue: $AGENT_RUNNERS_WINDOWS_QUEUE
-    plugins:
-      - test-collector#v1.11.0:
-          files: "junit-*.xml"
-          format: "junit"
-          tags:
-            - "os=windows"
-            - "arch=arm64"
-            - "race=false"
-
-  - name: ":coverage: Test coverage report Linux ARM64"
-    key: test-coverage-linux-arm64
-    command: ".buildkite/steps/test-coverage-report.sh"
-    artifact_paths:
-      - "cover.html"
-      - "cover.out"
-    depends_on:
-      - test-linux-arm64
-    plugins:
-      - docker-compose#v4.14.0:
-          config: .buildkite/docker-compose.yml
-          cli-version: 2
-          run: agent
-      - artifacts#v1.9.4:
-          download: "coverage/**"
-          step: test-linux-arm64
-
-  - name: ":coverage: Test coverage report Linux AMD64"
-    key: test-coverage-linux-amd64
-    command: ".buildkite/steps/test-coverage-report.sh"
-    artifact_paths:
-      - "cover.html"
-      - "cover.out"
-    depends_on:
-      - test-linux-amd64
-    plugins:
-      - docker-compose#v4.14.0:
-          config: .buildkite/docker-compose.yml
-          cli-version: 2
-          run: agent
-      - artifacts#v1.9.4:
-          download: "coverage/**"
-          step: test-linux-amd64
-
-  - name: ":coverage: Test coverage report Linux ARM64 Race"
-    key: test-coverage-linux-arm64-race
-    command: ".buildkite/steps/test-coverage-report.sh"
-    artifact_paths:
-      - "cover.html"
-      - "cover.out"
-    depends_on:
-      - test-race-linux-arm64
-    plugins:
-      - docker-compose#v4.14.0:
-          config: .buildkite/docker-compose.yml
-          cli-version: 2
-          run: agent
-      - artifacts#v1.9.4:
-          download: "coverage/**"
-          step: test-race-linux-arm64
-
-  - label: ":writing_hand: Annotate with Test Failures"
-    depends_on:
-      - test-linux-amd64
-      - test-race-linux-arm64
-      - test-linux-arm64
-      - test-windows
-    allow_dependency_failure: true
-    plugins:
-      - junit-annotate#v1.6.0:
-          artifacts: junit-*.xml
+  - group: ":go::scientist: Tests and Coverage"
+    if_changed: "{go.mod,go.sum,**.go,**/fixtures/**,.buildkite/steps/{tests,test-coverage-report}.sh}"
+    steps:
+    - name: ":linux: Linux AMD64 Tests"
+      key: test-linux-amd64
+      command: ".buildkite/steps/tests.sh"
+      parallelism: 2
+      artifact_paths:
+        - junit-*.xml
+        - "coverage/**/*"
+      plugins:
+        - docker-compose#v4.14.0:
+            config: .buildkite/docker-compose.yml
+            cli-version: 2
+            propagate-environment: true
+            run: agent
+        - test-collector#v1.11.0:
+            files: "junit-*.xml"
+            format: "junit"
+            tags:
+              - "os=linux"
+              - "arch=amd64"
+              - "race=false"
+  
+    - name: ":linux: Linux ARM64 Tests"
+      key: test-linux-arm64
+      command: ".buildkite/steps/tests.sh"
+      parallelism: 2
+      artifact_paths:
+        - junit-*.xml
+        - "coverage/**/*"
+      agents:
+        queue: $AGENT_RUNNERS_LINUX_ARM64_QUEUE
+      plugins:
+        - docker-compose#v4.14.0:
+            config: .buildkite/docker-compose.yml
+            cli-version: 2
+            propagate-environment: true
+            run: agent
+        - test-collector#v1.11.0:
+            files: "junit-*.xml"
+            format: "junit"
+            tags:
+              - "os=linux"
+              - "arch=arm64"
+              - "race=false"
+              
+    - name: ":windows: Windows AMD64 Tests"
+      key: test-windows
+      command: "bash .buildkite\\steps\\tests.sh"
+      parallelism: 2
+      artifact_paths:
+        - junit-*.xml
+        - "coverage/**/*"
+      agents:
+        queue: $AGENT_RUNNERS_WINDOWS_QUEUE
+      plugins:
+        - test-collector#v1.11.0:
+            files: "junit-*.xml"
+            format: "junit"
+            tags:
+              - "os=windows"
+              - "arch=arm64"
+              - "race=false"
+  
+    - name: ":satellite: Detect Data Races"
+      key: test-race-linux-arm64
+      command: ".buildkite/steps/tests.sh -race"
+      # Extra parallelism because this data race test is slow
+      parallelism: 3
+      artifact_paths:
+        - junit-*.xml
+        - "coverage/**/*"
+      agents:
+        queue: $AGENT_RUNNERS_LINUX_ARM64_QUEUE
+      plugins:
+        - docker-compose#v4.14.0:
+            config: .buildkite/docker-compose.yml
+            cli-version: 2
+            propagate-environment: true
+            run: agent
+        - test-collector#v1.11.0:
+            files: "junit-*.xml"
+            format: "junit"
+            tags:
+              - "os=linux"
+              - "arch=arm64"
+              - "race=true"
+              
+    - name: ":coverage: Test coverage report Linux ARM64"
+      key: test-coverage-linux-arm64
+      command: ".buildkite/steps/test-coverage-report.sh"
+      artifact_paths:
+        - "cover.html"
+        - "cover.out"
+      depends_on:
+        - test-linux-arm64
+      plugins:
+        - docker-compose#v4.14.0:
+            config: .buildkite/docker-compose.yml
+            cli-version: 2
+            run: agent
+        - artifacts#v1.9.4:
+            download: "coverage/**"
+            step: test-linux-arm64
+    
+    - name: ":coverage: Test coverage report Linux AMD64"
+      key: test-coverage-linux-amd64
+      command: ".buildkite/steps/test-coverage-report.sh"
+      artifact_paths:
+        - "cover.html"
+        - "cover.out"
+      depends_on:
+        - test-linux-amd64
+      plugins:
+        - docker-compose#v4.14.0:
+            config: .buildkite/docker-compose.yml
+            cli-version: 2
+            run: agent
+        - artifacts#v1.9.4:
+            download: "coverage/**"
+            step: test-linux-amd64
+    
+    - name: ":coverage: Test coverage report Linux ARM64 Race"
+      key: test-coverage-linux-arm64-race
+      command: ".buildkite/steps/test-coverage-report.sh"
+      artifact_paths:
+        - "cover.html"
+        - "cover.out"
+      depends_on:
+        - test-race-linux-arm64
+      plugins:
+        - docker-compose#v4.14.0:
+            config: .buildkite/docker-compose.yml
+            cli-version: 2
+            run: agent
+        - artifacts#v1.9.4:
+            download: "coverage/**"
+            step: test-race-linux-arm64
+  
+    - label: ":writing_hand: Annotate with Test Failures"
+      depends_on:
+        - test-linux-amd64
+        - test-race-linux-arm64
+        - test-linux-arm64
+        - test-windows
+      allow_dependency_failure: true
+      plugins:
+        - junit-annotate#v1.6.0:
+            artifacts: junit-*.xml
+            
+  # --- end Tests and Coverage ---
 
   - group: ":hammer_and_wrench: Binary builds"
     steps:
@@ -219,6 +225,8 @@ steps:
 
             - with: { os: openbsd, arch: arm64 }
               skip: "arm64 OpenBSD is not currently supported"
+              
+  # --- end Binary builds ---
 
   - label: ":bathtub: Check version string is clean"
     key: check-version-string
@@ -332,6 +340,8 @@ steps:
               - ubuntu-22.04
               - ubuntu-24.04
               - sidecar
+              
+  # --- end Docker Image tests ---
 
   - name: ":debian: Debian package build"
     key: build-debian-packages


### PR DESCRIPTION
### Description

Reduce the number of steps that run if no Go code (or their non-code dependencies) has changed.

### Context

Dogfood `if_changed` support

### Changes

- Group Tests and Coverage
- Make Lint step only run if code or the script that runs it has changed
- Make Tests and Coverage group only run if code or related scripts changed

### Testing

Pipeline change only - but particularly, these are _not_ run because the code didn't change!

- ~~[] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.~~ 
- ~~[] Code is formatted (with `go fmt ./...`)~~
