### PR TITLE
Fix error variable shadowing causing incorrect OTEL spans in hooks

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -131,9 +131,8 @@ func (e *Executor) refreshCheckoutRoot() error {
 
 // CheckoutPhase creates the build directory and makes sure we're running the
 // build at the right commit.
-func (e *Executor) CheckoutPhase(ctx context.Context) error {
+func (e *Executor) CheckoutPhase(ctx context.Context) (err error) {
 	span, ctx := tracetools.StartSpanFromContext(ctx, "checkout", e.TracingBackend)
-	var err error
 	defer func() { span.FinishWithError(err) }()
 
 	if err = e.executeGlobalHook(ctx, "pre-checkout"); err != nil {
@@ -168,17 +167,17 @@ func (e *Executor) CheckoutPhase(ctx context.Context) error {
 	}
 
 	// Make sure the build directory exists
-	if err := e.createCheckoutDir(); err != nil {
+	if err = e.createCheckoutDir(); err != nil {
 		return err
 	}
 
-	if err := e.checkout(ctx); err != nil {
+	if err = e.checkout(ctx); err != nil {
 		return err
 	}
 
-	err = e.sendCommitToBuildkite(ctx)
-	if err != nil {
-		e.shell.OptionalWarningf("git-commit-resolution-failed", "Couldn't send commit information to Buildkite: %v", err)
+	// sendCommitToBuildkite is non-critical, don't propagate to span
+	if sendErr := e.sendCommitToBuildkite(ctx); sendErr != nil {
+		e.shell.OptionalWarningf("git-commit-resolution-failed", "Couldn't send commit information to Buildkite: %v", sendErr)
 	}
 
 	// Store the current value of BUILDKITE_BUILD_CHECKOUT_PATH, so we can detect if
@@ -189,15 +188,15 @@ func (e *Executor) CheckoutPhase(ctx context.Context) error {
 	}
 
 	// Run post-checkout hooks
-	if err := e.executeGlobalHook(ctx, "post-checkout"); err != nil {
+	if err = e.executeGlobalHook(ctx, "post-checkout"); err != nil {
 		return err
 	}
 
-	if err := e.executeLocalHook(ctx, "post-checkout"); err != nil {
+	if err = e.executeLocalHook(ctx, "post-checkout"); err != nil {
 		return err
 	}
 
-	if err := e.executePluginHook(ctx, "post-checkout", e.pluginCheckouts); err != nil {
+	if err = e.executePluginHook(ctx, "post-checkout", e.pluginCheckouts); err != nil {
 		return err
 	}
 
@@ -208,7 +207,7 @@ func (e *Executor) CheckoutPhase(ctx context.Context) error {
 	if previousCheckoutPath != "" && previousCheckoutPath != newCheckoutPath {
 		e.shell.Headerf("A post-checkout hook has changed the working directory to \"%s\"", newCheckoutPath)
 
-		if err := e.shell.Chdir(newCheckoutPath); err != nil {
+		if err = e.shell.Chdir(newCheckoutPath); err != nil {
 			return err
 		}
 	}
@@ -828,14 +827,13 @@ func (e *Executor) fetchSource(ctx context.Context) error {
 
 // defaultCheckoutPhase is called by the CheckoutPhase if no global or plugin checkout
 // hook exists. It performs the default checkout on the Repository provided in the config
-func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
+func (e *Executor) defaultCheckoutPhase(ctx context.Context) (err error) {
 	span, _ := tracetools.StartSpanFromContext(ctx, "repo-checkout", e.TracingBackend)
 	span.AddAttributes(map[string]string{
 		"checkout.repo_name": e.Repository,
 		"checkout.refspec":   e.RefSpec,
 		"checkout.commit":    e.Commit,
 	})
-	var err error
 	defer func() { span.FinishWithError(err) }()
 
 	if e.SSHKeyscan {
@@ -856,7 +854,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 	}
 
 	// Make sure the build directory exists and that we change directory into it
-	if err := e.createCheckoutDir(); err != nil {
+	if err = e.createCheckoutDir(); err != nil {
 		return fmt.Errorf("creating checkout dir: %w", err)
 	}
 
@@ -880,7 +878,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 	if osutil.FileExists(existingGitDir) {
 		// Ensure the origin matches the configured repo, so we can
 		// gracefully handle repository renames.
-		if _, err := e.updateRemoteURL(ctx, "", e.Repository); err != nil {
+		if _, err = e.updateRemoteURL(ctx, "", e.Repository); err != nil {
 			return fmt.Errorf("setting origin: %w", err)
 		}
 
@@ -889,13 +887,13 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 			case "dissociate":
 				// If the existing repo is still relying on the reference, then
 				// "dissociate" it (git repack, and delete the alternates file).
-				if err := e.dissociateIfNeeded(ctx, existingGitDir); err != nil {
+				if err = e.dissociateIfNeeded(ctx, existingGitDir); err != nil {
 					return fmt.Errorf("dissociating existing reference clone: %w", err)
 				}
 			case "reference":
 				// If the existing repo does not have a reference to the mirror,
 				// create one. Existing objects don't need cleaning up.
-				if err := e.reassociateIfNeeded(ctx, existingGitDir, mirrorDir); err != nil {
+				if err = e.reassociateIfNeeded(ctx, existingGitDir, mirrorDir); err != nil {
 					return fmt.Errorf("reassociating existing clone: %w", err)
 				}
 			}
@@ -917,7 +915,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 		}
 
 		// Do the clone.
-		if err := gitClone(ctx, e.shell, gitCloneFlags, e.Repository, "."); err != nil {
+		if err = gitClone(ctx, e.shell, gitCloneFlags, e.Repository, "."); err != nil {
 			return fmt.Errorf("cloning git repository: %w", err)
 		}
 	}
@@ -925,27 +923,27 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 	// Git clean prior to checkout, we do this even if submodules have been
 	// disabled to ensure previous submodules are cleaned up
 	if hasGitSubmodules(e.shell) {
-		if err := gitCleanSubmodules(ctx, e.shell, e.GitCleanFlags); err != nil {
+		if err = gitCleanSubmodules(ctx, e.shell, e.GitCleanFlags); err != nil {
 			return fmt.Errorf("cleaning git submodules: %w", err)
 		}
 	}
 
-	if err := gitClean(ctx, e.shell, e.GitCleanFlags); err != nil {
+	if err = gitClean(ctx, e.shell, e.GitCleanFlags); err != nil {
 		return fmt.Errorf("cleaning git repository: %w", err)
 	}
 
-	if err := e.fetchSource(ctx); err != nil {
+	if err = e.fetchSource(ctx); err != nil {
 		return err
 	}
 
 	gitCheckoutFlags := e.GitCheckoutFlags
 
 	if e.Commit == "HEAD" {
-		if err := gitCheckout(ctx, e.shell, gitCheckoutFlags, "FETCH_HEAD"); err != nil {
+		if err = gitCheckout(ctx, e.shell, gitCheckoutFlags, "FETCH_HEAD"); err != nil {
 			return fmt.Errorf("checking out FETCH_HEAD: %w", err)
 		}
 	} else {
-		if err := gitCheckout(ctx, e.shell, gitCheckoutFlags, e.Commit); err != nil {
+		if err = gitCheckout(ctx, e.shell, gitCheckoutFlags, e.Commit); err != nil {
 			return fmt.Errorf("checking out commit %q: %w", e.Commit, err)
 		}
 	}
@@ -966,7 +964,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 		// is only available in git version 1.8.1, so
 		// if the call fails, continue the job
 		// script, and show an informative error.
-		if err := e.shell.Command("git", "submodule", "sync", "--recursive").Run(ctx); err != nil {
+		if syncErr := e.shell.Command("git", "submodule", "sync", "--recursive").Run(ctx); syncErr != nil {
 			gitVersionOutput, _ := e.shell.Command("git", "--version").RunAndCaptureStdout(ctx)
 			e.shell.Warningf("Failed to recursively sync git submodules. This is most likely because you have an older version of git installed (" + gitVersionOutput + ") and you need version 1.8.1 and above. If you're using submodules, it's highly recommended you upgrade if you can.")
 		}
@@ -983,9 +981,9 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 		}
 
 		// Checking for submodule repositories
-		submoduleRepos, err := gitEnumerateSubmoduleURLs(ctx, e.shell)
-		if err != nil {
-			e.shell.Warningf("Failed to enumerate git submodules: %v", err)
+		submoduleRepos, enumErr := gitEnumerateSubmoduleURLs(ctx, e.shell)
+		if enumErr != nil {
+			e.shell.Warningf("Failed to enumerate git submodules: %v", enumErr)
 		} else {
 			mirrorSubmodules := e.GitMirrorsPath != ""
 			for _, repository := range submoduleRepos {
@@ -999,19 +997,19 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 				}
 				// It's all mirrored submodules for the rest of the loop.
 
-				mirrorDir, err := e.getOrUpdateMirrorDir(ctx, repository)
-				if err != nil {
-					return fmt.Errorf("getting/updating mirror dir for submodules: %w", err)
+				subMirrorDir, mirrorErr := e.getOrUpdateMirrorDir(ctx, repository)
+				if mirrorErr != nil {
+					return fmt.Errorf("getting/updating mirror dir for submodules: %w", mirrorErr)
 				}
 
 				// Switch back to the checkout dir, doing other operations from GitMirrorsPath will fail.
-				if err := e.createCheckoutDir(); err != nil {
+				if err = e.createCheckoutDir(); err != nil {
 					return fmt.Errorf("creating checkout dir: %w", err)
 				}
 
 				submoduleArgs := slices.Clone(args)
-				if mirrorDir != "" {
-					submoduleArgs = append(submoduleArgs, "submodule", "update", "--init", "--recursive", "--force", "--reference", mirrorDir)
+				if subMirrorDir != "" {
+					submoduleArgs = append(submoduleArgs, "submodule", "update", "--init", "--recursive", "--force", "--reference", subMirrorDir)
 					if e.GitMirrorCheckoutMode == "dissociate" {
 						submoduleArgs = append(submoduleArgs, "--dissociate")
 					}
@@ -1020,20 +1018,20 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 					submoduleArgs = append(submoduleArgs, "submodule", "update", "--init", "--recursive", "--force")
 				}
 
-				if err := e.shell.Command("git", submoduleArgs...).Run(ctx); err != nil {
+				if err = e.shell.Command("git", submoduleArgs...).Run(ctx); err != nil {
 					return fmt.Errorf("updating submodules: %w", err)
 				}
 			}
 
 			if !mirrorSubmodules {
 				args = append(args, "submodule", "update", "--init", "--recursive", "--force")
-				if err := e.shell.Command("git", args...).Run(ctx); err != nil {
+				if err = e.shell.Command("git", args...).Run(ctx); err != nil {
 					return fmt.Errorf("updating submodules: %w", err)
 				}
 			}
 
 			cmd := e.shell.Command("git", "submodule", "foreach", "--recursive", "git reset --hard")
-			if err := cmd.Run(ctx); err != nil {
+			if err = cmd.Run(ctx); err != nil {
 				return fmt.Errorf("resetting submodules: %w", err)
 			}
 		}
@@ -1044,12 +1042,12 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) error {
 	// good solution to this problem that we've found
 	e.shell.Commentf("Cleaning again to catch any post-checkout changes")
 
-	if err := gitClean(ctx, e.shell, e.GitCleanFlags); err != nil {
+	if err = gitClean(ctx, e.shell, e.GitCleanFlags); err != nil {
 		return fmt.Errorf("cleaning repository post-checkout: %w", err)
 	}
 
 	if gitSubmodules {
-		if err := gitCleanSubmodules(ctx, e.shell, e.GitCleanFlags); err != nil {
+		if err = gitCleanSubmodules(ctx, e.shell, e.GitCleanFlags); err != nil {
 			return fmt.Errorf("cleaning submodules post-checkout: %w", err)
 		}
 	}

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -131,22 +131,22 @@ func (e *Executor) refreshCheckoutRoot() error {
 
 // CheckoutPhase creates the build directory and makes sure we're running the
 // build at the right commit.
-func (e *Executor) CheckoutPhase(ctx context.Context) (err error) {
+func (e *Executor) CheckoutPhase(ctx context.Context) (retErr error) {
 	span, ctx := tracetools.StartSpanFromContext(ctx, "checkout", e.TracingBackend)
-	defer func() { span.FinishWithError(err) }()
+	defer func() { span.FinishWithError(retErr) }()
 
-	if err = e.executeGlobalHook(ctx, "pre-checkout"); err != nil {
+	if err := e.executeGlobalHook(ctx, "pre-checkout"); err != nil {
 		return err
 	}
 
-	if err = e.executePluginHook(ctx, "pre-checkout", e.pluginCheckouts); err != nil {
+	if err := e.executePluginHook(ctx, "pre-checkout", e.pluginCheckouts); err != nil {
 		return err
 	}
 
 	// Remove the checkout directory if BUILDKITE_CLEAN_CHECKOUT is present
 	if e.CleanCheckout {
 		e.shell.Headerf("Cleaning pipeline checkout")
-		if err = e.removeCheckoutDir(); err != nil {
+		if err := e.removeCheckoutDir(); err != nil {
 			return err
 		}
 	}
@@ -155,8 +155,7 @@ func (e *Executor) CheckoutPhase(ctx context.Context) (err error) {
 
 	// If we have a blank repository then use a temp dir for builds
 	if e.Repository == "" {
-		var buildDir string
-		buildDir, err = os.MkdirTemp("", "buildkite-job-"+e.JobID)
+		buildDir, err := os.MkdirTemp("", "buildkite-job-"+e.JobID)
 		if err != nil {
 			return err
 		}
@@ -167,17 +166,16 @@ func (e *Executor) CheckoutPhase(ctx context.Context) (err error) {
 	}
 
 	// Make sure the build directory exists
-	if err = e.createCheckoutDir(); err != nil {
+	if err := e.createCheckoutDir(); err != nil {
 		return err
 	}
 
-	if err = e.checkout(ctx); err != nil {
+	if err := e.checkout(ctx); err != nil {
 		return err
 	}
 
-	// sendCommitToBuildkite is non-critical, don't propagate to span
-	if sendErr := e.sendCommitToBuildkite(ctx); sendErr != nil {
-		e.shell.OptionalWarningf("git-commit-resolution-failed", "Couldn't send commit information to Buildkite: %v", sendErr)
+	if err := e.sendCommitToBuildkite(ctx); err != nil {
+		e.shell.OptionalWarningf("git-commit-resolution-failed", "Couldn't send commit information to Buildkite: %v", err)
 	}
 
 	// Store the current value of BUILDKITE_BUILD_CHECKOUT_PATH, so we can detect if
@@ -188,15 +186,15 @@ func (e *Executor) CheckoutPhase(ctx context.Context) (err error) {
 	}
 
 	// Run post-checkout hooks
-	if err = e.executeGlobalHook(ctx, "post-checkout"); err != nil {
+	if err := e.executeGlobalHook(ctx, "post-checkout"); err != nil {
 		return err
 	}
 
-	if err = e.executeLocalHook(ctx, "post-checkout"); err != nil {
+	if err := e.executeLocalHook(ctx, "post-checkout"); err != nil {
 		return err
 	}
 
-	if err = e.executePluginHook(ctx, "post-checkout", e.pluginCheckouts); err != nil {
+	if err := e.executePluginHook(ctx, "post-checkout", e.pluginCheckouts); err != nil {
 		return err
 	}
 
@@ -207,7 +205,7 @@ func (e *Executor) CheckoutPhase(ctx context.Context) (err error) {
 	if previousCheckoutPath != "" && previousCheckoutPath != newCheckoutPath {
 		e.shell.Headerf("A post-checkout hook has changed the working directory to \"%s\"", newCheckoutPath)
 
-		if err = e.shell.Chdir(newCheckoutPath); err != nil {
+		if err := e.shell.Chdir(newCheckoutPath); err != nil {
 			return err
 		}
 	}
@@ -827,14 +825,14 @@ func (e *Executor) fetchSource(ctx context.Context) error {
 
 // defaultCheckoutPhase is called by the CheckoutPhase if no global or plugin checkout
 // hook exists. It performs the default checkout on the Repository provided in the config
-func (e *Executor) defaultCheckoutPhase(ctx context.Context) (err error) {
+func (e *Executor) defaultCheckoutPhase(ctx context.Context) (retErr error) {
 	span, _ := tracetools.StartSpanFromContext(ctx, "repo-checkout", e.TracingBackend)
 	span.AddAttributes(map[string]string{
 		"checkout.repo_name": e.Repository,
 		"checkout.refspec":   e.RefSpec,
 		"checkout.commit":    e.Commit,
 	})
-	defer func() { span.FinishWithError(err) }()
+	defer func() { span.FinishWithError(retErr) }()
 
 	if e.SSHKeyscan {
 		addRepositoryHostToSSHKnownHosts(ctx, e.shell, e.Repository)
@@ -845,6 +843,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (err error) {
 	// If we can, get a mirror of the git repository to use for reference later
 	if e.GitMirrorsPath != "" && e.Repository != "" {
 		span.AddAttributes(map[string]string{"checkout.is_using_git_mirrors": "true"})
+		var err error
 		mirrorDir, err = e.getOrUpdateMirrorDir(ctx, e.Repository)
 		if err != nil {
 			return fmt.Errorf("getting/updating git mirror: %w", err)
@@ -854,7 +853,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (err error) {
 	}
 
 	// Make sure the build directory exists and that we change directory into it
-	if err = e.createCheckoutDir(); err != nil {
+	if err := e.createCheckoutDir(); err != nil {
 		return fmt.Errorf("creating checkout dir: %w", err)
 	}
 
@@ -878,7 +877,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (err error) {
 	if osutil.FileExists(existingGitDir) {
 		// Ensure the origin matches the configured repo, so we can
 		// gracefully handle repository renames.
-		if _, err = e.updateRemoteURL(ctx, "", e.Repository); err != nil {
+		if _, err := e.updateRemoteURL(ctx, "", e.Repository); err != nil {
 			return fmt.Errorf("setting origin: %w", err)
 		}
 
@@ -887,13 +886,13 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (err error) {
 			case "dissociate":
 				// If the existing repo is still relying on the reference, then
 				// "dissociate" it (git repack, and delete the alternates file).
-				if err = e.dissociateIfNeeded(ctx, existingGitDir); err != nil {
+				if err := e.dissociateIfNeeded(ctx, existingGitDir); err != nil {
 					return fmt.Errorf("dissociating existing reference clone: %w", err)
 				}
 			case "reference":
 				// If the existing repo does not have a reference to the mirror,
 				// create one. Existing objects don't need cleaning up.
-				if err = e.reassociateIfNeeded(ctx, existingGitDir, mirrorDir); err != nil {
+				if err := e.reassociateIfNeeded(ctx, existingGitDir, mirrorDir); err != nil {
 					return fmt.Errorf("reassociating existing clone: %w", err)
 				}
 			}
@@ -915,7 +914,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (err error) {
 		}
 
 		// Do the clone.
-		if err = gitClone(ctx, e.shell, gitCloneFlags, e.Repository, "."); err != nil {
+		if err := gitClone(ctx, e.shell, gitCloneFlags, e.Repository, "."); err != nil {
 			return fmt.Errorf("cloning git repository: %w", err)
 		}
 	}
@@ -923,27 +922,27 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (err error) {
 	// Git clean prior to checkout, we do this even if submodules have been
 	// disabled to ensure previous submodules are cleaned up
 	if hasGitSubmodules(e.shell) {
-		if err = gitCleanSubmodules(ctx, e.shell, e.GitCleanFlags); err != nil {
+		if err := gitCleanSubmodules(ctx, e.shell, e.GitCleanFlags); err != nil {
 			return fmt.Errorf("cleaning git submodules: %w", err)
 		}
 	}
 
-	if err = gitClean(ctx, e.shell, e.GitCleanFlags); err != nil {
+	if err := gitClean(ctx, e.shell, e.GitCleanFlags); err != nil {
 		return fmt.Errorf("cleaning git repository: %w", err)
 	}
 
-	if err = e.fetchSource(ctx); err != nil {
+	if err := e.fetchSource(ctx); err != nil {
 		return err
 	}
 
 	gitCheckoutFlags := e.GitCheckoutFlags
 
 	if e.Commit == "HEAD" {
-		if err = gitCheckout(ctx, e.shell, gitCheckoutFlags, "FETCH_HEAD"); err != nil {
+		if err := gitCheckout(ctx, e.shell, gitCheckoutFlags, "FETCH_HEAD"); err != nil {
 			return fmt.Errorf("checking out FETCH_HEAD: %w", err)
 		}
 	} else {
-		if err = gitCheckout(ctx, e.shell, gitCheckoutFlags, e.Commit); err != nil {
+		if err := gitCheckout(ctx, e.shell, gitCheckoutFlags, e.Commit); err != nil {
 			return fmt.Errorf("checking out commit %q: %w", e.Commit, err)
 		}
 	}
@@ -964,7 +963,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (err error) {
 		// is only available in git version 1.8.1, so
 		// if the call fails, continue the job
 		// script, and show an informative error.
-		if syncErr := e.shell.Command("git", "submodule", "sync", "--recursive").Run(ctx); syncErr != nil {
+		if err := e.shell.Command("git", "submodule", "sync", "--recursive").Run(ctx); err != nil {
 			gitVersionOutput, _ := e.shell.Command("git", "--version").RunAndCaptureStdout(ctx)
 			e.shell.Warningf("Failed to recursively sync git submodules. This is most likely because you have an older version of git installed (" + gitVersionOutput + ") and you need version 1.8.1 and above. If you're using submodules, it's highly recommended you upgrade if you can.")
 		}
@@ -981,9 +980,9 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (err error) {
 		}
 
 		// Checking for submodule repositories
-		submoduleRepos, enumErr := gitEnumerateSubmoduleURLs(ctx, e.shell)
-		if enumErr != nil {
-			e.shell.Warningf("Failed to enumerate git submodules: %v", enumErr)
+		submoduleRepos, err := gitEnumerateSubmoduleURLs(ctx, e.shell)
+		if err != nil {
+			e.shell.Warningf("Failed to enumerate git submodules: %v", err)
 		} else {
 			mirrorSubmodules := e.GitMirrorsPath != ""
 			for _, repository := range submoduleRepos {
@@ -997,19 +996,19 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (err error) {
 				}
 				// It's all mirrored submodules for the rest of the loop.
 
-				subMirrorDir, mirrorErr := e.getOrUpdateMirrorDir(ctx, repository)
-				if mirrorErr != nil {
-					return fmt.Errorf("getting/updating mirror dir for submodules: %w", mirrorErr)
+				mirrorDir, err := e.getOrUpdateMirrorDir(ctx, repository)
+				if err != nil {
+					return fmt.Errorf("getting/updating mirror dir for submodules: %w", err)
 				}
 
 				// Switch back to the checkout dir, doing other operations from GitMirrorsPath will fail.
-				if err = e.createCheckoutDir(); err != nil {
+				if err := e.createCheckoutDir(); err != nil {
 					return fmt.Errorf("creating checkout dir: %w", err)
 				}
 
 				submoduleArgs := slices.Clone(args)
-				if subMirrorDir != "" {
-					submoduleArgs = append(submoduleArgs, "submodule", "update", "--init", "--recursive", "--force", "--reference", subMirrorDir)
+				if mirrorDir != "" {
+					submoduleArgs = append(submoduleArgs, "submodule", "update", "--init", "--recursive", "--force", "--reference", mirrorDir)
 					if e.GitMirrorCheckoutMode == "dissociate" {
 						submoduleArgs = append(submoduleArgs, "--dissociate")
 					}
@@ -1018,20 +1017,20 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (err error) {
 					submoduleArgs = append(submoduleArgs, "submodule", "update", "--init", "--recursive", "--force")
 				}
 
-				if err = e.shell.Command("git", submoduleArgs...).Run(ctx); err != nil {
+				if err := e.shell.Command("git", submoduleArgs...).Run(ctx); err != nil {
 					return fmt.Errorf("updating submodules: %w", err)
 				}
 			}
 
 			if !mirrorSubmodules {
 				args = append(args, "submodule", "update", "--init", "--recursive", "--force")
-				if err = e.shell.Command("git", args...).Run(ctx); err != nil {
+				if err := e.shell.Command("git", args...).Run(ctx); err != nil {
 					return fmt.Errorf("updating submodules: %w", err)
 				}
 			}
 
 			cmd := e.shell.Command("git", "submodule", "foreach", "--recursive", "git reset --hard")
-			if err = cmd.Run(ctx); err != nil {
+			if err := cmd.Run(ctx); err != nil {
 				return fmt.Errorf("resetting submodules: %w", err)
 			}
 		}
@@ -1042,12 +1041,12 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (err error) {
 	// good solution to this problem that we've found
 	e.shell.Commentf("Cleaning again to catch any post-checkout changes")
 
-	if err = gitClean(ctx, e.shell, e.GitCleanFlags); err != nil {
+	if err := gitClean(ctx, e.shell, e.GitCleanFlags); err != nil {
 		return fmt.Errorf("cleaning repository post-checkout: %w", err)
 	}
 
 	if gitSubmodules {
-		if err = gitCleanSubmodules(ctx, e.shell, e.GitCleanFlags); err != nil {
+		if err := gitCleanSubmodules(ctx, e.shell, e.GitCleanFlags); err != nil {
 			return fmt.Errorf("cleaning submodules post-checkout: %w", err)
 		}
 	}

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -372,11 +372,10 @@ func (e *Executor) tracingImplementationSpecificHookScope(scope string) string {
 }
 
 // executeHook runs a hook script with the hookRunner
-func (e *Executor) executeHook(ctx context.Context, hookCfg HookConfig) error {
+func (e *Executor) executeHook(ctx context.Context, hookCfg HookConfig) (err error) {
 	scopeName := e.tracingImplementationSpecificHookScope(hookCfg.Scope)
 	spanName := e.implementationSpecificSpanName(fmt.Sprintf("%s %s hook", scopeName, hookCfg.Name), "hook.execute")
 	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, e.TracingBackend)
-	var err error
 	defer func() { span.FinishWithError(err) }()
 	span.AddAttributes(map[string]string{
 		"hook.type":    scopeName,
@@ -419,28 +418,27 @@ func (e *Executor) executeHook(ctx context.Context, hookCfg HookConfig) error {
 			// Regardless: not supported right now, or potentially ever.
 			sheb, _ := shellscript.ShebangLine(hookCfg.Path) // we know this won't error because it must have a shebang to be a script
 
-			err := fmt.Errorf(`when trying to run the hook at %q, the agent found that it was a script with a shebang that isn't for a shellscripting language - in this case, %q.
+			return fmt.Errorf(`when trying to run the hook at %q, the agent found that it was a script with a shebang that isn't for a shellscripting language - in this case, %q.
 Hooks of this kind are unfortunately not supported on Windows, as we have no way of interpreting a shebang on Windows`, hookCfg.Path, sheb)
-			return err
 		}
 
 		// It's a script, and we can rely on the OS to figure out how to run it (because we're not on windows), so run it
 		// directly without wrapping
-		if err := e.runUnwrappedHook(ctx, hookName, hookCfg); err != nil {
+		if err = e.runUnwrappedHook(ctx, hookName, hookCfg); err != nil {
 			return fmt.Errorf("running %q script hook: %w", hookName, err)
 		}
 
 		return nil
 	case hook.TypeBinary:
 		// It's a binary, so we'll just run it directly, no wrapping needed or possible
-		if err := e.runUnwrappedHook(ctx, hookName, hookCfg); err != nil {
+		if err = e.runUnwrappedHook(ctx, hookName, hookCfg); err != nil {
 			return fmt.Errorf("running %q binary hook: %w", hookName, err)
 		}
 
 		return nil
 	case hook.TypeShell:
 		// It's definitely a shell script, wrap it so that we can snaffle the changed environment variables
-		if err := e.runWrappedShellScriptHook(ctx, hookName, hookCfg); err != nil {
+		if err = e.runWrappedShellScriptHook(ctx, hookName, hookCfg); err != nil {
 			return fmt.Errorf("running %q shell hook: %w", hookName, err)
 		}
 
@@ -864,9 +862,8 @@ func addRepositoryHostToSSHKnownHosts(ctx context.Context, sh *shell.Shell, repo
 
 // setUp is run before all the phases run. It's responsible for initializing the
 // job environment
-func (e *Executor) setUp(ctx context.Context) error {
+func (e *Executor) setUp(ctx context.Context) (err error) {
 	span, ctx := tracetools.StartSpanFromContext(ctx, "environment", e.TracingBackend)
-	var err error
 	defer func() { span.FinishWithError(err) }()
 
 	// Add the $BUILDKITE_BIN_PATH to the $PATH if we've been given one
@@ -917,7 +914,7 @@ func (e *Executor) setUp(ctx context.Context) error {
 
 	// Fetch and set secrets before environment hook execution
 	if e.Secrets != "" {
-		if err := e.fetchAndSetSecrets(ctx); err != nil {
+		if err = e.fetchAndSetSecrets(ctx); err != nil {
 			return fmt.Errorf("failed to fetch secrets for job: %w", err)
 		}
 	}
@@ -925,8 +922,7 @@ func (e *Executor) setUp(ctx context.Context) error {
 	// It's important to do this before checking out plugins, in case you want
 	// to use the global environment hook to whitelist the plugins that are
 	// allowed to be used.
-	err = e.executeGlobalHook(ctx, "environment")
-	return err
+	return e.executeGlobalHook(ctx, "environment")
 }
 
 // fetchAndSetSecrets handles secrets fetching and processing directly
@@ -1051,10 +1047,10 @@ func (e *Executor) runPreCommandHooks(ctx context.Context) (err error) {
 	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, e.TracingBackend)
 	defer func() { span.FinishWithError(err) }()
 
-	if err := e.executeGlobalHook(ctx, "pre-command"); err != nil {
+	if err = e.executeGlobalHook(ctx, "pre-command"); err != nil {
 		return err
 	}
-	if err := e.executeLocalHook(ctx, "pre-command"); err != nil {
+	if err = e.executeLocalHook(ctx, "pre-command"); err != nil {
 		return err
 	}
 	return e.executePluginHook(ctx, "pre-command", e.pluginCheckouts)
@@ -1081,10 +1077,10 @@ func (e *Executor) runPostCommandHooks(ctx context.Context) (err error) {
 	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, e.TracingBackend)
 	defer func() { span.FinishWithError(err) }()
 
-	if err := e.executeGlobalHook(ctx, "post-command"); err != nil {
+	if err = e.executeGlobalHook(ctx, "post-command"); err != nil {
 		return err
 	}
-	if err := e.executeLocalHook(ctx, "post-command"); err != nil {
+	if err = e.executeLocalHook(ctx, "post-command"); err != nil {
 		return err
 	}
 	return e.executePluginHook(ctx, "post-command", e.pluginCheckouts)
@@ -1156,16 +1152,15 @@ func (e *Executor) CommandPhase(ctx context.Context) (hookErr, commandErr error)
 }
 
 // defaultCommandPhase is executed if there is no global or plugin command hook
-func (e *Executor) defaultCommandPhase(ctx context.Context) error {
+func (e *Executor) defaultCommandPhase(ctx context.Context) (err error) {
 	defer func() {
-		if err := e.redactors.Flush(); err != nil {
-			e.shell.Errorf("Error flushing redactors: %v", err)
+		if flushErr := e.redactors.Flush(); flushErr != nil {
+			e.shell.Errorf("Error flushing redactors: %v", flushErr)
 		}
 	}()
 
 	spanName := e.implementationSpecificSpanName("default command hook", "hook.execute")
 	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, e.TracingBackend)
-	var err error
 	defer func() { span.FinishWithError(err) }()
 	span.AddAttributes(map[string]string{
 		"hook.name": "command",
@@ -1277,8 +1272,7 @@ func (e *Executor) defaultCommandPhase(ctx context.Context) error {
 		if e.Debug {
 			e.shell.Commentf("Detected deprecated docker environment variables")
 		}
-		err = runDeprecatedDockerIntegration(ctx, e.shell, []string{cmdToExec})
-		return err
+		return runDeprecatedDockerIntegration(ctx, e.shell, []string{cmdToExec})
 	}
 
 	var cmd []string
@@ -1291,8 +1285,7 @@ func (e *Executor) defaultCommandPhase(ctx context.Context) error {
 		e.shell.Promptf("%s", cmdToExec)
 	}
 
-	err = e.shell.Command(cmd[0], cmd[1:]...).Run(ctx, shell.ShowPrompt(false))
-	return err
+	return e.shell.Command(cmd[0], cmd[1:]...).Run(ctx, shell.ShowPrompt(false))
 }
 
 /*

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -1092,7 +1092,11 @@ func (e *Executor) CommandPhase(ctx context.Context) (hookErr, commandErr error)
 
 	span, ctx := tracetools.StartSpanFromContext(ctx, "command", e.TracingBackend)
 	defer func() {
-		span.FinishWithError(hookErr)
+		if hookErr != nil {
+			span.FinishWithError(hookErr)
+		} else {
+			span.FinishWithError(commandErr)
+		}
 	}()
 
 	// Run postCommandHooks, even if there is an error from the command, but not if there is an

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -134,10 +134,10 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 		e.shell = sh
 	}
 
-	var err error
+	var retErr error
 	span, ctx, stopper := e.startTracing(ctx)
 	defer stopper()
-	defer func() { span.FinishWithError(err) }()
+	defer func() { span.FinishWithError(retErr) }()
 
 	// Listen for cancellation. Once ctx is cancelled, some tasks can run
 	// afterwards during the signal grace period. These use graceCtx.
@@ -157,6 +157,7 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 		cleanup, err := e.startJobAPI()
 		if err != nil {
 			e.shell.Errorf("Error setting up Job API: %v", err)
+			retErr = err
 			return 1
 		}
 		defer cleanup()
@@ -186,6 +187,7 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 		err := e.configureGitCredentialHelper(ctx)
 		if err != nil {
 			e.shell.Errorf("Error configuring git credential helper: %v", err)
+			retErr = err
 			return shell.ExitCode(err)
 		}
 
@@ -193,6 +195,7 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 		err = e.configureHTTPSInsteadOfSSH(ctx)
 		if err != nil {
 			e.shell.Errorf("Error configuring https instead of ssh: %v", err)
+			retErr = err
 			return shell.ExitCode(err)
 		}
 	}
@@ -200,13 +203,13 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 	// Initialize the environment, a failure here will still call the tearDown.
 	// setUp can fail due to infrastructure errors (secret fetch, env init)
 	// or due to a user hook (environment hook) returning non-zero.
-	if err = e.setUp(ctx); err != nil {
-		e.shell.Errorf("Error setting up job executor: %v", err)
+	if retErr = e.setUp(ctx); retErr != nil {
+		e.shell.Errorf("Error setting up job executor: %v", retErr)
 
 		// If the error is a typed ExitError (e.g. from a hook), preserve
 		// the hook's exit code. Otherwise it's an infra error — return
 		// ExitCodeSetupFailure so the parent can map it to -1.
-		if exitErr := new(shell.ExitError); errors.As(err, &exitErr) {
+		if exitErr := new(shell.ExitError); errors.As(retErr, &exitErr) {
 			return exitErr.Code
 		}
 		return ExitCodeSetupFailure
@@ -296,7 +299,7 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 	// Phase errors are where something of ours broke that merits a big red error
 	// this won't include command failures, as we view that as more in the user space
 	if phaseErr != nil {
-		err = phaseErr
+		retErr = phaseErr
 		e.shell.Errorf("%v", phaseErr)
 		return shell.ExitCode(phaseErr)
 	}
@@ -372,11 +375,11 @@ func (e *Executor) tracingImplementationSpecificHookScope(scope string) string {
 }
 
 // executeHook runs a hook script with the hookRunner
-func (e *Executor) executeHook(ctx context.Context, hookCfg HookConfig) (err error) {
+func (e *Executor) executeHook(ctx context.Context, hookCfg HookConfig) (retErr error) {
 	scopeName := e.tracingImplementationSpecificHookScope(hookCfg.Scope)
 	spanName := e.implementationSpecificSpanName(fmt.Sprintf("%s %s hook", scopeName, hookCfg.Name), "hook.execute")
 	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, e.TracingBackend)
-	defer func() { span.FinishWithError(err) }()
+	defer func() { span.FinishWithError(retErr) }()
 	span.AddAttributes(map[string]string{
 		"hook.type":    scopeName,
 		"hook.name":    hookCfg.Name,
@@ -418,27 +421,28 @@ func (e *Executor) executeHook(ctx context.Context, hookCfg HookConfig) (err err
 			// Regardless: not supported right now, or potentially ever.
 			sheb, _ := shellscript.ShebangLine(hookCfg.Path) // we know this won't error because it must have a shebang to be a script
 
-			return fmt.Errorf(`when trying to run the hook at %q, the agent found that it was a script with a shebang that isn't for a shellscripting language - in this case, %q.
+			err := fmt.Errorf(`when trying to run the hook at %q, the agent found that it was a script with a shebang that isn't for a shellscripting language - in this case, %q.
 Hooks of this kind are unfortunately not supported on Windows, as we have no way of interpreting a shebang on Windows`, hookCfg.Path, sheb)
+			return err
 		}
 
 		// It's a script, and we can rely on the OS to figure out how to run it (because we're not on windows), so run it
 		// directly without wrapping
-		if err = e.runUnwrappedHook(ctx, hookName, hookCfg); err != nil {
+		if err := e.runUnwrappedHook(ctx, hookName, hookCfg); err != nil {
 			return fmt.Errorf("running %q script hook: %w", hookName, err)
 		}
 
 		return nil
 	case hook.TypeBinary:
 		// It's a binary, so we'll just run it directly, no wrapping needed or possible
-		if err = e.runUnwrappedHook(ctx, hookName, hookCfg); err != nil {
+		if err := e.runUnwrappedHook(ctx, hookName, hookCfg); err != nil {
 			return fmt.Errorf("running %q binary hook: %w", hookName, err)
 		}
 
 		return nil
 	case hook.TypeShell:
 		// It's definitely a shell script, wrap it so that we can snaffle the changed environment variables
-		if err = e.runWrappedShellScriptHook(ctx, hookName, hookCfg); err != nil {
+		if err := e.runWrappedShellScriptHook(ctx, hookName, hookCfg); err != nil {
 			return fmt.Errorf("running %q shell hook: %w", hookName, err)
 		}
 
@@ -862,9 +866,9 @@ func addRepositoryHostToSSHKnownHosts(ctx context.Context, sh *shell.Shell, repo
 
 // setUp is run before all the phases run. It's responsible for initializing the
 // job environment
-func (e *Executor) setUp(ctx context.Context) (err error) {
+func (e *Executor) setUp(ctx context.Context) (retErr error) {
 	span, ctx := tracetools.StartSpanFromContext(ctx, "environment", e.TracingBackend)
-	defer func() { span.FinishWithError(err) }()
+	defer func() { span.FinishWithError(retErr) }()
 
 	// Add the $BUILDKITE_BIN_PATH to the $PATH if we've been given one
 	if e.BinPath != "" {
@@ -914,7 +918,7 @@ func (e *Executor) setUp(ctx context.Context) (err error) {
 
 	// Fetch and set secrets before environment hook execution
 	if e.Secrets != "" {
-		if err = e.fetchAndSetSecrets(ctx); err != nil {
+		if err := e.fetchAndSetSecrets(ctx); err != nil {
 			return fmt.Errorf("failed to fetch secrets for job: %w", err)
 		}
 	}
@@ -1002,10 +1006,9 @@ func (e *Executor) fetchAndSetSecrets(ctx context.Context) error {
 }
 
 // tearDown is called before the executor exits, even on error
-func (e *Executor) tearDown(ctx context.Context) error {
+func (e *Executor) tearDown(ctx context.Context) (retErr error) {
 	span, ctx := tracetools.StartSpanFromContext(ctx, "pre-exit", e.TracingBackend)
-	var err error
-	defer func() { span.FinishWithError(err) }()
+	defer func() { span.FinishWithError(retErr) }()
 
 	// In vanilla agent usage, there's always a command phase.
 	// But over in agent-stack-k8s, which splits the agent phases among
@@ -1014,15 +1017,15 @@ func (e *Executor) tearDown(ctx context.Context) error {
 	// Unfortunately pre-exit hooks are often not written with this split in
 	// mind.
 	if e.includePhase("command") {
-		if err = e.executeGlobalHook(ctx, "pre-exit"); err != nil {
+		if err := e.executeGlobalHook(ctx, "pre-exit"); err != nil {
 			return err
 		}
 
-		if err = e.executeLocalHook(ctx, "pre-exit"); err != nil {
+		if err := e.executeLocalHook(ctx, "pre-exit"); err != nil {
 			return err
 		}
 
-		if err = e.executePluginHook(ctx, "pre-exit", e.pluginCheckouts); err != nil {
+		if err := e.executePluginHook(ctx, "pre-exit", e.pluginCheckouts); err != nil {
 			return err
 		}
 	}
@@ -1033,7 +1036,7 @@ func (e *Executor) tearDown(ctx context.Context) error {
 	}
 
 	for _, dir := range e.cleanupDirs {
-		if err = os.RemoveAll(dir); err != nil {
+		if err := os.RemoveAll(dir); err != nil {
 			e.shell.Warningf("Failed to remove dir %s: %v", dir, err)
 		}
 	}
@@ -1042,15 +1045,15 @@ func (e *Executor) tearDown(ctx context.Context) error {
 }
 
 // runPreCommandHooks runs the pre-command hooks and adds tracing spans.
-func (e *Executor) runPreCommandHooks(ctx context.Context) (err error) {
+func (e *Executor) runPreCommandHooks(ctx context.Context) (retErr error) {
 	spanName := e.implementationSpecificSpanName("pre-command", "pre-command hooks")
 	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, e.TracingBackend)
-	defer func() { span.FinishWithError(err) }()
+	defer func() { span.FinishWithError(retErr) }()
 
-	if err = e.executeGlobalHook(ctx, "pre-command"); err != nil {
+	if err := e.executeGlobalHook(ctx, "pre-command"); err != nil {
 		return err
 	}
-	if err = e.executeLocalHook(ctx, "pre-command"); err != nil {
+	if err := e.executeLocalHook(ctx, "pre-command"); err != nil {
 		return err
 	}
 	return e.executePluginHook(ctx, "pre-command", e.pluginCheckouts)
@@ -1072,15 +1075,15 @@ func (e *Executor) runCommand(ctx context.Context) error {
 }
 
 // runPostCommandHooks runs the post-command hooks and adds tracing spans.
-func (e *Executor) runPostCommandHooks(ctx context.Context) (err error) {
+func (e *Executor) runPostCommandHooks(ctx context.Context) (retErr error) {
 	spanName := e.implementationSpecificSpanName("post-command", "post-command hooks")
 	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, e.TracingBackend)
-	defer func() { span.FinishWithError(err) }()
+	defer func() { span.FinishWithError(retErr) }()
 
-	if err = e.executeGlobalHook(ctx, "post-command"); err != nil {
+	if err := e.executeGlobalHook(ctx, "post-command"); err != nil {
 		return err
 	}
-	if err = e.executeLocalHook(ctx, "post-command"); err != nil {
+	if err := e.executeLocalHook(ctx, "post-command"); err != nil {
 		return err
 	}
 	return e.executePluginHook(ctx, "post-command", e.pluginCheckouts)
@@ -1156,16 +1159,16 @@ func (e *Executor) CommandPhase(ctx context.Context) (hookErr, commandErr error)
 }
 
 // defaultCommandPhase is executed if there is no global or plugin command hook
-func (e *Executor) defaultCommandPhase(ctx context.Context) (err error) {
+func (e *Executor) defaultCommandPhase(ctx context.Context) (retErr error) {
 	defer func() {
-		if flushErr := e.redactors.Flush(); flushErr != nil {
-			e.shell.Errorf("Error flushing redactors: %v", flushErr)
+		if err := e.redactors.Flush(); err != nil {
+			e.shell.Errorf("Error flushing redactors: %v", err)
 		}
 	}()
 
 	spanName := e.implementationSpecificSpanName("default command hook", "hook.execute")
 	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, e.TracingBackend)
-	defer func() { span.FinishWithError(err) }()
+	defer func() { span.FinishWithError(retErr) }()
 	span.AddAttributes(map[string]string{
 		"hook.name": "command",
 		"hook.type": "default",
@@ -1276,7 +1279,8 @@ func (e *Executor) defaultCommandPhase(ctx context.Context) (err error) {
 		if e.Debug {
 			e.shell.Commentf("Detected deprecated docker environment variables")
 		}
-		return runDeprecatedDockerIntegration(ctx, e.shell, []string{cmdToExec})
+		err = runDeprecatedDockerIntegration(ctx, e.shell, []string{cmdToExec})
+		return err
 	}
 
 	var cmd []string
@@ -1289,7 +1293,8 @@ func (e *Executor) defaultCommandPhase(ctx context.Context) (err error) {
 		e.shell.Promptf("%s", cmdToExec)
 	}
 
-	return e.shell.Command(cmd[0], cmd[1:]...).Run(ctx, shell.ShowPrompt(false))
+	err = e.shell.Command(cmd[0], cmd[1:]...).Run(ctx, shell.ShowPrompt(false))
+	return err
 }
 
 /*


### PR DESCRIPTION
## Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
The observed problem is that the internals of [Tracing in the Buildkite agent](https://buildkite.com/docs/agent/v3/tracing#using-opentelemetry-tracing) incorrectly report `OK` spans that should be `ERROR` spans.

### Issue 1: Variable shadowing in child spans

| Before | After |
|--------|-------|
| ![broken](https://github.com/user-attachments/assets/f7082bc2-a699-4e4a-ab78-4984eb4c9064) | ![fixed](https://github.com/user-attachments/assets/77345e29-9ce3-4365-b165-f711482f9dac) |

The OTEL span capture is done with a predeclared `err` value accessed in a `defer` block, but not all error returning lines set the `error` that the `defer` block accesses, and are instead creating their own shadowed version of `err`.

Here's the problem in practice:

```go
func stuff() error {
  var err error
  defer func() { span.FinishWithError(err) }() // <-- this err is always nil, because
  if err := someFunction(); err != nil { // <-- err := here creates a new variable called err
    return err
  }
}
```

A fixed version of this code either looks like :

```go
func stuff() error {
  var err error
  defer func() { span.FinishWithError(err) }()
  if err = someFunction(); err != nil { // <-- note err = , not err :=
    return err
  }
}
```

or, equally valid

```go
func stuff() (err error) {
  defer func() { span.FinishWithError(err) }()
  if err = someFunction(); err != nil {
    return err
  }
}
```

### Issue 2: Command span ignoring command errors

| Before | After |
|--------|-------|
| ![broken](https://github.com/user-attachments/assets/97565f80-0048-402b-8602-1906dab1b6b4) | ![fixed](https://github.com/user-attachments/assets/7ca7f74b-7790-45e9-95c7-1e56d01f81e6) |

The `command` span in `CommandPhase` was only finishing with `hookErr`, ignoring `commandErr`. When the command itself failed (not a pre/post hook), the span showed OK while its child `default command hook` span showed ERROR.

```go
func CommandPhase() (hookErr, commandErr error) {
    defer func() { span.FinishWithError(hookErr) }() // <-- ignores commandErr
    // ...
    commandErr = runCommand() // this error never reaches the span, so the span is OK
    return nil, commandErr
}
```

Fixed to check both:

```go
defer func() {
    if hookErr != nil {
        span.FinishWithError(hookErr)
    } else {
        span.FinishWithError(commandErr)
    }
}()
```

### Alternatives considered

I considered not using a named `err` return value, and instead continue to use `var err error`. The downside of this is that you need to remember at every error-returning line to set the variable:

```go
func stuff() (err error) {
  var err error
  defer func() { span.FinishWithError(err) }()
  // ...
  err = fmt.Errorf("something bad: %w", err)
  return err
}
```

Failure to do the above will result in a mismatch between the function returned error and the span finish with error.

It's far more ergonomic to simply have the following, and then you don't have to worry about forgetting to set `err`.

```go
func stuff() (err error) {
  defer func() { span.FinishWithError(err) }()
  return fmt.Errorf("something bad: %w", err)
}
```

## Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->
N/A

## Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->
- Fix variable shadowing so child spans (hooks, checkout, etc.) show `ERROR` when they fail
- Fix `command` span to reflect command errors, not just hook errors
- Rename non-fatal non-OTEL-capturing errors for clarity, e.g. [here](https://github.com/buildkite/agent/pull/3932/changes#diff-ab2257bcff4d75670c1e896bba230e26db13910cc84f23621d7528518d211c48R178-R181) and [here](https://github.com/buildkite/agent/pull/3932/changes#diff-ab2257bcff4d75670c1e896bba230e26db13910cc84f23621d7528518d211c48R967-R970). This isn't a change in behavior, but the now renamed non-shadowed errors makes it clear they are unrelated to our span capture `error` variable. This is correct (and unchanged) behavior per the OTEL spec that these non-fatal errors should not capture exceptions:

> An exception SHOULD be recorded as an Event on the span during which it occurred if and only if it remains unhandled when the span ends and causes the span status to be set to ERROR.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)
- Have build the binary locally and tested. Expand for how to reproduce the testing I did
<!--
Note: if the tests fail to run locally, please let us know!
-->

<details>
<summary>End-to-end local validation process (expand me)</summary>

````bash
# Start Jaeger
docker run -d --name jaeger -p 4543:16686 -p 4344:4317 jaegertracing/all-in-one:latest

# Create failing hook
mkdir -p /tmp/bk-test/hooks /tmp/bk-test/builds /tmp/bk-test/checkout
echo -e '#!/bin/bash\nexit 1' > /tmp/bk-test/hooks/pre-command
chmod +x /tmp/bk-test/hooks/pre-command

# Build both versions
git checkout main && go build -o /tmp/agent-broken .
git checkout refactor-error-handling-for-tracing && go build -o /tmp/agent-fixed .

# Run broken (span shows OK)
OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4344 BUILDKITE_BUILD_CHECKOUT_PATH=/tmp/bk-test/checkout \
  /tmp/agent-broken bootstrap --command "echo hi" --job broken --repository x --commit HEAD \
  --branch main --build-path /tmp/bk-test/builds --hooks-path /tmp/bk-test/hooks \
  --phases command --tracing-backend opentelemetry --tracing-service-name broken \
  --agent a --organization o --pipeline p --pipeline-provider github

# Run fixed (span shows ERROR)
OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4344 BUILDKITE_BUILD_CHECKOUT_PATH=/tmp/bk-test/checkout \
  /tmp/agent-fixed bootstrap --command "echo hi" --job fixed --repository x --commit HEAD \
  --branch main --build-path /tmp/bk-test/builds --hooks-path /tmp/bk-test/hooks \
  --phases command --tracing-backend opentelemetry --tracing-service-name fixed \
  --agent a --organization o --pipeline p --pipeline-provider github

# View traces at http://localhost:4543
# Compare "agent pre-command hook" span - broken has no error, fixed has otel.status_code=ERROR
````

</details>

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->
http://github.com/Canva

## Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
I identified the problem and an opportunity to use named return values, then used Claude Opus 4.5 to implement and validate the desired fix.
