### PR TITLE
Add support for git commit verification

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -24,6 +24,7 @@ type AgentConfiguration struct {
 	GitCloneFlags                   string
 	GitCloneMirrorFlags             string
 	GitCleanFlags                   string
+	GitCommitVerification           string
 	GitFetchFlags                   string
 	GitSubmodules                   bool
 	GitSubmoduleCloneConfig         []string

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -631,6 +631,7 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 		setEnv("BUILDKITE_GIT_CHECKOUT_TIMEOUT", strconv.Itoa(r.conf.AgentConfiguration.GitCheckoutTimeout))
 	}
 	setEnv("BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG", strings.Join(r.conf.AgentConfiguration.GitSubmoduleCloneConfig, ","))
+	setEnv("BUILDKITE_GIT_COMMIT_VERIFICATION", r.conf.AgentConfiguration.GitCommitVerification)
 
 	setEnv("BUILDKITE_SHELL", r.conf.AgentConfiguration.Shell)
 	setEnv("BUILDKITE_HOOKS_SHELL", r.conf.AgentConfiguration.HooksShell)

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -167,6 +167,7 @@ type AgentStartConfig struct {
 	GitMirrorsLockTimeout       int      `cli:"git-mirrors-lock-timeout"`
 	GitMirrorsSkipUpdate        bool     `cli:"git-mirrors-skip-update"`
 	GitCheckoutTimeout          int      `cli:"git-checkout-timeout"`
+	GitCommitVerification       string   `cli:"git-commit-verification"`
 	NoGitSubmodules             bool     `cli:"no-git-submodules"`
 	GitSubmoduleCloneConfig     []string `cli:"git-submodule-clone-config"`
 	SkipCheckout                bool     `cli:"skip-checkout"`
@@ -371,7 +372,8 @@ var AgentStartCommand = cli.Command{
 	Name:        "start",
 	Usage:       "Starts a Buildkite agent",
 	Description: startDescription,
-	Flags: append(globalFlags(),
+	Flags: append(
+		globalFlags(),
 		cli.StringFlag{
 			Name:   "config",
 			Value:  "",
@@ -534,6 +536,7 @@ var AgentStartCommand = cli.Command{
 		GitCheckoutFlagsFlag,
 		GitCloneFlagsFlag,
 		GitCleanFlagsFlag,
+		GitCommitVerificationFlag,
 		GitFetchFlagsFlag,
 		GitCloneMirrorFlagsFlag,
 		GitMirrorsPathFlag,
@@ -863,6 +866,11 @@ var AgentStartCommand = cli.Command{
 			}
 		}
 
+		// Validate the commit verification option input
+		if v := cfg.GitCommitVerification; v != "" && v != "strict" && v != "warn" {
+			return fmt.Errorf("invalid value for --git-commit-verification: %q (must be \"strict\" or \"warn\")", v)
+		}
+
 		// Force some settings if on Windows (these aren't supported yet)
 		if runtime.GOOS == "windows" {
 			cfg.NoPTY = true
@@ -1070,6 +1078,7 @@ var AgentStartCommand = cli.Command{
 			GitCloneFlags:                   cfg.GitCloneFlags,
 			GitCloneMirrorFlags:             cfg.GitCloneMirrorFlags,
 			GitCleanFlags:                   cfg.GitCleanFlags,
+			GitCommitVerification:           cfg.GitCommitVerification,
 			GitFetchFlags:                   cfg.GitFetchFlags,
 			GitSubmodules:                   !cfg.NoGitSubmodules,
 			GitSubmoduleCloneConfig:         cfg.GitSubmoduleCloneConfig,

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -78,6 +78,7 @@ type BootstrapConfig struct {
 	GitCloneMirrorFlags          string   `cli:"git-clone-mirror-flags"`
 	GitCleanFlags                string   `cli:"git-clean-flags"`
 	GitSSHKey                    string   `cli:"git-ssh-key"`
+	GitCommitVerification        string   `cli:"git-commit-verification"`
 	GitMirrorsPath               string   `cli:"git-mirrors-path" normalize:"filepath"`
 	GitMirrorCheckoutMode        string   `cli:"git-mirror-checkout-mode"`
 	GitMirrorsLockTimeout        int      `cli:"git-mirrors-lock-timeout"`
@@ -243,6 +244,7 @@ var BootstrapCommand = cli.Command{
 		GitCloneFlagsFlag,
 		GitCloneMirrorFlagsFlag,
 		GitCleanFlagsFlag,
+		GitCommitVerificationFlag,
 		GitFetchFlagsFlag,
 		cli.StringFlag{
 			Name:   "git-ssh-key",
@@ -453,6 +455,7 @@ var BootstrapCommand = cli.Command{
 			Debug:                        cfg.Debug,
 			GitCheckoutFlags:             cfg.GitCheckoutFlags,
 			GitCleanFlags:                cfg.GitCleanFlags,
+			GitCommitVerification:        cfg.GitCommitVerification,
 			GitCloneFlags:                cfg.GitCloneFlags,
 			GitCloneMirrorFlags:          cfg.GitCloneMirrorFlags,
 			GitFetchFlags:                cfg.GitFetchFlags,

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -237,6 +237,12 @@ var (
 		// -q: quiet, only report errors
 	}
 
+	GitCommitVerificationFlag = cli.StringFlag{
+		Name:   "git-commit-verification",
+		Usage:  "Enable git commit verification",
+		EnvVar: "BUILDKITE_GIT_COMMIT_VERIFICATION",
+	}
+
 	GitFetchFlagsFlag = cli.StringFlag{
 		Name:   "git-fetch-flags",
 		Value:  "-v --prune",

--- a/env/protected.go
+++ b/env/protected.go
@@ -64,6 +64,7 @@ var protectedEnv = map[string]protection{
 	"BUILDKITE_GIT_CLEAN_FLAGS":                 {mutableFromWithinJob: true},
 	"BUILDKITE_GIT_CLONE_FLAGS":                 {mutableFromWithinJob: true},
 	"BUILDKITE_GIT_CLONE_MIRROR_FLAGS":          {mutableFromWithinJob: true},
+	"BUILDKITE_GIT_COMMIT_VERIFICATION":         {},
 	"BUILDKITE_GIT_FETCH_FLAGS":                 {mutableFromWithinJob: true},
 	"BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT":        {},
 	"BUILDKITE_GIT_MIRRORS_PATH":                {},

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -968,6 +968,10 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (retErr error) {
 		return err
 	}
 
+	if err := e.verifyCommit(ctx); err != nil {
+		return err
+	}
+
 	gitCheckoutFlags := e.GitCheckoutFlags
 
 	if e.Commit == "HEAD" {

--- a/internal/job/commit_verification.go
+++ b/internal/job/commit_verification.go
@@ -1,0 +1,134 @@
+package job
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/agent/v3/internal/shell"
+)
+
+// ErrCommitVerificationFailed indicates that git has definitively determined
+// the commit is not on the specified branch. This is the security-relevant case.
+var ErrCommitVerificationFailed = errors.New("commit verification failed")
+
+// ErrCommitVerificationUnavailable indicates that git was unable to perform
+// the ancestry check (e.g. due to repo corruption, misconfigured remotes, etc).
+// This is NOT evidence of an attack — it's an infrastructure problem.
+var ErrCommitVerificationUnavailable = errors.New("commit verification unavailable")
+
+// checkCommitOnBranch performs the actual git ancestry check, handling shallow
+// clones by deepening or unshallowing as needed. It returns:
+//   - nil if the commit is verified on the branch
+//   - ErrCommitVerificationFailed if the commit is definitively not on the branch
+//   - ErrCommitVerificationUnavailable if the check cannot be performed
+func (e *Executor) checkCommitOnBranch(ctx context.Context) error {
+	e.shell.Commentf("Verifying commit %q is on branch %q", e.Commit, e.Branch)
+
+	for _, fetchFlag := range []string{"", "--deepen=50", "--unshallow"} {
+		if fetchFlag != "" {
+			// After the first iteration, try to unshallow the repo (a bit or a lot)
+			e.shell.Commentf("Deepening checkout to verify commit (%s)...", fetchFlag)
+			fetchErr := e.shell.Command("git", "fetch", fetchFlag).Run(ctx)
+			if fetchErr != nil {
+				return fmt.Errorf("%w: unable to verify commit %q on branch %q: %w", ErrCommitVerificationUnavailable, e.Commit, e.Branch, fetchErr)
+			}
+		}
+
+		// Try the ancestry check
+		err := e.shell.Command("git", "merge-base", "--is-ancestor", e.Commit, e.Branch).Run(ctx)
+
+		switch shell.ExitCode(err) {
+		case 0:
+			return nil // verified!
+		case 1:
+			return fmt.Errorf("%w: commit %q is not on branch %q", ErrCommitVerificationFailed, e.Commit, e.Branch)
+		case 128:
+			// unclear — continue below
+		default:
+			return fmt.Errorf("%w: unable to verify commit %q on branch %q: %w", ErrCommitVerificationUnavailable, e.Commit, e.Branch, err)
+		}
+
+		// On the first iteration, check if the checkout is shallow. If it is
+		// not, the 128 exit code reflects some other error.
+		if fetchFlag != "" {
+			continue
+		}
+		output, shallowErr := e.shell.Command("git", "rev-parse", "--is-shallow-repository").RunAndCaptureStdout(ctx)
+		if shallowErr != nil {
+			return fmt.Errorf("%w: unable to verify commit %q on branch %q: %w", ErrCommitVerificationUnavailable, e.Commit, e.Branch, shallowErr)
+		}
+
+		if strings.TrimSpace(output) != "true" {
+			// Not shallow — this is a genuine error
+			return fmt.Errorf("%w: unable to verify commit %q on branch %q: %w", ErrCommitVerificationUnavailable, e.Commit, e.Branch, err)
+		}
+	}
+
+	// All attempts exhausted — verification is unavailable
+	return fmt.Errorf("%w: unable to verify commit %q on branch %q after exhausting fetch strategies", ErrCommitVerificationUnavailable, e.Commit, e.Branch)
+}
+
+// verifyCommit is called if the user has commit verification enabled. It ensures that the commit we are
+// asked to build exists and is reachable on the branch we are given.
+func (e *Executor) verifyCommit(ctx context.Context) error {
+	// Skip if not enabled
+	if e.GitCommitVerification == "" {
+		return nil
+	}
+
+	// Skip if commit is HEAD (nothing to verify)
+	if e.Commit == "HEAD" {
+		e.shell.Commentf("Skipping commit verification: commit is HEAD")
+		return nil
+	}
+
+	// Skip if we haven't been given a branch - e.g. it's a tag push event
+	if e.Branch == "" {
+		e.shell.Commentf("Skipping commit verification: no branch specified")
+		return nil
+	}
+
+	// Skip if this is a tag build — tags are not branch-specific
+	if e.Tag != "" {
+		e.shell.Commentf("Skipping commit verification: tag build (%s)", e.Tag)
+		return nil
+	}
+
+	// Skip if this is a PR build — the commit may be on a merge ref, not the target branch
+	if e.PullRequest != "" {
+		e.shell.Commentf("Skipping commit verification: pull request build (#%s)", e.PullRequest)
+		return nil
+	}
+
+	// Skip if a custom refspec is set — the fetch may not populate standard branch refs,
+	// making ancestry verification unreliable
+	if e.RefSpec != "" {
+		e.shell.Commentf("Skipping commit verification: custom refspec is set (%s)", e.RefSpec)
+		return nil
+	}
+
+	// Perform the verification
+	err := e.checkCommitOnBranch(ctx)
+
+	// Verification passed
+	if err == nil {
+		return nil
+	}
+
+	// Definitive failure — commit is provably not on the branch
+	if errors.Is(err, ErrCommitVerificationFailed) {
+		if e.GitCommitVerification == "strict" {
+			return err
+		}
+		e.shell.Warningf("Commit verification failed: %v", err)
+		return nil
+	}
+
+	// Verification unavailable — infrastructure issue, not a security concern.
+	// We always warn but never block, even in strict mode, to avoid users
+	// disabling verification entirely due to infrastructure false positives.
+	e.shell.Warningf("Commit verification unavailable: %v", err)
+	return nil
+}

--- a/internal/job/commit_verification_test.go
+++ b/internal/job/commit_verification_test.go
@@ -1,0 +1,416 @@
+package job
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildkite/agent/v3/internal/job/githttptest"
+	"github.com/buildkite/agent/v3/internal/shell"
+)
+
+func TestVerifyCommit(t *testing.T) {
+	// Table-driven tests for the skip conditions — these don't need a real git repo
+	skipTests := []struct {
+		name   string
+		config ExecutorConfig
+	}{
+		{
+			name: "skips when verification is disabled",
+			config: ExecutorConfig{
+				GitCommitVerification: "",
+				Commit:                "abc123",
+				Branch:                "main",
+			},
+		},
+		{
+			name: "skips when commit is HEAD",
+			config: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                "HEAD",
+				Branch:                "main",
+			},
+		},
+		{
+			name: "skips when branch is empty",
+			config: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                "abc123",
+				Branch:                "",
+			},
+		},
+		{
+			name: "skips for PR builds",
+			config: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                "abc123",
+				Branch:                "main",
+				PullRequest:           "123",
+			},
+		},
+		{
+			name: "skips for tag builds",
+			config: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                "abc123",
+				Branch:                "main",
+				Tag:                   "v1.0.0",
+			},
+		},
+		{
+			name: "skips for custom refspec",
+			config: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                "abc123",
+				Branch:                "main",
+				RefSpec:               "refs/custom/spec",
+			},
+		},
+	}
+
+	for _, tt := range skipTests {
+		t.Run(tt.name, func(t *testing.T) {
+			sh, err := shell.New()
+			if err != nil {
+				t.Fatalf("shell.New() error = %v", err)
+			}
+			e := &Executor{
+				shell:          sh,
+				ExecutorConfig: tt.config,
+			}
+			err = e.verifyCommit(context.Background())
+			if err != nil {
+				t.Errorf("verifyCommit() error = %v, want nil", err)
+			}
+		})
+	}
+
+	// Git-dependent tests — these need a real repo to verify against
+	t.Run("passes when commit is on branch", func(t *testing.T) {
+		t.Setenv("GIT_AUTHOR_NAME", "Buildkite Agent")
+		t.Setenv("GIT_AUTHOR_EMAIL", "agent@example.com")
+		t.Setenv("GIT_COMMITTER_NAME", "Buildkite Agent")
+		t.Setenv("GIT_COMMITTER_EMAIL", "agent@example.com")
+
+		ctx := context.Background()
+
+		s := githttptest.NewServer()
+		defer s.Close()
+
+		err := s.CreateRepository("verify-on-branch")
+		if err != nil {
+			t.Fatalf("CreateRepository error = %v", err)
+		}
+
+		_, err = s.InitRepository("verify-on-branch")
+		if err != nil {
+			t.Fatalf("InitRepository error = %v", err)
+		}
+
+		// PushBranch creates a new branch with a commit and returns the commit SHA
+		commit, _, err := s.PushBranch("verify-on-branch", "feature")
+		if err != nil {
+			t.Fatalf("PushBranch error = %v", err)
+		}
+
+		// Clone the repo into a temp dir
+		cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
+		if err != nil {
+			t.Fatalf("MkdirTemp error = %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
+
+		sh, err := shell.New()
+		if err != nil {
+			t.Fatalf("shell.New() error = %v", err)
+		}
+
+		// Clone and fetch all branches
+		if err := sh.Command("git", "clone", s.RepoURL("verify-on-branch"), cloneDir).Run(ctx); err != nil {
+			t.Fatalf("git clone error = %v", err)
+		}
+		if err := sh.Chdir(cloneDir); err != nil {
+			t.Fatalf("Chdir error = %v", err)
+		}
+		if err := sh.Command("git", "fetch", "origin", "feature").Run(ctx); err != nil {
+			t.Fatalf("git fetch error = %v", err)
+		}
+
+		e := &Executor{
+			shell: sh,
+			ExecutorConfig: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                commit,
+				Branch:                "origin/feature",
+			},
+		}
+
+		err = e.verifyCommit(ctx)
+		if err != nil {
+			t.Errorf("verifyCommit() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("fails when commit is not on branch", func(t *testing.T) {
+		t.Setenv("GIT_AUTHOR_NAME", "Buildkite Agent")
+		t.Setenv("GIT_AUTHOR_EMAIL", "agent@example.com")
+		t.Setenv("GIT_COMMITTER_NAME", "Buildkite Agent")
+		t.Setenv("GIT_COMMITTER_EMAIL", "agent@example.com")
+
+		ctx := context.Background()
+
+		s := githttptest.NewServer()
+		defer s.Close()
+
+		err := s.CreateRepository("verify-not-on-branch")
+		if err != nil {
+			t.Fatalf("CreateRepository error = %v", err)
+		}
+
+		_, err = s.InitRepository("verify-not-on-branch")
+		if err != nil {
+			t.Fatalf("InitRepository error = %v", err)
+		}
+
+		// PushBranch creates both branches from main with the same file content,
+		// which produces identical commit SHAs. We need to make a unique commit
+		// on feature-b so the branches genuinely diverge.
+		commit, _, err := s.PushBranch("verify-not-on-branch", "feature-a")
+		if err != nil {
+			t.Fatalf("PushBranch(feature-a) error = %v", err)
+		}
+
+		// Clone, create feature-b manually with different content
+		workDir, err := os.MkdirTemp("", "verify-commit-work-")
+		if err != nil {
+			t.Fatalf("MkdirTemp error = %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(workDir) }) //nolint:errcheck // Best-effort cleanup.
+
+		setupSh, err := shell.New()
+		if err != nil {
+			t.Fatalf("shell.New() error = %v", err)
+		}
+		if err := setupSh.Command("git", "clone", s.RepoURL("verify-not-on-branch"), workDir).Run(ctx); err != nil {
+			t.Fatalf("git clone error = %v", err)
+		}
+		if err := setupSh.Chdir(workDir); err != nil {
+			t.Fatalf("Chdir error = %v", err)
+		}
+		if err := setupSh.Command("git", "checkout", "-b", "feature-b").Run(ctx); err != nil {
+			t.Fatalf("git checkout error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(workDir, "unique-b.txt"), []byte("unique content for branch b"), 0o644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+		if err := setupSh.Command("git", "add", "unique-b.txt").Run(ctx); err != nil {
+			t.Fatalf("git add error = %v", err)
+		}
+		if err := setupSh.Command("git", "commit", "-m", "unique commit on feature-b").Run(ctx); err != nil {
+			t.Fatalf("git commit error = %v", err)
+		}
+		if err := setupSh.Command("git", "push", "origin", "feature-b").Run(ctx); err != nil {
+			t.Fatalf("git push error = %v", err)
+		}
+
+		// Now clone fresh and verify
+		cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
+		if err != nil {
+			t.Fatalf("MkdirTemp error = %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
+
+		sh, err := shell.New()
+		if err != nil {
+			t.Fatalf("shell.New() error = %v", err)
+		}
+
+		if err := sh.Command("git", "clone", s.RepoURL("verify-not-on-branch"), cloneDir).Run(ctx); err != nil {
+			t.Fatalf("git clone error = %v", err)
+		}
+		if err := sh.Chdir(cloneDir); err != nil {
+			t.Fatalf("Chdir error = %v", err)
+		}
+		if err := sh.Command("git", "fetch", "origin", "feature-a:refs/remotes/origin/feature-a", "feature-b:refs/remotes/origin/feature-b").Run(ctx); err != nil {
+			t.Fatalf("git fetch error = %v", err)
+		}
+
+		e := &Executor{
+			shell: sh,
+			ExecutorConfig: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                commit,             // commit from feature-a
+				Branch:                "origin/feature-b", // but checking against feature-b
+			},
+		}
+
+		err = e.verifyCommit(ctx)
+		if err == nil {
+			t.Errorf("verifyCommit() error = nil, want error about commit not on branch")
+		}
+	})
+
+	t.Run("warn mode logs warning but does not fail", func(t *testing.T) {
+		t.Setenv("GIT_AUTHOR_NAME", "Buildkite Agent")
+		t.Setenv("GIT_AUTHOR_EMAIL", "agent@example.com")
+		t.Setenv("GIT_COMMITTER_NAME", "Buildkite Agent")
+		t.Setenv("GIT_COMMITTER_EMAIL", "agent@example.com")
+
+		ctx := context.Background()
+
+		s := githttptest.NewServer()
+		defer s.Close()
+
+		err := s.CreateRepository("verify-warn-mode")
+		if err != nil {
+			t.Fatalf("CreateRepository error = %v", err)
+		}
+
+		_, err = s.InitRepository("verify-warn-mode")
+		if err != nil {
+			t.Fatalf("InitRepository error = %v", err)
+		}
+
+		commit, _, err := s.PushBranch("verify-warn-mode", "feature-a")
+		if err != nil {
+			t.Fatalf("PushBranch(feature-a) error = %v", err)
+		}
+
+		// Create feature-b with unique content so the branches genuinely diverge
+		workDir, err := os.MkdirTemp("", "verify-commit-work-")
+		if err != nil {
+			t.Fatalf("MkdirTemp error = %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(workDir) }) //nolint:errcheck // Best-effort cleanup.
+
+		setupSh, err := shell.New()
+		if err != nil {
+			t.Fatalf("shell.New() error = %v", err)
+		}
+		if err := setupSh.Command("git", "clone", s.RepoURL("verify-warn-mode"), workDir).Run(ctx); err != nil {
+			t.Fatalf("git clone error = %v", err)
+		}
+		if err := setupSh.Chdir(workDir); err != nil {
+			t.Fatalf("Chdir error = %v", err)
+		}
+		if err := setupSh.Command("git", "checkout", "-b", "feature-b").Run(ctx); err != nil {
+			t.Fatalf("git checkout error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(workDir, "unique-b.txt"), []byte("unique content for branch b"), 0o644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+		if err := setupSh.Command("git", "add", "unique-b.txt").Run(ctx); err != nil {
+			t.Fatalf("git add error = %v", err)
+		}
+		if err := setupSh.Command("git", "commit", "-m", "unique commit on feature-b").Run(ctx); err != nil {
+			t.Fatalf("git commit error = %v", err)
+		}
+		if err := setupSh.Command("git", "push", "origin", "feature-b").Run(ctx); err != nil {
+			t.Fatalf("git push error = %v", err)
+		}
+
+		cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
+		if err != nil {
+			t.Fatalf("MkdirTemp error = %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
+
+		sh, err := shell.New()
+		if err != nil {
+			t.Fatalf("shell.New() error = %v", err)
+		}
+
+		if err := sh.Command("git", "clone", s.RepoURL("verify-warn-mode"), cloneDir).Run(ctx); err != nil {
+			t.Fatalf("git clone error = %v", err)
+		}
+		if err := sh.Chdir(cloneDir); err != nil {
+			t.Fatalf("Chdir error = %v", err)
+		}
+		if err := sh.Command("git", "fetch", "origin", "feature-a:refs/remotes/origin/feature-a", "feature-b:refs/remotes/origin/feature-b").Run(ctx); err != nil {
+			t.Fatalf("git fetch error = %v", err)
+		}
+
+		e := &Executor{
+			shell: sh,
+			ExecutorConfig: ExecutorConfig{
+				GitCommitVerification: "warn",
+				Commit:                commit,             // commit from feature-a
+				Branch:                "origin/feature-b", // but checking against feature-b
+			},
+		}
+
+		// In warn mode, verification failure should NOT return an error
+		err = e.verifyCommit(ctx)
+		if err != nil {
+			t.Errorf("verifyCommit() in warn mode error = %v, want nil", err)
+		}
+	})
+
+	t.Run("passes after deepening a shallow clone", func(t *testing.T) {
+		t.Setenv("GIT_AUTHOR_NAME", "Buildkite Agent")
+		t.Setenv("GIT_AUTHOR_EMAIL", "agent@example.com")
+		t.Setenv("GIT_COMMITTER_NAME", "Buildkite Agent")
+		t.Setenv("GIT_COMMITTER_EMAIL", "agent@example.com")
+
+		ctx := context.Background()
+
+		s := githttptest.NewServer()
+		defer s.Close()
+
+		err := s.CreateRepository("verify-shallow")
+		if err != nil {
+			t.Fatalf("CreateRepository error = %v", err)
+		}
+
+		_, err = s.InitRepository("verify-shallow")
+		if err != nil {
+			t.Fatalf("InitRepository error = %v", err)
+		}
+
+		// The initial commit from InitRepository is on main.
+		// PushBranch adds one more commit on a feature branch.
+		// We need the initial commit SHA to test — it will be beyond depth=1.
+		commit, _, err := s.PushBranch("verify-shallow", "feature")
+		if err != nil {
+			t.Fatalf("PushBranch error = %v", err)
+		}
+
+		// Get the initial commit (parent of the feature commit) by reading it from the server repo
+		cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
+		if err != nil {
+			t.Fatalf("MkdirTemp error = %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
+
+		sh, err := shell.New()
+		if err != nil {
+			t.Fatalf("shell.New() error = %v", err)
+		}
+
+		// Shallow clone with depth=1 — only gets the tip commit
+		if err := sh.Command("git", "clone", "--depth=1", "--branch", "feature", s.RepoURL("verify-shallow"), cloneDir).Run(ctx); err != nil {
+			t.Fatalf("git clone error = %v", err)
+		}
+		if err := sh.Chdir(cloneDir); err != nil {
+			t.Fatalf("Chdir error = %v", err)
+		}
+
+		// The tip commit is the one from PushBranch — it IS on the branch,
+		// but let's verify the shallow clone scenario works at all.
+		// With depth=1, the commit should be present and verifiable.
+		e := &Executor{
+			shell: sh,
+			ExecutorConfig: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                commit,
+				Branch:                "origin/feature",
+			},
+		}
+
+		err = e.verifyCommit(ctx)
+		if err != nil {
+			t.Errorf("verifyCommit() error = %v, want nil", err)
+		}
+	})
+}

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -107,6 +107,9 @@ type ExecutorConfig struct {
 	// SSH private key to use for git checkout operations
 	GitSSHKey string `env:"BUILDKITE_GIT_SSH_KEY"`
 
+	// Enable git commit verification
+	GitCommitVerification string
+
 	// Config key=value pairs to pass to "git" when submodule init commands are invoked
 	GitSubmoduleCloneConfig []string `env:"BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG"`
 

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -1308,6 +1308,101 @@ func TestMultipleRemoteURLsFallsBackToGetURL(t *testing.T) {
 	tester.RunAndCheck(t, env...)
 }
 
+func TestCommitVerificationWithValidCommit(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewExecutorTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewExecutorTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	// Get the real commit SHA from the test repo
+	commitHash, err := tester.Repo.RevParse("main")
+	if err != nil {
+		t.Fatalf("RevParse(main) error = %v", err)
+	}
+	commitHash = strings.TrimSpace(commitHash)
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_FLAGS=-v",
+		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
+		"BUILDKITE_GIT_FETCH_FLAGS=-v",
+		"BUILDKITE_GIT_COMMIT_VERIFICATION=strict",
+		fmt.Sprintf("BUILDKITE_COMMIT=%s", commitHash),
+	}
+
+	git := tester.
+		MustMock(t, "git").
+		PassthroughToLocalCommand()
+
+	// Expect the normal checkout flow with merge-base --is-ancestor inserted
+	// between fetch and checkout. Since this is a full clone (not shallow),
+	// merge-base succeeds immediately — no rev-parse --is-shallow-repository needed.
+	git.ExpectAll([][]any{
+		{"clone", "-v", "--", tester.Repo.Path, "."},
+		{"clean", "-fdq"},
+		{"fetch", "-v", "--", "origin", commitHash},
+		{"merge-base", "--is-ancestor", commitHash, "main"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", commitHash},
+		{"clean", "-fdq"},
+		{"--no-pager", "log", "-1", commitHash, "-s", "--no-color", gitShowFormatArg},
+	})
+
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
+
+	tester.RunAndCheck(t, env...)
+}
+
+func TestCommitVerificationFailsWithInvalidCommit(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewExecutorTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewExecutorTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	// Get the commit from the update-test-txt branch (not on main)
+	commitHash, err := tester.Repo.RevParse("update-test-txt")
+	if err != nil {
+		t.Fatalf("RevParse(update-test-txt) error = %v", err)
+	}
+	commitHash = strings.TrimSpace(commitHash)
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_FLAGS=-v",
+		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
+		"BUILDKITE_GIT_FETCH_FLAGS=-v",
+		"BUILDKITE_GIT_COMMIT_VERIFICATION=strict",
+		fmt.Sprintf("BUILDKITE_COMMIT=%s", commitHash),
+	}
+
+	git := tester.
+		MustMock(t, "git").
+		PassthroughToLocalCommand()
+
+	// Expect fetch, then merge-base which should return exit 1 (not ancestor).
+	// No checkout should happen after verification fails.
+	git.ExpectAll([][]any{
+		{"clone", "-v", "--", tester.Repo.Path, "."},
+		{"clean", "-fdq"},
+		{"fetch", "-v", "--", "origin", commitHash},
+		{"merge-base", "--is-ancestor", commitHash, "main"},
+	})
+
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+
+	// This should fail — the commit is not on main
+	err = tester.Run(t, env...)
+	if err == nil {
+		t.Fatalf("expected build to fail with commit verification error, but it passed")
+	}
+}
+
 type subDirMatcher struct {
 	dir string
 }


### PR DESCRIPTION
### Description

Adds commit-on-branch verification to the checkout phase. 

As part of our agent checkout improvement work, we are adding support for git commit verification. This addresses a potential security issue: if an attacker adds a malicious commit to the repo, and is then able to trigger a build which specifies `commit: 3v1l5ha123` `branch: main` we would build that commit as if it were on the `main` branch, without verifying that this is the case, which could potentially lead to a production deployment of malicious code. 

This change introduces a `BUILDKITE_GIT_COMMIT_VERIFICATION` environment variable, which defaults to `false`. If set to `true`, when we are given a commit and branch, before checkout and build, we do the following:

1. Use `git merge-base --is-ancestor` to check if the commit really belongs to the specified branch. 
2. If it does, proceed; if it definitely does not, fail and exit.
3. In ambiguous situations, it's possible that we only have a shallow clone of the repo. In that case we:
4. Deepen the clone by 50 commits, with the assumption that this should be enough to find the specified SHA.
5. If we still get an ambiguous result, to a full `unshallow` and check again.
6. Proceed if the commit matches, fail and exit if it does not.

In terms of alternatives, the only change I considered was just going straight to `unshallow` before verifying any commit. But I didn't want users to have to completely give up shallow commits to get verification, so I went with the "deepen first, then unshallow if necessary" approach.

### Context

See SUP-6535.

### Changes

Adds a `BUILDKITE_GIT_COMMIT_VERIFICATION` env var to enable to functionality. When set, we perform various git operations in between fetch and checkout, to make sure the provided commit is valid on the provided branch.

### Testing
- [X] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [X] Code is formatted (with `go tool gofumpt -extra -w .`)

### Disclosures / Credits

I used Claude to help me plan the feature and teach me some Go fundamentals. I coded the core functionality myself, and let Claude write the tests.