### PR TITLE
Bump go-pipeline to v0.17.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20221221133751-67e37ae746cd
 	github.com/buildkite/bintest/v3 v3.3.0
 	github.com/buildkite/go-buildkite/v4 v4.19.0
-	github.com/buildkite/go-pipeline v0.16.0
+	github.com/buildkite/go-pipeline v0.17.0
 	github.com/buildkite/interpolate v0.1.5
 	github.com/buildkite/roko v1.4.0
 	github.com/buildkite/shellwords v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/buildkite/bintest/v3 v3.3.0 h1:RTWcSaJRlOT6t/K311ejPf+0J3LE/QEODzVG3v
 github.com/buildkite/bintest/v3 v3.3.0/go.mod h1:btqpTsVODiJcb0NMdkkmtMQ6xoFc2W/nY5yy+3I0zcs=
 github.com/buildkite/go-buildkite/v4 v4.19.0 h1:HPc6+V/Ky6v8eDWHxyvzHtxuhruCLUyuRrChOKvJE1I=
 github.com/buildkite/go-buildkite/v4 v4.19.0/go.mod h1:8+7GiWBKwEPAWoZnRU/kpNCt46j1iVH8kFMMbD4YDfc=
-github.com/buildkite/go-pipeline v0.16.0 h1:wEgWUMRAgSg1ZnWOoA3AovtYYdTvN0dLY1zwUWmPP+4=
-github.com/buildkite/go-pipeline v0.16.0/go.mod h1:VE37qY3X5pmAKKUMoDZvPsHOQuyakB9cmXj9Qn6QasA=
+github.com/buildkite/go-pipeline v0.17.0 h1:/80mKEgxxNA2o63y10viKkG9NO8tyKBXYKn0ivUw5bQ=
+github.com/buildkite/go-pipeline v0.17.0/go.mod h1:VE37qY3X5pmAKKUMoDZvPsHOQuyakB9cmXj9Qn6QasA=
 github.com/buildkite/interpolate v0.1.5 h1:v2Ji3voik69UZlbfoqzx+qfcsOKLA61nHdU79VV+tPU=
 github.com/buildkite/interpolate v0.1.5/go.mod h1:dHnrwHew5O8VNOAgMDpwRlFnhL5VSN6M1bHVmRZ9Ccc=
 github.com/buildkite/roko v1.4.0 h1:DxixoCdpNqxu4/1lXrXbfsKbJSd7r1qoxtef/TT2J80=


### PR DESCRIPTION
### Description

`go-pipeline` was updated to replace the yaml parsing with json to allow for greater character usage within a pipeline definition. This was changed for both `CommandStep` and `Plugins`, allowing those blocks to now include additional control characters that the yaml parser would otherwise reject. The rejection is forceful, meaning that the pipeline would be entirely discarded and prevent any running.

### Context

Part of A-1170

### Changes

Bump `buildkite/go-pipeline` to `v0.17.0`

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

I edited `go.mod` with my trusty `nvim` and then ran `go mod tidy` and `go test ./...`