### PR TITLE
A-1050 and A-1060: Make checkout retry attempt configurable, increasing default retry

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -28,6 +28,7 @@ type AgentConfiguration struct {
 	GitSubmoduleCloneConfig         []string
 	SkipCheckout                    bool
 	GitSkipFetchExistingCommits     bool
+	CheckoutAttempts                int
 	AllowedRepositories             []*regexp.Regexp
 	AllowedPlugins                  []*regexp.Regexp
 	AllowedEnvironmentVariables     []*regexp.Regexp

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -564,6 +564,7 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 	if r.conf.AgentConfiguration.GitSkipFetchExistingCommits {
 		setEnv("BUILDKITE_GIT_SKIP_FETCH_EXISTING_COMMITS", "true")
 	}
+	setEnv("BUILDKITE_CHECKOUT_ATTEMPTS", strconv.Itoa(r.conf.AgentConfiguration.CheckoutAttempts))
 	setEnv("BUILDKITE_COMMAND_EVAL", fmt.Sprint(r.conf.AgentConfiguration.CommandEval))
 	setEnv("BUILDKITE_PLUGINS_ENABLED", fmt.Sprint(r.conf.AgentConfiguration.PluginsEnabled))
 	// Allow BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH to be enabled either by config

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -169,6 +169,7 @@ type AgentStartConfig struct {
 	GitSubmoduleCloneConfig     []string `cli:"git-submodule-clone-config"`
 	SkipCheckout                bool     `cli:"skip-checkout"`
 	GitSkipFetchExistingCommits bool     `cli:"git-skip-fetch-existing-commits"`
+	CheckoutAttempts            int      `cli:"checkout-attempts"`
 
 	NoSSHKeyscan            bool     `cli:"no-ssh-keyscan"`
 	NoCommandEval           bool     `cli:"no-command-eval"`
@@ -534,6 +535,7 @@ var AgentStartCommand = cli.Command{
 		GitMirrorsSkipUpdateFlag,
 		GitSubmoduleCloneConfigFlag,
 		GitSkipFetchExistingCommitsFlag,
+		CheckoutAttemptsFlag,
 
 		cli.StringFlag{
 			Name:   "bootstrap-script",
@@ -1063,6 +1065,7 @@ var AgentStartCommand = cli.Command{
 			GitSubmoduleCloneConfig:         cfg.GitSubmoduleCloneConfig,
 			SkipCheckout:                    cfg.SkipCheckout,
 			GitSkipFetchExistingCommits:     cfg.GitSkipFetchExistingCommits,
+			CheckoutAttempts:                cfg.CheckoutAttempts,
 			SSHKeyscan:                      !cfg.NoSSHKeyscan,
 			CommandEval:                     !cfg.NoCommandEval,
 			PluginsEnabled:                  !cfg.NoPlugins,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -112,6 +112,7 @@ type BootstrapConfig struct {
 	TraceContextEncoding         string   `cli:"trace-context-encoding"`
 	NoJobAPI                     bool     `cli:"no-job-api"`
 	DisableWarningsFor           []string `cli:"disable-warnings-for" normalize:"list"`
+	CheckoutAttempts             int      `cli:"checkout-attempts"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -246,6 +247,7 @@ var BootstrapCommand = cli.Command{
 		GitMirrorsSkipUpdateFlag,
 		GitSubmoduleCloneConfigFlag,
 		GitSkipFetchExistingCommitsFlag,
+		CheckoutAttemptsFlag,
 
 		cli.StringFlag{
 			Name:   "bin-path",
@@ -477,6 +479,7 @@ var BootstrapCommand = cli.Command{
 			JobAPI:                       !cfg.NoJobAPI,
 			DisabledWarnings:             cfg.DisableWarningsFor,
 			Secrets:                      cfg.Secrets,
+			CheckoutAttempts:             cfg.CheckoutAttempts,
 		})
 
 		cctx, cancel := context.WithCancel(ctx)

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -271,6 +271,13 @@ var (
 		Usage:  "Skip git fetch if the commit already exists in the local git directory (default: false)",
 		EnvVar: "BUILDKITE_GIT_SKIP_FETCH_EXISTING_COMMITS",
 	}
+
+	CheckoutAttemptsFlag = cli.IntFlag{
+		Name:   "checkout-attempts",
+		Value:  6,
+		Usage:  "Number of checkout attempts (including the initial attempt). Failed attempts are retried with exponential backoff (factor of 2, starting at 1s: 1s, 2s, 4s, ...)",
+		EnvVar: "BUILDKITE_CHECKOUT_ATTEMPTS",
+	}
 )
 
 // GlobalConfig includes very common shared config options for easy inclusion across

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -239,9 +239,15 @@ func (e *Executor) checkout(ctx context.Context) error {
 			break
 		}
 
+		maxAttempts := e.CheckoutAttempts
+		if maxAttempts <= 0 {
+			maxAttempts = 6
+		}
+
 		if err := roko.NewRetrier(
-			roko.WithMaxAttempts(3),
-			roko.WithStrategy(roko.Constant(2*time.Second)),
+			roko.WithMaxAttempts(maxAttempts),
+			roko.WithStrategy(roko.Exponential(2*time.Second, 0)),
+			roko.WithJitter(),
 		).DoWithContext(ctx, func(r *roko.Retrier) error {
 			err := e.defaultCheckoutPhase(ctx)
 			if err == nil {

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -202,6 +202,10 @@ type ExecutorConfig struct {
 
 	// Secrets definition for the job step
 	Secrets string
+
+	// Number of checkout attempts (including the initial attempt).
+	// Uses exponential backoff with jitter between retries.
+	CheckoutAttempts int
 }
 
 // ReadFromEnvironment reads configuration from the Environment, returns a map


### PR DESCRIPTION
### Description

Git checkout operation sometimes are subject to the mercy of network stability, a DNS blip can last for 30s+. Our current retry strategy is static and try 3 times, once every 2s. This may not capture some transient network failure scenarios and can be frustrating. 

Git checkout errors, apart from initial pipeline setup, can arguably all be categorized as transient errors. So I reckon we should do two things: 

1. Make the retry configurable.
2. Increase the default retry so that it will retry in the span of 30s (5 attempts, with exponential backoff)

### Context

A-1050 and A-1060 


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

Me and a LLM donkey