### PR TITLE
Bump zzglob to v0.4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.5
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0
-	drjosh.dev/zzglob v0.4.1
+	drjosh.dev/zzglob v0.4.2
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.2
 	github.com/DataDog/datadog-go/v5 v5.8.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIi
 cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
-drjosh.dev/zzglob v0.4.1 h1:HIf8v8REooNw//kGDUgSqPG5uMY7D69/jfZTUjmRT6A=
-drjosh.dev/zzglob v0.4.1/go.mod h1:SbYDdesQC13iyGiEwV8dJfJbyz7/Qiawrd5ODdJQCoo=
+drjosh.dev/zzglob v0.4.2 h1:q+e5Cp6SFCyz+Yurhk/edSrTKEk3tn60vzoaXLmtiBo=
+drjosh.dev/zzglob v0.4.2/go.mod h1:SbYDdesQC13iyGiEwV8dJfJbyz7/Qiawrd5ODdJQCoo=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1 h1:5YTBM8QDVIBN3sxBil89WfdAAqDZbyJTgh688DSxX5w=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1/go.mod h1:YD5h/ldMsG0XiIw7PdyNhLxaM317eFh5yNLccNfGdyw=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.0 h1:KpMC6LFL7mqpExyMC9jVOYRiVhLmamjeZfRsUpB7l4s=


### PR DESCRIPTION
### Description

Fixes bug where patterns containing `~` other than at the start of the pattern would fail to parse with `invalid punctuation �`.

### Context

Fixes error mentioned here: https://forum.buildkite.community/t/no-pattern-option-for-buildkite-agent-artifact-upload/4527

cc #3535 

### Changes

Bump dependency version

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)


### Disclosures / Credits

`go get drjosh.dev/zzglob@v0.4.2 && go mod tidy`