### PR TITLE
Make the 'Pipeline upload not yet applied: processing' message info, not warning

### DIFF
--- a/agent/pipeline_uploader.go
+++ b/agent/pipeline_uploader.go
@@ -209,7 +209,7 @@ func (u *PipelineUploader) pollForPiplineUploadStatus(ctx context.Context, l log
 		case "pending", "processing":
 			setNextIntervalFromResponse(r, resp)
 			err := fmt.Errorf("Pipeline upload not yet applied: %s", uploadStatus.State)
-			l.Warn("%s (%s)", err, r)
+			l.Info("%s (%s)", err, r)
 			return err
 		case "rejected", "failed":
 			l.Error("Unrecoverable error, skipping retries")


### PR DESCRIPTION
### Description

Fixes https://github.com/buildkite/agent/issues/3418

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

