### PR TITLE
[OIDC] - Enable Agent Level Max Token Lifetime

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -72,6 +72,6 @@ type AgentConfiguration struct {
 	TraceContextEncoding         string
 	DisableWarningsFor           []string
 	AllowMultipartArtifactUpload bool
-	OIDCTokenMaxLifetimeSeconds int
-	PingMode string
+	OIDCTokenMaxLifetimeSeconds  int
+	PingMode                     string
 }

--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -72,6 +72,6 @@ type AgentConfiguration struct {
 	TraceContextEncoding         string
 	DisableWarningsFor           []string
 	AllowMultipartArtifactUpload bool
-
+	OIDCTokenMaxLifetimeSeconds int
 	PingMode string
 }

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -658,6 +658,10 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 
 	setEnv("BUILDKITE_AGENT_DISABLE_WARNINGS_FOR", strings.Join(r.conf.AgentConfiguration.DisableWarningsFor, ","))
 
+	if r.conf.AgentConfiguration.OIDCTokenMaxLifetimeSeconds > 0 {
+		setEnv("BUILDKITE_AGENT_OIDC_TOKEN_MAX_LIFETIME_SECONDS", strconv.Itoa(r.conf.AgentConfiguration.OIDCTokenMaxLifetimeSeconds))
+	}
+
 	// see documentation for BuildkiteMessageMax
 	if err := truncateEnv(r.agentLogger, env, BuildkiteMessageName, BuildkiteMessageMax); err != nil {
 		r.agentLogger.Warn("failed to truncate %s: %v", BuildkiteMessageName, err)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -195,11 +195,11 @@ type AgentStartConfig struct {
 	TracingPropagateTraceparent bool   `cli:"tracing-propagate-traceparent"`
 
 	// Other shared flags
-	StrictSingleHooks             bool   `cli:"strict-single-hooks"`
-	KubernetesExec                bool   `cli:"kubernetes-exec"`
-	TraceContextEncoding          string `cli:"trace-context-encoding"`
-	NoMultipartArtifactUpload     bool   `cli:"no-multipart-artifact-upload"`
-	OIDCTokenMaxLifetimeSeconds   int    `cli:"oidc-token-max-lifetime-seconds"`
+	StrictSingleHooks           bool   `cli:"strict-single-hooks"`
+	KubernetesExec              bool   `cli:"kubernetes-exec"`
+	TraceContextEncoding        string `cli:"trace-context-encoding"`
+	NoMultipartArtifactUpload   bool   `cli:"no-multipart-artifact-upload"`
+	OIDCTokenMaxLifetimeSeconds int    `cli:"oidc-token-max-lifetime-seconds"`
 
 	// API + agent behaviour
 	PingMode string `cli:"ping-mode"`
@@ -1089,7 +1089,7 @@ var AgentStartCommand = cli.Command{
 			TracingPropagateTraceparent:  cfg.TracingPropagateTraceparent,
 			TraceContextEncoding:         cfg.TraceContextEncoding,
 			AllowMultipartArtifactUpload: !cfg.NoMultipartArtifactUpload,
-			OIDCTokenMaxLifetimeSeconds:   cfg.OIDCTokenMaxLifetimeSeconds,
+			OIDCTokenMaxLifetimeSeconds:  cfg.OIDCTokenMaxLifetimeSeconds,
 			KubernetesExec:               cfg.KubernetesExec,
 			PingMode:                     cfg.PingMode,
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -195,10 +195,11 @@ type AgentStartConfig struct {
 	TracingPropagateTraceparent bool   `cli:"tracing-propagate-traceparent"`
 
 	// Other shared flags
-	StrictSingleHooks         bool   `cli:"strict-single-hooks"`
-	KubernetesExec            bool   `cli:"kubernetes-exec"`
-	TraceContextEncoding      string `cli:"trace-context-encoding"`
-	NoMultipartArtifactUpload bool   `cli:"no-multipart-artifact-upload"`
+	StrictSingleHooks             bool   `cli:"strict-single-hooks"`
+	KubernetesExec                bool   `cli:"kubernetes-exec"`
+	TraceContextEncoding          string `cli:"trace-context-encoding"`
+	NoMultipartArtifactUpload     bool   `cli:"no-multipart-artifact-upload"`
+	OIDCTokenMaxLifetimeSeconds   int    `cli:"oidc-token-max-lifetime-seconds"`
 
 	// API + agent behaviour
 	PingMode string `cli:"ping-mode"`
@@ -754,6 +755,12 @@ var AgentStartCommand = cli.Command{
 		StrictSingleHooksFlag,
 		TraceContextEncodingFlag,
 		NoMultipartArtifactUploadFlag,
+		cli.IntFlag{
+			Name:   "oidc-token-max-lifetime-seconds",
+			Value:  0,
+			Usage:  "Maximum lifetime (seconds) for OIDC tokens requested via `buildkite-agent oidc request-token` in jobs. When greater than 0, `--lifetime` cannot exceed this value. 0 means no agent-side limit.",
+			EnvVar: "BUILDKITE_AGENT_OIDC_TOKEN_MAX_LIFETIME_SECONDS",
+		},
 
 		// Deprecated flags which will be removed in v4
 		KubernetesLogCollectionGracePeriodFlag,
@@ -936,6 +943,10 @@ var AgentStartCommand = cli.Command{
 			return fmt.Errorf("while parsing trace context encoding: %v", err)
 		}
 
+		if cfg.OIDCTokenMaxLifetimeSeconds < 0 {
+			return fmt.Errorf("oidc-token-max-lifetime-seconds must be a non-negative integer")
+		}
+
 		mc := metrics.NewCollector(l, metrics.CollectorConfig{
 			Datadog:              cfg.MetricsDatadog,
 			DatadogHost:          cfg.MetricsDatadogHost,
@@ -1078,6 +1089,7 @@ var AgentStartCommand = cli.Command{
 			TracingPropagateTraceparent:  cfg.TracingPropagateTraceparent,
 			TraceContextEncoding:         cfg.TraceContextEncoding,
 			AllowMultipartArtifactUpload: !cfg.NoMultipartArtifactUpload,
+			OIDCTokenMaxLifetimeSeconds:   cfg.OIDCTokenMaxLifetimeSeconds,
 			KubernetesExec:               cfg.KubernetesExec,
 			PingMode:                     cfg.PingMode,
 

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/buildkite/agent/v3/api"
@@ -114,6 +116,16 @@ var OIDCRequestTokenCommand = cli.Command{
 			return fmt.Errorf("format %q is not valid. Supported values are 'jwt' and 'gcp'", cfg.Format)
 		}
 
+		lifetime := cfg.Lifetime
+		const envOIDCTokenMaxLifetimeSeconds = "BUILDKITE_AGENT_OIDC_TOKEN_MAX_LIFETIME_SECONDS"
+
+		if maxSec := parseNonNegativeIntEnv(envOIDCTokenMaxLifetimeSeconds); maxSec > 0 {
+			if eff, clamped := clampOIDCTokenLifetimeSeconds(lifetime, maxSec); clamped {
+				l.Debug("OIDC token lifetime clamped from %ds to %ds (%s=%d)", lifetime, eff, envOIDCTokenMaxLifetimeSeconds, maxSec)
+				lifetime = eff
+			}
+		}
+
 		// Create the API client
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
 
@@ -126,7 +138,7 @@ var OIDCRequestTokenCommand = cli.Command{
 			req := &api.OIDCTokenRequest{
 				Job:            cfg.Job,
 				Audience:       cfg.Audience,
-				Lifetime:       cfg.Lifetime,
+				Lifetime:       lifetime,
 				Claims:         cfg.Claims,
 				AWSSessionTags: cfg.AWSSessionTags,
 				SubjectClaim:   cfg.SubjectClaim,
@@ -201,4 +213,29 @@ var OIDCRequestTokenCommand = cli.Command{
 
 		return nil
 	},
+}
+
+// parseNonNegativeIntEnv returns 0 if the variable is unset, invalid, or negative.
+func parseNonNegativeIntEnv(key string) int {
+	s := os.Getenv(key)
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+// clampOIDCTokenLifetimeSeconds returns the effective lifetime and whether
+// clamping occurred. When requested is 0 (API default), it is not changed.
+func clampOIDCTokenLifetimeSeconds(requested, maxLifetime int) (effective int, clamped bool) {
+	if maxLifetime <= 0 || requested <= 0 {
+		return requested, false
+	}
+	if requested > maxLifetime {
+		return maxLifetime, true
+	}
+	return requested, false
 }

--- a/clicommand/oidc_request_token_test.go
+++ b/clicommand/oidc_request_token_test.go
@@ -1,0 +1,34 @@
+package clicommand
+
+import (
+	"testing"
+)
+
+func TestClampOIDCTokenLifetimeSeconds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		requested   int
+		maxLifetime int
+		wantEff     int
+		wantClamp   bool
+	}{
+		{"no cap", 600, 0, 600, false},
+		{"no cap negative max", 600, -1, 600, false},
+		{"api default unchanged", 0, 300, 0, false},
+		{"under cap", 100, 300, 100, false},
+		{"at cap", 300, 300, 300, false},
+		{"over cap", 600, 300, 300, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, clamped := clampOIDCTokenLifetimeSeconds(tt.requested, tt.maxLifetime)
+			if got != tt.wantEff || clamped != tt.wantClamp {
+				t.Errorf("clampOIDCTokenLifetimeSeconds(%d, %d) = (%d, %v), want (%d, %v)",
+					tt.requested, tt.maxLifetime, got, clamped, tt.wantEff, tt.wantClamp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
* Currently `buildkite-agent request token` has no guardrails at the agent level for how long a token can live for, by default it lives for 5 minutes


### Context
* Using the `--lifetime` [flag](https://buildkite.com/docs/agent/cli/reference/oidc#lifetime), the token lifespan can live much longer and if leaked can mean a valid token can live longer than what is preferential to broker services.

### Changes
* Added an optional start up flag called `oidc-token-max-lifetime-seconds` which when passed the to the buildkite-agent binary will limit any subsequent calls to `buildkite-agent request token --lifetime <seconds>` to at clamp the total time set by the agent startup

### Testing
```
% go test ./...
go: downloading github.com/buildkite/bintest/v3 v3.3.0
go: downloading gotest.tools/v3 v3.5.2
go: downloading github.com/gliderlabs/ssh v0.3.8
go: downloading github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
?       github.com/buildkite/agent/v3   [no test files]
ok      github.com/buildkite/agent/v3/agent     6.760s
ok      github.com/buildkite/agent/v3/agent/integration       7.449s
ok      github.com/buildkite/agent/v3/agent/plugin   0.654s
ok      github.com/buildkite/agent/v3/api       0.923s
?       github.com/buildkite/agent/v3/api/proto/gen  [no test files]
?       github.com/buildkite/agent/v3/api/proto/gen/agentedgev1connect        [no test files]
ok      github.com/buildkite/agent/v3/clicommand     7.410s
?       github.com/buildkite/agent/v3/cliconfig [no test files]
?       github.com/buildkite/agent/v3/core      [no test files]
ok      github.com/buildkite/agent/v3/env       1.981s
ok      github.com/buildkite/agent/v3/internal/agentapi       1.552s
?       github.com/buildkite/agent/v3/internal/agenthttp      [no test files]
ok      github.com/buildkite/agent/v3/internal/artifact       1.850s
?       github.com/buildkite/agent/v3/internal/awslib[no test files]
?       github.com/buildkite/agent/v3/internal/bkgql [no test files]
ok      github.com/buildkite/agent/v3/internal/cache 2.463s
?       github.com/buildkite/agent/v3/internal/cryptosigner/aws       [no test files]
ok      github.com/buildkite/agent/v3/internal/cryptosigner/gcp       2.206s
?       github.com/buildkite/agent/v3/internal/e2e   [no test files]
ok      github.com/buildkite/agent/v3/internal/experiments    2.574s
?       github.com/buildkite/agent/v3/internal/file  [no test files]
ok      github.com/buildkite/agent/v3/internal/job   13.159s
?       github.com/buildkite/agent/v3/internal/job/githttptest        [no test files]
ok      github.com/buildkite/agent/v3/internal/job/hook       8.111s
ok      github.com/buildkite/agent/v3/internal/job/integration  38.524s
?       github.com/buildkite/agent/v3/internal/job/integration/test-binary-hook [no test files]
ok      github.com/buildkite/agent/v3/internal/mime     2.482s
ok      github.com/buildkite/agent/v3/internal/olfactor 2.333s
ok      github.com/buildkite/agent/v3/internal/osutil   2.358s
?       github.com/buildkite/agent/v3/internal/ptr      [no test files]
?       github.com/buildkite/agent/v3/internal/race     [no test files]
ok      github.com/buildkite/agent/v3/internal/redact   2.279s
ok      github.com/buildkite/agent/v3/internal/replacer 2.199s
ok      github.com/buildkite/agent/v3/internal/secrets  2.264s
?       github.com/buildkite/agent/v3/internal/self     [no test files]
ok      github.com/buildkite/agent/v3/internal/shell    3.795s
ok      github.com/buildkite/agent/v3/internal/shellscript      1.755s
ok      github.com/buildkite/agent/v3/internal/socket   1.884s
ok      github.com/buildkite/agent/v3/internal/stdin    1.790s
?       github.com/buildkite/agent/v3/internal/system   [no test files]
ok      github.com/buildkite/agent/v3/internal/tempfile 1.908s
ok      github.com/buildkite/agent/v3/internal/trie     1.879s
ok      github.com/buildkite/agent/v3/jobapi    1.119s
ok      github.com/buildkite/agent/v3/kubernetes        6.083s
ok      github.com/buildkite/agent/v3/lock      1.274s
ok      github.com/buildkite/agent/v3/logger    1.217s
?       github.com/buildkite/agent/v3/metrics   [no test files]
ok      github.com/buildkite/agent/v3/process   1.468s
ok      github.com/buildkite/agent/v3/status    1.325s
?       github.com/buildkite/agent/v3/test/fixtures/hook        [no test files]
ok      github.com/buildkite/agent/v3/tracetools        1.242s
ok      github.com/buildkite/agent/v3/version   1.058s
```

- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits
* Intent + general design of functionality were made by @krishnakpandian but changes were largely orchestrated through `cursor` 

https://github.com/buildkite/agent/issues/3793