### PR TITLE
docs: correct use to use spaces instead of tabs formatting

### DIFF
--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -38,9 +38,9 @@ Example:
     $ buildkite-agent step update "label" " (add to end of label)" --append
     $ buildkite-agent step update "label" < ./tmp/some-new-label
     $ ./script/label-generator | buildkite-agent step update "label"
-	$ buildkite-agent step update "priority" 10 --step "my-step-key"
-	$ buildkite-agent step update "notify" '[{"github_commit_status": {"context": "my-context"}}]' --append
-	$ buildkite-agent step update "notify" '[{"slack": "my-slack-workspace#my-channel"}]' --append
+    $ buildkite-agent step update "priority" 10 --step "my-step-key"
+    $ buildkite-agent step update "notify" '[{"github_commit_status": {"context": "my-context"}}]' --append
+    $ buildkite-agent step update "notify" '[{"slack": "my-slack-workspace#my-channel"}]' --append
 `
 
 type StepUpdateConfig struct {


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

Correcting to use spaces instead of tabs to fix formatting:

With Tabs:
<img width="764" height="151" alt="image" src="https://github.com/user-attachments/assets/132dc485-a64c-4787-8a6a-a04b6575716e" />


With Spaces:
<img width="769" height="144" alt="image" src="https://github.com/user-attachments/assets/10aae5df-36a5-47b9-ab42-8384a3403e71" />


### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

Original changes made here: https://github.com/buildkite/agent/pull/3532

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples: 
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->