### PR TITLE
IdleMonitor-related fixes

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -49,8 +49,8 @@ type AgentConfiguration struct {
 	TimestampLines               bool
 	HealthCheckAddr              string
 	DisconnectAfterJob           bool
-	DisconnectAfterIdleTimeout   int
-	DisconnectAfterUptime        int
+	DisconnectAfterIdleTimeout   time.Duration
+	DisconnectAfterUptime        time.Duration
 	CancelGracePeriod            int
 	SignalGracePeriod            time.Duration
 	EnableJobLogTmpfile          bool

--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -317,7 +317,7 @@ func TestAgentWorker_Start_AcquireJob_JobAcquisitionRejected(t *testing.T) {
 	)
 	worker.noWaitBetweenPingsForTesting = true
 
-	idleMonitor := NewIdleMonitor(1)
+	idleMonitor := newIdleMonitor(1)
 
 	// we expect the worker to try to acquire the job, but fail with ErrJobAcquisitionRejected
 	// because the server returns a 422 Unprocessable Entity.
@@ -401,7 +401,7 @@ func TestAgentWorker_Start_AcquireJob_Pause_Unpause(t *testing.T) {
 	)
 	worker.noWaitBetweenPingsForTesting = true
 
-	idleMonitor := NewIdleMonitor(1)
+	idleMonitor := newIdleMonitor(1)
 
 	if err := worker.Start(ctx, idleMonitor); err != nil {
 		t.Errorf("worker.Start() = %v", err)
@@ -495,7 +495,7 @@ func TestAgentWorker_DisconnectAfterJob_Start_Pause_Unpause(t *testing.T) {
 	)
 	worker.noWaitBetweenPingsForTesting = true
 
-	idleMonitor := NewIdleMonitor(1)
+	idleMonitor := newIdleMonitor(1)
 
 	if err := worker.Start(ctx, idleMonitor); err != nil {
 		t.Errorf("worker.Start() = %v", err)
@@ -576,13 +576,13 @@ func TestAgentWorker_DisconnectAfterUptime(t *testing.T) {
 				BootstrapScript:       dummyBootstrap,
 				BuildPath:             buildPath,
 				HooksPath:             hooksPath,
-				DisconnectAfterUptime: 1, // 1 second max uptime
+				DisconnectAfterUptime: 1 * time.Second, // max uptime
 			},
 		},
 	)
 	worker.noWaitBetweenPingsForTesting = true
 
-	idleMonitor := NewIdleMonitor(1)
+	idleMonitor := newIdleMonitor(1)
 
 	// Record start time
 	startTime := time.Now()
@@ -666,7 +666,7 @@ func TestAgentWorker_SetEndpointDuringRegistration(t *testing.T) {
 	)
 	worker.noWaitBetweenPingsForTesting = true
 
-	if err := worker.Start(ctx, NewIdleMonitor(1)); err != nil {
+	if err := worker.Start(ctx, newIdleMonitor(1)); err != nil {
 		t.Errorf("worker.Start() = %v", err)
 	}
 
@@ -755,7 +755,7 @@ func TestAgentWorker_UpdateEndpointDuringPing(t *testing.T) {
 	)
 	worker.noWaitBetweenPingsForTesting = true
 
-	if err := worker.Start(ctx, NewIdleMonitor(1)); err != nil {
+	if err := worker.Start(ctx, newIdleMonitor(1)); err != nil {
 		t.Errorf("worker.Start() = %v", err)
 	}
 
@@ -835,7 +835,7 @@ func TestAgentWorker_UpdateEndpointDuringPing_FailAndRevert(t *testing.T) {
 	)
 	worker.noWaitBetweenPingsForTesting = true
 
-	if err := worker.Start(ctx, NewIdleMonitor(1)); err != nil {
+	if err := worker.Start(ctx, newIdleMonitor(1)); err != nil {
 		t.Errorf("worker.Start() = %v", err)
 	}
 
@@ -904,7 +904,7 @@ func TestAgentWorker_SetRequestHeadersDuringRegistration(t *testing.T) {
 	)
 	worker.noWaitBetweenPingsForTesting = true
 
-	if err := worker.Start(ctx, NewIdleMonitor(1)); err != nil {
+	if err := worker.Start(ctx, newIdleMonitor(1)); err != nil {
 		t.Errorf("worker.Start() = %v", err)
 	}
 
@@ -992,7 +992,7 @@ func TestAgentWorker_UpdateRequestHeadersDuringPing(t *testing.T) {
 	)
 	worker.noWaitBetweenPingsForTesting = true
 
-	if err := worker.Start(ctx, NewIdleMonitor(1)); err != nil {
+	if err := worker.Start(ctx, newIdleMonitor(1)); err != nil {
 		t.Errorf("worker.Start() = %v", err)
 	}
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1037,8 +1037,8 @@ var AgentStartCommand = cli.Command{
 			ANSITimestamps:               !cfg.NoANSITimestamps,
 			TimestampLines:               cfg.TimestampLines,
 			DisconnectAfterJob:           cfg.DisconnectAfterJob,
-			DisconnectAfterIdleTimeout:   cfg.DisconnectAfterIdleTimeout,
-			DisconnectAfterUptime:        cfg.DisconnectAfterUptime,
+			DisconnectAfterIdleTimeout:   time.Duration(cfg.DisconnectAfterIdleTimeout) * time.Second,
+			DisconnectAfterUptime:        time.Duration(cfg.DisconnectAfterUptime) * time.Second,
 			CancelGracePeriod:            cfg.CancelGracePeriod,
 			SignalGracePeriod:            signalGracePeriod,
 			EnableJobLogTmpfile:          cfg.EnableJobLogTmpfile,
@@ -1131,11 +1131,11 @@ var AgentStartCommand = cli.Command{
 		}
 
 		if agentConf.DisconnectAfterIdleTimeout > 0 {
-			l.Info("Agents will disconnect after %d seconds of inactivity", agentConf.DisconnectAfterIdleTimeout)
+			l.Info("Agents will disconnect after %v of inactivity", agentConf.DisconnectAfterIdleTimeout)
 		}
 
 		if agentConf.DisconnectAfterUptime > 0 {
-			l.Info("Agents will disconnect after %d seconds of uptime and shut down after any running jobs complete", agentConf.DisconnectAfterUptime)
+			l.Info("Agents will disconnect after %v of uptime and shut down after any running jobs complete", agentConf.DisconnectAfterUptime)
 		}
 
 		if len(cfg.AllowedRepositories) > 0 {


### PR DESCRIPTION
### Description

Various fixes and cleanups related to IdleMonitor. Particularly, if an agent worker stops or crashes, it should be treated as dead for the purposes of the disconnect-after-idle-timeout.

### Context

https://linear.app/buildkite/issue/PS-1390/3-buildkite-agent-crashingstopped-workers-breaks-idlemonitor

If multiple workers are spawned and then any of them either crash or are gracefully stopped by the API (or by clicking the Stop Agent button in UI), then idleMonitor.Idle() will never [evaluate](https://github.com/buildkite/agent/blob/v3.111.0/agent/idle_monitor.go#L31) to true.

### Changes

- Add a new agent state in IdleMonitor, "dead", which is when an agent has exited. "Dead" is like "idle" but is terminal (an agent can't exit the "dead" state).
- Move idleness timeout logic from the ping loop to the IdleMonitor. `idleMonitor` now decides when the agent should exit due to idleness.
- Un-export `idleMonitor`, `newIdleMonitor`, and all `idleMonitor` methods.
- Move `int` -> `time.Duration` conversion earlier (when producing `AgentConfiguration`).

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)
- [x] Some manual testing


### Disclosures / Credits

I did not use AI tools at all