### PR TITLE
chore: rename mise config and add tasks

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,0 @@
-[tools]
-go = "1.25.9"
-golangci-lint = "2.9.0"
-ruby = "3.4.9"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,15 @@
+[tools]
+go = "1.25.9"
+golangci-lint = "2.9.0"
+ruby = "3.4.9"
+
+[tasks.test]
+description = "Run automated tests"
+run = "go tool gotestsum --format pkgname --"
+
+[tasks.lint]
+description = "Run formatting and lint checks"
+run = [
+  "go tool gofumpt -extra -w .",
+  "golangci-lint run",
+]


### PR DESCRIPTION
## Summary

This switches the repo over to a standard `mise.toml` config and adds a couple of project tasks for the common local workflows.

The main change is that `mise run test` and `mise run lint` now work out of the box. The test task uses `go tool gotestsum`, which matches how CI already runs tests, instead of installing a separate `gotestsum` binary through `mise`. That keeps tool versioning in one place, via the Go tool block in `go.mod`.

## Changes

- rename `.mise.toml` to `mise.toml`
- add a `test` task for running `go tool gotestsum`
- add a `lint` task for running `go tool gofumpt -extra -w .` and `golangci-lint run`
- remove the separate `mise`-managed `gotestsum` dependency and use the repo-pinned Go tool instead

## Why

This makes the local developer workflow simpler without introducing another source of truth for tool versions.

In particular:
- `gotestsum` now follows the same pattern locally and in CI
- `gofumpt` and `gotestsum` are both sourced from the repo's Go tool definitions
- `mise` is used for the top-level workflow commands, not for duplicating tool version management

## Testing

- `mise tasks ls`
- `mise run test -- -run '^$' ./...`
- `mise run lint` currently reports existing repo lint failures unrelated to this change
