### PR TITLE
Log agent logs separately

### DIFF
--- a/internal/e2e/testcase.go
+++ b/internal/e2e/testcase.go
@@ -309,8 +309,16 @@ func (tc *testCase) startAgent(extraArgs ...string) *exec.Cmd {
 		"HOME=" + os.Getenv("HOME"),
 		"PATH=" + os.Getenv("PATH"),
 	}
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
+	var buf strings.Builder
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	tc.Cleanup(func() {
+		if err := cmd.Wait(); err != nil {
+			tc.Logf("Couldn't wait for agent to exit: cmd.Wait() = %v", err)
+		}
+		tc.Log("Agent output:")
+		tc.Log(buf.String())
+	})
 
 	// The agent should be cancelled automatically by t.Context.
 	// The default Cancel func set by CommandContext is `cmd.Process.Kill()`,


### PR DESCRIPTION
### Description

Instead of passing agent output directly to `os.Stderr`, capture in a buffer and log once during cleanup. This keeps the agent logs in one chunk separate from the test logs.

### Context

https://buildkite-corp.slack.com/archives/C061U5PG9K5/p1764821554921599?thread_ts=1764817320.578409&cid=C061U5PG9K5

### Changes

Per the description.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

I did not use AI tools at all
