### PR TITLE
Add --literal and --delimiter flags to artifact upload

### DIFF
--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -77,10 +77,11 @@ type ArtifactUploadConfig struct {
 	ContentType string `cli:"content-type"`
 
 	// Uploader flags
-	Literal                   bool `cli:"literal"`
-	GlobResolveFollowSymlinks bool `cli:"glob-resolve-follow-symlinks"`
-	UploadSkipSymlinks        bool `cli:"upload-skip-symlinks"`
-	NoMultipartUpload         bool `cli:"no-multipart-artifact-upload"`
+	Literal                   bool   `cli:"literal"`
+	Delimiter                 string `cli:"delimiter"`
+	GlobResolveFollowSymlinks bool   `cli:"glob-resolve-follow-symlinks"`
+	UploadSkipSymlinks        bool   `cli:"upload-skip-symlinks"`
+	NoMultipartUpload         bool   `cli:"no-multipart-artifact-upload"`
 
 	// deprecated
 	FollowSymlinks bool `cli:"follow-symlinks" deprecated-and-renamed-to:"GlobResolveFollowSymlinks"`
@@ -107,6 +108,12 @@ var ArtifactUploadCommand = cli.Command{
 			Name:   "literal",
 			Usage:  "Disables parsing of the upload paths as glob patterns; each path will be treated as a single literal file path",
 			EnvVar: "BUILDKITE_AGENT_ARTIFACT_LITERAL",
+		},
+		cli.StringFlag{
+			Name:   "delimiter",
+			Usage:  "Changes the delimiter used to split the upload paths into multiple paths; it can be more than 1 character. When set to the empty string, no splitting occurs",
+			EnvVar: "BUILDKITE_AGENT_ARTIFACT_DELIMITER",
+			Value:  ";",
 		},
 		cli.BoolFlag{
 			Name:   "glob-resolve-follow-symlinks",
@@ -144,6 +151,7 @@ var ArtifactUploadCommand = cli.Command{
 			DisableHTTP2:   cfg.NoHTTP2,
 			AllowMultipart: !cfg.NoMultipartUpload,
 			Literal:        cfg.Literal,
+			Delimiter:      cfg.Delimiter,
 
 			// If the deprecated flag was set to true, pretend its replacement was set to true too
 			// this works as long as the user only sets one of the two flags

--- a/internal/artifact/uploader_test.go
+++ b/internal/artifact/uploader_test.go
@@ -81,6 +81,7 @@ func TestCollect(t *testing.T) {
 			filepath.Join("fixtures", "**/*.jpg"),
 			filepath.Join(root, "fixtures", "**/*.gif"),
 		),
+		Delimiter: ";",
 	})
 
 	// For the normalised-upload-paths experiment, uploaded artifact paths are
@@ -164,6 +165,7 @@ func TestCollectThatDoesntMatchAnyFiles(t *testing.T) {
 			filepath.Join("mkmf.log"),
 			filepath.Join("log", "mkmf.log"),
 		}, ";"),
+		Delimiter: ";",
 	})
 
 	artifacts, err := uploader.collect(ctx)
@@ -184,6 +186,7 @@ func TestCollectWithSomeGlobsThatDontMatchAnything(t *testing.T) {
 			filepath.Join("dontmatchanything.zip"),
 			filepath.Join("fixtures", "**", "*.jpg"),
 		}, ";"),
+		Delimiter: ";",
 	})
 
 	artifacts, err := uploader.collect(ctx)
@@ -207,6 +210,7 @@ func TestCollectWithSomeGlobsThatDontMatchAnythingFollowingSymlinks(t *testing.T
 			filepath.Join("fixtures", "links", "folder-link", "dontmatchanything", "**", "*.jpg"),
 			filepath.Join("fixtures", "**", "*.jpg"),
 		}, ";"),
+		Delimiter:                 ";",
 		GlobResolveFollowSymlinks: true,
 	})
 
@@ -229,6 +233,7 @@ func TestCollectWithDuplicateMatches(t *testing.T) {
 			filepath.Join("fixtures", "**", "*.jpg"),
 			filepath.Join("fixtures", "folder", "Commando.jpg"), // dupe
 		}, ";"),
+		Delimiter: ";",
 	})
 
 	artifacts, err := uploader.collect(ctx)
@@ -261,6 +266,7 @@ func TestCollectWithDuplicateMatchesFollowingSymlinks(t *testing.T) {
 			filepath.Join("fixtures", "**", "*.jpg"),
 			filepath.Join("fixtures", "folder", "Commando.jpg"), // dupe
 		}, ";"),
+		Delimiter:                 ";",
 		GlobResolveFollowSymlinks: true,
 	})
 
@@ -294,6 +300,7 @@ func TestCollectMatchesUploadSymlinks(t *testing.T) {
 		Paths: strings.Join([]string{
 			filepath.Join("fixtures", "**", "*.jpg"),
 		}, ";"),
+		Delimiter:          ";",
 		UploadSkipSymlinks: true,
 	})
 
@@ -326,7 +333,8 @@ func TestCollect_Literal(t *testing.T) {
 			filepath.Join("fixtures", "links", "folder-link", "terminator2.jpg"),
 			filepath.Join("fixtures", "gifs", "Smile.gif"),
 		}, ";"),
-		Literal: true,
+		Delimiter: ";",
+		Literal:   true,
 	})
 
 	artifacts, err := uploader.collect(ctx)


### PR DESCRIPTION
### Description

Provide easier ways to specify file paths for uploading when they could be unintentionally parsed as globs, or they use the default splitting delimiter (`;`).

### Context

Fixes #3535

### Changes

- Add `--literal` flag; when set, send file paths directly to the next stage
- Add `--delimiter` flag; use its value to split the upload paths into multiple strings (or set to empty to disable splitting)

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

### Disclosures / Credits

100% free range human