### PR TITLE
fix: flaky TestCollect_Literal

### DIFF
--- a/internal/artifact/uploader_test.go
+++ b/internal/artifact/uploader_test.go
@@ -377,6 +377,8 @@ func TestCollect_Literal(t *testing.T) {
 		filepath.Join("fixtures", "links", "folder-link", "terminator2.jpg"),
 		filepath.Join("fixtures", "gifs", "Smile.gif"),
 	}
+	slices.Sort(got)
+	slices.Sort(want)
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("uploader.collect artifact paths diff (-got +want)\n%s", diff)
 	}


### PR DESCRIPTION
## Description

`TestCollect_Literal` is flaky, because the artifact collector is concurrent, sometimes producing output in a different order. The failure was masked by the Test Engine client automatic retry.

## Context

Noticed while doing the previous fix.

## Changes

Sort the data.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

I did not use AI tools at all
