### PR TITLE
chore: Add artifact upload span attributes

### DIFF
--- a/internal/artifact/uploader.go
+++ b/internal/artifact/uploader.go
@@ -25,6 +25,8 @@ import (
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/roko"
 	"github.com/dustin/go-humanize"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const ArtifactFallbackMimeType = "binary/octet-stream"
@@ -121,6 +123,21 @@ func (t *artifactUploadTimings) addUploadBatch(stats artifactUploadBatchStats) {
 	t.maxWorkerCount = max(t.maxWorkerCount, stats.workerCount)
 }
 
+func (t *artifactUploadTimings) setSpanAttributes(ctx context.Context) {
+	trace.SpanFromContext(ctx).SetAttributes(
+		attribute.Int("artifact.count", t.artifactCount),
+		attribute.Int64("artifact.bytes", t.artifactBytes),
+		attribute.Int("artifact.batch_count", t.batches),
+		attribute.Int("artifact.work_unit_count", t.workUnits),
+		attribute.Int("artifact.max_workers", t.maxWorkerCount),
+		attribute.Int("artifact.state_update_count", t.stateUpdateCount),
+		attribute.Int64("artifact.collect_ms", t.collectDuration.Milliseconds()),
+		attribute.Int64("artifact.create_ms", t.createDuration.Milliseconds()),
+		attribute.Int64("artifact.upload_ms", t.uploadDuration.Milliseconds()),
+		attribute.Int64("artifact.state_update_ms", t.stateDuration.Milliseconds()),
+	)
+}
+
 func (t *artifactUploadTimings) logSummary(l logger.Logger) {
 	l.Infof(
 		"Artifact upload timings: collect=%s create=%s upload=%s state_update=%s artifacts=%d bytes=%s batches=%d work_units=%d max_workers=%d state_updates=%d",
@@ -205,6 +222,7 @@ func (a *Uploader) Upload(ctx context.Context) error {
 		a.logger.Debugf("Uploaded %d artifact work units with %d workers in %s", stats.workUnits, stats.workerCount, stats.uploadDuration)
 	}
 
+	timings.setSpanAttributes(ctx)
 	timings.logSummary(a.logger)
 
 	return nil

--- a/internal/artifact/uploader_test.go
+++ b/internal/artifact/uploader_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/buildkite/agent/v3/internal/experiments"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/google/go-cmp/cmp"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func findArtifact(artifacts []*api.Artifact, search string) *api.Artifact {
@@ -513,6 +515,58 @@ func TestArtifactUploadTimingsSummary(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("timings summary = %q, want substring %q", got, want)
 		}
+	}
+}
+
+func TestArtifactUploadTimingsSpanAttributes(t *testing.T) {
+	t.Parallel()
+
+	timings := &artifactUploadTimings{
+		collectDuration: 1456 * time.Millisecond,
+		createDuration:  82 * time.Millisecond,
+		uploadDuration:  334 * time.Millisecond,
+		stateDuration:   11 * time.Millisecond,
+
+		artifactCount:    1296,
+		artifactBytes:    1296 * 4096,
+		batches:          44,
+		workUnits:        1296,
+		maxWorkerCount:   30,
+		stateUpdateCount: 44,
+	}
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	ctx, span := provider.Tracer("test").Start(t.Context(), "artifact-upload")
+	timings.setSpanAttributes(ctx)
+	span.End()
+
+	spans := recorder.Ended()
+	if got, want := len(spans), 1; got != want {
+		t.Fatalf("ended spans = %d, want %d", got, want)
+	}
+
+	got := make(map[string]any)
+	for _, attr := range spans[0].Attributes() {
+		got[string(attr.Key)] = attr.Value.AsInterface()
+	}
+
+	want := map[string]any{
+		"artifact.count":              int64(1296),
+		"artifact.bytes":              int64(1296 * 4096),
+		"artifact.batch_count":        int64(44),
+		"artifact.work_unit_count":    int64(1296),
+		"artifact.max_workers":        int64(30),
+		"artifact.state_update_count": int64(44),
+		"artifact.collect_ms":         int64(1456),
+		"artifact.create_ms":          int64(82),
+		"artifact.upload_ms":          int64(334),
+		"artifact.state_update_ms":    int64(11),
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("span attributes diff (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
The artifact upload timing summary is now visible in job logs, but tracing users still need to scrape those logs to get the same phase breakdown in their trace tooling.

This adds command-level attributes to the existing `artifact-upload` span using the same low-cardinality summary fields. The attributes describe the upload as a whole, not individual artifacts or work units, so traces get useful aggregate diagnostics without adding span volume or sensitive path/destination data.

The span now includes attributes like:

```text
artifact.count
artifact.bytes
artifact.batch_count
artifact.work_unit_count
artifact.max_workers
artifact.state_update_count
artifact.collect_ms
artifact.create_ms
artifact.upload_ms
artifact.state_update_ms
```

Artifact upload behavior and the existing job-log summary are unchanged.