### PR TITLE
chore: Fix golangci-lint issues

### DIFF
--- a/.buildkite/steps/check-code-committed.sh
+++ b/.buildkite/steps/check-code-committed.sh
@@ -49,9 +49,7 @@ golangci-lint found the following issues:
 ${lint_out}
 \`\`\`
 EOF
-  # While we're cleaning up things found by golangci-lint, don't fail if it
-  # finds things.
-  exit 0
+  exit 1
 fi
 
 echo +++ Everything is clean and tidy! 🎉

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -275,7 +275,7 @@ func (a *AgentWorker) Start(ctx context.Context, idleMon *idleMonitor) (startErr
 			// If the job acquisition was rejected, we can exit with an error
 			// so that supervisor knows that the job was not acquired due to the job being rejected.
 			if errors.Is(err, core.ErrJobAcquisitionRejected) {
-				return fmt.Errorf("Failed to acquire job %q: %w", a.agentConfiguration.AcquireJob, err)
+				return fmt.Errorf("failed to acquire job %q: %w", a.agentConfiguration.AcquireJob, err)
 			}
 
 			// If the job itself exited with nonzero code, then we want to exit
@@ -532,17 +532,17 @@ func (a *AgentWorker) RunJob(ctx context.Context, acceptResponse *api.Job, ignor
 		KubernetesContainerStartTimeout: a.agentConfiguration.KubernetesContainerStartTimeout,
 	})
 	if err != nil {
-		return fmt.Errorf("Failed to initialize job: %w", err)
+		return fmt.Errorf("failed to initialize job: %w", err)
 	}
 	if !a.jobRunner.CompareAndSwap(nil, jr) {
-		return fmt.Errorf("Agent worker already has a job running")
+		return fmt.Errorf("agent worker already has a job running")
 	}
 	// No more job, no more runner.
 	defer a.jobRunner.Store(nil)
 
 	// Start running the job
 	if err := jr.Run(ctx, ignoreAgentInDispatches); err != nil {
-		return fmt.Errorf("Failed to run job: %w", err)
+		return fmt.Errorf("failed to run job: %w", err)
 	}
 
 	return nil
@@ -562,12 +562,12 @@ func (a *AgentWorker) healthHandler() http.HandlerFunc {
 
 		if a.stats.lastHeartbeatError != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "ERROR: last heartbeat failed: %v. last successful was %v ago", a.stats.lastHeartbeatError, time.Since(a.stats.lastHeartbeat))
+			_, _ = fmt.Fprintf(w, "ERROR: last heartbeat failed: %v. last successful was %v ago", a.stats.lastHeartbeatError, time.Since(a.stats.lastHeartbeat))
 		} else {
 			if a.stats.lastHeartbeat.IsZero() {
-				fmt.Fprintf(w, "OK: no heartbeat yet")
+				_, _ = fmt.Fprintf(w, "OK: no heartbeat yet")
 			} else {
-				fmt.Fprintf(w, "OK: last heartbeat successful %v ago", time.Since(a.stats.lastHeartbeat))
+				_, _ = fmt.Fprintf(w, "OK: last heartbeat successful %v ago", time.Since(a.stats.lastHeartbeat))
 			}
 		}
 	}
@@ -575,12 +575,12 @@ func (a *AgentWorker) healthHandler() http.HandlerFunc {
 
 // Internal error values that should not escape to the user.
 var (
-	// internalStop is used when stopping.
-	internalStop = errors.New("stop")
+	// errInternalStop is used when stopping.
+	errInternalStop = errors.New("stop")
 
-	// internalBreak is used to stop an inner loop but continue
+	// errInternalBreak is used to stop an inner loop but continue
 	// an outer loop.
-	internalBreak = errors.New("break")
+	errInternalBreak = errors.New("break")
 )
 
 const (

--- a/agent/agent_worker_action.go
+++ b/agent/agent_worker_action.go
@@ -214,7 +214,7 @@ func (a *AgentWorker) AcceptAndRunJob(ctx context.Context, jobID string, idleMon
 
 	// If `accepted` is nil, then the job was never accepted
 	if accepted == nil {
-		return fmt.Errorf("Failed to accept job: %w", err)
+		return fmt.Errorf("failed to accept job: %w", err)
 	}
 
 	// If we're disconnecting-after-job, signal back to Buildkite that we're not

--- a/agent/agent_worker_ping.go
+++ b/agent/agent_worker_ping.go
@@ -82,7 +82,7 @@ func (a *AgentWorker) runPingLoop(ctx context.Context, bat *baton, outCh chan<- 
 		pingWaitDurations.Observe(time.Since(startWait).Seconds())
 
 		err := state.pingLoopInner(ctx)
-		if err == internalStop {
+		if err == errInternalStop {
 			return nil
 		}
 		if err != nil {
@@ -122,7 +122,7 @@ func (a *pingLoopState) pingLoopInner(ctx context.Context) error {
 
 	case <-a.stop:
 		a.logger.Debug("[runPingLoop] Stopping due to agent stop")
-		return internalStop
+		return errInternalStop
 	case <-ctx.Done():
 		a.logger.Debug("[runPingLoop] Stopping due to context cancel")
 		return ctx.Err()
@@ -157,7 +157,7 @@ func (a *pingLoopState) pingLoopInner(ctx context.Context) error {
 		// sent!
 	case <-a.stop:
 		a.logger.Debug("[runPingLoop] Stopping due to agent stop")
-		return internalStop
+		return errInternalStop
 	case <-ctx.Done():
 		a.logger.Debug("[runPingLoop] Stopping due to context cancel")
 		return ctx.Err()
@@ -194,7 +194,7 @@ func (a *pingLoopState) pingLoopInner(ctx context.Context) error {
 		return nil
 	case <-a.stop:
 		a.logger.Debug("[runPingLoop] Stopping due to agent stop")
-		return internalStop
+		return errInternalStop
 	case <-ctx.Done():
 		a.logger.Debug("[runPingLoop] Stopping due to context cancel")
 		return ctx.Err()
@@ -234,9 +234,9 @@ func (a *AgentWorker) Ping(ctx context.Context) (jobID, action string, err error
 		// If a ping fails, we don't really care, because it'll
 		// ping again after the interval.
 		if a.stats.lastPing.IsZero() {
-			return "", action, fmt.Errorf("Failed to ping: %w (No successful ping yet)", pingErr)
+			return "", action, fmt.Errorf("failed to ping: %w (no successful ping yet)", pingErr)
 		} else {
-			return "", action, fmt.Errorf("Failed to ping: %w (Last successful was %v ago)", pingErr, time.Since(a.stats.lastPing))
+			return "", action, fmt.Errorf("failed to ping: %w (last successful was %v ago)", pingErr, time.Since(a.stats.lastPing))
 		}
 	}
 

--- a/agent/agent_worker_streaming.go
+++ b/agent/agent_worker_streaming.go
@@ -88,7 +88,7 @@ func (a *AgentWorker) runStreamingPingLoop(ctx context.Context, outCh chan<- act
 		}
 
 		err := state.startStream(ctx, streamCtx)
-		if err == internalStop {
+		if err == errInternalStop {
 			return nil
 		}
 		if err != nil {
@@ -150,7 +150,7 @@ func (a *streamLoopState) startStream(ctx, streamCtx context.Context) error {
 			// sent!
 		case <-a.stop:
 			a.logger.Debug("[runStreamingPingLoop] Stopping due to agent stop")
-			return internalStop
+			return errInternalStop
 		case <-ctx.Done():
 			a.logger.Debug("[runStreamingPingLoop] Stopping due to context cancel")
 			return ctx.Err()
@@ -164,11 +164,11 @@ func (a *streamLoopState) startStream(ctx, streamCtx context.Context) error {
 	a.logger.Debug("[runStreamingPingLoop] Waiting for a message...")
 	for msg, streamErr := range stream {
 		err := a.handle(ctx, msg, streamErr)
-		if err == internalBreak {
+		if err == errInternalBreak {
 			break
 		}
-		if err == internalStop {
-			return internalStop
+		if err == errInternalStop {
+			return errInternalStop
 		}
 		if err != nil {
 			return err
@@ -194,7 +194,7 @@ func (a *streamLoopState) handle(ctx context.Context, msg *agentedgev1.StreamPin
 		// (The connection timed out, which we want to happen every so often).
 		if connect.CodeOf(streamErr) == connect.CodeDeadlineExceeded {
 			a.logger.Debug("[runStreamingPingLoop] Breaking stream loop to reconnect following deadline-exceeded")
-			return internalBreak
+			return errInternalBreak
 		}
 		// It's some other error. Go unhealthy, which unblocks the ping loop.
 		a.logger.Debug("[runStreamingPingLoop] Becoming unhealthy")
@@ -244,7 +244,7 @@ func (a *streamLoopState) handle(ctx context.Context, msg *agentedgev1.StreamPin
 		// sent!
 	case <-a.stop:
 		a.logger.Debug("[runStreamingPingLoop] Stopping due to agent stop")
-		return internalStop
+		return errInternalStop
 	case <-ctx.Done():
 		a.logger.Debug("[runStreamingPingLoop] Stopping due to context cancel")
 		return ctx.Err()
@@ -255,12 +255,12 @@ func (a *streamLoopState) handle(ctx context.Context, msg *agentedgev1.StreamPin
 	if amsg.action == "disconnect" {
 		a.logger.Debug("[runStreamingPingLoop] Stopping due to disconnect action")
 		a.internalStop()
-		return internalStop
+		return errInternalStop
 	}
 
 	if amsg.unhealthy {
 		a.logger.Debug("[runStreamingPingLoop] Breaking stream loop to reconnect because the stream is unhealthy")
-		return internalBreak
+		return errInternalBreak
 	}
 	// Stream is healthy, reset the retry counter
 	a.attempts = 0

--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -43,7 +43,7 @@ func TestDisconnect(t *testing.T) {
 		switch req.URL.Path {
 		case "/disconnect":
 			rw.WriteHeader(http.StatusOK)
-			fmt.Fprintf(rw, `{"id": "fakeuuid", "connection_state": "disconnected"}`)
+			_, _ = fmt.Fprintf(rw, `{"id": "fakeuuid", "connection_state": "disconnected"}`)
 		default:
 			t.Errorf("Unknown endpoint %s %s", req.Method, req.URL.Path)
 			http.Error(rw, "Not found", http.StatusNotFound)
@@ -195,7 +195,7 @@ func TestAcquireAndRunJobWaiting(t *testing.T) {
 
 			rw.Header().Set("Retry-After", fmt.Sprintf("%f", delay))
 			rw.WriteHeader(http.StatusLocked)
-			fmt.Fprintf(rw, `{"message": "Job waitinguuid is not yet eligible to be assigned"}`)
+			_, _ = fmt.Fprintf(rw, `{"message": "Job waitinguuid is not yet eligible to be assigned"}`)
 		default:
 			http.Error(rw, "Not found", http.StatusNotFound)
 		}
@@ -871,12 +871,11 @@ func TestAgentWorker_UpdateRequestHeadersDuringPing(t *testing.T) {
 	t.Parallel()
 
 	const agentSessionToken = "alpacas"
+	const headerKey = "Buildkite-Hello"
+	const headerValue = "world"
 
 	server := NewFakeAPIServer()
 	defer server.Close()
-
-	const headerKey = "Buildkite-Hello"
-	const headerValue = "world"
 
 	agent := server.AddAgent(agentSessionToken)
 	agent.PingHandler = func(req *http.Request) (api.Ping, error) {
@@ -959,9 +958,6 @@ func TestAgentWorker_UnrecoverableErrorInPing(t *testing.T) {
 
 	server := NewFakeAPIServer()
 	defer server.Close()
-
-	const headerKey = "Buildkite-Hello"
-	const headerValue = "world"
 
 	agent := server.AddAgent(agentSessionToken)
 	agent.PingHandler = func(req *http.Request) (api.Ping, error) {

--- a/agent/gcp_meta_data_test.go
+++ b/agent/gcp_meta_data_test.go
@@ -20,9 +20,9 @@ func TestGCPMetaDataGetPaths(t *testing.T) {
 
 		switch path := r.URL.EscapedPath(); path {
 		case "/computeMetadata/v1/value":
-			fmt.Fprintf(w, "I could live on only burritos for the rest of my life")
+			_, _ = fmt.Fprintf(w, "I could live on only burritos for the rest of my life")
 		case "/computeMetadata/v1/nested/paths/work":
-			fmt.Fprintf(w, "Velociraptors are terrifying")
+			_, _ = fmt.Fprintf(w, "Velociraptors are terrifying")
 		default:
 			// NB: Do not use t.Fatal/Fatalf/FailNow from outside the test
 			// runner goroutine. See https://pkg.go.dev/testing#T.FailNow

--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -389,7 +389,7 @@ func TestChunksIntervalSeconds_ControlsUploadTiming(t *testing.T) {
 		mb.Expect().Once().AndCallFunc(func(c *bintest.Call) {
 			start := time.Now()
 			for time.Since(start) < 4*time.Second {
-				fmt.Fprintf(c.Stdout, "Log output at start+%v\n", time.Since(start))
+				_, _ = fmt.Fprintf(c.Stdout, "Log output at start+%v\n", time.Since(start))
 				time.Sleep(100 * time.Millisecond)
 			}
 			c.Exit(0)

--- a/agent/integration/job_verification_integration_test.go
+++ b/agent/integration/job_verification_integration_test.go
@@ -347,23 +347,6 @@ var (
 		},
 		Token: "bkaj_job-token",
 	}
-
-	jobWithMismatchedSecrets = api.Job{
-		ChunksMaxSizeBytes: 1024,
-		ID:                 defaultJobID,
-		Step: pipeline.CommandStep{
-			Command: "echo hello world",
-			Secrets: pipeline.Secrets{
-				pipeline.Secret{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
-			},
-		},
-		Env: map[string]string{
-			"BUILDKITE_COMMAND": "echo hello world",
-			"BUILDKITE_REPO":    defaultRepositoryURL,
-			"DEPLOY":            "0",
-		},
-		Token: "bkaj_job-token",
-	}
 )
 
 func TestJobVerification(t *testing.T) {

--- a/agent/integration/test_helpers.go
+++ b/agent/integration/test_helpers.go
@@ -143,7 +143,7 @@ type route struct {
 func (t *testAgentEndpoint) getJobsHandler() http.HandlerFunc {
 	return func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
-		fmt.Fprintf(rw, `{"state":"running"}`)
+		_, _ = fmt.Fprintf(rw, `{"state":"running"}`)
 	}
 }
 

--- a/agent/job_logger_test.go
+++ b/agent/job_logger_test.go
@@ -20,7 +20,9 @@ func TestJobLoggerJSONFormat(t *testing.T) {
 	}
 
 	log := NewJobLogger(conf)
-	log.Write([]byte("hello\n"))
+	if _, err := log.Write([]byte("hello\n")); err != nil {
+		t.Fatalf("log.Write() = %v", err)
+	}
 
 	var entry map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
@@ -43,7 +45,9 @@ func TestJobLoggerTextFormat(t *testing.T) {
 	}
 
 	log := NewJobLogger(conf)
-	log.Write([]byte("hello\n"))
+	if _, err := log.Write([]byte("hello\n")); err != nil {
+		t.Fatalf("log.Write() = %v", err)
+	}
 
 	if err := json.Unmarshal(buf.Bytes(), &map[string]any{}); err == nil {
 		t.Error("expected non-JSON output for text format, but got valid JSON")

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -895,8 +895,8 @@ func createJobEnvFiles(l logger.Logger, jobID string, kubernetesExec bool) (shel
 
 	jsonFile, err = os.CreateTemp(tempDir, fmt.Sprintf("job-env-json-%s", jobID))
 	if err != nil {
-		shellFile.Close()
-		os.Remove(shellFile.Name())
+		_ = shellFile.Close()
+		_ = os.Remove(shellFile.Name())
 		return nil, nil, err
 	}
 	l.Debug("[JobRunner] Created env file (JSON format): %s", jsonFile.Name())

--- a/agent/json_job_logger_test.go
+++ b/agent/json_job_logger_test.go
@@ -28,7 +28,9 @@ func TestJSONJobLogger_JobFields(t *testing.T) {
 	}
 
 	log := NewJSONJobLogger(JobRunnerConfig{AgentStdout: &buf, Job: job})
-	log.Write([]byte("hello\n"))
+	if _, err := log.Write([]byte("hello\n")); err != nil {
+		t.Fatalf("log.Write() = %v", err)
+	}
 
 	var got map[string]string
 	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
@@ -94,7 +96,9 @@ func TestJSONJobLogger_TraceparentFields(t *testing.T) {
 			}
 
 			log := NewJSONJobLogger(JobRunnerConfig{AgentStdout: &buf, Job: job})
-			log.Write([]byte("hello\n"))
+			if _, err := log.Write([]byte("hello\n")); err != nil {
+				t.Fatalf("log.Write() = %v", err)
+			}
 
 			var got map[string]string
 			if err := json.Unmarshal(buf.Bytes(), &got); err != nil {

--- a/agent/log_streamer.go
+++ b/agent/log_streamer.go
@@ -85,7 +85,7 @@ func NewLogStreamer(
 // Start spins up a number of log streamer workers.
 func (ls *LogStreamer) Start(ctx context.Context) error {
 	if ls.conf.MaxChunkSizeBytes <= 0 {
-		return errors.New("Maximum chunk size must be more than 0. No logs will be sent.")
+		return errors.New("maximum chunk size must be more than 0 or logs cannot be sent")
 	}
 
 	if ls.conf.MaxSizeBytes <= 0 {

--- a/agent/pipeline_uploader.go
+++ b/agent/pipeline_uploader.go
@@ -61,7 +61,7 @@ type PipelineUploader struct {
 func (u *PipelineUploader) Upload(ctx context.Context, l logger.Logger) error {
 	result, err := u.pipelineUploadAsyncWithRetry(ctx, l)
 	if err != nil {
-		return fmt.Errorf("Failed to upload and accept pipeline: %w", err)
+		return fmt.Errorf("failed to upload and accept pipeline: %w", err)
 	}
 
 	// If the route does not support async uploads, and it did not error, then the pipeline
@@ -75,12 +75,12 @@ func (u *PipelineUploader) Upload(ctx context.Context, l logger.Logger) error {
 
 	jobIDFromResponse, uuidFromResponse, err := extractJobIdUUID(result.pipelineStatusURL.String())
 	if err != nil {
-		return fmt.Errorf("Failed to parse location to check status of pipeline: %w", err)
+		return fmt.Errorf("failed to parse location to check status of pipeline: %w", err)
 	}
 
 	if jobIDFromResponse != u.JobID {
 		return fmt.Errorf(
-			"JobID from API: %q does not match request: %s",
+			"job ID from API %q does not match request %s",
 			jobIDFromResponse,
 			u.JobID,
 		)
@@ -88,14 +88,14 @@ func (u *PipelineUploader) Upload(ctx context.Context, l logger.Logger) error {
 
 	if uuidFromResponse != u.Change.UUID {
 		return fmt.Errorf(
-			"Pipeline Upload UUID from API: %q does not match request: %s",
+			"pipeline upload UUID from API %q does not match request %s",
 			uuidFromResponse,
 			u.Change.UUID,
 		)
 	}
 
 	if err := u.pollForPiplineUploadStatus(ctx, l); err != nil {
-		return fmt.Errorf("Failed to upload and process pipeline: %w", err)
+		return fmt.Errorf("failed to upload and process pipeline: %w", err)
 	}
 
 	return nil
@@ -201,17 +201,17 @@ func (u *PipelineUploader) pollForPiplineUploadStatus(ctx context.Context, l log
 			return nil
 		case "pending", "processing":
 			setNextIntervalFromResponse(r, resp)
-			err := fmt.Errorf("Pipeline upload not yet applied: %s", uploadStatus.State)
+			err := fmt.Errorf("pipeline upload not yet applied: %s", uploadStatus.State)
 			l.Info("%s (%s)", err, r)
 			return err
 		case "rejected", "failed":
 			l.Error("Unrecoverable error, skipping retries")
 			r.Break()
-			return fmt.Errorf("Pipeline upload %s: %s", uploadStatus.State, uploadStatus.Message)
+			return fmt.Errorf("pipeline upload %s: %s", uploadStatus.State, uploadStatus.Message)
 		default:
 			l.Error("Unrecoverable error, skipping retries")
 			r.Break()
-			return fmt.Errorf("Unexpected pipeline upload state from API: %s", uploadStatus.State)
+			return fmt.Errorf("unexpected pipeline upload state from API: %s", uploadStatus.State)
 		}
 	})
 }

--- a/agent/pipeline_uploader_test.go
+++ b/agent/pipeline_uploader_test.go
@@ -36,7 +36,7 @@ func TestAsyncPipelineUpload(t *testing.T) {
 		{
 			state:          "rejected",
 			expectedSleeps: []time.Duration{},
-			err:            errors.New("Failed to upload and process pipeline: Pipeline upload rejected: "),
+			err:            errors.New("failed to upload and process pipeline: pipeline upload rejected: "),
 		},
 		{
 			state: "pending",
@@ -47,7 +47,7 @@ func TestAsyncPipelineUpload(t *testing.T) {
 				}
 				return sleeps
 			}(),
-			err: errors.New("Failed to upload and process pipeline: Pipeline upload not yet applied: pending"),
+			err: errors.New("failed to upload and process pipeline: pipeline upload not yet applied: pending"),
 		},
 	} {
 		t.Run(test.state, func(t *testing.T) {

--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -58,7 +58,7 @@ func CreatePlugin(location string, config map[string]any) (*Plugin, error) {
 	plugin.Vendored = strings.HasPrefix(plugin.Location, ".")
 
 	if plugin.Version != "" && strings.Count(plugin.Version, "#") > 0 {
-		return nil, fmt.Errorf("Too many '#'s in %q", location)
+		return nil, fmt.Errorf("too many '#'s in %q", location)
 	}
 
 	if u.User != nil {
@@ -114,7 +114,7 @@ func CreateFromJSON(j string) ([]*Plugin, error) {
 				// Since there is a config, it's gotta be a hash
 				config, ok := config.(map[string]any)
 				if !ok {
-					return nil, fmt.Errorf("Configuration for \"%s\" is not a hash", location)
+					return nil, fmt.Errorf("configuration for %q is not a hash", location)
 				}
 
 				// Add the plugin with config to the array
@@ -127,7 +127,7 @@ func CreateFromJSON(j string) ([]*Plugin, error) {
 			}
 
 		default:
-			return nil, fmt.Errorf("Unknown type in plugin definition (%s)", vv)
+			return nil, fmt.Errorf("unknown type in plugin definition (%s)", vv)
 		}
 	}
 
@@ -262,7 +262,7 @@ func flattenConfigToEnvMap(into map[string]string, v any, envPrefix string) erro
 		return nil
 
 	default:
-		return fmt.Errorf("Unknown type %T %v", v, v)
+		return fmt.Errorf("unknown type %T %v", v, v)
 	}
 }
 
@@ -352,24 +352,24 @@ func (p *Plugin) DisplayName() string {
 
 func (p *Plugin) constructRepositoryHost() (string, error) {
 	if p.Location == "" {
-		return "", fmt.Errorf("Missing plugin location")
+		return "", fmt.Errorf("missing plugin location")
 	}
 
 	parts := strings.Split(p.Location, "/")
 	if len(parts) < 2 {
-		return "", fmt.Errorf("Incomplete plugin path %q", p.Location)
+		return "", fmt.Errorf("incomplete plugin path %q", p.Location)
 	}
 
 	switch parts[0] {
 	case "github.com", "bitbucket.org":
 		if len(parts) < 3 {
-			return "", fmt.Errorf("Incomplete plugin path %q", p.Location)
+			return "", fmt.Errorf("incomplete plugin path %q", p.Location)
 		}
 		return strings.Join(parts[:3], "/"), nil
 
 	case "gitlab.com":
 		if len(parts) < 3 {
-			return "", fmt.Errorf("Incomplete plugin path %q", p.Location)
+			return "", fmt.Errorf("incomplete plugin path %q", p.Location)
 		}
 		return strings.Join(parts, "/"), nil
 

--- a/agent/plugin/plugin_test.go
+++ b/agent/plugin/plugin_test.go
@@ -133,7 +133,7 @@ func TestCreateFromJSONFailsOnParseErrors(t *testing.T) {
 		},
 		{
 			`["github.com/buildkite-plugins/ping#main#lololo"]`,
-			"Too many '#'s in \"github.com/buildkite-plugins/ping#main#lololo\"",
+			"too many '#'s in \"github.com/buildkite-plugins/ping#main#lololo\"",
 		},
 	}
 
@@ -341,15 +341,15 @@ func TestRespositoryAndSubdirectoryErrors(t *testing.T) {
 	}{
 		{
 			location: "github.com/buildkite",
-			wantErr:  `Incomplete plugin path "github.com/buildkite"`,
+			wantErr:  `incomplete plugin path "github.com/buildkite"`,
 		},
 		{
 			location: "bitbucket.org/buildkite",
-			wantErr:  `Incomplete plugin path "bitbucket.org/buildkite"`,
+			wantErr:  `incomplete plugin path "bitbucket.org/buildkite"`,
 		},
 		{
 			location: "",
-			wantErr:  "Missing plugin location",
+			wantErr:  "missing plugin location",
 		},
 	}
 	for _, tc := range tests {

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -166,23 +166,23 @@ func (r *JobRunner) Run(ctx context.Context, ignoreAgentInDispatches *bool) (err
 		default: // no error, all good, keep going
 			l := r.agentLogger.WithFields(logger.StringField("jobID", job.ID), logger.StringField("signature", job.Step.Signature.Value))
 			l.Info("Successfully verified job")
-			fmt.Fprintln(r.jobLogs, "~~~ ✅ Job signature verified")
-			fmt.Fprintf(r.jobLogs, "signature: %s\n", job.Step.Signature.Value)
+			_, _ = fmt.Fprintln(r.jobLogs, "~~~ ✅ Job signature verified")
+			_, _ = fmt.Fprintf(r.jobLogs, "signature: %s\n", job.Step.Signature.Value)
 		}
 	}
 
 	// Log a message if the job has cache settings but is running on a self-hosted agent.
 	if cache := job.Step.Cache; cache != nil && !cache.Disabled && len(cache.Paths) > 0 {
 		if job.Env["BUILDKITE_COMPUTE_TYPE"] == "self-hosted" {
-			fmt.Fprintln(r.jobLogs, "+++ ⚠️ Cache settings detected on self-hosted agent")
-			fmt.Fprintf(r.jobLogs, "cache paths: %s\n", strings.Join(cache.Paths, ", "))
+			_, _ = fmt.Fprintln(r.jobLogs, "+++ ⚠️ Cache settings detected on self-hosted agent")
+			_, _ = fmt.Fprintf(r.jobLogs, "cache paths: %s\n", strings.Join(cache.Paths, ", "))
 			r.agentLogger.Info("Job %s has cache settings but is running on a self-hosted agent", job.ID)
 		}
 	}
 
 	// Validate the repository if the list of allowed repositories is set.
 	if err := r.validateConfigAllowlists(job); err != nil {
-		fmt.Fprintln(r.jobLogs, err.Error())
+		_, _ = fmt.Fprintln(r.jobLogs, err.Error())
 		r.agentLogger.Error(err.Error())
 
 		exit.Status = -1
@@ -197,7 +197,7 @@ func (r *JobRunner) Run(ctx context.Context, ignoreAgentInDispatches *bool) (err
 		ok, err := r.executePreBootstrapHook(ctx, hook)
 		if !ok {
 			// Ensure the Job UI knows why this job resulted in failure
-			fmt.Fprintln(r.jobLogs, "pre-bootstrap hook rejected this job, see the buildkite-agent logs for more details")
+			_, _ = fmt.Fprintln(r.jobLogs, "pre-bootstrap hook rejected this job, see the buildkite-agent logs for more details")
 			// But disclose more information in the agent logs
 			r.agentLogger.Error("pre-bootstrap hook rejected this job: %s", err)
 
@@ -307,21 +307,21 @@ func (r *JobRunner) verificationFailureLogs(behavior string, err error) {
 	}
 
 	l.Warn("Job verification failed")
-	fmt.Fprintf(r.jobLogs, "%s Job signature verification failed\n", prefix)
-	fmt.Fprintf(r.jobLogs, "error: %s\n", err)
+	_, _ = fmt.Fprintf(r.jobLogs, "%s Job signature verification failed\n", prefix)
+	_, _ = fmt.Fprintf(r.jobLogs, "error: %s\n", err)
 
 	if errors.Is(err, ErrNoSignature) {
-		fmt.Fprintln(r.jobLogs, "no signature in job")
+		_, _ = fmt.Fprintln(r.jobLogs, "no signature in job")
 	} else if ise := new(invalidSignatureError); errors.As(err, &ise) {
-		fmt.Fprintf(r.jobLogs, "signature: %s\n", r.conf.Job.Step.Signature.Value)
+		_, _ = fmt.Fprintf(r.jobLogs, "signature: %s\n", r.conf.Job.Step.Signature.Value)
 	} else if mke := new(missingKeyError); errors.As(err, &mke) {
-		fmt.Fprintf(r.jobLogs, "signature: %s\n", mke.signature)
+		_, _ = fmt.Fprintf(r.jobLogs, "signature: %s\n", mke.signature)
 	}
 
 	if behavior == VerificationBehaviourWarn {
 		l.Warn("Job will be run whether or not it can be verified - this is not recommended.")
 		l.Warn("You can change this behavior with the `verification-failure-behavior` agent configuration option.")
-		fmt.Fprintln(r.jobLogs, "Job will be run without verification")
+		_, _ = fmt.Fprintln(r.jobLogs, "Job will be run without verification")
 	}
 }
 
@@ -330,7 +330,7 @@ func (r *JobRunner) runJob(ctx context.Context) core.ProcessExit {
 	// Run the process. This will block until it finishes.
 	if err := r.process.Run(ctx); err != nil {
 		// Send the error to job logs
-		fmt.Fprintf(r.jobLogs, "Error running job: %s\n", err)
+		_, _ = fmt.Fprintf(r.jobLogs, "Error running job: %s\n", err)
 
 		// The process did not run at all, so make sure it fails
 		return core.ProcessExit{
@@ -345,11 +345,11 @@ func (r *JobRunner) runJob(ctx context.Context) core.ProcessExit {
 	if isK8s && !r.agentStopping.Load() {
 		switch {
 		case r.cancelled.Load() && k8sProcess.AnyClientIn(kubernetes.StateNotYetConnected):
-			fmt.Fprint(r.jobLogs, `+++ Unknown container exit status
+			_, _ = fmt.Fprint(r.jobLogs, `+++ Unknown container exit status
 One or more containers never connected to the agent. Perhaps the container image specified in your podSpec could not be pulled (ImagePullBackOff)?
 `)
 		case k8sProcess.AnyClientIn(kubernetes.StateLost):
-			fmt.Fprint(r.jobLogs, `+++ Unknown container exit status
+			_, _ = fmt.Fprint(r.jobLogs, `+++ Unknown container exit status
 One or more containers connected to the agent, but then stopped communicating without exiting normally. Perhaps the container was OOM-killed?
 `)
 		}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1133,7 +1133,7 @@ var AgentStartCommand = cli.Command{
 			}
 		} else if cfg.LogFormat != "json" {
 			// TODO If/when cli is upgraded to v2, choice validation can be done with per-argument Actions.
-			return fmt.Errorf("invalid log format %q. Only 'text' or 'json' are allowed.", cfg.LogFormat)
+			return fmt.Errorf("invalid log format %q; only 'text' or 'json' are allowed", cfg.LogFormat)
 		}
 
 		l.Notice("Starting buildkite-agent v%s with PID: %s", version.Version(), strconv.Itoa(os.Getpid()))
@@ -1268,7 +1268,7 @@ var AgentStartCommand = cli.Command{
 
 		if cfg.SpawnPerCPU > 0 {
 			if cfg.Spawn > 1 {
-				return errors.New("You can't specify spawn and spawn-per-cpu at the same time")
+				return errors.New("you can't specify spawn and spawn-per-cpu at the same time")
 			}
 			cfg.Spawn = runtime.NumCPU() * cfg.SpawnPerCPU
 		}
@@ -1276,7 +1276,7 @@ var AgentStartCommand = cli.Command{
 		// Spawning multiple agents doesn't work if the agent is being
 		// booted in acquisition mode
 		if cfg.Spawn > 1 && cfg.AcquireJob != "" {
-			return errors.New("You can't spawn multiple agents and acquire a job at the same time")
+			return errors.New("you can't spawn multiple agents and acquire a job at the same time")
 		}
 
 		var workers []*agent.AgentWorker
@@ -1392,16 +1392,16 @@ var AgentStartCommand = cli.Command{
 func parseAndValidateJWKS(ctx context.Context, keysetType, path string) (jwk.Set, error) {
 	jwksBytes, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read job %s keyset: %w", keysetType, err)
+		return nil, fmt.Errorf("failed to read job %s keyset: %w", keysetType, err)
 	}
 
 	jwks, err := jwk.Parse(jwksBytes)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse job %s keyset: %w", keysetType, err)
+		return nil, fmt.Errorf("failed to parse job %s keyset: %w", keysetType, err)
 	}
 
 	if jwks.Len() == 0 {
-		return nil, fmt.Errorf("Job %s keyset is empty", keysetType)
+		return nil, fmt.Errorf("job %s keyset is empty", keysetType)
 	}
 
 	iter := jwks.Keys(ctx)
@@ -1409,11 +1409,11 @@ func parseAndValidateJWKS(ctx context.Context, keysetType, path string) (jwk.Set
 		keyI := iter.Pair().Value
 		key, ok := keyI.(jwk.Key)
 		if !ok {
-			return nil, fmt.Errorf("Job %s keyset contains a non-key at index %d", keysetType, iter.Pair().Index)
+			return nil, fmt.Errorf("job %s keyset contains a non-key at index %d", keysetType, iter.Pair().Index)
 		}
 
 		if _, ok = key.Get(jwk.AlgorithmKey); !ok {
-			return nil, fmt.Errorf("Job %s keyset contains a key without an algorithm at index %d. All keys used for signing and verification in the agent must have their `alg` key set", keysetType, iter.Pair().Index)
+			return nil, fmt.Errorf("job %s keyset contains a key without an algorithm at index %d. all keys used for signing and verification in the agent must have their `alg` key set", keysetType, iter.Pair().Index)
 		}
 	}
 
@@ -1597,7 +1597,7 @@ func runAgentAPI(ctx context.Context, l logger.Logger, socketsPath string) (func
 	// There should be only one Agent API socket per agent process.
 	// If a previous agent crashed and left behind a socket, we can
 	// remove it.
-	os.Remove(path)
+	_ = os.Remove(path)
 
 	svr, err := agentapi.NewServer(path, l)
 	if err != nil {
@@ -1618,9 +1618,11 @@ func runAgentAPI(ctx context.Context, l logger.Logger, socketsPath string) (func
 	go leaderPinger(ctx, l, path, leaderPath)
 
 	return func() {
-		svr.Shutdown(ctx)
+		if err := svr.Shutdown(ctx); err != nil {
+			l.Warn("Agent API: error shutting down server: %v", err)
+		}
 		if d, err := os.Readlink(leaderPath); err == nil && d == path {
-			os.Remove(leaderPath)
+			_ = os.Remove(leaderPath)
 		}
 	}, nil
 }
@@ -1653,8 +1655,10 @@ func leaderPinger(ctx context.Context, l logger.Logger, path, leaderPath string)
 		if err := pingLeader(); err != nil {
 			l.Warn("Agent API: Leader ping failed, staging coup: %v", err)
 			l.Warn("Agent API: Leader state (locks) has been lost!")
-			os.Remove(leaderPath)
-			os.Symlink(path, leaderPath)
+			_ = os.Remove(leaderPath)
+			if err := os.Symlink(path, leaderPath); err != nil {
+				l.Warn("Agent API: Failed to become leader: %v", err)
+			}
 		}
 	}
 }

--- a/clicommand/agent_start_test.go
+++ b/clicommand/agent_start_test.go
@@ -20,7 +20,7 @@ func setupHooksPath(t *testing.T) (string, func()) {
 	if err != nil {
 		assert.FailNow(t, "failed to create temp file: %v", err)
 	}
-	return hooksPath, func() { os.RemoveAll(hooksPath) }
+	return hooksPath, func() { _ = os.RemoveAll(hooksPath) }
 }
 
 func writeAgentHook(t *testing.T, dir, hookName, msg string) string {

--- a/clicommand/annotate_test.go
+++ b/clicommand/annotate_test.go
@@ -16,7 +16,7 @@ func newAnnotateTestServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.RequestURI() {
 		case "/jobs/jobid/annotations":
-			io.WriteString(rw, `{"context":"", style:"", body:"abc"}`)
+			_, _ = io.WriteString(rw, `{"context":"", style:"", body:"abc"}`)
 		default:
 			t.Errorf("unexpected HTTP request: %s %v", req.Method, req.URL.RequestURI())
 		}

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -126,7 +126,7 @@ var ArtifactSearchCommand = cli.Command{
 		// Handling all escape sequences, like \n, \t etc
 		unquoted, err := strconv.Unquote(`"` + printFormat + `"`)
 		if err != nil {
-			return fmt.Errorf("Unable to parse format %q", printFormat)
+			return fmt.Errorf("unable to parse format %q", printFormat)
 		}
 		printFormat = unquoted
 

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -108,15 +108,15 @@ func searchAndPrintShaSum(
 	searcher := artifact.NewSearcher(l, client, cfg.Build)
 	artifacts, err := searcher.Search(ctx, cfg.Query, cfg.Step, cfg.IncludeRetriedJobs, false)
 	if err != nil {
-		return fmt.Errorf("Error searching for artifacts: %s", err)
+		return fmt.Errorf("error searching for artifacts: %s", err)
 	}
 
 	artifactsFoundLength := len(artifacts)
 
 	if artifactsFoundLength == 0 {
-		return fmt.Errorf("No artifacts matched the search query")
+		return fmt.Errorf("no artifacts matched the search query")
 	} else if artifactsFoundLength > 1 {
-		return fmt.Errorf("Multiple artifacts were found. Try being more specific with the search or scope by step")
+		return fmt.Errorf("multiple artifacts were found. try being more specific with the search or scope by step")
 	} else {
 		a := artifacts[0]
 		l.Debug("Artifact \"%s\" found", a.Path)
@@ -124,13 +124,13 @@ func searchAndPrintShaSum(
 		var sha string
 		if cfg.Sha256 {
 			if a.Sha256Sum == "" {
-				return fmt.Errorf("SHA-256 requested but was not generated at upload time")
+				return fmt.Errorf("sha-256 was requested but was not generated at upload time")
 			}
 			sha = a.Sha256Sum
 		} else {
 			sha = a.Sha1Sum
 		}
-		fmt.Fprintln(stdout, sha)
+		_, _ = fmt.Fprintln(stdout, sha)
 	}
 
 	return nil

--- a/clicommand/artifact_shasum_test.go
+++ b/clicommand/artifact_shasum_test.go
@@ -18,7 +18,7 @@ func newArtifactTestServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.RequestURI() {
 		case "/builds/buildid/artifacts/search?query=foo.%2A&state=finished":
-			io.WriteString(rw, `[{"path": "foo.txt", "sha1sum": "theshastring", "sha256sum": "thesha256string"}]`)
+			_, _ = io.WriteString(rw, `[{"path": "foo.txt", "sha1sum": "theshastring", "sha256sum": "thesha256string"}]`)
 		default:
 			t.Errorf("unexpected HTTP request: %s %v", req.Method, req.URL.RequestURI())
 		}
@@ -44,7 +44,9 @@ func TestSearchAndPrintSha1Sum(t *testing.T) {
 	l := logger.NewBuffer()
 	stdout := new(bytes.Buffer)
 
-	searchAndPrintShaSum(ctx, cfg, l, stdout)
+	if err := searchAndPrintShaSum(ctx, cfg, l, stdout); err != nil {
+		t.Fatalf("searchAndPrintShaSum() error = %v", err)
+	}
 
 	assert.Equal(t, "theshastring\n", stdout.String())
 
@@ -72,7 +74,9 @@ func TestSearchAndPrintSha256Sum(t *testing.T) {
 	l := logger.NewBuffer()
 	stdout := new(bytes.Buffer)
 
-	searchAndPrintShaSum(ctx, cfg, l, stdout)
+	if err := searchAndPrintShaSum(ctx, cfg, l, stdout); err != nil {
+		t.Fatalf("searchAndPrintShaSum() error = %v", err)
+	}
 
 	assert.Equal(t, "thesha256string\n", stdout.String())
 

--- a/clicommand/build_cancel_test.go
+++ b/clicommand/build_cancel_test.go
@@ -18,7 +18,7 @@ func TestBuildCancel(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			rw.WriteHeader(http.StatusOK)
-			rw.Write([]byte(`{"status": "canceled", "uuid": "1"}`))
+			_, _ = rw.Write([]byte(`{"status": "canceled", "uuid": "1"}`))
 		}))
 
 		cfg := BuildCancelConfig{

--- a/clicommand/env_get.go
+++ b/clicommand/env_get.go
@@ -10,9 +10,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-const envClientErrMessage = `Could not create Job API client: %w
-This command can only be used from hooks or plugins running under a job executor
-where the agent's job API is available (in version v3.64.0 and later of the Buildkite Agent).`
+const envClientErrMessage = `could not create Job API client: %w
+this command can only be used from hooks or plugins running under a job executor
+where the agent's job API is available in Buildkite Agent v3.64.0 and later`
 
 const envGetHelpDescription = `Usage:
 
@@ -116,14 +116,14 @@ func envGetAction(c *cli.Context) error {
 		if len(c.Args()) == 1 {
 			// Just print the value.
 			for _, v := range envMap {
-				fmt.Fprintln(c.App.Writer, v)
+				_, _ = fmt.Fprintln(c.App.Writer, v)
 			}
 			break
 		}
 
 		// Print everything.
 		for _, v := range env.FromMap(envMap).ToSlice() {
-			fmt.Fprintln(c.App.Writer, v)
+			_, _ = fmt.Fprintln(c.App.Writer, v)
 		}
 
 	case "json", "json-pretty":

--- a/clicommand/env_set.go
+++ b/clicommand/env_set.go
@@ -138,19 +138,19 @@ func envSetAction(c *cli.Context) error {
 
 	case "plain":
 		if len(resp.Added) > 0 {
-			fmt.Fprintln(c.App.Writer, "Added:")
+			_, _ = fmt.Fprintln(c.App.Writer, "Added:")
 			for _, a := range resp.Added {
-				fmt.Fprintf(c.App.Writer, "+ %s\n", a)
+				_, _ = fmt.Fprintf(c.App.Writer, "+ %s\n", a)
 			}
 		}
 		if len(resp.Updated) > 0 {
-			fmt.Fprintln(c.App.Writer, "Updated:")
+			_, _ = fmt.Fprintln(c.App.Writer, "Updated:")
 			for _, u := range resp.Updated {
-				fmt.Fprintf(c.App.Writer, "~ %s\n", u)
+				_, _ = fmt.Fprintf(c.App.Writer, "~ %s\n", u)
 			}
 		}
 		if len(resp.Added) == 0 && len(resp.Updated) == 0 {
-			fmt.Fprintln(c.App.Writer, "No variables added or updated.")
+			_, _ = fmt.Fprintln(c.App.Writer, "No variables added or updated.")
 		}
 
 	case "json", "json-pretty":

--- a/clicommand/env_unset.go
+++ b/clicommand/env_unset.go
@@ -92,7 +92,7 @@ func envUnsetAction(c *cli.Context) error {
 		}
 
 	default:
-		fmt.Fprintf(c.App.ErrWriter, "Invalid input format %q\n", c.String("input-format"))
+		_, _ = fmt.Fprintf(c.App.ErrWriter, "Invalid input format %q\n", c.String("input-format"))
 	}
 
 	// Inspect each arg, which could either be "-" for stdin, or "KEY"
@@ -129,12 +129,12 @@ func envUnsetAction(c *cli.Context) error {
 
 	case "plain":
 		if len(unset) > 0 {
-			fmt.Fprintln(c.App.Writer, "Unset:")
+			_, _ = fmt.Fprintln(c.App.Writer, "Unset:")
 			for _, d := range unset {
-				fmt.Fprintf(c.App.Writer, "- %s\n", d)
+				_, _ = fmt.Fprintf(c.App.Writer, "- %s\n", d)
 			}
 		} else {
-			fmt.Fprintln(c.App.Writer, "No variables unset.")
+			_, _ = fmt.Fprintln(c.App.Writer, "No variables unset.")
 		}
 
 	case "json", "json-pretty":

--- a/clicommand/git_credentials_helper.go
+++ b/clicommand/git_credentials_helper.go
@@ -101,9 +101,9 @@ var GitCredentialsHelperCommand = cli.Command{
 			return handleAuthError(c, l, fmt.Errorf("failed to get github app credentials: %w", err))
 		}
 
-		fmt.Fprintln(c.App.Writer, "username=token")
-		fmt.Fprintln(c.App.Writer, "password="+tok)
-		fmt.Fprintln(c.App.Writer, "")
+		_, _ = fmt.Fprintln(c.App.Writer, "username=token")
+		_, _ = fmt.Fprintln(c.App.Writer, "password="+tok)
+		_, _ = fmt.Fprintln(c.App.Writer, "")
 
 		l.Debug("Authentication successful!")
 
@@ -117,9 +117,9 @@ var GitCredentialsHelperCommand = cli.Command{
 // this function always returns a cli.ExitError
 func handleAuthError(c *cli.Context, l logger.Logger, err error) error {
 	l.Error("Error: %v. Authentication will proceed, but will fail.", err)
-	fmt.Fprintln(c.App.Writer, "username=fail")
-	fmt.Fprintln(c.App.Writer, "password=fail")
-	fmt.Fprintln(c.App.Writer, "")
+	_, _ = fmt.Fprintln(c.App.Writer, "username=fail")
+	_, _ = fmt.Fprintln(c.App.Writer, "password=fail")
+	_, _ = fmt.Fprintln(c.App.Writer, "")
 
 	return cli.NewExitError("", 1)
 }

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -444,7 +444,7 @@ func UnsetConfigFromEnvironment(c *cli.Context) error {
 		// split comma delimited env
 		if envVars := f.String(); envVars != "" {
 			for env := range strings.SplitSeq(envVars, ",") {
-				os.Unsetenv(env)
+				_ = os.Unsetenv(env)
 			}
 		}
 	}
@@ -518,7 +518,7 @@ func setupLoggerAndConfig[T any](ctx context.Context, c *cli.Context, opts ...co
 
 	warnings, err := loader.Load()
 	if err != nil {
-		fmt.Fprintf(c.App.ErrWriter, "%s\n", err)
+		_, _ = fmt.Fprintf(c.App.ErrWriter, "%s\n", err)
 		os.Exit(1)
 	}
 

--- a/clicommand/kubernetes_bootstrap.go
+++ b/clicommand/kubernetes_bootstrap.go
@@ -195,7 +195,7 @@ var KubernetesBootstrapCommand = cli.Command{
 		}
 
 		phases := environ.GetString("BUILDKITE_BOOTSTRAP_PHASES", "(unknown)")
-		fmt.Fprintf(socket, "~~~ Bootstrapping phases %s\n", phases)
+		_, _ = fmt.Fprintf(socket, "~~~ Bootstrapping phases %s\n", phases)
 
 		// Now we can run the real `buildkite-agent bootstrap`.
 		// Compare with the setup in [agent.NewJobRunner].
@@ -245,11 +245,11 @@ var KubernetesBootstrapCommand = cli.Command{
 		}()
 
 		exitCode := -1
-		defer func() { socket.Exit(exitCode) }()
+		defer func() { _ = socket.Exit(exitCode) }()
 
 		// NB: Run blocks until the subprocess exits.
 		if err := proc.Run(ctx); err != nil {
-			fmt.Fprintf(socket, "Couldn't execute bootstrap: %v\n", err)
+			_, _ = fmt.Fprintf(socket, "Couldn't execute bootstrap: %v\n", err)
 			return &ExitError{1, err}
 		}
 

--- a/clicommand/lock_acquire.go
+++ b/clicommand/lock_acquire.go
@@ -57,7 +57,7 @@ var LockAcquireCommand = cli.Command{
 
 func lockAcquireAction(c *cli.Context) error {
 	if c.NArg() != 1 {
-		fmt.Fprint(c.App.ErrWriter, lockAcquireHelpDescription)
+		_, _ = fmt.Fprint(c.App.ErrWriter, lockAcquireHelpDescription)
 		return &SilentExitError{code: 1}
 	}
 	key := c.Args()[0]
@@ -66,7 +66,7 @@ func lockAcquireAction(c *cli.Context) error {
 	defer done()
 
 	if cfg.LockScope != "machine" {
-		return errors.New("only 'machine' scope for locks is supported in this version.")
+		return errors.New("only 'machine' scope for locks is supported in this version")
 	}
 
 	if cfg.LockWaitTimeout != 0 {

--- a/clicommand/lock_common.go
+++ b/clicommand/lock_common.go
@@ -2,10 +2,9 @@ package clicommand
 
 import "github.com/urfave/cli"
 
-const lockClientErrMessage = `Could not connect to Agent API: %v
-This command can only be used when at least one agent is running with the
-"agent-api" experiment enabled.
-`
+const lockClientErrMessage = `could not connect to Agent API: %v
+this command can only be used when at least one agent is running with the
+"agent-api" experiment enabled`
 
 // Flags used by all lock subcommands.
 func lockCommonFlags() []cli.Flag {

--- a/clicommand/lock_do.go
+++ b/clicommand/lock_do.go
@@ -62,7 +62,7 @@ var LockDoCommand = cli.Command{
 
 func lockDoAction(c *cli.Context) error {
 	if c.NArg() != 1 {
-		fmt.Fprint(c.App.ErrWriter, lockDoHelpDescription)
+		_, _ = fmt.Fprint(c.App.ErrWriter, lockDoHelpDescription)
 		return &SilentExitError{code: 1}
 	}
 	key := c.Args()[0]
@@ -71,7 +71,7 @@ func lockDoAction(c *cli.Context) error {
 	defer done()
 
 	if cfg.LockScope != "machine" {
-		return errors.New("only 'machine' scope for locks is supported in this version.")
+		return errors.New("only 'machine' scope for locks is supported in this version")
 	}
 
 	if cfg.LockWaitTimeout != 0 {

--- a/clicommand/lock_done.go
+++ b/clicommand/lock_done.go
@@ -44,7 +44,7 @@ var LockDoneCommand = cli.Command{
 
 func lockDoneAction(c *cli.Context) error {
 	if c.NArg() != 1 {
-		fmt.Fprint(c.App.ErrWriter, lockDoneHelpDescription)
+		_, _ = fmt.Fprint(c.App.ErrWriter, lockDoneHelpDescription)
 		return &SilentExitError{code: 1}
 	}
 	key := c.Args()[0]
@@ -53,7 +53,7 @@ func lockDoneAction(c *cli.Context) error {
 	defer done()
 
 	if cfg.LockScope != "machine" {
-		return errors.New("only 'machine' scope for locks is supported in this version.")
+		return errors.New("only 'machine' scope for locks is supported in this version")
 	}
 
 	client, err := lock.NewClient(ctx, cfg.SocketsPath)

--- a/clicommand/lock_get.go
+++ b/clicommand/lock_get.go
@@ -45,7 +45,7 @@ var LockGetCommand = cli.Command{
 
 func lockGetAction(c *cli.Context) error {
 	if c.NArg() != 1 {
-		fmt.Fprint(c.App.ErrWriter, lockGetHelpDescription)
+		_, _ = fmt.Fprint(c.App.ErrWriter, lockGetHelpDescription)
 		return &SilentExitError{code: 1}
 	}
 	key := c.Args()[0]
@@ -54,7 +54,7 @@ func lockGetAction(c *cli.Context) error {
 	defer done()
 
 	if cfg.LockScope != "machine" {
-		return errors.New("only 'machine' scope for locks is supported in this version.")
+		return errors.New("only 'machine' scope for locks is supported in this version")
 	}
 
 	client, err := lock.NewClient(ctx, cfg.SocketsPath)
@@ -67,7 +67,7 @@ func lockGetAction(c *cli.Context) error {
 		return fmt.Errorf("couldn't get lock state: %w", err)
 	}
 
-	fmt.Fprintln(c.App.Writer, v)
+	_, _ = fmt.Fprintln(c.App.Writer, v)
 
 	return nil
 }

--- a/clicommand/lock_release.go
+++ b/clicommand/lock_release.go
@@ -44,7 +44,7 @@ var LockReleaseCommand = cli.Command{
 
 func lockReleaseAction(c *cli.Context) error {
 	if c.NArg() != 2 {
-		fmt.Fprint(c.App.ErrWriter, lockReleaseHelpDescription)
+		_, _ = fmt.Fprint(c.App.ErrWriter, lockReleaseHelpDescription)
 		return &SilentExitError{code: 1}
 	}
 	key, token := c.Args()[0], c.Args()[1]
@@ -53,7 +53,7 @@ func lockReleaseAction(c *cli.Context) error {
 	defer done()
 
 	if cfg.LockScope != "machine" {
-		return fmt.Errorf("only 'machine' scope for locks is supported in this version.")
+		return fmt.Errorf("only 'machine' scope for locks is supported in this version")
 	}
 
 	client, err := lock.NewClient(ctx, cfg.SocketsPath)

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -102,7 +102,7 @@ var MetaDataGetCommand = cli.Command{
 					cfg.Key,
 					cfg.Default,
 				)
-				fmt.Fprint(c.App.Writer, cfg.Default)
+				_, _ = fmt.Fprint(c.App.Writer, cfg.Default)
 				return nil
 			}
 

--- a/clicommand/meta_data_keys.go
+++ b/clicommand/meta_data_keys.go
@@ -86,7 +86,7 @@ var MetaDataKeysCommand = cli.Command{
 		}
 
 		for _, key := range keys {
-			fmt.Fprintf(c.App.Writer, "%s\n", key)
+			_, _ = fmt.Fprintf(c.App.Writer, "%s\n", key)
 		}
 
 		return nil

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -106,7 +106,7 @@ var OIDCRequestTokenCommand = cli.Command{
 
 		// Note: if --lifetime is omitted, cfg.Lifetime = 0
 		if cfg.Lifetime < 0 {
-			return fmt.Errorf("lifetime %d must be a non-negative integer.", cfg.Lifetime)
+			return fmt.Errorf("lifetime %d must be a non-negative integer", cfg.Lifetime)
 		}
 
 		if cfg.Format != "jwt" && cfg.Format != "gcp" {

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -211,7 +211,7 @@ var PipelineUploadCommand = cli.Command{
 				if err != nil {
 					return fmt.Errorf("failed to read file: %w", err)
 				}
-				defer file.Close()
+				defer func() { _ = file.Close() }()
 				inputs = append(inputs, input{file, filepath.Base(fn)})
 			}
 
@@ -247,10 +247,10 @@ var PipelineUploadCommand = cli.Command{
 			// If more than 1 of the config files exist, throw an
 			// error. There can only be one!!
 			if len(exists) > 1 {
-				return fmt.Errorf("found multiple configuration files: %s. Please only have 1 configuration file present.", strings.Join(exists, ", "))
+				return fmt.Errorf("found multiple configuration files: %s; please keep only 1 configuration file present", strings.Join(exists, ", "))
 			}
 			if len(exists) == 0 {
-				return fmt.Errorf("could not find a default pipeline configuration file. See `buildkite-agent pipeline upload --help` for more information.")
+				return fmt.Errorf("could not find a default pipeline configuration file; see `buildkite-agent pipeline upload --help` for more information")
 			}
 
 			found := exists[0]
@@ -262,7 +262,7 @@ var PipelineUploadCommand = cli.Command{
 			if err != nil {
 				return fmt.Errorf("failed to read file %q: %w", found, err)
 			}
-			defer file.Close()
+			defer func() { _ = file.Close() }()
 			inputs = []input{{file, filepath.Base(found)}}
 		}
 
@@ -409,12 +409,12 @@ var PipelineUploadCommand = cli.Command{
 
 				// Check we have a job id set if not in dry run
 				if cfg.Job == "" {
-					return errors.New("missing job parameter. Usually this is set in the environment for a Buildkite job via BUILDKITE_JOB_ID.")
+					return errors.New("missing job parameter; this is usually set in the environment for a Buildkite job via BUILDKITE_JOB_ID")
 				}
 
 				// Check we have an agent access token if not in dry run
 				if cfg.AgentAccessToken == "" {
-					return errors.New("missing agent-access-token parameter. Usually this is set in the environment for a Buildkite job via BUILDKITE_AGENT_ACCESS_TOKEN.")
+					return errors.New("missing agent-access-token parameter; this is usually set in the environment for a Buildkite job via BUILDKITE_AGENT_ACCESS_TOKEN")
 				}
 
 				uploader := &agent.PipelineUploader{
@@ -464,7 +464,7 @@ func allEnvVars(o any, f func(p env.Pair)) {
 	switch x := o.(type) {
 	case *pipeline.Pipeline:
 		// First iterate through all pipeline env vars.
-		x.Env.Range(func(k, v string) error {
+		_ = x.Env.Range(func(k, v string) error {
 			f(env.Pair{Name: k, Value: v})
 			return nil
 		})

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -791,12 +791,14 @@ func TestReadChangedFilesFromPath(t *testing.T) {
 			if err != nil {
 				t.Fatalf("creating temp file: %v", err)
 			}
-			defer os.Remove(tmpFile.Name())
+			defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 			if _, err := tmpFile.WriteString(test.content); err != nil {
 				t.Fatalf("writing to temp file: %v", err)
 			}
-			tmpFile.Close()
+			if err := tmpFile.Close(); err != nil {
+				t.Fatalf("tmpFile.Close() = %v", err)
+			}
 
 			l := logger.NewBuffer()
 			got, err := readChangedFilesFromPath(l, tmpFile.Name())
@@ -819,12 +821,14 @@ func TestIfChangedApplicator_WithChangedFilesPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating temp file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	if _, err := tmpFile.WriteString("foo/README.md\nbar/test.go\n"); err != nil {
 		t.Fatalf("writing to temp file: %v", err)
 	}
-	tmpFile.Close()
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("tmpFile.Close() = %v", err)
+	}
 
 	steps := pipeline.Steps{
 		&pipeline.CommandStep{

--- a/clicommand/redactor_add.go
+++ b/clicommand/redactor_add.go
@@ -106,7 +106,7 @@ JSON does not allow duplicate keys. If you repeat the same key ("key"), the JSON
 			if err != nil {
 				return fmt.Errorf("failed to open file %s: %w", fileName, err)
 			}
-			defer secretsFile.Close()
+			defer func() { _ = secretsFile.Close() }()
 
 			secretsReader = bufio.NewReader(secretsFile)
 		}

--- a/clicommand/step_cancel.go
+++ b/clicommand/step_cancel.go
@@ -73,7 +73,7 @@ var StepCancelCommand = cli.Command{
 		defer done()
 
 		if cfg.ForceGracePeriodSeconds < 0 {
-			return fmt.Errorf("The value of ′--force-grace-period-seconds′ must be greater than or equal to 0")
+			return fmt.Errorf("the value of ′--force-grace-period-seconds′ must be greater than or equal to 0")
 		}
 
 		return cancelStep(ctx, cfg, l)
@@ -109,7 +109,7 @@ func cancelStep(ctx context.Context, cfg StepCancelConfig, l logger.Logger) erro
 		l.Info("Successfully cancelled step: %s", stepCancelResponse.UUID)
 		return nil
 	}); err != nil {
-		return fmt.Errorf("Failed to cancel step: %w", err)
+		return fmt.Errorf("failed to cancel step: %w", err)
 	}
 
 	return nil

--- a/clicommand/step_cancel_test.go
+++ b/clicommand/step_cancel_test.go
@@ -17,7 +17,7 @@ func TestStepCancel(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			rw.WriteHeader(http.StatusOK)
-			rw.Write([]byte(`{"uuid": "b0db1550-e68c-428f-9b4d-edf5599b2cff"}`))
+			_, _ = rw.Write([]byte(`{"uuid": "b0db1550-e68c-428f-9b4d-edf5599b2cff"}`))
 		}))
 
 		cfg := StepCancelConfig{

--- a/clicommand/step_cancel_test.go
+++ b/clicommand/step_cancel_test.go
@@ -54,6 +54,6 @@ func TestStepCancel(t *testing.T) {
 
 		l := logger.NewBuffer()
 		err := cancelStep(ctx, cfg, l)
-		assert.Contains(t, err.Error(), "Failed to cancel step")
+		assert.Contains(t, err.Error(), "failed to cancel step")
 	})
 }

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -267,7 +267,7 @@ func signOffline(ctx context.Context, c *cli.Context, l logger.Logger, key signa
 		if err != nil {
 			return fmt.Errorf("failed to read file: %w", err)
 		}
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 
 		input = file
 		filename = cfg.PipelineFile

--- a/internal/agenthttp/auth.go
+++ b/internal/agenthttp/auth.go
@@ -37,7 +37,7 @@ func (t authenticatedTransport) RoundTrip(req *http.Request) (*http.Response, er
 	}
 
 	if t.Token == "" && t.Bearer == "" {
-		return nil, fmt.Errorf("Invalid token, empty string supplied")
+		return nil, fmt.Errorf("invalid token: empty string supplied")
 	}
 
 	// Per net/http#RoundTripper:

--- a/internal/artifact/artifactory_downloader.go
+++ b/internal/artifact/artifactory_downloader.go
@@ -56,7 +56,7 @@ func (d ArtifactoryDownloader) Start(ctx context.Context) error {
 	username := os.Getenv("BUILDKITE_ARTIFACTORY_USER")
 	password := os.Getenv("BUILDKITE_ARTIFACTORY_PASSWORD")
 	if stringURL == "" || username == "" || password == "" {
-		return errors.New("Must set BUILDKITE_ARTIFACTORY_URL, BUILDKITE_ARTIFACTORY_USER, BUILDKITE_ARTIFACTORY_PASSWORD when using rt:// path")
+		return errors.New("must set BUILDKITE_ARTIFACTORY_URL, BUILDKITE_ARTIFACTORY_USER, and BUILDKITE_ARTIFACTORY_PASSWORD when using an rt:// path")
 	}
 
 	// create full URL

--- a/internal/artifact/artifactory_uploader.go
+++ b/internal/artifact/artifactory_uploader.go
@@ -66,7 +66,7 @@ func NewArtifactoryUploader(l logger.Logger, c ArtifactoryUploaderConfig) (*Arti
 	password := os.Getenv("BUILDKITE_ARTIFACTORY_PASSWORD")
 	// authentication is not set
 	if stringURL == "" || username == "" || password == "" {
-		return nil, errors.New("Must set BUILDKITE_ARTIFACTORY_URL, BUILDKITE_ARTIFACTORY_USER, BUILDKITE_ARTIFACTORY_PASSWORD when using rt:// path")
+		return nil, errors.New("must set BUILDKITE_ARTIFACTORY_URL, BUILDKITE_ARTIFACTORY_USER, and BUILDKITE_ARTIFACTORY_PASSWORD when using an rt:// path")
 	}
 
 	parsedURL, err := url.Parse(stringURL)

--- a/internal/artifact/downloader.go
+++ b/internal/artifact/downloader.go
@@ -62,7 +62,7 @@ func (a *Downloader) Download(ctx context.Context) error {
 	destination, _ := filepath.Abs(a.conf.Destination)
 	fileInfo, err := os.Stat(destination)
 	if err != nil {
-		return fmt.Errorf("Could not find information about destination: %s %v",
+		return fmt.Errorf("could not find information about destination: %s %v",
 			destination, err)
 	}
 	if !fileInfo.IsDir() {
@@ -78,7 +78,7 @@ func (a *Downloader) Download(ctx context.Context) error {
 	artifactCount := len(artifacts)
 
 	if artifactCount == 0 {
-		return errors.New("No artifacts found for downloading")
+		return errors.New("no artifacts found for downloading")
 	}
 
 	a.logger.Info("Found %d artifacts. Starting to download to: %s", artifactCount, destination)
@@ -169,7 +169,7 @@ func (a *Downloader) Download(ctx context.Context) error {
 	select {
 	case errors := <-errorsOutCh:
 		if len(errors) > 0 {
-			return fmt.Errorf("There were errors with downloading some of the artifacts")
+			return fmt.Errorf("there were errors downloading some of the artifacts")
 		}
 
 	case <-ctx.Done():

--- a/internal/artifact/gs_uploader.go
+++ b/internal/artifact/gs_uploader.go
@@ -145,7 +145,7 @@ func (u *gsUploaderWork) DoWork(_ context.Context) (*api.ArtifactPartETag, error
 		permission != "projectPrivate" &&
 		permission != "publicRead" &&
 		permission != "publicReadWrite" {
-		return nil, fmt.Errorf("Invalid GS ACL `%s`", permission)
+		return nil, fmt.Errorf("invalid GS ACL %q", permission)
 	}
 
 	if permission == "" {

--- a/internal/artifact/s3.go
+++ b/internal/artifact/s3.go
@@ -151,10 +151,10 @@ func NewS3Client(ctx context.Context, l logger.Logger, bucket string) (*s3.Clien
 		const errorTitle = "could not authenticate to AWS S3 using any of the included credential providers."
 
 		if hasProxy && !hasNoProxyIdmsException {
-			return nil, fmt.Errorf("%s Your HTTP proxy settings do not grant a NO_PROXY=169.254.169.254 exemption for the instance metadata service, instance profile credentials may not be retrievable via your HTTP proxy.", errorTitle)
+			return nil, fmt.Errorf("%s your HTTP proxy settings do not grant a NO_PROXY=169.254.169.254 exemption for the instance metadata service, so instance profile credentials may not be retrievable via your HTTP proxy", errorTitle)
 		}
 
-		return nil, fmt.Errorf("%s You can authenticate by setting Buildkite environment variables (BUILDKITE_S3_ACCESS_KEY_ID, BUILDKITE_S3_SECRET_ACCESS_KEY, BUILDKITE_S3_PROFILE), AWS environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_PROFILE), Web Identity environment variables (AWS_ROLE_ARN, AWS_ROLE_SESSION_NAME, AWS_WEB_IDENTITY_TOKEN_FILE), or if running on AWS EC2 ensuring network access to the EC2 Instance Metadata Service to use an instance profile’s IAM Role credentials.", errorTitle)
+		return nil, fmt.Errorf("%s you can authenticate by setting Buildkite environment variables (BUILDKITE_S3_ACCESS_KEY_ID, BUILDKITE_S3_SECRET_ACCESS_KEY, BUILDKITE_S3_PROFILE), AWS environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_PROFILE), web identity environment variables (AWS_ROLE_ARN, AWS_ROLE_SESSION_NAME, AWS_WEB_IDENTITY_TOKEN_FILE), or if running on AWS EC2 by ensuring network access to the EC2 Instance Metadata Service so an instance profile IAM role can be used", errorTitle)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("could not s3:ListObjects in your AWS S3 bucket %q in region %q: %w", bucket, cfg.Region, err)

--- a/internal/artifact/s3_uploader.go
+++ b/internal/artifact/s3_uploader.go
@@ -114,7 +114,8 @@ func (u *s3UploaderWork) DoWork(ctx context.Context) (*api.ArtifactPartETag, err
 		return nil, err
 	}
 
-	// Create an uploader with the session and default options
+	// Create an uploader with the session and default options.
+	//nolint:staticcheck // The pinned aws-sdk-go-v2 feature/s3 module in this repo does not yet provide transfermanager.
 	uploader := manager.NewUploader(u.client)
 
 	// Open file from filesystem
@@ -140,6 +141,7 @@ func (u *s3UploaderWork) DoWork(ctx context.Context) (*api.ArtifactPartETag, err
 		params.ServerSideEncryption = types.ServerSideEncryptionAes256
 	}
 
+	//nolint:staticcheck // The pinned aws-sdk-go-v2 feature/s3 module in this repo does not yet provide transfermanager.
 	_, err = uploader.Upload(ctx, params)
 	return nil, err
 }

--- a/internal/artifact/searcher_test.go
+++ b/internal/artifact/searcher_test.go
@@ -21,10 +21,10 @@ func TestArtifactSearcherConnectsToEndpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		switch req.URL.RequestURI() {
 		case "/builds/my-build/artifacts/search?query=llamas.txt&scope=my-build&state=finished":
-			fmt.Fprint(rw, `[{
-				"id": "4600ac5c-5a13-4e92-bb83-f86f218f7b32",
-				"file_size": 3,
-				"absolute_path": "llamas.txt",
+			_, _ = fmt.Fprint(rw, `[{
+					"id": "4600ac5c-5a13-4e92-bb83-f86f218f7b32",
+					"file_size": 3,
+					"absolute_path": "llamas.txt",
 				"path": "llamas.txt",
 				"url": "http://example.com/download"
 			}]`)

--- a/internal/cryptosigner/gcp/kms.go
+++ b/internal/cryptosigner/gcp/kms.go
@@ -60,14 +60,8 @@ func NewKMS(ctx context.Context, keyResourceName string, opts ...option.ClientOp
 		Name: keyResourceName,
 	})
 	if err != nil {
-		client.Close()
+		_ = client.Close()
 		return nil, fmt.Errorf("failed to get public key for %q: %w", keyResourceName, err)
-	}
-
-	// Validate key purpose
-	if pubKeyResp.ProtectionLevel == kmspb.ProtectionLevel_EXTERNAL {
-		// For external keys, we can't validate the purpose as easily
-		// so we'll trust the configuration
 	}
 
 	// Map GCP algorithm to JWA algorithm
@@ -99,7 +93,7 @@ func NewKMS(ctx context.Context, keyResourceName string, opts ...option.ClientOp
 		jwaAlg = jwa.PS512
 		hashAlg = crypto.SHA512
 	default:
-		client.Close()
+		_ = client.Close()
 		return nil, fmt.Errorf("%w: %s (supported: EC_SIGN_P256_SHA256, EC_SIGN_P384_SHA384, RSA_SIGN_*)",
 			ErrInvalidKeyAlgorithm, pubKeyResp.Algorithm)
 	}

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -56,7 +56,7 @@ func (e *Executor) removeCheckoutDir() error {
 	checkoutPath, _ := e.shell.Env.Get("BUILDKITE_BUILD_CHECKOUT_PATH")
 
 	if e.checkoutRoot != nil {
-		e.checkoutRoot.Close()
+		_ = e.checkoutRoot.Close()
 		e.checkoutRoot = nil
 	}
 
@@ -124,7 +124,7 @@ func (e *Executor) refreshCheckoutRoot() error {
 	}
 	// This cleanup is largely ornamental, since the executor pointer only
 	// becomes unreachable when the bootstrap exits.
-	runtime.AddCleanup(e, func(r *os.Root) { r.Close() }, root)
+	runtime.AddCleanup(e, func(r *os.Root) { _ = r.Close() }, root)
 	e.checkoutRoot = root
 	return nil
 }
@@ -767,7 +767,7 @@ func (e *Executor) fetchSource(ctx context.Context) error {
 				Retry:         retry,
 				RefSpecs:      refspecs,
 			}); err != nil {
-				return fmt.Errorf("Fetching PR refspec %q: %w", refspecs, err)
+				return fmt.Errorf("fetching PR refspec %q: %w", refspecs, err)
 			}
 		} else {
 			// If we know the commit, also fetch it directly. The commit might not be in the history of `refspec` if there
@@ -776,7 +776,7 @@ func (e *Executor) fetchSource(ctx context.Context) error {
 			refspecs = append(refspecs, e.Commit)
 			// We aim to eliminate network round-trip as much as possible so we use a single git fetch here.
 			if err := gitFetchWithFallback(ctx, e.shell, gitFetchFlags, refspecs...); err != nil {
-				return fmt.Errorf("Fetching PR refspec %q: %w", refspecs, err)
+				return fmt.Errorf("fetching PR refspec %q: %w", refspecs, err)
 			}
 		}
 
@@ -869,11 +869,15 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 			case "dissociate":
 				// If the existing repo is still relying on the reference, then
 				// "dissociate" it (git repack, and delete the alternates file).
-				e.dissociateIfNeeded(ctx, existingGitDir)
+				if err := e.dissociateIfNeeded(ctx, existingGitDir); err != nil {
+					return fmt.Errorf("dissociating existing reference clone: %w", err)
+				}
 			case "reference":
 				// If the existing repo does not have a reference to the mirror,
 				// create one. Existing objects don't need cleaning up.
-				e.reassociateIfNeeded(ctx, existingGitDir, mirrorDir)
+				if err := e.reassociateIfNeeded(ctx, existingGitDir, mirrorDir); err != nil {
+					return fmt.Errorf("reassociating existing clone: %w", err)
+				}
 			}
 		}
 

--- a/internal/job/docker.go
+++ b/internal/job/docker.go
@@ -50,7 +50,7 @@ func runDeprecatedDockerIntegration(ctx context.Context, sh *shell.Shell, cmd []
 		warnNotSet("BUILDKITE_DOCKER_COMPOSE_LEAVE_VOLUMES", "BUILDKITE_DOCKER_COMPOSE_CONTAINER")
 	}
 
-	return errors.New("Failed to find any docker env")
+	return errors.New("failed to find any docker env")
 }
 
 func tearDownDeprecatedDockerIntegration(ctx context.Context, sh *shell.Shell) error {

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -240,7 +240,7 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 		}
 		if root != nil {
 			e.checkoutRoot = root
-			runtime.AddCleanup(e, func(r *os.Root) { r.Close() }, root)
+			runtime.AddCleanup(e, func(r *os.Root) { _ = r.Close() }, root)
 		}
 	}
 
@@ -510,7 +510,11 @@ func logMissingHookInfo(l shell.Logger, hookName, wrapperPath string) {
 }
 
 func (e *Executor) runWrappedShellScriptHook(ctx context.Context, hookName string, hookCfg HookConfig) error {
-	defer e.redactors.Flush()
+	defer func() {
+		if err := e.redactors.Flush(); err != nil {
+			e.shell.Errorf("Error flushing redactors: %v", err)
+		}
+	}()
 
 	script, err := hook.NewWrapper(hook.WithPath(hookCfg.Path))
 	if err != nil {
@@ -570,7 +574,7 @@ func (e *Executor) runWrappedShellScriptHook(ctx context.Context, hookName strin
 		if shell.IsExitError(err) {
 			return &shell.ExitError{
 				Code: exitCode,
-				Err:  fmt.Errorf("The %s hook exited with status %d", hookName, exitCode),
+				Err:  fmt.Errorf("the %s hook exited with status %d", hookName, exitCode),
 			}
 		}
 
@@ -607,7 +611,7 @@ func (e *Executor) runWrappedShellScriptHook(ctx context.Context, hookName strin
 			break
 		default:
 			// ...because something else happened, report it and stop the job
-			return fmt.Errorf("Failed to get environment: %w", err)
+			return fmt.Errorf("failed to get environment: %w", err)
 		}
 	} else {
 		// Hook exited successfully (and not early!) We have an environment and
@@ -812,7 +816,7 @@ func (e *Executor) executeLocalHook(ctx context.Context, name string) error {
 	}
 
 	if !localHooksEnabled {
-		return fmt.Errorf("Refusing to run %s, local hooks are disabled", localHookPath)
+		return fmt.Errorf("refusing to run %s, local hooks are disabled", localHookPath)
 	}
 
 	return e.executeHook(ctx, HookConfig{
@@ -868,7 +872,7 @@ func (e *Executor) setUp(ctx context.Context) error {
 	// so that the environment will have a checkout path to work with
 	if _, exists := e.shell.Env.Get("BUILDKITE_BUILD_CHECKOUT_PATH"); !exists {
 		if e.BuildPath == "" {
-			return fmt.Errorf("Must set either a BUILDKITE_BUILD_PATH or a BUILDKITE_BUILD_CHECKOUT_PATH")
+			return fmt.Errorf("must set either a BUILDKITE_BUILD_PATH or a BUILDKITE_BUILD_CHECKOUT_PATH")
 		}
 		e.shell.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH",
 			filepath.Join(e.BuildPath, dirForAgentName(e.AgentName), e.OrganizationSlug, e.PipelineSlug))
@@ -1145,7 +1149,11 @@ func (e *Executor) CommandPhase(ctx context.Context) (hookErr, commandErr error)
 
 // defaultCommandPhase is executed if there is no global or plugin command hook
 func (e *Executor) defaultCommandPhase(ctx context.Context) error {
-	defer e.redactors.Flush()
+	defer func() {
+		if err := e.redactors.Flush(); err != nil {
+			e.shell.Errorf("Error flushing redactors: %v", err)
+		}
+	}()
 
 	spanName := e.implementationSpecificSpanName("default command hook", "hook.execute")
 	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, e.TracingBackend)
@@ -1158,7 +1166,7 @@ func (e *Executor) defaultCommandPhase(ctx context.Context) error {
 
 	// Make sure we actually have a command to run
 	if strings.TrimSpace(e.Command) == "" {
-		return fmt.Errorf("The command phase has no `command` to execute. Provide a `command` field in your step configuration, or define a `command` hook in a step plug-in, your repository `.buildkite/hooks`, or agent `hooks-path`.")
+		return fmt.Errorf("the command phase has no `command` to execute; provide a `command` field in your step configuration or define a `command` hook in a step plugin, your repository `.buildkite/hooks`, or the agent `hooks-path`")
 	}
 
 	scriptFileName := strings.ReplaceAll(e.Command, "\n", "")
@@ -1171,14 +1179,14 @@ func (e *Executor) defaultCommandPhase(ctx context.Context) error {
 	// check that the agent is allowed to eval commands.
 	if !commandIsScript && !e.CommandEval {
 		e.shell.Commentf("No such file: \"%s\"", scriptFileName)
-		return fmt.Errorf("This agent is not allowed to evaluate console commands. To allow this, re-run this agent without the `--no-command-eval` option, or specify a script within your repository to run instead (such as scripts/test.sh).")
+		return fmt.Errorf("this agent is not allowed to evaluate console commands; to allow this, re-run the agent without the `--no-command-eval` option or specify a script within your repository to run instead (such as scripts/test.sh)")
 	}
 
 	// Also make sure that the script we've resolved is definitely within this
 	// repository checkout and isn't elsewhere on the system.
 	if commandIsScript && !e.CommandEval && !strings.HasPrefix(pathToCommand, e.shell.Getwd()+string(os.PathSeparator)) {
 		e.shell.Commentf("No such file: \"%s\"", scriptFileName)
-		return fmt.Errorf("This agent is only allowed to run scripts within your repository. To allow this, re-run this agent without the `--no-command-eval` option, or specify a script within your repository to run instead (such as scripts/test.sh).")
+		return fmt.Errorf("this agent is only allowed to run scripts within your repository; to allow this, re-run the agent without the `--no-command-eval` option or specify a script within your repository to run instead (such as scripts/test.sh)")
 	}
 
 	var cmdToExec string
@@ -1186,11 +1194,11 @@ func (e *Executor) defaultCommandPhase(ctx context.Context) error {
 	// The interpreter gets parsed based on the operating system
 	interpreter, err := shellwords.Split(e.Shell)
 	if err != nil {
-		return fmt.Errorf("Failed to split shell (%q) into tokens: %w", e.Shell, err)
+		return fmt.Errorf("failed to split shell (%q) into tokens: %w", e.Shell, err)
 	}
 
 	if len(interpreter) == 0 {
-		return fmt.Errorf("No shell set for job")
+		return fmt.Errorf("no shell set for job")
 	}
 
 	// Windows CMD.EXE is horrible and can't handle newline delimited commands. We write
@@ -1200,7 +1208,7 @@ func (e *Executor) defaultCommandPhase(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		defer os.Remove(batchScript)
+		defer func() { _ = os.Remove(batchScript) }()
 
 		e.shell.Headerf("Running batch script")
 		if e.Debug {
@@ -1314,7 +1322,6 @@ func (e *Executor) writeBatchScript(cmd string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer scriptFile.Close()
 
 	scriptContents := []string{"@echo off"}
 
@@ -1331,6 +1338,11 @@ func (e *Executor) writeBatchScript(cmd string) (string, error) {
 
 	_, err = io.WriteString(scriptFile, strings.Join(scriptContents, "\n"))
 	if err != nil {
+		_ = scriptFile.Close()
+		return "", err
+	}
+
+	if err := scriptFile.Close(); err != nil {
 		return "", err
 	}
 

--- a/internal/job/git.go
+++ b/internal/job/git.go
@@ -262,7 +262,7 @@ func gitEnumerateSubmoduleURLs(ctx context.Context, sh *shell.Shell) ([]string, 
 	for line := range lines {
 		tokens := strings.SplitN(line, "\n", 2)
 		if len(tokens) != 2 {
-			return nil, fmt.Errorf("Failed to parse .gitmodules line %q", line)
+			return nil, fmt.Errorf("failed to parse .gitmodules line %q", line)
 		}
 		urls = append(urls, tokens[1])
 	}

--- a/internal/job/integration/artifact_integration_test.go
+++ b/internal/job/integration/artifact_integration_test.go
@@ -16,7 +16,11 @@ func TestArtifactsUploadAfterCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer func() {
+		if err := tester.CloseErr(); err != nil {
+			t.Errorf("tester.Close() = %v", err)
+		}
+	}()
 
 	// Write a file in the command hook
 	tester.ExpectGlobalHook("command").Once().AndCallFunc(func(c *bintest.Call) {
@@ -45,7 +49,11 @@ func TestArtifactsUploadAfterCommandFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer func() {
+		if err := tester.CloseErr(); err != nil {
+			t.Errorf("tester.Close() = %v", err)
+		}
+	}()
 
 	tester.MustMock(t, "my-command").Expect().AndCallFunc(func(c *bintest.Call) {
 		err := os.WriteFile(filepath.Join(c.Dir, "test.txt"), []byte("llamas"), 0o700)
@@ -79,7 +87,11 @@ func TestArtifactsUploadAfterCommandHookFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester.Close()
+	defer func() {
+		if err := tester.CloseErr(); err != nil {
+			t.Errorf("tester.Close() = %v", err)
+		}
+	}()
 
 	// Write a file in the command hook
 	tester.ExpectGlobalHook("command").Once().AndCallFunc(func(c *bintest.Call) {

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -165,7 +165,11 @@ func TestCheckingOutLocalGitProjectWithSubmodules_WithGitMirrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createTestGitRepository() error = %v", err)
 	}
-	defer submoduleRepo.Close()
+	defer func() {
+		if err := submoduleRepo.CloseErr(); err != nil {
+			t.Errorf("submoduleRepo.Close() = %v", err)
+		}
+	}()
 
 	out, err := tester.Repo.Execute("-c", "protocol.file.allow=always", "submodule", "add", submoduleRepo.Path)
 	if err != nil {
@@ -237,7 +241,11 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled_WithGitMirrors(t *test
 	if err != nil {
 		t.Fatalf("createTestGitRespository() error = %v", err)
 	}
-	defer submoduleRepo.Close()
+	defer func() {
+		if err := submoduleRepo.CloseErr(); err != nil {
+			t.Errorf("submoduleRepo.Close() = %v", err)
+		}
+	}()
 
 	out, err := tester.Repo.Execute("-c", "protocol.file.allow=always", "submodule", "add", submoduleRepo.Path)
 	if err != nil {
@@ -611,9 +619,9 @@ func TestCheckoutDoesNotRetryOnHookFailure_WithGitMirrors(t *testing.T) {
 
 	tester.ExpectGlobalHook("checkout").Once().AndCallFunc(func(c *bintest.Call) {
 		counter := atomic.AddInt32(&checkoutCounter, 1)
-		fmt.Fprintf(c.Stdout, "Checkout invocation %d\n", counter)
+		_, _ = fmt.Fprintf(c.Stdout, "Checkout invocation %d\n", counter)
 		if counter == 1 {
-			fmt.Fprintf(c.Stdout, "Sunspots have caused checkout to fail\n")
+			_, _ = fmt.Fprintf(c.Stdout, "Sunspots have caused checkout to fail\n")
 			c.Exit(1)
 		} else {
 			c.Exit(0)

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -122,7 +122,11 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createTestGitRepository() error = %v", err)
 	}
-	defer submoduleRepo.Close()
+	defer func() {
+		if err := submoduleRepo.CloseErr(); err != nil {
+			t.Errorf("submoduleRepo.Close() = %v", err)
+		}
+	}()
 
 	out, err := tester.Repo.Execute("-c", "protocol.file.allow=always", "submodule", "add", submoduleRepo.Path)
 	if err != nil {
@@ -969,9 +973,9 @@ func TestCheckoutDoesNotRetryOnHookFailure(t *testing.T) {
 
 	tester.ExpectGlobalHook("checkout").Once().AndCallFunc(func(c *bintest.Call) {
 		counter := atomic.AddInt32(&checkoutCounter, 1)
-		fmt.Fprintf(c.Stdout, "Checkout invocation %d\n", counter)
+		_, _ = fmt.Fprintf(c.Stdout, "Checkout invocation %d\n", counter)
 		if counter == 1 {
-			fmt.Fprintf(c.Stdout, "Sunspots have caused checkout to fail\n")
+			_, _ = fmt.Fprintf(c.Stdout, "Sunspots have caused checkout to fail\n")
 			c.Exit(1)
 		} else {
 			c.Exit(0)

--- a/internal/job/integration/executor_tester.go
+++ b/internal/job/integration/executor_tester.go
@@ -350,15 +350,20 @@ func (e *ExecutorTester) RunAndCheck(t *testing.T, env ...string) {
 	e.CheckMocks(t)
 }
 
-// Close the tester, delete all the directories and mocks
-func (e *ExecutorTester) Close() error {
+// Close the tester, delete all the directories and mocks.
+func (e *ExecutorTester) Close() {
+	_ = e.CloseErr()
+}
+
+// CloseErr closes the tester and returns any cleanup error.
+func (e *ExecutorTester) CloseErr() error {
 	for _, mock := range e.mocks {
 		if err := mock.Close(); err != nil {
 			return err
 		}
 	}
 	if e.Repo != nil {
-		if err := e.Repo.Close(); err != nil {
+		if err := e.Repo.CloseErr(); err != nil {
 			return err
 		}
 	}
@@ -405,7 +410,11 @@ func mockEnvAsJSONOnStdout(e *ExecutorTester) func(c *bintest.Call) {
 			c.Exit(1)
 		}
 
-		c.Stdout.Write(envJSON)
+		if _, err := c.Stdout.Write(envJSON); err != nil {
+			fmt.Println("Failed to write env map in mocked agent call:", err)
+			c.Exit(1)
+			return
+		}
 		c.Exit(0)
 	}
 }
@@ -434,7 +443,7 @@ func newTestLogWriter(t *testing.T) *testLogWriter {
 			r.CloseWithError(err)
 			return
 		}
-		r.Close()
+		_ = r.Close()
 	}()
 
 	return lw

--- a/internal/job/integration/git.go
+++ b/internal/job/integration/git.go
@@ -97,7 +97,7 @@ func createTestGitRespository() (*gitRepository, error) {
 func newGitRepository() (*gitRepository, error) {
 	tempDirRaw, err := os.MkdirTemp("", "git-repo")
 	if err != nil {
-		return nil, fmt.Errorf("Error creating temp dir: %w", err)
+		return nil, fmt.Errorf("error creating temp dir: %w", err)
 	}
 
 	// io.TempDir on Windows tilde-shortens (8.3 style?) long filenames in the path.
@@ -118,7 +118,7 @@ func newGitRepository() (*gitRepository, error) {
 	// EvalSymlinks seems best? Maybe there's a better way?
 	tempDir, err := filepath.EvalSymlinks(tempDirRaw)
 	if err != nil {
-		return nil, fmt.Errorf("EvalSymlinks for temp dir: %w", err)
+		return nil, fmt.Errorf("eval symlinks for temp dir: %w", err)
 	}
 
 	gr := &gitRepository{Path: tempDir}
@@ -159,7 +159,11 @@ func (gr *gitRepository) CreateBranch(branch string) error {
 	return nil
 }
 
-func (gr *gitRepository) Close() error {
+func (gr *gitRepository) Close() {
+	_ = gr.CloseErr()
+}
+
+func (gr *gitRepository) CloseErr() error {
 	return os.RemoveAll(gr.Path)
 }
 

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -50,7 +50,7 @@ func TestEnvironmentVariablesPassBetweenHooks(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, "MY_CUSTOM_ENV=1", "LLAMAS_ROCK=absolutely"); err != nil {
-			fmt.Fprintf(c.Stderr, "%v\n", err)
+			_, _ = fmt.Fprintf(c.Stderr, "%v\n", err)
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -101,7 +101,7 @@ func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if c.GetEnv("LLAMAS_ROCK") != "absolutely" {
-			fmt.Fprintf(c.Stderr, "Expected command hook to have environment variable LLAMAS_ROCK be %q, got %q\n", "absolutely", c.GetEnv("LLAMAS_ROCK"))
+			_, _ = fmt.Fprintf(c.Stderr, "Expected command hook to have environment variable LLAMAS_ROCK be %q, got %q\n", "absolutely", c.GetEnv("LLAMAS_ROCK"))
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -110,7 +110,7 @@ func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
 
 	tester.ExpectGlobalHook("pre-exit").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if c.GetEnv("LLAMAS_ROCK") != "" {
-			fmt.Fprintf(c.Stderr, "Expected pre-exit hook to have environment variable LLAMAS_ROCK be empty, got %q\n", c.GetEnv("LLAMAS_ROCK"))
+			_, _ = fmt.Fprintf(c.Stderr, "Expected pre-exit hook to have environment variable LLAMAS_ROCK be empty, got %q\n", c.GetEnv("LLAMAS_ROCK"))
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -146,7 +146,7 @@ func TestDirectoryPassesBetweenHooks(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if c.GetEnv("MY_CUSTOM_SUBDIR") != c.Dir {
-			fmt.Fprintf(c.Stderr, "Expected current dir to be %q, got %q\n", c.GetEnv("MY_CUSTOM_SUBDIR"), c.Dir)
+			_, _ = fmt.Fprintf(c.Stderr, "Expected current dir to be %q, got %q\n", c.GetEnv("MY_CUSTOM_SUBDIR"), c.Dir)
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -181,7 +181,7 @@ func TestDirectoryPassesBetweenHooksIgnoredUnderExit(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if c.GetEnv("BUILDKITE_BUILD_CHECKOUT_PATH") != c.Dir {
-			fmt.Fprintf(c.Stderr, "Expected current dir to be %q, got %q\n", c.GetEnv("BUILDKITE_BUILD_CHECKOUT_PATH"), c.Dir)
+			_, _ = fmt.Fprintf(c.Stderr, "Expected current dir to be %q, got %q\n", c.GetEnv("BUILDKITE_BUILD_CHECKOUT_PATH"), c.Dir)
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -233,7 +233,7 @@ func TestReplacingCheckoutHook(t *testing.T) {
 	// run a checkout in our checkout hook, otherwise we won't have local hooks to run
 	tester.ExpectGlobalHook("checkout").Once().AndCallFunc(func(c *bintest.Call) {
 		out, err := tester.Repo.Execute("clone", "-v", "--", tester.Repo.Path, c.GetEnv("BUILDKITE_BUILD_CHECKOUT_PATH"))
-		fmt.Fprint(c.Stderr, out)
+		_, _ = fmt.Fprint(c.Stderr, out)
 		if err != nil {
 			c.Exit(1)
 		} else {
@@ -550,7 +550,9 @@ func TestPreExitHooksFireAfterCancel(t *testing.T) {
 	})
 
 	time.Sleep(time.Millisecond * 500)
-	tester.Cancel()
+	if err := tester.Cancel(); err != nil {
+		t.Errorf("tester.Cancel() = %v", err)
+	}
 
 	t.Logf("Waiting for command to finish")
 	wg.Wait()
@@ -629,7 +631,7 @@ func TestPolyglotBinaryHooksCanBeRun(t *testing.T) {
 	tester.ExpectGlobalHook("post-command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		// Set via ./test-binary-hook/main.go
 		if c.GetEnv("OCEAN") != "Pacífico" {
-			fmt.Fprintf(c.Stderr, "Expected OCEAN to be Pacífico, got %q", c.GetEnv("OCEAN"))
+			_, _ = fmt.Fprintf(c.Stderr, "Expected OCEAN to be Pacífico, got %q", c.GetEnv("OCEAN"))
 			c.Exit(1)
 		} else {
 			c.Exit(0)

--- a/internal/job/integration/job_api_integration_test.go
+++ b/internal/job/integration/job_api_integration_test.go
@@ -107,7 +107,7 @@ func TestBootstrapRunsJobAPI(t *testing.T) {
 			c.Exit(1)
 			return
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
 			body, _ := io.ReadAll(resp.Body)
@@ -135,7 +135,7 @@ func TestBootstrapRunsJobAPI(t *testing.T) {
 
 	tester.ExpectGlobalHook("post-command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if got, want := c.GetEnv("MOUNTAIN"), "chimborazo"; got != want {
-			fmt.Fprintf(c.Stderr, "MOUNTAIN = %q, want %q\n", got, want)
+			_, _ = fmt.Fprintf(c.Stderr, "MOUNTAIN = %q, want %q\n", got, want)
 			c.Exit(1)
 		} else {
 			c.Exit(0)

--- a/internal/job/integration/plugin_integration_test.go
+++ b/internal/job/integration/plugin_integration_test.go
@@ -60,7 +60,7 @@ func TestRunningPlugins(t *testing.T) {
 
 	pluginMock.Expect("testing").Once().AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, "MY_CUSTOM_ENV=1", "LLAMAS_ROCK=absolutely"); err != nil {
-			fmt.Fprintf(c.Stderr, "%v\n", err)
+			_, _ = fmt.Fprintf(c.Stderr, "%v\n", err)
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -69,7 +69,7 @@ func TestRunningPlugins(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, "MY_CUSTOM_ENV=1", "LLAMAS_ROCK=absolutely"); err != nil {
-			fmt.Fprintf(c.Stderr, "%v\n", err)
+			_, _ = fmt.Fprintf(c.Stderr, "%v\n", err)
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -343,7 +343,7 @@ func TestModifiedPluginNoForcePull(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, "OSTRICH_EGGS=quite_large"); err != nil {
-			fmt.Fprintf(c.Stderr, "%v\n", err)
+			_, _ = fmt.Fprintf(c.Stderr, "%v\n", err)
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -357,7 +357,11 @@ func TestModifiedPluginNoForcePull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester2.Close()
+	defer func() {
+		if err := tester2.CloseErr(); err != nil {
+			t.Errorf("tester2.Close() = %v", err)
+		}
+	}()
 
 	// Same modification of BUILDKITE_PLUGINS_PATH.
 	tester2.PluginsDir = pluginsDir
@@ -381,7 +385,7 @@ func TestModifiedPluginNoForcePull(t *testing.T) {
 
 	tester2.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, "OSTRICH_EGGS=quite_large"); err != nil {
-			fmt.Fprintf(c.Stderr, "%v\n", err)
+			_, _ = fmt.Fprintf(c.Stderr, "%v\n", err)
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -433,7 +437,9 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 	p := createTestPlugin(t, hooks)
 
 	// Same branch-name jiggery pokery as in the previous integration test
-	p.CreateBranch("something-fixed")
+	if err := p.CreateBranch("something-fixed"); err != nil {
+		t.Fatalf("p.CreateBranch(something-fixed) = %v", err)
+	}
 	p.versionTag = "something-fixed"
 
 	json, err := p.ToJSON()
@@ -447,7 +453,7 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, "OSTRICH_EGGS=quite_large"); err != nil {
-			fmt.Fprintf(c.Stderr, "%v\n", err)
+			_, _ = fmt.Fprintf(c.Stderr, "%v\n", err)
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -460,7 +466,11 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutorTester() error = %v", err)
 	}
-	defer tester2.Close()
+	defer func() {
+		if err := tester2.CloseErr(); err != nil {
+			t.Errorf("tester2.Close() = %v", err)
+		}
+	}()
 
 	tester2.PluginsDir = pluginsDir
 	tester2.Env = replacePluginPathInEnv(tester2.Env, pluginsDir)
@@ -488,7 +498,7 @@ func TestModifiedPluginWithForcePull(t *testing.T) {
 	// run.
 	tester2.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, "OSTRICH_EGGS=huge_actually"); err != nil {
-			fmt.Fprintf(c.Stderr, "%v\n", err)
+			_, _ = fmt.Fprintf(c.Stderr, "%v\n", err)
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -634,7 +644,7 @@ func TestZipPluginFromLocalFile(t *testing.T) {
 
 	// Create a zip plugin
 	zipPath := createTestZipPlugin(t, hooks)
-	defer os.Remove(zipPath)
+	defer func() { _ = os.Remove(zipPath) }()
 
 	// Create plugin JSON with zip+file:// URL
 	pluginJSON := fmt.Sprintf(`[{"zip+file:///%s": {"config": "value"}}]`,
@@ -646,7 +656,7 @@ func TestZipPluginFromLocalFile(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 		if err := bintest.ExpectEnv(t, c.Env, "ZIP_PLUGIN_LOADED=yes"); err != nil {
-			fmt.Fprintf(c.Stderr, "%v\n", err)
+			_, _ = fmt.Fprintf(c.Stderr, "%v\n", err)
 			c.Exit(1)
 		} else {
 			c.Exit(0)
@@ -670,7 +680,7 @@ func TestZipPluginMissingHooksDirectory(t *testing.T) {
 
 	// Create a zip file without hooks directory
 	zipPath := createInvalidZipPlugin(t)
-	defer os.Remove(zipPath)
+	defer func() { _ = os.Remove(zipPath) }()
 
 	// Create plugin JSON with zip+file:// URL
 	pluginJSON := fmt.Sprintf(`[{"zip+file:///%s": {}}]`,
@@ -758,14 +768,12 @@ func createZipArchive(sourceDir, zipPath string) error {
 	if err != nil {
 		return err
 	}
-	defer zipFile.Close()
 
 	// Create zip writer
 	zipWriter := zip.NewWriter(zipFile)
-	defer zipWriter.Close()
 
 	// Walk through source directory and add files to zip
-	return filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -811,9 +819,18 @@ func createZipArchive(sourceDir, zipPath string) error {
 		if err != nil {
 			return err
 		}
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 
 		_, err = io.Copy(writer, file)
 		return err
-	})
+	}); err != nil {
+		_ = zipWriter.Close()
+		_ = zipFile.Close()
+		return err
+	}
+	if err := zipWriter.Close(); err != nil {
+		_ = zipFile.Close()
+		return err
+	}
+	return zipFile.Close()
 }

--- a/internal/job/integration/redaction_integration_test.go
+++ b/internal/job/integration/redaction_integration_test.go
@@ -20,7 +20,7 @@ func TestRedactorRedactsAgentToken(t *testing.T) {
 	defer tester.Close()
 
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
-		fmt.Fprintf(c.Stderr, "The agent token is: %s\n", c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN"))
+		_, _ = fmt.Fprintf(c.Stderr, "The agent token is: %s\n", c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN"))
 		c.Exit(0)
 	})
 
@@ -44,7 +44,7 @@ func TestRedactorDoesNotRedactAgentToken_WhenNotInRedactedVars(t *testing.T) {
 	defer tester.Close()
 
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
-		fmt.Fprintf(c.Stderr, "The agent token is: %s\n", c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN"))
+		_, _ = fmt.Fprintf(c.Stderr, "The agent token is: %s\n", c.GetEnv("BUILDKITE_AGENT_ACCESS_TOKEN"))
 		c.Exit(0)
 	})
 
@@ -142,7 +142,7 @@ func redactionTestCommandHook(t *testing.T, secret string) func(c *bintest.Call)
 			return
 		}
 
-		fmt.Fprintf(c.Stderr, "The secret is: %s\n", secret)
+		_, _ = fmt.Fprintf(c.Stderr, "The secret is: %s\n", secret)
 		time.Sleep(time.Second) // let the log line be written before we add it to the redactor
 
 		_, err = client.RedactionCreate(mainCtx, secret)
@@ -152,7 +152,7 @@ func redactionTestCommandHook(t *testing.T, secret string) func(c *bintest.Call)
 			return
 		}
 
-		fmt.Fprintf(c.Stderr, "There should be a redacted here: %s\n", secret)
+		_, _ = fmt.Fprintf(c.Stderr, "There should be a redacted here: %s\n", secret)
 		c.Exit(0)
 	}
 }

--- a/internal/job/integration/secrets_integration_test.go
+++ b/internal/job/integration/secrets_integration_test.go
@@ -19,8 +19,6 @@ import (
 
 // setupSecretsAPIServer creates a mock HTTP server that handles secrets API requests
 func setupSecretsAPIServer(t *testing.T, secrets map[string]string) *httptest.Server {
-	const jobID = "1111-1111-1111-1111" // Must match tester JobID
-
 	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		// Check auth token - agent uses "Token" instead of "Bearer"
 		authHeader := req.Header.Get("Authorization")
@@ -100,34 +98,34 @@ func TestSecretsIntegration_EnvironmentVariables(t *testing.T) {
 		// Verify each secret is available as an environment variable
 		dbURL := c.GetEnv("DATABASE_URL")
 		if dbURL == "" {
-			fmt.Fprintf(c.Stderr, "❌ DATABASE_URL is not set\n")
+			_, _ = fmt.Fprintf(c.Stderr, "❌ DATABASE_URL is not set\n")
 			c.Exit(1)
 			return
 		}
-		fmt.Fprintf(c.Stderr, "✅ DATABASE_URL is set: %s\n", dbURL)
+		_, _ = fmt.Fprintf(c.Stderr, "✅ DATABASE_URL is set: %s\n", dbURL)
 
 		apiToken := c.GetEnv("API_TOKEN")
 		if apiToken == "" {
-			fmt.Fprintf(c.Stderr, "❌ API_TOKEN is not set\n")
+			_, _ = fmt.Fprintf(c.Stderr, "❌ API_TOKEN is not set\n")
 			c.Exit(1)
 			return
 		}
-		fmt.Fprintf(c.Stderr, "✅ API_TOKEN is set: %s\n", apiToken)
+		_, _ = fmt.Fprintf(c.Stderr, "✅ API_TOKEN is set: %s\n", apiToken)
 
 		customVar := c.GetEnv("MY_CUSTOM_VAR")
 		if customVar == "" {
-			fmt.Fprintf(c.Stderr, "❌ MY_CUSTOM_VAR is not set\n")
+			_, _ = fmt.Fprintf(c.Stderr, "❌ MY_CUSTOM_VAR is not set\n")
 			c.Exit(1)
 			return
 		}
-		fmt.Fprintf(c.Stderr, "✅ MY_CUSTOM_VAR is set: %s\n", customVar)
+		_, _ = fmt.Fprintf(c.Stderr, "✅ MY_CUSTOM_VAR is set: %s\n", customVar)
 
 		c.Exit(0)
 	})
 
 	// Expect command hook to verify secrets persist
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
-		fmt.Fprintf(c.Stderr, "Command hook sees DATABASE_URL: %s\n", c.GetEnv("DATABASE_URL"))
+		_, _ = fmt.Fprintf(c.Stderr, "Command hook sees DATABASE_URL: %s\n", c.GetEnv("DATABASE_URL"))
 		c.Exit(0)
 	})
 
@@ -180,7 +178,7 @@ func TestSecretsIntegration_Redaction(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
 		// Print the secret value to stderr - should be redacted
-		fmt.Fprintf(c.Stderr, "The sensitive token is: %s\n", c.GetEnv("SENSITIVE_TOKEN"))
+		_, _ = fmt.Fprintf(c.Stderr, "The sensitive token is: %s\n", c.GetEnv("SENSITIVE_TOKEN"))
 		c.Exit(0)
 	})
 
@@ -211,12 +209,12 @@ func TestSecretsIntegration_BackwardCompatibility(t *testing.T) {
 
 	// Don't set BUILDKITE_SECRETS_CONFIG
 	tester.ExpectGlobalHook("environment").AndCallFunc(func(c *bintest.Call) {
-		fmt.Fprintf(c.Stderr, "Environment hook executed successfully\n")
+		_, _ = fmt.Fprintf(c.Stderr, "Environment hook executed successfully\n")
 		c.Exit(0)
 	})
 
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
-		fmt.Fprintf(c.Stderr, "Command hook executed successfully\n")
+		_, _ = fmt.Fprintf(c.Stderr, "Command hook executed successfully\n")
 		c.Exit(0)
 	})
 
@@ -247,12 +245,12 @@ func TestSecretsIntegration_EmptySecretsConfiguration(t *testing.T) {
 	secretsJSON := "[]"
 
 	tester.ExpectGlobalHook("environment").AndCallFunc(func(c *bintest.Call) {
-		fmt.Fprintf(c.Stderr, "Environment hook executed with empty secrets\n")
+		_, _ = fmt.Fprintf(c.Stderr, "Environment hook executed with empty secrets\n")
 		c.Exit(0)
 	})
 
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
-		fmt.Fprintf(c.Stderr, "Command hook executed with empty secrets\n")
+		_, _ = fmt.Fprintf(c.Stderr, "Command hook executed with empty secrets\n")
 		c.Exit(0)
 	})
 
@@ -348,7 +346,7 @@ func TestSecretsIntegration_MultilineSecretRedaction(t *testing.T) {
 
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
 		// Print the multiline secret - should be redacted
-		fmt.Fprintf(c.Stderr, "Multiline secret: %s\n", c.GetEnv("MULTILINE_SECRET"))
+		_, _ = fmt.Fprintf(c.Stderr, "Multiline secret: %s\n", c.GetEnv("MULTILINE_SECRET"))
 		c.Exit(0)
 	})
 
@@ -452,39 +450,39 @@ func TestSecretsIntegration_JobAPIRedactionIntegration(t *testing.T) {
 	tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
 		socketPath := c.GetEnv("BUILDKITE_AGENT_JOB_API_SOCKET")
 		if socketPath == "" {
-			fmt.Fprintf(c.Stderr, "Expected BUILDKITE_AGENT_JOB_API_SOCKET to be set\n")
+			_, _ = fmt.Fprintf(c.Stderr, "Expected BUILDKITE_AGENT_JOB_API_SOCKET to be set\n")
 			c.Exit(1)
 			return
 		}
 
 		socketToken := c.GetEnv("BUILDKITE_AGENT_JOB_API_TOKEN")
 		if socketToken == "" {
-			fmt.Fprintf(c.Stderr, "Expected BUILDKITE_AGENT_JOB_API_TOKEN to be set\n")
+			_, _ = fmt.Fprintf(c.Stderr, "Expected BUILDKITE_AGENT_JOB_API_TOKEN to be set\n")
 			c.Exit(1)
 			return
 		}
 
 		client, err := jobapi.NewClient(mainCtx, socketPath, socketToken)
 		if err != nil {
-			fmt.Fprintf(c.Stderr, "creating Job API client: %v\n", err)
+			_, _ = fmt.Fprintf(c.Stderr, "creating Job API client: %v\n", err)
 			c.Exit(1)
 			return
 		}
 
 		// Print the secret before redaction is added via Job API
-		fmt.Fprintf(c.Stderr, "Secret before explicit redaction: %s\n", c.GetEnv("JOB_API_SECRET"))
+		_, _ = fmt.Fprintf(c.Stderr, "Secret before explicit redaction: %s\n", c.GetEnv("JOB_API_SECRET"))
 		time.Sleep(100 * time.Millisecond) // brief pause
 
 		// Add additional redaction via Job API (should already be redacted from secrets fetch)
 		_, err = client.RedactionCreate(mainCtx, secretValue)
 		if err != nil {
-			fmt.Fprintf(c.Stderr, "creating redaction: %v\n", err)
+			_, _ = fmt.Fprintf(c.Stderr, "creating redaction: %v\n", err)
 			c.Exit(1)
 			return
 		}
 
 		// Print the secret after additional redaction
-		fmt.Fprintf(c.Stderr, "Secret after explicit redaction: %s\n", c.GetEnv("JOB_API_SECRET"))
+		_, _ = fmt.Fprintf(c.Stderr, "Secret after explicit redaction: %s\n", c.GetEnv("JOB_API_SECRET"))
 		c.Exit(0)
 	})
 

--- a/internal/job/knownhosts.go
+++ b/internal/job/knownhosts.go
@@ -22,7 +22,7 @@ type knownHosts struct {
 func findKnownHosts(sh *shell.Shell) (*knownHosts, error) {
 	userHomePath, err := osutil.UserHomeDir()
 	if err != nil {
-		return nil, fmt.Errorf("Could not find the current users home directory (%s)", err)
+		return nil, fmt.Errorf("could not find the current user's home directory (%s)", err)
 	}
 
 	// Construct paths to the known_hosts file
@@ -53,7 +53,7 @@ func (kh *knownHosts) Contains(host string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	normalized := knownhosts.Normalize(host)
 
@@ -112,7 +112,7 @@ func (kh *knownHosts) Add(ctx context.Context, host string) error {
 	// Scan the key and then write it to the known_host file
 	keyscanOutput, err := sshKeyScan(ctx, kh.Shell, host)
 	if err != nil {
-		return fmt.Errorf("Could not  `ssh-keyscan`: %w", err)
+		return fmt.Errorf("could not `ssh-keyscan`: %w", err)
 	}
 
 	kh.Shell.Commentf("Added host %q to known hosts at \"%s\"", host, kh.Path)
@@ -120,16 +120,16 @@ func (kh *knownHosts) Add(ctx context.Context, host string) error {
 	// Try and open the existing hostfile in (append_only) mode
 	f, err := os.OpenFile(kh.Path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o700)
 	if err != nil {
-		return fmt.Errorf("Could not open %q for appending: %w", kh.Path, err)
+		return fmt.Errorf("could not open %q for appending: %w", kh.Path, err)
 	}
 	defer f.Close() //nolint:errcheck // Best-effort cleanup - primary Close error is checked below.
 
 	if _, err := fmt.Fprintf(f, "%s\n", keyscanOutput); err != nil {
-		return fmt.Errorf("Could not write to %q: %w", kh.Path, err)
+		return fmt.Errorf("could not write to %q: %w", kh.Path, err)
 	}
 
 	if err := f.Close(); err != nil {
-		return fmt.Errorf("Could not close %q: %w", kh.Path, err)
+		return fmt.Errorf("could not close %q: %w", kh.Path, err)
 	}
 	return nil
 }
@@ -150,7 +150,7 @@ func (kh *knownHosts) AddFromRepository(ctx context.Context, repository string) 
 	host := resolveGitHost(ctx, kh.Shell, u.Host)
 
 	if err := kh.Add(ctx, host); err != nil {
-		return fmt.Errorf("Failed to add %q to known_hosts file %q: %w", host, u, err)
+		return fmt.Errorf("failed to add %q to known_hosts file %q: %w", host, u, err)
 	}
 
 	return nil

--- a/internal/job/knownhosts_test.go
+++ b/internal/job/knownhosts_test.go
@@ -25,8 +25,10 @@ func TestAddingToKnownHosts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("net.Listen(tcp, %q) error = %v", svr.Addr, err)
 	}
-	go svr.Serve(ln)
-	defer svr.Close()
+	go func() {
+		_ = svr.Serve(ln)
+	}()
+	defer func() { _ = svr.Close() }()
 
 	hostAddr := ln.Addr().String()
 	repoURL := fmt.Sprintf("ssh://git@%s/var/cache/git/project.git", hostAddr)

--- a/internal/job/plugin.go
+++ b/internal/job/plugin.go
@@ -58,18 +58,18 @@ func (e *Executor) preparePlugins() error {
 	// Check if we can run plugins (disabled via --no-plugins)
 	if !e.PluginsEnabled {
 		if !e.LocalHooksEnabled {
-			return fmt.Errorf("Plugins have been disabled on this agent with `--no-local-hooks`")
+			return fmt.Errorf("plugins have been disabled on this agent with `--no-local-hooks`")
 		} else if !e.CommandEval {
-			return fmt.Errorf("Plugins have been disabled on this agent with `--no-command-eval`")
+			return fmt.Errorf("plugins have been disabled on this agent with `--no-command-eval`")
 		} else {
-			return fmt.Errorf("Plugins have been disabled on this agent with `--no-plugins`")
+			return fmt.Errorf("plugins have been disabled on this agent with `--no-plugins`")
 		}
 	}
 
 	var err error
 	e.plugins, err = plugin.CreateFromJSON(e.Plugins)
 	if err != nil {
-		return fmt.Errorf("Failed to parse a plugin definition: %w", err)
+		return fmt.Errorf("failed to parse a plugin definition: %w", err)
 	}
 
 	if e.Debug {
@@ -148,7 +148,7 @@ func (e *Executor) PluginPhase(ctx context.Context) error {
 
 		checkout, err := e.checkoutPlugin(ctx, p)
 		if err != nil {
-			return fmt.Errorf("Failed to checkout plugin %s: %w", p.Name(), err)
+			return fmt.Errorf("failed to checkout plugin %s: %w", p.Name(), err)
 		}
 
 		err = e.validatePluginCheckout(ctx, checkout)
@@ -184,13 +184,13 @@ func (e *Executor) VendoredPluginPhase(ctx context.Context) error {
 
 		// Check that the plugin exists in the checkout.
 		if fi, err := e.checkoutRoot.Stat(p.Location); err != nil || !fi.IsDir() {
-			return fmt.Errorf("Vendored plugin path %q must be a directory within the checked-out repository: %w", p.Location, err)
+			return fmt.Errorf("vendored plugin path %q must be a directory within the checked-out repository: %w", p.Location, err)
 		}
 
 		// Similarly, check that the plugin's hooks exists in the checkout.
 		hooksPath := filepath.Join(p.Location, "hooks")
 		if fi, err := e.checkoutRoot.Stat(hooksPath); err != nil || !fi.IsDir() {
-			return fmt.Errorf("Vendored plugin hooks path %q must be a directory within the checked-out repository: %w", hooksPath, err)
+			return fmt.Errorf("vendored plugin hooks path %q must be a directory within the checked-out repository: %w", hooksPath, err)
 		}
 
 		checkout := &pluginCheckout{
@@ -275,7 +275,7 @@ func (e *Executor) executePluginHook(ctx context.Context, name string, checkouts
 			Name:       name,
 			Path:       hookPath,
 			Env:        envMap,
-			PluginName: p.Plugin.DisplayName(),
+			PluginName: p.DisplayName(),
 			SpanAttributes: map[string]string{
 				"plugin.name":        p.Plugin.Name(),
 				"plugin.version":     p.Version,
@@ -305,7 +305,7 @@ func (e *Executor) hasPluginHook(name string) bool {
 func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*pluginCheckout, error) {
 	// Make sure we have a plugin path before trying to do anything
 	if e.PluginsPath == "" {
-		return nil, fmt.Errorf("Can't checkout plugin without a `plugins-path`")
+		return nil, fmt.Errorf("can't checkout plugin without a `plugins-path`")
 	}
 
 	id, err := p.Identifier()
@@ -392,7 +392,7 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 		if err != nil {
 			return nil, fmt.Errorf("opening plugin directory as a root: %w", err)
 		}
-		runtime.AddCleanup(checkout, func(r *os.Root) { r.Close() }, pluginRoot)
+		runtime.AddCleanup(checkout, func(r *os.Root) { _ = r.Close() }, pluginRoot)
 		checkout.Root = pluginRoot
 
 		// Ensure hooks is a directory that exists within the checkout.
@@ -476,7 +476,7 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 	if err != nil {
 		return nil, fmt.Errorf("opening plugin directory as a root: %w", err)
 	}
-	runtime.AddCleanup(checkout, func(r *os.Root) { r.Close() }, pluginRoot)
+	runtime.AddCleanup(checkout, func(r *os.Root) { _ = r.Close() }, pluginRoot)
 	checkout.Root = pluginRoot
 
 	// Ensure hooks is a directory that exists within the checkout.

--- a/internal/job/plugin_zip.go
+++ b/internal/job/plugin_zip.go
@@ -60,7 +60,7 @@ func (e *Executor) checkoutZipPlugin(ctx context.Context, p *plugin.Plugin, chec
 	if err != nil {
 		return fmt.Errorf("failed to create temp directory: %w", err)
 	}
-	defer os.RemoveAll(tempDir) // Clean up temp dir
+	defer func() { _ = os.RemoveAll(tempDir) }() // Clean up temp dir
 
 	zipPath := filepath.Join(tempDir, "plugin.zip")
 
@@ -96,7 +96,7 @@ func (e *Executor) checkoutZipPlugin(ctx context.Context, p *plugin.Plugin, chec
 	if err != nil {
 		return fmt.Errorf("opening plugin directory as a root: %w", err)
 	}
-	runtime.AddCleanup(checkout, func(r *os.Root) { r.Close() }, pluginRoot)
+	runtime.AddCleanup(checkout, func(r *os.Root) { _ = r.Close() }, pluginRoot)
 	checkout.Root = pluginRoot
 
 	// Ensure hooks is a directory that exists within the checkout
@@ -198,7 +198,7 @@ func (e *Executor) downloadZipPluginHTTP(ctx context.Context, downloadURL, destP
 	if err != nil {
 		return fmt.Errorf("HTTP request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("HTTP request failed with status %d: %s", resp.StatusCode, resp.Status)
@@ -209,8 +209,10 @@ func (e *Executor) downloadZipPluginHTTP(ctx context.Context, downloadURL, destP
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
-	defer os.Remove(tempFile.Name())
-	defer tempFile.Close()
+	defer func() {
+		_ = tempFile.Close()
+		_ = os.Remove(tempFile.Name())
+	}()
 
 	// Copy data to temp file
 	if _, err := io.Copy(tempFile, resp.Body); err != nil {
@@ -235,15 +237,15 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 
 	out, err := os.Create(dst)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
 
 	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
 		return err
 	}
 
@@ -256,7 +258,7 @@ func computeFileSHA256(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	hash := sha256.New()
 	if _, err := io.Copy(hash, f); err != nil {
@@ -272,7 +274,7 @@ func extractZipPlugin(zipPath, destPath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open zip file: %w", err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 
 	// Check total size to prevent zip bombs
 	var totalSize uint64
@@ -326,14 +328,14 @@ func extractZipFile(f *zip.File, destPath string, remainingBytes *uint64) error 
 	if err != nil {
 		return fmt.Errorf("failed to open zip entry: %w", err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	// Create destination file
 	outFile, err := os.OpenFile(cleanPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
 	}
-	defer outFile.Close()
+	defer func() { _ = outFile.Close() }()
 
 	// Copy content through a budget-enforcing writer
 	if _, err := io.Copy(&limitWriter{w: outFile, remainingBytes: remainingBytes}, rc); err != nil {

--- a/internal/job/ssh.go
+++ b/internal/job/ssh.go
@@ -85,5 +85,5 @@ func findPathToSSHTools(ctx context.Context, sh *shell.Shell) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("Unable to find ssh-keyscan: %w", err)
+	return "", fmt.Errorf("unable to find ssh-keyscan: %w", err)
 }

--- a/internal/job/ssh_test.go
+++ b/internal/job/ssh_test.go
@@ -112,7 +112,11 @@ func TestSSHKeyscanRetriesOnBlankOutputAndExit0(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bintest.NewMock(ssh-keyscan) error = %v", err)
 	}
-	defer keyScan.CheckAndClose(t)
+	t.Cleanup(func() {
+		if err := keyScan.CheckAndClose(t); err != nil {
+			t.Errorf("keyScan.CheckAndClose(t) = %v", err)
+		}
+	})
 	//nolint:errcheck // bintest logs to t
 	sh.Env.Set("PATH", filepath.Dir(keyScan.Path))
 

--- a/internal/job/tracing.go
+++ b/internal/job/tracing.go
@@ -44,7 +44,9 @@ func (e *Executor) startTracing(ctx context.Context) (tracetools.Span, context.C
 		// Newer versions of the tracing libs print out diagnostic info which spams the
 		// Buildkite agent logs. Disable it by default unless it's been explicitly set.
 		if _, has := os.LookupEnv("DD_TRACE_STARTUP_LOGS"); !has {
-			os.Setenv("DD_TRACE_STARTUP_LOGS", "false")
+			if err := os.Setenv("DD_TRACE_STARTUP_LOGS", "false"); err != nil {
+				e.shell.Warningf("Couldn't set DD_TRACE_STARTUP_LOGS: %v", err)
+			}
 		}
 
 		return e.startTracingDatadog(ctx)

--- a/internal/osutil/file.go
+++ b/internal/osutil/file.go
@@ -9,12 +9,12 @@ import (
 func ChmodExecutable(filename string) error {
 	s, err := os.Stat(filename)
 	if err != nil {
-		return fmt.Errorf("Failed to retrieve file information of \"%s\" (%s)", filename, err)
+		return fmt.Errorf("failed to retrieve file information for %q: %w", filename, err)
 	}
 	if s.Mode()&0o100 == 0 {
 		err = os.Chmod(filename, s.Mode()|0o100)
 		if err != nil {
-			return fmt.Errorf("Failed to mark \"%s\" as executable (%s)", filename, err)
+			return fmt.Errorf("failed to mark %q as executable: %w", filename, err)
 		}
 	}
 	return nil

--- a/internal/process/ansi_test.go
+++ b/internal/process/ansi_test.go
@@ -51,7 +51,9 @@ func TestANSIParser(t *testing.T) {
 
 	for _, test := range tests {
 		var p ansiParser
-		p.Write([]byte(test.input))
+		if _, err := p.Write([]byte(test.input)); err != nil {
+			t.Fatalf("p.Write(%q) = %v", test.input, err)
+		}
 		if got := p.insideCode(); got != test.want {
 			t.Errorf("after p.feed(%q...): p.insideCode() = %t, want %t", test.input, got, test.want)
 		}
@@ -66,6 +68,8 @@ func BenchmarkANSIParser(b *testing.B) {
 
 	for b.Loop() {
 		var p ansiParser
-		p.Write(npm)
+		if _, err := p.Write(npm); err != nil {
+			b.Fatalf("p.Write(npm) = %v", err)
+		}
 	}
 }

--- a/internal/process/cat.go
+++ b/internal/process/cat.go
@@ -12,7 +12,7 @@ import (
 func Cat(path string) (string, error) {
 	files, err := filepath.Glob(path)
 	if err != nil {
-		return "", fmt.Errorf("Failed to get a list of files: %w", err)
+		return "", fmt.Errorf("failed to get a list of files: %w", err)
 	}
 
 	var buffer bytes.Buffer
@@ -20,7 +20,7 @@ func Cat(path string) (string, error) {
 	for _, file := range files {
 		data, err := os.ReadFile(file)
 		if err != nil {
-			return "", fmt.Errorf("Could not read file: %s (%T: %w)", file, err, err)
+			return "", fmt.Errorf("could not read file %s (%T: %w)", file, err, err)
 		}
 
 		buffer.WriteString(string(data))

--- a/internal/process/main_test.go
+++ b/internal/process/main_test.go
@@ -24,10 +24,10 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 
 	case "output":
-		fmt.Fprintf(os.Stdout, "llamas1\n")
-		fmt.Fprintf(os.Stderr, "alpacas1\r")
-		fmt.Fprintf(os.Stdout, "llamas2\r\n")
-		fmt.Fprintf(os.Stderr, "alpacas2\n")
+		_, _ = fmt.Fprintf(os.Stdout, "llamas1\n")
+		_, _ = fmt.Fprintf(os.Stderr, "alpacas1\r")
+		_, _ = fmt.Fprintf(os.Stdout, "llamas2\r\n")
+		_, _ = fmt.Fprintf(os.Stderr, "alpacas2\n")
 		os.Exit(0)
 
 	case "output-slow-exit":
@@ -56,7 +56,7 @@ func TestMain(m *testing.M) {
 
 		go func() {
 			for s := range signals {
-				fmt.Fprintf(os.Stdout, "received signal: %d", s)
+				_, _ = fmt.Fprintf(os.Stdout, "received signal: %d", s)
 				time.Sleep(10 * time.Second)
 				os.Exit(0)
 			}

--- a/internal/process/main_test.go
+++ b/internal/process/main_test.go
@@ -31,10 +31,10 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 
 	case "output-slow-exit":
-		fmt.Fprintf(os.Stdout, "llamas1\n")
-		fmt.Fprintf(os.Stderr, "alpacas1\r")
-		fmt.Fprintf(os.Stdout, "llamas2\r\n")
-		fmt.Fprintf(os.Stderr, "alpacas2\n")
+		_, _ = fmt.Fprintf(os.Stdout, "llamas1\n")
+		_, _ = fmt.Fprintf(os.Stderr, "alpacas1\r")
+		_, _ = fmt.Fprintf(os.Stdout, "llamas2\r\n")
+		_, _ = fmt.Fprintf(os.Stderr, "alpacas2\n")
 		time.Sleep(100 * time.Millisecond)
 		os.Exit(0)
 

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -231,7 +231,7 @@ func TestProcessTerminatesWhenContextDone(t *testing.T) {
 	})
 
 	go func() {
-		defer stdoutw.Close()
+		defer func() { _ = stdoutw.Close() }()
 		if err := p.Run(ctx); err != nil {
 			t.Errorf("p.Run(ctx) = %v", err)
 		}
@@ -273,7 +273,7 @@ func TestProcessWithSlowHandlerKilledWhenContextDone(t *testing.T) {
 	})
 
 	go func() {
-		defer stdoutw.Close()
+		defer func() { _ = stdoutw.Close() }()
 		if err := p.Run(ctx); err != nil {
 			t.Errorf("p.Run(ctx) = %v", err)
 		}
@@ -318,7 +318,7 @@ func TestProcessInterrupts(t *testing.T) {
 	})
 
 	go func() {
-		defer stdoutw.Close()
+		defer func() { _ = stdoutw.Close() }()
 		if err := p.Run(ctx); err != nil {
 			t.Errorf("p.Run(ctx) = %v", err)
 		}
@@ -386,7 +386,7 @@ func TestProcessInterruptsWithCustomSignal(t *testing.T) {
 	})
 
 	go func() {
-		defer stdoutw.Close()
+		defer func() { _ = stdoutw.Close() }()
 		if err := p.Run(ctx); err != nil {
 			t.Errorf("p.Run(ctx) = %v", err)
 		}

--- a/internal/process/scanner_test.go
+++ b/internal/process/scanner_test.go
@@ -27,11 +27,18 @@ func TestScanLines(t *testing.T) {
 	pr, pw := io.Pipe()
 
 	go func() {
+		defer func() {
+			if err := pw.Close(); err != nil {
+				t.Errorf("pw.Close() = %v", err)
+			}
+		}()
 		for line := range strings.SplitSeq(strings.TrimSuffix(longTestOutput, "\n"), "\n") {
-			fmt.Fprintf(pw, "%s\n", line)
+			if _, err := fmt.Fprintf(pw, "%s\n", line); err != nil {
+				t.Errorf("fmt.Fprintf(pw, %q) error = %v", line, err)
+				return
+			}
 			time.Sleep(time.Millisecond * 10)
 		}
-		pw.Close()
 	}()
 
 	scanner := process.NewScanner(logger.Discard)

--- a/internal/process/timestamper.go
+++ b/internal/process/timestamper.go
@@ -57,7 +57,7 @@ func (p *Timestamper) Write(data []byte) (n int, err error) {
 		var codeEnd []byte
 		for p.ansiParser.insideCode() && len(data) > len(codeEnd) {
 			fed := len(codeEnd)
-			p.ansiParser.Write(data[fed : fed+1])
+			_, _ = p.ansiParser.Write(data[fed : fed+1])
 			codeEnd = data[:fed+1]
 		}
 		if len(codeEnd) > 0 {
@@ -89,7 +89,7 @@ func (p *Timestamper) Write(data []byte) (n int, err error) {
 		if idx == nil {
 			// Write all remaining data. The line continues into the next Write
 			// call.
-			p.ansiParser.Write(data)
+			_, _ = p.ansiParser.Write(data)
 			n, err := p.out.Write(data)
 			written += n
 			return written, err
@@ -98,7 +98,7 @@ func (p *Timestamper) Write(data []byte) (n int, err error) {
 		// Write up to (and including) the newline / breaking sequence, ready to
 		// start a new line in the next iteration or Write.
 		chunk := data[:idx[1]]
-		p.ansiParser.Write(chunk)
+		_, _ = p.ansiParser.Write(chunk)
 		n, err = p.out.Write(chunk)
 		written += n
 		if err != nil {

--- a/internal/shell/logger.go
+++ b/internal/shell/logger.go
@@ -69,11 +69,11 @@ func (wl *WriterLogger) Write(b []byte) (int, error) {
 }
 
 func (wl *WriterLogger) Printf(format string, v ...any) {
-	fmt.Fprintf(wl.Writer, format+"\n", v...)
+	_, _ = fmt.Fprintf(wl.Writer, format+"\n", v...)
 }
 
 func (wl *WriterLogger) Headerf(format string, v ...any) {
-	fmt.Fprintf(wl.Writer, "~~~ "+format+"\n", v...)
+	_, _ = fmt.Fprintf(wl.Writer, "~~~ "+format+"\n", v...)
 }
 
 func (wl *WriterLogger) Commentf(format string, v ...any) {

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -140,7 +140,7 @@ func New(opts ...NewShellOpt) (*Shell, error) {
 	if shell.wd == "" {
 		wd, err := os.Getwd()
 		if err != nil {
-			return nil, fmt.Errorf("Failed to find current working directory: %w", err)
+			return nil, fmt.Errorf("failed to find current working directory: %w", err)
 		}
 		shell.wd = wd
 	}
@@ -183,7 +183,7 @@ func (s *Shell) Chdir(path string) error {
 	s.Promptf("cd %s", shellwords.Quote(path))
 
 	if _, err := os.Stat(path); err != nil {
-		return fmt.Errorf("Failed to change working: directory does not exist")
+		return fmt.Errorf("failed to change working directory: directory does not exist")
 	}
 
 	s.wd = path

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -30,7 +30,11 @@ func TestRunAndCaptureWithTTY(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bintest.CompileProxy(ssh-keygen) error = %v", err)
 	}
-	defer sshKeygen.Close()
+	defer func() {
+		if err := sshKeygen.Close(); err != nil {
+			t.Errorf("sshKeygen.Close() = %v", err)
+		}
+	}()
 
 	// WithPTY(true) should be overriden by RunAndCapture.
 	sh := newShellForTest(t, shell.WithPTY(true))
@@ -59,7 +63,11 @@ func TestRunAndCaptureWithExitCode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bintest.CompileProxy(ssh-keygen) error = %v", err)
 	}
-	defer sshKeygen.Close()
+	defer func() {
+		if err := sshKeygen.Close(); err != nil {
+			t.Errorf("sshKeygen.Close() = %v", err)
+		}
+	}()
 
 	sh := newShellForTest(t, shell.WithPTY(false))
 
@@ -86,7 +94,11 @@ func TestRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bintest.CompileProxy(ssh-keygen) error = %v", err)
 	}
-	defer sshKeygen.Close()
+	defer func() {
+		if err := sshKeygen.Close(); err != nil {
+			t.Errorf("sshKeygen.Close() = %v", err)
+		}
+	}()
 
 	out := &bytes.Buffer{}
 
@@ -98,7 +110,7 @@ func TestRun(t *testing.T) {
 
 	go func() {
 		call := <-sshKeygen.Ch
-		fmt.Fprintln(call.Stdout, "Llama party! 🎉")
+		_, _ = fmt.Fprintln(call.Stdout, "Llama party! 🎉")
 		call.Exit(0)
 	}()
 
@@ -292,7 +304,9 @@ func TestInterrupt(t *testing.T) {
 					t.Error("timeout waiting for process to start")
 				case <-started:
 					// Now interrupt the process.
-					sh.Interrupt()
+					if err := sh.Interrupt(); err != nil {
+						t.Errorf("sh.Interrupt() = %v", err)
+					}
 				}
 			}()
 

--- a/internal/socket/client.go
+++ b/internal/socket/client.go
@@ -57,7 +57,9 @@ func NewClient(ctx context.Context, path, token string) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("socket test connection: %w", err)
 	}
-	test.Close()
+	if err := test.Close(); err != nil {
+		return nil, fmt.Errorf("closing socket test connection: %w", err)
+	}
 
 	return &Client{
 		cli: &http.Client{
@@ -98,7 +100,7 @@ func (c *Client) Do(ctx context.Context, method, url string, req, resp any) erro
 	if err != nil {
 		return err
 	}
-	defer hresp.Body.Close()
+	defer func() { _ = hresp.Body.Close() }()
 	dec := json.NewDecoder(hresp.Body)
 
 	switch hresp.StatusCode / 100 {

--- a/internal/socket/client_test.go
+++ b/internal/socket/client_test.go
@@ -18,15 +18,15 @@ func (yesNoJSONServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	switch r.URL.Path {
 	case "/yes":
-		w.Write([]byte(`{"message":"Yes!"}\n`))
+		_, _ = w.Write([]byte(`{"message":"Yes!"}\n`))
 	case "/no":
-		w.Write([]byte(`{"message":"No."}\n`))
+		_, _ = w.Write([]byte(`{"message":"No."}\n`))
 	case "/secret":
 		if r.Header.Get("Authorization") != "Bearer llama" {
 			http.Error(w, `{"error":"invalid authorization token"}\n`, http.StatusUnauthorized)
 			return
 		}
-		w.Write([]byte(`{"message":"seekruts"}\n`))
+		_, _ = w.Write([]byte(`{"message":"seekruts"}\n`))
 	default:
 		http.Error(w, `{"error":"not found"}\n`, http.StatusNotFound)
 	}
@@ -51,7 +51,11 @@ func TestClientDo(t *testing.T) {
 	if err := svr.Start(); err != nil {
 		t.Fatalf("srv.Start() = %v", err)
 	}
-	t.Cleanup(func() { svr.Close() })
+	t.Cleanup(func() {
+		if err := svr.Close(); err != nil {
+			t.Errorf("svr.Close() = %v", err)
+		}
+	})
 
 	cli, err := NewClient(ctx, sockPath, "llama")
 	if err != nil {
@@ -108,7 +112,11 @@ func TestClientDoErrors(t *testing.T) {
 	if err := svr.Start(); err != nil {
 		t.Fatalf("srv.Start() = %v", err)
 	}
-	t.Cleanup(func() { svr.Close() })
+	t.Cleanup(func() {
+		if err := svr.Close(); err != nil {
+			t.Errorf("svr.Close() = %v", err)
+		}
+	})
 
 	cli, err := NewClient(ctx, sockPath, "alpaca")
 	if err != nil {

--- a/internal/socket/middleware_test.go
+++ b/internal/socket/middleware_test.go
@@ -12,7 +12,7 @@ import (
 
 func testHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("{}"))
+	_, _ = w.Write([]byte("{}"))
 }
 
 func shouldCall(t *testing.T) func(http.Handler) http.Handler {

--- a/internal/socket/server.go
+++ b/internal/socket/server.go
@@ -54,7 +54,9 @@ func (s *Server) Start() error {
 		return err
 	}
 
-	go s.svr.Serve(ln)
+	go func() {
+		_ = s.svr.Serve(ln)
+	}()
 	s.started = true
 
 	return nil

--- a/internal/socket/server_test.go
+++ b/internal/socket/server_test.go
@@ -31,9 +31,9 @@ func (yesNoServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	switch r.URL.Path {
 	case "/yes":
-		w.Write([]byte("Yes!\n"))
+		_, _ = w.Write([]byte("Yes!\n"))
 	case "/no":
-		w.Write([]byte("No.\n"))
+		_, _ = w.Write([]byte("No.\n"))
 	default:
 		http.Error(w, "not found", http.StatusNotFound)
 	}
@@ -72,7 +72,9 @@ func TestServerStartStop(t *testing.T) {
 		t.Fatalf("socket test connection: %v", err)
 	}
 
-	test.Close()
+	if err := test.Close(); err != nil {
+		t.Fatalf("test.Close() = %v", err)
+	}
 
 	if err := svr.Close(); err != nil {
 		t.Fatalf("svr.Close() = %v", err)
@@ -100,7 +102,11 @@ func TestServerHandler(t *testing.T) {
 	if err := svr.Start(); err != nil {
 		t.Fatalf("svr.Start() = %v", err)
 	}
-	t.Cleanup(func() { svr.Close() })
+	t.Cleanup(func() {
+		if err := svr.Close(); err != nil {
+			t.Errorf("svr.Close() = %v", err)
+		}
+	})
 
 	cli := &http.Client{
 		Transport: &http.Transport{
@@ -152,7 +158,7 @@ func TestServerHandler(t *testing.T) {
 			if err != nil {
 				t.Fatalf("cli.Do(req) = error %v", err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 			if got, want := resp.StatusCode, test.wantStatus; got != want {
 				t.Errorf("resp.Status = %v, want %v", got, want)
 			}

--- a/internal/stdin/main_test.go
+++ b/internal/stdin/main_test.go
@@ -69,7 +69,7 @@ func TestIsStdinIsReadableWithOutputRedirection(t *testing.T) {
 		t.Fatalf(`os.CreateTemp("", "output-redirect") error = %v`, err)
 	}
 
-	defer os.Remove(tmpfile.Name())
+	defer func() { _ = os.Remove(tmpfile.Name()) }()
 
 	if _, err := tmpfile.Write([]byte("output")); err != nil {
 		t.Fatalf(`tmpfile.Write([]byte("output")) error = %v`, err)

--- a/jobapi/client_test.go
+++ b/jobapi/client_test.go
@@ -41,19 +41,21 @@ func runFakeServer() (svr *fakeServer, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("net.Listen(unix, %q) error = %w", f.sock, err)
 	}
-	go f.svr.Serve(ln)
+	go func() {
+		_ = f.svr.Serve(ln)
+	}()
 	return f, nil
 }
 
-func (f *fakeServer) Close() { f.svr.Close() }
+func (f *fakeServer) Close() { _ = f.svr.Close() }
 
 func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Header.Get("Authorization") != "Bearer "+f.token {
-		socket.WriteError(w, "invalid Authorization header", http.StatusForbidden)
+		_ = socket.WriteError(w, "invalid Authorization header", http.StatusForbidden)
 		return
 	}
 	if r.URL.Path != "/api/current-job/v0/env" {
-		socket.WriteError(w, fmt.Sprintf("not found: %q", r.URL.Path), http.StatusNotFound)
+		_ = socket.WriteError(w, fmt.Sprintf("not found: %q", r.URL.Path), http.StatusNotFound)
 		return
 	}
 
@@ -61,23 +63,23 @@ func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "GET":
 		b := EnvGetResponse{Env: f.env}
 		if err := json.NewEncoder(w).Encode(&b); err != nil {
-			socket.WriteError(w, fmt.Sprintf("encoding response: %v", err), http.StatusInternalServerError)
+			_ = socket.WriteError(w, fmt.Sprintf("encoding response: %v", err), http.StatusInternalServerError)
 		}
 
 	case "PATCH":
 		var req EnvUpdateRequestPayload
 		var resp EnvUpdateResponse
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			socket.WriteError(w, fmt.Sprintf("decoding request: %v", err), http.StatusBadRequest)
+			_ = socket.WriteError(w, fmt.Sprintf("decoding request: %v", err), http.StatusBadRequest)
 			return
 		}
 		for k, v := range req.Env {
 			if k == "READONLY" {
-				socket.WriteError(w, "mutating READONLY is not allowed", http.StatusBadRequest)
+				_ = socket.WriteError(w, "mutating READONLY is not allowed", http.StatusBadRequest)
 				return
 			}
 			if v == nil {
-				socket.WriteError(w, fmt.Sprintf("setting %q to null is not allowed", k), http.StatusBadRequest)
+				_ = socket.WriteError(w, fmt.Sprintf("setting %q to null is not allowed", k), http.StatusBadRequest)
 				return
 			}
 		}
@@ -91,19 +93,19 @@ func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		resp.Normalize()
 		if err := json.NewEncoder(w).Encode(&resp); err != nil {
-			socket.WriteError(w, fmt.Sprintf("encoding response: %v", err), http.StatusInternalServerError)
+			_ = socket.WriteError(w, fmt.Sprintf("encoding response: %v", err), http.StatusInternalServerError)
 		}
 
 	case "DELETE":
 		var req EnvDeleteRequest
 		var resp EnvDeleteResponse
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			socket.WriteError(w, fmt.Sprintf("decoding request: %v", err), http.StatusBadRequest)
+			_ = socket.WriteError(w, fmt.Sprintf("decoding request: %v", err), http.StatusBadRequest)
 			return
 		}
 		for _, k := range req.Keys {
 			if k == "READONLY" {
-				socket.WriteError(w, "deleting READONLY is not allowed", http.StatusBadRequest)
+				_ = socket.WriteError(w, "deleting READONLY is not allowed", http.StatusBadRequest)
 			}
 		}
 		for _, k := range req.Keys {
@@ -115,11 +117,11 @@ func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		resp.Normalize()
 		if err := json.NewEncoder(w).Encode(&resp); err != nil {
-			socket.WriteError(w, fmt.Sprintf("encoding response: %v", err), http.StatusInternalServerError)
+			_ = socket.WriteError(w, fmt.Sprintf("encoding response: %v", err), http.StatusInternalServerError)
 		}
 
 	default:
-		socket.WriteError(w, fmt.Sprintf("unsupported method %q", r.Method), http.StatusBadRequest)
+		_ = socket.WriteError(w, fmt.Sprintf("unsupported method %q", r.Method), http.StatusBadRequest)
 	}
 }
 

--- a/jobapi/env.go
+++ b/jobapi/env.go
@@ -25,8 +25,8 @@ func (s *Server) getEnv(w http.ResponseWriter, _ *http.Request) {
 
 func (s *Server) patchEnv(w http.ResponseWriter, r *http.Request) {
 	var req EnvUpdateRequestPayload
+	defer func() { _ = r.Body.Close() }()
 	err := json.NewDecoder(r.Body).Decode(&req)
-	defer r.Body.Close()
 	if err != nil {
 		if err := socket.WriteError(w, fmt.Errorf("failed to decode request body: %w", err), http.StatusBadRequest); err != nil {
 			s.Logger.Errorf("Job API: couldn't write error: %v", err)
@@ -96,8 +96,8 @@ func (s *Server) patchEnv(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) deleteEnv(w http.ResponseWriter, r *http.Request) {
 	var req EnvDeleteRequest
+	defer func() { _ = r.Body.Close() }()
 	err := json.NewDecoder(r.Body).Decode(&req)
-	defer r.Body.Close()
 	if err != nil {
 		err := socket.WriteError(w, fmt.Errorf("failed to decode request body: %w", err), http.StatusBadRequest)
 		if err != nil {

--- a/jobapi/server_test.go
+++ b/jobapi/server_test.go
@@ -123,7 +123,9 @@ func TestServerStartStop(t *testing.T) {
 		t.Fatalf("socket test connection: %v", err)
 	}
 
-	test.Close()
+	if err := test.Close(); err != nil {
+		t.Fatalf("test.Close() = %v", err)
+	}
 
 	err = srv.Stop()
 	if err != nil {
@@ -154,7 +156,11 @@ func TestServerStartStop_WithPreExistingSocket(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected initial server start to succeed, got %v", err)
 	}
-	defer srv1.Stop()
+	defer func() {
+		if err := srv1.Stop(); err != nil {
+			t.Errorf("srv1.Stop() = %v", err)
+		}
+	}()
 
 	expectedErr := fmt.Sprintf("creating socket server: file already exists at socket path %s", sockName)
 	_, _, err = jobapi.NewServer(shell.TestingLogger{T: t}, sockName, env.New(), replacer.NewMux())
@@ -446,7 +452,9 @@ func TestCreateRedaction(t *testing.T) {
 	_, err = rdc.Write([]byte("From Quito, go back to Guayaquil.\n"))
 	assert.NilError(t, err)
 
-	mux.Flush()
+	if err := mux.Flush(); err != nil {
+		t.Fatalf("mux.Flush() = %v", err)
+	}
 
 	assert.Equal(
 		t,

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -165,5 +165,8 @@ func (c *Client) StatusLoop(ctx context.Context, onInterrupt func(error)) error 
 }
 
 func (c *Client) Close() {
-	c.client.Close()
+	if c.client == nil {
+		return
+	}
+	_ = c.client.Close()
 }

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -269,12 +269,12 @@ func TestTerminateAfterStart(t *testing.T) {
 
 func newRunner(t *testing.T, clientCount int) *Runner {
 	tempDir, err := os.MkdirTemp("", t.Name())
-	if err := err; err != nil {
+	if err != nil {
 		t.Errorf("err error = %v", err)
 	}
 	socketPath := filepath.Join(tempDir, "bk.sock")
 	t.Cleanup(func() {
-		os.RemoveAll(tempDir)
+		_ = os.RemoveAll(tempDir)
 	})
 	runner := NewRunner(logger.Discard, RunnerConfig{
 		SocketPath:         socketPath,
@@ -283,8 +283,16 @@ func newRunner(t *testing.T, clientCount int) *Runner {
 		ClientLostTimeout:  2 * time.Second,
 	})
 	runnerCtx, cancelRunner := context.WithCancel(context.Background())
-	go runner.Run(runnerCtx)
-	t.Cleanup(cancelRunner)
+	runErrCh := make(chan error, 1)
+	go func() {
+		runErrCh <- runner.Run(runnerCtx)
+	}()
+	t.Cleanup(func() {
+		cancelRunner()
+		if err := <-runErrCh; err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("runner.Run(runnerCtx) = %v", err)
+		}
+	})
 
 	// wait for runner to listen
 	timeout := time.After(10 * time.Second)

--- a/kubernetes/runner.go
+++ b/kubernetes/runner.go
@@ -116,8 +116,12 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	<-r.done
-	return nil
+	select {
+	case <-r.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // startupCheck blocks until all containers have connected, or times out.

--- a/kubernetes/runner.go
+++ b/kubernetes/runner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -81,7 +82,9 @@ type Runner struct {
 
 // Run runs the socket server.
 func (r *Runner) Run(ctx context.Context) error {
-	r.server.Register(r)
+	if err := r.server.Register(r); err != nil {
+		return fmt.Errorf("registering kubernetes RPC server: %w", err)
+	}
 	r.mux.Handle(rpc.DefaultRPCPath, r.server)
 
 	oldUmask, err := Umask(0) // set umask of socket file to 0o777 (world read-write-executable)
@@ -92,12 +95,18 @@ func (r *Runner) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to listen: %w", err)
 	}
-	defer l.Close()
-	defer os.Remove(r.conf.SocketPath)
+	defer func() { _ = l.Close() }()
+	defer func() { _ = os.Remove(r.conf.SocketPath) }()
 
-	Umask(oldUmask) // change back to regular umask
+	if _, err := Umask(oldUmask); err != nil { // change back to regular umask
+		return fmt.Errorf("failed to restore socket umask: %w", err)
+	}
 	r.listener = l
-	go http.Serve(l, r.mux)
+	go func() {
+		if err := http.Serve(l, r.mux); err != nil && !errors.Is(err, net.ErrClosed) {
+			r.logger.Error("kubernetes runner HTTP server stopped: %v", err)
+		}
+	}()
 
 	if r.conf.ClientLostTimeout > 0 {
 		go r.livenessCheck(ctx)
@@ -164,7 +173,9 @@ func (r *Runner) livenessCheck(ctx context.Context) {
 				if client.State == StateConnected && lhf > r.conf.ClientLostTimeout {
 					r.logger.Error("Container (ID %d) was last heard from %v ago; marking lost and self-terminating...", id, lhf)
 					client.State = StateLost
-					r.Terminate()
+					if err := r.Terminate(); err != nil {
+						r.logger.Error("terminating lost kubernetes runner: %v", err)
+					}
 				}
 				client.mu.Unlock()
 			}
@@ -261,7 +272,9 @@ func (r *Runner) Exit(args ExitCode, reply *Empty) error {
 	client.mu.Unlock()
 
 	if args.ExitStatus != 0 {
-		r.Terminate()
+		if err := r.Terminate(); err != nil {
+			return fmt.Errorf("terminating runner after non-zero exit: %w", err)
+		}
 	}
 
 	allTerminal := true
@@ -276,7 +289,9 @@ func (r *Runner) Exit(args ExitCode, reply *Empty) error {
 		}
 	}
 	if allTerminal {
-		r.Terminate()
+		if err := r.Terminate(); err != nil {
+			return fmt.Errorf("terminating runner after all clients exited: %w", err)
+		}
 	}
 	return nil
 }

--- a/lock/lock_test.go
+++ b/lock/lock_test.go
@@ -57,7 +57,11 @@ func TestLockUnlock(t *testing.T) {
 	t.Cleanup(canc)
 
 	svr, cli := testServerAndClient(t, ctx)
-	t.Cleanup(func() { svr.Close() })
+	t.Cleanup(func() {
+		if err := svr.Close(); err != nil {
+			t.Errorf("svr.Close() = %v", err)
+		}
+	})
 
 	// Lock it
 	token, err := cli.Lock(ctx, "llama")
@@ -90,7 +94,11 @@ func TestLocker(t *testing.T) {
 	t.Cleanup(canc)
 
 	svr, cli := testServerAndClient(t, ctx)
-	t.Cleanup(func() { svr.Close() })
+	t.Cleanup(func() {
+		if err := svr.Close(); err != nil {
+			t.Errorf("svr.Close() = %v", err)
+		}
+	})
 
 	// This constitutes a test by virtue of Lock/Unlock panicking on any
 	// internal error.
@@ -119,7 +127,11 @@ func TestDoOnce(t *testing.T) {
 	t.Cleanup(canc)
 
 	svr, cli := testServerAndClient(t, ctx)
-	t.Cleanup(func() { svr.Close() })
+	t.Cleanup(func() {
+		if err := svr.Close(); err != nil {
+			t.Errorf("svr.Close() = %v", err)
+		}
+	})
 
 	var wg sync.WaitGroup
 	var calls atomic.Int32

--- a/logger/log.go
+++ b/logger/log.go
@@ -249,15 +249,15 @@ func NewJSONPrinter(w io.Writer) *JSONPrinter {
 func (p *JSONPrinter) Print(level Level, msg string, fields Fields) {
 	var b strings.Builder
 
-	b.WriteString(fmt.Sprintf(`"ts":%q,`, time.Now().Format(time.RFC3339)))
-	b.WriteString(fmt.Sprintf(`"level":%q,`, level.String()))
+	_, _ = fmt.Fprintf(&b, `"ts":%q,`, time.Now().Format(time.RFC3339))
+	_, _ = fmt.Fprintf(&b, `"level":%q,`, level.String())
 
 	// Serialize msg to JSON so we're not producing invalid JSON
 	jsonMsg, err := json.Marshal(msg)
 	if err != nil {
 		jsonMsg = []byte(`"error marshaling message"`)
 	}
-	b.WriteString(fmt.Sprintf(`"msg":%s,`, jsonMsg))
+	_, _ = fmt.Fprintf(&b, `"msg":%s,`, jsonMsg)
 
 	for _, field := range fields {
 		b.WriteString(fmt.Sprintf("%q:%q,", field.Key(), field.String()))

--- a/logger/log.go
+++ b/logger/log.go
@@ -260,7 +260,7 @@ func (p *JSONPrinter) Print(level Level, msg string, fields Fields) {
 	_, _ = fmt.Fprintf(&b, `"msg":%s,`, jsonMsg)
 
 	for _, field := range fields {
-		b.WriteString(fmt.Sprintf("%q:%q,", field.Key(), field.String()))
+		_, _ = fmt.Fprintf(&b, "%q:%q,", field.Key(), field.String())
 	}
 
 	// Make sure we're only outputting a line one at a time

--- a/logger/log.go
+++ b/logger/log.go
@@ -218,11 +218,11 @@ func (l *TextPrinter) Print(level Level, msg string, fields Fields) {
 
 	// Make sure we're only outputting a line one at a time
 	mutex.Lock()
-	fmt.Fprint(l.Writer, line)
+	_, _ = fmt.Fprint(l.Writer, line)
 	if len(fields) > 0 {
-		fmt.Fprintf(l.Writer, " %s", strings.Join(fieldStrs, " "))
+		_, _ = fmt.Fprintf(l.Writer, " %s", strings.Join(fieldStrs, " "))
 	}
-	fmt.Fprint(l.Writer, "\n")
+	_, _ = fmt.Fprint(l.Writer, "\n")
 	mutex.Unlock()
 }
 
@@ -265,7 +265,7 @@ func (p *JSONPrinter) Print(level Level, msg string, fields Fields) {
 
 	// Make sure we're only outputting a line one at a time
 	mutex.Lock()
-	fmt.Fprintf(p.Writer, "{%s}\n", strings.TrimSuffix(b.String(), ","))
+	_, _ = fmt.Fprintf(p.Writer, "{%s}\n", strings.TrimSuffix(b.String(), ","))
 	mutex.Unlock()
 }
 

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ Options:
 `
 
 func printVersion(c *cli.Context) {
-	fmt.Fprintf(c.App.Writer, "%s version %s\n", c.App.Name, version.FullVersion())
+	_, _ = fmt.Fprintf(c.App.Writer, "%s version %s\n", c.App.Name, version.FullVersion())
 }
 
 func main() {
@@ -66,8 +66,8 @@ func main() {
 
 	// When a sub command can't be found
 	app.CommandNotFound = func(c *cli.Context, command string) {
-		fmt.Fprintf(app.ErrWriter, "buildkite-agent: unknown subcommand %q\n", command)
-		fmt.Fprintf(app.ErrWriter, "Run '%s --help' for usage.\n", c.App.Name)
+		_, _ = fmt.Fprintf(app.ErrWriter, "buildkite-agent: unknown subcommand %q\n", command)
+		_, _ = fmt.Fprintf(app.ErrWriter, "Run '%s --help' for usage.\n", c.App.Name)
 		os.Exit(1)
 	}
 

--- a/status/status.go
+++ b/status/status.go
@@ -165,19 +165,23 @@ func (i *templatedItem) Eval(ctx context.Context) template.HTML {
 
 	data, err := i.cb(ctx)
 	if err != nil {
-		errorTmpl.Execute(&sb, errorData{
+		if execErr := errorTmpl.Execute(&sb, errorData{
 			Operation: "Error from item callback",
 			Error:     err,
 			Item:      data,
-		})
+		}); execErr != nil {
+			return template.HTML(template.HTMLEscapeString(execErr.Error()))
+		}
 		return template.HTML(sb.String())
 	}
 	if err := i.tmpl.Execute(&sb, data); err != nil {
-		errorTmpl.Execute(&sb, errorData{
+		if execErr := errorTmpl.Execute(&sb, errorData{
 			Operation: "Error while executing item template",
 			Error:     err,
 			Item:      data,
-		})
+		}); execErr != nil {
+			return template.HTML(template.HTMLEscapeString(execErr.Error()))
+		}
 	}
 	return template.HTML(sb.String())
 }
@@ -208,11 +212,13 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 	rootItem.mu.RLock()
 	defer rootItem.mu.RUnlock()
 	if err := statusTmpl.Execute(w, data); err != nil {
-		errorTmpl.Execute(w, errorData{
+		if execErr := errorTmpl.Execute(w, errorData{
 			Operation: "Error while executing main template",
 			Error:     err,
 			Item:      data,
-		})
+		}); execErr != nil {
+			http.Error(w, execErr.Error(), http.StatusInternalServerError)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- address golangci-lint findings across the repo so the lint pass is clean again
- make explicit ignored or handled write and cleanup results in tests and helpers where errcheck flagged them
- normalize error strings and a few cleanup helpers to satisfy staticcheck without changing runtime behavior

## Why
- the repo had accumulated errcheck and staticcheck findings that caused `golangci-lint` to fail

## Validation
- `mise exec -- golangci-lint run`

## Notes
- broader Go test suites were not run in this pass
