### PR TITLE
fix: new logger method names in the s3 multipart download

### DIFF
--- a/internal/artifact/s3_downloader.go
+++ b/internal/artifact/s3_downloader.go
@@ -138,7 +138,7 @@ func (d S3Downloader) startMultipart(ctx context.Context) error {
 	defer os.Remove(temp.Name()) //nolint:errcheck // Best-effort cleanup.
 	defer temp.Close()           //nolint:errcheck // Primary Close checked below.
 
-	d.logger.Debug("Multipart downloading s3://%s/%s to %s", d.BucketName(), d.BucketFileLocation(), targetPath)
+	d.logger.Debugf("Multipart downloading s3://%s/%s to %s", d.BucketName(), d.BucketFileLocation(), targetPath)
 
 	tmClient := transfermanager.New(d.conf.S3Client, func(o *transfermanager.Options) {
 		o.PartSizeBytes = s3MultipartDownloadPartSize
@@ -187,7 +187,7 @@ func (d S3Downloader) startMultipart(ctx context.Context) error {
 		return fmt.Errorf("renaming temp file to target: %w", err)
 	}
 
-	d.logger.Info("Successfully downloaded %q %s with SHA256 %s", d.conf.Path, humanize.IBytes(uint64(bytes)), gotSHA256)
+	d.logger.Infof("Successfully downloaded %q %s with SHA256 %s", d.conf.Path, humanize.IBytes(uint64(bytes)), gotSHA256)
 	return nil
 }
 


### PR DESCRIPTION
### Description

Two PRs merged, but the combination doesn't build (one added new code using the old method name, the other changed the method name): #3875 #3881 

### Context

Noticed the build failure on main.



### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)
