### PR TITLE
Newline after meta data get

### DIFF
--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -102,15 +102,14 @@ var MetaDataGetCommand = cli.Command{
 					cfg.Key,
 					cfg.Default,
 				)
-				fmt.Fprint(c.App.Writer, cfg.Default)
+				fmt.Fprintln(c.App.Writer, cfg.Default)
 				return nil
 			}
 
 			return fmt.Errorf("failed to get meta-data: %w", err)
 		}
 
-		// TODO: in the next agent magor version, we should terminate with a newline using fmt.FPrintln
-		_, err = fmt.Fprint(c.App.Writer, metaData.Value)
+		_, err = fmt.Fprintln(c.App.Writer, metaData.Value)
 		return err
 	},
 }


### PR DESCRIPTION
### Description

More breaking changes for v4. Is this one breaking? Arguably no, but it's as good a time to fix it as any.

### Changes

Now, meta data from `buildkite-agent meta-data get` gets a newline printed after it.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

i literally added two characters twice.