### PR TITLE
Preserve percent sequences in JSON job logs

### DIFF
--- a/agent/json_job_logger.go
+++ b/agent/json_job_logger.go
@@ -56,6 +56,6 @@ func (l JSONJobLogger) Write(data []byte) (int, error) {
 	// When writing as a structured log, trailing newlines and carriage returns
 	// generally don't make sense.
 	msg := strings.TrimRight(string(data), "\r\n")
-	l.log.Info(msg)
+	l.log.Info("%s", msg)
 	return len(data), nil
 }

--- a/agent/json_job_logger_test.go
+++ b/agent/json_job_logger_test.go
@@ -60,6 +60,32 @@ func TestJSONJobLogger_JobFields(t *testing.T) {
 	}
 }
 
+func TestJSONJobLogger_PreservesPercentSequences(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+
+	log := NewJSONJobLogger(JobRunnerConfig{
+		AgentStdout: &buf,
+		Job: &api.Job{
+			ID:  "test-job",
+			Env: map[string]string{},
+		},
+	})
+	const line = "Receiving objects:   0% (1/140)\n"
+	if _, err := log.Write([]byte(line)); err != nil {
+		t.Fatalf("log.Write() = %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("failed to parse JSON log: %v", err)
+	}
+
+	if got, want := got["msg"], "Receiving objects:   0% (1/140)"; got != want {
+		t.Errorf("logged msg = %q, want %q", got, want)
+	}
+}
+
 func TestJSONJobLogger_TraceparentFields(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
### Description

`JSONJobLogger.Write` currently passes job output directly to `Logger.Info`. `Logger.Info` treats its first argument as a Go format string, so job output containing a percent sequence can be rewritten before it reaches the JSON `msg` field.

This PR changes `JSONJobLogger.Write` to pass the job output as a `%s` argument instead. That keeps literal output such as `Receiving objects:   0% (1/140)` unchanged.

### Context

We observed JSON job logs where literal percent sequences in command output were changed by Go formatting before log consumers saw them.

### Changes

- Preserve literal percent sequences in `JSONJobLogger.Write`.
- Add a regression test for a Git-style progress line containing `%`.

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

I used Codex to inspect the logging path, make this small patch, and run the local tests.
