### PR TITLE
Add e2e test for uploading/downloading artifacts ferom custom buckets

### DIFF
--- a/internal/e2e/artifact_test.go
+++ b/internal/e2e/artifact_test.go
@@ -19,3 +19,21 @@ func TestArtifactUploadDownload(t *testing.T) {
 		t.Errorf("Build state = %q, want %q", got, want)
 	}
 }
+
+// Test that an agent can upload and download artifact to/from a customer-managed S3 bucket
+func TestArtifactUploadDownload_CustomBucket(t *testing.T) {
+	ctx := t.Context()
+	tc := newTestCase(t, "artifact_custom_bucket.yaml")
+
+	tc.startAgent()
+	build := tc.triggerBuild()
+	state := tc.waitForBuild(ctx, build)
+
+	logs := tc.fetchLogs(ctx, build)
+	t.Log("Job logs:")
+	t.Log(logs)
+
+	if got, want := state, "passed"; got != want {
+		t.Errorf("Build state = %q, want %q", got, want)
+	}
+}

--- a/internal/e2e/fixtures/artifact_custom_bucket.yaml
+++ b/internal/e2e/fixtures/artifact_custom_bucket.yaml
@@ -1,0 +1,33 @@
+agents:
+  queue: {{ .queue }}
+steps:
+  - key: upload
+    plugins:
+      - aws-assume-role-with-web-identity#v1.4.0:
+          role-arn: arn:aws:iam::172840064832:role/ pipeline-buildkite-buildkite-agent-e2e
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+    commands:
+      - echo "hello world" > artifact.txt
+      - buildkite-agent artifact upload artifact.txt
+    env:
+      BUILDKITE_ARTIFACT_UPLOAD_DESTINATION: s3://buildkite-agent-e2e-tests-custom-artifacts
+      # NB: not using ACLs (which is what this ACL does) means artifacts won't be available from the buildkite UI.
+      # This isn't really a big deal because the jobs and pipelines that these tests generate are ephemeral
+      BUILDKITE_S3_ACL: bucket-owner-full-control
+  - key: download
+    depends_on: upload
+    plugins:
+      - aws-assume-role-with-web-identity#v1.4.0:
+          role-arn: arn:aws:iam::172840064832:role/ pipeline-buildkite-buildkite-agent-e2e
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+    commands:
+      - buildkite-agent artifact download artifact.txt . && if [[ $(cat artifact.txt) == "hello world" ]]; then exit 0; else exit 1; fi
+    env:
+      BUILDKITE_ARTIFACT_UPLOAD_DESTINATION: s3://buildkite-agent-e2e-tests-custom-artifacts
+      BUILDKITE_S3_ACL: bucket-owner-full-control

--- a/internal/e2e/testcase.go
+++ b/internal/e2e/testcase.go
@@ -106,21 +106,25 @@ func newTestCase(t testing.TB, file string) *testCase {
 		}
 	})
 
+	t.Logf("Created cluster queue %q in org %q", queue.Key, targetOrg)
+
 	var pipelineCfg strings.Builder
 	tmplInput := map[string]string{"queue": queue.Key}
 	if err := tmpl.Execute(&pipelineCfg, tmplInput); err != nil {
 		t.Fatalf("Could not execute pipeline config template: tmpl.Execute(%q) error = %v", tmplInput, err)
 	}
 
-	pipeline, cleanupPipeline, err := createPipeline(ctx, client, name, pipelineCfg.String())
+	pipeline, _, err := createPipeline(ctx, client, name, pipelineCfg.String())
 	if err != nil {
 		t.Fatalf("Could not create pipeline with the following config in org %q: testHelper.createPipeline(%q, pipelineCfg) error = %v\n%s", targetOrg, name, err, pipelineCfg.String())
 	}
 	t.Cleanup(func() {
-		if err := cleanupPipeline(); err != nil {
-			t.Logf("Could not clean up pipeline %q (id = %s) in org %q: cleanup() = %v", pipeline.Slug, pipeline.ID, targetOrg, err)
-		}
+		// if err := cleanupPipeline(); err != nil {
+		// 	t.Logf("Could not clean up pipeline %q (id = %s) in org %q: cleanup() = %v", pipeline.Slug, pipeline.ID, targetOrg, err)
+		// }
 	})
+
+	t.Logf("Created pipeline %q in org %q", pipeline.Slug, targetOrg)
 
 	return &testCase{
 		TB:             t,


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
