### PR TITLE
fix: Stop sending file paths on context cancellation

### DIFF
--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -222,7 +222,11 @@ func (a *Uploader) literal(ctx context.Context, paths iter.Seq[string], filesCh 
 		if path == "" {
 			continue
 		}
-		filesCh <- path
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case filesCh <- path:
+		}
 	}
 	return nil
 }
@@ -256,8 +260,12 @@ func (a *Uploader) glob(ctx context.Context, paths iter.Seq[string], filesCh cha
 			a.logger.Warnf("One of the glob patterns matched a directory: %s", path)
 			return nil
 		}
-		filesCh <- path
-		return nil
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case filesCh <- path:
+			return nil
+		}
 	}
 	err := zzglob.MultiGlob(ctx, patterns, walkDirFunc, zzglob.TraverseSymlinks(a.conf.GlobResolveFollowSymlinks))
 	if err != nil {


### PR DESCRIPTION
## Description

Fix a potential deadlock in artifact uploader.

## Context

https://slopcannon.tail952194.ts.net/lachlan/deepsec-buildkite-agent/BUG/agent-other-deadlock-eeb0c25a7e.md

## Changes

If the context is done, stop sending.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

Bug was found by an LLM (deepsec), and fixed by me.