### PR TITLE
Read target org and cluster from agent token

### DIFF
--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -1,10 +1,6 @@
 agents:
   queue: agent-runners-linux-amd64
 
-env:
-  CI_E2E_TESTS_TARGET_ORG: agent-e2e-testing
-  CI_E2E_TESTS_TARGET_CLUSTER: e1773a06-b43c-4b77-84e5-5e088a737f6a
-
 steps:
   - label: ":go::sleuth_or_spy: Run agent end-to-end tests"
     command: .buildkite/steps/e2e-tests.sh

--- a/api/token.go
+++ b/api/token.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"context"
+	"net/http"
+)
+
+// AgentTokenIdentity describes token identity information.
+type AgentTokenIdentity struct {
+	UUID                  string `json:"uuid"`
+	Description           string `json:"description"`
+	TokenType             string `json:"token_type"`
+	OrganizationSlug      string `json:"organization_slug"`
+	OrganizationUUID      string `json:"organization_uuid"`
+	ClusterUUID           string `json:"cluster_uuid"`
+	ClusterName           string `json:"cluster_name"`
+	OrganizationQueueUUID string `json:"organization_queue_uuid"`
+	OrganizationQueueKey  string `json:"organization_queue_key"`
+}
+
+// GetTokenIdentity gets the identity information of an agent token.
+func (c *Client) GetTokenIdentity(ctx context.Context) (*AgentTokenIdentity, *Response, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, "token", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ident := new(AgentTokenIdentity)
+	resp, err := c.doRequest(req, ident)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ident, resp, nil
+}

--- a/internal/e2e/main_test.go
+++ b/internal/e2e/main_test.go
@@ -1,0 +1,28 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/logger"
+)
+
+func TestMain(m *testing.M) {
+	l := logger.NewConsoleLogger(logger.NewTextPrinter(os.Stderr), os.Exit)
+	client := api.NewClient(l, api.Config{
+		Token: agentToken,
+	})
+	ctx := context.Background()
+	ident, _, err := client.GetTokenIdentity(ctx)
+	if err != nil {
+		l.Fatal("Could not read token identity: %v", err)
+	}
+	targetOrg = ident.OrganizationSlug
+	targetCluster = ident.ClusterUUID
+
+	os.Exit(m.Run())
+}

--- a/internal/e2e/testcase.go
+++ b/internal/e2e/testcase.go
@@ -29,9 +29,11 @@ var (
 	agentToken = os.Getenv("CI_E2E_TESTS_AGENT_TOKEN")
 
 	// E2E testing config
-	agentPath     = os.Getenv("CI_E2E_TESTS_AGENT_PATH")
-	targetOrg     = os.Getenv("CI_E2E_TESTS_TARGET_ORG")
-	targetCluster = os.Getenv("CI_E2E_TESTS_TARGET_CLUSTER")
+	agentPath = os.Getenv("CI_E2E_TESTS_AGENT_PATH")
+
+	// Obtained from agentToken in main_test.go
+	targetOrg     string
+	targetCluster string
 
 	// Values from the Buildkite job running the tests
 	jobID = cmp.Or(


### PR DESCRIPTION
### Description

Instead of hard- or firmly-coding the org and cluster, interrogate Buildkite with the Agent token.

### Context

https://linear.app/buildkite/issue/PB-989/obtain-the-target-org-and-cluster-from-the-api-token

### Changes

Per description.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)


### Disclosures / Credits

Copied and then rewrote parts of the API client from agent-stack-k8s.
