### PR TITLE
fix: flaky TestContextCancelInterrupts

### DIFF
--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -202,7 +202,7 @@ func TestContextCancelInterrupts(t *testing.T) {
 			defer cancel()
 
 			// Wait for the process to start before cancelling the context.
-			// This is more reliable than time.Sleep.
+			// This is more reliable than time.Sleep, but still not perfect.
 			started := make(chan struct{})
 
 			go func() {
@@ -210,6 +210,9 @@ func TestContextCancelInterrupts(t *testing.T) {
 				case <-time.After(1 * time.Minute):
 					t.Errorf("timeout waiting for process to start")
 				case <-started:
+					// TODO: figure out why this still needs a sleep to be
+					// reliable.
+					time.Sleep(100 * time.Millisecond)
 					// Now cancel the context, which should cause the interrupt.
 					cancel()
 				}


### PR DESCRIPTION
## Description

(Try to) fix another flaky test, this time `TestContextCancelInterrupts/SIGINT`. To be honest I don't have a theoretical explanation for why this is flaky. There must be a command and an `*os.Process` after `Start`, but perhaps there is a small window in which the subprocess isn't able to handle `SIGINT`?

## Context

Found after merging the last fix.

## Changes

Add a small sleep after the process `started` channel is closed, to be even more sure the subprocess has started (?)  I hate it

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

I was rained on today while coming home from lunch.
