### PR TITLE
A-1270 part 5: rename Cache -> Cache Entry

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -32,8 +32,8 @@ var ErrCacheEntryNotFound = errors.New("cache entry not found")
 
 var cacheTracer = otel.Tracer("github.com/buildkite/agent/v3/api/cache")
 
-// CacheCreateReq is the request body for creating a cache entry.
-type CacheCreateReq struct {
+// CacheEntryCreateReq is the request body for creating a cache entry.
+type CacheEntryCreateReq struct {
 	Store        string   `json:"store"`
 	Key          string   `json:"key"`
 	FallbackKeys []string `json:"fallback_keys"`
@@ -47,15 +47,15 @@ type CacheCreateReq struct {
 	Organization string   `json:"owner"`
 }
 
-// CacheRetrieveReq is the query for retrieving a cache entry.
-type CacheRetrieveReq struct {
+// CacheEntryRetrieveReq is the query for retrieving a cache entry.
+type CacheEntryRetrieveReq struct {
 	Key          string `url:"key"`
 	Branch       string `url:"branch"`
 	FallbackKeys string `url:"fallback_keys"`
 }
 
-// CacheRetrieveResp describes the cache entry to download.
-type CacheRetrieveResp struct {
+// CacheEntryRetrieveResp describes the cache entry to download.
+type CacheEntryRetrieveResp struct {
 	Store                string    `json:"store"`
 	Key                  string    `json:"key"`
 	Fallback             bool      `json:"fallback"`
@@ -67,8 +67,8 @@ type CacheRetrieveResp struct {
 	Message              string    `json:"message"`
 }
 
-// CacheCreateResp describes where and how to upload the new cache entry.
-type CacheCreateResp struct {
+// CacheEntryCreateResp describes where and how to upload the new cache entry.
+type CacheEntryCreateResp struct {
 	UploadID           string   `json:"upload_id"`
 	StoreObjectName    string   `json:"store_object_name"`
 	Multipart          bool     `json:"multipart"`
@@ -76,14 +76,14 @@ type CacheCreateResp struct {
 	Message            string   `json:"message"`
 }
 
-// CachePeekReq is the query for checking whether a cache entry exists.
-type CachePeekReq struct {
+// CacheEntryPeekReq is the query for checking whether a cache entry exists.
+type CacheEntryPeekReq struct {
 	Key    string `url:"key"`
 	Branch string `url:"branch"`
 }
 
-// CachePeekResp describes the cache entry returned by a peek.
-type CachePeekResp struct {
+// CacheEntryPeekResp describes the cache entry returned by a peek.
+type CacheEntryPeekResp struct {
 	Store        string    `json:"store"`
 	Digest       string    `json:"digest"`
 	ExpiresAt    time.Time `json:"expires_at"`
@@ -110,13 +110,13 @@ type CacheRegistryResp struct {
 	Store string `json:"store"`
 }
 
-// CacheCommitReq is the request body for committing a previously created cache entry.
-type CacheCommitReq struct {
+// CacheEntryCommitReq is the request body for committing a previously created cache entry.
+type CacheEntryCommitReq struct {
 	UploadID string `json:"upload_id"`
 }
 
-// CacheCommitResp acknowledges a commit.
-type CacheCommitResp struct {
+// CacheEntryCommitResp acknowledges a commit.
+type CacheEntryCommitResp struct {
 	Message string `json:"message"`
 }
 
@@ -142,14 +142,14 @@ func (c *Client) CacheRegistry(ctx context.Context, registry string) (CacheRegis
 	return resp, nil
 }
 
-// CachePeekExists checks whether a cache entry exists.
+// CacheEntryPeekExists checks whether a cache entry exists.
 // Returns (resp, true, nil) on hit, (resp, false, nil) on miss (HTTP 404 with
 // CacheEntryNotFound), or (resp, false, err) on any other failure.
-func (c *Client) CachePeekExists(ctx context.Context, registry string, peek CachePeekReq) (CachePeekResp, bool, error) {
-	ctx, span := cacheTracer.Start(ctx, "Client.CachePeekExists")
+func (c *Client) CacheEntryPeekExists(ctx context.Context, registry string, peek CacheEntryPeekReq) (CacheEntryPeekResp, bool, error) {
+	ctx, span := cacheTracer.Start(ctx, "Client.CacheEntryPeekExists")
 	defer span.End()
 
-	var resp CachePeekResp
+	var resp CacheEntryPeekResp
 
 	path, err := cacheQueryPath("/cache_registries/%s/peek", registry, peek)
 	if err != nil {
@@ -168,12 +168,12 @@ func (c *Client) CachePeekExists(ctx context.Context, registry string, peek Cach
 	return interpretCacheResponse(span, res, resp)
 }
 
-// CacheCreate creates a new cache entry and returns upload instructions.
-func (c *Client) CacheCreate(ctx context.Context, registry string, create CacheCreateReq) (CacheCreateResp, error) {
-	ctx, span := cacheTracer.Start(ctx, "Client.CacheCreate")
+// CacheEntryCreate creates a new cache entry and returns upload instructions.
+func (c *Client) CacheEntryCreate(ctx context.Context, registry string, create CacheEntryCreateReq) (CacheEntryCreateResp, error) {
+	ctx, span := cacheTracer.Start(ctx, "Client.CacheEntryCreate")
 	defer span.End()
 
-	var resp CacheCreateResp
+	var resp CacheEntryCreateResp
 
 	req, err := c.newRequest(ctx, http.MethodPut, cachePath("/cache_registries/%s/store", registry), &create)
 	if err != nil {
@@ -190,12 +190,12 @@ func (c *Client) CacheCreate(ctx context.Context, registry string, create CacheC
 	return resp, nil
 }
 
-// CacheCommit marks a previously created cache entry as committed.
-func (c *Client) CacheCommit(ctx context.Context, registry string, commit CacheCommitReq) (CacheCommitResp, error) {
-	ctx, span := cacheTracer.Start(ctx, "Client.CacheCommit")
+// CacheEntryCommit marks a previously created cache entry as committed.
+func (c *Client) CacheEntryCommit(ctx context.Context, registry string, commit CacheEntryCommitReq) (CacheEntryCommitResp, error) {
+	ctx, span := cacheTracer.Start(ctx, "Client.CacheEntryCommit")
 	defer span.End()
 
-	var resp CacheCommitResp
+	var resp CacheEntryCommitResp
 
 	req, err := c.newRequest(ctx, http.MethodPut, cachePath("/cache_registries/%s/commit", registry), &commit)
 	if err != nil {
@@ -212,14 +212,14 @@ func (c *Client) CacheCommit(ctx context.Context, registry string, commit CacheC
 	return resp, nil
 }
 
-// CacheRetrieve retrieves download instructions for a cache entry.
+// CacheEntryRetrieve retrieves download instructions for a cache entry.
 // Returns (resp, true, nil) on hit (possibly via a fallback key), (resp, false,
 // nil) on miss, or (resp, false, err) on any other failure.
-func (c *Client) CacheRetrieve(ctx context.Context, registry string, retrieve CacheRetrieveReq) (CacheRetrieveResp, bool, error) {
-	ctx, span := cacheTracer.Start(ctx, "Client.CacheRetrieve")
+func (c *Client) CacheEntryRetrieve(ctx context.Context, registry string, retrieve CacheEntryRetrieveReq) (CacheEntryRetrieveResp, bool, error) {
+	ctx, span := cacheTracer.Start(ctx, "Client.CacheEntryRetrieve")
 	defer span.End()
 
-	var resp CacheRetrieveResp
+	var resp CacheEntryRetrieveResp
 
 	path, err := cacheQueryPath("/cache_registries/%s/retrieve", registry, retrieve)
 	if err != nil {
@@ -301,8 +301,8 @@ type cacheMessage interface {
 	cacheMessage() string
 }
 
-func (r CachePeekResp) cacheMessage() string     { return r.Message }
-func (r CacheRetrieveResp) cacheMessage() string { return r.Message }
+func (r CacheEntryPeekResp) cacheMessage() string     { return r.Message }
+func (r CacheEntryRetrieveResp) cacheMessage() string { return r.Message }
 
 // interpretCacheResponse maps the dual "200 = hit, 404 + message = miss"
 // convention into the (resp, exists, err) return shape used by peek/retrieve.

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -21,7 +21,7 @@ func newTestCacheClient(t *testing.T, endpoint string) *api.Client {
 	})
 }
 
-func TestCachePeekExists_Success(t *testing.T) {
+func TestCacheEntryPeekExists_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("method = %q, want %q", r.Method, http.MethodGet)
@@ -35,18 +35,18 @@ func TestCachePeekExists_Success(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(api.CachePeekResp{Message: "Cache exists"})
+		_ = json.NewEncoder(w).Encode(api.CacheEntryPeekResp{Message: "Cache exists"})
 	}))
 	defer server.Close()
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, exists, err := client.CachePeekExists(context.Background(), "test-slug", api.CachePeekReq{
+	resp, exists, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
 		Key:    "test-key",
 		Branch: "main",
 	})
 	if err != nil {
-		t.Fatalf("CachePeekExists error = %v, want nil", err)
+		t.Fatalf("CacheEntryPeekExists error = %v, want nil", err)
 	}
 	if !exists {
 		t.Error("exists = false, want true")
@@ -56,22 +56,22 @@ func TestCachePeekExists_Success(t *testing.T) {
 	}
 }
 
-func TestCachePeekExists_NotFound(t *testing.T) {
+func TestCacheEntryPeekExists_NotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		_ = json.NewEncoder(w).Encode(api.CachePeekResp{Message: api.CacheEntryNotFound})
+		_ = json.NewEncoder(w).Encode(api.CacheEntryPeekResp{Message: api.CacheEntryNotFound})
 	}))
 	defer server.Close()
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, exists, err := client.CachePeekExists(context.Background(), "test-slug", api.CachePeekReq{
+	resp, exists, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
 		Key:    "nonexistent-key",
 		Branch: "main",
 	})
 	if err != nil {
-		t.Fatalf("CachePeekExists error = %v, want nil", err)
+		t.Fatalf("CacheEntryPeekExists error = %v, want nil", err)
 	}
 	if exists {
 		t.Error("exists = true, want false")
@@ -81,7 +81,7 @@ func TestCachePeekExists_NotFound(t *testing.T) {
 	}
 }
 
-func TestCachePeekExists_WrongContentType(t *testing.T) {
+func TestCacheEntryPeekExists_WrongContentType(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
@@ -91,50 +91,50 @@ func TestCachePeekExists_WrongContentType(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	_, _, err := client.CachePeekExists(context.Background(), "test-slug", api.CachePeekReq{
+	_, _, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
 		Key:    "test-key",
 		Branch: "main",
 	})
 	if err == nil {
-		t.Error("CachePeekExists error = nil, want non-nil for wrong content type")
+		t.Error("CacheEntryPeekExists error = nil, want non-nil for wrong content type")
 	}
 }
 
-func TestCachePeekExists_CacheRegistryNotFound(t *testing.T) {
+func TestCacheEntryPeekExists_CacheRegistryNotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		_ = json.NewEncoder(w).Encode(api.CachePeekResp{Message: api.CacheRegistryNotFound})
+		_ = json.NewEncoder(w).Encode(api.CacheEntryPeekResp{Message: api.CacheRegistryNotFound})
 	}))
 	defer server.Close()
 
 	client := newTestCacheClient(t, server.URL)
 
-	_, _, err := client.CachePeekExists(context.Background(), "test-slug", api.CachePeekReq{
+	_, _, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
 		Key:    "test-key",
 		Branch: "main",
 	})
 	if err == nil {
-		t.Error("CachePeekExists error = nil, want non-nil for cache registry not found")
+		t.Error("CacheEntryPeekExists error = nil, want non-nil for cache registry not found")
 	}
 }
 
-func TestCachePeekExists_ContentTypeWithCharset(t *testing.T) {
+func TestCacheEntryPeekExists_ContentTypeWithCharset(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(api.CachePeekResp{Message: "Cache exists"})
+		_ = json.NewEncoder(w).Encode(api.CacheEntryPeekResp{Message: "Cache exists"})
 	}))
 	defer server.Close()
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, exists, err := client.CachePeekExists(context.Background(), "test-slug", api.CachePeekReq{
+	resp, exists, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
 		Key:    "test-key",
 		Branch: "main",
 	})
 	if err != nil {
-		t.Fatalf("CachePeekExists error = %v, want nil", err)
+		t.Fatalf("CacheEntryPeekExists error = %v, want nil", err)
 	}
 	if !exists {
 		t.Error("exists = false, want true")
@@ -144,12 +144,12 @@ func TestCachePeekExists_ContentTypeWithCharset(t *testing.T) {
 	}
 }
 
-func TestCacheCreate_Success(t *testing.T) {
+func TestCacheEntryCreate_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut {
 			t.Errorf("method = %q, want %q", r.Method, http.MethodPut)
 		}
-		var req api.CacheCreateReq
+		var req api.CacheEntryCreateReq
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode request body: %v", err)
 		}
@@ -159,7 +159,7 @@ func TestCacheCreate_Success(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(api.CacheCreateResp{
+		_ = json.NewEncoder(w).Encode(api.CacheEntryCreateResp{
 			UploadID:           "upload-123",
 			Multipart:          false,
 			UploadInstructions: []string{"curl -X PUT..."},
@@ -170,7 +170,7 @@ func TestCacheCreate_Success(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, err := client.CacheCreate(context.Background(), "test-slug", api.CacheCreateReq{
+	resp, err := client.CacheEntryCreate(context.Background(), "test-slug", api.CacheEntryCreateReq{
 		Key:          "test-key",
 		FallbackKeys: []string{"fallback-1", "fallback-2"},
 		Compression:  "gzip",
@@ -183,7 +183,7 @@ func TestCacheCreate_Success(t *testing.T) {
 		Organization: "test-org",
 	})
 	if err != nil {
-		t.Fatalf("CacheCreate error = %v, want nil", err)
+		t.Fatalf("CacheEntryCreate error = %v, want nil", err)
 	}
 	if got, want := resp.UploadID, "upload-123"; got != want {
 		t.Errorf("resp.UploadID = %q, want %q", got, want)
@@ -193,7 +193,7 @@ func TestCacheCreate_Success(t *testing.T) {
 	}
 }
 
-func TestCacheRetrieve_Success(t *testing.T) {
+func TestCacheEntryRetrieve_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("method = %q, want %q", r.Method, http.MethodGet)
@@ -204,7 +204,7 @@ func TestCacheRetrieve_Success(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(api.CacheRetrieveResp{
+		_ = json.NewEncoder(w).Encode(api.CacheEntryRetrieveResp{
 			Key:                  "test-key",
 			Fallback:             false,
 			ExpiresAt:            time.Now().Add(24 * time.Hour),
@@ -217,13 +217,13 @@ func TestCacheRetrieve_Success(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, found, err := client.CacheRetrieve(context.Background(), "test-slug", api.CacheRetrieveReq{
+	resp, found, err := client.CacheEntryRetrieve(context.Background(), "test-slug", api.CacheEntryRetrieveReq{
 		Key:          "test-key",
 		Branch:       "main",
 		FallbackKeys: "fallback-1,fallback-2",
 	})
 	if err != nil {
-		t.Fatalf("CacheRetrieve error = %v, want nil", err)
+		t.Fatalf("CacheEntryRetrieve error = %v, want nil", err)
 	}
 	if !found {
 		t.Error("found = false, want true")
@@ -236,22 +236,22 @@ func TestCacheRetrieve_Success(t *testing.T) {
 	}
 }
 
-func TestCacheRetrieve_NotFound(t *testing.T) {
+func TestCacheEntryRetrieve_NotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		_ = json.NewEncoder(w).Encode(api.CacheRetrieveResp{Message: api.CacheEntryNotFound})
+		_ = json.NewEncoder(w).Encode(api.CacheEntryRetrieveResp{Message: api.CacheEntryNotFound})
 	}))
 	defer server.Close()
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, found, err := client.CacheRetrieve(context.Background(), "test-slug", api.CacheRetrieveReq{
+	resp, found, err := client.CacheEntryRetrieve(context.Background(), "test-slug", api.CacheEntryRetrieveReq{
 		Key:    "nonexistent-key",
 		Branch: "main",
 	})
 	if err != nil {
-		t.Fatalf("CacheRetrieve error = %v, want nil", err)
+		t.Fatalf("CacheEntryRetrieve error = %v, want nil", err)
 	}
 	if found {
 		t.Error("found = true, want false")
@@ -261,12 +261,12 @@ func TestCacheRetrieve_NotFound(t *testing.T) {
 	}
 }
 
-func TestCacheCommit_Success(t *testing.T) {
+func TestCacheEntryCommit_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut {
 			t.Errorf("method = %q, want %q", r.Method, http.MethodPut)
 		}
-		var req api.CacheCommitReq
+		var req api.CacheEntryCommitReq
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode request body: %v", err)
 		}
@@ -276,37 +276,37 @@ func TestCacheCommit_Success(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(api.CacheCommitResp{Message: "Committed successfully"})
+		_ = json.NewEncoder(w).Encode(api.CacheEntryCommitResp{Message: "Committed successfully"})
 	}))
 	defer server.Close()
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, err := client.CacheCommit(context.Background(), "test-slug", api.CacheCommitReq{
+	resp, err := client.CacheEntryCommit(context.Background(), "test-slug", api.CacheEntryCommitReq{
 		UploadID: "upload-123",
 	})
 	if err != nil {
-		t.Fatalf("CacheCommit error = %v, want nil", err)
+		t.Fatalf("CacheEntryCommit error = %v, want nil", err)
 	}
 	if got, want := resp.Message, "Committed successfully"; got != want {
 		t.Errorf("resp.Message = %q, want %q", got, want)
 	}
 }
 
-func TestCacheCommit_Failure(t *testing.T) {
+func TestCacheEntryCommit_Failure(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		_ = json.NewEncoder(w).Encode(api.CacheCommitResp{Message: "Invalid upload ID"})
+		_ = json.NewEncoder(w).Encode(api.CacheEntryCommitResp{Message: "Invalid upload ID"})
 	}))
 	defer server.Close()
 
 	client := newTestCacheClient(t, server.URL)
 
-	_, err := client.CacheCommit(context.Background(), "test-slug", api.CacheCommitReq{
+	_, err := client.CacheEntryCommit(context.Background(), "test-slug", api.CacheEntryCommitReq{
 		UploadID: "invalid-upload-id",
 	})
 	if err == nil {
-		t.Error("CacheCommit error = nil, want non-nil for bad request")
+		t.Error("CacheEntryCommit error = nil, want non-nil for bad request")
 	}
 }

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -177,7 +177,7 @@ func saveWithClient(ctx context.Context, l logger.Logger, c cacheOps, cacheIDs [
 					}
 
 					switch {
-					case result.CacheCreated:
+					case result.CacheEntryCreated:
 						l.WithFields(
 							logger.StringField("cache_id", cacheID),
 							logger.StringField("cache_key", result.Key),

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -58,15 +58,15 @@ func createTempCacheConfig(t *testing.T, content string) string {
 
 // Tests for saveWithClient
 
-func TestSaveWithClient_CacheCreated(t *testing.T) {
+func TestSaveWithClient_CacheEntryCreated(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
 	mock := &mockCacheClient{
 		saveFunc: func(ctx context.Context, cacheID string) (SaveResult, error) {
 			return SaveResult{
-				CacheCreated: true,
-				Key:          "test-key-v1",
+				CacheEntryCreated: true,
+				Key:               "test-key-v1",
 				Archive: ArchiveMetrics{
 					Size:             1024,
 					WrittenBytes:     1024,
@@ -93,8 +93,8 @@ func TestSaveWithClient_CacheAlreadyExists(t *testing.T) {
 	mock := &mockCacheClient{
 		saveFunc: func(ctx context.Context, cacheID string) (SaveResult, error) {
 			return SaveResult{
-				CacheCreated: false,
-				Key:          "test-key-v1",
+				CacheEntryCreated: false,
+				Key:               "test-key-v1",
 			}, nil
 		},
 	}
@@ -114,8 +114,8 @@ func TestSaveWithClient_MultipleCaches(t *testing.T) {
 		saveFunc: func(ctx context.Context, cacheID string) (SaveResult, error) {
 			callCount++
 			return SaveResult{
-				CacheCreated: true,
-				Key:          fmt.Sprintf("key-%s", cacheID),
+				CacheEntryCreated: true,
+				Key:               fmt.Sprintf("key-%s", cacheID),
 				Archive: ArchiveMetrics{
 					Size:             100,
 					WrittenBytes:     100,

--- a/internal/cache/client.go
+++ b/internal/cache/client.go
@@ -27,10 +27,10 @@ import (
 // over hand-rolled mocks.
 type cacheAPI interface {
 	CacheRegistry(ctx context.Context, registry string) (api.CacheRegistryResp, error)
-	CachePeekExists(ctx context.Context, registry string, req api.CachePeekReq) (api.CachePeekResp, bool, error)
-	CacheCreate(ctx context.Context, registry string, req api.CacheCreateReq) (api.CacheCreateResp, error)
-	CacheCommit(ctx context.Context, registry string, req api.CacheCommitReq) (api.CacheCommitResp, error)
-	CacheRetrieve(ctx context.Context, registry string, req api.CacheRetrieveReq) (api.CacheRetrieveResp, bool, error)
+	CacheEntryPeekExists(ctx context.Context, registry string, req api.CacheEntryPeekReq) (api.CacheEntryPeekResp, bool, error)
+	CacheEntryCreate(ctx context.Context, registry string, req api.CacheEntryCreateReq) (api.CacheEntryCreateResp, error)
+	CacheEntryCommit(ctx context.Context, registry string, req api.CacheEntryCommitReq) (api.CacheEntryCommitResp, error)
+	CacheEntryRetrieve(ctx context.Context, registry string, req api.CacheEntryRetrieveReq) (api.CacheEntryRetrieveResp, bool, error)
 }
 
 // Sentinel errors for common scenarios.
@@ -171,23 +171,23 @@ type ProgressCallback func(cacheID, stage, message string, current, total int)
 
 // SaveResult contains detailed information about a cache save operation.
 type SaveResult struct {
-	// CacheCreated indicates whether a new cache entry was created.
+	// CacheEntryCreated indicates whether a new cache entry was created.
 	// false means the cache already existed and no upload occurred.
 	// When false, Transfer will be nil since no upload was performed.
-	CacheCreated bool
+	CacheEntryCreated bool
 
 	// Key is the actual cache key that was used (after template expansion).
 	Key string
 
 	// UploadID is the unique identifier for this upload (if created).
-	// Empty if CacheCreated is false.
+	// Empty if CacheEntryCreated is false.
 	UploadID string
 
 	// Archive contains information about the archive that was built.
 	Archive ArchiveMetrics
 
 	// Transfer contains information about the upload (if performed).
-	// Nil if CacheCreated is false (cache already existed).
+	// Nil if CacheEntryCreated is false (cache already existed).
 	Transfer *TransferMetrics
 
 	// TotalDuration is the end-to-end duration of the save operation.

--- a/internal/cache/integration_test.go
+++ b/internal/cache/integration_test.go
@@ -72,18 +72,18 @@ func (m *mockAPIClient) CacheRegistry(ctx context.Context, registry string) (api
 	}, nil
 }
 
-func (m *mockAPIClient) CachePeekExists(ctx context.Context, registry string, req api.CachePeekReq) (api.CachePeekResp, bool, error) {
+func (m *mockAPIClient) CacheEntryPeekExists(ctx context.Context, registry string, req api.CacheEntryPeekReq) (api.CacheEntryPeekResp, bool, error) {
 	reg, ok := m.registries[registry]
 	if !ok {
-		return api.CachePeekResp{}, false, fmt.Errorf("registry not found: %s", registry)
+		return api.CacheEntryPeekResp{}, false, fmt.Errorf("registry not found: %s", registry)
 	}
 
 	entry, exists := reg.cache[req.Key]
 	if !exists || !entry.committed {
-		return api.CachePeekResp{Message: api.CacheEntryNotFound}, false, nil
+		return api.CacheEntryPeekResp{Message: api.CacheEntryNotFound}, false, nil
 	}
 
-	return api.CachePeekResp{
+	return api.CacheEntryPeekResp{
 		Store:        reg.store,
 		Digest:       entry.digest,
 		ExpiresAt:    entry.expiresAt,
@@ -103,10 +103,10 @@ func (m *mockAPIClient) CachePeekExists(ctx context.Context, registry string, re
 	}, true, nil
 }
 
-func (m *mockAPIClient) CacheCreate(ctx context.Context, registry string, req api.CacheCreateReq) (api.CacheCreateResp, error) {
+func (m *mockAPIClient) CacheEntryCreate(ctx context.Context, registry string, req api.CacheEntryCreateReq) (api.CacheEntryCreateResp, error) {
 	reg, ok := m.registries[registry]
 	if !ok {
-		return api.CacheCreateResp{}, fmt.Errorf("registry not found: %s", registry)
+		return api.CacheEntryCreateResp{}, fmt.Errorf("registry not found: %s", registry)
 	}
 
 	uploadID := fmt.Sprintf("upload-%d", time.Now().UnixNano())
@@ -131,37 +131,37 @@ func (m *mockAPIClient) CacheCreate(ctx context.Context, registry string, req ap
 
 	reg.cache[req.Key] = entry
 
-	return api.CacheCreateResp{
+	return api.CacheEntryCreateResp{
 		UploadID:        uploadID,
 		StoreObjectName: storeObjectName,
 	}, nil
 }
 
-func (m *mockAPIClient) CacheCommit(ctx context.Context, registry string, req api.CacheCommitReq) (api.CacheCommitResp, error) {
+func (m *mockAPIClient) CacheEntryCommit(ctx context.Context, registry string, req api.CacheEntryCommitReq) (api.CacheEntryCommitResp, error) {
 	reg, ok := m.registries[registry]
 	if !ok {
-		return api.CacheCommitResp{}, fmt.Errorf("registry not found: %s", registry)
+		return api.CacheEntryCommitResp{}, fmt.Errorf("registry not found: %s", registry)
 	}
 
 	for _, entry := range reg.cache {
 		if entry.uploadID == req.UploadID {
 			entry.committed = true
-			return api.CacheCommitResp{Message: "Cache entry committed successfully"}, nil
+			return api.CacheEntryCommitResp{Message: "Cache entry committed successfully"}, nil
 		}
 	}
 
-	return api.CacheCommitResp{}, fmt.Errorf("upload ID not found: %s", req.UploadID)
+	return api.CacheEntryCommitResp{}, fmt.Errorf("upload ID not found: %s", req.UploadID)
 }
 
-func (m *mockAPIClient) CacheRetrieve(ctx context.Context, registry string, req api.CacheRetrieveReq) (api.CacheRetrieveResp, bool, error) {
+func (m *mockAPIClient) CacheEntryRetrieve(ctx context.Context, registry string, req api.CacheEntryRetrieveReq) (api.CacheEntryRetrieveResp, bool, error) {
 	reg, ok := m.registries[registry]
 	if !ok {
-		return api.CacheRetrieveResp{}, false, fmt.Errorf("registry not found: %s", registry)
+		return api.CacheEntryRetrieveResp{}, false, fmt.Errorf("registry not found: %s", registry)
 	}
 
 	// Try exact key match first
 	if entry, exists := reg.cache[req.Key]; exists && entry.committed {
-		return api.CacheRetrieveResp{
+		return api.CacheEntryRetrieveResp{
 			Store:           reg.store,
 			Key:             entry.key,
 			Fallback:        false,
@@ -178,7 +178,7 @@ func (m *mockAPIClient) CacheRetrieve(ctx context.Context, registry string, req 
 		for _, fbKey := range fallbackKeys {
 			fbKey = strings.TrimSpace(fbKey)
 			if entry, exists := reg.cache[fbKey]; exists && entry.committed {
-				return api.CacheRetrieveResp{
+				return api.CacheEntryRetrieveResp{
 					Store:           reg.store,
 					Key:             entry.key,
 					Fallback:        true,
@@ -190,7 +190,7 @@ func (m *mockAPIClient) CacheRetrieve(ctx context.Context, registry string, req 
 		}
 	}
 
-	return api.CacheRetrieveResp{Message: api.CacheEntryNotFound}, false, nil
+	return api.CacheEntryRetrieveResp{Message: api.CacheEntryNotFound}, false, nil
 }
 
 // createRandomFile creates a file filled with random data
@@ -330,7 +330,7 @@ func TestCacheIntegration_SaveAndRestore(t *testing.T) {
 			t.Fatalf("Save: %v", err)
 		}
 
-		if !result.CacheCreated {
+		if !result.CacheEntryCreated {
 			t.Error("cache should be created")
 		}
 		if result.Key != "v1-test-key" {
@@ -476,7 +476,7 @@ func TestCacheIntegration_SaveAlreadyExists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	if !result1.CacheCreated {
+	if !result1.CacheEntryCreated {
 		t.Error("first save should create cache")
 	}
 
@@ -485,7 +485,7 @@ func TestCacheIntegration_SaveAlreadyExists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	if result2.CacheCreated {
+	if result2.CacheEntryCreated {
 		t.Error("second save should not create cache")
 	}
 	if result2.Transfer != nil {
@@ -534,7 +534,7 @@ func TestCacheIntegration_RestoreWithFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	if !saveResult.CacheCreated {
+	if !saveResult.CacheEntryCreated {
 		t.Error("fallback cache should be created")
 	}
 	t.Logf("Saved fallback cache with key: %s", saveResult.Key)
@@ -592,8 +592,8 @@ func TestCacheIntegration_LargeFileChecksum(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	if !result.CacheCreated {
-		t.Fatal("expected CacheCreated to be true")
+	if !result.CacheEntryCreated {
+		t.Fatal("expected CacheEntryCreated to be true")
 	}
 
 	checksum1 := result.Archive.Sha256Sum
@@ -618,7 +618,7 @@ func TestCacheIntegration_LargeFileChecksum(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	if result2.CacheCreated {
+	if result2.CacheEntryCreated {
 		t.Error("cache should already exist")
 	}
 }

--- a/internal/cache/restore.go
+++ b/internal/cache/restore.go
@@ -95,7 +95,7 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 	c.callProgress(cacheID, "checking_exists", "Checking if cache exists", 0, 0)
 
 	// Check if cache exists
-	retrieveResp, exists, err := c.api.CacheRetrieve(ctx, c.registry, api.CacheRetrieveReq{
+	retrieveResp, exists, err := c.api.CacheEntryRetrieve(ctx, c.registry, api.CacheEntryRetrieveReq{
 		Key:          cacheConfig.Key,
 		Branch:       c.branch,
 		FallbackKeys: strings.Join(cacheConfig.FallbackKeys, ","),
@@ -217,7 +217,7 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 }
 
 // downloadCache downloads a cache archive from storage
-func (c *client) downloadCache(ctx context.Context, retrieveResp api.CacheRetrieveResp, bucketURL string) (tmpDir, archiveFile string, transferInfo *store.TransferInfo, err error) {
+func (c *client) downloadCache(ctx context.Context, retrieveResp api.CacheEntryRetrieveResp, bucketURL string) (tmpDir, archiveFile string, transferInfo *store.TransferInfo, err error) {
 	tracer := otel.Tracer("github.com/buildkite/agent/v3/internal/cache")
 	ctx, span := tracer.Start(ctx, "Client.downloadCache")
 	defer span.End()

--- a/internal/cache/save.go
+++ b/internal/cache/save.go
@@ -25,7 +25,7 @@ import (
 //  6. Commits the cache entry
 //
 // If the cache already exists, no upload is performed and the function returns
-// early with CacheCreated=false and Transfer=nil.
+// early with CacheEntryCreated=false and Transfer=nil.
 //
 // The operation respects context cancellation and will stop immediately when
 // ctx is cancelled, cleaning up any temporary resources.
@@ -42,7 +42,7 @@ import (
 //	if err != nil {
 //	    log.Fatalf("Cache save failed: %v", err)
 //	}
-//	if !result.CacheCreated {
+//	if !result.CacheEntryCreated {
 //	    log.Printf("Cache already exists for key: %s", result.Key)
 //	} else {
 //	    log.Printf("Cache saved: %s (%.2f MB)", result.Key, float64(result.Archive.Size)/(1024*1024))
@@ -93,7 +93,7 @@ func (c *client) Save(ctx context.Context, cacheID string) (SaveResult, error) {
 	c.callProgress(cacheID, "checking_exists", "Checking if cache already exists", 0, 0)
 
 	// Check if cache already exists
-	_, exists, err := c.api.CachePeekExists(ctx, c.registry, api.CachePeekReq{
+	_, exists, err := c.api.CacheEntryPeekExists(ctx, c.registry, api.CacheEntryPeekReq{
 		Key:    cacheConfig.Key,
 		Branch: c.branch,
 	})
@@ -105,7 +105,7 @@ func (c *client) Save(ctx context.Context, cacheID string) (SaveResult, error) {
 
 	if exists {
 		// Cache already exists, no need to upload
-		result.CacheCreated = false
+		result.CacheEntryCreated = false
 		result.TotalDuration = time.Since(startTime)
 		span.SetAttributes(
 			attribute.Bool("cache.created", false),
@@ -170,7 +170,7 @@ func (c *client) Save(ctx context.Context, cacheID string) (SaveResult, error) {
 	c.callProgress(cacheID, "creating_entry", "Creating cache entry", 0, 0)
 
 	// Create cache entry
-	createResp, err := c.api.CacheCreate(ctx, registryResp.Name, api.CacheCreateReq{
+	createResp, err := c.api.CacheEntryCreate(ctx, registryResp.Name, api.CacheEntryCreateReq{
 		Key:          cacheConfig.Key,
 		FallbackKeys: cacheConfig.FallbackKeys,
 		Compression:  c.format,
@@ -232,7 +232,7 @@ func (c *client) Save(ctx context.Context, cacheID string) (SaveResult, error) {
 	c.callProgress(cacheID, "committing", "Committing cache entry", 0, 0)
 
 	// Commit cache
-	_, err = c.api.CacheCommit(ctx, c.registry, api.CacheCommitReq{
+	_, err = c.api.CacheEntryCommit(ctx, c.registry, api.CacheEntryCommitReq{
 		UploadID: createResp.UploadID,
 	})
 	if err != nil {
@@ -241,7 +241,7 @@ func (c *client) Save(ctx context.Context, cacheID string) (SaveResult, error) {
 		return result, fmt.Errorf("failed to commit cache: %w", err)
 	}
 
-	result.CacheCreated = true
+	result.CacheEntryCreated = true
 	result.TotalDuration = time.Since(startTime)
 
 	// Add final result attributes to span


### PR DESCRIPTION
## Description

Addressing @buildkate's [comment](https://github.com/buildkite/agent/pull/3960#discussion_r3308463789), by consistently using the "Cache Entry" as a name to differentiate with Cache registry.

## Context

finishes A-1270

## Disclosures / Credits

LLM .