### PR TITLE
Enforce that command descriptions indent using spaces, not tabs

### DIFF
--- a/clicommand/step_cancel.go
+++ b/clicommand/step_cancel.go
@@ -25,7 +25,7 @@ Example:
     $ buildkite-agent step cancel --step "key"
     $ buildkite-agent step cancel --step "key" --force
     $ buildkite-agent step cancel --step "key" --force --force-grace-period-seconds 30
-		`
+`
 
 type StepCancelConfig struct {
 	GlobalConfig

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -38,9 +38,9 @@ Example:
     $ buildkite-agent step update "label" " (add to end of label)" --append
     $ buildkite-agent step update "label" < ./tmp/some-new-label
     $ ./script/label-generator | buildkite-agent step update "label"
-	$ buildkite-agent step update "priority" 10 --step "my-step-key"
-	$ buildkite-agent step update "notify" '[{"github_commit_status": {"context": "my-context"}}]' --append
-	$ buildkite-agent step update "notify" '[{"slack": "my-slack-workspace#my-channel"}]' --append
+    $ buildkite-agent step update "priority" 10 --step "my-step-key"
+    $ buildkite-agent step update "notify" '[{"github_commit_status": {"context": "my-context"}}]' --append
+    $ buildkite-agent step update "notify" '[{"slack": "my-slack-workspace#my-channel"}]' --append
 `
 
 type StepUpdateConfig struct {


### PR DESCRIPTION
### Description

In https://github.com/buildkite/agent/pull/3552, we realised that the descriptions for the some of the commands on the agent were tab-indented (as go prefers), but this breaks formatting for the docs site.

This PR adds a test to ensure that this doesn't happen again.

### Context

https://github.com/buildkite/agent/pull/3552

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

AI-less