### PR TITLE
Fix beta pipeline OIDC claim names

### DIFF
--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -17,7 +17,7 @@ steps:
             - organization_slug
             - organization_id
             - pipeline_slug
-            - branch_name
+            - build_branch
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -41,7 +41,7 @@ steps:
             - organization_slug
             - organization_id
             - pipeline_slug
-            - branch_name
+            - build_branch
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -66,7 +66,7 @@ steps:
             - organization_slug
             - organization_id
             - pipeline_slug
-            - branch_name
+            - build_branch
       - docker#v5.8.0:
           environment:
             - "AWS_ACCESS_KEY_ID"
@@ -128,7 +128,7 @@ steps:
             - organization_slug
             - organization_id
             - pipeline_slug
-            - branch_name
+            - build_branch
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"
@@ -194,7 +194,7 @@ steps:
                 - organization_slug
                 - organization_id
                 - pipeline_slug
-                - branch_name
+                - build_branch
           - ecr#v2.7.0:
               login: true
               account-ids: "445615400570"
@@ -222,7 +222,7 @@ steps:
             - organization_slug
             - organization_id
             - pipeline_slug
-            - branch_name
+            - build_branch
       - ecr#v2.7.0:
           login: true
           account-ids: "032379705303"


### PR DESCRIPTION
### Description

In https://github.com/buildkite/agent/pull/3614, we added `branch_name` to the list of claims that we add to the OIDC token we use for interacting with AWS in the process of a beta release.

Unfortunately, we used the wrong claim name — it's `build_branch` not `branch_name`. This PR fixes that.

### Context

https://github.com/buildkite/agent/pull/3614

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

Perhaps if i'd used an LLM this might not have happened in the first place, but alas! The code written to fix it was also produced by me.
