### PR TITLE
chore: move the tool.go to new tool dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -175,3 +175,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+tool github.com/Khan/genqlient/generate

--- a/tools.go
+++ b/tools.go
@@ -1,8 +1,0 @@
-//go:build tools
-// +build tools
-
-package main
-
-import (
-	_ "github.com/Khan/genqlient/generate"
-)


### PR DESCRIPTION
We can now add tool dependencies in `go.mod`.

```
go get -tool  github.com/Khan/genqlient/generate
```

### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
