### PR TITLE
internal/redact: Add another test with minor cleanup

### DIFF
--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -10,49 +10,64 @@ import (
 func TestVars(t *testing.T) {
 	t.Parallel()
 
-	redactConfig := []string{
-		"*_PASSWORD",
-		"*_TOKEN",
-	}
-	environment := []env.Pair{
-		{Name: "BUILDKITE_PIPELINE", Value: "unit-test"},
-		// These are example values, and are not leaked credentials
-		{Name: "DATABASE_USERNAME", Value: "AzureDiamond"},
-		{Name: "DATABASE_PASSWORD", Value: "hunter2"},
+	tests := []struct {
+		name         string
+		redactConfig []string
+		environment  []env.Pair
+		wantMatched  []env.Pair
+		wantShort    []string
+	}{
+		{
+			name:         "hunter2",
+			redactConfig: []string{"*_PASSWORD", "*_TOKEN"},
+			environment: []env.Pair{
+				{Name: "BUILDKITE_PIPELINE", Value: "unit-test"},
+				// These are example values, and are not leaked credentials
+				{Name: "DATABASE_USERNAME", Value: "AzureDiamond"},
+				{Name: "DATABASE_PASSWORD", Value: "hunter2"},
+			},
+			wantMatched: []env.Pair{{Name: "DATABASE_PASSWORD", Value: "hunter2"}},
+			wantShort:   nil,
+		},
+		{
+			name:         "short",
+			redactConfig: []string{"*_PASSWORD", "*_TOKEN"},
+			environment: []env.Pair{
+				{Name: "BUILDKITE_PIPELINE", Value: "unit-test"},
+				// These are example values, and are not leaked credentials
+				{Name: "DATABASE_USERNAME", Value: "AzureDiamond"},
+				{Name: "DATABASE_PASSWORD", Value: "hunt"},
+			},
+			wantMatched: nil,
+			wantShort:   []string{"DATABASE_PASSWORD"},
+		},
+		{
+			name:         "empty",
+			redactConfig: nil,
+			environment: []env.Pair{
+				{Name: "FOO", Value: "BAR"},
+				{Name: "BUILDKITE_PIPELINE", Value: "unit-test"},
+			},
+			wantMatched: nil,
+			wantShort:   nil,
+		},
 	}
 
-	got, short, err := Vars(redactConfig, environment)
-	if err != nil {
-		t.Errorf("Vars(%q, %q) error = %v", redactConfig, environment, err)
-	}
-	if len(short) > 0 {
-		t.Errorf("Vars(%q, %q) short = %q", redactConfig, environment, short)
-	}
-	want := []env.Pair{{Name: "DATABASE_PASSWORD", Value: "hunter2"}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Vars(%q, %q) diff (-got +want)\n%s", redactConfig, environment, diff)
-	}
-}
-
-func TestValuesToRedactEmpty(t *testing.T) {
-	t.Parallel()
-
-	redactConfig := []string{}
-	environment := []env.Pair{
-		{Name: "FOO", Value: "BAR"},
-		{Name: "BUILDKITE_PIPELINE", Value: "unit-test"},
-	}
-
-	got, short, err := Vars(redactConfig, environment)
-	if err != nil {
-		t.Errorf("Vars(%q, %q) error = %v", redactConfig, environment, err)
-	}
-	if len(short) > 0 {
-		t.Errorf("Vars(%q, %q) short = %q", redactConfig, environment, short)
-	}
-	if len(got) != 0 {
-		t.Errorf("Vars(%q, %q) = %q, want empty slice", redactConfig, environment, got)
+			matched, short, err := Vars(test.redactConfig, test.environment)
+			if err != nil {
+				t.Fatalf("Vars(%q, %q) error = %v", test.redactConfig, test.environment, err)
+			}
+			if diff := cmp.Diff(matched, test.wantMatched); diff != "" {
+				t.Errorf("Vars(%q, %q) matched diff (-got +want)\n%s", test.redactConfig, test.environment, diff)
+			}
+			if diff := cmp.Diff(short, test.wantShort); diff != "" {
+				t.Errorf("Vars(%q, %q) short diff (-got +want)\n%s", test.redactConfig, test.environment, diff)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
### Description

While investigating #3588, I realised we have no test showing `redact.Vars` splits out env var names for short secrets. This adds such a test and collects the tests into a table-driven test.

### Context

#3588

### Changes

- Add a new test
- Rearrange tests into a table-driven structure.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)


### Disclosures / Credits

I did not use AI tools at all