### PR TITLE
fix: check for changes on main if committing to main

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -613,7 +613,7 @@ func (cfg *PipelineUploadConfig) parseAndInterpolate(ctx context.Context, src st
 func gatherChangedFiles(diffBase string) (mergeBase string, changedPaths []string, err error) {
 	// Use three-dot syntax to find the merge base and diff in one command.
 	// This handles both feature branches and commits directly on main.
-	gitDiff, err := exec.Command("git", "diff", "--name-only", diffBase+"...HEAD").Output()
+	gitDiff, err := exec.Command("git", "diff", "--name-only", diffBase+"...HEAD~1").Output()
 	if err != nil {
 		return "", nil, gitDiffError{mergeBase: diffBase, wrapped: err}
 	}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -322,9 +322,7 @@ var PipelineUploadCommand = cli.Command{
 					searchForSecrets(l, &cfg, environ, result, input.name)
 				}
 
-				var (
-					key signature.Key
-				)
+				var key signature.Key
 
 				switch {
 				case cfg.SigningAWSKMSKey != "":

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -607,3 +607,28 @@ func TestIfChangedApplicator_WeirdPipeline(t *testing.T) {
 	}
 
 }
+
+func TestGatherChangedFiles(t *testing.T) {
+	t.Parallel()
+
+	// This test requires a git repository to be present
+	// If git commands fail, we skip the test
+	_, _, err := gatherChangedFiles("HEAD")
+	if err != nil {
+		t.Skipf("Skipping test, git commands failed: %v", err)
+	}
+
+	// Test that comparing against HEAD works (should return empty or current changes)
+	mergeBase, changedPaths, err := gatherChangedFiles("HEAD")
+	if err != nil {
+		t.Fatalf("gatherChangedFiles(HEAD) failed: %v", err)
+	}
+
+	if mergeBase == "" {
+		t.Error("gatherChangedFiles(HEAD) returned empty merge base")
+	}
+
+	// When comparing HEAD...HEAD, we should get changes between HEAD and working directory
+	// This may be empty if there are no uncommitted changes
+	t.Logf("Found %d changed files compared to HEAD", len(changedPaths))
+}

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -605,7 +605,6 @@ func TestIfChangedApplicator_WeirdPipeline(t *testing.T) {
 	if diff := cmp.Diff(steps, want); diff != "" {
 		t.Errorf("after ica.apply(l, steps) (-got, +want):\n%s", diff)
 	}
-
 }
 
 func TestGatherChangedFiles(t *testing.T) {


### PR DESCRIPTION
### Description

Currently we don't seem to check for a diff if committing directly to `main`; we compare the current commit to `HEAD` which may therefore evaluate to no changes.

### Context

Plain: https://app.plain.com/workspace/w_01J0T5SBKJHGBT6FZZHAMH3GRB/thread/th_01K6H416REM51XCQ4H40708308/

### Changes

Checks using `...HEAD` instead so that we can check when `HEAD` and `diffBase` point to the same branch

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)


### Disclosures / Credits

I used AI to point at whether or not our current testing would cover this; it concluded that it would but that it might be best to add a test, too. 

It pointed out that we would need a `.git` repository present for the test to work, and added comments covering that/added a `skip` if we don't have one present so that tests didn't fail due to that.
