### PR TITLE
A-1244 agent: fix issue template and add an affiliation field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,31 +1,29 @@
 ---
- name: Bug report
- about: Create a report to help us improve
- title: ''
- labels: ''
- assignees: ''
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
 
- ---
+---
 
- **Describe the bug**
- A clear and concise description of what the bug is.
+## Describe the bug
+A clear and concise description of what the bug is.
 
- **Steps To Reproduce**
- Steps to reproduce the behavior:
- 1. Go to '...'
- 2. Click on '....'
- 3. Scroll down to '....'
- 4. See error
+## Steps To Reproduce
+Steps to reproduce the behavior.
 
- **Expected behavior**
- A clear and concise description of what you expected to happen, and any commands required to demonstrate it.
+## Expected behavior
+A clear and concise description of what you expected to happen, and any commands required to demonstrate it.
 
- **Actual behaviour**
- What happened instead.
+## Actual behaviour
+What happened instead.
 
- **Stack parameters (please complete the following information):**
-  - AWS Region: [e.g. us-east-1]
-  - Version [e.g. v5.6.1]
+## Stack parameters (please complete the following information)
+ - Version [e.g. v5.6.1]
 
- **Additional context**
- Add any other context about the problem here.
+## Affiliation (optional)
+If you're comfortable sharing, let us know your company or organisation — it helps us prioritise and may accelerate a response.
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,17 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+## Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+## Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+## Affiliation (optional)
+If you're comfortable sharing, let us know your company or organisation — it helps us prioritise and may accelerate a response.
+
+## Additional context
 Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,17 @@
-### Description
+## Description
 
 <!--
 - What problem are you trying to solve, and how are you solving it?
 - What alternatives did you consider?
 -->
 
-### Context
+## Context
 
 <!--
 For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
 -->
 
-### Changes
+## Changes
 
 <!--
 List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.
@@ -19,7 +19,7 @@ List of what the PR changes. If the PR changes the CLI arguments, consider addin
 Can skip if changes are simple or clear from the commit messages.
 -->
 
-### Testing
+## Testing
 - [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
 - [ ] Code is formatted (with `go tool gofumpt -extra -w .`)
 
@@ -27,8 +27,13 @@ Can skip if changes are simple or clear from the commit messages.
 Note: if the tests fail to run locally, please let us know!
 -->
 
+## Affiliation (optional, external contributors)
 
-### Disclosures / Credits
+<!--
+If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
+-->
+
+## Disclosures / Credits
 
 <!--
 If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.


### PR DESCRIPTION
### Description

Tidies up the GitHub issue and PR templates so contributors get a clearer, more consistent experience when filing bugs, feature requests, or PRs.

The bug report template was also silently broken: every line had a leading space (including the `---` frontmatter delimiters), which prevented GitHub from parsing the YAML frontmatter and meant the template was never offered in the "New issue" picker.


### Context

part of A-1244

### Changes

- **`.github/ISSUE_TEMPLATE/bug-report.md`**: removed the leading whitespace on every line so GitHub now recognises and offers the template.
- **`.github/ISSUE_TEMPLATE/bug-report.md`** and **`.github/ISSUE_TEMPLATE/feature_request.md`**: converted `**bold**` section headers to `##` markdown headings.
- **`.github/ISSUE_TEMPLATE/bug-report.md`** and **`.github/ISSUE_TEMPLATE/feature_request.md`**: added an optional **Affiliation** section just above **Additional context**, with soft wording inviting (not requiring) reporters to share their company/organisation, noting it may accelerate a response.
- **`.github/pull_request_template.md`**: converted `###` to `##` headings for consistency with the issue templates, and added an **Affiliation (optional, external contributors)** section above **Disclosures / Credits**, scoped clearly to outside contributors.