### PR TITLE
fix: surface permission errors when checking plugin directories

### DIFF
--- a/internal/job/plugin.go
+++ b/internal/job/plugin.go
@@ -16,7 +16,6 @@ import (
 	"github.com/buildkite/agent/v3/agent/plugin"
 	"github.com/buildkite/agent/v3/internal/experiments"
 	"github.com/buildkite/agent/v3/internal/job/hook"
-	"github.com/buildkite/agent/v3/internal/osutil"
 	"github.com/buildkite/roko"
 	"github.com/buildkite/shellwords"
 )
@@ -368,16 +367,26 @@ func (e *Executor) checkoutPlugin(ctx context.Context, p *plugin.Plugin) (*plugi
 	// that means a potentially slow and unnecessary clone on every build step.  Sigh.  I think the
 	// tradeoff is favourable for just blowing away an existing clone if we want least-hassle
 	// guarantee that the user will get the latest version of their plugin branch/tag/whatever.
-	if e.PluginsAlwaysCloneFresh && osutil.FileExists(pluginDirectory) {
-		e.shell.Commentf("BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH is true; removing previous checkout of plugin %s", p.Label())
-		if err := os.RemoveAll(pluginDirectory); err != nil {
-			e.shell.Errorf("Oh no, something went wrong removing %s", pluginDirectory)
-			return nil, err
+	if e.PluginsAlwaysCloneFresh {
+		_, statErr := os.Stat(pluginDirectory)
+		if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			return nil, fmt.Errorf("checking plugin directory %q: %w", pluginDirectory, statErr)
+		}
+		if statErr == nil {
+			e.shell.Commentf("BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH is true; removing previous checkout of plugin %s", p.Label())
+			if err := os.RemoveAll(pluginDirectory); err != nil {
+				e.shell.Errorf("Oh no, something went wrong removing %s", pluginDirectory)
+				return nil, err
+			}
 		}
 	}
 
-	// Does the .git directory exist? (i.e. it's already checkout out?)
-	if osutil.FileExists(pluginGitDirectory) {
+	// Does the .git directory exist? (i.e. it's already checked out?)
+	_, statErr := os.Stat(pluginGitDirectory)
+	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return nil, fmt.Errorf("checking plugin git directory %q: %w", pluginGitDirectory, statErr)
+	}
+	if statErr == nil {
 		// It'd be nice to show the current commit of the plugin, so
 		// let's figure that out.
 		headCommit, err := gitRevParseInWorkingDirectory(ctx, e.shell, pluginDirectory, "--short=7", "HEAD")

--- a/internal/job/plugin_zip.go
+++ b/internal/job/plugin_zip.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,7 +18,6 @@ import (
 
 	"github.com/buildkite/agent/v3/agent/plugin"
 	"github.com/buildkite/agent/v3/internal/agenthttp"
-	"github.com/buildkite/agent/v3/internal/osutil"
 	"github.com/buildkite/agent/v3/version"
 	"github.com/buildkite/roko"
 )
@@ -39,7 +39,11 @@ func (e *Executor) checkoutZipPlugin(ctx context.Context, p *plugin.Plugin, chec
 	}
 
 	// Remove existing directory if present, as of right now caching is not supported.
-	if osutil.FileExists(pluginDirectory) {
+	_, statErr := os.Stat(pluginDirectory)
+	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return fmt.Errorf("checking zip plugin directory %q: %w", pluginDirectory, statErr)
+	}
+	if statErr == nil {
 		if err := os.RemoveAll(pluginDirectory); err != nil {
 			e.shell.Errorf("Failed to remove existing plugin directory %s", pluginDirectory)
 			return err


### PR DESCRIPTION
### Description

Previously, osutil.FileExists silently returned false for any stat error, including permission denied. This caused the agent to attempt a re-clone of an already-checked-out plugin when the plugin directory was inaccessible. Now os.Stat is used directly so permission errors are returned immediately with a clear message, rather than falling through to a doomed re-clone.

### Context

https://linear.app/buildkite/issue/A-1065/plugin-code-does-not-distinguish-between-permission-errors-and-non

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->


### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
