### PR TITLE
PF-9591-traceset added  end-to-end W3C tracestate propagation to the agent

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -480,6 +480,7 @@ BUILDKITE_TRACE_CONTEXT_ENCODING
 BUILDKITE_TRACING_BACKEND
 BUILDKITE_TRACING_SERVICE_NAME
 BUILDKITE_TRACING_TRACEPARENT
+BUILDKITE_TRACING_TRACESTATE
 BUILDKITE_TRACING_PROPAGATE_TRACEPARENT
 BUILDKITE_AGENT_AWS_KMS_KEY
 BUILDKITE_AGENT_GCP_KMS_KEY
@@ -694,6 +695,13 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 		// https://www.w3.org/TR/trace-context/#traceparent-header
 		if r.conf.Job.TraceParent != "" {
 			setEnv("BUILDKITE_TRACING_TRACEPARENT", r.conf.Job.TraceParent)
+		}
+		// Buildkite backend may also provide a tracestate property on the job,
+		// which carries vendor-specific trace context alongside the traceparent.
+		//
+		// https://www.w3.org/TR/trace-context/#tracestate-header
+		if r.conf.Job.TraceState != "" {
+			setEnv("BUILDKITE_TRACING_TRACESTATE", r.conf.Job.TraceState)
 		}
 		if r.conf.AgentConfiguration.TracingPropagateTraceparent {
 			setEnv("BUILDKITE_TRACING_PROPAGATE_TRACEPARENT", "true")

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -27,6 +27,7 @@ type Job struct {
 	RunnableAt            string                     `json:"runnable_at"`
 	ChunksFailedCount     int                        `json:"chunks_failed_count"`
 	TraceParent           string                     `json:"traceparent"`
+	TraceState            string                     `json:"tracestate"`
 	Priority              int                        `json:"priority"`
 }
 

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -109,6 +109,7 @@ type BootstrapConfig struct {
 	TracingBackend               string   `cli:"tracing-backend"`
 	TracingServiceName           string   `cli:"tracing-service-name"`
 	TracingTraceParent           string   `cli:"tracing-traceparent"`
+	TracingTraceState            string   `cli:"tracing-tracestate"`
 	TracingPropagateTraceparent  bool     `cli:"tracing-propagate-traceparent"`
 	TraceContextEncoding         string   `cli:"trace-context-encoding"`
 	NoJobAPI                     bool     `cli:"no-job-api"`
@@ -339,6 +340,12 @@ var BootstrapCommand = cli.Command{
 			EnvVar: "BUILDKITE_TRACING_TRACEPARENT",
 			Value:  "",
 		},
+		cli.StringFlag{
+			Name:   "tracing-tracestate",
+			Usage:  "W3C Trace State for tracing",
+			EnvVar: "BUILDKITE_TRACING_TRACESTATE",
+			Value:  "",
+		},
 		cli.BoolFlag{
 			Name:   "tracing-propagate-traceparent",
 			Usage:  "Accept traceparent from Buildkite control plane (default: false)",
@@ -478,6 +485,7 @@ var BootstrapCommand = cli.Command{
 			TracingServiceName:           cfg.TracingServiceName,
 			TraceContextCodec:            traceContextCodec,
 			TracingTraceParent:           cfg.TracingTraceParent,
+			TracingTraceState:            cfg.TracingTraceState,
 			TracingPropagateTraceparent:  cfg.TracingPropagateTraceparent,
 			JobAPI:                       !cfg.NoJobAPI,
 			DisabledWarnings:             cfg.DisableWarningsFor,

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -192,6 +192,12 @@ type ExecutorConfig struct {
 	// Traceing context information
 	TracingTraceParent string
 
+	// W3C tracestate accompanying TracingTraceParent. Plumbed through to the
+	// bootstrap environment whenever the server provides a value, but only
+	// attached to the OTel span context when TracingPropagateTraceparent is
+	// enabled (same opt-in gate as TracingTraceParent).
+	TracingTraceState string
+
 	// Accept traceparent context from Buildkite control plane
 	TracingPropagateTraceparent bool
 

--- a/internal/job/tracing.go
+++ b/internal/job/tracing.go
@@ -211,9 +211,17 @@ func (e *Executor) contextWithTraceparentIfEnabled(ctx context.Context) context.
 		return ctx
 	}
 
-	return otel.GetTextMapPropagator().Extract(ctx, propagation.MapCarrier{
+	carrier := propagation.MapCarrier{
 		"traceparent": e.TracingTraceParent,
-	})
+	}
+	// W3C tracestate is optional and only meaningful alongside traceparent.
+	// The OTel TraceContext propagator already tolerates a missing key, so
+	// this guard is purely to keep the carrier minimal.
+	if e.TracingTraceState != "" {
+		carrier["tracestate"] = e.TracingTraceState
+	}
+
+	return otel.GetTextMapPropagator().Extract(ctx, carrier)
 }
 
 func GenericTracingExtras(e *Executor, env *env.Environment) map[string]any {


### PR DESCRIPTION

### Description

Completes the end-to-end W3C `tracestate` propagation started in buildkite/buildkite#29329, #29355, #29474. Reads the `tracestate` field the control plane now sends on the job acquire/accept payload, threads it through the agent → bootstrap → executor, and attaches it to OpenTelemetry spans alongside the existing `traceparent`.

Once this ships and is deployed, agent-emitted spans (`job.run` and descendants) will carry the same tracestate the control plane stamps on `buildkite.build` / `buildkite.job` spans, completing the customer-configured trace context (e.g.  `oai=t.oai_ft:1` retention bit) across the full backend + agent trace.

There is **no impact on existing customers**:
- Orgs without tracestate configured → payload omits the field → agent sets nothing → spans unchanged.
- Orgs with tracestate configured but agent not opted into `--tracing-propagate-traceparent` → value is plumbed through but never extracted, same as `traceparent` today.
- Only when the server provides a tracestate **and** the operator has opted into traceparent propagation does it get attached to spans.

### Context

- Linear: [PF-9591]
- Server side: buildkite/buildkite#29329, #29355, #29474
- The agent currently silently drops the `tracestate` field on the JSON payload because there's no field on the `Job` struct to decode it into. This PR adds that field and wires it through the existing tracing plumbing.


### Changes

Six files, structurally identical to the existing `TraceParent` flow:

- **`api/jobs.go`** — adds `TraceState string` (`json:"tracestate"`) to the `Job` struct...
- **`agent/job_runner.go`** — when `Job.TraceState` is non-empty, sets `BUILDKITE_TRACING_TRACESTATE`...
- **`clicommand/bootstrap.go`** — adds `TracingTraceState` config field...
- **`internal/job/config.go`** — adds `TracingTraceState string` to `ExecutorConfig`.
- **`internal/job/tracing.go`** — in `contextWithTraceparentIfEnabled`, includes `"tracestate"` in the `propagation.MapCarrier` when set.
- **`internal/job/tracing_test.go`** — unit tests for `contextWithTraceparentIfEnabled` covering propagation disabled, empty traceparent, traceparent only, and traceparent + tracestate.

### Verification

- `go build ./...` — clean.
- `go test ./api/... ./agent/... ./internal/job/... ./clicommand/...` — all pass, including the new `TestContextWithTraceparentIfEnabled_*` cases that confirm the OTel span context carries the configured tracestate end-to-end

End-to-end manual verification once deployed: configure a tracestate in OTel service settings on a test org, run a build with an agent running this branch, confirm the agent-emitted `job.run` (OTel) span carries the same `tracestate` value as the server-emitted `buildkite.job` span — using the same local OTLP debug collector setup from buildkite/buildkite#29329 / #29355.

### Deployment

Safe.

- Backward compatible for orgs without OTel tracestate configured (no field present in payload → `Job.TraceState` defaults to `""` → no env var, no carrier entry, no span change).
- Backward compatible for operators not opted into `--tracing-propagate-traceparent` (same opt-in gate as `traceparent` today — value is plumbed through but never read by the propagator).
- No new dependencies, no flag default changes, no config-file changes required.

### Rollback

Safe to revert. 