### PR TITLE
refactor(cache): rename Save/Restore to RunSave/RunRestore

### DIFF
--- a/clicommand/cache_restore.go
+++ b/clicommand/cache_restore.go
@@ -97,6 +97,6 @@ var CacheRestoreCommand = cli.Command{
 		}
 
 		// Perform cache restore (logging happens inside)
-		return cache.Restore(ctx, l, apiClient, cacheCfg)
+		return cache.RunRestore(ctx, l, apiClient, cacheCfg)
 	},
 }

--- a/clicommand/cache_save.go
+++ b/clicommand/cache_save.go
@@ -97,6 +97,6 @@ var CacheSaveCommand = cli.Command{
 		}
 
 		// Perform cache save (logging happens inside)
-		return cache.Save(ctx, l, apiClient, cacheCfg)
+		return cache.RunSave(ctx, l, apiClient, cacheCfg)
 	},
 }

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -38,9 +38,9 @@ type cacheOps interface {
 	ListCaches() []configuration.Cache
 }
 
-// Save saves caches based on the provided configuration and logs results as
+// RunSave saves caches based on the provided configuration and logs results as
 // each cache is processed.
-func Save(ctx context.Context, l logger.Logger, apiClient *api.Client, cfg Config) error {
+func RunSave(ctx context.Context, l logger.Logger, apiClient *api.Client, cfg Config) error {
 	c, cacheIDs, err := newClient(l, apiClient, cfg)
 	if err != nil {
 		return err
@@ -52,9 +52,9 @@ func Save(ctx context.Context, l logger.Logger, apiClient *api.Client, cfg Confi
 	return saveWithClient(ctx, l, c, cacheIDs, cfg.Concurrency)
 }
 
-// Restore restores caches based on the provided configuration and logs results
+// RunRestore restores caches based on the provided configuration and logs results
 // as each cache is processed.
-func Restore(ctx context.Context, l logger.Logger, apiClient *api.Client, cfg Config) error {
+func RunRestore(ctx context.Context, l logger.Logger, apiClient *api.Client, cfg Config) error {
 	c, cacheIDs, err := newClient(l, apiClient, cfg)
 	if err != nil {
 		return err

--- a/internal/cache/client.go
+++ b/internal/cache/client.go
@@ -1,6 +1,6 @@
 // Package cache saves and restores cache archives via the Buildkite cache API.
 //
-// The CLI entry points are Save and Restore in cache.go. Internally they build
+// The CLI entry points are RunSave and RunRestore in cache.go. Internally they build
 // a client (a configured handle bundling the API client, storage bucket and
 // the expanded cache definitions) and dispatch Save/Restore per cache ID.
 package cache


### PR DESCRIPTION
## Description

Rename Save/Restore to RunSave/RunRestore

Disambiguates the package-level orchestrators from the per-cache-ID
(*client).Save/Restore methods. No behaviour change.
<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

## Context
Resolves A-1329
<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

## Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

## Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits
Orders dictated by me, executed by Claude.
<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
