### PR TITLE
[TE-6071] Request xgboost selection plan in collect-commit-metadata

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,6 +63,9 @@ steps:
           config: .buildkite/docker-compose.yml
           cli-version: 2
           propagate-environment: true
+          # Mount the agent binary so the step can stash the xgboost plan
+          # identifier via `buildkite-agent meta-data set`. See TE-6071.
+          mount-buildkite-agent: true
           run: agent
 
   - group: ":go::scientist: Tests and Coverage"

--- a/.buildkite/steps/collect-commit-metadata.sh
+++ b/.buildkite/steps/collect-commit-metadata.sh
@@ -37,8 +37,9 @@ go tool test-engine-client --version
 
 echo "+++ :test_tube: Collecting git commit metadata via bktec plan (discarded)"
 
-# bktec needs a writable RESULT_PATH for plan output config validation. The
-# --json output is redirected to /dev/null below so this file is never read.
+# bktec needs a writable RESULT_PATH for plan-output config validation. It
+# is the run-results file, distinct from the plan's stdout we capture below
+# -- this file is never read.
 export BUILDKITE_TEST_ENGINE_RESULT_PATH=/tmp/bktec-plan-metadata.json
 
 # Feature-branch builds (TE-6071): also request an xgboost-ranked plan so the

--- a/.buildkite/steps/collect-commit-metadata.sh
+++ b/.buildkite/steps/collect-commit-metadata.sh
@@ -57,7 +57,7 @@ export BUILDKITE_TEST_ENGINE_RESULT_PATH=/tmp/bktec-plan-metadata.json
 # (rank) every candidate rather than capping at the default count_cutoff.
 # Mirrors the bk/bk-rspec xgboost path. Files are ranked, not filtered.
 selection_flags=()
-if [ "${BUILDKITE_BRANCH:-}" != "main" ]; then
+if [[ "${BUILDKITE_BRANCH:-}" != "main" ]]; then
   selection_flags=(
     --selection-strategy "xgboost"
     --selection-param "score_cutoff=0"
@@ -82,12 +82,12 @@ echo "Plan request issued -- git commit metadata sent to Test Engine."
 # rspec_xgboost_plan_id metadata). Parse with ruby (present in this image;
 # jq is not) and skip silently if the field is absent -- this is a
 # measurement aid, not a build-correctness signal.
-if [ ${#selection_flags[@]} -gt 0 ]; then
-  plan_id=$(printf '%s' "$plan_output" \
-    | ruby -rjson -e 'puts (JSON.parse(STDIN.read)["BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER"] rescue "")')
-  if [ -n "$plan_id" ]; then
-    buildkite-agent meta-data set "agent_xgboost_plan_id" "$plan_id"
-    echo "Stashed xgboost plan id as build metadata: $plan_id"
+if [[ ${#selection_flags[@]} -gt 0 ]]; then
+  plan_id="$(printf '%s' "${plan_output}" \
+    | ruby -rjson -e 'puts (JSON.parse(STDIN.read)["BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER"] rescue "")')"
+  if [[ -n "${plan_id}" ]]; then
+    buildkite-agent meta-data set "agent_xgboost_plan_id" "${plan_id}"
+    echo "Stashed xgboost plan id as build metadata: ${plan_id}"
   else
     echo "No plan identifier returned; skipping agent_xgboost_plan_id metadata."
   fi

--- a/.buildkite/steps/collect-commit-metadata.sh
+++ b/.buildkite/steps/collect-commit-metadata.sh
@@ -63,10 +63,31 @@ if [ "${BUILDKITE_BRANCH:-}" != "main" ]; then
   )
 fi
 
-BKTEC_PREVIEW_SELECTION=1 go tool test-engine-client plan \
+# `bktec plan --json` emits a JSON object to stdout of the shape:
+#   {"BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER":"<id>",
+#    "BUILDKITE_TEST_ENGINE_PARALLELISM":"<int-as-string>"}
+# Capture it so the plan identifier can be stashed as build metadata;
+# parallelism is ignored -- the gotest steps keep their declared values.
+plan_output=$(BKTEC_PREVIEW_SELECTION=1 go tool test-engine-client plan \
   --json \
   --collect-git-metadata \
-  "${selection_flags[@]}" \
-  > /dev/null
+  "${selection_flags[@]}")
 
 echo "Plan request issued -- git commit metadata sent to Test Engine."
+
+# TE-6071: when we requested an xgboost-ranked plan, stash the plan
+# identifier as build metadata so a follow-up can correlate the build with
+# the discarded plan it produced (mirrors the bk/bk-rspec
+# rspec_xgboost_plan_id metadata). Parse with ruby (present in this image;
+# jq is not) and skip silently if the field is absent -- this is a
+# measurement aid, not a build-correctness signal.
+if [ ${#selection_flags[@]} -gt 0 ]; then
+  plan_id=$(printf '%s' "$plan_output" \
+    | ruby -rjson -e 'puts (JSON.parse(STDIN.read)["BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER"] rescue "")')
+  if [ -n "$plan_id" ]; then
+    buildkite-agent meta-data set "agent_xgboost_plan_id" "$plan_id"
+    echo "Stashed xgboost plan id as build metadata: $plan_id"
+  else
+    echo "No plan identifier returned; skipping agent_xgboost_plan_id metadata."
+  fi
+fi

--- a/.buildkite/steps/collect-commit-metadata.sh
+++ b/.buildkite/steps/collect-commit-metadata.sh
@@ -3,13 +3,24 @@
 #
 # This is a metadata-only side-channel for the buildkite-agent Test Engine
 # suite. The plan output is discarded -- the existing test steps continue to
-# use their declared `parallelism:` values unchanged. The only purpose of this
-# step is to ship commit / branch / diff metadata to the Test Engine plan
-# metadata pipeline on every build.
+# use their declared `parallelism:` values unchanged. The first purpose of
+# this step is to ship commit / branch / diff metadata to the Test Engine
+# plan metadata pipeline on every build.
 #
 # See TE-5828 (and the bk/bk-rspec reference implementation in TE-5766) for
 # context. The step is soft-failed at the pipeline level so a Test Engine API
 # hiccup never blocks the build.
+#
+# Secondary purpose (TE-6071): on feature-branch builds, this step also
+# requests an xgboost-ordered test selection plan (--selection-strategy
+# xgboost --selection-param score_cutoff=0, mirroring the bk/bk-rspec
+# rspec_collect_metadata step in TE-5867). The selection request drives a
+# test-prediction inference for the buildkite-agent suite through the shared
+# `test-prediction-mme` Multi-Model Endpoint, against that suite's per-suite
+# TargetModel. Combined with the already-live bk/bk-rspec selection path,
+# this validates the MME serving multiple models for multiple suites (the
+# TE-5970 cutover goal). The plan output is still discarded -- the gotest
+# steps keep their declared `parallelism:`.
 #
 # Runs inside the `agent` docker-compose service (see
 # .buildkite/docker-compose.yml), which is a linux/amd64+arm64 golang image.
@@ -30,6 +41,32 @@ echo "+++ :test_tube: Collecting git commit metadata via bktec plan (discarded)"
 # --json output is redirected to /dev/null below so this file is never read.
 export BUILDKITE_TEST_ENGINE_RESULT_PATH=/tmp/bktec-plan-metadata.json
 
-BKTEC_PREVIEW_SELECTION=1 go tool test-engine-client plan --json --collect-git-metadata > /dev/null
+# Feature-branch builds (TE-6071): also request an xgboost-ranked plan so the
+# request exercises the buildkite-agent TargetModel through the MME.
+#
+# Skipped on `main`: xgboost requires a non-empty `files_changed`. On `main`,
+# $BUILDKITE_PULL_REQUEST_BASE_BRANCH is unset and bktec falls back to
+# `origin/main`, producing an empty diff (HEAD == origin/main), which the
+# Test Engine API rejects. The metadata-only request still runs on `main`.
+# See the bk/bk-rspec rspec_collect_metadata / rspec_plan steps for the same
+# guard and the `--metadata base_branch=HEAD^` main workaround we deliberately
+# do not duplicate here (this validation is about feature-branch selection).
+#
+# `--selection-param score_cutoff=0` forces the server-side selector to admit
+# (rank) every candidate rather than capping at the default count_cutoff.
+# Mirrors the bk/bk-rspec xgboost path. Files are ranked, not filtered.
+selection_flags=()
+if [ "${BUILDKITE_BRANCH:-}" != "main" ]; then
+  selection_flags=(
+    --selection-strategy "xgboost"
+    --selection-param "score_cutoff=0"
+  )
+fi
+
+BKTEC_PREVIEW_SELECTION=1 go tool test-engine-client plan \
+  --json \
+  --collect-git-metadata \
+  "${selection_flags[@]}" \
+  > /dev/null
 
 echo "Plan request issued -- git commit metadata sent to Test Engine."


### PR DESCRIPTION
Feature-branch builds: `.buildkite/steps/collect-commit-metadata.sh` now asks Test Engine API for xgboost-ordered selection plan for `buildkite-agent` suite, on top of git-metadata request already made. Plan output stay discarded.

Why: shared `test-prediction-mme` endpoint already serves `buildkite-rspec` suite (one model). `buildkite-agent` suite has deployed tarball + `active-version.txt` pointer, but no CI step requested selection plan for it, so its model never invoked through plan endpoint. Adding `--selection-strategy xgboost --selection-param score_cutoff=0` validates MME endpoint works as expected and supports test prediction / selection for multiple suites and different models.

`score_cutoff=0` ranks every candidate, no cap at default `count_cutoff`. Selection skipped on `main` — `files_changed` empty there (HEAD == origin/main), API rejects xgboost. Metadata-only request still runs on `main`.

**Discarded output:** gotest steps keep declared `parallelism:`. Selection request exists only to exercise MME, not drive parallelism.

On xgboost path, step also captures plan `--json` output, parses `BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER`, stashes as build metadata `agent_xgboost_plan_id` so follow-up can correlate build with discarded plan. Parsed with ruby (in agent compose image; jq not). docker-compose step now mounts agent binary for `buildkite-agent meta-data set`.

## Context

TE-6071.

## Changes

- `[TE-6071] Request xgboost selection plan in collect-commit-metadata`
- `[TE-6071] Stash xgboost plan id as build metadata`

Best reviewed commit-by-commit.

## Verification

- `bash -n` + `shellcheck --severity=style` clean.
- Empty-array expansion under `set -u` passes zero args on `main` (base image `golang:1.25`, bash 5).
- ruby parse: returns identifier when present, empty (skip) when absent.
- Post-merge: feature-branch build `collect-commit-metadata` step issues xgboost plan, sets `agent_xgboost_plan_id`; agent suite `TargetModel` shows `test-prediction-mme` invocation via plan-endpoint observability surface.

Backed by manual validation; AI assisted.

## Rollback

Yes. Revert restores metadata-only request.
