### PR TITLE
Register application/zstd MIME type for .zst files

### DIFF
--- a/internal/mime/generate.go
+++ b/internal/mime/generate.go
@@ -129,6 +129,17 @@ func addNginxTypes(types map[string]string) error {
 	return nil
 }
 
+func addZstdTypes(types map[string]string) error {
+	// RFC 8878 registers application/zstd with extension "zst".
+	// Apache/nginx mime.types have not universally adopted this yet,
+	// so set it explicitly unless already present.
+	const zstdMime = "application/zstd"
+	if _, ok := types["zst"]; !ok {
+		types["zst"] = zstdMime
+	}
+	return nil
+}
+
 func addYamlTypes(types map[string]string) error {
 	// Most recent movement on the IEFT is
 	// https://mailarchive.ietf.org/arch/msg/media-types/bdCyTe91zNz-i-9tuJGDa9bHcpQ/
@@ -155,6 +166,10 @@ func generate() error {
 		return err
 	}
 	err = addYamlTypes(types)
+	if err != nil {
+		return err
+	}
+	err = addZstdTypes(types)
 	if err != nil {
 		return err
 	}

--- a/internal/mime/mime.go
+++ b/internal/mime/mime.go
@@ -1038,4 +1038,5 @@ var types = map[string]string{
 	".zir":         "application/vnd.zul",
 	".zirz":        "application/vnd.zul",
 	".zmm":         "application/vnd.handheld-entertainment+xml",
+	".zst":         "application/zstd",
 }


### PR DESCRIPTION
### Description

Support the Zstandard MIME type `application/zstd` for files with the `.zst` extension. This mapping is defined by [RFC 8878](https://datatracker.ietf.org/doc/html/rfc8878) but is not yet present in the Apache or nginx `mime.types` sources that drive `internal/mime/mime.go`. Without it, the agent's artifact uploader falls through to the OS `/etc/mime.types` (inconsistent across platforms) or the empty-string fallback, meaning `.zst` artifacts were uploaded with an incorrect or generic Content-Type.

In practice, `.zst` artifacts show up in the Buildkite UI as `binary/octet-stream`:

<img width="405" height="166" alt="Screenshot 2026-04-28 at 11 41 58 AM" src="https://github.com/user-attachments/assets/ba1b5b1f-133c-4fa7-84cb-b11242facebf" />

Alternatives considered:
- Directly editing the generated `mime.go` — rejected because it's auto-generated and the next regeneration would clobber the change.
- Registering via `mime.AddExtensionType` at runtime — redundant given the static map is consulted first.

### Context

`internal/mime/generate.go` already has an `addYamlTypes` override for a similar case (IETF-registered but not yet in upstream `mime.types`). This PR follows the same pattern for `.zst`.


### Changes

- `internal/mime/generate.go`: add `addZstdTypes` function (mirrors `addYamlTypes`), call it from `generate()`.
- `internal/mime/mime.go`: regenerated via `go generate ./...` — adds a single entry `".zst": "application/zstd"`.

### Testing
- [x] Tests have run locally (`go test ./internal/mime/...` — passes; the existing `TestTypeByExtension` iterates the full map and covers the new entry)
- [x] Code is formatted (generator runs `gofumpt` on the output)

### Disclosures / Credits

Claude Code (Opus 4.7) investigated the MIME handling pipeline, implemented the generator override, regenerated `mime.go`, and drafted this PR body. I reviewed and directed each step.