### PR TITLE
A-1115 follow up: e2e test coverage for bulk artifacts upload/download case

### DIFF
--- a/internal/e2e/artifact_test.go
+++ b/internal/e2e/artifact_test.go
@@ -39,7 +39,7 @@ func TestArtifactUploadDownload_CustomBucket(t *testing.T) {
 	}
 }
 
-// Test that we can upload/downdload artifact using a custom GCS bucket.
+// Test that we can upload/download artifact using a custom GCS bucket.
 // Everything that gets uploaded here gets auto removed in 30 days.
 func TestArtifactUploadDownload_GCS(t *testing.T) {
 	ctx := t.Context()
@@ -49,6 +49,21 @@ func TestArtifactUploadDownload_GCS(t *testing.T) {
 	build := tc.triggerBuild()
 	state := tc.waitForBuild(ctx, build)
 
+	if got, want := state, "passed"; got != want {
+		t.Errorf("Build state = %q, want %q", got, want)
+	}
+}
+
+// Test that an agent can upload and download many artifacts (100 files).
+// This exercises the batch creator iterator producing multiple batches (batch size = 30).
+func TestArtifactUploadMany(t *testing.T) {
+	ctx := t.Context()
+
+	tc := newTestCase(t, "artifact_upload_many.yaml")
+
+	tc.startAgent()
+	build := tc.triggerBuild()
+	state := tc.waitForBuild(ctx, build)
 	if got, want := state, "passed"; got != want {
 		t.Errorf("Build state = %q, want %q", got, want)
 	}

--- a/internal/e2e/fixtures/artifact_upload_many.yaml
+++ b/internal/e2e/fixtures/artifact_upload_many.yaml
@@ -1,0 +1,13 @@
+agents:
+  queue: {{ .queue }}
+steps:
+  - key: upload
+    commands:
+      - mkdir -p artifacts
+      - for i in $$(seq 1 100); do echo "content-$$i" > "artifacts/file-$$i.txt"; done
+      - {{ .buildkite_agent_binary }} artifact upload 'artifacts/*'
+  - key: download
+    depends_on: upload
+    commands:
+      - {{ .buildkite_agent_binary }} artifact download 'artifacts/*' .
+      - test "$$(ls artifacts/ | wc -l | tr -d ' ')" -eq 100


### PR DESCRIPTION
### Description

Test coverage for bulk artifact upload and download

### Context

part of A-1115, but not blocking it 

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

me and LLM minion