### PR TITLE
fix: Reverse ordering for post- hooks

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -52,3 +52,61 @@ We previously made this the default behaviour of the agent (as of v3.63.0) but h
 Allows plugins to be downloaded as zip archives instead of being cloned from a Git repository. This is useful for plugins hosted as zip files on HTTP(S) URLs.
 
 **Status:** Experimental while we test zip archive support for plugins.
+
+### `legacy-post-hook-order`
+
+This experiment is an escape hatch that reverts to the v3 execution order of `post-checkout` and `post-command` hooks.
+
+In Agent v3, hooks of any kind would run in the same order as one another (for plugins, the order in which plugins are specified for a step). In v4, multiple `post-checkout`, `post-command`, or `pre-exit` hooks execute in _reverse_ order. This change makes it easier for multiple plugins and hooks to compose.
+
+For example, suppose a step specifies two plugins A and B, and there are also agent and repository hooks. Under version 3, each hook type would execute in the same order:
+
+- agent pre-checkout
+- (pre-checkout is not possible for repository hooks)
+- plugin A pre-checkout
+- plugin B pre-checkout
+- (checkout)
+- agent post-checkout
+- repository post-checkout
+- plugin A post-checkout
+- plugin B post-checkout
+- agent pre-command
+- repository pre-command
+- plugin A pre-command
+- plugin B pre-command
+- (command)
+- agent post-command
+- repository post-command
+- plugin A post-command
+- plugin B post-command
+- agent pre-exit
+- repository pre-exit
+- plugin A pre-exit
+- plugin B pre-exit
+
+Under version 4, the execution order is (key differences in bold):
+
+- agent pre-checkout
+- (pre-checkout is not possible for repository hooks)
+- plugin A pre-checkout
+- plugin B pre-checkout
+- (checkout)
+- plugin **B** post-checkout
+- plugin **A** post-checkout
+- **repository** post-checkout
+- **agent** post-checkout
+- agent pre-command
+- repository pre-command
+- plugin A pre-command
+- plugin B pre-command
+- (command)
+- plugin **B** post-command
+- plugin **A** post-command
+- **repository** post-command
+- **agent** post-command
+- plugin **B** pre-exit
+- plugin **A** pre-exit
+- **repository** pre-exit
+- **agent** pre-exit
+
+**Status:** This escape-hatch experiment will be removed in a future release, once we are confident that it isn't needed.

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -26,6 +26,7 @@ const (
 	AgentAPI                       = "agent-api"
 	InterpolationPrefersRuntimeEnv = "interpolation-prefers-runtime-env"
 	PTYRaw                         = "pty-raw"
+	LegacyPostHookOrder            = "legacy-post-hook-order"
 	ZipPlugins                     = "zip-plugins"
 
 	// Promoted or removed experiments - un-export these to ensure no new code
@@ -52,6 +53,7 @@ var (
 	Available = map[string]struct{}{
 		AgentAPI:                       {},
 		InterpolationPrefersRuntimeEnv: {},
+		LegacyPostHookOrder:            {},
 		PTYRaw:                         {},
 		ZipPlugins:                     {},
 	}

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -1,6 +1,7 @@
 package job
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/buildkite/agent/v4/internal/experiments"
 	"github.com/buildkite/agent/v4/internal/osutil"
 	"github.com/buildkite/agent/v4/internal/self"
 	"github.com/buildkite/agent/v4/internal/shell"
@@ -188,16 +190,24 @@ func (e *Executor) CheckoutPhase(ctx context.Context) error {
 	}
 
 	// Run post-checkout hooks
-	if err := e.executeGlobalHook(ctx, "post-checkout"); err != nil {
-		return err
-	}
-
-	if err := e.executeLocalHook(ctx, "post-checkout"); err != nil {
-		return err
-	}
-
-	if err := e.executePluginHook(ctx, "post-checkout", e.pluginCheckouts); err != nil {
-		return err
+	if experiments.IsEnabled(ctx, experiments.LegacyPostHookOrder) {
+		// Legacy order = same order as pre-checkout
+		if err := cmp.Or(
+			e.executeGlobalHook(ctx, "post-checkout"),
+			e.executeLocalHook(ctx, "post-checkout"),
+			e.executePluginHook(ctx, "post-checkout", e.pluginCheckouts),
+		); err != nil {
+			return err
+		}
+	} else {
+		// Modern order = reverse, to make composition easier
+		if err := cmp.Or(
+			e.executePluginHook(ctx, "post-checkout", e.pluginCheckoutsReversed),
+			e.executeLocalHook(ctx, "post-checkout"),
+			e.executeGlobalHook(ctx, "post-checkout"),
+		); err != nil {
+			return err
+		}
 	}
 
 	// Capture the new checkout path so we can see if it's changed.

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/buildkite/agent/v4/agent/plugin"
 	"github.com/buildkite/agent/v4/api"
 	"github.com/buildkite/agent/v4/env"
+	"github.com/buildkite/agent/v4/internal/experiments"
 	"github.com/buildkite/agent/v4/internal/file"
 	"github.com/buildkite/agent/v4/internal/job/hook"
 	"github.com/buildkite/agent/v4/internal/osutil"
@@ -61,7 +62,8 @@ type Executor struct {
 	plugins []*plugin.Plugin
 
 	// Plugin checkouts from the plugin phases
-	pluginCheckouts []*pluginCheckout
+	pluginCheckouts         []*pluginCheckout
+	pluginCheckoutsReversed []*pluginCheckout
 
 	// Directories to clean up at end of job execution
 	cleanupDirs []string
@@ -1006,16 +1008,24 @@ func (e *Executor) tearDown(ctx context.Context) error {
 	// Unfortunately pre-exit hooks are often not written with this split in
 	// mind.
 	if e.includePhase("command") {
-		if err = e.executeGlobalHook(ctx, "pre-exit"); err != nil {
-			return err
-		}
-
-		if err = e.executeLocalHook(ctx, "pre-exit"); err != nil {
-			return err
-		}
-
-		if err = e.executePluginHook(ctx, "pre-exit", e.pluginCheckouts); err != nil {
-			return err
+		if experiments.IsEnabled(ctx, experiments.LegacyPostHookOrder) {
+			// Legacy order = same order as environment
+			if err := cmp.Or(
+				e.executeGlobalHook(ctx, "pre-exit"),
+				e.executeLocalHook(ctx, "pre-exit"),
+				e.executePluginHook(ctx, "pre-exit", e.pluginCheckouts),
+			); err != nil {
+				return err
+			}
+		} else {
+			// Modern order = reverse, to make composition easier
+			if err := cmp.Or(
+				e.executePluginHook(ctx, "pre-exit", e.pluginCheckoutsReversed),
+				e.executeLocalHook(ctx, "pre-exit"),
+				e.executeGlobalHook(ctx, "pre-exit"),
+			); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -1064,13 +1074,20 @@ func (e *Executor) runPostCommandHooks(ctx context.Context) (err error) {
 	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, e.TracingBackend)
 	defer func() { span.FinishWithError(err) }()
 
-	if err := e.executeGlobalHook(ctx, "post-command"); err != nil {
-		return err
+	if experiments.IsEnabled(ctx, experiments.LegacyPostHookOrder) {
+		// Legacy order = same order as pre-command
+		return cmp.Or(
+			e.executeGlobalHook(ctx, "post-command"),
+			e.executeLocalHook(ctx, "post-command"),
+			e.executePluginHook(ctx, "post-command", e.pluginCheckouts),
+		)
 	}
-	if err := e.executeLocalHook(ctx, "post-command"); err != nil {
-		return err
-	}
-	return e.executePluginHook(ctx, "post-command", e.pluginCheckouts)
+	// Modern order = reverse, to make composition easier
+	return cmp.Or(
+		e.executePluginHook(ctx, "post-command", e.pluginCheckoutsReversed),
+		e.executeLocalHook(ctx, "post-command"),
+		e.executeGlobalHook(ctx, "post-command"),
+	)
 }
 
 // CommandPhase determines how to run the build, and then runs it

--- a/internal/job/plugin.go
+++ b/internal/job/plugin.go
@@ -163,6 +163,10 @@ func (e *Executor) PluginPhase(ctx context.Context) error {
 	// Store the checkouts for future use
 	e.pluginCheckouts = checkouts
 
+	// Create a reversed copy of the slice
+	e.pluginCheckoutsReversed = slices.Clone(e.pluginCheckouts)
+	slices.Reverse(e.pluginCheckoutsReversed)
+
 	// Now we can run plugin environment hooks too
 	return e.executePluginHook(ctx, "environment", checkouts)
 }
@@ -209,6 +213,10 @@ func (e *Executor) VendoredPluginPhase(ctx context.Context) error {
 
 	// Finally append our vendored checkouts to the rest for subsequent hooks
 	e.pluginCheckouts = append(e.pluginCheckouts, vendoredCheckouts...)
+
+	// Create a reversed copy of the slice
+	e.pluginCheckoutsReversed = slices.Clone(e.pluginCheckouts)
+	slices.Reverse(e.pluginCheckoutsReversed)
 
 	// Now we can run plugin environment hooks too
 	return e.executePluginHook(ctx, "environment", vendoredCheckouts)


### PR DESCRIPTION
### Description

By default, run `post-checkout`, `post-command`, and `pre-exit` hooks in the reverse of the usual order. Add an escape-hatch experiment to revert to the legacy order.

### Context

#1646

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

I am the author.