### PR TITLE
Clarify agent idlemonitor states

### DIFF
--- a/agent/idle_monitor.go
+++ b/agent/idle_monitor.go
@@ -9,7 +9,9 @@ import (
 // logic.
 //
 // In addition to "busy", "idle", and "dead", idleMonitor has an implicit
-// "initial" state. Agents always start in the "initial" state
+// "initial" state. Agents always start in the "initial" state, but typically
+// quickly transistion into either the idle or busy states (as soon as they
+// have completed their first ping.)
 /*
 //                -> Busy --
 //              /     ^      \
@@ -17,8 +19,6 @@ import (
 //              \     v      /
 //                -> Idle --
 */
-// This (intentionally) ensures the DisconnectAfterIdleTimeout doesn't fire
-// before agents have had a chance to run a job.
 type idleMonitor struct {
 	mu          sync.Mutex
 	exiting     bool


### PR DESCRIPTION
### Description

`DisconnectAfterIdleTimeout` _is_ actually supposed to exit an agent that doesn't get assigned a job at all, but "doesn't fire before agents have had a chance to run a job" could be interpreted as the opposite. So remove that, and instead reiterate that each agent becomes either idle or busy during the first ping.

### Context

From #3579 

### Changes

See Description

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go fmt ./...`)

### Disclosures / Credits

Spittin' from the top of my dome