### PR TITLE
Add an option to fail startup if we cannot fetch instance tags

### DIFF
--- a/agent/tags.go
+++ b/agent/tags.go
@@ -27,14 +27,17 @@ type FetchTagsConfig struct {
 	TagsFromGCPMetaDataPaths  []string
 	TagsFromGCPLabels         bool
 	TagsFromHost              bool
+	FailOnMissingTags         bool
 	WaitForEC2TagsTimeout     time.Duration
 	WaitForEC2MetaDataTimeout time.Duration
 	WaitForECSMetaDataTimeout time.Duration
 	WaitForGCPLabelsTimeout   time.Duration
 }
 
-// FetchTags loads tags from a variety of sources
-func FetchTags(ctx context.Context, l logger.Logger, conf FetchTagsConfig) []string {
+// FetchTags loads tags from a variety of sources.
+// If conf.FailOnMissingTags is true, an error is returned when any enabled
+// cloud tag source (EC2, ECS, GCP) fails to provide tags.
+func FetchTags(ctx context.Context, l logger.Logger, conf FetchTagsConfig) ([]string, error) {
 	f := &tagFetcher{
 		k8s: func() (map[string]string, error) {
 			return K8sTagsFromEnv(os.Environ())
@@ -75,7 +78,7 @@ type tagFetcher struct {
 	gcpLabels          func() (map[string]string, error)
 }
 
-func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsConfig) []string {
+func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsConfig) ([]string, error) {
 	tags := conf.Tags
 
 	if conf.TagsFromK8s {
@@ -129,8 +132,10 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 
 			return err
 		})
-		// Don't blow up if we can't find them, just show a nasty error.
 		if err != nil {
+			if conf.FailOnMissingTags {
+				return nil, fmt.Errorf("failed to fetch EC2 meta-data: %w", err)
+			}
 			l.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
 		}
 	}
@@ -144,7 +149,9 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 
 		ec2Tags, err := t.ec2MetaDataPaths(paths)
 		if err != nil {
-			// Don't blow up if we can't find them, just show a nasty error.
+			if conf.FailOnMissingTags {
+				return nil, fmt.Errorf("failed to fetch EC2 meta-data from paths: %w", err)
+			}
 			l.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
 		} else {
 			for tag, value := range ec2Tags {
@@ -179,8 +186,10 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 			}
 			return err
 		})
-		// Don't blow up if we can't find them, just show a nasty error.
 		if err != nil {
+			if conf.FailOnMissingTags {
+				return nil, fmt.Errorf("failed to fetch EC2 tags: %w", err)
+			}
 			l.Error(fmt.Sprintf("Failed to find EC2 tags: %s", err.Error()))
 		}
 	}
@@ -207,8 +216,10 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 
 			return err
 		})
-		// Don't blow up if we can't find them, just show a nasty error.
 		if err != nil {
+			if conf.FailOnMissingTags {
+				return nil, fmt.Errorf("failed to fetch ECS meta-data: %w", err)
+			}
 			l.Error(fmt.Sprintf("Failed to fetch ECS meta-data: %s", err.Error()))
 		}
 	}
@@ -235,8 +246,10 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 
 			return nil
 		})
-		// Don't blow up if we can't find them, just show a nasty error.
 		if err != nil {
+			if conf.FailOnMissingTags {
+				return nil, fmt.Errorf("failed to fetch GCP meta-data: %w", err)
+			}
 			l.Error(fmt.Sprintf("Failed to fetch GCP meta-data: %s", err.Error()))
 		}
 	}
@@ -250,7 +263,9 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 
 		gcpTags, err := t.gcpMetaDataPaths(paths)
 		if err != nil {
-			// Don't blow up if we can't find them, just show a nasty error.
+			if conf.FailOnMissingTags {
+				return nil, fmt.Errorf("failed to fetch GCP meta-data from paths: %w", err)
+			}
 			l.Error(fmt.Sprintf("Failed to fetch Google Cloud meta-data: %s", err.Error()))
 		} else {
 			for tag, value := range gcpTags {
@@ -282,13 +297,15 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 			}
 			return err
 		})
-		// Don't blow up if we can't find them, just show a nasty error.
 		if err != nil {
+			if conf.FailOnMissingTags {
+				return nil, fmt.Errorf("failed to fetch GCP instance labels: %w", err)
+			}
 			l.Error(fmt.Sprintf("Failed to find GCP instance labels: %s", err.Error()))
 		}
 	}
 
-	return tags
+	return tags, nil
 }
 
 func parseTagValuePathPairs(paths []string) (map[string]string, error) {

--- a/agent/tags_test.go
+++ b/agent/tags_test.go
@@ -10,12 +10,14 @@ import (
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFetchingTags(t *testing.T) {
-	tags := (&tagFetcher{}).Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+	tags, err := (&tagFetcher{}).Fetch(context.Background(), logger.Discard, FetchTagsConfig{
 		Tags: []string{"llamas", "rock"},
 	})
+	require.NoError(t, err)
 
 	if diff := cmp.Diff(tags, []string{"llamas", "rock"}); diff != "" {
 		t.Errorf("(*tagFetcher).Fetch() diff (-got +want):\n%v", diff)
@@ -23,10 +25,11 @@ func TestFetchingTags(t *testing.T) {
 }
 
 func TestFetchingTagsWithHostTags(t *testing.T) {
-	tags := (&tagFetcher{}).Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+	tags, err := (&tagFetcher{}).Fetch(context.Background(), logger.Discard, FetchTagsConfig{
 		Tags:         []string{"llamas", "rock"},
 		TagsFromHost: true,
 	})
+	require.NoError(t, err)
 
 	assert.Contains(t, tags, "llamas")
 	assert.Contains(t, tags, "rock")
@@ -55,11 +58,12 @@ func TestFetchingTagsFromEC2(t *testing.T) {
 		},
 	}
 
-	tags := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+	tags, err := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
 		Tags:                []string{"llamas", "rock"},
 		TagsFromEC2MetaData: true,
 		TagsFromEC2Tags:     true,
 	})
+	require.NoError(t, err)
 
 	assert.ElementsMatch(t, tags,
 		[]string{"llamas", "rock", "aws:instance-id=i-blahblah", "aws:instance-type=t2.small", "custom_tag=true"})
@@ -74,9 +78,10 @@ func TestFetchingTagsFromEC2Tags(t *testing.T) {
 		},
 	}
 
-	tags := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+	tags, err := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
 		TagsFromEC2Tags: true,
 	})
+	require.NoError(t, err)
 
 	assert.ElementsMatch(t, tags,
 		[]string{"custom_tag=true"})
@@ -93,10 +98,11 @@ func TestFetchingTagsFromECS(t *testing.T) {
 		},
 	}
 
-	tags := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+	tags, err := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
 		Tags:                []string{"llamas", "rock"},
 		TagsFromECSMetaData: true,
 	})
+	require.NoError(t, err)
 
 	assert.ElementsMatch(t, tags,
 		[]string{
@@ -130,11 +136,12 @@ func TestFetchingTagsFromGCP(t *testing.T) {
 		},
 	}
 
-	tags := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+	tags, err := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
 		Tags:                []string{"llamas", "rock"},
 		TagsFromGCPMetaData: true,
 		TagsFromGCPLabels:   true,
 	})
+	require.NoError(t, err)
 
 	assert.ElementsMatch(t, tags,
 		[]string{"llamas", "rock", "gcp:instance-id=my-instance", "gcp:zone=blah", "custom_tag=true"})
@@ -167,7 +174,7 @@ func TestFetchingTagsFromAllSources(t *testing.T) {
 		},
 	}
 
-	tags := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+	tags, err := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
 		Tags:                     []string{"llamas", "rock"},
 		TagsFromGCPMetaData:      true,
 		TagsFromGCPMetaDataPaths: []string{"tag=some/gcp/value"},
@@ -178,6 +185,7 @@ func TestFetchingTagsFromAllSources(t *testing.T) {
 		TagsFromEC2MetaDataPaths: []string{"tag=some/ec2/value"},
 		TagsFromEC2Tags:          true,
 	})
+	require.NoError(t, err)
 
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -194,5 +202,217 @@ func TestFetchingTagsFromAllSources(t *testing.T) {
 	assert.Contains(t, tags, "ecs_metadata=true")
 	assert.Contains(t, tags, "ec2_metadata_paths=true")
 	assert.Contains(t, tags, "hostname="+hostname)
+	assert.Contains(t, tags, "os="+runtime.GOOS)
+}
+
+// Tests for --fail-on-missing-tags behavior
+
+func TestFailOnMissingTags_EC2MetaData(t *testing.T) {
+	fetcher := &tagFetcher{
+		ec2MetaDataDefault: func() (map[string]string, error) {
+			return nil, errors.New("IMDS unavailable")
+		},
+	}
+
+	// With FailOnMissingTags=false (default), should soft-fail
+	tags, err := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:                []string{"llamas"},
+		TagsFromEC2MetaData: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"llamas"}, tags)
+
+	// With FailOnMissingTags=true, should return error
+	_, err = fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:                []string{"llamas"},
+		TagsFromEC2MetaData: true,
+		FailOnMissingTags:   true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch EC2 meta-data")
+}
+
+func TestFailOnMissingTags_EC2MetaDataPaths(t *testing.T) {
+	fetcher := &tagFetcher{
+		ec2MetaDataPaths: func(paths map[string]string) (map[string]string, error) {
+			return nil, errors.New("IMDS unavailable")
+		},
+	}
+
+	// With FailOnMissingTags=false (default), should soft-fail
+	tags, err := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:                     []string{"llamas"},
+		TagsFromEC2MetaDataPaths: []string{"tag=some/path"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"llamas"}, tags)
+
+	// With FailOnMissingTags=true, should return error
+	_, err = fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:                     []string{"llamas"},
+		TagsFromEC2MetaDataPaths: []string{"tag=some/path"},
+		FailOnMissingTags:        true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch EC2 meta-data from paths")
+}
+
+func TestFailOnMissingTags_EC2Tags(t *testing.T) {
+	fetcher := &tagFetcher{
+		ec2Tags: func() (map[string]string, error) {
+			return nil, errors.New("RequestLimitExceeded")
+		},
+	}
+
+	// With FailOnMissingTags=false (default), should soft-fail
+	tags, err := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:            []string{"llamas"},
+		TagsFromEC2Tags: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"llamas"}, tags)
+
+	// With FailOnMissingTags=true, should return error
+	_, err = fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:              []string{"llamas"},
+		TagsFromEC2Tags:   true,
+		FailOnMissingTags: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch EC2 tags")
+}
+
+func TestFailOnMissingTags_ECSMetaData(t *testing.T) {
+	fetcher := &tagFetcher{
+		ecsMetaDataDefault: func() (map[string]string, error) {
+			return nil, errors.New("ECS metadata unavailable")
+		},
+	}
+
+	// With FailOnMissingTags=false (default), should soft-fail
+	tags, err := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:                []string{"llamas"},
+		TagsFromECSMetaData: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"llamas"}, tags)
+
+	// With FailOnMissingTags=true, should return error
+	_, err = fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:                []string{"llamas"},
+		TagsFromECSMetaData: true,
+		FailOnMissingTags:   true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch ECS meta-data")
+}
+
+func TestFailOnMissingTags_GCPMetaData(t *testing.T) {
+	fetcher := &tagFetcher{
+		gcpMetaDataDefault: func() (map[string]string, error) {
+			return nil, errors.New("GCP metadata unavailable")
+		},
+	}
+
+	// With FailOnMissingTags=false (default), should soft-fail
+	tags, err := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:                []string{"llamas"},
+		TagsFromGCPMetaData: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"llamas"}, tags)
+
+	// With FailOnMissingTags=true, should return error
+	_, err = fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:                []string{"llamas"},
+		TagsFromGCPMetaData: true,
+		FailOnMissingTags:   true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch GCP meta-data")
+}
+
+func TestFailOnMissingTags_GCPMetaDataPaths(t *testing.T) {
+	fetcher := &tagFetcher{
+		gcpMetaDataPaths: func(paths map[string]string) (map[string]string, error) {
+			return nil, errors.New("GCP metadata unavailable")
+		},
+	}
+
+	// With FailOnMissingTags=false (default), should soft-fail
+	tags, err := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:                     []string{"llamas"},
+		TagsFromGCPMetaDataPaths: []string{"tag=some/path"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"llamas"}, tags)
+
+	// With FailOnMissingTags=true, should return error
+	_, err = fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:                     []string{"llamas"},
+		TagsFromGCPMetaDataPaths: []string{"tag=some/path"},
+		FailOnMissingTags:        true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch GCP meta-data from paths")
+}
+
+func TestFailOnMissingTags_GCPLabels(t *testing.T) {
+	fetcher := &tagFetcher{
+		gcpLabels: func() (map[string]string, error) {
+			return nil, errors.New("GCP labels unavailable")
+		},
+	}
+
+	// With FailOnMissingTags=false (default), should soft-fail
+	tags, err := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:              []string{"llamas"},
+		TagsFromGCPLabels: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"llamas"}, tags)
+
+	// With FailOnMissingTags=true, should return error
+	_, err = fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:              []string{"llamas"},
+		TagsFromGCPLabels: true,
+		FailOnMissingTags: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch GCP instance labels")
+}
+
+// Verify that FailOnMissingTags has no effect when cloud sources succeed
+func TestFailOnMissingTags_NoErrorWhenSourcesSucceed(t *testing.T) {
+	fetcher := &tagFetcher{
+		ec2MetaDataDefault: func() (map[string]string, error) {
+			return map[string]string{"aws:instance-id": "i-1234"}, nil
+		},
+		ec2Tags: func() (map[string]string, error) {
+			return map[string]string{"env": "prod"}, nil
+		},
+	}
+
+	tags, err := fetcher.Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:                []string{"llamas"},
+		TagsFromEC2MetaData: true,
+		TagsFromEC2Tags:     true,
+		FailOnMissingTags:   true,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, tags, "llamas")
+	assert.Contains(t, tags, "aws:instance-id=i-1234")
+	assert.Contains(t, tags, "env=prod")
+}
+
+// Verify that FailOnMissingTags does not affect non-cloud sources (host, k8s)
+func TestFailOnMissingTags_DoesNotAffectHostTags(t *testing.T) {
+	tags, err := (&tagFetcher{}).Fetch(context.Background(), logger.Discard, FetchTagsConfig{
+		Tags:              []string{"llamas"},
+		TagsFromHost:      true,
+		FailOnMissingTags: true,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, tags, "llamas")
 	assert.Contains(t, tags, "os="+runtime.GOOS)
 }

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -459,9 +459,8 @@ var AgentStartCommand = cli.Command{
 			Usage:  "Include tags from the host (hostname, machine-id, os) (default: false)",
 			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_HOST",
 		},
-		cli.StringSliceFlag{
+		cli.BoolFlag{
 			Name:   "tags-from-ec2-meta-data",
-			Value:  &cli.StringSlice{},
 			Usage:  "Include the default set of host EC2 meta-data as tags (instance-id, instance-type, ami-id, and instance-life-cycle)",
 			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_EC2_META_DATA",
 		},

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -151,6 +151,7 @@ type AgentStartConfig struct {
 	TagsFromGCPMetaDataPaths  []string `cli:"tags-from-gcp-meta-data-paths" normalize:"list"`
 	TagsFromGCPLabels         bool     `cli:"tags-from-gcp-labels"`
 	TagsFromHost              bool     `cli:"tags-from-host"`
+	FailOnMissingTags         bool     `cli:"fail-on-missing-tags"`
 	WaitForEC2TagsTimeout     string   `cli:"wait-for-ec2-tags-timeout"`
 	WaitForEC2MetaDataTimeout string   `cli:"wait-for-ec2-meta-data-timeout"`
 	WaitForECSMetaDataTimeout string   `cli:"wait-for-ecs-meta-data-timeout"`
@@ -520,6 +521,11 @@ var AgentStartCommand = cli.Command{
 			Usage:  "The amount of time to wait for labels from GCP before proceeding",
 			EnvVar: "BUILDKITE_AGENT_WAIT_FOR_GCP_LABELS_TIMEOUT",
 			Value:  time.Second * 10,
+		},
+		cli.BoolFlag{
+			Name:   "fail-on-missing-tags",
+			Usage:  "Exit the agent with an error if any enabled cloud tag source (EC2, ECS, GCP) fails to return tags (default: false)",
+			EnvVar: "BUILDKITE_AGENT_FAIL_ON_MISSING_TAGS",
 		},
 
 		// Various git related flags shared with bootstrap
@@ -1211,7 +1217,7 @@ var AgentStartCommand = cli.Command{
 			return fmt.Errorf("failed to parse cancel-signal: %w", err)
 		}
 
-		tags := agent.FetchTags(ctx, l, agent.FetchTagsConfig{
+		tags, err := agent.FetchTags(ctx, l, agent.FetchTagsConfig{
 			Tags:                      cfg.Tags,
 			TagsFromK8s:               cfg.KubernetesExec,
 			TagsFromEC2MetaData:       (cfg.TagsFromEC2MetaData || cfg.TagsFromEC2),
@@ -1222,11 +1228,15 @@ var AgentStartCommand = cli.Command{
 			TagsFromGCPMetaDataPaths:  cfg.TagsFromGCPMetaDataPaths,
 			TagsFromGCPLabels:         cfg.TagsFromGCPLabels,
 			TagsFromHost:              cfg.TagsFromHost,
+			FailOnMissingTags:         cfg.FailOnMissingTags,
 			WaitForEC2TagsTimeout:     ec2TagTimeout,
 			WaitForEC2MetaDataTimeout: ec2MetaDataTimeout,
 			WaitForECSMetaDataTimeout: ecsMetaDataTimeout,
 			WaitForGCPLabelsTimeout:   gcpLabelsTimeout,
 		})
+		if err != nil {
+			l.Fatal("%v", err)
+		}
 
 		// Munge the value from --queue (if it exists) into the tags slice
 		if cfg.Queue != "" {


### PR DESCRIPTION
### Description

This is a customer-requested feature. They use EC2 instance tags to signal which AWS launch template should be used to launch an instance. In their workflow, when instance tags are unavailable (they've seen this due to AWS API rate-limiting), the agent will start up and connect to Buildkite, but isn't usable for their builds. They requested an option to make this conditional fatal during agent startup, to make it easier to diagnose and respond to the issue.

I considered using an agent-startup hook to check this and abort the startup if tags are not available, but this code change is pretty self-contained, and it felt low-risk and cleaner than the hook workaround.

### Context

PF-9576

### Changes

Adds a `--fail-on-missing-tags` argument to `buildkite-agent start`. 

> Exit the agent with an error if any enabled cloud tag source (EC2, ECS, GCP) fails to return tags (default: false) [$BUILDKITE_AGENT_FAIL_ON_MISSING_TAGS]


### Testing
- [X] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [X] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

Claude wrote the code and tests. I reviewed the changes myself, to the best of my ability, and also used a separate Claude agent to poke holes, and made a couple of minor improvements based on that feedback.