### PR TITLE
fix: Add automatic tracing to CLI subcommands

### DIFF
--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/roko"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 const (
@@ -115,6 +116,8 @@ var AnnotateCommand = cli.Command{
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[AnnotateConfig](ctx, c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "annotate")
+		defer span.End()
 
 		if err := annotate(ctx, cfg, l); err != nil {
 			return err

--- a/clicommand/annotation_remove.go
+++ b/clicommand/annotation_remove.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/roko"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 const annotationRemoveHelpDescription = `Usage:
@@ -64,6 +65,8 @@ var AnnotationRemoveCommand = cli.Command{
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[AnnotationRemoveConfig](ctx, c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "annotation-remove")
+		defer span.End()
 
 		// Create the API client
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))

--- a/clicommand/artifact_download.go
+++ b/clicommand/artifact_download.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/internal/artifact"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 const downloadHelpDescription = `Usage:
@@ -84,6 +85,8 @@ var ArtifactDownloadCommand = cli.Command{
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[ArtifactDownloadConfig](ctx, c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "artifact-download")
+		defer span.End()
 
 		// Create the API client
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -11,6 +11,7 @@ import (
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/internal/artifact"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 const searchHelpDescription = `Usage:
@@ -117,6 +118,8 @@ var ArtifactSearchCommand = cli.Command{
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[ArtifactSearchConfig](ctx, c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "artifact-search")
+		defer span.End()
 
 		printFormat := cfg.PrintFormat
 		if strings.Contains(printFormat, `"`) {

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -11,6 +11,7 @@ import (
 	"github.com/buildkite/agent/v3/internal/artifact"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 const shasumHelpDescription = `Usage:
@@ -91,6 +92,8 @@ var ArtifactShasumCommand = cli.Command{
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[ArtifactShasumConfig](ctx, c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "artifact-shasum")
+		defer span.End()
 		return searchAndPrintShaSum(ctx, cfg, l, os.Stdout)
 	},
 }

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/internal/artifact"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 const uploadHelpDescription = `Usage:
@@ -136,6 +137,9 @@ var ArtifactUploadCommand = cli.Command{
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[ArtifactUploadConfig](ctx, c)
 		defer done()
+
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "artifact-upload")
+		defer span.End()
 
 		// Create the API client
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))

--- a/clicommand/cache_restore.go
+++ b/clicommand/cache_restore.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/buildkite/agent/v3/internal/cache"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 const cacheRestoreHelpDescription = `Usage:
@@ -76,6 +77,8 @@ var CacheRestoreCommand = cli.Command{
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[CacheRestoreConfig](ctx, c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "cache-restore")
+		defer span.End()
 
 		l.Info("Cache restore command executed")
 

--- a/clicommand/cache_save.go
+++ b/clicommand/cache_save.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/buildkite/agent/v3/internal/cache"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 const cacheSaveHelpDescription = `Usage:
@@ -70,6 +71,8 @@ var CacheSaveCommand = cli.Command{
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[CacheSaveConfig](ctx, c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "cache-save")
+		defer span.End()
 
 		l.Info("Cache save command executed")
 

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -12,10 +12,14 @@ import (
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/cliconfig"
 	"github.com/buildkite/agent/v3/internal/experiments"
+	"github.com/buildkite/agent/v3/internal/job"
 	"github.com/buildkite/agent/v3/logger"
+	"github.com/buildkite/agent/v3/tracetools"
 	"github.com/buildkite/agent/v3/version"
 	"github.com/oleiade/reflections"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 const (
@@ -537,5 +541,32 @@ func setupLoggerAndConfig[T any](ctx context.Context, c *cli.Context, opts ...co
 
 	// Setup any global configuration options
 	ctx, done = HandleGlobalFlags(ctx, l, cfg)
+
+	// If this process is a subcommand running inside a traced job, initialize
+	// a TracerProvider so spans emitted here appear under the parent job's trace.
+	if os.Getenv("BUILDKITE_TRACING_BACKEND") == tracetools.BackendOpenTelemetry {
+		if traceParent := os.Getenv("TRACEPARENT"); traceParent != "" {
+			serviceName := os.Getenv("BUILDKITE_TRACING_SERVICE_NAME")
+			traceProvider, err := job.InitOTelTracerProvider(ctx, serviceName, nil)
+			if err != nil {
+				l.Warn("Failed to initialize tracing: %v", err)
+			} else {
+				carrier := propagation.MapCarrier{"traceparent": traceParent}
+				if traceState := os.Getenv("TRACESTATE"); traceState != "" {
+					carrier["tracestate"] = traceState
+				}
+				ctx = otel.GetTextMapPropagator().Extract(ctx, carrier)
+				prevDone := done
+				done = func() {
+					prevDone()
+					flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+					defer cancel()
+					_ = traceProvider.ForceFlush(flushCtx)
+					_ = traceProvider.Shutdown(flushCtx)
+				}
+			}
+		}
+	}
+
 	return ctx, cfg, l, loader.File, done
 }

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/roko"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 const metaDataExistsHelpDescription = `Usage:
@@ -55,6 +56,8 @@ var MetaDataExistsCommand = cli.Command{
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[MetaDataExistsConfig](ctx, c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "meta-data-exists")
+		defer span.End()
 
 		// Create the API client
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/roko"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 const metaDataGetHelpDescription = `Usage:
@@ -60,6 +61,8 @@ var MetaDataGetCommand = cli.Command{
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[MetaDataGetConfig](ctx, c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "meta-data-get")
+		defer span.End()
 
 		// Create the API client
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))

--- a/clicommand/meta_data_keys.go
+++ b/clicommand/meta_data_keys.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/roko"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 const metaDataKeysHelpDescription = `Usage:
@@ -54,6 +55,8 @@ var MetaDataKeysCommand = cli.Command{
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[MetaDataKeysConfig](ctx, c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "meta-data-keys")
+		defer span.End()
 
 		// Create the API client
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildkite/agent/v3/internal/redact"
 	"github.com/buildkite/roko"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 const metaDataSetHelpDescription = `Usage:
@@ -63,6 +64,8 @@ var MetaDataSetCommand = cli.Command{
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[MetaDataSetConfig](ctx, c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "meta-data-set")
+		defer span.End()
 
 		// Read the value from STDIN if argument omitted entirely
 		if len(c.Args()) < 2 {

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -11,6 +11,7 @@ import (
 	"github.com/buildkite/agent/v3/jobapi"
 	"github.com/buildkite/roko"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 type OIDCTokenConfig struct {
@@ -103,6 +104,8 @@ var OIDCRequestTokenCommand = cli.Command{
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[OIDCTokenConfig](ctx, c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "oidc-request-token")
+		defer span.End()
 
 		// Note: if --lifetime is omitted, cfg.Lifetime = 0
 		if cfg.Lifetime < 0 {

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -37,6 +37,7 @@ import (
 	"github.com/buildkite/go-pipeline/warning"
 	"github.com/buildkite/interpolate"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 	"gopkg.in/yaml.v3"
 )
 
@@ -194,6 +195,8 @@ var PipelineUploadCommand = cli.Command{
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[PipelineUploadConfig](ctx, c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "pipeline-upload")
+		defer span.End()
 
 		// Find the pipeline either from STDIN or the non-flag arguments
 		type input struct {

--- a/clicommand/secret_get.go
+++ b/clicommand/secret_get.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildkite/agent/v3/jobapi"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 type SecretGetConfig struct {
@@ -86,6 +87,8 @@ Examples:
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[SecretGetConfig](ctx, c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "secret-get")
+		defer span.End()
 		return secretGet(ctx, cfg, c.App.Writer, l)
 	},
 }

--- a/clicommand/step_cancel.go
+++ b/clicommand/step_cancel.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/roko"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 const stepCancelHelpDescription = `Usage:
@@ -71,6 +72,8 @@ var StepCancelCommand = cli.Command{
 	Action: func(c *cli.Context) error {
 		ctx, cfg, l, _, done := setupLoggerAndConfig[StepCancelConfig](context.Background(), c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "step-cancel")
+		defer span.End()
 
 		if cfg.ForceGracePeriodSeconds < 0 {
 			return fmt.Errorf("the value of ′--force-grace-period-seconds′ must be greater than or equal to 0")

--- a/clicommand/step_get.go
+++ b/clicommand/step_get.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/roko"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 const stepGetHelpDescription = `Usage:
@@ -67,6 +68,8 @@ var StepGetCommand = cli.Command{
 	Action: func(c *cli.Context) error {
 		ctx, cfg, l, _, done := setupLoggerAndConfig[StepGetConfig](context.Background(), c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "step-get")
+		defer span.End()
 
 		// Create the API client
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildkite/agent/v3/internal/redact"
 	"github.com/buildkite/roko"
 	"github.com/urfave/cli"
+	"go.opentelemetry.io/otel"
 )
 
 const stepUpdateHelpDescription = `Usage:
@@ -82,6 +83,8 @@ var StepUpdateCommand = cli.Command{
 	Action: func(c *cli.Context) error {
 		ctx, cfg, l, _, done := setupLoggerAndConfig[StepUpdateConfig](context.Background(), c)
 		defer done()
+		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "step-update")
+		defer span.End()
 
 		// Read the value from STDIN if argument omitted entirely
 		if len(c.Args()) < 2 {

--- a/internal/job/tracing.go
+++ b/internal/job/tracing.go
@@ -181,7 +181,7 @@ func (e *Executor) startTracingOpenTelemetry(ctx context.Context) (tracetools.Sp
 	extras, warnings := toOpenTelemetryAttributes(GenericTracingExtras(e, e.shell.Env))
 	for k, v := range warnings {
 		e.shell.Warningf("Unknown attribute type (key: %v, value: %v (%T)) passed when initialising OpenTelemetry. This is a bug, submit this error message at https://github.com/buildkite/agent/issues", k, v, v)
-		e.shell.Warningf("OpenTelemetry will still work, but the attribute %v and its value above will not be included", v)
+		e.shell.Warningf("OpenTelemetry will still work, but the attribute %v and its value above will not be included", k)
 	}
 
 	tracerProvider, err := InitOTelTracerProvider(ctx, e.TracingServiceName, extras)

--- a/internal/job/tracing.go
+++ b/internal/job/tracing.go
@@ -127,8 +127,10 @@ func (e *Executor) otRootSpanName() string {
 	return base + "job"
 }
 
-func (e *Executor) startTracingOpenTelemetry(ctx context.Context) (tracetools.Span, context.Context, stopper) {
-	// Set up trace exporter based on protocol
+// initOTelTracerProvider creates and globally registers an OpenTelemetry TracerProvider
+// and text map propagator. Caller must call ForceFlush and Shutdown
+// on the returned provider before the process exits.
+func InitOTelTracerProvider(ctx context.Context, serviceName string, extraAttrs []attribute.KeyValue) (*sdktrace.TracerProvider, error) {
 	protocol := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
 	// default to grpc to avoid breaking change
 	if protocol == "" {
@@ -143,27 +145,18 @@ func (e *Executor) startTracingOpenTelemetry(ctx context.Context) (tracetools.Sp
 	case "http/protobuf", "http":
 		exporter, err = otlptracehttp.New(ctx)
 	default:
-		e.shell.Errorf("Unsupported OTLP protocol: %s. Disabling tracing.", protocol)
-		return &tracetools.NoopSpan{}, ctx, noopStopper
+		return nil, fmt.Errorf("unsupported OTLP protocol: %s", protocol)
 	}
 	if err != nil {
-		e.shell.Errorf("Error creating OTLP trace exporter %s. Disabling tracing.", err)
-		return &tracetools.NoopSpan{}, ctx, noopStopper
+		return nil, fmt.Errorf("creating OTLP trace exporter: %w", err)
 	}
 
 	attributes := []attribute.KeyValue{
-		semconv.ServiceNameKey.String(e.TracingServiceName),
+		semconv.ServiceNameKey.String(serviceName),
 		semconv.ServiceVersionKey.String(version.Version()),
 		semconv.DeploymentEnvironmentKey.String("ci"),
 	}
-
-	extras, warnings := toOpenTelemetryAttributes(GenericTracingExtras(e, e.shell.Env))
-	for k, v := range warnings {
-		e.shell.Warningf("Unknown attribute type (key: %v, value: %v (%T)) passed when initialising OpenTelemetry. This is a bug, submit this error message at https://github.com/buildkite/agent/issues", k, v, v)
-		e.shell.Warningf("OpenTelemetry will still work, but the attribute %v and its value above will not be included", v)
-	}
-
-	attributes = append(attributes, extras...)
+	attributes = append(attributes, extraAttrs...)
 
 	resources := resource.NewWithAttributes(semconv.SchemaURL, attributes...)
 	tracerProvider := sdktrace.NewTracerProvider(
@@ -180,6 +173,22 @@ func (e *Executor) startTracingOpenTelemetry(ctx context.Context) (tracetools.Sp
 		&ot.OT{},
 		&xray.Propagator{},
 	))
+
+	return tracerProvider, nil
+}
+
+func (e *Executor) startTracingOpenTelemetry(ctx context.Context) (tracetools.Span, context.Context, stopper) {
+	extras, warnings := toOpenTelemetryAttributes(GenericTracingExtras(e, e.shell.Env))
+	for k, v := range warnings {
+		e.shell.Warningf("Unknown attribute type (key: %v, value: %v (%T)) passed when initialising OpenTelemetry. This is a bug, submit this error message at https://github.com/buildkite/agent/issues", k, v, v)
+		e.shell.Warningf("OpenTelemetry will still work, but the attribute %v and its value above will not be included", v)
+	}
+
+	tracerProvider, err := InitOTelTracerProvider(ctx, e.TracingServiceName, extras)
+	if err != nil {
+		e.shell.Errorf("Error initialising OpenTelemetry tracing: %s. Disabling tracing.", err)
+		return &tracetools.NoopSpan{}, ctx, noopStopper
+	}
 
 	tracer := tracerProvider.Tracer(
 		"buildkite-agent",


### PR DESCRIPTION
### Description

When `BUILDKITE_TRACING_BACKEND=opentelemetry` is configured, the bootstrap process initialises a TracerProvider and creates spans for each job phase (artifact-upload, etc.). However, subcommands like `buildkite-agent artifact upload `run as separate OS processes and never initialised their own TracerProvider, so even though `TRACEPARENT` and `BUILDKITE_TRACING_BACKEND` were present in their environment, no spans were emitted. The executor's phase spans were not visible internally.

### Context
https://linear.app/buildkite/issue/A-1168/add-automatic-tracing-to-cli-subcommands-artifact-upload-pipeline

### Changes
- internal/job/tracing.go — extracted InitOTelTracerProvider as a standalone exported function; startTracingOpenTelemetry now delegates to it

- clicommand/global.go — setupLoggerAndConfig now initialises a TracerProvider and extracts TRACEPARENT/TRACESTATE into context when running as a subprocess of a traced job

Every subcommand (`artifact upload`, `pipeline upload`, etc.) gets tracing for free.

- `ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "<sub-command-name>")`
create a new span named after the sub-command-name. Because ctx already has the parent trace context extracted from `TRACEPARENT`, OTel automatically makes this span a child of the executor's span. 

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

Grafana screenshots:
<img width="1988" height="1524" alt="image" src="https://github.com/user-attachments/assets/3bb35886-0d9a-43c9-a312-2115bdff77bc" /> 
<img width="1988" height="1524" alt="image" src="https://github.com/user-attachments/assets/b4bf2fad-d26d-4663-9064-339eb7636e03" />



### Disclosures / Credits
Implementation was carried out in consultation with Claude 
