### PR TITLE
Make pipeline secret redaction default behaviour

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -86,7 +86,7 @@ type PipelineUploadConfig struct {
 	DryRunFormat    string   `cli:"format"`
 	NoInterpolation bool     `cli:"no-interpolation"`
 	RedactedVars    []string `cli:"redacted-vars" normalize:"list"`
-	RejectSecrets   bool     `cli:"reject-secrets"`
+	AllowSecrets    bool     `cli:"allow-secrets"`
 
 	// Used for if_changed processing
 	ApplyIfChanged   bool   `cli:"apply-if-changed"`
@@ -135,9 +135,9 @@ var PipelineUploadCommand = cli.Command{
 			EnvVar: "BUILDKITE_PIPELINE_NO_INTERPOLATION",
 		},
 		cli.BoolFlag{
-			Name:   "reject-secrets",
-			Usage:  "When true, fail the pipeline upload early if the pipeline contains secrets (default: false)",
-			EnvVar: "BUILDKITE_AGENT_PIPELINE_UPLOAD_REJECT_SECRETS",
+			Name:   "allow-secrets",
+			Usage:  "When true, allows the uploaded pipeline to be uploaded when it has interpolated secrets. Included for compatibility with Agent v3, using this flag is insecure. (default: false)",
+			EnvVar: "BUILDKITE_AGENT_PIPELINE_UPLOAD_ALLOW_SECRETS",
 		},
 		cli.BoolTFlag{
 			Name:   "apply-if-changed",
@@ -594,13 +594,13 @@ func searchForSecrets(
 		secretsFound := slices.Collect(maps.Keys(secretsFound))
 		slices.Sort(secretsFound)
 
-		if cfg.RejectSecrets {
+		if !cfg.AllowSecrets {
 			return fmt.Errorf("pipeline %q contains values interpolated from the following secret environment variables: %v, and cannot be uploaded to Buildkite", src, secretsFound)
 		}
 
 		l.Warnf("Pipeline %q contains values interpolated from the following secret environment variables: %v, which could leak sensitive information into the Buildkite UI.", src, secretsFound)
-		l.Warnf("This pipeline will still be uploaded, but if you'd like to to prevent this from happening, you can use the `--reject-secrets` cli flag, or the `BUILDKITE_AGENT_PIPELINE_UPLOAD_REJECT_SECRETS` environment variable, which will make the `buildkite-agent pipeline upload` command fail if it finds secrets in the pipeline.")
-		l.Warnf("The behaviour in the above flags will become default in Buildkite Agent v4")
+		l.Warnf("This pipeline will still be uploaded, because you've used the `--allow-secrets` flag or the `BUILDKITE_AGENT_PIPELINE_UPLOAD_ALLOW_SECRETS` environment variable.")
+		l.Warnf("This behaviour is insecure, and may be removed in a future version of the agent")
 	}
 
 	return nil

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -19,8 +19,8 @@ func TestSearchForSecrets(t *testing.T) {
 	t.Parallel()
 
 	cfg := &PipelineUploadConfig{
-		RedactedVars:  []string{"SEKRET", "SSH_KEY"},
-		RejectSecrets: true,
+		RedactedVars: []string{"SEKRET", "SSH_KEY"},
+		AllowSecrets: false,
 	}
 
 	plainPipeline := &pipeline.Pipeline{
@@ -157,8 +157,8 @@ func TestPipelineInterpolationCaseSensitivity(t *testing.T) {
 	t.Parallel()
 
 	cfg := &PipelineUploadConfig{
-		RedactedVars:  []string{},
-		RejectSecrets: true,
+		RedactedVars: []string{},
+		AllowSecrets: false,
 	}
 
 	// this is the data structure we use for environment variables in the agent
@@ -240,8 +240,8 @@ steps:
 - command: echo $GREETING
 `
 			cfg := &PipelineUploadConfig{
-				RedactedVars:  []string{},
-				RejectSecrets: true,
+				RedactedVars: []string{},
+				AllowSecrets: false,
 			}
 			ctx := context.Background()
 			if test.preferRuntimeEnv {
@@ -305,7 +305,7 @@ steps:
 			cfg := &PipelineUploadConfig{
 				NoInterpolation: !test.interpolation,
 				RedactedVars:    []string{},
-				RejectSecrets:   true,
+				AllowSecrets:    false,
 			}
 			ctx := context.Background()
 


### PR DESCRIPTION
### Description

It's like #1593, but for v4.

> Further to https://github.com/buildkite/agent/pull/1589, pipeline secret redaction should become default in Agent v4.
> 
> This PR makes it so that default behaviour is to disallow pipeline uploads containing interpolations of potentially secret environment variables. We add flag to buildkite-agent pipeline upload to allow uploading pipelines with these secrets, but note in the CLI help and the log output that this behaviour is insecure.
> 
> We won't merge this until we release Agent v4

### Context

Closes #1593

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)


### Disclosures / Credits

@moskyb