### PR TITLE
fix: make logger.Logger methods end in f

### DIFF
--- a/internal/artifact/s3_downloader.go
+++ b/internal/artifact/s3_downloader.go
@@ -138,7 +138,7 @@ func (d S3Downloader) startMultipart(ctx context.Context) error {
 	defer os.Remove(temp.Name()) //nolint:errcheck // Best-effort cleanup.
 	defer temp.Close()           //nolint:errcheck // Primary Close checked below.
 
-	d.logger.Debug("Multipart downloading s3://%s/%s to %s", d.BucketName(), d.BucketFileLocation(), targetPath)
+	d.logger.Debugf("Multipart downloading s3://%s/%s to %s", d.BucketName(), d.BucketFileLocation(), targetPath)
 
 	tmClient := transfermanager.New(d.conf.S3Client, func(o *transfermanager.Options) {
 		o.PartSizeBytes = s3MultipartDownloadPartSize
@@ -187,7 +187,7 @@ func (d S3Downloader) startMultipart(ctx context.Context) error {
 		return fmt.Errorf("renaming temp file to target: %w", err)
 	}
 
-	d.logger.Info("Successfully downloaded %q %s with SHA256 %s", d.conf.Path, humanize.IBytes(uint64(bytes)), gotSHA256)
+	d.logger.Infof("Successfully downloaded %q %s with SHA256 %s", d.conf.Path, humanize.IBytes(uint64(bytes)), gotSHA256)
 	return nil
 }
 


### PR DESCRIPTION
### Description

Ensure logger methods in `s3_downloader.go` end in `f`, eg `logger.Debugf`
<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

### Context

Similar to https://github.com/buildkite/agent/pull/3878/changes

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
