### PR TITLE
Promote use-zzglob experiment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gowebpki/jcs v1.0.1
 	github.com/lestrrat-go/jwx/v2 v2.1.6
-	github.com/mattn/go-zglob v0.0.6
 	github.com/oleiade/reflections v1.1.0
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pborman/uuid v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,6 @@ github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNB
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 h1:PpXWgLPs+Fqr325bN2FD2ISlRRztXibcX6e8f5FR5Dc=
 github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
-github.com/mattn/go-zglob v0.0.6 h1:mP8RnmCgho4oaUYDIDn6GNxYk+qJGUs8fJLn+twYj2A=
-github.com/mattn/go-zglob v0.0.6/go.mod h1:MxxjyoXXnMxfIpxTK2GAkw1w8glPsQILx3N5wrKakiY=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/artifact/uploader_test.go
+++ b/internal/artifact/uploader_test.go
@@ -1,7 +1,6 @@
 package artifact
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,7 +25,7 @@ func findArtifact(artifacts []*api.Artifact, search string) *api.Artifact {
 
 func TestCollect(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	root, _ := os.Getwd()
 
@@ -154,7 +153,7 @@ func TestCollect(t *testing.T) {
 
 func TestCollectThatDoesntMatchAnyFiles(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
 		Paths: strings.Join([]string{
@@ -175,7 +174,7 @@ func TestCollectThatDoesntMatchAnyFiles(t *testing.T) {
 
 func TestCollectWithSomeGlobsThatDontMatchAnything(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
 		Paths: strings.Join([]string{
@@ -197,7 +196,7 @@ func TestCollectWithSomeGlobsThatDontMatchAnything(t *testing.T) {
 
 func TestCollectWithSomeGlobsThatDontMatchAnythingFollowingSymlinks(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
 		Paths: strings.Join([]string{
@@ -221,7 +220,7 @@ func TestCollectWithSomeGlobsThatDontMatchAnythingFollowingSymlinks(t *testing.T
 
 func TestCollectWithDuplicateMatches(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
 		Paths: strings.Join([]string{
@@ -253,7 +252,7 @@ func TestCollectWithDuplicateMatches(t *testing.T) {
 
 func TestCollectWithDuplicateMatchesFollowingSymlinks(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
 		Paths: strings.Join([]string{
@@ -287,299 +286,7 @@ func TestCollectWithDuplicateMatchesFollowingSymlinks(t *testing.T) {
 
 func TestCollectMatchesUploadSymlinks(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
-
-	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
-		Paths: strings.Join([]string{
-			filepath.Join("fixtures", "**", "*.jpg"),
-		}, ";"),
-		UploadSkipSymlinks: true,
-	})
-
-	artifacts, err := uploader.collect(ctx)
-	if err != nil {
-		t.Fatalf("uploader.Collect() error = %v", err)
-	}
-
-	paths := []string{}
-	for _, a := range artifacts {
-		paths = append(paths, a.Path)
-	}
-	assert.ElementsMatch(
-		t,
-		[]string{
-			filepath.Join("fixtures", "Mr Freeze.jpg"),
-			filepath.Join("fixtures", "folder", "Commando.jpg"),
-			filepath.Join("fixtures", "this is a folder with a space", "The Terminator.jpg"),
-		},
-		paths,
-	)
-}
-
-func TestCollect_WithZZGlob(t *testing.T) {
-	t.Parallel()
-	ctx, _ := experiments.Enable(context.Background(), experiments.UseZZGlob)
-
-	root, _ := os.Getwd()
-
-	volumeName := filepath.VolumeName(root)
-	rootWithoutVolume := strings.TrimPrefix(root, volumeName)
-
-	var testCases = []struct {
-		Name         string
-		Path         []string
-		AbsolutePath string
-		FileSize     int
-		Sha1Sum      string
-		Sha256Sum    string
-	}{
-		{
-			Name:         "Mr Freeze.jpg",
-			Path:         []string{"fixtures", "Mr Freeze.jpg"},
-			AbsolutePath: filepath.Join(root, "fixtures", "Mr Freeze.jpg"),
-			FileSize:     362371,
-			Sha1Sum:      "f5bc7bc9f5f9c3e543dde0eb44876c6f9acbfb6b",
-			Sha256Sum:    "0c657a363d92093e68224e0716ed8b8b5d4bbc3dfe9b026e32b241fc9b369d47",
-		},
-		{
-			Name:         "Commando.jpg",
-			Path:         []string{"fixtures", "folder", "Commando.jpg"},
-			AbsolutePath: filepath.Join(root, "fixtures", "folder", "Commando.jpg"),
-			FileSize:     113000,
-			Sha1Sum:      "811d7cb0317582e22ebfeb929d601cdabea4b3c0",
-			Sha256Sum:    "fcfbe62fd7b6638165a61e8de901ac9df93fc1389906f2772bdefed5de115426",
-		},
-		{
-			Name:         "The Terminator.jpg",
-			Path:         []string{"fixtures", "this is a folder with a space", "The Terminator.jpg"},
-			AbsolutePath: filepath.Join(root, "fixtures", "this is a folder with a space", "The Terminator.jpg"),
-			FileSize:     47301,
-			Sha1Sum:      "ed76566ede9cb6edc975fcadca429665aad8785a",
-			Sha256Sum:    "5b4228a4bbef3d9f676e0a2e8cf6ea06759124ef0fbdb27a6c35df8759fcd39d",
-		},
-		{
-			Name:         "Smile.gif",
-			Path:         []string{rootWithoutVolume[1:], "fixtures", "gifs", "Smile.gif"},
-			AbsolutePath: filepath.Join(root, "fixtures", "gifs", "Smile.gif"),
-			FileSize:     2038453,
-			Sha1Sum:      "bd4caf2e01e59777744ac1d52deafa01c2cb9bfd",
-			Sha256Sum:    "fc5e8608c7772e4ae834fbc47eec3d902099eb3599f5191e40d9e3d9b3764b0e",
-		},
-	}
-
-	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
-		Paths: fmt.Sprintf("%s;%s",
-			filepath.Join("fixtures", "**/*.jpg"),
-			filepath.Join(root, "fixtures", "**/*.gif"),
-		),
-	})
-
-	// For the normalised-upload-paths experiment, uploaded artifact paths are
-	// normalised with Unix/URI style path separators, even on Windows.
-	// Without the experiment on, we use the file path given by the file system
-	//
-	// To simulate that in this test, we collect artifacts from the file system
-	// twice, once with the experiment explicitly disabled, and one with it
-	// enabled. We then check the test cases against both sets of artifacts,
-	// comparing to paths processed with filepath.Join (which uses native OS
-	// path separators), and then with the experiment enabled and with the
-	// path.Join function instead (which uses Unix/URI-style path separators,
-	// regardless of platform)
-
-	ctxExpEnabled, _ := experiments.Enable(ctx, experiments.NormalisedUploadPaths)
-	ctxExpDisabled := experiments.Disable(ctx, experiments.NormalisedUploadPaths)
-
-	artifactsWithoutExperimentEnabled, err := uploader.collect(ctxExpDisabled)
-	if err != nil {
-		t.Fatalf("[normalised-upload-paths disabled] uploader.Collect() error = %v", err)
-	}
-	assert.Equal(t, 5, len(artifactsWithoutExperimentEnabled))
-
-	artifactsWithExperimentEnabled, err := uploader.collect(ctxExpEnabled)
-	if err != nil {
-		t.Fatalf("[normalised-upload-paths enabled] uploader.Collect() error = %v", err)
-	}
-	assert.Equal(t, 5, len(artifactsWithExperimentEnabled))
-
-	// These test cases use filepath.Join, which uses per-OS path separators;
-	// this is the behaviour without normalised-upload-paths.
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			t.Parallel()
-			a := findArtifact(artifactsWithoutExperimentEnabled, tc.Name)
-			if a == nil {
-				t.Fatalf("findArtifact(%q) == nil", tc.Name)
-			}
-
-			assert.Equal(t, filepath.Join(tc.Path...), a.Path)
-			assert.Equal(t, tc.AbsolutePath, a.AbsolutePath)
-			assert.Equal(t, tc.FileSize, int(a.FileSize))
-			assert.Equal(t, tc.Sha1Sum, a.Sha1Sum)
-			assert.Equal(t, tc.Sha256Sum, a.Sha256Sum)
-		})
-	}
-
-	// These test cases uses filepath.ToSlash(), which always emits forward-slashes.
-	// this is the behaviour with normalised-upload-paths.
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			t.Parallel()
-			a := findArtifact(artifactsWithExperimentEnabled, tc.Name)
-			if a == nil {
-				t.Fatalf("findArtifact(%q) == nil", tc.Name)
-			}
-
-			// Note that the rootWithoutVolume component of some tc.Path values
-			// may already have backslashes in them on Windows:
-			// []string{"path\to\codebase", "fixtures", "hello"}
-			// So forward-slash joining them with path.Join(tc.Path...} isn't enough.
-			forwardSlashed := filepath.ToSlash(filepath.Join(tc.Path...))
-
-			assert.Equal(t, forwardSlashed, a.Path)
-			assert.Equal(t, tc.AbsolutePath, a.AbsolutePath)
-			assert.Equal(t, tc.FileSize, int(a.FileSize))
-			assert.Equal(t, tc.Sha1Sum, a.Sha1Sum)
-			assert.Equal(t, tc.Sha256Sum, a.Sha256Sum)
-		})
-	}
-}
-
-func TestCollectThatDoesntMatchAnyFiles_WithZZGlob(t *testing.T) {
-	t.Parallel()
-	ctx, _ := experiments.Enable(context.Background(), experiments.UseZZGlob)
-
-	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
-		Paths: strings.Join([]string{
-			filepath.Join("log", "*"),
-			filepath.Join("tmp", "capybara", "**", "*"),
-			filepath.Join("mkmf.log"),
-			filepath.Join("log", "mkmf.log"),
-		}, ";"),
-	})
-
-	artifacts, err := uploader.collect(ctx)
-	if err != nil {
-		t.Fatalf("uploader.Collect() error = %v", err)
-	}
-
-	assert.Equal(t, len(artifacts), 0)
-}
-
-func TestCollectWithSomeGlobsThatDontMatchAnything_WithZZGlob(t *testing.T) {
-	t.Parallel()
-	ctx, _ := experiments.Enable(context.Background(), experiments.UseZZGlob)
-
-	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
-		Paths: strings.Join([]string{
-			filepath.Join("dontmatchanything", "*"),
-			filepath.Join("dontmatchanything.zip"),
-			filepath.Join("fixtures", "**", "*.jpg"),
-		}, ";"),
-	})
-
-	artifacts, err := uploader.collect(ctx)
-	if err != nil {
-		t.Fatalf("uploader.Collect() error = %v", err)
-	}
-
-	if len(artifacts) != 4 {
-		t.Errorf("len(artifacts) = %d, want 4", len(artifacts))
-	}
-}
-
-func TestCollectWithSomeGlobsThatDontMatchAnythingFollowingSymlinks_WithZZGlob(t *testing.T) {
-	t.Parallel()
-	ctx, _ := experiments.Enable(context.Background(), experiments.UseZZGlob)
-
-	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
-		Paths: strings.Join([]string{
-			filepath.Join("dontmatchanything", "*"),
-			filepath.Join("dontmatchanything.zip"),
-			filepath.Join("fixtures", "links", "folder-link", "dontmatchanything", "**", "*.jpg"),
-			filepath.Join("fixtures", "**", "*.jpg"),
-		}, ";"),
-		GlobResolveFollowSymlinks: true,
-	})
-
-	artifacts, err := uploader.collect(ctx)
-	if err != nil {
-		t.Fatalf("uploader.Collect() error = %v", err)
-	}
-
-	if len(artifacts) != 5 {
-		t.Errorf("len(artifacts) = %d, want 5", len(artifacts))
-	}
-}
-
-func TestCollectWithDuplicateMatches_WithZZGlob(t *testing.T) {
-	t.Parallel()
-	ctx, _ := experiments.Enable(context.Background(), experiments.UseZZGlob)
-
-	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
-		Paths: strings.Join([]string{
-			filepath.Join("fixtures", "**", "*.jpg"),
-			filepath.Join("fixtures", "folder", "Commando.jpg"), // dupe
-		}, ";"),
-	})
-
-	artifacts, err := uploader.collect(ctx)
-	if err != nil {
-		t.Fatalf("uploader.Collect() error = %v", err)
-	}
-
-	paths := []string{}
-	for _, a := range artifacts {
-		paths = append(paths, a.Path)
-	}
-	assert.ElementsMatch(
-		t,
-		[]string{
-			filepath.Join("fixtures", "Mr Freeze.jpg"),
-			filepath.Join("fixtures", "folder", "Commando.jpg"),
-			filepath.Join("fixtures", "this is a folder with a space", "The Terminator.jpg"),
-			filepath.Join("fixtures", "links", "terminator", "terminator2.jpg"),
-		},
-		paths,
-	)
-}
-
-func TestCollectWithDuplicateMatchesFollowingSymlinks_WithZZGlob(t *testing.T) {
-	t.Parallel()
-	ctx, _ := experiments.Enable(context.Background(), experiments.UseZZGlob)
-
-	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
-		Paths: strings.Join([]string{
-			filepath.Join("fixtures", "**", "*.jpg"),
-			filepath.Join("fixtures", "folder", "Commando.jpg"), // dupe
-		}, ";"),
-		GlobResolveFollowSymlinks: true,
-	})
-
-	artifacts, err := uploader.collect(ctx)
-	if err != nil {
-		t.Fatalf("uploader.Collect() error = %v", err)
-	}
-
-	paths := []string{}
-	for _, a := range artifacts {
-		paths = append(paths, a.Path)
-	}
-	assert.ElementsMatch(
-		t,
-		[]string{
-			filepath.Join("fixtures", "Mr Freeze.jpg"),
-			filepath.Join("fixtures", "folder", "Commando.jpg"),
-			filepath.Join("fixtures", "this is a folder with a space", "The Terminator.jpg"),
-			filepath.Join("fixtures", "links", "terminator", "terminator2.jpg"),
-			filepath.Join("fixtures", "links", "folder-link", "terminator2.jpg"),
-		},
-		paths,
-	)
-}
-
-func TestCollectMatchesUploadSymlinks_WithZZGlob(t *testing.T) {
-	t.Parallel()
-	ctx, _ := experiments.Enable(context.Background(), experiments.UseZZGlob)
+	ctx := t.Context()
 
 	uploader := NewUploader(logger.Discard, nil, UploaderConfig{
 		Paths: strings.Join([]string{

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -31,7 +31,6 @@ const (
 	OverrideZeroExitOnCancel       = "override-zero-exit-on-cancel"
 	PTYRaw                         = "pty-raw"
 	ResolveCommitAfterCheckout     = "resolve-commit-after-checkout"
-	UseZZGlob                      = "use-zzglob"
 
 	// Promoted experiments
 	ANSITimestamps         = "ansi-timestamps"
@@ -43,6 +42,7 @@ const (
 	JobAPI                 = "job-api"
 	KubernetesExec         = "kubernetes-exec"
 	PolyglotHooks          = "polyglot-hooks"
+	UseZZGlob              = "use-zzglob"
 )
 
 var (
@@ -55,7 +55,6 @@ var (
 		OverrideZeroExitOnCancel:       {},
 		PTYRaw:                         {},
 		ResolveCommitAfterCheckout:     {},
-		UseZZGlob:                      {},
 	}
 
 	Promoted = map[string]string{
@@ -68,6 +67,7 @@ var (
 		JobAPI:                 standardPromotionMsg(JobAPI, "v3.64.0"),
 		KubernetesExec:         "The kubernetes-exec experiment has been replaced with the --kubernetes-exec flag as of agent v3.74.0",
 		PolyglotHooks:          standardPromotionMsg(PolyglotHooks, "v3.85.0"),
+		UseZZGlob:              standardPromotionMsg(PolyglotHooks, "v3.104.0"),
 	}
 
 	// Used to track experiments possibly in use.


### PR DESCRIPTION
### Description

Promote `use-zzglob` to default.

### Context

Well it's about time.

### Changes

- Mark `use-zzglob` as promoted
- Remove the old zglob library.
- Remove doubled tests.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
