### PR TITLE
PS-980: fix custom TMPDIR break hook wrapper

### DIFF
--- a/internal/job/hook/wrapper.go
+++ b/internal/job/hook/wrapper.go
@@ -203,11 +203,22 @@ func NewWrapper(opts ...WrapperOpt) (*Wrapper, error) {
 		templateType = PosixShellTemplateType
 	}
 
+	// The os.TempDir might not exist, since user can set $TMPDIR.
+	// Although we attempt to do the same in job_runner, part of job_runner runs before backend env
+	// populated the process.
+	// So TLDR, $TMPDIR could change between job_runner and hook wrapper.
+	osTempDir := os.TempDir()
+	if _, err := os.Stat(osTempDir); os.IsNotExist(err) {
+		if err = os.MkdirAll(osTempDir, 0o777); err != nil {
+			return nil, err
+		}
+	}
+
 	// On systems where multiple buildkite-agents are running under different
 	// users, a shared path could be owned by a different user.
 	// Creating a new temporary directory to hold the temporary files avoids
 	// this issue and makes cleanup easier.
-	tempDir, err := os.MkdirTemp(os.TempDir(), hookWrapperDir)
+	tempDir, err := os.MkdirTemp(osTempDir, hookWrapperDir)
 	if err != nil {
 		return nil, fmt.Errorf("creating temporary directory for hook wrapper: %w", err)
 	}


### PR DESCRIPTION
### Description

When a customer specify `$TMPDIR` in `env`, if the directory does not exist it will break the the hook wrapper. 

It seems to be a long standing issue, it is unclear why it was claimed to be working in one of recent agent release. 

### Context

PS-980

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

Minimum reproduce case: 

```
env:
  TMPDIR: "/tmp/not-exist"

steps:
- label: ":pipeline:"
  command: echo "hello world"
  plugins:
  - improbable-eng/metahook:
      pre-command: echo "pre-command"
```
