### PR TITLE
Lower Go containers back to 1.24

### DIFF
--- a/.buildkite/Dockerfile-compile
+++ b/.buildkite/Dockerfile-compile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.25.0@sha256:5502b0e56fca23feba76dbc5387ba59c593c02ccc2f0f7355871ea9a0852cebe
+FROM public.ecr.aws/docker/library/golang:1.24.7@sha256:6b6b69bb9ee3fda88e831e4582312727d2b3fdaea298e644446c182b1d5c4184
 COPY build/ssh.conf /etc/ssh/ssh_config.d/
 
 RUN go install github.com/google/go-licenses@latest


### PR DESCRIPTION
### Description

Revert to 1.24 series of Go versions for the builder container.

### Context

Until we're ready to make a conscious decision to bump to Go 1.25, we should continue using Go 1.24 containers to stop us accidentally merging code that would be incompatible with Go 1.24 (e.g. that uses recently added stdlib functionality).
 
### Changes

See description.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

### Disclosures / Credits

Thanks to `docker` for printing the `sha256` hash when pulling an image.