### PR TITLE
Pass aws config to ec2 client for fetching tags

### DIFF
--- a/agent/ec2_tags.go
+++ b/agent/ec2_tags.go
@@ -35,7 +35,7 @@ func (e EC2Tags) Get(ctx context.Context) (map[string]string, error) {
 		return nil, fmt.Errorf("reading instance ID from metadata: %w", err)
 	}
 
-	svc := ec2.New(ec2.Options{})
+	svc := ec2.NewFromConfig(cfg)
 
 	// Describe the tags of the current instance
 	resp, err := svc.DescribeTags(ctx, &ec2.DescribeTagsInput{


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

Attempt to fix EC2 tags to be available again on agent metadata.

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

By passing the `aws` config to the ec2 client, the calls should start working again. Currently, using the latest release, EC2 tags stopped being accessible via `buildkite-agent meta-data get <key>`.

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples: 
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->