### PR TITLE
Update to use OIDC session tags on AWS role assumption

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -6,8 +6,13 @@ steps:
     env:
       CODENAME: "experimental"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -26,8 +31,13 @@ steps:
       CODENAME: "experimental"
       RPM_S3_BUCKET: "yum.buildkite.com"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch
       - docker#v5.8.0:
           image: "buildkite/agent:3.55.0-ubuntu"
           entrypoint: bash
@@ -79,8 +89,13 @@ steps:
       CODENAME: "experimental"
       DEB_S3_BUCKET: "apt.buildkite.com/buildkite-agent"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -144,8 +159,13 @@ steps:
           CODENAME: "experimental"
           REGISTRY: "{{matrix.registry}}"
         plugins:
-          - aws-assume-role-with-web-identity:
+          - aws-assume-role-with-web-identity#v1.4.0:
               role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-edge
+              session-tags:
+                - organization_slug
+                - organization_id
+                - pipeline_slug
+                - build_branch
           - ecr#v2.7.0:
               login: true
               account-ids: "445615400570"

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -11,8 +11,13 @@ steps:
     env:
       CODENAME: "stable"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -30,8 +35,13 @@ steps:
     env:
       CODENAME: "stable"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -50,8 +60,13 @@ steps:
       CODENAME: "stable"
       RPM_S3_BUCKET: "yum.buildkite.com"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch
       - docker#v5.8.0:
           environment:
             - "AWS_ACCESS_KEY_ID"
@@ -107,8 +122,13 @@ steps:
       CODENAME: "stable"
       DEB_S3_BUCKET: "apt.buildkite.com/buildkite-agent"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -168,8 +188,13 @@ steps:
           CODENAME: "stable"
           REGISTRY: "{{matrix.registry}}"
         plugins:
-          - aws-assume-role-with-web-identity:
+          - aws-assume-role-with-web-identity#v1.4.0:
               role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
+              session-tags:
+                - organization_slug
+                - organization_id
+                - pipeline_slug
+                - build_branch
           - ecr#v2.7.0:
               login: true
               account-ids: "445615400570"
@@ -191,8 +216,13 @@ steps:
     env:
       CODENAME: "stable"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-stable
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -11,8 +11,12 @@ steps:
     env:
       CODENAME: "unstable"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -30,8 +34,12 @@ steps:
     env:
       CODENAME: "unstable"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -50,8 +58,12 @@ steps:
       CODENAME: "unstable"
       RPM_S3_BUCKET: "yum.buildkite.com"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
       - docker#v5.8.0:
           environment:
             - "AWS_ACCESS_KEY_ID"
@@ -107,8 +119,12 @@ steps:
       CODENAME: "unstable"
       DEB_S3_BUCKET: "apt.buildkite.com/buildkite-agent"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -168,8 +184,12 @@ steps:
           CODENAME: "unstable"
           REGISTRY: "{{matrix.registry}}"
         plugins:
-          - aws-assume-role-with-web-identity:
+          - aws-assume-role-with-web-identity#v1.4.0:
               role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
+              session-tags:
+                - organization_slug
+                - organization_id
+                - pipeline_slug
           - ecr#v2.7.0:
               login: true
               account-ids: "445615400570"
@@ -191,8 +211,12 @@ steps:
     env:
       CODENAME: "unstable"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-beta
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"


### PR DESCRIPTION
### Description

Roll out using session tags for OIDC assumable IAM role trust policy. 
<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

### Context

Follow on from the work to support session tags in https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/pull/18

Requires matching update to the IAM role in PR: https://github.com/buildkite/aws-buildkite-dev/pull/474

https://linear.app/buildkite/issue/PLT-4154/update-oidc-assumable-roles-to-use-session-tokens 
<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

### Changes

This is only changing the one pipeline, which uses an IAM role in `buildkite-dev` account. Additional pipelines defined in this repo will be updated when I move on to working on the `ops` repo roles. 
<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->
