### PR TITLE
fix: missing \ in release-homebrew.sh

### DIFF
--- a/.buildkite/steps/release-homebrew.sh
+++ b/.buildkite/steps/release-homebrew.sh
@@ -92,7 +92,7 @@ BASE_FORMULA_FILE="buildkite-agent@${AGENT_VERSION%%.*}.rb"
 FORMULA_FILE="./pkg/${BASE_FORMULA_FILE}"
 UPDATED_FORMULA_FILE=./pkg/${BASE_FORMULA_FILE}.updated
 
-CONTENTS_API_RESPONSE="$(curl
+CONTENTS_API_RESPONSE="$(curl \
   "https://api.github.com/repos/buildkite/homebrew-buildkite/contents/Formula/${BASE_FORMULA_FILE}" \
   -H "Authorization: token ${GITHUB_RELEASE_ACCESS_TOKEN}")"
 


### PR DESCRIPTION
## Description

Fix a broken command in release-homebrew.sh.

## Context

Found because it broke the Homebrew formula update for v3.127.1.

## Changes

Add the required `\`.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)


## Disclosures / Credits

I broke it, I fix it