### PR TITLE
Propose an executor setting to run job bootstrap in Docker containers

### DIFF
--- a/docs/proposals/job-executor-abstraction.md
+++ b/docs/proposals/job-executor-abstraction.md
@@ -1,0 +1,394 @@
+# Job Executor Abstraction
+
+> Drafted with GPT-5.4, with human input and review.
+
+> Note: this proposal is not about reviving or extending the deprecated `BUILDKITE_DOCKER*` / `BUILDKITE_DOCKER_COMPOSE_*` job behavior. That legacy command-phase integration is separate, deprecated, and not the basis for the proposed executor model.
+
+## Summary
+
+Introduce an agent-side executor abstraction for the job-level bootstrap process.
+
+The first two executors would be:
+
+- `exec`: the current behavior, and the default. The agent starts the configured `bootstrap-script` as a local subprocess.
+- `docker`: the agent runs `buildkite-agent bootstrap` inside an ephemeral Docker container, following the same overall pattern as [buildkite/docker-bootstrap-example](https://github.com/buildkite/docker-bootstrap-example).
+
+This creates a stable seam for future sandbox backends such as Firecracker, gVisor, or remote worker APIs without changing the bootstrap itself.
+
+It also leaves room for a Kubernetes-native execution path, where the transport is "run this job in a Pod" and the isolation choice is expressed via `runtimeClassName`, user namespaces, and other Pod-level features rather than by inventing a separate top-level executor for each sandbox runtime.
+
+## Why
+
+Today there are three different concepts in the repo that are close to "how a job runs", but none of them is a clean abstraction:
+
+- The agent starts one job-level subprocess from `agent/job_runner.go`.
+- The bootstrap runtime lives in `internal/job/executor.go`.
+- Kubernetes is already a special execution mode with its own transport in `kubernetes/runner.go` and `clicommand/kubernetes_bootstrap.go`.
+
+That leaves us with two problems:
+
+1. `bootstrap-script` is a powerful escape hatch, but it is just a command string. It is not a typed backend with a lifecycle, cleanup, or tests for backend-specific behavior.
+2. The deprecated Docker logic in `internal/job/docker.go` only wraps the command phase inside bootstrap. It does not execute the full job lifecycle in Docker, which is why it is not a substitute for an agent-level executor.
+
+If we want sandboxing to be a first-class capability, the seam should be around the whole bootstrap process, not just the final command phase.
+
+The proposed Docker executor should therefore be treated as a new agent-level execution backend, not an evolution of the deprecated command-phase Docker integration.
+
+## Goals
+
+- Preserve current behavior by default.
+- Keep `buildkite-agent bootstrap` as the unit that executes job phases.
+- Make the agent choose a job executor in a structured, testable way.
+- Allow each executor to own setup, cancellation, exit status mapping, and cleanup.
+- Make Docker an opt-in backend now, while keeping the design broad enough for Firecracker and other providers later.
+
+## Non-goals
+
+- Rewriting bootstrap phases in `internal/job`.
+- Replacing the existing `bootstrap-script` escape hatch in this change.
+- Extending or modernizing the deprecated `BUILDKITE_DOCKER*` / `BUILDKITE_DOCKER_COMPOSE_*` behavior.
+- Solving full hostile-build isolation. Docker still has well-known gaps around network access and Docker socket exposure.
+- Collapsing Kubernetes into the new config surface immediately.
+
+## Current Architecture
+
+The current execution chain is:
+
+1. `clicommand/agent_start.go` builds `AgentConfiguration`.
+2. `agent/job_runner.go` creates job env files, log streaming, and a `jobProcess`.
+3. `jobProcess` is either:
+   - a local `process.Process` running `bootstrap-script`, or
+   - a `kubernetes.Runner`.
+4. The subprocess runs `clicommand/bootstrap.go`, which then executes `internal/job.Executor`.
+
+This is already close to the right seam. The missing piece is replacing the `if kubernetes { ... } else { ... }` branch in `NewJobRunner` with a real executor interface.
+
+## Proposal
+
+Add an agent-side executor interface that owns how the bootstrap is launched.
+
+```go
+type JobExecutor interface {
+	New(ctx context.Context, req JobExecutionRequest) (JobExecution, error)
+}
+
+type JobExecution interface {
+	Started() <-chan struct{}
+	Done() <-chan struct{}
+	Run(ctx context.Context) error
+	Interrupt() error
+	Terminate() error
+	WaitStatus() process.WaitStatus
+	Cleanup(context.Context) error
+}
+```
+
+`JobExecution` intentionally looks like the existing `jobProcess` plus explicit cleanup. That keeps `JobRunner.Run`, log streaming, cancellation polling, and finish-job behavior largely unchanged.
+
+`JobExecutionRequest` should include:
+
+- the job and agent configuration
+- the full resolved environment slice
+- paths to `BUILDKITE_ENV_FILE` and `BUILDKITE_ENV_JSON_FILE`
+- stdout and stderr writers
+- build path and other filesystem paths from agent config
+- cancel signal and signal grace period
+
+This interface should be implemented at the `agent` layer, not in `internal/job`, because it chooses how bootstrap itself is launched.
+
+## Reconciling Current Kubernetes Support
+
+The current Kubernetes path should be treated as one driver implementation, not as a special case outside the model.
+
+Today, `JobRunner` already chooses between two execution mechanisms in `agent/job_runner.go`:
+
+- local `process.Process`
+- `kubernetes.Runner`
+
+So the simplest reconciliation is to replace that branch with a driver factory, while keeping the current Kubernetes transport intact.
+
+A useful mental model is:
+
+- `ExecutionDriver`: agent-side choice of where and how bootstrap runs
+- `Execution`: the running job lifecycle handle
+- bootstrap transport/protocol: backend-specific coordination details used by some drivers
+
+Under that model:
+
+- `exec` wraps the current local subprocess behavior
+- `docker` wraps a local Docker-launched bootstrap
+- current Kubernetes support becomes a `kubernetes-stack` driver that wraps `kubernetes.Runner` on the agent side and keeps `kubernetes-bootstrap` as the container-side protocol
+
+This is important because the existing Kubernetes code is not generic sandbox launch logic. It is pod coordination logic for the Buildkite Kubernetes stack:
+
+- the pod shape and container layout are created outside the agent
+- the agent distributes environment and execution state across containers
+- checkout and command containers run `kubernetes-bootstrap`
+- the runner aggregates logs, cancellation, and exit status back into one job result
+
+That means current Kubernetes support maps cleanly onto the proposed driver abstraction, but it should not be confused with a generic "sandbox runtime" driver.
+
+### Compatibility path
+
+The existing `--kubernetes-exec` behavior should remain supported.
+
+Internally, resolution would become:
+
+- if `--kubernetes-exec`, select the current Kubernetes-backed driver
+- else if `executor=docker`, select Docker
+- else select `exec`
+
+This keeps existing `agent-stack-k8s` users unchanged while allowing the rest of the execution model to become structured.
+
+## Config Surface
+
+Add a new agent config option:
+
+- `executor` with values `exec` or `docker`
+
+MVP Docker-specific config:
+
+- `executor-docker-image`
+- `executor-docker-arg` as a repeated escape hatch for extra `docker run` flags
+- `executor-docker-expose-socket` default `false`
+
+These should be normal agent configuration settings, defined the same way as existing `buildkite-agent start` options:
+
+- CLI flags on `buildkite-agent start`
+- environment variables
+- `buildkite-agent.cfg`
+
+In practice, the primary configuration point should be `buildkite-agent.cfg`, because the Docker executor is an agent-level execution choice, not a per-step toggle.
+
+Behavior:
+
+- Default `executor` is `exec`.
+- `executor-docker-image` is required when `executor=docker`.
+- `bootstrap-script` remains supported and is used only by `exec`.
+- If `executor=docker`, `bootstrap-script` is ignored and the agent logs a warning if it was explicitly set.
+- `kubernetes-exec` keeps its current behavior for now and remains authoritative when enabled.
+
+The reason to keep `bootstrap-script` as an `exec`-only mechanism is that it is already the compatibility surface. We should not overload it further and then try to infer typed Docker behavior from an arbitrary shell string.
+
+For example:
+
+```cfg
+executor="docker"
+executor-docker-image="ghcr.io/example/buildkite-agent-executor:2026-03-08"
+```
+
+The image should be selected per agent or per agent pool, not inferred from each job. If users need different executor images, they should generally run separate agent pools or queues with different agent configuration.
+
+## Exec Executor
+
+The `exec` executor is a straight extraction of current behavior:
+
+- parse `AgentConfiguration.BootstrapScript`
+- create a `process.Process`
+- wire stdout, stderr, PTY, working dir, env, signals, and grace period exactly as today
+
+This change should be behavior-preserving and land first.
+
+## Docker Executor
+
+The Docker executor should run the full bootstrap in a container, not just the command phase.
+
+Conceptually:
+
+```text
+agent -> docker run ... <image> bootstrap
+```
+
+This is the same pattern as the docker bootstrap example, but implemented in Go inside the agent rather than as an external shell script.
+
+### Docker execution contract
+
+The Docker executor should:
+
+- run an attached container so stdout and stderr continue to flow through the existing job log pipeline
+- pass the resolved job environment into Docker with `--env KEY` entries, using the generated env from `JobRunner`
+- make `BUILDKITE_ENV_FILE` and `BUILDKITE_ENV_JSON_FILE` available inside the container
+- run `bootstrap` inside the container image
+- use a stable container name derived from the job ID so cancellation and cleanup can address it directly
+- remove transient resources on normal exit and on agent-side interruption
+
+The executor image contract should be explicit:
+
+- Linux image
+- contains a compatible `buildkite-agent` binary
+- can run `buildkite-agent bootstrap`
+- contains the tooling needed for full bootstrap execution inside the container, not just the user command
+
+### Mounting strategy
+
+The MVP should preserve path semantics rather than invent a new filesystem model.
+
+Auto-mount these configured paths at the same path inside the container when set:
+
+- build path: read-write
+- plugins path: read-write
+- sockets path: read-write
+- git mirrors path: read-write
+- hooks path and additional hooks paths: read-only
+- signing key files, config files, or similar explicit file paths: read-only
+
+Generated env files need special handling:
+
+- `BUILDKITE_ENV_FILE` and `BUILDKITE_ENV_JSON_FILE` must be visible inside the container
+- the safest compatibility path is to create them under a mounted writable path rather than host-only `/tmp`
+- `BUILDKITE_ENV_FILE` in particular may need to remain writable for compatibility with hooks or plugins that append to it
+
+This is less isolated than a pure named-volume approach, but it is much simpler and preserves current agent behavior for hooks, plugin cache, mirrors, and sockets.
+
+### User and privilege model
+
+Follow the same ideas as the example where possible:
+
+- if the agent is not running as root on Linux, run the container as the same uid:gid
+- mount `/etc/passwd` and `/etc/group` read-only when needed for name resolution
+- set `no-new-privileges`
+- do not mount the Docker socket by default
+
+File ownership on host-mounted paths is a real concern:
+
+- if the container runs as `root` and writes into bind-mounted host paths, those files will typically be owned by `root` on the host
+- that can break later cleanup, checkout reuse, plugin reuse, or mixed host/container execution on the same agent
+
+So for the MVP, Linux Docker execution should default to inheriting the agent process uid:gid when writing to mounted host paths.
+
+Some images will assume `root` or expect a named user and writable home directory, so the design should allow a future explicit override such as `executor-docker-user`, but root should not be the default.
+
+### Cancellation and cleanup
+
+Do not rely on signal proxying from the `docker run` CLI alone.
+
+The Docker executor should own container lifecycle explicitly:
+
+- `Interrupt()` should call `docker stop --signal <cancel-signal> --time <grace-seconds> <name>`
+- `Terminate()` should call `docker kill <name>` followed by forced removal if needed
+- `Cleanup()` should remove any named container still present
+
+The attached `docker run` process can still be used for log streaming and exit status, but container lifecycle should be controlled directly by the executor.
+
+### How this differs from the Docker Buildkite Plugin
+
+This proposal is also distinct from the `docker-buildkite-plugin`.
+
+That plugin runs a pipeline step command in Docker and provides step-level controls such as:
+
+- required `image`
+- environment propagation
+- volume mounts
+- optional checkout mounting behavior
+
+By contrast, the proposed Docker executor is an agent-level execution backend.
+
+Key differences:
+
+- the plugin is configured in pipeline YAML per step; the executor is configured on the agent in `buildkite-agent.cfg` or equivalent agent config
+- the plugin wraps the step command; the executor runs the full `buildkite-agent bootstrap` lifecycle in Docker
+- with the plugin, checkout, hooks, plugin setup, and artifact handling still fundamentally belong to the host-side bootstrap flow; with the executor, those phases run inside the selected execution backend
+- the plugin is a build-step tool; the executor is part of the agent’s job runtime model
+
+The two solve different problems:
+
+- the plugin is primarily for step-level toolchain and environment control
+- the executor is for choosing where a job runs and establishing a future path to broader sandbox providers
+
+## Kubernetes Direction
+
+Keep this brief in the initial proposal:
+
+- current `kubernetes-exec` support already maps naturally to a driver implementation
+- if Kubernetes becomes a first-class executor later, it should be modeled as `executor=kubernetes`
+- sandbox choice on Kubernetes should usually be expressed through runtime and Pod settings such as `runtimeClassName`, not separate top-level executors for each sandbox runtime
+
+In practice:
+
+- local Docker on a host is a distinct execution backend
+- Firecracker or Kata on Kubernetes is usually a Kubernetes backend plus a runtime profile
+
+## Why this belongs in the agent, not inside bootstrap
+
+The bootstrap only knows how to run job phases after it has already started.
+
+The choice between:
+
+- run locally
+- run in Docker
+- run in Firecracker
+- run via a remote provider
+
+has to happen before bootstrap starts, because it changes:
+
+- where stdout and stderr come from
+- how signals are delivered
+- how filesystem paths are mounted or mapped
+- how cleanup is performed
+- which process or sandbox exit status we report upstream
+
+That makes `agent/job_runner.go` the correct layer for the abstraction.
+
+## Simplest Path There
+
+### Phase 1: Extract the current behavior behind an interface
+
+- Add the new executor interface in the agent layer.
+- Implement `execExecutor`.
+- Replace the local `process.New(...)` branch in `NewJobRunner` with the executor.
+- Keep Kubernetes behavior as-is or wrap it behind the same interface without changing config semantics.
+
+This is mostly refactoring and should not change behavior.
+
+### Phase 2: Add opt-in Docker support
+
+- Add `executor=docker` and the small Docker config surface.
+- Implement `dockerExecutor`.
+- Keep `buildkite-agent bootstrap` unchanged.
+- Start Linux-only.
+
+This delivers the user-visible feature while keeping the blast radius small.
+
+### Phase 3: Broaden the interface if needed
+
+After `exec` and `docker` exist, decide whether to:
+
+- move `kubernetes-exec` behind the same driver factory while keeping the old flag as a compatibility alias
+- add a Kubernetes executor with runtime-class-driven sandbox selection
+- add a Firecracker executor only for non-Kubernetes environments where the agent provisions the VM directly
+- add a generic provider registry or plugin model
+
+The important point is that phase 1 and phase 2 should not wait on phase 3.
+
+## Testing
+
+### Phase 1
+
+- unit tests for executor selection
+- parity tests showing `exec` builds the same process config as today
+- existing `agent` and bootstrap tests should continue to pass unchanged
+
+### Phase 2
+
+- unit tests for Docker CLI argument construction
+- unit tests for mount generation from `AgentConfiguration`
+- tests for cancellation mapping to `docker stop` and `docker kill`
+- integration-style tests using mocked `docker` binaries, similar to existing command-phase Docker tests in `internal/job/integration/docker_integration_test.go`
+
+## Risks and tradeoffs
+
+- Docker isolation is incomplete. This should be presented as a better boundary than host `exec`, not as a complete hostile-build solution.
+- Path-preserving bind mounts are pragmatic, but they leak more host structure into the container than a stricter sandbox would.
+- Requiring an explicit Docker image in the MVP is slightly less convenient, but it avoids hidden version drift rules.
+- There is naming collision with `internal/job.Executor`. Internally we should prefer names like `JobExecutor`, `ExecutionBackend`, or `JobExecution` at the agent layer.
+
+## Recommendation
+
+Land this as an agent-side abstraction in two changes:
+
+1. Refactor the current local subprocess path into `execExecutor` with no behavior change.
+2. Add an opt-in `dockerExecutor` that runs the full bootstrap inside a container.
+
+Then evaluate Kubernetes as the next top-level executor, with sandbox flavor controlled by runtime and Pod settings.
+
+That gives us a clean, minimal abstraction now, solves the concrete Docker use case, and creates a real extension point for Firecracker and other sandbox providers later without forcing Kubernetes-specific runtime choices into the wrong layer.

--- a/docs/proposals/job-executor-abstraction.md
+++ b/docs/proposals/job-executor-abstraction.md
@@ -11,8 +11,9 @@ process is launched*, and add Docker as the first non-local backend.
   local subprocess.
 - `docker`: the agent runs `buildkite-agent bootstrap` inside an ephemeral
   container on the same host.
-- `kubernetes-exec`: today's Kubernetes stack support, unchanged in behaviour
-  but expressed as one more implementation of the same interface.
+- `kubernetes`: today's Kubernetes stack support, unchanged in behaviour but
+  expressed as one more implementation of the same interface. `--kubernetes-exec`
+  remains as an alias for `executor=kubernetes`.
 
 The seam is the whole bootstrap process, not the command phase. That is what
 makes it reusable for stronger sandboxes later (Firecracker, gVisor, remote
@@ -137,20 +138,21 @@ Validate the resolved configuration (flags, env vars, and `buildkite-agent.cfg`
 combined) at agent start, then select:
 
 ```text
-executor not in {unset, exec, docker}       -> agent start fails: unknown executor
---kubernetes-exec and executor=docker        -> agent start fails: conflicting executors
---kubernetes-exec                            -> kubernetes execution (wraps kubernetes.Runner)
+--kubernetes-exec and executor unset         -> executor = kubernetes
+--kubernetes-exec and executor != kubernetes -> agent start fails: conflicting executors
+executor not in {exec, docker, kubernetes}   -> agent start fails: unknown executor
+executor=kubernetes                          -> kubernetes execution (wraps kubernetes.Runner)
 executor=docker                              -> docker execution
-otherwise                                    -> exec execution
+executor=exec (or unset)                     -> exec execution
 ```
 
-An unset `executor` means `exec`. Any other value is rejected before anything
-else is considered, so a typo such as `executor=dokcer` cannot fail open to
-running jobs on the host, with or without `--kubernetes-exec`.
-
-`--kubernetes-exec` stays a separate flag so `agent-stack-k8s` users see no
-change. Folding it into `executor=kubernetes-exec` as an alias is a later,
-optional step.
+`executor` is the single canonical value. `--kubernetes-exec` is kept so
+`agent-stack-k8s` users see no change, but it is normalised into
+`executor=kubernetes` while the configuration is resolved, the same way
+`--debug` is folded into the log level in `HandleGlobalFlags`; nothing after
+the selection step looks at the boolean. Unknown values are rejected before
+anything else is considered, so a typo such as `executor=dokcer` cannot fail
+open to running jobs on the host.
 
 ### Config surface
 
@@ -159,7 +161,7 @@ New `buildkite-agent start` settings, available as flags, env vars, and
 
 | Setting | Values | Notes |
 |---|---|---|
-| `executor` | `exec` (default), `docker` | |
+| `executor` | `exec` (default), `docker`, `kubernetes` | `--kubernetes-exec` is an alias for `kubernetes` |
 | `executor-docker-image` | image ref | required when `executor=docker` |
 | `executor-docker-arg` | repeatable | extra `docker create` flags; escape hatch |
 | `executor-docker-expose-socket` | bool, default `false` | mounts `/var/run/docker.sock`; follow-up, not MVP |
@@ -172,8 +174,8 @@ Rules:
   `--rm` (defeats `inspect`), `--restart` other than `no` (defeats "one
   ephemeral execution"), and every singleton flag the executor sets itself:
   `--name`, `--user`/`-u`, `--workdir`/`-w`, `--init`, `--tty`/`-t`, plus
-  `--env BUILDKITE_BOOTSTRAP_ENV_JSON_FILE` and mounts targeting the job
-  context directory. Match all spellings
+  `--env BUILDKITE_BOOTSTRAP_ENV_JSON_FILE`, `--env HOME`, and mounts
+  targeting the job context directory. Match all spellings
   (`--workdir=/x`, `--workdir /x`, `-w /x`). Docker's parser is last-value-wins
   for singletons, so as a second line of defence the executor's own flags are
   appended after the user's args; the reject list exists because relying on
@@ -181,7 +183,20 @@ Rules:
 - `$HOME` in the container is fixed at `/tmp/buildkite-home` for the MVP (see
   the user model below). A setting can follow if anyone needs to move it.
 - The image is an agent-pool decision. Users who need different images run
-  different queues.
+  different queues. Two reasons, one hard and one soft. Hard: the image runs
+  *all* of bootstrap (checkout, hooks, plugins), so it must contain a
+  compatible `buildkite-agent`; a step-level `image: ruby:4.0.3` cannot do
+  that as designed, and per-step images for just the command phase are what
+  the docker-buildkite-plugin already provides (they compose, see below).
+  Soft: the executor is an operator control; the container holds the job
+  token and the operator's chosen mounts, so a pipeline-chosen image would
+  need an operator allowlist. Both are relaxable later: the agent is built
+  with `CGO_ENABLED=0`, so the host's own binary could be bind-mounted
+  read-only into any same-arch Linux image and prepended to `PATH`, which is
+  how agent-stack-k8s gets the agent into user images. That would remove the
+  image version check and most of the image contract and make a per-step
+  `image:` behind an allowlist a natural follow-up. It is not in the MVP, and
+  whether it should replace the image contract is an open question.
 
 ## `exec` execution
 
@@ -219,7 +234,7 @@ Interrupt():  record "interrupt"; docker kill --signal <cancel-signal> <id> if r
 Terminate():  record "terminate";  docker kill <id> if running;
               if that fails, cancel Run's subprocess context (start + any inspect)
               so Run returns
-(every inspect/kill/rm call has its own 10 s timeout; start --attach does not)
+(create has a 60 s timeout, inspect/kill/rm 10 s each; start --attach has none)
 Cleanup():    docker rm --force --volumes <id>   (ignore "no such container")
               remove the env file
 ```
@@ -301,11 +316,14 @@ Cleanup():    docker rm --force --volumes <id>   (ignore "no such container")
   and `Run` returns an error instead of waiting on a daemon that is not
   responding; the container may be leaked at that point and `Cleanup` reports
   it if `rm --force` fails too (see Risks).
-- Every control command other than `start --attach` runs under its own short
-  timeout (10 s) in addition to `Run`'s context: the readiness-poll
-  `inspect`s, the final `inspect`, `kill`, and `rm`. Only `start --attach` is
-  unbounded, because it lives as long as the job. An `inspect` that times out
-  is an executor failure: `Run` attempts `docker kill`, then returns an error.
+- Every control command other than `start --attach` runs under its own
+  timeout in addition to `Run`'s context: `create` gets 60 s (the image is
+  already local by ID, so this covers only daemon latency), and the
+  readiness-poll `inspect`s, the final `inspect`, `kill`, and `rm` get 10 s.
+  Only `start --attach` is unbounded, because it lives as long as the job. A
+  `create` that times out is handled like a cancelled create (`rm --force`
+  by name, return an error); an `inspect` that times out is an executor
+  failure: `Run` attempts `docker kill`, then returns an error.
   Without this, a daemon that stops answering mid-poll would leave `Run`
   blocked in `inspect` where killing `start` alone would not free it.
 - Apply the same SIGKILL→SIGTERM downgrade as `exec`. A SIGKILL to bootstrap
@@ -356,10 +374,12 @@ Two environments are in play and they must not mix:
   below).
 - The **container** environment: the resolved job env slice from
   `createEnvironment` (job env plus the agent's `BUILDKITE_*` additions), with
-  the adjustments below. It deliberately excludes the host's `os.Environ()`:
-  `PATH`, `HOME`, and the like come from the image, not the host. So do proxy
-  settings: an operator whose host agent relies on `HTTP_PROXY` passes it via
-  `executor-docker-arg --env HTTP_PROXY=...`.
+  the adjustments below. It deliberately excludes the host's `os.Environ()`.
+  The rule is simple: nothing from the agent's process environment reaches
+  the container. `PATH`, `HOME`, and the like come from the image, and
+  anything an operator wants in the container beyond the job env goes via
+  `executor-docker-arg --env ...`. Proxy settings are the common example: an
+  operator whose host agent relies on `HTTP_PROXY` has to pass it explicitly.
 
 Transport the container environment through a file, not through `docker`'s
 env flags:
@@ -369,8 +389,10 @@ env flags:
   it with `O_CREATE|O_EXCL` (or `os.CreateTemp`, as `createJobEnvFiles`
   already does) so a pre-existing path or symlink is never followed. The job
   context dir is already bind-mounted, so the path is the same on both sides.
-- `docker create` passes exactly one env var:
-  `--env BUILDKITE_BOOTSTRAP_ENV_JSON_FILE=<path>`.
+- `docker create` passes two env vars with values:
+  `--env BUILDKITE_BOOTSTRAP_ENV_JSON_FILE=<path>` and
+  `--env HOME=/tmp/buildkite-home` (plus the name-only OTLP exporter
+  variables described below). Everything else goes through the file.
 - `buildkite-agent bootstrap` honours that variable. The loading has to
   happen before urfave/cli parses flags: `cli.EnvVars` sources are read
   during parsing, ahead of any `Before` hook or the `Action`, so nothing
@@ -438,7 +460,12 @@ Adjust these before writing the file:
   drops. The executor takes the path from the runner, puts it in the env
   file, and bind-mounts the log file itself read-only (below); the agent
   appends to the same inode on the host, so the container sees the live log.
-- `HOME`: set to `/tmp/buildkite-home`. See the user model below.
+- `HOME`: set to `/tmp/buildkite-home`, and *also* passed as
+  `--env HOME=/tmp/buildkite-home` on `docker create` (it is not secret). The
+  env file is only read once bootstrap starts, but the image entrypoint runs
+  first: the official image's `ssh-env-config.sh` writes under `~/.ssh`, and
+  with a non-root `--user` and the image's `HOME=/root` it would fail before
+  bootstrap ever ran. See the user model below.
 
 ### Mounts
 
@@ -538,14 +565,19 @@ them under that path via `executor-docker-arg`.
   an older image of the same major would ignore the variable and run
   bootstrap with no job configuration. `agent start` enforces this once,
   after config validation and before registering, under a single bounded
-  context (2 minutes; `docker pull` dominates): `docker pull <image>`, then
+  context (2 minutes; `docker pull` dominates): `docker version --format
+  '{{.Server.APIVersion}}'` against a stated minimum, then `docker pull <image>`, then
   `docker image inspect --format '{{.Id}}' <image>` to resolve the tag to an
   ID exactly once, then `docker run --rm --entrypoint buildkite-agent <id>
   --version` against that ID. Agent start fails on a version below the
   minimum, a non-zero exit, or timeout. The checked ID is retained and every
   `docker create` uses it rather than the tag, so a tag moving under a
   running agent, or between the check and the first job, cannot swap in an
-  unchecked image. This keeps Docker calls
+  unchecked image. The Docker minimum exists because shelling out to the CLI
+  is a soft version coupling: every flag and subcommand used here has been
+  stable since the 1.13 CLI reorganisation (2017), so the risk is low, but a
+  too-old daemon should fail at start with a clear message rather than at the
+  first job. This keeps Docker calls
   out of `New` (which would orphan work if `StartJob` failed) and out of
   `Run`'s cancellation path, and means the pull that would otherwise happen
   on the first job happens before the agent accepts one.
@@ -590,8 +622,10 @@ separate top-level executors per runtime.
    `agent/`, implement `execExecution` and wrap `kubernetes.Runner`, replace
    the branch in `NewJobRunner` with a selector, add the `Cleanup` call to
    `JobRunner.cleanup`. Both existing executions keep prepending
-   `os.Environ()` exactly as today. No config changes; existing tests pass
-   unchanged; add a selection test.
+   `os.Environ()` exactly as today. Add the `executor` setting with values
+   `exec` and `kubernetes` only, and normalise `--kubernetes-exec` into it;
+   `docker` is rejected until slice 3. Existing tests pass unchanged; add a
+   selection test.
 2. **Bootstrap env file.** `main` loads `BUILDKITE_BOOTSTRAP_ENV_JSON_FILE`
    before `app.Run`. Small, independently testable, and useful on its own for
    anyone wrapping bootstrap.
@@ -606,15 +640,15 @@ separate top-level executors per runtime.
    `no-new-privileges`, `rm --force --volumes`. Linux only; error out on other
    platforms.
 4. **Follow-ups if needed.** `executor-docker-expose-socket`,
-   `executor-docker-user`, `executor-docker-home`, `executor=kubernetes-exec`
-   alias.
+   `executor-docker-user`, `executor-docker-home`.
 
 ## Testing
 
 Slice 1:
 
-- Table test for executor selection, including rejection of unknown values
-  and of `--kubernetes-exec` combined with `executor=docker`.
+- Table test for executor selection, including rejection of unknown values,
+  `--kubernetes-exec` normalising to `executor=kubernetes`, and rejection of
+  `--kubernetes-exec` combined with `executor=docker` or `executor=exec`.
 - Parity test: `execExecution` produces the same `process.Config` as the
   current code for a fixed `JobRunnerConfig`, including the host env prepend.
 
@@ -629,8 +663,9 @@ Slice 3, with a fake `docker` binary on `PATH` that records its argv and env
 and exits with a scripted status, in the style of the existing
 `internal/job/integration` fakes:
 
-- `docker create` argv construction from `AgentConfiguration`: the single
-  `--env`, mount table, `--user`, `--group-add`, `--workdir`, `--tty` when
+- `docker create` argv construction from `AgentConfiguration`: the two
+  `--env KEY=VALUE` flags (env file path, `HOME`) and nothing else with a
+  value, mount table, `--user`, `--group-add`, `--workdir`, `--tty` when
   `run-in-pty` is on, `--init`, `--tmpfs` for `HOME`; rejection of reserved
   `executor-docker-arg` flags in every spelling (`--workdir=/x`,
   `--workdir /x`, `-w /x`); accepted user args appear before the executor's

--- a/docs/proposals/job-executor-abstraction.md
+++ b/docs/proposals/job-executor-abstraction.md
@@ -1,77 +1,89 @@
 # Job Executor Abstraction
 
-> Drafted with GPT-5.4, with human input and review.
-
-> Note: this proposal is not about reviving or extending the deprecated `BUILDKITE_DOCKER*` / `BUILDKITE_DOCKER_COMPOSE_*` job behavior. That legacy command-phase integration is separate, deprecated, and not the basis for the proposed executor model.
+> Drafted with GPT-5.4 and revised with Amp, with human input and review.
 
 ## Summary
 
-Introduce an agent-side executor abstraction for the job-level bootstrap process.
+Give the agent a typed, tested abstraction for *how the job-level bootstrap
+process is launched*, and add Docker as the first non-local backend.
 
-The first two executors would be:
+- `exec` (default): today's behaviour. The agent starts `bootstrap-script` as a
+  local subprocess.
+- `docker`: the agent runs `buildkite-agent bootstrap` inside an ephemeral
+  container on the same host.
+- `kubernetes-exec`: today's Kubernetes stack support, unchanged in behaviour
+  but expressed as one more implementation of the same interface.
 
-- `exec`: the current behavior, and the default. The agent starts the configured `bootstrap-script` as a local subprocess.
-- `docker`: the agent runs `buildkite-agent bootstrap` inside an ephemeral Docker container, following the same overall pattern as [buildkite/docker-bootstrap-example](https://github.com/buildkite/docker-bootstrap-example).
-
-This creates a stable seam for future sandbox backends such as Firecracker, gVisor, or remote worker APIs without changing the bootstrap itself.
-
-It also leaves room for a Kubernetes-native execution path, where the transport is "run this job in a Pod" and the isolation choice is expressed via `runtimeClassName`, user namespaces, and other Pod-level features rather than by inventing a separate top-level executor for each sandbox runtime.
+The seam is the whole bootstrap process, not the command phase. That is what
+makes it reusable for stronger sandboxes later (Firecracker, gVisor, remote
+workers) without touching `internal/job`.
 
 ## Why
 
-Today there are three different concepts in the repo that are close to "how a job runs", but none of them is a clean abstraction:
+The agent already has the interface this proposal wants. `agent/job_runner.go`
+declares:
 
-- The agent starts one job-level subprocess from `agent/job_runner.go`.
-- The bootstrap runtime lives in `internal/job/executor.go`.
-- Kubernetes is already a special execution mode with its own transport in `kubernetes/runner.go` and `clicommand/kubernetes_bootstrap.go`.
+```go
+// jobProcess is either a *process.Process, or a *kubernetes.Runner.
+type jobProcess interface {
+	Done() <-chan struct{}
+	Started() <-chan struct{}
+	Interrupt() error
+	Terminate() error
+	Run(ctx context.Context) error
+	WaitStatus() process.WaitStatus
+}
+```
 
-That leaves us with two problems:
+and `NewJobRunner` picks an implementation with
+`if conf.KubernetesExec { kubernetes.NewRunner(...) } else { process.New(...) }`.
+Everything downstream (`JobRunner.Run`, log streaming, cancellation polling,
+`FinishJob`) already works against `jobProcess`.
 
-1. `bootstrap-script` is a powerful escape hatch, but it is just a command string. It is not a typed backend with a lifecycle, cleanup, or tests for backend-specific behavior.
-2. The deprecated Docker logic in `internal/job/docker.go` only wraps the command phase inside bootstrap. It does not execute the full job lifecycle in Docker, which is why it is not a substitute for an agent-level executor.
+Two things are missing:
 
-If we want sandboxing to be a first-class capability, the seam should be around the whole bootstrap process, not just the final command phase.
+1. The choice is an `if` on one bool, so there is no room for a third backend
+   and no unit test of selection.
+2. `bootstrap-script` is the only way to run bootstrap somewhere else. It is a
+   command string with no lifecycle: no way to name the thing that was
+   launched, cancel it directly, map its exit status, or clean it up. The
+   [docker-bootstrap-example](https://github.com/buildkite/docker-bootstrap-example)
+   shows both the idea and the limits of a shell-script-only approach: no
+   container name, no signal handling, no cleanup.
 
-The proposed Docker executor should therefore be treated as a new agent-level execution backend, not an evolution of the deprecated command-phase Docker integration.
+The deprecated in-bootstrap Docker integration (`BUILDKITE_DOCKER*`,
+`BUILDKITE_DOCKER_COMPOSE_*`) was removed in
+[17f5fb47](https://github.com/buildkite/agent/commit/17f5fb47). It only wrapped
+the command phase and is not related to this proposal.
 
 ## Goals
 
-- Preserve current behavior by default.
-- Keep `buildkite-agent bootstrap` as the unit that executes job phases.
-- Make the agent choose a job executor in a structured, testable way.
-- Allow each executor to own setup, cancellation, exit status mapping, and cleanup.
-- Make Docker an opt-in backend now, while keeping the design broad enough for Firecracker and other providers later.
+- Preserve current behaviour by default.
+- Keep `buildkite-agent bootstrap` as the unit that runs job phases.
+- Let each backend own launch, cancellation, exit-status mapping, and cleanup.
+- Land Docker as an opt-in Linux backend.
 
 ## Non-goals
 
-- Rewriting bootstrap phases in `internal/job`.
-- Replacing the existing `bootstrap-script` escape hatch in this change.
-- Extending or modernizing the deprecated `BUILDKITE_DOCKER*` / `BUILDKITE_DOCKER_COMPOSE_*` behavior.
-- Solving full hostile-build isolation. Docker still has well-known gaps around network access and Docker socket exposure.
-- Collapsing Kubernetes into the new config surface immediately.
-
-## Current Architecture
-
-The current execution chain is:
-
-1. `clicommand/agent_start.go` builds `AgentConfiguration`.
-2. `agent/job_runner.go` creates job env files, log streaming, and a `jobProcess`.
-3. `jobProcess` is either:
-   - a local `process.Process` running `bootstrap-script`, or
-   - a `kubernetes.Runner`.
-4. The subprocess runs `clicommand/bootstrap.go`, which then executes `internal/job.Executor`.
-
-This is already close to the right seam. The missing piece is replacing the `if kubernetes { ... } else { ... }` branch in `NewJobRunner` with a real executor interface.
+- Changing bootstrap phases in `internal/job`.
+- Removing `bootstrap-script`.
+- Full hostile-build isolation. Docker still shares the kernel and, by default,
+  the host network.
+- Changing `--kubernetes-exec` config or the `kubernetes-bootstrap` protocol.
 
 ## Proposal
 
-Add an agent-side executor interface that owns how the bootstrap is launched.
+### Interface
+
+Rename `jobProcess` to `JobExecution`, add `Cleanup`, and add a factory:
 
 ```go
+// JobExecutor chooses where and how bootstrap runs.
 type JobExecutor interface {
 	New(ctx context.Context, req JobExecutionRequest) (JobExecution, error)
 }
 
+// JobExecution is one running job. It is the existing jobProcess plus Cleanup.
 type JobExecution interface {
 	Started() <-chan struct{}
 	Done() <-chan struct{}
@@ -79,316 +91,273 @@ type JobExecution interface {
 	Interrupt() error
 	Terminate() error
 	WaitStatus() process.WaitStatus
-	Cleanup(context.Context) error
+	Cleanup(ctx context.Context) error
 }
 ```
 
-`JobExecution` intentionally looks like the existing `jobProcess` plus explicit cleanup. That keeps `JobRunner.Run`, log streaming, cancellation polling, and finish-job behavior largely unchanged.
+`JobExecutionRequest` carries what `NewJobRunner` already computes:
 
-`JobExecutionRequest` should include:
+- `Job` and `AgentConfiguration`
+- the resolved job env slice (the output of `createEnvironment`)
+- the job context directory (`jobContextDir(conf)`), which holds
+  `BUILDKITE_ENV_FILE`, `BUILDKITE_ENV_JSON_FILE`, and the job-timeout marker
+- the stdout/stderr writer (`r.jobLogs`)
+- `CancelSignal` and `CancelSignalTimeout`
 
-- the job and agent configuration
-- the full resolved environment slice
-- paths to `BUILDKITE_ENV_FILE` and `BUILDKITE_ENV_JSON_FILE`
-- stdout and stderr writers
-- build path and other filesystem paths from agent config
-- cancel signal and signal grace period
+`Run` returning an error means "the job never started"; `runJob` already maps
+that to exit -1 with `SignalReasonProcessRunError`. Backends must use that
+channel for launch failures rather than inventing an exit code.
 
-This interface should be implemented at the `agent` layer, not in `internal/job`, because it chooses how bootstrap itself is launched.
+`runJob` currently type-asserts `r.process.(*kubernetes.Runner)` to print
+"unknown container exit status" diagnostics. Move that behind an optional
+interface (`ExplainExit(w io.Writer)` or similar) implemented by the
+Kubernetes execution so `JobRunner` stops naming a concrete backend.
 
-## Reconciling Current Kubernetes Support
+The interface lives in `agent/`, not `internal/job`, because it decides how
+bootstrap is launched; bootstrap only exists after that decision.
 
-The current Kubernetes path should be treated as one driver implementation, not as a special case outside the model.
-
-Today, `JobRunner` already chooses between two execution mechanisms in `agent/job_runner.go`:
-
-- local `process.Process`
-- `kubernetes.Runner`
-
-So the simplest reconciliation is to replace that branch with a driver factory, while keeping the current Kubernetes transport intact.
-
-A useful mental model is:
-
-- `ExecutionDriver`: agent-side choice of where and how bootstrap runs
-- `Execution`: the running job lifecycle handle
-- bootstrap transport/protocol: backend-specific coordination details used by some drivers
-
-Under that model:
-
-- `exec` wraps the current local subprocess behavior
-- `docker` wraps a local Docker-launched bootstrap
-- current Kubernetes support becomes a `kubernetes-stack` driver that wraps `kubernetes.Runner` on the agent side and keeps `kubernetes-bootstrap` as the container-side protocol
-
-This is important because the existing Kubernetes code is not generic sandbox launch logic. It is pod coordination logic for the Buildkite Kubernetes stack:
-
-- the pod shape and container layout are created outside the agent
-- the agent distributes environment and execution state across containers
-- checkout and command containers run `kubernetes-bootstrap`
-- the runner aggregates logs, cancellation, and exit status back into one job result
-
-That means current Kubernetes support maps cleanly onto the proposed driver abstraction, but it should not be confused with a generic "sandbox runtime" driver.
-
-### Compatibility path
-
-The existing `--kubernetes-exec` behavior should remain supported.
-
-Internally, resolution would become:
-
-- if `--kubernetes-exec`, select the current Kubernetes-backed driver
-- else if `executor=docker`, select Docker
-- else select `exec`
-
-This keeps existing `agent-stack-k8s` users unchanged while allowing the rest of the execution model to become structured.
-
-## Config Surface
-
-Add a new agent config option:
-
-- `executor` with values `exec` or `docker`
-
-MVP Docker-specific config:
-
-- `executor-docker-image`
-- `executor-docker-arg` as a repeated escape hatch for extra `docker run` flags
-- `executor-docker-expose-socket` default `false`
-
-These should be normal agent configuration settings, defined the same way as existing `buildkite-agent start` options:
-
-- CLI flags on `buildkite-agent start`
-- environment variables
-- `buildkite-agent.cfg`
-
-In practice, the primary configuration point should be `buildkite-agent.cfg`, because the Docker executor is an agent-level execution choice, not a per-step toggle.
-
-Behavior:
-
-- Default `executor` is `exec`.
-- `executor-docker-image` is required when `executor=docker`.
-- `bootstrap-script` remains supported and is used only by `exec`.
-- If `executor=docker`, `bootstrap-script` is ignored and the agent logs a warning if it was explicitly set.
-- `kubernetes-exec` keeps its current behavior for now and remains authoritative when enabled.
-
-The reason to keep `bootstrap-script` as an `exec`-only mechanism is that it is already the compatibility surface. We should not overload it further and then try to infer typed Docker behavior from an arbitrary shell string.
-
-For example:
-
-```cfg
-executor="docker"
-executor-docker-image="ghcr.io/example/buildkite-agent-executor:2026-03-08"
-```
-
-The image should be selected per agent or per agent pool, not inferred from each job. If users need different executor images, they should generally run separate agent pools or queues with different agent configuration.
-
-## Exec Executor
-
-The `exec` executor is a straight extraction of current behavior:
-
-- parse `AgentConfiguration.BootstrapScript`
-- create a `process.Process`
-- wire stdout, stderr, PTY, working dir, env, signals, and grace period exactly as today
-
-This change should be behavior-preserving and land first.
-
-## Docker Executor
-
-The Docker executor should run the full bootstrap in a container, not just the command phase.
-
-Conceptually:
+### Selection
 
 ```text
-agent -> docker run ... <image> bootstrap
+if --kubernetes-exec      -> kubernetes execution (wraps kubernetes.Runner)
+else if executor=docker   -> docker execution
+else                      -> exec execution
 ```
 
-This is the same pattern as the docker bootstrap example, but implemented in Go inside the agent rather than as an external shell script.
+`--kubernetes-exec` stays authoritative so `agent-stack-k8s` users see no
+change. Folding it into `executor=kubernetes-exec` as an alias is a later,
+optional step.
 
-### Docker execution contract
+### Config surface
 
-The Docker executor should:
+New `buildkite-agent start` settings, available as flags, env vars, and
+`buildkite-agent.cfg` entries like every other agent option:
 
-- run an attached container so stdout and stderr continue to flow through the existing job log pipeline
-- pass the resolved job environment into Docker with `--env KEY` entries, using the generated env from `JobRunner`
-- make `BUILDKITE_ENV_FILE` and `BUILDKITE_ENV_JSON_FILE` available inside the container
-- run `bootstrap` inside the container image
-- use a stable container name derived from the job ID so cancellation and cleanup can address it directly
-- remove transient resources on normal exit and on agent-side interruption
+| Setting | Values | Notes |
+|---|---|---|
+| `executor` | `exec` (default), `docker` | |
+| `executor-docker-image` | image ref | required when `executor=docker` |
+| `executor-docker-arg` | repeatable | extra `docker run`/`docker create` flags; escape hatch |
+| `executor-docker-expose-socket` | bool, default `false` | mounts `/var/run/docker.sock` |
+| `executor-docker-home` | path, default `/tmp/buildkite-home` | `$HOME` inside the container; see below |
 
-The executor image contract should be explicit:
+Rules:
 
-- Linux image
-- contains a compatible `buildkite-agent` binary
-- can run `buildkite-agent bootstrap`
-- contains the tooling needed for full bootstrap execution inside the container, not just the user command
+- `bootstrap-script` is used only by `exec`. If `executor=docker` and
+  `bootstrap-script` was set explicitly, log a warning and ignore it.
+- The image is an agent-pool decision. Users who need different images run
+  different queues.
 
-### Mounting strategy
+## `exec` execution
 
-The MVP should preserve path semantics rather than invent a new filesystem model.
+A straight extraction of the current `else` branch: `shellwords.Split` the
+bootstrap script, build `process.Config` with the same `Dir`, `Env`, `PTY`,
+`Stdout`, `Stderr`, `InterruptSignal`, and `SignalGracePeriod` as today,
+including the SIGKILL→SIGTERM downgrade of the interrupt signal. `Cleanup` is a
+no-op. This must be behaviour-preserving and lands first.
 
-Auto-mount these configured paths at the same path inside the container when set:
+## `docker` execution
 
-- build path: read-write
-- plugins path: read-write
-- sockets path: read-write
-- git mirrors path: read-write
-- hooks path and additional hooks paths: read-only
-- signing key files, config files, or similar explicit file paths: read-only
+### Lifecycle
 
-Generated env files need special handling:
+Use `docker create` + `docker start --attach` rather than a single
+`docker run`, so the container has a name before anything can go wrong and so
+launch failures are separable from bootstrap exit codes.
 
-- `BUILDKITE_ENV_FILE` and `BUILDKITE_ENV_JSON_FILE` must be visible inside the container
-- the safest compatibility path is to create them under a mounted writable path rather than host-only `/tmp`
-- `BUILDKITE_ENV_FILE` in particular may need to remain writable for compatibility with hooks or plugins that append to it
+```text
+New():        docker create --name buildkite-job-<jobid> <flags> <image> bootstrap
+Run():        docker start --attach buildkite-job-<jobid>   (stdout/stderr -> jobLogs)
+              on exit: docker inspect --format '{{.State.ExitCode}}' -> WaitStatus
+Interrupt():  docker kill --signal <cancel-signal> buildkite-job-<jobid>
+Terminate():  docker kill buildkite-job-<jobid>
+Cleanup():    docker rm --force buildkite-job-<jobid>   (ignore "no such container")
+```
 
-This is less isolated than a pure named-volume approach, but it is much simpler and preserves current agent behavior for hooks, plugin cache, mirrors, and sockets.
+- If `docker create` or `docker start` fails before the container runs, `Run`
+  returns an error. Do not surface the docker CLI's own 125/126/127 exit codes
+  as the job exit status: 125 collides with `job.ExitCodeSetupFailure`, which
+  `runJob` already rewrites to -1, and 126/127 would look like the user's
+  command failing.
+- `Started()` closes when `docker start` has been spawned. That is early by a
+  few hundred milliseconds, which only affects when log streaming and the
+  cancellation poller begin; both tolerate that.
+- `Interrupt` must be non-blocking. `docker stop --time N` is wrong here: it
+  blocks for up to N seconds and then SIGKILLs, duplicating the grace period
+  that `JobRunner.Cancel` already enforces before calling `Terminate`. The
+  agent, not Docker, owns the timing.
+- Apply the same SIGKILL→SIGTERM downgrade as `exec`. A SIGKILL to bootstrap
+  skips pre-exit hooks and loses the command's exit status.
+- Pass `--init`. Bootstrap is PID 1 in the container and Go does not reap
+  orphaned grandchildren left behind by hooks and shells.
+- Job-level timeouts work unchanged: `Cancel` writes the marker file into the
+  job context directory before signalling, and bootstrap reads it via
+  `BUILDKITE_AGENT_JOB_TIMEOUT_FILE`. This requires the context directory to
+  be a live bind mount (below), not a copy taken at `docker create` time.
+
+### Environment
+
+Pass the resolved job env as `--env KEY` (name only) for every entry in the
+env slice. The `docker` CLI process inherits `os.Environ() + env` exactly as
+the `exec` bootstrap does today, so Docker reads the values from there. This
+avoids quoting problems with multi-line values and keeps values out of the
+`docker create` argv.
+
+`docker --env-file` is not an option: `BUILDKITE_ENV_FILE` is written with Go
+`%q` quoting for the pre-bootstrap hook to validate, and Docker's env-file
+parser does not unquote.
+
+Override or omit host-specific values before passing them through:
+
+- `BUILDKITE_BIN_PATH`: set to empty. Bootstrap appends it to `PATH`; the
+  host path is meaningless in the container and the image must already have
+  `buildkite-agent` on `PATH`. (`kubernetes-bootstrap` resolves the same
+  problem by recomputing it from `os.Executable`.)
+- `BUILDKITE_AGENT_PID`: omit.
+- `HOME`: set to `executor-docker-home`. See the user model below.
+
+### Mounts
+
+Preserve host paths inside the container so that nothing in bootstrap, hooks,
+or plugins needs to learn a new filesystem layout:
+
+| Host path (from `AgentConfiguration`) | Mode |
+|---|---|
+| `build-path` | rw |
+| `plugins-path` | rw |
+| `git-mirrors-path` (when set) | rw |
+| `sockets-path` | rw |
+| job context dir (`--job-context-dir`, default `os.TempDir()`) | rw |
+| `hooks-path`, each `additional-hooks-paths` entry | ro |
+| `config-path`, `signing-jwks-file` (when set) | ro |
+| `/etc/passwd`, `/etc/group` (when not running as root) | ro |
+| `/var/run/docker.sock` (only when `executor-docker-expose-socket`) | rw |
+
+The job context directory already exists as a concept:
+`--job-context-dir` / `BUILDKITE_JOB_CONTEXT_DIR` (added for the Kubernetes
+stack in [535aeaf2](https://github.com/buildkite/agent/commit/535aeaf2)) is
+where the agent puts `BUILDKITE_ENV_FILE`, `BUILDKITE_ENV_JSON_FILE`, and the
+job-timeout marker. Bind-mounting that directory at the same path makes all
+three visible in the container with no path rewriting. Mounting the default
+`os.TempDir()` (usually `/tmp`) into the container is more than we want, so
+when `executor=docker` and the operator has not set `job-context-dir`, agent
+start should default it to a dedicated directory such as
+`/var/lib/buildkite-agent/job-context`. This has to happen at config
+resolution time, before `NewJobRunner` creates the env files there.
+
+`sockets-path` is mounted because the host agent's local API socket lives
+there (`agentapi.DefaultSocketPath`), and `buildkite-agent lock` inside the
+container needs to reach it. Its default is under the host `$HOME`
+(`~/.buildkite-agent/sockets`), which is fine: the path is passed explicitly
+via `BUILDKITE_SOCKETS_PATH` and does not depend on `$HOME` in the container.
+
+Mirror locking uses `gofrs/flock`, which works across bind mounts on the same
+kernel, so `git-mirrors-path` can be shared between host and container jobs on
+one agent.
 
 ### User and privilege model
 
-Follow the same ideas as the example where possible:
+- On Linux, when the agent is not running as root, run the container with
+  `--user <uid>:<gid>` matching the agent process and mount `/etc/passwd` and
+  `/etc/group` read-only so the uid resolves to a name.
+- Always set `--security-opt no-new-privileges`.
+- Do not mount the Docker socket by default.
 
-- if the agent is not running as root on Linux, run the container as the same uid:gid
-- mount `/etc/passwd` and `/etc/group` read-only when needed for name resolution
-- set `no-new-privileges`
-- do not mount the Docker socket by default
+Running as root inside a bind-mounted build path creates root-owned files on
+the host that break later cleanup, checkout reuse, and mixed host/container
+agents. Inheriting the agent uid is the default; an explicit
+`executor-docker-user` override can come later.
 
-File ownership on host-mounted paths is a real concern:
+Mounting the host `/etc/passwd` has a side effect the docker-bootstrap-example
+ignores: `$HOME` resolves to the host user's home directory, which does not
+exist in the image. The agent itself depends on a usable `$HOME`: the cache
+feature reads `os.UserHomeDir()` for its default store and for `~` expansion
+in cache paths, and git and ssh want somewhere writable. So the executor sets
+`HOME=<executor-docker-home>` and mounts a per-job tmpfs or empty directory
+there. Users who need ssh keys or git config inside the container mount them
+via `executor-docker-arg`.
 
-- if the container runs as `root` and writes into bind-mounted host paths, those files will typically be owned by `root` on the host
-- that can break later cleanup, checkout reuse, plugin reuse, or mixed host/container execution on the same agent
+### Image contract
 
-So for the MVP, Linux Docker execution should default to inheriting the agent process uid:gid when writing to mounted host paths.
+- Linux image.
+- `buildkite-agent` on `PATH`, of a version compatible with the host agent.
+  Enforce at least a major-version match by running
+  `docker run --rm --entrypoint buildkite-agent <image> --version` once per
+  image per agent process and caching the result.
+- The image entrypoint accepts `bootstrap` as its arguments and ends up
+  running `buildkite-agent bootstrap`. The official `buildkite/agent` image
+  does: `buildkite-agent-entrypoint` runs `/docker-entrypoint.d`, then
+  `exec tini -- ssh-env-config.sh buildkite-agent "$@"`. The executor does not
+  override the entrypoint for the job container, so those wrappers keep
+  working. (`--init` is redundant when the image already runs tini, and
+  harmless.)
+- Contains everything bootstrap needs for the whole job: git, bash (or the
+  configured `shell`), ssh if repositories use it, plus whatever hooks and
+  plugins call.
 
-Some images will assume `root` or expect a named user and writable home directory, so the design should allow a future explicit override such as `executor-docker-user`, but root should not be the default.
+### Relationship to the docker-buildkite-plugin
 
-### Cancellation and cleanup
+The plugin runs one step's command in a container chosen in pipeline YAML;
+checkout, hooks, and plugin setup still run on the host. The executor is agent
+configuration and runs all of bootstrap in the container. They compose: a step
+may still use the plugin inside an agent that uses the Docker executor,
+provided the socket is exposed.
 
-Do not rely on signal proxying from the `docker run` CLI alone.
+## Kubernetes
 
-The Docker executor should own container lifecycle explicitly:
+`kubernetes.Runner` already implements the interface. Wrapping it changes no
+behaviour. The Kubernetes stack is not a generic sandbox launcher: the pod
+shape is created outside the agent, the agent coordinates several containers
+over a socket, and `kubernetes-bootstrap` is the container-side protocol. Keep
+calling it what it is.
 
-- `Interrupt()` should call `docker stop --signal <cancel-signal> --time <grace-seconds> <name>`
-- `Terminate()` should call `docker kill <name>` followed by forced removal if needed
-- `Cleanup()` should remove any named container still present
+If Kubernetes later becomes a first-class executor that the agent drives
+itself, sandbox choice belongs in `runtimeClassName` and pod settings, not in
+separate top-level executors per runtime.
 
-The attached `docker run` process can still be used for log streaming and exit status, but container lifecycle should be controlled directly by the executor.
+## Delivery slices
 
-### How this differs from the Docker Buildkite Plugin
-
-This proposal is also distinct from the `docker-buildkite-plugin`.
-
-That plugin runs a pipeline step command in Docker and provides step-level controls such as:
-
-- required `image`
-- environment propagation
-- volume mounts
-- optional checkout mounting behavior
-
-By contrast, the proposed Docker executor is an agent-level execution backend.
-
-Key differences:
-
-- the plugin is configured in pipeline YAML per step; the executor is configured on the agent in `buildkite-agent.cfg` or equivalent agent config
-- the plugin wraps the step command; the executor runs the full `buildkite-agent bootstrap` lifecycle in Docker
-- with the plugin, checkout, hooks, plugin setup, and artifact handling still fundamentally belong to the host-side bootstrap flow; with the executor, those phases run inside the selected execution backend
-- the plugin is a build-step tool; the executor is part of the agent’s job runtime model
-
-The two solve different problems:
-
-- the plugin is primarily for step-level toolchain and environment control
-- the executor is for choosing where a job runs and establishing a future path to broader sandbox providers
-
-## Kubernetes Direction
-
-Keep this brief in the initial proposal:
-
-- current `kubernetes-exec` support already maps naturally to a driver implementation
-- if Kubernetes becomes a first-class executor later, it should be modeled as `executor=kubernetes`
-- sandbox choice on Kubernetes should usually be expressed through runtime and Pod settings such as `runtimeClassName`, not separate top-level executors for each sandbox runtime
-
-In practice:
-
-- local Docker on a host is a distinct execution backend
-- Firecracker or Kata on Kubernetes is usually a Kubernetes backend plus a runtime profile
-
-## Why this belongs in the agent, not inside bootstrap
-
-The bootstrap only knows how to run job phases after it has already started.
-
-The choice between:
-
-- run locally
-- run in Docker
-- run in Firecracker
-- run via a remote provider
-
-has to happen before bootstrap starts, because it changes:
-
-- where stdout and stderr come from
-- how signals are delivered
-- how filesystem paths are mounted or mapped
-- how cleanup is performed
-- which process or sandbox exit status we report upstream
-
-That makes `agent/job_runner.go` the correct layer for the abstraction.
-
-## Simplest Path There
-
-### Phase 1: Extract the current behavior behind an interface
-
-- Add the new executor interface in the agent layer.
-- Implement `execExecutor`.
-- Replace the local `process.New(...)` branch in `NewJobRunner` with the executor.
-- Keep Kubernetes behavior as-is or wrap it behind the same interface without changing config semantics.
-
-This is mostly refactoring and should not change behavior.
-
-### Phase 2: Add opt-in Docker support
-
-- Add `executor=docker` and the small Docker config surface.
-- Implement `dockerExecutor`.
-- Keep `buildkite-agent bootstrap` unchanged.
-- Start Linux-only.
-
-This delivers the user-visible feature while keeping the blast radius small.
-
-### Phase 3: Broaden the interface if needed
-
-After `exec` and `docker` exist, decide whether to:
-
-- move `kubernetes-exec` behind the same driver factory while keeping the old flag as a compatibility alias
-- add a Kubernetes executor with runtime-class-driven sandbox selection
-- add a Firecracker executor only for non-Kubernetes environments where the agent provisions the VM directly
-- add a generic provider registry or plugin model
-
-The important point is that phase 1 and phase 2 should not wait on phase 3.
+1. **Extract the interface.** Introduce `JobExecutor`/`JobExecution` in
+   `agent/`, implement `execExecution` and wrap `kubernetes.Runner`, replace
+   the branch in `NewJobRunner` with a selector, move the `*kubernetes.Runner`
+   assertion behind an optional interface. No config changes; existing tests
+   pass unchanged; add a selection test.
+2. **Docker, minimum viable.** `executor`, `executor-docker-image`,
+   `executor-docker-arg`, `executor-docker-home`. `create`/`start`/`inspect`
+   lifecycle, `--env KEY`, the mount table above, uid inheritance, `--init`,
+   `no-new-privileges`. Linux only; error out on other platforms.
+3. **Follow-ups if needed.** `executor-docker-expose-socket`,
+   `executor-docker-user`, version check caching, `executor=kubernetes-exec`
+   alias.
 
 ## Testing
 
-### Phase 1
+Slice 1:
 
-- unit tests for executor selection
-- parity tests showing `exec` builds the same process config as today
-- existing `agent` and bootstrap tests should continue to pass unchanged
+- Table test for executor selection.
+- Parity test: `execExecution` produces the same `process.Config` as the
+  current code for a fixed `JobRunnerConfig`.
 
-### Phase 2
+Slice 2:
 
-- unit tests for Docker CLI argument construction
-- unit tests for mount generation from `AgentConfiguration`
-- tests for cancellation mapping to `docker stop` and `docker kill`
-- integration-style tests using mocked `docker` binaries, similar to existing command-phase Docker tests in `internal/job/integration/docker_integration_test.go`
+- Unit tests for `docker create` argv construction from `AgentConfiguration`:
+  env names, mount table, uid flags, `--init`, `HOME`.
+- Unit tests that `Interrupt`/`Terminate`/`Cleanup` issue the expected
+  `docker kill`/`docker rm` invocations, and that the SIGKILL downgrade is
+  applied.
+- Exit mapping tests: a `docker start` failure yields `Run` error; a
+  container exit code from `inspect` becomes `WaitStatus`; `docker`'s own 125
+  is never reported as the job exit status.
+- An integration test with a fake `docker` binary on `PATH` that records its
+  argv and exits with a scripted status, in the style of the existing
+  `internal/job/integration` fakes.
 
-## Risks and tradeoffs
+## Risks
 
-- Docker isolation is incomplete. This should be presented as a better boundary than host `exec`, not as a complete hostile-build solution.
-- Path-preserving bind mounts are pragmatic, but they leak more host structure into the container than a stricter sandbox would.
-- Requiring an explicit Docker image in the MVP is slightly less convenient, but it avoids hidden version drift rules.
-- There is naming collision with `internal/job.Executor`. Internally we should prefer names like `JobExecutor`, `ExecutionBackend`, or `JobExecution` at the agent layer.
-
-## Recommendation
-
-Land this as an agent-side abstraction in two changes:
-
-1. Refactor the current local subprocess path into `execExecutor` with no behavior change.
-2. Add an opt-in `dockerExecutor` that runs the full bootstrap inside a container.
-
-Then evaluate Kubernetes as the next top-level executor, with sandbox flavor controlled by runtime and Pod settings.
-
-That gives us a clean, minimal abstraction now, solves the concrete Docker use case, and creates a real extension point for Firecracker and other sandbox providers later without forcing Kubernetes-specific runtime choices into the wrong layer.
+- Docker is a weaker boundary than a VM. Present it as better than host
+  `exec`, not as safe for untrusted builds.
+- Path-preserving bind mounts leak host layout into the container. Accepted
+  for compatibility with existing hooks and plugin caches.
+- A bad `executor-docker-image` (missing tools, wrong agent version) fails
+  every job on the agent. The version check catches only the second case.
+- Naming: `internal/job.Executor` already exists and means "bootstrap runtime".
+  Use `JobExecutor`/`JobExecution` at the agent layer and do not shorten them.

--- a/docs/proposals/job-executor-abstraction.md
+++ b/docs/proposals/job-executor-abstraction.md
@@ -65,7 +65,8 @@ the command phase and is not related to this proposal.
 
 ## Non-goals
 
-- Changing bootstrap phases in `internal/job`.
+- Changing bootstrap phases in `internal/job`. The only bootstrap change is
+  a new way to receive its environment (`BUILDKITE_BOOTSTRAP_ENV_JSON_FILE`).
 - Removing `bootstrap-script`.
 - Full hostile-build isolation. Docker still shares the kernel and, by default,
   the host network.
@@ -121,8 +122,14 @@ bootstrap is launched; bootstrap only exists after that decision.
 ```text
 if --kubernetes-exec      -> kubernetes execution (wraps kubernetes.Runner)
 else if executor=docker   -> docker execution
-else                      -> exec execution
+else if executor=exec     -> exec execution
+else if executor unset    -> exec execution
+else                      -> agent start fails: unknown executor
 ```
+
+An unset `executor` means `exec`. Any other explicit value is rejected at
+startup, so a typo such as `executor=dokcer` cannot fail open to running jobs
+on the host.
 
 `--kubernetes-exec` stays authoritative so `agent-stack-k8s` users see no
 change. Folding it into `executor=kubernetes-exec` as an alias is a later,
@@ -161,26 +168,40 @@ no-op. This must be behaviour-preserving and lands first.
 ### Lifecycle
 
 Use `docker create` + `docker start --attach` rather than a single
-`docker run`, so the container has a name before anything can go wrong and so
-launch failures are separable from bootstrap exit codes.
+`docker run`, so the container has a known name from the moment it exists and
+so launch failures are separable from bootstrap exit codes.
 
 ```text
-New():        docker create --name buildkite-job-<jobid> <flags> <image> bootstrap
-Run():        docker start --attach buildkite-job-<jobid>   (stdout/stderr -> jobLogs)
+New():        validate config, compute the container name; no docker calls
+Run():        write the env file (below)
+              docker create --name buildkite-job-<jobid> <flags> <image> bootstrap
+              docker start --attach buildkite-job-<jobid>   (stdout/stderr -> jobLogs)
               on exit: docker inspect --format '{{.State.ExitCode}}' -> WaitStatus
 Interrupt():  docker kill --signal <cancel-signal> buildkite-job-<jobid>
 Terminate():  docker kill buildkite-job-<jobid>
 Cleanup():    docker rm --force buildkite-job-<jobid>   (ignore "no such container")
+              remove the env file
 ```
 
-- If `docker create` or `docker start` fails before the container runs, `Run`
-  returns an error. Do not surface the docker CLI's own 125/126/127 exit codes
-  as the job exit status: 125 collides with `job.ExitCodeSetupFailure`, which
-  `runJob` already rewrites to -1, and 126/127 would look like the user's
-  command failing.
+- `New` makes no docker calls. `NewJobRunner` calls it before `StartJob`, and
+  if `StartJob` fails the runner returns without running `cleanup`, so
+  anything created in `New` would be orphaned. Both `docker create` and
+  `docker start` happen inside `Run`, where `runJob` maps an error to exit -1
+  with `SignalReasonProcessRunError` and `cleanup` always runs afterwards.
+- Do not surface the docker CLI's own 125/126/127 exit codes as the job exit
+  status: 125 collides with `job.ExitCodeSetupFailure`, which `runJob` already
+  rewrites to -1, and 126/127 would look like the user's command failing.
+  `WaitStatus` comes only from `inspect` on a container that ran.
 - `Started()` closes when `docker start` has been spawned. That is early by a
   few hundred milliseconds, which only affects when log streaming and the
   cancellation poller begin; both tolerate that.
+- `Interrupt` and `Terminate` can be called before the container exists:
+  `JobRunner.Cancel` calls them whenever it runs, and the agent may be stopping
+  while `Run` is mid-`docker create`. Both record the request in the execution
+  and return nil if there is no container yet. `Run` checks the flag after
+  `docker create` returns; if set, it removes the container and returns an
+  error instead of starting it. Cancel before `Run` is already handled by
+  `JobRunner.Run` returning "job already cancelled before running".
 - `Interrupt` must be non-blocking. `docker stop --time N` is wrong here: it
   blocks for up to N seconds and then SIGKILLs, duplicating the grace period
   that `JobRunner.Cancel` already enforces before calling `Terminate`. The
@@ -196,17 +217,49 @@ Cleanup():    docker rm --force buildkite-job-<jobid>   (ignore "no such contain
 
 ### Environment
 
-Pass the resolved job env as `--env KEY` (name only) for every entry in the
-env slice. The `docker` CLI process inherits `os.Environ() + env` exactly as
-the `exec` bootstrap does today, so Docker reads the values from there. This
-avoids quoting problems with multi-line values and keeps values out of the
-`docker create` argv.
+Two environments are in play and they must not mix:
 
-`docker --env-file` is not an option: `BUILDKITE_ENV_FILE` is written with Go
-`%q` quoting for the pre-bootstrap hook to validate, and Docker's env-file
-parser does not unquote.
+- The **control process** environment: what the `docker create`, `start`,
+  `kill`, `rm`, and `inspect` subprocesses run with. This is the agent's own
+  `os.Environ()`, unmodified. Job env never enters it. A job that sets
+  `DOCKER_HOST`, `DOCKER_CONTEXT`, `DOCKER_CONFIG`, or `HOME` must not be able
+  to redirect the executor to another daemon or hide the agent user's
+  registry credentials.
+- The **container** environment: the resolved job env slice from
+  `createEnvironment` (job env plus the agent's `BUILDKITE_*` additions), with
+  the adjustments below. It deliberately excludes the host's `os.Environ()`:
+  `PATH`, `HOME`, and the like come from the image, not the host.
 
-Override or omit host-specific values before passing them through:
+Transport the container environment through a file, not through `docker`'s
+env flags:
+
+- `Run` writes `<job-context-dir>/job-exec-env-<jobid>.json` (mode 0600, a
+  single JSON object) before `docker create`, and `Cleanup` removes it. The
+  job context dir is already bind-mounted, so the path is the same on both
+  sides.
+- `docker create` passes exactly one env var:
+  `--env BUILDKITE_BOOTSTRAP_ENV_JSON_FILE=<path>`.
+- `buildkite-agent bootstrap` gains support for that variable: when set, it
+  loads the file's variables into its own environment before resolving the
+  rest of its configuration. This is the one bootstrap change in the
+  proposal. It mirrors `kubernetes-bootstrap`, which receives the env over
+  the socket and launches `bootstrap` with it.
+
+Why not the docker flags:
+
+- `--env KEY` (name only) makes Docker read values from the client process,
+  which means the job env would have to be in the control process
+  environment. That is the leak above.
+- `--env KEY=VALUE` puts every value, including
+  `BUILDKITE_AGENT_ACCESS_TOKEN`, in `docker create`'s argv, which is
+  world-readable via `/proc/<pid>/cmdline` for the life of the call.
+- `--env-file` cannot carry multi-line values, and `BUILDKITE_COMMAND` is
+  routinely multi-line. Reusing `BUILDKITE_ENV_FILE` is also out: it is
+  `%q`-quoted for the pre-bootstrap hook, Docker's parser does not unquote,
+  and it intentionally omits agent-added variables such as the access token
+  and the OTLP exporter credentials.
+
+Adjust these before writing the file:
 
 - `BUILDKITE_BIN_PATH`: set to empty. Bootstrap appends it to `PATH`; the
   host path is meaningless in the container and the image must already have
@@ -259,6 +312,13 @@ one agent.
 - On Linux, when the agent is not running as root, run the container with
   `--user <uid>:<gid>` matching the agent process and mount `/etc/passwd` and
   `/etc/group` read-only so the uid resolves to a name.
+- Pass `--group-add <gid>` for every supplementary group of the agent process
+  (`os.Getgroups()`). `--user` sets only the primary group, and mounting
+  `/etc/group` provides names, not memberships. Without this, anything the
+  agent reaches through a supplementary group breaks in the container: most
+  visibly `/var/run/docker.sock` via the `docker` group when
+  `executor-docker-expose-socket` is on, and any group-writable build, plugin,
+  or mirror directory.
 - Always set `--security-opt no-new-privileges`.
 - Do not mount the Docker socket by default.
 
@@ -321,11 +381,15 @@ separate top-level executors per runtime.
    the branch in `NewJobRunner` with a selector, move the `*kubernetes.Runner`
    assertion behind an optional interface. No config changes; existing tests
    pass unchanged; add a selection test.
-2. **Docker, minimum viable.** `executor`, `executor-docker-image`,
-   `executor-docker-arg`, `executor-docker-home`. `create`/`start`/`inspect`
-   lifecycle, `--env KEY`, the mount table above, uid inheritance, `--init`,
+2. **Bootstrap env file.** `buildkite-agent bootstrap` honours
+   `BUILDKITE_BOOTSTRAP_ENV_JSON_FILE`. Small, independently testable, and
+   useful on its own for anyone wrapping bootstrap.
+3. **Docker, minimum viable.** `executor` with strict value validation,
+   `executor-docker-image`, `executor-docker-arg`, `executor-docker-home`.
+   `create`/`start`/`inspect` lifecycle inside `Run`, env file transport, the
+   mount table above, uid inheritance with `--group-add`, `--init`,
    `no-new-privileges`. Linux only; error out on other platforms.
-3. **Follow-ups if needed.** `executor-docker-expose-socket`,
+4. **Follow-ups if needed.** `executor-docker-expose-socket`,
    `executor-docker-user`, version check caching, `executor=kubernetes-exec`
    alias.
 
@@ -333,20 +397,29 @@ separate top-level executors per runtime.
 
 Slice 1:
 
-- Table test for executor selection.
+- Table test for executor selection, including rejection of unknown values.
 - Parity test: `execExecution` produces the same `process.Config` as the
   current code for a fixed `JobRunnerConfig`.
 
 Slice 2:
 
+- Bootstrap loads a JSON env file with multi-line values and a value
+  containing `=`; a missing or unreadable file is a setup failure.
+
+Slice 3:
+
 - Unit tests for `docker create` argv construction from `AgentConfiguration`:
-  env names, mount table, uid flags, `--init`, `HOME`.
+  the single `--env`, mount table, `--user` and `--group-add` flags, `--init`.
+- The control process env passed to the fake `docker` is exactly the agent's
+  environment: a job env `DOCKER_HOST` must not appear in it, and must appear
+  in the env file.
 - Unit tests that `Interrupt`/`Terminate`/`Cleanup` issue the expected
-  `docker kill`/`docker rm` invocations, and that the SIGKILL downgrade is
-  applied.
-- Exit mapping tests: a `docker start` failure yields `Run` error; a
-  container exit code from `inspect` becomes `WaitStatus`; `docker`'s own 125
-  is never reported as the job exit status.
+  `docker kill`/`docker rm` invocations, that the SIGKILL downgrade is
+  applied, and that an interrupt during `docker create` removes the container
+  and makes `Run` return an error.
+- Exit mapping tests: a `docker create` or `docker start` failure yields
+  `Run` error; a container exit code from `inspect` becomes `WaitStatus`;
+  `docker`'s own 125 is never reported as the job exit status.
 - An integration test with a fake `docker` binary on `PATH` that records its
   argv and exits with a scripted status, in the style of the existing
   `internal/job/integration` fakes.

--- a/docs/proposals/job-executor-abstraction.md
+++ b/docs/proposals/job-executor-abstraction.md
@@ -217,7 +217,9 @@ Run():        write the env file (below); close Started()
               -> if the container is still running: attach was lost; docker kill, return error
 Interrupt():  record "interrupt"; docker kill --signal <cancel-signal> <id> if running
 Terminate():  record "terminate";  docker kill <id> if running;
-              if that fails, kill the docker start subprocess so Run returns
+              if that fails, cancel Run's subprocess context (start + any inspect)
+              so Run returns
+(every inspect/kill/rm call has its own 10 s timeout; start --attach does not)
 Cleanup():    docker rm --force --volumes <id>   (ignore "no such container")
               remove the env file
 ```
@@ -294,10 +296,18 @@ Cleanup():    docker rm --force --volumes <id>   (ignore "no such container")
   already recorded, so `Cancel` proceeds to the grace period and `Terminate`
   retries with `docker kill` (SIGKILL), and `Cleanup` finishes with
   `rm --force --volumes` regardless. If `Terminate`'s `docker kill` also
-  fails, `Terminate` kills the `docker start --attach` subprocess directly so
-  `Run` returns an error instead of waiting on a daemon that is not
+  fails, `Terminate` cancels the context that `Run` derives for all of its
+  subprocesses, so `docker start --attach` and any in-flight `inspect` exit
+  and `Run` returns an error instead of waiting on a daemon that is not
   responding; the container may be leaked at that point and `Cleanup` reports
   it if `rm --force` fails too (see Risks).
+- Every control command other than `start --attach` runs under its own short
+  timeout (10 s) in addition to `Run`'s context: the readiness-poll
+  `inspect`s, the final `inspect`, `kill`, and `rm`. Only `start --attach` is
+  unbounded, because it lives as long as the job. An `inspect` that times out
+  is an executor failure: `Run` attempts `docker kill`, then returns an error.
+  Without this, a daemon that stops answering mid-poll would leave `Run`
+  blocked in `inspect` where killing `start` alone would not free it.
 - Apply the same SIGKILL→SIGTERM downgrade as `exec`. A SIGKILL to bootstrap
   skips pre-exit hooks and loses the command's exit status.
 - Pass `--init` so something reaps orphaned grandchildren left behind by
@@ -527,13 +537,15 @@ them under that path via `executor-docker-arg`.
   `BUILDKITE_BOOTSTRAP_ENV_JSON_FILE`. A major-version match is not enough:
   an older image of the same major would ignore the variable and run
   bootstrap with no job configuration. `agent start` enforces this once,
-  after config validation and before registering: `docker pull <image>`, then
-  `docker run --rm --entrypoint buildkite-agent <image> --version`, under a
-  single bounded context (2 minutes; `docker pull` dominates), failing agent
-  start on a version below the minimum, a non-zero exit, or timeout. It then
-  records the image ID (`docker image inspect --format '{{.Id}}'`) and every
-  `docker create` uses that ID rather than the tag, so a tag moving under a
-  running agent cannot swap in an unchecked image. This keeps Docker calls
+  after config validation and before registering, under a single bounded
+  context (2 minutes; `docker pull` dominates): `docker pull <image>`, then
+  `docker image inspect --format '{{.Id}}' <image>` to resolve the tag to an
+  ID exactly once, then `docker run --rm --entrypoint buildkite-agent <id>
+  --version` against that ID. Agent start fails on a version below the
+  minimum, a non-zero exit, or timeout. The checked ID is retained and every
+  `docker create` uses it rather than the tag, so a tag moving under a
+  running agent, or between the check and the first job, cannot swap in an
+  unchecked image. This keeps Docker calls
   out of `New` (which would orphan work if `StartJob` failed) and out of
   `Run`'s cancellation path, and means the pull that would otherwise happen
   on the first job happens before the agent accepts one.
@@ -631,10 +643,14 @@ and exits with a scripted status, in the style of the existing
   name-only `--env` flags, and are present in the fake `docker create`'s
   environment but not in `start`/`kill`/`rm`/`inspect`'s. With a job-supplied
   OTLP destination they are in the env file and not in the control env.
-- `agent start` with `executor=docker` runs `pull`, `run --version`, and
-  `image inspect` against the fake, fails start on a too-old version, a
-  non-zero exit, or a fake that sleeps past the timeout, and the recorded
-  image ID (not the tag) is what `docker create` receives.
+- `agent start` with `executor=docker` runs `pull`, then `image inspect`,
+  then `run --version` against the fake, in that order; the ID from `image
+  inspect` is what `run --version` and later `docker create` receive, not the
+  tag. Start fails on a too-old version, a non-zero exit, or a fake that
+  sleeps past the timeout.
+- A fake `docker inspect` that hangs makes `Run` return an error within the
+  per-call timeout (after a `docker kill` attempt); `Terminate` during a
+  hanging `inspect` or `start` makes `Run` return promptly.
 - `Interrupt`/`Terminate`/`Cleanup` issue the expected `docker kill`/`docker
   rm --force --volumes` invocations against the container ID, the SIGKILL
   downgrade is applied, an interrupt during a (fake, slow) `docker create`
@@ -684,10 +700,11 @@ with `VOLUME`.
   a `docker image prune` while the agent is running also fails every job
   ("No such image") until the agent is restarted; the error message names
   the fix.
-- An unresponsive Docker daemon can leak a container. `kill` and `rm` are
-  bounded by short timeouts and `Terminate` can always unblock `Run` by
-  killing the `docker start` client, so the agent slot is freed, but the
-  container itself may keep running until the daemon recovers. The labels
-  exist so an operator can sweep these; `exec` has no equivalent failure mode.
+- An unresponsive Docker daemon can leak a container. Every control command
+  except `start --attach` has a short timeout, and `Terminate` can cancel
+  `Run`'s subprocess context, so `Run` always returns and the agent slot is
+  freed, but the container itself may keep running until the daemon recovers.
+  The labels exist so an operator can sweep these; `exec` has no equivalent
+  failure mode.
 - Naming: `internal/job.Executor` already exists and means "bootstrap runtime".
   Use `JobExecutor`/`JobExecution` at the agent layer and do not shorten them.

--- a/docs/proposals/job-executor-abstraction.md
+++ b/docs/proposals/job-executor-abstraction.md
@@ -65,11 +65,11 @@ the command phase and is not related to this proposal.
 
 ## Non-goals
 
-- Changing bootstrap phases in `internal/job`. The only bootstrap change is
-  a new way to receive its environment (`BUILDKITE_BOOTSTRAP_ENV_JSON_FILE`).
+- Changing bootstrap phases in `internal/job`. The only bootstrap-side change
+  is a new way to receive its environment (`BUILDKITE_BOOTSTRAP_ENV_JSON_FILE`).
 - Removing `bootstrap-script`.
-- Full hostile-build isolation. Docker still shares the kernel and, by default,
-  the host network.
+- Full hostile-build isolation. Docker still shares the kernel, and the MVP
+  uses Docker's default bridge network.
 - Changing `--kubernetes-exec` config or the `kubernetes-bootstrap` protocol.
 
 ## Proposal
@@ -99,39 +99,52 @@ type JobExecution interface {
 `JobExecutionRequest` carries what `NewJobRunner` already computes:
 
 - `Job` and `AgentConfiguration`
-- the resolved job env slice (the output of `createEnvironment`)
+- the job env slice (the output of `createEnvironment`), *without* the host
+  `os.Environ()`. Today `NewJobRunner` computes
+  `processEnv := append(os.Environ(), env...)` and hands it to both the exec
+  and Kubernetes branches; those two executions keep doing that prepend
+  themselves. Docker does not.
 - the job context directory (`jobContextDir(conf)`), which holds
   `BUILDKITE_ENV_FILE`, `BUILDKITE_ENV_JSON_FILE`, and the job-timeout marker
 - the stdout/stderr writer (`r.jobLogs`)
 - `CancelSignal` and `CancelSignalTimeout`
 
-`Run` returning an error means "the job never started"; `runJob` already maps
-that to exit -1 with `SignalReasonProcessRunError`. Backends must use that
-channel for launch failures rather than inventing an exit code.
+`Run` returning an error means "the executor failed and there is no
+trustworthy job result"; `runJob` already maps that to exit -1 with
+`SignalReasonProcessRunError`. Backends must use that channel for launch and
+control-plane failures rather than inventing an exit code. It does not
+guarantee the job had no side effects: the Kubernetes runner already returns
+errors after containers have started, and Docker can lose its attach after
+bootstrap has started.
 
-`runJob` currently type-asserts `r.process.(*kubernetes.Runner)` to print
-"unknown container exit status" diagnostics. Move that behind an optional
-interface (`ExplainExit(w io.Writer)` or similar) implemented by the
-Kubernetes execution so `JobRunner` stops naming a concrete backend.
+`runJob` type-asserts `r.process.(*kubernetes.Runner)` to print "unknown
+container exit status" diagnostics, gated on `r.cancelled` and
+`r.agentStopping`. Slice 1 leaves that assertion alone. Hiding it behind an
+optional interface is possible later, but the method needs the runner's
+cancelled/stopping state as input, so it is not a pure win and is not required
+for a third backend.
 
 The interface lives in `agent/`, not `internal/job`, because it decides how
 bootstrap is launched; bootstrap only exists after that decision.
 
 ### Selection
 
+Validate the resolved configuration (flags, env vars, and `buildkite-agent.cfg`
+combined) at agent start, then select:
+
 ```text
-if --kubernetes-exec      -> kubernetes execution (wraps kubernetes.Runner)
-else if executor=docker   -> docker execution
-else if executor=exec     -> exec execution
-else if executor unset    -> exec execution
-else                      -> agent start fails: unknown executor
+executor not in {unset, exec, docker}       -> agent start fails: unknown executor
+--kubernetes-exec and executor=docker        -> agent start fails: conflicting executors
+--kubernetes-exec                            -> kubernetes execution (wraps kubernetes.Runner)
+executor=docker                              -> docker execution
+otherwise                                    -> exec execution
 ```
 
-An unset `executor` means `exec`. Any other explicit value is rejected at
-startup, so a typo such as `executor=dokcer` cannot fail open to running jobs
-on the host.
+An unset `executor` means `exec`. Any other value is rejected before anything
+else is considered, so a typo such as `executor=dokcer` cannot fail open to
+running jobs on the host, with or without `--kubernetes-exec`.
 
-`--kubernetes-exec` stays authoritative so `agent-stack-k8s` users see no
+`--kubernetes-exec` stays a separate flag so `agent-stack-k8s` users see no
 change. Folding it into `executor=kubernetes-exec` as an alias is a later,
 optional step.
 
@@ -144,14 +157,19 @@ New `buildkite-agent start` settings, available as flags, env vars, and
 |---|---|---|
 | `executor` | `exec` (default), `docker` | |
 | `executor-docker-image` | image ref | required when `executor=docker` |
-| `executor-docker-arg` | repeatable | extra `docker run`/`docker create` flags; escape hatch |
-| `executor-docker-expose-socket` | bool, default `false` | mounts `/var/run/docker.sock` |
-| `executor-docker-home` | path, default `/tmp/buildkite-home` | `$HOME` inside the container; see below |
+| `executor-docker-arg` | repeatable | extra `docker create` flags; escape hatch |
+| `executor-docker-expose-socket` | bool, default `false` | mounts `/var/run/docker.sock`; follow-up, not MVP |
 
 Rules:
 
 - `bootstrap-script` is used only by `exec`. If `executor=docker` and
   `bootstrap-script` was set explicitly, log a warning and ignore it.
+- `executor-docker-arg` may not override what the executor owns. Reject
+  `--rm` (defeats `inspect`), `--restart` other than `no` (defeats "one
+  ephemeral execution"), `--name`, `--user`, `--env BUILDKITE_BOOTSTRAP_ENV_JSON_FILE`,
+  and mounts targeting the job context directory.
+- `$HOME` in the container is fixed at `/tmp/buildkite-home` for the MVP (see
+  the user model below). A setting can follow if anyone needs to move it.
 - The image is an agent-pool decision. Users who need different images run
   different queues.
 
@@ -168,18 +186,25 @@ no-op. This must be behaviour-preserving and lands first.
 ### Lifecycle
 
 Use `docker create` + `docker start --attach` rather than a single
-`docker run`, so the container has a known name from the moment it exists and
+`docker run`, so the container exists with a known identity before it runs and
 so launch failures are separable from bootstrap exit codes.
 
 ```text
-New():        validate config, compute the container name; no docker calls
+New():        validate config; no docker calls
 Run():        write the env file (below)
-              docker create --name buildkite-job-<jobid> <flags> <image> bootstrap
-              docker start --attach buildkite-job-<jobid>   (stdout/stderr -> jobLogs)
-              on exit: docker inspect --format '{{.State.ExitCode}}' -> WaitStatus
-Interrupt():  docker kill --signal <cancel-signal> buildkite-job-<jobid>
-Terminate():  docker kill buildkite-job-<jobid>
-Cleanup():    docker rm --force buildkite-job-<jobid>   (ignore "no such container")
+              docker create --name buildkite-job-<jobid>-<random> \
+                --label com.buildkite.job-id=<jobid> --label com.buildkite.agent-run=<run-id> \
+                <flags> <image> bootstrap
+              -> record the container ID printed by create; every later call uses the ID
+              spawn docker start --attach <id>   (stdout/stderr -> jobLogs); close Started()
+              poll docker inspect <id> until State.Status is running or a terminal state;
+              deliver any pending signal
+              wait for docker start to exit, then docker inspect <id> -> State
+              -> if State is terminal: WaitStatus = State.ExitCode
+              -> if the container is still running: attach was lost; docker kill, return error
+Interrupt():  record "interrupt"; docker kill --signal <cancel-signal> <id> if running
+Terminate():  record "terminate";  docker kill <id> if running
+Cleanup():    docker rm --force --volumes <id>   (ignore "no such container")
               remove the env file
 ```
 
@@ -188,32 +213,80 @@ Cleanup():    docker rm --force buildkite-job-<jobid>   (ignore "no such contain
   anything created in `New` would be orphaned. Both `docker create` and
   `docker start` happen inside `Run`, where `runJob` maps an error to exit -1
   with `SignalReasonProcessRunError` and `cleanup` always runs afterwards.
+- The execution only ever kills or removes the container ID that its own
+  `docker create` returned. The name carries a random suffix so a stale
+  container from a crashed agent cannot make `create` fail with a name clash,
+  and cleanup-by-name cannot remove something this execution did not create.
+  The labels are for operators sweeping leftovers.
+- `docker start --attach` exiting is not the same as the container exiting.
+  The CLI returns non-zero both for a non-zero container exit and for losing
+  its connection to the daemon while the container keeps running. Always
+  `inspect` after `start` returns and branch on `State.Status`, not on the
+  CLI's exit code. `WaitStatus` comes only from a container in a terminal
+  state. A still-running container after `start` returns is an executor
+  failure: kill it and return an error from `Run`.
 - Do not surface the docker CLI's own 125/126/127 exit codes as the job exit
   status: 125 collides with `job.ExitCodeSetupFailure`, which `runJob` already
-  rewrites to -1, and 126/127 would look like the user's command failing.
-  `WaitStatus` comes only from `inspect` on a container that ran.
-- `Started()` closes when `docker start` has been spawned. That is early by a
-  few hundred milliseconds, which only affects when log streaming and the
-  cancellation poller begin; both tolerate that.
-- `Interrupt` and `Terminate` can be called before the container exists:
-  `JobRunner.Cancel` calls them whenever it runs, and the agent may be stopping
-  while `Run` is mid-`docker create`. Both record the request in the execution
-  and return nil if there is no container yet. `Run` checks the flag after
-  `docker create` returns; if set, it removes the container and returns an
-  error instead of starting it. Cancel before `Run` is already handled by
-  `JobRunner.Run` returning "job already cancelled before running".
-- `Interrupt` must be non-blocking. `docker stop --time N` is wrong here: it
+  rewrites to -1, and 126/127 would look like the user's command failing. A
+  bootstrap that itself exits 125 inside the container still reaches `runJob`
+  via `inspect` and is mapped to -1 as today.
+- `Started()` closes as soon as `docker start` has been spawned, not when the
+  container is observed running. Log streaming and the cancellation poller in
+  `JobRunner` wait on `Started()`, and a slow image pull or a hung daemon must
+  stay cancellable. Container readiness is tracked privately for signal
+  delivery.
+- `Interrupt` and `Terminate` can be called at any point: `JobRunner.Cancel`
+  calls them whenever it runs, including while `Run` is mid-`docker create`
+  or before the container is running. `docker kill` on a container that is
+  created but not yet running fails, and `Cancel` returns early on an
+  `Interrupt` error without ever reaching `Terminate`. So the execution keeps
+  a mutex-protected pending state (`none → interrupt → terminate`,
+  monotonic), records the request first, and only issues `docker kill` once
+  it has observed the container running. `Run` checks the state after
+  `docker create` (remove the container, return an error) and again once the
+  readiness poll sees `running` (deliver the recorded signal). Interrupt must
+  succeed at most once per container: bootstrap removes its signal handler
+  after the first signal, so a repeated SIGTERM would bypass its cleanup.
+  Cancel before `Run` is already handled by `JobRunner.Run` returning "job
+  already cancelled before running".
+- `Interrupt` must return promptly. `docker stop --time N` is wrong here: it
   blocks for up to N seconds and then SIGKILLs, duplicating the grace period
   that `JobRunner.Cancel` already enforces before calling `Terminate`. The
-  agent, not Docker, owns the timing.
+  agent, not Docker, owns the timing. Run `docker kill` with a short timeout
+  so a hung daemon cannot wedge `Cancel`.
 - Apply the same SIGKILL→SIGTERM downgrade as `exec`. A SIGKILL to bootstrap
   skips pre-exit hooks and loses the command's exit status.
-- Pass `--init`. Bootstrap is PID 1 in the container and Go does not reap
-  orphaned grandchildren left behind by hooks and shells.
+- Pass `--init` so something reaps orphaned grandchildren left behind by
+  hooks and shells; Go does not. Bootstrap is then a child of `docker-init`,
+  not PID 1. `docker-init` forwards signals and maps a signalled child to
+  `128+signal`.
+- Pass `--workdir <build-path>`. `exec` sets `process.Config.Dir` to
+  `BuildPath` and bootstrap's shell starts in the process cwd; a bind mount
+  alone does not set it.
+- Pass `--tty` when `run-in-pty` is on. `docker create --tty` followed by
+  `docker start --attach` (no `--interactive`) works with a non-TTY agent
+  stdin and merges stdout/stderr, which matches the shared `jobLogs` writer.
+  This allocates the PTY inside the container; it is not identical to the
+  host PTY `process` sets up (`TERM`, fixed window size). Bootstrap's own
+  `BUILDKITE_PTY` for the commands it runs is unaffected.
+- Exit status is the raw container exit code with `Signaled() == false`, the
+  same shape `kubernetes.Runner` uses. Docker does not report the signal
+  separately, and inferring one from `128+n` would misreport a command that
+  exits 137 on purpose. `exit.Signal` is therefore empty for Docker jobs where
+  `exec` reports `SIGTERM`/`SIGKILL`; `SignalReason` (cancel, agent stop) is
+  unaffected because `runJob` derives it from runner state.
 - Job-level timeouts work unchanged: `Cancel` writes the marker file into the
   job context directory before signalling, and bootstrap reads it via
   `BUILDKITE_AGENT_JOB_TIMEOUT_FILE`. This requires the context directory to
   be a live bind mount (below), not a copy taken at `docker create` time.
+- `Cleanup` uses `--volumes`: the official image declares `VOLUME /buildkite`,
+  so every `create` allocates an anonymous volume that `docker rm --force`
+  alone leaves behind. Named volumes and bind mounts are unaffected.
+- `JobRunner.cleanup` must call `Cleanup` before it removes the env files and
+  before `FinishJob` (which can hand the agent its next job), with a bounded
+  context derived from `context.WithoutCancel` so a cancelled job still gets
+  its container removed. Cleanup failures are logged at error level: a leaked
+  container holds the build directory and the env file.
 
 ### Environment
 
@@ -228,22 +301,41 @@ Two environments are in play and they must not mix:
 - The **container** environment: the resolved job env slice from
   `createEnvironment` (job env plus the agent's `BUILDKITE_*` additions), with
   the adjustments below. It deliberately excludes the host's `os.Environ()`:
-  `PATH`, `HOME`, and the like come from the image, not the host.
+  `PATH`, `HOME`, and the like come from the image, not the host. So do proxy
+  settings: an operator whose host agent relies on `HTTP_PROXY` passes it via
+  `executor-docker-arg --env HTTP_PROXY=...`.
 
 Transport the container environment through a file, not through `docker`'s
 env flags:
 
 - `Run` writes `<job-context-dir>/job-exec-env-<jobid>.json` (mode 0600, a
-  single JSON object) before `docker create`, and `Cleanup` removes it. The
-  job context dir is already bind-mounted, so the path is the same on both
-  sides.
+  single JSON object) before `docker create`, and `Cleanup` removes it. Create
+  it with `O_CREATE|O_EXCL` (or `os.CreateTemp`, as `createJobEnvFiles`
+  already does) so a pre-existing path or symlink is never followed. The job
+  context dir is already bind-mounted, so the path is the same on both sides.
 - `docker create` passes exactly one env var:
   `--env BUILDKITE_BOOTSTRAP_ENV_JSON_FILE=<path>`.
-- `buildkite-agent bootstrap` gains support for that variable: when set, it
-  loads the file's variables into its own environment before resolving the
-  rest of its configuration. This is the one bootstrap change in the
-  proposal. It mirrors `kubernetes-bootstrap`, which receives the env over
-  the socket and launches `bootstrap` with it.
+- `buildkite-agent bootstrap` honours that variable. The loading has to
+  happen before urfave/cli parses flags: `cli.EnvVars` sources are read
+  during parsing, ahead of any `Before` hook or the `Action`, so nothing
+  inside the `bootstrap` command runs early enough. `main` therefore calls a
+  small `clicommand` helper before `app.Run` that, when the variable is set,
+  reads the whole JSON object, applies it over the process environment with
+  `os.Setenv`, and
+  unsets `BUILDKITE_BOOTSTRAP_ENV_JSON_FILE` so hooks and the
+  `buildkite-agent` subcommands they run never see it (the JSON may not set
+  that key). Explicit flags still win over env, as they do today. A missing,
+  unreadable, or malformed file exits with `job.ExitCodeSetupFailure` (125),
+  which `runJob` maps to -1. This is the only bootstrap-side change. Options
+  considered and rejected: re-`exec`ing bootstrap after loading (a second
+  CLI parse, and it cannot rescue a first parse that already failed on a bad
+  image env), and a `docker-bootstrap` launcher command like
+  `kubernetes-bootstrap` (a second process plus signal forwarding for no
+  protocol gain).
+- Anything the image runs before `buildkite-agent bootstrap`, such as the
+  official image's `/docker-entrypoint.d` scripts and `ssh-env-config.sh`,
+  sees only the container environment above, not the job env. Setup that
+  depends on job variables belongs in `environment` or `pre-checkout` hooks.
 
 Why not the docker flags:
 
@@ -265,8 +357,10 @@ Adjust these before writing the file:
   host path is meaningless in the container and the image must already have
   `buildkite-agent` on `PATH`. (`kubernetes-bootstrap` resolves the same
   problem by recomputing it from `os.Executable`.)
-- `BUILDKITE_AGENT_PID`: omit.
-- `HOME`: set to `executor-docker-home`. See the user model below.
+- `BUILDKITE_AGENT_PID`: omit. Nothing in the job uses it; `buildkite-agent
+  lock` talks to the leader socket, not the PID.
+- `BUILDKITE_CONFIG_PATH`: omit. The agent config file is not mounted (below).
+- `HOME`: set to `/tmp/buildkite-home`. See the user model below.
 
 ### Mounts
 
@@ -281,9 +375,26 @@ or plugins needs to learn a new filesystem layout:
 | `sockets-path` | rw |
 | job context dir (`--job-context-dir`, default `os.TempDir()`) | rw |
 | `hooks-path`, each `additional-hooks-paths` entry | ro |
-| `config-path`, `signing-jwks-file` (when set) | ro |
-| `/etc/passwd`, `/etc/group` (when not running as root) | ro |
+| `signing-jwks-file` (when set) | ro |
+| `/etc/passwd`, `/etc/group` | ro |
 | `/var/run/docker.sock` (only when `executor-docker-expose-socket`) | rw |
+
+Before `docker create`, the execution creates every rw directory that does
+not yet exist, as the agent user, and checks that every file source exists.
+Agent start only guarantees `build-path` today; if Docker is left to create a
+missing bind source it does so as root, and a root-owned `plugins-path` or
+mirrors directory then fails the first job. All paths are passed absolute.
+
+`config-path` is deliberately not mounted. It is the agent's own
+configuration, which commonly holds the registration token, and bootstrap
+does not read it: everything it needs arrives through the environment. Hooks
+that read `BUILDKITE_CONFIG_PATH` on the host will not find it in the
+container; an operator who needs that mounts it via `executor-docker-arg`.
+
+The MVP assumes the Docker daemon sees the same filesystem and uid space as
+the agent process. An agent running in a container of its own with the
+daemon socket mounted, or a daemon with user namespace remapping, breaks the
+path-preserving and uid-preserving assumptions and is out of scope.
 
 The job context directory already exists as a concept:
 `--job-context-dir` / `BUILDKITE_JOB_CONTEXT_DIR` (added for the Kubernetes
@@ -309,9 +420,11 @@ one agent.
 
 ### User and privilege model
 
-- On Linux, when the agent is not running as root, run the container with
-  `--user <uid>:<gid>` matching the agent process and mount `/etc/passwd` and
-  `/etc/group` read-only so the uid resolves to a name.
+- Always pass `--user <uid>:<gid>` matching the agent process, including
+  `0:0` when the agent runs as root, and mount `/etc/passwd` and `/etc/group`
+  read-only so the uid resolves to a name. Never inherit the image's `USER`:
+  an image that drops to a non-root user could not read the root-owned 0600
+  env file, and one that runs as root would litter the build path.
 - Pass `--group-add <gid>` for every supplementary group of the agent process
   (`os.Getgroups()`). `--user` sets only the primary group, and mounting
   `/etc/group` provides names, not memberships. Without this, anything the
@@ -332,24 +445,32 @@ ignores: `$HOME` resolves to the host user's home directory, which does not
 exist in the image. The agent itself depends on a usable `$HOME`: the cache
 feature reads `os.UserHomeDir()` for its default store and for `~` expansion
 in cache paths, and git and ssh want somewhere writable. So the executor sets
-`HOME=<executor-docker-home>` and mounts a per-job tmpfs or empty directory
-there. Users who need ssh keys or git config inside the container mount them
-via `executor-docker-arg`.
+`HOME=/tmp/buildkite-home` and passes
+`--tmpfs /tmp/buildkite-home:uid=<uid>,gid=<gid>,mode=0700`; without the
+ownership options the tmpfs is root-owned and `HOME` is not writable for a
+non-root uid. Users who need ssh keys or git config inside the container mount
+them under that path via `executor-docker-arg`.
 
 ### Image contract
 
 - Linux image.
-- `buildkite-agent` on `PATH`, of a version compatible with the host agent.
-  Enforce at least a major-version match by running
-  `docker run --rm --entrypoint buildkite-agent <image> --version` once per
-  image per agent process and caching the result.
+- `buildkite-agent` on `PATH`, at a version that understands
+  `BUILDKITE_BOOTSTRAP_ENV_JSON_FILE`. A major-version match is not enough:
+  an older image of the same major would ignore the variable and run
+  bootstrap with no job configuration. Enforce a minimum version by running
+  `docker run --rm --entrypoint buildkite-agent <image> --version` before the
+  first job; caching the result per image per agent process is a follow-up.
 - The image entrypoint accepts `bootstrap` as its arguments and ends up
   running `buildkite-agent bootstrap`. The official `buildkite/agent` image
   does: `buildkite-agent-entrypoint` runs `/docker-entrypoint.d`, then
   `exec tini -- ssh-env-config.sh buildkite-agent "$@"`. The executor does not
   override the entrypoint for the job container, so those wrappers keep
-  working. (`--init` is redundant when the image already runs tini, and
-  harmless.)
+  working, but they run under the executor's `--user` with the container
+  environment only (see above). With `--init` the image's tini is no longer
+  PID 1 and logs a warning to that effect; it still forwards signals.
+- A container that started does not prove bootstrap started: an entrypoint
+  script failing exits the container with that script's status, and the
+  executor cannot tell the two apart.
 - Contains everything bootstrap needs for the whole job: git, bash (or the
   configured `shell`), ssh if repositories use it, plus whatever hooks and
   plugins call.
@@ -378,51 +499,69 @@ separate top-level executors per runtime.
 
 1. **Extract the interface.** Introduce `JobExecutor`/`JobExecution` in
    `agent/`, implement `execExecution` and wrap `kubernetes.Runner`, replace
-   the branch in `NewJobRunner` with a selector, move the `*kubernetes.Runner`
-   assertion behind an optional interface. No config changes; existing tests
-   pass unchanged; add a selection test.
-2. **Bootstrap env file.** `buildkite-agent bootstrap` honours
-   `BUILDKITE_BOOTSTRAP_ENV_JSON_FILE`. Small, independently testable, and
-   useful on its own for anyone wrapping bootstrap.
+   the branch in `NewJobRunner` with a selector, add the `Cleanup` call to
+   `JobRunner.cleanup`. Both existing executions keep prepending
+   `os.Environ()` exactly as today. No config changes; existing tests pass
+   unchanged; add a selection test.
+2. **Bootstrap env file.** `main` loads `BUILDKITE_BOOTSTRAP_ENV_JSON_FILE`
+   before `app.Run`. Small, independently testable, and useful on its own for
+   anyone wrapping bootstrap.
 3. **Docker, minimum viable.** `executor` with strict value validation,
-   `executor-docker-image`, `executor-docker-arg`, `executor-docker-home`.
-   `create`/`start`/`inspect` lifecycle inside `Run`, env file transport, the
-   mount table above, uid inheritance with `--group-add`, `--init`,
-   `no-new-privileges`. Linux only; error out on other platforms.
+   `executor-docker-image`, `executor-docker-arg` with the reserved-flag
+   check, minimum-image-version check. `create`/`start`/`inspect` lifecycle
+   inside `Run` with the pending-signal state and readiness poll, env file
+   transport, mount table and source provisioning, explicit `--user` with
+   `--group-add`, fixed `HOME` on a tmpfs, `--workdir`, `--tty`, `--init`,
+   `no-new-privileges`, `rm --force --volumes`. Linux only; error out on other
+   platforms.
 4. **Follow-ups if needed.** `executor-docker-expose-socket`,
-   `executor-docker-user`, version check caching, `executor=kubernetes-exec`
-   alias.
+   `executor-docker-user`, `executor-docker-home`, version check caching,
+   `executor=kubernetes-exec` alias.
 
 ## Testing
 
 Slice 1:
 
-- Table test for executor selection, including rejection of unknown values.
+- Table test for executor selection, including rejection of unknown values
+  and of `--kubernetes-exec` combined with `executor=docker`.
 - Parity test: `execExecution` produces the same `process.Config` as the
-  current code for a fixed `JobRunnerConfig`.
+  current code for a fixed `JobRunnerConfig`, including the host env prepend.
 
 Slice 2:
 
 - Bootstrap loads a JSON env file with multi-line values and a value
-  containing `=`; a missing or unreadable file is a setup failure.
+  containing `=`; an explicit flag still beats a value from the file; the
+  variable is absent from the environment bootstrap hands to hooks; a
+  missing, unreadable, or malformed file exits 125.
 
-Slice 3:
+Slice 3, with a fake `docker` binary on `PATH` that records its argv and env
+and exits with a scripted status, in the style of the existing
+`internal/job/integration` fakes:
 
-- Unit tests for `docker create` argv construction from `AgentConfiguration`:
-  the single `--env`, mount table, `--user` and `--group-add` flags, `--init`.
+- `docker create` argv construction from `AgentConfiguration`: the single
+  `--env`, mount table, `--user`, `--group-add`, `--workdir`, `--tty` when
+  `run-in-pty` is on, `--init`, `--tmpfs` for `HOME`; rejection of reserved
+  `executor-docker-arg` flags.
 - The control process env passed to the fake `docker` is exactly the agent's
   environment: a job env `DOCKER_HOST` must not appear in it, and must appear
   in the env file.
-- Unit tests that `Interrupt`/`Terminate`/`Cleanup` issue the expected
-  `docker kill`/`docker rm` invocations, that the SIGKILL downgrade is
-  applied, and that an interrupt during `docker create` removes the container
-  and makes `Run` return an error.
-- Exit mapping tests: a `docker create` or `docker start` failure yields
-  `Run` error; a container exit code from `inspect` becomes `WaitStatus`;
-  `docker`'s own 125 is never reported as the job exit status.
-- An integration test with a fake `docker` binary on `PATH` that records its
-  argv and exits with a scripted status, in the style of the existing
-  `internal/job/integration` fakes.
+- `Interrupt`/`Terminate`/`Cleanup` issue the expected `docker kill`/`docker
+  rm --force --volumes` invocations against the container ID, the SIGKILL
+  downgrade is applied, an interrupt during `docker create` removes the
+  container and makes `Run` return an error, and an interrupt recorded before
+  the container is running is delivered once the readiness poll sees it.
+- Exit mapping: a `docker create` or `docker start` failure yields a `Run`
+  error; a terminal `State.ExitCode` from `inspect` becomes `WaitStatus`;
+  `docker`'s own 125 is never reported as the job exit status; `start`
+  returning while `inspect` still shows `running` yields a `Run` error and a
+  `docker kill`.
+
+Slice 3 also needs a small set of tests against a real Docker daemon, gated
+behind a build tag or an env var, because a scripted fake cannot check these:
+a non-root agent uid can read the env file and write to `HOME` and the build
+path; cancellation while the container is starting still stops the job;
+`docker rm --force --volumes` leaves no anonymous volume behind for an image
+with `VOLUME`.
 
 ## Risks
 
@@ -430,7 +569,17 @@ Slice 3:
   `exec`, not as safe for untrusted builds.
 - Path-preserving bind mounts leak host layout into the container. Accepted
   for compatibility with existing hooks and plugin caches.
-- A bad `executor-docker-image` (missing tools, wrong agent version) fails
-  every job on the agent. The version check catches only the second case.
+- The env file is the first on-disk copy of `BUILDKITE_AGENT_ACCESS_TOKEN`
+  the agent writes (the existing env files omit agent-added variables). It is
+  0600, lives for one job, and is removed in `Cleanup`; an agent that dies
+  mid-job leaves it behind. The job token is short-lived, so this is accepted
+  for the MVP; a sweep of stale `job-exec-env-*.json` files at agent start is
+  cheap if it turns out to matter.
+- Exit metadata differs from `exec`: no `exit.Signal` on cancellation, only
+  the `128+n` code. Anything keying on the signal name will not see it for
+  Docker jobs.
+- A bad `executor-docker-image` (missing tools, entrypoint failing under the
+  agent uid) fails every job on the agent. The version check catches only an
+  agent that is too old.
 - Naming: `internal/job.Executor` already exists and means "bootstrap runtime".
   Use `JobExecutor`/`JobExecution` at the agent layer and do not shorten them.

--- a/docs/proposals/job-executor-abstraction.md
+++ b/docs/proposals/job-executor-abstraction.md
@@ -104,6 +104,10 @@ type JobExecution interface {
   `processEnv := append(os.Environ(), env...)` and hands it to both the exec
   and Kubernetes branches; those two executions keep doing that prepend
   themselves. Docker does not.
+- the names of env entries that must not be persisted: today only the
+  control-plane OTLP exporter variables, when `createEnvironment` delivered
+  them. `exec` and Kubernetes ignore the set; Docker uses it to decide what
+  stays out of the env file (see Environment).
 - the job context directory (`jobContextDir(conf)`), which holds
   `BUILDKITE_ENV_FILE`, `BUILDKITE_ENV_JSON_FILE`, and the job-timeout marker
 - the stdout/stderr writer (`r.jobLogs`)
@@ -253,8 +257,9 @@ Cleanup():    docker rm --force --volumes <id>   (ignore "no such container")
   container is observed running. It means "the launch attempt has begun".
   `jobCancellationChecker` and the log processor in `JobRunner` both block on
   `Started()`, so if it closed any later a server-side cancel or job timeout
-  arriving during an image pull would go unnoticed until the pull finished.
-  Container readiness is tracked privately for signal delivery.
+  arriving while `create` was slow (a busy daemon, or the image ID gone
+  after a prune) would go unnoticed until `create` returned. Container
+  readiness is tracked privately for signal delivery.
 - `Interrupt` and `Terminate` can be called at any point: `JobRunner.Cancel`
   calls them whenever it runs, including while `Run` is mid-`docker create`
   or before the container is running. `docker kill` on a container that is
@@ -262,8 +267,8 @@ Cleanup():    docker rm --force --volumes <id>   (ignore "no such container")
   `Interrupt` error without ever reaching `Terminate`. So the execution keeps
   a mutex-protected pending state (`none → interrupt → terminate`,
   monotonic) and records the request first. Then:
-  - If `docker create` is in flight, cancel its context so the CLI exits
-    (aborting the pull), `docker rm --force --volumes` by the execution's
+  - If `docker create` is in flight, cancel its context so the CLI exits,
+    `docker rm --force --volumes` by the execution's
     unique name in case the daemon created the container before the CLI
     died (no ID was returned), and return an error from `Run`. A cancelled
     create is never followed by a start.
@@ -336,7 +341,9 @@ Two environments are in play and they must not mix:
   `os.Environ()`, unmodified. Job env never enters it. A job that sets
   `DOCKER_HOST`, `DOCKER_CONTEXT`, `DOCKER_CONFIG`, or `HOME` must not be able
   to redirect the executor to another daemon or hide the agent user's
-  registry credentials.
+  registry credentials. The one addition is agent-owned, not job-owned: the
+  control-plane OTLP exporter variables, for the `create` call only (see
+  below).
 - The **container** environment: the resolved job env slice from
   `createEnvironment` (job env plus the agent's `BUILDKITE_*` additions), with
   the adjustments below. It deliberately excludes the host's `os.Environ()`:
@@ -399,6 +406,22 @@ Adjust these before writing the file:
 - `BUILDKITE_AGENT_PID`: omit. Nothing in the job uses it; `buildkite-agent
   lock` talks to the leader socket, not the PID.
 - `BUILDKITE_CONFIG_PATH`: omit. The agent config file is not mounted (below).
+- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`/`_PROTOCOL`/`_HEADERS` when they came
+  from the control-plane exporter: omit from the file. `api.TracingExporter`
+  requires that these (the headers can carry vendor credentials) never reach
+  a persisted env file, which is why `createEnvironment` adds them only after
+  writing today's env files. The runner tells the execution which keys are
+  exporter-supplied (`controlPlaneOTLPEnv` produces them, so the set is
+  known). The docker execution passes each as a name-only `--env KEY` and puts
+  the values in the environment of the `docker create` subprocess only: the
+  CLI reads a name-only `--env` from its own environment, so the values cross
+  the daemon socket without touching the agent's disk or `create`'s argv.
+  They are then held in the daemon's container config until `Cleanup`
+  removes the container, root-readable only, which is the same exposure any
+  `--env` gives. A job that set its own `OTEL_EXPORTER_OTLP_*` destination
+  is unaffected: `createEnvironment` does not deliver the control-plane
+  exporter in that case, and the job's own values are job env and go in the
+  file as usual.
 - `BUILDKITE_JOB_LOG_TMPFILE`: add it when `enable-job-log-tmpfile` is on.
   `NewJobRunner` sets it with `os.Setenv` after `createEnvironment` returns,
   so today it reaches bootstrap only via the host-env prepend that Docker
@@ -503,9 +526,17 @@ them under that path via `executor-docker-arg`.
 - `buildkite-agent` on `PATH`, at a version that understands
   `BUILDKITE_BOOTSTRAP_ENV_JSON_FILE`. A major-version match is not enough:
   an older image of the same major would ignore the variable and run
-  bootstrap with no job configuration. Enforce a minimum version by running
-  `docker run --rm --entrypoint buildkite-agent <image> --version` before the
-  first job; caching the result per image per agent process is a follow-up.
+  bootstrap with no job configuration. `agent start` enforces this once,
+  after config validation and before registering: `docker pull <image>`, then
+  `docker run --rm --entrypoint buildkite-agent <image> --version`, under a
+  single bounded context (2 minutes; `docker pull` dominates), failing agent
+  start on a version below the minimum, a non-zero exit, or timeout. It then
+  records the image ID (`docker image inspect --format '{{.Id}}'`) and every
+  `docker create` uses that ID rather than the tag, so a tag moving under a
+  running agent cannot swap in an unchecked image. This keeps Docker calls
+  out of `New` (which would orphan work if `StartJob` failed) and out of
+  `Run`'s cancellation path, and means the pull that would otherwise happen
+  on the first job happens before the agent accepts one.
 - The image entrypoint accepts `bootstrap` as its arguments and ends up
   running `buildkite-agent bootstrap`. The official `buildkite/agent` image
   does: `buildkite-agent-entrypoint` runs `/docker-entrypoint.d`, then
@@ -554,15 +585,17 @@ separate top-level executors per runtime.
    anyone wrapping bootstrap.
 3. **Docker, minimum viable.** `executor` with strict value validation,
    `executor-docker-image`, `executor-docker-arg` with the reserved-flag
-   check, minimum-image-version check. `create`/`start`/`inspect` lifecycle
-   inside `Run` with the pending-signal state and readiness poll, env file
-   transport, mount table and source provisioning, explicit `--user` with
+   check, start-time pull + version check recording the image ID.
+   `create`/`start`/`inspect` lifecycle inside `Run` with the pending-signal
+   state and readiness poll, env file transport with the OTLP exporter
+   carried via name-only `--env`, mount table and source provisioning,
+   explicit `--user` with
    `--group-add`, fixed `HOME` on a tmpfs, `--workdir`, `--tty`, `--init`,
    `no-new-privileges`, `rm --force --volumes`. Linux only; error out on other
    platforms.
 4. **Follow-ups if needed.** `executor-docker-expose-socket`,
-   `executor-docker-user`, `executor-docker-home`, version check caching,
-   `executor=kubernetes-exec` alias.
+   `executor-docker-user`, `executor-docker-home`, `executor=kubernetes-exec`
+   alias.
 
 ## Testing
 
@@ -593,6 +626,15 @@ and exits with a scripted status, in the style of the existing
 - The control process env passed to the fake `docker` is exactly the agent's
   environment: a job env `DOCKER_HOST` must not appear in it, and must appear
   in the env file.
+- With a control-plane exporter configured, the `OTEL_EXPORTER_OTLP_TRACES_*`
+  values are absent from the env file and from `create`'s argv, appear as
+  name-only `--env` flags, and are present in the fake `docker create`'s
+  environment but not in `start`/`kill`/`rm`/`inspect`'s. With a job-supplied
+  OTLP destination they are in the env file and not in the control env.
+- `agent start` with `executor=docker` runs `pull`, `run --version`, and
+  `image inspect` against the fake, fails start on a too-old version, a
+  non-zero exit, or a fake that sleeps past the timeout, and the recorded
+  image ID (not the tag) is what `docker create` receives.
 - `Interrupt`/`Terminate`/`Cleanup` issue the expected `docker kill`/`docker
   rm --force --volumes` invocations against the container ID, the SIGKILL
   downgrade is applied, an interrupt during a (fake, slow) `docker create`
@@ -637,8 +679,11 @@ with `VOLUME`.
   the `128+n` code. Anything keying on the signal name will not see it for
   Docker jobs.
 - A bad `executor-docker-image` (missing tools, entrypoint failing under the
-  agent uid) fails every job on the agent. The version check catches only an
-  agent that is too old.
+  agent uid) fails every job on the agent. The start-time version check
+  catches only an image that is too old. Because `create` runs by image ID,
+  a `docker image prune` while the agent is running also fails every job
+  ("No such image") until the agent is restarted; the error message names
+  the fix.
 - An unresponsive Docker daemon can leak a container. `kill` and `rm` are
   bounded by short timeouts and `Terminate` can always unblock `Run` by
   killing the `docker start` client, so the agent slot is freed, but the

--- a/docs/proposals/job-executor-abstraction.md
+++ b/docs/proposals/job-executor-abstraction.md
@@ -166,8 +166,14 @@ Rules:
   `bootstrap-script` was set explicitly, log a warning and ignore it.
 - `executor-docker-arg` may not override what the executor owns. Reject
   `--rm` (defeats `inspect`), `--restart` other than `no` (defeats "one
-  ephemeral execution"), `--name`, `--user`, `--env BUILDKITE_BOOTSTRAP_ENV_JSON_FILE`,
-  and mounts targeting the job context directory.
+  ephemeral execution"), and every singleton flag the executor sets itself:
+  `--name`, `--user`/`-u`, `--workdir`/`-w`, `--init`, `--tty`/`-t`, plus
+  `--env BUILDKITE_BOOTSTRAP_ENV_JSON_FILE` and mounts targeting the job
+  context directory. Match all spellings
+  (`--workdir=/x`, `--workdir /x`, `-w /x`). Docker's parser is last-value-wins
+  for singletons, so as a second line of defence the executor's own flags are
+  appended after the user's args; the reject list exists because relying on
+  ordering alone leaves `--rm`-style flags with no safe later value.
 - `$HOME` in the container is fixed at `/tmp/buildkite-home` for the MVP (see
   the user model below). A setting can follow if anyone needs to move it.
 - The image is an agent-pool decision. Users who need different images run
@@ -197,13 +203,17 @@ Run():        write the env file (below); close Started()
                 <flags> <image> bootstrap          (cancellable: Interrupt/Terminate abort it)
               -> record the container ID printed by create; every later call uses the ID
               spawn docker start --attach <id>   (stdout/stderr -> jobLogs)
-              poll docker inspect <id> until State.Status is running or a terminal state;
-              deliver any pending signal
-              wait for docker start to exit, then docker inspect <id> -> State
+              poll docker inspect <id> until State.Status is running or exited,
+              State.Error is set, or docker start has exited
+              -> running: deliver any pending signal, then wait for docker start to exit
+              -> exited (fast job): fall through to the final inspect
+              -> still created (start failed / State.Error): launch failed; return error
+              docker inspect <id> -> State
               -> if State is terminal: WaitStatus = State.ExitCode
               -> if the container is still running: attach was lost; docker kill, return error
 Interrupt():  record "interrupt"; docker kill --signal <cancel-signal> <id> if running
-Terminate():  record "terminate";  docker kill <id> if running
+Terminate():  record "terminate";  docker kill <id> if running;
+              if that fails, kill the docker start subprocess so Run returns
 Cleanup():    docker rm --force --volumes <id>   (ignore "no such container")
               remove the env file
 ```
@@ -225,6 +235,15 @@ Cleanup():    docker rm --force --volumes <id>   (ignore "no such container")
   CLI's exit code. `WaitStatus` comes only from a container in a terminal
   state. A still-running container after `start` returns is an executor
   failure: kill it and return an error from `Run`.
+- The readiness poll must not wait only for `running` or a terminal state. A
+  `docker start` that fails in OCI/runtime setup (bad `--user`, missing mount
+  source, seccomp error) leaves the container in `created` with `State.Error`
+  set, and the CLI exits non-zero; neither is `running` or `exited`. The poll
+  therefore also ends when `State.Error` is non-empty or when the `start`
+  subprocess has exited, and a container still in `created` at that point is
+  a launch failure: `Run` returns an error carrying `State.Error` and the
+  CLI's stderr. A container observed already `exited` is a fast job, not a
+  failure, and falls through to the normal exit mapping.
 - Do not surface the docker CLI's own 125/126/127 exit codes as the job exit
   status: 125 collides with `job.ExitCodeSetupFailure`, which `runJob` already
   rewrites to -1, and 126/127 would look like the user's command failing. A
@@ -262,6 +281,18 @@ Cleanup():    docker rm --force --volumes <id>   (ignore "no such container")
   that `JobRunner.Cancel` already enforces before calling `Terminate`. The
   agent, not Docker, owns the timing. Run `docker kill` with a short timeout
   so a hung daemon cannot wedge `Cancel`.
+- A failed `docker kill` in `Interrupt` must not abort cancellation.
+  `JobRunner.Cancel` returns as soon as `Interrupt` returns an error and never
+  reaches the grace period or `Terminate`, so a timed-out or refused kill
+  would leave the container running with nothing left to escalate. `Interrupt`
+  logs the failure at error level and returns nil; the pending state is
+  already recorded, so `Cancel` proceeds to the grace period and `Terminate`
+  retries with `docker kill` (SIGKILL), and `Cleanup` finishes with
+  `rm --force --volumes` regardless. If `Terminate`'s `docker kill` also
+  fails, `Terminate` kills the `docker start --attach` subprocess directly so
+  `Run` returns an error instead of waiting on a daemon that is not
+  responding; the container may be leaked at that point and `Cleanup` reports
+  it if `rm --force` fails too (see Risks).
 - Apply the same SIGKILL→SIGTERM downgrade as `exec`. A SIGKILL to bootstrap
   skips pre-exit hooks and loses the command's exit status.
 - Pass `--init` so something reaps orphaned grandchildren left behind by
@@ -556,7 +587,9 @@ and exits with a scripted status, in the style of the existing
 - `docker create` argv construction from `AgentConfiguration`: the single
   `--env`, mount table, `--user`, `--group-add`, `--workdir`, `--tty` when
   `run-in-pty` is on, `--init`, `--tmpfs` for `HOME`; rejection of reserved
-  `executor-docker-arg` flags.
+  `executor-docker-arg` flags in every spelling (`--workdir=/x`,
+  `--workdir /x`, `-w /x`); accepted user args appear before the executor's
+  own flags in argv.
 - The control process env passed to the fake `docker` is exactly the agent's
   environment: a job env `DOCKER_HOST` must not appear in it, and must appear
   in the env file.
@@ -567,10 +600,16 @@ and exits with a scripted status, in the style of the existing
   error, `Started()` is closed before `create` is invoked, and an interrupt
   recorded before the container is running is delivered once the readiness
   poll sees it.
+- A failing `docker kill` (fake exits non-zero or hangs past the timeout)
+  makes `Interrupt` return nil, and a subsequent `Terminate` kills the fake
+  `docker start` so `Run` returns an error rather than blocking.
 - With `enable-job-log-tmpfile`, `BUILDKITE_JOB_LOG_TMPFILE` is in the env
   file and the file is in the mount list.
 - Exit mapping: a `docker create` or `docker start` failure yields a `Run`
-  error; a terminal `State.ExitCode` from `inspect` becomes `WaitStatus`;
+  error, including a `start` that exits while `inspect` still reports
+  `created` with `State.Error` set (the poll must not wait forever); a
+  container already `exited` at the first poll is mapped normally; a
+  terminal `State.ExitCode` from `inspect` becomes `WaitStatus`;
   `docker`'s own 125 is never reported as the job exit status; `start`
   returning while `inspect` still shows `running` yields a `Run` error and a
   `docker kill`.
@@ -600,5 +639,10 @@ with `VOLUME`.
 - A bad `executor-docker-image` (missing tools, entrypoint failing under the
   agent uid) fails every job on the agent. The version check catches only an
   agent that is too old.
+- An unresponsive Docker daemon can leak a container. `kill` and `rm` are
+  bounded by short timeouts and `Terminate` can always unblock `Run` by
+  killing the `docker start` client, so the agent slot is freed, but the
+  container itself may keep running until the daemon recovers. The labels
+  exist so an operator can sweep these; `exec` has no equivalent failure mode.
 - Naming: `internal/job.Executor` already exists and means "bootstrap runtime".
   Use `JobExecutor`/`JobExecution` at the agent layer and do not shorten them.

--- a/docs/proposals/job-executor-abstraction.md
+++ b/docs/proposals/job-executor-abstraction.md
@@ -191,12 +191,12 @@ so launch failures are separable from bootstrap exit codes.
 
 ```text
 New():        validate config; no docker calls
-Run():        write the env file (below)
+Run():        write the env file (below); close Started()
               docker create --name buildkite-job-<jobid>-<random> \
                 --label com.buildkite.job-id=<jobid> --label com.buildkite.agent-run=<run-id> \
-                <flags> <image> bootstrap
+                <flags> <image> bootstrap          (cancellable: Interrupt/Terminate abort it)
               -> record the container ID printed by create; every later call uses the ID
-              spawn docker start --attach <id>   (stdout/stderr -> jobLogs); close Started()
+              spawn docker start --attach <id>   (stdout/stderr -> jobLogs)
               poll docker inspect <id> until State.Status is running or a terminal state;
               deliver any pending signal
               wait for docker start to exit, then docker inspect <id> -> State
@@ -230,25 +230,33 @@ Cleanup():    docker rm --force --volumes <id>   (ignore "no such container")
   rewrites to -1, and 126/127 would look like the user's command failing. A
   bootstrap that itself exits 125 inside the container still reaches `runJob`
   via `inspect` and is mapped to -1 as today.
-- `Started()` closes as soon as `docker start` has been spawned, not when the
-  container is observed running. Log streaming and the cancellation poller in
-  `JobRunner` wait on `Started()`, and a slow image pull or a hung daemon must
-  stay cancellable. Container readiness is tracked privately for signal
-  delivery.
+- `Started()` closes at the top of `Run`, before `docker create`, not when the
+  container is observed running. It means "the launch attempt has begun".
+  `jobCancellationChecker` and the log processor in `JobRunner` both block on
+  `Started()`, so if it closed any later a server-side cancel or job timeout
+  arriving during an image pull would go unnoticed until the pull finished.
+  Container readiness is tracked privately for signal delivery.
 - `Interrupt` and `Terminate` can be called at any point: `JobRunner.Cancel`
   calls them whenever it runs, including while `Run` is mid-`docker create`
   or before the container is running. `docker kill` on a container that is
   created but not yet running fails, and `Cancel` returns early on an
   `Interrupt` error without ever reaching `Terminate`. So the execution keeps
   a mutex-protected pending state (`none → interrupt → terminate`,
-  monotonic), records the request first, and only issues `docker kill` once
-  it has observed the container running. `Run` checks the state after
-  `docker create` (remove the container, return an error) and again once the
-  readiness poll sees `running` (deliver the recorded signal). Interrupt must
-  succeed at most once per container: bootstrap removes its signal handler
-  after the first signal, so a repeated SIGTERM would bypass its cleanup.
-  Cancel before `Run` is already handled by `JobRunner.Run` returning "job
-  already cancelled before running".
+  monotonic) and records the request first. Then:
+  - If `docker create` is in flight, cancel its context so the CLI exits
+    (aborting the pull), `docker rm --force --volumes` by the execution's
+    unique name in case the daemon created the container before the CLI
+    died (no ID was returned), and return an error from `Run`. A cancelled
+    create is never followed by a start.
+  - If the container exists but is not yet observed running, do nothing more;
+    `Run` re-checks the state once the readiness poll sees `running` and
+    delivers the recorded signal (or, if `create` returned after the request
+    was recorded, removes the container and returns an error).
+  - If the container is running, `docker kill` it with the recorded signal.
+  Interrupt must succeed at most once per container: bootstrap removes its
+  signal handler after the first signal, so a repeated SIGTERM would bypass
+  its cleanup. Cancel before `Run` is already handled by `JobRunner.Run`
+  returning "job already cancelled before running".
 - `Interrupt` must return promptly. `docker stop --time N` is wrong here: it
   blocks for up to N seconds and then SIGKILLs, duplicating the grace period
   that `JobRunner.Cancel` already enforces before calling `Terminate`. The
@@ -360,6 +368,12 @@ Adjust these before writing the file:
 - `BUILDKITE_AGENT_PID`: omit. Nothing in the job uses it; `buildkite-agent
   lock` talks to the leader socket, not the PID.
 - `BUILDKITE_CONFIG_PATH`: omit. The agent config file is not mounted (below).
+- `BUILDKITE_JOB_LOG_TMPFILE`: add it when `enable-job-log-tmpfile` is on.
+  `NewJobRunner` sets it with `os.Setenv` after `createEnvironment` returns,
+  so today it reaches bootstrap only via the host-env prepend that Docker
+  drops. The executor takes the path from the runner, puts it in the env
+  file, and bind-mounts the log file itself read-only (below); the agent
+  appends to the same inode on the host, so the container sees the live log.
 - `HOME`: set to `/tmp/buildkite-home`. See the user model below.
 
 ### Mounts
@@ -376,6 +390,7 @@ or plugins needs to learn a new filesystem layout:
 | job context dir (`--job-context-dir`, default `os.TempDir()`) | rw |
 | `hooks-path`, each `additional-hooks-paths` entry | ro |
 | `signing-jwks-file` (when set) | ro |
+| the job log tmpfile (when `enable-job-log-tmpfile`) | ro |
 | `/etc/passwd`, `/etc/group` | ro |
 | `/var/run/docker.sock` (only when `executor-docker-expose-socket`) | rw |
 
@@ -547,9 +562,13 @@ and exits with a scripted status, in the style of the existing
   in the env file.
 - `Interrupt`/`Terminate`/`Cleanup` issue the expected `docker kill`/`docker
   rm --force --volumes` invocations against the container ID, the SIGKILL
-  downgrade is applied, an interrupt during `docker create` removes the
-  container and makes `Run` return an error, and an interrupt recorded before
-  the container is running is delivered once the readiness poll sees it.
+  downgrade is applied, an interrupt during a (fake, slow) `docker create`
+  kills the CLI, removes the container by name and makes `Run` return an
+  error, `Started()` is closed before `create` is invoked, and an interrupt
+  recorded before the container is running is delivered once the readiness
+  poll sees it.
+- With `enable-job-log-tmpfile`, `BUILDKITE_JOB_LOG_TMPFILE` is in the env
+  file and the file is in the mount list.
 - Exit mapping: a `docker create` or `docker start` failure yields a `Run`
   error; a terminal `State.ExitCode` from `inspect` becomes `WaitStatus`;
   `docker`'s own 125 is never reported as the job exit status; `start`


### PR DESCRIPTION
## Description

Design proposal (docs only): let an agent run each job's bootstrap somewhere other than directly on the host, starting with Docker.

Today the agent always runs `buildkite-agent bootstrap` as a local subprocess (or, for the Kubernetes stack, via a special-case `if`). The only hook for changing that is `bootstrap-script`, which is a command string: the agent can't name what it launched, signal it, read its exit code reliably, or clean it up.

The proposal adds an `executor` setting on `buildkite-agent start`:

```ini
# buildkite-agent.cfg
executor=docker
executor-docker-image=buildkite/agent:4
```

With that, every job's bootstrap (checkout, hooks, plugins, command) runs in a throwaway container on the same host, as the agent's uid, with the build, plugins, hooks and mirrors directories bind-mounted at their host paths so existing hooks and plugins keep working. `exec` stays the default and is unchanged. The Kubernetes path becomes one more implementation of the same interface, with no behaviour change.

The doc covers the interface, the Docker container lifecycle (create, start, cancel, clean up), how the job environment gets into the container without leaking into the agent's `docker` calls, the mount and user model, the image requirements, and a delivery plan in three slices. Full text: [docs/proposals/job-executor-abstraction.md](docs/proposals/job-executor-abstraction.md).

## Context

Revives the March draft. The core idea held up; the Docker details were reworked after review (cancellation timing, exit-code collisions with Docker's own 125/126/127, `$HOME`, env transport, cleanup).

## Public documentation
**Status:** not needed

## Testing
Docs-only change; no code to test or format.

## Disclosures / Credits

First draft written with GPT-5.4. Revised with Amp (Claude), including the reviews that found the design problems fixed here. Human input and review throughout.
