### PR TITLE
Fetch and compare job logs

### DIFF
--- a/internal/e2e/basic_test.go
+++ b/internal/e2e/basic_test.go
@@ -2,7 +2,10 @@
 
 package e2e
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestBasicE2E(t *testing.T) {
 	ctx := t.Context()
@@ -14,15 +17,14 @@ steps:
 `)
 
 	tc.startAgent()
-
 	build := tc.triggerBuild()
-	state, err := tc.waitForBuild(ctx, build)
-	if err != nil {
-		t.Fatalf("tc.waitForBuild(build %s) error = %v", build.ID, err)
-	}
+	state := tc.waitForBuild(ctx, build)
 	if got, want := state, "passed"; got != want {
 		t.Errorf("Build state = %q, want %q", got, want)
 	}
 
-	// TODO: add ability to inspect job logs
+	logs := tc.fetchLogs(ctx, build)
+	if !strings.Contains(logs, "hello world") {
+		t.Errorf("tc.fetchLogs(ctx, build %q) logs as follows, did not contain 'hello world'\n%s", build.ID, logs)
+	}
 }


### PR DESCRIPTION
### Description

Add ability to fetch job logs to the E2E test helpers, and show that it works in the basic E2E test.

### Context

https://linear.app/buildkite/issue/PB-990/add-mechanism-to-read-job-logs

### Changes

Per Description.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)
- [x] It works


### Disclosures / Credits

Some bits copied from https://github.com/buildkite/agent-stack-k8s.
