### PR TITLE
Retry git checkout when per-attempt timeout fires

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -213,10 +213,16 @@ func (e *Executor) CheckoutPhase(ctx context.Context) (retErr error) {
 	return nil
 }
 
+// errCheckoutAttemptTimedOut is a sentinel marker, joined into the error
+// returned by runDefaultCheckoutAttempt when the per-attempt timeout fires.
+// The retry loop matches it explicitly so a timeout-killed git process is
+// retried instead of being treated like a user signal.
+var errCheckoutAttemptTimedOut = errors.New("checkout attempt timed out")
+
 // runDefaultCheckoutAttempt runs defaultCheckoutPhase, applying a per-attempt
-// timeout if BUILDKITE_GIT_CHECKOUT_TIMEOUT is set. On timeout the underlying
-// error is wrapped so the retry loop's generic failure path can log a
-// meaningful message and clean up before retrying.
+// timeout if BUILDKITE_GIT_CHECKOUT_TIMEOUT is set. On timeout the returned
+// error is joined with errCheckoutAttemptTimedOut so the retry loop can
+// distinguish a timeout-kill from other signal-terminated processes.
 func (e *Executor) runDefaultCheckoutAttempt(ctx context.Context) error {
 	if e.GitCheckoutTimeout <= 0 {
 		return e.defaultCheckoutPhase(ctx)
@@ -228,7 +234,8 @@ func (e *Executor) runDefaultCheckoutAttempt(ctx context.Context) error {
 
 	err := e.defaultCheckoutPhase(attemptCtx)
 	if err != nil && attemptCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
-		return fmt.Errorf("checkout attempt timed out after %s: %w", timeout, err)
+		return errors.Join(errCheckoutAttemptTimedOut,
+			fmt.Errorf("checkout attempt timed out after %s: %w", timeout, err))
 	}
 	return err
 }
@@ -275,6 +282,20 @@ func (e *Executor) checkout(ctx context.Context) error {
 			var errGit *gitError
 
 			switch {
+			case errors.Is(err, errCheckoutAttemptTimedOut):
+				// The per-attempt timeout fired and git was signal-killed.
+				// Treat this like a generic transient failure: warn, clean
+				// the checkout dir, and let the retrier try again.
+				e.shell.Warningf("Checkout failed! %s (%s)", err, r)
+
+				if err := e.removeCheckoutDir(); err != nil {
+					e.shell.Warningf("Failed to remove checkout dir while cleaning up after a checkout error: %v", err)
+				}
+
+				if err := e.createCheckoutDir(); err != nil {
+					return err
+				}
+
 			case shell.IsExitError(err) && shell.ExitCode(err) == -1:
 				e.shell.Warningf("Checkout was interrupted by a signal")
 				r.Break()

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -234,8 +234,7 @@ func (e *Executor) runDefaultCheckoutAttempt(ctx context.Context) error {
 
 	err := e.defaultCheckoutPhase(attemptCtx)
 	if err != nil && attemptCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
-		return errors.Join(errCheckoutAttemptTimedOut,
-			fmt.Errorf("checkout attempt timed out after %s: %w", timeout, err))
+		return fmt.Errorf("%w after %s: %w", errCheckoutAttemptTimedOut, timeout, err)
 	}
 	return err
 }


### PR DESCRIPTION
## Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

`git-checkout-timeout` (added in #3794) is supposed to retry, but on timeout the retry never happens. The per-attempt context cancellation kills git with SIGTERM, which returns `exec.ExitError` with `ExitCode() == -1`. 
The retrier switch in `checkout()` matched that as a generic signal interruption and called `r.Break()`, so the loop exited after one attempt regardless of `--checkout-attempts`.

Fix: join a sentinel `errCheckoutAttemptTimedOut` into the error from `runDefaultCheckoutAttempt` on deadline, and match it in the switch before the signal-kill case. The new branch cleans the checkout dir and returns the error so the retrier can back off and try again.


## Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

https://linear.app/buildkite/issue/PS-2047

## Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

- `internal/job/checkout.go`: add `errCheckoutAttemptTimedOut` sentinel; join it into the timeout error returned by `runDefaultCheckoutAttempt`, add a matching branch in the retrier switch before the signal interruption case that cleans the checkout dir and falls through to retry.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

Verified with a hanging git endpoint (e.g.: `socat -u TCP-LISTEN:9418,reuseaddr,fork EXEC:'sleep 3600'` plus `--git-checkout-timeout 30 --checkout-attempts 3`: three clone attempts with backoff, not one.

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->

[Club Mate](https://www.club-mate.de/en/) helped me in bringing this PR to life.