### PR TITLE
Automatically redact OIDC tokens

### DIFF
--- a/clicommand/redactor_add.go
+++ b/clicommand/redactor_add.go
@@ -30,6 +30,7 @@ var (
 
 	errSecretParse   = errors.New("failed to parse secrets")
 	errSecretRedact  = errors.New("failed to redact secrets")
+	errOIDCRedact    = errors.New("failed to redact OIDC token")
 	errUnknownFormat = errors.New("unknown format")
 )
 


### PR DESCRIPTION
OIDC tokens are now automatically redacted from build logs by default, with an optional --skip-redaction flag to disable this behavior when needed.

```
$ buildkite-agent oidc request-token
[REDACTED]
```

```
$ buildkite-agent oidc request-token --skip-redaction
eyJra....
```

This uses the same mechanisms as `buildkite-agent secret get` for redacting the token.

### Context

Fixes PS-1128

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

Amp wrote the change with this prompt:

We want to implement auto-redaction for OIDC tokens. `buildkite-agent secret get <SECRET_NAME>` already supports auto-redaction. We want to extend this to `buildkite-agent oidc request-token`. This should work the same as secret redaction where the token is automatically redacted by the CLI command and does not require manual redaction. Add a skip-redaction flag. Read agent/clicommand/secret_get.go for how secrets are redacted.
