### PR TITLE
Remove debugging log line

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -238,7 +238,6 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 		if exists {
 			_ = e.shell.Chdir(checkoutDir)
 		}
-		e.shell.Printf("e.shell.Getwd() = %q", e.shell.Getwd())
 		root, err := os.OpenRoot(e.shell.Getwd())
 		if err != nil {
 			phaseErr = cmp.Or(phaseErr, err)


### PR DESCRIPTION
### Description

Oops.

<img width="388" height="131" alt="Screenshot 2025-09-24 at 2 23 42 pm" src="https://github.com/user-attachments/assets/46159288-f519-4a53-9b39-f200a45a39e8" />

### Context

Noticed while playing around with the latest point release.

### Changes

Remove unnecessary log output.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

### Disclosures / Credits

Maybe AI would have helped? 🤔