### PR TITLE
Remove deprecated CLI flags

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -212,16 +212,6 @@ type AgentStartConfig struct {
 	Token     string `cli:"token" validate:"required"`
 	Endpoint  string `cli:"endpoint" validate:"required"`
 	NoHTTP2   bool   `cli:"no-http2"`
-	// Deprecated
-	KubernetesLogCollectionGracePeriod time.Duration `cli:"kubernetes-log-collection-grace-period"`
-	NoSSHFingerprintVerification       bool          `cli:"no-automatic-ssh-fingerprint-verification" deprecated-and-renamed-to:"NoSSHKeyscan"`
-	MetaData                           []string      `cli:"meta-data" deprecated-and-renamed-to:"Tags"`
-	MetaDataEC2                        bool          `cli:"meta-data-ec2" deprecated-and-renamed-to:"TagsFromEC2"`
-	MetaDataEC2Tags                    bool          `cli:"meta-data-ec2-tags" deprecated-and-renamed-to:"TagsFromEC2Tags"`
-	MetaDataGCP                        bool          `cli:"meta-data-gcp" deprecated-and-renamed-to:"TagsFromGCP"`
-	TagsFromEC2                        bool          `cli:"tags-from-ec2" deprecated-and-renamed-to:"TagsFromEC2MetaData"`
-	TagsFromGCP                        bool          `cli:"tags-from-gcp" deprecated-and-renamed-to:"TagsFromGCPMetaData"`
-	DisconnectAfterJobTimeout          int           `cli:"disconnect-after-job-timeout" deprecated:"Use disconnect-after-idle-timeout instead"`
 }
 
 func (asc AgentStartConfig) Features(ctx context.Context) []string {
@@ -770,51 +760,6 @@ var AgentStartCommand = cli.Command{
 		StrictSingleHooksFlag,
 		TraceContextEncodingFlag,
 		NoMultipartArtifactUploadFlag,
-
-		// Deprecated flags which will be removed in v4
-		KubernetesLogCollectionGracePeriodFlag,
-		cli.StringSliceFlag{
-			Name:   "meta-data",
-			Value:  &cli.StringSlice{},
-			Hidden: true,
-			EnvVar: "BUILDKITE_AGENT_META_DATA",
-		},
-		cli.BoolFlag{
-			Name:   "meta-data-ec2",
-			Hidden: true,
-			EnvVar: "BUILDKITE_AGENT_META_DATA_EC2",
-		},
-		cli.BoolFlag{
-			Name:   "meta-data-ec2-tags",
-			Hidden: true,
-			EnvVar: "BUILDKITE_AGENT_META_DATA_EC2_TAGS",
-		},
-		cli.BoolFlag{
-			Name:   "meta-data-gcp",
-			Hidden: true,
-			EnvVar: "BUILDKITE_AGENT_META_DATA_GCP",
-		},
-		cli.BoolFlag{
-			Name:   "no-automatic-ssh-fingerprint-verification",
-			Hidden: true,
-			EnvVar: "BUILDKITE_NO_AUTOMATIC_SSH_FINGERPRINT_VERIFICATION",
-		},
-		cli.BoolFlag{
-			Name:   "tags-from-ec2",
-			Usage:  "Include the host's EC2 meta-data as tags (instance-id, instance-type, and ami-id)",
-			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_EC2",
-		},
-		cli.BoolFlag{
-			Name:   "tags-from-gcp",
-			Usage:  "Include the host's Google Cloud instance meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)",
-			EnvVar: "BUILDKITE_AGENT_TAGS_FROM_GCP",
-		},
-		cli.IntFlag{
-			Name:   "disconnect-after-job-timeout",
-			Hidden: true,
-			Usage:  "When --disconnect-after-job is specified, the number of seconds to wait for a job before shutting down",
-			EnvVar: "BUILDKITE_AGENT_DISCONNECT_AFTER_JOB_TIMEOUT",
-		},
 	),
 	Action: func(c *cli.Context) error {
 		ctx := context.Background()
@@ -905,11 +850,6 @@ var AgentStartCommand = cli.Command{
 		// Guess the shell if none is provided
 		if cfg.Shell == "" {
 			cfg.Shell = DefaultShell()
-		}
-
-		// Handle deprecated DisconnectAfterJobTimeout
-		if cfg.DisconnectAfterJobTimeout > 0 {
-			cfg.DisconnectAfterIdleTimeout = cfg.DisconnectAfterJobTimeout
 		}
 
 		var ec2TagTimeout time.Duration
@@ -1220,11 +1160,11 @@ var AgentStartCommand = cli.Command{
 		tags := agent.FetchTags(ctx, l, agent.FetchTagsConfig{
 			Tags:                      cfg.Tags,
 			TagsFromK8s:               cfg.KubernetesExec,
-			TagsFromEC2MetaData:       (cfg.TagsFromEC2MetaData || cfg.TagsFromEC2),
+			TagsFromEC2MetaData:       cfg.TagsFromEC2MetaData,
 			TagsFromEC2MetaDataPaths:  cfg.TagsFromEC2MetaDataPaths,
 			TagsFromEC2Tags:           cfg.TagsFromEC2Tags,
 			TagsFromECSMetaData:       cfg.TagsFromECSMetaData,
-			TagsFromGCPMetaData:       (cfg.TagsFromGCPMetaData || cfg.TagsFromGCP),
+			TagsFromGCPMetaData:       cfg.TagsFromGCPMetaData,
 			TagsFromGCPMetaDataPaths:  cfg.TagsFromGCPMetaDataPaths,
 			TagsFromGCPLabels:         cfg.TagsFromGCPLabels,
 			TagsFromHost:              cfg.TagsFromHost,

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -82,9 +82,6 @@ type ArtifactUploadConfig struct {
 	GlobResolveFollowSymlinks bool   `cli:"glob-resolve-follow-symlinks"`
 	UploadSkipSymlinks        bool   `cli:"upload-skip-symlinks"`
 	NoMultipartUpload         bool   `cli:"no-multipart-artifact-upload"`
-
-	// deprecated
-	FollowSymlinks bool `cli:"follow-symlinks" deprecated-and-renamed-to:"GlobResolveFollowSymlinks"`
 }
 
 var ArtifactUploadCommand = cli.Command{
@@ -125,11 +122,6 @@ var ArtifactUploadCommand = cli.Command{
 			Usage:  "After the glob has been resolved to a list of files to upload, skip uploading those that are symlinks to files (default: false)",
 			EnvVar: "BUILDKITE_ARTIFACT_UPLOAD_SKIP_SYMLINKS",
 		},
-		cli.BoolFlag{ // Deprecated
-			Name:   "follow-symlinks",
-			Usage:  "Follow symbolic links while resolving globs. Note this argument is deprecated. Use `--glob-resolve-follow-symlinks` instead (default: false)",
-			EnvVar: "BUILDKITE_AGENT_ARTIFACT_SYMLINKS",
-		},
 		NoMultipartArtifactUploadFlag,
 	}),
 	Action: func(c *cli.Context) error {
@@ -153,9 +145,7 @@ var ArtifactUploadCommand = cli.Command{
 			Literal:        cfg.Literal,
 			Delimiter:      cfg.Delimiter,
 
-			// If the deprecated flag was set to true, pretend its replacement was set to true too
-			// this works as long as the user only sets one of the two flags
-			GlobResolveFollowSymlinks: (cfg.GlobResolveFollowSymlinks || cfg.FollowSymlinks),
+			GlobResolveFollowSymlinks: cfg.GlobResolveFollowSymlinks,
 			UploadSkipSymlinks:        cfg.UploadSkipSymlinks,
 		})
 

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/buildkite/agent/v4/api"
 	"github.com/buildkite/agent/v4/cliconfig"
@@ -99,13 +98,6 @@ var (
 			"(github.com/buildkite/agent-stack-k8s); it sets an ID number " +
 			"used to identify this container within the pod",
 		EnvVar: "BUILDKITE_CONTAINER_ID",
-	}
-
-	KubernetesLogCollectionGracePeriodFlag = cli.DurationFlag{
-		Name:   "kubernetes-log-collection-grace-period",
-		Usage:  "Deprecated, do not use",
-		EnvVar: "BUILDKITE_KUBERNETES_LOG_COLLECTION_GRACE_PERIOD",
-		Value:  50 * time.Second,
 	}
 
 	NoMultipartArtifactUploadFlag = cli.BoolFlag{


### PR DESCRIPTION
### Description

In the agent, we have a bunch of flags that have been deprecated (and emitting warnings whenever they're used) for a good long while. We're doing v4! Let's throw em out the window.

### Changes

Removed the following flags:
- from `agent_start.go`: 
  - `--meta-data`, 
  - `--meta-data-ec2`, 
  - `--meta-data-ec2-tags`, 
  - `--meta-data-gcp`, 
  - `--no-automatic-ssh-fingerprint-verification`, 
  - `--tags-from-ec2`, 
  - `--tags-from-gcp`, 
  - `--disconnect-after-job-timeout`, 
  - `--kubernetes-log-collection-grace-period`,
- from `artifact_upload.go`: `--follow-symlinks`
- from `global.go`: `--kubernetes-log-collection-grace-period`

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

Ctrl-F was instrumental to me in this work.
