### PR TITLE
Better env var for disabling if_changed

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -138,7 +138,7 @@ var PipelineUploadCommand = cli.Command{
 		cli.BoolTFlag{
 			Name:   "apply-if-changed",
 			Usage:  "When enabled, steps containing an ′if_changed′ key are evaluated against the git diff. If the ′if_changed′ glob pattern match no files changed in the build, the step is skipped. Minimum Buildkite Agent version: v3.99 (with --apply-if-changed flag), v3.103.0 (enabled by default)",
-			EnvVar: "BUILDKITE_AGENT_APPLY_SKIP_IF_UNCHANGED",
+			EnvVar: "BUILDKITE_AGENT_APPLY_IF_CHANGED,BUILDKITE_AGENT_APPLY_SKIP_IF_UNCHANGED",
 		},
 		cli.StringFlag{
 			Name:   "git-diff-base",


### PR DESCRIPTION
### Description

`BUILDKITE_AGENT_APPLY_SKIP_IF_UNCHANGED` doesn't match the current name of the flag or the YAML key (`--apply-if-changed` / `if_changed`). Add a more approproate different name with higher precedence.

### Context

https://buildkite-corp.slack.com/archives/C08B3Q94U02/p1758897401118519

### Changes

As in the description.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)


### Disclosures / Credits

I did not use AI tools at all