### PR TITLE
chore: Add artifact upload timing summary

### DIFF
--- a/internal/artifact/batch_creator.go
+++ b/internal/artifact/batch_creator.go
@@ -27,6 +27,9 @@ type BatchCreatorConfig struct {
 
 	// Whether to allow multipart uploads to the BK-hosted bucket.
 	AllowMultipart bool
+
+	// OnBatchCreated observes successful CreateArtifacts calls.
+	OnBatchCreated func(artifactCount int, duration time.Duration)
 }
 
 type BatchCreator struct {
@@ -80,6 +83,7 @@ func (a *BatchCreator) Batches(ctx context.Context) iter.Seq2[[]*api.Artifact, e
 				roko.WithMaxAttempts(10),
 				roko.WithStrategy(roko.ExponentialSubsecond(500*time.Millisecond)),
 			)
+			started := time.Now()
 			creation, err := roko.DoFunc(ctx, r, func(r *roko.Retrier) (*api.ArtifactBatchCreateResponse, error) {
 				ctxTimeout := ctx
 				if timeout != 0 {
@@ -110,9 +114,13 @@ func (a *BatchCreator) Batches(ctx context.Context) iter.Seq2[[]*api.Artifact, e
 
 				return creation, err
 			})
+			duration := time.Since(started)
 			if err != nil {
 				yield(nil, err)
 				return
+			}
+			if a.conf.OnBatchCreated != nil {
+				a.conf.OnBatchCreated(len(theseArtifacts), duration)
 			}
 
 			for index, id := range creation.ArtifactIDs {

--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -78,6 +78,65 @@ type Uploader struct {
 	apiClient APIClient
 }
 
+type artifactUploadTimings struct {
+	collectDuration time.Duration
+	createDuration  time.Duration
+	uploadDuration  time.Duration
+	stateDuration   time.Duration
+
+	artifactCount    int
+	artifactBytes    int64
+	batches          int
+	workUnits        int
+	maxWorkerCount   int
+	stateUpdateCount int
+}
+
+type artifactUploadBatchStats struct {
+	workUnits      int
+	workerCount    int
+	uploadDuration time.Duration
+
+	stateUpdateDuration time.Duration
+	stateUpdateCount    int
+}
+
+func (t *artifactUploadTimings) addArtifacts(artifacts []*api.Artifact) {
+	t.artifactCount = len(artifacts)
+	for _, artifact := range artifacts {
+		t.artifactBytes += artifact.FileSize
+	}
+}
+
+func (t *artifactUploadTimings) addCreateBatch(duration time.Duration) {
+	t.createDuration += duration
+	t.batches++
+}
+
+func (t *artifactUploadTimings) addUploadBatch(stats artifactUploadBatchStats) {
+	t.uploadDuration += stats.uploadDuration
+	t.stateDuration += stats.stateUpdateDuration
+	t.workUnits += stats.workUnits
+	t.stateUpdateCount += stats.stateUpdateCount
+	t.maxWorkerCount = max(t.maxWorkerCount, stats.workerCount)
+}
+
+func (t *artifactUploadTimings) logSummary(l logger.Logger) {
+	l.Infof(
+		"Artifact upload timings: collect=%s create=%s upload=%s state_update=%s artifacts=%d bytes=%s batches=%d work_units=%d max_workers=%d state_updates=%d",
+		t.collectDuration,
+		t.createDuration,
+		t.uploadDuration,
+		t.stateDuration,
+		t.artifactCount,
+		humanize.IBytes(uint64(t.artifactBytes)),
+		t.batches,
+		t.workUnits,
+		t.maxWorkerCount,
+		t.stateUpdateCount,
+	)
+}
+
 func NewUploader(l logger.Logger, ac APIClient, c UploaderConfig) *Uploader {
 	return &Uploader{
 		logger:    l,
@@ -92,7 +151,10 @@ func DefaultUploadConcurrency() int {
 
 func (a *Uploader) Upload(ctx context.Context) error {
 	// Create artifact structs for all the files we need to upload
+	timings := &artifactUploadTimings{}
+	collectStart := time.Now()
 	artifacts, err := a.collect(ctx)
+	timings.collectDuration = time.Since(collectStart)
 	if err != nil {
 		return fmt.Errorf("collecting artifacts: %w", err)
 	}
@@ -103,6 +165,7 @@ func (a *Uploader) Upload(ctx context.Context) error {
 	}
 
 	a.logger.Infof("Found %d files that match %q", len(artifacts), a.conf.Paths)
+	timings.addArtifacts(artifacts)
 
 	// Determine what uploader to use
 	uploader, err := a.createUploader(ctx)
@@ -125,15 +188,24 @@ func (a *Uploader) Upload(ctx context.Context) error {
 		UploadDestination:      a.conf.Destination,
 		CreateArtifactsTimeout: 10 * time.Second,
 		AllowMultipart:         a.conf.AllowMultipart,
+		OnBatchCreated: func(count int, duration time.Duration) {
+			timings.addCreateBatch(duration)
+			a.logger.Debugf("Created %d artifacts in %s", count, duration)
+		},
 	})
 	for chunk, err := range batchCreator.Batches(ctx) {
 		if err != nil {
 			return err
 		}
-		if err := a.upload(ctx, chunk, uploader); err != nil {
+		stats, err := a.upload(ctx, chunk, uploader)
+		timings.addUploadBatch(stats)
+		if err != nil {
 			return fmt.Errorf("uploading artifacts: %w", err)
 		}
+		a.logger.Debugf("Uploaded %d artifact work units with %d workers in %s", stats.workUnits, stats.workerCount, stats.uploadDuration)
 	}
+
+	timings.logSummary(a.logger)
 
 	return nil
 }
@@ -190,11 +262,15 @@ func (a *Uploader) collect(ctx context.Context) ([]*api.Artifact, error) {
 
 	// Start resolving globs (or not) and sending file paths to workers.
 	a.logger.Debugf("Searching for %s", a.conf.Paths)
+	searchStart := time.Now()
 	if err := fileFinder(wctx, a.paths(), filesCh); err != nil {
 		cancel(err)
 	}
+	a.logger.Debugf("Artifact path discovery finished in %s", time.Since(searchStart))
 
+	drainStart := time.Now()
 	wg.Wait()
+	a.logger.Debugf("Artifact collection workers drained in %s", time.Since(drainStart))
 
 	if err := context.Cause(wctx); err != nil {
 		return nil, err
@@ -496,6 +572,9 @@ type artifactUploadWorker struct {
 	// The map is written at the start of upload, and other goroutines only read
 	// afterwards.
 	trackers map[*api.Artifact]*artifactTracker
+
+	stateUpdateDuration time.Duration
+	stateUpdateCount    int
 }
 
 // artifactTracker tracks the amount of work pending for an artifact.
@@ -536,11 +615,12 @@ type artifactTracker struct {
 	api.ArtifactState
 }
 
-func (a *Uploader) upload(ctx context.Context, artifacts []*api.Artifact, uploader workCreator) error {
+func (a *Uploader) upload(ctx context.Context, artifacts []*api.Artifact, uploader workCreator) (artifactUploadBatchStats, error) {
 	worker := &artifactUploadWorker{
 		Uploader: a,
 		trackers: make(map[*api.Artifact]*artifactTracker),
 	}
+	stats := artifactUploadBatchStats{}
 
 	// Create work and trackers for each artifact.
 	var workUnitCount int
@@ -548,7 +628,7 @@ func (a *Uploader) upload(ctx context.Context, artifacts []*api.Artifact, upload
 		workUnits, err := uploader.CreateWork(artifact)
 		if err != nil {
 			a.logger.Errorf("Couldn't create upload workers for artifact %q: %v", artifact.Path, err)
-			return err
+			return stats, err
 		}
 		workUnitCount += len(workUnits)
 
@@ -566,8 +646,10 @@ func (a *Uploader) upload(ctx context.Context, artifacts []*api.Artifact, upload
 	}
 
 	workerCount := a.uploadWorkerCount(workUnitCount)
+	stats.workUnits = workUnitCount
+	stats.workerCount = workerCount
 	if workerCount == 0 {
-		return nil
+		return stats, nil
 	}
 	a.logger.Debugf("Uploading %d artifact work units with %d workers", workUnitCount, workerCount)
 
@@ -590,11 +672,12 @@ func (a *Uploader) upload(ctx context.Context, artifacts []*api.Artifact, upload
 
 	// Send the work units for each artifact to the workers.
 	// This must happen after creating worker goroutines listening on workUnitsCh.
+	uploadStart := time.Now()
 	for _, tracker := range worker.trackers {
 		for _, workUnit := range tracker.work {
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return stats, ctx.Err()
 			case unitsCh <- workUnit:
 			}
 		}
@@ -607,6 +690,7 @@ func (a *Uploader) upload(ctx context.Context, artifacts []*api.Artifact, upload
 
 	// Wait for the workers to finish
 	wg.Wait()
+	stats.uploadDuration = time.Since(uploadStart)
 
 	// Since the workers are done, all work unit states have been sent to the
 	// state updater.
@@ -616,12 +700,16 @@ func (a *Uploader) upload(ctx context.Context, artifacts []*api.Artifact, upload
 
 	// Wait for the statuses to finish uploading
 	if err := <-errCh; err != nil {
-		return fmt.Errorf("errors uploading artifacts: %w", err)
+		stats.stateUpdateDuration = worker.stateUpdateDuration
+		stats.stateUpdateCount = worker.stateUpdateCount
+		return stats, fmt.Errorf("errors uploading artifacts: %w", err)
 	}
+	stats.stateUpdateDuration = worker.stateUpdateDuration
+	stats.stateUpdateCount = worker.stateUpdateCount
 
 	a.logger.Infof("Artifact uploads completed successfully")
 
-	return nil
+	return stats, nil
 }
 
 func (a *Uploader) uploadWorkerCount(workUnitCount int) int {
@@ -778,6 +866,7 @@ func (a *artifactUploadWorker) updateStates(ctx context.Context) error {
 	timeout := 5 * time.Second
 
 	// Update the states of the artifacts in bulk.
+	started := time.Now()
 	err := roko.NewRetrier(
 		roko.WithMaxAttempts(10),
 		roko.WithStrategy(roko.ExponentialSubsecond(500*time.Millisecond)),
@@ -805,6 +894,9 @@ func (a *artifactUploadWorker) updateStates(ctx context.Context) error {
 
 		return err
 	})
+	duration := time.Since(started)
+	a.stateUpdateDuration += duration
+	a.stateUpdateCount++
 	if err != nil {
 		a.logger.Errorf("Error updating artifact states: %v", err)
 		return err
@@ -814,7 +906,7 @@ func (a *artifactUploadWorker) updateStates(ctx context.Context) error {
 		// Don't send this state again.
 		tracker.State = "sent"
 	}
-	a.logger.Debugf("Updated %d artifact states", len(statesToUpload))
+	a.logger.Debugf("Updated %d artifact states in %s", len(statesToUpload), duration)
 	return nil
 }
 

--- a/internal/artifact/uploader_test.go
+++ b/internal/artifact/uploader_test.go
@@ -427,27 +427,44 @@ func TestUploadUsesConfiguredConcurrency(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
-	errCh := make(chan error, 1)
+	errCh := make(chan struct {
+		stats artifactUploadBatchStats
+		err   error
+	}, 1)
 	go func() {
-		errCh <- uploader.upload(ctx, artifacts, workCreator)
+		stats, err := uploader.upload(ctx, artifacts, workCreator)
+		errCh <- struct {
+			stats artifactUploadBatchStats
+			err   error
+		}{stats, err}
 	}()
 
 	select {
 	case <-state.ready:
 	case <-time.After(2 * time.Second):
 		cancel()
-		err := <-errCh
-		t.Fatalf("upload did not start %d concurrent workers before timeout: %v", wantConcurrency, err)
+		result := <-errCh
+		t.Fatalf("upload did not start %d concurrent workers before timeout: %v", wantConcurrency, result.err)
 	}
 
 	close(state.release)
 
-	if err := <-errCh; err != nil {
-		t.Fatalf("uploader.upload() error = %v", err)
+	result := <-errCh
+	if result.err != nil {
+		t.Fatalf("uploader.upload() error = %v", result.err)
 	}
 
 	if got := state.max.Load(); got != wantConcurrency {
 		t.Fatalf("max concurrent uploads = %d, want %d", got, wantConcurrency)
+	}
+	if got, want := result.stats.workUnits, len(artifacts); got != want {
+		t.Fatalf("upload stats workUnits = %d, want %d", got, want)
+	}
+	if got := result.stats.workerCount; got != int(wantConcurrency) {
+		t.Fatalf("upload stats workerCount = %d, want %d", got, wantConcurrency)
+	}
+	if got := result.stats.stateUpdateCount; got != 1 {
+		t.Fatalf("upload stats stateUpdateCount = %d, want 1", got)
 	}
 }
 
@@ -456,6 +473,46 @@ func TestDefaultUploadConcurrencyMatchesExistingWorkerCount(t *testing.T) {
 
 	if got, want := DefaultUploadConcurrency(), runtime.GOMAXPROCS(0); got != want {
 		t.Fatalf("DefaultUploadConcurrency() = %d, want %d", got, want)
+	}
+}
+
+func TestArtifactUploadTimingsSummary(t *testing.T) {
+	t.Parallel()
+
+	timings := &artifactUploadTimings{
+		collectDuration: 1456 * time.Millisecond,
+		createDuration:  82 * time.Millisecond,
+		uploadDuration:  334 * time.Millisecond,
+		stateDuration:   11 * time.Millisecond,
+
+		artifactCount:    1296,
+		artifactBytes:    1296 * 4096,
+		batches:          44,
+		workUnits:        1296,
+		maxWorkerCount:   30,
+		stateUpdateCount: 44,
+	}
+
+	l := logger.NewBuffer()
+	timings.logSummary(l)
+
+	got := strings.Join(l.Messages, "\n")
+	for _, want := range []string{
+		"Artifact upload timings:",
+		"collect=1.456s",
+		"create=82ms",
+		"upload=334ms",
+		"state_update=11ms",
+		"artifacts=1296",
+		"bytes=5.1 MiB",
+		"batches=44",
+		"work_units=1296",
+		"max_workers=30",
+		"state_updates=44",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("timings summary = %q, want substring %q", got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
Large artifact uploads currently leave us guessing which part of the pipeline is slow. The job log shows the overall artifact upload step and per-artifact activity, but it does not give a compact breakdown of collection, Buildkite artifact creation, upload worker time, or state update calls.

This adds a single info-level summary after successful artifact uploads so operators can compare runs without enabling HTTP tracing or reconstructing timings from many log lines. Example:

```text
Artifact upload timings: collect=1.456s create=82ms upload=334ms state_update=11ms artifacts=1296 bytes=5.1 MiB batches=44 work_units=1296 max_workers=30 state_updates=44
```

The change also adds debug timing breadcrumbs for path discovery, collection worker drain time, artifact creation batches, upload batches, and state update calls. The upload behavior and default concurrency are unchanged.