### PR TITLE
Fix env set/unset panic on Job API errors

### DIFF
--- a/clicommand/env_set.go
+++ b/clicommand/env_set.go
@@ -69,7 +69,7 @@ var EnvSetCommand = cli.Command{
 
 func envSetAction(c *cli.Context) error {
 	ctx := context.Background()
-	ctx, cfg, l, _, done := setupLoggerAndConfig[EnvSetConfig](ctx, c)
+	ctx, cfg, _, _, done := setupLoggerAndConfig[EnvSetConfig](ctx, c)
 	defer done()
 
 	client, err := jobapi.NewDefaultClient(ctx)
@@ -129,7 +129,7 @@ func envSetAction(c *cli.Context) error {
 
 	resp, err := client.EnvUpdate(ctx, req)
 	if err != nil {
-		l.Errorf("Couldn't update the job executor environment: %v", err)
+		return fmt.Errorf("couldn't update the job executor environment: %w", err)
 	}
 
 	switch cfg.OutputFormat {

--- a/clicommand/env_unset.go
+++ b/clicommand/env_unset.go
@@ -67,7 +67,7 @@ var EnvUnsetCommand = cli.Command{
 
 func envUnsetAction(c *cli.Context) error {
 	ctx := context.Background()
-	ctx, cfg, l, _, done := setupLoggerAndConfig[EnvUnsetConfig](ctx, c)
+	ctx, cfg, _, _, done := setupLoggerAndConfig[EnvUnsetConfig](ctx, c)
 	defer done()
 
 	client, err := jobapi.NewDefaultClient(ctx)
@@ -120,7 +120,7 @@ func envUnsetAction(c *cli.Context) error {
 
 	unset, err := client.EnvDelete(ctx, del)
 	if err != nil {
-		l.Errorf("couldn't unset the job executor environment variables: %v", err)
+		return fmt.Errorf("couldn't unset the job executor environment variables: %w", err)
 	}
 
 	switch cfg.OutputFormat {


### PR DESCRIPTION
## Description

`buildkite-agent env set` and `buildkite-agent env unset` logged the error returned by the Job API client but did not return it, then fell through to use the response value. `EnvUpdate`/`EnvDelete` return a nil response on error, so:

- `env set`, with the default `plain` output format, dereferenced the nil response (`resp.Added`) and panicked.
- `env unset` silently swallowed the error and exited 0, printing "No variables unset."

Both now return the error, so the command fails cleanly with a non-zero exit code and a useful message instead of panicking or hiding the failure.

## Changes

- `clicommand/env_set.go`: return the `EnvUpdate` error instead of logging and continuing; drop the now-unused logger binding.
- `clicommand/env_unset.go`: same for the `EnvDelete` error.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

The original fix was implemented by @scadu in commit 33546381 on the `git-checkout-features` branch. During a code review of that branch using Claude Code (Opus 4.8), the same bug was found still present on `main`, so the fix was extracted to this standalone branch for an isolated fix.