### PR TITLE
Gzip agent api request bodies before sending them off

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -50,6 +50,9 @@ type Config struct {
 	// If true timings for each request will be logged
 	TraceHTTP bool
 
+	// If true, request bodies will be gzip compressed
+	GzipAPIRequests bool
+
 	// The http client used, leave nil for the default
 	HTTPClient *http.Client
 
@@ -227,14 +230,20 @@ func (c *Client) newRequest(
 	buf := new(bytes.Buffer)
 
 	if body != nil {
-		gzipWriter := gzip.NewWriter(buf)
-		err := json.NewEncoder(gzipWriter).Encode(body)
-		if err != nil {
-			return nil, err
-		}
+		if c.conf.GzipAPIRequests {
+			gzipWriter := gzip.NewWriter(buf)
+			err := json.NewEncoder(gzipWriter).Encode(body)
+			if err != nil {
+				return nil, err
+			}
 
-		if err := gzipWriter.Close(); err != nil {
-			return nil, fmt.Errorf("closing gzip writer: %w", err)
+			if err := gzipWriter.Close(); err != nil {
+				return nil, fmt.Errorf("closing gzip writer: %w", err)
+			}
+		} else {
+			if err := json.NewEncoder(buf).Encode(body); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -267,7 +276,9 @@ func (c *Client) newRequest(
 
 	if body != nil {
 		req.Header.Add("Content-Type", "application/json")
-		req.Header.Add("Content-Encoding", "gzip")
+		if c.conf.GzipAPIRequests {
+			req.Header.Add("Content-Encoding", "gzip")
+		}
 	}
 
 	return req, nil

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -185,11 +185,12 @@ type AgentStartConfig struct {
 	NoMultipartArtifactUpload bool   `cli:"no-multipart-artifact-upload"`
 
 	// API config
-	DebugHTTP bool   `cli:"debug-http"`
-	TraceHTTP bool   `cli:"trace-http"`
-	Token     string `cli:"token" validate:"required"`
-	Endpoint  string `cli:"endpoint" validate:"required"`
-	NoHTTP2   bool   `cli:"no-http2"`
+	DebugHTTP       bool   `cli:"debug-http"`
+	TraceHTTP       bool   `cli:"trace-http"`
+	GzipAPIRequests bool   `cli:"gzip-api-requests"`
+	Token           string `cli:"token" validate:"required"`
+	Endpoint        string `cli:"endpoint" validate:"required"`
+	NoHTTP2         bool   `cli:"no-http2"`
 
 	// Deprecated
 	NoSSHFingerprintVerification bool     `cli:"no-automatic-ssh-fingerprint-verification" deprecated-and-renamed-to:"NoSSHKeyscan"`
@@ -742,6 +743,7 @@ var AgentStartCommand = cli.Command{
 		NoHTTP2Flag,
 		DebugHTTPFlag,
 		TraceHTTPFlag,
+		GzipAPIRequestsFlag,
 
 		// Other shared flags
 		RedactedVars,

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -128,6 +128,12 @@ var (
 		EnvVar: "BUILDKITE_AGENT_EXPERIMENT",
 	}
 
+	GzipAPIRequestsFlag = cli.BoolFlag{
+		Name:   "gzip-api-requests",
+		Usage:  "Enable gzip compression for API request bodies",
+		EnvVar: "BUILDKITE_GZIP_API_REQUESTS",
+	}
+
 	RedactedVars = cli.StringSliceFlag{
 		Name:   "redacted-vars",
 		Usage:  "Pattern of environment variable names containing sensitive values",
@@ -172,6 +178,7 @@ type APIConfig struct {
 	TraceHTTP        bool   `cli:"trace-http"`
 	Endpoint         string `cli:"endpoint" validate:"required"`
 	NoHTTP2          bool   `cli:"no-http2"`
+	GzipAPIRequests  bool   `cli:"gzip-api-requests"`
 }
 
 func globalFlags() []cli.Flag {
@@ -191,6 +198,7 @@ func apiFlags() []cli.Flag {
 		NoHTTP2Flag,
 		DebugHTTPFlag,
 		TraceHTTPFlag,
+		GzipAPIRequestsFlag,
 	}
 }
 
@@ -353,6 +361,11 @@ func loadAPIClientConfig(cfg any, tokenField string) api.Config {
 	noHTTP2, err := reflections.GetField(cfg, "NoHTTP2")
 	if err == nil {
 		conf.DisableHTTP2 = noHTTP2.(bool)
+	}
+
+	gzipAPIRequests, err := reflections.GetField(cfg, "GzipAPIRequests")
+	if err == nil {
+		conf.GzipAPIRequests = gzipAPIRequests.(bool)
 	}
 
 	return conf


### PR DESCRIPTION
This PR introduces support for gzipping agent API requests to improve the performance of pipeline uploads in low-bandwidth environments. Compression is opt-in so existing deployments will continue with uncompressed requests unless explicitly enabled.

- **Added Compression**: API client compresses requests when flag is enabled (disabled by default)
- **Added CLI flag**: `--gzip-api-requests` with environment variable `BUILDKITE_GZIP_API_REQUESTS`