### PR TITLE
feat: add BUILDKITE_JOB_TIMED_OUT env var for hooks

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -138,6 +138,12 @@ type JobRunner struct {
 	// Files containing a copy of the job env
 	envShellFile *os.File
 	envJSONFile  *os.File
+
+	// jobTimeoutFilePath is the path to a marker file that, if present at
+	// post-command hook time, signals to the executor that the job was
+	// cancelled because of a Buildkite job-level timeout. The path is passed
+	// to the bootstrap subprocess via BUILDKITE_AGENT_JOB_TIMEOUT_FILE.
+	jobTimeoutFilePath string
 }
 
 // jobProcess is either a *process.Process, or a *kubernetes.Runner.
@@ -210,6 +216,12 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient *api.Client, c
 	if err != nil {
 		return nil, err
 	}
+
+	// Reserve a path for the job timeout marker file. It is only created on
+	// disk if the job is cancelled because of a Buildkite job-level timeout
+	// (see Cancel). The bootstrap subprocess reads this path from the
+	// BUILDKITE_AGENT_JOB_TIMEOUT_FILE env var.
+	r.jobTimeoutFilePath = jobTimeoutFilePath(r.conf.Job.ID, conf.KubernetesExec)
 
 	env, err := r.createEnvironment(ctx)
 	if err != nil {
@@ -502,6 +514,14 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 	}
 	if r.envJSONFile != nil {
 		setEnv("BUILDKITE_ENV_JSON_FILE", r.envJSONFile.Name())
+	}
+
+	// Tell the bootstrap where to look for the job timeout marker. Cancel
+	// writes to this path only when cancellation is caused by a Buildkite
+	// job-level timeout, allowing the executor to expose
+	// BUILDKITE_JOB_TIMED_OUT=true to the post-command hook.
+	if r.jobTimeoutFilePath != "" {
+		setEnv("BUILDKITE_AGENT_JOB_TIMEOUT_FILE", r.jobTimeoutFilePath)
 	}
 
 	cache := r.conf.Job.Step.Cache
@@ -842,9 +862,14 @@ func (r *JobRunner) jobCancellationChecker(ctx context.Context) {
 			}
 			continue // the loop
 		}
-		if jobState.State == "canceling" || jobState.State == "canceled" {
+		switch jobState.State {
+		case "canceling", "canceled":
 			if err := r.Cancel(CancelReasonJobState); err != nil {
 				r.agentLogger.Errorf("Unexpected error canceling process as requested by server (job: %s) (err: %s)", r.conf.Job.ID, err)
+			}
+		case "timing_out", "timed_out":
+			if err := r.Cancel(CancelReasonJobTimeout); err != nil {
+				r.agentLogger.Error("Unexpected error canceling process as requested by server (job: %s) (err: %s)", r.conf.Job.ID, err)
 			}
 		}
 	}
@@ -902,4 +927,17 @@ func createJobEnvFiles(l logger.Logger, jobID string, kubernetesExec bool) (shel
 	l.Debugf("[JobRunner] Created env file (JSON format): %s", jsonFile.Name())
 
 	return shellFile, jsonFile, nil
+}
+
+// jobTimeoutFilePath returns a deterministic path within the job temp
+// directory used to signal to the bootstrap that the job was cancelled
+// because of a Buildkite job-level timeout. The file is not created until
+// the timeout actually fires; the bootstrap detects the timeout by checking
+// whether the file exists.
+func jobTimeoutFilePath(jobID string, kubernetesExec bool) string {
+	tempDir := os.TempDir()
+	if kubernetesExec {
+		tempDir = "/workspace"
+	}
+	return filepath.Join(tempDir, fmt.Sprintf("job-timeout-%s", jobID))
 }

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -869,7 +869,7 @@ func (r *JobRunner) jobCancellationChecker(ctx context.Context) {
 			}
 		case "timing_out", "timed_out":
 			if err := r.Cancel(CancelReasonJobTimeout); err != nil {
-				r.agentLogger.Error("Unexpected error canceling process as requested by server (job: %s) (err: %s)", r.conf.Job.ID, err)
+				r.agentLogger.Errorf("Unexpected error canceling process as requested by server (job: %s) (err: %s)", r.conf.Job.ID, err)
 			}
 		}
 	}

--- a/agent/job_runner_test.go
+++ b/agent/job_runner_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -57,6 +59,41 @@ func TestValidateJobValue(t *testing.T) {
 		err := validateJobValue(tc.allowedTargets, tc.pipelineTarget)
 		if (err != nil) != tc.wantErr {
 			t.Errorf("validateJobValue() error = %v, wantErr = %v", err, tc.wantErr)
+		}
+	}
+}
+
+func TestJobTimeoutFilePath(t *testing.T) {
+	t.Parallel()
+
+	got := jobTimeoutFilePath("abc123", false)
+	want := filepath.Join(os.TempDir(), "job-timeout-abc123")
+	if got != want {
+		t.Errorf("jobTimeoutFilePath(%q, false) = %q, want %q", "abc123", got, want)
+	}
+
+	if got, want := jobTimeoutFilePath("abc123", true), "/workspace/job-timeout-abc123"; got != want {
+		t.Errorf("jobTimeoutFilePath(%q, true) = %q, want %q", "abc123", got, want)
+	}
+}
+
+func TestCancelReasonString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		reason CancelReason
+		want   string
+	}{
+		{CancelReasonJobState, "job cancelled on Buildkite"},
+		{CancelReasonAgentStopping, "agent is stopping"},
+		{CancelReasonInvalidToken, "access token is invalid"},
+		{CancelReasonJobTimeout, "job timed out on Buildkite"},
+		{CancelReason(99), "unknown"},
+	}
+
+	for _, tc := range tests {
+		if got := tc.reason.String(); got != tc.want {
+			t.Errorf("CancelReason(%d).String() = %q, want %q", tc.reason, got, tc.want)
 		}
 	}
 }

--- a/agent/job_runner_test.go
+++ b/agent/job_runner_test.go
@@ -72,7 +72,7 @@ func TestJobTimeoutFilePath(t *testing.T) {
 		t.Errorf("jobTimeoutFilePath(%q, false) = %q, want %q", "abc123", got, want)
 	}
 
-	if got, want := jobTimeoutFilePath("abc123", true), "/workspace/job-timeout-abc123"; got != want {
+	if got, want := jobTimeoutFilePath("abc123", true), filepath.Join("/workspace", "job-timeout-abc123"); got != want {
 		t.Errorf("jobTimeoutFilePath(%q, true) = %q, want %q", "abc123", got, want)
 	}
 }

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -432,6 +432,14 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 		r.agentLogger.Debugf("[JobRunner] Deleted env file: %s", f.Name())
 	}
 
+	// Remove the job timeout marker file if it was created. It is fine if
+	// the file does not exist — Cancel only writes it on a job-level timeout.
+	if r.jobTimeoutFilePath != "" {
+		if err := os.Remove(r.jobTimeoutFilePath); err != nil && !os.IsNotExist(err) {
+			r.agentLogger.Warn("[JobRunner] Error cleaning up job timeout file: %s", err)
+		}
+	}
+
 	// Write some metrics about the job run
 	jobMetrics := r.conf.MetricsScope.With(metrics.Tags{"exit_code": strconv.Itoa(exit.Status)})
 
@@ -604,6 +612,18 @@ func (r *JobRunner) Cancel(reason CancelReason) error {
 		reason,
 	)
 
+	// If we are cancelling because of a Buildkite job-level timeout, write the
+	// marker file before sending the signal. The bootstrap's signal handler
+	// reads the file from the path in BUILDKITE_AGENT_JOB_TIMEOUT_FILE and uses
+	// its presence to set BUILDKITE_JOB_TIMED_OUT=true for the post-command
+	// hook. Failing to write the marker is non-fatal: the cancellation still
+	// proceeds and the hook will simply see BUILDKITE_JOB_CANCELLED only.
+	if reason == CancelReasonJobTimeout && r.jobTimeoutFilePath != "" {
+		if err := os.WriteFile(r.jobTimeoutFilePath, []byte("true"), 0o644); err != nil {
+			r.agentLogger.Warn("Failed to write job timeout marker file %s: %v", r.jobTimeoutFilePath, err)
+		}
+	}
+
 	// First we interrupt the process with the configured CancelSignal.
 	// At some point in the past, for subprocesses, the default was intended to
 	// be SIGINT, but you will find that the cancel-signal flag default and
@@ -640,6 +660,7 @@ const (
 	CancelReasonJobState CancelReason = iota
 	CancelReasonAgentStopping
 	CancelReasonInvalidToken
+	CancelReasonJobTimeout
 )
 
 func (r CancelReason) String() string {
@@ -650,6 +671,8 @@ func (r CancelReason) String() string {
 		return "agent is stopping"
 	case CancelReasonInvalidToken:
 		return "access token is invalid"
+	case CancelReasonJobTimeout:
+		return "job timed out on Buildkite"
 	}
 	return "unknown"
 }

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -436,7 +436,7 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 	// the file does not exist — Cancel only writes it on a job-level timeout.
 	if r.jobTimeoutFilePath != "" {
 		if err := os.Remove(r.jobTimeoutFilePath); err != nil && !os.IsNotExist(err) {
-			r.agentLogger.Warn("[JobRunner] Error cleaning up job timeout file: %s", err)
+			r.agentLogger.Warnf("[JobRunner] Error cleaning up job timeout file: %s", err)
 		}
 	}
 
@@ -620,7 +620,7 @@ func (r *JobRunner) Cancel(reason CancelReason) error {
 	// proceeds and the hook will simply see BUILDKITE_JOB_CANCELLED only.
 	if reason == CancelReasonJobTimeout && r.jobTimeoutFilePath != "" {
 		if err := os.WriteFile(r.jobTimeoutFilePath, []byte("true"), 0o644); err != nil {
-			r.agentLogger.Warn("Failed to write job timeout marker file %s: %v", r.jobTimeoutFilePath, err)
+			r.agentLogger.Warnf("Failed to write job timeout marker file %s: %v", r.jobTimeoutFilePath, err)
 		}
 	}
 

--- a/env/protected.go
+++ b/env/protected.go
@@ -51,6 +51,7 @@ var protectedEnv = map[string]protection{
 	"BUILDKITE_AGENT_ACCESS_TOKEN":              {},
 	"BUILDKITE_AGENT_DEBUG":                     {},
 	"BUILDKITE_AGENT_ENDPOINT":                  {},
+	"BUILDKITE_AGENT_JOB_TIMEOUT_FILE":          {},
 	"BUILDKITE_AGENT_PID":                       {},
 	"BUILDKITE_ARTIFACT_PATHS":                  {mutableFromWithinJob: true},
 	"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION":     {mutableFromWithinJob: true},

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -327,6 +327,14 @@ func (e *Executor) Cancel() error {
 	}
 	e.cancelled = true
 	e.shell.Env.Set("BUILDKITE_JOB_CANCELLED", "true")
+	// If the agent dropped a timeout marker before signaling us, surface that
+	// to the post-command hook as BUILDKITE_JOB_TIMED_OUT=true so users can
+	// distinguish a job-level timeout from other cancellations.
+	if path, ok := e.shell.Env.Get("BUILDKITE_AGENT_JOB_TIMEOUT_FILE"); ok && path != "" {
+		if _, err := os.Stat(path); err == nil {
+			e.shell.Env.Set("BUILDKITE_JOB_TIMED_OUT", "true")
+		}
+	}
 	close(e.cancelCh)
 	return nil
 }

--- a/internal/job/executor_test.go
+++ b/internal/job/executor_test.go
@@ -2,9 +2,12 @@ package job
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
+	"github.com/buildkite/agent/v3/env"
 	"github.com/buildkite/agent/v3/internal/shell"
 	"github.com/buildkite/agent/v3/tracetools"
 	"github.com/google/go-cmp/cmp"
@@ -103,4 +106,88 @@ func TestStartTracing_Datadog(t *testing.T) {
 		t.Errorf("opentracing.SpanFromContext(ctx) = %v, want %v", got, want)
 	}
 	stopper()
+}
+
+// newCancelTestExecutor returns an Executor whose shell.Env starts empty,
+// suitable for exercising Cancel without depending on the host environment.
+func newCancelTestExecutor(t *testing.T) *Executor {
+	t.Helper()
+
+	e := New(ExecutorConfig{})
+
+	sh, err := shell.New(shell.WithEnv(env.New()))
+	if err != nil {
+		t.Fatalf("shell.New() error = %v, want nil", err)
+	}
+	e.shell = sh
+
+	return e
+}
+
+// TestCancelSetsJobCancelledEnv verifies the precedent set in #3213: any
+// cancellation surfaces BUILDKITE_JOB_CANCELLED=true to the post-command hook.
+func TestCancelSetsJobCancelledEnv(t *testing.T) {
+	t.Parallel()
+
+	e := newCancelTestExecutor(t)
+
+	if err := e.Cancel(); err != nil {
+		t.Fatalf("e.Cancel() = %v, want nil", err)
+	}
+
+	if got, ok := e.shell.Env.Get("BUILDKITE_JOB_CANCELLED"); !ok || got != "true" {
+		t.Errorf(`e.shell.Env.Get("BUILDKITE_JOB_CANCELLED") = (%q, %v), want ("true", true)`, got, ok)
+	}
+	if _, ok := e.shell.Env.Get("BUILDKITE_JOB_TIMED_OUT"); ok {
+		t.Errorf("BUILDKITE_JOB_TIMED_OUT was set on a non-timeout cancellation, want unset")
+	}
+}
+
+// TestCancelSetsJobTimedOutEnvWhenMarkerExists verifies that when the agent
+// drops the timeout marker file before signaling, Cancel surfaces
+// BUILDKITE_JOB_TIMED_OUT=true alongside BUILDKITE_JOB_CANCELLED.
+func TestCancelSetsJobTimedOutEnvWhenMarkerExists(t *testing.T) {
+	t.Parallel()
+
+	e := newCancelTestExecutor(t)
+
+	markerPath := filepath.Join(t.TempDir(), "job-timeout-marker")
+	if err := os.WriteFile(markerPath, []byte("true"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile(%q) = %v", markerPath, err)
+	}
+	e.shell.Env.Set("BUILDKITE_AGENT_JOB_TIMEOUT_FILE", markerPath)
+
+	if err := e.Cancel(); err != nil {
+		t.Fatalf("e.Cancel() = %v, want nil", err)
+	}
+
+	if got, ok := e.shell.Env.Get("BUILDKITE_JOB_CANCELLED"); !ok || got != "true" {
+		t.Errorf(`e.shell.Env.Get("BUILDKITE_JOB_CANCELLED") = (%q, %v), want ("true", true)`, got, ok)
+	}
+	if got, ok := e.shell.Env.Get("BUILDKITE_JOB_TIMED_OUT"); !ok || got != "true" {
+		t.Errorf(`e.shell.Env.Get("BUILDKITE_JOB_TIMED_OUT") = (%q, %v), want ("true", true)`, got, ok)
+	}
+}
+
+// TestCancelDoesNotSetTimedOutWhenMarkerMissing verifies that having the env
+// var pointing at a path that does not exist (the normal case for a non-
+// timeout cancellation) does not falsely flag the job as timed out.
+func TestCancelDoesNotSetTimedOutWhenMarkerMissing(t *testing.T) {
+	t.Parallel()
+
+	e := newCancelTestExecutor(t)
+
+	missingPath := filepath.Join(t.TempDir(), "does-not-exist")
+	e.shell.Env.Set("BUILDKITE_AGENT_JOB_TIMEOUT_FILE", missingPath)
+
+	if err := e.Cancel(); err != nil {
+		t.Fatalf("e.Cancel() = %v, want nil", err)
+	}
+
+	if got, ok := e.shell.Env.Get("BUILDKITE_JOB_CANCELLED"); !ok || got != "true" {
+		t.Errorf(`e.shell.Env.Get("BUILDKITE_JOB_CANCELLED") = (%q, %v), want ("true", true)`, got, ok)
+	}
+	if _, ok := e.shell.Env.Get("BUILDKITE_JOB_TIMED_OUT"); ok {
+		t.Errorf("BUILDKITE_JOB_TIMED_OUT was set despite missing marker file, want unset")
+	}
 }


### PR DESCRIPTION
### Description
Adds `BUILDKITE_JOB_TIMED_OUT` for hooks (and `CancelReasonJobTimeout`) so post-command hooks can distinguish timeout from other cancellations. Mirrors `#3213`'s `BUILDKITE_JOB_CANCELLED` design.

Fixes #3592

The agent doesn't enforce timeouts itself — `JobRunner.jobCancellationChecker` polls `GetJobState` and now routes `timing_out`/`timed_out` server states through `Cancel(CancelReasonJobTimeout)`. Cross-process signal → bootstrap → hook env uses a per-job marker file (path passed via `BUILDKITE_AGENT_JOB_TIMEOUT_FILE`, protected from job-level override): agent writes the marker before signaling, bootstrap's `Cancel` reads it and sets `BUILDKITE_JOB_TIMED_OUT=true` on the hook env.

### Testing
- [x] `go test ./...` clean
- [x] `go test -race ./agent/ ./internal/job/ ./env/` clean
- [x] `go tool gofumpt -extra -d .` clean
- [x] `golangci-lint run` 0 issues
- Added unit tests for `executor.Cancel` (no-marker / marker-present / bad-path), `jobTimeoutFilePath`, and `CancelReason.String()`

### Disclosures / Credits
Used Claude Code (Opus 4.7) to design the marker-file plumbing and draft the patch. Reviewed and tested locally.