### PR TITLE
PS-1491: Fix double retry issue for k8s mode bootstrap

### DIFF
--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -309,6 +309,8 @@ func init() {
 
 // helper for ignoring the response from regular client.Connect
 func connect(ctx context.Context, c *Client) error {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 	_, err := c.Connect(ctx)
 	return err
 }


### PR DESCRIPTION
### Description

Starting #3306 and subsequently worsen by #3398, we have created a double retry mechanism that will make k8s agent to spend 1200 seconds on retry when it's unable to connect to the coordinating agent container. 

This PR remove double retry mechanism, centralize the retry logic to socket.Connect.

### Context

PS-1491

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

Human