### PR TITLE
PB-895: Agent nudge client side POC

### DIFF
--- a/agent/nudge_worker.go
+++ b/agent/nudge_worker.go
@@ -1,0 +1,227 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand/v2"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/buildkite/agent/v3/internal/experiments"
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	nudgeReconnectDelay = 30 * time.Second
+	nudgeWriteTimeout   = 10 * time.Second
+	nudgePingInterval   = 30 * time.Second
+	nudgePongWait       = 60 * time.Second
+)
+
+type NudgeWorker struct {
+	logger      logger.Logger
+	endpoint    string
+	accessToken string
+	conn        *websocket.Conn
+	connMu      sync.Mutex
+	nudgeChan   chan struct{}
+	stopOnce    sync.Once
+	stop        chan struct{}
+}
+
+func NewNudgeWorker(l logger.Logger, endpoint, accessToken string, nudgeChan chan struct{}) *NudgeWorker {
+	return &NudgeWorker{
+		logger:      l,
+		endpoint:    endpoint,
+		accessToken: accessToken,
+		nudgeChan:   nudgeChan,
+		stop:        make(chan struct{}),
+	}
+}
+
+func (n *NudgeWorker) Start(ctx context.Context) {
+	if !experiments.IsEnabled(ctx, experiments.AgentNudge) {
+		n.logger.Debug("Agent nudge experiment not enabled, skipping nudge worker")
+		return
+	}
+
+	n.logger.Info("Starting nudge worker")
+	go n.run(ctx)
+}
+
+func (n *NudgeWorker) Stop() {
+	n.stopOnce.Do(func() {
+		close(n.stop)
+		n.closeConnection()
+	})
+}
+
+func (n *NudgeWorker) run(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			n.logger.Debug("Nudge worker stopping due to context cancellation")
+			return
+		case <-n.stop:
+			n.logger.Debug("Nudge worker stopping")
+			return
+		default:
+		}
+
+		if err := n.connectAndListen(ctx); err != nil {
+			n.logger.Warn("Nudge worker connection failed: %v", err)
+		}
+
+		reconnectDelay := nudgeReconnectDelay + time.Duration(rand.N(10*time.Second))
+		n.logger.Debug("Nudge worker will reconnect in %v", reconnectDelay)
+
+		select {
+		case <-time.After(reconnectDelay):
+		case <-ctx.Done():
+			return
+		case <-n.stop:
+			return
+		}
+	}
+}
+
+func (n *NudgeWorker) connectAndListen(ctx context.Context) error {
+	wsURL, err := n.buildWebSocketURL()
+	if err != nil {
+		return fmt.Errorf("failed to build WebSocket URL: %w", err)
+	}
+
+	n.logger.Debug("Connecting to nudge WebSocket at %s", wsURL)
+
+	dialer := websocket.Dialer{
+		HandshakeTimeout: 10 * time.Second,
+	}
+
+	headers := http.Header{}
+	headers.Set("Authorization", fmt.Sprintf("Token %s", n.accessToken))
+
+	conn, _, err := dialer.DialContext(ctx, wsURL, headers)
+	if err != nil {
+		return fmt.Errorf("failed to dial WebSocket: %w", err)
+	}
+
+	n.connMu.Lock()
+	n.conn = conn
+	n.connMu.Unlock()
+
+	defer n.closeConnection()
+
+	n.logger.Info("Connected to nudge WebSocket")
+
+	errCh := make(chan error, 1)
+	go n.readMessages(conn, errCh)
+	go n.writePings(ctx, conn, errCh)
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-n.stop:
+		return nil
+	}
+	// Note: defer n.closeConnection() will run here, which unblocks
+	// conn.ReadMessage() in readMessages, allowing that goroutine to exit
+}
+
+func (n *NudgeWorker) readMessages(conn *websocket.Conn, errCh chan error) {
+	// Set up pong handler to reset the read deadline when we receive a pong
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(nudgePongWait))
+	})
+
+	// Set initial read deadline
+	if err := conn.SetReadDeadline(time.Now().Add(nudgePongWait)); err != nil {
+		errCh <- fmt.Errorf("failed to set initial read deadline: %w", err)
+		return
+	}
+
+	for {
+		messageType, message, err := conn.ReadMessage()
+		if err != nil {
+			errCh <- fmt.Errorf("failed to read message: %w", err)
+			return
+		}
+
+		if messageType == websocket.TextMessage {
+			n.handleMessage(message)
+		}
+	}
+}
+
+func (n *NudgeWorker) writePings(ctx context.Context, conn *websocket.Conn, errCh chan error) {
+	ticker := time.NewTicker(nudgePingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := conn.SetWriteDeadline(time.Now().Add(nudgeWriteTimeout)); err != nil {
+				errCh <- fmt.Errorf("failed to set write deadline: %w", err)
+				return
+			}
+			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				errCh <- fmt.Errorf("failed to write ping: %w", err)
+				return
+			}
+		case <-ctx.Done():
+			return
+		case <-n.stop:
+			return
+		}
+	}
+}
+
+func (n *NudgeWorker) handleMessage(message []byte) {
+	var data map[string]interface{}
+	if err := json.Unmarshal(message, &data); err != nil {
+		n.logger.Warn("Failed to parse nudge message: %v", err)
+		return
+	}
+
+	n.logger.Debug("Received nudge message: %v", data)
+
+	select {
+	case n.nudgeChan <- struct{}{}:
+		n.logger.Debug("Nudge signal sent to ping loop")
+	default:
+		n.logger.Debug("Nudge channel full, skipping")
+	}
+}
+
+func (n *NudgeWorker) closeConnection() {
+	n.connMu.Lock()
+	defer n.connMu.Unlock()
+
+	if n.conn != nil {
+		n.conn.Close()
+		n.conn = nil
+	}
+}
+
+func (n *NudgeWorker) buildWebSocketURL() (string, error) {
+	u, err := url.Parse(n.endpoint)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse endpoint: %w", err)
+	}
+
+	if u.Scheme == "https" {
+		u.Scheme = "wss"
+	} else {
+		u.Scheme = "ws"
+	}
+
+	u.Path = strings.TrimSuffix(u.Path, "/") + "/nudge"
+
+	return u.String(), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/gowebpki/jcs v1.0.1
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/oleiade/reflections v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -229,8 +229,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.6 h1:GW/XbdyBFQ8Qe+YAmFU
 github.com/googleapis/enterprise-certificate-proxy v0.3.6/go.mod h1:MkHOF77EYAE7qfSuSS9PU6g4Nt4e11cnsDUowfwewLA=
 github.com/googleapis/gax-go/v2 v2.15.0 h1:SyjDc1mGgZU5LncH8gimWo9lW1DtIfPibOG81vgd/bo=
 github.com/googleapis/gax-go/v2 v2.15.0/go.mod h1:zVVkkxAQHa1RQpg9z2AUCMnKhi0Qld9rcmyfL1OZhoc=
-github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
-github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gowebpki/jcs v1.0.1 h1:Qjzg8EOkrOTuWP7DqQ1FbYtcpEbeTzUoTN9bptp8FOU=
 github.com/gowebpki/jcs v1.0.1/go.mod h1:CID1cNZ+sHp1CCpAR8mPf6QRtagFBgPJE0FCUQ6+BrI=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 h1:NmZ1PKzSTQbuGHw9DGPFomqkkLWMC+vZCkfs+FHv1Vg=

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -24,6 +24,7 @@ const (
 const (
 	// Available experiments
 	AgentAPI                       = "agent-api"
+	AgentNudge                     = "agent-nudge"
 	AllowArtifactPathTraversal     = "allow-artifact-path-traversal"
 	DescendingSpawnPriority        = "descending-spawn-priority"
 	InterpolationPrefersRuntimeEnv = "interpolation-prefers-runtime-env"
@@ -49,6 +50,7 @@ const (
 var (
 	Available = map[string]struct{}{
 		AgentAPI:                       {},
+		AgentNudge:                     {},
 		AllowArtifactPathTraversal:     {},
 		DescendingSpawnPriority:        {},
 		InterpolationPrefersRuntimeEnv: {},


### PR DESCRIPTION
### Description

You may want to review this together with its [backend change](https://github.com/buildkite/buildkite/pull/26396). 

When agent start, it will spawn a websocket client worker that listen for agent nudge. When an agent nudge arrives, it will shortcut agent ping, make it ping immediately. 

Outcome: 

<img width="620" height="296" alt="Screenshot 2025-11-05 at 3 07 37 PM" src="https://github.com/user-attachments/assets/335b7a6b-0edc-447f-af33-99e6d679204a" />
<img width="683" height="302" alt="Screenshot 2025-11-05 at 3 06 54 PM" src="https://github.com/user-attachments/assets/039a22e9-bdb1-4023-af53-66a7f79a86d2" />
<img width="1207" height="42" alt="Screenshot 2025-11-05 at 3 05 57 PM" src="https://github.com/user-attachments/assets/5cc30ec2-e615-4e35-b058-8b431b6fedac" />


### Context

part of PB-895

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go fmt ./...`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

Since it's a POC project, I used LLM to write some a bit of code here.