### PR TITLE
Update shellwords to v1.0.1, relax Go version directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/buildkite/agent/v3
 
-go 1.24.3
+go 1.24.0
+
+toolchain go1.24.5
 
 require (
 	cloud.google.com/go/compute/metadata v0.8.0
@@ -19,7 +21,7 @@ require (
 	github.com/buildkite/go-pipeline v0.15.0
 	github.com/buildkite/interpolate v0.1.5
 	github.com/buildkite/roko v1.4.0
-	github.com/buildkite/shellwords v1.0.0
+	github.com/buildkite/shellwords v1.0.1
 	github.com/creack/pty v1.1.19
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dustin/go-humanize v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/buildkite/interpolate v0.1.5 h1:v2Ji3voik69UZlbfoqzx+qfcsOKLA61nHdU79
 github.com/buildkite/interpolate v0.1.5/go.mod h1:dHnrwHew5O8VNOAgMDpwRlFnhL5VSN6M1bHVmRZ9Ccc=
 github.com/buildkite/roko v1.4.0 h1:DxixoCdpNqxu4/1lXrXbfsKbJSd7r1qoxtef/TT2J80=
 github.com/buildkite/roko v1.4.0/go.mod h1:0vbODqUFEcVf4v2xVXRfZZRsqJVsCCHTG/TBRByGK4E=
-github.com/buildkite/shellwords v1.0.0 h1:NqZ4Ynp0dar6ACdP5X2RwI8BnNSvuKFf+2StuJl8tjM=
-github.com/buildkite/shellwords v1.0.0/go.mod h1:h/h4NjidF4MJARI+cfAmA/GFChSdroL1GOJXD68s6qU=
+github.com/buildkite/shellwords v1.0.1 h1:88OjMbEBf+EliVB0tizXJynpAM2CKOvYwepg5n8O70M=
+github.com/buildkite/shellwords v1.0.1/go.mod h1:so0eQnTxgbo58CTYX+4BCx5UuMzvRha9dcKdCKl6NV4=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=


### PR DESCRIPTION
### Description

We previously relied on a dependency, [`shellwords`](https://github.com/buildkite/shellwords), that required that the Agent to be on a very specific version of Go (1.24.3). In Shellwords [v1.0.1](https://github.com/buildkite/shellwords/releases/tag/v1.0.1), we relaxed this requirement to 1.24, so we should continue up the stream and make the agent as a go module a little more usable

> Note that in general, we don't recommend that people use the agent as a go module, and don't consider it to be versioned at all. However, people are going to be doing it anyway, and we should endeavour to not make their lives needlessly difficult.

This PR also adds a `toolchain` directive to the `go.mod`, which will do the work of actually selecting a go version to run commands like `go test` etc, where that heavy lifting was previously done by an overly-zealous `go` directive.

This work is pretty much taken wholesale from @haydentherapper's #3449, but with a couple tweaks.

### Context

#3449
https://github.com/buildkite/shellwords/pull/5

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

### Disclosures / Credits

Thanks to @haydentherapper and @vpnachev for pushing this!

closes #3449