### PR TITLE
feat: honour Retry-After for artifact retries

### DIFF
--- a/internal/artifact/BUILD.bazel
+++ b/internal/artifact/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "downloader.go",
         "gs_downloader.go",
         "gs_uploader.go",
+        "retry_after.go",
         "s3.go",
         "s3_downloader.go",
         "s3_uploader.go",

--- a/internal/artifact/batch_creator.go
+++ b/internal/artifact/batch_creator.go
@@ -99,6 +99,9 @@ func (a *BatchCreator) Create(ctx context.Context) ([]*api.Artifact, error) {
 			if resp != nil && resp.StatusCode == 429 {
 				saw429 = true
 			}
+			if applyRetryAfterHeader(resp, r) {
+				a.logger.Debug("CreateArtifacts retry interval updated from Retry-After header")
+			}
 			// the server returns a 403 code if the artifact has exceeded the service quota
 			// Break the retry on any 4xx code except for 429 Too Many Requests.
 			if resp != nil && (resp.StatusCode != 429 && resp.StatusCode >= 400 && resp.StatusCode <= 499) {

--- a/internal/artifact/batching_test.go
+++ b/internal/artifact/batching_test.go
@@ -6,11 +6,20 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/stretchr/testify/require"
 )
+
+type nextIntervalRecorder struct {
+	next time.Duration
+}
+
+func (n *nextIntervalRecorder) SetNextInterval(d time.Duration) {
+	n.next = d
+}
 
 type stubArtifactAPIClient struct {
 	createFn func(context.Context, string, *api.ArtifactBatch) (*api.ArtifactBatchCreateResponse, *api.Response, error)
@@ -116,4 +125,26 @@ func TestUpdateStatesRespectsConfiguredBatchMax(t *testing.T) {
 	for _, tracker := range worker.trackers {
 		require.Equal(t, "sent", tracker.State)
 	}
+}
+
+func TestApplyRetryAfterHeaderSetsRetryInterval(t *testing.T) {
+	t.Parallel()
+
+	r := &nextIntervalRecorder{}
+	resp := &api.Response{Response: &http.Response{Header: http.Header{"Retry-After": []string{"3"}}}}
+
+	updated := applyRetryAfterHeader(resp, r)
+	require.True(t, updated)
+	require.Equal(t, 3*time.Second, r.next)
+}
+
+func TestApplyRetryAfterHeaderIgnoresInvalidValues(t *testing.T) {
+	t.Parallel()
+
+	r := &nextIntervalRecorder{}
+	resp := &api.Response{Response: &http.Response{Header: http.Header{"Retry-After": []string{"not-a-number"}}}}
+
+	updated := applyRetryAfterHeader(resp, r)
+	require.False(t, updated)
+	require.Equal(t, time.Duration(0), r.next)
 }

--- a/internal/artifact/retry_after.go
+++ b/internal/artifact/retry_after.go
@@ -1,0 +1,30 @@
+package artifact
+
+import (
+	"time"
+
+	"github.com/buildkite/agent/v3/api"
+)
+
+type retryIntervalSetter interface {
+	SetNextInterval(time.Duration)
+}
+
+func applyRetryAfterHeader(resp *api.Response, r retryIntervalSetter) bool {
+	if resp == nil {
+		return false
+	}
+
+	retryAfter := resp.Header.Get("Retry-After")
+	if retryAfter == "" {
+		return false
+	}
+
+	duration, err := time.ParseDuration(retryAfter + "s")
+	if err != nil {
+		return false
+	}
+
+	r.SetNextInterval(duration)
+	return true
+}

--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -773,7 +773,10 @@ func (a *artifactUploadWorker) updateStates(ctx context.Context) error {
 				defer cancel()
 			}
 
-			_, err := a.apiClient.UpdateArtifacts(ctxTimeout, a.conf.JobID, chunk)
+			resp, err := a.apiClient.UpdateArtifacts(ctxTimeout, a.conf.JobID, chunk)
+			if applyRetryAfterHeader(resp, r) {
+				a.logger.Debug("UpdateArtifacts retry interval updated from Retry-After header")
+			}
 			if err != nil {
 				a.logger.Warn("%s (%s)", err, r)
 			}


### PR DESCRIPTION
### Summary

This follow-up teaches artifact retry loops to honour server-provided `Retry-After` headers, so retry pacing can be coordinated by the backend during pressure events.

### What Changed

1. Added a small shared helper in `internal/artifact/retry_after.go` to parse and apply `Retry-After` values to retry intervals.
1. Wired `Retry-After` handling into `CreateArtifacts` retries in `internal/artifact/batch_creator.go`.
1. Wired `Retry-After` handling into `UpdateArtifacts` retries in `internal/artifact/uploader.go`.
1. Added tests in `internal/artifact/batching_test.go` for valid and invalid `Retry-After` behaviour.

### Why

1. Improves stability by letting the server shape retry timing during load.
1. Reduces risk of synchronized retry bursts from many agents.
1. Keeps existing retry behaviour intact when `Retry-After` is absent or invalid.

### Validation

1. `go tool gofumpt -extra -w internal/artifact/retry_after.go internal/artifact/batch_creator.go internal/artifact/uploader.go internal/artifact/batching_test.go`
1. `go test ./internal/artifact -count=1`
1. `go test ./api ./agent ./clicommand -count=1`

### Notes

1. This PR is stacked on top of #3736.
