### PR TITLE
chore: add cleanroom config

### DIFF
--- a/cleanroom.yaml
+++ b/cleanroom.yaml
@@ -1,0 +1,42 @@
+version: 1
+repository:
+  enabled: false
+backends:
+  darwin-vz:
+    memory_mib: 12288
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/debian@sha256:28c3f638fabe1ed780f87b82cfb0c6dda2549c86b9e4edbe519e8250243411c5
+  dependencies:
+    command: |
+      mise settings ruby.compile=false
+      mise install
+      mise exec -- go mod download
+    key:
+      files:
+        - mise.toml
+        - go.mod
+        - go.sum
+  network:
+    default: deny
+    allow:
+      - host: github.com
+        ports: [443]
+      - host: api.github.com
+        ports: [443]
+      - host: dl.google.com
+        ports: [443]
+      - host: proxy.golang.org
+        ports: [443]
+      - host: sum.golang.org
+        ports: [443]
+      - host: storage.googleapis.com
+        ports: [443]
+      - host: mise-versions.jdx.dev
+        ports: [443]
+      - host: mise.jdx.dev
+        ports: [443]
+      - host: release-assets.githubusercontent.com
+        ports: [443]
+      - host: tuf-repo-cdn.sigstore.dev
+        ports: [443]

--- a/cleanroom.yaml
+++ b/cleanroom.yaml
@@ -1,6 +1,4 @@
 version: 1
-repository:
-  enabled: false
 backends:
   darwin-vz:
     memory_mib: 12288


### PR DESCRIPTION
## Draft

This PR is stacked on top of #3839 and should not be merged until that PR lands first.

## Summary

Add a repo-level `cleanroom.yaml` based on the existing Buildkite Agent example in the `cleanroom` repo.

This gives the agent repo a checked-in cleanroom policy for running inside a sandbox with deny-by-default egress, explicit `mise` bootstrap, and cached Go module dependency warmup.

## Changes

- add `cleanroom.yaml` at the repo root
- copy the policy from `../cleanroom/examples/buildkite-agent/cleanroom.yaml`
- update the dependency cache key to use `mise.toml` instead of `.mise.toml`
- enable default repo bootstrap so `cleanroom exec -- mise ...` works from this checkout

## Why

This keeps the cleanroom policy alongside the repo it is meant to run, instead of only existing as an external example.

It also depends on the earlier `mise.toml` rename in #3839, since the dependency-stage cache key now points at `mise.toml`.

## Testing

- `cleanroom policy validate`
- `cleanroom exec -- mise x -- go version`
