### PR TITLE
fix: Always restore process umask

### DIFF
--- a/kubernetes/runner.go
+++ b/kubernetes/runner.go
@@ -87,10 +87,13 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 	r.mux.Handle(rpc.DefaultRPCPath, r.server)
 
-	oldUmask, err := Umask(0) // set umask of socket file to 0o777 (world read-write-executable)
+	// Set umask to 0, so the socket is created with mode 0o777 (world
+	// read-write-executable)
+	oldUmask, err := Umask(0)
 	if err != nil {
 		return fmt.Errorf("failed to set socket umask: %w", err)
 	}
+	defer Umask(oldUmask) //nolint:errcheck // Best-effort cleanup on failure
 	l, err := (&net.ListenConfig{}).Listen(ctx, "unix", r.conf.SocketPath)
 	if err != nil {
 		return fmt.Errorf("failed to listen: %w", err)


### PR DESCRIPTION
## Description

Ensure the process umask is restored, even if there is a failure to listen on the socket.

## Context

https://slopcannon.tail952194.ts.net/lachlan/deepsec-buildkite-agent/MEDIUM/agent-other-insecure-permissions-0da6fccd11.md

## Changes

Add a deferred `Umask(oldUmask)` immediately after checking the error from the first umask.
Setting the same umask twice (defer + usual call after creating the socket) is fine.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

The bug was found by deepsec, the fix is by me.
