### PR TITLE
fix: use single-quoted shell escaping for --format env output

### DIFF
--- a/clicommand/secret_get.go
+++ b/clicommand/secret_get.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"slices"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/internal/secrets"
 	"github.com/buildkite/agent/v3/jobapi"
+	"github.com/buildkite/agent/v3/logger"
 	"github.com/urfave/cli"
 )
 
@@ -84,67 +86,74 @@ Examples:
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[SecretGetConfig](ctx, c)
 		defer done()
-
-		if len(cfg.Keys) == 0 {
-			return errors.New("at least one secret key must be provided")
-		}
-
-		if !slices.Contains([]string{"default", "json", "env"}, cfg.Format) {
-			return fmt.Errorf("invalid format %q: must be one of 'default', 'json', or 'env'", cfg.Format)
-		}
-
-		agentClient := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
-		secrets, errs := secrets.FetchSecrets(ctx, l, agentClient, cfg.Job, cfg.Keys, 10)
-		if len(errs) > 0 {
-			sb := &strings.Builder{}
-			sb.WriteString("Failed to fetch some secrets:\n")
-			for _, err := range errs {
-				_, _ = fmt.Fprintf(sb, " - %v\n", err)
-			}
-			return errors.New(sb.String())
-		}
-
-		if !cfg.SkipRedaction {
-			jobClient, err := jobapi.NewDefaultClient(ctx)
-			if err != nil {
-				return fmt.Errorf("failed to create Job API client: %w", err)
-			}
-
-			for _, secret := range secrets {
-				if err := AddToRedactor(ctx, l, jobClient, secret.Value); err != nil {
-					if cfg.Debug {
-						return err
-					}
-					return errSecretRedact
-				}
-			}
-		}
-
-		// Otherwise, print in the requested format
-		secretsMap := make(map[string]string, len(secrets))
-		for _, secret := range secrets {
-			secretsMap[secret.Key] = secret.Value
-		}
-
-		switch {
-		case len(cfg.Keys) == 1 && cfg.Format == "default":
-			_, _ = fmt.Fprintln(c.App.Writer, secrets[0].Value)
-			return nil
-
-		case cfg.Format == "json" || (cfg.Format == "default" && len(cfg.Keys) > 1):
-			if err := json.NewEncoder(c.App.Writer).Encode(secretsMap); err != nil {
-				return fmt.Errorf("failed to write JSON response: %w", err)
-			}
-
-		case cfg.Format == "env":
-			for _, key := range slices.Sorted(maps.Keys(secretsMap)) {
-				fmt.Fprintf(c.App.Writer, "%s=%q\n", strings.ToUpper(key), secretsMap[key])
-			}
-
-		default:
-			return fmt.Errorf("unsupported format %q", cfg.Format)
-		}
-
-		return nil
+		return secretGet(ctx, cfg, c.App.Writer, l)
 	},
+}
+
+func secretGet(ctx context.Context, cfg SecretGetConfig, w io.Writer, l logger.Logger) error {
+	if len(cfg.Keys) == 0 {
+		return errors.New("at least one secret key must be provided")
+	}
+
+	if !slices.Contains([]string{"default", "json", "env"}, cfg.Format) {
+		return fmt.Errorf("invalid format %q: must be one of 'default', 'json', or 'env'", cfg.Format)
+	}
+
+	agentClient := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
+	fetchedSecrets, errs := secrets.FetchSecrets(ctx, l, agentClient, cfg.Job, cfg.Keys, 10)
+	if len(errs) > 0 {
+		sb := &strings.Builder{}
+		sb.WriteString("Failed to fetch some secrets:\n")
+		for _, err := range errs {
+			_, _ = fmt.Fprintf(sb, " - %v\n", err)
+		}
+		return errors.New(sb.String())
+	}
+
+	if !cfg.SkipRedaction {
+		jobClient, err := jobapi.NewDefaultClient(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to create Job API client: %w", err)
+		}
+
+		for _, secret := range fetchedSecrets {
+			if err := AddToRedactor(ctx, l, jobClient, secret.Value); err != nil {
+				if cfg.Debug {
+					return err
+				}
+				return errSecretRedact
+			}
+		}
+	}
+	// Otherwise, print in the requested format
+	secretsMap := make(map[string]string, len(fetchedSecrets))
+	for _, secret := range fetchedSecrets {
+		secretsMap[secret.Key] = secret.Value
+	}
+
+	switch {
+	case len(cfg.Keys) == 1 && cfg.Format == "default":
+		_, _ = fmt.Fprintln(w, fetchedSecrets[0].Value)
+		return nil
+
+	case cfg.Format == "json" || (cfg.Format == "default" && len(cfg.Keys) > 1):
+		if err := json.NewEncoder(w).Encode(secretsMap); err != nil {
+			return fmt.Errorf("failed to write JSON response: %w", err)
+		}
+
+	case cfg.Format == "env":
+		for _, key := range slices.Sorted(maps.Keys(secretsMap)) {
+			_, _ = fmt.Fprintf(w, "%s=%s\n", strings.ToUpper(key), shellQuote(secretsMap[key]))
+		}
+
+	default:
+		return fmt.Errorf("unsupported format %q", cfg.Format)
+	}
+
+	return nil
+}
+
+// shellQuote wraps the string in single quotes, which suppresses all shell expansions
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/clicommand/secret_get_test.go
+++ b/clicommand/secret_get_test.go
@@ -1,0 +1,130 @@
+package clicommand
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func newSecretGetTestServer(t *testing.T, secrets map[string]string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		key := req.URL.Query().Get("key")
+		val, ok := secrets[key]
+		if !ok {
+			_, _ = fmt.Fprintf(rw, `{"message": "secret not found"}`)
+			return
+		}
+		_, _ = fmt.Fprintf(rw, `{"key": %q, "value": %q, "uuid": "test-uuid"}`, key, val)
+	}))
+}
+
+func baseSecretGetConfig(serverURL string, keys []string, format string) SecretGetConfig {
+	return SecretGetConfig{
+		Keys:   keys,
+		Format: format,
+		Job:    "job-123",
+		APIConfig: APIConfig{
+			AgentAccessToken: "agentaccesstoken",
+			Endpoint:         serverURL,
+		},
+		SkipRedaction: true,
+	}
+}
+
+func TestSecretGet(t *testing.T) {
+	t.Run("error when no keys provided", func(t *testing.T) {
+		t.Parallel()
+		server := newSecretGetTestServer(t, map[string]string{})
+		defer server.Close()
+		var out bytes.Buffer
+		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{}, "default"), &out, logger.NewBuffer())
+		assert.EqualError(t, err, "at least one secret key must be provided")
+	})
+
+	t.Run("error on invalid format", func(t *testing.T) {
+		t.Parallel()
+		server := newSecretGetTestServer(t, map[string]string{"deploy_key": "shhsecret"})
+		defer server.Close()
+		var out bytes.Buffer
+		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key"}, "xml"), &out, logger.NewBuffer())
+		assert.EqualError(t, err, `invalid format "xml": must be one of 'default', 'json', or 'env'`)
+	})
+
+	t.Run("single key default format prints value", func(t *testing.T) {
+		t.Parallel()
+		server := newSecretGetTestServer(t, map[string]string{"deploy_key": "shhsecret"})
+		defer server.Close()
+		var out bytes.Buffer
+		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key"}, "default"), &out, logger.NewBuffer())
+		assert.NoError(t, err)
+		assert.Equal(t, "shhsecret\n", out.String())
+	})
+
+	t.Run("multiple keys default format outputs json", func(t *testing.T) {
+		t.Parallel()
+		server := newSecretGetTestServer(t, map[string]string{
+			"deploy_key":     "secret1",
+			"github_api_key": "secret2",
+		})
+		defer server.Close()
+		var out bytes.Buffer
+		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key", "github_api_key"}, "default"), &out, logger.NewBuffer())
+		assert.NoError(t, err)
+
+		var result map[string]string
+		// unmarshalling and asserting the result to ensure the output is valid JSON and has the expected keys and values
+		assert.NoError(t, json.Unmarshal(out.Bytes(), &result))
+		assert.Equal(t, map[string]string{
+			"deploy_key":     "secret1",
+			"github_api_key": "secret2",
+		}, result)
+	})
+
+	t.Run("json format", func(t *testing.T) {
+		t.Parallel()
+		server := newSecretGetTestServer(t, map[string]string{"deploy_key": "supersecret"})
+		defer server.Close()
+		var out bytes.Buffer
+		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key"}, "json"), &out, logger.NewBuffer())
+		assert.NoError(t, err)
+
+		var result map[string]string
+		assert.NoError(t, json.Unmarshal(out.Bytes(), &result))
+		assert.Equal(t, map[string]string{"deploy_key": "supersecret"}, result)
+	})
+
+	t.Run("env format - sorts keys, uppercases and shellQuotes", func(t *testing.T) {
+		t.Parallel()
+		server := newSecretGetTestServer(t, map[string]string{
+			"deploy_key":     "secret1",
+			"github_api_key": "secret2",
+		})
+		defer server.Close()
+
+		var out bytes.Buffer
+		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key", "github_api_key"}, "env"), &out, logger.NewBuffer())
+		assert.NoError(t, err)
+		assert.Equal(t, "DEPLOY_KEY='secret1'\nGITHUB_API_KEY='secret2'\n", out.String())
+	})
+
+	t.Run("api error returns error with details", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		var out bytes.Buffer
+		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"missing_key"}, "default"), &out, logger.NewBuffer())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Failed to fetch some secrets:")
+		assert.Contains(t, err.Error(), "missing_key")
+	})
+}

--- a/clicommand/secret_get_test.go
+++ b/clicommand/secret_get_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/agent/v3/logger"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newSecretGetTestServer(t *testing.T, secrets map[string]string) *httptest.Server {
@@ -45,7 +45,7 @@ func TestSecretGet(t *testing.T) {
 		defer server.Close()
 		var out bytes.Buffer
 		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{}, "default"), &out, logger.NewBuffer())
-		assert.EqualError(t, err, "at least one secret key must be provided")
+		require.EqualError(t, err, "at least one secret key must be provided")
 	})
 
 	t.Run("error on invalid format", func(t *testing.T) {
@@ -54,7 +54,7 @@ func TestSecretGet(t *testing.T) {
 		defer server.Close()
 		var out bytes.Buffer
 		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key"}, "xml"), &out, logger.NewBuffer())
-		assert.EqualError(t, err, `invalid format "xml": must be one of 'default', 'json', or 'env'`)
+		require.EqualError(t, err, `invalid format "xml": must be one of 'default', 'json', or 'env'`)
 	})
 
 	t.Run("single key default format prints value", func(t *testing.T) {
@@ -63,8 +63,8 @@ func TestSecretGet(t *testing.T) {
 		defer server.Close()
 		var out bytes.Buffer
 		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key"}, "default"), &out, logger.NewBuffer())
-		assert.NoError(t, err)
-		assert.Equal(t, "shhsecret\n", out.String())
+		require.NoError(t, err)
+		require.Equal(t, "shhsecret\n", out.String())
 	})
 
 	t.Run("multiple keys default format outputs json", func(t *testing.T) {
@@ -76,12 +76,12 @@ func TestSecretGet(t *testing.T) {
 		defer server.Close()
 		var out bytes.Buffer
 		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key", "github_api_key"}, "default"), &out, logger.NewBuffer())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		var result map[string]string
-		// unmarshalling and asserting the result to ensure the output is valid JSON and has the expected keys and values
-		assert.NoError(t, json.Unmarshal(out.Bytes(), &result))
-		assert.Equal(t, map[string]string{
+		// unmarshalling and requiring the result to ensure the output is valid JSON and has the expected keys and values
+		require.NoError(t, json.Unmarshal(out.Bytes(), &result))
+		require.Equal(t, map[string]string{
 			"deploy_key":     "secret1",
 			"github_api_key": "secret2",
 		}, result)
@@ -93,11 +93,11 @@ func TestSecretGet(t *testing.T) {
 		defer server.Close()
 		var out bytes.Buffer
 		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key"}, "json"), &out, logger.NewBuffer())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		var result map[string]string
-		assert.NoError(t, json.Unmarshal(out.Bytes(), &result))
-		assert.Equal(t, map[string]string{"deploy_key": "supersecret"}, result)
+		require.NoError(t, json.Unmarshal(out.Bytes(), &result))
+		require.Equal(t, map[string]string{"deploy_key": "supersecret"}, result)
 	})
 
 	t.Run("env format - sorts keys, uppercases and shellQuotes", func(t *testing.T) {
@@ -110,8 +110,22 @@ func TestSecretGet(t *testing.T) {
 
 		var out bytes.Buffer
 		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key", "github_api_key"}, "env"), &out, logger.NewBuffer())
-		assert.NoError(t, err)
-		assert.Equal(t, "DEPLOY_KEY='secret1'\nGITHUB_API_KEY='secret2'\n", out.String())
+		require.NoError(t, err)
+		require.Equal(t, "DEPLOY_KEY='secret1'\nGITHUB_API_KEY='secret2'\n", out.String())
+	})
+
+	t.Run("env format - secret contains newline and single quote, returns valid shell syntax", func(t *testing.T) {
+		t.Parallel()
+		server := newSecretGetTestServer(t, map[string]string{
+			"deploy_key":     "'sec\\nret1'",
+			"github_api_key": "se'c'ret2",
+		})
+		defer server.Close()
+
+		var out bytes.Buffer
+		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key", "github_api_key"}, "env"), &out, logger.NewBuffer())
+		require.NoError(t, err)
+		require.Equal(t, "DEPLOY_KEY=''\\''sec\\nret1'\\'''\nGITHUB_API_KEY='se'\\''c'\\''ret2'\n", out.String())
 	})
 
 	t.Run("api error returns error with details", func(t *testing.T) {
@@ -123,8 +137,8 @@ func TestSecretGet(t *testing.T) {
 
 		var out bytes.Buffer
 		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"missing_key"}, "default"), &out, logger.NewBuffer())
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Failed to fetch some secrets:")
-		assert.Contains(t, err.Error(), "missing_key")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Failed to fetch some secrets:")
+		require.Contains(t, err.Error(), "missing_key")
 	})
 }


### PR DESCRIPTION
### Description

Extracts the secretGet logic from the CLI action into a testable function, and adds a unit test suite for it. Also fixes the env format output to use single-quoted shell escaping (via shellQuote) instead of Go's %q double-quoting, so values are safe to source in shell without unintended interpolation.

### Context

The secretGet logic previously lived inside the cli.Command action, making it impossible to unit test without going through the CLI framework. The env format also used %q which produces Go-style double-quoted strings — not correct shell quoting for use with source or declare -x.

### Changes

- Extracted secretGet into a standalone function accepting 

- Fixed env format to use shellQuote (single quotes with '\'' escaping) instead of %q

- Added clicommand/secret_get_test.go 

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

Claude Code wrote some of the unit tests, then I changed most of it 😄 
