### PR TITLE
Replaces docs redirects for v2/v3

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -6,7 +6,7 @@ We frequently introduce new experimental features to the agent. You can use the 
 buildkite-agent start --experiment experiment1 --experiment experiment2
 ```
 
-Or you can set them in your [agent configuration file](https://buildkite.com/docs/agent/v3/configuration):
+Or you can set them in your [agent configuration file](https://buildkite.com/docs/agent/self-hosted/configure):
 
 ```
 experiment="experiment1,experiment2"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ platforms without extras. On Linux hosts it requires `dbus`.
 
 [The agents page](https://buildkite.com/organizations/-/agents) on Buildkite has
 personalised instructions, or you can refer to
-[the Buildkite docs](https://buildkite.com/docs/agent/v3/installation). Both
+[the Buildkite docs](https://buildkite.com/docs/agent/self-hosted/install). Both
 cover installing the agent with Ubuntu (via apt), Debian (via apt), macOS (via
 homebrew), Windows and Linux.
 

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -37,7 +37,7 @@ command phase that executes the specified command in the created environment.
 You can run only specific phases with the --phases flag.
 
 The bootstrap is also responsible for executing hooks around the phases.
-See https://buildkite.com/docs/agent/v3/hooks for more details.
+See https://buildkite.com/docs/agent/hooks for more details.
 
 Example:
 

--- a/install.ps1
+++ b/install.ps1
@@ -127,7 +127,7 @@ You can now start the agent!
 
 For docs, help and support:
 
-  https://buildkite.com/docs/agent/v3
+  https://buildkite.com/docs/agent
 
 Happy building! <3
 "

--- a/install.sh
+++ b/install.sh
@@ -242,7 +242,7 @@ You can now start the agent!
 
 For docs, help and support:
 
-  https://buildkite.com/docs/agent/v3
+  https://buildkite.com/docs/agent
 
 Happy building! <3
 "

--- a/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
+++ b/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg
@@ -67,13 +67,13 @@ plugins-path="/etc/buildkite-agent/plugins"
 # no-color=true
 
 # The next two options are relevant to the Datadog integration, available 3.7.0 and on
-# See https://buildkite.com/docs/agent/v3/configuration#metrics-datadog
+# See https://buildkite.com/docs/agent/self-hosted/configure#metrics-datadog
 # Send metrics to DogStatsD running on metrics-datadog-host
 # metrics-datadog=true
 
 # Host to collect Buildkite metrics
 # datadog-agent will need to run DogStatsD, presumed on port 8125.
-# See https://buildkite.com/docs/agent/v3/configuration#metrics-datadog-host
+# See https://buildkite.com/docs/agent/self-hosted/configure#metrics-datadog-host
 # Specify port below like my-host:8126 if not using 8125
 # metrics-datadog-host=127.0.0.1
 

--- a/packaging/linux/root/usr/share/buildkite-agent/hooks/checkout.sample
+++ b/packaging/linux/root/usr/share/buildkite-agent/hooks/checkout.sample
@@ -5,6 +5,6 @@
 # behaviour
 
 # Note that as the script is sourced not run directly, the shebang line will be ignored
-# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
+# See https://buildkite.com/docs/agent/hooks#creating-hook-scripts
 
 set -e

--- a/packaging/linux/root/usr/share/buildkite-agent/hooks/command.sample
+++ b/packaging/linux/root/usr/share/buildkite-agent/hooks/command.sample
@@ -4,6 +4,6 @@
 # the build command.
 
 # Note that as the script is sourced not run directly, the shebang line will be ignored
-# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
+# See https://buildkite.com/docs/agent/hooks#creating-hook-scripts
 
 set -e

--- a/packaging/linux/root/usr/share/buildkite-agent/hooks/environment.sample
+++ b/packaging/linux/root/usr/share/buildkite-agent/hooks/environment.sample
@@ -9,6 +9,6 @@
 # export SECRET_VAR=token
 
 # Note that as the script is sourced not run directly, the shebang line will be ignored
-# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
+# See https://buildkite.com/docs/agent/hooks#creating-hook-scripts
 
 set -e

--- a/packaging/linux/root/usr/share/buildkite-agent/hooks/post-artifact.sample
+++ b/packaging/linux/root/usr/share/buildkite-agent/hooks/post-artifact.sample
@@ -3,6 +3,6 @@
 # The `post-artifact` hook will run just after artifacts are uploaded
 
 # Note that as the script is sourced not run directly, the shebang line will be ignored
-# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
+# See https://buildkite.com/docs/agent/hooks#creating-hook-scripts
 
 set -e

--- a/packaging/linux/root/usr/share/buildkite-agent/hooks/post-checkout.sample
+++ b/packaging/linux/root/usr/share/buildkite-agent/hooks/post-checkout.sample
@@ -4,6 +4,6 @@
 # your pipelines source code.
 
 # Note that as the script is sourced not run directly, the shebang line will be ignored
-# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
+# See https://buildkite.com/docs/agent/hooks#creating-hook-scripts
 
 set -e

--- a/packaging/linux/root/usr/share/buildkite-agent/hooks/post-command.sample
+++ b/packaging/linux/root/usr/share/buildkite-agent/hooks/post-command.sample
@@ -4,6 +4,6 @@
 # build commands
 
 # Note that as the script is sourced not run directly, the shebang line will be ignored
-# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
+# See https://buildkite.com/docs/agent/hooks#creating-hook-scripts
 
 set -e

--- a/packaging/linux/root/usr/share/buildkite-agent/hooks/pre-artifact.sample
+++ b/packaging/linux/root/usr/share/buildkite-agent/hooks/pre-artifact.sample
@@ -3,6 +3,6 @@
 # The `pre-artifact` hook will run just before artifacts are uploaded
 
 # Note that as the script is sourced not run directly, the shebang line will be ignored
-# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
+# See https://buildkite.com/docs/agent/hooks#creating-hook-scripts
 
 set -e

--- a/packaging/linux/root/usr/share/buildkite-agent/hooks/pre-checkout.sample
+++ b/packaging/linux/root/usr/share/buildkite-agent/hooks/pre-checkout.sample
@@ -4,7 +4,7 @@
 # checked out from your SCM provider
 
 # Note that as the script is sourced not run directly, the shebang line will be ignored
-# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
+# See https://buildkite.com/docs/agent/hooks#creating-hook-scripts
 
 
 set -e

--- a/packaging/linux/root/usr/share/buildkite-agent/hooks/pre-command.sample
+++ b/packaging/linux/root/usr/share/buildkite-agent/hooks/pre-command.sample
@@ -3,6 +3,6 @@
 # The `pre-command` hook will run just before your build command runs
 
 # Note that as the script is sourced not run directly, the shebang line will be ignored
-# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
+# See https://buildkite.com/docs/agent/hooks#creating-hook-scripts
 
 set -e

--- a/packaging/linux/root/usr/share/buildkite-agent/hooks/pre-exit.sample
+++ b/packaging/linux/root/usr/share/buildkite-agent/hooks/pre-exit.sample
@@ -3,6 +3,6 @@
 # The `pre-exit` hook will run just before your build job finishes
 
 # Note that as the script is sourced not run directly, the shebang line will be ignored
-# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
+# See https://buildkite.com/docs/agent/hooks#creating-hook-scripts
 
 set -e


### PR DESCRIPTION
## Description

This PR updates outdated links to the pages in Docs that have been moved and accompanying redirects with the most recent URLs for Docs pages to remove the redirects altogether.

Only updates documentation links in comments, sample files, and install messages, so it is safe to revert.

## Context

Part of an ongoing SEO optimization effort on the Buildkite Documentation website — removing references that currently rely on redirects so that links resolve directly to their canonical URLs.

URL changes applied:
- buildkite.com/docs/agent/v3/configuration → buildkite.com/docs/agent/self-hosted/configure
- buildkite.com/docs/agent/v3/installation → buildkite.com/docs/agent/self-hosted/install
- buildkite.com/docs/agent/v3/hooks → buildkite.com/docs/agent/hooks
- buildkite.com/docs/agent/v3 → buildkite.com/docs/agent

## Changes

- [EXPERIMENTS.md](../blob/fixing-old-redirects/EXPERIMENTS.md): updated link to the agent configuration page.
- [README.md](../blob/fixing-old-redirects/README.md): updated link to the agent installation page.
- [clicommand/bootstrap.go](../blob/fixing-old-redirects/clicommand/bootstrap.go): updated hooks docs link in the bootstrap command help text.
- [install.ps1](../blob/fixing-old-redirects/install.ps1) and [install.sh](../blob/fixing-old-redirects/install.sh): updated the post-install "docs, help and support" link.
- [packaging/linux/.../buildkite-agent.cfg](../blob/fixing-old-redirects/packaging/linux/root/usr/share/buildkite-agent/buildkite-agent.cfg): updated the two Datadog integration links in the sample config.
- [packaging/linux/.../hooks/*.sample](../blob/fixing-old-redirects/packaging/linux/root/usr/share/buildkite-agent/hooks): updated the "creating hook scripts" link in all 10 sample hook files (checkout, command, environment, post-artifact, post-checkout, post-command, pre-artifact, pre-checkout, pre-command, pre-exit).

No code behavior, CLI arguments, or runtime functionality are affected.

## Testing

Changes are limited to comments, sample files, and user-facing help/install messages, so no new tests are required. The updated URLs were verified to resolve to canonical Docs pages without a redirect.

## Disclosures / Credits

AI-assisted replacements, tested by a human being.
