### PR TITLE
Add skip checkout tests for `no-checkout-override`

### DIFF
--- a/agent/integration/job_environment_integration_test.go
+++ b/agent/integration/job_environment_integration_test.go
@@ -290,6 +290,30 @@ func TestCheckoutScopedJobEnvOverrideHonorsNoCheckoutOverride(t *testing.T) {
 			wantEnvValue:       "false",
 			wantIgnoredEnvVars: []string{"BUILDKITE_GIT_SUBMODULES"},
 		},
+		{
+			name:    "disabled_allows_job_env_to_override_skip_checkout",
+			varName: "BUILDKITE_SKIP_CHECKOUT",
+			jobEnv: map[string]string{
+				"BUILDKITE_SKIP_CHECKOUT": "false",
+			},
+			agentCfg: agent.AgentConfiguration{
+				SkipCheckout: true,
+			},
+			wantEnvValue: "false",
+		},
+		{
+			name:    "enabled_locks_skip_checkout_to_agent_config",
+			varName: "BUILDKITE_SKIP_CHECKOUT",
+			jobEnv: map[string]string{
+				"BUILDKITE_SKIP_CHECKOUT": "false",
+			},
+			agentCfg: agent.AgentConfiguration{
+				SkipCheckout:       true,
+				NoCheckoutOverride: true,
+			},
+			wantEnvValue:       "true",
+			wantIgnoredEnvVars: []string{"BUILDKITE_SKIP_CHECKOUT"},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -169,7 +169,7 @@ func TestEnvironmentHookNoCheckoutOverride(t *testing.T) {
 
 			tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
 				if got, want := c.GetEnv("BUILDKITE_SKIP_CHECKOUT"), tc.wantSkipCheckoutEnv; got != want {
-					fmt.Fprintf(c.Stderr, "Expected BUILDKITE_SKIP_CHECKOUT=%q, got %q\n", want, got)
+					_, _ = fmt.Fprintf(c.Stderr, "Expected BUILDKITE_SKIP_CHECKOUT=%q, got %q\n", want, got)
 					c.Exit(1)
 					return
 				}

--- a/internal/job/integration/secrets_integration_test.go
+++ b/internal/job/integration/secrets_integration_test.go
@@ -600,7 +600,7 @@ func TestSecretsIntegration_NoCheckoutOverride(t *testing.T) {
 			if !tc.wantErr {
 				tester.ExpectGlobalHook("command").AndCallFunc(func(c *bintest.Call) {
 					if got, want := c.GetEnv("BUILDKITE_GIT_CLONE_FLAGS"), "--mirror"; got != want {
-						fmt.Fprintf(c.Stderr, "Expected BUILDKITE_GIT_CLONE_FLAGS=%q, got %q\n", want, got)
+						_, _ = fmt.Fprintf(c.Stderr, "Expected BUILDKITE_GIT_CLONE_FLAGS=%q, got %q\n", want, got)
 						c.Exit(1)
 						return
 					}


### PR DESCRIPTION
### Description

Adds two table cases to `TestCheckoutScopedJobEnvOverrideHonorsNoCheckoutOverride` covering `BUILDKITE_SKIP_CHECKOUT`, alongside the existing `BUILDKITE_GIT_CLONE_FLAGS` and `BUILDKITE_GIT_SUBMODULES` cases. Locks in the agent-level precedence behavior between `Job.Env` and agent config for the skip-checkout var so it can't silently regress.

No production code changes. `BUILDKITE_SKIP_CHECKOUT` is already wrapped by `setCheckoutEnv` (`agent/job_runner.go:583-584`) and is a member of `checkoutOverrideScope` (`env/protected.go:83`).

Also fixes two pre-existing `errcheck` violations on `fmt.Fprintf(c.Stderr, ...)` calls that surfaced after the recent merge from `main` bumped the lint container from `golangci-lint:v2.11` to `v2.12`. Brings them in line with every other `fmt.Fprintf` to `c.Stderr` in the same files.

### Context

Spotted while working on [SUP-7022](https://linear.app/buildkite/issue/SUP-7022/agent-verify-skip-checkout-env-var-bridge-for-pipeline-support). The other acceptance scenarios in that issue are already covered by `TestSkippingCheckout` (`internal/job/integration/checkout_integration_test.go`) and `TestEnvironmentHookNoCheckoutOverride` (`internal/job/integration/hooks_integration_test.go`).

### Changes

Two new cases in `agent/integration/job_environment_integration_test.go`:

- `disabled_allows_job_env_to_override_skip_checkout`: pipeline `BUILDKITE_SKIP_CHECKOUT=false` wins over agent `SkipCheckout=true` when `NoCheckoutOverride=false`.
- `enabled_locks_skip_checkout_to_agent_config`: agent `SkipCheckout=true` with `NoCheckoutOverride=true` overwrites pipeline `BUILDKITE_SKIP_CHECKOUT=false` and adds `BUILDKITE_SKIP_CHECKOUT` to `BUILDKITE_IGNORED_ENV`.

Lint fixes:

- `internal/job/integration/hooks_integration_test.go:172`: prepend `_, _ =` to the `fmt.Fprintf(c.Stderr, ...)` call.
- `internal/job/integration/secrets_integration_test.go:603`: same fix.

### Testing

- [x] Tests have run locally (with `go test ./...`).
- [x] Code is formatted (with `go tool gofumpt -extra -w .`).
- `golangci-lint run ./...` reports 0 issues.

### Disclosures / Credits

Claude Code (Opus 4.7) drafted the two new table cases and the lint fixes. I directed the scope and reviewed the changes.
