### PR TITLE
chore: Add comments rationalising authless world-accessible socket

### DIFF
--- a/kubernetes/runner.go
+++ b/kubernetes/runner.go
@@ -88,7 +88,15 @@ func (r *Runner) Run(ctx context.Context) error {
 	r.mux.Handle(rpc.DefaultRPCPath, r.server)
 
 	// Set umask to 0, so the socket is created with mode 0o777 (world
-	// read-write-executable)
+	// read-write-executable).
+	// The other containers may be running under any arbitrary uid/gid, and
+	// the socket needs to be accessible to them.
+	// This is acceptable because the security boundary of the job is
+	// considered to be _the pod_. The socket is exposed by us only within
+	// the pod.
+	// Note that with or without accessing the socket, a rogue container or
+	// process within the pod can do all sorts of things to disrupt the
+	// normal operation of the job.
 	oldUmask, err := Umask(0)
 	if err != nil {
 		return fmt.Errorf("failed to set socket umask: %w", err)
@@ -313,6 +321,13 @@ type ExitCode struct {
 // contains the env vars that would normally be in the environment of the
 // bootstrap subcommand, particularly, the agent session token.
 func (r *Runner) Register(id int, reply *RegisterResponse) error {
+	// Note that there is no authentication of the client.
+	// This is acceptable because the security boundary of the job is
+	// considered to be _the pod_. The socket is exposed by us only within
+	// the pod.
+	// Note that with or without accessing the socket, a rogue container or
+	// process within the pod can do all sorts of things to disrupt the
+	// normal operation of the job.
 	if id < 0 || id >= len(r.clients) {
 		return fmt.Errorf("unrecognized client id: %d", id)
 	}


### PR DESCRIPTION
## Description

Make the Kubernetes socket less of a HackerOne / deepsec magnet.

## Context

https://slopcannon.tail952194.ts.net/lachlan/deepsec-buildkite-agent/HIGH/agent-missing-auth-efa096ce58.md

## Changes

Add some comments.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

It keeps being reported on H1, and was also found by deepsec.
I authored the words.