### PR TITLE
A-1320 retry cache commands

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -121,121 +121,124 @@ type CacheEntryCommitResp struct {
 }
 
 // CacheRegistry retrieves information about a cache registry.
-func (c *Client) CacheRegistry(ctx context.Context, registry string) (CacheRegistryResp, error) {
+func (c *Client) CacheRegistry(ctx context.Context, registry string) (CacheRegistryResp, *Response, error) {
 	ctx, span := cacheTracer.Start(ctx, "Client.CacheRegistry")
 	defer span.End()
 
-	var resp CacheRegistryResp
+	var cacheResp CacheRegistryResp
 
 	req, err := c.newRequest(ctx, http.MethodGet, cachePath("/cache_registries/%s", registry), nil)
 	if err != nil {
-		return resp, cacheSpanErr(span, "failed to create request: %w", err)
+		return cacheResp, nil, cacheSpanErr(span, "failed to create request: %w", err)
 	}
 
-	res, err := c.cacheDo(req, &resp)
+	apiResp, err := c.cacheDo(req, &cacheResp)
 	if err != nil {
-		return resp, cacheSpanErr(span, "%w", err)
+		return cacheResp, apiResp, cacheSpanErr(span, "%w", err)
 	}
-	if res.StatusCode != http.StatusOK {
-		return resp, cacheSpanErr(span, "failed to get cache registry: %s", res.Status)
+	if apiResp.StatusCode != http.StatusOK {
+		return cacheResp, apiResp, cacheSpanErr(span, "failed to get cache registry: %s", apiResp.Status)
 	}
-	return resp, nil
+	return cacheResp, apiResp, nil
 }
 
 // CacheEntryPeekExists checks whether a cache entry exists.
-// Returns (resp, true, nil) on hit, (resp, false, nil) on miss (HTTP 404 with
-// CacheEntryNotFound), or (resp, false, err) on any other failure.
-func (c *Client) CacheEntryPeekExists(ctx context.Context, registry string, peek CacheEntryPeekReq) (CacheEntryPeekResp, bool, error) {
+// Returns (resp, true, _, nil) on hit, (resp, false, _, nil) on miss (HTTP 404
+// with CacheEntryNotFound), or (resp, false, _, err) on any other failure.
+func (c *Client) CacheEntryPeekExists(ctx context.Context, registry string, peek CacheEntryPeekReq) (CacheEntryPeekResp, bool, *Response, error) {
 	ctx, span := cacheTracer.Start(ctx, "Client.CacheEntryPeekExists")
 	defer span.End()
 
-	var resp CacheEntryPeekResp
+	var cacheResp CacheEntryPeekResp
 
 	path, err := cacheQueryPath("/cache_registries/%s/peek", registry, peek)
 	if err != nil {
-		return resp, false, cacheSpanErr(span, "%w", err)
+		return cacheResp, false, nil, cacheSpanErr(span, "%w", err)
 	}
 
 	req, err := c.newRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
-		return resp, false, cacheSpanErr(span, "failed to create request: %w", err)
+		return cacheResp, false, nil, cacheSpanErr(span, "failed to create request: %w", err)
 	}
 
-	res, err := c.cacheDo(req, &resp)
+	apiResp, err := c.cacheDo(req, &cacheResp)
 	if err != nil {
-		return resp, false, cacheSpanErr(span, "%w", err)
+		return cacheResp, false, apiResp, cacheSpanErr(span, "%w", err)
 	}
-	return interpretCacheResponse(span, res, resp)
+	cacheResp, exists, err := interpretCacheResponse(span, apiResp, cacheResp)
+	return cacheResp, exists, apiResp, err
 }
 
 // CacheEntryCreate creates a new cache entry and returns upload instructions.
-func (c *Client) CacheEntryCreate(ctx context.Context, registry string, create CacheEntryCreateReq) (CacheEntryCreateResp, error) {
+func (c *Client) CacheEntryCreate(ctx context.Context, registry string, create CacheEntryCreateReq) (CacheEntryCreateResp, *Response, error) {
 	ctx, span := cacheTracer.Start(ctx, "Client.CacheEntryCreate")
 	defer span.End()
 
-	var resp CacheEntryCreateResp
+	var cacheResp CacheEntryCreateResp
 
 	req, err := c.newRequest(ctx, http.MethodPut, cachePath("/cache_registries/%s/store", registry), &create)
 	if err != nil {
-		return resp, cacheSpanErr(span, "failed to create request: %w", err)
+		return cacheResp, nil, cacheSpanErr(span, "failed to create request: %w", err)
 	}
 
-	res, err := c.cacheDo(req, &resp)
+	apiResp, err := c.cacheDo(req, &cacheResp)
 	if err != nil {
-		return resp, cacheSpanErr(span, "%w", err)
+		return cacheResp, apiResp, cacheSpanErr(span, "%w", err)
 	}
-	if res.StatusCode != http.StatusOK {
-		return resp, cacheSpanErr(span, "failed to save: %s", res.Status)
+	if apiResp.StatusCode != http.StatusOK {
+		return cacheResp, apiResp, cacheSpanErr(span, "failed to save: %s", apiResp.Status)
 	}
-	return resp, nil
+	return cacheResp, apiResp, nil
 }
 
 // CacheEntryCommit marks a previously created cache entry as committed.
-func (c *Client) CacheEntryCommit(ctx context.Context, registry string, commit CacheEntryCommitReq) (CacheEntryCommitResp, error) {
+func (c *Client) CacheEntryCommit(ctx context.Context, registry string, commit CacheEntryCommitReq) (CacheEntryCommitResp, *Response, error) {
 	ctx, span := cacheTracer.Start(ctx, "Client.CacheEntryCommit")
 	defer span.End()
 
-	var resp CacheEntryCommitResp
+	var cacheResp CacheEntryCommitResp
 
 	req, err := c.newRequest(ctx, http.MethodPut, cachePath("/cache_registries/%s/commit", registry), &commit)
 	if err != nil {
-		return resp, cacheSpanErr(span, "failed to create request: %w", err)
+		return cacheResp, nil, cacheSpanErr(span, "failed to create request: %w", err)
 	}
 
-	res, err := c.cacheDo(req, &resp)
+	apiResp, err := c.cacheDo(req, &cacheResp)
 	if err != nil {
-		return resp, cacheSpanErr(span, "%w", err)
+		return cacheResp, apiResp, cacheSpanErr(span, "%w", err)
 	}
-	if res.StatusCode != http.StatusOK {
-		return resp, cacheSpanErr(span, "failed to commit: %s", res.Status)
+	if apiResp.StatusCode != http.StatusOK {
+		return cacheResp, apiResp, cacheSpanErr(span, "failed to commit: %s", apiResp.Status)
 	}
-	return resp, nil
+	return cacheResp, apiResp, nil
 }
 
 // CacheEntryRetrieve retrieves download instructions for a cache entry.
-// Returns (resp, true, nil) on hit (possibly via a fallback key), (resp, false,
-// nil) on miss, or (resp, false, err) on any other failure.
-func (c *Client) CacheEntryRetrieve(ctx context.Context, registry string, retrieve CacheEntryRetrieveReq) (CacheEntryRetrieveResp, bool, error) {
+// Returns (resp, true, _, nil) on hit (possibly via a fallback key),
+// (resp, false, _, nil) on miss, or (resp, false, _, err) on any other failure.
+func (c *Client) CacheEntryRetrieve(ctx context.Context, registry string, retrieve CacheEntryRetrieveReq) (CacheEntryRetrieveResp, bool, *Response, error) {
 	ctx, span := cacheTracer.Start(ctx, "Client.CacheEntryRetrieve")
 	defer span.End()
 
-	var resp CacheEntryRetrieveResp
+	var cacheResp CacheEntryRetrieveResp
 
 	path, err := cacheQueryPath("/cache_registries/%s/retrieve", registry, retrieve)
 	if err != nil {
-		return resp, false, cacheSpanErr(span, "%w", err)
+		return cacheResp, false, nil, cacheSpanErr(span, "%w", err)
 	}
 
 	req, err := c.newRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
-		return resp, false, cacheSpanErr(span, "failed to create request: %w", err)
+		return cacheResp, false, nil, cacheSpanErr(span, "failed to create request: %w", err)
 	}
 
-	res, err := c.cacheDo(req, &resp)
+	apiResp, err := c.cacheDo(req, &cacheResp)
 	if err != nil {
-		return resp, false, cacheSpanErr(span, "%w", err)
+		return cacheResp, false, apiResp, cacheSpanErr(span, "%w", err)
 	}
-	return interpretCacheResponse(span, res, resp)
+
+	cacheResp, exists, err := interpretCacheResponse(span, apiResp, cacheResp)
+	return cacheResp, exists, apiResp, err
 }
 
 // cachePath formats a cache API path with URL-safe escaping for path components.
@@ -260,7 +263,7 @@ func cacheQueryPath(format, registry string, params any) (string, error) {
 // and decodes a JSON body into resp. Unlike Client.doRequest, it does not
 // treat non-2xx as an error — cache responses use 404 + a message to signal a
 // miss, and callers want to inspect the status themselves.
-func (c *Client) cacheDo(req *http.Request, resp any) (*http.Response, error) {
+func (c *Client) cacheDo(req *http.Request, resp any) (*Response, error) {
 	httpResp, err := agenthttp.Do(c.logger, c.client, req,
 		agenthttp.WithDebugHTTP(c.conf.DebugHTTP),
 		agenthttp.WithTraceHTTP(c.conf.TraceHTTP),
@@ -271,29 +274,31 @@ func (c *Client) cacheDo(req *http.Request, resp any) (*http.Response, error) {
 	defer httpResp.Body.Close()              //nolint:errcheck
 	defer io.Copy(io.Discard, httpResp.Body) //nolint:errcheck
 
+	apiResp := newResponse(httpResp)
+
 	if httpResp.StatusCode >= 500 {
-		return httpResp, fmt.Errorf("request failed with status: %s", httpResp.Status)
+		return apiResp, fmt.Errorf("request failed with status: %s", httpResp.Status)
 	}
 	if httpResp.Body == http.NoBody {
-		return httpResp, nil
+		return apiResp, nil
 	}
 
 	contentType := httpResp.Header.Get("Content-Type")
 	if !isJSONContent(contentType) {
-		return httpResp, fmt.Errorf("unexpected content type: %s", contentType)
+		return apiResp, fmt.Errorf("unexpected content type: %s", contentType)
 	}
 
 	body, err := io.ReadAll(httpResp.Body)
 	if err != nil {
-		return httpResp, fmt.Errorf("failed to read response body: %w", err)
+		return apiResp, fmt.Errorf("failed to read response body: %w", err)
 	}
 	if len(body) == 0 {
-		return httpResp, nil
+		return apiResp, nil
 	}
 	if err := json.Unmarshal(body, resp); err != nil {
-		return httpResp, fmt.Errorf("failed to decode response body: %w", err)
+		return apiResp, fmt.Errorf("failed to decode response body: %w", err)
 	}
-	return httpResp, nil
+	return apiResp, nil
 }
 
 // cacheMessage is the subset of cache responses needed to classify a 404.
@@ -306,23 +311,23 @@ func (r CacheEntryRetrieveResp) cacheMessage() string { return r.Message }
 
 // interpretCacheResponse maps the dual "200 = hit, 404 + message = miss"
 // convention into the (resp, exists, err) return shape used by peek/retrieve.
-func interpretCacheResponse[T cacheMessage](span oteltrace.Span, res *http.Response, resp T) (T, bool, error) {
-	if res.StatusCode == http.StatusOK {
-		return resp, true, nil
+func interpretCacheResponse[T cacheMessage](span oteltrace.Span, apiResp *Response, cacheResp T) (T, bool, error) {
+	if apiResp.StatusCode == http.StatusOK {
+		return cacheResp, true, nil
 	}
-	switch res.StatusCode {
+	switch apiResp.StatusCode {
 	case http.StatusNotFound:
-		switch resp.cacheMessage() {
+		switch cacheResp.cacheMessage() {
 		case CacheEntryNotFound:
-			return resp, false, nil
+			return cacheResp, false, nil
 		case CacheRegistryNotFound:
-			return resp, false, cacheSpanErr(span, "cache registry not found: %s", res.Status)
+			return cacheResp, false, cacheSpanErr(span, "cache registry not found: %s", apiResp.Status)
 		}
-		return resp, false, cacheSpanErr(span, "not found: %s", res.Status)
+		return cacheResp, false, cacheSpanErr(span, "not found: %s", apiResp.Status)
 	case http.StatusBadRequest:
-		return resp, false, cacheSpanErr(span, "bad request: %s", res.Status)
+		return cacheResp, false, cacheSpanErr(span, "bad request: %s", apiResp.Status)
 	default:
-		return resp, false, cacheSpanErr(span, "request failed with status: %s", res.Status)
+		return cacheResp, false, cacheSpanErr(span, "request failed with status: %s", apiResp.Status)
 	}
 }
 

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -41,7 +41,7 @@ func TestCacheEntryPeekExists_Success(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, exists, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
+	resp, exists, _, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
 		Key:    "test-key",
 		Branch: "main",
 	})
@@ -66,7 +66,7 @@ func TestCacheEntryPeekExists_NotFound(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, exists, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
+	resp, exists, _, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
 		Key:    "nonexistent-key",
 		Branch: "main",
 	})
@@ -91,7 +91,7 @@ func TestCacheEntryPeekExists_WrongContentType(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	_, _, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
+	_, _, _, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
 		Key:    "test-key",
 		Branch: "main",
 	})
@@ -110,7 +110,7 @@ func TestCacheEntryPeekExists_CacheRegistryNotFound(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	_, _, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
+	_, _, _, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
 		Key:    "test-key",
 		Branch: "main",
 	})
@@ -129,7 +129,7 @@ func TestCacheEntryPeekExists_ContentTypeWithCharset(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, exists, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
+	resp, exists, _, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
 		Key:    "test-key",
 		Branch: "main",
 	})
@@ -170,7 +170,7 @@ func TestCacheEntryCreate_Success(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, err := client.CacheEntryCreate(context.Background(), "test-slug", api.CacheEntryCreateReq{
+	resp, _, err := client.CacheEntryCreate(context.Background(), "test-slug", api.CacheEntryCreateReq{
 		Key:          "test-key",
 		FallbackKeys: []string{"fallback-1", "fallback-2"},
 		Compression:  "gzip",
@@ -217,7 +217,7 @@ func TestCacheEntryRetrieve_Success(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, found, err := client.CacheEntryRetrieve(context.Background(), "test-slug", api.CacheEntryRetrieveReq{
+	resp, found, _, err := client.CacheEntryRetrieve(context.Background(), "test-slug", api.CacheEntryRetrieveReq{
 		Key:          "test-key",
 		Branch:       "main",
 		FallbackKeys: "fallback-1,fallback-2",
@@ -246,7 +246,7 @@ func TestCacheEntryRetrieve_NotFound(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, found, err := client.CacheEntryRetrieve(context.Background(), "test-slug", api.CacheEntryRetrieveReq{
+	resp, found, _, err := client.CacheEntryRetrieve(context.Background(), "test-slug", api.CacheEntryRetrieveReq{
 		Key:    "nonexistent-key",
 		Branch: "main",
 	})
@@ -282,7 +282,7 @@ func TestCacheEntryCommit_Success(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, err := client.CacheEntryCommit(context.Background(), "test-slug", api.CacheEntryCommitReq{
+	resp, _, err := client.CacheEntryCommit(context.Background(), "test-slug", api.CacheEntryCommitReq{
 		UploadID: "upload-123",
 	})
 	if err != nil {
@@ -303,7 +303,7 @@ func TestCacheEntryCommit_Failure(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	_, err := client.CacheEntryCommit(context.Background(), "test-slug", api.CacheEntryCommitReq{
+	_, _, err := client.CacheEntryCommit(context.Background(), "test-slug", api.CacheEntryCommitReq{
 		UploadID: "invalid-upload-id",
 	})
 	if err == nil {

--- a/internal/cache/client.go
+++ b/internal/cache/client.go
@@ -26,11 +26,11 @@ import (
 // server returning canned responses — this repo prefers real HTTP servers
 // over hand-rolled mocks.
 type cacheAPI interface {
-	CacheRegistry(ctx context.Context, registry string) (api.CacheRegistryResp, error)
-	CacheEntryPeekExists(ctx context.Context, registry string, req api.CacheEntryPeekReq) (api.CacheEntryPeekResp, bool, error)
-	CacheEntryCreate(ctx context.Context, registry string, req api.CacheEntryCreateReq) (api.CacheEntryCreateResp, error)
-	CacheEntryCommit(ctx context.Context, registry string, req api.CacheEntryCommitReq) (api.CacheEntryCommitResp, error)
-	CacheEntryRetrieve(ctx context.Context, registry string, req api.CacheEntryRetrieveReq) (api.CacheEntryRetrieveResp, bool, error)
+	CacheRegistry(ctx context.Context, registry string) (api.CacheRegistryResp, *api.Response, error)
+	CacheEntryPeekExists(ctx context.Context, registry string, req api.CacheEntryPeekReq) (api.CacheEntryPeekResp, bool, *api.Response, error)
+	CacheEntryCreate(ctx context.Context, registry string, req api.CacheEntryCreateReq) (api.CacheEntryCreateResp, *api.Response, error)
+	CacheEntryCommit(ctx context.Context, registry string, req api.CacheEntryCommitReq) (api.CacheEntryCommitResp, *api.Response, error)
+	CacheEntryRetrieve(ctx context.Context, registry string, req api.CacheEntryRetrieveReq) (api.CacheEntryRetrieveResp, bool, *api.Response, error)
 }
 
 // Sentinel errors for common scenarios.

--- a/internal/cache/integration_test.go
+++ b/internal/cache/integration_test.go
@@ -60,27 +60,27 @@ func (m *mockAPIClient) Do(req *http.Request) (*http.Response, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (m *mockAPIClient) CacheRegistry(ctx context.Context, registry string) (api.CacheRegistryResp, error) {
+func (m *mockAPIClient) CacheRegistry(ctx context.Context, registry string) (api.CacheRegistryResp, *api.Response, error) {
 	reg, ok := m.registries[registry]
 	if !ok {
-		return api.CacheRegistryResp{}, fmt.Errorf("registry not found: %s", registry)
+		return api.CacheRegistryResp{}, nil, fmt.Errorf("registry not found: %s", registry)
 	}
 
 	return api.CacheRegistryResp{
 		Name:  reg.name,
 		Store: reg.store,
-	}, nil
+	}, nil, nil
 }
 
-func (m *mockAPIClient) CacheEntryPeekExists(ctx context.Context, registry string, req api.CacheEntryPeekReq) (api.CacheEntryPeekResp, bool, error) {
+func (m *mockAPIClient) CacheEntryPeekExists(ctx context.Context, registry string, req api.CacheEntryPeekReq) (api.CacheEntryPeekResp, bool, *api.Response, error) {
 	reg, ok := m.registries[registry]
 	if !ok {
-		return api.CacheEntryPeekResp{}, false, fmt.Errorf("registry not found: %s", registry)
+		return api.CacheEntryPeekResp{}, false, nil, fmt.Errorf("registry not found: %s", registry)
 	}
 
 	entry, exists := reg.cache[req.Key]
 	if !exists || !entry.committed {
-		return api.CacheEntryPeekResp{Message: api.CacheEntryNotFound}, false, nil
+		return api.CacheEntryPeekResp{Message: api.CacheEntryNotFound}, false, nil, nil
 	}
 
 	return api.CacheEntryPeekResp{
@@ -100,13 +100,13 @@ func (m *mockAPIClient) CacheEntryPeekExists(ctx context.Context, registry strin
 		AgentID:      "test-agent-id",
 		JobID:        "test-job-id",
 		BuildID:      "test-build-id",
-	}, true, nil
+	}, true, nil, nil
 }
 
-func (m *mockAPIClient) CacheEntryCreate(ctx context.Context, registry string, req api.CacheEntryCreateReq) (api.CacheEntryCreateResp, error) {
+func (m *mockAPIClient) CacheEntryCreate(ctx context.Context, registry string, req api.CacheEntryCreateReq) (api.CacheEntryCreateResp, *api.Response, error) {
 	reg, ok := m.registries[registry]
 	if !ok {
-		return api.CacheEntryCreateResp{}, fmt.Errorf("registry not found: %s", registry)
+		return api.CacheEntryCreateResp{}, nil, fmt.Errorf("registry not found: %s", registry)
 	}
 
 	uploadID := fmt.Sprintf("upload-%d", time.Now().UnixNano())
@@ -134,29 +134,29 @@ func (m *mockAPIClient) CacheEntryCreate(ctx context.Context, registry string, r
 	return api.CacheEntryCreateResp{
 		UploadID:        uploadID,
 		StoreObjectName: storeObjectName,
-	}, nil
+	}, nil, nil
 }
 
-func (m *mockAPIClient) CacheEntryCommit(ctx context.Context, registry string, req api.CacheEntryCommitReq) (api.CacheEntryCommitResp, error) {
+func (m *mockAPIClient) CacheEntryCommit(ctx context.Context, registry string, req api.CacheEntryCommitReq) (api.CacheEntryCommitResp, *api.Response, error) {
 	reg, ok := m.registries[registry]
 	if !ok {
-		return api.CacheEntryCommitResp{}, fmt.Errorf("registry not found: %s", registry)
+		return api.CacheEntryCommitResp{}, nil, fmt.Errorf("registry not found: %s", registry)
 	}
 
 	for _, entry := range reg.cache {
 		if entry.uploadID == req.UploadID {
 			entry.committed = true
-			return api.CacheEntryCommitResp{Message: "Cache entry committed successfully"}, nil
+			return api.CacheEntryCommitResp{Message: "Cache entry committed successfully"}, nil, nil
 		}
 	}
 
-	return api.CacheEntryCommitResp{}, fmt.Errorf("upload ID not found: %s", req.UploadID)
+	return api.CacheEntryCommitResp{}, nil, fmt.Errorf("upload ID not found: %s", req.UploadID)
 }
 
-func (m *mockAPIClient) CacheEntryRetrieve(ctx context.Context, registry string, req api.CacheEntryRetrieveReq) (api.CacheEntryRetrieveResp, bool, error) {
+func (m *mockAPIClient) CacheEntryRetrieve(ctx context.Context, registry string, req api.CacheEntryRetrieveReq) (api.CacheEntryRetrieveResp, bool, *api.Response, error) {
 	reg, ok := m.registries[registry]
 	if !ok {
-		return api.CacheEntryRetrieveResp{}, false, fmt.Errorf("registry not found: %s", registry)
+		return api.CacheEntryRetrieveResp{}, false, nil, fmt.Errorf("registry not found: %s", registry)
 	}
 
 	// Try exact key match first
@@ -168,7 +168,7 @@ func (m *mockAPIClient) CacheEntryRetrieve(ctx context.Context, registry string,
 			StoreObjectName: entry.storeObjectName,
 			ExpiresAt:       entry.expiresAt,
 			CompressionType: entry.compression,
-		}, true, nil
+		}, true, nil, nil
 	}
 
 	// Try fallback keys - check if the entry key matches any of the requested fallback keys
@@ -185,12 +185,12 @@ func (m *mockAPIClient) CacheEntryRetrieve(ctx context.Context, registry string,
 					StoreObjectName: entry.storeObjectName,
 					ExpiresAt:       entry.expiresAt,
 					CompressionType: entry.compression,
-				}, true, nil
+				}, true, nil, nil
 			}
 		}
 	}
 
-	return api.CacheEntryRetrieveResp{Message: api.CacheEntryNotFound}, false, nil
+	return api.CacheEntryRetrieveResp{Message: api.CacheEntryNotFound}, false, nil, nil
 }
 
 // createRandomFile creates a file filled with random data

--- a/internal/cache/restore.go
+++ b/internal/cache/restore.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/internal/cache/archive"
 	"github.com/buildkite/agent/v3/internal/cache/store"
+	"github.com/buildkite/roko"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -34,6 +35,11 @@ import (
 //
 // The operation respects context cancellation and will stop immediately when
 // ctx is cancelled, cleaning up any temporary resources (downloaded archives).
+//
+// Transient API errors (429, 5xx, connection reset/timeout/EOF) on
+// CacheEntryRetrieve are retried automatically per api.BreakOnNonRetryable.
+// Non-retryable errors (4xx other than 429) cause the operation to fail
+// immediately.
 //
 // Progress callbacks (if configured) are invoked at each stage with the
 // following stages: "validating", "checking_exists", "downloading", "extracting",
@@ -94,11 +100,35 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 
 	c.callProgress(cacheID, "checking_exists", "Checking if cache exists", 0, 0)
 
-	// Check if cache exists
-	retrieveResp, exists, err := c.api.CacheEntryRetrieve(ctx, c.registry, api.CacheEntryRetrieveReq{
-		Key:          cacheConfig.Key,
-		Branch:       c.branch,
-		FallbackKeys: strings.Join(cacheConfig.FallbackKeys, ","),
+	var (
+		apiResp      *api.Response
+		retrieveResp api.CacheEntryRetrieveResp
+		exists       bool
+	)
+
+	// Cache restore is latency-sensitive: it runs at the start of a job and
+	// blocks forward progress, so transient failures should retry quickly
+	// After ~5 attempts (~3.4s wall-clock with this curve),
+	// treat repeated failures as a cache miss.
+	err = roko.NewRetrier(
+		roko.WithMaxAttempts(5),
+		roko.WithStrategy(roko.ExponentialSubsecond(500*time.Millisecond)),
+		roko.WithJitter(),
+	).DoWithContext(ctx, func(r *roko.Retrier) error {
+		var err error
+		retrieveResp, exists, apiResp, err = c.api.CacheEntryRetrieve(ctx, c.registry, api.CacheEntryRetrieveReq{
+			Key:          cacheConfig.Key,
+			Branch:       c.branch,
+			FallbackKeys: strings.Join(cacheConfig.FallbackKeys, ","),
+		})
+		if api.BreakOnNonRetryable(r, apiResp, err) {
+			return err
+		}
+		if err != nil {
+			slog.Warn("cache retrieve failed, retrying", "err", err, "retrier", r.String())
+			return err
+		}
+		return nil
 	})
 	if err != nil {
 		span.RecordError(err)

--- a/internal/cache/save.go
+++ b/internal/cache/save.go
@@ -3,12 +3,14 @@ package cache
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"time"
 
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/internal/cache/archive"
 	"github.com/buildkite/agent/v3/internal/cache/store"
+	"github.com/buildkite/roko"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -29,6 +31,11 @@ import (
 //
 // The operation respects context cancellation and will stop immediately when
 // ctx is cancelled, cleaning up any temporary resources.
+//
+// Transient API errors (429, 5xx, connection reset/timeout/EOF) on
+// CacheEntryPeekExists, CacheRegistry, CacheEntryCreate, and CacheEntryCommit
+// are retried automatically per api.BreakOnNonRetryable. Non-retryable errors
+// (4xx other than 429) cause the operation to fail immediately.
 //
 // Progress callbacks (if configured) are invoked at each stage with the
 // following stages: "validating", "checking_exists", "fetching_registry",
@@ -93,9 +100,29 @@ func (c *client) Save(ctx context.Context, cacheID string) (SaveResult, error) {
 	c.callProgress(cacheID, "checking_exists", "Checking if cache already exists", 0, 0)
 
 	// Check if cache already exists
-	_, exists, err := c.api.CacheEntryPeekExists(ctx, c.registry, api.CacheEntryPeekReq{
-		Key:    cacheConfig.Key,
-		Branch: c.branch,
+	var (
+		peekApiResp *api.Response
+		exists      bool
+	)
+
+	err = roko.NewRetrier(
+		roko.WithMaxAttempts(5),
+		roko.WithStrategy(roko.ExponentialSubsecond(500*time.Millisecond)),
+		roko.WithJitter(),
+	).DoWithContext(ctx, func(r *roko.Retrier) error {
+		var err error
+		_, exists, peekApiResp, err = c.api.CacheEntryPeekExists(ctx, c.registry, api.CacheEntryPeekReq{
+			Key:    cacheConfig.Key,
+			Branch: c.branch,
+		})
+		if api.BreakOnNonRetryable(r, peekApiResp, err) {
+			return err
+		}
+		if err != nil {
+			slog.Warn("cache peek failed, retrying", "err", err, "retrier", r.String())
+			return err
+		}
+		return nil
 	})
 	if err != nil {
 		span.RecordError(err)
@@ -120,7 +147,27 @@ func (c *client) Save(ctx context.Context, cacheID string) (SaveResult, error) {
 	c.callProgress(cacheID, "fetching_registry", "Looking up cache registry", 0, 0)
 
 	// Get cache registry information
-	registryResp, err := c.api.CacheRegistry(ctx, c.registry)
+	var (
+		registryApiResp *api.Response
+		registryResp    api.CacheRegistryResp
+	)
+
+	err = roko.NewRetrier(
+		roko.WithMaxAttempts(5),
+		roko.WithStrategy(roko.ExponentialSubsecond(500*time.Millisecond)),
+		roko.WithJitter(),
+	).DoWithContext(ctx, func(r *roko.Retrier) error {
+		var err error
+		registryResp, registryApiResp, err = c.api.CacheRegistry(ctx, c.registry)
+		if api.BreakOnNonRetryable(r, registryApiResp, err) {
+			return err
+		}
+		if err != nil {
+			slog.Warn("cache registry lookup failed, retrying", "err", err, "retrier", r.String())
+			return err
+		}
+		return nil
+	})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to get cache registry")
@@ -169,19 +216,41 @@ func (c *client) Save(ctx context.Context, cacheID string) (SaveResult, error) {
 
 	c.callProgress(cacheID, "creating_entry", "Creating cache entry", 0, 0)
 
-	// Create cache entry
-	createResp, err := c.api.CacheEntryCreate(ctx, registryResp.Name, api.CacheEntryCreateReq{
-		Key:          cacheConfig.Key,
-		FallbackKeys: cacheConfig.FallbackKeys,
-		Compression:  c.format,
-		FileSize:     int(archiveInfo.Size),
-		Digest:       fmt.Sprintf("sha256:%s", archiveInfo.Sha256sum),
-		Paths:        cacheConfig.Paths,
-		Platform:     c.platform,
-		Pipeline:     c.pipeline,
-		Branch:       c.branch,
-		Organization: c.organization,
-		Store:        registryResp.Store,
+	// Create cache entry.
+	// Retry-safe: server generates a fresh upload_uuid per call; orphaned temp
+	// rows + presigned URLs self-expire.
+	var (
+		createApiResp *api.Response
+		createResp    api.CacheEntryCreateResp
+	)
+
+	err = roko.NewRetrier(
+		roko.WithMaxAttempts(5),
+		roko.WithStrategy(roko.ExponentialSubsecond(500*time.Millisecond)),
+		roko.WithJitter(),
+	).DoWithContext(ctx, func(r *roko.Retrier) error {
+		var err error
+		createResp, createApiResp, err = c.api.CacheEntryCreate(ctx, registryResp.Name, api.CacheEntryCreateReq{
+			Key:          cacheConfig.Key,
+			FallbackKeys: cacheConfig.FallbackKeys,
+			Compression:  c.format,
+			FileSize:     int(archiveInfo.Size),
+			Digest:       fmt.Sprintf("sha256:%s", archiveInfo.Sha256sum),
+			Paths:        cacheConfig.Paths,
+			Platform:     c.platform,
+			Pipeline:     c.pipeline,
+			Branch:       c.branch,
+			Organization: c.organization,
+			Store:        registryResp.Store,
+		})
+		if api.BreakOnNonRetryable(r, createApiResp, err) {
+			return err
+		}
+		if err != nil {
+			slog.Warn("cache entry create failed, retrying", "err", err, "retrier", r.String())
+			return err
+		}
+		return nil
 	})
 	if err != nil {
 		span.RecordError(err)
@@ -231,9 +300,28 @@ func (c *client) Save(ctx context.Context, cacheID string) (SaveResult, error) {
 
 	c.callProgress(cacheID, "committing", "Committing cache entry", 0, 0)
 
-	// Commit cache
-	_, err = c.api.CacheEntryCommit(ctx, c.registry, api.CacheEntryCommitReq{
-		UploadID: createResp.UploadID,
+	// Commit cache.
+	// Retry-safe: server-side put_item is an unconditional overwrite with
+	// deterministic content.
+	var commitApiResp *api.Response
+
+	err = roko.NewRetrier(
+		roko.WithMaxAttempts(5),
+		roko.WithStrategy(roko.ExponentialSubsecond(500*time.Millisecond)),
+		roko.WithJitter(),
+	).DoWithContext(ctx, func(r *roko.Retrier) error {
+		var err error
+		_, commitApiResp, err = c.api.CacheEntryCommit(ctx, c.registry, api.CacheEntryCommitReq{
+			UploadID: createResp.UploadID,
+		})
+		if api.BreakOnNonRetryable(r, commitApiResp, err) {
+			return err
+		}
+		if err != nil {
+			slog.Warn("cache entry commit failed, retrying", "err", err, "retrier", r.String())
+			return err
+		}
+		return nil
 	})
 	if err != nil {
 		span.RecordError(err)


### PR DESCRIPTION
## Description
Adds retry coverage to the cache CLI commands (`cache restore` and `cache save`), matching the consolidated retry pattern from `api/retryable.go` and sibling commands. Each API call is wrapped individually with `roko.NewRetrier(...).DoWithContext(...)` + `api.BreakOnNonRetryable` so transient 429/5xx/network errors retry with backoff while non-retryable 4xx breaks immediately.
## Context
- Linear: [A-1320](https://linear.app/buildkite/issue/A-1320/add-retry-coverage-to-cache-restore-and-cache-save-cli-commands)
## Changes
- All five cache API methods now return `*api.Response` (positioned second-to-last to match the sibling convention in `api/`) so callers can drive `BreakOnNonRetryable` decisions; `cacheAPI` interface and `mockAPIClient` updated in lockstep.
- Wrapped each individual cache API call in `internal/cache/restore.go` and `internal/cache/save.go` with retriers using the `meta_data_get` config (`WithMaxAttempts(10)`, `Constant(5*time.Second)`, `WithJitter()`).
- Verified `CacheEntryCreate` and `CacheEntryCommit` are retry-safe by reading the server-side code in `buildkite/buildkite`; short comments at each wrap site cite the verified server behaviour.
## Key decisions
- **Retry lives at the per-API-call boundary inside `internal/cache`, not at the CLI or as one outer wrap around `Save`/`Restore`** — outer-wrapping would replay already-succeeded caches in the fan-out and redo expensive non-API work (archive build, upload) when only the final API call failed.
- **Closure-capture pattern over `roko.DoFunc[N]`** — matches the 28 other retry call sites in the codebase and sidesteps the `DoFunc3` arity ceiling.
## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go tool gofumpt -extra -w .`)
## Disclosures / Credits
Used opencode (Claude) to walk the codebase, evaluate retry-scoping alternatives, verify server-side idempotency, and write the implementation. All decisions and final code reviewed by me.