### PR TITLE
PB-1025: improve e2e test DevEX

### DIFF
--- a/bin/e2e-local
+++ b/bin/e2e-local
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run e2e tests locally against a freshly compiled buildkite-agent.
+#
+# NOTE: Tests run against a production Buildkite org, not a test environment.
+#
+# Required environment variables:
+#   CI_E2E_TESTS_BUILDKITE_API_TOKEN - Buildkite API token
+#   CI_E2E_TESTS_AGENT_TOKEN         - Buildkite agent token
+#
+# Optional environment variables:
+#   CI_E2E_TESTS_PRINT_JOB_LOGS=true     - Print job logs after each test
+#
+# Usage:
+#   bin/e2e-local                     # run all e2e tests
+#   bin/e2e-local -run TestBasicE2E   # run a specific test
+#   bin/e2e-local -v                  # verbose output
+
+# Compile buildkite-agent
+AGENT_BINARY="$(pwd)/pkg/buildkite-agent-$(go env GOOS)-$(go env GOARCH)"
+echo "Compiling buildkite-agent to ${AGENT_BINARY}..."
+go build -o "${AGENT_BINARY}" .
+
+# Run e2e tests
+export CI_E2E_TESTS_AGENT_PATH="${AGENT_BINARY}"
+exec go test -tags e2e ./internal/e2e/... "$@"


### PR DESCRIPTION
### Description

* Provide handy script for people to run e2e against dev agent version. 
* Make it easy for user to read build logs. (otherwise the pipeline gets cleared, people won't be able to see any log after test finishes) 
* When upload pipeline failed with validation error, print the full error response. 
* Improve documentation.

### Context

PB-1025

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)


### Disclosures / Credits

Human and AI