### PR TITLE
Update apply-if-changed information with agent minimum version

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -137,7 +137,7 @@ var PipelineUploadCommand = cli.Command{
 		},
 		cli.BoolTFlag{
 			Name:   "apply-if-changed",
-			Usage:  "When enabled, steps containing an ′if_changed′ key are evaluated against the git diff. If the ′if_changed′ glob pattern match no files changed in the build, the step is skipped.",
+			Usage:  "When enabled, steps containing an ′if_changed′ key are evaluated against the git diff. If the ′if_changed′ glob pattern match no files changed in the build, the step is skipped. Minimum Buildkite Agent version: v3.99 (with --apply-if-changed flag), v3.103.0 (enabled by default)",
 			EnvVar: "BUILDKITE_AGENT_APPLY_SKIP_IF_UNCHANGED",
 		},
 		cli.StringFlag{


### PR DESCRIPTION
### Description


When reviewing this [document](https://buildkite.com/docs/agent/v3/cli-pipeline#apply-if-changed) the minimum agent version required is not displayed 


### Context

Users may get errors when trying to use the `--apply-if-changed` flag until they notice it is required to have their agent be on at least `v3.99` as described [ here](https://buildkite.com/docs/pipelines/configure/step-types/command-step#agent-applied-attributes)


### Changes

Added minimum agent version required information for `--apply-if-changed` flag as this will help users with older than  v3.99 version quickly identify and upgrade to the minimum version required for their agent before they can use this flag
