### PR TITLE
Ability to checkout subdirectories of Plugins

### DIFF
--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -319,9 +319,9 @@ func (p *Plugin) Label() string {
 
 // DisplayName returns a human-friendly name for the plugin suitable for logs.
 // Examples:
-//  - github.com/org/repo           => repo
-//  - github.com/org/repo/.buildkite => repo/.buildkite
-//  - file:///path/to/plugin         => plugin (last path element)
+//   - github.com/org/repo           => repo
+//   - github.com/org/repo/.buildkite => repo/.buildkite
+//   - file:///path/to/plugin         => plugin (last path element)
 func (p *Plugin) DisplayName() string {
 	// Filesystem paths: fall back to Name(), which returns the last segment normalized
 	if strings.HasPrefix(p.Location, "/") || strings.HasPrefix(p.Location, ".") || strings.Contains(p.Location, "\\") {

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -147,6 +147,12 @@ func (p *Plugin) Name() string {
 	parts := strings.Split(location, "/")
 	name := parts[len(parts)-1]
 
+	// If the last path segment starts with a dot (e.g. ".buildkite"), trim leading dots
+	// so the human-friendly name isn't rendered as "-buildkite" after normalization.
+	if strings.HasPrefix(name, ".") {
+		name = strings.TrimLeft(name, ".")
+	}
+
 	// Clean up the name
 	name = strings.ToLower(name)
 	name = whitespaceRE.ReplaceAllString(name, " ")
@@ -167,7 +173,8 @@ func (p *Plugin) Identifier() (string, error) {
 	return id, nil
 }
 
-// Repository returns the repository host where the code is stored.
+// Repository returns the repository URL where the plugin code is stored, without any subdirectory path.
+// For example, for "github.com/buildkite/plugins/docker-compose/plugin", it returns "github.com/buildkite/plugins".
 func (p *Plugin) Repository() (string, error) {
 	s, err := p.constructRepositoryHost()
 	if err != nil {
@@ -192,6 +199,8 @@ func (p *Plugin) Repository() (string, error) {
 }
 
 // RepositorySubdirectory returns the subdirectory path that the plugin is in.
+// For example, for "github.com/buildkite/plugins/docker-compose/plugin", it returns "docker-compose/plugin".
+// If the plugin is in the root of the repository, it returns an empty string.
 func (p *Plugin) RepositorySubdirectory() (string, error) {
 	repository, err := p.constructRepositoryHost()
 	if err != nil {
@@ -199,8 +208,12 @@ func (p *Plugin) RepositorySubdirectory() (string, error) {
 	}
 
 	dir := strings.TrimPrefix(p.Location, repository)
+	dir = strings.TrimPrefix(dir, "/")
 
-	return strings.TrimPrefix(dir, "/"), nil
+	// Remove .git suffix if present as it's not part of the subdirectory
+	dir = strings.TrimSuffix(dir, ".git")
+
+	return dir, nil
 }
 
 // formatEnvKey converts strings into an ENV key friendly format
@@ -302,6 +315,35 @@ func (p *Plugin) Label() string {
 		return p.Location
 	}
 	return p.Location + "#" + p.Version
+}
+
+// DisplayName returns a human-friendly name for the plugin suitable for logs.
+// Examples:
+//  - github.com/org/repo           => repo
+//  - github.com/org/repo/.buildkite => repo/.buildkite
+//  - file:///path/to/plugin         => plugin (last path element)
+func (p *Plugin) DisplayName() string {
+	// Filesystem paths: fall back to Name(), which returns the last segment normalized
+	if strings.HasPrefix(p.Location, "/") || strings.HasPrefix(p.Location, ".") || strings.Contains(p.Location, "\\") {
+		return p.Name()
+	}
+
+	host, err := p.constructRepositoryHost()
+	if err != nil || host == "" {
+		return p.Name()
+	}
+
+	// derive repo name from host path
+	parts := strings.Split(host, "/")
+	repo := parts[len(parts)-1]
+	repo = strings.TrimSuffix(repo, ".git")
+
+	// append subdirectory if present
+	subdir, err := p.RepositorySubdirectory()
+	if err != nil || subdir == "" {
+		return repo
+	}
+	return repo + "/" + subdir
 }
 
 func (p *Plugin) constructRepositoryHost() (string, error) {

--- a/internal/job/integration/plugin_integration_test.go
+++ b/internal/job/integration/plugin_integration_test.go
@@ -591,12 +591,13 @@ func (tp *testPlugin) MarshalJSON() ([]byte, error) {
 // NewExecutorTester().  We need to do that because the tester relies on BUILDKITE_PLUGINS_PATH,
 // not on the .PluginsDir field as one might expect.
 func replacePluginPathInEnv(originalEnv []string, pluginsDir string) (newEnv []string) {
-	newEnv = []string{}
-	for _, val := range originalEnv {
-		if !strings.HasPrefix(val, "BUILDKITE_PLUGINS_PATH=") {
-			newEnv = append(newEnv, val)
+	newEnv = make([]string, 0, len(originalEnv))
+	for _, e := range originalEnv {
+		if strings.HasPrefix(e, "BUILDKITE_PLUGINS_PATH=") {
+			newEnv = append(newEnv, "BUILDKITE_PLUGINS_PATH="+pluginsDir)
+		} else {
+			newEnv = append(newEnv, e)
 		}
 	}
-	newEnv = append(newEnv, "BUILDKITE_PLUGINS_PATH="+pluginsDir)
 	return newEnv
 }

--- a/internal/job/plugin.go
+++ b/internal/job/plugin.go
@@ -315,9 +315,6 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 	if err != nil {
 		return nil, fmt.Errorf("failed to get repository subdirectory: %w", err)
 	}
-	if e.Debug {
-		e.shell.Commentf("Plugin subdirectory: %q", subdir)
-	}
 
 	// Create a path to the plugin
 	pluginDirectory := filepath.Join(pluginParentDir, id)
@@ -332,9 +329,9 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 	if subdir != "" {
 		checkout.PluginDir = subdir
 		checkout.HooksDir = filepath.Join(subdir, "hooks")
-		if e.Debug {
-			e.shell.Commentf("Subdirectory plugin paths - PluginDir: %q, HooksDir: %q", checkout.PluginDir, checkout.HooksDir)
-		}
+	}
+	if e.Debug {
+		e.shell.Commentf("Plugin checkout paths - PluginDir: %q, HooksDir: %q", checkout.PluginDir, checkout.HooksDir)
 	}
 
 	// If there is already a clone, the user may want to ensure it's fresh (e.g., by setting
@@ -379,9 +376,6 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 
 		// Ensure hooks is a directory that exists within the checkout.
 		if fi, err := pluginRoot.Stat(checkout.HooksDir); err != nil || !fi.IsDir() {
-			if e.Debug {
-				e.shell.Commentf("Plugin paths - PluginDir: %q, HooksDir: %q", checkout.PluginDir, checkout.HooksDir)
-			}
 			return nil, fmt.Errorf("%q was not a directory within the %q plugin: %w", checkout.HooksDir, checkout.Plugin.Name(), err)
 		}
 		return checkout, nil

--- a/internal/job/plugin.go
+++ b/internal/job/plugin.go
@@ -315,6 +315,9 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 	if err != nil {
 		return nil, fmt.Errorf("failed to get repository subdirectory: %w", err)
 	}
+	if e.Debug {
+		e.shell.Commentf("Plugin subdirectory: %q", subdir)
+	}
 
 	// Create a path to the plugin
 	pluginDirectory := filepath.Join(pluginParentDir, id)
@@ -329,6 +332,9 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 	if subdir != "" {
 		checkout.PluginDir = subdir
 		checkout.HooksDir = filepath.Join(subdir, "hooks")
+		if e.Debug {
+			e.shell.Commentf("Subdirectory plugin paths - PluginDir: %q, HooksDir: %q", checkout.PluginDir, checkout.HooksDir)
+		}
 	}
 
 	// If there is already a clone, the user may want to ensure it's fresh (e.g., by setting
@@ -373,6 +379,9 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 
 		// Ensure hooks is a directory that exists within the checkout.
 		if fi, err := pluginRoot.Stat(checkout.HooksDir); err != nil || !fi.IsDir() {
+			if e.Debug {
+				e.shell.Commentf("Plugin paths - PluginDir: %q, HooksDir: %q", checkout.PluginDir, checkout.HooksDir)
+			}
 			return nil, fmt.Errorf("%q was not a directory within the %q plugin: %w", checkout.HooksDir, checkout.Plugin.Name(), err)
 		}
 		return checkout, nil

--- a/internal/job/plugin.go
+++ b/internal/job/plugin.go
@@ -263,7 +263,7 @@ func (e *Executor) executePluginHook(ctx context.Context, name string, checkouts
 			Name:       name,
 			Path:       hookPath,
 			Env:        envMap,
-			PluginName: p.Plugin.Name(),
+			PluginName: p.Plugin.DisplayName(),
 			SpanAttributes: map[string]string{
 				"plugin.name":        p.Plugin.Name(),
 				"plugin.version":     p.Version,
@@ -310,6 +310,12 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 		return nil, err
 	}
 
+	// Get the subdirectory path if specified in the plugin location
+	subdir, err := p.RepositorySubdirectory()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get repository subdirectory: %w", err)
+	}
+
 	// Create a path to the plugin
 	pluginDirectory := filepath.Join(pluginParentDir, id)
 	pluginGitDirectory := filepath.Join(pluginDirectory, ".git")
@@ -317,6 +323,12 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 		Plugin:    p,
 		PluginDir: ".",
 		HooksDir:  "hooks",
+	}
+
+	// If there's a subdirectory, we'll adjust the paths accordingly
+	if subdir != "" {
+		checkout.PluginDir = subdir
+		checkout.HooksDir = filepath.Join(subdir, "hooks")
 	}
 
 	// If there is already a clone, the user may want to ensure it's fresh (e.g., by setting
@@ -366,7 +378,7 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 		return checkout, nil
 	}
 
-	e.shell.Commentf("Plugin %q will be checked out to %q", p.Location, pluginDirectory)
+	e.shell.Commentf("Plugin %q will be checked out to %q", p.DisplayName(), pluginDirectory)
 
 	repo, err := p.Repository()
 	if err != nil {
@@ -399,11 +411,21 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 	}()
 
 	args := []string{"clone", "-v"}
+
+	// If there's a subdirectory, prefer a sparse clone to reduce data transfer and avoid
+	// an initial checkout that would then be reconfigured. We'll checkout after configuring
+	// sparse-checkout below.
+	if subdir != "" {
+		e.shell.Commentf("Using sparse checkout for subdirectory %q", subdir)
+		args = append(args, "--filter=blob:none", "--sparse", "--no-checkout")
+	}
+
 	if e.GitSubmodules {
 		// "--recursive" was added in Git 1.6.5, and is an alias to
 		// "--recurse-submodules" from Git 2.13.
 		args = append(args, "--recursive")
 	}
+
 	args = append(args, "--", repo, ".")
 
 	// Plugin clones shouldn't use custom GitCloneFlags
@@ -417,10 +439,36 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 		return nil, err
 	}
 
-	// Switch to the version if we need to
+	// If there's a subdirectory, configure sparse checkout regardless of version
+	if subdir != "" {
+		e.shell.Commentf("Configuring sparse checkout for subdirectory %q", subdir)
+		// Enable sparse checkout via modern porcelain
+		if err = e.shell.Command("git", "sparse-checkout", "set", subdir).Run(ctx); err != nil {
+			// Fallback for older Git versions
+			if err2 := e.shell.Command("git", "config", "core.sparseCheckout", "true").Run(ctx); err2 != nil {
+				return nil, fmt.Errorf("failed to enable sparse checkout: %w", err)
+			}
+			sparseCheckoutFile := filepath.Join(".git", "info", "sparse-checkout")
+			sparseCheckoutContent := fmt.Sprintf("/%s/**\n", subdir)
+			if err2 := os.WriteFile(sparseCheckoutFile, []byte(sparseCheckoutContent), 0o644); err2 != nil {
+				return nil, fmt.Errorf("failed to write sparse checkout file: %w", err2)
+			}
+			if err2 := e.shell.Command("git", "read-tree", "-mu", "HEAD").Run(ctx); err2 != nil {
+				return nil, fmt.Errorf("failed to update index with sparse checkout: %w", err2)
+			}
+		}
+	}
+
+	// Perform checkout after configuring sparse-checkout.
+	// If a version was specified, checkout that ref; otherwise checkout the default HEAD.
 	if p.Version != "" {
 		e.shell.Commentf("Checking out `%s`", p.Version)
 		if err = e.shell.Command("git", "checkout", "-f", p.Version).Run(ctx); err != nil {
+			return nil, err
+		}
+	} else if subdir != "" {
+		// If we used --no-checkout due to sparse subdir, we need to materialize the working tree now.
+		if err = e.shell.Command("git", "checkout", "-f").Run(ctx); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

Currently it's not possible to specify subdirectories of Plugins to be used, meaning it's not possible for an user to have a monorepo with multiple Plugins inside and use them by referencing the subdirectory in e.g.,

```yml
 - label: "subdir plugin with .git"
    command: exit 0
    plugins:
      - ssh://git@github.com/tomowatt/test-plugin.git/subdir: ~
```

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->
Adds functionality to allow the Agent to clone Plugin repositories that specify a sub directory in their URL and then update the Plugin Dir and Hook paths so that the hooks from the sub directories can be used instead of those at root i.e., `./hooks`

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


Testing Pipeline with Test Plugin Repository, testing out the following:
* `.git` suffix on repositories
* multiple plugins at same level
* plugin deeper within directories
 
```yml
 env:
   BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH: true
   
 steps:
  - label: "branch agent - subdir plugin"
    agents:
      test: true
    command: exit 0
    plugins:
       - ssh://git@github.com/tomowatt/the-repository-of-many-buildkite-plugins.git/plugin-1: ~
       - ssh://git@github.com/tomowatt/the-repository-of-many-buildkite-plugins/plugin-2: ~
       - ssh://git@github.com/tomowatt/the-repository-of-many-buildkite-plugins/plugin-3/plugin-4: ~

  - label: "v3.107.2 agent - subdir plugin"
    command: exit 0
    soft_fail: true
    plugins:
       - ssh://git@github.com/tomowatt/the-repository-of-many-buildkite-plugins.git/plugin-1: ~
       - ssh://git@github.com/tomowatt/the-repository-of-many-buildkite-plugins/plugin-2: ~
       - ssh://git@github.com/tomowatt/the-repository-of-many-buildkite-plugins/plugin-3/plugin-4: ~
```

with Job Log Output:

```
Preparing plugins
Running plugin the-repository-of-many-buildkite-plugins/plugin-1 environment hook
Plugin 1 Environment Hook
Preparing working directory
Running commands
Running plugin the-repository-of-many-buildkite-plugins/plugin-2 post-command hook
Plugin 2 Post-Command Hook
Running plugin the-repository-of-many-buildkite-plugins/plugin-3/plugin-4 pre-exit hook
Plugin 4 Pre-Exit
```

### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples: 
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->

This is AI created.