### PR TITLE
Promote descending-spawn-priority experiment

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -46,9 +46,3 @@ When interpolating the pipeline level environment block, a pipeline level enviro
 We previously made this the default behaviour of the agent (as of v3.63.0) but have since reverted it.
 
 **Status:** Available as an experiment to allow users who have since depended on this behaviour to re-enable it. If you use this feature please let us know so we may better understand your use case.
-
-### `descending-spawn-priority`
-
-When using `--spawn` with `--spawn-with-priority`, the agent assigns ascending priorities to each spawned agent (1, 2, 3, ...). This experiment changes the priorities to be descending (-1, -2, -3, ...) instead. This helps jobs be assigned across all hosts in cases where the value of `--spawn` varies between hosts.
-
-**Status:** Experimental as an escape hatch to default behaviour. Will soon be promoted to a regular flag.

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -98,7 +98,7 @@ type AgentStartConfig struct {
 	Priority          string   `cli:"priority"`
 	Spawn             int      `cli:"spawn"`
 	SpawnPerCPU       int      `cli:"spawn-per-cpu"`
-	SpawnWithPriority bool     `cli:"spawn-with-priority"`
+	SpawnWithPriority string   `cli:"spawn-with-priority"`
 	RedactedVars      []string `cli:"redacted-vars" normalize:"list"`
 	CancelSignal      string   `cli:"cancel-signal"`
 
@@ -659,9 +659,10 @@ var AgentStartCommand = cli.Command{
 			Value:  0,
 			EnvVar: "BUILDKITE_AGENT_SPAWN_PER_CPU",
 		},
-		cli.BoolFlag{
+		cli.StringFlag{
 			Name:   "spawn-with-priority",
-			Usage:  "Assign priorities to every spawned agent (when using --spawn or --spawn-per-cpu) equal to the agent's index (default: false)",
+			Usage:  `Assign priorities to every spawned agent (when using --spawn or --spawn-per-cpu). Pass "static" (1, 1, 1, ...), "ascending" (1, 2, 3, ...), or "descending" (-1, -2, -3, ...). Descending helps jobs be assigned across all hosts when the value of --spawn varies between hosts`,
+			Value:  "static",
 			EnvVar: "BUILDKITE_AGENT_SPAWN_WITH_PRIORITY",
 		},
 		cancelSignalFlag,
@@ -827,6 +828,11 @@ var AgentStartCommand = cli.Command{
 		// on the very remote chance someone is using that.
 		if cfg.PingMode == pingModePingOnly {
 			cfg.PingMode = agent.PingModePollOnly
+		}
+
+		validSpawnWithPriorities := []string{"static", "ascending", "descending"}
+		if !slices.Contains(validSpawnWithPriorities, cfg.SpawnWithPriority) {
+			return fmt.Errorf("invalid spawn-with-priority, must be one of %v", validSpawnWithPriorities)
 		}
 
 		if cfg.VerificationJWKSFile != "" {
@@ -1273,16 +1279,22 @@ var AgentStartCommand = cli.Command{
 			// Handle per-spawn name interpolation, replacing %spawn with the spawn index
 			registerReq.Name = strings.ReplaceAll(cfg.Name, "%spawn", strconv.Itoa(i))
 
-			if cfg.SpawnWithPriority {
-				p := i
-				if experiments.IsEnabled(ctx, experiments.DescendingSpawnPriority) {
-					// This experiment helps jobs be assigned across all hosts
-					// in cases where the value of --spawn varies between hosts.
-					p = -i
-				}
-				l.Info("Assigning priority %d for agent %d", p, i)
-				registerReq.Priority = strconv.Itoa(p)
+			var priority string
+			switch cfg.SpawnWithPriority {
+			case "static":
+				priority = cfg.Priority
+
+			case "ascending":
+				priority = strconv.Itoa(i)
+
+			case "descending":
+				priority = strconv.Itoa(-i)
+
+			default:
+				return fmt.Errorf("unknown spawn-with-priority value %s", cfg.SpawnWithPriority)
 			}
+
+			registerReq.Priority = priority
 
 			// Register the agent with the buildkite API
 			reg, err := client.Register(ctx, registerReq)

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -24,12 +24,12 @@ const (
 const (
 	// Available experiments
 	AgentAPI                       = "agent-api"
-	DescendingSpawnPriority        = "descending-spawn-priority"
 	InterpolationPrefersRuntimeEnv = "interpolation-prefers-runtime-env"
 	PTYRaw                         = "pty-raw"
 
 	// Promoted or removed experiments - un-export these to ensure no new code
 	// can depend on them.
+	descendingSpawnPriority    = "descending-spawn-priority"
 	allowArtifactPathTraversal = "allow-artifact-path-traversal"
 	ansiTimestamps             = "ansi-timestamps"
 	avoidRecursiveTrap         = "avoid-recursive-trap"
@@ -50,12 +50,12 @@ const (
 var (
 	Available = map[string]struct{}{
 		AgentAPI:                       {},
-		DescendingSpawnPriority:        {},
 		InterpolationPrefersRuntimeEnv: {},
 		PTYRaw:                         {},
 	}
 
 	Promoted = map[string]string{
+		descendingSpawnPriority:    "The `descending-spawn-priority` has been replaced with `--spawn-with-priority descending` as of agent v4",
 		ansiTimestamps:             standardPromotionMsg(ansiTimestamps, "v3.48.0"),
 		allowArtifactPathTraversal: "The allow-artifact-path-traversal escape-hatch experiment has been removed as of agent v4, because the path traversal behaviour was insecure",
 		avoidRecursiveTrap:         standardPromotionMsg(avoidRecursiveTrap, "v3.66.0"),


### PR DESCRIPTION
### Description

The `descending-spawn-priority` experiment has been around for ages. we're making breaking changes, so let's make it real behaviour and change a flag definition!

### Context

top 10 places this idea came to me from, number 6 will shock you! (in a dream)

### Changes

Change `--spawn-with-priority` flag from being a bool (spawned agents get ascending priorities based on their spawn index, or descending if the `descending-spawn-priority` experiment is active) to a string flag with the following valid values:
- `static` (default): all spawned agents get the same priority from the `--priority` flag (default 0). same as in v3 if the `--spawn-with-priority` flag was not passed.
- `ascending`: same as v3 `--spawn-with-priority true`, spawned agents get ascending priorities based on their spawn index (1..n for n spawned agents)
- `descending`: same as old behaviour `--spawn-with-priority true --experiment descending-spawn-priority`, spawned agents get descending priorities based one their spawn index (n..-1)

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

I tried getting amp to do this to save myself ten minutes, and it did a really shit job, so i rewrote all of it (taking about 10 minutes)