### PR TITLE
Standardize artifact S3 credential loading

### DIFF
--- a/internal/artifact/s3.go
+++ b/internal/artifact/s3.go
@@ -72,21 +72,20 @@ func (p *credentialsProvider) IsExpired() bool {
 func awsS3Session(region string, l logger.Logger) (*session.Session, error) {
 	// Chicken and egg... but this is kinda how they do it in the sdk
 
-	// Determine the profile to use
 	profile := os.Getenv("BUILDKITE_S3_PROFILE")
 	if profile == "" {
 		profile = os.Getenv("AWS_PROFILE")
 	}
 
-	// Create session with above profile, using default credential chain
 	sess, err := session.NewSessionWithOptions(session.Options{
 		Profile: profile,
+		Config: aws.Config{
+			Region: aws.String(region),
+		},
 	})
 	if err != nil {
 		return nil, err
 	}
-
-	sess.Config.Region = aws.String(region)
 
 	defaultCredsProvider := &credentialsProvider{creds: sess.Config.Credentials}
 


### PR DESCRIPTION
### Description
- Rather than using an entirely custom credential chain, simply take the [default credential chain ](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html)& prepend the buildkite-specific provider (`BUILDKITE_S3` overrides)
- This expands support for currently unsupported options - like loading credentials from `~/.aws/config` and also normalizes the credential loading process here vs the AWS norms.

### Changes
- `buildkite-agent artifact upload/download` (not a visible api change)
- ⚠️  this is a breaking change to the extent that it changes the order of providers and adds currently unsupported providers that might be silently passing through

### Testing
- [ X ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ X ] Code is formatted (with `go fmt ./...`)

### Disclosures / Credits
 - I used Claude to help put this together. 