### PR TITLE
internal: [TE-5828] Add bktec plan step to collect commit metadata on agent builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,6 +37,23 @@ steps:
         mount-buildkite-agent: true
         run: lint
 
+  # Send git commit metadata to the Test Engine plan-metadata pipeline on
+  # every build. Plan output is discarded -- the Tests and Coverage group
+  # below continues to use its declared parallelism. This step has no
+  # depends_on and no dependents, and is soft_fail, so a Test Engine API
+  # hiccup never blocks the build. See TE-5828.
+  - name: ":test_tube: Collect commit metadata"
+    key: collect-commit-metadata
+    command: .buildkite/steps/collect-commit-metadata.sh
+    soft_fail: true
+    env:
+      BUILDKITE_TEST_ENGINE_SUITE_SLUG: buildkite-agent
+      BUILDKITE_TEST_ENGINE_TEST_RUNNER: gotest
+      # Test Engine API rejects parallelism = 0 even on metadata-only plan
+      # requests. See TE-5766 verification on bk/bk-rspec.
+      BUILDKITE_TEST_ENGINE_MAX_PARALLELISM: "2"
+      BUILDKITE_TEST_ENGINE_TARGET_TIME: "1m"
+
   - group: ":go::scientist: Tests and Coverage"
     if_changed:
       - go.{mod,sum}

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,7 +41,12 @@ steps:
   # every build. Plan output is discarded -- the Tests and Coverage group
   # below continues to use its declared parallelism. This step has no
   # depends_on and no dependents, and is soft_fail, so a Test Engine API
-  # hiccup never blocks the build. See TE-5828.
+  # hiccup never blocks the build.
+  #
+  # Runs inside the `agent` compose service so bktec's gotest runner has
+  # `go` on PATH (needed for `go list ./...` package discovery) and the
+  # Test Engine API token is forwarded (declared in docker-compose.yml).
+  # See TE-5828.
   - name: ":test_tube: Collect commit metadata"
     key: collect-commit-metadata
     command: .buildkite/steps/collect-commit-metadata.sh
@@ -53,6 +58,12 @@ steps:
       # requests. See TE-5766 verification on bk/bk-rspec.
       BUILDKITE_TEST_ENGINE_MAX_PARALLELISM: "2"
       BUILDKITE_TEST_ENGINE_TARGET_TIME: "1m"
+    plugins:
+      - docker-compose#v4.14.0:
+          config: .buildkite/docker-compose.yml
+          cli-version: 2
+          propagate-environment: true
+          run: agent
 
   - group: ":go::scientist: Tests and Coverage"
     if_changed:

--- a/.buildkite/steps/collect-commit-metadata.sh
+++ b/.buildkite/steps/collect-commit-metadata.sh
@@ -12,10 +12,10 @@
 # hiccup never blocks the build.
 #
 # Runs inside the `agent` docker-compose service (see
-# .buildkite/docker-compose.yml). The service provides `go` on PATH for
-# bktec's gotest runner (which shells out to `go list ./...` to discover
-# packages) and forwards BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN into the
-# container.
+# .buildkite/docker-compose.yml), which is a linux/amd64+arm64 golang image.
+# The service provides `go` on PATH for bktec's gotest runner (which shells
+# out to `go list ./...` to discover packages) and forwards
+# BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN into the container.
 #
 # bktec is downloaded fresh each run from the test-engine-client GitHub
 # release. The agent repo's go.mod pins test-engine-client v1.6.0 for use as
@@ -29,15 +29,6 @@ BKTEC_VERSION="${BKTEC_VERSION:-2.5.0}"
 
 echo "+++ :test_tube: Installing bktec v${BKTEC_VERSION}"
 
-case "$(uname -s)" in
-  Linux)  os=linux ;;
-  Darwin) os=darwin ;;
-  *)
-    echo "Unsupported OS: $(uname -s)" >&2
-    exit 1
-    ;;
-esac
-
 case "$(uname -m)" in
   x86_64)         arch=amd64 ;;
   aarch64|arm64)  arch=arm64 ;;
@@ -48,11 +39,9 @@ case "$(uname -m)" in
 esac
 
 bindir="$(mktemp -d)"
-asset="bktec_${BKTEC_VERSION}_${os}_${arch}"
-url="https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/${asset}"
+url="https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/bktec_${BKTEC_VERSION}_linux_${arch}"
 
-curl --fail --silent --show-error --location \
-  --output "${bindir}/bktec" "${url}"
+curl --fail --silent --show-error --location --output "${bindir}/bktec" "${url}"
 chmod +x "${bindir}/bktec"
 export PATH="${bindir}:${PATH}"
 
@@ -60,24 +49,10 @@ bktec --version
 
 echo "+++ :test_tube: Collecting git commit metadata via bktec plan (discarded)"
 
-# Test Engine API rejects metadata-only plan requests with parallelism = 0
-# and discards the entire payload (including --collect-git-metadata fields).
-# Set max-parallelism / target-time non-zero so bktec computes a non-zero
-# parallelism the API accepts. The plan output is still discarded below.
-# Surfaced by TE-5766 verification on bk/bk-rspec (build 190531).
-export BUILDKITE_TEST_ENGINE_SUITE_SLUG="${BUILDKITE_TEST_ENGINE_SUITE_SLUG:-buildkite-agent}"
-export BUILDKITE_TEST_ENGINE_TEST_RUNNER="${BUILDKITE_TEST_ENGINE_TEST_RUNNER:-gotest}"
-export BUILDKITE_TEST_ENGINE_MAX_PARALLELISM="${BUILDKITE_TEST_ENGINE_MAX_PARALLELISM:-2}"
-export BUILDKITE_TEST_ENGINE_TARGET_TIME="${BUILDKITE_TEST_ENGINE_TARGET_TIME:-1m}"
+# bktec needs a writable RESULT_PATH for plan output config validation. The
+# --json output is redirected to /dev/null below so this file is never read.
+export BUILDKITE_TEST_ENGINE_RESULT_PATH=/tmp/bktec-plan-metadata.json
 
-# bktec needs a writable RESULT_PATH for plan output. We redirect --json to
-# /dev/null below so the file is never consulted; this is here only to keep
-# bktec's config validation happy.
-export BUILDKITE_TEST_ENGINE_RESULT_PATH="${BUILDKITE_TEST_ENGINE_RESULT_PATH:-/tmp/bktec-plan-metadata.json}"
-
-BKTEC_PREVIEW_SELECTION=1 bktec plan \
-  --json \
-  --collect-git-metadata \
-  > /dev/null
+BKTEC_PREVIEW_SELECTION=1 bktec plan --json --collect-git-metadata > /dev/null
 
 echo "Plan request issued -- git commit metadata sent to Test Engine."

--- a/.buildkite/steps/collect-commit-metadata.sh
+++ b/.buildkite/steps/collect-commit-metadata.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Collect git commit metadata via `bktec plan --collect-git-metadata`.
+#
+# This is a metadata-only side-channel for the buildkite-agent Test Engine
+# suite. The plan output is discarded -- the existing test steps continue to
+# use their declared `parallelism:` values unchanged. The only purpose of this
+# step is to ship commit / branch / diff metadata to the Test Engine plan
+# metadata pipeline on every build.
+#
+# See TE-5828 (and the bk/bk-rspec reference implementation in TE-5766) for
+# context. The step is soft-failed at the pipeline level so a Test Engine API
+# hiccup never blocks the build.
+#
+# bktec is downloaded fresh each run from the test-engine-client GitHub
+# release. The agent repo's go.mod pins test-engine-client v1.6.0 for use as
+# a `go tool` on the runtime test path; that v1 shape predates the `plan`
+# subcommand and is intentionally left untouched here. A future change should
+# unify both call sites on a single bktec version.
+
+set -euo pipefail
+
+BKTEC_VERSION="${BKTEC_VERSION:-2.5.0}"
+
+echo "+++ :test_tube: Installing bktec v${BKTEC_VERSION}"
+
+case "$(uname -s)" in
+  Linux)  os=linux ;;
+  Darwin) os=darwin ;;
+  *)
+    echo "Unsupported OS: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64)         arch=amd64 ;;
+  aarch64|arm64)  arch=arm64 ;;
+  *)
+    echo "Unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+bindir="$(mktemp -d)"
+asset="bktec_${BKTEC_VERSION}_${os}_${arch}"
+url="https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/${asset}"
+
+curl --fail --silent --show-error --location \
+  --output "${bindir}/bktec" "${url}"
+chmod +x "${bindir}/bktec"
+export PATH="${bindir}:${PATH}"
+
+bktec --version
+
+echo "+++ :test_tube: Collecting git commit metadata via bktec plan (discarded)"
+
+# Test Engine API rejects metadata-only plan requests with parallelism = 0
+# and discards the entire payload (including --collect-git-metadata fields).
+# Set max-parallelism / target-time non-zero so bktec computes a non-zero
+# parallelism the API accepts. The plan output is still discarded below.
+# Surfaced by TE-5766 verification on bk/bk-rspec (build 190531).
+export BUILDKITE_TEST_ENGINE_SUITE_SLUG="${BUILDKITE_TEST_ENGINE_SUITE_SLUG:-buildkite-agent}"
+export BUILDKITE_TEST_ENGINE_TEST_RUNNER="${BUILDKITE_TEST_ENGINE_TEST_RUNNER:-gotest}"
+export BUILDKITE_TEST_ENGINE_MAX_PARALLELISM="${BUILDKITE_TEST_ENGINE_MAX_PARALLELISM:-2}"
+export BUILDKITE_TEST_ENGINE_TARGET_TIME="${BUILDKITE_TEST_ENGINE_TARGET_TIME:-1m}"
+
+# bktec needs a writable RESULT_PATH for plan output. We redirect --json to
+# /dev/null below so the file is never consulted; this is here only to keep
+# bktec's config validation happy.
+export BUILDKITE_TEST_ENGINE_RESULT_PATH="${BUILDKITE_TEST_ENGINE_RESULT_PATH:-/tmp/bktec-plan-metadata.json}"
+
+BKTEC_PREVIEW_SELECTION=1 bktec plan \
+  --json \
+  --collect-git-metadata \
+  > /dev/null
+
+echo "Plan request issued -- git commit metadata sent to Test Engine."

--- a/.buildkite/steps/collect-commit-metadata.sh
+++ b/.buildkite/steps/collect-commit-metadata.sh
@@ -11,6 +11,12 @@
 # context. The step is soft-failed at the pipeline level so a Test Engine API
 # hiccup never blocks the build.
 #
+# Runs inside the `agent` docker-compose service (see
+# .buildkite/docker-compose.yml). The service provides `go` on PATH for
+# bktec's gotest runner (which shells out to `go list ./...` to discover
+# packages) and forwards BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN into the
+# container.
+#
 # bktec is downloaded fresh each run from the test-engine-client GitHub
 # release. The agent repo's go.mod pins test-engine-client v1.6.0 for use as
 # a `go tool` on the runtime test path; that v1 shape predates the `plan`


### PR DESCRIPTION
## Description

Adds a discardable `bktec plan --collect-git-metadata` step to the
agent build pipeline so git commit metadata is sent to Buildkite Test
Engine on every build. The plan output is discarded -- existing test
steps continue to use their declared `parallelism:` values, so this is
a metadata-only side-channel with no run-time contract change.

`bktec` v2.5.0 is downloaded from the `test-engine-client` GitHub
release at step time. The agent repo pins `test-engine-client v1.6.0`
in `go.mod` for use as `go tool test-engine-client` in
`.buildkite/steps/tests.sh`, which predates the `plan` subcommand
(v2.0.0) and the `--collect-git-metadata` flag (v2.4.0). A coordinated
bump of both call sites is tracked as follow-up.

The step is `soft_fail: true`, has no `depends_on` and no dependents,
so a Test Engine API hiccup never blocks the build. It runs inside the
existing `agent` docker-compose service to pick up `go` on PATH (bktec
shells out to `go list ./...` for package discovery) and the
`BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN` env var.

## Context

Internal ticket: [TE-5828](https://linear.app/buildkite/issue/TE-5828).

## Changes

Best reviewed commit-by-commit:

- Add bktec plan script to collect git commit metadata
- Wire bktec metadata step into agent build pipeline
- Run bktec metadata step inside agent compose service
- Simplify metadata script for linux-only compose service

## Verification

The new `:test_tube: Collect commit metadata` step should:

- Print `bktec 2.5.0` after the download.
- Exit 0 with the log line `Plan request issued -- git commit metadata sent to Test Engine`.
- Not affect the Tests and Coverage group's timing or behaviour.

AI assisted.

## Deployment

Low risk. New step is `soft_fail: true` and has no dependents.

## Rollback

Yes -- single revert.
