### PR TITLE
Add disclosures/credits to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,3 +26,18 @@ Can skip if changes are simple or clear from the commit messages.
 <!--
 Note: if the tests fail to run locally, please let us know!
 -->
+
+
+### Disclosures / Credits
+
+<!--
+If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
+Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.
+
+Examples: 
+ - "Claude Code wrote the unit tests, then I implemented the rest of the change"
+ - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
+ - "I used Gemini to write the code and Midjourney to produce the diagrams"
+ - "Special thanks to the Wikipedia page on ANSI escape codes"
+ - "I did not use AI tools at all"
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 1. Commit your changes (`git commit -am 'Add some feature'`)
     - In an ideal world we have [atomic commits](https://www.pauline-vos.nl/atomic-commits/) and use [Tim Pope-style commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), but so long as it's clear what's happening in your PR, that's fine. We try to not be super persnickety about these things.
 1. Push to your branch (`git push origin my-new-feature`)
-1. Create a pull request for your branch. Make sure that your PR has a nice description, and that it's linked to any relevant issues.
+1. Create a pull request for your branch. Make sure that your PR has a nice description (fill in the template), and that it's linked to any relevant issues.
 
 The agent wranglers at Buildkite will review your PR, and start a CI build for it. For security reasons, we don't automatically run CI against forked repos, and a human will review your PR prior to its CI running.
 


### PR DESCRIPTION
### Description

For various reasons, we'd like to know when AI tools contribute to contributions. 

### Context

Inspired by https://github.com/ghostty-org/ghostty/pull/8289

### Changes

- Adds a Disclosures / Credits section to the PR template

### Testing
- ~~[ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.~~ N/A
- ~~[ ] Code is formatted (with `go fmt ./...`)~~ N/A

### Disclosures / Credits

I wrote all this myself, but was inspired by the new Ghostty policy to kick this off.