### PR TITLE
Mandatory golangci lint

### DIFF
--- a/.buildkite/steps/check-code-committed.sh
+++ b/.buildkite/steps/check-code-committed.sh
@@ -42,16 +42,14 @@ if ! lint_out="$(golangci-lint run --color=always)" ; then
   echo "golangci-lint found the following issues:"
   echo ""
   echo "${lint_out}"
-  buildkite-agent annotate --style=warning <<EOF
+  buildkite-agent annotate --style=error <<EOF
 golangci-lint found the following issues:
 
 \`\`\`term
 ${lint_out}
 \`\`\`
 EOF
-  # While we're cleaning up things found by golangci-lint, don't fail if it
-  # finds things.
-  exit 0
+  exit 1
 fi
 
 echo +++ Everything is clean and tidy! 🎉

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -260,7 +260,7 @@ func (a *AgentWorker) Start(ctx context.Context, idleMon *idleMonitor) (startErr
 			// If the job acquisition was rejected, we can exit with an error
 			// so that supervisor knows that the job was not acquired due to the job being rejected.
 			if errors.Is(err, core.ErrJobAcquisitionRejected) {
-				return fmt.Errorf("Failed to acquire job %q: %w", a.agentConfiguration.AcquireJob, err)
+				return fmt.Errorf("failed to acquire job %q: %w", a.agentConfiguration.AcquireJob, err)
 			}
 
 			// If the job itself exited with nonzero code, then we want to exit
@@ -652,9 +652,9 @@ func (a *AgentWorker) Ping(ctx context.Context) (job *api.Job, action string, er
 		// If a ping fails, we don't really care, because it'll
 		// ping again after the interval.
 		if a.stats.lastPing.IsZero() {
-			return nil, action, fmt.Errorf("Failed to ping: %w (No successful ping yet)", pingErr)
+			return nil, action, fmt.Errorf("failed to ping: %w (no successful ping yet)", pingErr)
 		} else {
-			return nil, action, fmt.Errorf("Failed to ping: %w (Last successful was %v ago)", pingErr, time.Since(a.stats.lastPing))
+			return nil, action, fmt.Errorf("failed to ping: %w (last successful was %v ago)", pingErr, time.Since(a.stats.lastPing))
 		}
 	}
 
@@ -748,7 +748,7 @@ func (a *AgentWorker) AcceptAndRunJob(ctx context.Context, job *api.Job, idleMon
 
 	// If `accepted` is nil, then the job was never accepted
 	if accepted == nil {
-		return fmt.Errorf("Failed to accept job: %w", err)
+		return fmt.Errorf("failed to accept job: %w", err)
 	}
 
 	// If we're disconnecting-after-job, signal back to Buildkite that we're not
@@ -791,17 +791,17 @@ func (a *AgentWorker) RunJob(ctx context.Context, acceptResponse *api.Job, ignor
 		KubernetesExec:     a.agentConfiguration.KubernetesExec,
 	})
 	if err != nil {
-		return fmt.Errorf("Failed to initialize job: %w", err)
+		return fmt.Errorf("failed to initialize job: %w", err)
 	}
 	if !a.jobRunner.CompareAndSwap(nil, jr) {
-		return fmt.Errorf("Agent worker already has a job running")
+		return fmt.Errorf("agent worker already has a job running")
 	}
 	// No more job, no more runner.
 	defer a.jobRunner.Store(nil)
 
 	// Start running the job
 	if err := jr.Run(ctx, ignoreAgentInDispatches); err != nil {
-		return fmt.Errorf("Failed to run job: %w", err)
+		return fmt.Errorf("failed to run job: %w", err)
 	}
 
 	return nil
@@ -821,12 +821,12 @@ func (a *AgentWorker) healthHandler() http.HandlerFunc {
 
 		if a.stats.lastHeartbeatError != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "ERROR: last heartbeat failed: %v. last successful was %v ago", a.stats.lastHeartbeatError, time.Since(a.stats.lastHeartbeat))
+			fmt.Fprintf(w, "ERROR: last heartbeat failed: %v. last successful was %v ago", a.stats.lastHeartbeatError, time.Since(a.stats.lastHeartbeat)) //nolint:errcheck // status page writer; errors are non-actionable
 		} else {
 			if a.stats.lastHeartbeat.IsZero() {
-				fmt.Fprintf(w, "OK: no heartbeat yet")
+				fmt.Fprintf(w, "OK: no heartbeat yet") //nolint:errcheck // status page writer; errors are non-actionable
 			} else {
-				fmt.Fprintf(w, "OK: last heartbeat successful %v ago", time.Since(a.stats.lastHeartbeat))
+				fmt.Fprintf(w, "OK: last heartbeat successful %v ago", time.Since(a.stats.lastHeartbeat)) //nolint:errcheck // status page writer; errors are non-actionable
 			}
 		}
 	}

--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -41,7 +41,7 @@ func TestDisconnect(t *testing.T) {
 		switch req.URL.Path {
 		case "/disconnect":
 			rw.WriteHeader(http.StatusOK)
-			fmt.Fprintf(rw, `{"id": "fakeuuid", "connection_state": "disconnected"}`)
+			fmt.Fprintf(rw, `{"id": "fakeuuid", "connection_state": "disconnected"}`) //nolint:errcheck // test handler
 		default:
 			t.Errorf("Unknown endpoint %s %s", req.Method, req.URL.Path)
 			http.Error(rw, "Not found", http.StatusNotFound)
@@ -203,7 +203,7 @@ func TestAcquireAndRunJobWaiting(t *testing.T) {
 
 			rw.Header().Set("Retry-After", fmt.Sprintf("%f", delay))
 			rw.WriteHeader(http.StatusLocked)
-			fmt.Fprintf(rw, `{"message": "Job waitinguuid is not yet eligible to be assigned"}`)
+			fmt.Fprintf(rw, `{"message": "Job waitinguuid is not yet eligible to be assigned"}`) //nolint:errcheck // test handler
 		default:
 			http.Error(rw, "Not found", http.StatusNotFound)
 		}
@@ -1010,9 +1010,6 @@ func TestAgentWorker_UnrecoverableErrorInPing(t *testing.T) {
 
 	server := NewFakeAPIServer()
 	defer server.Close()
-
-	const headerKey = "Buildkite-Hello"
-	const headerValue = "world"
 
 	agent := server.AddAgent(agentSessionToken)
 	agent.PingHandler = func(req *http.Request) (api.Ping, error) {

--- a/agent/gcp_meta_data_test.go
+++ b/agent/gcp_meta_data_test.go
@@ -20,9 +20,9 @@ func TestGCPMetaDataGetPaths(t *testing.T) {
 
 		switch path := r.URL.EscapedPath(); path {
 		case "/computeMetadata/v1/value":
-			fmt.Fprintf(w, "I could live on only burritos for the rest of my life")
+			fmt.Fprintf(w, "I could live on only burritos for the rest of my life") //nolint:errcheck // test handler
 		case "/computeMetadata/v1/nested/paths/work":
-			fmt.Fprintf(w, "Velociraptors are terrifying")
+			fmt.Fprintf(w, "Velociraptors are terrifying") //nolint:errcheck // test handler
 		default:
 			// NB: Do not use t.Fatal/Fatalf/FailNow from outside the test
 			// runner goroutine. See https://pkg.go.dev/testing#T.FailNow

--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -394,7 +394,7 @@ func TestChunksIntervalSeconds_ControlsUploadTiming(t *testing.T) {
 		mb.Expect().Once().AndCallFunc(func(c *bintest.Call) {
 			start := time.Now()
 			for time.Since(start) < 4*time.Second {
-				fmt.Fprintf(c.Stdout, "Log output at %v\n", time.Now())
+				fmt.Fprintf(c.Stdout, "Log output at %v\n", time.Now()) //nolint:errcheck // test helper; write error is non-actionable
 				time.Sleep(100 * time.Millisecond)
 			}
 			c.Exit(0)

--- a/agent/integration/job_verification_integration_test.go
+++ b/agent/integration/job_verification_integration_test.go
@@ -347,23 +347,6 @@ var (
 		},
 		Token: "bkaj_job-token",
 	}
-
-	jobWithMismatchedSecrets = api.Job{
-		ChunksMaxSizeBytes: 1024,
-		ID:                 defaultJobID,
-		Step: pipeline.CommandStep{
-			Command: "echo hello world",
-			Secrets: pipeline.Secrets{
-				pipeline.Secret{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
-			},
-		},
-		Env: map[string]string{
-			"BUILDKITE_COMMAND": "echo hello world",
-			"BUILDKITE_REPO":    defaultRepositoryURL,
-			"DEPLOY":            "0",
-		},
-		Token: "bkaj_job-token",
-	}
 )
 
 func TestJobVerification(t *testing.T) {

--- a/agent/integration/test_helpers.go
+++ b/agent/integration/test_helpers.go
@@ -143,7 +143,7 @@ type route struct {
 func (t *testAgentEndpoint) getJobsHandler() http.HandlerFunc {
 	return func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
-		fmt.Fprintf(rw, `{"state":"running"}`)
+		fmt.Fprintf(rw, `{"state":"running"}`) //nolint:errcheck // test handler
 	}
 }
 

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -906,8 +906,8 @@ func createJobEnvFiles(l logger.Logger, jobID string, kubernetesExec bool) (shel
 
 	jsonFile, err = os.CreateTemp(tempDir, fmt.Sprintf("job-env-json-%s", jobID))
 	if err != nil {
-		shellFile.Close()
-		os.Remove(shellFile.Name())
+		shellFile.Close()              //nolint:errcheck // cleaning up on error path; Close error is secondary
+		os.Remove(shellFile.Name())    //nolint:errcheck // best-effort cleanup on error path
 		return nil, nil, err
 	}
 	l.Debug("[JobRunner] Created env file (JSON format): %s", jsonFile.Name())

--- a/agent/log_streamer.go
+++ b/agent/log_streamer.go
@@ -85,7 +85,7 @@ func NewLogStreamer(
 // Start spins up a number of log streamer workers.
 func (ls *LogStreamer) Start(ctx context.Context) error {
 	if ls.conf.MaxChunkSizeBytes <= 0 {
-		return errors.New("Maximum chunk size must be more than 0. No logs will be sent.")
+		return errors.New("maximum chunk size must be more than 0, no logs will be sent")
 	}
 
 	if ls.conf.MaxSizeBytes <= 0 {

--- a/agent/pipeline_uploader.go
+++ b/agent/pipeline_uploader.go
@@ -61,7 +61,7 @@ type PipelineUploader struct {
 func (u *PipelineUploader) Upload(ctx context.Context, l logger.Logger) error {
 	result, err := u.pipelineUploadAsyncWithRetry(ctx, l)
 	if err != nil {
-		return fmt.Errorf("Failed to upload and accept pipeline: %w", err)
+		return fmt.Errorf("failed to upload and accept pipeline: %w", err)
 	}
 
 	// If the route does not support async uploads, and it did not error, then the pipeline
@@ -75,12 +75,12 @@ func (u *PipelineUploader) Upload(ctx context.Context, l logger.Logger) error {
 
 	jobIDFromResponse, uuidFromResponse, err := extractJobIdUUID(result.pipelineStatusURL.String())
 	if err != nil {
-		return fmt.Errorf("Failed to parse location to check status of pipeline: %w", err)
+		return fmt.Errorf("failed to parse location to check status of pipeline: %w", err)
 	}
 
 	if jobIDFromResponse != u.JobID {
 		return fmt.Errorf(
-			"JobID from API: %q does not match request: %s",
+			"jobID from API: %q does not match request: %s",
 			jobIDFromResponse,
 			u.JobID,
 		)
@@ -88,14 +88,14 @@ func (u *PipelineUploader) Upload(ctx context.Context, l logger.Logger) error {
 
 	if uuidFromResponse != u.Change.UUID {
 		return fmt.Errorf(
-			"Pipeline Upload UUID from API: %q does not match request: %s",
+			"pipeline upload UUID from API: %q does not match request: %s",
 			uuidFromResponse,
 			u.Change.UUID,
 		)
 	}
 
 	if err := u.pollForPiplineUploadStatus(ctx, l); err != nil {
-		return fmt.Errorf("Failed to upload and process pipeline: %w", err)
+		return fmt.Errorf("failed to upload and process pipeline: %w", err)
 	}
 
 	return nil
@@ -208,17 +208,17 @@ func (u *PipelineUploader) pollForPiplineUploadStatus(ctx context.Context, l log
 			return nil
 		case "pending", "processing":
 			setNextIntervalFromResponse(r, resp)
-			err := fmt.Errorf("Pipeline upload not yet applied: %s", uploadStatus.State)
+			err := fmt.Errorf("pipeline upload not yet applied: %s", uploadStatus.State)
 			l.Info("%s (%s)", err, r)
 			return err
 		case "rejected", "failed":
 			l.Error("Unrecoverable error, skipping retries")
 			r.Break()
-			return fmt.Errorf("Pipeline upload %s: %s", uploadStatus.State, uploadStatus.Message)
+			return fmt.Errorf("pipeline upload %s: %s", uploadStatus.State, uploadStatus.Message)
 		default:
 			l.Error("Unrecoverable error, skipping retries")
 			r.Break()
-			return fmt.Errorf("Unexpected pipeline upload state from API: %s", uploadStatus.State)
+			return fmt.Errorf("unexpected pipeline upload state from API: %s", uploadStatus.State)
 		}
 	})
 }

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -58,7 +58,7 @@ func CreatePlugin(location string, config map[string]any) (*Plugin, error) {
 	plugin.Vendored = strings.HasPrefix(plugin.Location, ".")
 
 	if plugin.Version != "" && strings.Count(plugin.Version, "#") > 0 {
-		return nil, fmt.Errorf("Too many '#'s in %q", location)
+		return nil, fmt.Errorf("too many '#'s in %q", location)
 	}
 
 	if u.User != nil {
@@ -114,7 +114,7 @@ func CreateFromJSON(j string) ([]*Plugin, error) {
 				// Since there is a config, it's gotta be a hash
 				config, ok := config.(map[string]any)
 				if !ok {
-					return nil, fmt.Errorf("Configuration for \"%s\" is not a hash", location)
+					return nil, fmt.Errorf("configuration for %q is not a hash", location)
 				}
 
 				// Add the plugin with config to the array
@@ -127,7 +127,7 @@ func CreateFromJSON(j string) ([]*Plugin, error) {
 			}
 
 		default:
-			return nil, fmt.Errorf("Unknown type in plugin definition (%s)", vv)
+			return nil, fmt.Errorf("unknown type in plugin definition (%s)", vv)
 		}
 	}
 
@@ -248,7 +248,7 @@ func flattenConfigToEnvMap(into map[string]string, v any, envPrefix string) erro
 		return nil
 
 	default:
-		return fmt.Errorf("Unknown type %T %v", v, v)
+		return fmt.Errorf("unknown type %T %v", v, v)
 	}
 }
 
@@ -338,24 +338,24 @@ func (p *Plugin) DisplayName() string {
 
 func (p *Plugin) constructRepositoryHost() (string, error) {
 	if p.Location == "" {
-		return "", fmt.Errorf("Missing plugin location")
+		return "", fmt.Errorf("missing plugin location")
 	}
 
 	parts := strings.Split(p.Location, "/")
 	if len(parts) < 2 {
-		return "", fmt.Errorf("Incomplete plugin path %q", p.Location)
+		return "", fmt.Errorf("incomplete plugin path %q", p.Location)
 	}
 
 	switch parts[0] {
 	case "github.com", "bitbucket.org":
 		if len(parts) < 3 {
-			return "", fmt.Errorf("Incomplete plugin path %q", p.Location)
+			return "", fmt.Errorf("incomplete plugin path %q", p.Location)
 		}
 		return strings.Join(parts[:3], "/"), nil
 
 	case "gitlab.com":
 		if len(parts) < 3 {
-			return "", fmt.Errorf("Incomplete plugin path %q", p.Location)
+			return "", fmt.Errorf("incomplete plugin path %q", p.Location)
 		}
 		return strings.Join(parts, "/"), nil
 

--- a/api/client.go
+++ b/api/client.go
@@ -332,7 +332,7 @@ func (c *Client) doRequest(req *http.Request, v any) (*Response, error) {
 			}
 		} else {
 			if strings.Contains(req.Header.Get("Content-Type"), "application/msgpack") {
-				return response, errors.New("Msgpack not supported")
+				return response, errors.New("msgpack not supported")
 			}
 
 			if err = json.NewDecoder(resp.Body).Decode(v); err != nil {

--- a/api/retryable.go
+++ b/api/retryable.go
@@ -36,12 +36,6 @@ func IsRetryableStatus(r *Response) bool {
 // Looks at a bunch of connection related errors, and returns true if the error
 // matches one of them.
 func IsRetryableError(err error) bool {
-	if neterr, ok := err.(net.Error); ok {
-		if neterr.Temporary() {
-			return true
-		}
-	}
-
 	if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
 		return true
 	}

--- a/clicommand/agent_start_test.go
+++ b/clicommand/agent_start_test.go
@@ -20,7 +20,7 @@ func setupHooksPath(t *testing.T) (string, func()) {
 	if err != nil {
 		assert.FailNow(t, "failed to create temp file: %v", err)
 	}
-	return hooksPath, func() { os.RemoveAll(hooksPath) }
+	return hooksPath, func() { os.RemoveAll(hooksPath) } //nolint:errcheck // best-effort cleanup in test
 }
 
 func writeAgentHook(t *testing.T, dir, hookName, msg string) string {

--- a/clicommand/annotate_test.go
+++ b/clicommand/annotate_test.go
@@ -16,7 +16,7 @@ func newAnnotateTestServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.RequestURI() {
 		case "/jobs/jobid/annotations":
-			io.WriteString(rw, `{"context":"", style:"", body:"abc"}`)
+			io.WriteString(rw, `{"context":"", style:"", body:"abc"}`) //nolint:errcheck // test handler
 		default:
 			t.Errorf("unexpected HTTP request: %s %v", req.Method, req.URL.RequestURI())
 		}

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -126,7 +126,7 @@ var ArtifactSearchCommand = cli.Command{
 		// Handling all escape sequences, like \n, \t etc
 		unquoted, err := strconv.Unquote(`"` + printFormat + `"`)
 		if err != nil {
-			return fmt.Errorf("Unable to parse format %q", printFormat)
+			return fmt.Errorf("unable to parse format %q", printFormat)
 		}
 		printFormat = unquoted
 

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -108,15 +108,15 @@ func searchAndPrintShaSum(
 	searcher := artifact.NewSearcher(l, client, cfg.Build)
 	artifacts, err := searcher.Search(ctx, cfg.Query, cfg.Step, cfg.IncludeRetriedJobs, false)
 	if err != nil {
-		return fmt.Errorf("Error searching for artifacts: %s", err)
+		return fmt.Errorf("error searching for artifacts: %s", err)
 	}
 
 	artifactsFoundLength := len(artifacts)
 
 	if artifactsFoundLength == 0 {
-		return fmt.Errorf("No artifacts matched the search query")
+		return fmt.Errorf("no artifacts matched the search query")
 	} else if artifactsFoundLength > 1 {
-		return fmt.Errorf("Multiple artifacts were found. Try being more specific with the search or scope by step")
+		return fmt.Errorf("multiple artifacts were found, try being more specific with the search or scope by step")
 	} else {
 		a := artifacts[0]
 		l.Debug("Artifact \"%s\" found", a.Path)
@@ -130,7 +130,7 @@ func searchAndPrintShaSum(
 		} else {
 			sha = a.Sha1Sum
 		}
-		fmt.Fprintln(stdout, sha)
+		fmt.Fprintln(stdout, sha) //nolint:errcheck // CLI output; errors are non-actionable
 	}
 
 	return nil

--- a/clicommand/artifact_shasum_test.go
+++ b/clicommand/artifact_shasum_test.go
@@ -18,7 +18,7 @@ func newArtifactTestServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.RequestURI() {
 		case "/builds/buildid/artifacts/search?query=foo.%2A&state=finished":
-			io.WriteString(rw, `[{"path": "foo.txt", "sha1sum": "theshastring", "sha256sum": "thesha256string"}]`)
+			io.WriteString(rw, `[{"path": "foo.txt", "sha1sum": "theshastring", "sha256sum": "thesha256string"}]`) //nolint:errcheck // test handler
 		default:
 			t.Errorf("unexpected HTTP request: %s %v", req.Method, req.URL.RequestURI())
 		}
@@ -44,7 +44,7 @@ func TestSearchAndPrintSha1Sum(t *testing.T) {
 	l := logger.NewBuffer()
 	stdout := new(bytes.Buffer)
 
-	searchAndPrintShaSum(ctx, cfg, l, stdout)
+	searchAndPrintShaSum(ctx, cfg, l, stdout) //nolint:errcheck // test assertion follows
 
 	assert.Equal(t, "theshastring\n", stdout.String())
 
@@ -72,7 +72,7 @@ func TestSearchAndPrintSha256Sum(t *testing.T) {
 	l := logger.NewBuffer()
 	stdout := new(bytes.Buffer)
 
-	searchAndPrintShaSum(ctx, cfg, l, stdout)
+	searchAndPrintShaSum(ctx, cfg, l, stdout) //nolint:errcheck // test assertion follows
 
 	assert.Equal(t, "thesha256string\n", stdout.String())
 

--- a/clicommand/build_cancel_test.go
+++ b/clicommand/build_cancel_test.go
@@ -18,7 +18,7 @@ func TestBuildCancel(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			rw.WriteHeader(http.StatusOK)
-			rw.Write([]byte(`{"status": "canceled", "uuid": "1"}`))
+			rw.Write([]byte(`{"status": "canceled", "uuid": "1"}`)) //nolint:errcheck // test handler
 		}))
 
 		cfg := BuildCancelConfig{

--- a/clicommand/env_get.go
+++ b/clicommand/env_get.go
@@ -10,9 +10,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-const envClientErrMessage = `Could not create Job API client: %w
-This command can only be used from hooks or plugins running under a job executor
-where the agent's job API is available (in version v3.64.0 and later of the Buildkite Agent).`
+const envClientErrMessage = `could not create Job API client: %w
+this command can only be used from hooks or plugins running under a job executor
+where the agent's job API is available (in version v3.64.0 and later of the Buildkite Agent)`
 
 const envGetHelpDescription = `Usage:
 
@@ -116,14 +116,14 @@ func envGetAction(c *cli.Context) error {
 		if len(c.Args()) == 1 {
 			// Just print the value.
 			for _, v := range envMap {
-				fmt.Fprintln(c.App.Writer, v)
+				fmt.Fprintln(c.App.Writer, v) //nolint:errcheck // CLI output; errors are non-actionable
 			}
 			break
 		}
 
 		// Print everything.
 		for _, v := range env.FromMap(envMap).ToSlice() {
-			fmt.Fprintln(c.App.Writer, v)
+			fmt.Fprintln(c.App.Writer, v) //nolint:errcheck // CLI output; errors are non-actionable
 		}
 
 	case "json", "json-pretty":

--- a/clicommand/env_set.go
+++ b/clicommand/env_set.go
@@ -138,19 +138,19 @@ func envSetAction(c *cli.Context) error {
 
 	case "plain":
 		if len(resp.Added) > 0 {
-			fmt.Fprintln(c.App.Writer, "Added:")
+			fmt.Fprintln(c.App.Writer, "Added:") //nolint:errcheck // CLI output; errors are non-actionable
 			for _, a := range resp.Added {
-				fmt.Fprintf(c.App.Writer, "+ %s\n", a)
+				fmt.Fprintf(c.App.Writer, "+ %s\n", a) //nolint:errcheck // CLI output; errors are non-actionable
 			}
 		}
 		if len(resp.Updated) > 0 {
-			fmt.Fprintln(c.App.Writer, "Updated:")
+			fmt.Fprintln(c.App.Writer, "Updated:") //nolint:errcheck // CLI output; errors are non-actionable
 			for _, u := range resp.Updated {
-				fmt.Fprintf(c.App.Writer, "~ %s\n", u)
+				fmt.Fprintf(c.App.Writer, "~ %s\n", u) //nolint:errcheck // CLI output; errors are non-actionable
 			}
 		}
 		if len(resp.Added) == 0 && len(resp.Updated) == 0 {
-			fmt.Fprintln(c.App.Writer, "No variables added or updated.")
+			fmt.Fprintln(c.App.Writer, "No variables added or updated.") //nolint:errcheck // CLI output; errors are non-actionable
 		}
 
 	case "json", "json-pretty":

--- a/clicommand/env_unset.go
+++ b/clicommand/env_unset.go
@@ -92,7 +92,7 @@ func envUnsetAction(c *cli.Context) error {
 		}
 
 	default:
-		fmt.Fprintf(c.App.ErrWriter, "Invalid input format %q\n", c.String("input-format"))
+		fmt.Fprintf(c.App.ErrWriter, "Invalid input format %q\n", c.String("input-format")) //nolint:errcheck // CLI output; errors are non-actionable
 	}
 
 	// Inspect each arg, which could either be "-" for stdin, or "KEY"
@@ -129,12 +129,12 @@ func envUnsetAction(c *cli.Context) error {
 
 	case "plain":
 		if len(unset) > 0 {
-			fmt.Fprintln(c.App.Writer, "Unset:")
+			fmt.Fprintln(c.App.Writer, "Unset:") //nolint:errcheck // CLI output; errors are non-actionable
 			for _, d := range unset {
-				fmt.Fprintf(c.App.Writer, "- %s\n", d)
+				fmt.Fprintf(c.App.Writer, "- %s\n", d) //nolint:errcheck // CLI output; errors are non-actionable
 			}
-		} else {
-			fmt.Fprintln(c.App.Writer, "No variables unset.")
+			} else {
+				fmt.Fprintln(c.App.Writer, "No variables unset.") //nolint:errcheck // CLI output; errors are non-actionable
 		}
 
 	case "json", "json-pretty":

--- a/clicommand/git_credentials_helper.go
+++ b/clicommand/git_credentials_helper.go
@@ -101,9 +101,9 @@ var GitCredentialsHelperCommand = cli.Command{
 			return handleAuthError(c, l, fmt.Errorf("failed to get github app credentials: %w", err))
 		}
 
-		fmt.Fprintln(c.App.Writer, "username=token")
-		fmt.Fprintln(c.App.Writer, "password="+tok)
-		fmt.Fprintln(c.App.Writer, "")
+		fmt.Fprintln(c.App.Writer, "username=token")  //nolint:errcheck // CLI output; errors are non-actionable
+		fmt.Fprintln(c.App.Writer, "password="+tok) //nolint:errcheck // CLI output; errors are non-actionable
+		fmt.Fprintln(c.App.Writer, "")              //nolint:errcheck // CLI output; errors are non-actionable
 
 		l.Debug("Authentication successful!")
 
@@ -117,9 +117,9 @@ var GitCredentialsHelperCommand = cli.Command{
 // this function always returns a cli.ExitError
 func handleAuthError(c *cli.Context, l logger.Logger, err error) error {
 	l.Error("Error: %v. Authentication will proceed, but will fail.", err)
-	fmt.Fprintln(c.App.Writer, "username=fail")
-	fmt.Fprintln(c.App.Writer, "password=fail")
-	fmt.Fprintln(c.App.Writer, "")
+	fmt.Fprintln(c.App.Writer, "username=fail") //nolint:errcheck // CLI output; errors are non-actionable
+	fmt.Fprintln(c.App.Writer, "password=fail") //nolint:errcheck // CLI output; errors are non-actionable
+	fmt.Fprintln(c.App.Writer, "")              //nolint:errcheck // CLI output; errors are non-actionable
 
 	return cli.NewExitError("", 1)
 }

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -312,12 +312,12 @@ func UnsetConfigFromEnvironment(c *cli.Context) error {
 		r := reflect.ValueOf(fl)
 		f := reflect.Indirect(r).FieldByName("EnvVar")
 		if !f.IsValid() {
-			return errors.New("EnvVar field not found on flag")
+			return errors.New("envVar field not found on flag")
 		}
 		// split comma delimited env
 		if envVars := f.String(); envVars != "" {
 			for env := range strings.SplitSeq(envVars, ",") {
-				os.Unsetenv(env)
+				os.Unsetenv(env) //nolint:errcheck // best-effort env cleanup
 			}
 		}
 	}
@@ -391,7 +391,7 @@ func setupLoggerAndConfig[T any](ctx context.Context, c *cli.Context, opts ...co
 
 	warnings, err := loader.Load()
 	if err != nil {
-		fmt.Fprintf(c.App.ErrWriter, "%s\n", err)
+		fmt.Fprintf(c.App.ErrWriter, "%s\n", err) //nolint:errcheck // CLI output; errors are non-actionable
 		os.Exit(1)
 	}
 

--- a/clicommand/kubernetes_bootstrap.go
+++ b/clicommand/kubernetes_bootstrap.go
@@ -185,7 +185,7 @@ var KubernetesBootstrapCommand = cli.Command{
 		}
 
 		phases := environ.GetString("BUILDKITE_BOOTSTRAP_PHASES", "(unknown)")
-		fmt.Fprintf(socket, "~~~ Bootstrapping phases %s\n", phases)
+		fmt.Fprintf(socket, "~~~ Bootstrapping phases %s\n", phases) //nolint:errcheck // k8s socket write; errors are non-actionable
 
 		// Now we can run the real `buildkite-agent bootstrap`.
 		// Compare with the setup in [agent.NewJobRunner].
@@ -235,11 +235,11 @@ var KubernetesBootstrapCommand = cli.Command{
 		}()
 
 		exitCode := -1
-		defer func() { socket.Exit(exitCode) }()
+		defer func() { socket.Exit(exitCode) }() //nolint:errcheck // best-effort exit notification
 
 		// NB: Run blocks until the subprocess exits.
 		if err := proc.Run(ctx); err != nil {
-			fmt.Fprintf(socket, "Couldn't execute bootstrap: %v\n", err)
+			fmt.Fprintf(socket, "Couldn't execute bootstrap: %v\n", err) //nolint:errcheck // k8s socket write; errors are non-actionable
 			return &ExitError{1, err}
 		}
 

--- a/clicommand/lock_acquire.go
+++ b/clicommand/lock_acquire.go
@@ -57,7 +57,7 @@ var LockAcquireCommand = cli.Command{
 
 func lockAcquireAction(c *cli.Context) error {
 	if c.NArg() != 1 {
-		fmt.Fprint(c.App.ErrWriter, lockAcquireHelpDescription)
+		fmt.Fprint(c.App.ErrWriter, lockAcquireHelpDescription) //nolint:errcheck // CLI help output
 		return &SilentExitError{code: 1}
 	}
 	key := c.Args()[0]
@@ -66,7 +66,7 @@ func lockAcquireAction(c *cli.Context) error {
 	defer done()
 
 	if cfg.LockScope != "machine" {
-		return errors.New("only 'machine' scope for locks is supported in this version.")
+		return errors.New("only 'machine' scope for locks is supported in this version")
 	}
 
 	if cfg.LockWaitTimeout != 0 {

--- a/clicommand/lock_common.go
+++ b/clicommand/lock_common.go
@@ -2,10 +2,9 @@ package clicommand
 
 import "github.com/urfave/cli"
 
-const lockClientErrMessage = `Could not connect to Agent API: %v
-This command can only be used when at least one agent is running with the
-"agent-api" experiment enabled.
-`
+const lockClientErrMessage = `could not connect to Agent API: %v
+this command can only be used when at least one agent is running with the
+"agent-api" experiment enabled`
 
 // Flags used by all lock subcommands.
 func lockCommonFlags() []cli.Flag {

--- a/clicommand/lock_do.go
+++ b/clicommand/lock_do.go
@@ -62,7 +62,7 @@ var LockDoCommand = cli.Command{
 
 func lockDoAction(c *cli.Context) error {
 	if c.NArg() != 1 {
-		fmt.Fprint(c.App.ErrWriter, lockDoHelpDescription)
+		fmt.Fprint(c.App.ErrWriter, lockDoHelpDescription) //nolint:errcheck // CLI help output
 		return &SilentExitError{code: 1}
 	}
 	key := c.Args()[0]
@@ -71,7 +71,7 @@ func lockDoAction(c *cli.Context) error {
 	defer done()
 
 	if cfg.LockScope != "machine" {
-		return errors.New("only 'machine' scope for locks is supported in this version.")
+		return errors.New("only 'machine' scope for locks is supported in this version")
 	}
 
 	if cfg.LockWaitTimeout != 0 {

--- a/clicommand/lock_done.go
+++ b/clicommand/lock_done.go
@@ -44,7 +44,7 @@ var LockDoneCommand = cli.Command{
 
 func lockDoneAction(c *cli.Context) error {
 	if c.NArg() != 1 {
-		fmt.Fprint(c.App.ErrWriter, lockDoneHelpDescription)
+		fmt.Fprint(c.App.ErrWriter, lockDoneHelpDescription) //nolint:errcheck // CLI help output
 		return &SilentExitError{code: 1}
 	}
 	key := c.Args()[0]
@@ -53,7 +53,7 @@ func lockDoneAction(c *cli.Context) error {
 	defer done()
 
 	if cfg.LockScope != "machine" {
-		return errors.New("only 'machine' scope for locks is supported in this version.")
+		return errors.New("only 'machine' scope for locks is supported in this version")
 	}
 
 	client, err := lock.NewClient(ctx, cfg.SocketsPath)

--- a/clicommand/lock_get.go
+++ b/clicommand/lock_get.go
@@ -45,7 +45,7 @@ var LockGetCommand = cli.Command{
 
 func lockGetAction(c *cli.Context) error {
 	if c.NArg() != 1 {
-		fmt.Fprint(c.App.ErrWriter, lockGetHelpDescription)
+		fmt.Fprint(c.App.ErrWriter, lockGetHelpDescription) //nolint:errcheck // CLI help output
 		return &SilentExitError{code: 1}
 	}
 	key := c.Args()[0]
@@ -54,7 +54,7 @@ func lockGetAction(c *cli.Context) error {
 	defer done()
 
 	if cfg.LockScope != "machine" {
-		return errors.New("only 'machine' scope for locks is supported in this version.")
+		return errors.New("only 'machine' scope for locks is supported in this version")
 	}
 
 	client, err := lock.NewClient(ctx, cfg.SocketsPath)
@@ -67,7 +67,7 @@ func lockGetAction(c *cli.Context) error {
 		return fmt.Errorf("couldn't get lock state: %w", err)
 	}
 
-	fmt.Fprintln(c.App.Writer, v)
+	fmt.Fprintln(c.App.Writer, v) //nolint:errcheck // CLI output; errors are non-actionable
 
 	return nil
 }

--- a/clicommand/lock_release.go
+++ b/clicommand/lock_release.go
@@ -44,7 +44,7 @@ var LockReleaseCommand = cli.Command{
 
 func lockReleaseAction(c *cli.Context) error {
 	if c.NArg() != 2 {
-		fmt.Fprint(c.App.ErrWriter, lockReleaseHelpDescription)
+		fmt.Fprint(c.App.ErrWriter, lockReleaseHelpDescription) //nolint:errcheck // CLI help output
 		return &SilentExitError{code: 1}
 	}
 	key, token := c.Args()[0], c.Args()[1]
@@ -53,7 +53,7 @@ func lockReleaseAction(c *cli.Context) error {
 	defer done()
 
 	if cfg.LockScope != "machine" {
-		return fmt.Errorf("only 'machine' scope for locks is supported in this version.")
+		return fmt.Errorf("only 'machine' scope for locks is supported in this version")
 	}
 
 	client, err := lock.NewClient(ctx, cfg.SocketsPath)

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -104,7 +104,7 @@ var MetaDataGetCommand = cli.Command{
 					cfg.Key,
 					cfg.Default,
 				)
-				fmt.Fprint(c.App.Writer, cfg.Default)
+				fmt.Fprint(c.App.Writer, cfg.Default) //nolint:errcheck // CLI output; errors are non-actionable
 				return nil
 			}
 

--- a/clicommand/meta_data_keys.go
+++ b/clicommand/meta_data_keys.go
@@ -86,7 +86,7 @@ var MetaDataKeysCommand = cli.Command{
 		}
 
 		for _, key := range keys {
-			fmt.Fprintf(c.App.Writer, "%s\n", key)
+			fmt.Fprintf(c.App.Writer, "%s\n", key) //nolint:errcheck // CLI output; errors are non-actionable
 		}
 
 		return nil

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -100,7 +100,7 @@ var OIDCRequestTokenCommand = cli.Command{
 
 		// Note: if --lifetime is omitted, cfg.Lifetime = 0
 		if cfg.Lifetime < 0 {
-			return fmt.Errorf("lifetime %d must be a non-negative integer.", cfg.Lifetime)
+			return fmt.Errorf("lifetime %d must be a non-negative integer", cfg.Lifetime)
 		}
 
 		if cfg.Format != "jwt" && cfg.Format != "gcp" {

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -203,7 +203,7 @@ var PipelineUploadCommand = cli.Command{
 				if err != nil {
 					return fmt.Errorf("failed to read file: %w", err)
 				}
-				defer file.Close()
+				defer file.Close() //nolint:errcheck // read-only file; close error is inconsequential
 				inputs = append(inputs, input{file, filepath.Base(fn)})
 			}
 
@@ -239,10 +239,10 @@ var PipelineUploadCommand = cli.Command{
 			// If more than 1 of the config files exist, throw an
 			// error. There can only be one!!
 			if len(exists) > 1 {
-				return fmt.Errorf("found multiple configuration files: %s. Please only have 1 configuration file present.", strings.Join(exists, ", "))
+				return fmt.Errorf("found multiple configuration files: %s; please only have 1 configuration file present", strings.Join(exists, ", "))
 			}
 			if len(exists) == 0 {
-				return fmt.Errorf("could not find a default pipeline configuration file. See `buildkite-agent pipeline upload --help` for more information.")
+				return fmt.Errorf("could not find a default pipeline configuration file, see `buildkite-agent pipeline upload --help` for more information")
 			}
 
 			found := exists[0]
@@ -254,7 +254,7 @@ var PipelineUploadCommand = cli.Command{
 			if err != nil {
 				return fmt.Errorf("failed to read file %q: %w", found, err)
 			}
-			defer file.Close()
+			defer file.Close() //nolint:errcheck // read-only file; close error is inconsequential
 			inputs = []input{{file, filepath.Base(found)}}
 		}
 
@@ -394,12 +394,12 @@ var PipelineUploadCommand = cli.Command{
 
 				// Check we have a job id set if not in dry run
 				if cfg.Job == "" {
-					return errors.New("missing job parameter. Usually this is set in the environment for a Buildkite job via BUILDKITE_JOB_ID.")
+					return errors.New("missing job parameter, usually this is set in the environment for a Buildkite job via BUILDKITE_JOB_ID")
 				}
 
 				// Check we have an agent access token if not in dry run
 				if cfg.AgentAccessToken == "" {
-					return errors.New("missing agent-access-token parameter. Usually this is set in the environment for a Buildkite job via BUILDKITE_AGENT_ACCESS_TOKEN.")
+					return errors.New("missing agent-access-token parameter, usually this is set in the environment for a Buildkite job via BUILDKITE_AGENT_ACCESS_TOKEN")
 				}
 
 				uploader := &agent.PipelineUploader{
@@ -448,7 +448,7 @@ func allEnvVars(o any, f func(p env.Pair)) {
 	switch x := o.(type) {
 	case *pipeline.Pipeline:
 		// First iterate through all pipeline env vars.
-		x.Env.Range(func(k, v string) error {
+		x.Env.Range(func(k, v string) error { //nolint:errcheck // callback never returns error
 			f(env.Pair{Name: k, Value: v})
 			return nil
 		})

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -791,12 +791,12 @@ func TestReadChangedFilesFromPath(t *testing.T) {
 			if err != nil {
 				t.Fatalf("creating temp file: %v", err)
 			}
-			defer os.Remove(tmpFile.Name())
+			defer os.Remove(tmpFile.Name()) //nolint:errcheck // best-effort cleanup in test
 
 			if _, err := tmpFile.WriteString(test.content); err != nil {
 				t.Fatalf("writing to temp file: %v", err)
 			}
-			tmpFile.Close()
+			tmpFile.Close() //nolint:errcheck // best-effort close in test
 
 			l := logger.NewBuffer()
 			got, err := readChangedFilesFromPath(l, tmpFile.Name())
@@ -819,12 +819,12 @@ func TestIfChangedApplicator_WithChangedFilesPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating temp file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer os.Remove(tmpFile.Name()) //nolint:errcheck // best-effort cleanup in test
 
 	if _, err := tmpFile.WriteString("foo/README.md\nbar/test.go\n"); err != nil {
 		t.Fatalf("writing to temp file: %v", err)
 	}
-	tmpFile.Close()
+	tmpFile.Close() //nolint:errcheck // best-effort close in test
 
 	steps := pipeline.Steps{
 		&pipeline.CommandStep{

--- a/clicommand/redactor_add.go
+++ b/clicommand/redactor_add.go
@@ -106,7 +106,7 @@ JSON does not allow duplicate keys. If you repeat the same key ("key"), the JSON
 			if err != nil {
 				return fmt.Errorf("failed to open file %s: %w", fileName, err)
 			}
-			defer secretsFile.Close()
+			defer secretsFile.Close() //nolint:errcheck // read-only file; close error is inconsequential
 
 			secretsReader = bufio.NewReader(secretsFile)
 		}

--- a/clicommand/secret_get.go
+++ b/clicommand/secret_get.go
@@ -138,7 +138,7 @@ Examples:
 
 		case cfg.Format == "env":
 			for _, key := range slices.Sorted(maps.Keys(secretsMap)) {
-				fmt.Fprintf(c.App.Writer, "%s=%q\n", strings.ToUpper(key), secretsMap[key])
+				fmt.Fprintf(c.App.Writer, "%s=%q\n", strings.ToUpper(key), secretsMap[key]) //nolint:errcheck // CLI output; errors are non-actionable
 			}
 
 		default:

--- a/clicommand/step_cancel.go
+++ b/clicommand/step_cancel.go
@@ -73,7 +73,7 @@ var StepCancelCommand = cli.Command{
 		defer done()
 
 		if cfg.ForceGracePeriodSeconds < 0 {
-			return fmt.Errorf("The value of ′--force-grace-period-seconds′ must be greater than or equal to 0")
+			return fmt.Errorf("the value of ′--force-grace-period-seconds′ must be greater than or equal to 0")
 		}
 
 		return cancelStep(ctx, cfg, l)
@@ -112,7 +112,7 @@ func cancelStep(ctx context.Context, cfg StepCancelConfig, l logger.Logger) erro
 		l.Info("Successfully cancelled step: %s", stepCancelResponse.UUID)
 		return nil
 	}); err != nil {
-		return fmt.Errorf("Failed to cancel step: %w", err)
+		return fmt.Errorf("failed to cancel step: %w", err)
 	}
 
 	return nil

--- a/clicommand/step_cancel_test.go
+++ b/clicommand/step_cancel_test.go
@@ -17,7 +17,7 @@ func TestStepCancel(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			rw.WriteHeader(http.StatusOK)
-			rw.Write([]byte(`{"uuid": "b0db1550-e68c-428f-9b4d-edf5599b2cff"}`))
+			rw.Write([]byte(`{"uuid": "b0db1550-e68c-428f-9b4d-edf5599b2cff"}`)) //nolint:errcheck // test handler
 		}))
 
 		cfg := StepCancelConfig{

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -204,7 +204,7 @@ Signing a pipeline from a file:
 
 		err = sign(ctx, c, l, key, &cfg)
 		if err != nil {
-			return fmt.Errorf("Error signing pipeline: %w", err)
+			return fmt.Errorf("error signing pipeline: %w", err)
 		}
 
 		return nil
@@ -250,7 +250,7 @@ func signOffline(ctx context.Context, c *cli.Context, l logger.Logger, key signa
 		if err != nil {
 			return fmt.Errorf("failed to read file: %w", err)
 		}
-		defer file.Close()
+		defer file.Close() //nolint:errcheck // read-only file; close error is inconsequential
 
 		input = file
 		filename = cfg.PipelineFile

--- a/internal/agenthttp/auth.go
+++ b/internal/agenthttp/auth.go
@@ -37,7 +37,7 @@ func (t authenticatedTransport) RoundTrip(req *http.Request) (*http.Response, er
 	}
 
 	if t.Token == "" && t.Bearer == "" {
-		return nil, fmt.Errorf("Invalid token, empty string supplied")
+		return nil, fmt.Errorf("invalid token, empty string supplied")
 	}
 
 	// Per net/http#RoundTripper:

--- a/internal/artifact/artifactory_downloader.go
+++ b/internal/artifact/artifactory_downloader.go
@@ -56,7 +56,7 @@ func (d ArtifactoryDownloader) Start(ctx context.Context) error {
 	username := os.Getenv("BUILDKITE_ARTIFACTORY_USER")
 	password := os.Getenv("BUILDKITE_ARTIFACTORY_PASSWORD")
 	if stringURL == "" || username == "" || password == "" {
-		return errors.New("Must set BUILDKITE_ARTIFACTORY_URL, BUILDKITE_ARTIFACTORY_USER, BUILDKITE_ARTIFACTORY_PASSWORD when using rt:// path")
+		return errors.New("must set BUILDKITE_ARTIFACTORY_URL, BUILDKITE_ARTIFACTORY_USER, BUILDKITE_ARTIFACTORY_PASSWORD when using rt:// path")
 	}
 
 	// create full URL

--- a/internal/artifact/artifactory_uploader.go
+++ b/internal/artifact/artifactory_uploader.go
@@ -66,7 +66,7 @@ func NewArtifactoryUploader(l logger.Logger, c ArtifactoryUploaderConfig) (*Arti
 	password := os.Getenv("BUILDKITE_ARTIFACTORY_PASSWORD")
 	// authentication is not set
 	if stringURL == "" || username == "" || password == "" {
-		return nil, errors.New("Must set BUILDKITE_ARTIFACTORY_URL, BUILDKITE_ARTIFACTORY_USER, BUILDKITE_ARTIFACTORY_PASSWORD when using rt:// path")
+		return nil, errors.New("must set BUILDKITE_ARTIFACTORY_URL, BUILDKITE_ARTIFACTORY_USER, BUILDKITE_ARTIFACTORY_PASSWORD when using rt:// path")
 	}
 
 	parsedURL, err := url.Parse(stringURL)

--- a/internal/artifact/bk_uploader.go
+++ b/internal/artifact/bk_uploader.go
@@ -337,7 +337,7 @@ func (m *multipartStreamer) WriteField(key, value string) error {
 // This can only be called once and must be the last thing written to the streamer
 func (m *multipartStreamer) WriteFile(key, artifactPath string, fh http.File) error {
 	if m.reader != nil {
-		return errors.New("WriteFile can't be called multiple times")
+		return errors.New("writeFile can't be called multiple times")
 	}
 
 	// Set up a reader that combines the body, the file and the closer in a stream

--- a/internal/artifact/download.go
+++ b/internal/artifact/download.go
@@ -158,7 +158,7 @@ func (d Download) try(ctx context.Context) error {
 		agenthttp.WithTraceHTTP(d.conf.TraceHTTP),
 	)
 	if err != nil {
-		return fmt.Errorf("Error while downloading %s (%T: %w)", d.conf.URL, err, err)
+		return fmt.Errorf("error while downloading %s (%T: %w)", d.conf.URL, err, err)
 	}
 	defer response.Body.Close() //nolint:errcheck // Idiomatic response body handling.
 

--- a/internal/artifact/downloader.go
+++ b/internal/artifact/downloader.go
@@ -62,7 +62,7 @@ func (a *Downloader) Download(ctx context.Context) error {
 	destination, _ := filepath.Abs(a.conf.Destination)
 	fileInfo, err := os.Stat(destination)
 	if err != nil {
-		return fmt.Errorf("Could not find information about destination: %s %v",
+		return fmt.Errorf("could not find information about destination: %s %v",
 			destination, err)
 	}
 	if !fileInfo.IsDir() {
@@ -78,7 +78,7 @@ func (a *Downloader) Download(ctx context.Context) error {
 	artifactCount := len(artifacts)
 
 	if artifactCount == 0 {
-		return errors.New("No artifacts found for downloading")
+		return errors.New("no artifacts found for downloading")
 	}
 
 	a.logger.Info("Found %d artifacts. Starting to download to: %s", artifactCount, destination)
@@ -172,7 +172,7 @@ func (a *Downloader) Download(ctx context.Context) error {
 	select {
 	case errors := <-errorsOutCh:
 		if len(errors) > 0 {
-			return fmt.Errorf("There were errors with downloading some of the artifacts")
+			return fmt.Errorf("there were errors with downloading some of the artifacts")
 		}
 
 	case <-ctx.Done():

--- a/internal/artifact/gs_uploader.go
+++ b/internal/artifact/gs_uploader.go
@@ -145,7 +145,7 @@ func (u *gsUploaderWork) DoWork(_ context.Context) (*api.ArtifactPartETag, error
 		permission != "projectPrivate" &&
 		permission != "publicRead" &&
 		permission != "publicReadWrite" {
-		return nil, fmt.Errorf("Invalid GS ACL `%s`", permission)
+		return nil, fmt.Errorf("invalid GS ACL `%s`", permission)
 	}
 
 	if permission == "" {

--- a/internal/artifact/s3.go
+++ b/internal/artifact/s3.go
@@ -141,10 +141,10 @@ func NewS3Client(ctx context.Context, l logger.Logger, bucket string) (*s3.Clien
 		const errorTitle = "could not authenticate to AWS S3 using any of the included credential providers."
 
 		if hasProxy && !hasNoProxyIdmsException {
-			return nil, fmt.Errorf("%s Your HTTP proxy settings do not grant a NO_PROXY=169.254.169.254 exemption for the instance metadata service, instance profile credentials may not be retrievable via your HTTP proxy.", errorTitle)
+			return nil, fmt.Errorf("%s your HTTP proxy settings do not grant a NO_PROXY=169.254.169.254 exemption for the instance metadata service, instance profile credentials may not be retrievable via your HTTP proxy", errorTitle)
 		}
 
-		return nil, fmt.Errorf("%s You can authenticate by setting Buildkite environment variables (BUILDKITE_S3_ACCESS_KEY_ID, BUILDKITE_S3_SECRET_ACCESS_KEY, BUILDKITE_S3_PROFILE), AWS environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_PROFILE), Web Identity environment variables (AWS_ROLE_ARN, AWS_ROLE_SESSION_NAME, AWS_WEB_IDENTITY_TOKEN_FILE), or if running on AWS EC2 ensuring network access to the EC2 Instance Metadata Service to use an instance profile’s IAM Role credentials.", errorTitle)
+		return nil, fmt.Errorf("%s you can authenticate by setting Buildkite environment variables (BUILDKITE_S3_ACCESS_KEY_ID, BUILDKITE_S3_SECRET_ACCESS_KEY, BUILDKITE_S3_PROFILE), AWS environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_PROFILE), Web Identity environment variables (AWS_ROLE_ARN, AWS_ROLE_SESSION_NAME, AWS_WEB_IDENTITY_TOKEN_FILE), or if running on AWS EC2 ensuring network access to the EC2 Instance Metadata Service to use an instance profile’s IAM Role credentials", errorTitle)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("could not s3:ListObjects in your AWS S3 bucket %q in region %q: %w", bucket, cfg.Region, err)

--- a/internal/artifact/s3_downloader.go
+++ b/internal/artifact/s3_downloader.go
@@ -52,7 +52,7 @@ func NewS3Downloader(l logger.Logger, c S3DownloaderConfig) *S3Downloader {
 
 func (d S3Downloader) Start(ctx context.Context) error {
 	if d.conf.S3Client == nil {
-		return fmt.Errorf("S3Downloader for %s: S3Client is nil", d.conf.S3Path)
+		return fmt.Errorf("s3Downloader for %s: S3Client is nil", d.conf.S3Path)
 	}
 
 	presigner := s3.NewPresignClient(d.conf.S3Client)

--- a/internal/artifact/searcher_test.go
+++ b/internal/artifact/searcher_test.go
@@ -21,6 +21,7 @@ func TestArtifactSearcherConnectsToEndpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.RequestURI() {
 		case "/builds/my-build/artifacts/search?query=llamas.txt&scope=my-build&state=finished":
+			//nolint:errcheck // test handler
 			fmt.Fprint(rw, `[{
 				"id": "4600ac5c-5a13-4e92-bb83-f86f218f7b32",
 				"file_size": 3,

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -55,7 +55,7 @@ func (e *Executor) removeCheckoutDir() error {
 	checkoutPath, _ := e.shell.Env.Get("BUILDKITE_BUILD_CHECKOUT_PATH")
 
 	if e.checkoutRoot != nil {
-		e.checkoutRoot.Close()
+		e.checkoutRoot.Close() //nolint:errcheck // best-effort cleanup before removal
 		e.checkoutRoot = nil
 	}
 
@@ -123,7 +123,7 @@ func (e *Executor) refreshCheckoutRoot() error {
 	}
 	// This cleanup is largely ornamental, since the executor pointer only
 	// becomes unreachable when the bootstrap exits.
-	runtime.AddCleanup(e, func(r *os.Root) { r.Close() }, root)
+	runtime.AddCleanup(e, func(r *os.Root) { r.Close() }, root) //nolint:errcheck // cleanup finalizer; close error is non-actionable
 	e.checkoutRoot = root
 	return nil
 }
@@ -702,7 +702,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 				Retry:         retry,
 				RefSpecs:      refspecs,
 			}); err != nil {
-				return fmt.Errorf("Fetching PR refspec %q: %w", refspecs, err)
+				return fmt.Errorf("fetching PR refspec %q: %w", refspecs, err)
 			}
 		} else {
 			// If we know the commit, also fetch it directly. The commit might not be in the history of `refspec` if there
@@ -711,7 +711,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 			refspecs = append(refspecs, e.Commit)
 			// We aim to eliminate network round-trip as much as possible so we use a single git fetch here.
 			if err := gitFetchWithFallback(ctx, e.shell, gitFetchFlags, refspecs...); err != nil {
-				return fmt.Errorf("Fetching PR refspec %q: %w", refspecs, err)
+				return fmt.Errorf("fetching PR refspec %q: %w", refspecs, err)
 			}
 		}
 

--- a/internal/job/docker.go
+++ b/internal/job/docker.go
@@ -50,7 +50,7 @@ func runDeprecatedDockerIntegration(ctx context.Context, sh *shell.Shell, cmd []
 		warnNotSet("BUILDKITE_DOCKER_COMPOSE_LEAVE_VOLUMES", "BUILDKITE_DOCKER_COMPOSE_CONTAINER")
 	}
 
-	return errors.New("Failed to find any docker env")
+	return errors.New("failed to find any docker env")
 }
 
 func tearDownDeprecatedDockerIntegration(ctx context.Context, sh *shell.Shell) error {

--- a/internal/job/git.go
+++ b/internal/job/git.go
@@ -256,7 +256,7 @@ func gitEnumerateSubmoduleURLs(ctx context.Context, sh *shell.Shell) ([]string, 
 	for line := range lines {
 		tokens := strings.SplitN(line, "\n", 2)
 		if len(tokens) != 2 {
-			return nil, fmt.Errorf("Failed to parse .gitmodules line %q", line)
+			return nil, fmt.Errorf("failed to parse .gitmodules line %q", line)
 		}
 		urls = append(urls, tokens[1])
 	}

--- a/internal/job/integration/artifact_integration_test.go
+++ b/internal/job/integration/artifact_integration_test.go
@@ -16,7 +16,7 @@ func TestArtifactsUploadAfterCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Write a file in the command hook
 	tester.ExpectGlobalHook("command").Once().AndCallFunc(func(c *bintest.Call) {
@@ -45,7 +45,7 @@ func TestArtifactsUploadAfterCommandFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester.MustMock(t, "my-command").Expect().AndCallFunc(func(c *bintest.Call) {
 		err := os.WriteFile(filepath.Join(c.Dir, "test.txt"), []byte("llamas"), 0o700)
@@ -79,7 +79,7 @@ func TestArtifactsUploadAfterCommandHookFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Write a file in the command hook
 	tester.ExpectGlobalHook("command").Once().AndCallFunc(func(c *bintest.Call) {

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -22,7 +22,7 @@ func TestCheckingOutGitHubPullRequests_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -67,7 +67,7 @@ func TestWithResolvingCommitExperiment_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -106,7 +106,7 @@ func TestCheckingOutLocalGitProject_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -155,7 +155,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -165,7 +165,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createTestGitRepository() error = %v", err)
 	}
-	defer submoduleRepo.Close()
+	defer submoduleRepo.Close() //nolint:errcheck // best-effort cleanup in test
 
 	out, err := tester.Repo.Execute("-c", "protocol.file.allow=always", "submodule", "add", submoduleRepo.Path)
 	if err != nil {
@@ -227,7 +227,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled_WithGitMirrors(t *test
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -237,7 +237,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled_WithGitMirrors(t *test
 	if err != nil {
 		t.Fatalf("createTestGitRespository() error = %v", err)
 	}
-	defer submoduleRepo.Close()
+	defer submoduleRepo.Close() //nolint:errcheck // best-effort cleanup in test
 
 	out, err := tester.Repo.Execute("-c", "protocol.file.allow=always", "submodule", "add", submoduleRepo.Path)
 	if err != nil {
@@ -288,7 +288,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -332,7 +332,7 @@ func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite_WithGitMirrors(t
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -352,7 +352,7 @@ func TestCheckingOutWithSSHKeyscan_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -384,7 +384,7 @@ func TestCheckingOutWithoutSSHKeyscan_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -409,7 +409,7 @@ func TestCheckingOutWithSSHKeyscanAndUnscannableRepo_WithGitMirrors(t *testing.T
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -442,7 +442,7 @@ func TestCleaningAnExistingCheckout_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -482,7 +482,7 @@ func TestForcingACleanCheckout_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -508,7 +508,7 @@ func TestCheckoutOnAnExistingRepositoryWithoutAGitFolder_WithGitMirrors(t *testi
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -539,7 +539,7 @@ func TestCheckoutRetriesOnCleanFailure_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -571,7 +571,7 @@ func TestCheckoutRetriesOnCloneFailure_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -601,7 +601,7 @@ func TestCheckoutDoesNotRetryOnHookFailure_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -611,9 +611,9 @@ func TestCheckoutDoesNotRetryOnHookFailure_WithGitMirrors(t *testing.T) {
 
 	tester.ExpectGlobalHook("checkout").Once().AndCallFunc(func(c *bintest.Call) {
 		counter := atomic.AddInt32(&checkoutCounter, 1)
-		fmt.Fprintf(c.Stdout, "Checkout invocation %d\n", counter)
+		fmt.Fprintf(c.Stdout, "Checkout invocation %d\n", counter) //nolint:errcheck // test helper; write error is non-actionable
 		if counter == 1 {
-			fmt.Fprintf(c.Stdout, "Sunspots have caused checkout to fail\n")
+			fmt.Fprintf(c.Stdout, "Sunspots have caused checkout to fail\n") //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -638,7 +638,7 @@ func TestRepositorylessCheckout_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -671,7 +671,7 @@ func TestGitMirrorEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)
@@ -726,7 +726,7 @@ func TestCheckingOutWithCustomRefspec_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if err := tester.EnableGitMirrors(); err != nil {
 		t.Fatalf("EnableGitMirrors() error = %v", err)

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -38,7 +38,7 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	env := []string{
 		"BUILDKITE_GIT_CLONE_FLAGS=-v",
@@ -72,7 +72,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	env := []string{
 		"BUILDKITE_GIT_CLONE_FLAGS=-v",
@@ -116,13 +116,13 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	submoduleRepo, err := createTestGitRespository()
 	if err != nil {
 		t.Fatalf("createTestGitRepository() error = %v", err)
 	}
-	defer submoduleRepo.Close()
+	defer submoduleRepo.Close() //nolint:errcheck // best-effort cleanup in test
 
 	out, err := tester.Repo.Execute("-c", "protocol.file.allow=always", "submodule", "add", submoduleRepo.Path)
 	if err != nil {
@@ -182,13 +182,13 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	submoduleRepo, err := createTestGitRespository()
 	if err != nil {
 		t.Fatalf("createTestGitRespository() error = %v", err)
 	}
-	defer submoduleRepo.Close()
+	defer submoduleRepo.Close() //nolint:errcheck // best-effort cleanup in test
 
 	out, err := tester.Repo.Execute("-c", "protocol.file.allow=always", "submodule", "add", submoduleRepo.Path)
 	if err != nil {
@@ -238,7 +238,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	env := []string{
 		"BUILDKITE_GIT_CLONE_FLAGS=--depth=1",
@@ -275,7 +275,7 @@ func TestCheckingOutLocalGitProjectWithShortCommitHash(t *testing.T) {
 
 	tester, err := NewExecutorTester(mainCtx)
 	assert.NilError(t, err)
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Do one checkout
 	tester.RunAndCheck(t)
@@ -332,7 +332,7 @@ func TestCheckingOutGitHubPullRequestWithCommitHash(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	commitHash, err := tester.Repo.RevParse("refs/pull/123/head")
 	assert.NilError(t, err)
@@ -361,7 +361,7 @@ func TestCheckingOutGitHubPullRequestAndCustomRefmap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	commitHash, err := tester.Repo.RevParse("refs/pull/123/head")
 	assert.NilError(t, err)
@@ -396,7 +396,7 @@ func TestCheckingOutGitHubPullRequestWithCommitHashAfterForcePush(t *testing.T) 
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	commitHash, err := tester.Repo.RevParse("refs/pull/123/head")
 	assert.NilError(t, err)
@@ -445,7 +445,7 @@ func TestCheckingOutGitHubPullRequestWithShortCommitHash(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	commitHash, err := tester.Repo.RevParse("refs/pull/123/head")
 	assert.NilError(t, err)
@@ -475,7 +475,7 @@ func TestCheckingOutGitHubPullRequestAtHead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	commitHash, err := tester.Repo.RevParse("refs/pull/123/head")
 	assert.NilError(t, err)
@@ -504,7 +504,7 @@ func TestCheckingOutGitHubPullRequestMergeRefspec(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	commitHash, err := tester.Repo.RevParse("refs/pull/123/merge")
 	assert.NilError(t, err)
@@ -546,7 +546,7 @@ func TestCheckingOutGitHubPullRequestAtHeadFromFork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	commitHash, err := tester.Repo.RevParse("refs/pull/123/head")
 	assert.NilError(t, err)
@@ -579,7 +579,7 @@ func TestCheckoutErrorIsRetried(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	env := []string{
 		"BUILDKITE_GIT_CLONE_FLAGS=-v",
@@ -642,7 +642,7 @@ func TestFetchErrorIsRetried(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	env := []string{
 		"BUILDKITE_GIT_CLONE_FLAGS=-v --depth=1",
@@ -704,7 +704,7 @@ func TestCheckingOutSetsCorrectGitMetadataAndSendsItToBuildkite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	agent := tester.MockAgent(t)
 	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
@@ -720,7 +720,7 @@ func TestCheckingOutWithSSHKeyscan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester.MustMock(t, "ssh-keyscan").
 		Expect("github.com").
@@ -748,7 +748,7 @@ func TestCheckingOutWithoutSSHKeyscan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester.MustMock(t, "ssh-keyscan").
 		Expect("github.com").
@@ -769,7 +769,7 @@ func TestCheckingOutWithSSHKeyscanAndUnscannableRepo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester.MustMock(t, "ssh-keyscan").
 		Expect("github.com").
@@ -798,7 +798,7 @@ func TestCleaningAnExistingCheckout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Create an existing checkout
 	out, err := tester.Repo.Execute("clone", "-v", "--", tester.Repo.Path, tester.CheckoutDir())
@@ -834,7 +834,7 @@ func TestForcingACleanCheckout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
@@ -856,7 +856,7 @@ func TestSkippingCheckout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester.RunAndCheck(t, "BUILDKITE_SKIP_CHECKOUT=true")
 
@@ -877,7 +877,7 @@ func TestCheckoutOnAnExistingRepositoryWithoutAGitFolder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Create an existing checkout
 	out, err := tester.Repo.Execute("clone", "-v", "--", tester.Repo.Path, tester.CheckoutDir())
@@ -904,7 +904,7 @@ func TestCheckoutRetriesOnCleanFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	var cleanCounter int32
 
@@ -932,7 +932,7 @@ func TestCheckoutRetriesOnCloneFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	var cloneCounter int32
 
@@ -958,15 +958,15 @@ func TestCheckoutDoesNotRetryOnHookFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	var checkoutCounter int32
 
 	tester.ExpectGlobalHook("checkout").Once().AndCallFunc(func(c *bintest.Call) {
 		counter := atomic.AddInt32(&checkoutCounter, 1)
-		fmt.Fprintf(c.Stdout, "Checkout invocation %d\n", counter)
+		fmt.Fprintf(c.Stdout, "Checkout invocation %d\n", counter) //nolint:errcheck // test helper; write error is non-actionable
 		if counter == 1 {
-			fmt.Fprintf(c.Stdout, "Sunspots have caused checkout to fail\n")
+			fmt.Fprintf(c.Stdout, "Sunspots have caused checkout to fail\n") //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -991,7 +991,7 @@ func TestRepositorylessCheckout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	script := []string{
 		"#!/usr/bin/env bash",
@@ -1020,7 +1020,7 @@ func TestGitCheckoutWithCommitResolved(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	env := []string{"BUILDKITE_COMMIT_RESOLVED=true"}
 
@@ -1047,7 +1047,7 @@ func TestGitCheckoutWithoutCommitResolved(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	env := []string{"BUILDKITE_COMMIT_RESOLVED=false"}
 
@@ -1074,7 +1074,7 @@ func TestGitCheckoutWithoutCommitResolvedAndNoMetaData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	env := []string{"BUILDKITE_COMMIT_RESOLVED=false"}
 

--- a/internal/job/integration/command_integration_test.go
+++ b/internal/job/integration/command_integration_test.go
@@ -19,7 +19,7 @@ func TestMultilineCommandRunUnderBatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	setup := tester.MustMock(t, "Setup.cmd")
 	build := tester.MustMock(t, "BuildProject.cmd")
@@ -49,7 +49,7 @@ func TestPreExitHooksRunsAfterCommandFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)

--- a/internal/job/integration/docker_integration_test.go
+++ b/internal/job/integration/docker_integration_test.go
@@ -22,7 +22,7 @@ func TestRunningCommandWithDocker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
@@ -55,7 +55,7 @@ func TestRunningCommandWithDockerAndCustomDockerfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
@@ -89,7 +89,7 @@ func TestRunningFailingCommandWithDocker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
@@ -128,7 +128,7 @@ func TestRunningCommandWithDockerCompose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
@@ -161,7 +161,7 @@ func TestRunningFailingCommandWithDockerCompose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
@@ -201,7 +201,7 @@ func TestRunningCommandWithDockerComposeAndExtraConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)
@@ -235,7 +235,7 @@ func TestRunningCommandWithDockerComposeAndBuildAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Mock out the meta-data calls to the agent after checkout
 	agent := tester.MockAgent(t)

--- a/internal/job/integration/executor_tester.go
+++ b/internal/job/integration/executor_tester.go
@@ -405,7 +405,7 @@ func mockEnvAsJSONOnStdout(e *ExecutorTester) func(c *bintest.Call) {
 			c.Exit(1)
 		}
 
-		c.Stdout.Write(envJSON)
+		c.Stdout.Write(envJSON) //nolint:errcheck // test helper; write error is non-actionable
 		c.Exit(0)
 	}
 }
@@ -434,7 +434,7 @@ func newTestLogWriter(t *testing.T) *testLogWriter {
 			r.CloseWithError(err)
 			return
 		}
-		r.Close()
+		r.Close() //nolint:errcheck // best-effort cleanup in test
 	}()
 
 	return lw

--- a/internal/job/integration/git.go
+++ b/internal/job/integration/git.go
@@ -97,7 +97,7 @@ func createTestGitRespository() (*gitRepository, error) {
 func newGitRepository() (*gitRepository, error) {
 	tempDirRaw, err := os.MkdirTemp("", "git-repo")
 	if err != nil {
-		return nil, fmt.Errorf("Error creating temp dir: %w", err)
+		return nil, fmt.Errorf("error creating temp dir: %w", err)
 	}
 
 	// io.TempDir on Windows tilde-shortens (8.3 style?) long filenames in the path.
@@ -118,7 +118,7 @@ func newGitRepository() (*gitRepository, error) {
 	// EvalSymlinks seems best? Maybe there's a better way?
 	tempDir, err := filepath.EvalSymlinks(tempDirRaw)
 	if err != nil {
-		return nil, fmt.Errorf("EvalSymlinks for temp dir: %w", err)
+		return nil, fmt.Errorf("evalSymlinks for temp dir: %w", err)
 	}
 
 	gr := &gitRepository{Path: tempDir}

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -23,7 +23,7 @@ func TestEnvironmentVariablesPassBetweenHooks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	filename := "environment"
 	script := []string{
@@ -50,7 +50,7 @@ func TestEnvironmentVariablesPassBetweenHooks(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, "MY_CUSTOM_ENV=1", "LLAMAS_ROCK=absolutely"); err != nil {
-			fmt.Fprintf(c.Stderr, "%v\n", err)
+			fmt.Fprintf(c.Stderr, "%v\n", err) //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -67,7 +67,7 @@ func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	preCmdFile, postCmdFile := "pre-command", "post-command"
 	preCommand := []string{
@@ -101,7 +101,7 @@ func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if c.GetEnv("LLAMAS_ROCK") != "absolutely" {
-			fmt.Fprintf(c.Stderr, "Expected command hook to have environment variable LLAMAS_ROCK be %q, got %q\n", "absolutely", c.GetEnv("LLAMAS_ROCK"))
+			fmt.Fprintf(c.Stderr, "Expected command hook to have environment variable LLAMAS_ROCK be %q, got %q\n", "absolutely", c.GetEnv("LLAMAS_ROCK")) //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -110,7 +110,7 @@ func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
 
 	tester.ExpectGlobalHook("pre-exit").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if c.GetEnv("LLAMAS_ROCK") != "" {
-			fmt.Fprintf(c.Stderr, "Expected pre-exit hook to have environment variable LLAMAS_ROCK be empty, got %q\n", c.GetEnv("LLAMAS_ROCK"))
+			fmt.Fprintf(c.Stderr, "Expected pre-exit hook to have environment variable LLAMAS_ROCK be empty, got %q\n", c.GetEnv("LLAMAS_ROCK")) //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -127,7 +127,7 @@ func TestDirectoryPassesBetweenHooks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if runtime.GOOS == "windows" {
 		t.Skip("Not implemented for windows yet")
@@ -146,7 +146,7 @@ func TestDirectoryPassesBetweenHooks(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if c.GetEnv("MY_CUSTOM_SUBDIR") != c.Dir {
-			fmt.Fprintf(c.Stderr, "Expected current dir to be %q, got %q\n", c.GetEnv("MY_CUSTOM_SUBDIR"), c.Dir)
+			fmt.Fprintf(c.Stderr, "Expected current dir to be %q, got %q\n", c.GetEnv("MY_CUSTOM_SUBDIR"), c.Dir) //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -161,7 +161,7 @@ func TestDirectoryPassesBetweenHooksIgnoredUnderExit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	if runtime.GOOS == "windows" {
 		t.Skip("Not implemented for windows yet")
@@ -181,7 +181,7 @@ func TestDirectoryPassesBetweenHooksIgnoredUnderExit(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if c.GetEnv("BUILDKITE_BUILD_CHECKOUT_PATH") != c.Dir {
-			fmt.Fprintf(c.Stderr, "Expected current dir to be %q, got %q\n", c.GetEnv("BUILDKITE_BUILD_CHECKOUT_PATH"), c.Dir)
+			fmt.Fprintf(c.Stderr, "Expected current dir to be %q, got %q\n", c.GetEnv("BUILDKITE_BUILD_CHECKOUT_PATH"), c.Dir) //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -198,7 +198,7 @@ func TestCheckingOutFiresCorrectHooks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester.ExpectGlobalHook("environment").Once()
 	tester.ExpectLocalHook("environment").NotCalled()
@@ -228,12 +228,12 @@ func TestReplacingCheckoutHook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// run a checkout in our checkout hook, otherwise we won't have local hooks to run
 	tester.ExpectGlobalHook("checkout").Once().AndCallFunc(func(c *bintest.Call) {
 		out, err := tester.Repo.Execute("clone", "-v", "--", tester.Repo.Path, c.GetEnv("BUILDKITE_BUILD_CHECKOUT_PATH"))
-		fmt.Fprint(c.Stderr, out)
+		fmt.Fprint(c.Stderr, out) //nolint:errcheck // test helper; write error is non-actionable
 		if err != nil {
 			c.Exit(1)
 		} else {
@@ -257,7 +257,7 @@ func TestReplacingGlobalCommandHook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0)
 
@@ -282,7 +282,7 @@ func TestReplacingLocalCommandHook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester.ExpectLocalHook("command").Once().AndExitWith(0)
 	tester.ExpectGlobalHook("command").NotCalled()
@@ -308,7 +308,7 @@ func TestPreExitHooksFireAfterCommandFailures(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester.ExpectGlobalHook("pre-exit").Once()
 	tester.ExpectLocalHook("pre-exit").Once()
@@ -327,7 +327,7 @@ func TestPreExitHooksDoesNotFireWithoutCommandPhase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester.ExpectGlobalHook("pre-exit").NotCalled()
 	tester.ExpectLocalHook("pre-exit").NotCalled()
@@ -420,7 +420,7 @@ func TestPreExitHooksFireAfterHookFailures(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewExecutorTester() error = %v", err)
 			}
-			defer tester.Close()
+			defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 			agent := tester.MockAgent(t)
 
@@ -470,7 +470,7 @@ func TestNoLocalHooksCalledWhenConfigSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester.Env = append(tester.Env, "BUILDKITE_NO_LOCAL_HOOKS=true")
 
@@ -506,7 +506,7 @@ func TestExitCodesPropagateOutFromGlobalHooks(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewExecutorTester() error = %v", err)
 			}
-			defer tester.Close()
+			defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 			tester.ExpectGlobalHook(hook).Once().AndExitWith(5)
 
@@ -536,7 +536,7 @@ func TestPreExitHooksFireAfterCancel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester.ExpectGlobalHook("pre-exit").Once()
 	tester.ExpectLocalHook("pre-exit").Once()
@@ -553,7 +553,7 @@ func TestPreExitHooksFireAfterCancel(t *testing.T) {
 	}()
 
 	time.Sleep(time.Millisecond * 500)
-	tester.Cancel()
+	tester.Cancel() //nolint:errcheck // best-effort cancel in test
 
 	t.Logf("Waiting for command to finish")
 	wg.Wait()
@@ -583,7 +583,7 @@ func TestPolyglotScriptHooksCanBeRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	filename := "environment"
 	script := []string{
@@ -611,7 +611,7 @@ func TestPolyglotBinaryHooksCanBeRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// We build a binary as part of this test so that we can produce a binary hook
 	// Forgive me for my sins, RSC, but it's better than the alternatives.
@@ -632,7 +632,7 @@ func TestPolyglotBinaryHooksCanBeRun(t *testing.T) {
 	tester.ExpectGlobalHook("post-command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		// Set via ./test-binary-hook/main.go
 		if c.GetEnv("OCEAN") != "Pacífico" {
-			fmt.Fprintf(c.Stderr, "Expected OCEAN to be Pacífico, got %q", c.GetEnv("OCEAN"))
+			fmt.Fprintf(c.Stderr, "Expected OCEAN to be Pacífico, got %q", c.GetEnv("OCEAN")) //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 		} else {
 			c.Exit(0)

--- a/internal/job/integration/job_api_integration_test.go
+++ b/internal/job/integration/job_api_integration_test.go
@@ -21,7 +21,7 @@ func TestBootstrapRunsJobAPI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester.ExpectGlobalHook("command").Once().AndCallFunc(func(c *bintest.Call) {
 		socketPath := c.GetEnv("BUILDKITE_AGENT_JOB_API_SOCKET")
@@ -107,7 +107,7 @@ func TestBootstrapRunsJobAPI(t *testing.T) {
 			c.Exit(1)
 			return
 		}
-		defer resp.Body.Close()
+		defer resp.Body.Close() //nolint:errcheck // response body close errors are inconsequential in tests
 
 		if resp.StatusCode != http.StatusOK {
 			body, _ := io.ReadAll(resp.Body)
@@ -135,7 +135,7 @@ func TestBootstrapRunsJobAPI(t *testing.T) {
 
 	tester.ExpectGlobalHook("post-command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if got, want := c.GetEnv("MOUNTAIN"), "chimborazo"; got != want {
-			fmt.Fprintf(c.Stderr, "MOUNTAIN = %q, want %q\n", got, want)
+			fmt.Fprintf(c.Stderr, "MOUNTAIN = %q, want %q\n", got, want) //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 		} else {
 			c.Exit(0)

--- a/internal/job/integration/plugin_integration_test.go
+++ b/internal/job/integration/plugin_integration_test.go
@@ -22,7 +22,7 @@ func TestRunningPlugins(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	pluginMock := tester.MustMock(t, "my-plugin")
 
@@ -57,7 +57,7 @@ func TestRunningPlugins(t *testing.T) {
 
 	pluginMock.Expect("testing").Once().AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, "MY_CUSTOM_ENV=1", "LLAMAS_ROCK=absolutely"); err != nil {
-			fmt.Fprintf(c.Stderr, "%v\n", err)
+			fmt.Fprintf(c.Stderr, "%v\n", err) //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -66,7 +66,7 @@ func TestRunningPlugins(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, "MY_CUSTOM_ENV=1", "LLAMAS_ROCK=absolutely"); err != nil {
-			fmt.Fprintf(c.Stderr, "%v\n", err)
+			fmt.Fprintf(c.Stderr, "%v\n", err) //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -83,7 +83,7 @@ func TestExitCodesPropagateOutFromPlugins(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	hooks := map[string][]string{
 		"environment": {
@@ -130,7 +130,7 @@ func TestMalformedPluginNamesDontCrashBootstrap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	env := []string{
 		`BUILDKITE_PLUGINS=["sdgmdgn.@$!sdf,asdf#llamas"]`,
@@ -154,7 +154,7 @@ func TestOverlappingPluginHooks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	var testPlugins []*testPlugin
 	var pluginMocks []*bintest.Mock
@@ -218,7 +218,7 @@ func TestPluginCloneRetried(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	hooks := map[string][]string{
 		"environment": {
@@ -287,7 +287,7 @@ func TestModifiedPluginNoForcePull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Let's set a fixed location for plugins, otherwise NewExecutorTester() gives us a random new
 	// tempdir every time, which defeats our test.  Later we'll use this pluginsDir for the second
@@ -340,7 +340,7 @@ func TestModifiedPluginNoForcePull(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, "OSTRICH_EGGS=quite_large"); err != nil {
-			fmt.Fprintf(c.Stderr, "%v\n", err)
+			fmt.Fprintf(c.Stderr, "%v\n", err) //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -354,7 +354,7 @@ func TestModifiedPluginNoForcePull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester2.Close()
+	defer tester2.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Same modification of BUILDKITE_PLUGINS_PATH.
 	tester2.PluginsDir = pluginsDir
@@ -378,7 +378,7 @@ func TestModifiedPluginNoForcePull(t *testing.T) {
 
 	tester2.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, "OSTRICH_EGGS=quite_large"); err != nil {
-			fmt.Fprintf(c.Stderr, "%v\n", err)
+			fmt.Fprintf(c.Stderr, "%v\n", err) //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -400,7 +400,7 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Let's set a fixed location for plugins, otherwise it'll be a random new tempdir every time
 	// which defeats our test.
@@ -430,7 +430,7 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 	p := createTestPlugin(t, hooks)
 
 	// Same branch-name jiggery pokery as in the previous integration test
-	p.CreateBranch("something-fixed")
+	p.CreateBranch("something-fixed") //nolint:errcheck // test helper; branch creation error is non-critical
 	p.versionTag = "something-fixed"
 
 	json, err := p.ToJSON()
@@ -444,7 +444,7 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, "OSTRICH_EGGS=quite_large"); err != nil {
-			fmt.Fprintf(c.Stderr, "%v\n", err)
+			fmt.Fprintf(c.Stderr, "%v\n", err) //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -457,7 +457,7 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester2.Close()
+	defer tester2.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester2.PluginsDir = pluginsDir
 	tester2.Env = replacePluginPathInEnv(tester2.Env, pluginsDir)
@@ -485,7 +485,7 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 	// run.
 	tester2.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, "OSTRICH_EGGS=huge_actually"); err != nil {
-			fmt.Fprintf(c.Stderr, "%v\n", err)
+			fmt.Fprintf(c.Stderr, "%v\n", err) //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 		} else {
 			c.Exit(0)

--- a/internal/job/integration/redaction_integration_test.go
+++ b/internal/job/integration/redaction_integration_test.go
@@ -17,10 +17,10 @@ func TestRedactorRedactsAgentToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setting up executor tester: %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
-		fmt.Fprintf(c.Stderr, "The agent token is: %s\n", c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN"))
+		fmt.Fprintf(c.Stderr, "The agent token is: %s\n", c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN")) //nolint:errcheck // test helper; write error is non-actionable
 		c.Exit(0)
 	})
 
@@ -41,10 +41,10 @@ func TestRedactorDoesNotRedactAgentToken_WhenNotInRedactedVars(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setting up executor tester: %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
-		fmt.Fprintf(c.Stderr, "The agent token is: %s\n", c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN"))
+		fmt.Fprintf(c.Stderr, "The agent token is: %s\n", c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN")) //nolint:errcheck // test helper; write error is non-actionable
 		c.Exit(0)
 	})
 
@@ -65,7 +65,7 @@ func TestRedactorAdd_RedactsVarsAfterUse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setting up executor tester: %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	secret := "hunter2"
 	tester.ExpectGlobalHook("command").AndCallFunc(redactionTestCommandHook(t, secret))
@@ -96,7 +96,7 @@ func TestRegression_TestRedactorAdd_StillWorksWhenNoInitialRedactedVarsAreProvid
 	if err != nil {
 		t.Fatalf("setting up executor tester: %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	secret := "hunter2"
 	tester.ExpectGlobalHook("command").AndCallFunc(redactionTestCommandHook(t, secret))
@@ -142,7 +142,7 @@ func redactionTestCommandHook(t *testing.T, secret string) func(c *bintest.Call)
 			return
 		}
 
-		fmt.Fprintf(c.Stderr, "The secret is: %s\n", secret)
+		fmt.Fprintf(c.Stderr, "The secret is: %s\n", secret) //nolint:errcheck // test helper; write error is non-actionable
 		time.Sleep(time.Second) // let the log line be written before we add it to the redactor
 
 		_, err = client.RedactionCreate(mainCtx, secret)
@@ -152,7 +152,7 @@ func redactionTestCommandHook(t *testing.T, secret string) func(c *bintest.Call)
 			return
 		}
 
-		fmt.Fprintf(c.Stderr, "There should be a redacted here: %s\n", secret)
+		fmt.Fprintf(c.Stderr, "There should be a redacted here: %s\n", secret) //nolint:errcheck // test helper; write error is non-actionable
 		c.Exit(0)
 	}
 }

--- a/internal/job/integration/secrets_integration_test.go
+++ b/internal/job/integration/secrets_integration_test.go
@@ -19,8 +19,6 @@ import (
 
 // setupSecretsAPIServer creates a mock HTTP server that handles secrets API requests
 func setupSecretsAPIServer(t *testing.T, secrets map[string]string) *httptest.Server {
-	const jobID = "1111-1111-1111-1111" // Must match tester JobID
-
 	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		// Check auth token - agent uses "Token" instead of "Bearer"
 		authHeader := req.Header.Get("Authorization")
@@ -62,7 +60,7 @@ func TestSecretsIntegration_EnvironmentVariables(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setting up executor tester: %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Set up mock API server with secret values
 	secretsMap := map[string]string{
@@ -100,34 +98,34 @@ func TestSecretsIntegration_EnvironmentVariables(t *testing.T) {
 		// Verify each secret is available as an environment variable
 		dbURL := c.GetEnv("DATABASE_URL")
 		if dbURL == "" {
-			fmt.Fprintf(c.Stderr, "❌ DATABASE_URL is not set\n")
+			fmt.Fprintf(c.Stderr, "❌ DATABASE_URL is not set\n") //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 			return
 		}
-		fmt.Fprintf(c.Stderr, "✅ DATABASE_URL is set: %s\n", dbURL)
+		fmt.Fprintf(c.Stderr, "✅ DATABASE_URL is set: %s\n", dbURL) //nolint:errcheck // test helper; write error is non-actionable
 
 		apiToken := c.GetEnv("API_TOKEN")
 		if apiToken == "" {
-			fmt.Fprintf(c.Stderr, "❌ API_TOKEN is not set\n")
+			fmt.Fprintf(c.Stderr, "❌ API_TOKEN is not set\n") //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 			return
 		}
-		fmt.Fprintf(c.Stderr, "✅ API_TOKEN is set: %s\n", apiToken)
+		fmt.Fprintf(c.Stderr, "✅ API_TOKEN is set: %s\n", apiToken) //nolint:errcheck // test helper; write error is non-actionable
 
 		customVar := c.GetEnv("MY_CUSTOM_VAR")
 		if customVar == "" {
-			fmt.Fprintf(c.Stderr, "❌ MY_CUSTOM_VAR is not set\n")
+			fmt.Fprintf(c.Stderr, "❌ MY_CUSTOM_VAR is not set\n") //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 			return
 		}
-		fmt.Fprintf(c.Stderr, "✅ MY_CUSTOM_VAR is set: %s\n", customVar)
+		fmt.Fprintf(c.Stderr, "✅ MY_CUSTOM_VAR is set: %s\n", customVar) //nolint:errcheck // test helper; write error is non-actionable
 
 		c.Exit(0)
 	})
 
 	// Expect command hook to verify secrets persist
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
-		fmt.Fprintf(c.Stderr, "Command hook sees DATABASE_URL: %s\n", c.GetEnv("DATABASE_URL"))
+		fmt.Fprintf(c.Stderr, "Command hook sees DATABASE_URL: %s\n", c.GetEnv("DATABASE_URL")) //nolint:errcheck // test helper; write error is non-actionable
 		c.Exit(0)
 	})
 
@@ -155,7 +153,7 @@ func TestSecretsIntegration_Redaction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setting up executor tester: %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Set up mock API server with secret values
 	secretValue := "very-sensitive-secret-value-123"
@@ -180,7 +178,7 @@ func TestSecretsIntegration_Redaction(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
 		// Print the secret value to stderr - should be redacted
-		fmt.Fprintf(c.Stderr, "The sensitive token is: %s\n", c.GetEnv("SENSITIVE_TOKEN"))
+		fmt.Fprintf(c.Stderr, "The sensitive token is: %s\n", c.GetEnv("SENSITIVE_TOKEN")) //nolint:errcheck // test helper; write error is non-actionable
 		c.Exit(0)
 	})
 
@@ -207,16 +205,16 @@ func TestSecretsIntegration_BackwardCompatibility(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setting up executor tester: %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Don't set BUILDKITE_SECRETS_CONFIG
 	tester.ExpectGlobalHook("environment").AndCallFunc(func(c *bintest.Call) {
-		fmt.Fprintf(c.Stderr, "Environment hook executed successfully\n")
+		fmt.Fprintf(c.Stderr, "Environment hook executed successfully\n") //nolint:errcheck // test helper; write error is non-actionable
 		c.Exit(0)
 	})
 
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
-		fmt.Fprintf(c.Stderr, "Command hook executed successfully\n")
+		fmt.Fprintf(c.Stderr, "Command hook executed successfully\n") //nolint:errcheck // test helper; write error is non-actionable
 		c.Exit(0)
 	})
 
@@ -241,18 +239,18 @@ func TestSecretsIntegration_EmptySecretsConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setting up executor tester: %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Set empty secrets array
 	secretsJSON := "[]"
 
 	tester.ExpectGlobalHook("environment").AndCallFunc(func(c *bintest.Call) {
-		fmt.Fprintf(c.Stderr, "Environment hook executed with empty secrets\n")
+		fmt.Fprintf(c.Stderr, "Environment hook executed with empty secrets\n") //nolint:errcheck // test helper; write error is non-actionable
 		c.Exit(0)
 	})
 
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
-		fmt.Fprintf(c.Stderr, "Command hook executed with empty secrets\n")
+		fmt.Fprintf(c.Stderr, "Command hook executed with empty secrets\n") //nolint:errcheck // test helper; write error is non-actionable
 		c.Exit(0)
 	})
 
@@ -277,7 +275,7 @@ func TestSecretsIntegration_SecretFetchFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setting up executor tester: %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Set up mock API server with only one secret - the other will fail
 	secretsMap := map[string]string{
@@ -323,7 +321,7 @@ func TestSecretsIntegration_MultilineSecretRedaction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setting up executor tester: %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Set up mock API server with multiline secret
 	multilineSecret := "line1\nline2\nline3"
@@ -348,7 +346,7 @@ func TestSecretsIntegration_MultilineSecretRedaction(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
 		// Print the multiline secret - should be redacted
-		fmt.Fprintf(c.Stderr, "Multiline secret: %s\n", c.GetEnv("MULTILINE_SECRET"))
+		fmt.Fprintf(c.Stderr, "Multiline secret: %s\n", c.GetEnv("MULTILINE_SECRET")) //nolint:errcheck // test helper; write error is non-actionable
 		c.Exit(0)
 	})
 
@@ -375,7 +373,7 @@ func TestSecretsIntegration_LocalHookAccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setting up executor tester: %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Set up mock API server with secret
 	secretsMap := map[string]string{
@@ -426,7 +424,7 @@ func TestSecretsIntegration_JobAPIRedactionIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setting up executor tester: %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Set up mock API server with secret
 	secretValue := "job-api-secret-value"
@@ -452,39 +450,39 @@ func TestSecretsIntegration_JobAPIRedactionIntegration(t *testing.T) {
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
 		socketPath := c.GetEnv("BUILDKITE_AGENT_JOB_API_SOCKET")
 		if socketPath == "" {
-			fmt.Fprintf(c.Stderr, "Expected BUILDKITE_AGENT_JOB_API_SOCKET to be set\n")
+			fmt.Fprintf(c.Stderr, "Expected BUILDKITE_AGENT_JOB_API_SOCKET to be set\n") //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 			return
 		}
 
 		socketToken := c.GetEnv("BUILDKITE_AGENT_JOB_API_TOKEN")
 		if socketToken == "" {
-			fmt.Fprintf(c.Stderr, "Expected BUILDKITE_AGENT_JOB_API_TOKEN to be set\n")
+			fmt.Fprintf(c.Stderr, "Expected BUILDKITE_AGENT_JOB_API_TOKEN to be set\n") //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 			return
 		}
 
 		client, err := jobapi.NewClient(mainCtx, socketPath, socketToken)
 		if err != nil {
-			fmt.Fprintf(c.Stderr, "creating Job API client: %v\n", err)
+			fmt.Fprintf(c.Stderr, "creating Job API client: %v\n", err) //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 			return
 		}
 
 		// Print the secret before redaction is added via Job API
-		fmt.Fprintf(c.Stderr, "Secret before explicit redaction: %s\n", c.GetEnv("JOB_API_SECRET"))
+		fmt.Fprintf(c.Stderr, "Secret before explicit redaction: %s\n", c.GetEnv("JOB_API_SECRET")) //nolint:errcheck // test helper; write error is non-actionable
 		time.Sleep(100 * time.Millisecond) // brief pause
 
 		// Add additional redaction via Job API (should already be redacted from secrets fetch)
 		_, err = client.RedactionCreate(mainCtx, secretValue)
 		if err != nil {
-			fmt.Fprintf(c.Stderr, "creating redaction: %v\n", err)
+			fmt.Fprintf(c.Stderr, "creating redaction: %v\n", err) //nolint:errcheck // test helper; write error is non-actionable
 			c.Exit(1)
 			return
 		}
 
 		// Print the secret after additional redaction
-		fmt.Fprintf(c.Stderr, "Secret after explicit redaction: %s\n", c.GetEnv("JOB_API_SECRET"))
+		fmt.Fprintf(c.Stderr, "Secret after explicit redaction: %s\n", c.GetEnv("JOB_API_SECRET")) //nolint:errcheck // test helper; write error is non-actionable
 		c.Exit(0)
 	})
 
@@ -514,7 +512,7 @@ func TestSecretsIntegration_ProtectedEnvironmentVariableRejection(t *testing.T) 
 	if err != nil {
 		t.Fatalf("setting up executor tester: %v", err)
 	}
-	defer tester.Close()
+	defer tester.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// Set up mock API server with secret values
 	secretsMap := map[string]string{

--- a/internal/job/knownhosts.go
+++ b/internal/job/knownhosts.go
@@ -22,7 +22,7 @@ type knownHosts struct {
 func findKnownHosts(sh *shell.Shell) (*knownHosts, error) {
 	userHomePath, err := osutil.UserHomeDir()
 	if err != nil {
-		return nil, fmt.Errorf("Could not find the current users home directory (%s)", err)
+		return nil, fmt.Errorf("could not find the current users home directory (%s)", err)
 	}
 
 	// Construct paths to the known_hosts file
@@ -53,7 +53,7 @@ func (kh *knownHosts) Contains(host string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer file.Close()
+	defer file.Close() //nolint:errcheck // read-only file; close error is inconsequential
 
 	normalized := knownhosts.Normalize(host)
 
@@ -112,7 +112,7 @@ func (kh *knownHosts) Add(ctx context.Context, host string) error {
 	// Scan the key and then write it to the known_host file
 	keyscanOutput, err := sshKeyScan(ctx, kh.Shell, host)
 	if err != nil {
-		return fmt.Errorf("Could not  `ssh-keyscan`: %w", err)
+		return fmt.Errorf("could not `ssh-keyscan`: %w", err)
 	}
 
 	kh.Shell.Commentf("Added host %q to known hosts at \"%s\"", host, kh.Path)
@@ -120,16 +120,16 @@ func (kh *knownHosts) Add(ctx context.Context, host string) error {
 	// Try and open the existing hostfile in (append_only) mode
 	f, err := os.OpenFile(kh.Path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o700)
 	if err != nil {
-		return fmt.Errorf("Could not open %q for appending: %w", kh.Path, err)
+		return fmt.Errorf("could not open %q for appending: %w", kh.Path, err)
 	}
 	defer f.Close() //nolint:errcheck // Best-effort cleanup - primary Close error is checked below.
 
 	if _, err := fmt.Fprintf(f, "%s\n", keyscanOutput); err != nil {
-		return fmt.Errorf("Could not write to %q: %w", kh.Path, err)
+		return fmt.Errorf("could not write to %q: %w", kh.Path, err)
 	}
 
 	if err := f.Close(); err != nil {
-		return fmt.Errorf("Could not close %q: %w", kh.Path, err)
+		return fmt.Errorf("could not close %q: %w", kh.Path, err)
 	}
 	return nil
 }
@@ -150,7 +150,7 @@ func (kh *knownHosts) AddFromRepository(ctx context.Context, repository string) 
 	host := resolveGitHost(ctx, kh.Shell, u.Host)
 
 	if err := kh.Add(ctx, host); err != nil {
-		return fmt.Errorf("Failed to add %q to known_hosts file %q: %w", host, u, err)
+		return fmt.Errorf("failed to add %q to known_hosts file %q: %w", host, u, err)
 	}
 
 	return nil

--- a/internal/job/knownhosts_test.go
+++ b/internal/job/knownhosts_test.go
@@ -25,8 +25,8 @@ func TestAddingToKnownHosts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("net.Listen(tcp, %q) error = %v", svr.Addr, err)
 	}
-	go svr.Serve(ln)
-	defer svr.Close()
+	go svr.Serve(ln) //nolint:errcheck // returns when listener closes
+	defer svr.Close() //nolint:errcheck // best-effort cleanup in test
 
 	hostAddr := ln.Addr().String()
 	repoURL := fmt.Sprintf("ssh://git@%s/var/cache/git/project.git", hostAddr)

--- a/internal/job/plugin.go
+++ b/internal/job/plugin.go
@@ -57,18 +57,18 @@ func (e *Executor) preparePlugins() error {
 	// Check if we can run plugins (disabled via --no-plugins)
 	if !e.PluginsEnabled {
 		if !e.LocalHooksEnabled {
-			return fmt.Errorf("Plugins have been disabled on this agent with `--no-local-hooks`")
+			return fmt.Errorf("plugins have been disabled on this agent with `--no-local-hooks`")
 		} else if !e.CommandEval {
-			return fmt.Errorf("Plugins have been disabled on this agent with `--no-command-eval`")
+			return fmt.Errorf("plugins have been disabled on this agent with `--no-command-eval`")
 		} else {
-			return fmt.Errorf("Plugins have been disabled on this agent with `--no-plugins`")
+			return fmt.Errorf("plugins have been disabled on this agent with `--no-plugins`")
 		}
 	}
 
 	var err error
 	e.plugins, err = plugin.CreateFromJSON(e.Plugins)
 	if err != nil {
-		return fmt.Errorf("Failed to parse a plugin definition: %w", err)
+		return fmt.Errorf("failed to parse a plugin definition: %w", err)
 	}
 
 	if e.Debug {
@@ -147,7 +147,7 @@ func (e *Executor) PluginPhase(ctx context.Context) error {
 
 		checkout, err := e.checkoutPlugin(ctx, p)
 		if err != nil {
-			return fmt.Errorf("Failed to checkout plugin %s: %w", p.Name(), err)
+			return fmt.Errorf("failed to checkout plugin %s: %w", p.Name(), err)
 		}
 
 		err = e.validatePluginCheckout(ctx, checkout)
@@ -183,13 +183,13 @@ func (e *Executor) VendoredPluginPhase(ctx context.Context) error {
 
 		// Check that the plugin exists in the checkout.
 		if fi, err := e.checkoutRoot.Stat(p.Location); err != nil || !fi.IsDir() {
-			return fmt.Errorf("Vendored plugin path %q must be a directory within the checked-out repository: %w", p.Location, err)
+			return fmt.Errorf("vendored plugin path %q must be a directory within the checked-out repository: %w", p.Location, err)
 		}
 
 		// Similarly, check that the plugin's hooks exists in the checkout.
 		hooksPath := filepath.Join(p.Location, "hooks")
 		if fi, err := e.checkoutRoot.Stat(hooksPath); err != nil || !fi.IsDir() {
-			return fmt.Errorf("Vendored plugin hooks path %q must be a directory within the checked-out repository: %w", hooksPath, err)
+			return fmt.Errorf("vendored plugin hooks path %q must be a directory within the checked-out repository: %w", hooksPath, err)
 		}
 
 		checkout := &pluginCheckout{
@@ -274,7 +274,7 @@ func (e *Executor) executePluginHook(ctx context.Context, name string, checkouts
 			Name:       name,
 			Path:       hookPath,
 			Env:        envMap,
-			PluginName: p.Plugin.DisplayName(),
+			PluginName: p.DisplayName(),
 			SpanAttributes: map[string]string{
 				"plugin.name":        p.Plugin.Name(),
 				"plugin.version":     p.Version,
@@ -304,7 +304,7 @@ func (e *Executor) hasPluginHook(name string) bool {
 func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*pluginCheckout, error) {
 	// Make sure we have a plugin path before trying to do anything
 	if e.PluginsPath == "" {
-		return nil, fmt.Errorf("Can't checkout plugin without a `plugins-path`")
+		return nil, fmt.Errorf("can't checkout plugin without a `plugins-path`")
 	}
 
 	id, err := p.Identifier()
@@ -382,7 +382,7 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 		if err != nil {
 			return nil, fmt.Errorf("opening plugin directory as a root: %w", err)
 		}
-		runtime.AddCleanup(checkout, func(r *os.Root) { r.Close() }, pluginRoot)
+		runtime.AddCleanup(checkout, func(r *os.Root) { r.Close() }, pluginRoot) //nolint:errcheck // cleanup finalizer; close error is non-actionable
 		checkout.Root = pluginRoot
 
 		// Ensure hooks is a directory that exists within the checkout.
@@ -466,7 +466,7 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 	if err != nil {
 		return nil, fmt.Errorf("opening plugin directory as a root: %w", err)
 	}
-	runtime.AddCleanup(checkout, func(r *os.Root) { r.Close() }, pluginRoot)
+	runtime.AddCleanup(checkout, func(r *os.Root) { r.Close() }, pluginRoot) //nolint:errcheck // cleanup finalizer; close error is non-actionable
 	checkout.Root = pluginRoot
 
 	// Ensure hooks is a directory that exists within the checkout.

--- a/internal/job/ssh.go
+++ b/internal/job/ssh.go
@@ -85,5 +85,5 @@ func findPathToSSHTools(ctx context.Context, sh *shell.Shell) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("Unable to find ssh-keyscan: %w", err)
+	return "", fmt.Errorf("unable to find ssh-keyscan: %w", err)
 }

--- a/internal/job/ssh_test.go
+++ b/internal/job/ssh_test.go
@@ -112,8 +112,7 @@ func TestSSHKeyscanRetriesOnBlankOutputAndExit0(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bintest.NewMock(ssh-keyscan) error = %v", err)
 	}
-	defer keyScan.CheckAndClose(t)
-	//nolint:errcheck // bintest logs to t
+	defer keyScan.CheckAndClose(t) //nolint:errcheck // bintest logs to t
 	sh.Env.Set("PATH", filepath.Dir(keyScan.Path))
 
 	keyScan.

--- a/internal/job/tracing.go
+++ b/internal/job/tracing.go
@@ -44,7 +44,7 @@ func (e *Executor) startTracing(ctx context.Context) (tracetools.Span, context.C
 		// Newer versions of the tracing libs print out diagnostic info which spams the
 		// Buildkite agent logs. Disable it by default unless it's been explicitly set.
 		if _, has := os.LookupEnv("DD_TRACE_STARTUP_LOGS"); !has {
-			os.Setenv("DD_TRACE_STARTUP_LOGS", "false")
+			os.Setenv("DD_TRACE_STARTUP_LOGS", "false") //nolint:errcheck // best-effort env var override
 		}
 
 		return e.startTracingDatadog(ctx)

--- a/internal/osutil/file.go
+++ b/internal/osutil/file.go
@@ -9,12 +9,12 @@ import (
 func ChmodExecutable(filename string) error {
 	s, err := os.Stat(filename)
 	if err != nil {
-		return fmt.Errorf("Failed to retrieve file information of \"%s\" (%s)", filename, err)
+		return fmt.Errorf("failed to retrieve file information of %q (%s)", filename, err)
 	}
 	if s.Mode()&0o100 == 0 {
 		err = os.Chmod(filename, s.Mode()|0o100)
 		if err != nil {
-			return fmt.Errorf("Failed to mark \"%s\" as executable (%s)", filename, err)
+			return fmt.Errorf("failed to mark %q as executable (%s)", filename, err)
 		}
 	}
 	return nil

--- a/internal/shell/logger.go
+++ b/internal/shell/logger.go
@@ -69,11 +69,11 @@ func (wl *WriterLogger) Write(b []byte) (int, error) {
 }
 
 func (wl *WriterLogger) Printf(format string, v ...any) {
-	fmt.Fprintf(wl.Writer, format+"\n", v...)
+	fmt.Fprintf(wl.Writer, format+"\n", v...) //nolint:errcheck // logger output; error handling would recurse
 }
 
 func (wl *WriterLogger) Headerf(format string, v ...any) {
-	fmt.Fprintf(wl.Writer, "~~~ "+format+"\n", v...)
+	fmt.Fprintf(wl.Writer, "~~~ "+format+"\n", v...) //nolint:errcheck // logger output; error handling would recurse
 }
 
 func (wl *WriterLogger) Commentf(format string, v ...any) {

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -140,7 +140,7 @@ func New(opts ...NewShellOpt) (*Shell, error) {
 	if shell.wd == "" {
 		wd, err := os.Getwd()
 		if err != nil {
-			return nil, fmt.Errorf("Failed to find current working directory: %w", err)
+			return nil, fmt.Errorf("failed to find current working directory: %w", err)
 		}
 		shell.wd = wd
 	}
@@ -183,7 +183,7 @@ func (s *Shell) Chdir(path string) error {
 	s.Promptf("cd %s", shellwords.Quote(path))
 
 	if _, err := os.Stat(path); err != nil {
-		return fmt.Errorf("Failed to change working: directory does not exist")
+		return fmt.Errorf("failed to change working: directory does not exist")
 	}
 
 	s.wd = path
@@ -318,7 +318,7 @@ func (s *Shell) Script(path string) (Command, error) {
 		// Find Bash, either part of Cygwin or MSYS. Must be in the path
 		bashPath, err := s.AbsolutePath("bash.exe")
 		if err != nil {
-			return Command{}, fmt.Errorf("Error finding bash.exe, needed to run scripts: %v. "+
+			return Command{}, fmt.Errorf("error finding bash.exe, needed to run scripts: %v. "+
 				"Is Git for Windows installed and correctly in your PATH variable?", err)
 		}
 		command = bashPath

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -29,7 +29,7 @@ func TestRunAndCaptureWithTTY(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bintest.CompileProxy(ssh-keygen) error = %v", err)
 	}
-	defer sshKeygen.Close()
+	defer sshKeygen.Close() //nolint:errcheck // best-effort cleanup in test
 
 	// WithPTY(true) should be overriden by RunAndCapture.
 	sh := newShellForTest(t, shell.WithPTY(true))
@@ -59,7 +59,7 @@ func TestRunAndCaptureWithExitCode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bintest.CompileProxy(ssh-keygen) error = %v", err)
 	}
-	defer sshKeygen.Close()
+	defer sshKeygen.Close() //nolint:errcheck // best-effort cleanup in test
 
 	sh := newShellForTest(t, shell.WithPTY(false))
 
@@ -87,7 +87,7 @@ func TestRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bintest.CompileProxy(ssh-keygen) error = %v", err)
 	}
-	defer sshKeygen.Close()
+	defer sshKeygen.Close() //nolint:errcheck // best-effort cleanup in test
 
 	out := &bytes.Buffer{}
 
@@ -99,7 +99,7 @@ func TestRun(t *testing.T) {
 
 	go func() {
 		call := <-sshKeygen.Ch
-		fmt.Fprintln(call.Stdout, "Llama party! 🎉")
+		fmt.Fprintln(call.Stdout, "Llama party! 🎉") //nolint:errcheck // test helper goroutine
 		call.Exit(0)
 	}()
 
@@ -146,7 +146,7 @@ func TestContextCancelTerminates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bintest.CompileProxy(sleep) error = %v", err)
 	}
-	defer sleepCmd.Close()
+	defer sleepCmd.Close() //nolint:errcheck // best-effort cleanup in test
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -183,7 +183,7 @@ func TestInterrupt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bintest.CompileProxy(sleep) error = %v", err)
 	}
-	defer sleepCmd.Close()
+	defer sleepCmd.Close() //nolint:errcheck // best-effort cleanup in test
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -204,7 +204,7 @@ func TestInterrupt(t *testing.T) {
 	// interrupt the process after 50ms
 	go func() {
 		<-time.After(time.Millisecond * 50)
-		sh.Interrupt()
+		sh.Interrupt() //nolint:errcheck // test helper; interrupt error doesn't matter
 	}()
 
 	if err := sh.Command(sleepCmd.Path).Run(ctx); err == nil {

--- a/internal/socket/client.go
+++ b/internal/socket/client.go
@@ -57,7 +57,7 @@ func NewClient(ctx context.Context, path, token string) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("socket test connection: %w", err)
 	}
-	test.Close()
+	test.Close() //nolint:errcheck // test connection verified; close is best-effort
 
 	return &Client{
 		cli: &http.Client{
@@ -98,7 +98,7 @@ func (c *Client) Do(ctx context.Context, method, url string, req, resp any) erro
 	if err != nil {
 		return err
 	}
-	defer hresp.Body.Close()
+	defer hresp.Body.Close() //nolint:errcheck // response body close errors are inconsequential
 	dec := json.NewDecoder(hresp.Body)
 
 	switch hresp.StatusCode / 100 {

--- a/internal/socket/client_test.go
+++ b/internal/socket/client_test.go
@@ -18,15 +18,15 @@ func (yesNoJSONServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	switch r.URL.Path {
 	case "/yes":
-		w.Write([]byte(`{"message":"Yes!"}\n`))
+		w.Write([]byte(`{"message":"Yes!"}\n`))   //nolint:errcheck // test handler
 	case "/no":
-		w.Write([]byte(`{"message":"No."}\n`))
+		w.Write([]byte(`{"message":"No."}\n`))     //nolint:errcheck // test handler
 	case "/secret":
 		if r.Header.Get("Authorization") != "Bearer llama" {
 			http.Error(w, `{"error":"invalid authorization token"}\n`, http.StatusUnauthorized)
 			return
 		}
-		w.Write([]byte(`{"message":"seekruts"}\n`))
+		w.Write([]byte(`{"message":"seekruts"}\n`)) //nolint:errcheck // test handler
 	default:
 		http.Error(w, `{"error":"not found"}\n`, http.StatusNotFound)
 	}
@@ -51,7 +51,7 @@ func TestClientDo(t *testing.T) {
 	if err := svr.Start(); err != nil {
 		t.Fatalf("srv.Start() = %v", err)
 	}
-	t.Cleanup(func() { svr.Close() })
+	t.Cleanup(func() { svr.Close() }) //nolint:errcheck // best-effort cleanup in test
 
 	cli, err := NewClient(ctx, sockPath, "llama")
 	if err != nil {
@@ -108,7 +108,7 @@ func TestClientDoErrors(t *testing.T) {
 	if err := svr.Start(); err != nil {
 		t.Fatalf("srv.Start() = %v", err)
 	}
-	t.Cleanup(func() { svr.Close() })
+	t.Cleanup(func() { svr.Close() }) //nolint:errcheck // best-effort cleanup in test
 
 	cli, err := NewClient(ctx, sockPath, "alpaca")
 	if err != nil {

--- a/internal/socket/middleware_test.go
+++ b/internal/socket/middleware_test.go
@@ -12,7 +12,7 @@ import (
 
 func testHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("{}"))
+	w.Write([]byte("{}")) //nolint:errcheck // test handler
 }
 
 func shouldCall(t *testing.T) func(http.Handler) http.Handler {

--- a/internal/socket/server.go
+++ b/internal/socket/server.go
@@ -54,7 +54,7 @@ func (s *Server) Start() error {
 		return err
 	}
 
-	go s.svr.Serve(ln)
+	go s.svr.Serve(ln) //nolint:errcheck // returns ErrServerClosed on normal shutdown
 	s.started = true
 
 	return nil

--- a/internal/socket/server_test.go
+++ b/internal/socket/server_test.go
@@ -31,9 +31,9 @@ func (yesNoServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	switch r.URL.Path {
 	case "/yes":
-		w.Write([]byte("Yes!\n"))
+		w.Write([]byte("Yes!\n")) //nolint:errcheck // test handler
 	case "/no":
-		w.Write([]byte("No.\n"))
+		w.Write([]byte("No.\n")) //nolint:errcheck // test handler
 	default:
 		http.Error(w, "not found", http.StatusNotFound)
 	}
@@ -72,7 +72,7 @@ func TestServerStartStop(t *testing.T) {
 		t.Fatalf("socket test connection: %v", err)
 	}
 
-	test.Close()
+	test.Close() //nolint:errcheck // test connection verified; close is best-effort
 
 	if err := svr.Close(); err != nil {
 		t.Fatalf("svr.Close() = %v", err)
@@ -100,7 +100,7 @@ func TestServerHandler(t *testing.T) {
 	if err := svr.Start(); err != nil {
 		t.Fatalf("svr.Start() = %v", err)
 	}
-	t.Cleanup(func() { svr.Close() })
+	t.Cleanup(func() { svr.Close() }) //nolint:errcheck // best-effort cleanup in test
 
 	cli := &http.Client{
 		Transport: &http.Transport{
@@ -152,7 +152,7 @@ func TestServerHandler(t *testing.T) {
 			if err != nil {
 				t.Fatalf("cli.Do(req) = error %v", err)
 			}
-			defer resp.Body.Close()
+			defer resp.Body.Close() //nolint:errcheck // response body close errors are inconsequential in tests
 			if got, want := resp.StatusCode, test.wantStatus; got != want {
 				t.Errorf("resp.Status = %v, want %v", got, want)
 			}

--- a/internal/stdin/main_test.go
+++ b/internal/stdin/main_test.go
@@ -69,7 +69,7 @@ func TestIsStdinIsReadableWithOutputRedirection(t *testing.T) {
 		t.Fatalf(`os.CreateTemp("", "output-redirect") error = %v`, err)
 	}
 
-	defer os.Remove(tmpfile.Name())
+	defer os.Remove(tmpfile.Name()) //nolint:errcheck // best-effort cleanup in test
 
 	if _, err := tmpfile.Write([]byte("output")); err != nil {
 		t.Fatalf(`tmpfile.Write([]byte("output")) error = %v`, err)

--- a/jobapi/env.go
+++ b/jobapi/env.go
@@ -26,7 +26,7 @@ func (s *Server) getEnv(w http.ResponseWriter, _ *http.Request) {
 func (s *Server) patchEnv(w http.ResponseWriter, r *http.Request) {
 	var req EnvUpdateRequestPayload
 	err := json.NewDecoder(r.Body).Decode(&req)
-	defer r.Body.Close()
+	defer r.Body.Close() //nolint:errcheck // HTTP request body close errors are inconsequential
 	if err != nil {
 		if err := socket.WriteError(w, fmt.Errorf("failed to decode request body: %w", err), http.StatusBadRequest); err != nil {
 			s.Logger.Errorf("Job API: couldn't write error: %v", err)
@@ -97,7 +97,7 @@ func (s *Server) patchEnv(w http.ResponseWriter, r *http.Request) {
 func (s *Server) deleteEnv(w http.ResponseWriter, r *http.Request) {
 	var req EnvDeleteRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
-	defer r.Body.Close()
+	defer r.Body.Close() //nolint:errcheck // HTTP request body close errors are inconsequential
 	if err != nil {
 		err := socket.WriteError(w, fmt.Errorf("failed to decode request body: %w", err), http.StatusBadRequest)
 		if err != nil {

--- a/jobapi/server_test.go
+++ b/jobapi/server_test.go
@@ -123,7 +123,7 @@ func TestServerStartStop(t *testing.T) {
 		t.Fatalf("socket test connection: %v", err)
 	}
 
-	test.Close()
+	test.Close() //nolint:errcheck // test connection verified; close is best-effort
 
 	err = srv.Stop()
 	if err != nil {
@@ -154,7 +154,7 @@ func TestServerStartStop_WithPreExistingSocket(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected initial server start to succeed, got %v", err)
 	}
-	defer srv1.Stop()
+	defer srv1.Stop() //nolint:errcheck // best-effort cleanup in test
 
 	expectedErr := fmt.Sprintf("creating socket server: file already exists at socket path %s", sockName)
 	_, _, err = jobapi.NewServer(shell.TestingLogger{T: t}, sockName, env.New(), replacer.NewMux())
@@ -446,7 +446,7 @@ func TestCreateRedaction(t *testing.T) {
 	_, err = rdc.Write([]byte("From Quito, go back to Guayaquil.\n"))
 	assert.NilError(t, err)
 
-	mux.Flush()
+	mux.Flush() //nolint:errcheck // best-effort flush in test
 
 	assert.Equal(
 		t,

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -165,5 +165,5 @@ func (c *Client) StatusLoop(ctx context.Context, onInterrupt func(error)) error 
 }
 
 func (c *Client) Close() {
-	c.client.Close()
+	c.client.Close() //nolint:errcheck // best-effort cleanup; rpc.Client.Close only closes the underlying conn
 }

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -274,7 +274,7 @@ func newRunner(t *testing.T, clientCount int) *Runner {
 	}
 	socketPath := filepath.Join(tempDir, "bk.sock")
 	t.Cleanup(func() {
-		os.RemoveAll(tempDir)
+		os.RemoveAll(tempDir) //nolint:errcheck // best-effort cleanup in test
 	})
 	runner := NewRunner(logger.Discard, RunnerConfig{
 		SocketPath:         socketPath,
@@ -283,7 +283,7 @@ func newRunner(t *testing.T, clientCount int) *Runner {
 		ClientLostTimeout:  2 * time.Second,
 	})
 	runnerCtx, cancelRunner := context.WithCancel(context.Background())
-	go runner.Run(runnerCtx)
+	go runner.Run(runnerCtx) //nolint:errcheck // test goroutine; errors checked via test assertions
 	t.Cleanup(cancelRunner)
 
 	// wait for runner to listen

--- a/lock/lock_test.go
+++ b/lock/lock_test.go
@@ -57,7 +57,7 @@ func TestLockUnlock(t *testing.T) {
 	t.Cleanup(canc)
 
 	svr, cli := testServerAndClient(t, ctx)
-	t.Cleanup(func() { svr.Close() })
+	t.Cleanup(func() { svr.Close() }) //nolint:errcheck // best-effort cleanup in test
 
 	// Lock it
 	token, err := cli.Lock(ctx, "llama")
@@ -90,7 +90,7 @@ func TestLocker(t *testing.T) {
 	t.Cleanup(canc)
 
 	svr, cli := testServerAndClient(t, ctx)
-	t.Cleanup(func() { svr.Close() })
+	t.Cleanup(func() { svr.Close() }) //nolint:errcheck // best-effort cleanup in test
 
 	// This constitutes a test by virtue of Lock/Unlock panicking on any
 	// internal error.
@@ -121,7 +121,7 @@ func TestDoOnce(t *testing.T) {
 	t.Cleanup(canc)
 
 	svr, cli := testServerAndClient(t, ctx)
-	t.Cleanup(func() { svr.Close() })
+	t.Cleanup(func() { svr.Close() }) //nolint:errcheck // best-effort cleanup in test
 
 	var wg sync.WaitGroup
 	var calls atomic.Int32

--- a/logger/log.go
+++ b/logger/log.go
@@ -218,11 +218,11 @@ func (l *TextPrinter) Print(level Level, msg string, fields Fields) {
 
 	// Make sure we're only outputting a line one at a time
 	mutex.Lock()
-	fmt.Fprint(l.Writer, line)
+	fmt.Fprint(l.Writer, line)                                  //nolint:errcheck // logger output; error handling would recurse
 	if len(fields) > 0 {
-		fmt.Fprintf(l.Writer, " %s", strings.Join(fieldStrs, " "))
+		fmt.Fprintf(l.Writer, " %s", strings.Join(fieldStrs, " ")) //nolint:errcheck // logger output; error handling would recurse
 	}
-	fmt.Fprint(l.Writer, "\n")
+	fmt.Fprint(l.Writer, "\n") //nolint:errcheck // logger output; error handling would recurse
 	mutex.Unlock()
 }
 
@@ -265,7 +265,7 @@ func (p *JSONPrinter) Print(level Level, msg string, fields Fields) {
 
 	// Make sure we're only outputting a line one at a time
 	mutex.Lock()
-	fmt.Fprintf(p.Writer, "{%s}\n", strings.TrimSuffix(b.String(), ","))
+	fmt.Fprintf(p.Writer, "{%s}\n", strings.TrimSuffix(b.String(), ",")) //nolint:errcheck // logger output; error handling would recurse
 	mutex.Unlock()
 }
 

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ Options:
 `
 
 func printVersion(c *cli.Context) {
-	fmt.Fprintf(c.App.Writer, "%s version %s\n", c.App.Name, version.FullVersion())
+	fmt.Fprintf(c.App.Writer, "%s version %s\n", c.App.Name, version.FullVersion()) //nolint:errcheck // CLI output; errors are non-actionable
 }
 
 func main() {
@@ -66,8 +66,8 @@ func main() {
 
 	// When a sub command can't be found
 	app.CommandNotFound = func(c *cli.Context, command string) {
-		fmt.Fprintf(app.ErrWriter, "buildkite-agent: unknown subcommand %q\n", command)
-		fmt.Fprintf(app.ErrWriter, "Run '%s --help' for usage.\n", c.App.Name)
+		fmt.Fprintf(app.ErrWriter, "buildkite-agent: unknown subcommand %q\n", command) //nolint:errcheck // CLI output; errors are non-actionable
+		fmt.Fprintf(app.ErrWriter, "Run '%s --help' for usage.\n", c.App.Name)      //nolint:errcheck // CLI output; errors are non-actionable
 		os.Exit(1)
 	}
 

--- a/process/ansi_test.go
+++ b/process/ansi_test.go
@@ -51,7 +51,7 @@ func TestANSIParser(t *testing.T) {
 
 	for _, test := range tests {
 		var p ansiParser
-		p.Write([]byte(test.input))
+		p.Write([]byte(test.input)) //nolint:errcheck // ansiParser.Write never returns errors
 		if got := p.insideCode(); got != test.want {
 			t.Errorf("after p.feed(%q...): p.insideCode() = %t, want %t", test.input, got, test.want)
 		}
@@ -66,6 +66,6 @@ func BenchmarkANSIParser(b *testing.B) {
 
 	for b.Loop() {
 		var p ansiParser
-		p.Write(npm)
+		p.Write(npm) //nolint:errcheck // ansiParser.Write never returns errors
 	}
 }

--- a/process/cat.go
+++ b/process/cat.go
@@ -12,7 +12,7 @@ import (
 func Cat(path string) (string, error) {
 	files, err := filepath.Glob(path)
 	if err != nil {
-		return "", fmt.Errorf("Failed to get a list of files: %w", err)
+		return "", fmt.Errorf("failed to get a list of files: %w", err)
 	}
 
 	var buffer bytes.Buffer
@@ -20,7 +20,7 @@ func Cat(path string) (string, error) {
 	for _, file := range files {
 		data, err := os.ReadFile(file)
 		if err != nil {
-			return "", fmt.Errorf("Could not read file: %s (%T: %w)", file, err, err)
+			return "", fmt.Errorf("could not read file: %s (%T: %w)", file, err, err)
 		}
 
 		buffer.WriteString(string(data))

--- a/process/main_test.go
+++ b/process/main_test.go
@@ -24,10 +24,10 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 
 	case "output":
-		fmt.Fprintf(os.Stdout, "llamas1\n")
-		fmt.Fprintf(os.Stderr, "alpacas1\r")
-		fmt.Fprintf(os.Stdout, "llamas2\r\n")
-		fmt.Fprintf(os.Stderr, "alpacas2\n")
+		fmt.Fprintf(os.Stdout, "llamas1\n") //nolint:errcheck // test helper process output
+		fmt.Fprintf(os.Stderr, "alpacas1\r")   //nolint:errcheck // test helper process output
+		fmt.Fprintf(os.Stdout, "llamas2\r\n") //nolint:errcheck // test helper process output
+		fmt.Fprintf(os.Stderr, "alpacas2\n")  //nolint:errcheck // test helper process output
 		os.Exit(0)
 
 	// don't handle the signals so that we can detect the process was signaled
@@ -48,7 +48,7 @@ func TestMain(m *testing.M) {
 
 		go func() {
 			for s := range signals {
-				fmt.Fprintf(os.Stdout, "received signal: %d", s)
+				fmt.Fprintf(os.Stdout, "received signal: %d", s) //nolint:errcheck // test helper process output
 				time.Sleep(10 * time.Second)
 				os.Exit(0)
 			}

--- a/process/process.go
+++ b/process/process.go
@@ -67,7 +67,7 @@ func (s Signal) String() string {
 func ParseSignal(sig string) (Signal, error) {
 	s, ok := signalMap[strings.ToUpper(sig)]
 	if !ok {
-		return Signal(0), fmt.Errorf("Unknown signal %q", sig)
+		return Signal(0), fmt.Errorf("unknown signal %q", sig)
 	}
 	return s, nil
 }
@@ -129,7 +129,7 @@ func (p *Process) WaitStatus() WaitStatus {
 // Run the command and block until it finishes
 func (p *Process) Run(ctx context.Context) error {
 	if p.command != nil {
-		return fmt.Errorf("Process is already running")
+		return fmt.Errorf("process is already running")
 	}
 
 	// Create a command
@@ -143,7 +143,7 @@ func (p *Process) Run(ctx context.Context) error {
 	// doesn't exist
 	if p.conf.Dir != "" {
 		if _, err := os.Stat(p.conf.Dir); os.IsNotExist(err) {
-			return fmt.Errorf("Process working directory %q doesn't exist", p.conf.Dir)
+			return fmt.Errorf("process working directory %q doesn't exist", p.conf.Dir)
 		}
 		p.command.Dir = p.conf.Dir
 	}
@@ -408,6 +408,6 @@ func timeoutWait(waitGroup *sync.WaitGroup) error {
 	case <-ch:
 		return nil
 	case <-time.After(10 * time.Second):
-		return errors.New("Timeout")
+		return errors.New("timeout")
 	}
 }

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -195,7 +195,7 @@ func TestProcessTerminatesWhenContextDone(t *testing.T) {
 	})
 
 	go func() {
-		defer stdoutw.Close()
+		defer stdoutw.Close() //nolint:errcheck // best-effort cleanup in test goroutine
 		if err := p.Run(ctx); err != nil {
 			t.Errorf("p.Run(ctx) = %v", err)
 		}
@@ -237,7 +237,7 @@ func TestProcessWithSlowHandlerKilledWhenContextDone(t *testing.T) {
 	})
 
 	go func() {
-		defer stdoutw.Close()
+		defer stdoutw.Close() //nolint:errcheck // best-effort cleanup in test goroutine
 		if err := p.Run(ctx); err != nil {
 			t.Errorf("p.Run(ctx) = %v", err)
 		}
@@ -282,7 +282,7 @@ func TestProcessInterrupts(t *testing.T) {
 	})
 
 	go func() {
-		defer stdoutw.Close()
+		defer stdoutw.Close() //nolint:errcheck // best-effort cleanup in test goroutine
 		if err := p.Run(ctx); err != nil {
 			t.Errorf("p.Run(ctx) = %v", err)
 		}
@@ -350,7 +350,7 @@ func TestProcessInterruptsWithCustomSignal(t *testing.T) {
 	})
 
 	go func() {
-		defer stdoutw.Close()
+		defer stdoutw.Close() //nolint:errcheck // best-effort cleanup in test goroutine
 		if err := p.Run(ctx); err != nil {
 			t.Errorf("p.Run(ctx) = %v", err)
 		}

--- a/process/scanner_test.go
+++ b/process/scanner_test.go
@@ -28,10 +28,10 @@ func TestScanLines(t *testing.T) {
 
 	go func() {
 		for line := range strings.SplitSeq(strings.TrimSuffix(longTestOutput, "\n"), "\n") {
-			fmt.Fprintf(pw, "%s\n", line)
+			fmt.Fprintf(pw, "%s\n", line) //nolint:errcheck // test helper goroutine
 			time.Sleep(time.Millisecond * 10)
 		}
-		pw.Close()
+		pw.Close() //nolint:errcheck // signals EOF to reader; error is inconsequential
 	}()
 
 	scanner := process.NewScanner(logger.Discard)

--- a/process/signal_windows.go
+++ b/process/signal_windows.go
@@ -89,7 +89,7 @@ func (p *Process) interruptProcessGroup() error {
 }
 
 func GetPgid(pid int) (int, error) {
-	return 0, errors.New("Not implemented on Windows")
+	return 0, errors.New("not implemented on Windows")
 }
 
 // SignalString returns the name of the given signal.

--- a/process/timestamper.go
+++ b/process/timestamper.go
@@ -57,7 +57,7 @@ func (p *Timestamper) Write(data []byte) (n int, err error) {
 		var codeEnd []byte
 		for p.ansiParser.insideCode() && len(data) > len(codeEnd) {
 			fed := len(codeEnd)
-			p.ansiParser.Write(data[fed : fed+1])
+			p.ansiParser.Write(data[fed : fed+1]) //nolint:errcheck // ansiParser.Write never returns errors
 			codeEnd = data[:fed+1]
 		}
 		if len(codeEnd) > 0 {
@@ -89,7 +89,7 @@ func (p *Timestamper) Write(data []byte) (n int, err error) {
 		if idx == nil {
 			// Write all remaining data. The line continues into the next Write
 			// call.
-			p.ansiParser.Write(data)
+			p.ansiParser.Write(data) //nolint:errcheck // ansiParser.Write never returns errors
 			n, err := p.out.Write(data)
 			written += n
 			return written, err
@@ -98,7 +98,7 @@ func (p *Timestamper) Write(data []byte) (n int, err error) {
 		// Write up to (and including) the newline / breaking sequence, ready to
 		// start a new line in the next iteration or Write.
 		chunk := data[:idx[1]]
-		p.ansiParser.Write(chunk)
+		p.ansiParser.Write(chunk) //nolint:errcheck // ansiParser.Write never returns errors
 		n, err = p.out.Write(chunk)
 		written += n
 		if err != nil {

--- a/status/status.go
+++ b/status/status.go
@@ -165,6 +165,7 @@ func (i *templatedItem) Eval(ctx context.Context) template.HTML {
 
 	data, err := i.cb(ctx)
 	if err != nil {
+		//nolint:errcheck // fallback error template; nothing else to do if this also fails
 		errorTmpl.Execute(&sb, errorData{
 			Operation: "Error from item callback",
 			Error:     err,
@@ -173,6 +174,7 @@ func (i *templatedItem) Eval(ctx context.Context) template.HTML {
 		return template.HTML(sb.String())
 	}
 	if err := i.tmpl.Execute(&sb, data); err != nil {
+		//nolint:errcheck // fallback error template; nothing else to do if this also fails
 		errorTmpl.Execute(&sb, errorData{
 			Operation: "Error while executing item template",
 			Error:     err,
@@ -208,6 +210,7 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 	rootItem.mu.RLock()
 	defer rootItem.mu.RUnlock()
 	if err := statusTmpl.Execute(w, data); err != nil {
+		//nolint:errcheck // fallback error template; nothing else to do if this also fails
 		errorTmpl.Execute(w, errorData{
 			Operation: "Error while executing main template",
 			Error:     err,


### PR DESCRIPTION
### Description

We've had golangci-lint as a soft-failing step in CI for a long time, and I think it's time we  turned it on for real. However, we have a lot of code that's not up to scratch.

That's ok though! I threw $10 at the sourcegraph corporation and they did a perfectly adequate job of fixing all of our GCIL errors.

### Changes

- errcheck: Added //nolint:errcheck pragmas with explanatory comments for deferred `Close()`, `os.Remove()`, logger/test writes, `http.Serve()` in goroutines, and similar best-effort operations
- staticcheck ST1005: Lowercased error string prefixes and removed trailing punctuation per Go conventions
- staticcheck SA1019: Removed deprecated `net.Error.Temporary()` call (timeout check already covers it)
- staticcheck QF1008: Simplified `p.Plugin.DisplayName()` → `p.DisplayName()` using promoted method
- unused: Removed unused constants and variables

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)


### Disclosures / Credits

Look, none of this was me, it was all Amp, but i'm so glad for that.