### PR TITLE
fix: nil deref if HTTP/2 is disabled

### DIFF
--- a/internal/agenthttp/client.go
+++ b/internal/agenthttp/client.go
@@ -102,6 +102,10 @@ func newTransport(conf *clientConfig) *http.Transport {
 		}
 	} else {
 		transport.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
+		// Ensure TLSClientConfig is not nil, to set NextProtos.
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = new(tls.Config)
+		}
 		// The default TLSClientConfig has h2 in NextProtos, so the
 		// negotiated TLS connection will assume h2 support.
 		// see https://github.com/golang/go/issues/50571


### PR DESCRIPTION
## Description

Fix potential nil dereference when disabling HTTP/2.

## Context

https://slopcannon.tail952194.ts.net/lachlan/deepsec-buildkite-agent/HIGH_BUG/agent-other-logic-bug-ec621ce249.md

## Changes

Ensure `TLSClientConfig` is not nil before setting `NextProtos`. Creating a blank `tls.Config` is fine, it's what Go itself does (see https://cs.opensource.google/go/go/+/refs/tags/go1.26.3:src/net/http/h2_bundle.go;l=7537) 

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

The bug was found with an LLM (deepsec), I made the fix myself.
