### PR TITLE
Put secret scan error into exit message

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -321,8 +321,7 @@ var PipelineUploadCommand = cli.Command{
 					// Interpolate merges the pipeline's env block into `environ`.
 					err := searchForSecrets(l, &cfg, environ, result, input.name)
 					if err != nil {
-						l.Error("%v", err)
-						return NewSilentExitError(1)
+						return NewExitError(1, err)
 					}
 				}
 


### PR DESCRIPTION
### Description

Instead of bare-logging an error and then returning a silent exit error, return the error as a (non-silent) exit error.

### Context

#3580

### Changes

See Description.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

### Disclosures / Credits

What would a computer do with a lifetime supply of chocolate?