### PR TITLE
PS-1373 Update error message for hashing failures

### DIFF
--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -356,11 +356,10 @@ func (a *Uploader) build(path string, absolutePath string) (*api.Artifact, error
 	defer file.Close() //nolint:errcheck // File is only open for read.
 
 	// Generate a SHA-1 and SHA-256 checksums for the file.
-	// Writing to hashes never errors, but reading from the file might.
 	hash1, hash256 := sha1.New(), sha256.New()
 	size, err := io.Copy(io.MultiWriter(hash1, hash256), file)
 	if err != nil {
-		return nil, fmt.Errorf("reading contents of %s: %w", absolutePath, err)
+		return nil, fmt.Errorf("hashing artifact file %s: %w", absolutePath, err)
 	}
 	sha1sum := fmt.Sprintf("%040x", hash1.Sum(nil))
 	sha256sum := fmt.Sprintf("%064x", hash256.Sum(nil))


### PR DESCRIPTION
### Description

When the FIPS140 mode is set to only, the agent produces a confusing error message:
```
fatal: failed to upload artifacts: collecting artifacts: building artifact: reading contents of /path/to/some/artifact: crypto/sha1: use of SHA-1 is not allowed in FIPS 140-only mode
```

the `reading contents of` in there makes it seem like we're failing to read the file, but we're actually failing to hash it. This failure to hash is also pointed out by the rest of the error message, but it's useful to be explicit.

### Context

PS-1373

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

### Disclosures / Credits

This twelve-character change was generated entirely by my human brain.