### PR TITLE
feat: add jobsRunning gauge and labels for Prometheus metrics

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -506,15 +507,27 @@ func (a *AgentWorker) RunJob(ctx context.Context, acceptResponse *api.Job, ignor
 	a.setBusy(acceptResponse.ID)
 	defer a.setIdle()
 
+	priorityLabel := strconv.Itoa(acceptResponse.Priority)
+	queueLabel := acceptResponse.Env["BUILDKITE_AGENT_META_DATA_QUEUE"]
+
+	// Legacy unlabelled counters; kept incrementing in lockstep with the
+	// labelled counters below so existing scrape consumers see no shape change.
 	jobsStarted.Inc()
 	defer jobsEnded.Inc()
+
+	jobsStartedWithLabels.WithLabelValues(priorityLabel, queueLabel).Inc()
+	defer jobsEndedWithLabels.WithLabelValues(priorityLabel, queueLabel).Inc()
+
+	running := jobsRunning.WithLabelValues(priorityLabel, queueLabel)
+	running.Inc()
+	defer running.Dec()
 
 	jobMetricsScope := a.metrics.With(metrics.Tags{
 		"pipeline": acceptResponse.Env["BUILDKITE_PIPELINE_SLUG"],
 		"org":      acceptResponse.Env["BUILDKITE_ORGANIZATION_SLUG"],
 		"branch":   acceptResponse.Env["BUILDKITE_BRANCH"],
 		"source":   acceptResponse.Env["BUILDKITE_SOURCE"],
-		"queue":    acceptResponse.Env["BUILDKITE_AGENT_META_DATA_QUEUE"],
+		"queue":    queueLabel,
 	})
 
 	// Now that we've got a job to do, we can start it.

--- a/agent/metrics.go
+++ b/agent/metrics.go
@@ -57,6 +57,9 @@ var (
 		Buckets:   prometheus.LinearBuckets(1, 1, 20),
 	})
 
+	// Original unlabelled counters — kept for backwards compatibility with
+	// existing scrape consumers. New code should prefer the labelled
+	// jobsStartedWithLabels / jobsEndedWithLabels counters below.
 	jobsStarted = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "jobs",
@@ -69,6 +72,29 @@ var (
 		Name:      "ended_total",
 		Help:      "Count of jobs ended (any outcome)",
 	})
+
+	// Labelled counters added for A-1100. These coexist with the unlabelled
+	// jobsStarted / jobsEnded above; both are incremented at the same call
+	// site so the unlabelled total always equals sum() over the labelled.
+	jobsStartedWithLabels = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: "jobs",
+		Name:      "started_with_labels_total",
+		Help:      "Count of jobs started, labelled by job priority and agent queue",
+	}, []string{"priority", "queue"})
+	jobsEndedWithLabels = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: "jobs",
+		Name:      "ended_with_labels_total",
+		Help:      "Count of jobs ended (any outcome), labelled by job priority and agent queue",
+	}, []string{"priority", "queue"})
+
+	jobsRunning = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metricsNamespace,
+		Subsystem: "jobs",
+		Name:      "running",
+		Help:      "Number of jobs currently running on this agent, labelled by job priority and agent queue",
+	}, []string{"priority", "queue"})
 
 	logChunksUploaded = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: metricsNamespace,

--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -1,0 +1,177 @@
+package agent
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestJobCountersAreLabelled(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name         string
+		job          *api.Job
+		wantPriority string
+		wantQueue    string
+	}{
+		{
+			name: "default priority and explicit queue",
+			job: &api.Job{
+				Priority: 0,
+				Env:      map[string]string{"BUILDKITE_AGENT_META_DATA_QUEUE": "default"},
+			},
+			wantPriority: "0",
+			wantQueue:    "default",
+		},
+		{
+			name: "explicit priority",
+			job: &api.Job{
+				Priority: 42,
+				Env:      map[string]string{"BUILDKITE_AGENT_META_DATA_QUEUE": "high-priority"},
+			},
+			wantPriority: "42",
+			wantQueue:    "high-priority",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			priority := strconv.Itoa(test.job.Priority)
+			queue := test.job.Env["BUILDKITE_AGENT_META_DATA_QUEUE"]
+
+			if priority != test.wantPriority {
+				t.Errorf("priority label = %q, want %q", priority, test.wantPriority)
+			}
+			if queue != test.wantQueue {
+				t.Errorf("queue label = %q, want %q", queue, test.wantQueue)
+			}
+
+			namedLabels := prometheus.Labels{"priority": priority, "queue": queue}
+
+			startsBeforePos := testutil.ToFloat64(jobsStartedWithLabels.WithLabelValues(priority, queue))
+			endsBeforePos := testutil.ToFloat64(jobsEndedWithLabels.WithLabelValues(priority, queue))
+			startsBeforeName := testutil.ToFloat64(jobsStartedWithLabels.With(namedLabels))
+			endsBeforeName := testutil.ToFloat64(jobsEndedWithLabels.With(namedLabels))
+
+			// Increment the same way RunJob does.
+			jobsStartedWithLabels.WithLabelValues(priority, queue).Inc()
+			jobsEndedWithLabels.WithLabelValues(priority, queue).Inc()
+
+			// The increment is observed via the positional API.
+			if got := testutil.ToFloat64(jobsStartedWithLabels.WithLabelValues(priority, queue)) - startsBeforePos; got != 1 {
+				t.Errorf("jobsStartedWithLabels{priority=%q,queue=%q} positional delta = %v, want 1", priority, queue, got)
+			}
+			if got := testutil.ToFloat64(jobsEndedWithLabels.WithLabelValues(priority, queue)) - endsBeforePos; got != 1 {
+				t.Errorf("jobsEndedWithLabels{priority=%q,queue=%q} positional delta = %v, want 1", priority, queue, got)
+			}
+
+			// The same increment is observed via the name-keyed API.
+			// If metrics.go registered the labels in a different order than
+			// agent_worker.go passes them to WithLabelValues, this read
+			// would land on a different counter than the one we incremented
+			// and the delta would be 0.
+			if got := testutil.ToFloat64(jobsStartedWithLabels.With(namedLabels)) - startsBeforeName; got != 1 {
+				t.Errorf("jobsStartedWithLabels{priority=%q,queue=%q} name-keyed delta = %v, want 1 — label registration order in metrics.go may not match WithLabelValues argument order in agent_worker.go", priority, queue, got)
+			}
+			if got := testutil.ToFloat64(jobsEndedWithLabels.With(namedLabels)) - endsBeforeName; got != 1 {
+				t.Errorf("jobsEndedWithLabels{priority=%q,queue=%q} name-keyed delta = %v, want 1 — label registration order in metrics.go may not match WithLabelValues argument order in agent_worker.go", priority, queue, got)
+			}
+		})
+	}
+
+	// Incrementing one label combination must not affect another.
+	// This catches a class of regressions where someone might accidentally
+	// register a Counter (no labels) instead of CounterVec, in which case all
+	// "label combinations" would alias to the same single counter.
+	t.Run("label combinations are independent", func(t *testing.T) {
+		t.Parallel()
+
+		a := testutil.ToFloat64(jobsStartedWithLabels.WithLabelValues("999", "queue-a"))
+		b := testutil.ToFloat64(jobsStartedWithLabels.WithLabelValues("999", "queue-b"))
+
+		jobsStartedWithLabels.WithLabelValues("999", "queue-a").Inc()
+
+		if got := testutil.ToFloat64(jobsStartedWithLabels.WithLabelValues("999", "queue-a")) - a; got != 1 {
+			t.Errorf("queue-a delta = %v, want 1", got)
+		}
+		if got := testutil.ToFloat64(jobsStartedWithLabels.WithLabelValues("999", "queue-b")) - b; got != 0 {
+			t.Errorf("queue-b should be unaffected by queue-a increment, delta = %v, want 0", got)
+		}
+	})
+}
+
+func TestJobRunningGaugeIsLabelled(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name         string
+		job          *api.Job
+		wantPriority string
+		wantQueue    string
+	}{
+		{
+			name: "default priority and explicit queue",
+			job: &api.Job{
+				Priority: 0,
+				Env:      map[string]string{"BUILDKITE_AGENT_META_DATA_QUEUE": "default"},
+			},
+			wantPriority: "0",
+			wantQueue:    "default",
+		},
+		{
+			name: "explicit priority",
+			job: &api.Job{
+				Priority: 42,
+				Env:      map[string]string{"BUILDKITE_AGENT_META_DATA_QUEUE": "high-priority"},
+			},
+			wantPriority: "42",
+			wantQueue:    "high-priority",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			priority := strconv.Itoa(test.job.Priority)
+			queue := test.job.Env["BUILDKITE_AGENT_META_DATA_QUEUE"]
+
+			if priority != test.wantPriority {
+				t.Errorf("priority label = %q, want %q", priority, test.wantPriority)
+			}
+			if queue != test.wantQueue {
+				t.Errorf("queue label = %q, want %q", queue, test.wantQueue)
+			}
+
+			namedLabels := prometheus.Labels{"priority": priority, "queue": queue}
+
+			beforePos := testutil.ToFloat64(jobsRunning.WithLabelValues(priority, queue))
+			beforeName := testutil.ToFloat64(jobsRunning.With(namedLabels))
+
+			// Mirror the start-of-job pattern in RunJob: cache the labelled
+			// gauge once, Inc on entry, Dec on exit.
+			running := jobsRunning.WithLabelValues(priority, queue)
+			running.Inc()
+
+			// During the "running" window the gauge should be +1.
+			if got := testutil.ToFloat64(jobsRunning.WithLabelValues(priority, queue)) - beforePos; got != 1 {
+				t.Errorf("jobsRunning{priority=%q,queue=%q} during-Inc positional delta = %v, want 1", priority, queue, got)
+			}
+			if got := testutil.ToFloat64(jobsRunning.With(namedLabels)) - beforeName; got != 1 {
+				t.Errorf("jobsRunning{priority=%q,queue=%q} during-Inc name-keyed delta = %v, want 1 — label registration order in metrics.go may not match WithLabelValues argument order in agent_worker.go", priority, queue, got)
+			}
+
+			// On exit the deferred Dec returns the gauge to its prior value.
+			running.Dec()
+
+			if got := testutil.ToFloat64(jobsRunning.WithLabelValues(priority, queue)) - beforePos; got != 0 {
+				t.Errorf("jobsRunning{priority=%q,queue=%q} after Inc/Dec positional delta = %v, want 0", priority, queue, got)
+			}
+			if got := testutil.ToFloat64(jobsRunning.With(namedLabels)) - beforeName; got != 0 {
+				t.Errorf("jobsRunning{priority=%q,queue=%q} after Inc/Dec name-keyed delta = %v, want 0", priority, queue, got)
+			}
+		})
+	}
+}

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -27,6 +27,7 @@ type Job struct {
 	RunnableAt            string                     `json:"runnable_at,omitempty"`
 	ChunksFailedCount     int                        `json:"chunks_failed_count,omitempty"`
 	TraceParent           string                     `json:"traceparent"`
+	Priority              int                        `json:"priority"`
 }
 
 type JobState struct {


### PR DESCRIPTION
### Description

- Adds priority and queue labels to Prometheus job start/ended counters
- Adds jobsRunning gauge for Prometheus with priority and queue labels

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

### Context

Resolves [A-1100](https://linear.app/buildkite/issue/A-1100/add-job-metadata-labels-to-agent-prometheus-metrics)
Corresponding PR in buildkite/buildkite https://github.com/buildkite/buildkite/pull/29440
<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [x] Unit tests added to cover changes
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits
In consultation with Claude Opus 4.7
<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
