### PR TITLE
PB-1007: add e2e test for gcs artifact upload/download

### DIFF
--- a/internal/e2e/artifact_test.go
+++ b/internal/e2e/artifact_test.go
@@ -1,5 +1,10 @@
 //go:build e2e
 
+// Note to external contributors: Many test cases in this file require
+// access to specific Buildkite organization resources and may not work
+// in your local environment. These tests can be safely skipped during
+// local development.
+
 package e2e
 
 import (
@@ -24,6 +29,21 @@ func TestArtifactUploadDownload(t *testing.T) {
 func TestArtifactUploadDownload_CustomBucket(t *testing.T) {
 	ctx := t.Context()
 	tc := newTestCase(t, "artifact_custom_s3_bucket.yaml")
+
+	tc.startAgent()
+	build := tc.triggerBuild()
+	state := tc.waitForBuild(ctx, build)
+
+	if got, want := state, "passed"; got != want {
+		t.Errorf("Build state = %q, want %q", got, want)
+	}
+}
+
+// Test that we can upload/downdload artifact using a custom GCS bucket.
+// Everything that gets uploaded here gets auto removed in 30 days.
+func TestArtifactUploadDownload_GCS(t *testing.T) {
+	ctx := t.Context()
+	tc := newTestCase(t, "artifact_custom_gcs_bucket.yaml")
 
 	tc.startAgent()
 	build := tc.triggerBuild()

--- a/internal/e2e/fixtures/artifact_custom_gcs_bucket.yaml
+++ b/internal/e2e/fixtures/artifact_custom_gcs_bucket.yaml
@@ -1,0 +1,23 @@
+env:
+  BUILDKITE_ARTIFACT_UPLOAD_DESTINATION: "gs://buildkite-agent-e2e-testing/$BUILDKITE_PIPELINE_ID"
+
+agents:
+  queue: {{ .queue }}
+
+secrets:
+  - GCP_E2E_TEST_CREDENTIALS_JSON
+
+steps:
+  - key: upload
+    commands:
+      - set -e
+      - echo "hello world" > artifact.txt
+      - export BUILDKITE_GS_APPLICATION_CREDENTIALS_JSON="$$GCP_E2E_TEST_CREDENTIALS_JSON"
+      - {{ .buildkite_agent_binary }} artifact upload artifact.txt
+  - key: download
+    depends_on: upload
+    commands:
+      - set -e
+      - export BUILDKITE_GS_APPLICATION_CREDENTIALS_JSON="$$GCP_E2E_TEST_CREDENTIALS_JSON"
+      - {{ .buildkite_agent_binary }} artifact download artifact.txt .
+      - if [[ $(cat artifact.txt) == "hello world" ]]; then exit 0; else exit 1; fi


### PR DESCRIPTION
### Description

E2E Test for GCS artifact upload/download

### Context

PB-1007

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

Human