### PR TITLE
Removal manual gates from deployment process

### DIFF
--- a/.buildkite/steps/upload-release-steps.sh
+++ b/.buildkite/steps/upload-release-steps.sh
@@ -39,11 +39,9 @@ trigger_step() {
 YAML
 }
 
-block_step() {
-  local label="$1"
+wait_step() {
   cat <<YAML
   - wait
-  - block: "${label}"
 YAML
 }
 
@@ -56,15 +54,13 @@ edge_steps_yaml() {
 }
 
 output_steps_yaml() {
-  block_step "beta?"
+  wait_step
 
-  trigger_step \
-    "beta ${agent_version}" \
-    "agent-release-beta"
-
-  if [[ ! "$agent_version" =~ (beta|rc) ]] ; then
-    block_step "stable?"
-
+  if [[ "$agent_version" =~ (beta|rc) ]] ; then
+    trigger_step \
+      "beta ${agent_version}" \
+      "agent-release-beta"
+  else
     trigger_step \
       "stable ${agent_version}" \
       "agent-release-stable"


### PR DESCRIPTION
Remove the `block: "beta?"` and `block: "stable?"` manual gates from the release pipeline, so the release flow proceeds automatically: edge → beta → stable.

## Why

We never use these manual gates, every release we just click through them. The pipeline already has sufficient safeguards:

* Release steps only run on `main` or `*-*-stable` branches
* If the git tag for the version already exists, beta/stable release is skipped entirely
* A VERSION file change is required to trigger a new release