### PR TITLE
Re-add test race detection, and skip a known-racy test under the race  regime

### DIFF
--- a/internal/job/checkout_test.go
+++ b/internal/job/checkout_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/v3/internal/job/githttptest"
+	"github.com/buildkite/agent/v3/internal/race"
 	"github.com/buildkite/agent/v3/internal/shell"
 	"github.com/stretchr/testify/require"
 )
@@ -130,6 +131,10 @@ func TestDefaultCheckoutPhase(t *testing.T) {
 }
 
 func TestDefaultCheckoutPhase_DelayedRefCreation(t *testing.T) {
+	if race.IsRaceTest {
+		t.Skip("this test simulates the agent recovering from a race condition, and needs to create one to test it.")
+	}
+
 	assert := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/race/race_disabled.go
+++ b/internal/race/race_disabled.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package race
+
+const IsRaceTest = false

--- a/internal/race/race_enabled.go
+++ b/internal/race/race_enabled.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package race
+
+const IsRaceTest = true


### PR DESCRIPTION
### Description

We have a test in the executor that relies on the presence of a race condition – it ensures that when a race condition happens, the agent can recover.

We used to have a thingy to skip racy tests, but we got rid of a lot of racy tests. This PR re-adds that utility, and adds it to the known-racy test above

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

This insanely complicated code is all off the top of the dome piece