### PR TITLE
PB-1023: remove old kubernetes bootstrap setup

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -78,7 +78,11 @@ type JobRunnerConfig struct {
 	// Whether to set debug HTTP Requests in the job
 	DebugHTTP bool
 
-	// Whether the job is executing as a k8s pod
+	// KubernetesExec enables Kubernetes execution mode. When true, the job runner
+	// creates a kubernetes.Runner that listens on a UNIX socket for other agent containers
+	// to connect, rather than spawning a local bootstrap subprocess. The other agent containers
+	// containers run `kubernetes-bootstrap` which connects to this socket, receives
+	// environment variables, and executes the bootstrap phases.
 	KubernetesExec bool
 
 	// Stdout of the parent agent process. Used for job log stdout writing arg, for simpler containerized log collection.
@@ -592,10 +596,6 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 	setEnv("BUILDKITE_CANCEL_GRACE_PERIOD", strconv.Itoa(r.conf.AgentConfiguration.CancelGracePeriod))
 	setEnv("BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS", strconv.Itoa(int(r.conf.AgentConfiguration.SignalGracePeriod/time.Second)))
 	setEnv("BUILDKITE_TRACE_CONTEXT_ENCODING", r.conf.AgentConfiguration.TraceContextEncoding)
-
-	if r.conf.KubernetesExec {
-		setEnv("BUILDKITE_KUBERNETES_EXEC", "true")
-	}
 
 	if !r.conf.AgentConfiguration.AllowMultipartArtifactUpload {
 		setEnv("BUILDKITE_NO_MULTIPART_ARTIFACT_UPLOAD", "true")

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -107,8 +107,6 @@ type BootstrapConfig struct {
 	TraceContextEncoding         string   `cli:"trace-context-encoding"`
 	NoJobAPI                     bool     `cli:"no-job-api"`
 	DisableWarningsFor           []string `cli:"disable-warnings-for" normalize:"list"`
-	KubernetesExec               bool     `cli:"kubernetes-exec"`
-	KubernetesContainerID        int      `cli:"kubernetes-container-id"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -398,7 +396,6 @@ var BootstrapCommand = cli.Command{
 			Usage:  "A list of warning IDs to disable",
 			EnvVar: "BUILDKITE_AGENT_DISABLE_WARNINGS_FOR",
 		},
-		KubernetesContainerIDFlag,
 		cancelSignalFlag,
 		cancelGracePeriodFlag,
 		signalGracePeriodSecondsFlag,
@@ -410,7 +407,6 @@ var BootstrapCommand = cli.Command{
 		ProfileFlag,
 		RedactedVars,
 		StrictSingleHooksFlag,
-		KubernetesExecFlag,
 		TraceContextEncodingFlag,
 	},
 	Action: func(c *cli.Context) error {
@@ -517,8 +513,6 @@ var BootstrapCommand = cli.Command{
 			TracingPropagateTraceparent:  cfg.TracingPropagateTraceparent,
 			JobAPI:                       !cfg.NoJobAPI,
 			DisabledWarnings:             cfg.DisableWarningsFor,
-			KubernetesExec:               cfg.KubernetesExec,
-			KubernetesContainerID:        cfg.KubernetesContainerID,
 			Secrets:                      cfg.Secrets,
 		})
 

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -184,10 +184,6 @@ type ExecutorConfig struct {
 	// Whether to start the JobAPI
 	JobAPI bool
 
-	// Whether to enable Kubernetes support, and which container we're running in
-	KubernetesExec        bool
-	KubernetesContainerID int
-
 	// The warnings that have been disabled by the user
 	DisabledWarnings []string
 

--- a/kubernetes/doc.go
+++ b/kubernetes/doc.go
@@ -1,0 +1,59 @@
+// Package kubernetes provides coordination between containers in a Kubernetes
+// pod when running Buildkite jobs.
+//
+// # Architecture
+//
+// In Kubernetes, a job runs across multiple containers within a single pod:
+//
+//   - Agent container: runs `buildkite-agent start --kubernetes-exec`, receives
+//     jobs from Buildkite, and acts as a coordinator.
+//   - Checkout container: clones the repository.
+//   - Command container(s): execute the build commands.
+//
+// These containers need coordination because:
+//
+//  1. Environment sharing: The agent container receives job details (API tokens,
+//     build metadata, plugin configs) from Buildkite. Other containers need this
+//     information but Kubernetes doesn't share environment variables between
+//     containers.
+//
+//  2. Sequential execution: The checkout container must complete before command
+//     containers start. Kubernetes starts all containers simultaneously by default.
+//
+//  3. Log aggregation: All container output must be collected and streamed to
+//     Buildkite as a single job log.
+//
+//  4. Cancellation: When a job is cancelled in Buildkite, all containers must
+//     be notified to gracefully shut down.
+//
+//  5. Exit status: The agent must collect exit statuses from all containers to
+//     report the final job result.
+//
+// # Components
+//
+// [Runner] implements the server side, running in the agent container. It
+// creates a Unix socket and exposes an RPC API for other containers to connect.
+//
+// [Client] implements the client side, used by `kubernetes-bootstrap` running
+// in checkout and command containers. It connects to the socket, receives
+// environment variables, and reports logs and exit status.
+//
+// # Flow
+//
+// 1. Agent container starts [Runner], which listens on a Unix socket.
+//
+// 2. Each container runs `kubernetes-bootstrap`, which creates a [Client] and
+// calls [Client.Connect] to register with the runner and receive environment
+// variables.
+//
+// 3. The client calls [Client.StatusLoop], which blocks until the runner
+// signals it can start (ensuring sequential execution).
+//
+// 4. The container executes `buildkite-agent bootstrap`, streaming logs through
+// the socket via [Client.Write].
+//
+// 5. On completion, the container calls [Client.Exit] to report its exit status.
+//
+// 6. If the job is cancelled, the runner broadcasts an interrupt to all
+// connected clients via the status polling mechanism.
+package kubernetes


### PR DESCRIPTION
### Description

Since https://github.com/buildkite/agent/pull/3306 we have stopped using `BUILDKITE_KUBERNETES_EXEC` to bootstrap agent in k8s, we should remove old code path.

### Context

PB-1023

### Changes

Remove anything that's related to `BUILDKITE_KUBERNETES_EXEC`

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)


### Disclosures / Credits

Docs are generated by AI. Reviewed by me. 