### PR TITLE
fix: compile badChars regexp once

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -807,14 +807,14 @@ func (e *Executor) executeLocalHook(ctx context.Context, name string) error {
 	})
 }
 
+var badCharsRE = regexp.MustCompile("[[:^alnum:]]")
+
 func dirForAgentName(agentName string) string {
-	badCharsPattern := regexp.MustCompile("[[:^alnum:]]")
-	return badCharsPattern.ReplaceAllString(agentName, "-")
+	return badCharsRE.ReplaceAllString(agentName, "-")
 }
 
 func dirForRepository(repository string) string {
-	badCharsPattern := regexp.MustCompile("[[:^alnum:]]")
-	return badCharsPattern.ReplaceAllString(repository, "-")
+	return badCharsRE.ReplaceAllString(repository, "-")
 }
 
 // Given a repository, it will add the host to the set of SSH known_hosts on the machine


### PR DESCRIPTION
### Description

Small optimisation fix: only `regexp.MustCompile` a regexp once. 

### Context

Found while working on something else.

### Changes

Move regexp compilation into a package var.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)


### Disclosures / Credits

I did not use AI tools at all.