### PR TITLE
fix: Test build failure due to missing context import

### DIFF
--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -12,7 +12,7 @@ fi
 export BUILDKITE_TEST_ENGINE_SUITE_SLUG=buildkite-agent
 export BUILDKITE_TEST_ENGINE_TEST_RUNNER=gotest
 export BUILDKITE_TEST_ENGINE_RESULT_PATH="junit-${BUILDKITE_JOB_ID}.xml"
-export BUILDKITE_TEST_ENGINE_RETRY_COUNT=1
+export BUILDKITE_TEST_ENGINE_RETRY_COUNT=0
 if [[ "$(go env GOOS)" == "windows" ]]; then
   # I can't get windows to work with the $COVERAGE_DIR, I tried cygpath but no luck.
   # need a Windows VM to debug.

--- a/internal/artifact/uploader_test.go
+++ b/internal/artifact/uploader_test.go
@@ -537,7 +537,7 @@ func TestArtifactUploadTimingsSpanAttributes(t *testing.T) {
 
 	recorder := tracetest.NewSpanRecorder()
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
-	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) }) //nolint:usetesting // t.Context() is cancelled before Cleanup funcs
 
 	ctx, span := provider.Tracer("test").Start(t.Context(), "artifact-upload")
 	timings.setSpanAttributes(ctx)

--- a/internal/job/checkout_test.go
+++ b/internal/job/checkout_test.go
@@ -306,8 +306,8 @@ func TestDefaultCheckoutPhase_CleansUpGitSSHKeyOnError(t *testing.T) {
 		}
 	})
 
-	if err := executor.defaultCheckoutPhase(context.Background()); err == nil {
-		t.Fatal("executor.defaultCheckoutPhase(context.Background()) error = nil, want non-nil")
+	if err := executor.defaultCheckoutPhase(t.Context()); err == nil {
+		t.Fatal("executor.defaultCheckoutPhase(t.Context()) error = nil, want non-nil")
 	}
 
 	matches, err := filepath.Glob(filepath.Join(checkoutParent, ".buildkite-ssh-key-*"))

--- a/internal/job/commit_verification_test.go
+++ b/internal/job/commit_verification_test.go
@@ -1,7 +1,6 @@
 package job
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -79,7 +78,7 @@ func TestVerifyCommit(t *testing.T) {
 				shell:          sh,
 				ExecutorConfig: tt.config,
 			}
-			err = e.verifyCommit(context.Background())
+			err = e.verifyCommit(t.Context())
 			if err != nil {
 				t.Errorf("verifyCommit() error = %v, want nil", err)
 			}
@@ -93,7 +92,7 @@ func TestVerifyCommit(t *testing.T) {
 		t.Setenv("GIT_COMMITTER_NAME", "Buildkite Agent")
 		t.Setenv("GIT_COMMITTER_EMAIL", "agent@example.com")
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		s := githttptest.NewServer()
 		defer s.Close()
@@ -158,7 +157,7 @@ func TestVerifyCommit(t *testing.T) {
 		t.Setenv("GIT_COMMITTER_NAME", "Buildkite Agent")
 		t.Setenv("GIT_COMMITTER_EMAIL", "agent@example.com")
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		s := githttptest.NewServer()
 		defer s.Close()
@@ -257,7 +256,7 @@ func TestVerifyCommit(t *testing.T) {
 		t.Setenv("GIT_COMMITTER_NAME", "Buildkite Agent")
 		t.Setenv("GIT_COMMITTER_EMAIL", "agent@example.com")
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		s := githttptest.NewServer()
 		defer s.Close()
@@ -353,7 +352,7 @@ func TestVerifyCommit(t *testing.T) {
 		t.Setenv("GIT_COMMITTER_NAME", "Buildkite Agent")
 		t.Setenv("GIT_COMMITTER_EMAIL", "agent@example.com")
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		s := githttptest.NewServer()
 		defer s.Close()


### PR DESCRIPTION
## Description

Replace more `context.Background()` calls in tests with `t.Context()`, particularly where the "context" import had been removed from a file.

Also test-engine-client doesn't seem to do the right thing with build failures (the test is retried and passes? Investigating...), so disable retries.

## Context

Breakage added when #3977 was merged

## Changes

As described above.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

I did it myself.