### PR TITLE
Split Dependabot container updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,13 +2,22 @@ version: 2
 updates:
   - package-ecosystem: docker
     directories:
-      - /.buildkite
       - /packaging/docker/alpine
       - /packaging/docker/alpine-k8s
       - /packaging/docker/sidecar
       - /packaging/docker/ubuntu-20.04
       - /packaging/docker/ubuntu-22.04
       - /packaging/docker/ubuntu-24.04
+    schedule:
+      interval: weekly
+    groups:
+      container-images:
+        patterns:
+          - "*"
+          
+  - package-ecosystem: docker
+    directories:
+      - /.buildkite
     schedule:
       interval: weekly
     groups:


### PR DESCRIPTION
### Description

Make dependabot raise two separate PRs for container updates:

- Updates to containers that we release
- Updates to containers needed for builds, tests, etc.

### Context

It'd be great to easily hold back the Go container version, but doing it all in one PR means editing the PR instead of telling Dependabot to back off. e.g. https://github.com/buildkite/agent/pull/3476

### Changes

Divide the dependabot configuration for Docker into two.

### Testing
- N/A ~~[ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.~~
- N/A ~~[ ] Code is formatted (with `go fmt ./...`)~~


### Disclosures / Credits

I did not use AI tools at all