### PR TITLE
Move pipeline YAML into fixtures dir

### DIFF
--- a/internal/e2e/basic_test.go
+++ b/internal/e2e/basic_test.go
@@ -9,12 +9,7 @@ import (
 
 func TestBasicE2E(t *testing.T) {
 	ctx := t.Context()
-	tc := newTestCase(t, `
-agents:
-  queue: {{.queue}}
-steps:
-  - command: echo hello world
-`)
+	tc := newTestCase(t, "basic_e2e.yaml")
 
 	tc.startAgent()
 	build := tc.triggerBuild()

--- a/internal/e2e/fixtures/basic_e2e.yaml
+++ b/internal/e2e/fixtures/basic_e2e.yaml
@@ -1,0 +1,4 @@
+agents:
+  queue: "{{.queue}}"
+steps:
+  - command: echo hello world


### PR DESCRIPTION
### Description

YAML will be easier to edit in separate files than within Go string literals.

### Context

https://linear.app/buildkite/issue/PB-1011/store-test-pipelines-in-individual-files

### Changes

Similar to agent-stack-k8s

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)
- [x] It works


### Disclosures / Credits

I did not use AI tools at all