### PR TITLE
feat: build and publish freebsd/arm64 binary

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -227,9 +227,6 @@ steps:
 
             - with: { os: dragonflybsd, arch: amd64 }
 
-            - with: { os: freebsd, arch: arm64 }
-              skip: "arm64 FreeBSD is not currently supported"
-
             - with: { os: linux, arch: arm }
             - with: { os: linux, arch: armhf }
             - with: { os: linux, arch: ppc64 }


### PR DESCRIPTION
### Description

Build and publish a FreeBSD/arm64 binary
<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

### Context

FreeBSD was not supported pre Go 1.13

Resolves https://linear.app/buildkite/issue/A-1141/freebsd-arm64-support
<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

### Changes

Remove explicit skip in build matrix.
<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [x] FreeBSD arm64 binary built successfully in the pipeline: https://buildkite.com/buildkite/agent/builds/12191#019dcca8-ffcf-4f29-99a0-1b978bbaf959

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
