### PR TITLE
Add E2E test for Azure Blob storage

### DIFF
--- a/internal/e2e/artifact_test.go
+++ b/internal/e2e/artifact_test.go
@@ -53,3 +53,19 @@ func TestArtifactUploadDownload_GCS(t *testing.T) {
 		t.Errorf("Build state = %q, want %q", got, want)
 	}
 }
+
+// Test that we can upload/downdload artifact using a custom Azure Blob storage
+// container.
+// Everything that gets uploaded here gets auto removed in 30 days.
+func TestArtifactUploadDownload_Azure(t *testing.T) {
+	ctx := t.Context()
+	tc := newTestCase(t, "artifact_custom_azure_storage.yaml")
+
+	tc.startAgent()
+	build := tc.triggerBuild()
+	state := tc.waitForBuild(ctx, build)
+
+	if got, want := state, "passed"; got != want {
+		t.Errorf("Build state = %q, want %q", got, want)
+	}
+}

--- a/internal/e2e/fixtures/artifact_custom_azure_storage.yaml
+++ b/internal/e2e/fixtures/artifact_custom_azure_storage.yaml
@@ -1,0 +1,21 @@
+env:
+  BUILDKITE_ARTIFACT_UPLOAD_DESTINATION: "https://l0srwtxpsx7s9h26qra8a40j.blob.core.windows.net/buildkite-agent-e2e-test/${BUILDKITE_PIPELINE_ID}"
+
+agents:
+  queue: {{ .queue }}
+
+secrets:
+  - AZURE_E2E_TEST_KEY
+
+steps:
+  - key: upload
+    commands: |
+      set -e
+      echo "hello world" > artifact.txt
+      BUILDKITE_AZURE_BLOB_ACCESS_KEY="$${AZURE_E2E_TEST_KEY}" {{ .buildkite_agent_binary }} artifact upload artifact.txt
+  - key: download
+    depends_on: upload
+    commands: |
+      set -e
+      BUILDKITE_AZURE_BLOB_ACCESS_KEY="$${AZURE_E2E_TEST_KEY}" {{ .buildkite_agent_binary }} artifact download artifact.txt .
+      [[ $(cat artifact.txt) == "hello world" ]]


### PR DESCRIPTION
### Description

Add an E2E test that uploads and downloads an artifact from Azure Blob storage.

### Context

https://linear.app/buildkite/issue/PB-1008/add-custom-azure-blob-storage-container-artifact-upload-download-test

### Changes

Adds the test.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)
- [x] It works

### Disclosures / Credits

I did not use AI tools at all, but I did significantly copy-pasta TestArtifactUploadDownload_GCS.