### PR TITLE
fix: Hide detached-HEAD advice

### DIFF
--- a/internal/job/git.go
+++ b/internal/job/git.go
@@ -65,7 +65,7 @@ func gitCheckout(ctx context.Context, sh *shell.Shell, gitCheckoutFlags, referen
 		return fmt.Errorf("%q %w", reference, errInvalidRef)
 	}
 
-	commandArgs := []string{"checkout"}
+	commandArgs := []string{"-c", "advice.detachedHead=false", "checkout"}
 	commandArgs = append(commandArgs, individualCheckoutFlags...)
 	commandArgs = append(commandArgs, reference)
 

--- a/internal/job/git_test.go
+++ b/internal/job/git_test.go
@@ -202,7 +202,7 @@ func TestGitCheckout(t *testing.T) {
 		t.Fatalf(`gitCheckout(ctx, sh, "-f -q", "main") = %v`, err)
 	}
 
-	wantLog := [][]string{{absoluteGit, "checkout", "-f", "-q", "main"}}
+	wantLog := [][]string{{absoluteGit, "-c", "advice.detachedHead=false", "checkout", "-f", "-q", "main"}}
 	if diff := cmp.Diff(gotLog, wantLog); diff != "" {
 		t.Errorf("executed commands diff (-got +want):\n%s", diff)
 	}

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -46,7 +46,7 @@ func TestCheckingOutGitHubPullRequests_WithGitMirrors(t *testing.T) {
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", "refs/pull/123/head"},
 		{"rev-parse", "FETCH_HEAD"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-ffxdq"},
 		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
@@ -91,7 +91,7 @@ func TestWithResolvingCommitExperiment_WithGitMirrors(t *testing.T) {
 		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"fetch", "-v", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
 		{"rev-parse", "HEAD"},
 	})
@@ -130,7 +130,7 @@ func TestCheckingOutLocalGitProject_WithGitMirrors(t *testing.T) {
 		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"fetch", "-v", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
 		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
@@ -197,7 +197,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules_WithGitMirrors(t *testing.T) {
 		{"clean", "-fdq"},
 		{"submodule", "foreach", "--recursive", "git clean -fdq"},
 		{"fetch", "-v", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"submodule", "sync", "--recursive"},
 		{"config", "--file", ".gitmodules", "--null", "--get-regexp", "submodule\\..+\\.url"},
 		{"-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--force", "--reference", matchSubDir(tester.GitMirrorsDir)},
@@ -268,7 +268,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled_WithGitMirrors(t *test
 		{"clean", "-fdq"},
 		{"submodule", "foreach", "--recursive", "git clean -fdq"},
 		{"fetch", "-v", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
 		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
@@ -312,7 +312,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject_WithGitMirrors(t *testing.T) {
 		{"clone", "--depth=1", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"fetch", "--depth=1", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
 		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
@@ -702,7 +702,7 @@ func TestGitMirrorEnv(t *testing.T) {
 		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"fetch", "-v", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
 		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
@@ -782,7 +782,7 @@ func TestCheckingOutWithCustomRefspec_WithGitMirrors(t *testing.T) {
 		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", customRef}, // Mirror fetches custom refspec (correct!)
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-ffxdq"},
 		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -57,7 +57,7 @@ func TestWithResolvingCommitExperiment(t *testing.T) {
 		{"clone", "-v", "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"fetch", "-v", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
 		{"rev-parse", "HEAD"},
 	})
@@ -91,7 +91,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 		{"clone", "-v", "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"fetch", "-v", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
 		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
@@ -152,7 +152,7 @@ func TestCheckingOutLocalGitProjectWithSubmodules(t *testing.T) {
 		{"clean", "-fdq"},
 		{"submodule", "foreach", "--recursive", "git clean -fdq"},
 		{"fetch", "-v", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"submodule", "sync", "--recursive"},
 		{"config", "--file", ".gitmodules", "--null", "--get-regexp", "submodule\\..+\\.url"},
 		{"-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--force"},
@@ -218,7 +218,7 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled(t *testing.T) {
 		{"clean", "-fdq"},
 		{"submodule", "foreach", "--recursive", "git clean -fdq"},
 		{"fetch", "-v", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
 		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
@@ -257,7 +257,7 @@ func TestCheckingOutShallowCloneOfLocalGitProject(t *testing.T) {
 		{"clone", "--depth=1", "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"fetch", "--depth=1", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
 		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
@@ -302,7 +302,7 @@ func TestCheckingOutLocalGitProjectWithShortCommitHash(t *testing.T) {
 		{"fetch", "-v", "--prune", "--", "origin", shortCommitHash},
 		{"config", "remote.origin.fetch"},
 		{"fetch", "-v", "--prune", "--", "origin", "+refs/heads/*:refs/remotes/origin/*", "+refs/tags/*:refs/tags/*"},
-		{"checkout", "-f", shortCommitHash},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", shortCommitHash},
 		{"clean", "-ffxdq"},
 		{"--no-pager", "log", "-1", shortCommitHash, "-s", "--no-color", gitShowFormatArg},
 	})
@@ -525,7 +525,7 @@ func TestCheckingOutGitHubPullRequestMergeRefspec(t *testing.T) {
 		{"clone", "--no-local", "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", "refs/pull/123/merge"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-ffxdq"},
 		{"rev-parse", "FETCH_HEAD"},
 	})
@@ -618,11 +618,11 @@ func TestCheckoutErrorIsRetried(t *testing.T) {
 		{"config", "--get-all", "remote.origin.url"},
 		{"clean", "-fdq"},
 		{"fetch", "-v", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clone", "-v", "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"fetch", "-v", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
 		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
@@ -684,7 +684,7 @@ func TestFetchErrorIsRetried(t *testing.T) {
 		{"clone", "-v", "--depth=1", "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--depth=1", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-ffxdq"},
 		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
@@ -1035,7 +1035,7 @@ func TestGitCheckoutWithCommitResolved(t *testing.T) {
 		{"clone", "-v", "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-ffxdq"},
 	})
 
@@ -1062,7 +1062,7 @@ func TestGitCheckoutWithoutCommitResolved(t *testing.T) {
 		{"clone", "-v", "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-ffxdq"},
 	})
 
@@ -1089,7 +1089,7 @@ func TestGitCheckoutWithoutCommitResolvedAndNoMetaData(t *testing.T) {
 		{"clone", "-v", "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-ffxdq"},
 		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})
@@ -1145,7 +1145,7 @@ func TestMultipleRemoteURLsFallsBackToGetURL(t *testing.T) {
 		{"remote", "get-url", "origin"},
 		{"clean", "-fdq"},
 		{"fetch", "-v", "--", "origin", "main"},
-		{"checkout", "-f", "FETCH_HEAD"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
 		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
 	})

--- a/internal/job/plugin.go
+++ b/internal/job/plugin.go
@@ -458,7 +458,7 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 	// Switch to the version if we need to
 	if p.Version != "" {
 		e.shell.Commentf("Checking out `%s`", p.Version)
-		if err = e.shell.Command("git", "checkout", "-f", p.Version).Run(ctx); err != nil {
+		if err = e.shell.Command("git", "-c", "advice.detachedHead=false", "checkout", "-f", p.Version).Run(ctx); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
### Description

Revival of #1878

### Context

Closes #1878

### Changes

- Add `-c advice.detachedHead=false` to invocations of `git checkout`
- Update the tests.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)


### Disclosures / Credits

Special shout-out to the find and replace functionality of my text editor.