### PR TITLE
feature: Add Job API + CLI support for setting the working directory from polyglot hooks

### DIFF
--- a/clicommand/commands.go
+++ b/clicommand/commands.go
@@ -150,4 +150,12 @@ var BuildkiteAgentCommands = []cli.Command{
 			ToolSignCommand,
 		},
 	},
+	{
+		Name:     "workdir",
+		Category: categoryJobCommands,
+		Usage:    "Interact with the working directory of the currently running job",
+		Subcommands: []cli.Command{
+			WorkdirSetCommand,
+		},
+	},
 }

--- a/clicommand/workdir_set.go
+++ b/clicommand/workdir_set.go
@@ -1,0 +1,126 @@
+package clicommand
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/buildkite/agent/v3/jobapi"
+	"github.com/urfave/cli"
+)
+
+const workdirSetHelpDescription = `Usage:
+
+    buildkite-agent workdir set <path>
+
+Description:
+
+Sets the working directory for subsequent phases of the current job. The change
+persists across later hooks and the command phase.
+
+This is intended for binary and polyglot (non-shell) hooks, which run in a child
+process whose own directory changes are otherwise lost. Wrapped POSIX shell
+hooks can change the working directory simply by ′cd′-ing.
+
+Relative paths are resolved against the current working directory of this command
+(i.e. the hook's actual working directory). The path must exist and be a
+directory.
+
+Examples:
+
+Setting the working directory to a subdirectory of the checkout:
+
+    $ buildkite-agent workdir set ./subdir
+
+Setting the working directory to an absolute path:
+
+    $ buildkite-agent workdir set /tmp/build-scratch`
+
+type WorkdirSetConfig struct {
+	GlobalConfig
+
+	OutputFormat string `cli:"output-format"`
+}
+
+var WorkdirSetCommand = cli.Command{
+	Name:        "set",
+	Usage:       "Sets the working directory for subsequent phases of the job",
+	Description: workdirSetHelpDescription,
+	Flags: append(globalFlags(),
+		cli.StringFlag{
+			Name:   "output-format",
+			Usage:  "Output format: quiet (no output), plain, or json",
+			EnvVar: "BUILDKITE_AGENT_WORKDIR_SET_OUTPUT_FORMAT",
+			Value:  "plain",
+		},
+	),
+	Action: workdirSetAction,
+}
+
+func workdirSetAction(c *cli.Context) error {
+	ctx := context.Background()
+	ctx, cfg, _, _, done := setupLoggerAndConfig[WorkdirSetConfig](ctx, c)
+	defer done()
+
+	args := c.Args()
+	if len(args) != 1 {
+		return fmt.Errorf("expected exactly one argument (the working directory), got %d", len(args))
+	}
+
+	abs, err := resolveWorkdir(args[0])
+	if err != nil {
+		return err
+	}
+
+	client, err := jobapi.NewDefaultClient(ctx)
+	if err != nil {
+		return fmt.Errorf(envClientErrMessage, err)
+	}
+
+	workdir, err := client.SetWorkdir(ctx, abs)
+	if err != nil {
+		return fmt.Errorf("setting the job working directory: %w", err)
+	}
+
+	switch cfg.OutputFormat {
+	case "quiet":
+		return nil
+
+	case "plain":
+		_, _ = fmt.Fprintln(c.App.Writer, workdir)
+
+	case "json":
+		enc := json.NewEncoder(c.App.Writer)
+		if err := enc.Encode(jobapi.WorkdirSetResponse{Workdir: workdir}); err != nil {
+			return fmt.Errorf("error marshalling JSON: %w", err)
+		}
+
+	default:
+		return fmt.Errorf("invalid output format %q", cfg.OutputFormat)
+	}
+
+	return nil
+}
+
+// resolveWorkdir resolves path to an absolute path against the current working
+// directory (the hook's actual working directory) and validates that it exists
+// and is a directory. The Job API endpoint only accepts absolute paths and does
+// not stat the filesystem, so this resolution and validation happens client-side.
+func resolveWorkdir(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolving absolute path of %q: %w", path, err)
+	}
+
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", fmt.Errorf("checking working directory %q: %w", abs, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("working directory %q is not a directory", abs)
+	}
+
+	return abs, nil
+}

--- a/clicommand/workdir_set_test.go
+++ b/clicommand/workdir_set_test.go
@@ -1,0 +1,75 @@
+package clicommand
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveWorkdir is deliberately not parallel: the "relative path" subtest
+// changes the process working directory, which would corrupt other tests if run
+// concurrently. Non-parallel tests run during testing's sequential phase, when
+// no parallel test is active.
+func TestResolveWorkdir(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("absolute existing directory", func(t *testing.T) {
+		got, err := resolveWorkdir(dir)
+		if err != nil {
+			t.Fatalf("resolveWorkdir(%q) error = %v, want nil", dir, err)
+		}
+		if got != dir {
+			t.Fatalf("resolveWorkdir(%q) = %q, want %q", dir, got, dir)
+		}
+	})
+
+	t.Run("relative path is resolved against cwd", func(t *testing.T) {
+		// Not parallel: changes the process working directory.
+		sub := "workdir-sub"
+		if err := os.Mkdir(filepath.Join(dir, sub), 0o700); err != nil {
+			t.Fatalf("os.Mkdir error = %v", err)
+		}
+
+		prev, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("os.Getwd() error = %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chdir(prev) })
+		if err := os.Chdir(dir); err != nil {
+			t.Fatalf("os.Chdir(%q) error = %v", dir, err)
+		}
+
+		// Compute want from the actual cwd, since os.Getwd (used by filepath.Abs)
+		// may resolve symlinks (e.g. /tmp -> /private/tmp on macOS).
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("os.Getwd() error = %v", err)
+		}
+
+		got, err := resolveWorkdir(sub)
+		if err != nil {
+			t.Fatalf("resolveWorkdir(%q) error = %v, want nil", sub, err)
+		}
+		want := filepath.Join(cwd, sub)
+		if got != want {
+			t.Fatalf("resolveWorkdir(%q) = %q, want %q", sub, got, want)
+		}
+	})
+
+	t.Run("nonexistent path errors", func(t *testing.T) {
+		missing := filepath.Join(dir, "does-not-exist")
+		if _, err := resolveWorkdir(missing); err == nil {
+			t.Fatalf("resolveWorkdir(%q) error = nil, want non-nil", missing)
+		}
+	})
+
+	t.Run("file (not a directory) errors", func(t *testing.T) {
+		file := filepath.Join(dir, "a-file")
+		if err := os.WriteFile(file, []byte("hi"), 0o600); err != nil {
+			t.Fatalf("os.WriteFile error = %v", err)
+		}
+		if _, err := resolveWorkdir(file); err == nil {
+			t.Fatalf("resolveWorkdir(%q) error = nil, want non-nil", file)
+		}
+	})
+}

--- a/internal/job/api.go
+++ b/internal/job/api.go
@@ -34,6 +34,7 @@ We'll continue to run your job, but you won't be able to use the Job API`)
 	if err != nil {
 		return cleanup, fmt.Errorf("creating job API server: %w", err)
 	}
+	e.jobAPI = srv
 
 	e.shell.Env.Set("BUILDKITE_AGENT_JOB_API_SOCKET", socketPath)
 	e.shell.Env.Set("BUILDKITE_AGENT_JOB_API_TOKEN", token)

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -34,6 +34,7 @@ import (
 	"github.com/buildkite/agent/v3/internal/shell"
 	"github.com/buildkite/agent/v3/internal/shellscript"
 	"github.com/buildkite/agent/v3/internal/tempfile"
+	"github.com/buildkite/agent/v3/jobapi"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/agent/v3/tracetools"
 	"github.com/buildkite/go-pipeline"
@@ -72,6 +73,11 @@ type Executor struct {
 	// redactors for the job logs. The will be populated with values both from environment variable and through the Job API.
 	// In order for the latter to happen, a reference is passed into the the Job API server as well
 	redactors *replacer.Mux
+
+	// jobAPI is the Job API server for this job. It's retained so the executor
+	// can consume out-of-band requests made by hooks, such as a working
+	// directory set by an unwrapped hook via the /workdir endpoint.
+	jobAPI *jobapi.Server
 }
 
 // New returns a new executor instance
@@ -463,7 +469,19 @@ func (e *Executor) runUnwrappedHook(ctx context.Context, _ string, hookCfg HookC
 	// Passing an empty env changes through because in polyglot hook we can't detect
 	// env change.
 	// But we call this method anyway because a hook might use buildkite-agent env set to update environment.
-	e.applyEnvironmentChanges(hook.EnvChanges{})
+	//
+	// Unwrapped hooks can also request a working directory change via
+	// `buildkite-agent workdir set`, which the Job API records as a pending
+	// workdir. Consume it here and apply it via applyEnvironmentChanges (which
+	// calls shell.Chdir). Once applied it persists in shell.wd, so subsequent
+	// hooks and the command phase run in the new directory.
+	changes := hook.EnvChanges{}
+	if e.jobAPI != nil {
+		if wd, ok := e.jobAPI.TakePendingWorkdir(); ok {
+			changes = hook.EnvChangesForWorkdir(wd)
+		}
+	}
+	e.applyEnvironmentChanges(changes)
 	return nil
 }
 

--- a/internal/job/hook/wrapper.go
+++ b/internal/job/hook/wrapper.go
@@ -87,6 +87,13 @@ type EnvChanges struct {
 	afterWd string
 }
 
+// EnvChangesForWorkdir returns EnvChanges that only request a working directory
+// change (no env var diff). It's used to apply a working directory set by an
+// unwrapped hook via the Job API /workdir endpoint.
+func EnvChangesForWorkdir(wd string) EnvChanges {
+	return EnvChanges{afterWd: wd}
+}
+
 func (changes *EnvChanges) GetAfterWd() (string, error) {
 	if changes.afterWd == "" {
 		return "", fmt.Errorf("%q was not present in the hook after environment", hookWorkingDirEnv)

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -191,6 +191,59 @@ func TestDirectoryPassesBetweenHooksIgnoredUnderExit(t *testing.T) {
 	tester.RunAndCheck(t, "MY_CUSTOM_ENV=1")
 }
 
+func TestBinaryHookCanSetWorkdir(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Binary hooks set the workdir via the Job API, which behaves the same on all platforms, but this test relies on POSIX-y path handling")
+	}
+
+	ctx := mainCtx
+
+	tester, err := NewExecutorTester(ctx)
+	if err != nil {
+		t.Fatalf("NewExecutorTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	// Build a binary pre-command hook that calls the Job API to set the working
+	// directory for subsequent phases. The source is in
+	// ./test-binary-hook-workdir/main.go.
+	t.Logf("Building test-binary-hook-workdir")
+	hookPath := filepath.Join(tester.HooksDir, "pre-command")
+	output, err := exec.Command("go", "build", "-o", hookPath, "./test-binary-hook-workdir").CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to build test-binary-hook-workdir: %v, output: %s", err, string(output))
+	}
+
+	// The command hook should run in the directory the binary hook requested.
+	tester.ExpectGlobalHook("command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
+		if want := c.GetEnv("EXPECTED_WORKDIR"); want != c.Dir {
+			_, _ = fmt.Fprintf(c.Stderr, "Expected command hook dir to be %q, got %q\n", want, c.Dir)
+			c.Exit(1)
+		} else {
+			c.Exit(0)
+		}
+	})
+
+	// A subsequent hook should also run in the requested directory, proving the
+	// change persists across hooks.
+	tester.ExpectGlobalHook("post-command").Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
+		if want := c.GetEnv("EXPECTED_WORKDIR"); want != c.Dir {
+			_, _ = fmt.Fprintf(c.Stderr, "Expected post-command hook dir to be %q, got %q\n", want, c.Dir)
+			c.Exit(1)
+		} else {
+			c.Exit(0)
+		}
+	})
+
+	tester.RunAndCheck(t)
+
+	if !strings.Contains(tester.Output, "hi there from the workdir-setting binary hook 📂") {
+		t.Fatalf("tester.Output %q does not contain expected output: %q", tester.Output, "hi there from the workdir-setting binary hook 📂")
+	}
+}
+
 func TestCheckingOutFiresCorrectHooks(t *testing.T) {
 	t.Parallel()
 

--- a/internal/job/integration/test-binary-hook-workdir/main.go
+++ b/internal/job/integration/test-binary-hook-workdir/main.go
@@ -20,7 +20,7 @@ import (
 // records the expected directory in EXPECTED_WORKDIR so the test's command and
 // post-command hooks can assert they run there.
 func main() {
-	ctx := context.TODO()
+	ctx := context.Background()
 
 	c, err := jobapi.NewDefaultClient(ctx)
 	if err != nil {

--- a/internal/job/integration/test-binary-hook-workdir/main.go
+++ b/internal/job/integration/test-binary-hook-workdir/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/buildkite/agent/v3/jobapi"
+)
+
+// This file gets built and used as part of the hooks integration test to ensure
+// that an unwrapped (binary) hook can change the working directory of subsequent
+// phases via the Job API /workdir endpoint.
+//
+// It creates a subdirectory of its own working directory (the checkout dir),
+// resolves it to an absolute, symlink-free path, then asks the executor to use
+// it as the working directory for subsequent hooks and the command. It also
+// records the expected directory in EXPECTED_WORKDIR so the test's command and
+// post-command hooks can assert they run there.
+func main() {
+	ctx := context.TODO()
+
+	c, err := jobapi.NewDefaultClient(ctx)
+	if err != nil {
+		log.Fatalf("error: %v", fmt.Errorf("creating job api client: %w", err))
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("error: %v", fmt.Errorf("getting working directory: %w", err))
+	}
+
+	target := filepath.Join(cwd, "binary-hook-subdir")
+	if err := os.MkdirAll(target, 0o777); err != nil {
+		log.Fatalf("error: %v", fmt.Errorf("creating target directory: %w", err))
+	}
+
+	// Resolve symlinks so the path matches what the command hook observes as its
+	// working directory (on macOS /tmp and /var are symlinks).
+	resolved, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		log.Fatalf("error: %v", fmt.Errorf("resolving target directory: %w", err))
+	}
+
+	if _, err := c.SetWorkdir(ctx, resolved); err != nil {
+		log.Fatalf("error: %v", fmt.Errorf("setting workdir: %w", err))
+	}
+
+	if _, err := c.EnvUpdate(ctx, &jobapi.EnvUpdateRequest{
+		Env: map[string]string{"EXPECTED_WORKDIR": resolved},
+	}); err != nil {
+		log.Fatalf("error: %v", fmt.Errorf("updating env: %w", err))
+	}
+
+	fmt.Println("hi there from the workdir-setting binary hook 📂")
+}

--- a/jobapi/client.go
+++ b/jobapi/client.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	envURL        = "http://job/api/current-job/v0/env"
+	workdirURL    = "http://job/api/current-job/v0/workdir"
 	redactionsURL = "http://job/api/current-job/v0/redactions"
 )
 
@@ -95,6 +96,18 @@ func (c *Client) EnvDelete(ctx context.Context, del []string) (deleted []string,
 	}
 	resp.Normalize()
 	return resp.Deleted, nil
+}
+
+// SetWorkdir requests that subsequent hooks and the command phase run in dir.
+// dir must be an absolute path. It returns the absolute working directory as
+// recorded by the executor.
+func (c *Client) SetWorkdir(ctx context.Context, dir string) (string, error) {
+	req := WorkdirSetRequest{Workdir: dir}
+	var resp WorkdirSetResponse
+	if err := c.client.Do(ctx, http.MethodPut, workdirURL, &req, &resp); err != nil {
+		return "", err
+	}
+	return resp.Workdir, nil
 }
 
 // RedactionCreate creates a redaction in the job executor.

--- a/jobapi/payloads.go
+++ b/jobapi/payloads.go
@@ -49,6 +49,16 @@ func (e EnvDeleteResponse) Normalize() {
 	sort.Strings(e.Deleted)
 }
 
+// WorkdirSetRequest is the request body for the PUT /workdir endpoint
+type WorkdirSetRequest struct {
+	Workdir string `json:"workdir"`
+}
+
+// WorkdirSetResponse echoes the absolute working directory.
+type WorkdirSetResponse struct {
+	Workdir string `json:"workdir"`
+}
+
 // RedactionCreateRequest is the request body for the POST /redactions endpoint
 type RedactionCreateRequest struct {
 	Redact string `json:"redact"`

--- a/jobapi/routes.go
+++ b/jobapi/routes.go
@@ -30,6 +30,8 @@ func (s *Server) router() chi.Router {
 		r.Patch("/env", s.patchEnv)
 		r.Delete("/env", s.deleteEnv)
 
+		r.Put("/workdir", s.setWorkdir)
+
 		r.Post("/redactions", s.createRedaction)
 	})
 

--- a/jobapi/server.go
+++ b/jobapi/server.go
@@ -34,6 +34,11 @@ type Server struct {
 	environ   *env.Environment
 	redactors *replacer.Mux
 
+	// pendingWorkdir holds an absolute working directory requested by a hook via
+	// the /workdir endpoint, waiting to be applied by the executor once the hook
+	// process exits. Guarded by mtx.
+	pendingWorkdir string
+
 	token   string
 	sockSvr *socket.Server
 }
@@ -72,6 +77,21 @@ func NewServer(
 	s.sockSvr = svr
 
 	return s, token, err
+}
+
+// TakePendingWorkdir returns the working directory requested by a hook via the
+// /workdir endpoint (if any) and clears the pending signal. The second return
+// value reports whether a directory was pending. The applied directory persists
+// in the executor's shell working directory; this only consumes the signal.
+func (s *Server) TakePendingWorkdir() (string, bool) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if s.pendingWorkdir == "" {
+		return "", false
+	}
+	wd := s.pendingWorkdir
+	s.pendingWorkdir = ""
+	return wd, true
 }
 
 // Start starts the server in a goroutine, returning an error if the server can't be started

--- a/jobapi/workdir.go
+++ b/jobapi/workdir.go
@@ -1,0 +1,52 @@
+package jobapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+
+	"github.com/buildkite/agent/v3/internal/socket"
+)
+
+// setWorkdir records a working directory requested by a hook. The directory is
+// applied by the executor after the hook process exits (see
+// Server.TakePendingWorkdir).
+//
+// The endpoint accepts only absolute paths and does not stat the filesystem -
+// the CLI is responsible for resolving relative paths (against the hook's actual
+// working directory) and validating that the path exists before calling here.
+func (s *Server) setWorkdir(w http.ResponseWriter, r *http.Request) {
+	var req WorkdirSetRequest
+	defer func() { _ = r.Body.Close() }()
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if err := socket.WriteError(w, fmt.Errorf("failed to decode request body: %w", err), http.StatusBadRequest); err != nil {
+			s.Logger.Errorf("Job API: couldn't write error: %v", err)
+		}
+		return
+	}
+
+	if req.Workdir == "" {
+		if err := socket.WriteError(w, "workdir must not be empty", http.StatusUnprocessableEntity); err != nil {
+			s.Logger.Errorf("Job API: couldn't write error: %v", err)
+		}
+		return
+	}
+
+	if !filepath.IsAbs(req.Workdir) {
+		if err := socket.WriteError(w, fmt.Sprintf("workdir must be an absolute path, got %q", req.Workdir), http.StatusUnprocessableEntity); err != nil {
+			s.Logger.Errorf("Job API: couldn't write error: %v", err)
+		}
+		return
+	}
+
+	s.mtx.Lock()
+	s.pendingWorkdir = req.Workdir
+	s.mtx.Unlock()
+
+	resp := WorkdirSetResponse{Workdir: req.Workdir}
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		s.Logger.Errorf("Job API: couldn't encode or write response: %v", err)
+	}
+}

--- a/jobapi/workdir.go
+++ b/jobapi/workdir.go
@@ -44,7 +44,7 @@ func (s *Server) setWorkdir(w http.ResponseWriter, r *http.Request) {
 	s.pendingWorkdir = req.Workdir
 	s.mtx.Unlock()
 
-	resp := WorkdirSetResponse{Workdir: req.Workdir}
+	resp := WorkdirSetResponse{Workdir: req.Workdir} //nolint:staticcheck // struct literal is clearer than conversion here
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		s.Logger.Errorf("Job API: couldn't encode or write response: %v", err)

--- a/jobapi/workdir_test.go
+++ b/jobapi/workdir_test.go
@@ -1,0 +1,98 @@
+package jobapi_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/buildkite/agent/v3/internal/replacer"
+	"github.com/buildkite/agent/v3/jobapi"
+)
+
+func TestSetWorkdir(t *testing.T) {
+	t.Parallel()
+
+	// An absolute path that exists on the running OS. The endpoint doesn't stat
+	// the filesystem, but using a real absolute path keeps the test portable
+	// across platforms (e.g. C:\... on Windows).
+	absDir := t.TempDir()
+
+	cases := []apiTestCase[jobapi.WorkdirSetRequest, jobapi.WorkdirSetResponse]{
+		{
+			name:                 "happy case",
+			requestBody:          &jobapi.WorkdirSetRequest{Workdir: absDir},
+			expectedStatus:       http.StatusOK,
+			expectedResponseBody: &jobapi.WorkdirSetResponse{Workdir: absDir},
+		},
+		{
+			name:           "relative path returns a 422",
+			requestBody:    &jobapi.WorkdirSetRequest{Workdir: "relative/path"},
+			expectedStatus: http.StatusUnprocessableEntity,
+			expectedError: &jobapi.ErrorResponse{
+				Error: `workdir must be an absolute path, got "relative/path"`,
+			},
+		},
+		{
+			name:           "empty path returns a 422",
+			requestBody:    &jobapi.WorkdirSetRequest{Workdir: ""},
+			expectedStatus: http.StatusUnprocessableEntity,
+			expectedError: &jobapi.ErrorResponse{
+				Error: "workdir must not be empty",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			environ := testEnviron()
+			srv, token, err := testServer(t, environ, replacer.NewMux())
+			if err != nil {
+				t.Fatalf("creating server: %v", err)
+			}
+
+			if err := srv.Start(); err != nil {
+				t.Fatalf("starting server: %v", err)
+			}
+
+			client := testSocketClient(srv.SocketPath)
+
+			defer func() {
+				if err := srv.Stop(); err != nil {
+					t.Fatalf("stopping server: %v", err)
+				}
+			}()
+
+			buf := bytes.NewBuffer(nil)
+			if err := json.NewEncoder(buf).Encode(c.requestBody); err != nil {
+				t.Fatalf("JSON-encoding c.requestBody into buf: %v", err)
+			}
+
+			req, err := http.NewRequest(http.MethodPut, "http://job/api/current-job/v0/workdir", buf)
+			if err != nil {
+				t.Fatalf("creating request: %v", err)
+			}
+
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+			testAPI(t, environ, req, client, c)
+
+			// TakePendingWorkdir should return the directory exactly once on
+			// success, then report no pending workdir on the next call.
+			gotWd, ok := srv.TakePendingWorkdir()
+			if c.expectedStatus == http.StatusOK {
+				if !ok || gotWd != absDir {
+					t.Fatalf("srv.TakePendingWorkdir() = (%q, %t), want (%q, true)", gotWd, ok, absDir)
+				}
+				if gotWd, ok := srv.TakePendingWorkdir(); ok {
+					t.Fatalf("second srv.TakePendingWorkdir() = (%q, %t), want (\"\", false)", gotWd, ok)
+				}
+			} else if ok {
+				t.Fatalf("srv.TakePendingWorkdir() = (%q, true) after a rejected request, want (\"\", false)", gotWd)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Today only wrapped POSIX shell hooks can change the working directory for subsequent hooks/commands — the hook wrapper exports `BUILDKITE_HOOK_WORKING_DIR=$PWD` after sourcing the hook and the executor `chdir`s to it.

Binary and polyglot (non-shell) hooks can't do this. They run via `runUnwrappedHook` in a child process, so any `chdir()` inside the child is lost.

This PR gives unwrapped hooks a first-class way to change the working directory for subsequent phases, via a new Job API endpoint and a matching `buildkite-agent workdir set <path>` CLI command.

**How it works:**
- The CLI resolves relative paths against its own cwd (the hook's actual working directory) and validates the path exists and is a directory.
- The Job API endpoint (`PUT /workdir`) accepts only absolute paths and records the request as pending (it does not stat the filesystem).
- Because the Job API handler runs in the server goroutine while `shell.wd` is single-writer, the endpoint only *records* the request. The executor consumes the pending workdir after the hook process exits and applies it through the existing `applyEnvironmentChanges` → `shell.Chdir` path — single-threaded, consistent with the wrapped-hook path.
- The change persists across subsequent hooks and the command phase via `shell.wd`; it is not reset between hooks.

Scope is intentionally the unwrapped hook path. Wrapped POSIX shell hooks continue to use the wrapper's `$PWD` capture and are unaffected.

## Context

Internal Linear ticket (Buildkite).

## Changes

- **Job API**: new `PUT /api/current-job/v0/workdir` endpoint (`jobapi/workdir.go`), `WorkdirSetRequest`/`WorkdirSetResponse` payloads, `Server.pendingWorkdir` + take-on-read `TakePendingWorkdir`, and `Client.SetWorkdir`.
- **Executor**: retain the `*jobapi.Server` on the `Executor`; `runUnwrappedHook` now consumes any pending workdir and applies it after the hook exits. New `hook.EnvChangesForWorkdir` constructor for workdir-only changes.
- **CLI**: new `workdir` parent command with a `set` subcommand (leaving room for a future `get`).

```bash
$ buildkite-agent workdir --help
Usage:

  buildkite-agent workdir <command> [options...]

Available commands are:

  set   Sets the working directory for subsequent phases of the job
  help  Shows a list of commands or help for one command
```

```bash
$ buildkite-agent workdir set --help
Usage:

    buildkite-agent workdir set <path>

Description:

Sets the working directory for subsequent phases of the current job. The change
persists across later hooks and the command phase.

This is intended for binary and polyglot (non-shell) hooks, which run in a child
process whose own directory changes are otherwise lost. Wrapped POSIX shell
hooks can change the working directory simply by `cd`-ing.

Relative paths are resolved against the current working directory of this command
(i.e. the hook's actual working directory). The path must exist and be a
directory.
```

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

New tests:
- `jobapi/workdir_test.go`: absolute path → 200 + pending workdir set; relative → 422; empty → 422; `TakePendingWorkdir` returns once then clears.
- `clicommand/workdir_set_test.go`: relative paths resolved against cwd; nonexistent path and non-directory both error before any API call.
- `internal/job/integration/hooks_integration_test.go` (`TestBinaryHookCanSetWorkdir`): a binary `pre-command` hook sets the workdir via the Job API; asserts both the `command` and `post-command` hooks run in the requested directory, proving the change persists across hooks.

## Disclosures / Credits

Claude Code (Opus) implemented this change from a written plan I authored and reviewed, including the tests; I reviewed and verified the result.
