### PR TITLE
Release oldstable from v3, edge from v4

### DIFF
--- a/.buildkite/pipeline.release-oldstable.yml
+++ b/.buildkite/pipeline.release-oldstable.yml
@@ -1,0 +1,233 @@
+steps:
+  - wait
+
+  - name: ":s3: Upload Oldstable Binaries to S3"
+    command: ".buildkite/steps/publish-to-s3.sh"
+    env:
+      CODENAME: "oldstable"
+    plugins:
+      - aws-assume-role-with-web-identity#v1.4.0:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-oldstable
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch
+      - ecr#v2.7.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v5.8.0:
+          environment:
+            - "AWS_ACCESS_KEY_ID"
+            - "AWS_SECRET_ACCESS_KEY"
+            - "AWS_SESSION_TOKEN"
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
+          propagate-environment: true
+          mount-buildkite-agent: true
+
+  - name: ":octocat: :rocket: Create Github Release (if necessary)"
+    skip: "TODO(v4 release): unskip when v3 no longer stable"
+    command: ".buildkite/steps/github-release.sh"
+    env:
+      CODENAME: "oldstable"
+    plugins:
+      - aws-assume-role-with-web-identity#v1.4.0:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-oldstable
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch
+      - ecr#v2.7.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v5.8.0:
+          environment:
+            - "AWS_ACCESS_KEY_ID"
+            - "AWS_SECRET_ACCESS_KEY"
+            - "AWS_SESSION_TOKEN"
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
+          propagate-environment: true
+          mount-buildkite-agent: true
+
+  - name: ":redhat: Publish Oldstable RPM Package"
+    command: ".buildkite/steps/publish-rpm-package.sh"
+    env:
+      CODENAME: "oldstable"
+      RPM_S3_BUCKET: "yum.buildkite.com"
+    plugins:
+      - aws-assume-role-with-web-identity#v1.4.0:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-oldstable
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch
+      - docker#v5.8.0:
+          environment:
+            - "AWS_ACCESS_KEY_ID"
+            - "AWS_SECRET_ACCESS_KEY"
+            - "AWS_SESSION_TOKEN"
+          image: "buildkite/agent:3.55.0-ubuntu"
+          entrypoint: bash
+          propagate-environment: true
+          mount-buildkite-agent: true
+          volumes:
+            - "/yum.buildkite.com"
+    retry:
+      automatic:
+        - exit_status: 1
+          limit: 3
+
+  - group: ":redhat: Publish Oldstable RPM Package to Buildkite Packages"
+    steps:
+      - name: ":redhat: Publish Oldstable {{matrix.pkg_arch}} RPM Package to Buildkite Packages"
+        plugins:
+          - publish-to-packages#v2.2.0:
+              artifacts: "rpm/buildkite-agent_*_{{matrix.pkg_arch}}.rpm"
+              registry: "buildkite/agent-rpm-oldstable"
+              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
+              attestations:
+                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
+                - "buildkite-agent-rpm-packages.package-attestation.json"
+        soft_fail: true
+        matrix:
+          setup:
+            go_arch:
+              - "amd64"
+              - "386"
+              - "arm64"
+              - "ppc64"
+              - "ppc64le"
+              - "riscv64"
+            pkg_arch:
+              - "SKIP_FAKE_ARCH"
+          adjustments:
+            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
+            - with: { go_arch: "386", pkg_arch: "i386" }
+            - with: { go_arch: "arm64", pkg_arch: "aarch64" }
+            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
+            - with: { go_arch: "ppc64le", pkg_arch: "ppc64le" }
+            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
+            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
+              skip: true
+
+  - name: ":debian: Publish Oldstable Debian Package"
+    command: ".buildkite/steps/publish-debian-package.sh"
+    env:
+      CODENAME: "oldstable"
+      DEB_S3_BUCKET: "apt.buildkite.com/buildkite-agent"
+    plugins:
+      - aws-assume-role-with-web-identity#v1.4.0:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-oldstable
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch
+      - ecr#v2.7.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v5.8.0:
+          environment:
+            - "AWS_ACCESS_KEY_ID"
+            - "AWS_SECRET_ACCESS_KEY"
+            - "AWS_SESSION_TOKEN"
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
+          propagate-environment: true
+          mount-buildkite-agent: true
+          tmpfs:
+            - "/root/.gnupg"
+
+  - group: ":debian: Publish Oldstable Debian Package to Buildkite Packages"
+    steps:
+      - name: ":debian: Publish Oldstable {{matrix.pkg_arch}} Debian Package to Buildkite Packages"
+        plugins:
+          - publish-to-packages#v2.2.0:
+              artifacts: "deb/buildkite-agent_*_{{matrix.pkg_arch}}.deb"
+              registry: "buildkite/agent-deb-oldstable"
+              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
+              attestations:
+                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
+                - "buildkite-agent-debian-packages.package-attestation.json"
+        soft_fail: true
+        matrix:
+          setup:
+            go_arch:
+              - "amd64"
+              - "386"
+              - "arm"
+              - "armhf"
+              - "arm64"
+              - "ppc64"
+              - "ppc64le"
+              - "riscv64"
+            pkg_arch:
+              - "SKIP_FAKE_ARCH"
+          adjustments:
+            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
+            - with: { go_arch: "386", pkg_arch: "i386" }
+            - with: { go_arch: "arm", pkg_arch: "arm" }
+            - with: { go_arch: "armhf", pkg_arch: "armhf" }
+            - with: { go_arch: "arm64", pkg_arch: "arm64" }
+            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
+            - with: { go_arch: "ppc64le", pkg_arch: "ppc64el" }
+            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
+            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
+              skip: true
+
+  - group: ":docker: Publish Oldstable Docker Images"
+    steps:
+      - name: ":docker: Publish Oldstable Images to {{matrix.registry}}"
+        command: ".buildkite/steps/publish-docker-images.sh"
+        env:
+          CODENAME: "oldstable"
+          REGISTRY: "{{matrix.registry}}"
+        plugins:
+          - aws-assume-role-with-web-identity#v1.4.0:
+              role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-oldstable
+              session-tags:
+                - organization_slug
+                - organization_id
+                - pipeline_slug
+                - build_branch
+          - ecr#v2.7.0:
+              login: true
+              account-ids: "445615400570"
+        matrix:
+          setup:
+            registry:
+              - docker.io
+              - ghcr.io
+              - packages.buildkite.com
+          adjustments:
+            - with: { registry: "packages.buildkite.com" }
+              soft_fail: true
+
+  - wait
+
+  - name: ":beer: Publish Oldstable Homebrew Package"
+    skip: "TODO(v4 release): unskip when v3 no longer stable"
+    command: ".buildkite/steps/release-homebrew.sh"
+    artifact_paths: "pkg/*.rb;pkg/*.json"
+    env:
+      CODENAME: "oldstable"
+    plugins:
+      - aws-assume-role-with-web-identity#v1.4.0:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-release-oldstable
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch
+      - ecr#v2.7.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v5.8.0:
+          environment:
+            - "AWS_ACCESS_KEY_ID"
+            - "AWS_SECRET_ACCESS_KEY"
+            - "AWS_SESSION_TOKEN"
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2022.07"
+          propagate-environment: true
+          mount-buildkite-agent: true

--- a/.buildkite/steps/github-release.sh
+++ b/.buildkite/steps/github-release.sh
@@ -10,10 +10,16 @@ dry_run() {
 }
 
 echo '--- Getting credentials from SSM'
-GH_TOKEN=$(aws ssm get-parameter --name /pipelines/agent/GITHUB_RELEASE_ACCESS_TOKEN --with-decryption --output text --query Parameter.Value --region us-east-1)
+GH_TOKEN="$(aws ssm get-parameter \
+  --name /pipelines/agent/GITHUB_RELEASE_ACCESS_TOKEN \
+  --with-decryption \
+  --output text \
+  --query Parameter.Value \
+  --region us-east-1 \
+)"
 export GH_TOKEN
 
-if [[ "$GH_TOKEN" == "" ]]; then
+if [[ "${GH_TOKEN}" == "" ]]; then
   echo "Error: Missing \$GH_TOKEN"
   exit 1
 fi
@@ -27,38 +33,38 @@ gh --version
 
 echo '--- Getting agent version from build meta data'
 
-export FULL_AGENT_VERSION=$(buildkite-agent meta-data get "agent-version-full")
-export AGENT_VERSION=$(buildkite-agent meta-data get "agent-version")
-export BUILD_VERSION=$(buildkite-agent meta-data get "agent-version-build")
-export IS_PRERELEASE=$(buildkite-agent meta-data get "agent-is-prerelease")
+export FULL_AGENT_VERSION="$(buildkite-agent meta-data get "agent-version-full")"
+export AGENT_VERSION="$(buildkite-agent meta-data get "agent-version")"
+export BUILD_VERSION="$(buildkite-agent meta-data get "agent-version-build")"
+export IS_PRERELEASE="$(buildkite-agent meta-data get "agent-is-prerelease")"
 
-echo "Full agent version: $FULL_AGENT_VERSION"
-echo "Agent version: $AGENT_VERSION"
-echo "Build version: $BUILD_VERSION"
-echo "Is prerelease?: $IS_PRERELEASE"
+echo "Full agent version: ${FULL_AGENT_VERSION}"
+echo "Agent version: ${AGENT_VERSION}"
+echo "Build version: ${BUILD_VERSION}"
+echo "Is prerelease?: ${IS_PRERELEASE}"
 
-if [[ "$CODENAME" == "unstable" && "$IS_PRERELEASE" == "0" ]] ; then
-  echo "Skipping github release, will happen in stable pipeline"
+if [[ "${CODENAME}" == "unstable" && "${IS_PRERELEASE}" == "0" ]] ; then
+  echo "Skipping github release, will happen in stable/oldstable pipeline"
   exit 0
 fi
 
-if [[ "$CODENAME" == "stable" && "$IS_PRERELEASE" == "1" ]] ; then
+if [[ ("${CODENAME}" == "stable" || "${CODENAME}" == "oldstable") && "${IS_PRERELEASE}" == "1" ]] ; then
   echo "Skipping github release, should have happened in unstable pipeline"
   exit 0
 fi
 
 echo '--- Downloading releases'
 
-artifacts_build=$(buildkite-agent meta-data get "agent-artifacts-build")
+artifacts_build="$(buildkite-agent meta-data get "agent-artifacts-build")"
 
 rm -rf releases
 mkdir -p releases
-buildkite-agent artifact download --build "$artifacts_build" "releases/*" .
+buildkite-agent artifact download --build "${artifacts_build}" "releases/*" .
 
-echo "Version is $FULL_AGENT_VERSION"
+echo "Version is ${FULL_AGENT_VERSION}"
 
 release_args=(
-  "v$AGENT_VERSION"
+  "v${AGENT_VERSION}"
   releases/*
   --repo buildkite/agent
   --target "$(git rev-parse HEAD)"
@@ -66,18 +72,26 @@ release_args=(
   --fail-on-no-commits
 )
 
-if [[ "$IS_PRERELEASE" == "1" ]]; then
-  echo "--- 🚀 $AGENT_VERSION (prerelease)"
+if [[ "${IS_PRERELEASE}" == "1" ]]; then
+  echo "--- 🚀 ${AGENT_VERSION} (prerelease)"
 
   buildkite-agent meta-data set github_release_type "prerelease"
-  buildkite-agent meta-data set github_release_version "$AGENT_VERSION"
 
   release_args+=(--prerelease)
-else
-  echo "--- 🚀 $AGENT_VERSION"
+
+elif [[ "${CODENAME}" == "oldstable" ]]; then
+  echo "--- 🚀 ${AGENT_VERSION} (oldstable)"
 
   buildkite-agent meta-data set github_release_type "stable"
-  buildkite-agent meta-data set github_release_version "$AGENT_VERSION"
+
+  release_args+=(--latest=false)
+
+else
+  echo "--- 🚀 ${AGENT_VERSION}"
+
+  buildkite-agent meta-data set github_release_type "stable"
 fi
+
+buildkite-agent meta-data set github_release_version "${AGENT_VERSION}"
 
 dry_run gh release create "${release_args[@]}"

--- a/.buildkite/steps/publish-debian-package.sh
+++ b/.buildkite/steps/publish-debian-package.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-artifacts_build=$(buildkite-agent meta-data get "agent-artifacts-build" )
+artifacts_build="$(buildkite-agent meta-data get "agent-artifacts-build")"
 
 # /root/.gnupg is a tmpfs volume, so we can safely store key data there and know
 # it won't be written to a disk
 secret_key_path="/root/.gnupg/gpg-secret.gpg"
 public_key_path="/root/.gnupg/gpg-public.gpg"
 
-if [[ "$CODENAME" == "" ]]; then
-  echo "Error: Missing \$CODENAME (stable or unstable)"
+if [[ "${CODENAME}" == "" ]]; then
+  echo "Error: Missing \$CODENAME (stable, unstable, oldstable)"
   exit 1
 fi
 
@@ -24,31 +24,49 @@ if ! findmnt --source tmpfs --target /root/.gnupg; then
 fi
 
 echo "fetching signing key..."
-export GPG_SIGNING_KEY=$(aws ssm get-parameter --name /pipelines/agent/GPG_SIGNING_KEY --with-decryption --output text --query Parameter.Value --region us-east-1)
+GPG_SIGNING_KEY="$(aws ssm get-parameter \
+  --name /pipelines/agent/GPG_SIGNING_KEY \
+  --with-decryption \
+  --output text \
+  --query Parameter.Value \
+  --region us-east-1)"
+export GPG_SIGNING_KEY
 
 echo "fetching secret key..."
-aws ssm get-parameter --name /pipelines/agent/GPG_SECRET_KEY_ASCII --with-decryption --output text --query Parameter.Value --region us-east-1 > ${secret_key_path}
+aws ssm get-parameter \
+  --name /pipelines/agent/GPG_SECRET_KEY_ASCII \
+  --with-decryption \
+  --output text \
+  --query Parameter.Value \
+  --region us-east-1 \
+  > ${secret_key_path}
 ls -lh /root/.gnupg/
-gpg --import --batch ${secret_key_path}
-rm ${secret_key_path}
+gpg --import --batch "${secret_key_path}"
+rm "${secret_key_path}"
 
 # technically we don't need the public key for signing, but it's helpful to keep a copy
 # in the same place as the secret key so we don't lose it
 echo "fetching public key..."
-aws ssm get-parameter --name /pipelines/agent/GPG_PUBLIC_KEY_ASCII --with-decryption --output text --query Parameter.Value --region us-east-1 > ${public_key_path}
-gpg --import --batch ${public_key_path}
-rm ${public_key_path}
+aws ssm get-parameter \
+  --name /pipelines/agent/GPG_PUBLIC_KEY_ASCII \
+  --with-decryption \
+  --output text \
+  --query Parameter.Value \
+  --region us-east-1 \
+  > "${public_key_path}"
+gpg --import --batch "${public_key_path}"
+rm "${public_key_path}"
 
 echo '--- Downloading built debian packages'
 rm -rf deb
 mkdir -p deb
-buildkite-agent artifact download --build "$artifacts_build" "deb/*.deb" deb/
+buildkite-agent artifact download --build "${artifacts_build}" "deb/*.deb" deb/
 
 echo '--- Installing dependencies'
 bundle install
 
 # Loop over all the .deb files and publish them
 for file in deb/*.deb; do
-  echo "+++ Publishing $file"
-  ./scripts/publish-debian-package.sh "$file" "$CODENAME"
+  echo "+++ Publishing ${file}"
+  ./scripts/publish-debian-package.sh "${file}" "${CODENAME}"
 done

--- a/.buildkite/steps/publish-docker-image.sh
+++ b/.buildkite/steps/publish-docker-image.sh
@@ -80,14 +80,25 @@ fi
 
 echo "Tagging docker images for $variant/$codename (version $version build $build)"
 
-# variants of edge/experimental
-if [[ "${codename}" == "experimental" ]] ; then
+case "${codename}" in
+experimental)
+  # variants of edge/experimental
   release_image "edge-build-${build}${variant_suffix}"
   release_image "edge${variant_suffix}"
-fi
+  ;;
 
-# variants of stable - e.g 2.3.2
-if [[ "${codename}" == "stable" ]] ; then
+oldstable)
+  release_image "oldstable${variant_suffix}"
+  for tag in $(parse_version "${version}") ; do
+    release_image "${tag}${variant_suffix}"
+  done
+  if [[ "${variant}" == "alpine" ]] ; then
+    release_image "oldstable"
+  fi
+  ;;
+
+stable)
+  # variants of stable - e.g 2.3.2
   for tag in $(parse_version "${version}") ; do
     release_image "${tag}${variant_suffix}"
   done
@@ -106,12 +117,14 @@ if [[ "${codename}" == "stable" ]] ; then
     release_image "latest"
     release_image "stable"
   fi
-fi
+  ;;
 
-# variants of beta/unstable - e.g 3.0-beta.16
-if [[ "${codename}" == "unstable" ]] ; then
+unstable)
+  # variants of beta/unstable - e.g 3.0-beta.16
   release_image "beta${variant_suffix}"
   if [[ "${version}" =~ -(alpha|beta|rc)\.[0-9]+$ ]] ; then
     release_image "${version}${variant_suffix}"
   fi
-fi
+  ;;
+
+esac

--- a/.buildkite/steps/publish-docker-images.sh
+++ b/.buildkite/steps/publish-docker-images.sh
@@ -10,7 +10,7 @@ dry_run() {
 }
 
 if [[ "${CODENAME:-}" == "" ]]; then
-  echo "Error: Missing \$CODENAME (stable, experimental or unstable)"
+  echo "Error: Missing \$CODENAME (stable, experimental, unstable, oldstable)"
   exit 1
 fi
 

--- a/.buildkite/steps/publish-rpm-package.sh
+++ b/.buildkite/steps/publish-rpm-package.sh
@@ -54,7 +54,7 @@ sync_from_s3() {
 }
 
 if [[ "${CODENAME}" == "" ]]; then
-  echo "Error: Missing \$CODENAME (stable or unstable)"
+  echo "Error: Missing \$CODENAME (stable, unstable, oldstable)"
   exit 1
 fi
 

--- a/.buildkite/steps/upload-release-steps.sh
+++ b/.buildkite/steps/upload-release-steps.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 trigger_step() {
   local name="$1"
   local trigger_pipeline="$2"
+  local skip="${3:-skip: false}"
   local branch="$BUILDKITE_BRANCH"
   local message_suffix=""
 
@@ -15,6 +16,7 @@ trigger_step() {
 
   cat <<YAML
   - name: ":rocket: Release ${name}${message_suffix}"
+    ${skip}
     trigger: "${trigger_pipeline}"
     async: false
     branches: "${branch}"
@@ -48,23 +50,53 @@ YAML
 edge_steps_yaml() {
   echo "steps:"
 
-  trigger_step \
-    "edge ${agent_version}.${build_version}" \
-    "agent-release-edge"
+  case "${agent_version}" in
+    4.*)
+      # Only release v4 to edge.
+      trigger_step \
+        "edge ${agent_version}.${build_version}" \
+        "agent-release-edge"
+      ;;
+
+    *)
+      # Do not release other versions to edge (upload the step with "skip" so
+      # it can still be inspected in the UI).
+      trigger_step \
+        "edge ${agent_version}.${build_version}" \
+        "agent-release-edge" \
+        "skip: \"Not releasing ${agent_version} to edge\""
+      ;;
+  esac
 }
 
 output_steps_yaml() {
   wait_step
 
-  if [[ "$agent_version" =~ (beta|rc) ]] ; then
-    trigger_step \
-      "beta ${agent_version}" \
-      "agent-release-beta"
-  else
-    trigger_step \
-      "stable ${agent_version}" \
-      "agent-release-stable"
-  fi
+  case "${agent_version}" in
+    *beta*|*rc*)
+      trigger_step \
+        "beta ${agent_version}" \
+        "agent-release-beta"
+      ;;
+
+    4.*)
+      # This case shouldn't be reached while the v4 branch version string
+      # includes "beta".
+      trigger_step \
+        "beta ${agent_version}" \
+        "agent-release-beta"
+      ;;
+
+    3.*)
+      # TODO(v4 release): move stable release to v4
+      trigger_step \
+        "oldstable ${agent_version}" \
+        "agent-release-oldstable"
+      trigger_step \
+        "stable ${agent_version}" \
+        "agent-release-stable"
+      ;;
+  esac
 }
 
 agent_version=$(buildkite-agent meta-data get "agent-version")


### PR DESCRIPTION
## Description

Create a new "codename" `oldstable` (like Debian's `oldstable`), and release v3 to it.
Also push to edge from v4 instead of v3, so that we can dogfood v4 more.

## Context

v4 is coming - #3807

## Changes

- Create an oldstable release pipeline.yml. (~~Depends on creating the pipeline and setting up the OIDC permissions~~ ✅ Done)
  - Skip GitHub and Homebrew releases from oldstable for the moment, because v3 is still stable and will do those.
- Update scripts to accept `oldstable` as a codename.
- Only push version tags (e.g. `3`, `3.123`) as container image tags from `oldstable`, and not e.g. `latest`
- Various shell style tweaks in touched files, mainly `$FOO` -> `${FOO}` and changing consecutive `if...fi` blocks into `case...esac`

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

I did not use AI tools at all... until getting buildsworth to review.