### PR TITLE
Flatten tracing config to be a single bool flag

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -69,7 +69,7 @@ type AgentConfiguration struct {
 	Profile                      string
 	RedactedVars                 []string
 	AcquireJob                   string
-	TracingBackend               string
+	OpenTelemetryTracing         bool
 	TracingServiceName           string
 	TracingPropagateTraceparent  bool
 	DisableWarningsFor           []string

--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -71,7 +71,6 @@ type AgentConfiguration struct {
 	AcquireJob                   string
 	OpenTelemetryTracing         bool
 	TracingServiceName           string
-	TracingPropagateTraceparent  bool
 	DisableWarningsFor           []string
 	AllowMultipartArtifactUpload bool
 

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -439,7 +439,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	if r.envShellFile != nil {
 		// Note that some variables in this list might not be defined later,
 		// when something comes to read the file. See below where they are
-		// added conditionally, e.g. BUILDKITE_TRACING_BACKEND.
+		// added conditionally, e.g. BUILDKITE_OPENTELEMETRY_TRACING.
 		// Docker in particular tolerates undefined vars in an env file
 		// without complaints.
 		const agentCfgVars = `BUILDKITE_GIT_CHECKOUT_FLAGS
@@ -463,7 +463,7 @@ BUILDKITE_HOOKS_SHELL
 BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS
 BUILDKITE_SSH_KEYSCAN
 BUILDKITE_STRICT_SINGLE_HOOKS
-BUILDKITE_TRACING_BACKEND
+BUILDKITE_OPENTELEMETRY_TRACING
 BUILDKITE_TRACING_SERVICE_NAME
 BUILDKITE_TRACING_TRACEPARENT
 BUILDKITE_TRACING_PROPAGATE_TRACEPARENT
@@ -657,8 +657,8 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 	}
 	setEnv("BUILDKITE_PLUGIN_VALIDATION", fmt.Sprint(enablePluginValidation))
 
-	if r.conf.AgentConfiguration.TracingBackend != "" {
-		setEnv("BUILDKITE_TRACING_BACKEND", r.conf.AgentConfiguration.TracingBackend)
+	if r.conf.AgentConfiguration.OpenTelemetryTracing {
+		setEnv("BUILDKITE_OPENTELEMETRY_TRACING", "true")
 		setEnv("BUILDKITE_TRACING_SERVICE_NAME", r.conf.AgentConfiguration.TracingServiceName)
 
 		// Buildkite backend can provide a traceparent property on the job

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -668,9 +668,6 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 		if r.conf.Job.TraceParent != "" {
 			setEnv("BUILDKITE_TRACING_TRACEPARENT", r.conf.Job.TraceParent)
 		}
-		if r.conf.AgentConfiguration.TracingPropagateTraceparent {
-			setEnv("BUILDKITE_TRACING_PROPAGATE_TRACEPARENT", "true")
-		}
 	}
 
 	setEnv("BUILDKITE_AGENT_DISABLE_WARNINGS_FOR", strings.Join(r.conf.AgentConfiguration.DisableWarningsFor, ","))

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"maps"
 	"net/url"
 	"os"
 	"os/signal"
@@ -38,7 +37,6 @@ import (
 	"github.com/buildkite/agent/v4/logger"
 	"github.com/buildkite/agent/v4/metrics"
 	"github.com/buildkite/agent/v4/status"
-	"github.com/buildkite/agent/v4/tracetools"
 	"github.com/buildkite/agent/v4/version"
 	"github.com/buildkite/shellwords"
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -191,7 +189,7 @@ type AgentStartConfig struct {
 	OpenTelemetryMetrics bool `cli:"opentelemetry-metrics"`
 
 	// Tracing config
-	TracingBackend              string `cli:"tracing-backend"`
+	OpenTelemetryTracing        bool   `cli:"opentelemetry-tracing"`
 	TracingServiceName          string `cli:"tracing-service-name"`
 	TracingPropagateTraceparent bool   `cli:"tracing-propagate-traceparent"`
 
@@ -233,7 +231,7 @@ func (asc AgentStartConfig) Features(ctx context.Context) []string {
 		features = append(features, "acquire-job")
 	}
 
-	if asc.TracingBackend == tracetools.BackendOpenTelemetry {
+	if asc.OpenTelemetryTracing {
 		features = append(features, "opentelemetry-tracing")
 	}
 
@@ -653,15 +651,14 @@ var AgentStartCommand = cli.Command{
 		},
 		cancelSignalFlag,
 		cancelCleanupTimeoutFlag,
-		cli.StringFlag{
-			Name:   "tracing-backend",
-			Usage:  `Enable tracing for build jobs by specifying a backend. Currently only "opentelemetry" (or empty) is supported`,
-			EnvVar: "BUILDKITE_TRACING_BACKEND",
-			Value:  "",
+		cli.BoolFlag{
+			Name:   "opentelemetry-tracing",
+			Usage:  "Enable tracing for build jobs with OpenTelemetry OTLP. Configure OTLP with standard OTEL_EXPORTER_OTLP_* env vars (default: false)",
+			EnvVar: "BUILDKITE_OPENTELEMETRY_TRACING",
 		},
 		cli.BoolFlag{
 			Name:   "tracing-propagate-traceparent",
-			Usage:  `Enable accepting traceparent context from Buildkite control plane (only supported for OpenTelemetry backend) (default: false)`,
+			Usage:  "Enable accepting traceparent context from Buildkite control plane. Requires --opentelemetry-tracing (default: false)",
 			EnvVar: "BUILDKITE_TRACING_PROPAGATE_TRACEPARENT",
 		},
 		cli.StringFlag{
@@ -879,15 +876,6 @@ var AgentStartCommand = cli.Command{
 			ServiceName: cfg.TracingServiceName,
 		})
 
-		// Sense check supported tracing backends, we don't want bootstrapped jobs to silently have no tracing
-		if _, has := tracetools.ValidTracingBackends[cfg.TracingBackend]; !has {
-			return fmt.Errorf(
-				"the given tracing backend %q is not supported. Valid backends are: %q",
-				cfg.TracingBackend,
-				slices.Collect(maps.Keys(tracetools.ValidTracingBackends)),
-			)
-		}
-
 		if experiments.IsEnabled(ctx, experiments.AgentAPI) {
 			shutdown, err := runAgentAPI(ctx, l, cfg.SocketsPath)
 			if err != nil {
@@ -1015,7 +1003,7 @@ var AgentStartCommand = cli.Command{
 			HooksShell:                      cfg.HooksShell,
 			RedactedVars:                    cfg.RedactedVars,
 			AcquireJob:                      cfg.AcquireJob,
-			TracingBackend:                  cfg.TracingBackend,
+			OpenTelemetryTracing:            cfg.OpenTelemetryTracing,
 			TracingServiceName:              cfg.TracingServiceName,
 			TracingPropagateTraceparent:     cfg.TracingPropagateTraceparent,
 			AllowMultipartArtifactUpload:    !cfg.NoMultipartArtifactUpload,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -189,9 +189,8 @@ type AgentStartConfig struct {
 	OpenTelemetryMetrics bool `cli:"opentelemetry-metrics"`
 
 	// Tracing config
-	OpenTelemetryTracing        bool   `cli:"opentelemetry-tracing"`
-	TracingServiceName          string `cli:"tracing-service-name"`
-	TracingPropagateTraceparent bool   `cli:"tracing-propagate-traceparent"`
+	OpenTelemetryTracing bool   `cli:"opentelemetry-tracing"`
+	TracingServiceName   string `cli:"tracing-service-name"`
 
 	// Other shared flags
 	StrictSingleHooks               bool          `cli:"strict-single-hooks"`
@@ -233,10 +232,6 @@ func (asc AgentStartConfig) Features(ctx context.Context) []string {
 
 	if asc.OpenTelemetryTracing {
 		features = append(features, "opentelemetry-tracing")
-	}
-
-	if asc.TracingPropagateTraceparent {
-		features = append(features, "propagate-traceparent")
 	}
 
 	if asc.DisconnectAfterJob {
@@ -656,11 +651,6 @@ var AgentStartCommand = cli.Command{
 			Usage:  "Enable tracing for build jobs with OpenTelemetry OTLP. Configure OTLP with standard OTEL_EXPORTER_OTLP_* env vars (default: false)",
 			EnvVar: "BUILDKITE_OPENTELEMETRY_TRACING",
 		},
-		cli.BoolFlag{
-			Name:   "tracing-propagate-traceparent",
-			Usage:  "Enable accepting traceparent context from Buildkite control plane. Requires --opentelemetry-tracing (default: false)",
-			EnvVar: "BUILDKITE_TRACING_PROPAGATE_TRACEPARENT",
-		},
 		cli.StringFlag{
 			Name:   "tracing-service-name",
 			Usage:  "Service name to use when reporting telemetry.",
@@ -1005,7 +995,6 @@ var AgentStartCommand = cli.Command{
 			AcquireJob:                      cfg.AcquireJob,
 			OpenTelemetryTracing:            cfg.OpenTelemetryTracing,
 			TracingServiceName:              cfg.TracingServiceName,
-			TracingPropagateTraceparent:     cfg.TracingPropagateTraceparent,
 			AllowMultipartArtifactUpload:    !cfg.NoMultipartArtifactUpload,
 			KubernetesExec:                  cfg.KubernetesExec,
 			KubernetesContainerStartTimeout: cfg.KubernetesContainerStartTimeout,

--- a/clicommand/agent_start_test.go
+++ b/clicommand/agent_start_test.go
@@ -1,10 +1,12 @@
 package clicommand
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"testing"
 
 	"github.com/buildkite/agent/v4/core"
@@ -12,6 +14,15 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/urfave/cli"
 )
+
+func TestAgentStartFeatures_OpenTelemetryTracing(t *testing.T) {
+	t.Parallel()
+
+	features := AgentStartConfig{OpenTelemetryTracing: true}.Features(context.Background())
+	if !slices.Contains(features, "opentelemetry-tracing") {
+		t.Fatalf("Features() = %v, want opentelemetry-tracing", features)
+	}
+}
 
 func setupHooksPath(t *testing.T) (string, func()) {
 	t.Helper()

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildkite/agent/v4/internal/process"
 	"github.com/buildkite/agent/v4/internal/self"
 	"github.com/buildkite/agent/v4/logger"
+	"github.com/buildkite/agent/v4/tracetools"
 	"github.com/urfave/cli"
 )
 
@@ -104,7 +105,7 @@ type BootstrapConfig struct {
 	CancelSignalTimeout          time.Duration `cli:"cancel-signal-timeout"`
 	CancelCleanupTimeout         time.Duration `cli:"cancel-cleanup-timeout"`
 	RedactedVars                 []string      `cli:"redacted-vars" normalize:"list"`
-	TracingBackend               string        `cli:"tracing-backend"`
+	OpenTelemetryTracing         bool          `cli:"opentelemetry-tracing"`
 	TracingServiceName           string        `cli:"tracing-service-name"`
 	TracingTraceParent           string        `cli:"tracing-traceparent"`
 	TracingPropagateTraceparent  bool          `cli:"tracing-propagate-traceparent"`
@@ -317,11 +318,10 @@ var BootstrapCommand = cli.Command{
 			Usage:  "The specific phases to execute. The order they're defined is irrelevant.",
 			EnvVar: "BUILDKITE_BOOTSTRAP_PHASES",
 		},
-		cli.StringFlag{
-			Name:   "tracing-backend",
-			Usage:  "The name of the tracing backend to use.",
-			EnvVar: "BUILDKITE_TRACING_BACKEND",
-			Value:  "",
+		cli.BoolFlag{
+			Name:   "opentelemetry-tracing",
+			Usage:  "Enable tracing for build jobs with OpenTelemetry OTLP. Configure OTLP with standard OTEL_EXPORTER_OTLP_* env vars (default: false)",
+			EnvVar: "BUILDKITE_OPENTELEMETRY_TRACING",
 		},
 		cli.StringFlag{
 			Name:   "tracing-service-name",
@@ -337,7 +337,7 @@ var BootstrapCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name:   "tracing-propagate-traceparent",
-			Usage:  "Accept traceparent from Buildkite control plane (default: false)",
+			Usage:  "Accept traceparent from Buildkite control plane. Requires --opentelemetry-tracing (default: false)",
 			EnvVar: "BUILDKITE_TRACING_PROPAGATE_TRACEPARENT",
 		},
 
@@ -404,6 +404,11 @@ var BootstrapCommand = cli.Command{
 			return fmt.Errorf("failed to parse cancel-signal: %w", err)
 		}
 
+		tracingBackend := tracetools.BackendNone
+		if cfg.OpenTelemetryTracing {
+			tracingBackend = tracetools.BackendOpenTelemetry
+		}
+
 		// Configure the bootstraper
 		bootstrap := job.New(job.ExecutorConfig{
 			AgentName:                    cfg.AgentName,
@@ -458,7 +463,7 @@ var BootstrapCommand = cli.Command{
 			HooksShell:                   cfg.HooksShell,
 			StrictSingleHooks:            cfg.StrictSingleHooks,
 			Tag:                          cfg.Tag,
-			TracingBackend:               cfg.TracingBackend,
+			TracingBackend:               tracingBackend,
 			TracingServiceName:           cfg.TracingServiceName,
 			TracingTraceParent:           cfg.TracingTraceParent,
 			TracingPropagateTraceparent:  cfg.TracingPropagateTraceparent,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -108,7 +108,6 @@ type BootstrapConfig struct {
 	OpenTelemetryTracing         bool          `cli:"opentelemetry-tracing"`
 	TracingServiceName           string        `cli:"tracing-service-name"`
 	TracingTraceParent           string        `cli:"tracing-traceparent"`
-	TracingPropagateTraceparent  bool          `cli:"tracing-propagate-traceparent"`
 	NoJobAPI                     bool          `cli:"no-job-api"`
 	DisableWarningsFor           []string      `cli:"disable-warnings-for" normalize:"list"`
 	CheckoutAttempts             int           `cli:"checkout-attempts"`
@@ -336,12 +335,6 @@ var BootstrapCommand = cli.Command{
 			Value:  "",
 		},
 		cli.BoolFlag{
-			Name:   "tracing-propagate-traceparent",
-			Usage:  "Accept traceparent from Buildkite control plane. Requires --opentelemetry-tracing (default: false)",
-			EnvVar: "BUILDKITE_TRACING_PROPAGATE_TRACEPARENT",
-		},
-
-		cli.BoolFlag{
 			Name:   "no-job-api",
 			Usage:  "Disables the Job API, which gives commands in jobs some abilities to introspect and mutate the state of the job (default: false)",
 			EnvVar: "BUILDKITE_AGENT_NO_JOB_API",
@@ -466,7 +459,6 @@ var BootstrapCommand = cli.Command{
 			TracingBackend:               tracingBackend,
 			TracingServiceName:           cfg.TracingServiceName,
 			TracingTraceParent:           cfg.TracingTraceParent,
-			TracingPropagateTraceparent:  cfg.TracingPropagateTraceparent,
 			JobAPI:                       !cfg.NoJobAPI,
 			DisabledWarnings:             cfg.DisableWarningsFor,
 			Secrets:                      cfg.Secrets,

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -188,9 +188,6 @@ type ExecutorConfig struct {
 	// Traceing context information
 	TracingTraceParent string
 
-	// Accept traceparent context from Buildkite control plane
-	TracingPropagateTraceparent bool
-
 	// Whether to start the JobAPI
 	JobAPI bool
 

--- a/internal/job/tracing.go
+++ b/internal/job/tracing.go
@@ -125,7 +125,7 @@ func (e *Executor) startTracingOpenTelemetry(ctx context.Context) (trace.Span, c
 		trace.WithSchemaURL(semconv.SchemaURL),
 	)
 
-	ctx = e.contextWithTraceparentIfEnabled(ctx)
+	ctx = e.contextWithTraceparentIfPresent(ctx)
 	ctx, span := tracer.Start(ctx, e.otRootSpanName(),
 		trace.WithAttributes(
 			attribute.String("analytics.event", "true"),
@@ -144,13 +144,8 @@ func (e *Executor) startTracingOpenTelemetry(ctx context.Context) (trace.Span, c
 // accepting traceparent from Buildkite control plane is an opt-in feature as its
 // technically a breaking change to the behaviour, and if the server-side tracing
 // isn't set up correctly, agent traces may end up without root spans to link to
-func (e *Executor) contextWithTraceparentIfEnabled(ctx context.Context) context.Context {
-	if !e.TracingPropagateTraceparent {
-		return ctx
-	}
-
+func (e *Executor) contextWithTraceparentIfPresent(ctx context.Context) context.Context {
 	if e.TracingTraceParent == "" {
-		e.shell.Warningf("tracing-propagate-traceparent enabled, but no traceparent provided by server")
 		return ctx
 	}
 


### PR DESCRIPTION
### Description

In https://github.com/buildkite/agent/pull/3867, we removed the opentracing tracing backend, leaving us with only opentelemetry (or none) as our available tracing backends. This PR updates the `buildkite-agent start` command such that:
- the `--tracing-backend` flag has been removed
- replaced with a `--opentelemetry-tracing` flag
- the `--tracing-propagate-traceparent` flag has been removed, and enabled by default when tracing is turned on

The internals of the agent's tracing bits and bobs have intentionally been left untouched. there's a bunch of code in there that exists to swap between interfaces for tracing that doesn't really need to be there anymore, but those changes will be internal-only, so i'll leave them for a later PR.

### Context

You'll never guess where it came to me.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

A bit of Amp, a bit of me.
