### PR TITLE
Add no-checkout-override flag

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -28,6 +28,7 @@ type AgentConfiguration struct {
 	GitSubmoduleCloneConfig         []string
 	SkipCheckout                    bool
 	GitSkipFetchExistingCommits     bool
+	NoCheckoutOverride              bool
 	CheckoutAttempts                int
 	AllowedRepositories             []*regexp.Regexp
 	AllowedPlugins                  []*regexp.Regexp

--- a/agent/integration/job_environment_integration_test.go
+++ b/agent/integration/job_environment_integration_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
@@ -227,5 +228,128 @@ func TestBuildkiteRequestHeaders(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("runJob() error = %v", err)
+	}
+}
+
+func TestCheckoutScopedJobEnvOverrideHonorsNoCheckoutOverride(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		varName            string
+		jobEnv             map[string]string
+		agentCfg           agent.AgentConfiguration
+		wantEnvValue       string
+		wantIgnoredEnvVars []string
+	}{
+		{
+			name:    "disabled_allows_job_env_to_override_clone_flags",
+			varName: "BUILDKITE_GIT_CLONE_FLAGS",
+			jobEnv: map[string]string{
+				"BUILDKITE_GIT_CLONE_FLAGS": "--no-tags",
+			},
+			agentCfg: agent.AgentConfiguration{
+				GitCloneFlags: "--mirror",
+			},
+			wantEnvValue: "--no-tags",
+		},
+		{
+			name:    "enabled_locks_clone_flags_to_agent_config",
+			varName: "BUILDKITE_GIT_CLONE_FLAGS",
+			jobEnv: map[string]string{
+				"BUILDKITE_GIT_CLONE_FLAGS": "--no-tags",
+			},
+			agentCfg: agent.AgentConfiguration{
+				GitCloneFlags:      "--mirror",
+				NoCheckoutOverride: true,
+			},
+			wantEnvValue:       "--mirror",
+			wantIgnoredEnvVars: []string{"BUILDKITE_GIT_CLONE_FLAGS"},
+		},
+		{
+			name:    "disabled_allows_job_env_to_enable_submodules",
+			varName: "BUILDKITE_GIT_SUBMODULES",
+			jobEnv: map[string]string{
+				"BUILDKITE_GIT_SUBMODULES": "true",
+			},
+			agentCfg: agent.AgentConfiguration{
+				GitSubmodules: false,
+			},
+			wantEnvValue: "true",
+		},
+		{
+			name:    "enabled_locks_submodules_to_agent_config",
+			varName: "BUILDKITE_GIT_SUBMODULES",
+			jobEnv: map[string]string{
+				"BUILDKITE_GIT_SUBMODULES": "true",
+			},
+			agentCfg: agent.AgentConfiguration{
+				GitSubmodules:      false,
+				NoCheckoutOverride: true,
+			},
+			wantEnvValue:       "false",
+			wantIgnoredEnvVars: []string{"BUILDKITE_GIT_SUBMODULES"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			jobEnv := map[string]string{
+				"BUILDKITE_COMMAND": "echo hello world",
+			}
+			for k, v := range tc.jobEnv {
+				jobEnv[k] = v
+			}
+
+			job := &api.Job{
+				ID:                 "my-job-id",
+				ChunksMaxSizeBytes: 1024,
+				Env:                jobEnv,
+				Token:              "bkaj_job-token",
+			}
+
+			mb := mockBootstrap(t)
+			defer mb.CheckAndClose(t) //nolint:errcheck // bintest logs to t
+
+			mb.Expect().Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
+				if got, want := c.GetEnv(tc.varName), tc.wantEnvValue; got != want {
+					t.Errorf("c.GetEnv(%s) = %q, want %q", tc.varName, got, want)
+					c.Exit(1)
+					return
+				}
+
+				ignored := strings.Split(strings.TrimSpace(c.GetEnv("BUILDKITE_IGNORED_ENV")), ",")
+				for _, wantIgnored := range tc.wantIgnoredEnvVars {
+					if !slices.Contains(ignored, wantIgnored) {
+						t.Errorf("BUILDKITE_IGNORED_ENV = %q, want it to contain %q", c.GetEnv("BUILDKITE_IGNORED_ENV"), wantIgnored)
+						c.Exit(1)
+						return
+					}
+				}
+				if len(tc.wantIgnoredEnvVars) == 0 && c.GetEnv("BUILDKITE_IGNORED_ENV") != "" {
+					t.Errorf("BUILDKITE_IGNORED_ENV = %q, want empty", c.GetEnv("BUILDKITE_IGNORED_ENV"))
+					c.Exit(1)
+					return
+				}
+
+				c.Exit(0)
+			})
+
+			e := createTestAgentEndpoint()
+			server := e.server()
+			defer server.Close()
+
+			if err := runJob(t, ctx, testRunJobConfig{
+				job:           job,
+				server:        server,
+				agentCfg:      tc.agentCfg,
+				mockBootstrap: mb,
+			}); err != nil {
+				t.Fatalf("runJob() error = %v", err)
+			}
+		})
 	}
 }

--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/internal/experiments"
 	"github.com/buildkite/bintest/v3"
 	"gotest.tools/v3/assert"
 )
@@ -269,6 +270,66 @@ func TestJobRunner_WhenJobHasToken_ItOverridesAccessToken(t *testing.T) {
 		job:           j,
 		server:        server,
 		agentCfg:      agent.AgentConfiguration{},
+		mockBootstrap: mb,
+	})
+	if err != nil {
+		t.Fatalf("runJob() error = %v", err)
+	}
+}
+
+func TestJobRunnerPassesNoCheckoutOverrideToBootstrapAndEnvFile(t *testing.T) {
+	t.Parallel()
+
+	ctx, _ := experiments.Enable(context.Background(), experiments.PropagateAgentConfigVars)
+
+	j := &api.Job{
+		ID:                 "my-job-id",
+		ChunksMaxSizeBytes: 1024,
+		Env: map[string]string{
+			"BUILDKITE_COMMAND": "echo hello world",
+		},
+		Token: "bkaj_job-token",
+	}
+
+	mb := mockBootstrap(t)
+	t.Cleanup(func() {
+		if err := mb.CheckAndClose(t); err != nil {
+			t.Errorf("mb.CheckAndClose(t) error = %v", err)
+		}
+	})
+
+	mb.Expect().Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
+		if got, want := c.GetEnv("BUILDKITE_NO_CHECKOUT_OVERRIDE"), "true"; got != want {
+			t.Errorf("c.GetEnv(BUILDKITE_NO_CHECKOUT_OVERRIDE) = %q, want %q", got, want)
+			c.Exit(1)
+			return
+		}
+
+		envFile := c.GetEnv("BUILDKITE_ENV_FILE")
+		contents, err := os.ReadFile(envFile)
+		if err != nil {
+			t.Errorf("os.ReadFile(%q) error = %v", envFile, err)
+			c.Exit(1)
+			return
+		}
+
+		if !strings.Contains(string(contents), "BUILDKITE_NO_CHECKOUT_OVERRIDE") {
+			t.Errorf("env file %q did not contain BUILDKITE_NO_CHECKOUT_OVERRIDE", envFile)
+			c.Exit(1)
+			return
+		}
+
+		c.Exit(0)
+	})
+
+	e := createTestAgentEndpoint()
+	server := e.server()
+	defer server.Close()
+
+	err := runJob(t, ctx, testRunJobConfig{
+		job:           j,
+		server:        server,
+		agentCfg:      agent.AgentConfiguration{NoCheckoutOverride: true},
 		mockBootstrap: mb,
 	})
 	if err != nil {

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -454,6 +454,7 @@ BUILDKITE_GIT_MIRRORS_PATH
 BUILDKITE_GIT_MIRRORS_SKIP_UPDATE
 BUILDKITE_GIT_SUBMODULES
 BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG
+BUILDKITE_NO_CHECKOUT_OVERRIDE
 BUILDKITE_CANCEL_GRACE_PERIOD
 BUILDKITE_COMMAND_EVAL
 BUILDKITE_LOCAL_HOOKS_ENABLED
@@ -577,6 +578,7 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 	if r.conf.AgentConfiguration.GitSkipFetchExistingCommits {
 		setEnv("BUILDKITE_GIT_SKIP_FETCH_EXISTING_COMMITS", "true")
 	}
+	setEnv("BUILDKITE_NO_CHECKOUT_OVERRIDE", fmt.Sprint(r.conf.AgentConfiguration.NoCheckoutOverride))
 	setEnv("BUILDKITE_CHECKOUT_ATTEMPTS", strconv.Itoa(r.conf.AgentConfiguration.CheckoutAttempts))
 	setEnv("BUILDKITE_COMMAND_EVAL", fmt.Sprint(r.conf.AgentConfiguration.CommandEval))
 	setEnv("BUILDKITE_PLUGINS_ENABLED", fmt.Sprint(r.conf.AgentConfiguration.PluginsEnabled))

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -428,6 +428,14 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 		}
 		env[name] = value
 	}
+	setCheckoutEnv := func(name, value string) {
+		if !r.conf.AgentConfiguration.NoCheckoutOverride {
+			if _, exists := env[name]; exists {
+				return
+			}
+		}
+		setEnv(name, value)
+	}
 
 	// Write out the job environment to file:
 	// - envShellFile: in k="v" format, with newlines escaped. If the
@@ -558,25 +566,25 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 	setEnv("BUILDKITE_CONFIG_PATH", r.conf.AgentConfiguration.ConfigPath)
 	setEnv("BUILDKITE_BUILD_PATH", r.conf.AgentConfiguration.BuildPath)
 	setEnv("BUILDKITE_SOCKETS_PATH", r.conf.AgentConfiguration.SocketsPath)
-	setEnv("BUILDKITE_GIT_MIRRORS_PATH", r.conf.AgentConfiguration.GitMirrorsPath)
-	setEnv("BUILDKITE_GIT_MIRRORS_SKIP_UPDATE", fmt.Sprint(r.conf.AgentConfiguration.GitMirrorsSkipUpdate))
+	setCheckoutEnv("BUILDKITE_GIT_MIRRORS_PATH", r.conf.AgentConfiguration.GitMirrorsPath)
+	setCheckoutEnv("BUILDKITE_GIT_MIRRORS_SKIP_UPDATE", fmt.Sprint(r.conf.AgentConfiguration.GitMirrorsSkipUpdate))
 	setEnv("BUILDKITE_HOOKS_PATH", r.conf.AgentConfiguration.HooksPath)
 	setEnv("BUILDKITE_ADDITIONAL_HOOKS_PATHS", strings.Join(r.conf.AgentConfiguration.AdditionalHooksPaths, ","))
 	setEnv("BUILDKITE_PLUGINS_PATH", r.conf.AgentConfiguration.PluginsPath)
-	setEnv("BUILDKITE_SSH_KEYSCAN", fmt.Sprint(r.conf.AgentConfiguration.SSHKeyscan))
+	setCheckoutEnv("BUILDKITE_SSH_KEYSCAN", fmt.Sprint(r.conf.AgentConfiguration.SSHKeyscan))
 	// Disable cloning submodules if specified in Agent config as precedence
 	// else allow pipeline/step env to control it via BUILDKITE_GIT_SUBMODULES
 	if !r.conf.AgentConfiguration.GitSubmodules {
-		setEnv("BUILDKITE_GIT_SUBMODULES", "false")
+		setCheckoutEnv("BUILDKITE_GIT_SUBMODULES", "false")
 	}
 	// Allow BUILDKITE_SKIP_CHECKOUT to be enabled either by agent config
 	// or by pipeline/step env
 	// This is here now to make it ready for if/when we add skip_checkout to the core app
 	if r.conf.AgentConfiguration.SkipCheckout {
-		setEnv("BUILDKITE_SKIP_CHECKOUT", "true")
+		setCheckoutEnv("BUILDKITE_SKIP_CHECKOUT", "true")
 	}
 	if r.conf.AgentConfiguration.GitSkipFetchExistingCommits {
-		setEnv("BUILDKITE_GIT_SKIP_FETCH_EXISTING_COMMITS", "true")
+		setCheckoutEnv("BUILDKITE_GIT_SKIP_FETCH_EXISTING_COMMITS", "true")
 	}
 	setEnv("BUILDKITE_NO_CHECKOUT_OVERRIDE", fmt.Sprint(r.conf.AgentConfiguration.NoCheckoutOverride))
 	setEnv("BUILDKITE_CHECKOUT_ATTEMPTS", strconv.Itoa(r.conf.AgentConfiguration.CheckoutAttempts))
@@ -589,14 +597,14 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 	}
 	setEnv("BUILDKITE_LOCAL_HOOKS_ENABLED", fmt.Sprint(r.conf.AgentConfiguration.LocalHooksEnabled))
 
-	setEnv("BUILDKITE_GIT_CHECKOUT_FLAGS", r.conf.AgentConfiguration.GitCheckoutFlags)
-	setEnv("BUILDKITE_GIT_CLONE_FLAGS", r.conf.AgentConfiguration.GitCloneFlags)
-	setEnv("BUILDKITE_GIT_FETCH_FLAGS", r.conf.AgentConfiguration.GitFetchFlags)
-	setEnv("BUILDKITE_GIT_CLONE_MIRROR_FLAGS", r.conf.AgentConfiguration.GitCloneMirrorFlags)
+	setCheckoutEnv("BUILDKITE_GIT_CHECKOUT_FLAGS", r.conf.AgentConfiguration.GitCheckoutFlags)
+	setCheckoutEnv("BUILDKITE_GIT_CLONE_FLAGS", r.conf.AgentConfiguration.GitCloneFlags)
+	setCheckoutEnv("BUILDKITE_GIT_FETCH_FLAGS", r.conf.AgentConfiguration.GitFetchFlags)
+	setCheckoutEnv("BUILDKITE_GIT_CLONE_MIRROR_FLAGS", r.conf.AgentConfiguration.GitCloneMirrorFlags)
 	setEnv("BUILDKITE_GIT_MIRROR_CHECKOUT_MODE", r.conf.AgentConfiguration.GitMirrorCheckoutMode)
-	setEnv("BUILDKITE_GIT_CLEAN_FLAGS", r.conf.AgentConfiguration.GitCleanFlags)
-	setEnv("BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT", strconv.Itoa(r.conf.AgentConfiguration.GitMirrorsLockTimeout))
-	setEnv("BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG", strings.Join(r.conf.AgentConfiguration.GitSubmoduleCloneConfig, ","))
+	setCheckoutEnv("BUILDKITE_GIT_CLEAN_FLAGS", r.conf.AgentConfiguration.GitCleanFlags)
+	setCheckoutEnv("BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT", strconv.Itoa(r.conf.AgentConfiguration.GitMirrorsLockTimeout))
+	setCheckoutEnv("BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG", strings.Join(r.conf.AgentConfiguration.GitSubmoduleCloneConfig, ","))
 
 	setEnv("BUILDKITE_SHELL", r.conf.AgentConfiguration.Shell)
 	setEnv("BUILDKITE_HOOKS_SHELL", r.conf.AgentConfiguration.HooksShell)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -169,6 +169,7 @@ type AgentStartConfig struct {
 	GitSubmoduleCloneConfig     []string `cli:"git-submodule-clone-config"`
 	SkipCheckout                bool     `cli:"skip-checkout"`
 	GitSkipFetchExistingCommits bool     `cli:"git-skip-fetch-existing-commits"`
+	NoCheckoutOverride          bool     `cli:"no-checkout-override"`
 	CheckoutAttempts            int      `cli:"checkout-attempts"`
 
 	NoSSHKeyscan            bool     `cli:"no-ssh-keyscan"`
@@ -524,6 +525,7 @@ var AgentStartCommand = cli.Command{
 
 		// Various git related flags shared with bootstrap
 		SkipCheckoutFlag,
+		NoCheckoutOverrideFlag,
 		GitCheckoutFlagsFlag,
 		GitCloneFlagsFlag,
 		GitCleanFlagsFlag,
@@ -1065,6 +1067,7 @@ var AgentStartCommand = cli.Command{
 			GitSubmoduleCloneConfig:         cfg.GitSubmoduleCloneConfig,
 			SkipCheckout:                    cfg.SkipCheckout,
 			GitSkipFetchExistingCommits:     cfg.GitSkipFetchExistingCommits,
+			NoCheckoutOverride:              cfg.NoCheckoutOverride,
 			CheckoutAttempts:                cfg.CheckoutAttempts,
 			SSHKeyscan:                      !cfg.NoSSHKeyscan,
 			CommandEval:                     !cfg.NoCommandEval,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -225,6 +225,12 @@ type AgentStartConfig struct {
 	DisconnectAfterJobTimeout          int           `cli:"disconnect-after-job-timeout" deprecated:"Use disconnect-after-idle-timeout instead"`
 }
 
+func (cfg *AgentStartConfig) lockCheckoutWhenCommandEvalDisabled() {
+	if cfg.NoCommandEval {
+		cfg.NoCheckoutOverride = true
+	}
+}
+
 func (asc AgentStartConfig) Features(ctx context.Context) []string {
 	if asc.NoFeatureReporting {
 		return []string{}
@@ -897,6 +903,8 @@ var AgentStartCommand = cli.Command{
 		if (cfg.NoCommandEval || cfg.NoLocalHooks) && !isSetNoPlugins {
 			cfg.NoPlugins = true
 		}
+
+		cfg.lockCheckoutWhenCommandEvalDisabled()
 
 		// Guess the shell if none is provided
 		if cfg.Shell == "" {

--- a/clicommand/agent_start_test.go
+++ b/clicommand/agent_start_test.go
@@ -223,3 +223,69 @@ func TestAgentStartJobAcquisitionRejected_ExitCode27(t *testing.T) {
 	assert.True(t, errors.As(cliErr, &exitErr), "Expected cli.ExitError, got: %v", cliErr)
 	assert.Equal(t, 27, exitErr.ExitCode(), "Expected exit code 27 for job acquisition rejected, got: %d", exitErr.ExitCode())
 }
+
+func TestNoCheckoutOverrideEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  AgentStartConfig
+		bCfg BootstrapConfig
+		kind string
+		want bool
+	}{
+		{
+			name: "agent_start_explicit_flag",
+			cfg:  AgentStartConfig{NoCheckoutOverride: true},
+			kind: "agent",
+			want: true,
+		},
+		{
+			name: "agent_start_no_command_eval_forces_lock",
+			cfg:  AgentStartConfig{NoCommandEval: true},
+			kind: "agent",
+			want: true,
+		},
+		{
+			name: "agent_start_defaults_unlocked",
+			cfg:  AgentStartConfig{},
+			kind: "agent",
+			want: false,
+		},
+		{
+			name: "bootstrap_explicit_flag",
+			bCfg: BootstrapConfig{NoCheckoutOverride: true, CommandEval: true},
+			kind: "bootstrap",
+			want: true,
+		},
+		{
+			name: "bootstrap_command_eval_disabled_forces_lock",
+			bCfg: BootstrapConfig{CommandEval: false},
+			kind: "bootstrap",
+			want: true,
+		},
+		{
+			name: "bootstrap_defaults_unlocked",
+			bCfg: BootstrapConfig{CommandEval: true},
+			kind: "bootstrap",
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			switch tc.kind {
+			case "agent":
+				tc.cfg.lockCheckoutWhenCommandEvalDisabled()
+				assert.Equal(t, tc.want, tc.cfg.NoCheckoutOverride)
+			case "bootstrap":
+				tc.bCfg.lockCheckoutWhenCommandEvalDisabled()
+				assert.Equal(t, tc.want, tc.bCfg.NoCheckoutOverride)
+			default:
+				t.Fatalf("unknown test kind %q", tc.kind)
+			}
+		})
+	}
+}

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -116,6 +116,12 @@ type BootstrapConfig struct {
 	CheckoutAttempts             int      `cli:"checkout-attempts"`
 }
 
+func (cfg *BootstrapConfig) lockCheckoutWhenCommandEvalDisabled() {
+	if !cfg.CommandEval {
+		cfg.NoCheckoutOverride = true
+	}
+}
+
 var BootstrapCommand = cli.Command{
 	Name:        "bootstrap",
 	Usage:       "Harness used internally by the agent to run jobs as subprocesses",
@@ -418,6 +424,8 @@ var BootstrapCommand = cli.Command{
 		if err != nil {
 			return fmt.Errorf("while parsing trace context encoding: %v", err)
 		}
+
+		cfg.lockCheckoutWhenCommandEvalDisabled()
 
 		// Configure the bootstraper
 		bootstrap := job.New(job.ExecutorConfig{

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -81,6 +81,7 @@ type BootstrapConfig struct {
 	GitMirrorsLockTimeout        int      `cli:"git-mirrors-lock-timeout"`
 	GitMirrorsSkipUpdate         bool     `cli:"git-mirrors-skip-update"`
 	GitSubmoduleCloneConfig      []string `cli:"git-submodule-clone-config" normalize:"list"`
+	NoCheckoutOverride           bool     `cli:"no-checkout-override"`
 	BinPath                      string   `cli:"bin-path" normalize:"filepath"`
 	BuildPath                    string   `cli:"build-path" normalize:"filepath"`
 	HooksPath                    string   `cli:"hooks-path" normalize:"filepath"`
@@ -236,6 +237,7 @@ var BootstrapCommand = cli.Command{
 
 		// Various git related flags shared with agent start
 		SkipCheckoutFlag,
+		NoCheckoutOverrideFlag,
 		GitCheckoutFlagsFlag,
 		GitCloneFlagsFlag,
 		GitCloneMirrorFlagsFlag,
@@ -431,6 +433,7 @@ var BootstrapCommand = cli.Command{
 			CleanCheckout:                cfg.CleanCheckout,
 			SkipCheckout:                 cfg.SkipCheckout,
 			GitSkipFetchExistingCommits:  cfg.GitSkipFetchExistingCommits,
+			NoCheckoutOverride:           cfg.NoCheckoutOverride,
 			Command:                      cfg.Command,
 			CommandEval:                  cfg.CommandEval,
 			Commit:                       cfg.Commit,

--- a/clicommand/env_set.go
+++ b/clicommand/env_set.go
@@ -69,7 +69,7 @@ var EnvSetCommand = cli.Command{
 
 func envSetAction(c *cli.Context) error {
 	ctx := context.Background()
-	ctx, cfg, l, _, done := setupLoggerAndConfig[EnvSetConfig](ctx, c)
+	ctx, cfg, _, _, done := setupLoggerAndConfig[EnvSetConfig](ctx, c)
 	defer done()
 
 	client, err := jobapi.NewDefaultClient(ctx)
@@ -129,7 +129,7 @@ func envSetAction(c *cli.Context) error {
 
 	resp, err := client.EnvUpdate(ctx, req)
 	if err != nil {
-		l.Error("Couldn't update the job executor environment: %v", err)
+		return fmt.Errorf("couldn't update the job executor environment: %w", err)
 	}
 
 	switch cfg.OutputFormat {

--- a/clicommand/env_unset.go
+++ b/clicommand/env_unset.go
@@ -67,7 +67,7 @@ var EnvUnsetCommand = cli.Command{
 
 func envUnsetAction(c *cli.Context) error {
 	ctx := context.Background()
-	ctx, cfg, l, _, done := setupLoggerAndConfig[EnvUnsetConfig](ctx, c)
+	ctx, cfg, _, _, done := setupLoggerAndConfig[EnvUnsetConfig](ctx, c)
 	defer done()
 
 	client, err := jobapi.NewDefaultClient(ctx)
@@ -120,7 +120,7 @@ func envUnsetAction(c *cli.Context) error {
 
 	unset, err := client.EnvDelete(ctx, del)
 	if err != nil {
-		l.Error("couldn't unset the job executor environment variables: %v", err)
+		return fmt.Errorf("couldn't unset the job executor environment variables: %w", err)
 	}
 
 	switch cfg.OutputFormat {

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -193,6 +193,12 @@ var (
 		EnvVar: "BUILDKITE_SKIP_CHECKOUT",
 	}
 
+	NoCheckoutOverrideFlag = cli.BoolFlag{
+		Name:   "no-checkout-override",
+		Usage:  "Prevent hooks, plugins, Job API, and secrets from overriding scoped checkout settings (default: false)",
+		EnvVar: "BUILDKITE_NO_CHECKOUT_OVERRIDE",
+	}
+
 	GitCheckoutFlagsFlag = cli.StringFlag{
 		Name:   "git-checkout-flags",
 		Value:  "-f",

--- a/env/protected.go
+++ b/env/protected.go
@@ -63,6 +63,11 @@ var protectedEnv = map[string]protection{
 	"BUILDKITE_SHELL":                       {},
 }
 
+// checkoutOverrideScope contains checkout-related vars that remain mutable in
+// hooks, plugins, Job API, and secrets by default so jobs can tailor checkout
+// behavior. When checkout override is enabled, those same vars become locked so
+// agent checkout config wins and git flags cannot be used to undermine
+// no-command-eval.
 var checkoutOverrideScope = map[string]struct{}{
 	"BUILDKITE_GIT_CHECKOUT_FLAGS":              {},
 	"BUILDKITE_GIT_CLEAN_FLAGS":                 {},

--- a/env/protected.go
+++ b/env/protected.go
@@ -22,16 +22,6 @@ type protection struct {
 // disables plugins, but even if it is changed by a hook, the agent doesn't
 // reconfigure no-command-eval based on any changes.)
 //
-// Git flags are an example of vars that are primarily driven by agent config,
-// but we want to allow plugins to set git flags to alter the default checkout
-// process (see for example the git-clean plugin). Doing this deliberately
-// reconfigures the executor (see ReadFromEnvironment and config struct tags in
-// internal/job/config.go).
-// But we don't want the job env from the backend to be able to set them,
-// because git is riddled with shell injections, and someone with privileges to
-// start a build and supply env vars could then bypass protections like
-// no-command-eval.
-//
 // The actual enforcement of protected env within the agent level (overriding
 // job-level env vars based on agent configuration) happens implicitly rather
 // than relying on this map - see createEnvironment in agent/job_runner.go.
@@ -45,41 +35,47 @@ type protection struct {
 // filter backend-supplied vars, and such vars are still necessary for a job to
 // function.
 //
-// When updating ExecutorConfig in internal/job/config.go, ensure
-// mutableFromWithinJob is enabled here for reconfigurable vars.
+// When updating ExecutorConfig in internal/job/config.go, ensure always-
+// protected reconfigurable vars set mutableFromWithinJob here, and checkout-
+// scoped vars are added to checkoutOverrideScope below.
 var protectedEnv = map[string]protection{
-	"BUILDKITE_AGENT_ACCESS_TOKEN":              {},
-	"BUILDKITE_AGENT_DEBUG":                     {},
-	"BUILDKITE_AGENT_ENDPOINT":                  {},
-	"BUILDKITE_AGENT_PID":                       {},
-	"BUILDKITE_ARTIFACT_PATHS":                  {mutableFromWithinJob: true},
-	"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION":     {mutableFromWithinJob: true},
-	"BUILDKITE_BIN_PATH":                        {},
-	"BUILDKITE_BUILD_PATH":                      {},
-	"BUILDKITE_COMMAND_EVAL":                    {},
-	"BUILDKITE_CONFIG_PATH":                     {},
-	"BUILDKITE_CONTAINER_COUNT":                 {},
-	"BUILDKITE_GIT_CHECKOUT_FLAGS":              {mutableFromWithinJob: true},
-	"BUILDKITE_GIT_CLEAN_FLAGS":                 {mutableFromWithinJob: true},
-	"BUILDKITE_GIT_CLONE_FLAGS":                 {mutableFromWithinJob: true},
-	"BUILDKITE_GIT_CLONE_MIRROR_FLAGS":          {mutableFromWithinJob: true},
-	"BUILDKITE_GIT_FETCH_FLAGS":                 {mutableFromWithinJob: true},
+	"BUILDKITE_AGENT_ACCESS_TOKEN":          {},
+	"BUILDKITE_AGENT_DEBUG":                 {},
+	"BUILDKITE_AGENT_ENDPOINT":              {},
+	"BUILDKITE_AGENT_PID":                   {},
+	"BUILDKITE_ARTIFACT_PATHS":              {mutableFromWithinJob: true},
+	"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": {mutableFromWithinJob: true},
+	"BUILDKITE_BIN_PATH":                    {},
+	"BUILDKITE_BUILD_PATH":                  {},
+	"BUILDKITE_COMMAND_EVAL":                {},
+	"BUILDKITE_CONFIG_PATH":                 {},
+	"BUILDKITE_CONTAINER_COUNT":             {},
+	"BUILDKITE_HOOKS_PATH":                  {},
+	"BUILDKITE_HOOKS_SHELL":                 {},
+	"BUILDKITE_KUBERNETES_EXEC":             {},
+	"BUILDKITE_LOCAL_HOOKS_ENABLED":         {},
+	"BUILDKITE_NO_CHECKOUT_OVERRIDE":        {},
+	"BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH":  {mutableFromWithinJob: true},
+	"BUILDKITE_PLUGINS_ENABLED":             {},
+	"BUILDKITE_PLUGINS_PATH":                {},
+	"BUILDKITE_REFSPEC":                     {mutableFromWithinJob: true},
+	"BUILDKITE_REPO":                        {mutableFromWithinJob: true},
+	"BUILDKITE_SHELL":                       {},
+}
+
+var checkoutOverrideScope = map[string]struct{}{
+	"BUILDKITE_GIT_CHECKOUT_FLAGS":              {},
+	"BUILDKITE_GIT_CLEAN_FLAGS":                 {},
+	"BUILDKITE_GIT_CLONE_FLAGS":                 {},
+	"BUILDKITE_GIT_CLONE_MIRROR_FLAGS":          {},
+	"BUILDKITE_GIT_FETCH_FLAGS":                 {},
 	"BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT":        {},
 	"BUILDKITE_GIT_MIRRORS_PATH":                {},
-	"BUILDKITE_GIT_MIRRORS_SKIP_UPDATE":         {mutableFromWithinJob: true},
-	"BUILDKITE_GIT_SKIP_FETCH_EXISTING_COMMITS": {mutableFromWithinJob: true},
-	"BUILDKITE_GIT_SUBMODULES":                  {mutableFromWithinJob: true},
-	"BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG":      {mutableFromWithinJob: true},
-	"BUILDKITE_HOOKS_PATH":                      {},
-	"BUILDKITE_HOOKS_SHELL":                     {},
-	"BUILDKITE_KUBERNETES_EXEC":                 {},
-	"BUILDKITE_LOCAL_HOOKS_ENABLED":             {},
-	"BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH":      {mutableFromWithinJob: true},
-	"BUILDKITE_PLUGINS_ENABLED":                 {},
-	"BUILDKITE_PLUGINS_PATH":                    {},
-	"BUILDKITE_REFSPEC":                         {mutableFromWithinJob: true},
-	"BUILDKITE_REPO":                            {mutableFromWithinJob: true},
-	"BUILDKITE_SHELL":                           {},
+	"BUILDKITE_GIT_MIRRORS_SKIP_UPDATE":         {},
+	"BUILDKITE_GIT_SKIP_FETCH_EXISTING_COMMITS": {},
+	"BUILDKITE_GIT_SUBMODULES":                  {},
+	"BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG":      {},
+	"BUILDKITE_SKIP_CHECKOUT":                   {},
 	"BUILDKITE_SSH_KEYSCAN":                     {},
 }
 
@@ -99,4 +95,9 @@ func IsProtectedFromWithinJob(name string) bool {
 		return false
 	}
 	return !prot.mutableFromWithinJob
+}
+
+func IsCheckoutOverrideScoped(name string) bool {
+	_, exists := checkoutOverrideScope[normalizeKeyName(name)]
+	return exists
 }

--- a/env/protected_test.go
+++ b/env/protected_test.go
@@ -17,22 +17,14 @@ func TestProtectedEnv(t *testing.T) {
 		"BUILDKITE_COMMAND_EVAL",
 		"BUILDKITE_CONFIG_PATH",
 		"BUILDKITE_CONTAINER_COUNT",
-		"BUILDKITE_GIT_CLEAN_FLAGS",
-		"BUILDKITE_GIT_CLONE_FLAGS",
-		"BUILDKITE_GIT_CLONE_MIRROR_FLAGS",
-		"BUILDKITE_GIT_FETCH_FLAGS",
-		"BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT",
-		"BUILDKITE_GIT_MIRRORS_PATH",
-		"BUILDKITE_GIT_MIRRORS_SKIP_UPDATE",
-		"BUILDKITE_GIT_SUBMODULES",
 		"BUILDKITE_HOOKS_PATH",
 		"BUILDKITE_KUBERNETES_EXEC",
 		"BUILDKITE_LOCAL_HOOKS_ENABLED",
+		"BUILDKITE_NO_CHECKOUT_OVERRIDE",
 		"BUILDKITE_PLUGINS_ENABLED",
 		"BUILDKITE_PLUGINS_PATH",
 		"BUILDKITE_SHELL",
 		"BUILDKITE_HOOKS_SHELL",
-		"BUILDKITE_SSH_KEYSCAN",
 	}
 
 	// Verify that all expected variables are protected
@@ -48,6 +40,10 @@ func TestProtectedEnv(t *testing.T) {
 		"SECRET_KEY",
 		"DATABASE_URL",
 		"API_TOKEN",
+		"BUILDKITE_GIT_CLONE_FLAGS",
+		"BUILDKITE_GIT_SUBMODULES",
+		"BUILDKITE_SKIP_CHECKOUT",
+		"BUILDKITE_SSH_KEYSCAN",
 		"BUILDKITE_BRANCH",  // This is a standard build env var, not protected
 		"BUILDKITE_COMMIT",  // This is a standard build env var, not protected
 		"BUILDKITE_MESSAGE", // This is a standard build env var, not protected
@@ -67,5 +63,52 @@ func TestIsProtected_Normalised(t *testing.T) {
 
 	if got != want {
 		t.Errorf("IsProtected(%q) = %t, want %t", name, got, want)
+	}
+}
+
+func TestCheckoutOverrideScope(t *testing.T) {
+	t.Parallel()
+
+	scoped := []string{
+		"BUILDKITE_GIT_CHECKOUT_FLAGS",
+		"BUILDKITE_GIT_CLONE_FLAGS",
+		"BUILDKITE_GIT_CLONE_MIRROR_FLAGS",
+		"BUILDKITE_GIT_CLEAN_FLAGS",
+		"BUILDKITE_GIT_FETCH_FLAGS",
+		"BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG",
+		"BUILDKITE_GIT_MIRRORS_PATH",
+		"BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT",
+		"BUILDKITE_GIT_MIRRORS_SKIP_UPDATE",
+		"BUILDKITE_GIT_SUBMODULES",
+		"BUILDKITE_GIT_SKIP_FETCH_EXISTING_COMMITS",
+		"BUILDKITE_SKIP_CHECKOUT",
+		"BUILDKITE_SSH_KEYSCAN",
+	}
+
+	for _, envVar := range scoped {
+		if got := IsCheckoutOverrideScoped(envVar); !got {
+			t.Errorf("IsCheckoutOverrideScoped(%q) = false, want true", envVar)
+		}
+	}
+
+	for _, envVar := range []string{
+		"BUILDKITE_GIT_CLONE_FLAGS",
+		"BUILDKITE_GIT_SUBMODULES",
+		"BUILDKITE_SKIP_CHECKOUT",
+		"BUILDKITE_SSH_KEYSCAN",
+	} {
+		if got := IsProtected(envVar); got {
+			t.Errorf("IsProtected(%q) = true, want false", envVar)
+		}
+	}
+
+	for _, envVar := range []string{
+		"BUILDKITE_GIT_MIRROR_CHECKOUT_MODE",
+		"BUILDKITE_COMMAND_EVAL",
+		"MY_CUSTOM_VAR",
+	} {
+		if got := IsCheckoutOverrideScoped(envVar); got {
+			t.Errorf("IsCheckoutOverrideScoped(%q) = true, want false", envVar)
+		}
 	}
 }

--- a/internal/job/api.go
+++ b/internal/job/api.go
@@ -30,6 +30,9 @@ We'll continue to run your job, but you won't be able to use the Job API`)
 	if e.Debug {
 		jobAPIOpts = append(jobAPIOpts, jobapi.WithDebug())
 	}
+	if e.NoCheckoutOverride {
+		jobAPIOpts = append(jobAPIOpts, jobapi.WithNoCheckoutOverride(true))
+	}
 	srv, token, err := jobapi.NewServer(e.shell.Logger, socketPath, e.shell.Env, e.redactors, jobAPIOpts...)
 	if err != nil {
 		return cleanup, fmt.Errorf("creating job API server: %w", err)

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -83,6 +83,9 @@ type ExecutorConfig struct {
 	// Skip git fetch if the commit already exists locally
 	GitSkipFetchExistingCommits bool `env:"BUILDKITE_GIT_SKIP_FETCH_EXISTING_COMMITS"`
 
+	// This intentionally has no env tag so hooks cannot disable it at runtime.
+	NoCheckoutOverride bool
+
 	// Flags to pass to "git checkout" command
 	GitCheckoutFlags string `env:"BUILDKITE_GIT_CHECKOUT_FLAGS"`
 

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -20,7 +20,7 @@ import (
 // To add a new config option that is mapped from an environment variable, add a
 // struct tag, then don't forget to add a corresponding CLI flag over in the
 // clicommand/bootstrap.go(BootstrapConfig) struct, otherwise it won't work.
-// Also check the protectedEnv map in env/protected.go.
+// Also check protectedEnv and checkoutOverrideScope in env/protected.go.
 
 type ExecutorConfig struct {
 	// The command to run
@@ -228,6 +228,10 @@ func (c *ExecutorConfig) ReadFromEnvironment(environ *env.Environment) map[strin
 
 		// Find struct fields with env tag
 		if tag := f.Tag.Get("env"); tag != "" && environ.Exists(tag) {
+			if c.NoCheckoutOverride && env.IsCheckoutOverrideScoped(tag) {
+				continue
+			}
+
 			newStr, _ := environ.Get(tag)
 
 			switch v.Kind() {

--- a/internal/job/config_test.go
+++ b/internal/job/config_test.go
@@ -93,6 +93,46 @@ func TestReadFromEnvironmentIgnoresMalformedBooleans(t *testing.T) {
 	}
 }
 
+func TestReadFromEnvironmentDoesNotRefreshNoCheckoutOverride(t *testing.T) {
+	t.Parallel()
+
+	config := &ExecutorConfig{NoCheckoutOverride: true}
+	environ := env.FromSlice([]string{"BUILDKITE_NO_CHECKOUT_OVERRIDE=false"})
+
+	changes := config.ReadFromEnvironment(environ)
+	if len(changes) != 0 {
+		t.Errorf("changes = %v, want none", changes)
+	}
+	if got, want := config.NoCheckoutOverride, true; got != want {
+		t.Errorf("config.NoCheckoutOverride = %t, want %t", got, want)
+	}
+}
+
+func TestReadFromEnvironmentSkipsCheckoutScopedVarsWhenNoCheckoutOverrideEnabled(t *testing.T) {
+	t.Parallel()
+
+	config := &ExecutorConfig{
+		NoCheckoutOverride: true,
+		SkipCheckout:       false,
+		GitCloneFlags:      "-v",
+	}
+	environ := env.FromSlice([]string{
+		"BUILDKITE_SKIP_CHECKOUT=true",
+		"BUILDKITE_GIT_CLONE_FLAGS=--mirror",
+	})
+
+	changes := config.ReadFromEnvironment(environ)
+	if len(changes) != 0 {
+		t.Errorf("changes = %v, want none", changes)
+	}
+	if got, want := config.SkipCheckout, false; got != want {
+		t.Errorf("config.SkipCheckout = %t, want %t", got, want)
+	}
+	if got, want := config.GitCloneFlags, "-v"; got != want {
+		t.Errorf("config.GitCloneFlags = %q, want %q", got, want)
+	}
+}
+
 func TestGitSubmodulesBidirectionalControl(t *testing.T) {
 	t.Parallel()
 

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -634,7 +634,8 @@ func (e *Executor) applyEnvironmentChanges(changes hook.EnvChanges) {
 	// breaks the rest of the job.
 	var protected []string
 	for k := range changes.Diff.Keys {
-		if env.IsProtectedFromWithinJob(k) {
+		if env.IsProtectedFromWithinJob(k) ||
+			(e.NoCheckoutOverride && env.IsCheckoutOverrideScoped(k)) {
 			protected = append(protected, k)
 			changes.Diff.Remove(k)
 		}
@@ -974,6 +975,9 @@ func (e *Executor) fetchAndSetSecrets(ctx context.Context) error {
 				// Check if the environment variable is protected
 				if env.IsProtected(pipelineSecret.EnvironmentVariable) {
 					return fmt.Errorf("secret %q cannot set protected environment variable %q", pipelineSecret.Key, pipelineSecret.EnvironmentVariable)
+				}
+				if e.NoCheckoutOverride && env.IsCheckoutOverrideScoped(pipelineSecret.EnvironmentVariable) {
+					return fmt.Errorf("secret %q cannot set checkout-locked environment variable %q while BUILDKITE_NO_CHECKOUT_OVERRIDE is enabled", pipelineSecret.Key, pipelineSecret.EnvironmentVariable)
 				}
 
 				var alreadySet bool

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -120,6 +120,78 @@ func TestHooksCanUnsetEnvironmentVariables(t *testing.T) {
 	tester.RunAndCheck(t, "MY_CUSTOM_ENV=1")
 }
 
+func TestEnvironmentHookNoCheckoutOverride(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		noCheckoutOverride  bool
+		wantSkipCheckoutEnv string
+		wantBlockedWarning  bool
+	}{
+		{
+			name:                "disabled_allows_mutation",
+			wantSkipCheckoutEnv: "true",
+		},
+		{
+			name:               "enabled_blocks_mutation",
+			noCheckoutOverride: true,
+			wantBlockedWarning: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tester, err := NewExecutorTester(mainCtx)
+			if err != nil {
+				t.Fatalf("NewExecutorTester() error = %v", err)
+			}
+			defer tester.Close()
+
+			filename := "environment"
+			script := []string{
+				"#!/usr/bin/env bash",
+				"export BUILDKITE_SKIP_CHECKOUT=true",
+			}
+			if runtime.GOOS == "windows" {
+				filename = "environment.bat"
+				script = []string{
+					"@echo off",
+					"set BUILDKITE_SKIP_CHECKOUT=true",
+				}
+			}
+
+			if err := os.WriteFile(filepath.Join(tester.HooksDir, filename), []byte(strings.Join(script, "\n")), 0o700); err != nil {
+				t.Fatalf("os.WriteFile(%q, script, 0o700) = %v", filename, err)
+			}
+
+			tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
+				if got, want := c.GetEnv("BUILDKITE_SKIP_CHECKOUT"), tc.wantSkipCheckoutEnv; got != want {
+					fmt.Fprintf(c.Stderr, "Expected BUILDKITE_SKIP_CHECKOUT=%q, got %q\n", want, got)
+					c.Exit(1)
+					return
+				}
+				c.Exit(0)
+			})
+
+			env := []string{}
+			if tc.noCheckoutOverride {
+				env = append(env, "BUILDKITE_NO_CHECKOUT_OVERRIDE=true")
+			}
+
+			tester.RunAndCheck(t, env...)
+
+			containsWarning := strings.Contains(tester.Output, "env vars were blocked") &&
+				strings.Contains(tester.Output, "BUILDKITE_SKIP_CHECKOUT")
+			if containsWarning != tc.wantBlockedWarning {
+				t.Fatalf("blocked warning presence = %t, want %t\noutput: %s", containsWarning, tc.wantBlockedWarning, tester.Output)
+			}
+		})
+	}
+}
+
 func TestDirectoryPassesBetweenHooks(t *testing.T) {
 	t.Parallel()
 

--- a/internal/job/integration/secrets_integration_test.go
+++ b/internal/job/integration/secrets_integration_test.go
@@ -565,3 +565,74 @@ func TestSecretsIntegration_ProtectedEnvironmentVariableRejection(t *testing.T) 
 		}
 	}
 }
+
+func TestSecretsIntegration_NoCheckoutOverride(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		noCheckoutOverride bool
+		wantErr            bool
+	}{
+		{name: "disabled_allows_checkout_scoped_secret"},
+		{name: "enabled_rejects_checkout_locked_secret", noCheckoutOverride: true, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tester, err := NewExecutorTester(mainCtx)
+			if err != nil {
+				t.Fatalf("setting up executor tester: %v", err)
+			}
+			defer tester.Close()
+
+			apiServer := setupSecretsAPIServer(t, map[string]string{"CLONE_FLAGS_SECRET": "--mirror"})
+			defer apiServer.Close()
+
+			secretsJSON, err := json.Marshal([]pipeline.Secret{{
+				Key:                 "CLONE_FLAGS_SECRET",
+				EnvironmentVariable: "BUILDKITE_GIT_CLONE_FLAGS",
+			}})
+			if err != nil {
+				t.Fatalf("marshaling secrets: %v", err)
+			}
+
+			if !tc.wantErr {
+				tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
+					if got, want := c.GetEnv("BUILDKITE_GIT_CLONE_FLAGS"), "--mirror"; got != want {
+						fmt.Fprintf(c.Stderr, "Expected BUILDKITE_GIT_CLONE_FLAGS=%q, got %q\n", want, got)
+						c.Exit(1)
+						return
+					}
+					c.Exit(0)
+				})
+			}
+
+			env := []string{
+				fmt.Sprintf("BUILDKITE_SECRETS_CONFIG=%s", string(secretsJSON)),
+				fmt.Sprintf("BUILDKITE_AGENT_ENDPOINT=%s", apiServer.URL),
+			}
+			if tc.noCheckoutOverride {
+				env = append(env, "BUILDKITE_NO_CHECKOUT_OVERRIDE=true")
+			}
+
+			err = tester.Run(t, env...)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected job to fail due to checkout-locked secret mapping, but it succeeded. Full output: %s", tester.Output)
+				}
+				if !strings.Contains(tester.Output, "checkout-locked environment variable") || !strings.Contains(tester.Output, "BUILDKITE_GIT_CLONE_FLAGS") {
+					t.Fatalf("expected output to mention checkout-locked env rejection, got: %s", tester.Output)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("running executor tester: %v", err)
+			}
+			tester.CheckMocks(t)
+		})
+	}
+}

--- a/jobapi/env.go
+++ b/jobapi/env.go
@@ -36,7 +36,7 @@ func (s *Server) patchEnv(w http.ResponseWriter, r *http.Request) {
 
 	added := make([]string, 0, len(req.Env))
 	updated := make([]string, 0, len(req.Env))
-	protected := checkProtected(slices.Collect(maps.Keys(req.Env)))
+	protected := s.checkProtected(slices.Collect(maps.Keys(req.Env)))
 
 	if len(protected) > 0 {
 		err := socket.WriteError(
@@ -106,7 +106,7 @@ func (s *Server) deleteEnv(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	protected := checkProtected(req.Keys)
+	protected := s.checkProtected(req.Keys)
 	if len(protected) > 0 {
 		err := socket.WriteError(
 			w,
@@ -138,12 +138,13 @@ func (s *Server) deleteEnv(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func checkProtected(candidates []string) []string {
+func (s *Server) checkProtected(candidates []string) []string {
 	protected := make([]string, 0, len(candidates))
 	for _, c := range candidates {
 		// The Job API is only accessible from within the job, so allow writes
 		// to vars that allow write from within job.
-		if env.IsProtectedFromWithinJob(c) {
+		if env.IsProtectedFromWithinJob(c) ||
+			(s.noCheckoutOverride && env.IsCheckoutOverrideScoped(c)) {
 			protected = append(protected, c)
 		}
 	}

--- a/jobapi/server.go
+++ b/jobapi/server.go
@@ -22,6 +22,12 @@ func WithDebug() ServerOpts {
 	}
 }
 
+func WithNoCheckoutOverride(enabled bool) ServerOpts {
+	return func(s *Server) {
+		s.noCheckoutOverride = enabled
+	}
+}
+
 // Server is a Job API server. It provides an HTTP API with which to interact with the job currently running in the buildkite agent
 // and allows jobs to introspect and mutate their own state
 type Server struct {
@@ -30,9 +36,10 @@ type Server struct {
 	Logger     shell.Logger
 	debug      bool
 
-	mtx       sync.RWMutex
-	environ   *env.Environment
-	redactors *replacer.Mux
+	mtx                sync.RWMutex
+	environ            *env.Environment
+	redactors          *replacer.Mux
+	noCheckoutOverride bool
 
 	token   string
 	sockSvr *socket.Server

--- a/jobapi/server_test.go
+++ b/jobapi/server_test.go
@@ -36,12 +36,18 @@ func testEnviron() *env.Environment {
 	return e
 }
 
-func testServer(t *testing.T, e *env.Environment, mux *replacer.Mux) (*jobapi.Server, string, error) {
+func testEnvironWith(key, value string) *env.Environment {
+	e := testEnviron()
+	e.Set(key, value)
+	return e
+}
+
+func testServer(t *testing.T, e *env.Environment, mux *replacer.Mux, opts ...jobapi.ServerOpts) (*jobapi.Server, string, error) {
 	sockName, err := jobapi.NewSocketPath(os.TempDir())
 	if err != nil {
 		return nil, "", fmt.Errorf("creating socket path: %w", err)
 	}
-	return jobapi.NewServer(shell.TestingLogger{T: t}, sockName, e, mux)
+	return jobapi.NewServer(shell.TestingLogger{T: t}, sockName, e, mux, opts...)
 }
 
 func testSocketClient(socketPath string) *http.Client {
@@ -343,6 +349,121 @@ func TestPatchEnv(t *testing.T) {
 			testAPI(t, environ, req, client, c)
 		})
 	}
+}
+
+func TestPatchEnvAllowsCheckoutScopedVarsWhenNoCheckoutOverrideDisabled(t *testing.T) {
+	t.Parallel()
+
+	environ := testEnvironWith("BUILDKITE_GIT_CLONE_FLAGS", "-v")
+	srv, token, err := testServer(t, environ, replacer.NewMux())
+	if err != nil {
+		t.Fatalf("creating server: %v", err)
+	}
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("starting server: %v", err)
+	}
+	defer func() {
+		if err := srv.Stop(); err != nil {
+			t.Fatalf("stopping server: %v", err)
+		}
+	}()
+
+	buf := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(buf).Encode(&jobapi.EnvUpdateRequestPayload{
+		Env: map[string]*string{"BUILDKITE_GIT_CLONE_FLAGS": pt("--mirror")},
+	}); err != nil {
+		t.Fatalf("encoding request body: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPatch, "http://job/api/current-job/v0/env", buf)
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	testAPI(t, environ, req, testSocketClient(srv.SocketPath), apiTestCase[jobapi.EnvUpdateRequestPayload, jobapi.EnvUpdateResponse]{
+		expectedStatus: http.StatusOK,
+		expectedEnv:    testEnvironWith("BUILDKITE_GIT_CLONE_FLAGS", "--mirror").Dump(),
+	})
+}
+
+func TestPatchEnvRejectsCheckoutScopedVarsWhenNoCheckoutOverrideEnabled(t *testing.T) {
+	t.Parallel()
+
+	environ := testEnvironWith("BUILDKITE_SKIP_CHECKOUT", "false")
+	srv, token, err := testServer(t, environ, replacer.NewMux(), jobapi.WithNoCheckoutOverride(true))
+	if err != nil {
+		t.Fatalf("creating server: %v", err)
+	}
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("starting server: %v", err)
+	}
+	defer func() {
+		if err := srv.Stop(); err != nil {
+			t.Fatalf("stopping server: %v", err)
+		}
+	}()
+
+	buf := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(buf).Encode(&jobapi.EnvUpdateRequestPayload{
+		Env: map[string]*string{"BUILDKITE_SKIP_CHECKOUT": pt("true")},
+	}); err != nil {
+		t.Fatalf("encoding request body: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPatch, "http://job/api/current-job/v0/env", buf)
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	testAPI(t, environ, req, testSocketClient(srv.SocketPath), apiTestCase[jobapi.EnvUpdateRequestPayload, jobapi.EnvUpdateResponse]{
+		expectedStatus: http.StatusUnprocessableEntity,
+		expectedError: &jobapi.ErrorResponse{
+			Error: "the following environment variables are protected, and cannot be modified: [BUILDKITE_SKIP_CHECKOUT]",
+		},
+		expectedEnv: testEnvironWith("BUILDKITE_SKIP_CHECKOUT", "false").Dump(),
+	})
+}
+
+func TestDeleteEnvRejectsCheckoutScopedVarsWhenNoCheckoutOverrideEnabled(t *testing.T) {
+	t.Parallel()
+
+	environ := testEnvironWith("BUILDKITE_SKIP_CHECKOUT", "false")
+	srv, token, err := testServer(t, environ, replacer.NewMux(), jobapi.WithNoCheckoutOverride(true))
+	if err != nil {
+		t.Fatalf("creating server: %v", err)
+	}
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("starting server: %v", err)
+	}
+	defer func() {
+		if err := srv.Stop(); err != nil {
+			t.Fatalf("stopping server: %v", err)
+		}
+	}()
+
+	buf := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(buf).Encode(&jobapi.EnvDeleteRequest{Keys: []string{"BUILDKITE_SKIP_CHECKOUT"}}); err != nil {
+		t.Fatalf("encoding request body: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, "http://job/api/current-job/v0/env", buf)
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	testAPI(t, environ, req, testSocketClient(srv.SocketPath), apiTestCase[jobapi.EnvDeleteRequest, jobapi.EnvDeleteResponse]{
+		expectedStatus: http.StatusUnprocessableEntity,
+		expectedError: &jobapi.ErrorResponse{
+			Error: "the following environment variables are protected, and cannot be modified: [BUILDKITE_SKIP_CHECKOUT]",
+		},
+		expectedEnv: testEnvironWith("BUILDKITE_SKIP_CHECKOUT", "false").Dump(),
+	})
 }
 
 func TestGetEnv(t *testing.T) {


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

This PR adds `no-checkout-override`, a flag that lets agent config lock checkout-related env vars.

Without the flag, checkout-scoped vars stay mutable and agent checkout config acts as a default. 
With the flag on, those vars become locked and agent checkout config acts as a hard override.

I looked at a couple of other approaches, like patching each surface separately or making checkout vars always protected, but both felt worse. One would have kept the behavior inconsistent, and the other would have changed the unlocked case.

Other approaches considered: adding `checkoutScoped` bool to the `protectedEnv` map, in addition to existing `mutableFromWithinJob` bool.

PR into `feat/git-checkout-features` which is meant to be used as a feature branch for all the checkout improvements.

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

https://linear.app/buildkite/issue/SUP-6423

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

- add the `no-checkout-override` flag
- split checkout-scoped env vars out from the always-protected env set
- only lock checkout-scoped vars when `BUILDKITE_NO_CHECKOUT_OVERRIDE=true`
- apply that rule to:
  - hook and plugin env mutation
  - Job API env updates and deletes
  - pipeline secrets
  - bootstrap / job-runner env merging
- add regression coverage for:
  - bootstrap-boundary env behavior
  - hook behavior
  - secrets behavior

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
