### PR TITLE
A-1115: refactor ArtifactBatchCreator to use iterator

### DIFF
--- a/internal/artifact/batch_creator.go
+++ b/internal/artifact/batch_creator.go
@@ -2,6 +2,8 @@ package artifact
 
 import (
 	"context"
+	"iter"
+	"slices"
 	"time"
 
 	"github.com/buildkite/agent/v3/api"
@@ -46,82 +48,84 @@ func NewArtifactBatchCreator(l logger.Logger, ac APIClient, c BatchCreatorConfig
 	}
 }
 
-func (a *BatchCreator) Create(ctx context.Context) ([]*api.Artifact, error) {
-	length := len(a.conf.Artifacts)
-	chunks := 30
+// Batches yields successive chunks of artifacts after batch-creating them on
+// Buildkite (which assigns IDs and upload instructions). Each chunk is created
+// immediately before it is yielded, keeping presigned upload URLs fresh.
+func (a *BatchCreator) Batches(ctx context.Context) iter.Seq2[[]*api.Artifact, error] {
+	return func(yield func([]*api.Artifact, error) bool) {
+		const chunkSize = 30
+		total := len(a.conf.Artifacts)
+		offset := 0
 
-	// Split into the artifacts into chunks so we're not uploading a ton of
-	// files at once.
-	for i := 0; i < length; i += chunks {
-		j := min(i+chunks, length)
+		for theseArtifacts := range slices.Chunk(a.conf.Artifacts, chunkSize) {
 
-		// The artifacts that will be uploaded in this chunk
-		theseArtifacts := a.conf.Artifacts[i:j]
-
-		// An ID is required so Buildkite can ensure this create
-		// operation is idompotent (if we try and upload the same ID
-		// twice, it'll just return the previous data and skip the
-		// upload)
-		batch := &api.ArtifactBatch{
-			ID:                 api.NewUUID(),
-			Artifacts:          theseArtifacts,
-			UploadDestination:  a.conf.UploadDestination,
-			MultipartSupported: a.conf.AllowMultipart,
-		}
-
-		a.logger.Info("Creating (%d-%d)/%d artifacts", i, j, length)
-
-		timeout := a.conf.CreateArtifactsTimeout
-
-		// Retry the batch upload a couple of times
-		r := roko.NewRetrier(
-			roko.WithMaxAttempts(10),
-			roko.WithStrategy(roko.ExponentialSubsecond(500*time.Millisecond)),
-		)
-		creation, err := roko.DoFunc(ctx, r, func(r *roko.Retrier) (*api.ArtifactBatchCreateResponse, error) {
-			ctxTimeout := ctx
-			if timeout != 0 {
-				var cancel func()
-				ctxTimeout, cancel = context.WithTimeout(ctx, a.conf.CreateArtifactsTimeout)
-				defer cancel()
+			// An ID is required so Buildkite can ensure this create
+			// operation is idempotent (if we try and upload the same
+			// ID twice, it'll just return the previous data and skip
+			// the upload)
+			batch := &api.ArtifactBatch{
+				ID:                 api.NewUUID(),
+				Artifacts:          theseArtifacts,
+				UploadDestination:  a.conf.UploadDestination,
+				MultipartSupported: a.conf.AllowMultipart,
 			}
 
-			creation, resp, err := a.apiClient.CreateArtifacts(ctxTimeout, a.conf.JobID, batch)
-			// the server returns a 403 code if the artifact has exceeded the service quota
-			// Break the retry on any 4xx code except for 429 Too Many Requests.
-			if resp != nil && (resp.StatusCode != 429 && resp.StatusCode >= 400 && resp.StatusCode <= 499) {
-				a.logger.Warn("Artifact creation failed with status code %d, breaking the retry loop", resp.StatusCode)
-				r.Break()
-			}
+			a.logger.Info("Creating (%d-%d)/%d artifacts", offset, offset+len(theseArtifacts), total)
+			offset += len(theseArtifacts)
+
+			timeout := a.conf.CreateArtifactsTimeout
+
+			// Retry the batch upload a couple of times
+			r := roko.NewRetrier(
+				roko.WithMaxAttempts(10),
+				roko.WithStrategy(roko.ExponentialSubsecond(500*time.Millisecond)),
+			)
+			creation, err := roko.DoFunc(ctx, r, func(r *roko.Retrier) (*api.ArtifactBatchCreateResponse, error) {
+				ctxTimeout := ctx
+				if timeout != 0 {
+					var cancel func()
+					ctxTimeout, cancel = context.WithTimeout(ctx, a.conf.CreateArtifactsTimeout)
+					defer cancel()
+				}
+
+				creation, resp, err := a.apiClient.CreateArtifacts(ctxTimeout, a.conf.JobID, batch)
+				// The server returns a 403 code if the artifact has exceeded the service quota.
+				// Break the retry on any 4xx code except for 429 Too Many Requests.
+				if resp != nil && (resp.StatusCode != 429 && resp.StatusCode >= 400 && resp.StatusCode <= 499) {
+					a.logger.Warn("Artifact creation failed with status code %d, breaking the retry loop", resp.StatusCode)
+					r.Break()
+				}
+				if err != nil {
+					a.logger.Warn("%s (%s)", err, r)
+				}
+
+				// after four attempts (0, 1, 2, 3)...
+				if r.AttemptCount() == 3 {
+					// The short timeout has given us fast feedback on the first couple of attempts,
+					// but perhaps the server needs more time to complete the request, so fall back to
+					// the default HTTP client timeout.
+					a.logger.Debug("CreateArtifacts timeout (%s) removed for subsequent attempts", timeout)
+					timeout = 0
+				}
+
+				return creation, err
+			})
 			if err != nil {
-				a.logger.Warn("%s (%s)", err, r)
+				yield(nil, err)
+				return
 			}
 
-			// after four attempts (0, 1, 2, 3)...
-			if r.AttemptCount() == 3 {
-				// The short timeout has given us fast feedback on the first couple of attempts,
-				// but perhaps the server needs more time to complete the request, so fall back to
-				// the default HTTP client timeout.
-				a.logger.Debug("CreateArtifacts timeout (%s) removed for subsequent attempts", timeout)
-				timeout = 0
+			for index, id := range creation.ArtifactIDs {
+				theseArtifacts[index].ID = id
+				theseArtifacts[index].UploadInstructions = creation.InstructionsTemplate
+				if specific := creation.PerArtifactInstructions[id]; specific != nil {
+					theseArtifacts[index].UploadInstructions = specific
+				}
 			}
 
-			return creation, err
-		})
-		// Did the batch creation eventually fail?
-		if err != nil {
-			return nil, err
-		}
-
-		// Save the id and instructions to each artifact
-		for index, id := range creation.ArtifactIDs {
-			theseArtifacts[index].ID = id
-			theseArtifacts[index].UploadInstructions = creation.InstructionsTemplate
-			if specific := creation.PerArtifactInstructions[id]; specific != nil {
-				theseArtifacts[index].UploadInstructions = specific
+			if !yield(theseArtifacts, nil) {
+				return
 			}
 		}
 	}
-
-	return a.conf.Artifacts, nil
 }

--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -107,7 +107,10 @@ func (a *Uploader) Upload(ctx context.Context) error {
 		artifact.URL = uploader.URL(artifact)
 	}
 
-	// Batch-create the artifact records on Buildkite
+	// Batch-create artifact records on Buildkite and upload each batch
+	// immediately. This keeps presigned upload URLs fresh — if all
+	// artifacts were were created upfront in a single batch, URLs for artifacts near the
+	// end of the queue could expire before the agent gets to them.
 	batchCreator := NewArtifactBatchCreator(a.logger, a.apiClient, BatchCreatorConfig{
 		JobID:                  a.conf.JobID,
 		Artifacts:              artifacts,
@@ -115,13 +118,13 @@ func (a *Uploader) Upload(ctx context.Context) error {
 		CreateArtifactsTimeout: 10 * time.Second,
 		AllowMultipart:         a.conf.AllowMultipart,
 	})
-	artifacts, err = batchCreator.Create(ctx)
-	if err != nil {
-		return err
-	}
-
-	if err := a.upload(ctx, artifacts, uploader); err != nil {
-		return fmt.Errorf("uploading artifacts: %w", err)
+	for chunk, err := range batchCreator.Batches(ctx) {
+		if err != nil {
+			return err
+		}
+		if err := a.upload(ctx, chunk, uploader); err != nil {
+			return fmt.Errorf("uploading artifacts: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
### Description

When there are many many small artifact files being uploaded, we currently get the presigned S3 url in the beginning. It could result in a situation, the combined round trip times are beyond S3 presidnged url TTL, causing artifact upload to fail. 

This PR refactor ArtifactBatchCreator to use iterator, so only obtain the upload right before yielding. 

### Context

A-1115


### Disclosures / Credits

My LLM minion