### PR TITLE
feat: Configure artifact upload concurrency

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -76,6 +76,7 @@ type AgentConfiguration struct {
 	TraceContextEncoding         string
 	DisableWarningsFor           []string
 	AllowMultipartArtifactUpload bool
+	ArtifactUploadConcurrency    int
 
 	PingMode string
 }

--- a/agent/integration/job_environment_integration_test.go
+++ b/agent/integration/job_environment_integration_test.go
@@ -229,3 +229,80 @@ func TestBuildkiteRequestHeaders(t *testing.T) {
 		t.Fatalf("runJob() error = %v", err)
 	}
 }
+
+func TestArtifactUploadConcurrencyFromAgentConfigIsSet(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	job := &api.Job{
+		ID:                 "artifact-upload-concurrency-job",
+		ChunksMaxSizeBytes: 1024,
+		Step:               pipeline.CommandStep{},
+		Token:              "bkaj_job-token",
+	}
+
+	mb := mockBootstrap(t)
+	defer mb.CheckAndClose(t) //nolint:errcheck // bintest logs to t
+
+	mb.Expect().Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
+		if got, want := c.GetEnv("BUILDKITE_ARTIFACT_UPLOAD_CONCURRENCY"), "7"; got != want {
+			t.Errorf("c.GetEnv(BUILDKITE_ARTIFACT_UPLOAD_CONCURRENCY) = %q, want %q", got, want)
+		}
+		c.Exit(0)
+	})
+
+	e := createTestAgentEndpoint()
+	server := e.server()
+	defer server.Close()
+
+	err := runJob(t, ctx, testRunJobConfig{
+		job:    job,
+		server: server,
+		agentCfg: agent.AgentConfiguration{
+			ArtifactUploadConcurrency: 7,
+		},
+		mockBootstrap: mb,
+	})
+	if err != nil {
+		t.Fatalf("runJob() error = %v", err)
+	}
+}
+
+func TestArtifactUploadConcurrencyFromJobEnvIsPreservedWhenAgentConfigUnset(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	job := &api.Job{
+		ID:                 "artifact-upload-concurrency-env-job",
+		ChunksMaxSizeBytes: 1024,
+		Env: map[string]string{
+			"BUILDKITE_ARTIFACT_UPLOAD_CONCURRENCY": "5",
+		},
+		Step:  pipeline.CommandStep{},
+		Token: "bkaj_job-token",
+	}
+
+	mb := mockBootstrap(t)
+	defer mb.CheckAndClose(t) //nolint:errcheck // bintest logs to t
+
+	mb.Expect().Once().AndExitWith(0).AndCallFunc(func(c *bintest.Call) {
+		if got, want := c.GetEnv("BUILDKITE_ARTIFACT_UPLOAD_CONCURRENCY"), "5"; got != want {
+			t.Errorf("c.GetEnv(BUILDKITE_ARTIFACT_UPLOAD_CONCURRENCY) = %q, want %q", got, want)
+		}
+		c.Exit(0)
+	})
+
+	e := createTestAgentEndpoint()
+	server := e.server()
+	defer server.Close()
+
+	err := runJob(t, ctx, testRunJobConfig{
+		job:           job,
+		server:        server,
+		agentCfg:      agent.AgentConfiguration{},
+		mockBootstrap: mb,
+	})
+	if err != nil {
+		t.Fatalf("runJob() error = %v", err)
+	}
+}

--- a/agent/integration/job_environment_integration_test.go
+++ b/agent/integration/job_environment_integration_test.go
@@ -233,7 +233,7 @@ func TestBuildkiteRequestHeaders(t *testing.T) {
 func TestArtifactUploadConcurrencyFromAgentConfigIsSet(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	job := &api.Job{
 		ID:                 "artifact-upload-concurrency-job",
 		ChunksMaxSizeBytes: 1024,
@@ -271,7 +271,7 @@ func TestArtifactUploadConcurrencyFromAgentConfigIsSet(t *testing.T) {
 func TestArtifactUploadConcurrencyFromJobEnvIsPreservedWhenAgentConfigUnset(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	job := &api.Job{
 		ID:                 "artifact-upload-concurrency-env-job",
 		ChunksMaxSizeBytes: 1024,

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -456,6 +456,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 			// Docker in particular tolerates undefined vars in an env file
 			// without complaints.
 			const agentCfgVars = `BUILDKITE_GIT_CHECKOUT_FLAGS
+BUILDKITE_ARTIFACT_UPLOAD_CONCURRENCY
 BUILDKITE_GIT_CLEAN_FLAGS
 BUILDKITE_GIT_CLONE_FLAGS
 BUILDKITE_GIT_CLONE_MIRROR_FLAGS
@@ -642,6 +643,9 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 
 	if !r.conf.AgentConfiguration.AllowMultipartArtifactUpload {
 		setEnv("BUILDKITE_NO_MULTIPART_ARTIFACT_UPLOAD", "true")
+	}
+	if r.conf.AgentConfiguration.ArtifactUploadConcurrency > 0 {
+		setEnv("BUILDKITE_ARTIFACT_UPLOAD_CONCURRENCY", strconv.Itoa(r.conf.AgentConfiguration.ArtifactUploadConcurrency))
 	}
 
 	// propagate CancelSignal to bootstrap, unless it's the default SIGTERM

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -204,6 +204,7 @@ type AgentStartConfig struct {
 	KubernetesContainerStartTimeout time.Duration `cli:"kubernetes-container-start-timeout"`
 	TraceContextEncoding            string        `cli:"trace-context-encoding"`
 	NoMultipartArtifactUpload       bool          `cli:"no-multipart-artifact-upload"`
+	ArtifactUploadConcurrency       int           `cli:"artifact-upload-concurrency"`
 
 	// API + agent behaviour
 	PingMode string `cli:"ping-mode"`
@@ -776,6 +777,7 @@ var AgentStartCommand = cli.Command{
 		StrictSingleHooksFlag,
 		TraceContextEncodingFlag,
 		NoMultipartArtifactUploadFlag,
+		AgentArtifactUploadConcurrencyFlag,
 
 		// Deprecated flags which will be removed in v4
 		KubernetesLogCollectionGracePeriodFlag,
@@ -1103,6 +1105,7 @@ var AgentStartCommand = cli.Command{
 			TracingPropagateTraceparent:     cfg.TracingPropagateTraceparent,
 			TraceContextEncoding:            cfg.TraceContextEncoding,
 			AllowMultipartArtifactUpload:    !cfg.NoMultipartArtifactUpload,
+			ArtifactUploadConcurrency:       cfg.ArtifactUploadConcurrency,
 			KubernetesExec:                  cfg.KubernetesExec,
 			KubernetesContainerStartTimeout: cfg.KubernetesContainerStartTimeout,
 			PingMode:                        cfg.PingMode,

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -143,7 +143,7 @@ var ArtifactUploadCommand = cli.Command{
 			Name:   "concurrency",
 			Value:  artifact.DefaultUploadConcurrency(),
 			Usage:  "Number of concurrent artifact upload operations",
-			EnvVar: "BUILDKITE_ARTIFACT_UPLOAD_CONCURRENCY",
+			EnvVar: ArtifactUploadConcurrencyEnvVar,
 		},
 		NoMultipartArtifactUploadFlag,
 	}),

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -90,6 +90,7 @@ type ArtifactUploadConfig struct {
 	GlobResolveFollowSymlinks bool   `cli:"glob-resolve-follow-symlinks"`
 	UploadSkipSymlinks        bool   `cli:"upload-skip-symlinks"`
 	NoMultipartUpload         bool   `cli:"no-multipart-artifact-upload"`
+	UploadConcurrency         int    `cli:"concurrency"`
 
 	// deprecated
 	FollowSymlinks bool `cli:"follow-symlinks" deprecated-and-renamed-to:"GlobResolveFollowSymlinks"`
@@ -138,6 +139,12 @@ var ArtifactUploadCommand = cli.Command{
 			Usage:  "Follow symbolic links while resolving globs. Note this argument is deprecated. Use `--glob-resolve-follow-symlinks` instead (default: false)",
 			EnvVar: "BUILDKITE_AGENT_ARTIFACT_SYMLINKS",
 		},
+		cli.IntFlag{
+			Name:   "concurrency",
+			Value:  artifact.DefaultUploadConcurrency(),
+			Usage:  "Number of concurrent artifact upload operations",
+			EnvVar: "BUILDKITE_ARTIFACT_UPLOAD_CONCURRENCY",
+		},
 		NoMultipartArtifactUploadFlag,
 	}),
 	Action: func(c *cli.Context) error {
@@ -153,16 +160,17 @@ var ArtifactUploadCommand = cli.Command{
 
 		// Setup the uploader
 		uploader := artifact.NewUploader(l, client, artifact.UploaderConfig{
-			JobID:          cfg.Job,
-			Paths:          cfg.UploadPaths,
-			Destination:    cfg.Destination,
-			ContentType:    cfg.ContentType,
-			DebugHTTP:      cfg.DebugHTTP,
-			TraceHTTP:      cfg.TraceHTTP,
-			DisableHTTP2:   cfg.NoHTTP2,
-			AllowMultipart: !cfg.NoMultipartUpload,
-			Literal:        cfg.Literal,
-			Delimiter:      cfg.Delimiter,
+			JobID:             cfg.Job,
+			Paths:             cfg.UploadPaths,
+			Destination:       cfg.Destination,
+			ContentType:       cfg.ContentType,
+			DebugHTTP:         cfg.DebugHTTP,
+			TraceHTTP:         cfg.TraceHTTP,
+			DisableHTTP2:      cfg.NoHTTP2,
+			AllowMultipart:    !cfg.NoMultipartUpload,
+			Literal:           cfg.Literal,
+			Delimiter:         cfg.Delimiter,
+			UploadConcurrency: cfg.UploadConcurrency,
 
 			// If the deprecated flag was set to true, pretend its replacement was set to true too
 			// this works as long as the user only sets one of the two flags

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	DefaultEndpoint = "https://agent-edge.buildkite.com/v3"
+	DefaultEndpoint                 = "https://agent-edge.buildkite.com/v3"
+	ArtifactUploadConcurrencyEnvVar = "BUILDKITE_ARTIFACT_UPLOAD_CONCURRENCY"
 )
 
 var (
@@ -116,6 +117,12 @@ var (
 		Name:   "no-multipart-artifact-upload",
 		Usage:  "For Buildkite-hosted artifacts, disables the use of multipart uploads. Has no effect on uploads to other destinations such as custom cloud buckets (default: false)",
 		EnvVar: "BUILDKITE_NO_MULTIPART_ARTIFACT_UPLOAD",
+	}
+
+	AgentArtifactUploadConcurrencyFlag = cli.IntFlag{
+		Name:   "artifact-upload-concurrency",
+		Usage:  "Maximum number of concurrent artifact upload operations used by jobs started by this agent. When unset, artifact uploads use their default",
+		EnvVar: ArtifactUploadConcurrencyEnvVar,
 	}
 
 	ExperimentsFlag = cli.StringSliceFlag{

--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -87,7 +87,7 @@ func NewUploader(l logger.Logger, ac APIClient, c UploaderConfig) *Uploader {
 }
 
 func DefaultUploadConcurrency() int {
-	return 10 * runtime.GOMAXPROCS(0)
+	return runtime.GOMAXPROCS(0)
 }
 
 func (a *Uploader) Upload(ctx context.Context) error {

--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -61,6 +61,10 @@ type UploaderConfig struct {
 
 	// Whether to allow multipart uploads to the BK-hosted bucket
 	AllowMultipart bool
+
+	// How many upload operations to run concurrently. When zero, defaults to
+	// DefaultUploadConcurrency.
+	UploadConcurrency int
 }
 
 type Uploader struct {
@@ -80,6 +84,10 @@ func NewUploader(l logger.Logger, ac APIClient, c UploaderConfig) *Uploader {
 		apiClient: ac,
 		conf:      c,
 	}
+}
+
+func DefaultUploadConcurrency() int {
+	return 10 * runtime.GOMAXPROCS(0)
 }
 
 func (a *Uploader) Upload(ctx context.Context) error {
@@ -535,12 +543,14 @@ func (a *Uploader) upload(ctx context.Context, artifacts []*api.Artifact, upload
 	}
 
 	// Create work and trackers for each artifact.
+	var workUnitCount int
 	for _, artifact := range artifacts {
 		workUnits, err := uploader.CreateWork(artifact)
 		if err != nil {
 			a.logger.Errorf("Couldn't create upload workers for artifact %q: %v", artifact.Path, err)
 			return err
 		}
+		workUnitCount += len(workUnits)
 
 		actx, acancel := context.WithCancelCause(ctx)
 		worker.trackers[artifact] = &artifactTracker{
@@ -555,6 +565,12 @@ func (a *Uploader) upload(ctx context.Context, artifacts []*api.Artifact, upload
 		}
 	}
 
+	workerCount := a.uploadWorkerCount(workUnitCount)
+	if workerCount == 0 {
+		return nil
+	}
+	a.logger.Debugf("Uploading %d artifact work units with %d workers", workUnitCount, workerCount)
+
 	// unitsCh: work unit creation --(work unit to be run)--> multiple worker goroutines
 	unitsCh := make(chan workUnit)
 	// resultsCh: multiple worker goroutines --(work unit result)--> state updater
@@ -568,7 +584,7 @@ func (a *Uploader) upload(ctx context.Context, artifacts []*api.Artifact, upload
 
 	// Worker goroutines that work on work units.
 	var wg sync.WaitGroup
-	for range runtime.GOMAXPROCS(0) {
+	for range workerCount {
 		wg.Go(func() { worker.doWorkUnits(ctx, unitsCh, resultsCh) })
 	}
 
@@ -606,6 +622,19 @@ func (a *Uploader) upload(ctx context.Context, artifacts []*api.Artifact, upload
 	a.logger.Infof("Artifact uploads completed successfully")
 
 	return nil
+}
+
+func (a *Uploader) uploadWorkerCount(workUnitCount int) int {
+	if workUnitCount <= 0 {
+		return 0
+	}
+
+	concurrency := a.conf.UploadConcurrency
+	if concurrency <= 0 {
+		concurrency = DefaultUploadConcurrency()
+	}
+
+	return min(concurrency, workUnitCount)
 }
 
 func (a *artifactUploadWorker) doWorkUnits(ctx context.Context, unitsCh <-chan workUnit, resultsCh chan<- workUnitResult) {

--- a/internal/artifact/uploader_test.go
+++ b/internal/artifact/uploader_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -447,6 +448,14 @@ func TestUploadUsesConfiguredConcurrency(t *testing.T) {
 
 	if got := state.max.Load(); got != wantConcurrency {
 		t.Fatalf("max concurrent uploads = %d, want %d", got, wantConcurrency)
+	}
+}
+
+func TestDefaultUploadConcurrencyMatchesExistingWorkerCount(t *testing.T) {
+	t.Parallel()
+
+	if got, want := DefaultUploadConcurrency(), runtime.GOMAXPROCS(0); got != want {
+		t.Fatalf("DefaultUploadConcurrency() = %d, want %d", got, want)
 	}
 }
 

--- a/internal/artifact/uploader_test.go
+++ b/internal/artifact/uploader_test.go
@@ -1,13 +1,17 @@
 package artifact
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/internal/experiments"
@@ -393,4 +397,129 @@ func TestCollect_LiteralPathNotFound(t *testing.T) {
 	if pathErr.Op != "open" {
 		t.Errorf("uploader.collect() error Op = %q, want open", pathErr.Op)
 	}
+}
+
+func TestUploadUsesConfiguredConcurrency(t *testing.T) {
+	t.Parallel()
+
+	const wantConcurrency int32 = 3
+
+	state := &uploadConcurrencyState{
+		want:    wantConcurrency,
+		ready:   make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	uploader := NewUploader(logger.Discard, &uploadConcurrencyAPIClient{}, UploaderConfig{
+		JobID:             "job-id",
+		UploadConcurrency: int(wantConcurrency),
+	})
+	workCreator := &uploadConcurrencyWorkCreator{state: state}
+
+	artifacts := make([]*api.Artifact, 10)
+	for i := range artifacts {
+		artifacts[i] = &api.Artifact{
+			ID:   fmt.Sprintf("artifact-%d", i),
+			Path: fmt.Sprintf("artifact-%d.txt", i),
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- uploader.upload(ctx, artifacts, workCreator)
+	}()
+
+	select {
+	case <-state.ready:
+	case <-time.After(2 * time.Second):
+		cancel()
+		err := <-errCh
+		t.Fatalf("upload did not start %d concurrent workers before timeout: %v", wantConcurrency, err)
+	}
+
+	close(state.release)
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("uploader.upload() error = %v", err)
+	}
+
+	if got := state.max.Load(); got != wantConcurrency {
+		t.Fatalf("max concurrent uploads = %d, want %d", got, wantConcurrency)
+	}
+}
+
+type uploadConcurrencyState struct {
+	want int32
+
+	active atomic.Int32
+	max    atomic.Int32
+
+	readyOnce sync.Once
+	ready     chan struct{}
+	release   chan struct{}
+}
+
+type uploadConcurrencyWorkCreator struct {
+	state *uploadConcurrencyState
+}
+
+func (u *uploadConcurrencyWorkCreator) URL(*api.Artifact) string {
+	return ""
+}
+
+func (u *uploadConcurrencyWorkCreator) CreateWork(artifact *api.Artifact) ([]workUnit, error) {
+	return []workUnit{&uploadConcurrencyWork{
+		artifact: artifact,
+		state:    u.state,
+	}}, nil
+}
+
+type uploadConcurrencyWork struct {
+	artifact *api.Artifact
+	state    *uploadConcurrencyState
+}
+
+func (u *uploadConcurrencyWork) Artifact() *api.Artifact {
+	return u.artifact
+}
+
+func (u *uploadConcurrencyWork) Description() string {
+	return u.artifact.Path
+}
+
+func (u *uploadConcurrencyWork) DoWork(ctx context.Context) (*api.ArtifactPartETag, error) {
+	active := u.state.active.Add(1)
+	for {
+		maxActive := u.state.max.Load()
+		if active <= maxActive || u.state.max.CompareAndSwap(maxActive, active) {
+			break
+		}
+	}
+	if active == u.state.want {
+		u.state.readyOnce.Do(func() { close(u.state.ready) })
+	}
+	defer u.state.active.Add(-1)
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-u.state.release:
+		return nil, nil
+	}
+}
+
+type uploadConcurrencyAPIClient struct{}
+
+func (*uploadConcurrencyAPIClient) CreateArtifacts(context.Context, string, *api.ArtifactBatch) (*api.ArtifactBatchCreateResponse, *api.Response, error) {
+	return nil, nil, errors.New("unexpected CreateArtifacts call")
+}
+
+func (*uploadConcurrencyAPIClient) SearchArtifacts(context.Context, string, *api.ArtifactSearchOptions) ([]*api.Artifact, *api.Response, error) {
+	return nil, nil, errors.New("unexpected SearchArtifacts call")
+}
+
+func (*uploadConcurrencyAPIClient) UpdateArtifacts(context.Context, string, []api.ArtifactState) (*api.Response, error) {
+	return nil, nil
 }


### PR DESCRIPTION
Artifact uploads are already parallel, but the worker count was fixed to `GOMAXPROCS`. That can be too conservative for jobs that upload many tiny artifacts, where wall time is dominated by per-request latency rather than CPU work. A job uploading 1,300 small files can spend minutes waiting on low-concurrency S3 form uploads.

This keeps the default artifact upload concurrency at the existing `GOMAXPROCS` behavior, so existing agents do not see a rollout-wide concurrency increase. Direct `buildkite-agent artifact upload` calls can opt into higher or lower concurrency with `--concurrency` or `BUILDKITE_ARTIFACT_UPLOAD_CONCURRENCY`.

The same env var can also be configured agent-wide via `agent start --artifact-upload-concurrency` or the `artifact-upload-concurrency` config file key. When set, the agent propagates `BUILDKITE_ARTIFACT_UPLOAD_CONCURRENCY` into jobs, so operators can tune upload fan-out for a fleet without editing every artifact upload step.

For example, a 4 CPU agent still defaults to 4 concurrent upload operations. Users uploading many small artifacts can opt into `artifact-upload-concurrency=30`, while high-core agents near file descriptor limits can choose a lower fleet-wide cap for multipart uploads.