### PR TITLE
lint: Prefer t.Context in tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+version: "2"
+
+linters:
+  enable:
+    - usetesting
+  settings:
+    usetesting:
+      os-create-temp: false
+      os-mkdir-temp: false
+      os-setenv: false
+      os-temp-dir: false
+      os-chdir: false
+      context-background: true
+      context-todo: false

--- a/agent/gcp_meta_data_test.go
+++ b/agent/gcp_meta_data_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestGCPMetaDataGetPaths(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/agent/integration/config_allowlisting_integration_test.go
+++ b/agent/integration/config_allowlisting_integration_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"context"
 	"maps"
 	"regexp"
 	"strings"
@@ -132,7 +131,7 @@ func TestConfigAllowlisting(t *testing.T) {
 			tc.mockBootstrapExpectation(mb)
 			defer mb.CheckAndClose(t) //nolint:errcheck // bintest logs to t
 
-			err := runJob(t, context.Background(), testRunJobConfig{
+			err := runJob(t, t.Context(), testRunJobConfig{
 				job:           job,
 				server:        server,
 				agentCfg:      tc.agentConfig,

--- a/agent/integration/job_environment_integration_test.go
+++ b/agent/integration/job_environment_integration_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -15,7 +14,7 @@ import (
 func TestWhenCachePathsSetInJobStep_CachePathsEnvVarIsSet(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	job := &api.Job{
 		ID:                 "my-job-id",
 		ChunksMaxSizeBytes: 1024,
@@ -56,7 +55,7 @@ func TestWhenCachePathsSetInJobStep_CachePathsEnvVarIsSet(t *testing.T) {
 func TestCacheSettingsOnSelfHosted_LogsMessage(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	jobID := "cache-self-hosted-job"
 	job := &api.Job{
 		ID:                 jobID,
@@ -102,7 +101,7 @@ func TestCacheSettingsOnSelfHosted_LogsMessage(t *testing.T) {
 func TestCacheSettingsOnHosted_DoesNotLogMessage(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	jobID := "cache-hosted-job"
 	job := &api.Job{
 		ID:                 jobID,
@@ -145,7 +144,7 @@ func TestCacheSettingsOnHosted_DoesNotLogMessage(t *testing.T) {
 func TestNoCacheSettings_DoesNotLogMessage(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	jobID := "no-cache-job"
 	job := &api.Job{
 		ID:                 jobID,
@@ -213,7 +212,7 @@ func TestBuildkiteRequestHeaders(t *testing.T) {
 		c.Exit(0)
 	})
 
-	err := runJob(t, context.Background(), testRunJobConfig{
+	err := runJob(t, t.Context(), testRunJobConfig{
 		job: &api.Job{
 			ID:                 "00000000-0000-0000-0000-000000000123",
 			ChunksMaxSizeBytes: 1024,

--- a/agent/integration/job_runner_integration_test.go
+++ b/agent/integration/job_runner_integration_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -78,7 +77,7 @@ func TestPreBootstrapHookScripts(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 
 			hooksDir, err := os.MkdirTemp("", "bootstrap-hooks")
 			if err != nil {
@@ -137,7 +136,7 @@ func TestPreBootstrapHookScripts(t *testing.T) {
 
 func TestPreBootstrapHookRefusesJob(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	hooksDir, err := os.MkdirTemp("", "bootstrap-hooks")
 	if err != nil {
@@ -196,7 +195,7 @@ func TestPreBootstrapHookRefusesJob(t *testing.T) {
 
 func TestJobRunner_WhenBootstrapExits_ItSendsTheExitStatusToTheAPI(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	exits := []int{0, 1, 2, 3}
 	for _, exit := range exits {
@@ -242,7 +241,7 @@ func TestJobRunner_WhenBootstrapExits_ItSendsTheExitStatusToTheAPI(t *testing.T)
 
 func TestJobRunner_WhenJobHasToken_ItOverridesAccessToken(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	jobToken := "bkaj_actually-llamas-are-only-okay"
 
@@ -285,7 +284,7 @@ func TestJobRunner_WhenJobHasToken_ItOverridesAccessToken(t *testing.T) {
 // Maybe that the job runner pulls the access token from the API client? but that's all handled in the `runJob` helper...
 func TestJobRunnerPassesAccessTokenToBootstrap(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	j := &api.Job{
 		ID:                 "my-job-id",
@@ -324,7 +323,7 @@ func TestJobRunnerPassesAccessTokenToBootstrap(t *testing.T) {
 
 func TestJobRunnerIgnoresPipelineChangesToProtectedVars(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	j := &api.Job{
 		ID:                 "my-job-id",

--- a/agent/log_streamer_test.go
+++ b/agent/log_streamer_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestLogStreamer(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	logger := logger.NewConsoleLogger(
 		logger.NewTextPrinter(os.Stderr),

--- a/agent/pipeline_uploader_test.go
+++ b/agent/pipeline_uploader_test.go
@@ -1,7 +1,6 @@
 package agent_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -20,7 +19,7 @@ import (
 func TestAsyncPipelineUpload(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	l := logger.NewBuffer()
 
 	for _, test := range []struct {
@@ -141,7 +140,7 @@ steps:
 func TestFallbackPipelineUpload(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	l := logger.NewBuffer()
 
 	genSleeps := func(n int, s time.Duration) []time.Duration {

--- a/agent/plugin/definition_test.go
+++ b/agent/plugin/definition_test.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -56,7 +55,7 @@ func TestDefinitionValidationFailsIfDependenciesNotMet(t *testing.T) {
 		Requirements: []string{"llamas"},
 	}
 
-	res := validator.Validate(context.Background(), def, nil)
+	res := validator.Validate(t.Context(), def, nil)
 
 	if res.Valid() {
 		t.Errorf("validator.Validate(def, nil).Valid() = true, want false")
@@ -94,7 +93,7 @@ func TestDefinitionValidatesConfiguration(t *testing.T) {
 	cfg := map[string]any{
 		"llamas": "always",
 	}
-	res := validator.Validate(context.Background(), def, cfg)
+	res := validator.Validate(t.Context(), def, cfg)
 
 	if res.Valid() {
 		t.Errorf("validator.Validate(def, % #v).Valid() = true, want false", cfg)
@@ -129,7 +128,7 @@ func TestDefinitionWithoutAdditionalProperties(t *testing.T) {
 		"alpacas": "definitely",
 		"camels":  "never",
 	}
-	res := validator.Validate(context.Background(), def, cfg)
+	res := validator.Validate(t.Context(), def, cfg)
 
 	if res.Valid() {
 		t.Errorf("validator.Validate(def, % #v).Valid() = true, want false", cfg)
@@ -164,7 +163,7 @@ func TestDefinitionWithAdditionalProperties(t *testing.T) {
 		"alpacas": "definitely",
 		"camels":  "never",
 	}
-	res := validator.Validate(context.Background(), def, cfg)
+	res := validator.Validate(t.Context(), def, cfg)
 
 	if !res.Valid() {
 		t.Errorf("validator.Validate(def, % #v).Valid() = false, want true", cfg)

--- a/agent/tags_test.go
+++ b/agent/tags_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"context"
 	"errors"
 	"os"
 	"runtime"
@@ -17,9 +16,9 @@ func TestFetchingTags(t *testing.T) {
 	cfg := FetchTagsConfig{
 		Tags: []string{"llamas", "rock"},
 	}
-	tags, err := (&tagFetcher{}).Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := (&tagFetcher{}).Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("(&tagFetcher{}).Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("(&tagFetcher{}).Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 
 	if diff := cmp.Diff(tags, []string{"llamas", "rock"}); diff != "" {
@@ -32,16 +31,16 @@ func TestFetchingTagsWithHostTags(t *testing.T) {
 		Tags:         []string{"llamas", "rock"},
 		TagsFromHost: true,
 	}
-	tags, err := (&tagFetcher{}).Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := (&tagFetcher{}).Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("(&tagFetcher{}).Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("(&tagFetcher{}).Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 
 	if got, want := tags, "llamas"; !slices.Contains(got, want) {
-		t.Errorf("(&tagFetcher{}).Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("(&tagFetcher{}).Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 	if got, want := tags, "rock"; !slices.Contains(got, want) {
-		t.Errorf("(&tagFetcher{}).Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("(&tagFetcher{}).Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 
 	hostname, err := os.Hostname()
@@ -50,10 +49,10 @@ func TestFetchingTagsWithHostTags(t *testing.T) {
 	}
 
 	if got, want := tags, "hostname="+hostname; !slices.Contains(got, want) {
-		t.Errorf("(&tagFetcher{}).Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("(&tagFetcher{}).Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 	if got, want := tags, "os="+runtime.GOOS; !slices.Contains(got, want) {
-		t.Errorf("(&tagFetcher{}).Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("(&tagFetcher{}).Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 }
 
@@ -77,13 +76,13 @@ func TestFetchingTagsFromEC2(t *testing.T) {
 		TagsFromEC2MetaData: true,
 		TagsFromEC2Tags:     true,
 	}
-	tags, err := fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 
 	if diff := cmp.Diff(slices.Sorted(slices.Values(tags)), slices.Sorted(slices.Values([]string{"llamas", "rock", "aws:instance-id=i-blahblah", "aws:instance-type=t2.small", "custom_tag=true"}))); diff != "" {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) sorted diff (-got +want):\n%s", diff)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) sorted diff (-got +want):\n%s", diff)
 	}
 }
 
@@ -99,13 +98,13 @@ func TestFetchingTagsFromEC2Tags(t *testing.T) {
 	cfg := FetchTagsConfig{
 		TagsFromEC2Tags: true,
 	}
-	tags, err := fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 
 	if diff := cmp.Diff(slices.Sorted(slices.Values(tags)), slices.Sorted(slices.Values([]string{"custom_tag=true"}))); diff != "" {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) sorted diff (-got +want):\n%s", diff)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) sorted diff (-got +want):\n%s", diff)
 	}
 }
 
@@ -123,9 +122,9 @@ func TestFetchingTagsFromECS(t *testing.T) {
 		Tags:                []string{"llamas", "rock"},
 		TagsFromECSMetaData: true,
 	}
-	tags, err := fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 
 	if diff := cmp.Diff(slices.Sorted(slices.Values(tags)), slices.Sorted(slices.Values([]string{
@@ -135,7 +134,7 @@ func TestFetchingTagsFromECS(t *testing.T) {
 		"ecs:image=buildkite/agent",
 		"ecs:task-arn=arn:aws:ecs:us-east-1:123456789012:task/MyCluster/4d590253bb114126b7afa7b58EXAMPLE",
 	}))); diff != "" {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) sorted diff (-got +want):\n%s", diff)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) sorted diff (-got +want):\n%s", diff)
 	}
 }
 
@@ -166,13 +165,13 @@ func TestFetchingTagsFromGCP(t *testing.T) {
 		TagsFromGCPMetaData: true,
 		TagsFromGCPLabels:   true,
 	}
-	tags, err := fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 
 	if diff := cmp.Diff(slices.Sorted(slices.Values(tags)), slices.Sorted(slices.Values([]string{"llamas", "rock", "gcp:instance-id=my-instance", "gcp:zone=blah", "custom_tag=true"}))); diff != "" {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) sorted diff (-got +want):\n%s", diff)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) sorted diff (-got +want):\n%s", diff)
 	}
 }
 
@@ -218,9 +217,9 @@ func TestFetchingTagsFromAllSources(t *testing.T) {
 		TagsFromEC2MetaDataPaths: []string{"tag=some/ec2/value"},
 		TagsFromEC2Tags:          true,
 	}
-	tags, err := fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 
 	hostname, err := os.Hostname()
@@ -229,37 +228,37 @@ func TestFetchingTagsFromAllSources(t *testing.T) {
 	}
 
 	if got, want := tags, "llamas"; !slices.Contains(got, want) {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 	if got, want := tags, "rock"; !slices.Contains(got, want) {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 	if got, want := tags, "gcp_metadata=true"; !slices.Contains(got, want) {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 	if got, want := tags, "gcp_metadata_paths=true"; !slices.Contains(got, want) {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 	if got, want := tags, "gcp_labels=true"; !slices.Contains(got, want) {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 	if got, want := tags, "ec2_tags=true"; !slices.Contains(got, want) {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 	if got, want := tags, "ec2_metadata=true"; !slices.Contains(got, want) {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 	if got, want := tags, "ecs_metadata=true"; !slices.Contains(got, want) {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 	if got, want := tags, "ec2_metadata_paths=true"; !slices.Contains(got, want) {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 	if got, want := tags, "hostname="+hostname; !slices.Contains(got, want) {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 	if got, want := tags, "os="+runtime.GOOS; !slices.Contains(got, want) {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 }
 
@@ -277,12 +276,12 @@ func TestFailOnMissingTags_EC2MetaData(t *testing.T) {
 		Tags:                []string{"llamas"},
 		TagsFromEC2MetaData: true,
 	}
-	tags, err := fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 	if diff := cmp.Diff(tags, []string{"llamas"}); diff != "" {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) diff (-got +want):\n%s", diff)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) diff (-got +want):\n%s", diff)
 	}
 
 	// With FailOnMissingTags=true, should return error
@@ -291,9 +290,9 @@ func TestFailOnMissingTags_EC2MetaData(t *testing.T) {
 		TagsFromEC2MetaData: true,
 		FailOnMissingTags:   true,
 	}
-	_, err = fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	_, err = fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err == nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want non-nil error", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want non-nil error", err)
 	}
 	if got, want := err.Error(), "failed to fetch EC2 meta-data"; !strings.Contains(got, want) {
 		t.Errorf("err.Error() = %q, want containing %q", got, want)
@@ -312,12 +311,12 @@ func TestFailOnMissingTags_EC2MetaDataPaths(t *testing.T) {
 		Tags:                     []string{"llamas"},
 		TagsFromEC2MetaDataPaths: []string{"tag=some/path"},
 	}
-	tags, err := fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 	if diff := cmp.Diff(tags, []string{"llamas"}); diff != "" {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) diff (-got +want):\n%s", diff)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) diff (-got +want):\n%s", diff)
 	}
 
 	// With FailOnMissingTags=true, should return error
@@ -326,9 +325,9 @@ func TestFailOnMissingTags_EC2MetaDataPaths(t *testing.T) {
 		TagsFromEC2MetaDataPaths: []string{"tag=some/path"},
 		FailOnMissingTags:        true,
 	}
-	_, err = fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	_, err = fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err == nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want non-nil error", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want non-nil error", err)
 	}
 	if got, want := err.Error(), "failed to fetch EC2 meta-data from paths"; !strings.Contains(got, want) {
 		t.Errorf("err.Error() = %q, want containing %q", got, want)
@@ -347,12 +346,12 @@ func TestFailOnMissingTags_EC2Tags(t *testing.T) {
 		Tags:            []string{"llamas"},
 		TagsFromEC2Tags: true,
 	}
-	tags, err := fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 	if diff := cmp.Diff(tags, []string{"llamas"}); diff != "" {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) diff (-got +want):\n%s", diff)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) diff (-got +want):\n%s", diff)
 	}
 
 	// With FailOnMissingTags=true, should return error
@@ -361,9 +360,9 @@ func TestFailOnMissingTags_EC2Tags(t *testing.T) {
 		TagsFromEC2Tags:   true,
 		FailOnMissingTags: true,
 	}
-	_, err = fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	_, err = fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err == nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want non-nil error", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want non-nil error", err)
 	}
 	if got, want := err.Error(), "failed to fetch EC2 tags"; !strings.Contains(got, want) {
 		t.Errorf("err.Error() = %q, want containing %q", got, want)
@@ -382,12 +381,12 @@ func TestFailOnMissingTags_ECSMetaData(t *testing.T) {
 		Tags:                []string{"llamas"},
 		TagsFromECSMetaData: true,
 	}
-	tags, err := fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 	if diff := cmp.Diff(tags, []string{"llamas"}); diff != "" {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) diff (-got +want):\n%s", diff)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) diff (-got +want):\n%s", diff)
 	}
 
 	// With FailOnMissingTags=true, should return error
@@ -396,9 +395,9 @@ func TestFailOnMissingTags_ECSMetaData(t *testing.T) {
 		TagsFromECSMetaData: true,
 		FailOnMissingTags:   true,
 	}
-	_, err = fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	_, err = fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err == nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want non-nil error", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want non-nil error", err)
 	}
 	if got, want := err.Error(), "failed to fetch ECS meta-data"; !strings.Contains(got, want) {
 		t.Errorf("err.Error() = %q, want containing %q", got, want)
@@ -417,12 +416,12 @@ func TestFailOnMissingTags_GCPMetaData(t *testing.T) {
 		Tags:                []string{"llamas"},
 		TagsFromGCPMetaData: true,
 	}
-	tags, err := fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 	if diff := cmp.Diff(tags, []string{"llamas"}); diff != "" {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) diff (-got +want):\n%s", diff)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) diff (-got +want):\n%s", diff)
 	}
 
 	// With FailOnMissingTags=true, should return error
@@ -431,9 +430,9 @@ func TestFailOnMissingTags_GCPMetaData(t *testing.T) {
 		TagsFromGCPMetaData: true,
 		FailOnMissingTags:   true,
 	}
-	_, err = fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	_, err = fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err == nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want non-nil error", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want non-nil error", err)
 	}
 	if got, want := err.Error(), "failed to fetch GCP meta-data"; !strings.Contains(got, want) {
 		t.Errorf("err.Error() = %q, want containing %q", got, want)
@@ -452,12 +451,12 @@ func TestFailOnMissingTags_GCPMetaDataPaths(t *testing.T) {
 		Tags:                     []string{"llamas"},
 		TagsFromGCPMetaDataPaths: []string{"tag=some/path"},
 	}
-	tags, err := fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 	if diff := cmp.Diff(tags, []string{"llamas"}); diff != "" {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) diff (-got +want):\n%s", diff)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) diff (-got +want):\n%s", diff)
 	}
 
 	// With FailOnMissingTags=true, should return error
@@ -466,9 +465,9 @@ func TestFailOnMissingTags_GCPMetaDataPaths(t *testing.T) {
 		TagsFromGCPMetaDataPaths: []string{"tag=some/path"},
 		FailOnMissingTags:        true,
 	}
-	_, err = fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	_, err = fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err == nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want non-nil error", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want non-nil error", err)
 	}
 	if got, want := err.Error(), "failed to fetch GCP meta-data from paths"; !strings.Contains(got, want) {
 		t.Errorf("err.Error() = %q, want containing %q", got, want)
@@ -487,12 +486,12 @@ func TestFailOnMissingTags_GCPLabels(t *testing.T) {
 		Tags:              []string{"llamas"},
 		TagsFromGCPLabels: true,
 	}
-	tags, err := fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 	if diff := cmp.Diff(tags, []string{"llamas"}); diff != "" {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) diff (-got +want):\n%s", diff)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) diff (-got +want):\n%s", diff)
 	}
 
 	// With FailOnMissingTags=true, should return error
@@ -501,9 +500,9 @@ func TestFailOnMissingTags_GCPLabels(t *testing.T) {
 		TagsFromGCPLabels: true,
 		FailOnMissingTags: true,
 	}
-	_, err = fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	_, err = fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err == nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want non-nil error", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want non-nil error", err)
 	}
 	if got, want := err.Error(), "failed to fetch GCP instance labels"; !strings.Contains(got, want) {
 		t.Errorf("err.Error() = %q, want containing %q", got, want)
@@ -527,18 +526,18 @@ func TestFailOnMissingTags_NoErrorWhenSourcesSucceed(t *testing.T) {
 		TagsFromEC2Tags:     true,
 		FailOnMissingTags:   true,
 	}
-	tags, err := fetcher.Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := fetcher.Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("fetcher.Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("fetcher.Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 	if got, want := tags, "llamas"; !slices.Contains(got, want) {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 	if got, want := tags, "aws:instance-id=i-1234"; !slices.Contains(got, want) {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 	if got, want := tags, "env=prod"; !slices.Contains(got, want) {
-		t.Errorf("fetcher.Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("fetcher.Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 }
 
@@ -549,14 +548,14 @@ func TestFailOnMissingTags_DoesNotAffectHostTags(t *testing.T) {
 		TagsFromHost:      true,
 		FailOnMissingTags: true,
 	}
-	tags, err := (&tagFetcher{}).Fetch(context.Background(), logger.Discard, cfg)
+	tags, err := (&tagFetcher{}).Fetch(t.Context(), logger.Discard, cfg)
 	if err != nil {
-		t.Fatalf("(&tagFetcher{}).Fetch(context.Background(), logger.Discard, cfg) error = %v, want nil", err)
+		t.Fatalf("(&tagFetcher{}).Fetch(t.Context(), logger.Discard, cfg) error = %v, want nil", err)
 	}
 	if got, want := tags, "llamas"; !slices.Contains(got, want) {
-		t.Errorf("(&tagFetcher{}).Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("(&tagFetcher{}).Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 	if got, want := tags, "os="+runtime.GOOS; !slices.Contains(got, want) {
-		t.Errorf("(&tagFetcher{}).Fetch(context.Background(), logger.Discard, cfg) = %v, want containing %q", got, want)
+		t.Errorf("(&tagFetcher{}).Fetch(t.Context(), logger.Discard, cfg) = %v, want containing %q", got, want)
 	}
 }

--- a/api/api_internal_test.go
+++ b/api/api_internal_test.go
@@ -12,7 +12,7 @@ import (
 func TestNewRequestBuildkiteTimeoutMilliseconds(t *testing.T) {
 	c := NewClient(logger.NewBuffer(), Config{})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	r, err := c.newRequest(ctx, "GET", "/foo", nil)
@@ -35,7 +35,7 @@ func TestNewRequestBuildkiteTimeoutMilliseconds(t *testing.T) {
 func TestNewRequestWithoutBuildkiteTimeoutMilliseconds(t *testing.T) {
 	c := NewClient(logger.NewBuffer(), Config{})
 
-	ctx := context.Background() // no timeout/deadline
+	ctx := t.Context() // no timeout/deadline
 
 	r, err := c.newRequest(ctx, "GET", "/foo", nil)
 	if err != nil {

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -1,7 +1,6 @@
 package api_test
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -41,7 +40,7 @@ func TestCacheEntryPeekExists_Success(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, exists, _, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
+	resp, exists, _, err := client.CacheEntryPeekExists(t.Context(), "test-slug", api.CacheEntryPeekReq{
 		Key:    "test-key",
 		Branch: "main",
 	})
@@ -66,7 +65,7 @@ func TestCacheEntryPeekExists_NotFound(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, exists, _, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
+	resp, exists, _, err := client.CacheEntryPeekExists(t.Context(), "test-slug", api.CacheEntryPeekReq{
 		Key:    "nonexistent-key",
 		Branch: "main",
 	})
@@ -91,7 +90,7 @@ func TestCacheEntryPeekExists_WrongContentType(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	_, _, _, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
+	_, _, _, err := client.CacheEntryPeekExists(t.Context(), "test-slug", api.CacheEntryPeekReq{
 		Key:    "test-key",
 		Branch: "main",
 	})
@@ -110,7 +109,7 @@ func TestCacheEntryPeekExists_CacheRegistryNotFound(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	_, _, _, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
+	_, _, _, err := client.CacheEntryPeekExists(t.Context(), "test-slug", api.CacheEntryPeekReq{
 		Key:    "test-key",
 		Branch: "main",
 	})
@@ -129,7 +128,7 @@ func TestCacheEntryPeekExists_ContentTypeWithCharset(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, exists, _, err := client.CacheEntryPeekExists(context.Background(), "test-slug", api.CacheEntryPeekReq{
+	resp, exists, _, err := client.CacheEntryPeekExists(t.Context(), "test-slug", api.CacheEntryPeekReq{
 		Key:    "test-key",
 		Branch: "main",
 	})
@@ -170,7 +169,7 @@ func TestCacheEntryCreate_Success(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, _, err := client.CacheEntryCreate(context.Background(), "test-slug", api.CacheEntryCreateReq{
+	resp, _, err := client.CacheEntryCreate(t.Context(), "test-slug", api.CacheEntryCreateReq{
 		Key:          "test-key",
 		FallbackKeys: []string{"fallback-1", "fallback-2"},
 		Compression:  "gzip",
@@ -217,7 +216,7 @@ func TestCacheEntryRetrieve_Success(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, found, _, err := client.CacheEntryRetrieve(context.Background(), "test-slug", api.CacheEntryRetrieveReq{
+	resp, found, _, err := client.CacheEntryRetrieve(t.Context(), "test-slug", api.CacheEntryRetrieveReq{
 		Key:          "test-key",
 		Branch:       "main",
 		FallbackKeys: "fallback-1,fallback-2",
@@ -246,7 +245,7 @@ func TestCacheEntryRetrieve_NotFound(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, found, _, err := client.CacheEntryRetrieve(context.Background(), "test-slug", api.CacheEntryRetrieveReq{
+	resp, found, _, err := client.CacheEntryRetrieve(t.Context(), "test-slug", api.CacheEntryRetrieveReq{
 		Key:    "nonexistent-key",
 		Branch: "main",
 	})
@@ -282,7 +281,7 @@ func TestCacheEntryCommit_Success(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	resp, _, err := client.CacheEntryCommit(context.Background(), "test-slug", api.CacheEntryCommitReq{
+	resp, _, err := client.CacheEntryCommit(t.Context(), "test-slug", api.CacheEntryCommitReq{
 		UploadID: "upload-123",
 	})
 	if err != nil {
@@ -303,7 +302,7 @@ func TestCacheEntryCommit_Failure(t *testing.T) {
 
 	client := newTestCacheClient(t, server.URL)
 
-	_, _, err := client.CacheEntryCommit(context.Background(), "test-slug", api.CacheEntryCommitReq{
+	_, _, err := client.CacheEntryCommit(t.Context(), "test-slug", api.CacheEntryCommitReq{
 		UploadID: "invalid-upload-id",
 	})
 	if err == nil {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,7 +1,6 @@
 package api_test
 
 import (
-	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -42,7 +41,7 @@ func TestRegisteringAndConnectingClient(t *testing.T) {
 	server.EnableHTTP2 = true
 	server.StartTLS()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Initial client with a registration token
 	c := api.NewClient(logger.Discard, api.Config{

--- a/api/oidc_test.go
+++ b/api/oidc_test.go
@@ -2,7 +2,6 @@ package api_test
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -90,7 +89,7 @@ func TestOIDCToken(t *testing.T) {
 	const audience = "sts.amazonaws.com"
 	const lifetime = 600
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		OIDCTokenRequest *api.OIDCTokenRequest
@@ -209,7 +208,7 @@ func TestOIDCTokenError(t *testing.T) {
 	const accessToken = "llamas"
 	const audience = "sts.amazonaws.com"
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		OIDCTokenRequest *api.OIDCTokenRequest

--- a/api/secrets_test.go
+++ b/api/secrets_test.go
@@ -1,7 +1,6 @@
 package api_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -29,7 +28,7 @@ func TestGetSecret(t *testing.T) {
 		nonAccessToken = "alpacas"
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	for _, test := range []struct {
 		name             string

--- a/clicommand/agent_pause_test.go
+++ b/clicommand/agent_pause_test.go
@@ -1,7 +1,6 @@
 package clicommand
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -25,7 +24,7 @@ func TestAgentPause(t *testing.T) {
 	server := newAgentPauseTestServer(t)
 	defer server.Close()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg := AgentPauseConfig{
 		APIConfig: APIConfig{
 			AgentAccessToken: "agentaccesstoken",

--- a/clicommand/agent_resume_test.go
+++ b/clicommand/agent_resume_test.go
@@ -1,7 +1,6 @@
 package clicommand
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -25,7 +24,7 @@ func TestAgentResume(t *testing.T) {
 	server := newAgentResumeTestServer(t)
 	defer server.Close()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg := AgentResumeConfig{
 		APIConfig: APIConfig{
 			AgentAccessToken: "agentaccesstoken",

--- a/clicommand/agent_stop_test.go
+++ b/clicommand/agent_stop_test.go
@@ -1,7 +1,6 @@
 package clicommand
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -25,7 +24,7 @@ func TestAgentStop(t *testing.T) {
 	server := newAgentStopTestServer(t)
 	defer server.Close()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg := AgentStopConfig{
 		APIConfig: APIConfig{
 			AgentAccessToken: "agentaccesstoken",

--- a/clicommand/artifact_shasum_test.go
+++ b/clicommand/artifact_shasum_test.go
@@ -2,7 +2,6 @@ package clicommand
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -31,7 +30,7 @@ func TestSearchAndPrintSha1Sum(t *testing.T) {
 	server := newArtifactTestServer(t)
 	defer server.Close()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cfg := ArtifactShasumConfig{
 		Query: "foo.*",
@@ -66,7 +65,7 @@ func TestSearchAndPrintSha256Sum(t *testing.T) {
 	server := newArtifactTestServer(t)
 	defer server.Close()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cfg := ArtifactShasumConfig{
 		Query:  "foo.*",

--- a/clicommand/build_cancel_test.go
+++ b/clicommand/build_cancel_test.go
@@ -1,7 +1,6 @@
 package clicommand
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +12,7 @@ import (
 
 func TestBuildCancel(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("success", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -1,7 +1,6 @@
 package clicommand
 
 import (
-	"context"
 	"os"
 	"runtime"
 	"strings"
@@ -190,7 +189,7 @@ steps:
 			},
 		}}
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	var gotPipelines []*pipeline.Pipeline
 
@@ -243,7 +242,7 @@ steps:
 				RedactedVars:  []string{},
 				RejectSecrets: true,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			if test.preferRuntimeEnv {
 				ctx, _ = experiments.Enable(ctx, experiments.InterpolationPrefersRuntimeEnv)
 			}
@@ -307,7 +306,7 @@ steps:
 				RedactedVars:    []string{},
 				RejectSecrets:   true,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 
 			var gotCommands []string
 

--- a/clicommand/secret_get_test.go
+++ b/clicommand/secret_get_test.go
@@ -2,7 +2,6 @@ package clicommand
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -45,9 +44,9 @@ func TestSecretGet(t *testing.T) {
 		server := newSecretGetTestServer(t, map[string]string{})
 		defer server.Close()
 		var out bytes.Buffer
-		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{}, "default"), &out, logger.NewBuffer())
+		err := secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{}, "default"), &out, logger.NewBuffer())
 		if want := "at least one secret key must be provided"; err == nil || err.Error() != want {
-			t.Fatalf("secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{}, \"default\"), &out, logger.NewBuffer()) error = %v, want error with message %q", err, want)
+			t.Fatalf("secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{}, \"default\"), &out, logger.NewBuffer()) error = %v, want error with message %q", err, want)
 		}
 	})
 
@@ -56,9 +55,9 @@ func TestSecretGet(t *testing.T) {
 		server := newSecretGetTestServer(t, map[string]string{"deploy_key": "shhsecret"})
 		defer server.Close()
 		var out bytes.Buffer
-		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key"}, "xml"), &out, logger.NewBuffer())
+		err := secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{"deploy_key"}, "xml"), &out, logger.NewBuffer())
 		if want := `invalid format "xml": must be one of 'default', 'json', or 'env'`; err == nil || err.Error() != want {
-			t.Fatalf("secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{\"deploy_key\"}, \"xml\"), &out, logger.NewBuffer()) error = %v, want error with message %q", err, want)
+			t.Fatalf("secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{\"deploy_key\"}, \"xml\"), &out, logger.NewBuffer()) error = %v, want error with message %q", err, want)
 		}
 	})
 
@@ -67,9 +66,9 @@ func TestSecretGet(t *testing.T) {
 		server := newSecretGetTestServer(t, map[string]string{"deploy_key": "shhsecret"})
 		defer server.Close()
 		var out bytes.Buffer
-		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key"}, "default"), &out, logger.NewBuffer())
+		err := secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{"deploy_key"}, "default"), &out, logger.NewBuffer())
 		if err != nil {
-			t.Fatalf("secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{\"deploy_key\"}, \"default\"), &out, logger.NewBuffer()) error = %v, want nil", err)
+			t.Fatalf("secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{\"deploy_key\"}, \"default\"), &out, logger.NewBuffer()) error = %v, want nil", err)
 		}
 		if got, want := out.String(), "shhsecret\n"; got != want {
 			t.Fatalf("out.String() = %q, want %q", got, want)
@@ -84,9 +83,9 @@ func TestSecretGet(t *testing.T) {
 		})
 		defer server.Close()
 		var out bytes.Buffer
-		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key", "github_api_key"}, "default"), &out, logger.NewBuffer())
+		err := secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{"deploy_key", "github_api_key"}, "default"), &out, logger.NewBuffer())
 		if err != nil {
-			t.Fatalf("secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{\"deploy_key\", \"github_api_key\"}, \"default\"), &out, logger.NewBuffer()) error = %v, want nil", err)
+			t.Fatalf("secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{\"deploy_key\", \"github_api_key\"}, \"default\"), &out, logger.NewBuffer()) error = %v, want nil", err)
 		}
 
 		var result map[string]string
@@ -107,9 +106,9 @@ func TestSecretGet(t *testing.T) {
 		server := newSecretGetTestServer(t, map[string]string{"deploy_key": "supersecret"})
 		defer server.Close()
 		var out bytes.Buffer
-		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key"}, "json"), &out, logger.NewBuffer())
+		err := secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{"deploy_key"}, "json"), &out, logger.NewBuffer())
 		if err != nil {
-			t.Fatalf("secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{\"deploy_key\"}, \"json\"), &out, logger.NewBuffer()) error = %v, want nil", err)
+			t.Fatalf("secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{\"deploy_key\"}, \"json\"), &out, logger.NewBuffer()) error = %v, want nil", err)
 		}
 
 		var result map[string]string
@@ -130,9 +129,9 @@ func TestSecretGet(t *testing.T) {
 		defer server.Close()
 
 		var out bytes.Buffer
-		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key", "github_api_key"}, "env"), &out, logger.NewBuffer())
+		err := secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{"deploy_key", "github_api_key"}, "env"), &out, logger.NewBuffer())
 		if err != nil {
-			t.Fatalf("secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{\"deploy_key\", \"github_api_key\"}, \"env\"), &out, logger.NewBuffer()) error = %v, want nil", err)
+			t.Fatalf("secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{\"deploy_key\", \"github_api_key\"}, \"env\"), &out, logger.NewBuffer()) error = %v, want nil", err)
 		}
 		if got, want := out.String(), "DEPLOY_KEY='secret1'\nGITHUB_API_KEY='secret2'\n"; got != want {
 			t.Fatalf("out.String() = %q, want %q", got, want)
@@ -148,9 +147,9 @@ func TestSecretGet(t *testing.T) {
 		defer server.Close()
 
 		var out bytes.Buffer
-		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"deploy_key", "github_api_key"}, "env"), &out, logger.NewBuffer())
+		err := secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{"deploy_key", "github_api_key"}, "env"), &out, logger.NewBuffer())
 		if err != nil {
-			t.Fatalf("secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{\"deploy_key\", \"github_api_key\"}, \"env\"), &out, logger.NewBuffer()) error = %v, want nil", err)
+			t.Fatalf("secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{\"deploy_key\", \"github_api_key\"}, \"env\"), &out, logger.NewBuffer()) error = %v, want nil", err)
 		}
 		if got, want := out.String(), "DEPLOY_KEY=''\\''sec\\nret1'\\'''\nGITHUB_API_KEY='se'\\''c'\\''ret2'\n"; got != want {
 			t.Fatalf("out.String() = %q, want %q", got, want)
@@ -165,9 +164,9 @@ func TestSecretGet(t *testing.T) {
 		defer server.Close()
 
 		var out bytes.Buffer
-		err := secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{"missing_key"}, "default"), &out, logger.NewBuffer())
+		err := secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{"missing_key"}, "default"), &out, logger.NewBuffer())
 		if err == nil {
-			t.Fatalf("secretGet(context.Background(), baseSecretGetConfig(server.URL, []string{\"missing_key\"}, \"default\"), &out, logger.NewBuffer()) error = %v, want non-nil error", err)
+			t.Fatalf("secretGet(t.Context(), baseSecretGetConfig(server.URL, []string{\"missing_key\"}, \"default\"), &out, logger.NewBuffer()) error = %v, want non-nil error", err)
 		}
 		if got, want := err.Error(), "Failed to fetch some secrets:"; !strings.Contains(got, want) {
 			t.Fatalf("err.Error() = %q, want containing %q", got, want)

--- a/clicommand/step_cancel_test.go
+++ b/clicommand/step_cancel_test.go
@@ -1,7 +1,6 @@
 package clicommand
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -13,7 +12,7 @@ import (
 
 func TestStepCancel(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("success", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {

--- a/internal/agentapi/client_server_test.go
+++ b/internal/agentapi/client_server_test.go
@@ -49,7 +49,7 @@ func testServerAndClient(t *testing.T, ctx context.Context) (*Server, *Client) {
 
 func TestPing(t *testing.T) {
 	t.Parallel()
-	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, canc := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(canc)
 
 	svr, cli := testServerAndClient(t, ctx)
@@ -62,7 +62,7 @@ func TestPing(t *testing.T) {
 
 func TestLockOperations(t *testing.T) {
 	t.Parallel()
-	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, canc := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(canc)
 
 	svr, cli := testServerAndClient(t, ctx)

--- a/internal/artifact/bk_uploader_test.go
+++ b/internal/artifact/bk_uploader_test.go
@@ -2,7 +2,6 @@ package artifact
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -21,7 +20,7 @@ import (
 )
 
 func TestFormUploading(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.Method != "POST" && req.URL.Path != "/buildkiteartifacts.com" {
@@ -130,7 +129,7 @@ func TestFormUploading(t *testing.T) {
 }
 
 func TestMultipartUploading(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.Method != "PUT" || req.URL.Path != "/llamas3.txt" {
@@ -244,7 +243,7 @@ func TestMultipartUploading(t *testing.T) {
 }
 
 func TestFormUploadFileMissing(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		http.Error(rw, "Not found", http.StatusNotFound)
 	}))

--- a/internal/artifact/download_test.go
+++ b/internal/artifact/download_test.go
@@ -3,7 +3,6 @@
 package artifact
 
 import (
-	"context"
 	"testing"
 
 	"github.com/buildkite/agent/v3/internal/experiments"
@@ -56,7 +55,7 @@ func TestTargetPath(t *testing.T) {
 		{dlPath: "../../../../etc/passwd", destPath: "dist/foo", want: "dist/foo/etc/passwd"},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	for _, test := range tests {
 		got := targetPath(ctx, test.dlPath, test.destPath)
@@ -79,7 +78,7 @@ func TestTargetPath_AllowPathTraversal(t *testing.T) {
 		// The download path _can_ walk up the destination path
 		{dlPath: "../../../../etc/passwd", destPath: "dist/foo", want: "../../etc/passwd"},
 	}
-	ctx, _ := experiments.Enable(context.Background(), experiments.AllowArtifactPathTraversal)
+	ctx, _ := experiments.Enable(t.Context(), experiments.AllowArtifactPathTraversal)
 
 	for _, test := range tests {
 		got := targetPath(ctx, test.dlPath, test.destPath)

--- a/internal/artifact/downloader_test.go
+++ b/internal/artifact/downloader_test.go
@@ -1,7 +1,6 @@
 package artifact
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -36,7 +35,7 @@ func TestArtifactDownloaderConnectsToEndpoint(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ac := api.NewClient(logger.Discard, api.Config{
 		Endpoint: server.URL,

--- a/internal/artifact/s3_downloader_test.go
+++ b/internal/artifact/s3_downloader_test.go
@@ -2,7 +2,6 @@ package artifact
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -153,7 +152,7 @@ func TestS3Downloader_MultipartDownload_HappyPath(t *testing.T) {
 		AllowS3Multipart: true,
 	})
 
-	if err := d.Start(context.Background()); err != nil {
+	if err := d.Start(t.Context()); err != nil {
 		t.Fatalf("d.Start() = %v", err)
 	}
 
@@ -193,7 +192,7 @@ func TestS3Downloader_MultipartDownload_VerifyChecksumMismatch(t *testing.T) {
 		AllowS3Multipart: true,
 	})
 
-	err := d.Start(context.Background())
+	err := d.Start(t.Context())
 	if err == nil {
 		t.Fatal("d.Start() = nil, want checksum mismatch error")
 	}
@@ -231,7 +230,7 @@ func TestS3Downloader_MultipartDownload_VerifyChecksumSkippedWhenAbsent(t *testi
 		// ExpectedSHA256 deliberately empty — legacy artifacts have no digest.
 	})
 
-	if err := d.Start(context.Background()); err != nil {
+	if err := d.Start(t.Context()); err != nil {
 		t.Fatalf("d.Start() = %v", err)
 	}
 
@@ -265,7 +264,7 @@ func TestS3Downloader_DisableMultipartDispatchesSingleStream(t *testing.T) {
 			AllowS3Multipart: false,
 		})
 
-		if err := d.Start(context.Background()); err != nil {
+		if err := d.Start(t.Context()); err != nil {
 			t.Fatalf("d.Start() = %v", err)
 		}
 
@@ -292,7 +291,7 @@ func TestS3Downloader_DisableMultipartDispatchesSingleStream(t *testing.T) {
 			AllowS3Multipart: true,
 		})
 
-		if err := d.Start(context.Background()); err != nil {
+		if err := d.Start(t.Context()); err != nil {
 			t.Fatalf("d.Start() = %v", err)
 		}
 
@@ -326,7 +325,7 @@ func TestS3Downloader_MultipartDownload_CleansUpOnDownloadError(t *testing.T) {
 		Retries:          1,
 	})
 
-	if err := d.Start(context.Background()); err == nil {
+	if err := d.Start(t.Context()); err == nil {
 		t.Fatal("d.Start() = nil, want download error")
 	}
 

--- a/internal/artifact/searcher_test.go
+++ b/internal/artifact/searcher_test.go
@@ -1,7 +1,6 @@
 package artifact
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -35,7 +34,7 @@ func TestArtifactSearcherConnectsToEndpoint(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ac := api.NewClient(logger.Discard, api.Config{
 		Endpoint: server.URL,

--- a/internal/cache/archive/create_test.go
+++ b/internal/cache/archive/create_test.go
@@ -1,7 +1,6 @@
 package archive
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -19,7 +18,7 @@ func TestBuildArchive(t *testing.T) {
 		t.Skip("archive byte layout is platform-specific")
 	}
 
-	_, err := trace.NewProvider(context.Background(), "noop", "test", "0.0.1")
+	_, err := trace.NewProvider(t.Context(), "noop", "test", "0.0.1")
 	if err != nil {
 		t.Fatalf("trace.NewProvider: %v", err)
 	}
@@ -31,7 +30,7 @@ func TestBuildArchive(t *testing.T) {
 
 	setHomeDir(t, home)
 
-	archiveInfo, err := BuildArchive(context.Background(), []string{"testdata"}, "test")
+	archiveInfo, err := BuildArchive(t.Context(), []string{"testdata"}, "test")
 	if err != nil {
 		t.Fatalf("BuildArchive: %v", err)
 	}
@@ -52,7 +51,7 @@ func TestBuildArchive(t *testing.T) {
 }
 
 func TestBuildAndExtractArchive_MultipleHomeDirPaths(t *testing.T) {
-	_, err := trace.NewProvider(context.Background(), "noop", "test", "0.0.1")
+	_, err := trace.NewProvider(t.Context(), "noop", "test", "0.0.1")
 	if err != nil {
 		t.Fatalf("trace.NewProvider: %v", err)
 	}
@@ -87,7 +86,7 @@ func TestBuildAndExtractArchive_MultipleHomeDirPaths(t *testing.T) {
 		"~/go/pkg/mod",
 	}
 
-	archiveInfo, err := BuildArchive(context.Background(), paths, "go-cache")
+	archiveInfo, err := BuildArchive(t.Context(), paths, "go-cache")
 	if err != nil {
 		t.Fatalf("BuildArchive: %v", err)
 	}
@@ -127,7 +126,7 @@ func TestBuildAndExtractArchive_MultipleHomeDirPaths(t *testing.T) {
 	}
 	defer func() { _ = zipFile.Close() }()
 
-	entries, err := ListArchive(context.Background(), zipFile, archiveInfo.Size)
+	entries, err := ListArchive(t.Context(), zipFile, archiveInfo.Size)
 	if err != nil {
 		t.Fatalf("ListArchive: %v", err)
 	}
@@ -143,7 +142,7 @@ func TestBuildAndExtractArchive_MultipleHomeDirPaths(t *testing.T) {
 		t.Fatalf("Seek: %v", err)
 	}
 
-	extractInfo, err := ExtractFiles(context.Background(), zipFile, archiveInfo.Size, paths)
+	extractInfo, err := ExtractFiles(t.Context(), zipFile, archiveInfo.Size, paths)
 	if err != nil {
 		t.Fatalf("ExtractFiles: %v", err)
 	}
@@ -169,7 +168,7 @@ func TestBuildAndExtractArchive_MultipleHomeDirPaths(t *testing.T) {
 }
 
 func TestBuildArchive_MissingPathOnFilesystem(t *testing.T) {
-	_, err := trace.NewProvider(context.Background(), "noop", "test", "0.0.1")
+	_, err := trace.NewProvider(t.Context(), "noop", "test", "0.0.1")
 	if err != nil {
 		t.Fatalf("trace.NewProvider: %v", err)
 	}
@@ -193,7 +192,7 @@ func TestBuildArchive_MissingPathOnFilesystem(t *testing.T) {
 		"~/go/pkg/mod",
 	}
 
-	archiveInfo, err := BuildArchive(context.Background(), paths, "go-cache")
+	archiveInfo, err := BuildArchive(t.Context(), paths, "go-cache")
 	if err != nil {
 		t.Fatalf("BuildArchive: %v", err)
 	}
@@ -205,7 +204,7 @@ func TestBuildArchive_MissingPathOnFilesystem(t *testing.T) {
 	}
 	defer func() { _ = zipFile.Close() }()
 
-	entries, err := ListArchive(context.Background(), zipFile, archiveInfo.Size)
+	entries, err := ListArchive(t.Context(), zipFile, archiveInfo.Size)
 	if err != nil {
 		t.Fatalf("ListArchive: %v", err)
 	}
@@ -221,7 +220,7 @@ func TestBuildArchive_MissingPathOnFilesystem(t *testing.T) {
 }
 
 func TestExtractArchive_MissingPathInArchive(t *testing.T) {
-	_, err := trace.NewProvider(context.Background(), "noop", "test", "0.0.1")
+	_, err := trace.NewProvider(t.Context(), "noop", "test", "0.0.1")
 	if err != nil {
 		t.Fatalf("trace.NewProvider: %v", err)
 	}
@@ -240,7 +239,7 @@ func TestExtractArchive_MissingPathInArchive(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	archiveInfo, err := BuildArchive(context.Background(), []string{"~/.go-build"}, "go-cache")
+	archiveInfo, err := BuildArchive(t.Context(), []string{"~/.go-build"}, "go-cache")
 	if err != nil {
 		t.Fatalf("BuildArchive: %v", err)
 	}
@@ -257,7 +256,7 @@ func TestExtractArchive_MissingPathInArchive(t *testing.T) {
 	}
 	defer func() { _ = zipFile.Close() }()
 
-	entries, err := ListArchive(context.Background(), zipFile, archiveInfo.Size)
+	entries, err := ListArchive(t.Context(), zipFile, archiveInfo.Size)
 	if err != nil {
 		t.Fatalf("ListArchive: %v", err)
 	}
@@ -278,7 +277,7 @@ func TestExtractArchive_MissingPathInArchive(t *testing.T) {
 		"~/go/pkg/mod",
 	}
 
-	extractInfo, err := ExtractFiles(context.Background(), zipFile, archiveInfo.Size, pathsWithMissing)
+	extractInfo, err := ExtractFiles(t.Context(), zipFile, archiveInfo.Size, pathsWithMissing)
 	if err != nil {
 		t.Fatalf("ExtractFiles: %v", err)
 	}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -60,7 +60,7 @@ func createTempCacheConfig(t *testing.T, content string) string {
 
 func TestSaveWithClient_CacheEntryCreated(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mock := &mockCacheClient{
 		saveFunc: func(ctx context.Context, cacheID string) (SaveResult, error) {
@@ -88,7 +88,7 @@ func TestSaveWithClient_CacheEntryCreated(t *testing.T) {
 
 func TestSaveWithClient_CacheAlreadyExists(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mock := &mockCacheClient{
 		saveFunc: func(ctx context.Context, cacheID string) (SaveResult, error) {
@@ -107,7 +107,7 @@ func TestSaveWithClient_CacheAlreadyExists(t *testing.T) {
 
 func TestSaveWithClient_MultipleCaches(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	callCount := 0
 	mock := &mockCacheClient{
@@ -140,7 +140,7 @@ func TestSaveWithClient_MultipleCaches(t *testing.T) {
 
 func TestSaveWithClient_Error(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	expectedErr := errors.New("save failed")
 	mock := &mockCacheClient{
@@ -163,7 +163,7 @@ func TestSaveWithClient_Error(t *testing.T) {
 
 func TestSaveWithClient_EmptyCacheIDs(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mock := &mockCacheClient{
 		saveFunc: func(ctx context.Context, cacheID string) (SaveResult, error) {
@@ -182,7 +182,7 @@ func TestSaveWithClient_EmptyCacheIDs(t *testing.T) {
 
 func TestRestoreWithClient_CacheHit(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mock := &mockCacheClient{
 		restoreFunc: func(ctx context.Context, cacheID string) (RestoreResult, error) {
@@ -212,7 +212,7 @@ func TestRestoreWithClient_CacheHit(t *testing.T) {
 
 func TestRestoreWithClient_FallbackUsed(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mock := &mockCacheClient{
 		restoreFunc: func(ctx context.Context, cacheID string) (RestoreResult, error) {
@@ -242,7 +242,7 @@ func TestRestoreWithClient_FallbackUsed(t *testing.T) {
 
 func TestRestoreWithClient_CacheMiss(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mock := &mockCacheClient{
 		restoreFunc: func(ctx context.Context, cacheID string) (RestoreResult, error) {
@@ -263,7 +263,7 @@ func TestRestoreWithClient_CacheMiss(t *testing.T) {
 
 func TestRestoreWithClient_MultipleCaches(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	callCount := 0
 	mock := &mockCacheClient{
@@ -288,7 +288,7 @@ func TestRestoreWithClient_MultipleCaches(t *testing.T) {
 
 func TestRestoreWithClient_Error(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	expectedErr := errors.New("restore failed")
 	mock := &mockCacheClient{
@@ -311,7 +311,7 @@ func TestRestoreWithClient_Error(t *testing.T) {
 
 func TestRestoreWithClient_EmptyCacheIDs(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mock := &mockCacheClient{
 		restoreFunc: func(ctx context.Context, cacheID string) (RestoreResult, error) {

--- a/internal/cache/integration_test.go
+++ b/internal/cache/integration_test.go
@@ -318,7 +318,7 @@ func setupTestCache(t *testing.T, storageType string) (cacheClient *client, cach
 }
 
 func TestCacheIntegration_SaveAndRestore(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Setup test cache with local file storage
 	cacheClient, cacheDir, storageDir := setupTestCache(t, "local_file")
@@ -467,7 +467,7 @@ func TestCacheIntegration_SaveAndRestore(t *testing.T) {
 }
 
 func TestCacheIntegration_SaveAlreadyExists(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cacheClient, _, _ := setupTestCache(t, "local_file")
 
@@ -497,7 +497,7 @@ func TestCacheIntegration_SaveAlreadyExists(t *testing.T) {
 }
 
 func TestCacheIntegration_RestoreCacheMiss(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cacheClient, _, _ := setupTestCache(t, "local_file")
 
@@ -522,7 +522,7 @@ func TestCacheIntegration_RestoreCacheMiss(t *testing.T) {
 }
 
 func TestCacheIntegration_RestoreWithFallback(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Use setupTestCache to create test environment
 	cacheClient, cacheDir, _ := setupTestCache(t, "local_file")
@@ -583,7 +583,7 @@ func TestCacheIntegration_RestoreWithFallback(t *testing.T) {
 }
 
 func TestCacheIntegration_LargeFileChecksum(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cacheClient, cacheDir, _ := setupTestCache(t, "local_file")
 
@@ -624,7 +624,7 @@ func TestCacheIntegration_LargeFileChecksum(t *testing.T) {
 }
 
 func TestCacheIntegration_TransferMetrics(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cacheClient, _, _ := setupTestCache(t, "local_file")
 

--- a/internal/cache/restore_test.go
+++ b/internal/cache/restore_test.go
@@ -24,7 +24,7 @@ func TestCleanPath(t *testing.T) {
 			t.Fatalf("WriteFile: %v", err)
 		}
 
-		if err := cleanPath(context.Background(), testDir); err != nil {
+		if err := cleanPath(t.Context(), testDir); err != nil {
 			t.Fatalf("cleanPath: %v", err)
 		}
 
@@ -51,7 +51,7 @@ func TestCleanPath(t *testing.T) {
 			t.Fatalf("Chmod: %v", err)
 		}
 
-		if err := cleanPath(context.Background(), testDir); err != nil {
+		if err := cleanPath(t.Context(), testDir); err != nil {
 			t.Fatalf("cleanPath: %v", err)
 		}
 
@@ -62,13 +62,13 @@ func TestCleanPath(t *testing.T) {
 	})
 
 	t.Run("succeeds on non-existent path", func(t *testing.T) {
-		if err := cleanPath(context.Background(), "/nonexistent/path/that/does/not/exist"); err != nil {
+		if err := cleanPath(t.Context(), "/nonexistent/path/that/does/not/exist"); err != nil {
 			t.Fatalf("cleanPath: %v", err)
 		}
 	})
 
 	t.Run("rejects empty path", func(t *testing.T) {
-		err := cleanPath(context.Background(), "")
+		err := cleanPath(t.Context(), "")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -78,7 +78,7 @@ func TestCleanPath(t *testing.T) {
 	})
 
 	t.Run("rejects root path", func(t *testing.T) {
-		err := cleanPath(context.Background(), "/")
+		err := cleanPath(t.Context(), "/")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -88,7 +88,7 @@ func TestCleanPath(t *testing.T) {
 	})
 
 	t.Run("rejects current directory", func(t *testing.T) {
-		err := cleanPath(context.Background(), ".")
+		err := cleanPath(t.Context(), ".")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -103,7 +103,7 @@ func TestCleanPath(t *testing.T) {
 			t.Fatalf("UserHomeDir: %v", err)
 		}
 
-		err = cleanPath(context.Background(), home)
+		err = cleanPath(t.Context(), home)
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -119,7 +119,7 @@ func TestCleanPath(t *testing.T) {
 			t.Fatalf("MkdirAll: %v", err)
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
 
 		err := cleanPath(ctx, testDir)
@@ -137,7 +137,7 @@ func TestCleanPathWindowsDriveRoot(t *testing.T) {
 		t.Skip("Windows-specific test")
 	}
 
-	err := cleanPath(context.Background(), "C:\\")
+	err := cleanPath(t.Context(), "C:\\")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/internal/cache/store/file_test.go
+++ b/internal/cache/store/file_test.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,7 +10,7 @@ import (
 )
 
 func TestNewLocalFileBlob(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		name        string
@@ -146,7 +145,7 @@ func TestValidateFileKey(t *testing.T) {
 }
 
 func TestLocalFileBlobUpload(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tmpDir := t.TempDir()
 	rootDir := filepath.Join(tmpDir, "cache-root")
@@ -203,7 +202,7 @@ func TestLocalFileBlobUpload(t *testing.T) {
 }
 
 func TestLocalFileBlobDownload(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tmpDir := t.TempDir()
 	rootDir := filepath.Join(tmpDir, "cache-root")
@@ -262,7 +261,7 @@ func TestLocalFileBlobDownload(t *testing.T) {
 }
 
 func TestLocalFileBlobUploadOverwrite(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tmpDir := t.TempDir()
 	rootDir := filepath.Join(tmpDir, "cache-root")
@@ -317,7 +316,7 @@ func TestLocalFileBlobUploadOverwrite(t *testing.T) {
 }
 
 func TestLocalFileBlobDownloadNonExistent(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tmpDir := t.TempDir()
 	rootDir := filepath.Join(tmpDir, "cache-root")
@@ -343,7 +342,7 @@ func TestLocalFileBlobDownloadNonExistent(t *testing.T) {
 }
 
 func TestLocalFileBlobUploadInvalidKey(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tmpDir := t.TempDir()
 	rootDir := filepath.Join(tmpDir, "cache-root")
@@ -373,7 +372,7 @@ func TestLocalFileBlobUploadInvalidKey(t *testing.T) {
 }
 
 func TestLocalFileBlobDownloadInvalidKey(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tmpDir := t.TempDir()
 	rootDir := filepath.Join(tmpDir, "cache-root")
@@ -400,7 +399,7 @@ func TestLocalFileBlobDownloadInvalidKey(t *testing.T) {
 
 func TestKeyToPaths(t *testing.T) {
 	tmpDir := t.TempDir()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	blob, err := NewLocalFileBlob(ctx, fileURL(tmpDir))
 	if err != nil {
@@ -484,7 +483,7 @@ func TestLocalFileBlobConcurrentUpload(t *testing.T) {
 		t.Skip("concurrent rename-to-same-key is not safe on Windows")
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tmpDir := t.TempDir()
 	rootDir := filepath.Join(tmpDir, "cache-root")
@@ -557,7 +556,7 @@ func TestLocalFileBlobConcurrentUpload(t *testing.T) {
 }
 
 func TestNewBlobStoreLocalFile(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	tmpDir := t.TempDir()
 
 	blob, err := NewBlobStore(ctx, LocalFileStore, fileURL(tmpDir))

--- a/internal/cache/store/nsc_test.go
+++ b/internal/cache/store/nsc_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -197,7 +196,7 @@ func TestValidateKey(t *testing.T) {
 }
 
 func TestRunCommandValidation(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Test empty args
 	result, err := runCommand(ctx, "" /* no args */)
@@ -220,7 +219,7 @@ func TestNscStore_Upload_Validation(t *testing.T) {
 		t.Fatalf("NewNscStore: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a temporary test file
 	tmpDir, err := os.MkdirTemp("", "nsc-test")
@@ -274,7 +273,7 @@ func TestNscStore_Download_Validation(t *testing.T) {
 		t.Fatalf("NewNscStore: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tmpDir, err := os.MkdirTemp("", "nsc-test")
 	if err != nil {
@@ -329,7 +328,7 @@ func TestNscStore_Integration(t *testing.T) {
 		t.Fatalf("NewNscStore: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create temporary directories and files
 	tmpDir, err := os.MkdirTemp("", "nsc-integration-test")

--- a/internal/e2e/main_test.go
+++ b/internal/e2e/main_test.go
@@ -16,6 +16,7 @@ func TestMain(m *testing.M) {
 	client := api.NewClient(l, api.Config{
 		Token: agentToken,
 	})
+	// TestMain has no testing.T, so this setup call intentionally uses a root context.
 	ctx := context.Background()
 	ident, _, err := client.GetTokenIdentity(ctx)
 	if err != nil {

--- a/internal/job/checkout_test.go
+++ b/internal/job/checkout_test.go
@@ -1,7 +1,6 @@
 package job
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
@@ -12,7 +11,7 @@ import (
 )
 
 func TestDefaultCheckoutPhase(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	shell, err := shell.New()
 	if err != nil {
@@ -156,7 +155,7 @@ func TestDefaultCheckoutPhase(t *testing.T) {
 func TestSkipCheckout(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sh, err := shell.New()
 	if err != nil {

--- a/internal/job/executor_test.go
+++ b/internal/job/executor_test.go
@@ -1,7 +1,6 @@
 package job
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -58,7 +57,7 @@ func TestStartTracing_NoTracingBackend(t *testing.T) {
 	// When there's no tracing backend, the tracer should be a no-op.
 	e := New(ExecutorConfig{})
 
-	oriCtx := context.Background()
+	oriCtx := t.Context()
 	e.shell, err = shell.New()
 	if err != nil {
 		t.Errorf("shell.New() error = %v, want nil", err)
@@ -85,7 +84,7 @@ func TestStartTracing_Datadog(t *testing.T) {
 	cfg := ExecutorConfig{TracingBackend: "datadog"}
 	e := New(cfg)
 
-	oriCtx := context.Background()
+	oriCtx := t.Context()
 	e.shell, err = shell.New()
 	if err != nil {
 		t.Errorf("shell.New() error = %v, want nil", err)

--- a/internal/job/git_test.go
+++ b/internal/job/git_test.go
@@ -1,7 +1,6 @@
 package job
 
 import (
-	"context"
 	"errors"
 	"os"
 	"testing"
@@ -125,7 +124,7 @@ func TestResolvingGitHostAliasesWithFlagSupport(t *testing.T) {
 	// Use the real SSH bundled in the Go Docker image, with the config
 	// .buildkite/build/ssh.conf.
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sh := shell.NewTestShell(t)
 	sh.Env.Set("PATH", os.Getenv("PATH"))
@@ -178,7 +177,7 @@ func TestGitCheckRefFormat(t *testing.T) {
 
 func TestGitCheckoutValidatesRef(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	sh := shell.NewTestShell(t, shell.WithDryRun(true))
 	err := gitCheckout(ctx, sh, "", "--nope")
 	if got, want := err.Error(), `"--nope" is not a valid git ref format`; got != want {
@@ -188,7 +187,7 @@ func TestGitCheckoutValidatesRef(t *testing.T) {
 
 func TestGitCheckout(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	var gotLog [][]string
 	sh := shell.NewTestShell(t, shell.WithDryRun(true), shell.WithCommandLog(&gotLog))
@@ -210,7 +209,7 @@ func TestGitCheckout(t *testing.T) {
 
 func TestGitCheckoutSketchyArgs(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sh := shell.NewTestShell(t, shell.WithDryRun(true))
 	err := gitCheckout(ctx, sh, "-f -q", "  --hello")
@@ -221,7 +220,7 @@ func TestGitCheckoutSketchyArgs(t *testing.T) {
 
 func TestGitClone(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	var gotLog [][]string
 	sh := shell.NewTestShell(t, shell.WithDryRun(true), shell.WithCommandLog(&gotLog))
@@ -243,7 +242,7 @@ func TestGitClone(t *testing.T) {
 
 func TestGitClean(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	var gotLog [][]string
 	sh := shell.NewTestShell(t, shell.WithDryRun(true), shell.WithCommandLog(&gotLog))
@@ -265,7 +264,7 @@ func TestGitClean(t *testing.T) {
 
 func TestGitCleanSubmodules(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	var gotLog [][]string
 	sh := shell.NewTestShell(t, shell.WithDryRun(true), shell.WithCommandLog(&gotLog))
@@ -287,7 +286,7 @@ func TestGitCleanSubmodules(t *testing.T) {
 
 func TestGitFetch(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	var gotLog [][]string
 	sh := shell.NewTestShell(t, shell.WithDryRun(true), shell.WithCommandLog(&gotLog))

--- a/internal/job/hook/wrapper_test.go
+++ b/internal/job/hook/wrapper_test.go
@@ -1,7 +1,6 @@
 package hook_test
 
 import (
-	"context"
 	"errors"
 	"io"
 	"os"
@@ -70,7 +69,7 @@ echo "hello world"
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			hookFilename := writeTestHook(t, tc.name, tc.hook)
 			wrapper, err := hook.NewWrapper(hook.WithPath(hookFilename), hook.WithOS(tc.os))
@@ -169,7 +168,7 @@ echo hello world
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			hookFilename := writeTestHook(t, tc.name, tc.hook)
 			wrapper, err := hook.NewWrapper(hook.WithPath(hookFilename), hook.WithOS(tc.os))

--- a/internal/job/integration/main_test.go
+++ b/internal/job/integration/main_test.go
@@ -14,8 +14,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-// This context needs to be stored here in order to pass experiments to tests,
-// because testing.M can only Run (without passing arguments or context).
+// This root context needs to be stored here in order to pass experiments to tests,
+// because testing.M can only Run (without passing arguments or context), and
+// TestMain has no testing.T for t.Context.
 // In ordinary code, pass contexts as arguments!
 var mainCtx = context.Background()
 

--- a/internal/job/knownhosts_test.go
+++ b/internal/job/knownhosts_test.go
@@ -1,7 +1,6 @@
 package job
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"os"
@@ -64,7 +63,7 @@ func TestAddingToKnownHosts(t *testing.T) {
 
 	// Add the host - this resolves any SSH client configuration
 	// (in case the URL contains an alias), and runs ssh-keyscan to get its key.
-	if err := kh.AddFromRepository(context.Background(), repoURL); err != nil {
+	if err := kh.AddFromRepository(t.Context(), repoURL); err != nil {
 		t.Errorf("kh.AddFromRespository(%q) = %v", repoURL, err)
 	}
 

--- a/internal/job/ssh_test.go
+++ b/internal/job/ssh_test.go
@@ -1,7 +1,6 @@
 package job
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -24,7 +23,7 @@ func TestFindingSSHTools(t *testing.T) {
 
 	sh.Logger = shell.TestingLogger{T: t}
 
-	if _, err := findPathToSSHTools(context.Background(), sh); err != nil {
+	if _, err := findPathToSSHTools(t.Context(), sh); err != nil {
 		t.Errorf("findPathToSSHTools(sh) error = %v", err)
 	}
 }
@@ -47,13 +46,13 @@ func TestSSHKeyscanReturnsOutput(t *testing.T) {
 		AndWriteToStdout("github.com ssh-rsa xxx=").
 		AndExitWith(0)
 
-	keyScanOutput, err := sshKeyScan(context.Background(), sh, "github.com")
+	keyScanOutput, err := sshKeyScan(t.Context(), sh, "github.com")
 
 	if got, want := keyScanOutput, "github.com ssh-rsa xxx="; got != want {
-		t.Errorf("sshKeyScan(context.Background(), sh, %q) = %q, want %q", "github.com", got, want)
+		t.Errorf("sshKeyScan(t.Context(), sh, %q) = %q, want %q", "github.com", got, want)
 	}
 	if err != nil {
-		t.Errorf("sshKeyScan(context.Background(), sh, %q) error = %v, want nil", "github.com", err)
+		t.Errorf("sshKeyScan(t.Context(), sh, %q) error = %v, want nil", "github.com", err)
 	}
 }
 
@@ -75,13 +74,13 @@ func TestSSHKeyscanWithHostAndPortReturnsOutput(t *testing.T) {
 		AndWriteToStdout("github.com ssh-rsa xxx=").
 		AndExitWith(0)
 
-	keyScanOutput, err := sshKeyScan(context.Background(), sh, "github.com:123")
+	keyScanOutput, err := sshKeyScan(t.Context(), sh, "github.com:123")
 
 	if got, want := keyScanOutput, "github.com ssh-rsa xxx="; got != want {
-		t.Errorf("sshKeyScan(context.Background(), sh, %q) = %q, want %q", "github.com:123", got, want)
+		t.Errorf("sshKeyScan(t.Context(), sh, %q) = %q, want %q", "github.com:123", got, want)
 	}
 	if err != nil {
-		t.Errorf("sshKeyScan(context.Background(), sh, %q) error = %v, want nil", "github.com:123", err)
+		t.Errorf("sshKeyScan(t.Context(), sh, %q) error = %v, want nil", "github.com:123", err)
 	}
 }
 
@@ -104,13 +103,13 @@ func TestSSHKeyscanRetriesOnExit1(t *testing.T) {
 		Exactly(3).
 		AndExitWith(1)
 
-	keyScanOutput, err := sshKeyScan(context.Background(), sh, "github.com")
+	keyScanOutput, err := sshKeyScan(t.Context(), sh, "github.com")
 
 	if got, want := keyScanOutput, ""; got != want {
-		t.Errorf("sshKeyScan(context.Background(), sh, %q) = %q, want %q", "github.com", got, want)
+		t.Errorf("sshKeyScan(t.Context(), sh, %q) = %q, want %q", "github.com", got, want)
 	}
 	if want := "`ssh-keyscan \"github.com\"` failed"; err == nil || err.Error() != want {
-		t.Errorf("sshKeyScan(context.Background(), sh, %q) error = %v, want error with message %q", "github.com", err, want)
+		t.Errorf("sshKeyScan(t.Context(), sh, %q) error = %v, want error with message %q", "github.com", err, want)
 	}
 }
 
@@ -137,12 +136,12 @@ func TestSSHKeyscanRetriesOnBlankOutputAndExit0(t *testing.T) {
 		Exactly(3).
 		AndExitWith(0)
 
-	keyScanOutput, err := sshKeyScan(context.Background(), sh, "github.com")
+	keyScanOutput, err := sshKeyScan(t.Context(), sh, "github.com")
 
 	if got, want := keyScanOutput, ""; got != want {
-		t.Errorf("sshKeyScan(context.Background(), sh, %q) = %q, want %q", "github.com", got, want)
+		t.Errorf("sshKeyScan(t.Context(), sh, %q) = %q, want %q", "github.com", got, want)
 	}
 	if want := "`ssh-keyscan \"github.com\"` returned nothing"; err == nil || err.Error() != want {
-		t.Errorf("sshKeyScan(context.Background(), sh, %q) error = %v, want error with message %q", "github.com", err, want)
+		t.Errorf("sshKeyScan(t.Context(), sh, %q) error = %v, want error with message %q", "github.com", err, want)
 	}
 }

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -121,7 +121,7 @@ func TestProcessOutputPTY_PTYRawExperimentWritesBeforeRawMode(t *testing.T) {
 		t.Skip("PTY not supported on windows")
 	}
 
-	ctx, _ := experiments.Enable(context.Background(), experiments.PTYRaw)
+	ctx, _ := experiments.Enable(t.Context(), experiments.PTYRaw)
 
 	originalHook := processAfterPTYStartHookSwap(func() {
 		time.Sleep(50 * time.Millisecond)

--- a/internal/shell/main_test.go
+++ b/internal/shell/main_test.go
@@ -40,6 +40,7 @@ func acquiringLockHelperProcess() error {
 	sh.Logger = shell.DiscardLogger
 
 	log.Printf("🔓 Locking %s forever...", fileName)
+	// This runs in a helper process outside a test function, so there is no testing.T for t.Context.
 	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
 	defer canc()
 	if _, err := sh.LockFile(ctx, fileName); err != nil {

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -356,7 +356,7 @@ func TestDefaultWorkingDirFromSystem(t *testing.T) {
 
 func TestWorkingDir(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tempDir, err := os.MkdirTemp("", "shelltest")
 	if err != nil {

--- a/internal/socket/client_test.go
+++ b/internal/socket/client_test.go
@@ -39,7 +39,7 @@ type messageResponse struct {
 func TestClientDo(t *testing.T) {
 	t.Parallel()
 
-	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, canc := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(canc)
 
 	sockPath := testSocketPath()
@@ -100,7 +100,7 @@ func TestClientDo(t *testing.T) {
 func TestClientDoErrors(t *testing.T) {
 	t.Parallel()
 
-	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, canc := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(canc)
 
 	sockPath := testSocketPath()

--- a/internal/socket/server_test.go
+++ b/internal/socket/server_test.go
@@ -90,7 +90,7 @@ func TestServerStartStop(t *testing.T) {
 func TestServerHandler(t *testing.T) {
 	t.Parallel()
 
-	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, canc := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(canc)
 
 	sockPath := testSocketPath()

--- a/jobapi/client_test.go
+++ b/jobapi/client_test.go
@@ -128,7 +128,7 @@ func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func TestClient_NoSocket(t *testing.T) {
 	// t.Parallel() // Can't be parallelised, because it uses the t.Setenv() function
 
-	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, canc := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(canc)
 
 	t.Setenv("BUILDKITE_AGENT_JOB_API_SOCKET", "") // This may be set if the test is being run by a buildkite agent!
@@ -141,7 +141,7 @@ func TestClient_NoSocket(t *testing.T) {
 func TestClient_NoToken(t *testing.T) {
 	// t.Parallel() // Can't be parallelised, because it uses the t.Setenv() function
 
-	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, canc := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(canc)
 
 	t.Setenv("BUILDKITE_AGENT_JOB_API_SOCKET", "/tmp/fake-socket") // Just to make sure it's set
@@ -162,7 +162,7 @@ func TestClientEnvGet(t *testing.T) {
 	}
 	defer svr.Close()
 
-	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, canc := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(canc)
 
 	cli, err := NewClient(ctx, svr.sock, svr.token)
@@ -170,7 +170,7 @@ func TestClientEnvGet(t *testing.T) {
 		t.Fatalf("NewClient(%q, %q) error = %v", svr.sock, svr.token, err)
 	}
 
-	got, err := cli.EnvGet(context.Background())
+	got, err := cli.EnvGet(t.Context())
 	if err != nil {
 		t.Fatalf("cli.EnvGet() error = %v", err)
 	}
@@ -195,7 +195,7 @@ func TestClientEnvUpdate(t *testing.T) {
 	}
 	defer svr.Close()
 
-	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, canc := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(canc)
 
 	cli, err := NewClient(ctx, svr.sock, svr.token)
@@ -210,7 +210,7 @@ func TestClientEnvUpdate(t *testing.T) {
 		},
 	}
 
-	got, err := cli.EnvUpdate(context.Background(), req)
+	got, err := cli.EnvUpdate(t.Context(), req)
 	if err != nil {
 		t.Fatalf("cli.EnvUpdate() error = %v", err)
 	}
@@ -233,7 +233,7 @@ func TestClientEnvDelete(t *testing.T) {
 	}
 	defer svr.Close()
 
-	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, canc := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(canc)
 
 	cli, err := NewClient(ctx, svr.sock, svr.token)
@@ -242,7 +242,7 @@ func TestClientEnvDelete(t *testing.T) {
 	}
 
 	req := []string{"YZMA"}
-	got, err := cli.EnvDelete(context.Background(), req)
+	got, err := cli.EnvDelete(t.Context(), req)
 	if err != nil {
 		t.Fatalf("cli.EnvUpdate() error = %v", err)
 	}

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -21,7 +21,7 @@ func TestOrderedClients(t *testing.T) {
 
 	clients := []*Client{{ID: 0}, {ID: 1}, {ID: 2}}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
 	for _, client := range clients {
@@ -60,7 +60,7 @@ func TestLivenessCheck(t *testing.T) {
 
 	clients := []*Client{{ID: 0}, {ID: 1}}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(cancel)
 
 	for _, client := range clients {
@@ -105,7 +105,7 @@ func TestDuplicateClients(t *testing.T) {
 	client0 := &Client{ID: 0, SocketPath: socketPath}
 	client1 := &Client{ID: 0, SocketPath: socketPath}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
 	if err := connect(ctx, client0); err != nil {
@@ -123,7 +123,7 @@ func TestExcessClients(t *testing.T) {
 	client0 := &Client{ID: 0, SocketPath: socketPath}
 	client1 := &Client{ID: 1, SocketPath: socketPath}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
 	if err := connect(ctx, client0); err != nil {
@@ -140,7 +140,7 @@ func TestWaitStatusNonZero(t *testing.T) {
 	client0 := &Client{ID: 0, SocketPath: runner.conf.SocketPath}
 	client1 := &Client{ID: 1, SocketPath: runner.conf.SocketPath}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
 	if err := connect(ctx, client0); err != nil {
@@ -162,7 +162,7 @@ func TestWaitStatusNonZero(t *testing.T) {
 
 func TestInterruptBeforeStart(t *testing.T) {
 	runner := newRunner(t, 2)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 	client0 := &Client{ID: 0, SocketPath: runner.conf.SocketPath}
 
@@ -185,7 +185,7 @@ func TestInterruptBeforeStart(t *testing.T) {
 
 func TestTerminateBeforeStart(t *testing.T) {
 	runner := newRunner(t, 2)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 	client0 := &Client{ID: 0, SocketPath: runner.conf.SocketPath}
 
@@ -208,7 +208,7 @@ func TestTerminateBeforeStart(t *testing.T) {
 
 func TestInterruptAfterStart(t *testing.T) {
 	runner := newRunner(t, 2)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 	client0 := &Client{ID: 0, SocketPath: runner.conf.SocketPath}
 
@@ -237,7 +237,7 @@ func TestInterruptAfterStart(t *testing.T) {
 
 func TestTerminateAfterStart(t *testing.T) {
 	runner := newRunner(t, 2)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 	client0 := &Client{ID: 0, SocketPath: runner.conf.SocketPath}
 
@@ -282,7 +282,7 @@ func newRunner(t *testing.T, clientCount int) *Runner {
 		ClientStartTimeout: 10 * time.Minute,
 		ClientLostTimeout:  2 * time.Second,
 	})
-	runnerCtx, cancelRunner := context.WithCancel(context.Background())
+	runnerCtx, cancelRunner := context.WithCancel(t.Context())
 	runErrCh := make(chan error, 1)
 	go func() {
 		runErrCh <- runner.Run(runnerCtx)

--- a/lock/lock_test.go
+++ b/lock/lock_test.go
@@ -53,7 +53,7 @@ func testServerAndClient(t *testing.T, ctx context.Context) (*agentapi.Server, *
 
 func TestLockUnlock(t *testing.T) {
 	t.Parallel()
-	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, canc := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(canc)
 
 	svr, cli := testServerAndClient(t, ctx)
@@ -90,7 +90,7 @@ func TestLockUnlock(t *testing.T) {
 
 func TestLocker(t *testing.T) {
 	t.Parallel()
-	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, canc := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(canc)
 
 	svr, cli := testServerAndClient(t, ctx)
@@ -123,7 +123,7 @@ func TestLocker(t *testing.T) {
 
 func TestDoOnce(t *testing.T) {
 	t.Parallel()
-	ctx, canc := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, canc := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(canc)
 
 	svr, cli := testServerAndClient(t, ctx)

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -60,7 +60,7 @@ func TestSmokeStatusTemplate(t *testing.T) {
 		StartTime:    startTime.Format(time.RFC1123),
 		StartTimeAgo: time.Since(startTime),
 		CurrentTime:  time.Now().Format(time.RFC1123),
-		Ctx:          context.Background(),
+		Ctx:          t.Context(),
 	}
 
 	if err := statusTmpl.Execute(io.Discard, data); err != nil {
@@ -69,7 +69,7 @@ func TestSmokeStatusTemplate(t *testing.T) {
 }
 
 func TestSmokeHandle(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	cctx, setStat, done := AddSimpleItem(ctx, "Llamas")
 	defer done()
 	setStat("Essence of Llama")

--- a/tracetools/propagate_test.go
+++ b/tracetools/propagate_test.go
@@ -2,7 +2,6 @@ package tracetools
 
 import (
 	"bytes"
-	"context"
 	"encoding/base64"
 	"encoding/gob"
 	"errors"
@@ -112,7 +111,7 @@ func TestEncodeTraceContext(t *testing.T) {
 				t.Fatalf("ParseEncoding(%q) error = %v", test.encoding, err)
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			parent := opentracing.StartSpan("job.parent")
 			ctx = opentracing.ContextWithSpan(ctx, parent)
 


### PR DESCRIPTION
Tests should use the test lifecycle when creating root contexts so work is cancelled before test cleanup runs. The repo already targets a Go version with `testing.T.Context`, but there was no lint rule preventing new `context.Background()` calls in tests.

This enables the `usetesting` linter for `context.Background()` and updates the existing lint-reported test call sites to use `t.Context()` instead. For example, test operations now pass `t.Context()` directly or derive timeouts and cancellable contexts from it with `context.WithTimeout(t.Context(), ...)`.

The remaining `context.Background()` uses are limited to places where no `testing.T` exists, such as `TestMain` setup and helper-process code, with comments explaining why they intentionally use a root context. Other `usetesting` suggestions such as `t.TempDir` and `t.Setenv` remain disabled so this PR only enforces the context rule.