### PR TITLE
fix: incorrect check in TestAnnotateMaxBodySize, clean up assert

### DIFF
--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -153,7 +153,7 @@ func annotate(ctx context.Context, cfg AnnotateConfig, l logger.Logger) error {
 	}
 
 	if bodySize := len(body); bodySize > maxBodySize {
-		return fmt.Errorf("annotation body size (%dB) exceeds maximum (%dB)", bodySize, maxBodySize)
+		return annotationTooBigError{bodySize}
 	}
 
 	// Create the API client
@@ -197,4 +197,12 @@ func annotate(ctx context.Context, cfg AnnotateConfig, l logger.Logger) error {
 	l.Debug("Successfully annotated build")
 
 	return nil
+}
+
+type annotationTooBigError struct {
+	bodySize int
+}
+
+func (e annotationTooBigError) Error() string {
+	return fmt.Sprintf("annotation body size (%dB) exceeds maximum (%dB)", e.bodySize, maxBodySize)
 }

--- a/clicommand/annotate_test.go
+++ b/clicommand/annotate_test.go
@@ -1,15 +1,15 @@
 package clicommand
 
 import (
-	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/buildkite/agent/v3/logger"
-	"github.com/stretchr/testify/assert"
 )
 
 func newAnnotateTestServer(t *testing.T) *httptest.Server {
@@ -27,7 +27,6 @@ func TestAnnotate(t *testing.T) {
 	server := newAnnotateTestServer(t)
 	defer server.Close()
 
-	ctx := context.Background()
 	cfg := AnnotateConfig{
 		Body: "abc",
 		Job:  "jobid",
@@ -39,18 +38,24 @@ func TestAnnotate(t *testing.T) {
 	}
 	l := logger.NewBuffer()
 
-	err := annotate(ctx, cfg, l)
-	assert.NoError(t, err)
-	assert.Contains(t, l.Messages, "[debug] Successfully annotated build")
+	err := annotate(t.Context(), cfg, l)
+	if err != nil {
+		t.Errorf("annotate(ctx, %v, l) error = %v", cfg, err)
+	}
+	if want := "[debug] Successfully annotated build"; !slices.Contains(l.Messages, want) {
+		t.Errorf("annotate(ctx, %v, l) logged messages = %q, missing %q", cfg, l.Messages, want)
+	}
 }
 
 func TestAnnotateMaxBodySize(t *testing.T) {
-	ctx := context.Background()
 	cfg := AnnotateConfig{
 		Body: strings.Repeat("a", 1048577),
 	}
 	l := logger.NewBuffer()
 
-	err := annotate(ctx, cfg, l)
-	assert.Error(t, err, "Annotation body size (1048577) exceeds maximum (1048576)")
+	err := annotate(t.Context(), cfg, l)
+	wantErr := annotationTooBigError{bodySize: 1048577}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("annotate(ctx, AnnotateConfig{Body: \"aaa...aaa\"}, l) error = %v, want %[2]T %[2]v", err, wantErr)
+	}
 }


### PR DESCRIPTION
### Description

- Fix a test by returning a new error type and checking for it with `errors.Is`
- Remove `assert` from the test file

### Context

The bug in the test was discovered and reported by @ss1909 (I think? I'm not 100% sure of GH username)

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

I did not use AI tools at all
