### PR TITLE
Ensure that bootstrap waits for its self-signal to propagate before exiting

### DIFF
--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -8,9 +8,11 @@ import (
 	"runtime"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/buildkite/agent/v3/internal/job"
 	"github.com/buildkite/agent/v3/internal/self"
+	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/agent/v3/process"
 	"github.com/buildkite/agent/v3/tracetools"
 	"github.com/urfave/cli"
@@ -513,7 +515,8 @@ var BootstrapCommand = cli.Command{
 			syscall.SIGHUP,
 			syscall.SIGTERM,
 			syscall.SIGINT,
-			syscall.SIGQUIT)
+			syscall.SIGQUIT,
+		)
 		defer signal.Stop(signals)
 
 		var (
@@ -550,18 +553,31 @@ var BootstrapCommand = cli.Command{
 		// If cancelled and our child process returns a non-zero, we should terminate
 		// ourselves with the same signal so that our caller can detect and handle appropriately
 		if cancelled && runtime.GOOS != "windows" {
-			p, err := os.FindProcess(os.Getpid())
-			if err != nil {
-				l.Error("Failed to find current process: %v", err)
-			}
-
-			l.Debug("Terminating bootstrap after cancellation with %v", received)
-			err = p.Signal(received)
-			if err != nil {
+			if err := signalSelf(l, received); err != nil {
 				l.Error("Failed to signal self: %v", err)
 			}
 		}
 
 		return &SilentExitError{code: exitCode}
 	},
+}
+
+func signalSelf(l logger.Logger, sig os.Signal) error {
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		return fmt.Errorf("failed to find current process: %w", err)
+	}
+
+	l.Debug("Terminating bootstrap after cancellation with %v", sig)
+	err = p.Signal(sig)
+	if err != nil {
+		return fmt.Errorf("failed to signal self: %v", err)
+	}
+
+	// Wait for a bit to allow the signal to be processed. Without this, the program can exit before the signal actually
+	// get sent and received, and the WaitStatus of this process won't indicate that it was signalled.
+	// Note that in almost all cases, we won't actually wait for 10 seconds, as the signal is generally processed extremely
+	// quickly. Sending ourself a SIGTERM will stop the agent before the time.Sleep is up.
+	time.Sleep(10 * time.Second)
+	return nil
 }


### PR DESCRIPTION
### Description

One piece of information that the Buildkite Agent reports about the jobs it runs is what signal was used to terminate them, if any. However, under POSIX, the wait status of a process (as reported by [the `wait` syscall](https://www.man7.org/linux/man-pages/man2/wait.2.html)) only reports the terminating signal of a process if that signal is unhandled -- ie, if it's not captured by `trap`, `signal.Notify` and friends.

The bootstrap process does catch signals using `signal.Notify` so as to gracefully shut down jobs, but it still needs to report the signal that terminated it, so it does a little bit of sorcery to pull this off. When the bootstrap process recieves a signal, it:
- Catches the signal using `signal.Notify`
- Gracefully terminates the job process
- Shuts down its signal notifier
- **Sends itself the original signal it caught**, self terminating the process

This ensures that the job process can be gracefully terminated, but also reports that the process was killed by a signal to its parents in the process tree.

However, there was a bit of a race condition encoded in this behaviour: the self-signalling was the very last thing to happen in the bootstrap process prior to exiting with some exit status, so depending on the vagaries of how long it takes a signal to propagate, the wait status of the process would have an inconsistent value for whether it was signalled. If the program managed to exit before the self-signal made it through, then it would have no signal in the wait status, but if the signal got through, it would have it as intended.

This PR fixes that race condition the way God intended: By adding a call to `time.Sleep` with an arbitrary value in it. Jokes aside, this basically means we wait for the signal to come through, which will abort the `time.Sleep`. If in some exceptional case, the signal takes longer than ten seconds (out arbitrary value) to process, it will fall back to exiting before the signal propagates, which will still fail the job, but won't include the signal information in the job payload.

### Context

PS-1069

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

### Disclosures / Credits

Many thanks to @DrJosh9000 who helped me work through this and figure it out! 