### PR TITLE
A-1130: fix --glob-resolve-follow-symlinks regression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0
 	cloud.google.com/go/kms v1.28.0
 	connectrpc.com/connect v1.19.1
-	drjosh.dev/zzglob v0.4.2
+	drjosh.dev/zzglob v0.4.3
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/DataDog/datadog-go/v5 v5.8.3

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ cloud.google.com/go/longrunning v0.9.0 h1:0EzbDEGsAvOZNbqXopgniY0w0a1phvu5IdUFq8
 cloud.google.com/go/longrunning v0.9.0/go.mod h1:pkTz846W7bF4o2SzdWJ40Hu0Re+UoNT6Q5t+igIcb8E=
 connectrpc.com/connect v1.19.1 h1:R5M57z05+90EfEvCY1b7hBxDVOUl45PrtXtAV2fOC14=
 connectrpc.com/connect v1.19.1/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
-drjosh.dev/zzglob v0.4.2 h1:q+e5Cp6SFCyz+Yurhk/edSrTKEk3tn60vzoaXLmtiBo=
-drjosh.dev/zzglob v0.4.2/go.mod h1:SbYDdesQC13iyGiEwV8dJfJbyz7/Qiawrd5ODdJQCoo=
+drjosh.dev/zzglob v0.4.3 h1:m7kBj5XU4Tl3y2Yn+cP8j4vWfn/fFt11Xlftxwz6NIc=
+drjosh.dev/zzglob v0.4.3/go.mod h1:SbYDdesQC13iyGiEwV8dJfJbyz7/Qiawrd5ODdJQCoo=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 h1:fou+2+WFTib47nS+nz/ozhEBnvU96bKHy6LjRsY4E28=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0/go.mod h1:t76Ruy8AHvUAC8GfMWJMa0ElSbuIcO03NLpynfbgsPA=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpzme37xbCDdNTxU7O9eb5+LB4=

--- a/internal/e2e/artifact_test.go
+++ b/internal/e2e/artifact_test.go
@@ -69,6 +69,21 @@ func TestArtifactUploadMany(t *testing.T) {
 	}
 }
 
+// Test that artifact upload with --glob-resolve-follow-symlinks follows symlinked directories.
+// Regression test for https://github.com/buildkite/agent/issues/3826
+func TestArtifactUploadFollowSymlinks(t *testing.T) {
+	ctx := t.Context()
+
+	tc := newTestCase(t, "artifact_upload_symlink_glob.yaml")
+
+	tc.startAgent()
+	build := tc.triggerBuild()
+	state := tc.waitForBuild(ctx, build)
+	if got, want := state, "passed"; got != want {
+		t.Errorf("Build state = %q, want %q", got, want)
+	}
+}
+
 // Test that we can upload/downdload artifact using a custom Azure Blob storage
 // container.
 // Everything that gets uploaded here gets auto removed in 30 days.

--- a/internal/e2e/fixtures/artifact_upload_symlink_glob.yaml
+++ b/internal/e2e/fixtures/artifact_upload_symlink_glob.yaml
@@ -1,0 +1,15 @@
+agents:
+  queue: {{ .queue }}
+steps:
+  - key: upload
+    commands:
+      - mkdir -p a/b/other_path/c
+      - echo "<testsuite/>" > a/b/other_path/c/result.xml
+      - ln -s other_path a/b/c
+      - {{ .buildkite_agent_binary }} artifact upload --glob-resolve-follow-symlinks "**/*"
+  - key: download
+    depends_on: upload
+    commands:
+      - {{ .buildkite_agent_binary }} artifact download "a/b/c/c/result.xml" .
+      - test -f a/b/c/c/result.xml
+      - grep -q testsuite a/b/c/c/result.xml


### PR DESCRIPTION
Fixes #3826

### Problem

`buildkite-agent artifact upload --glob-resolve-follow-symlinks "**/*"` fails to descend into symlinked directories. When a glob pattern fully matches a symlink path (e.g. `**/*` matches `a/b/c`), zzglob returns immediately after the callback without falling through to the symlink traversal code — so the directory behind the symlink is never walked.

### Fix

Upgrade `drjosh.dev/zzglob` from v0.4.2 to v0.4.3, which fixes the early-return bug in `walkDirFunc` for fully-matched directory symlinks.

The upstream fix is in https://github.com/DrJosh9000/zzglob/pull/19


### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

Me and my LLM minion