### PR TITLE
fix: Prevent agent HTTP auth redirect leaks

### DIFF
--- a/internal/agenthttp/client.go
+++ b/internal/agenthttp/client.go
@@ -55,7 +55,21 @@ func NewClient(opts ...ClientOption) *http.Client {
 			Token:    conf.Token,
 			Delegate: transport,
 		},
+		CheckRedirect: checkAuthenticatedRedirect,
 	}
+}
+
+func checkAuthenticatedRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+
+	origin := via[0].URL
+	if req.URL.Scheme != origin.Scheme || req.URL.Host != origin.Host {
+		return http.ErrUseLastResponse
+	}
+
+	return nil
 }
 
 // Various NewClient options.

--- a/internal/agenthttp/client_test.go
+++ b/internal/agenthttp/client_test.go
@@ -1,0 +1,105 @@
+package agenthttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAuthenticatedClientDoesNotFollowCrossOriginRedirect(t *testing.T) {
+	redirectTargetReached := make(chan string, 1)
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectTargetReached <- r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(redirectTarget.Close)
+
+	redirectSource := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL, http.StatusFound)
+	}))
+	t.Cleanup(redirectSource.Close)
+
+	client := NewClient(WithAuthToken("secret-token"))
+	resp, err := client.Get(redirectSource.URL)
+	if err != nil {
+		t.Fatalf("client.Get(%q) error = %v", redirectSource.URL, err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	if got, want := resp.StatusCode, http.StatusFound; got != want {
+		t.Fatalf("response status = %d, want %d", got, want)
+	}
+
+	select {
+	case got := <-redirectTargetReached:
+		t.Fatalf("cross-origin redirect target received Authorization header %q", got)
+	default:
+	}
+}
+
+func TestAuthenticatedClientFollowsSameOriginRedirect(t *testing.T) {
+	finalAuthorization := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/redirect":
+			http.Redirect(w, r, "/final", http.StatusFound)
+		case "/final":
+			finalAuthorization <- r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(WithAuthBearer("secret-bearer"))
+	resp, err := client.Get(server.URL + "/redirect")
+	if err != nil {
+		t.Fatalf("client.Get(%q) error = %v", server.URL+"/redirect", err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	if got, want := resp.StatusCode, http.StatusNoContent; got != want {
+		t.Fatalf("response status = %d, want %d", got, want)
+	}
+
+	select {
+	case got := <-finalAuthorization:
+		if want := "Bearer secret-bearer"; got != want {
+			t.Fatalf("final Authorization header = %q, want %q", got, want)
+		}
+	default:
+		t.Fatal("same-origin redirect target was not reached")
+	}
+}
+
+func TestUnauthenticatedClientFollowsCrossOriginRedirect(t *testing.T) {
+	redirectTargetReached := make(chan struct{}, 1)
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectTargetReached <- struct{}{}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(redirectTarget.Close)
+
+	redirectSource := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL, http.StatusFound)
+	}))
+	t.Cleanup(redirectSource.Close)
+
+	client := NewClient()
+	resp, err := client.Get(redirectSource.URL)
+	if err != nil {
+		t.Fatalf("client.Get(%q) error = %v", redirectSource.URL, err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	if got, want := resp.StatusCode, http.StatusNoContent; got != want {
+		t.Fatalf("response status = %d, want %d", got, want)
+	}
+
+	select {
+	case <-redirectTargetReached:
+	default:
+		t.Fatal("cross-origin redirect target was not reached")
+	}
+}


### PR DESCRIPTION
Authenticated agent HTTP clients currently inject credentials in the transport layer, after Go's redirect sanitizer has already decided whether to strip `Authorization`. If a trusted Buildkite endpoint ever redirected to a different host or scheme, the redirected request could receive the agent token or bearer credential.

This keeps the normal redirect behavior for unauthenticated clients, but authenticated clients now stop at redirects that change scheme or host and return the redirect response instead. Same-origin redirects still follow normally and continue to include the expected authorization header.

For example, an authenticated request from `https://agent.buildkite.com/...` to a `Location: https://example.invalid/...` response will no longer follow that redirect with credentials attached, while `/old` to `/new` on the same origin continues to work.