### PR TITLE
Read env after running unwrapped hook

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -432,7 +432,16 @@ func (e *Executor) runUnwrappedHook(ctx context.Context, _ string, hookCfg HookC
 	environ.Set("BUILDKITE_HOOK_PATH", hookCfg.Path)
 	environ.Set("BUILDKITE_HOOK_SCOPE", hookCfg.Scope)
 
-	return e.shell.Command(hookCfg.Path).Run(ctx, shell.WithExtraEnv(environ))
+	if err := e.shell.Command(hookCfg.Path).Run(ctx, shell.WithExtraEnv(environ)); err != nil {
+		return err
+	}
+
+	if e.Debug {
+		e.shell.Commentf("Refreshing executor config to reflect changes made through the job API")
+	}
+	e.ReadFromEnvironment(e.shell.Env)
+
+	return nil
 }
 
 func logOpenedHookInfo(l shell.Logger, debug bool, hookName, path string) {


### PR DESCRIPTION
### Description
Certain runtime agent configs are not updated after running non-shell hooks. This PR calls `ExecutorConfig.ReadFromEnvironment` after the hook to update from the latest environment.

### Context
When running a shell hook, `ExecutorConfig.ReadFromEnvironment` is called as part of `Executor.runWrappedShellScriptHook`, so changes to env vars that affect the agent's behaviour (e.g. `BUILDKITE_REPO`) are properly reflected in the agent's internal state.

When running non-shell hooks (Python scripts, compiled binaries, etc), the hook is run through `Executor.runUnwrappedHook`, which doesn't capture env changes after running the hook (the Job API is used to set environment variables).

### Changes
- Adds an explicit call to `ExecutorConfig.ReadFromEnvironment` in `Executor.runUnwrappedHook` after the hook exits successfully

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

TODO: add a new test for this


### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples: 
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->