### PR TITLE
chore: replace unlabelled jobStarted and jobEnded metrics

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -510,13 +510,8 @@ func (a *AgentWorker) RunJob(ctx context.Context, acceptResponse *api.Job, ignor
 	priorityLabel := strconv.Itoa(acceptResponse.Priority)
 	queueLabel := acceptResponse.Env["BUILDKITE_AGENT_META_DATA_QUEUE"]
 
-	// Legacy unlabelled counters; kept incrementing in lockstep with the
-	// labelled counters below so existing scrape consumers see no shape change.
-	jobsStarted.Inc()
-	defer jobsEnded.Inc()
-
-	jobsStartedWithLabels.WithLabelValues(priorityLabel, queueLabel).Inc()
-	defer jobsEndedWithLabels.WithLabelValues(priorityLabel, queueLabel).Inc()
+	jobsStarted.WithLabelValues(priorityLabel, queueLabel).Inc()
+	defer jobsEnded.WithLabelValues(priorityLabel, queueLabel).Inc()
 
 	running := jobsRunning.WithLabelValues(priorityLabel, queueLabel)
 	running.Inc()

--- a/agent/metrics.go
+++ b/agent/metrics.go
@@ -57,35 +57,17 @@ var (
 		Buckets:   prometheus.LinearBuckets(1, 1, 20),
 	})
 
-	// Original unlabelled counters — kept for backwards compatibility with
-	// existing scrape consumers. New code should prefer the labelled
-	// jobsStartedWithLabels / jobsEndedWithLabels counters below.
-	jobsStarted = promauto.NewCounter(prometheus.CounterOpts{
+	// Job counters, labelled by job priority and agent queue.
+	jobsStarted = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "jobs",
 		Name:      "started_total",
-		Help:      "Count of jobs started",
-	})
-	jobsEnded = promauto.NewCounter(prometheus.CounterOpts{
+		Help:      "Count of jobs started, labelled by job priority and agent queue",
+	}, []string{"priority", "queue"})
+	jobsEnded = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "jobs",
 		Name:      "ended_total",
-		Help:      "Count of jobs ended (any outcome)",
-	})
-
-	// Labelled counters added for A-1100. These coexist with the unlabelled
-	// jobsStarted / jobsEnded above; both are incremented at the same call
-	// site so the unlabelled total always equals sum() over the labelled.
-	jobsStartedWithLabels = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: metricsNamespace,
-		Subsystem: "jobs",
-		Name:      "started_with_labels_total",
-		Help:      "Count of jobs started, labelled by job priority and agent queue",
-	}, []string{"priority", "queue"})
-	jobsEndedWithLabels = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: metricsNamespace,
-		Subsystem: "jobs",
-		Name:      "ended_with_labels_total",
 		Help:      "Count of jobs ended (any outcome), labelled by job priority and agent queue",
 	}, []string{"priority", "queue"})
 

--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -52,21 +52,21 @@ func TestJobCountersAreLabelled(t *testing.T) {
 
 			namedLabels := prometheus.Labels{"priority": priority, "queue": queue}
 
-			startsBeforePos := testutil.ToFloat64(jobsStartedWithLabels.WithLabelValues(priority, queue))
-			endsBeforePos := testutil.ToFloat64(jobsEndedWithLabels.WithLabelValues(priority, queue))
-			startsBeforeName := testutil.ToFloat64(jobsStartedWithLabels.With(namedLabels))
-			endsBeforeName := testutil.ToFloat64(jobsEndedWithLabels.With(namedLabels))
+			startsBeforePos := testutil.ToFloat64(jobsStarted.WithLabelValues(priority, queue))
+			endsBeforePos := testutil.ToFloat64(jobsEnded.WithLabelValues(priority, queue))
+			startsBeforeName := testutil.ToFloat64(jobsStarted.With(namedLabels))
+			endsBeforeName := testutil.ToFloat64(jobsEnded.With(namedLabels))
 
 			// Increment the same way RunJob does.
-			jobsStartedWithLabels.WithLabelValues(priority, queue).Inc()
-			jobsEndedWithLabels.WithLabelValues(priority, queue).Inc()
+			jobsStarted.WithLabelValues(priority, queue).Inc()
+			jobsEnded.WithLabelValues(priority, queue).Inc()
 
 			// The increment is observed via the positional API.
-			if got := testutil.ToFloat64(jobsStartedWithLabels.WithLabelValues(priority, queue)) - startsBeforePos; got != 1 {
-				t.Errorf("jobsStartedWithLabels{priority=%q,queue=%q} positional delta = %v, want 1", priority, queue, got)
+			if got := testutil.ToFloat64(jobsStarted.WithLabelValues(priority, queue)) - startsBeforePos; got != 1 {
+				t.Errorf("jobsStarted{priority=%q,queue=%q} positional delta = %v, want 1", priority, queue, got)
 			}
-			if got := testutil.ToFloat64(jobsEndedWithLabels.WithLabelValues(priority, queue)) - endsBeforePos; got != 1 {
-				t.Errorf("jobsEndedWithLabels{priority=%q,queue=%q} positional delta = %v, want 1", priority, queue, got)
+			if got := testutil.ToFloat64(jobsEnded.WithLabelValues(priority, queue)) - endsBeforePos; got != 1 {
+				t.Errorf("jobsEnded{priority=%q,queue=%q} positional delta = %v, want 1", priority, queue, got)
 			}
 
 			// The same increment is observed via the name-keyed API.
@@ -74,11 +74,11 @@ func TestJobCountersAreLabelled(t *testing.T) {
 			// agent_worker.go passes them to WithLabelValues, this read
 			// would land on a different counter than the one we incremented
 			// and the delta would be 0.
-			if got := testutil.ToFloat64(jobsStartedWithLabels.With(namedLabels)) - startsBeforeName; got != 1 {
-				t.Errorf("jobsStartedWithLabels{priority=%q,queue=%q} name-keyed delta = %v, want 1 — label registration order in metrics.go may not match WithLabelValues argument order in agent_worker.go", priority, queue, got)
+			if got := testutil.ToFloat64(jobsStarted.With(namedLabels)) - startsBeforeName; got != 1 {
+				t.Errorf("jobsStarted{priority=%q,queue=%q} name-keyed delta = %v, want 1 — label registration order in metrics.go may not match WithLabelValues argument order in agent_worker.go", priority, queue, got)
 			}
-			if got := testutil.ToFloat64(jobsEndedWithLabels.With(namedLabels)) - endsBeforeName; got != 1 {
-				t.Errorf("jobsEndedWithLabels{priority=%q,queue=%q} name-keyed delta = %v, want 1 — label registration order in metrics.go may not match WithLabelValues argument order in agent_worker.go", priority, queue, got)
+			if got := testutil.ToFloat64(jobsEnded.With(namedLabels)) - endsBeforeName; got != 1 {
+				t.Errorf("jobsEnded{priority=%q,queue=%q} name-keyed delta = %v, want 1 — label registration order in metrics.go may not match WithLabelValues argument order in agent_worker.go", priority, queue, got)
 			}
 		})
 	}
@@ -90,15 +90,15 @@ func TestJobCountersAreLabelled(t *testing.T) {
 	t.Run("label combinations are independent", func(t *testing.T) {
 		t.Parallel()
 
-		a := testutil.ToFloat64(jobsStartedWithLabels.WithLabelValues("999", "queue-a"))
-		b := testutil.ToFloat64(jobsStartedWithLabels.WithLabelValues("999", "queue-b"))
+		a := testutil.ToFloat64(jobsStarted.WithLabelValues("999", "queue-a"))
+		b := testutil.ToFloat64(jobsStarted.WithLabelValues("999", "queue-b"))
 
-		jobsStartedWithLabels.WithLabelValues("999", "queue-a").Inc()
+		jobsStarted.WithLabelValues("999", "queue-a").Inc()
 
-		if got := testutil.ToFloat64(jobsStartedWithLabels.WithLabelValues("999", "queue-a")) - a; got != 1 {
+		if got := testutil.ToFloat64(jobsStarted.WithLabelValues("999", "queue-a")) - a; got != 1 {
 			t.Errorf("queue-a delta = %v, want 1", got)
 		}
-		if got := testutil.ToFloat64(jobsStartedWithLabels.WithLabelValues("999", "queue-b")) - b; got != 0 {
+		if got := testutil.ToFloat64(jobsStarted.WithLabelValues("999", "queue-b")) - b; got != 0 {
 			t.Errorf("queue-b should be unaffected by queue-a increment, delta = %v, want 0", got)
 		}
 	})


### PR DESCRIPTION
## Description

Removes the legacy unlabelled `buildkite_agent_jobs_started_total` /
`buildkite_agent_jobs_ended_total` counters and promotes the labelled
counters introduced in #3900 into their place. The canonical
`started_total` / `ended_total` names now carry the `priority` and
`queue` labels directly, rather than living alongside separate
`*_with_labels_total` series.

This follows up on #3900, which added the labelled counters in lockstep
with the unlabelled ones for a transition window. With consumers now
reading the labelled series, the duplicate unlabelled counters are no
longer needed.

> [!WARNING]
> This is a breaking change to the Prometheus scrape output:
> `buildkite_agent_jobs_started_total` and `buildkite_agent_jobs_ended_total`
> now carry `priority` and `queue` labels (previously label-free), and the
> short-lived `*_with_labels_total` series are removed. Dashboards and alerts
> that reference these metrics may need updating.

## Context

Follow-up to #3900.
Resolves [A-1100](https://linear.app/buildkite/issue/A-1100/add-job-metadata-labels-to-agent-prometheus-metrics)

## Changes

- `agent/metrics.go`: delete the unlabelled `jobsStarted` / `jobsEnded`
  `Counter`s; rename the labelled `CounterVec`s to the canonical
  `started_total` / `ended_total` names, keeping the `priority`/`queue`
  labels. `jobsRunning` gauge unchanged.
- `agent/agent_worker.go`: `RunJob` now increments only the labelled
  counters via `WithLabelValues(priorityLabel, queueLabel)`.
- `agent/metrics_test.go`: update references to the renamed counters.

## Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

Drafted and implemented with OpenCode (Claude Opus 4.8).