### PR TITLE
feat: add metrics to record histogram of chunk sizes and compressed size

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -195,6 +195,8 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient *api.Client, c
 			logUploadDurations.Observe(time.Since(startUpload).Seconds())
 			logChunksUploaded.Inc()
 			logBytesUploaded.Add(float64(chunk.Size))
+			logCompressedBytesUploaded.Add(float64(chunk.CompressedBytes))
+			logChunkSizeBytes.Observe(float64(chunk.Size))
 			return nil
 		},
 		LogStreamerConfig{

--- a/agent/metrics.go
+++ b/agent/metrics.go
@@ -102,4 +102,17 @@ var (
 		// Log chunk upload can be retried for a while.
 		Buckets: prometheus.ExponentialBuckets(0.015625, 2, 16),
 	})
+	logCompressedBytesUploaded = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: "logs",
+		Name:      "compressed_bytes_uploaded_total",
+		Help:      "Count of compressed log bytes sent over the wire",
+	})
+	logChunkSizeBytes = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: metricsNamespace,
+		Subsystem: "logs",
+		Name:      "chunk_size_bytes",
+		Help:      "Distribution of log chunk sizes in bytes at upload time",
+		Buckets:   prometheus.ExponentialBuckets(256, 4, 10), // 256B to ~64MB
+	})
 )

--- a/api/chunks.go
+++ b/api/chunks.go
@@ -9,10 +9,11 @@ import (
 
 // Chunk represents a Buildkite Agent API Chunk
 type Chunk struct {
-	Data     []byte
-	Sequence uint64
-	Offset   uint64
-	Size     uint64
+	Data            []byte
+	Sequence        uint64
+	Offset          uint64
+	Size            uint64
+	CompressedBytes uint64
 }
 
 // Uploads the chunk to the Buildkite Agent API. This request sends the
@@ -27,6 +28,7 @@ func (c *Client) UploadChunk(ctx context.Context, jobId string, chunk *Chunk) (*
 	if err := gzipper.Close(); err != nil {
 		return nil, err
 	}
+	chunk.CompressedBytes = uint64(body.Len())
 
 	// Pass most params as query
 	u := fmt.Sprintf("jobs/%s/chunks?sequence=%d&offset=%d&size=%d", railsPathEscape(jobId), chunk.Sequence, chunk.Offset, chunk.Size)


### PR DESCRIPTION

### Description

Add some new metrics which cover log chunk compression and upload sizes.

<img width="1153" height="1040" alt="Screenshot 2026-04-19 at 8 28 36 pm" src="https://github.com/user-attachments/assets/e209112d-d440-4dba-8d12-9fccc2fac0e0" />

### Context

These metrics are helpful to under the range of chunk sizes, and how the current compression algorythm is performing.

### Changes

Adds two new metrics.

* compressed_bytes_uploaded_total
* chunk_size_bytes

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

I did not use AI tools at all