### PR TITLE
Normalise HTTP status-based retry policies across the agent

### DIFF
--- a/agent/pipeline_uploader.go
+++ b/agent/pipeline_uploader.go
@@ -130,22 +130,15 @@ func (u *PipelineUploader) pipelineUploadAsyncWithRetry(
 			},
 		)
 		if err != nil {
-			l.Warn("%s (%s)", err, r)
-
+			// JSON marshaling errors are permanent — the pipeline data itself is bad.
 			if jsonerr := new(json.MarshalerError); errors.As(err, &jsonerr) {
-				l.Error("Unrecoverable error, skipping retries")
 				r.Break()
 				return nil, err
 			}
 
-			// 422 responses will always fail no need to retry
-			if api.IsErrHavingStatus(err, http.StatusUnprocessableEntity) {
-				l.Error("Unrecoverable error, skipping retries")
-				r.Break()
-				return nil, err
+			if !api.BreakOnNonRetryable(r, resp, err) {
+				l.Warn("%s (%s)", err, r)
 			}
-
-			// 529 or other non 2xx
 			return nil, err
 		}
 

--- a/api/client.go
+++ b/api/client.go
@@ -332,7 +332,7 @@ func (c *Client) doRequest(req *http.Request, v any) (*Response, error) {
 			}
 		} else {
 			if strings.Contains(req.Header.Get("Content-Type"), "application/msgpack") {
-				return response, errors.New("Msgpack not supported")
+				return response, errors.New("msgpack not supported")
 			}
 
 			if err = json.NewDecoder(resp.Body).Decode(v); err != nil {

--- a/api/retryable.go
+++ b/api/retryable.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -11,7 +12,7 @@ import (
 	"github.com/buildkite/roko"
 )
 
-var retrableErrorSuffixes = []string{
+var retriableErrorSuffixes = []string{
 	syscall.ECONNREFUSED.Error(),
 	syscall.ECONNRESET.Error(),
 	syscall.ETIMEDOUT.Error(),
@@ -37,22 +38,16 @@ func IsRetryableStatus(r *Response) bool {
 // Looks at a bunch of connection related errors, and returns true if the error
 // matches one of them.
 func IsRetryableError(err error) bool {
-	if neterr, ok := err.(net.Error); ok {
-		if neterr.Temporary() {
+	var neterr net.Error
+	if errors.As(err, &neterr) {
+		if neterr.Timeout() {
 			return true
 		}
 	}
 
-	if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
-		return true
-	}
-
-	if urlerr, ok := err.(*url.Error); ok {
+	var urlerr *url.Error
+	if errors.As(err, &urlerr) {
 		if strings.Contains(urlerr.Error(), "use of closed network connection") {
-			return true
-		}
-
-		if neturlerr, ok := urlerr.Err.(net.Error); ok && neturlerr.Timeout() {
 			return true
 		}
 	}
@@ -62,7 +57,7 @@ func IsRetryableError(err error) bool {
 	}
 
 	s := err.Error()
-	for _, suffix := range retrableErrorSuffixes {
+	for _, suffix := range retriableErrorSuffixes {
 		if strings.HasSuffix(s, suffix) {
 			return true
 		}

--- a/api/retryable.go
+++ b/api/retryable.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"strings"
 	"syscall"
+
+	"github.com/buildkite/roko"
 )
 
 var retrableErrorSuffixes = []string{
@@ -19,17 +21,17 @@ var retrableErrorSuffixes = []string{
 	io.EOF.Error(),
 }
 
-var retryableStatuses = map[int]bool{
-	http.StatusTooManyRequests:     true, // 429
-	http.StatusInternalServerError: true, // 500
-	http.StatusBadGateway:          true, // 502
-	http.StatusServiceUnavailable:  true, // 503
-	http.StatusGatewayTimeout:      true, // 504
-}
-
 // IsRetryableStatus returns true if the response's StatusCode is one that we should retry.
+// Success statuses (2xx) are not considered retryable — they are not errors.
 func IsRetryableStatus(r *Response) bool {
-	return retryableStatuses[r.StatusCode]
+	switch {
+	case r.StatusCode == http.StatusTooManyRequests:
+		return true
+	case r.StatusCode >= 500:
+		return true
+	default:
+		return false
+	}
 }
 
 // Looks at a bunch of connection related errors, and returns true if the error
@@ -66,5 +68,34 @@ func IsRetryableError(err error) bool {
 		}
 	}
 
+	return false
+}
+
+// BreakOnNonRetryable calls r.Break() if the error from an API call is not
+// worth retrying. An error is retryable if the response has a retryable status
+// code (429, 5xx) or if there was no response and the error is a retryable
+// network-level error (connection reset, timeout, etc.). All other errors
+// — including all non-429 4xx status codes — cause a break.
+//
+// This should be called inside roko retry callbacks after every API call.
+// If err is nil, this is a no-op.
+// BreakOnNonRetryable returns true if it called r.Break() (i.e. the error is
+// non-retryable). Callers can use this to avoid logging misleading retry
+// information when the retrier is about to give up.
+func BreakOnNonRetryable(r *roko.Retrier, resp *Response, err error) (broke bool) {
+	if err == nil {
+		return false
+	}
+	if resp != nil {
+		if !IsRetryableStatus(resp) {
+			r.Break()
+			return true
+		}
+		return false
+	}
+	if !IsRetryableError(err) {
+		r.Break()
+		return true
+	}
 	return false
 }

--- a/clicommand/agent_pause.go
+++ b/clicommand/agent_pause.go
@@ -78,13 +78,9 @@ func pause(ctx context.Context, cfg AgentPauseConfig, l logger.Logger) error {
 			TimeoutInMinutes: cfg.TimeoutInMinutes,
 		})
 
-		// Don't bother retrying if the response was one of these statuses
-		if resp != nil && resp.StatusCode == 422 {
-			r.Break()
+		if api.BreakOnNonRetryable(r, resp, err) {
 			return err
 		}
-
-		// Show the unexpected error
 		if err != nil {
 			l.Warn("%s (%s)", err, r)
 			return err

--- a/clicommand/agent_resume.go
+++ b/clicommand/agent_resume.go
@@ -58,13 +58,9 @@ func resume(ctx context.Context, cfg AgentResumeConfig, l logger.Logger) error {
 		// Attempt to resume the agent
 		resp, err := client.Resume(ctx)
 
-		// Don't bother retrying if the response was one of these statuses
-		if resp != nil && resp.StatusCode == 422 {
-			r.Break()
+		if api.BreakOnNonRetryable(r, resp, err) {
 			return err
 		}
-
-		// Show the unexpected error
 		if err != nil {
 			l.Warn("%s (%s)", err, r)
 			return err

--- a/clicommand/agent_stop.go
+++ b/clicommand/agent_stop.go
@@ -70,13 +70,9 @@ func stop(ctx context.Context, cfg AgentStopConfig, l logger.Logger) error {
 			Force: cfg.Force,
 		})
 
-		// Don't bother retrying if the response was one of these statuses
-		if resp != nil && (resp.StatusCode == 422) {
-			r.Break()
+		if api.BreakOnNonRetryable(r, resp, err) {
 			return err
 		}
-
-		// Show the unexpected error
 		if err != nil {
 			l.Warn("%s (%s)", err, r)
 			return err

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -178,13 +178,9 @@ func annotate(ctx context.Context, cfg AnnotateConfig, l logger.Logger) error {
 		// Attempt to create the annotation
 		resp, err := client.Annotate(ctx, cfg.Job, annotation)
 
-		// Don't bother retrying if the response was one of these statuses
-		if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 400) {
-			r.Break()
+		if api.BreakOnNonRetryable(r, resp, err) {
 			return err
 		}
-
-		// Show the unexpected error
 		if err != nil {
 			l.Warn("%s (%s)", err, r)
 			return err

--- a/clicommand/annotation_remove.go
+++ b/clicommand/annotation_remove.go
@@ -77,13 +77,9 @@ var AnnotationRemoveCommand = cli.Command{
 			// Attempt to remove the annotation
 			resp, err := client.AnnotationRemove(ctx, cfg.Job, cfg.Context, cfg.Scope)
 
-			// Don't bother retrying if the response was one of these statuses
-			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 400 || resp.StatusCode == 410) {
-				r.Break()
+			if api.BreakOnNonRetryable(r, resp, err) {
 				return err
 			}
-
-			// Show the unexpected error
 			if err != nil {
 				l.Warn("%s (%s)", err, r)
 				return err

--- a/clicommand/build_cancel.go
+++ b/clicommand/build_cancel.go
@@ -66,13 +66,9 @@ func cancelBuild(ctx context.Context, cfg BuildCancelConfig, l logger.Logger) er
 		// Attempt to cancel the build
 		build, resp, err := client.CancelBuild(ctx, cfg.Build)
 
-		// Don't bother retrying if the response was one of these statuses
-		if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 400) {
-			r.Break()
+		if api.BreakOnNonRetryable(r, resp, err) {
 			return err
 		}
-
-		// Show the unexpected error
 		if err != nil {
 			l.Warn("%s (%s)", err, r)
 			return err

--- a/clicommand/job_update.go
+++ b/clicommand/job_update.go
@@ -84,8 +84,8 @@ var JobUpdateCommand = cli.Command{
 			roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
 		).DoWithContext(ctx, func(r *roko.Retrier) error {
 			_, resp, err := client.UpdateJob(ctx, cfg.Job, attrs)
-			if resp != nil && (resp.StatusCode == 400 || resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 422) {
-				r.Break()
+			if api.BreakOnNonRetryable(r, resp, err) {
+				return err
 			}
 			if err != nil {
 				l.Warn("%s (%s)", err, r)

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -74,8 +74,8 @@ var MetaDataExistsCommand = cli.Command{
 		)
 		exists, err := roko.DoFunc(ctx, r, func(r *roko.Retrier) (*api.MetaDataExists, error) {
 			exists, resp, err := client.ExistsMetaData(ctx, scope, id, cfg.Key)
-			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404) {
-				r.Break()
+			if api.BreakOnNonRetryable(r, resp, err) {
+				return nil, err
 			}
 			if err != nil {
 				l.Warn("%s (%s)", err, r)

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -80,9 +80,7 @@ var MetaDataGetCommand = cli.Command{
 		)
 		metaData, resp, err := roko.DoFunc2(ctx, r, func(r *roko.Retrier) (*api.MetaData, *api.Response, error) {
 			metaData, resp, err := client.GetMetaData(ctx, scope, id, cfg.Key)
-			// Don't bother retrying if the response was one of these statuses
-			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 400) {
-				r.Break()
+			if api.BreakOnNonRetryable(r, resp, err) {
 				return nil, resp, err
 			}
 			if err != nil {

--- a/clicommand/meta_data_keys.go
+++ b/clicommand/meta_data_keys.go
@@ -73,8 +73,8 @@ var MetaDataKeysCommand = cli.Command{
 		)
 		keys, err := roko.DoFunc(ctx, r, func(r *roko.Retrier) ([]string, error) {
 			keys, resp, err := client.MetaDataKeys(ctx, scope, id)
-			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404) {
-				r.Break()
+			if api.BreakOnNonRetryable(r, resp, err) {
+				return keys, err
 			}
 			if err != nil {
 				l.Warn("%s (%s)", err, r)

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -109,8 +109,8 @@ var MetaDataSetCommand = cli.Command{
 			roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
 		).DoWithContext(ctx, func(r *roko.Retrier) error {
 			resp, err := client.SetMetaData(ctx, cfg.Job, metaData)
-			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404) {
-				r.Break()
+			if api.BreakOnNonRetryable(r, resp, err) {
+				return err
 			}
 			if err != nil {
 				l.Warn("%s (%s)", err, r)

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"slices"
 	"time"
 
@@ -133,15 +132,9 @@ var OIDCRequestTokenCommand = cli.Command{
 			}
 
 			token, resp, err := client.OIDCToken(ctx, req)
-			if resp != nil {
-				switch resp.StatusCode {
-				// Don't bother retrying if the response was one of these statuses
-				case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusUnprocessableEntity:
-					r.Break()
-					return nil, err
-				}
+			if api.BreakOnNonRetryable(r, resp, err) {
+				return nil, err
 			}
-
 			if err != nil {
 				l.Warn("%s (%s)", err, r)
 			}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -428,7 +428,8 @@ var PipelineUploadCommand = cli.Command{
 					RetrySleepFunc: time.Sleep,
 				}
 				if err := uploader.Upload(ctx, l); err != nil {
-					return err
+					l.Error(err.Error())
+					return NewSilentExitError(1)
 				}
 
 				l.Info("Successfully parsed and uploaded pipeline #%d from %q", count, input.name)

--- a/clicommand/step_cancel.go
+++ b/clicommand/step_cancel.go
@@ -98,12 +98,9 @@ func cancelStep(ctx context.Context, cfg StepCancelConfig, l logger.Logger) erro
 		// Attempt to cancel the step
 		stepCancelResponse, resp, err := client.StepCancel(ctx, cfg.StepOrKey, cancel)
 
-		// Don't bother retrying if the response was one of these statuses
-		if resp != nil && (resp.StatusCode == 400 || resp.StatusCode == 401 || resp.StatusCode == 404) {
-			r.Break()
+		if api.BreakOnNonRetryable(r, resp, err) {
+			return err
 		}
-
-		// Show the unexpected error
 		if err != nil {
 			l.Warn("%s (%s)", err, r)
 			return err

--- a/clicommand/step_get.go
+++ b/clicommand/step_get.go
@@ -85,9 +85,8 @@ var StepGetCommand = cli.Command{
 		)
 		stepExportResponse, err := roko.DoFunc(ctx, r, func(r *roko.Retrier) (*api.StepExportResponse, error) {
 			stepExportResponse, resp, err := client.StepExport(ctx, cfg.StepOrKey, stepExportRequest)
-			// Don't bother retrying if the response was one of these statuses
-			if resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 400) {
-				r.Break()
+			if api.BreakOnNonRetryable(r, resp, err) {
+				return stepExportResponse, err
 			}
 			if err != nil {
 				l.Warn("%s (%s)", err, r)

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -127,8 +127,8 @@ var StepUpdateCommand = cli.Command{
 			roko.WithStrategy(roko.Constant(5*time.Second)),
 		).DoWithContext(ctx, func(r *roko.Retrier) error {
 			resp, err := client.StepUpdate(ctx, cfg.StepOrKey, update)
-			if resp != nil && (resp.StatusCode == 400 || resp.StatusCode == 401 || resp.StatusCode == 404) {
-				r.Break()
+			if api.BreakOnNonRetryable(r, resp, err) {
+				return err
 			}
 			if err != nil {
 				l.Warn("%s (%s)", err, r)

--- a/core/client.go
+++ b/core/client.go
@@ -222,32 +222,18 @@ func (c *Client) FinishJob(ctx context.Context, job *api.Job, finishedAt time.Ti
 	defer cancel()
 
 	return roko.NewRetrier(
-		// retry for ~a day with exponential backoff
 		roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
-		roko.WithMaxAttempts(12), // 12 attempts will take 26 minutes
+		roko.WithMaxAttempts(12), // 12 attempts ≈ 10 minutes of total sleep
 		roko.WithJitter(),
 		roko.WithSleepFunc(c.RetrySleepFunc),
 	).DoWithContext(ctx, func(retrier *roko.Retrier) error {
 		response, err := c.APIClient.FinishJob(ctx, job, ignoreAgentInDispatches)
 		if err != nil {
-			// If the API returns with a 422, that means that we
-			// successfully tried to finish the job, but Buildkite
-			// rejected the finish for some reason. This can
-			// sometimes mean that Buildkite has cancelled the job
-			// before we get a chance to send the final API call
-			// (maybe this agent took too long to kill the
-			// process).
-			// The API may also return a 401 when job tokens
-			// are enabled.
-			// In either case, we don't want to keep trying
-			// to finish the job forever so we'll just bail out and
-			// go find some more work to do.
-			if response != nil && (response.StatusCode == 422 || response.StatusCode == 401) {
-				c.Logger.Warn("Buildkite rejected the call to finish the job (%s)", err)
-				retrier.Break()
-				return err
+			// Non-retryable responses (e.g. 422, or 401 when job tokens are being used) mean the job has been cancelled or
+			// otherwise already finished. We should stop trying and go find more work to do.
+			if !api.BreakOnNonRetryable(retrier, response, err) {
+				c.Logger.Warn("%s (%s)", err, retrier)
 			}
-			c.Logger.Warn("%s (%s)", err, retrier)
 		}
 
 		return err
@@ -281,10 +267,7 @@ func (c *Client) Register(ctx context.Context, req api.AgentRegisterRequest) (*a
 	registered, err := roko.DoFunc(ctx, r, func(r *roko.Retrier) (*api.AgentRegisterResponse, error) {
 		registered, resp, err := c.APIClient.Register(ctx, &req)
 		if err != nil {
-			if resp != nil && resp.StatusCode == 401 {
-				c.Logger.Warn("Buildkite rejected the registration (%s)", err)
-				r.Break()
-			} else {
+			if !api.BreakOnNonRetryable(r, resp, err) {
 				c.Logger.Warn("%s (%s)", err, r)
 			}
 			return registered, err
@@ -356,9 +339,8 @@ func (c *Client) UploadChunk(ctx context.Context, jobID string, chunk *api.Chunk
 	defer cancel()
 
 	return roko.NewRetrier(
-		// retry for ~a day with exponential backoff
 		roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
-		roko.WithMaxAttempts(12), // 12 attempts will take 26 minutes
+		roko.WithMaxAttempts(12), // 12 attempts ≈ 10 minutes of total sleep
 		roko.WithJitter(),
 		roko.WithSleepFunc(c.RetrySleepFunc),
 	).DoWithContext(ctx, func(retrier *roko.Retrier) error {


### PR DESCRIPTION
### Description

Across the agent, there are a bunch of interactions with the Buildkite Agent API that all have their own, bespoke retry policies to retry certain HTTP status codes. Many of these policies are very silly, retrying permission errors and the like.

This PR attempts to normalise these policies, adding a helper in the `api` package called `BreakOnNonRetryableStatus`, which breaks the roko retrier when the HTTP response has a status code which is non-retryable, and applying this helper across all calls to retried calls to the agent API.

### Context

I was working on a thing where in my local environment i was failing meta data gets with a permission error, and had this very silly situation:
<img width="4114" height="2516" alt="CleanShot 2026-04-17 at 14 49 30@2x" src="https://github.com/user-attachments/assets/96d6587c-ea81-4e56-a827-12845cdc8adf" />

where meta data gets failing with a permission error leads to them being retried for ~5 minutes.

### Changes

Where calls to the buildkite agent api are being retried through `roko`, ensure that when those calls receive a status that's non-retryable (any non-2xx that's _not_ one of these)
```Go
var retryableStatuses = map[int]bool{
	http.StatusTooManyRequests:     true, // 429
	529:                            true, // Buildkite-specific "still waiting" (used by pipeline upload)
	http.StatusInternalServerError: true, // 500
	http.StatusBadGateway:          true, // 502
	http.StatusServiceUnavailable:  true, // 503
	http.StatusGatewayTimeout:      true, // 504
}
```

that they break immediately and don't attempt to retry.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
