### PR TITLE
A-1214 part 5: upgrade gh version on release pipeline

### DIFF
--- a/.buildkite/steps/github-release.sh
+++ b/.buildkite/steps/github-release.sh
@@ -19,7 +19,7 @@ if [[ "$GH_TOKEN" == "" ]]; then
 fi
 
 echo '--- Installing gh CLI'
-GH_VERSION=2.62.0
+GH_VERSION=2.92.0
 curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
   | tar -xz -C /tmp
 install "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh


### PR DESCRIPTION
## Description

Upgrade `gh` on gh release step so it knows about a new CLI flag.

## Context

part of A-1214