### PR TITLE
fix: prevent snapshot logic if command phase isn't included

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -565,8 +565,17 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string) (dir 
 // It's not impossible (perhaps we need a process to age-out existing checkouts)
 // but something to think about, and when we have a good implementation enable
 // it for more cases.
+//
+// Why no snapshots if the command phase isn't included:
+// The cleanup mechanism happens when this instance of the executor tears down,
+// not when the last executor among many tears down. In a split-phase setup
+// (such as in agent-stack-k8s) where one container runs the checkout phase and
+// another runs the command phase, the snapshot would be deleted after the
+// checkout phase, which could break many git operations in the command phase.
+// Presently we have no way to pass cleanup instructions between containers,
+// which would enable this case.
 func (e *Executor) snapshotMirror(ctx context.Context, repository, mirrorDir string) (string, error) {
-	if !e.CleanCheckout {
+	if !e.CleanCheckout || !e.includePhase("command") {
 		return mirrorDir, nil
 	}
 


### PR DESCRIPTION
### Description

Follow-up to #3789: require the command phase in the current executor to be included for the snapshot logic to trigger.

### Context

Codex actually made a good point in #3789.

https://linear.app/buildkite/issue/A-1073



### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)


### Disclosures / Credits

I did the typing manually.