### PR TITLE
Fix the pipeline upload --reject-secrets flag not rejecting secrets

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -319,7 +319,11 @@ var PipelineUploadCommand = cli.Command{
 				if len(cfg.RedactedVars) > 0 {
 					// Secret detection uses the original environment, since
 					// Interpolate merges the pipeline's env block into `environ`.
-					searchForSecrets(l, &cfg, environ, result, input.name)
+					err := searchForSecrets(l, &cfg, environ, result, input.name)
+					if err != nil {
+						l.Error("%v", err)
+						return NewSilentExitError(1)
+					}
 				}
 
 				var (
@@ -509,6 +513,7 @@ func searchForSecrets(
 	if err != nil {
 		l.Warn("Couldn't match environment variable names against redacted-vars: %v", err)
 	}
+
 	for _, name := range short {
 		shortValues[name] = struct{}{}
 	}


### PR DESCRIPTION
### Description

Long, long ago (https://github.com/buildkite/agent/pull/1523, https://github.com/buildkite/agent/pull/1589), we made it so that customers could opt into rejecting pipeline uploads that contained secret values -- eg, if you accidentally committed a pipeline like:
```yaml
steps:
  - command: "psql -c 'DROP TABLES *;'"
    env:
      DATABASE_PASSWORD: hunter2
```
the agent would recognise that there's a cleartext secret in there (`DATABASE_PASSWORD`) and refuse to upload it to buildkite.

However, much later on we refactored the redactor (https://github.com/buildkite/agent/pull/2277), and extracted the secrets detection into a function. That function would return an error if it thought the pipeline shouldn't be uploaded.

... and then we didn't check the error return of the function, meaning that secrets that probably shouldn't get uploaded were uploaded anyway.

This PR adds an error check to that function call, reinstating the behaviour that if a user adds `--reject-secrets` to their pipeline upload call, it'll refuse to upload sensitive values.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

### Disclosures / Credits

I didn't use AI.