### PR TITLE
A-1214 part 1: implement a PR label linter

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+changelog:
+  exclude:
+    labels:
+      - release
+      - skip-changelog
+
+  categories:
+    - title: 🔒 Security
+      labels:
+        - security
+
+    - title: ✨ Added
+      labels:
+        - feature
+
+    - title: 🐛 Fixed
+      labels:
+        - bug
+
+    - title: 🔧 Changed
+      labels:
+        - change
+
+    - title: 🏠 Internal
+      labels:
+        - internal
+        - dependencies
+        - "*"

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,21 @@
+name: PR Labels
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  require-label:
+    name: Require category label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for required label
+        uses: mheap/github-action-required-labels@v5
+        with:
+          mode: minimum
+          count: 1
+          labels: "bug, feature, internal, dependencies, change"
+          message: "This PR must have at least one of these labels: {{ provided }}."


### PR DESCRIPTION
### Description

* make all PR to have consistent labeling to ease the release note generation. 
  * From now on, ever PR must have one of these labels: `internal`, `bug`, `change`, `feature`, or `security`. 
* Added .github/release.yml to prepare for removing the changelog file. 

There will be another follow up PR here to change the release pipeline. 🙏🏿 

You might want to ask "why label" and not conventional commits. 
Answer: I am not really fussed on this but label works pretty well with `gh`'s native changelog generation. 

Feedback welcomed! 

### Context

part of A-1214

### Disclosures / Credits

My LLM minion
