### PR TITLE
fix: separate OTel provider provisioning from span generation

### DIFF
--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -542,28 +542,45 @@ func setupLoggerAndConfig[T any](ctx context.Context, c *cli.Context, opts ...co
 	// Setup any global configuration options
 	ctx, done = HandleGlobalFlags(ctx, l, cfg)
 
-	// If this process is a subcommand running inside a traced job, initialize
-	// a TracerProvider so spans emitted here appear under the parent job's trace.
-	if os.Getenv("BUILDKITE_TRACING_BACKEND") == tracetools.BackendOpenTelemetry {
-		if traceParent := os.Getenv("TRACEPARENT"); traceParent != "" {
-			serviceName := os.Getenv("BUILDKITE_TRACING_SERVICE_NAME")
-			traceProvider, err := job.InitOTelTracerProvider(ctx, serviceName, nil)
-			if err != nil {
-				l.Warnf("Failed to initialize tracing: %v", err)
-			} else {
-				carrier := propagation.MapCarrier{"traceparent": traceParent}
-				if traceState := os.Getenv("TRACESTATE"); traceState != "" {
-					carrier["tracestate"] = traceState
-				}
+	// When OpenTelemetry tracing is enabled, always initialize a TracerProvider
+	// so that every command (bootstrap or standalone subcommand) can emit spans.
+	tracingBackend := os.Getenv("BUILDKITE_TRACING_BACKEND")
+	if tb, err := reflections.GetField(cfg, "TracingBackend"); err == nil {
+		if tbStr, ok := tb.(string); ok && tbStr != "" {
+			tracingBackend = tbStr
+		}
+	}
+
+	if tracingBackend == tracetools.BackendOpenTelemetry {
+		serviceName := os.Getenv("BUILDKITE_TRACING_SERVICE_NAME")
+		if sn, err := reflections.GetField(cfg, "TracingServiceName"); err == nil {
+			if snStr, ok := sn.(string); ok && snStr != "" {
+				serviceName = snStr
+			}
+		}
+		traceProvider, err := job.InitOTelTracerProvider(ctx, serviceName, nil)
+		if err != nil {
+			l.Warnf("Failed to initialize tracing: %v", err)
+		} else {
+			// Extract any incoming trace context so spans created in this process
+			// are linked to the parent job's trace.
+			carrier := propagation.MapCarrier{}
+			if traceParent := os.Getenv("TRACEPARENT"); traceParent != "" {
+				carrier["traceparent"] = traceParent
+			}
+			if traceState := os.Getenv("TRACESTATE"); traceState != "" {
+				carrier["tracestate"] = traceState
+			}
+			if len(carrier) > 0 {
 				ctx = otel.GetTextMapPropagator().Extract(ctx, carrier)
-				prevDone := done
-				done = func() {
-					prevDone()
-					flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-					defer cancel()
-					_ = traceProvider.ForceFlush(flushCtx)
-					_ = traceProvider.Shutdown(flushCtx)
-				}
+			}
+			prevDone := done
+			done = func() {
+				prevDone()
+				flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				_ = traceProvider.ForceFlush(flushCtx)
+				_ = traceProvider.Shutdown(flushCtx)
 			}
 		}
 	}

--- a/internal/job/tracing.go
+++ b/internal/job/tracing.go
@@ -127,7 +127,7 @@ func (e *Executor) otRootSpanName() string {
 	return base + "job"
 }
 
-// initOTelTracerProvider creates and globally registers an OpenTelemetry TracerProvider
+// InitOTelTracerProvider creates and globally registers an OpenTelemetry TracerProvider
 // and text map propagator. Caller must call ForceFlush and Shutdown
 // on the returned provider before the process exits.
 func InitOTelTracerProvider(ctx context.Context, serviceName string, extraAttrs []attribute.KeyValue) (*sdktrace.TracerProvider, error) {
@@ -184,32 +184,18 @@ func (e *Executor) startTracingOpenTelemetry(ctx context.Context) (tracetools.Sp
 		e.shell.Warningf("OpenTelemetry will still work, but the attribute %v and its value above will not be included", k)
 	}
 
-	tracerProvider, err := InitOTelTracerProvider(ctx, e.TracingServiceName, extras)
-	if err != nil {
-		e.shell.Errorf("Error initialising OpenTelemetry tracing: %s. Disabling tracing.", err)
-		return &tracetools.NoopSpan{}, ctx, noopStopper
-	}
-
-	tracer := tracerProvider.Tracer(
+	tracer := otel.GetTracerProvider().Tracer(
 		"buildkite-agent",
 		trace.WithInstrumentationVersion(version.Version()),
 		trace.WithSchemaURL(semconv.SchemaURL),
 	)
 
 	ctx = e.contextWithTraceparentIfEnabled(ctx)
+	spanAttrs := append(extras, attribute.String("analytics.event", "true"))
 	ctx, span := tracer.Start(ctx, e.otRootSpanName(),
-		trace.WithAttributes(
-			attribute.String("analytics.event", "true"),
-		),
+		trace.WithAttributes(spanAttrs...),
 	)
-
-	stop := func() {
-		ctx := context.Background()
-		_ = tracerProvider.ForceFlush(ctx)
-		_ = tracerProvider.Shutdown(ctx)
-	}
-
-	return tracetools.NewOpenTelemetrySpan(span), ctx, stop
+	return tracetools.NewOpenTelemetrySpan(span), ctx, noopStopper
 }
 
 // accepting traceparent from Buildkite control plane is an opt-in feature as its


### PR DESCRIPTION
### Description

#### Problem

`setupLoggerAndConfig` only initialised the OpenTelemetry TracerProvider when `TRACEPARENT` was set in the environment. This was unreliable: `TRACEPARENT` is injected into every subprocess the agent spawns (git, bootstrap, hooks) so its presence is not a reliable signal that the current process is a traced subcommand.

This also caused a double-initialisation bug in the bootstrap flow: `setupLoggerAndConfig` created one provider, and `startTracingOpenTelemetry` created a second, loosing the first one.

#### Fix

Separate the two concerns:

- `setupLoggerAndConfig` always initialises the provider when `BUILDKITE_TRACING_BACKEND=opentelemetry`, and owns its lifecycle (`ForceFlush` + `Shutdown` in `done()`)
- `startTracingOpenTelemetry` uses `otel.GetTracerProvider()` to obtain the already-registered provider and only creates the root job span, adding job-specific attributes (pipeline slug, job ID, etc.) at span level rather than resource level since they are not available at provider init time

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

screenshots on grafana to show the subcommands:
<img width="1484" height="1516" alt="image" src="https://github.com/user-attachments/assets/930300b4-4531-443a-8174-67be7597695f" />



### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
