### PR TITLE
Replace `cancel-grace-period` and `signal-grace-period-seconds` with `cancel-signal-timeout` and `cancel-cleanup-timeout`

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -58,8 +58,8 @@ type AgentConfiguration struct {
 	DisconnectAfterJob           bool
 	DisconnectAfterIdleTimeout   time.Duration
 	DisconnectAfterUptime        time.Duration
-	CancelGracePeriod            int
-	SignalGracePeriod            time.Duration
+	CancelSignalTimeout          time.Duration
+	CancelCleanupTimeout         time.Duration
 	EnableJobLogTmpfile          bool
 	JobLogPath                   string
 	WriteJobLogsToStdout         bool

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -360,7 +360,7 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient *api.Client, c
 			Stdout:            r.jobLogs,
 			Stderr:            r.jobLogs,
 			InterruptSignal:   cancelSignal,
-			SignalGracePeriod: conf.AgentConfiguration.SignalGracePeriod,
+			SignalGracePeriod: conf.AgentConfiguration.CancelSignalTimeout,
 		})
 	}
 
@@ -599,8 +599,8 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 	setEnv("BUILDKITE_AGENT_EXPERIMENT", strings.Join(experiments.Enabled(ctx), ","))
 	setEnv("BUILDKITE_REDACTED_VARS", strings.Join(r.conf.AgentConfiguration.RedactedVars, ","))
 	setEnv("BUILDKITE_STRICT_SINGLE_HOOKS", fmt.Sprint(r.conf.AgentConfiguration.StrictSingleHooks))
-	setEnv("BUILDKITE_CANCEL_GRACE_PERIOD", strconv.Itoa(r.conf.AgentConfiguration.CancelGracePeriod))
-	setEnv("BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS", strconv.Itoa(int(r.conf.AgentConfiguration.SignalGracePeriod/time.Second)))
+	setEnv("BUILDKITE_CANCEL_SIGNAL_TIMEOUT", r.conf.AgentConfiguration.CancelSignalTimeout.String())
+	setEnv("BUILDKITE_CANCEL_CLEANUP_TIMEOUT", r.conf.AgentConfiguration.CancelCleanupTimeout.String())
 	setEnv("BUILDKITE_TRACE_CONTEXT_ENCODING", r.conf.AgentConfiguration.TraceContextEncoding)
 
 	if !r.conf.AgentConfiguration.AllowMultipartArtifactUpload {

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -597,7 +597,7 @@ func (r *JobRunner) Cancel(reason CancelReason) error {
 	r.agentLogger.Info(
 		"Canceling job %s with a signal grace period of %v (%s)",
 		r.conf.Job.ID,
-		r.conf.AgentConfiguration.SignalGracePeriod,
+		r.conf.AgentConfiguration.CancelSignalTimeout,
 		reason,
 	)
 
@@ -614,11 +614,11 @@ func (r *JobRunner) Cancel(reason CancelReason) error {
 	// Extra time between the end of the signal grace period and the end of the
 	// cancel grace period is the time we (agent side) need to upload logs and
 	// disconnect (if the agent is exiting).
-	case <-time.After(r.conf.AgentConfiguration.SignalGracePeriod):
+	case <-time.After(r.conf.AgentConfiguration.CancelSignalTimeout):
 		r.agentLogger.Info(
 			"Job %s hasn't stopped within %v, terminating",
 			r.conf.Job.ID,
-			r.conf.AgentConfiguration.SignalGracePeriod,
+			r.conf.AgentConfiguration.CancelSignalTimeout,
 		)
 
 		// Terminate the process as we've exceeded our context

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -112,13 +112,13 @@ type AgentStartConfig struct {
 	VerificationJWKSFile        string `cli:"verification-jwks-file" normalize:"filepath"`
 	VerificationFailureBehavior string `cli:"verification-failure-behavior"`
 
-	AcquireJob                 string `cli:"acquire-job"`
-	DisconnectAfterJob         bool   `cli:"disconnect-after-job"`
-	DisconnectAfterIdleTimeout int    `cli:"disconnect-after-idle-timeout"`
-	DisconnectAfterUptime      int    `cli:"disconnect-after-uptime"`
-	CancelGracePeriod          int    `cli:"cancel-grace-period"`
-	SignalGracePeriodSeconds   int    `cli:"signal-grace-period-seconds"`
-	ReflectExitStatus          bool   `cli:"reflect-exit-status"`
+	AcquireJob                 string        `cli:"acquire-job"`
+	DisconnectAfterJob         bool          `cli:"disconnect-after-job"`
+	DisconnectAfterIdleTimeout int           `cli:"disconnect-after-idle-timeout"`
+	DisconnectAfterUptime      int           `cli:"disconnect-after-uptime"`
+	CancelSignalTimeout        time.Duration `cli:"cancel-signal-timeout"`
+	CancelCleanupTimeout       time.Duration `cli:"cancel-cleanup-timeout"`
+	ReflectExitStatus          bool          `cli:"reflect-exit-status"`
 
 	EnableJobLogTmpfile bool   `cli:"enable-job-log-tmpfile"`
 	JobLogPath          string `cli:"job-log-path" normalize:"filepath"`
@@ -406,7 +406,7 @@ var AgentStartCommand = cli.Command{
 			Usage:  "The maximum uptime in seconds before the agent stops accepting new jobs and shuts down after any running jobs complete. The default of 0 means no timeout",
 			EnvVar: "BUILDKITE_AGENT_DISCONNECT_AFTER_UPTIME",
 		},
-		cancelGracePeriodFlag,
+		cancelSignalTimeoutFlag,
 		cli.BoolFlag{
 			Name:   "enable-job-log-tmpfile",
 			Usage:  "Store the job logs in a temporary file ′BUILDKITE_JOB_LOG_TMPFILE′ that is accessible during the job and removed at the end of the job (default: false)",
@@ -670,7 +670,7 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_AGENT_SPAWN_WITH_PRIORITY",
 		},
 		cancelSignalFlag,
-		signalGracePeriodSecondsFlag,
+		cancelCleanupTimeoutFlag,
 		cli.StringFlag{
 			Name:   "tracing-backend",
 			Usage:  `Enable tracing for build jobs by specifying a backend, "datadog" or "opentelemetry"`,
@@ -893,11 +893,6 @@ var AgentStartCommand = cli.Command{
 			}
 		}
 
-		signalGracePeriod, err := signalGracePeriod(cfg.CancelGracePeriod, cfg.SignalGracePeriodSeconds)
-		if err != nil {
-			return err
-		}
-
 		if _, err := tracetools.ParseEncoding(cfg.TraceContextEncoding); err != nil {
 			return fmt.Errorf("while parsing trace context encoding: %v", err)
 		}
@@ -927,7 +922,10 @@ var AgentStartCommand = cli.Command{
 
 		// if the agent is provided a KMS key ID, it should use the KMS signer, otherwise
 		// it should load the JWKS from the file
-		var verificationJWKS any
+		var (
+			verificationJWKS any
+			err              error
+		)
 		switch {
 		case cfg.SigningAWSKMSKey != "":
 
@@ -1031,8 +1029,8 @@ var AgentStartCommand = cli.Command{
 			DisconnectAfterJob:              cfg.DisconnectAfterJob,
 			DisconnectAfterIdleTimeout:      time.Duration(cfg.DisconnectAfterIdleTimeout) * time.Second,
 			DisconnectAfterUptime:           time.Duration(cfg.DisconnectAfterUptime) * time.Second,
-			CancelGracePeriod:               cfg.CancelGracePeriod,
-			SignalGracePeriod:               signalGracePeriod,
+			CancelSignalTimeout:             cfg.CancelSignalTimeout,
+			CancelCleanupTimeout:            cfg.CancelCleanupTimeout,
 			EnableJobLogTmpfile:             cfg.EnableJobLogTmpfile,
 			JobLogPath:                      cfg.JobLogPath,
 			WriteJobLogsToStdout:            cfg.WriteJobLogsToStdout,
@@ -1278,7 +1276,7 @@ var AgentStartCommand = cli.Command{
 				agent.AgentWorkerConfig{
 					AgentConfiguration: agentConf,
 					CancelSignal:       cancelSig,
-					SignalGracePeriod:  signalGracePeriod,
+					SignalGracePeriod:  cfg.CancelSignalTimeout,
 					Debug:              cfg.Debug,
 					DebugHTTP:          cfg.DebugHTTP,
 					SpawnIndex:         i,
@@ -1302,7 +1300,7 @@ var AgentStartCommand = cli.Command{
 		poolSigs := &poolSignals{
 			log:               l,
 			pool:              pool,
-			cancelGracePeriod: time.Duration(cfg.CancelGracePeriod) * time.Second,
+			cancelGracePeriod: cfg.CancelSignalTimeout + cfg.CancelCleanupTimeout,
 			// Under Kubernetes, there is no user interactively signalling us,
 			// so on SIGTERM, stop un-gracefully.
 			skipGraceful: cfg.KubernetesExec,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -48,71 +48,71 @@ Example:
     $ buildkite-agent bootstrap --build-path builds`
 
 type BootstrapConfig struct {
-	Command                      string   `cli:"command"`
-	JobID                        string   `cli:"job" validate:"required"`
-	Repository                   string   `cli:"repository" validate:"required"`
-	Commit                       string   `cli:"commit" validate:"required"`
-	Branch                       string   `cli:"branch" validate:"required"`
-	Tag                          string   `cli:"tag"`
-	RefSpec                      string   `cli:"refspec"`
-	Plugins                      string   `cli:"plugins"`
-	Secrets                      string   `cli:"secrets"`
-	PullRequest                  string   `cli:"pullrequest"`
-	PullRequestUsingMergeRefspec bool     `cli:"pull-request-using-merge-refspec"`
-	GitSubmodules                bool     `cli:"git-submodules"`
-	SSHKeyscan                   bool     `cli:"ssh-keyscan"`
-	AgentName                    string   `cli:"agent" validate:"required"`
-	Queue                        string   `cli:"queue"`
-	OrganizationSlug             string   `cli:"organization" validate:"required"`
-	PipelineSlug                 string   `cli:"pipeline" validate:"required"`
-	PipelineProvider             string   `cli:"pipeline-provider" validate:"required"`
-	AutomaticArtifactUploadPaths string   `cli:"artifact-upload-paths"`
-	ArtifactUploadDestination    string   `cli:"artifact-upload-destination"`
-	CleanCheckout                bool     `cli:"clean-checkout"`
-	SkipCheckout                 bool     `cli:"skip-checkout"`
-	GitSkipFetchExistingCommits  bool     `cli:"git-skip-fetch-existing-commits"`
-	GitCheckoutFlags             string   `cli:"git-checkout-flags"`
-	GitCloneFlags                string   `cli:"git-clone-flags"`
-	GitFetchFlags                string   `cli:"git-fetch-flags"`
-	GitCloneMirrorFlags          string   `cli:"git-clone-mirror-flags"`
-	GitCleanFlags                string   `cli:"git-clean-flags"`
-	GitMirrorsPath               string   `cli:"git-mirrors-path" normalize:"filepath"`
-	GitMirrorCheckoutMode        string   `cli:"git-mirror-checkout-mode"`
-	GitMirrorsLockTimeout        int      `cli:"git-mirrors-lock-timeout"`
-	GitMirrorsSkipUpdate         bool     `cli:"git-mirrors-skip-update"`
-	GitSubmoduleCloneConfig      []string `cli:"git-submodule-clone-config" normalize:"list"`
-	BinPath                      string   `cli:"bin-path" normalize:"filepath"`
-	BuildPath                    string   `cli:"build-path" normalize:"filepath"`
-	HooksPath                    string   `cli:"hooks-path" normalize:"filepath"`
-	AdditionalHooksPaths         []string `cli:"additional-hooks-paths" normalize:"list"`
-	SocketsPath                  string   `cli:"sockets-path" normalize:"filepath"`
-	PluginsPath                  string   `cli:"plugins-path" normalize:"filepath"`
-	CommandEval                  bool     `cli:"command-eval"`
-	PluginsEnabled               bool     `cli:"plugins-enabled"`
-	PluginValidation             bool     `cli:"plugin-validation"`
-	PluginsAlwaysCloneFresh      bool     `cli:"plugins-always-clone-fresh"`
-	LocalHooksEnabled            bool     `cli:"local-hooks-enabled"`
-	StrictSingleHooks            bool     `cli:"strict-single-hooks"`
-	PTY                          bool     `cli:"pty"`
-	LogLevel                     string   `cli:"log-level"`
-	Debug                        bool     `cli:"debug"`
-	Shell                        string   `cli:"shell"`
-	HooksShell                   string   `cli:"hooks-shell"`
-	Experiments                  []string `cli:"experiment" normalize:"list"`
-	Phases                       []string `cli:"phases" normalize:"list"`
-	Profile                      string   `cli:"profile"`
-	CancelSignal                 string   `cli:"cancel-signal"`
-	CancelGracePeriod            int      `cli:"cancel-grace-period"`
-	SignalGracePeriodSeconds     int      `cli:"signal-grace-period-seconds"`
-	RedactedVars                 []string `cli:"redacted-vars" normalize:"list"`
-	TracingBackend               string   `cli:"tracing-backend"`
-	TracingServiceName           string   `cli:"tracing-service-name"`
-	TracingTraceParent           string   `cli:"tracing-traceparent"`
-	TracingPropagateTraceparent  bool     `cli:"tracing-propagate-traceparent"`
-	TraceContextEncoding         string   `cli:"trace-context-encoding"`
-	NoJobAPI                     bool     `cli:"no-job-api"`
-	DisableWarningsFor           []string `cli:"disable-warnings-for" normalize:"list"`
-	CheckoutAttempts             int      `cli:"checkout-attempts"`
+	Command                      string        `cli:"command"`
+	JobID                        string        `cli:"job" validate:"required"`
+	Repository                   string        `cli:"repository" validate:"required"`
+	Commit                       string        `cli:"commit" validate:"required"`
+	Branch                       string        `cli:"branch" validate:"required"`
+	Tag                          string        `cli:"tag"`
+	RefSpec                      string        `cli:"refspec"`
+	Plugins                      string        `cli:"plugins"`
+	Secrets                      string        `cli:"secrets"`
+	PullRequest                  string        `cli:"pullrequest"`
+	PullRequestUsingMergeRefspec bool          `cli:"pull-request-using-merge-refspec"`
+	GitSubmodules                bool          `cli:"git-submodules"`
+	SSHKeyscan                   bool          `cli:"ssh-keyscan"`
+	AgentName                    string        `cli:"agent" validate:"required"`
+	Queue                        string        `cli:"queue"`
+	OrganizationSlug             string        `cli:"organization" validate:"required"`
+	PipelineSlug                 string        `cli:"pipeline" validate:"required"`
+	PipelineProvider             string        `cli:"pipeline-provider" validate:"required"`
+	AutomaticArtifactUploadPaths string        `cli:"artifact-upload-paths"`
+	ArtifactUploadDestination    string        `cli:"artifact-upload-destination"`
+	CleanCheckout                bool          `cli:"clean-checkout"`
+	SkipCheckout                 bool          `cli:"skip-checkout"`
+	GitSkipFetchExistingCommits  bool          `cli:"git-skip-fetch-existing-commits"`
+	GitCheckoutFlags             string        `cli:"git-checkout-flags"`
+	GitCloneFlags                string        `cli:"git-clone-flags"`
+	GitFetchFlags                string        `cli:"git-fetch-flags"`
+	GitCloneMirrorFlags          string        `cli:"git-clone-mirror-flags"`
+	GitCleanFlags                string        `cli:"git-clean-flags"`
+	GitMirrorsPath               string        `cli:"git-mirrors-path" normalize:"filepath"`
+	GitMirrorCheckoutMode        string        `cli:"git-mirror-checkout-mode"`
+	GitMirrorsLockTimeout        int           `cli:"git-mirrors-lock-timeout"`
+	GitMirrorsSkipUpdate         bool          `cli:"git-mirrors-skip-update"`
+	GitSubmoduleCloneConfig      []string      `cli:"git-submodule-clone-config" normalize:"list"`
+	BinPath                      string        `cli:"bin-path" normalize:"filepath"`
+	BuildPath                    string        `cli:"build-path" normalize:"filepath"`
+	HooksPath                    string        `cli:"hooks-path" normalize:"filepath"`
+	AdditionalHooksPaths         []string      `cli:"additional-hooks-paths" normalize:"list"`
+	SocketsPath                  string        `cli:"sockets-path" normalize:"filepath"`
+	PluginsPath                  string        `cli:"plugins-path" normalize:"filepath"`
+	CommandEval                  bool          `cli:"command-eval"`
+	PluginsEnabled               bool          `cli:"plugins-enabled"`
+	PluginValidation             bool          `cli:"plugin-validation"`
+	PluginsAlwaysCloneFresh      bool          `cli:"plugins-always-clone-fresh"`
+	LocalHooksEnabled            bool          `cli:"local-hooks-enabled"`
+	StrictSingleHooks            bool          `cli:"strict-single-hooks"`
+	PTY                          bool          `cli:"pty"`
+	LogLevel                     string        `cli:"log-level"`
+	Debug                        bool          `cli:"debug"`
+	Shell                        string        `cli:"shell"`
+	HooksShell                   string        `cli:"hooks-shell"`
+	Experiments                  []string      `cli:"experiment" normalize:"list"`
+	Phases                       []string      `cli:"phases" normalize:"list"`
+	Profile                      string        `cli:"profile"`
+	CancelSignal                 string        `cli:"cancel-signal"`
+	CancelSignalTimeout          time.Duration `cli:"cancel-signal-timeout"`
+	CancelCleanupTimeout         time.Duration `cli:"cancel-cleanup-timeout"`
+	RedactedVars                 []string      `cli:"redacted-vars" normalize:"list"`
+	TracingBackend               string        `cli:"tracing-backend"`
+	TracingServiceName           string        `cli:"tracing-service-name"`
+	TracingTraceParent           string        `cli:"tracing-traceparent"`
+	TracingPropagateTraceparent  bool          `cli:"tracing-propagate-traceparent"`
+	TraceContextEncoding         string        `cli:"trace-context-encoding"`
+	NoJobAPI                     bool          `cli:"no-job-api"`
+	DisableWarningsFor           []string      `cli:"disable-warnings-for" normalize:"list"`
+	CheckoutAttempts             int           `cli:"checkout-attempts"`
 }
 
 var BootstrapCommand = cli.Command{
@@ -354,8 +354,8 @@ var BootstrapCommand = cli.Command{
 			EnvVar: "BUILDKITE_AGENT_DISABLE_WARNINGS_FOR",
 		},
 		cancelSignalFlag,
-		cancelGracePeriodFlag,
-		signalGracePeriodSecondsFlag,
+		cancelSignalTimeoutFlag,
+		cancelCleanupTimeoutFlag,
 
 		// Global flags
 		DebugFlag,
@@ -407,11 +407,6 @@ var BootstrapCommand = cli.Command{
 			return fmt.Errorf("failed to parse cancel-signal: %w", err)
 		}
 
-		signalGracePeriod, err := signalGracePeriod(cfg.CancelGracePeriod, cfg.SignalGracePeriodSeconds)
-		if err != nil {
-			return err
-		}
-
 		traceContextCodec, err := tracetools.ParseEncoding(cfg.TraceContextEncoding)
 		if err != nil {
 			return fmt.Errorf("while parsing trace context encoding: %v", err)
@@ -427,7 +422,7 @@ var BootstrapCommand = cli.Command{
 			BuildPath:                    cfg.BuildPath,
 			SocketsPath:                  cfg.SocketsPath,
 			CancelSignal:                 cancelSig,
-			SignalGracePeriod:            signalGracePeriod,
+			SignalGracePeriod:            cfg.CancelSignalTimeout,
 			CleanCheckout:                cfg.CleanCheckout,
 			SkipCheckout:                 cfg.SkipCheckout,
 			GitSkipFetchExistingCommits:  cfg.GitSkipFetchExistingCommits,

--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	defaultCancelSignalTimeout  = 9 * time.Second
-	defaultCancelCleanupTimeout = 1 * time.Second
+	defaultCancelSignalTimeout  = 10 * time.Second
+	defaultCancelCleanupTimeout = 5 * time.Second
 )
 
 var (

--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -1,25 +1,22 @@
 package clicommand
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/urfave/cli"
 )
 
 const (
-	defaultCancelGracePeriodSecs = 10
-	defaultSignalGracePeriodSecs = -1
-	defaultSignalGracePeriod     = (defaultCancelGracePeriodSecs + defaultSignalGracePeriodSecs) * time.Second
+	defaultCancelSignalTimeout  = 9 * time.Second
+	defaultCancelCleanupTimeout = 1 * time.Second
 )
 
 var (
-	cancelGracePeriodFlag = cli.IntFlag{
-		Name:  "cancel-grace-period",
-		Value: defaultCancelGracePeriodSecs,
-		Usage: "The number of seconds a canceled or timed out job is given " +
-			"to gracefully terminate and upload its artifacts",
-		EnvVar: "BUILDKITE_CANCEL_GRACE_PERIOD",
+	cancelSignalTimeoutFlag = cli.DurationFlag{
+		Name:   "cancel-signal-timeout",
+		Value:  defaultCancelSignalTimeout,
+		Usage:  "The amount of time given to a subprocess to handle the cancel signal before SIGKILL is sent",
+		EnvVar: "BUILDKITE_CANCEL_SIGNAL_TIMEOUT",
 	}
 	cancelSignalFlag = cli.StringFlag{
 		Name:   "cancel-signal",
@@ -27,46 +24,10 @@ var (
 		Usage:  "The signal to use for cancellation",
 		EnvVar: "BUILDKITE_CANCEL_SIGNAL",
 	}
-	signalGracePeriodSecondsFlag = cli.IntFlag{
-		Name:  "signal-grace-period-seconds",
-		Value: defaultSignalGracePeriodSecs,
-		Usage: "The number of seconds given to a subprocess to handle being sent ′cancel-signal′. " +
-			"After this period has elapsed, SIGKILL will be sent. " +
-			"Negative values are taken relative to ′cancel-grace-period′. " +
-			"The default value (-1) means that the effective signal grace period is equal to ′cancel-grace-period′ minus 1.",
-		EnvVar: "BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS",
+	cancelCleanupTimeoutFlag = cli.DurationFlag{
+		Name:   "cancel-cleanup-timeout",
+		Value:  defaultCancelCleanupTimeout,
+		Usage:  "The amount of time given to the agent after the process exits or is killed to upload logs and artifacts",
+		EnvVar: "BUILDKITE_CANCEL_CLEANUP_TIMEOUT",
 	}
 )
-
-// signalGracePeriod computes the signal grace period based on the various
-// possible flag configurations:
-//   - If signalGracePeriodSecs is negative, it is relative to
-//     cancelGracePeriodSecs.
-//   - If cancelGracePeriodSecs is less than signalGracePeriodSecs that is an
-//     error.
-//
-// If the combination is invalid, both the defaultSignalGracePeriod and an error
-// is returned.
-func signalGracePeriod(cancelGracePeriodSecs, signalGracePeriodSecs int) (time.Duration, error) {
-	// Treat a negative signal grace period as relative to the cancel grace period
-	if signalGracePeriodSecs < 0 {
-		if cancelGracePeriodSecs < -signalGracePeriodSecs {
-			return defaultSignalGracePeriod, fmt.Errorf(
-				"cancel-grace-period (%d) must be at least as big as signal-grace-period-seconds (%d)",
-				cancelGracePeriodSecs,
-				signalGracePeriodSecs,
-			)
-		}
-		signalGracePeriodSecs = cancelGracePeriodSecs + signalGracePeriodSecs
-	}
-
-	if cancelGracePeriodSecs <= signalGracePeriodSecs {
-		return defaultSignalGracePeriod, fmt.Errorf(
-			"cancel-grace-period (%d) must be greater than signal-grace-period-seconds (%d)",
-			cancelGracePeriodSecs,
-			signalGracePeriodSecs,
-		)
-	}
-
-	return time.Duration(signalGracePeriodSecs) * time.Second, nil
-}

--- a/clicommand/kubernetes_bootstrap.go
+++ b/clicommand/kubernetes_bootstrap.go
@@ -125,13 +125,23 @@ var KubernetesBootstrapCommand = cli.Command{
 			}
 			cancelSignal = cs
 		}
-		cancelGracePeriodSecs := environ.GetInt("BUILDKITE_CANCEL_GRACE_PERIOD", defaultCancelGracePeriodSecs)
-		cancelGracePeriod := time.Duration(cancelGracePeriodSecs) * time.Second
-		signalGracePeriodSecs := environ.GetInt("BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS", defaultSignalGracePeriodSecs)
-		signalGracePeriod, err := signalGracePeriod(cancelGracePeriodSecs, signalGracePeriodSecs)
-		if err != nil {
-			return err
+		cancelSignalTimeout := defaultCancelSignalTimeout
+		if s, has := environ.Get("BUILDKITE_CANCEL_SIGNAL_TIMEOUT"); has {
+			d, err := time.ParseDuration(s)
+			if err != nil {
+				return fmt.Errorf("failed to parse BUILDKITE_CANCEL_SIGNAL_TIMEOUT: %w", err)
+			}
+			cancelSignalTimeout = d
 		}
+		cancelCleanupTimeout := defaultCancelCleanupTimeout
+		if s, has := environ.Get("BUILDKITE_CANCEL_CLEANUP_TIMEOUT"); has {
+			d, err := time.ParseDuration(s)
+			if err != nil {
+				return fmt.Errorf("failed to parse BUILDKITE_CANCEL_CLEANUP_TIMEOUT: %w", err)
+			}
+			cancelCleanupTimeout = d
+		}
+		cancelGracePeriod := cancelSignalTimeout + cancelCleanupTimeout
 
 		// BUILDKITE_KUBERNETES_EXEC is a legacy environment variable. It was used to activate the socket
 		// on the bootstrap command, and to activate the socket server on `buildkite-agent start`.
@@ -211,7 +221,7 @@ var KubernetesBootstrapCommand = cli.Command{
 			Dir:               buildPath,
 			PTY:               runInPTY,
 			InterruptSignal:   cancelSignal,
-			SignalGracePeriod: signalGracePeriod,
+			SignalGracePeriod: cancelSignalTimeout,
 		})
 
 		// We aren't expecting the user to Ctrl-C the process (we're in k8s),

--- a/clicommand/step_cancel.go
+++ b/clicommand/step_cancel.go
@@ -63,7 +63,7 @@ var StepCancelCommand = cli.Command{
 
 		cli.Int64Flag{
 			Name:   "force-grace-period-seconds",
-			Value:  defaultCancelGracePeriodSecs,
+			Value:  int64((defaultCancelSignalTimeout + defaultCancelCleanupTimeout) / time.Second),
 			Usage:  "The number of seconds to wait for agents to finish uploading artifacts before transitioning unfinished jobs to a canceled state. ′--force′ must also be supplied for this to take affect",
 			EnvVar: "BUILDKITE_STEP_CANCEL_FORCE_GRACE_PERIOD_SECONDS,BUILDKITE_CANCEL_GRACE_PERIOD",
 		},


### PR DESCRIPTION
### Description

Previously, `cancel-grace-period` (default 10s) was the *total* time budget covering both process shutdown and agent-side cleanup (log uploads, artifact uploads, disconnects). `signal-grace-period-seconds` (default -1) controlled how much of that budget went to the process, using negative-relative arithmetic: -1 meant "`cancel-grace-period` minus 1", so the process got 9s and the agent got 1s. This made configuration confusing — the flag that *sounded* like the process's grace period (`cancel-grace-period`) was actually the total, and the actual process grace period required subtracting a negative number from it. Validation was also complex because the two values had to be checked against each other, and invalid combinations (e.g.  `signal-grace-period-seconds` >= `cancel-grace-period`) returned errors.

The new model uses two independent, positive durations:

- `--cancel-signal-timeout` (default 10s): how long the subprocess gets to handle the cancel signal before receiving SIGKILL. This is (ofetn) the value users actually think about when configuring cancellation.
- `--cancel-cleanup-timeout` (default 5s): how long the agent gets after the process exits or is killed to upload logs and artifacts.

The total grace period is simply their sum. There is no validation logic because the values cannot conflict. Both flags accept Go duration syntax (e.g. "30s", "1m30s") via `cli.DurationFlag` instead of integer seconds, matching the convention used by other timeout flags in the agent (`wait-for-ec2-tags-timeout`, `kubernetes-container-start-timeout`, etc.).

The defaults produce the same effective behaviour as before: 9s for the process, 1s for agent cleanup, 10s total.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

This one was mostly implemented with Amp, with some fine tuning and tweaking (and checking work) by moi