### PR TITLE
Fix experiment promotion message

### DIFF
--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -67,7 +67,7 @@ var (
 		JobAPI:                 standardPromotionMsg(JobAPI, "v3.64.0"),
 		KubernetesExec:         "The kubernetes-exec experiment has been replaced with the --kubernetes-exec flag as of agent v3.74.0",
 		PolyglotHooks:          standardPromotionMsg(PolyglotHooks, "v3.85.0"),
-		UseZZGlob:              standardPromotionMsg(PolyglotHooks, "v3.104.0"),
+		UseZZGlob:              standardPromotionMsg(UseZZGlob, "v3.104.0"),
 	}
 
 	// Used to track experiments possibly in use.


### PR DESCRIPTION
### Description

Copy-pasta error

### Context

Noticed in recent build (uses edge agents).

### Changes

The message printed when you try the `use-zzglob` experiment

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
