### PR TITLE
chore: inject service name so children inherit buildkite-agent

### DIFF
--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -527,6 +527,11 @@ func (s *Shell) injectTraceCtx(ctx context.Context, env *env.Environment) {
 			envKey := strings.ToUpper(strings.ReplaceAll(k, "-", "_"))
 			env.Set(envKey, v)
 		}
+
+		// Propagate service name so child processes don't create their own service
+		if serviceName := env.Get("BUILDKITE_TRACING_SERVICE_NAME"); serviceName != "" {
+			env.Set("OTEL_SERVICE_NAME", serviceName)
+		}
 	}
 }
 

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -529,7 +529,7 @@ func (s *Shell) injectTraceCtx(ctx context.Context, env *env.Environment) {
 		}
 
 		// Propagate service name so child processes don't create their own service
-		if serviceName := env.Get("BUILDKITE_TRACING_SERVICE_NAME"); serviceName != "" {
+		if serviceName, ok := env.Get("BUILDKITE_TRACING_SERVICE_NAME"); ok {
 			env.Set("OTEL_SERVICE_NAME", serviceName)
 		}
 	}


### PR DESCRIPTION
### Description

Currently, the buildkite-agent service doesn't seem to be set as the service name for child processes such as plugins (docker pull in the docker-compose plugin).

### Changes

This sets the `OTEL_SERVICE_NAME` value to the default (`buildkite-agent`) unless it's been overwritten via config flags.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

### Caveats

There is a chance we may want to allow plugins to set their own service context in the future? However, plugins such as `docker-compose` often run commands on behalf of the agent, so having the service as the agent itself might be sensible...
