### PR TITLE
Fix inconsistency in artifact search --format flag documentation

### DIFF
--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -39,9 +39,9 @@ jobs, you can target the particular job you want to search the artifacts from us
 
 You can also use the step's job id (provided by the environment variable $BUILDKITE_JOB_ID)
 
-Output formatting can be altered with the -format flag as follows:
+Output formatting can be altered with the --format flag as follows:
 
-    $ buildkite-agent artifact search "*" -format "%p\n"
+    $ buildkite-agent artifact search "*" --format "%p\n"
 
 The above will return a list of filenames separated by newline.`
 


### PR DESCRIPTION
## Summary

This PR fixes an inconsistency in the artifact search command documentation where the  flag was incorrectly documented as  (single dash) instead of  (double dash).

## Changes

- Updated help text to use  instead of 
- Updated example command to use  instead of 
- Ensures consistency with standard CLI flag conventions

## Testing

The changes are documentation-only and maintain consistency with the actual flag implementation in the code.