### PR TITLE
chore: make logger.Logger methods end in f

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -47,10 +47,10 @@ func (ap *AgentPool) StartStatusServer(ctx context.Context, l logger.Logger, add
 		defer done()
 		setStatus("👂 Listening")
 
-		l.Notice("Starting HTTP health check server on %v", addr)
+		l.Noticef("Starting HTTP health check server on %v", addr)
 		err := http.ListenAndServe(addr, mux)
 		if err != nil {
-			l.Error("Could not start health check server: %v", err)
+			l.Errorf("Could not start health check server: %v", err)
 		}
 	}()
 }
@@ -155,14 +155,14 @@ func (ap *AgentPool) statusJSONHandler(l logger.Logger) http.HandlerFunc {
 			Workers:         statuses,
 		})
 		if err != nil {
-			l.Error("Could not encode status.json response: %v", err)
+			l.Errorf("Could not encode status.json response: %v", err)
 		}
 	}
 }
 
 func healthHandler(l logger.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		l.Debug("agent_pool.go/healthHandler: %s %s", r.Method, r.URL.Path)
+		l.Debugf("agent_pool.go/healthHandler: %s %s", r.Method, r.URL.Path)
 		if r.URL.Path != "/" {
 			http.NotFound(w, r)
 		} else {

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -287,7 +287,7 @@ func (a *AgentWorker) Start(ctx context.Context, idleMon *idleMonitor) (startErr
 				}()
 			}
 
-			a.logger.Error("Failed to acquire and run job: %v", err)
+			a.logger.Errorf("Failed to acquire and run job: %v", err)
 		}
 	}
 
@@ -314,12 +314,12 @@ func (a *AgentWorker) Start(ctx context.Context, idleMon *idleMonitor) (startErr
 				// In streaming-only mode, an unrecoverable failure
 				// in the streaming loop should be reported and should
 				// terminate the agent worker.
-				a.logger.Error("Streaming ping mode failed due to an unrecoverable error: %v", err)
+				a.logger.Errorf("Streaming ping mode failed due to an unrecoverable error: %v", err)
 			default:
 				// In auto mode, the worker should fall back to the ping loop
 				// and carry on. The user might find that interesting (especially if
 				// they are expecting streaming to work).
-				a.logger.Info("Streaming ping mode is unavailable, permanently falling back to polling-based ping mode (the underlying error was: %v)", err)
+				a.logger.Infof("Streaming ping mode is unavailable, permanently falling back to polling-based ping mode (the underlying error was: %v)", err)
 				// If the ping loop then has its own unrecoverable error, then
 				// *that* will terminate the worker. But the streaming loop shouldn't.
 				// So treat the error from the streaming loop as "business as usual".
@@ -392,7 +392,7 @@ func (a *AgentWorker) internalStop() {
 func (a *AgentWorker) StopGracefully() {
 	select {
 	case <-a.stop:
-		a.logger.Warn("Agent is already gracefully stopping...")
+		a.logger.Warnf("Agent is already gracefully stopping...")
 		return
 
 	default:
@@ -402,9 +402,9 @@ func (a *AgentWorker) StopGracefully() {
 	// If we have a job, tell the user that we'll wait for it to finish
 	// before disconnecting
 	if a.jobRunner.Load() != nil {
-		a.logger.Info("Gracefully stopping agent. Waiting for current job to finish before disconnecting...")
+		a.logger.Infof("Gracefully stopping agent. Waiting for current job to finish before disconnecting...")
 	} else {
-		a.logger.Info("Gracefully stopping agent. Since there is no job running, the agent will disconnect immediately")
+		a.logger.Infof("Gracefully stopping agent. Since there is no job running, the agent will disconnect immediately")
 	}
 
 	a.internalStop()
@@ -417,16 +417,16 @@ func (a *AgentWorker) StopUngracefully() {
 
 	// If there's a job running, kill it, then disconnect.
 	if jr := a.jobRunner.Load(); jr != nil {
-		a.logger.Info("Forcefully stopping agent. The current job will be canceled before disconnecting...")
+		a.logger.Infof("Forcefully stopping agent. The current job will be canceled before disconnecting...")
 
 		// Kill the current job. Doesn't do anything if the job
 		// is already being killed, so it's safe to call
 		// multiple times.
 		if err := jr.Cancel(CancelReasonAgentStopping); err != nil {
-			a.logger.Error("Unexpected error canceling job (err: %s)", err)
+			a.logger.Errorf("Unexpected error canceling job (err: %s)", err)
 		}
 	} else {
-		a.logger.Info("Forcefully stopping agent. Since there is no job running, the agent will disconnect immediately")
+		a.logger.Infof("Forcefully stopping agent. Since there is no job running, the agent will disconnect immediately")
 	}
 }
 
@@ -452,7 +452,7 @@ func (a *AgentWorker) Heartbeat(ctx context.Context) error {
 				return nil, &errUnrecoverable{action: "Heartbeat", response: resp, err: err}
 			}
 
-			a.logger.Warn("%s (%s)", err, r)
+			a.logger.Warnf("%s (%s)", err, r)
 			return nil, err
 		}
 		return b, nil
@@ -470,7 +470,7 @@ func (a *AgentWorker) Heartbeat(ctx context.Context) error {
 	// Track a timestamp for the successful heartbeat for better errors
 	a.stats.lastHeartbeat = time.Now()
 
-	a.logger.Debug("Heartbeat sent at %s and received at %s", beat.SentAt, beat.ReceivedAt)
+	a.logger.Debugf("Heartbeat sent at %s and received at %s", beat.SentAt, beat.ReceivedAt)
 	return nil
 }
 

--- a/agent/agent_worker_action.go
+++ b/agent/agent_worker_action.go
@@ -12,8 +12,8 @@ import (
 )
 
 func (a *AgentWorker) runActionLoop(ctx context.Context, idleMon *idleMonitor, fromPingLoop, fromDebouncer <-chan actionMessage) error {
-	a.logger.Debug("[runActionLoop] Starting")
-	defer a.logger.Debug("[runActionLoop] Exiting")
+	a.logger.Debugf("[runActionLoop] Starting")
+	defer a.logger.Debugf("[runActionLoop] Exiting")
 
 	// Once this loop terminates, there's no point continuing the others,
 	// because nothing remains to execute their actions.
@@ -37,7 +37,7 @@ func (a *AgentWorker) runActionLoop(ctx context.Context, idleMon *idleMonitor, f
 	for {
 		// Did both sources of actions terminate? Then we're done too.
 		if fromPingLoop == nil && fromDebouncer == nil {
-			a.logger.Debug("[runActionLoop] All action sources channels are closed, exiting")
+			a.logger.Debugf("[runActionLoop] All action sources channels are closed, exiting")
 			return nil
 		}
 
@@ -49,7 +49,7 @@ func (a *AgentWorker) runActionLoop(ctx context.Context, idleMon *idleMonitor, f
 		//   (if DisconnectAfterIdleTimeout is configured & we're not paused)
 		// - disconnect after uptime
 		//   (if DisconnectAfterUptime is configured & we're not paused)
-		a.logger.Debug("[runActionLoop] Waiting for an action...")
+		a.logger.Debugf("[runActionLoop] Waiting for an action...")
 		setStat("⌚️ Waiting for an action...")
 		var msg actionMessage
 		select {
@@ -60,7 +60,7 @@ func (a *AgentWorker) runActionLoop(ctx context.Context, idleMon *idleMonitor, f
 				fromPingLoop = nil
 				continue
 			}
-			a.logger.Debug("[runActionLoop] Got action %q, jobID %q from ping loop", m.action, m.jobID)
+			a.logger.Debugf("[runActionLoop] Got action %q, jobID %q from ping loop", m.action, m.jobID)
 			msg = m
 			// continue below
 
@@ -69,38 +69,38 @@ func (a *AgentWorker) runActionLoop(ctx context.Context, idleMon *idleMonitor, f
 				fromDebouncer = nil
 				continue
 			}
-			a.logger.Debug("[runActionLoop] Got action %q, jobID %q from streaming loop debouncer", m.action, m.jobID)
+			a.logger.Debugf("[runActionLoop] Got action %q, jobID %q from streaming loop debouncer", m.action, m.jobID)
 			msg = m
 			// continue below
 
 		case <-ctx.Done():
-			a.logger.Debug("[runActionLoop] Stopping due to context cancel")
+			a.logger.Debugf("[runActionLoop] Stopping due to context cancel")
 			return ctx.Err()
 
 		case <-a.stop:
-			a.logger.Debug("[runActionLoop] Stopping due to agent stop")
+			a.logger.Debugf("[runActionLoop] Stopping due to agent stop")
 			return nil
 
 		case <-disconnectAfterUptime:
-			a.logger.Info("Agent has exceeded max uptime of %v", maxUptime)
+			a.logger.Infof("Agent has exceeded max uptime of %v", maxUptime)
 			if paused {
 				// Wait to be unpaused before exiting
-				a.logger.Info("Awaiting resume before disconnecting...")
+				a.logger.Infof("Awaiting resume before disconnecting...")
 				exitWhenNotPaused = true
 				continue
 			}
-			a.logger.Info("Disconnecting...")
+			a.logger.Infof("Disconnecting...")
 			return nil
 
 		case <-idleMon.Exiting():
 			// This should only happen if the agent isn't paused.
 			// (Pausedness is a kind of non-idleness.)
-			a.logger.Info("All agents have been idle for at least %v. Disconnecting...", idleMon.idleTimeout)
+			a.logger.Infof("All agents have been idle for at least %v. Disconnecting...", idleMon.idleTimeout)
 			return nil
 		}
 
 		// Let's handle the action!
-		a.logger.Debug("[runActionLoop] Performing action %q, jobID %q", msg.action, msg.jobID)
+		a.logger.Debugf("[runActionLoop] Performing action %q, jobID %q", msg.action, msg.jobID)
 		setStat(fmt.Sprintf("🧑‍🍳 Performing %q action...", msg.action))
 		pingActions.WithLabelValues(msg.action).Inc()
 
@@ -109,7 +109,7 @@ func (a *AgentWorker) runActionLoop(ctx context.Context, idleMon *idleMonitor, f
 		// Otherwise, be sure to `close(msg.errCh)`!
 		switch msg.action {
 		case "disconnect":
-			a.logger.Debug("[runActionLoop] Stopping action loop due to disconnect action")
+			a.logger.Debugf("[runActionLoop] Stopping action loop due to disconnect action")
 			return nil
 
 		case "pause":
@@ -117,7 +117,7 @@ func (a *AgentWorker) runActionLoop(ctx context.Context, idleMon *idleMonitor, f
 			// paused agent is expected to remain alive and pinging for
 			// instructions.
 			// *This includes acquire-job and disconnect-after-idle-timeout.*
-			a.logger.Debug("[runActionLoop] Entering pause state")
+			a.logger.Debugf("[runActionLoop] Entering pause state")
 			paused = true
 			// For the purposes of deciding whether or not to exit,
 			// pausedness is a kind of non-idleness.
@@ -129,12 +129,12 @@ func (a *AgentWorker) runActionLoop(ctx context.Context, idleMon *idleMonitor, f
 
 		// At this point, action was neither "disconnect" nor "pause".
 		if exitWhenNotPaused {
-			a.logger.Debug("[runActionLoop] Stopping action loop because exitWhenNotPaused is true")
+			a.logger.Debugf("[runActionLoop] Stopping action loop because exitWhenNotPaused is true")
 			return nil
 		}
 		if paused {
 			// We're not paused any more! Log a helpful message.
-			a.logger.Info("Agent has resumed after being paused")
+			a.logger.Infof("Agent has resumed after being paused")
 			paused = false
 		}
 
@@ -142,7 +142,7 @@ func (a *AgentWorker) runActionLoop(ctx context.Context, idleMon *idleMonitor, f
 		// so jobID should be empty. If not, complain.
 		if a.agentConfiguration.AcquireJob != "" {
 			if msg.jobID != "" {
-				a.logger.Error("Agent ping dispatched a job (id %q) but agent is in acquire-job mode! Ignoring the new job", msg.jobID)
+				a.logger.Errorf("Agent ping dispatched a job (id %q) but agent is in acquire-job mode! Ignoring the new job", msg.jobID)
 			}
 			// Disconnect after acquire-job.
 			return nil
@@ -152,9 +152,9 @@ func (a *AgentWorker) runActionLoop(ctx context.Context, idleMon *idleMonitor, f
 		// ignore-in-dispatches=true. So jobID should be empty. If not, complain.
 		if ranJob && a.agentConfiguration.DisconnectAfterJob {
 			if msg.jobID != "" {
-				a.logger.Error("Agent ping dispatched a job (id %q) but agent is in disconnect-after-job mode (and already ran a job)! Ignoring the new job", msg.jobID)
+				a.logger.Errorf("Agent ping dispatched a job (id %q) but agent is in disconnect-after-job mode (and already ran a job)! Ignoring the new job", msg.jobID)
 			}
-			a.logger.Info("Job ran, and disconnect-after-job is enabled. Disconnecting...")
+			a.logger.Infof("Job ran, and disconnect-after-job is enabled. Disconnecting...")
 			return nil
 		}
 
@@ -171,7 +171,7 @@ func (a *AgentWorker) runActionLoop(ctx context.Context, idleMon *idleMonitor, f
 
 		// Runs the job, only errors if something goes wrong
 		if err := a.AcceptAndRunJob(ctx, msg.jobID, idleMon); err != nil {
-			a.logger.Error("%v", err)
+			a.logger.Errorf("%v", err)
 			setStat(fmt.Sprintf("✅ Finished job with error: %v", err))
 			msg.errCh <- err // so the ping loop can do something special
 			close(msg.errCh)
@@ -185,7 +185,7 @@ func (a *AgentWorker) runActionLoop(ctx context.Context, idleMon *idleMonitor, f
 
 // Accepts a job and runs it, only returns an error if something goes wrong
 func (a *AgentWorker) AcceptAndRunJob(ctx context.Context, jobID string, idleMon *idleMonitor) error {
-	a.logger.Info("Assigned job %s. Accepting...", jobID)
+	a.logger.Infof("Assigned job %s. Accepting...", jobID)
 
 	// An agent is busy during a job, and idle when the job is done.
 	idleMon.MarkBusy(a)
@@ -203,9 +203,9 @@ func (a *AgentWorker) AcceptAndRunJob(ctx context.Context, jobID string, idleMon
 		accepted, _, err := a.apiClient.AcceptJob(ctx, jobID)
 		if err != nil {
 			if api.IsRetryableError(err) {
-				a.logger.Warn("%s (%s)", err, r)
+				a.logger.Warnf("%s (%s)", err, r)
 			} else {
-				a.logger.Warn("Buildkite rejected the call to accept the job (%s)", err)
+				a.logger.Warnf("Buildkite rejected the call to accept the job (%s)", err)
 				r.Break()
 			}
 		}

--- a/agent/agent_worker_debouncer.go
+++ b/agent/agent_worker_debouncer.go
@@ -28,8 +28,8 @@ import (
 // exit in a one-shot mode, even though the second "pause" means the
 // user actually *did* want the agent to be paused.
 func (a *AgentWorker) runDebouncer(ctx context.Context, bat *baton, outCh chan<- actionMessage, inCh <-chan actionMessage) error {
-	a.logger.Debug("[runDebouncer] Starting")
-	defer a.logger.Debug("[runDebouncer] Exiting")
+	a.logger.Debugf("[runDebouncer] Starting")
+	defer a.logger.Debugf("[runDebouncer] Exiting")
 
 	// When the debouncer returns, close the output channel to let the next
 	// loop know to stop listening to it.
@@ -40,7 +40,7 @@ func (a *AgentWorker) runDebouncer(ctx context.Context, bat *baton, outCh chan<-
 
 	// We begin holding the baton, ensure it is released when we exit.
 	defer func() {
-		a.logger.Debug("[runDebouncer] Releasing the baton")
+		a.logger.Debugf("[runDebouncer] Releasing the baton")
 		bat.Release(actorDebouncer)
 	}()
 
@@ -61,34 +61,34 @@ func (a *AgentWorker) runDebouncer(ctx context.Context, bat *baton, outCh chan<-
 	for {
 		select {
 		case <-a.stop:
-			a.logger.Debug("[runDebouncer] Stopping due to agent stop")
+			a.logger.Debugf("[runDebouncer] Stopping due to agent stop")
 			return nil
 		case <-ctx.Done():
-			a.logger.Debug("[runDebouncer] Stopping due to context cancel")
+			a.logger.Debugf("[runDebouncer] Stopping due to context cancel")
 			return ctx.Err()
 
 		case <-iif(healthy, bat.Acquire()): // if the stream is healthy, take the baton if available
 			bat.Acquired(actorDebouncer)
-			a.logger.Debug("[runDebouncer] Took the baton")
+			a.logger.Debugf("[runDebouncer] Took the baton")
 			// We now have the baton!
 			// continue below to send any pending message, if able
 
 		case msg, open := <-inCh: // streaming loop has produced an event
 			if !open {
-				a.logger.Debug("[runDebouncer] Stopping due to input channel closing")
+				a.logger.Debugf("[runDebouncer] Stopping due to input channel closing")
 				return nil
 			}
 
 			healthy = !msg.unhealthy
 
 			if !healthy {
-				a.logger.Debug("[runDebouncer] Streaming loop is unhealthy")
+				a.logger.Debugf("[runDebouncer] Streaming loop is unhealthy")
 
 				// It is not healthy, so release the baton as soon as we can
 				// (when the current action is done).
 				if !actionInProgress {
 					// We can release the baton now.
-					a.logger.Debug("[runDebouncer] Releasing the baton")
+					a.logger.Debugf("[runDebouncer] Releasing the baton")
 					bat.Release(actorDebouncer)
 				}
 				break // out of the select
@@ -101,7 +101,7 @@ func (a *AgentWorker) runDebouncer(ctx context.Context, bat *baton, outCh chan<-
 			// continue below to send it
 
 		case <-lastActionResult: // most recent action has completed
-			a.logger.Debug("[runDebouncer] Last action has completed")
+			a.logger.Debugf("[runDebouncer] Last action has completed")
 			// Set the channel variable to nil so we don't spinloop.
 			// (Operations on a nil channel block forever.)
 			lastActionResult = nil
@@ -115,7 +115,7 @@ func (a *AgentWorker) runDebouncer(ctx context.Context, bat *baton, outCh chan<-
 		if !healthy || !bat.HeldBy(actorDebouncer) || actionInProgress || pending == nil {
 			continue
 		}
-		a.logger.Debug("[runDebouncer] Sending action %q, jobID %q", pending.action, pending.jobID)
+		a.logger.Debugf("[runDebouncer] Sending action %q, jobID %q", pending.action, pending.jobID)
 		lastActionResult = make(chan error)
 		pending.errCh = lastActionResult
 		select {
@@ -124,10 +124,10 @@ func (a *AgentWorker) runDebouncer(ctx context.Context, bat *baton, outCh chan<-
 			pending = nil
 			actionInProgress = true
 		case <-a.stop:
-			a.logger.Debug("[runDebouncer] Stopping due to agent stop")
+			a.logger.Debugf("[runDebouncer] Stopping due to agent stop")
 			return nil
 		case <-ctx.Done():
-			a.logger.Debug("[runDebouncer] Stopping due to context cancel")
+			a.logger.Debugf("[runDebouncer] Stopping due to context cancel")
 			return ctx.Err()
 		}
 	}

--- a/agent/agent_worker_heartbeat.go
+++ b/agent/agent_worker_heartbeat.go
@@ -22,7 +22,7 @@ func (a *AgentWorker) runHeartbeatLoop(ctx context.Context) error {
 			setStat("❤️ Sending heartbeat")
 			if err := a.Heartbeat(ctx); err != nil {
 				if isUnrecoverable(err) {
-					a.logger.Error("%s", err)
+					a.logger.Errorf("%s", err)
 					// unrecoverable heartbeat failure also stops everything else
 					a.StopUngracefully()
 					return err
@@ -31,17 +31,17 @@ func (a *AgentWorker) runHeartbeatLoop(ctx context.Context) error {
 				// Get the last heartbeat time to the nearest microsecond
 				a.stats.Lock()
 				if a.stats.lastHeartbeat.IsZero() {
-					a.logger.Error("Failed to heartbeat %s. Will try again in %v. (No heartbeat yet)",
+					a.logger.Errorf("Failed to heartbeat %s. Will try again in %v. (No heartbeat yet)",
 						err, heartbeatInterval)
 				} else {
-					a.logger.Error("Failed to heartbeat %s. Will try again in %v. (Last successful was %v ago)",
+					a.logger.Errorf("Failed to heartbeat %s. Will try again in %v. (Last successful was %v ago)",
 						err, heartbeatInterval, time.Since(a.stats.lastHeartbeat))
 				}
 				a.stats.Unlock()
 			}
 
 		case <-ctx.Done():
-			a.logger.Debug("Stopping heartbeats due to context cancel")
+			a.logger.Debugf("Stopping heartbeats due to context cancel")
 			// An alternative to returning nil would be ctx.Err(), but we use
 			// the context for ordinary termination of this loop.
 			// A context cancellation from outside the agent worker would still

--- a/agent/agent_worker_ping.go
+++ b/agent/agent_worker_ping.go
@@ -12,8 +12,8 @@ import (
 
 // runPingLoop runs the (classical) loop that pings Buildkite for work.
 func (a *AgentWorker) runPingLoop(ctx context.Context, bat *baton, outCh chan<- actionMessage) error {
-	a.logger.Debug("[runPingLoop] Starting")
-	defer a.logger.Debug("[runPingLoop] Exiting")
+	a.logger.Debugf("[runPingLoop] Starting")
+	defer a.logger.Debugf("[runPingLoop] Exiting")
 
 	// When this loop returns, close the channel to let the action handler loop
 	// stop listening for actions from it.
@@ -43,11 +43,11 @@ func (a *AgentWorker) runPingLoop(ctx context.Context, bat *baton, outCh chan<- 
 		close(state.skipWait)
 	}
 
-	a.logger.Info("Waiting for instructions...")
+	a.logger.Infof("Waiting for instructions...")
 
 	for {
 		startWait := time.Now()
-		a.logger.Debug("[runPingLoop] Waiting for pingTicker")
+		a.logger.Debugf("[runPingLoop] Waiting for pingTicker")
 		setStat("😴 Waiting until next ping interval tick")
 		select {
 		case <-state.skipWait:
@@ -55,17 +55,17 @@ func (a *AgentWorker) runPingLoop(ctx context.Context, bat *baton, outCh chan<- 
 		case <-state.pingTicker.C:
 			// continue below
 		case <-a.stop:
-			a.logger.Debug("[runPingLoop] Stopping due to agent stop")
+			a.logger.Debugf("[runPingLoop] Stopping due to agent stop")
 			return nil
 		case <-ctx.Done():
-			a.logger.Debug("[runPingLoop] Stopping due to context cancel")
+			a.logger.Debugf("[runPingLoop] Stopping due to context cancel")
 			return ctx.Err()
 		}
 
 		// Within the interval, wait a random amount of time to avoid
 		// spontaneous synchronisation across agents.
 		jitter := rand.N(pingInterval)
-		a.logger.Debug("[runPingLoop] Waiting for jitter %v", jitter)
+		a.logger.Debugf("[runPingLoop] Waiting for jitter %v", jitter)
 		setStat(fmt.Sprintf("🫨 Jittering for %v", jitter))
 		select {
 		case <-state.skipWait:
@@ -73,10 +73,10 @@ func (a *AgentWorker) runPingLoop(ctx context.Context, bat *baton, outCh chan<- 
 		case <-time.After(jitter):
 			// continue below
 		case <-a.stop:
-			a.logger.Debug("[runPingLoop] Stopping due to agent stop")
+			a.logger.Debugf("[runPingLoop] Stopping due to agent stop")
 			return nil
 		case <-ctx.Done():
-			a.logger.Debug("[runPingLoop] Stopping due to context cancel")
+			a.logger.Debugf("[runPingLoop] Stopping due to context cancel")
 			return ctx.Err()
 		}
 		pingWaitDurations.Observe(time.Since(startWait).Seconds())
@@ -110,25 +110,25 @@ func (a *pingLoopState) pingLoopInner(ctx context.Context) error {
 	// to prevent the streaming loop from resuming control until then,
 	// but we always release the baton, because the streaming loop is
 	// preferred.
-	a.logger.Debug("[runPingLoop] Waiting for baton")
+	a.logger.Debugf("[runPingLoop] Waiting for baton")
 	select {
 	case <-a.bat.Acquire(): // the baton is ours!
 		a.bat.Acquired(actorPingLoop)
-		a.logger.Debug("[runPingLoop] Acquired the baton")
+		a.logger.Debugf("[runPingLoop] Acquired the baton")
 		defer func() { // <- this is why the ping loop body is in a func
-			a.logger.Debug("[runPingLoop] Releasing the baton")
+			a.logger.Debugf("[runPingLoop] Releasing the baton")
 			a.bat.Release(actorPingLoop)
 		}()
 
 	case <-a.stop:
-		a.logger.Debug("[runPingLoop] Stopping due to agent stop")
+		a.logger.Debugf("[runPingLoop] Stopping due to agent stop")
 		return errInternalStop
 	case <-ctx.Done():
-		a.logger.Debug("[runPingLoop] Stopping due to context cancel")
+		a.logger.Debugf("[runPingLoop] Stopping due to context cancel")
 		return ctx.Err()
 	}
 
-	a.logger.Debug("[runPingLoop] Pinging buildkite for instructions")
+	a.logger.Debugf("[runPingLoop] Pinging buildkite for instructions")
 	a.setStat("📡 Pinging Buildkite for instructions")
 	pingsSent.Inc()
 	startPing := time.Now()
@@ -136,14 +136,14 @@ func (a *pingLoopState) pingLoopInner(ctx context.Context) error {
 	if err != nil {
 		pingErrors.Inc()
 		if isUnrecoverable(err) {
-			a.logger.Error("%v", err)
+			a.logger.Errorf("%v", err)
 			return err
 		}
-		a.logger.Warn("%v", err)
+		a.logger.Warnf("%v", err)
 	}
 	pingDurations.Observe(time.Since(startPing).Seconds())
 
-	a.logger.Debug("[runPingLoop] Sending action")
+	a.logger.Debugf("[runPingLoop] Sending action")
 
 	// Send the action to the action loop
 	errCh := make(chan error)
@@ -156,10 +156,10 @@ func (a *pingLoopState) pingLoopInner(ctx context.Context) error {
 	case a.outCh <- msg:
 		// sent!
 	case <-a.stop:
-		a.logger.Debug("[runPingLoop] Stopping due to agent stop")
+		a.logger.Debugf("[runPingLoop] Stopping due to agent stop")
 		return errInternalStop
 	case <-ctx.Done():
-		a.logger.Debug("[runPingLoop] Stopping due to context cancel")
+		a.logger.Debugf("[runPingLoop] Stopping due to context cancel")
 		return ctx.Err()
 	}
 
@@ -193,10 +193,10 @@ func (a *pingLoopState) pingLoopInner(ctx context.Context) error {
 		}
 		return nil
 	case <-a.stop:
-		a.logger.Debug("[runPingLoop] Stopping due to agent stop")
+		a.logger.Debugf("[runPingLoop] Stopping due to agent stop")
 		return errInternalStop
 	case <-ctx.Done():
-		a.logger.Debug("[runPingLoop] Stopping due to context cancel")
+		a.logger.Debugf("[runPingLoop] Stopping due to context cancel")
 		return ctx.Err()
 	}
 }
@@ -213,7 +213,7 @@ func (a *AgentWorker) Ping(ctx context.Context) (jobID, action string, err error
 	if ping != nil {
 		// Is there a message that should be shown in the logs?
 		if ping.Message != "" {
-			a.logger.Info(ping.Message)
+			a.logger.Infof(ping.Message)
 		}
 
 		action = ping.Action
@@ -253,7 +253,7 @@ func (a *AgentWorker) Ping(ctx context.Context) (jobID, action string, err error
 		// valid. If it is, switch and carry on, otherwise ignore the switch
 		newPing, _, err := newAPIClient.Ping(ctx)
 		if err != nil {
-			a.logger.Warn("Failed to ping the new endpoint %s - ignoring switch for now (%s)", ping.Endpoint, err)
+			a.logger.Warnf("Failed to ping the new endpoint %s - ignoring switch for now (%s)", ping.Endpoint, err)
 		} else {
 			// Replace the APIClient and process the new ping
 			a.apiClient = newAPIClient

--- a/agent/agent_worker_streaming.go
+++ b/agent/agent_worker_streaming.go
@@ -15,8 +15,8 @@ import (
 // (allowed to fail and fall back to the regular ping loop) but when it works
 // it is preferred because there is less waiting around.
 func (a *AgentWorker) runStreamingPingLoop(ctx context.Context, outCh chan<- actionMessage) error {
-	a.logger.Debug("[runStreamingPingLoop] Starting")
-	defer a.logger.Debug("[runStreamingPingLoop] Exiting")
+	a.logger.Debugf("[runStreamingPingLoop] Starting")
+	defer a.logger.Debugf("[runStreamingPingLoop] Exiting")
 
 	// When this loop returns, close the channel to let the next loop stop
 	// listening to it.
@@ -79,17 +79,17 @@ func (a *AgentWorker) runStreamingPingLoop(ctx context.Context, outCh chan<- act
 		// spontaneous synchronisation across agents.
 		jitter := rand.N(window)
 		setStat(fmt.Sprintf("🫨 Jittering for %v (max %v)", jitter, window))
-		a.logger.Debug("[runStreamingPingLoop] Waiting for jitter %v (max %v)", jitter, window)
+		a.logger.Debugf("[runStreamingPingLoop] Waiting for jitter %v (max %v)", jitter, window)
 		select {
 		case <-skipWait:
 			// continue below
 		case <-time.After(jitter):
 			// continue below
 		case <-a.stop:
-			a.logger.Debug("[runStreamingPingLoop] Stopping due to agent stop")
+			a.logger.Debugf("[runStreamingPingLoop] Stopping due to agent stop")
 			return nil
 		case <-ctx.Done():
-			a.logger.Debug("[runStreamingPingLoop] Stopping due to context cancel")
+			a.logger.Debugf("[runStreamingPingLoop] Stopping due to context cancel")
 			return ctx.Err()
 		}
 
@@ -109,17 +109,17 @@ func (a *AgentWorker) runStreamingPingLoop(ctx context.Context, outCh chan<- act
 		// Central Limit Theorem! We'd rather have a uniform distribution
 		// over a window.)
 		setStat("😴 Waiting for remainder of window")
-		a.logger.Debug("[runStreamingPingLoop] Waiting for remainder of window")
+		a.logger.Debugf("[runStreamingPingLoop] Waiting for remainder of window")
 		select {
 		case <-skipWait:
 			// continue next iteration
 		case <-windowEnd:
 			// continue next iteration
 		case <-a.stop:
-			a.logger.Debug("[runStreamingPingLoop] Stopping due to agent stop")
+			a.logger.Debugf("[runStreamingPingLoop] Stopping due to agent stop")
 			return nil
 		case <-ctx.Done():
-			a.logger.Debug("[runStreamingPingLoop] Stopping due to context cancel")
+			a.logger.Debugf("[runStreamingPingLoop] Stopping due to context cancel")
 			return ctx.Err()
 		}
 	}
@@ -138,37 +138,37 @@ type streamLoopState struct {
 // startStream attempts 1 connection to the stream and handles its messages.
 func (a *streamLoopState) startStream(ctx, streamCtx context.Context) error {
 	a.setStat(fmt.Sprintf("📱 Connecting to ping stream (attempt %d)...", a.attempts))
-	a.logger.Debug("[runStreamingPingLoop] Connecting (attempt %d)", a.attempts)
+	a.logger.Debugf("[runStreamingPingLoop] Connecting (attempt %d)", a.attempts)
 	stream, err := a.apiClient.StreamPings(streamCtx, a.agent.UUID)
 	if err != nil {
 		// TODO: after we've made streaming endpoints generally available,
 		// think about making some of these logs error or warning level.
-		a.logger.Debug("[runStreamingPingLoop] Connection to ping stream failed: %v", err)
+		a.logger.Debugf("[runStreamingPingLoop] Connection to ping stream failed: %v", err)
 		if isUnrecoverable(err) {
-			a.logger.Debug("[runStreamingPingLoop] Stopping because the error is unrecoverable")
+			a.logger.Debugf("[runStreamingPingLoop] Stopping because the error is unrecoverable")
 			return err
 		}
 		// Fast fallback to the ping loop
-		a.logger.Debug("[runStreamingPingLoop] Becoming unhealthy")
+		a.logger.Debugf("[runStreamingPingLoop] Becoming unhealthy")
 		// Re-arm the "connection established" log so the next successful
 		// connection (after this mode switch to the ping loop) logs.
 		a.firstMsg = true
 		select {
 		case a.outCh <- actionMessage{unhealthy: true}:
-			a.logger.Debug("[runStreamingPingLoop] Unhealthy message sent to debouncer")
+			a.logger.Debugf("[runStreamingPingLoop] Unhealthy message sent to debouncer")
 			// sent!
 		case <-a.stop:
-			a.logger.Debug("[runStreamingPingLoop] Stopping due to agent stop")
+			a.logger.Debugf("[runStreamingPingLoop] Stopping due to agent stop")
 			return errInternalStop
 		case <-ctx.Done():
-			a.logger.Debug("[runStreamingPingLoop] Stopping due to context cancel")
+			a.logger.Debugf("[runStreamingPingLoop] Stopping due to context cancel")
 			return ctx.Err()
 		}
 		return nil // continue outer streaming loop
 	}
 
 	a.setStat("🏞️ Streaming actions from Buildkite")
-	a.logger.Debug("[runStreamingPingLoop] Waiting for a message...")
+	a.logger.Debugf("[runStreamingPingLoop] Waiting for a message...")
 	for msg, streamErr := range stream {
 		err := a.handle(ctx, msg, streamErr)
 		if err == errInternalBreak {
@@ -185,36 +185,36 @@ func (a *streamLoopState) startStream(ctx, streamCtx context.Context) error {
 }
 
 func (a *streamLoopState) handle(ctx context.Context, msg *agentedgev1.StreamPingsResponse, streamErr error) error {
-	a.logger.Debug("[runStreamingPingLoop] Received msg %v, err %v", msg, streamErr)
+	a.logger.Debugf("[runStreamingPingLoop] Received msg %v, err %v", msg, streamErr)
 
 	var amsg actionMessage
 	switch {
 	case streamErr != nil:
 		// TODO: after we've made streaming endpoints generally available,
 		// think about making some of these logs error or warning level.
-		a.logger.Debug("[runStreamingPingLoop] Connection to ping stream failed or ended: %v", streamErr)
+		a.logger.Debugf("[runStreamingPingLoop] Connection to ping stream failed or ended: %v", streamErr)
 		if isUnrecoverable(streamErr) {
-			a.logger.Debug("[runStreamingPingLoop] Stopping because the error is unrecoverable")
+			a.logger.Debugf("[runStreamingPingLoop] Stopping because the error is unrecoverable")
 			return streamErr
 		}
 		// Stay healthy if the error is deadline-exceeded.
 		// (The connection timed out, which we want to happen every so often).
 		if connect.CodeOf(streamErr) == connect.CodeDeadlineExceeded {
-			a.logger.Debug("[runStreamingPingLoop] Breaking stream loop to reconnect following deadline-exceeded")
+			a.logger.Debugf("[runStreamingPingLoop] Breaking stream loop to reconnect following deadline-exceeded")
 			return errInternalBreak
 		}
 		// It's some other error. Go unhealthy, which unblocks the ping loop.
-		a.logger.Debug("[runStreamingPingLoop] Becoming unhealthy")
+		a.logger.Debugf("[runStreamingPingLoop] Becoming unhealthy")
 		amsg.unhealthy = true
 
 	case msg == nil:
-		a.logger.Debug("[runStreamingPingLoop] Ping stream yielded a nil message, so assuming the stream is broken")
-		a.logger.Debug("[runStreamingPingLoop] Becoming unhealthy")
+		a.logger.Debugf("[runStreamingPingLoop] Ping stream yielded a nil message, so assuming the stream is broken")
+		a.logger.Debugf("[runStreamingPingLoop] Becoming unhealthy")
 		amsg.unhealthy = true
 
 	default:
 		if a.firstMsg {
-			a.logger.Info("Ping stream connection established")
+			a.logger.Infof("Ping stream connection established")
 			a.firstMsg = false
 		}
 
@@ -224,21 +224,21 @@ func (a *streamLoopState) handle(ctx context.Context, msg *agentedgev1.StreamPin
 
 		case *agentedgev1.StreamPingsResponse_Pause:
 			if reason := act.Pause.GetReason(); reason != "" {
-				a.logger.Info("Pause reason: %s", reason)
+				a.logger.Infof("Pause reason: %s", reason)
 			}
 			amsg.action = "pause"
 
 		case *agentedgev1.StreamPingsResponse_Disconnect:
 			if reason := act.Disconnect.GetReason(); reason != "" {
-				a.logger.Info("Disconnect reason: %s", reason)
+				a.logger.Infof("Disconnect reason: %s", reason)
 			}
 			amsg.action = "disconnect"
 
 		case *agentedgev1.StreamPingsResponse_JobAssigned:
 			amsg.jobID = act.JobAssigned.GetJob().GetId()
 			if amsg.jobID == "" {
-				a.logger.Error("Ping stream yielded a JobAssigned message with nil job or empty job ID, so assuming the stream is broken")
-				a.logger.Debug("[runStreamingPingLoop] Becoming unhealthy")
+				a.logger.Errorf("Ping stream yielded a JobAssigned message with nil job or empty job ID, so assuming the stream is broken")
+				a.logger.Debugf("[runStreamingPingLoop] Becoming unhealthy")
 				amsg.unhealthy = true
 			}
 		}
@@ -247,26 +247,26 @@ func (a *streamLoopState) handle(ctx context.Context, msg *agentedgev1.StreamPin
 	// Send the message to the debouncer.
 	select {
 	case a.outCh <- amsg:
-		a.logger.Debug("[runStreamingPingLoop] Message sent to debouncer")
+		a.logger.Debugf("[runStreamingPingLoop] Message sent to debouncer")
 		// sent!
 	case <-a.stop:
-		a.logger.Debug("[runStreamingPingLoop] Stopping due to agent stop")
+		a.logger.Debugf("[runStreamingPingLoop] Stopping due to agent stop")
 		return errInternalStop
 	case <-ctx.Done():
-		a.logger.Debug("[runStreamingPingLoop] Stopping due to context cancel")
+		a.logger.Debugf("[runStreamingPingLoop] Stopping due to context cancel")
 		return ctx.Err()
 	}
 
 	// In case the server sends a disconnect but doesn't close the
 	// stream, be sure to exit.
 	if amsg.action == "disconnect" {
-		a.logger.Debug("[runStreamingPingLoop] Stopping due to disconnect action")
+		a.logger.Debugf("[runStreamingPingLoop] Stopping due to disconnect action")
 		a.internalStop()
 		return errInternalStop
 	}
 
 	if amsg.unhealthy {
-		a.logger.Debug("[runStreamingPingLoop] Breaking stream loop to reconnect because the stream is unhealthy")
+		a.logger.Debugf("[runStreamingPingLoop] Breaking stream loop to reconnect because the stream is unhealthy")
 		// Re-arm the "connection established" log so the next successful
 		// connection (after this mode switch to the ping loop) logs.
 		a.firstMsg = true

--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -60,7 +60,7 @@ func TestDisconnect(t *testing.T) {
 		APIClient: apiClient,
 		Logger:    l,
 		RetrySleepFunc: func(time.Duration) {
-			t.Error("unexpected retrier sleep")
+			t.Errorf("unexpected retrier sleep")
 		},
 	}
 

--- a/agent/baton_test.go
+++ b/agent/baton_test.go
@@ -38,6 +38,6 @@ func TestBaton_NoDroppedBatonDeadlock(t *testing.T) {
 	case <-done:
 		// It probably doesn't deadlock that way
 	case <-time.After(10 * time.Second):
-		t.Error("Repeated baton.Acquire/Release failed to progress, possible deadlock")
+		t.Errorf("Repeated baton.Acquire/Release failed to progress, possible deadlock")
 	}
 }

--- a/agent/header_times_streamer.go
+++ b/agent/header_times_streamer.go
@@ -73,7 +73,7 @@ func (h *headerTimesStreamer) Run(ctx context.Context) {
 
 	defer close(h.streamingDoneCh)
 
-	h.logger.Debug("[HeaderTimesStreamer] Streamer has started...")
+	h.logger.Debugf("[HeaderTimesStreamer] Streamer has started...")
 
 	nextIndex := 0
 	chanOpen := true
@@ -99,7 +99,7 @@ func (h *headerTimesStreamer) Run(ctx context.Context) {
 				break batchLoop
 
 			case <-ctx.Done(): // pack it all up
-				h.logger.Debug("[HeaderTimesStreamer] %v", ctx.Err())
+				h.logger.Debugf("[HeaderTimesStreamer] %v", ctx.Err())
 				return
 			}
 		}
@@ -120,13 +120,13 @@ func (h *headerTimesStreamer) Run(ctx context.Context) {
 		// Call our callback with the times for upload
 		setStatus(fmt.Sprintf("📡 Uploading %d header times", len(times)))
 
-		h.logger.Debug("[HeaderTimesStreamer] Uploading header times %d..%d", startIdx, nextIndex-1)
+		h.logger.Debugf("[HeaderTimesStreamer] Uploading header times %d..%d", startIdx, nextIndex-1)
 		h.uploadCallback(ctx, startIdx, nextIndex, payload)
-		h.logger.Debug("[HeaderTimesStreamer] Finished uploading header times %d..%d", startIdx, nextIndex-1)
+		h.logger.Debugf("[HeaderTimesStreamer] Finished uploading header times %d..%d", startIdx, nextIndex-1)
 	}
 
 	setStatus("👋 Finished!")
-	h.logger.Debug("[HeaderTimesStreamer] Streamer has finished...")
+	h.logger.Debugf("[HeaderTimesStreamer] Streamer has finished...")
 }
 
 // Scan takes a line of log output and tracks a time if it's a header.
@@ -142,7 +142,7 @@ func (h *headerTimesStreamer) Scan(line string) bool {
 		return headerExpansionRE.MatchString(line)
 	}
 
-	h.logger.Debug("[HeaderTimesStreamer] Found header %q", line)
+	h.logger.Debugf("[HeaderTimesStreamer] Found header %q", line)
 
 	// Use mutex to prevent concurrently sending and closing the channel.
 	h.streamingMu.Lock()
@@ -167,6 +167,6 @@ func (h *headerTimesStreamer) Stop() {
 	close(h.timesCh)
 	h.streamingMu.Unlock()
 
-	h.logger.Debug("[HeaderTimesStreamer] Waiting for all the header times to be uploaded")
+	h.logger.Debugf("[HeaderTimesStreamer] Waiting for all the header times to be uploaded")
 	<-h.streamingDoneCh
 }

--- a/agent/header_times_streamer_test.go
+++ b/agent/header_times_streamer_test.go
@@ -31,7 +31,7 @@ func TestHeaderTimesStreamerScanAfterStopDoesNotPanic(t *testing.T) {
 
 		select {
 		case <-deadline:
-			t.Fatal("timed out waiting for header times streamer to start")
+			t.Fatalf("timed out waiting for header times streamer to start")
 		default:
 			time.Sleep(1 * time.Millisecond)
 		}
@@ -46,7 +46,7 @@ func TestHeaderTimesStreamerScanAfterStopDoesNotPanic(t *testing.T) {
 	select {
 	case <-stopDone:
 	case <-time.After(500 * time.Millisecond):
-		t.Fatal("timed out waiting for header times streamer to stop")
+		t.Fatalf("timed out waiting for header times streamer to stop")
 	}
 
 	defer func() {
@@ -62,6 +62,6 @@ func TestHeaderTimesStreamerScanAfterStopDoesNotPanic(t *testing.T) {
 	select {
 	case <-runDone:
 	case <-time.After(500 * time.Millisecond):
-		t.Fatal("timed out waiting for header times streamer run loop to exit")
+		t.Fatalf("timed out waiting for header times streamer run loop to exit")
 	}
 }

--- a/agent/idle_monitor_test.go
+++ b/agent/idle_monitor_test.go
@@ -33,7 +33,7 @@ func TestIdleMonitor(t *testing.T) {
 
 	case <-time.After(2 * idleTimeout):
 		// TODO: use testing/synctest when that becomes available
-		t.Error("timed out waiting on <-i.Exiting()")
+		t.Errorf("timed out waiting on <-i.Exiting()")
 	}
 }
 
@@ -62,7 +62,7 @@ func TestIdleMonitor_AllDead(t *testing.T) {
 		}
 	case <-time.After(idleTimeout):
 		// TODO: use testing/synctest when that becomes available
-		t.Error("timed out waiting on <-i.Exiting()")
+		t.Errorf("timed out waiting on <-i.Exiting()")
 	}
 }
 
@@ -83,7 +83,7 @@ func TestIdleMonitor_Busy(t *testing.T) {
 
 	select {
 	case <-i.Exiting():
-		t.Error("<-i.Exiting() happened while at least one agent was still busy")
+		t.Errorf("<-i.Exiting() happened while at least one agent was still busy")
 
 	case <-time.After(2 * idleTimeout):
 		// This case should win.

--- a/agent/job_logger_test.go
+++ b/agent/job_logger_test.go
@@ -50,7 +50,7 @@ func TestJobLoggerTextFormat(t *testing.T) {
 	}
 
 	if err := json.Unmarshal(buf.Bytes(), &map[string]any{}); err == nil {
-		t.Error("expected non-JSON output for text format, but got valid JSON")
+		t.Errorf("expected non-JSON output for text format, but got valid JSON")
 	}
 	if got := buf.String(); got != "hello\n" {
 		t.Errorf("output = %q, want %q", got, "hello\n")

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -231,7 +231,7 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient *api.Client, c
 		jobLogDir := ""
 		if conf.AgentConfiguration.JobLogPath != "" {
 			jobLogDir = conf.AgentConfiguration.JobLogPath
-			r.agentLogger.Debug("[JobRunner] Job Log Path: %s", jobLogDir)
+			r.agentLogger.Debugf("[JobRunner] Job Log Path: %s", jobLogDir)
 		}
 		tmpFile, err = os.CreateTemp(jobLogDir, "buildkite_job_log")
 		if err != nil {
@@ -283,7 +283,7 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient *api.Client, c
 				_, _ = outputWriter.Write([]byte(line + "\n"))
 			})
 			if err != nil {
-				r.agentLogger.Error("[JobRunner] Encountered error %v", err)
+				r.agentLogger.Errorf("[JobRunner] Encountered error %v", err)
 			}
 		}()
 
@@ -300,7 +300,7 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient *api.Client, c
 				r.headerTimesStreamer.Scan(line)
 			})
 			if err != nil {
-				r.agentLogger.Error("[JobRunner] Encountered error %v", err)
+				r.agentLogger.Errorf("[JobRunner] Encountered error %v", err)
 			}
 		}()
 	}
@@ -368,11 +368,11 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient *api.Client, c
 	go func() {
 		<-r.process.Done()
 		if err := pw.Close(); err != nil {
-			r.agentLogger.Error("%v", err)
+			r.agentLogger.Errorf("%v", err)
 		}
 		if tmpFile != nil {
 			if err := os.Remove(tmpFile.Name()); err != nil {
-				r.agentLogger.Error("%v", err)
+				r.agentLogger.Errorf("%v", err)
 			}
 		}
 	}()
@@ -410,7 +410,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	if pluginsJSON := env["BUILDKITE_PLUGINS"]; pluginsJSON != "" && r.conf.KubernetesExec {
 		filtered, err := removeKubernetesPlugin([]byte(pluginsJSON))
 		if err != nil {
-			r.agentLogger.Error("Invalid BUILDKITE_PLUGINS: %w", err)
+			r.agentLogger.Errorf("Invalid BUILDKITE_PLUGINS: %w", err)
 		}
 		if string(filtered) == "" {
 			delete(env, "BUILDKITE_PLUGINS")
@@ -513,7 +513,7 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 	if len(r.conf.Job.Step.Secrets) > 0 {
 		secretsJSON, err := json.Marshal(r.conf.Job.Step.Secrets)
 		if err != nil {
-			r.agentLogger.Error("Failed to marshal secrets configuration: %v", err)
+			r.agentLogger.Errorf("Failed to marshal secrets configuration: %v", err)
 			return nil, err
 		}
 
@@ -681,7 +681,7 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 
 	// see documentation for BuildkiteMessageMax
 	if err := truncateEnv(r.agentLogger, env, BuildkiteMessageName, BuildkiteMessageMax); err != nil {
-		r.agentLogger.Warn("failed to truncate %s: %v", BuildkiteMessageName, err)
+		r.agentLogger.Warnf("failed to truncate %s: %v", BuildkiteMessageName, err)
 		// attempt to continue anyway
 	}
 
@@ -715,7 +715,7 @@ func truncateEnv(l logger.Logger, env map[string]string, key string, max int) er
 	}
 	keeplen := msgmax - len(apology)
 	env[key] = env[key][0:keeplen] + apology
-	l.Warn("%s %s", key, description)
+	l.Warnf("%s %s", key, description)
 	return nil
 }
 
@@ -736,12 +736,12 @@ type LogWriter struct {
 }
 
 func (w LogWriter) Write(bytes []byte) (int, error) {
-	w.l.Info("%s", bytes)
+	w.l.Infof("%s", bytes)
 	return len(bytes), nil
 }
 
 func (r *JobRunner) executePreBootstrapHook(ctx context.Context, hook string) (bool, error) {
-	r.agentLogger.Info("Running pre-bootstrap hook %q", hook)
+	r.agentLogger.Infof("Running pre-bootstrap hook %q", hook)
 
 	sh, err := shell.New(
 		shell.WithStdout(LogWriter{l: r.agentLogger}),
@@ -768,14 +768,14 @@ func (r *JobRunner) executePreBootstrapHook(ctx context.Context, hook string) (b
 
 	script, err := sh.Script(hook, r.conf.AgentConfiguration.HooksShell)
 	if err != nil {
-		r.agentLogger.Error("Finished pre-bootstrap hook %q: script not runnable: %v", hook, err)
+		r.agentLogger.Errorf("Finished pre-bootstrap hook %q: script not runnable: %v", hook, err)
 		return false, err
 	}
 	if err := script.Run(ctx, shell.ShowPrompt(false), shell.WithExtraEnv(environ)); err != nil {
-		r.agentLogger.Error("Finished pre-bootstrap hook %q: job rejected: %v", hook, err)
+		r.agentLogger.Errorf("Finished pre-bootstrap hook %q: job rejected: %v", hook, err)
 		return false, err
 	}
-	r.agentLogger.Info("Finished pre-bootstrap hook %q: job accepted", hook)
+	r.agentLogger.Infof("Finished pre-bootstrap hook %q: job accepted", hook)
 	return true, nil
 }
 
@@ -787,7 +787,7 @@ func (r *JobRunner) jobCancellationChecker(ctx context.Context) {
 	defer done()
 	setStat("Starting...")
 
-	defer r.agentLogger.Debug("[JobRunner] Routine that refreshes the job has finished")
+	defer r.agentLogger.Debugf("[JobRunner] Routine that refreshes the job has finished")
 
 	select {
 	case <-r.process.Started():
@@ -832,19 +832,19 @@ func (r *JobRunner) jobCancellationChecker(ctx context.Context) {
 		jobState, response, err := r.apiClient.GetJobState(ctx, r.conf.Job.ID)
 		if err != nil {
 			if response != nil && response.StatusCode == 401 {
-				r.agentLogger.Error("Invalid access token, cancelling job %s", r.conf.Job.ID)
+				r.agentLogger.Errorf("Invalid access token, cancelling job %s", r.conf.Job.ID)
 				if err := r.Cancel(CancelReasonInvalidToken); err != nil {
-					r.agentLogger.Error("Failed to cancel the process (job: %s): %v", r.conf.Job.ID, err)
+					r.agentLogger.Errorf("Failed to cancel the process (job: %s): %v", r.conf.Job.ID, err)
 				}
 			} else {
 				// We don't really care if it fails, we'll just try again soon anyway
-				r.agentLogger.Warn("Problem with getting job state %s (%s)", r.conf.Job.ID, err)
+				r.agentLogger.Warnf("Problem with getting job state %s (%s)", r.conf.Job.ID, err)
 			}
 			continue // the loop
 		}
 		if jobState.State == "canceling" || jobState.State == "canceled" {
 			if err := r.Cancel(CancelReasonJobState); err != nil {
-				r.agentLogger.Error("Unexpected error canceling process as requested by server (job: %s) (err: %s)", r.conf.Job.ID, err)
+				r.agentLogger.Errorf("Unexpected error canceling process as requested by server (job: %s) (err: %s)", r.conf.Job.ID, err)
 			}
 		}
 	}
@@ -858,17 +858,17 @@ func (r *JobRunner) onUploadHeaderTime(ctx context.Context, cursor, total int, t
 		response, err := r.apiClient.SaveHeaderTimes(ctx, r.conf.Job.ID, &api.HeaderTimes{Times: times})
 		if err != nil {
 			if response != nil && (response.StatusCode >= 400 && response.StatusCode <= 499) {
-				r.agentLogger.Warn("Buildkite rejected the header times (%s)", err)
+				r.agentLogger.Warnf("Buildkite rejected the header times (%s)", err)
 				retrier.Break()
 			} else {
-				r.agentLogger.Warn("%s (%s)", err, retrier)
+				r.agentLogger.Warnf("%s (%s)", err, retrier)
 			}
 		}
 
 		return err
 	})
 	if err != nil {
-		r.agentLogger.Error("Ultimately unable to upload header times: %v", err)
+		r.agentLogger.Errorf("Ultimately unable to upload header times: %v", err)
 	}
 }
 
@@ -891,7 +891,7 @@ func createJobEnvFiles(l logger.Logger, jobID string, kubernetesExec bool) (shel
 	if err != nil {
 		return nil, nil, err
 	}
-	l.Debug("[JobRunner] Created env file (shell format): %s", shellFile.Name())
+	l.Debugf("[JobRunner] Created env file (shell format): %s", shellFile.Name())
 
 	jsonFile, err = os.CreateTemp(tempDir, fmt.Sprintf("job-env-json-%s", jobID))
 	if err != nil {
@@ -899,7 +899,7 @@ func createJobEnvFiles(l logger.Logger, jobID string, kubernetesExec bool) (shel
 		_ = os.Remove(shellFile.Name())
 		return nil, nil, err
 	}
-	l.Debug("[JobRunner] Created env file (JSON format): %s", jsonFile.Name())
+	l.Debugf("[JobRunner] Created env file (JSON format): %s", jsonFile.Name())
 
 	return shellFile, jsonFile, nil
 }

--- a/agent/json_job_logger.go
+++ b/agent/json_job_logger.go
@@ -56,6 +56,6 @@ func (l JSONJobLogger) Write(data []byte) (int, error) {
 	// When writing as a structured log, trailing newlines and carriage returns
 	// generally don't make sense.
 	msg := strings.TrimRight(string(data), "\r\n")
-	l.log.Info("%s", msg)
+	l.log.Infof("%s", msg)
 	return len(data), nil
 }

--- a/agent/log_streamer.go
+++ b/agent/log_streamer.go
@@ -119,7 +119,7 @@ func (ls *LogStreamer) Process(ctx context.Context, output []byte) error {
 		// Have we exceeded the max size?
 		// (This check is also performed on the server side.)
 		if ls.bytes > ls.conf.MaxSizeBytes && !ls.warnedAboutSize {
-			ls.logger.Warn("The job log has reached %s in size, which has "+
+			ls.logger.Warnf("The job log has reached %s in size, which has "+
 				"exceeded the maximum size (%s). Further logs may be dropped "+
 				"by the server, and a future version of the agent will stop "+
 				"sending logs at this point.",
@@ -170,15 +170,15 @@ func (ls *LogStreamer) Stop() {
 	close(ls.queue)
 	ls.processMutex.Unlock()
 
-	ls.logger.Debug("[LogStreamer] Waiting for workers to shut down")
+	ls.logger.Debugf("[LogStreamer] Waiting for workers to shut down")
 	ls.workerWG.Wait()
 }
 
 // The actual log streamer worker
 func (ls *LogStreamer) worker(ctx context.Context, id int) {
-	ls.logger.Debug("[LogStreamer/Worker#%d] Worker is starting...", id)
+	ls.logger.Debugf("[LogStreamer/Worker#%d] Worker is starting...", id)
 
-	defer ls.logger.Debug("[LogStreamer/Worker#%d] Worker has shutdown", id)
+	defer ls.logger.Debugf("[LogStreamer/Worker#%d] Worker has shutdown", id)
 
 	ctx, setStat, done := status.AddSimpleItem(ctx, fmt.Sprintf("Log Streamer Worker %d", id))
 	defer done()
@@ -206,7 +206,7 @@ func (ls *LogStreamer) worker(ctx context.Context, id int) {
 		if err != nil {
 			atomic.AddInt32(&ls.chunksFailedCount, 1)
 
-			ls.logger.Error("Giving up on uploading chunk %d, this will result in only a partial build log on Buildkite", chunk.Sequence)
+			ls.logger.Errorf("Giving up on uploading chunk %d, this will result in only a partial build log on Buildkite", chunk.Sequence)
 		}
 	}
 }

--- a/agent/pipeline_uploader.go
+++ b/agent/pipeline_uploader.go
@@ -137,7 +137,7 @@ func (u *PipelineUploader) pipelineUploadAsyncWithRetry(
 			}
 
 			if !api.BreakOnNonRetryable(r, resp, err) {
-				l.Warn("%s (%s)", err, r)
+				l.Warnf("%s (%s)", err, r)
 			}
 			return nil, err
 		}
@@ -159,7 +159,7 @@ func (u *PipelineUploader) pipelineUploadAsyncWithRetry(
 		}
 
 		if result.pipelineStatusURL, err = resp.Location(); err != nil {
-			l.Warn("%s (%s)", err, r)
+			l.Warnf("%s (%s)", err, r)
 			return nil, err
 		}
 
@@ -183,11 +183,11 @@ func (u *PipelineUploader) pollForPiplineUploadStatus(ctx context.Context, l log
 			},
 		)
 		if err != nil {
-			l.Warn("%s (%s)", err, r)
+			l.Warnf("%s (%s)", err, r)
 
 			// 422 responses will always fail no need to retry
 			if api.IsErrHavingStatus(err, http.StatusUnprocessableEntity) {
-				l.Error("Unrecoverable error, skipping retries")
+				l.Errorf("Unrecoverable error, skipping retries")
 				r.Break()
 				return err
 			}
@@ -202,14 +202,14 @@ func (u *PipelineUploader) pollForPiplineUploadStatus(ctx context.Context, l log
 		case "pending", "processing":
 			setNextIntervalFromResponse(r, resp)
 			err := fmt.Errorf("pipeline upload not yet applied: %s", uploadStatus.State)
-			l.Info("%s (%s)", err, r)
+			l.Infof("%s (%s)", err, r)
 			return err
 		case "rejected", "failed":
-			l.Error("Unrecoverable error, skipping retries")
+			l.Errorf("Unrecoverable error, skipping retries")
 			r.Break()
 			return fmt.Errorf("pipeline upload %s: %s", uploadStatus.State, uploadStatus.Message)
 		default:
-			l.Error("Unrecoverable error, skipping retries")
+			l.Errorf("Unrecoverable error, skipping retries")
 			r.Break()
 			return fmt.Errorf("unexpected pipeline upload state from API: %s", uploadStatus.State)
 		}

--- a/agent/pipeline_uploader_test.go
+++ b/agent/pipeline_uploader_test.go
@@ -239,7 +239,7 @@ steps:
 							return
 						}
 					case fmt.Sprintf("/jobs/%s/pipelines/%s", jobID, stepUploadUUID):
-						t.Error("should not call the status route")
+						t.Errorf("should not call the status route")
 
 						http.Error(
 							rw,

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -77,7 +77,7 @@ func (r *JobRunner) Run(ctx context.Context, ignoreAgentInDispatches *bool) (err
 		return errors.New("job already cancelled before running")
 	}
 
-	r.agentLogger.Info("Starting job %s for build at %s", r.conf.Job.ID, r.conf.Job.Env["BUILDKITE_BUILD_URL"])
+	r.agentLogger.Infof("Starting job %s for build at %s", r.conf.Job.ID, r.conf.Job.Env["BUILDKITE_BUILD_URL"])
 
 	ctx, done := status.AddItem(ctx, "Job Runner", "", nil)
 	defer done()
@@ -96,7 +96,7 @@ func (r *JobRunner) Run(ctx context.Context, ignoreAgentInDispatches *bool) (err
 	if r.conf.Job.RunnableAt != "" {
 		runnableAt, err := time.Parse(time.RFC3339Nano, r.conf.Job.RunnableAt)
 		if err != nil {
-			r.agentLogger.Error("Metric submission failed to parse %s", r.conf.Job.RunnableAt)
+			r.agentLogger.Errorf("Metric submission failed to parse %s", r.conf.Job.RunnableAt)
 		} else {
 			r.conf.MetricsScope.Timing("queue.duration", r.startedAt.Sub(runnableAt))
 		}
@@ -165,7 +165,7 @@ func (r *JobRunner) Run(ctx context.Context, ignoreAgentInDispatches *bool) (err
 
 		default: // no error, all good, keep going
 			l := r.agentLogger.WithFields(logger.StringField("jobID", job.ID), logger.StringField("signature", job.Step.Signature.Value))
-			l.Info("Successfully verified job")
+			l.Infof("Successfully verified job")
 			_, _ = fmt.Fprintln(r.jobLogs, "~~~ ✅ Job signature verified")
 			_, _ = fmt.Fprintf(r.jobLogs, "signature: %s\n", job.Step.Signature.Value)
 		}
@@ -176,14 +176,14 @@ func (r *JobRunner) Run(ctx context.Context, ignoreAgentInDispatches *bool) (err
 		if job.Env["BUILDKITE_COMPUTE_TYPE"] == "self-hosted" {
 			_, _ = fmt.Fprintln(r.jobLogs, "+++ ⚠️ Cache settings detected on self-hosted agent")
 			_, _ = fmt.Fprintf(r.jobLogs, "cache paths: %s\n", strings.Join(cache.Paths, ", "))
-			r.agentLogger.Info("Job %s has cache settings but is running on a self-hosted agent", job.ID)
+			r.agentLogger.Infof("Job %s has cache settings but is running on a self-hosted agent", job.ID)
 		}
 	}
 
 	// Validate the repository if the list of allowed repositories is set.
 	if err := r.validateConfigAllowlists(job); err != nil {
 		_, _ = fmt.Fprintln(r.jobLogs, err.Error())
-		r.agentLogger.Error(err.Error())
+		r.agentLogger.Errorf(err.Error())
 
 		exit.Status = -1
 		exit.SignalReason = SignalReasonAgentRefused
@@ -199,7 +199,7 @@ func (r *JobRunner) Run(ctx context.Context, ignoreAgentInDispatches *bool) (err
 			// Ensure the Job UI knows why this job resulted in failure
 			_, _ = fmt.Fprintln(r.jobLogs, "pre-bootstrap hook rejected this job, see the buildkite-agent logs for more details")
 			// But disclose more information in the agent logs
-			r.agentLogger.Error("pre-bootstrap hook rejected this job: %s", err)
+			r.agentLogger.Errorf("pre-bootstrap hook rejected this job: %s", err)
 
 			exit.Status = -1
 			exit.SignalReason = SignalReasonAgentRefused
@@ -306,7 +306,7 @@ func (r *JobRunner) verificationFailureLogs(behavior string, err error) {
 		prefix = "+++ ⛔"
 	}
 
-	l.Warn("Job verification failed")
+	l.Warnf("Job verification failed")
 	_, _ = fmt.Fprintf(r.jobLogs, "%s Job signature verification failed\n", prefix)
 	_, _ = fmt.Fprintf(r.jobLogs, "error: %s\n", err)
 
@@ -319,8 +319,8 @@ func (r *JobRunner) verificationFailureLogs(behavior string, err error) {
 	}
 
 	if behavior == VerificationBehaviourWarn {
-		l.Warn("Job will be run whether or not it can be verified - this is not recommended.")
-		l.Warn("You can change this behavior with the `verification-failure-behavior` agent configuration option.")
+		l.Warnf("Job will be run whether or not it can be verified - this is not recommended.")
+		l.Warnf("You can change this behavior with the `verification-failure-behavior` agent configuration option.")
 		_, _ = fmt.Fprintln(r.jobLogs, "Job will be run without verification")
 	}
 }
@@ -402,7 +402,7 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 	// start the process will still be buffered. Also, there may still be logs in the buffer that
 	// were left behind because the uploader goroutine exited before it could flush them.
 	if err := r.logStreamer.Process(ctx, r.output.ReadAndTruncate()); err != nil {
-		r.agentLogger.Warn("Log streamer couldn't process final logs: %v", err)
+		r.agentLogger.Warnf("Log streamer couldn't process final logs: %v", err)
 	}
 
 	// Stop the log streamer. This will block until all the chunks have been uploaded
@@ -413,11 +413,11 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 
 	// Warn about failed chunks
 	if count := r.logStreamer.FailedChunks(); count > 0 {
-		r.agentLogger.Warn("%d chunks failed to upload for this job", count)
+		r.agentLogger.Warnf("%d chunks failed to upload for this job", count)
 	}
 
 	// Wait for the routines that we spun up to finish
-	r.agentLogger.Debug("[JobRunner] Waiting for all other routines to finish")
+	r.agentLogger.Debugf("[JobRunner] Waiting for all other routines to finish")
 	wg.Wait()
 
 	// Remove the env file, if any
@@ -426,10 +426,10 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 			continue
 		}
 		if err := os.Remove(f.Name()); err != nil {
-			r.agentLogger.Warn("[JobRunner] Error cleaning up env file: %s", err)
+			r.agentLogger.Warnf("[JobRunner] Error cleaning up env file: %s", err)
 			continue
 		}
-		r.agentLogger.Debug("[JobRunner] Deleted env file: %s", f.Name())
+		r.agentLogger.Debugf("[JobRunner] Deleted env file: %s", f.Name())
 	}
 
 	// Write some metrics about the job run
@@ -446,10 +446,10 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 	// Finish the build in the Buildkite Agent API
 	// Once we tell the API we're finished it might assign us new work, so make sure everything else is done first.
 	if err := r.client.FinishJob(ctx, r.conf.Job, finishedAt, exit, r.logStreamer.FailedChunks(), ignoreAgentInDispatches); err != nil {
-		r.agentLogger.Error("Couldn't mark job as finished: %v", err)
+		r.agentLogger.Errorf("Couldn't mark job as finished: %v", err)
 	}
 
-	r.agentLogger.Info("Finished job %s for build at %s", r.conf.Job.ID, r.conf.Job.Env["BUILDKITE_BUILD_URL"])
+	r.agentLogger.Infof("Finished job %s for build at %s", r.conf.Job.ID, r.conf.Job.Env["BUILDKITE_BUILD_URL"])
 }
 
 // streamJobLogsAfterProcessStart waits for the process to start, then grabs the job output
@@ -460,7 +460,7 @@ func (r *JobRunner) streamJobLogsAfterProcessStart(ctx context.Context) {
 	setStat("🏃 Starting...")
 
 	defer func() {
-		r.agentLogger.Debug("[JobRunner] Routine that processes the log has finished")
+		r.agentLogger.Debugf("[JobRunner] Routine that processes the log has finished")
 	}()
 
 	select {
@@ -531,14 +531,14 @@ func (r *JobRunner) streamJobLogsAfterProcessStart(ctx context.Context) {
 
 			// Send the output of the process to the log streamer for processing
 			if err := r.logStreamer.Process(ctx, r.output.ReadAndTruncate()); err != nil {
-				r.agentLogger.Error("Could not stream the log output: %v", err)
+				r.agentLogger.Errorf("Could not stream the log output: %v", err)
 				// LogStreamer.Process only returns an error when it can no longer
 				// accept logs (maybe Stop was called, or a hard limit was reached).
 				// Since we can no longer send logs, Close the buffer, which causes
 				// future Writes to return io.ErrClosedPipe, typically SIGPIPE-ing
 				// the running process (if it is still running).
 				if err := r.output.Close(); err != nil && err != process.ErrAlreadyClosed {
-					r.agentLogger.Error("Process output buffer could not be closed: %v", err)
+					r.agentLogger.Errorf("Process output buffer could not be closed: %v", err)
 				}
 				return
 			}
@@ -593,11 +593,11 @@ func (r *JobRunner) Cancel(reason CancelReason) error {
 	}
 
 	if r.process == nil {
-		r.agentLogger.Error("No process to kill")
+		r.agentLogger.Errorf("No process to kill")
 		return nil
 	}
 
-	r.agentLogger.Info(
+	r.agentLogger.Infof(
 		"Canceling job %s with a signal grace period of %v (%s)",
 		r.conf.Job.ID,
 		r.conf.AgentConfiguration.SignalGracePeriod,
@@ -618,7 +618,7 @@ func (r *JobRunner) Cancel(reason CancelReason) error {
 	// cancel grace period is the time we (agent side) need to upload logs and
 	// disconnect (if the agent is exiting).
 	case <-time.After(r.conf.AgentConfiguration.SignalGracePeriod):
-		r.agentLogger.Info(
+		r.agentLogger.Infof(
 			"Job %s hasn't stopped within %v, terminating",
 			r.conf.Job.ID,
 			r.conf.AgentConfiguration.SignalGracePeriod,

--- a/agent/tags.go
+++ b/agent/tags.go
@@ -84,7 +84,7 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 	if conf.TagsFromK8s {
 		k8sTags, err := t.k8s()
 		if err != nil {
-			l.Warn("Could not fetch tags from k8s: %s", err)
+			l.Warnf("Could not fetch tags from k8s: %s", err)
 		}
 		for tag, value := range k8sTags {
 			tags = append(tags, fmt.Sprintf("%s=%s", tag, value))
@@ -95,7 +95,7 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 	if conf.TagsFromHost {
 		hostname, err := os.Hostname()
 		if err != nil {
-			l.Warn("Failed to find hostname: %v", err)
+			l.Warnf("Failed to find hostname: %v", err)
 		}
 
 		tags = append(tags,
@@ -112,7 +112,7 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 
 	// Attempt to add the default EC2 meta-data tags
 	if conf.TagsFromEC2MetaData {
-		l.Info("Fetching EC2 meta-data...")
+		l.Infof("Fetching EC2 meta-data...")
 
 		err := roko.NewRetrier(
 			roko.WithMaxAttempts(5),
@@ -121,9 +121,9 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 		).DoWithContext(ctx, func(r *roko.Retrier) error {
 			ec2Tags, err := t.ec2MetaDataDefault()
 			if err != nil {
-				l.Warn("%s (%s)", err, r)
+				l.Warnf("%s (%s)", err, r)
 			} else {
-				l.Info("Successfully fetched EC2 meta-data")
+				l.Infof("Successfully fetched EC2 meta-data")
 				for tag, value := range ec2Tags {
 					tags = append(tags, fmt.Sprintf("%s=%s", tag, value))
 				}
@@ -136,7 +136,7 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 			if conf.FailOnMissingTags {
 				return nil, fmt.Errorf("failed to fetch EC2 meta-data: %w", err)
 			}
-			l.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
+			l.Errorf(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
 		}
 	}
 
@@ -144,7 +144,7 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 	if len(conf.TagsFromEC2MetaDataPaths) > 0 {
 		paths, err := parseTagValuePathPairs(conf.TagsFromEC2MetaDataPaths)
 		if err != nil {
-			l.Error(fmt.Sprintf("Error parsing meta-data tag and path pairs: %s", err.Error()))
+			l.Errorf(fmt.Sprintf("Error parsing meta-data tag and path pairs: %s", err.Error()))
 		}
 
 		ec2Tags, err := t.ec2MetaDataPaths(paths)
@@ -152,7 +152,7 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 			if conf.FailOnMissingTags {
 				return nil, fmt.Errorf("failed to fetch EC2 meta-data from paths: %w", err)
 			}
-			l.Error(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
+			l.Errorf(fmt.Sprintf("Failed to fetch EC2 meta-data: %s", err.Error()))
 		} else {
 			for tag, value := range ec2Tags {
 				tags = append(tags, fmt.Sprintf("%s=%s", tag, value))
@@ -162,7 +162,7 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 
 	// Attempt to add the EC2 tags
 	if conf.TagsFromEC2Tags {
-		l.Info("Fetching EC2 tags...")
+		l.Infof("Fetching EC2 tags...")
 
 		err := roko.NewRetrier(
 			roko.WithMaxAttempts(5),
@@ -176,9 +176,9 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 				err = errors.New("EC2 tags are empty")
 			}
 			if err != nil {
-				l.Warn("%s (%s)", err, r)
+				l.Warnf("%s (%s)", err, r)
 			} else {
-				l.Info("Successfully fetched EC2 tags")
+				l.Infof("Successfully fetched EC2 tags")
 				for tag, value := range ec2Tags {
 					tags = append(tags, fmt.Sprintf("%s=%s", tag, value))
 				}
@@ -190,13 +190,13 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 			if conf.FailOnMissingTags {
 				return nil, fmt.Errorf("failed to fetch EC2 tags: %w", err)
 			}
-			l.Error(fmt.Sprintf("Failed to find EC2 tags: %s", err.Error()))
+			l.Errorf(fmt.Sprintf("Failed to find EC2 tags: %s", err.Error()))
 		}
 	}
 
 	// Attempt to add the default ECS meta-data tags
 	if conf.TagsFromECSMetaData {
-		l.Info("Fetching ECS meta-data...")
+		l.Infof("Fetching ECS meta-data...")
 
 		err := roko.NewRetrier(
 			roko.WithMaxAttempts(5),
@@ -205,9 +205,9 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 		).Do(func(r *roko.Retrier) error {
 			ecsTags, err := t.ecsMetaDataDefault()
 			if err != nil {
-				l.Warn("%s (%s)", err, r)
+				l.Warnf("%s (%s)", err, r)
 			} else {
-				l.Info("Successfully fetched ECS meta-data")
+				l.Infof("Successfully fetched ECS meta-data")
 				for tag, value := range ecsTags {
 					tags = append(tags, fmt.Sprintf("%s=%s", tag, value))
 				}
@@ -220,13 +220,13 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 			if conf.FailOnMissingTags {
 				return nil, fmt.Errorf("failed to fetch ECS meta-data: %w", err)
 			}
-			l.Error(fmt.Sprintf("Failed to fetch ECS meta-data: %s", err.Error()))
+			l.Errorf(fmt.Sprintf("Failed to fetch ECS meta-data: %s", err.Error()))
 		}
 	}
 
 	// Attempt to add the default GCP meta-data tags
 	if conf.TagsFromGCPMetaData {
-		l.Info("Fetching GCP meta-data...")
+		l.Infof("Fetching GCP meta-data...")
 
 		err := roko.NewRetrier(
 			roko.WithMaxAttempts(5),
@@ -236,7 +236,7 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 			gcpTags, err := t.gcpMetaDataDefault()
 			if err != nil {
 				// Don't blow up if we can't find them, just show a nasty error.
-				l.Error(fmt.Sprintf("Failed to fetch Google Cloud meta-data: %s", err.Error()))
+				l.Errorf(fmt.Sprintf("Failed to fetch Google Cloud meta-data: %s", err.Error()))
 				return err
 			}
 
@@ -250,7 +250,7 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 			if conf.FailOnMissingTags {
 				return nil, fmt.Errorf("failed to fetch GCP meta-data: %w", err)
 			}
-			l.Error(fmt.Sprintf("Failed to fetch GCP meta-data: %s", err.Error()))
+			l.Errorf(fmt.Sprintf("Failed to fetch GCP meta-data: %s", err.Error()))
 		}
 	}
 
@@ -258,7 +258,7 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 	if len(conf.TagsFromGCPMetaDataPaths) > 0 {
 		paths, err := parseTagValuePathPairs(conf.TagsFromGCPMetaDataPaths)
 		if err != nil {
-			l.Error(fmt.Sprintf("Error parsing meta-data tag and path pairs: %s", err.Error()))
+			l.Errorf(fmt.Sprintf("Error parsing meta-data tag and path pairs: %s", err.Error()))
 		}
 
 		gcpTags, err := t.gcpMetaDataPaths(paths)
@@ -266,7 +266,7 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 			if conf.FailOnMissingTags {
 				return nil, fmt.Errorf("failed to fetch GCP meta-data from paths: %w", err)
 			}
-			l.Error(fmt.Sprintf("Failed to fetch Google Cloud meta-data: %s", err.Error()))
+			l.Errorf(fmt.Sprintf("Failed to fetch Google Cloud meta-data: %s", err.Error()))
 		} else {
 			for tag, value := range gcpTags {
 				tags = append(tags, fmt.Sprintf("%s=%s", tag, value))
@@ -276,7 +276,7 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 
 	// Attempt to add the Google Compute instance labels
 	if conf.TagsFromGCPLabels {
-		l.Info("Fetching GCP instance labels...")
+		l.Infof("Fetching GCP instance labels...")
 		err := roko.NewRetrier(
 			roko.WithMaxAttempts(5),
 			roko.WithStrategy(roko.Constant(conf.WaitForGCPLabelsTimeout/5)),
@@ -287,9 +287,9 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 				err = errors.New("GCP instance labels are empty")
 			}
 			if err != nil {
-				l.Warn("%s (%s)", err, r)
+				l.Warnf("%s (%s)", err, r)
 			} else {
-				l.Info("Successfully fetched GCP instance labels")
+				l.Infof("Successfully fetched GCP instance labels")
 				for label, value := range labels {
 					tags = append(tags, fmt.Sprintf("%s=%s", label, value))
 				}
@@ -301,7 +301,7 @@ func (t *tagFetcher) Fetch(ctx context.Context, l logger.Logger, conf FetchTagsC
 			if conf.FailOnMissingTags {
 				return nil, fmt.Errorf("failed to fetch GCP instance labels: %w", err)
 			}
-			l.Error(fmt.Sprintf("Failed to find GCP instance labels: %s", err.Error()))
+			l.Errorf(fmt.Sprintf("Failed to find GCP instance labels: %s", err.Error()))
 		}
 	}
 

--- a/agent/verify_job.go
+++ b/agent/verify_job.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/go-pipeline/signature"
 	"github.com/gowebpki/jcs"
 )
@@ -44,22 +45,22 @@ func (r *JobRunner) verifyJob(ctx context.Context, keySet any) error {
 		keySet,
 		r.conf.Job.Env["BUILDKITE_REPO"],
 		signature.WithEnv(r.conf.Job.Env),
-		signature.WithLogger(r.agentLogger),
+		signature.WithLogger(logger.DeprecatedLogger{Logger: r.agentLogger}),
 		signature.WithDebugSigning(r.conf.AgentConfiguration.DebugSigning),
 	)
 	if err == signature.ErrNoSignature {
-		r.agentLogger.Debug("verifyJob: Job.Step.Signature == nil")
+		r.agentLogger.Debugf("verifyJob: Job.Step.Signature == nil")
 		return ErrNoSignature
 	}
 	if err != nil {
-		r.agentLogger.Debug("failed to verifyJob: step.Signature.Verify(Job.Env, stepWithInvariants, JWKS) = %v", err)
+		r.agentLogger.Debugf("failed to verifyJob: step.Signature.Verify(Job.Env, stepWithInvariants, JWKS) = %v", err)
 		return newInvalidSignatureError(ErrVerificationFailed)
 	}
 
 	// Interpolate the matrix permutation (validating the permutation in the
 	// process).
 	if err := step.InterpolateMatrixPermutation(r.conf.Job.MatrixPermutation); err != nil {
-		r.agentLogger.Debug("failed to verifyJob: step.InterpolateMatrixPermutation(% #v) = %v", r.conf.Job.MatrixPermutation, err)
+		r.agentLogger.Debugf("failed to verifyJob: step.InterpolateMatrixPermutation(% #v) = %v", r.conf.Job.MatrixPermutation, err)
 		return newInvalidSignatureError(ErrInvalidJob)
 	}
 
@@ -111,7 +112,7 @@ func (r *JobRunner) verifyJob(ctx context.Context, keySet any) error {
 		case "command": // compare directly
 			jobCommand := r.conf.Job.Env["BUILDKITE_COMMAND"]
 			if step.Command != jobCommand {
-				r.agentLogger.Debug("failed to verifyJob: BUILDKITE_COMMAND = %q != %q = step.Command", jobCommand, step.Command)
+				r.agentLogger.Debugf("failed to verifyJob: BUILDKITE_COMMAND = %q != %q = step.Command", jobCommand, step.Command)
 				return newInvalidSignatureError(ErrInvalidJob)
 			}
 
@@ -121,11 +122,11 @@ func (r *JobRunner) verifyJob(ctx context.Context, keySet any) error {
 			for name, stepEnvValue := range step.Env {
 				jobEnvValue, has := r.conf.Job.Env[name]
 				if !has {
-					r.agentLogger.Debug("failed to verifyJob: %q missing from Job.Env; step.Env[%q] = %q", name, name, stepEnvValue)
+					r.agentLogger.Debugf("failed to verifyJob: %q missing from Job.Env; step.Env[%q] = %q", name, name, stepEnvValue)
 					return newInvalidSignatureError(ErrInvalidJob)
 				}
 				if jobEnvValue != stepEnvValue {
-					r.agentLogger.Debug("failed to verifyJob: Job.Env[%q] = %q != %q = step.Env[%q]", name, jobEnvValue, stepEnvValue, name)
+					r.agentLogger.Debugf("failed to verifyJob: Job.Env[%q] = %q != %q = step.Env[%q]", name, jobEnvValue, stepEnvValue, name)
 					return newInvalidSignatureError(ErrInvalidJob)
 				}
 			}
@@ -139,33 +140,33 @@ func (r *JobRunner) verifyJob(ctx context.Context, keySet any) error {
 			emptyJobPlugins := (jobPluginsJSON == "" || jobPluginsJSON == "null" || jobPluginsJSON == "[]")
 
 			if emptyStepPlugins && emptyJobPlugins {
-				r.agentLogger.Debug("verifyJob: both BUILDKITE_PLUGINS and step.Plugins are empty/null")
+				r.agentLogger.Debugf("verifyJob: both BUILDKITE_PLUGINS and step.Plugins are empty/null")
 				continue // both empty
 			}
 			if emptyStepPlugins != emptyJobPlugins {
 				// one is empty but the other is not
-				r.agentLogger.Debug("failed to verifyJob: emptyJobPlugins = %t != %t = emptyStepPlugins", emptyJobPlugins, emptyStepPlugins)
+				r.agentLogger.Debugf("failed to verifyJob: emptyJobPlugins = %t != %t = emptyStepPlugins", emptyJobPlugins, emptyStepPlugins)
 				return newInvalidSignatureError(ErrInvalidJob)
 			}
 
 			stepPluginsJSON, err := json.Marshal(step.Plugins)
 			if err != nil {
-				r.agentLogger.Debug("failed to verifyJob: json.Marshal(step.Plugins) = %v", err)
+				r.agentLogger.Debugf("failed to verifyJob: json.Marshal(step.Plugins) = %v", err)
 				return newInvalidSignatureError(ErrInvalidJob)
 			}
 			stepPluginsNorm, err := jcs.Transform(stepPluginsJSON)
 			if err != nil {
-				r.agentLogger.Debug("failed to verifyJob: jcs.Transform(stepPluginsJSON) = %v", err)
+				r.agentLogger.Debugf("failed to verifyJob: jcs.Transform(stepPluginsJSON) = %v", err)
 				return newInvalidSignatureError(ErrInvalidJob)
 			}
 			jobPluginsNorm, err := jcs.Transform([]byte(jobPluginsJSON))
 			if err != nil {
-				r.agentLogger.Debug("failed to verifyJob: jcs.Transform(jobPluginsJSON) = %v", err)
+				r.agentLogger.Debugf("failed to verifyJob: jcs.Transform(jobPluginsJSON) = %v", err)
 				return newInvalidSignatureError(ErrInvalidJob)
 			}
 
 			if !bytes.Equal(jobPluginsNorm, stepPluginsNorm) {
-				r.agentLogger.Debug("failed to verifyJob: jobPluginsNorm = %q != %q = stepPluginsNorm", jobPluginsNorm, stepPluginsNorm)
+				r.agentLogger.Debugf("failed to verifyJob: jobPluginsNorm = %q != %q = stepPluginsNorm", jobPluginsNorm, stepPluginsNorm)
 				return newInvalidSignatureError(ErrInvalidJob)
 			}
 
@@ -181,12 +182,12 @@ func (r *JobRunner) verifyJob(ctx context.Context, keySet any) error {
 			jobSecrets := r.conf.Job.Step.Secrets
 
 			if len(step.Secrets) == 0 && len(jobSecrets) == 0 {
-				r.agentLogger.Debug("verifyJob: both job.Step.Secrets and step.Secrets are empty")
+				r.agentLogger.Debugf("verifyJob: both job.Step.Secrets and step.Secrets are empty")
 				continue // both empty
 			}
 
 			if len(step.Secrets) != len(jobSecrets) {
-				r.agentLogger.Debug("failed to verifyJob: step.Secrets length %d != jobSecrets length %d", len(step.Secrets), len(jobSecrets))
+				r.agentLogger.Debugf("failed to verifyJob: step.Secrets length %d != jobSecrets length %d", len(step.Secrets), len(jobSecrets))
 				return newInvalidSignatureError(ErrInvalidJob)
 			}
 
@@ -194,12 +195,12 @@ func (r *JobRunner) verifyJob(ctx context.Context, keySet any) error {
 				jobSecret := jobSecrets[i]
 
 				if stepSecret.Key != jobSecret.Key {
-					r.agentLogger.Debug("failed to verifyJob: secret at index %d - Step key %q did not match job key %q", i, stepSecret.Key, jobSecret.Key)
+					r.agentLogger.Debugf("failed to verifyJob: secret at index %d - Step key %q did not match job key %q", i, stepSecret.Key, jobSecret.Key)
 					return newInvalidSignatureError(ErrInvalidJob)
 				}
 
 				if stepSecret.EnvironmentVariable != jobSecret.EnvironmentVariable {
-					r.agentLogger.Debug("failed to verifyJob: secret at index %d - Step environment variable %q did not match job environment variable %q", i, stepSecret.EnvironmentVariable, jobSecret.EnvironmentVariable)
+					r.agentLogger.Debugf("failed to verifyJob: secret at index %d - Step environment variable %q did not match job environment variable %q", i, stepSecret.EnvironmentVariable, jobSecret.EnvironmentVariable)
 					return newInvalidSignatureError(ErrInvalidJob)
 				}
 			}
@@ -209,7 +210,7 @@ func (r *JobRunner) verifyJob(ctx context.Context, keySet any) error {
 			if name, isEnv := strings.CutPrefix(field, signature.EnvNamespacePrefix); isEnv {
 				if _, has := r.conf.Job.Env[name]; !has {
 					// A pipeline env var that is now missing.
-					r.agentLogger.Debug("failed to verifyJob: %q missing from Job.Env", name)
+					r.agentLogger.Debugf("failed to verifyJob: %q missing from Job.Env", name)
 					return newInvalidSignatureError(ErrInvalidJob)
 				}
 				// The env var is present. Signature.Verify used the value from
@@ -219,7 +220,7 @@ func (r *JobRunner) verifyJob(ctx context.Context, keySet any) error {
 
 			// We don't know this field, so we cannot ensure it is consistent
 			// with the job.
-			r.agentLogger.Debug("failed to verifyJob: mystery signed field %q", field)
+			r.agentLogger.Debugf("failed to verifyJob: mystery signed field %q", field)
 			return newInvalidSignatureError(ErrInvalidJob)
 		}
 	}

--- a/api/client.go
+++ b/api/client.go
@@ -185,7 +185,7 @@ func (c *Client) setRequestHeaders(headers map[string]string) {
 	if c.logger.Level() <= logger.DEBUG {
 		for k, values := range c.requestHeaders {
 			for _, v := range values {
-				c.logger.Debug("Server-specified request header: %s: %s", k, v)
+				c.logger.Debugf("Server-specified request header: %s: %s", k, v)
 			}
 		}
 	}

--- a/clicommand/agent_pause.go
+++ b/clicommand/agent_pause.go
@@ -82,11 +82,11 @@ func pause(ctx context.Context, cfg AgentPauseConfig, l logger.Logger) error {
 			return err
 		}
 		if err != nil {
-			l.Warn("%s (%s)", err, r)
+			l.Warnf("%s (%s)", err, r)
 			return err
 		}
 
-		l.Info("Successfully paused agent")
+		l.Infof("Successfully paused agent")
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to pause agent: %w", err)

--- a/clicommand/agent_resume.go
+++ b/clicommand/agent_resume.go
@@ -62,11 +62,11 @@ func resume(ctx context.Context, cfg AgentResumeConfig, l logger.Logger) error {
 			return err
 		}
 		if err != nil {
-			l.Warn("%s (%s)", err, r)
+			l.Warnf("%s (%s)", err, r)
 			return err
 		}
 
-		l.Info("Successfully resumed agent")
+		l.Infof("Successfully resumed agent")
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to resume agent: %w", err)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -889,9 +889,9 @@ var AgentStartCommand = cli.Command{
 
 			switch {
 			case cfg.NoCommandEval:
-				l.Warn(msg, "no-command-eval")
+				l.Warnf(msg, "no-command-eval")
 			case cfg.NoLocalHooks:
-				l.Warn(msg, "no-local-hooks")
+				l.Warnf(msg, "no-local-hooks")
 			}
 		}
 
@@ -1019,7 +1019,7 @@ var AgentStartCommand = cli.Command{
 			var err error
 			verificationJWKS, err = parseAndValidateJWKS(ctx, "verification", cfg.VerificationJWKSFile)
 			if err != nil {
-				l.Fatal("Verification JWKS failed validation: %v", err)
+				l.Fatalf("Verification JWKS failed validation: %v", err)
 			}
 		}
 
@@ -1027,12 +1027,12 @@ var AgentStartCommand = cli.Command{
 			// The actual JWKS itself doesn't get used until `buildkite-agent pipeline upload` is called, but validate it here anyway
 			_, err := parseAndValidateJWKS(ctx, "signing", cfg.SigningJWKSFile)
 			if err != nil {
-				l.Fatal("Signing JWKS failed validation: %v", err)
+				l.Fatalf("Signing JWKS failed validation: %v", err)
 			}
 		}
 
 		if len(cfg.AllowedEnvironmentVariables) > 0 && !cfg.EnableEnvironmentVariableAllowList {
-			l.Fatal("allowed-environment-variables is set, but enable-environment-variable-allowlist is not set")
+			l.Fatalf("allowed-environment-variables is set, but enable-environment-variable-allowlist is not set")
 		}
 
 		var allowedEnvironmentVariables []*regexp.Regexp
@@ -1042,7 +1042,7 @@ var AgentStartCommand = cli.Command{
 			for _, v := range cfg.AllowedEnvironmentVariables {
 				re, err := regexp.Compile(v)
 				if err != nil {
-					l.Fatal("Regex %s in allowed-environment-variables failed to compile: %v", v, err)
+					l.Fatalf("Regex %s in allowed-environment-variables failed to compile: %v", v, err)
 				}
 
 				allowedEnvironmentVariables = append(allowedEnvironmentVariables, re)
@@ -1141,50 +1141,50 @@ var AgentStartCommand = cli.Command{
 			return fmt.Errorf("invalid log format %q; only 'text' or 'json' are allowed", cfg.LogFormat)
 		}
 
-		l.Notice("Starting buildkite-agent v%s with PID: %s", version.Version(), strconv.Itoa(os.Getpid()))
-		l.Notice("The agent source code can be found here: https://github.com/buildkite/agent")
-		l.Notice("For questions and support, email us at: hello@buildkite.com")
+		l.Noticef("Starting buildkite-agent v%s with PID: %s", version.Version(), strconv.Itoa(os.Getpid()))
+		l.Noticef("The agent source code can be found here: https://github.com/buildkite/agent")
+		l.Noticef("For questions and support, email us at: hello@buildkite.com")
 
 		if agentConf.ConfigPath != "" {
-			l.WithFields(logger.StringField(`path`, agentConf.ConfigPath)).Info("Configuration loaded")
+			l.WithFields(logger.StringField(`path`, agentConf.ConfigPath)).Infof("Configuration loaded")
 		}
 
-		l.Debug("Bootstrap command: %s", agentConf.BootstrapScript)
-		l.Debug("Build path: %s", agentConf.BuildPath)
-		l.Debug("Hooks directory: %s", agentConf.HooksPath)
-		l.Debug("Additional hooks directories: %v", agentConf.AdditionalHooksPaths)
-		l.Debug("Plugins directory: %s", agentConf.PluginsPath)
+		l.Debugf("Bootstrap command: %s", agentConf.BootstrapScript)
+		l.Debugf("Build path: %s", agentConf.BuildPath)
+		l.Debugf("Hooks directory: %s", agentConf.HooksPath)
+		l.Debugf("Additional hooks directories: %v", agentConf.AdditionalHooksPaths)
+		l.Debugf("Plugins directory: %s", agentConf.PluginsPath)
 
 		if exps := experiments.KnownAndEnabled(ctx); len(exps) > 0 {
-			l.WithFields(logger.StringField("experiments", fmt.Sprintf("%v", exps))).Info("Experiments are enabled")
+			l.WithFields(logger.StringField("experiments", fmt.Sprintf("%v", exps))).Infof("Experiments are enabled")
 		}
 
 		if !agentConf.SSHKeyscan {
-			l.Info("Automatic ssh-keyscan has been disabled")
+			l.Infof("Automatic ssh-keyscan has been disabled")
 		}
 
 		if !agentConf.CommandEval {
-			l.Info("Evaluating console commands has been disabled")
+			l.Infof("Evaluating console commands has been disabled")
 		}
 
 		if !agentConf.PluginsEnabled {
-			l.Info("Plugins have been disabled")
+			l.Infof("Plugins have been disabled")
 		}
 
 		if !agentConf.RunInPty {
-			l.Info("Running builds within a pseudoterminal (PTY) has been disabled")
+			l.Infof("Running builds within a pseudoterminal (PTY) has been disabled")
 		}
 
 		if agentConf.DisconnectAfterJob {
-			l.Info("Agents will disconnect after a job run has completed")
+			l.Infof("Agents will disconnect after a job run has completed")
 		}
 
 		if agentConf.DisconnectAfterIdleTimeout > 0 {
-			l.Info("Agents will disconnect after %v of inactivity", agentConf.DisconnectAfterIdleTimeout)
+			l.Infof("Agents will disconnect after %v of inactivity", agentConf.DisconnectAfterIdleTimeout)
 		}
 
 		if agentConf.DisconnectAfterUptime > 0 {
-			l.Info("Agents will disconnect after %v of uptime and shut down after any running jobs complete", agentConf.DisconnectAfterUptime)
+			l.Infof("Agents will disconnect after %v of uptime and shut down after any running jobs complete", agentConf.DisconnectAfterUptime)
 		}
 
 		if len(cfg.AllowedRepositories) > 0 {
@@ -1192,11 +1192,11 @@ var AgentStartCommand = cli.Command{
 			for _, v := range cfg.AllowedRepositories {
 				r, err := regexp.Compile(v)
 				if err != nil {
-					l.Fatal("Regex %s is allowed-repositories failed to compile: %v", v, err)
+					l.Fatalf("Regex %s is allowed-repositories failed to compile: %v", v, err)
 				}
 				agentConf.AllowedRepositories = append(agentConf.AllowedRepositories, r)
 			}
-			l.Info("Allowed repositories patterns: %q", agentConf.AllowedRepositories)
+			l.Infof("Allowed repositories patterns: %q", agentConf.AllowedRepositories)
 		}
 
 		if len(cfg.AllowedPlugins) > 0 {
@@ -1204,11 +1204,11 @@ var AgentStartCommand = cli.Command{
 			for _, v := range cfg.AllowedPlugins {
 				r, err := regexp.Compile(v)
 				if err != nil {
-					l.Fatal("Regex %s in allowed-plugins failed to compile: %v", v, err)
+					l.Fatalf("Regex %s in allowed-plugins failed to compile: %v", v, err)
 				}
 				agentConf.AllowedPlugins = append(agentConf.AllowedPlugins, r)
 			}
-			l.Info("Allowed plugins patterns: %q", agentConf.AllowedPlugins)
+			l.Infof("Allowed plugins patterns: %q", agentConf.AllowedPlugins)
 		}
 
 		cancelSig, err := process.ParseSignal(cfg.CancelSignal)
@@ -1234,7 +1234,7 @@ var AgentStartCommand = cli.Command{
 			WaitForGCPLabelsTimeout:   gcpLabelsTimeout,
 		})
 		if err != nil {
-			l.Fatal("%v", err)
+			l.Fatalf("%v", err)
 		}
 
 		// Munge the value from --queue (if it exists) into the tags slice
@@ -1243,7 +1243,7 @@ var AgentStartCommand = cli.Command{
 				return strings.HasPrefix(strings.TrimSpace(s), "queue=")
 			})
 			if i != -1 {
-				l.Fatal("Queue must be present in only one of the --tags or the --queue flags")
+				l.Fatalf("Queue must be present in only one of the --tags or the --queue flags")
 			}
 			tags = append(tags, "queue="+cfg.Queue)
 		}
@@ -1251,7 +1251,7 @@ var AgentStartCommand = cli.Command{
 		// confirm the BuildPath is exists. The bootstrap is going to write to it when a job executes,
 		// so we may as well check that'll work now and fail early if it's a problem
 		if !osutil.FileExists(agentConf.BuildPath) {
-			l.Info("Build Path doesn't exist, creating it (%s)", agentConf.BuildPath)
+			l.Infof("Build Path doesn't exist, creating it (%s)", agentConf.BuildPath)
 			// Actual file permissions will be reduced by umask, and won't be 0o777 unless the user has manually changed the umask to 000
 			if err := os.MkdirAll(agentConf.BuildPath, 0o777); err != nil {
 				return fmt.Errorf("failed to create builds path: %w", err)
@@ -1292,9 +1292,9 @@ var AgentStartCommand = cli.Command{
 
 		for i := 1; i <= cfg.Spawn; i++ {
 			if cfg.Spawn == 1 {
-				l.Info("Registering agent with Buildkite...")
+				l.Infof("Registering agent with Buildkite...")
 			} else {
-				l.Info("Registering agent %d of %d with Buildkite...", i, cfg.Spawn)
+				l.Infof("Registering agent %d of %d with Buildkite...", i, cfg.Spawn)
 			}
 
 			// Handle per-spawn name interpolation, replacing %spawn with the spawn index
@@ -1307,7 +1307,7 @@ var AgentStartCommand = cli.Command{
 					// in cases where the value of --spawn varies between hosts.
 					p = -i
 				}
-				l.Info("Assigning priority %d for agent %d", p, i)
+				l.Infof("Assigning priority %d for agent %d", p, i)
 				registerReq.Priority = strconv.Itoa(p)
 			}
 
@@ -1358,8 +1358,8 @@ var AgentStartCommand = cli.Command{
 		signals := poolSigs.handle(ctx)
 		defer close(signals)
 
-		l.Info("Starting %d Agent(s)", cfg.Spawn)
-		l.Info("You can press Ctrl-C to stop the agents")
+		l.Infof("Starting %d Agent(s)", cfg.Spawn)
+		l.Infof("You can press Ctrl-C to stop the agents")
 
 		// Determine the health check listening address and port for this agent
 		if cfg.HealthCheckAddr != "" {
@@ -1471,13 +1471,13 @@ func (ps *poolSignals) handleLoop(ctx context.Context, signals chan os.Signal) {
 			// allow 1 second to send agent disconnects.
 			time.Sleep(ps.cancelGracePeriod + 1*time.Second)
 			// We get here if the main goroutine hasn't returned yet.
-			ps.log.Info("Timed out waiting for agents to exit; exiting immediately with status 1")
+			ps.log.Infof("Timed out waiting for agents to exit; exiting immediately with status 1")
 			os.Exit(1)
 		}()
 	}
 
 	for sig := range signals {
-		ps.log.Debug("Received signal `%v`", sig)
+		ps.log.Debugf("Received signal `%v`", sig)
 		setStatus(fmt.Sprintf("Received signal `%v`", sig))
 
 		switch sig {
@@ -1488,23 +1488,23 @@ func (ps *poolSignals) handleLoop(ctx context.Context, signals chan os.Signal) {
 			interruptCount++
 			switch interruptCount {
 			case 1:
-				ps.log.Info("Received CTRL-C, send again to forcefully kill the agent(s)")
+				ps.log.Infof("Received CTRL-C, send again to forcefully kill the agent(s)")
 				ps.pool.StopGracefully()
 
 			case 2:
-				ps.log.Info("Forcefully stopping running jobs and stopping the agent(s) in %v", ps.cancelGracePeriod)
+				ps.log.Infof("Forcefully stopping running jobs and stopping the agent(s) in %v", ps.cancelGracePeriod)
 				if !ps.skipGraceful {
-					ps.log.Info("Press Ctrl-C one more time to exit immediately without disconnecting - note that agents will be considered lost!")
+					ps.log.Infof("Press Ctrl-C one more time to exit immediately without disconnecting - note that agents will be considered lost!")
 				}
 				ungracefulStop()
 
 			case 3:
-				ps.log.Info("Exiting immediately with status 1")
+				ps.log.Infof("Exiting immediately with status 1")
 				os.Exit(1)
 			}
 
 		default:
-			ps.log.Debug("Ignoring signal `%s`", sig.String())
+			ps.log.Debugf("Ignoring signal `%s`", sig.String())
 		}
 	}
 }
@@ -1526,7 +1526,7 @@ func agentLifecycleHook(hookName string, log logger.Logger, cfg AgentStartConfig
 	p, err := hook.Find(nil, cfg.HooksPath, hookName)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			log.Error("Error finding %q hook: %v", hookName, err)
+			log.Errorf("Error finding %q hook: %v", hookName, err)
 			return err
 		}
 	} else {
@@ -1538,7 +1538,7 @@ func agentLifecycleHook(hookName string, log logger.Logger, cfg AgentStartConfig
 		p, err = hook.Find(nil, h, hookName)
 		if err != nil {
 			if !os.IsNotExist(err) {
-				log.Error("Error finding %q hook: %v", hookName, err)
+				log.Errorf("Error finding %q hook: %v", hookName, err)
 			}
 		} else {
 			hooks = append(hooks, p)
@@ -1556,7 +1556,7 @@ func agentLifecycleHook(hookName string, log logger.Logger, cfg AgentStartConfig
 		shell.WithLogger(shell.NewWriterLogger(w, !cfg.NoColor, nil)), // for Promptf
 	)
 	if err != nil {
-		log.Error("creating shell for %q hook: %v", hookName, err)
+		log.Errorf("creating shell for %q hook: %v", hookName, err)
 		return err
 	}
 
@@ -1565,7 +1565,7 @@ func agentLifecycleHook(hookName string, log logger.Logger, cfg AgentStartConfig
 		scan := bufio.NewScanner(r) // log each line separately
 		log = log.WithFields(logger.StringField("hook", hookName))
 		for scan.Scan() {
-			log.Info(scan.Text())
+			log.Infof(scan.Text())
 		}
 	})
 	defer func() {
@@ -1577,13 +1577,13 @@ func agentLifecycleHook(hookName string, log logger.Logger, cfg AgentStartConfig
 	for _, p = range hooks {
 		script, err := sh.Script(p, cfg.HooksShell)
 		if err != nil {
-			log.Error("%q hook: %v", hookName, err)
+			log.Errorf("%q hook: %v", hookName, err)
 			return err
 		}
 		// For these hooks, hide the interpreter from the "prompt".
 		sh.Promptf("%s", p)
 		if err := script.Run(context.TODO(), shell.ShowPrompt(false)); err != nil {
-			log.Error("%q hook: %v", hookName, err)
+			log.Errorf("%q hook: %v", hookName, err)
 			return err
 		}
 	}
@@ -1620,7 +1620,7 @@ func runAgentAPI(ctx context.Context, l logger.Logger, socketsPath string) (func
 	// Try to be the leader - no worries if this fails.
 	leaderPath := agentapi.LeaderPath(socketsPath)
 	if err := os.Symlink(path, leaderPath); err == nil {
-		l.Info("Agent API: This agent became leader")
+		l.Infof("Agent API: This agent became leader")
 	}
 
 	// Whoever the leader is, ping them every so often as a health-check.
@@ -1628,7 +1628,7 @@ func runAgentAPI(ctx context.Context, l logger.Logger, socketsPath string) (func
 
 	return func() {
 		if err := svr.Shutdown(ctx); err != nil {
-			l.Warn("Agent API: error shutting down server: %v", err)
+			l.Warnf("Agent API: error shutting down server: %v", err)
 		}
 		if d, err := os.Readlink(leaderPath); err == nil && d == path {
 			_ = os.Remove(leaderPath)
@@ -1662,11 +1662,11 @@ func leaderPinger(ctx context.Context, l logger.Logger, path, leaderPath string)
 
 	for range time.Tick(100 * time.Millisecond) {
 		if err := pingLeader(); err != nil {
-			l.Warn("Agent API: Leader ping failed, staging coup: %v", err)
-			l.Warn("Agent API: Leader state (locks) has been lost!")
+			l.Warnf("Agent API: Leader ping failed, staging coup: %v", err)
+			l.Warnf("Agent API: Leader state (locks) has been lost!")
 			_ = os.Remove(leaderPath)
 			if err := os.Symlink(path, leaderPath); err != nil {
-				l.Warn("Agent API: Failed to become leader: %v", err)
+				l.Warnf("Agent API: Failed to become leader: %v", err)
 			}
 		}
 	}

--- a/clicommand/agent_stop.go
+++ b/clicommand/agent_stop.go
@@ -74,11 +74,11 @@ func stop(ctx context.Context, cfg AgentStopConfig, l logger.Logger) error {
 			return err
 		}
 		if err != nil {
-			l.Warn("%s (%s)", err, r)
+			l.Warnf("%s (%s)", err, r)
 			return err
 		}
 
-		l.Info("Successfully stopped agent")
+		l.Infof("Successfully stopped agent")
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to stop agent: %w", err)

--- a/clicommand/annotate.go
+++ b/clicommand/annotate.go
@@ -133,7 +133,7 @@ func annotate(ctx context.Context, cfg AnnotateConfig, l logger.Logger) error {
 	if cfg.Body != "" {
 		body = cfg.Body
 	} else if stdin.IsReadable() {
-		l.Info("Reading annotation body from STDIN")
+		l.Infof("Reading annotation body from STDIN")
 
 		// Actually read the file from STDIN
 		stdin, err := io.ReadAll(os.Stdin)
@@ -151,7 +151,7 @@ func annotate(ctx context.Context, cfg AnnotateConfig, l logger.Logger) error {
 		return err
 	}
 	if redactedBody := redact.String(body, needles); redactedBody != body {
-		l.Warn("Annotation body contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret")
+		l.Warnf("Annotation body contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret")
 		body = redactedBody
 	}
 
@@ -185,7 +185,7 @@ func annotate(ctx context.Context, cfg AnnotateConfig, l logger.Logger) error {
 			return err
 		}
 		if err != nil {
-			l.Warn("%s (%s)", err, r)
+			l.Warnf("%s (%s)", err, r)
 			return err
 		}
 		return nil
@@ -193,7 +193,7 @@ func annotate(ctx context.Context, cfg AnnotateConfig, l logger.Logger) error {
 		return fmt.Errorf("failed to annotate build: %w", err)
 	}
 
-	l.Debug("Successfully annotated build")
+	l.Debugf("Successfully annotated build")
 
 	return nil
 }

--- a/clicommand/annotation_remove.go
+++ b/clicommand/annotation_remove.go
@@ -84,7 +84,7 @@ var AnnotationRemoveCommand = cli.Command{
 				return err
 			}
 			if err != nil {
-				l.Warn("%s (%s)", err, r)
+				l.Warnf("%s (%s)", err, r)
 				return err
 			}
 			return nil
@@ -92,7 +92,7 @@ var AnnotationRemoveCommand = cli.Command{
 			return fmt.Errorf("failed to remove annotation: %w", err)
 		}
 
-		l.Debug("Successfully removed annotation")
+		l.Debugf("Successfully removed annotation")
 
 		return nil
 	},

--- a/clicommand/artifact_search.go
+++ b/clicommand/artifact_search.go
@@ -147,7 +147,7 @@ var ArtifactSearchCommand = cli.Command{
 			if !cfg.AllowEmptyResults {
 				return fmt.Errorf("no matches found for %q", cfg.Query)
 			}
-			l.Info("No matches found for %q", cfg.Query)
+			l.Infof("No matches found for %q", cfg.Query)
 		}
 
 		for _, artifact := range artifacts {

--- a/clicommand/artifact_shasum.go
+++ b/clicommand/artifact_shasum.go
@@ -122,7 +122,7 @@ func searchAndPrintShaSum(
 		return fmt.Errorf("multiple artifacts were found. try being more specific with the search or scope by step")
 	} else {
 		a := artifacts[0]
-		l.Debug("Artifact \"%s\" found", a.Path)
+		l.Debugf("Artifact \"%s\" found", a.Path)
 
 		var sha string
 		if cfg.Sha256 {

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -508,7 +508,7 @@ var BootstrapCommand = cli.Command{
 
 			// Cancel the bootstrap
 			if err := bootstrap.Cancel(); err != nil {
-				l.Debug("Failed to cancel bootstrap: %v", err)
+				l.Debugf("Failed to cancel bootstrap: %v", err)
 			}
 
 			// Track the state and signal used
@@ -536,7 +536,7 @@ var BootstrapCommand = cli.Command{
 				return &SilentExitError{code: 131} // 128 + 3 (SIGQUIT).
 			}
 			if err := signalSelf(l, received); err != nil {
-				l.Error("Failed to signal self: %v", err)
+				l.Errorf("Failed to signal self: %v", err)
 			}
 		}
 
@@ -550,7 +550,7 @@ func signalSelf(l logger.Logger, sig os.Signal) error {
 		return fmt.Errorf("failed to find current process: %w", err)
 	}
 
-	l.Debug("Terminating bootstrap after cancellation with %v", sig)
+	l.Debugf("Terminating bootstrap after cancellation with %v", sig)
 	err = p.Signal(sig)
 	if err != nil {
 		return fmt.Errorf("failed to signal self: %v", err)

--- a/clicommand/build_cancel.go
+++ b/clicommand/build_cancel.go
@@ -70,11 +70,11 @@ func cancelBuild(ctx context.Context, cfg BuildCancelConfig, l logger.Logger) er
 			return err
 		}
 		if err != nil {
-			l.Warn("%s (%s)", err, r)
+			l.Warnf("%s (%s)", err, r)
 			return err
 		}
 
-		l.Info("Successfully cancelled build %s", build.UUID)
+		l.Infof("Successfully cancelled build %s", build.UUID)
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to cancel build: %w", err)

--- a/clicommand/cache_restore.go
+++ b/clicommand/cache_restore.go
@@ -80,7 +80,7 @@ var CacheRestoreCommand = cli.Command{
 		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "cache-restore")
 		defer span.End()
 
-		l.Info("Cache restore command executed")
+		l.Infof("Cache restore command executed")
 
 		apiCfg := loadAPIClientConfig(cfg, "AgentAccessToken")
 

--- a/clicommand/cache_save.go
+++ b/clicommand/cache_save.go
@@ -74,7 +74,7 @@ var CacheSaveCommand = cli.Command{
 		ctx, span := otel.Tracer("buildkite-agent").Start(ctx, "cache-save")
 		defer span.End()
 
-		l.Info("Cache save command executed")
+		l.Infof("Cache save command executed")
 
 		apiCfg := loadAPIClientConfig(cfg, "AgentAccessToken")
 

--- a/clicommand/env_get.go
+++ b/clicommand/env_get.go
@@ -103,7 +103,7 @@ func envGetAction(c *cli.Context) error {
 			v, ok := envMap[arg]
 			if !ok {
 				notFound = true
-				l.Warn("%q is not set", arg)
+				l.Warnf("%q is not set", arg)
 				continue
 			}
 			em[arg] = v
@@ -136,7 +136,7 @@ func envGetAction(c *cli.Context) error {
 		}
 
 	default:
-		l.Error("Invalid output format %q\n", cfg.Format)
+		l.Errorf("Invalid output format %q\n", cfg.Format)
 	}
 
 	if notFound {

--- a/clicommand/env_set.go
+++ b/clicommand/env_set.go
@@ -129,7 +129,7 @@ func envSetAction(c *cli.Context) error {
 
 	resp, err := client.EnvUpdate(ctx, req)
 	if err != nil {
-		l.Error("Couldn't update the job executor environment: %v", err)
+		l.Errorf("Couldn't update the job executor environment: %v", err)
 	}
 
 	switch cfg.OutputFormat {

--- a/clicommand/env_unset.go
+++ b/clicommand/env_unset.go
@@ -120,7 +120,7 @@ func envUnsetAction(c *cli.Context) error {
 
 	unset, err := client.EnvDelete(ctx, del)
 	if err != nil {
-		l.Error("couldn't unset the job executor environment variables: %v", err)
+		l.Errorf("couldn't unset the job executor environment variables: %v", err)
 	}
 
 	switch cfg.OutputFormat {

--- a/clicommand/git_credentials_helper.go
+++ b/clicommand/git_credentials_helper.go
@@ -64,7 +64,7 @@ var GitCredentialsHelperCommand = cli.Command{
 		ctx, cfg, l, _, done := setupLoggerAndConfig[GitCredentialsHelperConfig](ctx, c)
 		defer done()
 
-		l.Debug("Action: %s", cfg.Action)
+		l.Debugf("Action: %s", cfg.Action)
 		if cfg.Action != "get" {
 			// other actions are store and erase, which we don't support
 			// see: https://git-scm.com/docs/gitcredentials#Documentation/gitcredentials.txt-codegetcode
@@ -74,8 +74,8 @@ var GitCredentialsHelperCommand = cli.Command{
 		// ie, if the flags are from the command line rather than from the environment, which is how they should be passed
 		// to this process when it's called through the job executor
 		if os.Getenv("BUILDKITE_JOB_ID") == "" {
-			l.Warn("📎💬 It looks like you're calling this command directly in a step, rather than having the agent automatically call it")
-			l.Warn("This command is intended to be used as a git credential helper, and not called directly.")
+			l.Warnf("📎💬 It looks like you're calling this command directly in a step, rather than having the agent automatically call it")
+			l.Warnf("This command is intended to be used as a git credential helper, and not called directly.")
 		}
 
 		// git passes the details of the current clone process to the credential helper via stdin
@@ -86,9 +86,9 @@ var GitCredentialsHelperCommand = cli.Command{
 			return handleAuthError(c, l, fmt.Errorf("failed to read stdin: %w", err))
 		}
 
-		l.Debug("Git credential input:\n%s\n", string(stdin))
+		l.Debugf("Git credential input:\n%s\n", string(stdin))
 
-		l.Debug("Authenticating checkout using Buildkite Github App Credentials...")
+		l.Debugf("Authenticating checkout using Buildkite Github App Credentials...")
 
 		repo, err := parseGitURLFromCredentialInput(string(stdin))
 		if err != nil {
@@ -105,7 +105,7 @@ var GitCredentialsHelperCommand = cli.Command{
 		_, _ = fmt.Fprintln(c.App.Writer, "password="+tok)
 		_, _ = fmt.Fprintln(c.App.Writer, "")
 
-		l.Debug("Authentication successful!")
+		l.Debugf("Authentication successful!")
 
 		return nil
 	},
@@ -116,7 +116,7 @@ var GitCredentialsHelperCommand = cli.Command{
 // the clone to fail
 // this function always returns a cli.ExitError
 func handleAuthError(c *cli.Context, l logger.Logger, err error) error {
-	l.Error("Error: %v. Authentication will proceed, but will fail.", err)
+	l.Errorf("Error: %v. Authentication will proceed, but will fail.", err)
 	_, _ = fmt.Fprintln(c.App.Writer, "username=fail")
 	_, _ = fmt.Fprintln(c.App.Writer, "password=fail")
 	_, _ = fmt.Fprintln(c.App.Writer, "")

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -371,7 +371,7 @@ func CreateLogger(cfg any) logger.Logger {
 
 	err := handleLogLevelFlag(l, cfg)
 	if err != nil {
-		l.Warn("Error when setting log level: %v. Defaulting log level to NOTICE", err)
+		l.Warnf("Error when setting log level: %v. Defaulting log level to NOTICE", err)
 	}
 
 	// Enable debugging if a Debug option is present
@@ -407,7 +407,7 @@ func HandleGlobalFlags(ctx context.Context, l logger.Logger, cfg any) (context.C
 	for _, name := range experimentNamesSlice {
 		nctx, state := experiments.EnableWithWarnings(ctx, l, name)
 		if state == experiments.StateKnown {
-			l.Debug("Enabled experiment %q", name)
+			l.Debugf("Enabled experiment %q", name)
 		}
 		ctx = nctx
 	}
@@ -532,11 +532,11 @@ func setupLoggerAndConfig[T any](ctx context.Context, c *cli.Context, opts ...co
 		l = l.WithFields(logger.StringField("command", c.Command.FullName()))
 	}
 
-	l.Debug("Loaded config")
+	l.Debugf("Loaded config")
 
 	// Now that we have a logger, log out the warnings that loading config generated
 	for _, warning := range warnings {
-		l.Warn("%s", warning)
+		l.Warnf("%s", warning)
 	}
 
 	// Setup any global configuration options
@@ -549,7 +549,7 @@ func setupLoggerAndConfig[T any](ctx context.Context, c *cli.Context, opts ...co
 			serviceName := os.Getenv("BUILDKITE_TRACING_SERVICE_NAME")
 			traceProvider, err := job.InitOTelTracerProvider(ctx, serviceName, nil)
 			if err != nil {
-				l.Warn("Failed to initialize tracing: %v", err)
+				l.Warnf("Failed to initialize tracing: %v", err)
 			} else {
 				carrier := propagation.MapCarrier{"traceparent": traceParent}
 				if traceState := os.Getenv("TRACESTATE"); traceState != "" {

--- a/clicommand/job_update.go
+++ b/clicommand/job_update.go
@@ -57,7 +57,7 @@ var JobUpdateCommand = cli.Command{
 		defer done()
 
 		if len(c.Args()) < 2 {
-			l.Info("Reading value from STDIN")
+			l.Infof("Reading value from STDIN")
 
 			input, err := io.ReadAll(os.Stdin)
 			if err != nil {
@@ -73,7 +73,7 @@ var JobUpdateCommand = cli.Command{
 			return err
 		}
 		if redactedValue := redact.String(cfg.Value, needles); redactedValue != cfg.Value {
-			l.Warn("New value for job %q attribute %q contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret", cfg.Job, cfg.Attribute)
+			l.Warnf("New value for job %q attribute %q contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret", cfg.Job, cfg.Attribute)
 			cfg.Value = redactedValue
 		}
 
@@ -88,7 +88,7 @@ var JobUpdateCommand = cli.Command{
 				return err
 			}
 			if err != nil {
-				l.Warn("%s (%s)", err, r)
+				l.Warnf("%s (%s)", err, r)
 				return err
 			}
 			return nil

--- a/clicommand/kubernetes_bootstrap.go
+++ b/clicommand/kubernetes_bootstrap.go
@@ -169,9 +169,9 @@ var KubernetesBootstrapCommand = cli.Command{
 			// is in state interrupted or the connection died or ...), we should
 			// cancel the job.
 			if err != nil {
-				l.Error("kubernetes-bootstrap: Error waiting for client interrupt: %v; cancelling work", err)
+				l.Errorf("kubernetes-bootstrap: Error waiting for client interrupt: %v; cancelling work", err)
 			} else {
-				l.Warn("kubernetes-bootstrap: Either the job was cancelled or the pod is being deleted; cancelling work")
+				l.Warnf("kubernetes-bootstrap: Either the job was cancelled or the pod is being deleted; cancelling work")
 			}
 			// The context cancellation handler in process.Run first calls
 			// Interrupt, waits for its signalGracePeriod, and then calls
@@ -187,7 +187,7 @@ var KubernetesBootstrapCommand = cli.Command{
 				// in that case is superfluous.)
 				time.Sleep(cancelGracePeriod)
 				// We get here if the main goroutine hasn't returned yet.
-				l.Info("kubernetes-bootstrap: Timed out waiting for subprocess to exit; exiting immediately with status 1")
+				l.Infof("kubernetes-bootstrap: Timed out waiting for subprocess to exit; exiting immediately with status 1")
 				os.Exit(1)
 			}()
 		}); err != nil {
@@ -239,7 +239,7 @@ var KubernetesBootstrapCommand = cli.Command{
 					return
 				case sig := <-signals:
 					// Log but otherwise swallow the signal
-					l.Info("kubernetes-bootstrap: Received %v; awaiting interrupt from agent", sig)
+					l.Infof("kubernetes-bootstrap: Received %v; awaiting interrupt from agent", sig)
 				}
 			}
 		}()

--- a/clicommand/meta_data_exists.go
+++ b/clicommand/meta_data_exists.go
@@ -81,7 +81,7 @@ var MetaDataExistsCommand = cli.Command{
 				return nil, err
 			}
 			if err != nil {
-				l.Warn("%s (%s)", err, r)
+				l.Warnf("%s (%s)", err, r)
 				return nil, err
 			}
 			return exists, nil

--- a/clicommand/meta_data_get.go
+++ b/clicommand/meta_data_get.go
@@ -87,7 +87,7 @@ var MetaDataGetCommand = cli.Command{
 				return nil, resp, err
 			}
 			if err != nil {
-				l.Warn("%s (%s)", err, r)
+				l.Warnf("%s (%s)", err, r)
 				return nil, resp, err
 			}
 			return metaData, resp, nil
@@ -100,7 +100,7 @@ var MetaDataGetCommand = cli.Command{
 			// We also use `IsSet` instead of `cfg.Default != ""`
 			// to allow people to use a default of a blank string.
 			if resp != nil && resp.StatusCode == 404 && c.IsSet("default") {
-				l.Warn(
+				l.Warnf(
 					"No meta-data value exists with key %q, returning the supplied default %q",
 					cfg.Key,
 					cfg.Default,

--- a/clicommand/meta_data_keys.go
+++ b/clicommand/meta_data_keys.go
@@ -80,7 +80,7 @@ var MetaDataKeysCommand = cli.Command{
 				return keys, err
 			}
 			if err != nil {
-				l.Warn("%s (%s)", err, r)
+				l.Warnf("%s (%s)", err, r)
 			}
 			return keys, err
 		})

--- a/clicommand/meta_data_set.go
+++ b/clicommand/meta_data_set.go
@@ -69,7 +69,7 @@ var MetaDataSetCommand = cli.Command{
 
 		// Read the value from STDIN if argument omitted entirely
 		if len(c.Args()) < 2 {
-			l.Info("Reading meta-data value from STDIN")
+			l.Infof("Reading meta-data value from STDIN")
 
 			input, err := io.ReadAll(os.Stdin)
 			if err != nil {
@@ -92,7 +92,7 @@ var MetaDataSetCommand = cli.Command{
 			return err
 		}
 		if redactedValue := redact.String(cfg.Value, needles); redactedValue != cfg.Value {
-			l.Warn("Meta-data value for key %q contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret", cfg.Key)
+			l.Warnf("Meta-data value for key %q contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret", cfg.Key)
 			cfg.Value = redactedValue
 		}
 
@@ -116,7 +116,7 @@ var MetaDataSetCommand = cli.Command{
 				return err
 			}
 			if err != nil {
-				l.Warn("%s (%s)", err, r)
+				l.Warnf("%s (%s)", err, r)
 				return err
 			}
 			return nil

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -139,15 +139,15 @@ var OIDCRequestTokenCommand = cli.Command{
 				return nil, err
 			}
 			if err != nil {
-				l.Warn("%s (%s)", err, r)
+				l.Warnf("%s (%s)", err, r)
 			}
 			return token, err
 		})
 		if err != nil {
 			if len(cfg.Audience) > 0 {
-				l.Error("Could not obtain OIDC token for audience %s", cfg.Audience)
+				l.Errorf("Could not obtain OIDC token for audience %s", cfg.Audience)
 			} else {
-				l.Error("Could not obtain OIDC token for default audience")
+				l.Errorf("Could not obtain OIDC token for default audience")
 			}
 			return err
 		}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -207,7 +207,7 @@ var PipelineUploadCommand = cli.Command{
 
 		switch {
 		case len(cfg.FilePaths) > 0:
-			l.Info("Reading pipeline configs from %q", cfg.FilePaths)
+			l.Infof("Reading pipeline configs from %q", cfg.FilePaths)
 
 			for _, fn := range cfg.FilePaths {
 				file, err := os.Open(fn)
@@ -219,13 +219,13 @@ var PipelineUploadCommand = cli.Command{
 			}
 
 		case stdin.IsReadable():
-			l.Info("Reading pipeline config from STDIN")
+			l.Infof("Reading pipeline config from STDIN")
 
 			// Actually read the file from STDIN
 			inputs = []input{{os.Stdin, "(stdin)"}}
 
 		default:
-			l.Info("Searching for pipeline config...")
+			l.Infof("Searching for pipeline config...")
 
 			paths := []string{
 				"buildkite.yml",
@@ -258,7 +258,7 @@ var PipelineUploadCommand = cli.Command{
 
 			found := exists[0]
 
-			l.Info("Found config file %q", found)
+			l.Infof("Found config file %q", found)
 
 			// Read the default file
 			file, err := os.Open(found)
@@ -338,7 +338,7 @@ var PipelineUploadCommand = cli.Command{
 					if w == nil {
 						return err
 					}
-					l.Warn("There were some issues with the pipeline input - pipeline upload will proceed, but might not succeed:\n%v", w)
+					l.Warnf("There were some issues with the pipeline input - pipeline upload will proceed, but might not succeed:\n%v", w)
 				}
 
 				if len(cfg.RedactedVars) > 0 {
@@ -386,7 +386,7 @@ var PipelineUploadCommand = cli.Command{
 						key,
 						os.Getenv("BUILDKITE_REPO"),
 						signature.WithEnv(result.Env.ToMap()),
-						signature.WithLogger(l),
+						signature.WithLogger(logger.DeprecatedLogger{Logger: l}),
 						signature.WithDebugSigning(cfg.DebugSigning),
 					)
 					if err != nil {
@@ -431,11 +431,11 @@ var PipelineUploadCommand = cli.Command{
 					RetrySleepFunc: time.Sleep,
 				}
 				if err := uploader.Upload(ctx, l); err != nil {
-					l.Error(err.Error())
+					l.Errorf(err.Error())
 					return NewSilentExitError(1)
 				}
 
-				l.Info("Successfully parsed and uploaded pipeline #%d from %q", count, input.name)
+				l.Infof("Successfully parsed and uploaded pipeline #%d from %q", count, input.name)
 				count++
 			}
 		}
@@ -452,11 +452,11 @@ func resolveCommit(l logger.Logger, environ *env.Environment) {
 	}
 	cmdOut, err := exec.Command("git", "rev-parse", commitRef).Output()
 	if err != nil {
-		l.Warn("Error running git rev-parse %q: %v", commitRef, err)
+		l.Warnf("Error running git rev-parse %q: %v", commitRef, err)
 		return
 	}
 	trimmedCmdOut := strings.TrimSpace(string(cmdOut))
-	l.Info("Updating BUILDKITE_COMMIT to %q", trimmedCmdOut)
+	l.Infof("Updating BUILDKITE_COMMIT to %q", trimmedCmdOut)
 	environ.Set("BUILDKITE_COMMIT", trimmedCmdOut)
 }
 
@@ -541,7 +541,7 @@ func searchForSecrets(
 	// So we can declare the secrets to be found if they match the usual rules.
 	matched, short, err := redact.Vars(cfg.RedactedVars, allVars)
 	if err != nil {
-		l.Warn("Couldn't match environment variable names against redacted-vars: %v", err)
+		l.Warnf("Couldn't match environment variable names against redacted-vars: %v", err)
 	}
 
 	for _, name := range short {
@@ -555,7 +555,7 @@ func searchForSecrets(
 	// Filter these down to the vars normally redacted.
 	matched, short, err = redact.Vars(cfg.RedactedVars, environ.DumpPairs())
 	if err != nil {
-		l.Warn("Couldn't match environment variable names against redacted-vars: %v", err)
+		l.Warnf("Couldn't match environment variable names against redacted-vars: %v", err)
 	}
 	for _, name := range short {
 		shortValues[name] = struct{}{}
@@ -588,7 +588,7 @@ func searchForSecrets(
 	if len(shortValues) > 0 {
 		vars := slices.Collect(maps.Keys(shortValues))
 		slices.Sort(vars)
-		l.Warn("Some variables have values below minimum length (%d bytes) and will not be redacted: %s", redact.LengthMin, strings.Join(vars, ", "))
+		l.Warnf("Some variables have values below minimum length (%d bytes) and will not be redacted: %s", redact.LengthMin, strings.Join(vars, ", "))
 	}
 
 	if len(secretsFound) > 0 {
@@ -599,9 +599,9 @@ func searchForSecrets(
 			return fmt.Errorf("pipeline %q contains values interpolated from the following secret environment variables: %v, and cannot be uploaded to Buildkite", src, secretsFound)
 		}
 
-		l.Warn("Pipeline %q contains values interpolated from the following secret environment variables: %v, which could leak sensitive information into the Buildkite UI.", src, secretsFound)
-		l.Warn("This pipeline will still be uploaded, but if you'd like to to prevent this from happening, you can use the `--reject-secrets` cli flag, or the `BUILDKITE_AGENT_PIPELINE_UPLOAD_REJECT_SECRETS` environment variable, which will make the `buildkite-agent pipeline upload` command fail if it finds secrets in the pipeline.")
-		l.Warn("The behaviour in the above flags will become default in Buildkite Agent v4")
+		l.Warnf("Pipeline %q contains values interpolated from the following secret environment variables: %v, which could leak sensitive information into the Buildkite UI.", src, secretsFound)
+		l.Warnf("This pipeline will still be uploaded, but if you'd like to to prevent this from happening, you can use the `--reject-secrets` cli flag, or the `BUILDKITE_AGENT_PIPELINE_UPLOAD_REJECT_SECRETS` environment variable, which will make the `buildkite-agent pipeline upload` command fail if it finds secrets in the pipeline.")
+		l.Warnf("The behaviour in the above flags will become default in Buildkite Agent v4")
 	}
 
 	return nil
@@ -661,7 +661,7 @@ func readChangedFilesFromPath(l logger.Logger, path string) ([]string, error) {
 	if len(changedPaths) == 1 {
 		plural = "file"
 	}
-	l.Info("if_changed read %d changed %s from %q", len(changedPaths), plural, path)
+	l.Infof("if_changed read %d changed %s from %q", len(changedPaths), plural, path)
 	return changedPaths, nil
 }
 
@@ -687,8 +687,8 @@ func computeGitDiff(l logger.Logger, diffBase string) (changedPaths []string, er
 		// and its parent (the first parent, if it is a merge commit).
 		// If _multiple_ commits were pushed at once, then this approach will
 		// miss changes from earlier commits. Thus, log a warning.
-		l.Warn("Applying if_changed conditions relative to the first parent of HEAD (because HEAD = %q)", diffBase)
-		l.Warn("If this build is intended to include more than one commit on this branch, if_changed may calculate an incomplete diff. You may need to adjust the --git-diff-base flag or BUILDKITE_GIT_DIFF_BASE env var to choose a different base commit for calculating diffs.")
+		l.Warnf("Applying if_changed conditions relative to the first parent of HEAD (because HEAD = %q)", diffBase)
+		l.Warnf("If this build is intended to include more than one commit on this branch, if_changed may calculate an incomplete diff. You may need to adjust the --git-diff-base flag or BUILDKITE_GIT_DIFF_BASE env var to choose a different base commit for calculating diffs.")
 
 		// Flag Explainer:
 		// `--first-parent`: when reaching a merge commit, follow the first parent
@@ -709,7 +709,7 @@ func computeGitDiff(l logger.Logger, diffBase string) (changedPaths []string, er
 			return nil, gitMergeBaseError{diffBase: diffBase, wrapped: err}
 		}
 		mergeBase := strings.TrimSpace(string(mergeBaseOut))
-		l.Info("Applying if_changed conditions relative to %q (the merge-base of %q and HEAD)", mergeBase, diffBase)
+		l.Infof("Applying if_changed conditions relative to %q (the merge-base of %q and HEAD)", mergeBase, diffBase)
 
 		gitDiff, err := exec.Command("git", "diff", "--name-only", mergeBase).Output()
 		if err != nil {
@@ -724,7 +724,7 @@ func computeGitDiff(l logger.Logger, diffBase string) (changedPaths []string, er
 	if len(changedPaths) == 1 {
 		plural = "file"
 	}
-	l.Info("if_changed found %d changed %s", len(changedPaths), plural)
+	l.Infof("if_changed found %d changed %s", len(changedPaths), plural)
 	return changedPaths, nil
 }
 
@@ -848,13 +848,13 @@ stepsLoop:
 			//   exclude: (optional; string or list)
 			inclVal, has := x.Get("include")
 			if !has {
-				l.Warn("The value for if_changed was a mapping, but it didn't have an `include` key. The step will not be skipped.")
+				l.Warnf("The value for if_changed was a mapping, but it didn't have an `include` key. The step will not be skipped.")
 				continue stepsLoop
 			}
 			var err error
 			include, err = ifChangedPatterns(inclVal)
 			if err != nil {
-				l.Warn("Couldn't parse if_changed.include patterns: %v. The step will not be skipped.", err)
+				l.Warnf("Couldn't parse if_changed.include patterns: %v. The step will not be skipped.", err)
 				continue stepsLoop
 			}
 			exclVal, has := x.Get("exclude")
@@ -863,7 +863,7 @@ stepsLoop:
 			}
 			exclude, err = ifChangedPatterns(exclVal)
 			if err != nil {
-				l.Warn("Couldn't parse if_changed.exclude patterns: %v. The step will not be skipped.", err)
+				l.Warnf("Couldn't parse if_changed.exclude patterns: %v. The step will not be skipped.", err)
 				continue stepsLoop
 			}
 
@@ -871,7 +871,7 @@ stepsLoop:
 			// Should be either a simple string or a list of strings.
 			inc, err := ifChangedPatterns(x)
 			if err != nil {
-				l.Warn("Couldn't parse if_changed patterns: %v. The step will not be skipped.", err)
+				l.Warnf("Couldn't parse if_changed patterns: %v. The step will not be skipped.", err)
 				continue stepsLoop
 			}
 			include = inc
@@ -908,7 +908,7 @@ func (ica *ifChangedApplicator) gatherChangedPaths(l logger.Logger) ([]string, e
 		// Read changed files from the provided file path.
 		cps, err := readChangedFilesFromPath(l, ica.changedFilesPath)
 		if err != nil {
-			l.Error("Couldn't read changed files from %q, not skipping any pipeline steps: %v", ica.changedFilesPath, err)
+			l.Errorf("Couldn't read changed files from %q, not skipping any pipeline steps: %v", ica.changedFilesPath, err)
 			return nil, err
 		}
 		return cps, nil
@@ -918,45 +918,45 @@ func (ica *ifChangedApplicator) gatherChangedPaths(l logger.Logger) ([]string, e
 		// First, fetch the remote refspec specified by diffBase.
 		remote, refspec, slash := strings.Cut(ica.diffBase, "/")
 		if !slash {
-			l.Warn("The diff-base %q was not in 'remote/refspec' form - continuing with the remote 'origin'", ica.diffBase)
+			l.Warnf("The diff-base %q was not in 'remote/refspec' form - continuing with the remote 'origin'", ica.diffBase)
 			remote = "origin"
 			refspec = ica.diffBase
 		}
 		if err := exec.Command("git", "fetch", "--", remote, refspec).Run(); err != nil {
-			l.Error("Couldn't fetch %q from origin: %v", err)
+			l.Errorf("Couldn't fetch %q from origin: %v", err)
 			var exitErr *exec.ExitError
 			if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
 				// stderr came from git, which is typically human readable
-				l.Error("git: %s", exitErr.Stderr)
+				l.Errorf("git: %s", exitErr.Stderr)
 			}
-			l.Info("if_changed will continue processing, but the diff may fail, or produce more paths than expected.")
+			l.Infof("if_changed will continue processing, but the diff may fail, or produce more paths than expected.")
 		}
 	}
 
 	// Determine changed files using git.
 	cps, err := computeGitDiff(l, ica.diffBase)
 	if err != nil {
-		l.Error("Couldn't determine git diff from upstream, not skipping any pipeline steps: %v", err)
+		l.Errorf("Couldn't determine git diff from upstream, not skipping any pipeline steps: %v", err)
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
 			// stderr came from git, which is typically human readable
-			l.Error("git: %s", exitErr.Stderr)
+			l.Errorf("git: %s", exitErr.Stderr)
 		}
 		switch err := err.(type) {
 		case gitRevParseError:
-			l.Error("This could be because %q might not be a commit in the repository.\n"+
+			l.Errorf("This could be because %q might not be a commit in the repository.\n"+
 				"You may need to change the --git-diff-base flag or BUILDKITE_GIT_DIFF_BASE env var, or add --fetch-diff-base.",
 				err.arg,
 			)
 
 		case gitMergeBaseError:
-			l.Error("This could be because %q might not be a commit in the repository.\n"+
+			l.Errorf("This could be because %q might not be a commit in the repository.\n"+
 				"You may need to change the --git-diff-base flag or BUILDKITE_GIT_DIFF_BASE env var, or add --fetch-diff-base.",
 				err.diffBase,
 			)
 
 		case gitDiffError:
-			l.Error("This could be because the merge-base that Git found, %q, might be invalid.\n"+
+			l.Errorf("This could be because the merge-base that Git found, %q, might be invalid.\n"+
 				"You may need to change the --git-diff-base flag or BUILDKITE_GIT_DIFF_BASE env var, or add --fetch-diff-base.",
 				err.mergeBase,
 			)

--- a/clicommand/profiler.go
+++ b/clicommand/profiler.go
@@ -45,7 +45,7 @@ func Profile(l logger.Logger, mode string) func() {
 	case "trace":
 		p.mode = traceMode
 	default:
-		p.logger.Fatal("Unknown profile mode %q", mode)
+		p.logger.Fatalf("Unknown profile mode %q", mode)
 	}
 
 	p.Start()
@@ -61,33 +61,33 @@ func (p *profiler) Stop() {
 func (p *profiler) Start() {
 	path, err := os.MkdirTemp("", "profile")
 	if err != nil {
-		p.logger.Fatal("Could not create initial output directory: %v", err)
+		p.logger.Fatalf("Could not create initial output directory: %v", err)
 	}
 
 	// create a pprof file for the mode
 	fn := filepath.Join(path, string(p.mode)+".pprof")
 	f, err := os.Create(fn)
 	if err != nil {
-		p.logger.Fatal("Could not create %s profile %q: %v", p.mode, fn, err)
+		p.logger.Fatalf("Could not create %s profile %q: %v", p.mode, fn, err)
 	}
 
 	// called after mode specific closers
 	closer := func() {
 		if err := f.Close(); err != nil {
-			p.logger.Fatal("Failed to close %s: %v", fn, err)
+			p.logger.Fatalf("Failed to close %s: %v", fn, err)
 		}
-		p.logger.Info("Finished %s profiling finished, %s", p.mode, fn)
+		p.logger.Infof("Finished %s profiling finished, %s", p.mode, fn)
 	}
 
 	must := func(err error) {
 		if err != nil {
-			p.logger.Fatal("Profiler mode %s failed: %v", p.mode, err)
+			p.logger.Fatalf("Profiler mode %s failed: %v", p.mode, err)
 		}
 	}
 
 	switch p.mode {
 	case cpuMode:
-		p.logger.Info("CPU profiling enabled, %s", fn)
+		p.logger.Infof("CPU profiling enabled, %s", fn)
 		must(pprof.StartCPUProfile(f))
 		p.closer = func() {
 			pprof.StopCPUProfile()
@@ -95,7 +95,7 @@ func (p *profiler) Start() {
 		}
 
 	case memMode:
-		p.logger.Info("Memory profiling enabled, %s", fn)
+		p.logger.Infof("Memory profiling enabled, %s", fn)
 		p.closer = func() {
 			must(pprof.WriteHeapProfile(f))
 			closer()
@@ -103,7 +103,7 @@ func (p *profiler) Start() {
 
 	case mutexMode:
 		runtime.SetMutexProfileFraction(1)
-		p.logger.Info("Mutex profiling enabled, %s", fn)
+		p.logger.Infof("Mutex profiling enabled, %s", fn)
 		p.closer = func() {
 			if mp := pprof.Lookup("mutex"); mp != nil {
 				must(mp.WriteTo(f, 0))
@@ -114,7 +114,7 @@ func (p *profiler) Start() {
 
 	case blockMode:
 		runtime.SetBlockProfileRate(1)
-		p.logger.Info("Block profiling enabled, %s", fn)
+		p.logger.Infof("Block profiling enabled, %s", fn)
 		p.closer = func() {
 			must(pprof.Lookup("block").WriteTo(f, 0))
 			runtime.SetBlockProfileRate(0)
@@ -122,7 +122,7 @@ func (p *profiler) Start() {
 		}
 
 	case threadCreateMode:
-		p.logger.Info("Thread creation profiling enabled, %s", fn)
+		p.logger.Infof("Thread creation profiling enabled, %s", fn)
 		p.closer = func() {
 			if mp := pprof.Lookup("threadcreate"); mp != nil {
 				must(mp.WriteTo(f, 0))
@@ -132,9 +132,9 @@ func (p *profiler) Start() {
 
 	case traceMode:
 		if err := trace.Start(f); err != nil {
-			p.logger.Fatal("Could not start profiling trace: %v", err)
+			p.logger.Fatalf("Could not start profiling trace: %v", err)
 		}
-		p.logger.Info("Trace enabled, %s", fn)
+		p.logger.Infof("Trace enabled, %s", fn)
 		p.closer = func() {
 			trace.Stop()
 			closer()

--- a/clicommand/redactor_add.go
+++ b/clicommand/redactor_add.go
@@ -111,7 +111,7 @@ JSON does not allow duplicate keys. If you repeat the same key ("key"), the JSON
 			secretsReader = bufio.NewReader(secretsFile)
 		}
 
-		l.Info("Reading secrets from %s for redaction", fileName)
+		l.Infof("Reading secrets from %s for redaction", fileName)
 
 		secrets, err := ParseSecrets(l, cfg, secretsReader)
 		if err != nil {

--- a/clicommand/step_cancel.go
+++ b/clicommand/step_cancel.go
@@ -105,11 +105,11 @@ func cancelStep(ctx context.Context, cfg StepCancelConfig, l logger.Logger) erro
 			return err
 		}
 		if err != nil {
-			l.Warn("%s (%s)", err, r)
+			l.Warnf("%s (%s)", err, r)
 			return err
 		}
 
-		l.Info("Successfully cancelled step: %s", stepCancelResponse.UUID)
+		l.Infof("Successfully cancelled step: %s", stepCancelResponse.UUID)
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to cancel step: %w", err)

--- a/clicommand/step_get.go
+++ b/clicommand/step_get.go
@@ -92,7 +92,7 @@ var StepGetCommand = cli.Command{
 				return stepExportResponse, err
 			}
 			if err != nil {
-				l.Warn("%s (%s)", err, r)
+				l.Warnf("%s (%s)", err, r)
 			}
 			return stepExportResponse, err
 		})

--- a/clicommand/step_update.go
+++ b/clicommand/step_update.go
@@ -88,7 +88,7 @@ var StepUpdateCommand = cli.Command{
 
 		// Read the value from STDIN if argument omitted entirely
 		if len(c.Args()) < 2 {
-			l.Info("Reading value from STDIN")
+			l.Infof("Reading value from STDIN")
 
 			input, err := io.ReadAll(os.Stdin)
 			if err != nil {
@@ -106,7 +106,7 @@ var StepUpdateCommand = cli.Command{
 			return err
 		}
 		if redactedValue := redact.String(cfg.Value, needles); redactedValue != cfg.Value {
-			l.Warn("New value for step %q attribute %q contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret", cfg.StepOrKey, cfg.Attribute)
+			l.Warnf("New value for step %q attribute %q contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret", cfg.StepOrKey, cfg.Attribute)
 			cfg.Value = redactedValue
 		}
 
@@ -134,7 +134,7 @@ var StepUpdateCommand = cli.Command{
 				return err
 			}
 			if err != nil {
-				l.Warn("%s (%s)", err, r)
+				l.Warnf("%s (%s)", err, r)
 				return err
 			}
 			return nil

--- a/clicommand/tool_keygen.go
+++ b/clicommand/tool_keygen.go
@@ -69,23 +69,23 @@ for information about JWKS, see https://tools.ietf.org/html/rfc7517`,
 
 		if cfg.Alg == "" {
 			cfg.Alg = "EdDSA"
-			l.Info("No algorithm provided, using %s", cfg.Alg)
+			l.Infof("No algorithm provided, using %s", cfg.Alg)
 		}
 
 		if cfg.KeyID == "" {
 			cfg.KeyID = petname.Generate(2, "-")
-			l.Info("No key ID provided, using a randomly generated one: %s", cfg.KeyID)
+			l.Infof("No key ID provided, using a randomly generated one: %s", cfg.KeyID)
 		}
 
 		sigAlg := jwa.SignatureAlgorithm(cfg.Alg)
 
 		if !slices.Contains(jwkutil.ValidSigningAlgorithms, sigAlg) {
-			l.Fatal("Invalid signing algorithm: %s. Valid signing algorithms are: %s", cfg.Alg, jwkutil.ValidSigningAlgorithms)
+			l.Fatalf("Invalid signing algorithm: %s. Valid signing algorithms are: %s", cfg.Alg, jwkutil.ValidSigningAlgorithms)
 		}
 
 		priv, pub, err := jwkutil.NewKeyPair(cfg.KeyID, sigAlg)
 		if err != nil {
-			l.Fatal("Failed to generate key pair: %v", err)
+			l.Fatalf("Failed to generate key pair: %v", err)
 		}
 
 		if cfg.PrivateJWKSFile == "" {
@@ -96,29 +96,29 @@ for information about JWKS, see https://tools.ietf.org/html/rfc7517`,
 			cfg.PublicJWKSFile = fmt.Sprintf("./%s-%s-public.json", cfg.Alg, cfg.KeyID)
 		}
 
-		l.Info("Writing private key set to %s...", cfg.PrivateJWKSFile)
+		l.Infof("Writing private key set to %s...", cfg.PrivateJWKSFile)
 		pKey, err := json.Marshal(priv)
 		if err != nil {
-			l.Fatal("Failed to marshal private key: %v", err)
+			l.Fatalf("Failed to marshal private key: %v", err)
 		}
 
 		err = writeIfNotExists(cfg.PrivateJWKSFile, pKey)
 		if err != nil {
-			l.Fatal("Failed to write private key file: %v", err)
+			l.Fatalf("Failed to write private key file: %v", err)
 		}
 
-		l.Info("Writing public key set to %s...", cfg.PublicJWKSFile)
+		l.Infof("Writing public key set to %s...", cfg.PublicJWKSFile)
 		pubKey, err := json.Marshal(pub)
 		if err != nil {
-			l.Fatal("Failed to marshal private key: %v", err)
+			l.Fatalf("Failed to marshal private key: %v", err)
 		}
 
 		err = writeIfNotExists(cfg.PublicJWKSFile, pubKey)
 		if err != nil {
-			l.Fatal("Failed to write private key file: %v", err)
+			l.Fatalf("Failed to write private key file: %v", err)
 		}
 
-		l.Info("Done! Enjoy your new keys ^_^")
+		l.Infof("Done! Enjoy your new keys ^_^")
 	},
 }
 

--- a/clicommand/tool_sign.go
+++ b/clicommand/tool_sign.go
@@ -261,7 +261,7 @@ func signOffline(ctx context.Context, c *cli.Context, l logger.Logger, key signa
 
 	switch {
 	case cfg.PipelineFile != "":
-		l.Info("Reading pipeline config from %q", cfg.PipelineFile)
+		l.Infof("Reading pipeline config from %q", cfg.PipelineFile)
 
 		file, err := os.Open(cfg.PipelineFile)
 		if err != nil {
@@ -273,7 +273,7 @@ func signOffline(ctx context.Context, c *cli.Context, l logger.Logger, key signa
 		filename = cfg.PipelineFile
 
 	case stdin.IsReadable():
-		l.Info("Reading pipeline config from STDIN")
+		l.Infof("Reading pipeline config from STDIN")
 
 		input = os.Stdin
 		filename = "(stdin)"
@@ -298,7 +298,7 @@ func signOffline(ctx context.Context, c *cli.Context, l logger.Logger, key signa
 		if w == nil {
 			return fmt.Errorf("pipeline parsing of %q failed: %w", filename, err)
 		}
-		l.Warn("There were some issues with the pipeline input - signing will be attempted but might not succeed:\n%v", w)
+		l.Warnf("There were some issues with the pipeline input - signing will be attempted but might not succeed:\n%v", w)
 	}
 
 	if cfg.Debug {
@@ -307,7 +307,7 @@ func signOffline(ctx context.Context, c *cli.Context, l logger.Logger, key signa
 		if err := enc.Encode(parsedPipeline); err != nil {
 			return fmt.Errorf("couldn't encode pipeline: %w", err)
 		}
-		l.Debug("Pipeline parsed successfully:\n%v", parsedPipeline)
+		l.Debugf("Pipeline parsed successfully:\n%v", parsedPipeline)
 	}
 
 	// Merge pipeline-level secrets with step-level secrets before signing
@@ -323,7 +323,7 @@ func signOffline(ctx context.Context, c *cli.Context, l logger.Logger, key signa
 		key,
 		cfg.Repository,
 		signature.WithEnv(parsedPipeline.Env.ToMap()),
-		signature.WithLogger(l),
+		signature.WithLogger(logger.DeprecatedLogger{Logger: l}),
 		signature.WithDebugSigning(cfg.DebugSigning),
 	)
 	if err != nil {
@@ -339,7 +339,7 @@ func signWithGraphQL(ctx context.Context, c *cli.Context, l logger.Logger, key s
 	orgPipelineSlug := fmt.Sprintf("%s/%s", cfg.OrganizationSlug, cfg.PipelineSlug)
 	debugL := l.WithFields(logger.StringField("orgPipelineSlug", orgPipelineSlug))
 
-	l.Info("Retrieving pipeline from the GraphQL API")
+	l.Infof("Retrieving pipeline from the GraphQL API")
 
 	client := bkgql.NewClient(cfg.GraphQLEndpoint, cfg.GraphQLToken)
 
@@ -357,7 +357,7 @@ func signWithGraphQL(ctx context.Context, c *cli.Context, l logger.Logger, key s
 		)
 	}
 
-	debugL.Debug("Pipeline retrieved successfully: %#v", resp)
+	debugL.Debugf("Pipeline retrieved successfully: %#v", resp)
 
 	pipelineString := resp.Pipeline.Steps.Yaml
 	err = validateNoInterpolations(pipelineString)
@@ -371,7 +371,7 @@ func signWithGraphQL(ctx context.Context, c *cli.Context, l logger.Logger, key s
 		if w == nil {
 			return fmt.Errorf("pipeline parsing failed: %w", err)
 		}
-		l.Warn("There were some issues with the pipeline input - signing will be attempted but might not succeed:\n%v", w)
+		l.Warnf("There were some issues with the pipeline input - signing will be attempted but might not succeed:\n%v", w)
 	}
 
 	if cfg.Debug {
@@ -380,10 +380,19 @@ func signWithGraphQL(ctx context.Context, c *cli.Context, l logger.Logger, key s
 		if err := enc.Encode(parsedPipeline); err != nil {
 			return fmt.Errorf("couldn't encode pipeline: %w", err)
 		}
-		debugL.Debug("Pipeline parsed successfully: %v", parsedPipeline)
+		debugL.Debugf("Pipeline parsed successfully: %v", parsedPipeline)
 	}
 
-	if err := signature.SignSteps(ctx, parsedPipeline.Steps, key, resp.Pipeline.Repository.Url, signature.WithEnv(parsedPipeline.Env.ToMap()), signature.WithLogger(debugL), signature.WithDebugSigning(cfg.DebugSigning)); err != nil {
+	err = signature.SignSteps(
+		ctx,
+		parsedPipeline.Steps,
+		key,
+		resp.Pipeline.Repository.Url,
+		signature.WithEnv(parsedPipeline.Env.ToMap()),
+		signature.WithLogger(logger.DeprecatedLogger{Logger: debugL}),
+		signature.WithDebugSigning(cfg.DebugSigning),
+	)
+	if err != nil {
 		return fmt.Errorf("couldn't sign pipeline: %w", err)
 	}
 
@@ -401,7 +410,7 @@ func signWithGraphQL(ctx context.Context, c *cli.Context, l logger.Logger, key s
 	}
 
 	signedPipelineYaml := strings.TrimSpace(signedPipelineYamlBuilder.String())
-	l.Info("Replacing pipeline with signed version:\n%s", signedPipelineYaml)
+	l.Infof("Replacing pipeline with signed version:\n%s", signedPipelineYaml)
 
 	updatePipeline, err := promptConfirm(
 		c, cfg, "\n\x1b[1mAre you sure you want to update the pipeline? This may break your builds!\x1b[0m",
@@ -411,7 +420,7 @@ func signWithGraphQL(ctx context.Context, c *cli.Context, l logger.Logger, key s
 	}
 
 	if !updatePipeline {
-		l.Info("Aborting without updating pipeline")
+		l.Infof("Aborting without updating pipeline")
 		return nil
 	}
 
@@ -420,7 +429,7 @@ func signWithGraphQL(ctx context.Context, c *cli.Context, l logger.Logger, key s
 		return err
 	}
 
-	l.Info("Pipeline updated successfully")
+	l.Infof("Pipeline updated successfully")
 
 	return nil
 }

--- a/core/client.go
+++ b/core/client.go
@@ -53,7 +53,7 @@ type Client struct {
 // It doesn't interpret or run the job - the caller is responsible for that.
 // It contains a builtin timeout of 330 seconds and makes up to 7 attempts, backing off exponentially.
 func (c *Client) AcquireJob(ctx context.Context, jobID string) (*api.Job, error) {
-	c.Logger.Info("Attempting to acquire job %s...", jobID)
+	c.Logger.Infof("Attempting to acquire job %s...", jobID)
 
 	// Timeout the context to prevent the exponential backoff from growing too
 	// large if the job is in the waiting state.
@@ -86,7 +86,7 @@ func (c *Client) AcquireJob(ctx context.Context, jobID string) (*api.Job, error)
 		)
 		if err != nil {
 			if resp == nil {
-				c.Logger.Warn("%s (%s)", err, r)
+				c.Logger.Warnf("%s (%s)", err, r)
 				return nil, err
 			}
 
@@ -112,7 +112,7 @@ func (c *Client) AcquireJob(ctx context.Context, jobID string) (*api.Job, error)
 			case resp.StatusCode == http.StatusUnprocessableEntity:
 				// If the API returns with a 422, it usually means that the job is in a state where it can't be acquired -
 				// e.g. it's already running on another agent, or has been cancelled, or has already run. Don't retry
-				c.Logger.Error("Buildkite rejected the call to acquire the job: %s", err)
+				c.Logger.Errorf("Buildkite rejected the call to acquire the job: %s", err)
 				r.Break()
 
 				return nil, fmt.Errorf("%w: %w", ErrJobAcquisitionRejected, err)
@@ -120,13 +120,13 @@ func (c *Client) AcquireJob(ctx context.Context, jobID string) (*api.Job, error)
 			case resp.StatusCode >= 400 && resp.StatusCode < 500:
 				// It's some other client error - not 429 or 423, which we retry, or 422, which we don't, but gets a special log message
 				// Don't retry it, the odds of success are low
-				c.Logger.Error("%s", err)
+				c.Logger.Errorf("%s", err)
 				r.Break()
 
 				return nil, err
 
 			default:
-				c.Logger.Warn("%s (%s)", err, r)
+				c.Logger.Warnf("%s (%s)", err, r)
 				return nil, err
 			}
 		}
@@ -138,7 +138,7 @@ func (c *Client) AcquireJob(ctx context.Context, jobID string) (*api.Job, error)
 func handleRetriableJobAcquisitionError(warning string, resp *api.Response, r *roko.Retrier, logger logger.Logger) {
 	// log the warning and the retrier state at the end of this function. if we logged the error before the call to
 	// `r.SetNextInterval`, the `Retrying in ...` message wouldn't include the server-set Retry-After, if it was set
-	defer func(r *roko.Retrier) { logger.Warn("%s (%s)", warning, r) }(r)
+	defer func(r *roko.Retrier) { logger.Warnf("%s (%s)", warning, r) }(r)
 
 	if resp == nil {
 		return
@@ -162,7 +162,7 @@ func handleRetriableJobAcquisitionError(warning string, resp *api.Response, r *r
 // Connect connects the agent to the Buildkite Agent API, retrying up to 10 times with 5
 // seconds delay if it fails.
 func (c *Client) Connect(ctx context.Context) error {
-	c.Logger.Info("Connecting to Buildkite...")
+	c.Logger.Infof("Connecting to Buildkite...")
 
 	return roko.NewRetrier(
 		roko.WithMaxAttempts(10),
@@ -171,7 +171,7 @@ func (c *Client) Connect(ctx context.Context) error {
 	).DoWithContext(ctx, func(r *roko.Retrier) error {
 		_, err := c.APIClient.Connect(ctx)
 		if err != nil {
-			c.Logger.Warn("%s (%s)", err, r)
+			c.Logger.Warnf("%s (%s)", err, r)
 		}
 		return err
 	})
@@ -181,28 +181,28 @@ func (c *Client) Connect(ctx context.Context) error {
 // permanently disconnecting. Don't spend long retrying, because we want to
 // disconnect as fast as possible.
 func (c *Client) Disconnect(ctx context.Context) error {
-	c.Logger.Info("Disconnecting...")
+	c.Logger.Infof("Disconnecting...")
 	err := roko.NewRetrier(
 		roko.WithMaxAttempts(4),
 		roko.WithStrategy(roko.Constant(1*time.Second)),
 		roko.WithSleepFunc(c.RetrySleepFunc),
 	).DoWithContext(ctx, func(r *roko.Retrier) error {
 		if _, err := c.APIClient.Disconnect(ctx); err != nil {
-			c.Logger.Warn("%s (%s)", err, r) // e.g. POST https://...: 500 (Attempt 0/4 Retrying in ..)
+			c.Logger.Warnf("%s (%s)", err, r) // e.g. POST https://...: 500 (Attempt 0/4 Retrying in ..)
 			return err
 		}
 		return nil
 	})
 	if err != nil {
 		// none of the retries worked
-		c.Logger.Warn(
+		c.Logger.Warnf(
 			"There was an error sending the disconnect API call to Buildkite. "+
 				"If this agent still appears online, you may have to manually stop it (%s)",
 			err,
 		)
 		return err
 	}
-	c.Logger.Info("Disconnected")
+	c.Logger.Infof("Disconnected")
 	return nil
 }
 
@@ -215,7 +215,7 @@ func (c *Client) FinishJob(ctx context.Context, job *api.Job, finishedAt time.Ti
 	job.SignalReason = exit.SignalReason
 	job.ChunksFailedCount = failedChunkCount
 
-	c.Logger.Debug("[JobRunner] Finishing job with exit_status=%s, signal=%s and signal_reason=%s",
+	c.Logger.Debugf("[JobRunner] Finishing job with exit_status=%s, signal=%s and signal_reason=%s",
 		job.ExitStatus, job.Signal, job.SignalReason)
 
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Hour)
@@ -232,7 +232,7 @@ func (c *Client) FinishJob(ctx context.Context, job *api.Job, finishedAt time.Ti
 			// Non-retryable responses (e.g. 422, or 401 when job tokens are being used) mean the job has been cancelled or
 			// otherwise already finished. We should stop trying and go find more work to do.
 			if !api.BreakOnNonRetryable(retrier, response, err) {
-				c.Logger.Warn("%s (%s)", err, retrier)
+				c.Logger.Warnf("%s (%s)", err, retrier)
 			}
 		}
 
@@ -268,7 +268,7 @@ func (c *Client) Register(ctx context.Context, req api.AgentRegisterRequest) (*a
 		registered, resp, err := c.APIClient.Register(ctx, &req)
 		if err != nil {
 			if !api.BreakOnNonRetryable(r, resp, err) {
-				c.Logger.Warn("%s (%s)", err, r)
+				c.Logger.Warnf("%s (%s)", err, r)
 			}
 			return registered, err
 		}
@@ -279,15 +279,15 @@ func (c *Client) Register(ctx context.Context, req api.AgentRegisterRequest) (*a
 		return registered, err
 	}
 
-	c.Logger.Info("Successfully registered agent \"%s\" with tags [%s]", registered.Name,
+	c.Logger.Infof("Successfully registered agent \"%s\" with tags [%s]", registered.Name,
 		strings.Join(registered.Tags, ", "))
 
-	c.Logger.Debug("Ping interval: %ds", registered.PingInterval)
-	c.Logger.Debug("Job status interval: %ds", registered.JobStatusInterval)
-	c.Logger.Debug("Heartbeat interval: %ds", registered.HeartbeatInterval)
+	c.Logger.Debugf("Ping interval: %ds", registered.PingInterval)
+	c.Logger.Debugf("Job status interval: %ds", registered.JobStatusInterval)
+	c.Logger.Debugf("Heartbeat interval: %ds", registered.HeartbeatInterval)
 
 	if registered.Endpoint != "" {
-		c.Logger.Debug("Endpoint: %s", registered.Endpoint)
+		c.Logger.Debugf("Endpoint: %s", registered.Endpoint)
 	}
 
 	return registered, nil
@@ -308,15 +308,15 @@ func (c *Client) StartJob(ctx context.Context, job *api.Job, startedAt time.Time
 		response, err := c.APIClient.StartJob(ctx, job)
 		if err != nil {
 			if response != nil && api.IsRetryableStatus(response) {
-				c.Logger.Warn("%s (%s)", err, rtr)
+				c.Logger.Warnf("%s (%s)", err, rtr)
 				return err
 			}
 			if api.IsRetryableError(err) {
-				c.Logger.Warn("%s (%s)", err, rtr)
+				c.Logger.Warnf("%s (%s)", err, rtr)
 				return err
 			}
 
-			c.Logger.Warn("Buildkite rejected the call to start the job (%s)", err)
+			c.Logger.Warnf("Buildkite rejected the call to start the job (%s)", err)
 			rtr.Break()
 		}
 
@@ -347,11 +347,11 @@ func (c *Client) UploadChunk(ctx context.Context, jobID string, chunk *api.Chunk
 		response, err := c.APIClient.UploadChunk(ctx, jobID, chunk)
 		if err != nil {
 			if response != nil && (response.StatusCode >= 400 && response.StatusCode <= 499) {
-				c.Logger.Warn("Buildkite rejected the chunk upload (%s)", err)
+				c.Logger.Warnf("Buildkite rejected the chunk upload (%s)", err)
 				retrier.Break()
 				return err
 			}
-			c.Logger.Warn("%s (%s)", err, retrier)
+			c.Logger.Warnf("%s (%s)", err, retrier)
 		}
 
 		return err
@@ -363,16 +363,16 @@ func cacheRegisterSystemInfo(l logger.Logger) {
 
 	machineID, err = machineid.ProtectedID("buildkite-agent")
 	if err != nil {
-		l.Warn("Failed to find unique machine-id: %v", err)
+		l.Warnf("Failed to find unique machine-id: %v", err)
 	}
 
 	hostname, err = os.Hostname()
 	if err != nil {
-		l.Warn("Failed to find hostname: %s", err)
+		l.Warnf("Failed to find hostname: %s", err)
 	}
 
 	osVersionDump, err = system.VersionDump(l)
 	if err != nil {
-		l.Warn("Failed to find OS information: %s", err)
+		l.Warnf("Failed to find OS information: %s", err)
 	}
 }

--- a/internal/agentapi/lock_server.go
+++ b/internal/agentapi/lock_server.go
@@ -35,7 +35,7 @@ func (s *lockServer) getLock(w http.ResponseWriter, r *http.Request) {
 	key := r.URL.Query().Get("key")
 	if key == "" {
 		if err := socket.WriteError(w, "key missing", http.StatusNotFound); err != nil {
-			s.logger.Error("Agent API: couldn't write error: %v", err)
+			s.logger.Errorf("Agent API: couldn't write error: %v", err)
 		}
 		return
 	}
@@ -43,7 +43,7 @@ func (s *lockServer) getLock(w http.ResponseWriter, r *http.Request) {
 		Value: s.locks.load(key),
 	}
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		s.logger.Error("Agent API: couldn't encode response body: %v", err)
+		s.logger.Errorf("Agent API: couldn't encode response body: %v", err)
 	}
 }
 
@@ -52,7 +52,7 @@ func (s *lockServer) patchLock(w http.ResponseWriter, r *http.Request) {
 	key := r.URL.Query().Get("key")
 	if key == "" {
 		if err := socket.WriteError(w, "key missing", http.StatusNotFound); err != nil {
-			s.logger.Error("Agent API: couldn't write error: %v", err)
+			s.logger.Errorf("Agent API: couldn't write error: %v", err)
 		}
 		return
 	}
@@ -60,7 +60,7 @@ func (s *lockServer) patchLock(w http.ResponseWriter, r *http.Request) {
 	var req LockCASRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		if err := socket.WriteError(w, fmt.Sprintf("couldn't decode request body: %v", err), http.StatusBadRequest); err != nil {
-			s.logger.Error("Agent API: couldn't write error: %v", err)
+			s.logger.Errorf("Agent API: couldn't write error: %v", err)
 		}
 		return
 	}
@@ -78,6 +78,6 @@ func (s *lockServer) patchLock(w http.ResponseWriter, r *http.Request) {
 	// - practical consequences of a successful JSON injection, given that this
 	//   API is, by default, only accessible to the same user on the same host.
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		s.logger.Error("Agent API: couldn't encode response body: %v", err)
+		s.logger.Errorf("Agent API: couldn't encode response body: %v", err)
 	}
 }

--- a/internal/agentapi/routes.go
+++ b/internal/agentapi/routes.go
@@ -16,7 +16,7 @@ func (s *Server) router(log logger.Logger) chi.Router {
 	r := chi.NewRouter()
 	r.Use(
 		// Agent API is quite chatty, so only log at Debug level.
-		socket.LoggerMiddleware("Agent API", log.Debug),
+		socket.LoggerMiddleware("Agent API", log.Debugf),
 		middleware.Recoverer,
 		// All responses are in JSON.
 		socket.HeadersMiddleware(http.Header{"Content-Type": []string{"application/json"}}),
@@ -34,7 +34,7 @@ func pingHandler(log logger.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		resp := &PingResponse{Now: time.Now()}
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			log.Error("Agent API: couldn't encode response body: %v", err)
+			log.Errorf("Agent API: couldn't encode response body: %v", err)
 		}
 	}
 }

--- a/internal/agenthttp/do.go
+++ b/internal/agenthttp/do.go
@@ -29,9 +29,9 @@ func Do(l logger.Logger, client *http.Client, req *http.Request, opts ...DoOptio
 		dumpBody := !strings.Contains(req.Header.Get("Content-Type"), "multipart/form-data")
 		requestDump, err := httputil.DumpRequestOut(req, dumpBody)
 		if err != nil {
-			l.Debug("ERR: %s\n%s", err, string(requestDump))
+			l.Debugf("ERR: %s\n%s", err, string(requestDump))
 		} else {
-			l.Debug("%s", string(requestDump))
+			l.Debugf("%s", string(requestDump))
 		}
 	}
 
@@ -44,7 +44,7 @@ func Do(l logger.Logger, client *http.Client, req *http.Request, opts ...DoOptio
 
 	ts := time.Now()
 
-	l.Debug("%s %s", req.Method, req.URL)
+	l.Debugf("%s %s", req.Method, req.URL)
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -58,14 +58,14 @@ func Do(l logger.Logger, client *http.Client, req *http.Request, opts ...DoOptio
 		logger.StringField("proto", resp.Proto),
 		logger.IntField("status", resp.StatusCode),
 		logger.DurationField("Δ", time.Since(ts)),
-	).Debug("↳ %s %s", req.Method, req.URL)
+	).Debugf("↳ %s %s", req.Method, req.URL)
 
 	if cfg.debugHTTP {
 		responseDump, err := httputil.DumpResponse(resp, true)
 		if err != nil {
-			l.Debug("\nERR: %s\n%s", err, string(responseDump))
+			l.Debugf("\nERR: %s\n%s", err, string(responseDump))
 		} else {
-			l.Debug("\n%s", string(responseDump))
+			l.Debugf("\n%s", string(responseDump))
 		}
 	}
 	if cfg.traceHTTP {
@@ -111,13 +111,13 @@ func (t *tracer) EmitTraceToLog(level logger.Level) {
 	msg := "HTTP Timing Trace"
 	switch level {
 	case logger.DEBUG:
-		t.Debug(msg)
+		t.Debugf(msg)
 	case logger.INFO:
-		t.Info(msg)
+		t.Infof(msg)
 	case logger.WARN:
-		t.Warn(msg)
+		t.Warnf(msg)
 	case logger.ERROR:
-		t.Error(msg)
+		t.Errorf(msg)
 	}
 }
 

--- a/internal/artifact/artifactory_uploader.go
+++ b/internal/artifact/artifactory_uploader.go
@@ -125,14 +125,14 @@ func (u *artifactoryUploaderWork) Description() string {
 
 func (u *artifactoryUploaderWork) DoWork(context.Context) (*api.ArtifactPartETag, error) {
 	// Open file from filesystem
-	u.logger.Debug("Reading file %q", u.artifact.AbsolutePath)
+	u.logger.Debugf("Reading file %q", u.artifact.AbsolutePath)
 	f, err := os.Open(u.artifact.AbsolutePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q (%w)", u.artifact.AbsolutePath, err)
 	}
 
 	// Upload the file to Artifactory.
-	u.logger.Debug("Uploading %q to %q", u.artifact.Path, u.URL(u.artifact))
+	u.logger.Debugf("Uploading %q to %q", u.artifact.Path, u.URL(u.artifact))
 
 	req, err := http.NewRequest("PUT", u.URL(u.artifact), f)
 	req.SetBasicAuth(u.user, u.password)

--- a/internal/artifact/azure_blob.go
+++ b/internal/artifact/azure_blob.go
@@ -21,7 +21,7 @@ func NewAzureBlobClient(l logger.Logger, storageAccountName string) (*service.Cl
 	// https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#readme-credential-types
 
 	if connStr := os.Getenv("BUILDKITE_AZURE_BLOB_CONNECTION_STRING"); connStr != "" {
-		l.Debug("Connecting to Azure Blob Storage using Connection String")
+		l.Debugf("Connecting to Azure Blob Storage using Connection String")
 		client, err := service.NewClientFromConnectionString(connStr, nil)
 		if err != nil {
 			return nil, fmt.Errorf("creating Azure Blob storage client with connection string: %w", err)
@@ -32,7 +32,7 @@ func NewAzureBlobClient(l logger.Logger, storageAccountName string) (*service.Cl
 	url := fmt.Sprintf("https://%s%s/", storageAccountName, azureBlobHostSuffix)
 
 	if accKey := os.Getenv("BUILDKITE_AZURE_BLOB_ACCESS_KEY"); accKey != "" {
-		l.Debug("Connecting to Azure Blob Storage using Shared Key Credential")
+		l.Debugf("Connecting to Azure Blob Storage using Shared Key Credential")
 		cred, err := service.NewSharedKeyCredential(storageAccountName, accKey)
 		if err != nil {
 			return nil, fmt.Errorf("creating Azure shared key credential: %w", err)
@@ -44,7 +44,7 @@ func NewAzureBlobClient(l logger.Logger, storageAccountName string) (*service.Cl
 		return client, nil
 	}
 
-	l.Debug("Connecting to Azure Blob Storage using Default Azure Credential")
+	l.Debugf("Connecting to Azure Blob Storage using Default Azure Credential")
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating default Azure credential: %w", err)

--- a/internal/artifact/azure_blob_downloader.go
+++ b/internal/artifact/azure_blob_downloader.go
@@ -44,7 +44,7 @@ func (d *AzureBlobDownloader) Start(ctx context.Context) error {
 		return err
 	}
 
-	d.logger.Debug("Azure Blob Storage path: %v", loc)
+	d.logger.Debugf("Azure Blob Storage path: %v", loc)
 
 	client, err := NewAzureBlobClient(d.logger, loc.StorageAccountName)
 	if err != nil {
@@ -71,7 +71,7 @@ func (d *AzureBlobDownloader) Start(ctx context.Context) error {
 	fullPath := path.Join(loc.BlobPath, d.conf.Path)
 
 	// Show a nice message that we're starting to download the file
-	d.logger.Debug("Downloading %s to %s", loc.URL(d.conf.Path), targetPath)
+	d.logger.Debugf("Downloading %s to %s", loc.URL(d.conf.Path), targetPath)
 
 	opts := &azblob.DownloadFileOptions{
 		RetryReaderOptionsPerBlock: azblob.RetryReaderOptions{
@@ -103,7 +103,7 @@ func (d *AzureBlobDownloader) Start(ctx context.Context) error {
 		return fmt.Errorf("renaming temp file to target (%T: %w)", err, err)
 	}
 
-	d.logger.Info("Successfully downloaded %q %s", d.conf.Path, humanize.IBytes(uint64(bytes)))
+	d.logger.Infof("Successfully downloaded %q %s", d.conf.Path, humanize.IBytes(uint64(bytes)))
 
 	return nil
 }

--- a/internal/artifact/azure_blob_uploader.go
+++ b/internal/artifact/azure_blob_uploader.go
@@ -69,7 +69,7 @@ func (u *AzureBlobUploader) URL(artifact *api.Artifact) string {
 
 	dur, err := time.ParseDuration(sasDur)
 	if err != nil {
-		u.logger.Error("BUILDKITE_AZURE_BLOB_SAS_TOKEN_DURATION is not a valid duration: %v", err)
+		u.logger.Errorf("BUILDKITE_AZURE_BLOB_SAS_TOKEN_DURATION is not a valid duration: %v", err)
 		return outURL
 	}
 
@@ -80,11 +80,11 @@ func (u *AzureBlobUploader) URL(artifact *api.Artifact) string {
 
 	sasURL, err := blobClient.GetSASURL(perms, expiry, nil)
 	if err != nil {
-		u.logger.Error("Couldn't generate SAS URL for container: %v", err)
+		u.logger.Errorf("Couldn't generate SAS URL for container: %v", err)
 		return outURL
 	}
 
-	u.logger.Debug("Generated Azure Blob SAS URL %q", sasURL)
+	u.logger.Debugf("Generated Azure Blob SAS URL %q", sasURL)
 	return sasURL
 }
 
@@ -108,7 +108,7 @@ func (u *azureBlobUploaderWork) Description() string {
 
 // DoWork uploads an artifact file.
 func (u *azureBlobUploaderWork) DoWork(ctx context.Context) (*api.ArtifactPartETag, error) {
-	u.logger.Debug("Reading file %q", u.artifact.AbsolutePath)
+	u.logger.Debugf("Reading file %q", u.artifact.AbsolutePath)
 	f, err := os.Open(u.artifact.AbsolutePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q (%w)", u.artifact.AbsolutePath, err)
@@ -117,7 +117,7 @@ func (u *azureBlobUploaderWork) DoWork(ctx context.Context) (*api.ArtifactPartET
 
 	blobName := path.Join(u.loc.BlobPath, u.artifact.Path)
 
-	u.logger.Debug("Uploading %s to %s", u.artifact.Path, u.loc.URL(blobName))
+	u.logger.Debugf("Uploading %s to %s", u.artifact.Path, u.loc.URL(blobName))
 
 	bbc := u.client.NewContainerClient(u.loc.ContainerName).NewBlockBlobClient(blobName)
 	_, err = bbc.UploadFile(ctx, f, nil)

--- a/internal/artifact/batch_creator.go
+++ b/internal/artifact/batch_creator.go
@@ -70,7 +70,7 @@ func (a *BatchCreator) Batches(ctx context.Context) iter.Seq2[[]*api.Artifact, e
 				MultipartSupported: a.conf.AllowMultipart,
 			}
 
-			a.logger.Info("Creating (%d-%d)/%d artifacts", offset, offset+len(theseArtifacts), total)
+			a.logger.Infof("Creating (%d-%d)/%d artifacts", offset, offset+len(theseArtifacts), total)
 			offset += len(theseArtifacts)
 
 			timeout := a.conf.CreateArtifactsTimeout
@@ -92,11 +92,11 @@ func (a *BatchCreator) Batches(ctx context.Context) iter.Seq2[[]*api.Artifact, e
 				// The server returns a 403 code if the artifact has exceeded the service quota.
 				// Break the retry on any 4xx code except for 429 Too Many Requests.
 				if resp != nil && (resp.StatusCode != 429 && resp.StatusCode >= 400 && resp.StatusCode <= 499) {
-					a.logger.Warn("Artifact creation failed with status code %d, breaking the retry loop", resp.StatusCode)
+					a.logger.Warnf("Artifact creation failed with status code %d, breaking the retry loop", resp.StatusCode)
 					r.Break()
 				}
 				if err != nil {
-					a.logger.Warn("%s (%s)", err, r)
+					a.logger.Warnf("%s (%s)", err, r)
 				}
 
 				// after four attempts (0, 1, 2, 3)...
@@ -104,7 +104,7 @@ func (a *BatchCreator) Batches(ctx context.Context) iter.Seq2[[]*api.Artifact, e
 					// The short timeout has given us fast feedback on the first couple of attempts,
 					// but perhaps the server needs more time to complete the request, so fall back to
 					// the default HTTP client timeout.
-					a.logger.Debug("CreateArtifacts timeout (%s) removed for subsequent attempts", timeout)
+					a.logger.Debugf("CreateArtifacts timeout (%s) removed for subsequent attempts", timeout)
 					timeout = 0
 				}
 

--- a/internal/artifact/bk_uploader.go
+++ b/internal/artifact/bk_uploader.go
@@ -177,7 +177,7 @@ func (u *bkMultipartUpload) DoWork(ctx context.Context) (*api.ArtifactPartETag, 
 	}
 
 	etag := resp.Header.Get("Etag")
-	u.logger.Debug("Artifact %s part %d has ETag = %s", u.artifact.ID, u.action.PartNumber, etag)
+	u.logger.Debugf("Artifact %s part %d has ETag = %s", u.artifact.ID, u.action.PartNumber, etag)
 	if etag == "" {
 		return nil, errors.New("response missing ETag header")
 	}

--- a/internal/artifact/download.go
+++ b/internal/artifact/download.go
@@ -79,7 +79,7 @@ func (d Download) Start(ctx context.Context) error {
 		roko.WithStrategy(roko.Constant(5*time.Second)),
 	).DoWithContext(ctx, func(r *roko.Retrier) error {
 		if err := d.try(ctx); err != nil {
-			d.logger.Warn("Error trying to download %s (%s) %s", d.conf.URL, err, r)
+			d.logger.Warnf("Error trying to download %s (%s) %s", d.conf.URL, err, r)
 			return err
 		}
 		return nil
@@ -130,7 +130,7 @@ func (d Download) try(ctx context.Context) error {
 	targetDirectory, targetFile := filepath.Split(targetPath)
 
 	// Show a nice message that we're starting to download the file
-	d.logger.Debug("Downloading %s to %s", d.conf.URL, targetPath)
+	d.logger.Debugf("Downloading %s to %s", d.conf.URL, targetPath)
 
 	method := cmp.Or(d.conf.Method, http.MethodGet)
 
@@ -215,7 +215,7 @@ func (d Download) try(ctx context.Context) error {
 		return fmt.Errorf("renaming temp file to target (%T: %w)", err, err)
 	}
 
-	d.logger.Info("Successfully downloaded %q %s with SHA256 %s", d.conf.Path, humanize.IBytes(uint64(bytes)), gotSHA256)
+	d.logger.Infof("Successfully downloaded %q %s with SHA256 %s", d.conf.Path, humanize.IBytes(uint64(bytes)), gotSHA256)
 
 	return nil
 }

--- a/internal/artifact/downloader.go
+++ b/internal/artifact/downloader.go
@@ -81,7 +81,7 @@ func (a *Downloader) Download(ctx context.Context) error {
 		return errors.New("no artifacts found for downloading")
 	}
 
-	a.logger.Info("Found %d artifacts. Starting to download to: %s", artifactCount, destination)
+	a.logger.Infof("Found %d artifacts. Starting to download to: %s", artifactCount, destination)
 
 	s3Clients, err := a.generateS3Clients(ctx, artifacts)
 	if err != nil {
@@ -134,7 +134,7 @@ func (a *Downloader) Download(ctx context.Context) error {
 				dler := a.createDownloader(artifact, path, destination, s3Clients)
 
 				if err := dler.Start(ctx); err != nil {
-					a.logger.Error("Failed to download artifact: %s", err)
+					a.logger.Errorf("Failed to download artifact: %s", err)
 					select {
 					case errorsCh <- err:
 						// error sent

--- a/internal/artifact/gs_uploader.go
+++ b/internal/artifact/gs_uploader.go
@@ -149,10 +149,10 @@ func (u *gsUploaderWork) DoWork(_ context.Context) (*api.ArtifactPartETag, error
 	}
 
 	if permission == "" {
-		u.logger.Debug("Uploading \"%s\" to bucket \"%s\" with default permission",
+		u.logger.Debugf("Uploading \"%s\" to bucket \"%s\" with default permission",
 			u.artifactPath(u.artifact), u.BucketName)
 	} else {
-		u.logger.Debug("Uploading \"%s\" to bucket \"%s\" with permission \"%s\"",
+		u.logger.Debugf("Uploading \"%s\" to bucket \"%s\" with permission \"%s\"",
 			u.artifactPath(u.artifact), u.BucketName, permission)
 	}
 	object := &storage.Object{
@@ -169,7 +169,7 @@ func (u *gsUploaderWork) DoWork(_ context.Context) (*api.ArtifactPartETag, error
 		call = call.PredefinedAcl(permission)
 	}
 	if res, err := call.Media(file, googleapi.ContentType("")).Do(); err == nil {
-		u.logger.Debug("Created object %v at location %v\n\n", res.Name, res.SelfLink)
+		u.logger.Debugf("Created object %v at location %v\n\n", res.Name, res.SelfLink)
 	} else {
 		return nil, fmt.Errorf("failed to PUT file %q: %w", u.artifactPath(u.artifact), err)
 	}

--- a/internal/artifact/s3.go
+++ b/internal/artifact/s3.go
@@ -68,7 +68,7 @@ func NewS3Client(ctx context.Context, l logger.Logger, bucket string) (*s3.Clien
 
 	regionHint := os.Getenv(regionHintEnvVar)
 	if regionHint != "" {
-		l.Debug("Using bucket region %q from environment variable %q", regionHint, regionHintEnvVar)
+		l.Debugf("Using bucket region %q from environment variable %q", regionHint, regionHintEnvVar)
 		// If there is a region hint provided, we use it unconditionally
 		tempCfg, err := awsS3Config(ctx, regionHint)
 		if err != nil {
@@ -84,18 +84,18 @@ func NewS3Client(ctx context.Context, l logger.Logger, bucket string) (*s3.Clien
 		}
 		cfg = tempCfg
 
-		l.Debug("Discovered current region as %q", cfg.Region)
+		l.Debugf("Discovered current region as %q", cfg.Region)
 
 		client := s3.NewFromConfig(cfg)
 
 		bucketRegion, err := manager.GetBucketRegion(ctx, client, bucket)
 		if err != nil || bucketRegion == "" {
-			l.Error(
+			l.Errorf(
 				"Could not discover region for bucket %q. Using the %q region as a fallback, if this is not correct configure a bucket region using the %q environment variable. (%v)",
 				bucket, cfg.Region, regionHintEnvVar, err,
 			)
 		} else {
-			l.Debug("Discovered %q bucket region as %q", bucket, bucketRegion)
+			l.Debugf("Discovered %q bucket region as %q", bucket, bucketRegion)
 			cfg.Region = bucketRegion
 		}
 	}
@@ -105,7 +105,7 @@ func NewS3Client(ctx context.Context, l logger.Logger, bucket string) (*s3.Clien
 	// This is useful for S3-compatible servers like MinIO.
 	usePathStyle := false
 	if endpoint := os.Getenv(s3EndpointEnvVar); endpoint != "" {
-		l.Debug("S3 session Endpoint from %s: %q", s3EndpointEnvVar, endpoint)
+		l.Debugf("S3 session Endpoint from %s: %q", s3EndpointEnvVar, endpoint)
 		cfg.BaseEndpoint = aws.String(endpoint)
 
 		// Configure the S3 client to use path-style addressing instead of the
@@ -118,7 +118,7 @@ func NewS3Client(ctx context.Context, l logger.Logger, bucket string) (*s3.Clien
 		// AWS CLI does this by default when a custom endpoint is specified [1] so
 		// we will too.
 		// [1]: https://github.com/aws/aws-cli/blob/2.9.18/awscli/botocore/args.py#L414-L417
-		l.Debug("S3 UsePathStyle=true because custom Endpoint specified")
+		l.Debugf("S3 UsePathStyle=true because custom Endpoint specified")
 		usePathStyle = true
 	}
 
@@ -130,13 +130,13 @@ func NewS3Client(ctx context.Context, l logger.Logger, bucket string) (*s3.Clien
 	if credErr == nil {
 		profile := cmp.Or(os.Getenv("BUILDKITE_S3_PROFILE"), os.Getenv("AWS_PROFILE"))
 		if creds.Source == "buildkiteEnvProvider" {
-			l.Info("S3 credentials found in Buildkite environment (BUILDKITE_S3_ACCESS_KEY_ID, BUILDKITE_S3_SECRET_ACCESS_KEY)")
+			l.Infof("S3 credentials found in Buildkite environment (BUILDKITE_S3_ACCESS_KEY_ID, BUILDKITE_S3_SECRET_ACCESS_KEY)")
 		} else {
-			l.Info("S3 credentials loaded from the default AWS credential chain or BUILDKITE_S3_PROFILE, profile: %q", profile)
+			l.Infof("S3 credentials loaded from the default AWS credential chain or BUILDKITE_S3_PROFILE, profile: %q", profile)
 		}
 	}
 
-	l.Debug("Testing AWS S3 credentials for bucket %q in region %q...", bucket, cfg.Region)
+	l.Debugf("Testing AWS S3 credentials for bucket %q in region %q...", bucket, cfg.Region)
 
 	// Test the authentication by trying to list the first 0 objects in the bucket.
 	_, err := s3client.ListObjects(ctx, &s3.ListObjectsInput{

--- a/internal/artifact/s3_uploader.go
+++ b/internal/artifact/s3_uploader.go
@@ -119,14 +119,14 @@ func (u *s3UploaderWork) DoWork(ctx context.Context) (*api.ArtifactPartETag, err
 	uploader := manager.NewUploader(u.client)
 
 	// Open file from filesystem
-	u.logger.Debug("Reading file %q", u.artifact.AbsolutePath)
+	u.logger.Debugf("Reading file %q", u.artifact.AbsolutePath)
 	f, err := os.Open(u.artifact.AbsolutePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %q (%w)", u.artifact.AbsolutePath, err)
 	}
 
 	// Upload the file to S3.
-	u.logger.Debug("Uploading %q to bucket with permission %q", u.artifactPath(u.artifact), permission)
+	u.logger.Debugf("Uploading %q to bucket with permission %q", u.artifactPath(u.artifact), permission)
 
 	params := &s3.PutObjectInput{
 		Bucket:      aws.String(u.BucketName),

--- a/internal/artifact/searcher.go
+++ b/internal/artifact/searcher.go
@@ -30,9 +30,9 @@ func NewSearcher(l logger.Logger, ac APIClient, buildID string) *Searcher {
 
 func (a *Searcher) Search(ctx context.Context, query, scope string, includeRetriedJobs, includeDuplicates bool) ([]*api.Artifact, error) {
 	if scope == "" {
-		a.logger.Info("Searching for artifacts: \"%s\"", query)
+		a.logger.Infof("Searching for artifacts: \"%s\"", query)
 	} else {
-		a.logger.Info("Searching for artifacts: \"%s\" within step: \"%s\"", query, scope)
+		a.logger.Infof("Searching for artifacts: \"%s\" within step: \"%s\"", query, scope)
 	}
 
 	// Retry on transport errors, a failed search will return 0 artifacts

--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -90,11 +90,11 @@ func (a *Uploader) Upload(ctx context.Context) error {
 	}
 
 	if len(artifacts) == 0 {
-		a.logger.Info("No files matched paths: %s", a.conf.Paths)
+		a.logger.Infof("No files matched paths: %s", a.conf.Paths)
 		return nil
 	}
 
-	a.logger.Info("Found %d files that match %q", len(artifacts), a.conf.Paths)
+	a.logger.Infof("Found %d files that match %q", len(artifacts), a.conf.Paths)
 
 	// Determine what uploader to use
 	uploader, err := a.createUploader(ctx)
@@ -181,7 +181,7 @@ func (a *Uploader) collect(ctx context.Context) ([]*api.Artifact, error) {
 	}
 
 	// Start resolving globs (or not) and sending file paths to workers.
-	a.logger.Debug("Searching for %s", a.conf.Paths)
+	a.logger.Debugf("Searching for %s", a.conf.Paths)
 	if err := fileFinder(wctx, a.paths(), filesCh); err != nil {
 		cancel(err)
 	}
@@ -249,11 +249,11 @@ func (a *Uploader) glob(ctx context.Context, paths iter.Seq[string], filesCh cha
 
 	walkDirFunc := func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			a.logger.Warn("Couldn't walk path %s", path)
+			a.logger.Warnf("Couldn't walk path %s", path)
 			return nil
 		}
 		if d != nil && d.IsDir() {
-			a.logger.Warn("One of the glob patterns matched a directory: %s", path)
+			a.logger.Warnf("One of the glob patterns matched a directory: %s", path)
 			return nil
 		}
 		filesCh <- path
@@ -297,18 +297,18 @@ func (c *artifactCollector) worker(ctx context.Context, filesCh <-chan string) e
 		c.mu.Unlock()
 
 		if seen {
-			c.logger.Debug("Skipping duplicate path %s", file)
+			c.logger.Debugf("Skipping duplicate path %s", file)
 			continue
 		}
 
 		// Ignore directories, we only want files
 		if isDir(absolutePath) {
-			c.logger.Debug("Skipping directory %s", file)
+			c.logger.Debugf("Skipping directory %s", file)
 			continue
 		}
 
 		if c.conf.UploadSkipSymlinks && isSymlink(absolutePath) {
-			c.logger.Debug("Skipping symlink %s", file)
+			c.logger.Debugf("Skipping symlink %s", file)
 			continue
 		}
 
@@ -397,12 +397,12 @@ func (a *Uploader) createUploader(ctx context.Context) (_ workCreator, err error
 		if err != nil || dest == "" {
 			return
 		}
-		a.logger.Info("Uploading to %s (%q), using your agent configuration", dest, a.conf.Destination)
+		a.logger.Infof("Uploading to %s (%q), using your agent configuration", dest, a.conf.Destination)
 	}()
 
 	switch {
 	case a.conf.Destination == "":
-		a.logger.Info("Uploading to default Buildkite artifact storage")
+		a.logger.Infof("Uploading to default Buildkite artifact storage")
 		return NewBKUploader(a.logger, BKUploaderConfig{
 			DebugHTTP:    a.conf.DebugHTTP,
 			TraceHTTP:    a.conf.TraceHTTP,
@@ -530,7 +530,7 @@ func (a *Uploader) upload(ctx context.Context, artifacts []*api.Artifact, upload
 	for _, artifact := range artifacts {
 		workUnits, err := uploader.CreateWork(artifact)
 		if err != nil {
-			a.logger.Error("Couldn't create upload workers for artifact %q: %v", artifact.Path, err)
+			a.logger.Errorf("Couldn't create upload workers for artifact %q: %v", artifact.Path, err)
 			return err
 		}
 
@@ -579,7 +579,7 @@ func (a *Uploader) upload(ctx context.Context, artifacts []*api.Artifact, upload
 	// All work units have been sent to workers.
 	close(unitsCh)
 
-	a.logger.Debug("Waiting for uploads to complete...")
+	a.logger.Debugf("Waiting for uploads to complete...")
 
 	// Wait for the workers to finish
 	wg.Wait()
@@ -588,14 +588,14 @@ func (a *Uploader) upload(ctx context.Context, artifacts []*api.Artifact, upload
 	// state updater.
 	close(resultsCh)
 
-	a.logger.Debug("Uploads complete, waiting for upload status to be sent to Buildkite...")
+	a.logger.Debugf("Uploads complete, waiting for upload status to be sent to Buildkite...")
 
 	// Wait for the statuses to finish uploading
 	if err := <-errCh; err != nil {
 		return fmt.Errorf("errors uploading artifacts: %w", err)
 	}
 
-	a.logger.Info("Artifact uploads completed successfully")
+	a.logger.Infof("Artifact uploads completed successfully")
 
 	return nil
 }
@@ -612,7 +612,7 @@ func (a *artifactUploadWorker) doWorkUnits(ctx context.Context, unitsCh <-chan w
 			}
 			tracker := a.trackers[workUnit.Artifact()]
 			// Show a nice message that we're starting to upload the file
-			a.logger.Info("Uploading %s", workUnit.Description())
+			a.logger.Infof("Uploading %s", workUnit.Description())
 
 			// Upload the artifact and then set the state depending
 			// on whether or not it passed. We'll retry the upload
@@ -624,13 +624,13 @@ func (a *artifactUploadWorker) doWorkUnits(ctx context.Context, unitsCh <-chan w
 			partETag, err := roko.DoFunc(tracker.ctx, r, func(r *roko.Retrier) (*api.ArtifactPartETag, error) {
 				etag, err := workUnit.DoWork(tracker.ctx)
 				if err != nil {
-					a.logger.Warn("%s (%s)", err, r)
+					a.logger.Warnf("%s (%s)", err, r)
 				}
 				return etag, err
 			})
 			// If it failed, abort any other work items for this artifact.
 			if err != nil {
-				a.logger.Info("Upload failed for %s: %v", workUnit.Description(), err)
+				a.logger.Infof("Upload failed for %s: %v", workUnit.Description(), err)
 				tracker.cancel(err)
 				// then the error is sent to the status updater
 			}
@@ -676,7 +676,7 @@ selectLoop:
 				// The work unit failed, so the whole artifact upload has failed.
 				errs = append(errs, result.err)
 				tracker.State = "error"
-				a.logger.Debug("Artifact %s has entered state %s", tracker.ID, tracker.State)
+				a.logger.Debugf("Artifact %s has entered state %s", tracker.ID, tracker.State)
 				continue
 			}
 
@@ -693,7 +693,7 @@ selectLoop:
 			// No pending units remain, so the whole artifact is complete.
 			// Add it to the next batch of states to upload.
 			tracker.State = "finished"
-			a.logger.Debug("Artifact %s has entered state %s", tracker.ID, tracker.State)
+			a.logger.Debugf("Artifact %s has entered state %s", tracker.ID, tracker.State)
 		}
 	}
 
@@ -754,7 +754,7 @@ func (a *artifactUploadWorker) updateStates(ctx context.Context) error {
 
 		_, err := a.apiClient.UpdateArtifacts(ctxTimeout, a.conf.JobID, statesToUpload)
 		if err != nil {
-			a.logger.Warn("%s (%s)", err, r)
+			a.logger.Warnf("%s (%s)", err, r)
 		}
 
 		// after four attempts (0, 1, 2, 3)...
@@ -762,14 +762,14 @@ func (a *artifactUploadWorker) updateStates(ctx context.Context) error {
 			// The short timeout has given us fast feedback on the first couple of attempts,
 			// but perhaps the server needs more time to complete the request, so fall back to
 			// the default HTTP client timeout.
-			a.logger.Debug("UpdateArtifacts timeout (%s) removed for subsequent attempts", timeout)
+			a.logger.Debugf("UpdateArtifacts timeout (%s) removed for subsequent attempts", timeout)
 			timeout = 0
 		}
 
 		return err
 	})
 	if err != nil {
-		a.logger.Error("Error updating artifact states: %v", err)
+		a.logger.Errorf("Error updating artifact states: %v", err)
 		return err
 	}
 
@@ -777,7 +777,7 @@ func (a *artifactUploadWorker) updateStates(ctx context.Context) error {
 		// Don't send this state again.
 		tracker.State = "sent"
 	}
-	a.logger.Debug("Updated %d artifact states", len(statesToUpload))
+	a.logger.Debugf("Updated %d artifact states", len(statesToUpload))
 	return nil
 }
 

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -60,7 +60,7 @@ func Save(ctx context.Context, l logger.Logger, cfg Config) error {
 	}
 
 	if cacheClient == nil {
-		l.Info("No caches defined in the cache configuration file, nothing to save")
+		l.Infof("No caches defined in the cache configuration file, nothing to save")
 		return nil
 	}
 
@@ -75,7 +75,7 @@ func Restore(ctx context.Context, l logger.Logger, cfg Config) error {
 	}
 
 	if cacheClient == nil {
-		l.Info("No caches defined in the cache configuration file, nothing to restore")
+		l.Infof("No caches defined in the cache configuration file, nothing to restore")
 		return nil
 	}
 
@@ -123,7 +123,7 @@ func setupCacheClient(ctx context.Context, l logger.Logger, cfg Config) (*zstash
 				logger.StringField("cache_id", cacheID),
 				logger.StringField("stage", stage),
 				logger.StringField("message", message),
-			).Info("Cache progress")
+			).Infof("Cache progress")
 		},
 	})
 	if err != nil {
@@ -182,7 +182,7 @@ func restoreWithClient(ctx context.Context, l logger.Logger, client CacheClient,
 						return
 					}
 
-					l.Info("Restoring cache: %s", cacheID)
+					l.Infof("Restoring cache: %s", cacheID)
 					result, err := client.Restore(wctx, cacheID)
 					if err != nil {
 						cancel(fmt.Errorf("failed to restore cache %q: %w", cacheID, err))
@@ -202,12 +202,12 @@ func restoreWithClient(ctx context.Context, l logger.Logger, client CacheClient,
 							logger.StringField("transfer_speed", fmt.Sprintf("%.2fMB/s", result.Transfer.TransferSpeed)),
 							logger.IntField("part_count", result.Transfer.PartCount),
 							logger.IntField("concurrency", result.Transfer.Concurrency),
-						).Info("Cache restored")
+						).Infof("Cache restored")
 					default:
 						l.WithFields(
 							logger.StringField("cache_id", cacheID),
 							logger.StringField("cache_key", result.Key),
-						).Info("Cache not restored (not found)")
+						).Infof("Cache not restored (not found)")
 					}
 
 				case <-wctx.Done():
@@ -258,7 +258,7 @@ func saveWithClient(ctx context.Context, l logger.Logger, client CacheClient, ca
 						return
 					}
 
-					l.Info("Saving cache: %s", cacheID)
+					l.Infof("Saving cache: %s", cacheID)
 					result, err := client.Save(wctx, cacheID)
 					if err != nil {
 						cancel(fmt.Errorf("failed to save cache %q: %w", cacheID, err))
@@ -277,12 +277,12 @@ func saveWithClient(ctx context.Context, l logger.Logger, client CacheClient, ca
 							logger.StringField("transfer_speed", fmt.Sprintf("%.2fMB/s", result.Transfer.TransferSpeed)),
 							logger.IntField("part_count", result.Transfer.PartCount),
 							logger.IntField("concurrency", result.Transfer.Concurrency),
-						).Info("Cache created")
+						).Infof("Cache created")
 					default:
 						l.WithFields(
 							logger.StringField("cache_id", cacheID),
 							logger.StringField("cache_key", result.Key),
-						).Info("Cache already exists, not saving")
+						).Infof("Cache already exists, not saving")
 					}
 
 				case <-wctx.Done():

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -168,7 +168,7 @@ func TestSaveWithClient_EmptyCacheIDs(t *testing.T) {
 
 	mock := &mockCacheClient{
 		saveFunc: func(ctx context.Context, cacheID string) (zstash.SaveResult, error) {
-			t.Fatal("Save should not be called with empty cache IDs")
+			t.Fatalf("Save should not be called with empty cache IDs")
 			return zstash.SaveResult{}, nil
 		},
 	}
@@ -316,7 +316,7 @@ func TestRestoreWithClient_EmptyCacheIDs(t *testing.T) {
 
 	mock := &mockCacheClient{
 		restoreFunc: func(ctx context.Context, cacheID string) (zstash.RestoreResult, error) {
-			t.Fatal("Restore should not be called with empty cache IDs")
+			t.Fatalf("Restore should not be called with empty cache IDs")
 			return zstash.RestoreResult{}, nil
 		},
 	}

--- a/internal/e2e/main_test.go
+++ b/internal/e2e/main_test.go
@@ -19,7 +19,7 @@ func TestMain(m *testing.M) {
 	ctx := context.Background()
 	ident, _, err := client.GetTokenIdentity(ctx)
 	if err != nil {
-		l.Fatal("Could not read token identity: %v", err)
+		l.Fatalf("Could not read token identity: %v", err)
 	}
 	targetOrg = ident.OrganizationSlug
 	targetCluster = ident.ClusterUUID

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -95,9 +95,9 @@ func EnableWithWarnings(ctx context.Context, l logger.Logger, key string) (conte
 	case StateKnown:
 	// Noop
 	case StateUnknown:
-		l.Warn("Unknown experiment %q", key)
+		l.Warnf("Unknown experiment %q", key)
 	case StatePromoted:
-		l.Warn(Promoted[key])
+		l.Warnf(Promoted[key])
 	}
 	return newctx, state
 }

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -505,7 +505,7 @@ func TestForcingACleanCheckout_WithGitMirrors(t *testing.T) {
 	tester.RunAndCheck(t, "BUILDKITE_CLEAN_CHECKOUT=true")
 
 	if !strings.Contains(tester.Output, "Cleaning pipeline checkout") {
-		t.Fatal(`tester.Output does not contain "Cleaning pipeline checkout"`)
+		t.Fatalf(`tester.Output does not contain "Cleaning pipeline checkout"`)
 	}
 }
 

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -916,7 +916,7 @@ func TestForcingACleanCheckout(t *testing.T) {
 	tester.RunAndCheck(t, "BUILDKITE_CLEAN_CHECKOUT=true")
 
 	if !strings.Contains(tester.Output, "Cleaning pipeline checkout") {
-		t.Fatal(`tester.Output does not contain "Cleaning pipeline checkout"`)
+		t.Fatalf(`tester.Output does not contain "Cleaning pipeline checkout"`)
 	}
 }
 
@@ -932,17 +932,17 @@ func TestSkippingCheckout(t *testing.T) {
 	tester.RunAndCheck(t, "BUILDKITE_SKIP_CHECKOUT=true")
 
 	if !strings.Contains(tester.Output, "Skipping checkout") {
-		t.Error(`tester.Output does not contain "Skipping checkout"`)
+		t.Errorf(`tester.Output does not contain "Skipping checkout"`)
 	}
 
 	// Verify no git commands were run (no clone, fetch, checkout)
 	if strings.Contains(tester.Output, "git clone") {
-		t.Error(`tester.Output should not contain "git clone" when checkout is skipped`)
+		t.Errorf(`tester.Output should not contain "git clone" when checkout is skipped`)
 	}
 
 	// Verify no git commit metadata was checked or sent when checkout is skipped
 	if strings.Contains(tester.Output, "Checking to see if git commit information needs to be sent to Buildkite") {
-		t.Error(`tester.Output should not contain "Checking to see if git commit information needs to be sent to Buildkite" when checkout is skipped`)
+		t.Errorf(`tester.Output should not contain "Checking to see if git commit information needs to be sent to Buildkite" when checkout is skipped`)
 	}
 }
 

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -573,7 +573,7 @@ func TestPolyglotScriptHooksCanBeRun(t *testing.T) {
 	}
 
 	if path == "" {
-		t.Fatal("ruby not found in $PATH. This test requires ruby to be installed on the host")
+		t.Fatalf("ruby not found in $PATH. This test requires ruby to be installed on the host")
 	}
 
 	ctx := mainCtx

--- a/internal/mime/mime_test.go
+++ b/internal/mime/mime_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestTypeByExtension(t *testing.T) {
 	if len(types) == 0 {
-		t.Error("Mime types list is empty")
+		t.Errorf("Mime types list is empty")
 	}
 	for ext, expectedType := range types {
 		if ext[0:1] != "." {

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -151,7 +151,7 @@ func (p *Process) Run(ctx context.Context) error {
 	}
 	defer cleanup()
 
-	p.logger.Info("[Process] Process is running with PID: %d", p.pid())
+	p.logger.Infof("[Process] Process is running with PID: %d", p.pid())
 
 	// Wait until the process has finished. The returned error is nil if the
 	// command runs, has no problems copying stdin, stdout, and stderr, and
@@ -186,7 +186,7 @@ func (p *Process) start(ctx context.Context) (func(), error) {
 	}
 
 	if err := p.postStart(); err != nil {
-		p.logger.Error("[Process] postStart failed: %v", err)
+		p.logger.Errorf("[Process] postStart failed: %v", err)
 	}
 	// Signal waiting consumers in Started() by closing the started channel
 	close(p.started)
@@ -235,7 +235,7 @@ func (p *Process) setup(ctx context.Context) error {
 // to stdout. The cleanup function waits for the copy to finish and closes the
 // PTY handle.
 func (p *Process) startWithPTY(ctx context.Context) (func(), error) {
-	p.logger.Debug("[Process] Running with a PTY")
+	p.logger.Debugf("[Process] Running with a PTY")
 
 	// Commands like tput expect a TERM value for a PTY
 	p.command.Env = append(p.command.Env, "TERM="+termType)
@@ -250,7 +250,7 @@ func (p *Process) startWithPTY(ctx context.Context) (func(), error) {
 	afterPTYStartHook()
 
 	if rawPTY {
-		p.logger.Debug("[Process] Setting raw mode for PTY %s (fd:%d)", pty.Name(), pty.Fd())
+		p.logger.Debugf("[Process] Setting raw mode for PTY %s (fd:%d)", pty.Name(), pty.Fd())
 	}
 
 	// Copy and close the PTY, if it exists.
@@ -260,11 +260,11 @@ func (p *Process) startWithPTY(ctx context.Context) (func(), error) {
 	return func() {
 		// Sometimes (in docker containers) io.Copy never seems to finish. This is a
 		// mega hack around it. If it doesn't finish after 10 seconds, just continue.
-		p.logger.Debug("[Process] Waiting for routines to finish")
+		p.logger.Debugf("[Process] Waiting for routines to finish")
 
 		select {
 		case <-time.After(10 * time.Second):
-			p.logger.Debug("[Process] Timed out waiting for PTY->stdout copy")
+			p.logger.Debugf("[Process] Timed out waiting for PTY->stdout copy")
 		case <-copyDone:
 			// it's done
 		}
@@ -276,7 +276,7 @@ func (p *Process) startWithPTY(ctx context.Context) (func(), error) {
 // startWithoutPTY starts the process without using a PTY. The cleanup function
 // is a no-op.
 func (p *Process) startWithoutPTY(context.Context) (func(), error) {
-	p.logger.Debug("[Process] Running without a PTY")
+	p.logger.Debugf("[Process] Running without a PTY")
 
 	p.command.Stdin = p.conf.Stdin
 	p.command.Stdout = p.conf.Stdout
@@ -291,7 +291,7 @@ func (p *Process) startWithoutPTY(context.Context) (func(), error) {
 // copyPTYToStdout copies pty to p.conf.Stdout. It should be a new goroutine.
 func (p *Process) copyPTYToStdout(pty *os.File, copyDone chan<- struct{}) {
 	defer close(copyDone)
-	p.logger.Debug("[Process] Starting to copy PTY to the buffer")
+	p.logger.Debugf("[Process] Starting to copy PTY to the buffer")
 
 	// Copy the pty to our writer. This will block until it EOFs or something breaks.
 	_, err := io.Copy(p.conf.Stdout, pty)
@@ -304,13 +304,13 @@ func (p *Process) copyPTYToStdout(pty *os.File, copyDone chan<- struct{}) {
 		// See: https://github.com/buildkite/agent/pull/34#issuecomment-46080419
 		//
 		// We will still log the error to aid debugging on other platforms.
-		p.logger.Debug("[Process] PTY has finished being copied to the buffer: %v", err)
+		p.logger.Debugf("[Process] PTY has finished being copied to the buffer: %v", err)
 
 	case err == nil:
-		p.logger.Debug("[Process] PTY has finished being copied to the buffer")
+		p.logger.Debugf("[Process] PTY has finished being copied to the buffer")
 
 	default:
-		p.logger.Error("[Process] PTY output copy failed with error: %T: %v", err, err)
+		p.logger.Errorf("[Process] PTY output copy failed with error: %T: %v", err, err)
 	}
 }
 
@@ -343,7 +343,7 @@ func (p *Process) complete(waitResult error) error {
 	if p.status.Signaled() {
 		exitSignal = SignalString(p.status.Signal())
 	}
-	p.logger.Info("Process with PID: %d finished with Exit Status: %d, Signal: %s",
+	p.logger.Infof("Process with PID: %d finished with Exit Status: %d, Signal: %s",
 		p.pid(), p.status.ExitStatus(), exitSignal)
 	return nil
 }
@@ -352,9 +352,9 @@ func (p *Process) complete(waitResult error) error {
 // signal grace period, then terminates the process. It is called by the
 // Command.Cancel mechanism when the context for p.command is cancelled.
 func (p *Process) onContextCancel() error {
-	p.logger.Debug("[Process] Context done, terminating. pid=%d", p.pid())
+	p.logger.Debugf("[Process] Context done, terminating. pid=%d", p.pid())
 	if err := p.Interrupt(); err != nil {
-		p.logger.Warn("[Process] Failed termination: %v", err)
+		p.logger.Warnf("[Process] Failed termination: %v", err)
 	}
 
 	// We could almost use Command.WaitDelay to implement the signal grace
@@ -370,10 +370,10 @@ func (p *Process) onContextCancel() error {
 			// continue below
 		}
 
-		p.logger.Warn("[Process] Has not terminated in time, killing. pid=%d", p.pid())
+		p.logger.Warnf("[Process] Has not terminated in time, killing. pid=%d", p.pid())
 		if err := p.Terminate(); err != nil {
 			// Oh Well, At Least We Tried™
-			p.logger.Error("[Process] error sending SIGKILL: %s", err)
+			p.logger.Errorf("[Process] error sending SIGKILL: %s", err)
 		}
 	}()
 
@@ -412,7 +412,7 @@ func (p *Process) Interrupt() error {
 	defer p.mu.Unlock()
 
 	if p.command == nil || p.command.Process == nil {
-		p.logger.Debug("[Process] No process to interrupt yet")
+		p.logger.Debugf("[Process] No process to interrupt yet")
 		return nil
 	}
 
@@ -422,11 +422,11 @@ func (p *Process) Interrupt() error {
 	if err := p.interruptProcessGroup(); err != nil {
 		//  No process or process group can be found corresponding to that specified by pid.
 		if errors.Is(err, syscall.ESRCH) {
-			p.logger.Warn("[Process] Process %d has already exited", p.pid())
+			p.logger.Warnf("[Process] Process %d has already exited", p.pid())
 			return nil
 		}
 
-		p.logger.Error("[Process] Failed to interrupt process %d: %v", p.pid(), err)
+		p.logger.Errorf("[Process] Failed to interrupt process %d: %v", p.pid(), err)
 
 		// Fallback to terminating if we get an error
 		return p.terminateProcessGroup()
@@ -445,7 +445,7 @@ func (p *Process) Terminate() error {
 	defer p.mu.Unlock()
 
 	if p.command == nil || p.command.Process == nil {
-		p.logger.Debug("[Process] No process to terminate yet")
+		p.logger.Debugf("[Process] No process to terminate yet")
 		return nil
 	}
 

--- a/internal/process/run.go
+++ b/internal/process/run.go
@@ -10,7 +10,7 @@ import (
 func Run(l logger.Logger, command string, arg ...string) (string, error) {
 	output, err := exec.Command(command, arg...).Output()
 	if err != nil {
-		l.Debug("Could not run: %s %s (returned %s) (%T: %v)", command, arg, output, err, err)
+		l.Debugf("Could not run: %s %s (returned %s) (%T: %v)", command, arg, output, err, err)
 		return "", err
 	}
 

--- a/internal/process/scanner.go
+++ b/internal/process/scanner.go
@@ -21,7 +21,7 @@ func (s *Scanner) ScanLines(r io.Reader, f func(line string)) error {
 	reader := bufio.NewReader(r)
 	var appending []byte
 
-	s.logger.Debug("[LineScanner] Starting to read lines")
+	s.logger.Debugf("[LineScanner] Starting to read lines")
 
 	// Note that we do this manually rather than
 	// because we need to handle very long lines
@@ -30,7 +30,7 @@ func (s *Scanner) ScanLines(r io.Reader, f func(line string)) error {
 		line, isPrefix, err := reader.ReadLine()
 		if err != nil {
 			if err == io.EOF {
-				s.logger.Debug("[LineScanner] Encountered EOF")
+				s.logger.Debugf("[LineScanner] Encountered EOF")
 				break
 			}
 			return err
@@ -41,7 +41,7 @@ func (s *Scanner) ScanLines(r io.Reader, f func(line string)) error {
 		// until isPrefix is false (which means the long line
 		// has ended.
 		if isPrefix && appending == nil {
-			s.logger.Debug("[LineScanner] Line is too long to read, going to buffer it until it finishes")
+			s.logger.Debugf("[LineScanner] Line is too long to read, going to buffer it until it finishes")
 
 			// bufio.ReadLine returns a slice which is only valid until the next invocation
 			// since it points to its own internal buffer array. To accumulate the entire
@@ -59,7 +59,7 @@ func (s *Scanner) ScanLines(r io.Reader, f func(line string)) error {
 
 			// No more isPrefix! Line is finished!
 			if !isPrefix {
-				s.logger.Debug("[LineScanner] Finished buffering long line")
+				s.logger.Debugf("[LineScanner] Finished buffering long line")
 				line = appending
 
 				// Reset appending back to nil
@@ -73,6 +73,6 @@ func (s *Scanner) ScanLines(r io.Reader, f func(line string)) error {
 		f(string(line))
 	}
 
-	s.logger.Debug("[LineScanner] Finished")
+	s.logger.Debugf("[LineScanner] Finished")
 	return nil
 }

--- a/internal/process/signal_notwindows.go
+++ b/internal/process/signal_notwindows.go
@@ -34,7 +34,7 @@ func (p *Process) postStart() error {
 func (p *Process) terminateProcessGroup() error {
 	// Note: terminateProcessGroup is called from within p.Terminate, which
 	// holds p.mu.
-	p.logger.Debug("[Process] Sending signal SIGKILL to PGID: %d", p.pid())
+	p.logger.Debugf("[Process] Sending signal SIGKILL to PGID: %d", p.pid())
 	return syscall.Kill(-p.pid(), syscall.SIGKILL)
 }
 
@@ -48,7 +48,7 @@ func (p *Process) interruptProcessGroup() error {
 		intSignal = SIGTERM
 	}
 
-	p.logger.Debug("[Process] Sending signal %s to PGID: %d", intSignal, p.pid())
+	p.logger.Debugf("[Process] Sending signal %s to PGID: %d", intSignal, p.pid())
 	return syscall.Kill(-p.pid(), syscall.Signal(intSignal))
 }
 

--- a/internal/process/signal_windows.go
+++ b/internal/process/signal_windows.go
@@ -53,7 +53,7 @@ func (p *Process) setupProcessGroup() {
 	}
 	jobHandle, err := newJobObject()
 	if err != nil {
-		p.logger.Error("Creating Job Object failed: %v", err)
+		p.logger.Errorf("Creating Job Object failed: %v", err)
 	}
 	p.winJobHandle = jobHandle
 }
@@ -107,10 +107,10 @@ func (p *Process) postStart() (err error) {
 
 func (p *Process) terminateProcessGroup() error {
 	if p.terminateFunc != nil {
-		p.logger.Debug("[Process] Terminating process")
+		p.logger.Debugf("[Process] Terminating process")
 		return p.terminateFunc()
 	}
-	p.logger.Debug("[Process] Terminating process tree by destroying job")
+	p.logger.Debugf("[Process] Terminating process tree by destroying job")
 	return windows.CloseHandle(windows.Handle(p.winJobHandle))
 }
 

--- a/internal/secrets/secret.go
+++ b/internal/secrets/secret.go
@@ -92,12 +92,12 @@ func FetchSecrets(ctx context.Context, l logger.Logger, client APIClient, jobID 
 				secret, resp, err := client.GetSecret(ctx, &api.GetSecretRequest{Key: key, JobID: jobID})
 				if err != nil {
 					if resp != nil && api.IsRetryableStatus(resp) {
-						l.Warn("Retrying secret %q fetch after retryable HTTP status %d (%s)", key, resp.StatusCode, r)
+						l.Warnf("Retrying secret %q fetch after retryable HTTP status %d (%s)", key, resp.StatusCode, r)
 						return nil, err
 					}
 
 					if api.IsRetryableError(err) {
-						l.Warn("Retrying secret %q fetch after retryable error: %v (%s)", key, err, r)
+						l.Warnf("Retrying secret %q fetch after retryable error: %v (%s)", key, err, r)
 						return nil, err
 					}
 

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -208,7 +208,7 @@ func TestContextCancelInterrupts(t *testing.T) {
 			go func() {
 				select {
 				case <-time.After(1 * time.Minute):
-					t.Error("timeout waiting for process to start")
+					t.Errorf("timeout waiting for process to start")
 				case <-started:
 					// Now cancel the context, which should cause the interrupt.
 					cancel()
@@ -300,7 +300,7 @@ func TestInterrupt(t *testing.T) {
 			go func() {
 				select {
 				case <-time.After(1 * time.Minute):
-					t.Error("timeout waiting for process to start")
+					t.Errorf("timeout waiting for process to start")
 				case <-started:
 					// Now interrupt the process.
 					if err := sh.Interrupt(); err != nil {

--- a/internal/socket/middleware_test.go
+++ b/internal/socket/middleware_test.go
@@ -26,7 +26,7 @@ func shouldCall(t *testing.T) func(http.Handler) http.Handler {
 func shouldNotCall(t *testing.T) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			t.Error("next.ServeHTTP should not be called")
+			t.Errorf("next.ServeHTTP should not be called")
 		})
 	}
 }

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -50,7 +50,7 @@ func TestOrderedClients(t *testing.T) {
 	case <-runner.Done():
 		break
 	default:
-		t.Fatal("runner should be done when all clients have exited")
+		t.Fatalf("runner should be done when all clients have exited")
 	}
 }
 

--- a/kubernetes/runner.go
+++ b/kubernetes/runner.go
@@ -104,7 +104,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	r.listener = l
 	go func() {
 		if err := http.Serve(l, r.mux); err != nil && !errors.Is(err, net.ErrClosed) {
-			r.logger.Error("kubernetes runner HTTP server stopped: %v", err)
+			r.logger.Errorf("kubernetes runner HTTP server stopped: %v", err)
 		}
 	}()
 
@@ -175,10 +175,10 @@ func (r *Runner) livenessCheck(ctx context.Context) {
 				// we can just terminate.
 				lhf := time.Since(client.LastHeardFrom)
 				if client.State == StateConnected && lhf > r.conf.ClientLostTimeout {
-					r.logger.Error("Container (ID %d) was last heard from %v ago; marking lost and self-terminating...", id, lhf)
+					r.logger.Errorf("Container (ID %d) was last heard from %v ago; marking lost and self-terminating...", id, lhf)
 					client.State = StateLost
 					if err := r.Terminate(); err != nil {
-						r.logger.Error("terminating lost kubernetes runner: %v", err)
+						r.logger.Errorf("terminating lost kubernetes runner: %v", err)
 					}
 				}
 				client.mu.Unlock()
@@ -268,7 +268,7 @@ func (r *Runner) Exit(args ExitCode, reply *Empty) error {
 		return fmt.Errorf("unrecognized client id: %d", args.ID)
 	}
 	client := r.clients[args.ID]
-	r.logger.Info("client %d exited with code %d", args.ID, args.ExitStatus)
+	r.logger.Infof("client %d exited with code %d", args.ID, args.ExitStatus)
 
 	client.mu.Lock()
 	client.ExitStatus = args.ExitStatus
@@ -324,7 +324,7 @@ func (r *Runner) Register(id int, reply *RegisterResponse) error {
 	if client.State != StateNotYetConnected {
 		return fmt.Errorf("client id %d already registered", id)
 	}
-	r.logger.Info("client %d connected", id)
+	r.logger.Infof("client %d connected", id)
 	client.LastHeardFrom = time.Now()
 	client.State = StateConnected
 

--- a/logger/buffer.go
+++ b/logger/buffer.go
@@ -21,37 +21,37 @@ func NewBuffer() *Buffer {
 	}
 }
 
-func (b *Buffer) Debug(format string, v ...any) {
+func (b *Buffer) Debugf(format string, v ...any) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.Messages = append(b.Messages, "[debug] "+fmt.Sprintf(format, v...))
 }
 
-func (b *Buffer) Error(format string, v ...any) {
+func (b *Buffer) Errorf(format string, v ...any) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.Messages = append(b.Messages, "[error] "+fmt.Sprintf(format, v...))
 }
 
-func (b *Buffer) Fatal(format string, v ...any) {
+func (b *Buffer) Fatalf(format string, v ...any) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.Messages = append(b.Messages, "[fatal] "+fmt.Sprintf(format, v...))
 }
 
-func (b *Buffer) Notice(format string, v ...any) {
+func (b *Buffer) Noticef(format string, v ...any) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.Messages = append(b.Messages, "[notice] "+fmt.Sprintf(format, v...))
 }
 
-func (b *Buffer) Warn(format string, v ...any) {
+func (b *Buffer) Warnf(format string, v ...any) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.Messages = append(b.Messages, "[warn] "+fmt.Sprintf(format, v...))
 }
 
-func (b *Buffer) Info(format string, v ...any) {
+func (b *Buffer) Infof(format string, v ...any) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.Messages = append(b.Messages, "[info] "+fmt.Sprintf(format, v...))

--- a/logger/buffer_test.go
+++ b/logger/buffer_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestBuffer(t *testing.T) {
 	l := logger.NewBuffer()
-	l.Info("hello %s", "world")
+	l.Infof("hello %s", "world")
 	func(x logger.Logger) {
-		x.Debug("foo bar")
+		x.Debugf("foo bar")
 	}(l)
 	if diff := cmp.Diff(l.Messages, []string{
 		"[info] hello world",

--- a/logger/log.go
+++ b/logger/log.go
@@ -41,12 +41,12 @@ var (
 )
 
 type Logger interface {
-	Debug(format string, v ...any)
-	Error(format string, v ...any)
-	Fatal(format string, v ...any)
-	Notice(format string, v ...any)
-	Warn(format string, v ...any)
-	Info(format string, v ...any)
+	Debugf(format string, v ...any)
+	Errorf(format string, v ...any)
+	Fatalf(format string, v ...any)
+	Noticef(format string, v ...any)
+	Warnf(format string, v ...any)
+	Infof(format string, v ...any)
 
 	WithFields(fields ...Field) Logger
 	SetLevel(level Level)
@@ -81,7 +81,7 @@ func (l *ConsoleLogger) SetLevel(level Level) {
 	l.level = level
 }
 
-func (l *ConsoleLogger) Debug(format string, v ...any) {
+func (l *ConsoleLogger) Debugf(format string, v ...any) {
 	if l.level == DEBUG {
 		debugFields := make(Fields, len(l.fields))
 		copy(debugFields, l.fields)
@@ -90,28 +90,28 @@ func (l *ConsoleLogger) Debug(format string, v ...any) {
 	}
 }
 
-func (l *ConsoleLogger) Error(format string, v ...any) {
+func (l *ConsoleLogger) Errorf(format string, v ...any) {
 	l.printer.Print(ERROR, fmt.Sprintf(format, v...), l.fields)
 }
 
-func (l *ConsoleLogger) Fatal(format string, v ...any) {
+func (l *ConsoleLogger) Fatalf(format string, v ...any) {
 	l.printer.Print(FATAL, fmt.Sprintf(format, v...), l.fields)
 	l.exitFn(1)
 }
 
-func (l *ConsoleLogger) Notice(format string, v ...any) {
+func (l *ConsoleLogger) Noticef(format string, v ...any) {
 	if l.level <= NOTICE {
 		l.printer.Print(NOTICE, fmt.Sprintf(format, v...), l.fields)
 	}
 }
 
-func (l *ConsoleLogger) Info(format string, v ...any) {
+func (l *ConsoleLogger) Infof(format string, v ...any) {
 	if l.level <= INFO {
 		l.printer.Print(INFO, fmt.Sprintf(format, v...), l.fields)
 	}
 }
 
-func (l *ConsoleLogger) Warn(format string, v ...any) {
+func (l *ConsoleLogger) Warnf(format string, v ...any) {
 	if l.level <= WARN {
 		l.printer.Print(WARN, fmt.Sprintf(format, v...), l.fields)
 	}
@@ -289,3 +289,16 @@ func (tp TestPrinter) Print(level Level, msg string, fields Fields) {
 	now := time.Now().Format(DateFormat)
 	tp.tb.Logf("%s %s %s %v", now, level, msg, fields)
 }
+
+// DeprecatedLogger wraps the logger with the deprecated (no trailing "f")
+// method names.
+type DeprecatedLogger struct {
+	Logger
+}
+
+func (d DeprecatedLogger) Debug(format string, v ...any)  { d.Debugf(format, v...) }
+func (d DeprecatedLogger) Error(format string, v ...any)  { d.Errorf(format, v...) }
+func (d DeprecatedLogger) Fatal(format string, v ...any)  { d.Fatalf(format, v...) }
+func (d DeprecatedLogger) Notice(format string, v ...any) { d.Noticef(format, v...) }
+func (d DeprecatedLogger) Warn(format string, v ...any)   { d.Warnf(format, v...) }
+func (d DeprecatedLogger) Info(format string, v ...any)   { d.Infof(format, v...) }

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -21,11 +21,11 @@ func TestConsoleLogger(t *testing.T) {
 	})
 	l.SetLevel(logger.INFO)
 
-	l.Debug("Debug %q", "llamas")
-	l.Info("Info %q", "llamas")
-	l.Warn("Warn %q", "llamas")
-	l.Error("Error %q", "llamas")
-	l.Fatal("Fatal %q", "llamas")
+	l.Debugf("Debug %q", "llamas")
+	l.Infof("Info %q", "llamas")
+	l.Warnf("Warn %q", "llamas")
+	l.Errorf("Error %q", "llamas")
+	l.Fatalf("Fatal %q", "llamas")
 
 	lines := strings.Split(strings.TrimRight(b.String(), "\n"), "\n")
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -50,7 +50,7 @@ func (c *Collector) Start() error {
 			c.config.DatadogHost += fmt.Sprintf(":%d", defaultDogStatsdPort)
 		}
 
-		c.logger.Info("Starting datadog metrics collection to %s", c.config.DatadogHost)
+		c.logger.Infof("Starting datadog metrics collection to %s", c.config.DatadogHost)
 
 		var err error
 		c.client, err = statsd.New(c.config.DatadogHost,
@@ -66,7 +66,7 @@ func (c *Collector) Start() error {
 
 func (c *Collector) Stop() error {
 	if c.config.Datadog && c.client != nil {
-		c.logger.Info("Stopping metrics collection")
+		c.logger.Infof("Stopping metrics collection")
 		return c.client.Close()
 	}
 	return nil
@@ -91,7 +91,7 @@ func (s *Scope) Timing(name string, value time.Duration, tags ...Tags) {
 	}
 
 	mergedTags := s.mergeTags(tags...).StringSlice()
-	s.c.logger.Debug("Metrics timing %s=%v %v", name, value, mergedTags)
+	s.c.logger.Debugf("Metrics timing %s=%v %v", name, value, mergedTags)
 
 	var err error
 	if s.c.config.DatadogDistributions {
@@ -106,7 +106,7 @@ func (s *Scope) Timing(name string, value time.Duration, tags ...Tags) {
 		err = s.c.client.Timing(name, value, mergedTags, 1)
 	}
 	if err != nil {
-		s.c.logger.Error("Metrics timing failed: %v", err)
+		s.c.logger.Errorf("Metrics timing failed: %v", err)
 	}
 }
 
@@ -125,10 +125,10 @@ func (s *Scope) Count(name string, value int64, tags ...Tags) {
 	}
 
 	mergedTags := s.mergeTags(tags...).StringSlice()
-	s.c.logger.Debug("Metrics count %s=%v %v", name, value, mergedTags)
+	s.c.logger.Debugf("Metrics count %s=%v %v", name, value, mergedTags)
 
 	if err := s.c.client.Count(name, value, mergedTags, 1); err != nil {
-		s.c.logger.Error("Metrics count failed: %v", err)
+		s.c.logger.Errorf("Metrics count failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
### Description

It's easy to forget that the first arg to Debug/Info/Warn/Error/Fatal/Notice is a format arg, because it didn't use the convention of putting an `f` on the end of the method name.

### Context

#3877

### Changes

- Change the method names
- Add a compatibility wrapper for `signature`

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)


### Disclosures / Credits

Search and replace - 10 minute job.