### PR TITLE
chore: run go1.26.3 fix ./...

### DIFF
--- a/internal/cache/configuration/configuration.go
+++ b/internal/cache/configuration/configuration.go
@@ -102,7 +102,7 @@ func loadTemplates() (map[string]Cache, error) {
 
 	decoder := json.NewDecoder(file)
 
-	rawTemplates := make(map[string]interface{})
+	rawTemplates := make(map[string]any)
 	err = decoder.Decode(&rawTemplates)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse template file: %w", err)
@@ -123,8 +123,8 @@ func loadTemplates() (map[string]Cache, error) {
 }
 
 // extractTemplateCache safely extracts a Cache from raw template data
-func extractTemplateCache(templateName string, template interface{}) (Cache, error) {
-	templateMap, ok := template.(map[string]interface{})
+func extractTemplateCache(templateName string, template any) (Cache, error) {
+	templateMap, ok := template.(map[string]any)
 	if !ok {
 		return Cache{}, fmt.Errorf("template %s is not a valid object", templateName)
 	}
@@ -155,7 +155,7 @@ func extractTemplateCache(templateName string, template interface{}) (Cache, err
 }
 
 // extractStringField safely extracts a string field from a map
-func extractStringField(m map[string]interface{}, field string, required bool) (string, error) {
+func extractStringField(m map[string]any, field string, required bool) (string, error) {
 	value, exists := m[field]
 	if !exists {
 		if required {
@@ -174,7 +174,7 @@ func extractStringField(m map[string]interface{}, field string, required bool) (
 }
 
 // extractStringArrayField safely extracts a []string field from a map
-func extractStringArrayField(m map[string]interface{}, field string, required bool) ([]string, error) {
+func extractStringArrayField(m map[string]any, field string, required bool) ([]string, error) {
 	value, exists := m[field]
 	if !exists {
 		if required {
@@ -184,7 +184,7 @@ func extractStringArrayField(m map[string]interface{}, field string, required bo
 		}
 	}
 
-	array, ok := value.([]interface{})
+	array, ok := value.([]any)
 	if !ok {
 		return nil, fmt.Errorf("field '%s' must be an array, got %T", field, value)
 	}

--- a/internal/cache/integration_test.go
+++ b/internal/cache/integration_test.go
@@ -174,8 +174,8 @@ func (m *mockAPIClient) CacheEntryRetrieve(ctx context.Context, registry string,
 	// Try fallback keys - check if the entry key matches any of the requested fallback keys
 	if req.FallbackKeys != "" {
 		// FallbackKeys is a comma-separated string
-		fallbackKeys := strings.Split(req.FallbackKeys, ",")
-		for _, fbKey := range fallbackKeys {
+		fallbackKeys := strings.SplitSeq(req.FallbackKeys, ",")
+		for fbKey := range fallbackKeys {
 			fbKey = strings.TrimSpace(fbKey)
 			if entry, exists := reg.cache[fbKey]; exists && entry.committed {
 				return api.CacheEntryRetrieveResp{
@@ -213,10 +213,7 @@ func createRandomFile(t *testing.T, path string, sizeBytes int64) {
 	remaining := sizeBytes
 
 	for remaining > 0 {
-		toWrite := int64(chunkSize)
-		if remaining < toWrite {
-			toWrite = remaining
-		}
+		toWrite := min(remaining, int64(chunkSize))
 
 		if _, err := rand.Read(buf[:toWrite]); err != nil {
 			t.Fatalf("rand.Read: %v", err)

--- a/internal/job/executor_test.go
+++ b/internal/job/executor_test.go
@@ -72,7 +72,7 @@ func TestStartTracing_NoTracingBackend(t *testing.T) {
 
 	// If you call opentracing.GlobalTracer() without having set it first, it returns a NoopTracer
 	// In this test case, we haven't touched opentracing at all, so we get the NoopTracer
-	if got, want := reflect.TypeOf(opentracing.GlobalTracer()), reflect.TypeOf(opentracing.NoopTracer{}); got != want {
+	if got, want := reflect.TypeOf(opentracing.GlobalTracer()), reflect.TypeFor[opentracing.NoopTracer](); got != want {
 		t.Errorf("opentracing.GlobalTracer() = %v, want %v", got, want)
 	}
 	stopper()

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -121,8 +121,8 @@ func TestCheckingOutLocalGitProjectWithGitSSHKey(t *testing.T) {
 		case "clone", "fetch":
 			var gitSSHCommand string
 			for _, envVar := range i.Env {
-				if strings.HasPrefix(envVar, "GIT_SSH_COMMAND=") {
-					gitSSHCommand = strings.TrimPrefix(envVar, "GIT_SSH_COMMAND=")
+				if after, ok := strings.CutPrefix(envVar, "GIT_SSH_COMMAND="); ok {
+					gitSSHCommand = after
 					break
 				}
 			}


### PR DESCRIPTION
## Description

Automatically update some anachronistic Go using `go fix` from Go 1.26.

## Context

Some `interface{}` has snuck in, reported in #3967 but that PR deleted a bunch of code instead of fixing it.

## Changes

As generated by `go1.26.3 fix ./...`.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)


## Disclosures / Credits

The Go team for creating `go fix`.