### PR TITLE
Add branch_name to aws assume role session tags for beta release pipeline

### DIFF
--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -17,6 +17,7 @@ steps:
             - organization_slug
             - organization_id
             - pipeline_slug
+            - branch_name
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -40,6 +41,7 @@ steps:
             - organization_slug
             - organization_id
             - pipeline_slug
+            - branch_name
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -64,6 +66,7 @@ steps:
             - organization_slug
             - organization_id
             - pipeline_slug
+            - branch_name
       - docker#v5.8.0:
           environment:
             - "AWS_ACCESS_KEY_ID"
@@ -125,6 +128,7 @@ steps:
             - organization_slug
             - organization_id
             - pipeline_slug
+            - branch_name
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -190,6 +194,7 @@ steps:
                 - organization_slug
                 - organization_id
                 - pipeline_slug
+                - branch_name
           - ecr#v2.7.0:
               login: true
               account-ids: "445615400570"
@@ -217,6 +222,7 @@ steps:
             - organization_slug
             - organization_id
             - pipeline_slug
+            - branch_name
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"


### PR DESCRIPTION
### Description

Recently, we updated the trust policy on the role that the beta release pipeline assumes to do AWS stuff such that it ensures that the branch name is either `main` or ends with `-stable`, but we forgot to add the branch name aws session tag to the OIDC token we use to assume that role.

This PR adds the `branch_name` session tag to the assume role calls for the beta release pipeline.

### Context

[PLT-5041](https://linear.app/buildkite/issue/PLT-5041/agent-releases-borked)

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

Thanks to AWS support for pointing out our mistake after we sort of just assumed it was their fault 🫠 