### PR TITLE
Update URLs in agent cfg comments

### DIFF
--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -67,14 +67,15 @@ plugins-path="/etc/buildkite-agent/plugins"
 # no-color=true
 
 # The next two options are relevant to the Datadog integration, available 3.7.0 and on
-# See https://forum.buildkite.community/t/about-our-datadog-integration/216 for details
+# See https://buildkite.com/docs/agent/v3/configuration#metrics-datadog
 # Send metrics to DogStatsD running on metrics-datadog-host
 # metrics-datadog=true
 
 # Host to collect Buildkite metrics
-# datadog-agent will need to run DogStatsD, presumed on port 8125. 
+# datadog-agent will need to run DogStatsD, presumed on port 8125.
+# See https://buildkite.com/docs/agent/v3/configuration#metrics-datadog-host
 # Specify port below like my-host:8126 if not using 8125
 # metrics-datadog-host=127.0.0.1
 
-# If set and valid, the given tracing backend will be enabled. Eg: datadog
+# If set and valid, the given tracing backend will be enabled. Eg: datadog, opentelemetry
 # tracing-backend=""


### PR DESCRIPTION
### Description

Fixes https://github.com/buildkite/agent/issues/3175

Cleanup of some of the URLs in the agent's config file comments.

### Context

The community forum URL called out is no longer publicly accessible.

### Changes

Wording changes

### Testing
- [X] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [X] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

Just me on this one.