### PR TITLE
chore: go modernize to do a bit of a tidy up and remove some junk

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -13,7 +13,7 @@ type Job struct {
 	Endpoint              string                     `json:"endpoint"`
 	State                 string                     `json:"state,omitempty"`
 	Env                   map[string]string          `json:"env,omitempty"`
-	Step                  pipeline.CommandStep       `json:"step,omitempty"`
+	Step                  pipeline.CommandStep       `json:"step"`
 	MatrixPermutation     pipeline.MatrixPermutation `json:"matrix_permutation,omitempty"`
 	ChunksMaxSizeBytes    uint64                     `json:"chunks_max_size_bytes,omitempty"`
 	ChunksIntervalSeconds int                        `json:"chunks_interval_seconds,omitempty"`

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -324,7 +324,7 @@ func UnsetConfigFromEnvironment(c *cli.Context) error {
 		}
 		// split comma delimited env
 		if envVars := f.String(); envVars != "" {
-			for _, env := range strings.Split(envVars, ",") {
+			for env := range strings.SplitSeq(envVars, ",") {
 				os.Unsetenv(env)
 			}
 		}

--- a/cliconfig/loader.go
+++ b/cliconfig/loader.go
@@ -343,10 +343,10 @@ func (l Loader) fieldValueIsEmpty(fieldName string) bool {
 
 func (l Loader) validateField(fieldName string, label string, validationRules string) error {
 	// Split up the validation rules
-	rules := strings.Split(validationRules, ",")
+	rules := strings.SplitSeq(validationRules, ",")
 
 	// Loop through each rule, and perform it
-	for _, rule := range rules {
+	for rule := range rules {
 		switch rule {
 		case "required":
 			if l.fieldValueIsEmpty(fieldName) {
@@ -428,7 +428,7 @@ func (l Loader) normalizeField(fieldName string, normalization string) error {
 
 			for _, value := range valueAsSlice {
 				// Split values with commas into fields
-				for _, normalized := range strings.Split(value, ",") {
+				for normalized := range strings.SplitSeq(value, ",") {
 					if normalized == "" {
 						continue
 					}

--- a/internal/job/docker.go
+++ b/internal/job/docker.go
@@ -144,8 +144,8 @@ func runDockerCompose(ctx context.Context, sh *shell.Shell, projectName string, 
 	}
 
 	// composeFile might be multiple files, spaces or colons
-	for _, chunk := range strings.Fields(composeFile) {
-		for _, file := range strings.Split(chunk, ":") {
+	for chunk := range strings.FieldsSeq(composeFile) {
+		for file := range strings.SplitSeq(chunk, ":") {
 			args = append(args, "-f", file)
 		}
 	}

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -872,7 +872,7 @@ func (e *Executor) setUp(ctx context.Context) error {
 		e.shell.Commentf("Your pipeline environment has protected environment variables set. " +
 			"These can only be set via hooks, plugins or the agent configuration.")
 
-		for _, env := range strings.Split(ignored, ",") {
+		for env := range strings.SplitSeq(ignored, ",") {
 			e.shell.Warningf("Ignored %s", env)
 		}
 
@@ -1307,7 +1307,7 @@ func (e *Executor) writeBatchScript(cmd string) (string, error) {
 
 	scriptContents := []string{"@echo off"}
 
-	for _, line := range strings.Split(cmd, "\n") {
+	for line := range strings.SplitSeq(cmd, "\n") {
 		if line != "" {
 			if shouldCallBatchLine(line) {
 				scriptContents = append(scriptContents, "call "+line)

--- a/internal/job/git.go
+++ b/internal/job/git.go
@@ -250,10 +250,10 @@ func gitEnumerateSubmoduleURLs(ctx context.Context, sh *shell.Shell) ([]string, 
 	}
 
 	// splits lines on null-bytes to gracefully handle line endings and repositories with newlines
-	lines := strings.Split(strings.TrimRight(output, "\x00"), "\x00")
+	lines := strings.SplitSeq(strings.TrimRight(output, "\x00"), "\x00")
 
 	// process each line
-	for _, line := range lines {
+	for line := range lines {
 		tokens := strings.SplitN(line, "\n", 2)
 		if len(tokens) != 2 {
 			return nil, fmt.Errorf("Failed to parse .gitmodules line %q", line)

--- a/internal/job/knownhosts.go
+++ b/internal/job/knownhosts.go
@@ -79,7 +79,7 @@ func (kh *knownHosts) Contains(host string) (bool, error) {
 		if len(fields) != 3 {
 			continue
 		}
-		for _, addr := range strings.Split(fields[0], ",") {
+		for addr := range strings.SplitSeq(fields[0], ",") {
 			if addr == normalized || addr == knownhosts.HashHostname(normalized) {
 				return true, nil
 			}

--- a/internal/replacer/big_lipsum_test.go
+++ b/internal/replacer/big_lipsum_test.go
@@ -21,7 +21,7 @@ var bigLipsumSecrets []string
 func init() {
 	// Find 10 most frequent words in bigLipsum to use as "secrets"
 	hist := make(map[string]int)
-	for _, w := range strings.Fields(bigLipsum) {
+	for w := range strings.FieldsSeq(bigLipsum) {
 		hist[strings.Trim(w, ".,")]++
 	}
 	words := make([]string, 0, len(hist))

--- a/internal/replacer/bm_redactor_test.go
+++ b/internal/replacer/bm_redactor_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 func BenchmarkBMRedactor(b *testing.B) {
-	b.ResetTimer()
+
 	r := NewBMRedactor(io.Discard, "[REDACTED]", bigLipsumSecrets)
-	for range b.N {
+	for b.Loop() {
 		if _, err := fmt.Fprintln(r, bigLipsum); err != nil {
 			b.Errorf("fmt.Fprintln(r, bigLipsum) error = %v", err)
 		}

--- a/internal/shell/logger_test.go
+++ b/internal/shell/logger_test.go
@@ -124,7 +124,7 @@ func BenchmarkDoubleFmt(b *testing.B) {
 		fmt.Fprintf(io.Discard, "%s", fmt.Sprintf(format, v...))
 		fmt.Fprintln(io.Discard)
 	}
-	for range b.N {
+	for b.Loop() {
 		logf("asdfghjkl %s %d %t", "hi", 42, true)
 	}
 }
@@ -134,7 +134,7 @@ func BenchmarkFmtConcat(b *testing.B) {
 	logf := func(format string, v ...any) {
 		fmt.Fprintf(io.Discard, format+"\n", v...)
 	}
-	for range b.N {
+	for b.Loop() {
 		logf("asdfghjkl %s %d %t", "hi", 42, true)
 	}
 }

--- a/process/ansi_test.go
+++ b/process/ansi_test.go
@@ -63,8 +63,8 @@ func BenchmarkANSIParser(b *testing.B) {
 	if err != nil {
 		b.Fatalf("os.ReadFile(fixtures/npm.sh.raw) error = %v", err)
 	}
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		var p ansiParser
 		p.Write(npm)
 	}

--- a/process/main_test.go
+++ b/process/main_test.go
@@ -17,7 +17,7 @@ import (
 func TestMain(m *testing.M) {
 	switch os.Getenv("TEST_MAIN") {
 	case "tester":
-		for _, line := range strings.Split(strings.TrimSuffix(longTestOutput, "\n"), "\n") {
+		for line := range strings.SplitSeq(strings.TrimSuffix(longTestOutput, "\n"), "\n") {
 			fmt.Printf("%s\n", line)
 			time.Sleep(time.Millisecond * 20)
 		}

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -407,7 +407,7 @@ func assertProcessDoesntExist(t *testing.T, p *process.Process) {
 }
 
 func BenchmarkProcess(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		proc := process.New(logger.Discard, process.Config{
 			Path: os.Args[0],
 			Env:  []string{"TEST_MAIN=output"},

--- a/process/scanner_test.go
+++ b/process/scanner_test.go
@@ -27,7 +27,7 @@ func TestScanLines(t *testing.T) {
 	pr, pw := io.Pipe()
 
 	go func() {
-		for _, line := range strings.Split(strings.TrimSuffix(longTestOutput, "\n"), "\n") {
+		for line := range strings.SplitSeq(strings.TrimSuffix(longTestOutput, "\n"), "\n") {
 			fmt.Fprintf(pw, "%s\n", line)
 			time.Sleep(time.Millisecond * 10)
 		}


### PR DESCRIPTION
### Description

Ran `go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...`

### Context

I read a couple of posts about how to clean up an older codebase, I think we have used a few of these features but using an automated tool to spruce up the code seemed like a good idea.

### Changes

The changes mostly center around `for strings.SplitSeq` and `for b.Loop()`.

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

### Disclosures / Credits

I did not use AI tools at all