### PR TITLE
fix: set PTY raw mode before process start

### DIFF
--- a/process/export_test.go
+++ b/process/export_test.go
@@ -1,0 +1,9 @@
+package process
+
+func AfterPTYStartHookGet() func() {
+	return afterPTYStartHook
+}
+
+func AfterPTYStartHookSet(next func()) {
+	afterPTYStartHook = next
+}

--- a/process/main_test.go
+++ b/process/main_test.go
@@ -30,6 +30,14 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "alpacas2\n")
 		os.Exit(0)
 
+	case "output-slow-exit":
+		fmt.Fprintf(os.Stdout, "llamas1\n")
+		fmt.Fprintf(os.Stderr, "alpacas1\r")
+		fmt.Fprintf(os.Stdout, "llamas2\r\n")
+		fmt.Fprintf(os.Stderr, "alpacas2\n")
+		time.Sleep(100 * time.Millisecond)
+		os.Exit(0)
+
 	// don't handle the signals so that we can detect the process was signaled
 	case "tester-no-handler":
 		fmt.Println("Ready")

--- a/process/process.go
+++ b/process/process.go
@@ -18,12 +18,15 @@ import (
 
 	"github.com/buildkite/agent/v3/internal/experiments"
 	"github.com/buildkite/agent/v3/logger"
-	"golang.org/x/term"
 )
 
 const (
 	termType = "xterm-256color"
 )
+
+// afterPTYStartHook lets tests force work to happen after the PTY helper
+// returns so they can verify raw-mode ordering around process startup.
+var afterPTYStartHook = func() {}
 
 type Signal int
 
@@ -174,21 +177,20 @@ func (p *Process) Run(ctx context.Context) error {
 		// Commands like tput expect a TERM value for a PTY
 		p.command.Env = append(p.command.Env, "TERM="+termType)
 
-		pty, err := StartPTY(p.command)
+		rawPTY := experiments.IsEnabled(ctx, experiments.PTYRaw)
+
+		pty, err := StartPTY(p.command, rawPTY)
 		if err != nil {
 			return fmt.Errorf("error starting pty: %w", err)
 		}
 
+		afterPTYStartHook()
+
 		// Make sure to close the pty at the end.
 		defer func() { _ = pty.Close() }()
 
-		if experiments.IsEnabled(ctx, experiments.PTYRaw) {
+		if rawPTY {
 			p.logger.Debug("[Process] Setting raw mode for PTY %s (fd:%d)", pty.Name(), pty.Fd())
-			// No need to capture/restore old state, because we close the PTY when we're done.
-			_, err = term.MakeRaw(int(pty.Fd()))
-			if err != nil {
-				return fmt.Errorf("error putting PTY into raw mode: %w", err)
-			}
 		}
 
 		p.mu.Lock()

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -116,6 +116,46 @@ func TestProcessOutputPTY_PTYRawExperiment(t *testing.T) {
 	assertProcessDoesntExist(t, p)
 }
 
+func TestProcessOutputPTY_PTYRawExperimentWritesBeforeRawMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on windows")
+	}
+
+	ctx, _ := experiments.Enable(context.Background(), experiments.PTYRaw)
+
+	originalHook := processAfterPTYStartHookSwap(func() {
+		time.Sleep(50 * time.Millisecond)
+	})
+	t.Cleanup(func() {
+		processAfterPTYStartHookSwap(originalHook)
+	})
+
+	stdout := &bytes.Buffer{}
+	logger := logger.NewBuffer()
+	p := process.New(logger, process.Config{
+		Path:   os.Args[0],
+		Env:    []string{"TEST_MAIN=output-slow-exit"},
+		PTY:    true,
+		Stdout: stdout,
+	})
+
+	if err := p.Run(ctx); err != nil {
+		t.Fatalf("p.Run() = %v", err)
+	}
+
+	if got, want := stdout.String(), "llamas1\nalpacas1\rllamas2\r\nalpacas2\n"; got != want {
+		t.Fatalf("stdout.String() = %q, want %q", got, want)
+	}
+
+	assertProcessDoesntExist(t, p)
+}
+
+func processAfterPTYStartHookSwap(next func()) func() {
+	prev := process.AfterPTYStartHookGet()
+	process.AfterPTYStartHookSet(next)
+	return prev
+}
+
 func TestProcessInput(t *testing.T) {
 	t.Parallel()
 

--- a/process/pty.go
+++ b/process/pty.go
@@ -16,7 +16,7 @@ func StartPTY(c *exec.Cmd, raw bool) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = tty.Close() }()
+	defer tty.Close() //nolint:errcheck // Best-effort cleanup.
 
 	if err := pty.Setsize(ptmx, &pty.Winsize{
 		Rows: 100,
@@ -24,13 +24,13 @@ func StartPTY(c *exec.Cmd, raw bool) (*os.File, error) {
 		X:    0, // unused
 		Y:    0, // unused
 	}); err != nil {
-		_ = ptmx.Close()
+		ptmx.Close() //nolint:errcheck // Best-effort cleanup.
 		return nil, err
 	}
 
 	if raw {
 		if _, err := term.MakeRaw(int(ptmx.Fd())); err != nil {
-			_ = ptmx.Close()
+			ptmx.Close() //nolint:errcheck // Best-effort cleanup.
 			return nil, err
 		}
 	}
@@ -52,7 +52,7 @@ func StartPTY(c *exec.Cmd, raw bool) (*os.File, error) {
 	c.SysProcAttr.Setctty = true
 
 	if err := c.Start(); err != nil {
-		_ = ptmx.Close()
+		ptmx.Close() //nolint:errcheck // Best-effort cleanup.
 		return nil, err
 	}
 

--- a/process/pty.go
+++ b/process/pty.go
@@ -5,15 +5,56 @@ package process
 import (
 	"os"
 	"os/exec"
+	"syscall"
 
 	"github.com/creack/pty"
+	"golang.org/x/term"
 )
 
-func StartPTY(c *exec.Cmd) (*os.File, error) {
-	return pty.StartWithSize(c, &pty.Winsize{
+func StartPTY(c *exec.Cmd, raw bool) (*os.File, error) {
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tty.Close() }()
+
+	if err := pty.Setsize(ptmx, &pty.Winsize{
 		Rows: 100,
 		Cols: 160,
 		X:    0, // unused
 		Y:    0, // unused
-	})
+	}); err != nil {
+		_ = ptmx.Close()
+		return nil, err
+	}
+
+	if raw {
+		if _, err := term.MakeRaw(int(ptmx.Fd())); err != nil {
+			_ = ptmx.Close()
+			return nil, err
+		}
+	}
+
+	if c.Stdout == nil {
+		c.Stdout = tty
+	}
+	if c.Stderr == nil {
+		c.Stderr = tty
+	}
+	if c.Stdin == nil {
+		c.Stdin = tty
+	}
+
+	if c.SysProcAttr == nil {
+		c.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	c.SysProcAttr.Setsid = true
+	c.SysProcAttr.Setctty = true
+
+	if err := c.Start(); err != nil {
+		_ = ptmx.Close()
+		return nil, err
+	}
+
+	return ptmx, nil
 }

--- a/process/pty_windows.go
+++ b/process/pty_windows.go
@@ -6,6 +6,6 @@ import (
 	"os/exec"
 )
 
-func StartPTY(c *exec.Cmd) (*os.File, error) {
+func StartPTY(c *exec.Cmd, raw bool) (*os.File, error) {
 	return nil, errors.New("PTY is not supported on Windows")
 }


### PR DESCRIPTION
## Summary
- apply PTY raw mode before starting the child process, so early output cannot be transformed by the default line discipline
- keep PTY sizing and controlling-terminal setup in the PTY helper
- add regression coverage for output written before raw mode used to be applied

## Problem
We were seeing a startup race in the `pty-raw` path.

The child process was being started before the PTY master was put into raw mode, so output written immediately on startup could still be processed with the default PTY line discipline. When that happened, `\n` was rewritten to `\r\n`, which made `TestProcessOutputPTY_PTYRawExperiment` fail intermittently.

## Testing
- go test ./process
- go test ./process -run TestProcessOutputPTY_PTYRawExperimentWritesBeforeRawMode -count=1
- go test ./process -failfast -count=100 -run TestProcessOutputPTY_PTYRawExperiment
