### PR TITLE
Add `buildkite-agent job promise-failure` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 
+/buildkite-agent
 /tmp
 /pkg
 /releases

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -137,6 +137,29 @@ func (c *Client) FinishJob(ctx context.Context, job *Job, ignoreAgentInDispatche
 	return c.doRequest(req, nil)
 }
 
+// JobPromiseFailureRequest declares a promised (early) exit-status failure for
+// a job. ExitStatus must be a non-zero integer; the server rejects zero,
+// non-integer, and out-of-range values.
+type JobPromiseFailureRequest struct {
+	ExitStatus int    `json:"exit_status"`
+	Reason     string `json:"reason,omitempty"`
+}
+
+// PromiseFailure declares a promised (early) exit-status failure for a job,
+// allowing the build-failing cascade to begin before the job finishes. The job
+// itself keeps running and finishes normally. On success the endpoint responds
+// with 204 No Content and no body.
+func (c *Client) PromiseFailure(ctx context.Context, id string, req *JobPromiseFailureRequest) (*Response, error) {
+	u := fmt.Sprintf("jobs/%s/promise_failure", railsPathEscape(id))
+
+	r, err := c.newRequest(ctx, "PUT", u, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.doRequest(r, nil)
+}
+
 // JobUpdateResponse is the response from updating a job
 type JobUpdateResponse struct {
 	ID string `json:"id"`

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -1,0 +1,123 @@
+package api_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/logger"
+)
+
+func TestPromiseFailure(t *testing.T) {
+	const jobID = "b078e2d2-86e9-4c12-bf3b-612a8058d0a4"
+	const accessToken = "llamas"
+
+	ctx := t.Context()
+
+	tests := []struct {
+		name           string
+		request        *api.JobPromiseFailureRequest
+		expectedBody   []byte
+		responseStatus int
+		wantErr        bool
+	}{
+		{
+			name:         "success",
+			request:      &api.JobPromiseFailureRequest{ExitStatus: 1},
+			expectedBody: []byte(`{"exit_status":1}` + "\n"),
+		},
+		{
+			name:         "with reason",
+			request:      &api.JobPromiseFailureRequest{ExitStatus: 42, Reason: "detected failing tests"},
+			expectedBody: []byte(`{"exit_status":42,"reason":"detected failing tests"}` + "\n"),
+		},
+		{
+			name:           "feature disabled",
+			request:        &api.JobPromiseFailureRequest{ExitStatus: 1},
+			expectedBody:   []byte(`{"exit_status":1}` + "\n"),
+			responseStatus: http.StatusNotFound,
+			wantErr:        true,
+		},
+		{
+			name:           "conflict",
+			request:        &api.JobPromiseFailureRequest{ExitStatus: 1},
+			expectedBody:   []byte(`{"exit_status":1}` + "\n"),
+			responseStatus: http.StatusConflict,
+			wantErr:        true,
+		},
+		{
+			name:           "job not running",
+			request:        &api.JobPromiseFailureRequest{ExitStatus: 1},
+			expectedBody:   []byte(`{"exit_status":1}` + "\n"),
+			responseStatus: http.StatusUnprocessableEntity,
+			wantErr:        true,
+		},
+	}
+
+	path := fmt.Sprintf("/jobs/%s/promise_failure", url.PathEscape(jobID))
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Success cases respond with 204 No Content.
+			responseStatus := test.responseStatus
+			if responseStatus == 0 {
+				responseStatus = http.StatusNoContent
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				if got, want := authToken(req), accessToken; got != want {
+					http.Error(rw, fmt.Sprintf("authToken(req) = %q, want %q", got, want), http.StatusUnauthorized)
+					return
+				}
+				if got, want := req.Method, http.MethodPut; got != want {
+					t.Errorf("req.Method = %q, want %q", got, want)
+				}
+				if got, want := req.URL.Path, path; got != want {
+					t.Errorf("req.URL.Path = %q, want %q", got, want)
+				}
+
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Errorf("reading request body: %v", err)
+				}
+				if !bytes.Equal(body, test.expectedBody) {
+					t.Errorf("request body = %q, want %q", body, test.expectedBody)
+				}
+
+				rw.WriteHeader(responseStatus)
+			}))
+			defer server.Close()
+
+			client := api.NewClient(logger.Discard, api.Config{
+				UserAgent: "Test",
+				Endpoint:  server.URL,
+				Token:     accessToken,
+				DebugHTTP: true,
+			})
+
+			resp, err := client.PromiseFailure(ctx, jobID, test.request)
+
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("PromiseFailure(%q) error = nil, want error", jobID)
+				}
+				if !api.IsErrHavingStatus(err, responseStatus) {
+					t.Errorf("IsErrHavingStatus(err, %d) = false, want true (err = %v)", responseStatus, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("PromiseFailure(%q) error = %v, want nil", jobID, err)
+			}
+			if resp.StatusCode != http.StatusNoContent {
+				t.Errorf("resp.StatusCode = %d, want %d", resp.StatusCode, http.StatusNoContent)
+			}
+		})
+	}
+}

--- a/clicommand/commands.go
+++ b/clicommand/commands.go
@@ -49,6 +49,7 @@ var BuildkiteAgentCommands = []cli.Command{
 		Usage:    "Interact with a Buildkite job",
 		Subcommands: []cli.Command{
 			JobUpdateCommand,
+			JobPromiseFailureCommand,
 		},
 	},
 	{

--- a/clicommand/config_completeness_test.go
+++ b/clicommand/config_completeness_test.go
@@ -35,6 +35,7 @@ var commandConfigPairs = []configCommandPair{
 	{Config: EnvSetConfig{}, Command: EnvSetCommand},
 	{Config: EnvUnsetConfig{}, Command: EnvUnsetCommand},
 	{Config: GitCredentialsHelperConfig{}, Command: GitCredentialsHelperCommand},
+	{Config: JobPromiseFailureConfig{}, Command: JobPromiseFailureCommand},
 	{Config: KubernetesBootstrapConfig{}, Command: KubernetesBootstrapCommand},
 	{Config: LockAcquireConfig{}, Command: LockAcquireCommand},
 	{Config: LockDoConfig{}, Command: LockDoCommand},

--- a/clicommand/job_promise_failure.go
+++ b/clicommand/job_promise_failure.go
@@ -20,17 +20,22 @@ const jobPromiseFailureHelpDescription = `Usage:
 
 Description:
 
-Declare a promised (early) failure for the current job. This records a
-non-zero exit status that the job is expected to finish with, allowing the
-build to begin failing before the job actually completes. The job keeps
-running and finishes normally; only the build-failing cascade starts early.
+Promise the current job will finish with a failing exit status. This records
+a non-zero exit status that the job is expected to finish with, allowing the
+build to begin failing before the job actually completes.
+
+The promise is binding: it sets a floor on the job's outcome. If the job is
+later reported as a success, the promised exit status is recorded instead, so
+the job still fails. Likewise, if a hard failure was promised but the job
+reports a soft-failure status, the promised status is kept. Any other
+reported failure is recorded as reported.
 
 Repeated calls with the same exit status are idempotent. Declaring a
 different exit status once one is already recorded is rejected.
 
-This command requires the early-failure feature to be enabled for your
-organization. If it is not, the command logs a warning and exits
-successfully, so it can safely be added to pipelines ahead of rollout.
+The command exits non-zero if the promise is not accepted (for example, if
+the job is no longer running, or a different exit status was already
+promised). Append '|| true' if you would prefer to ignore that in a script.
 
 Example:
 
@@ -50,8 +55,9 @@ type JobPromiseFailureConfig struct {
 
 var JobPromiseFailureCommand = cli.Command{
 	Name:        "promise-failure",
-	Usage:       "Declare a promised (early) failure for a job",
+	Usage:       "Promise a job will finish with a failing exit status",
 	Description: jobPromiseFailureHelpDescription,
+	Hidden:      true, // hidden until the early-failure feature is generally available
 	Flags: slices.Concat(globalFlags(), apiFlags(), []cli.Flag{
 		cli.StringFlag{
 			Name:   "job",
@@ -109,25 +115,18 @@ var JobPromiseFailureCommand = cli.Command{
 			return nil
 		})
 		if err != nil {
-			// These statuses are expected during a gradual rollout and aren't
-			// worth failing the build over, so warn and exit successfully.
+			// The promise wasn't accepted. Exit non-zero so the outcome is
+			// visible to scripts; callers who consider a given case acceptable
+			// can append '|| true'.
 			switch {
 			case api.IsErrHavingStatus(err, http.StatusNotFound):
-				// The early-failure feature is not enabled for this organization.
-				l.Warnf("Promised job failure is not enabled for this organization; skipping declaration")
-				return nil
+				return fmt.Errorf("promised failures are not enabled for this organization: %w", err)
 
 			case api.IsErrHavingStatus(err, http.StatusConflict):
-				// A different promised exit status was already declared; the
-				// first declaration already took effect.
-				l.Warnf("A different promised exit status has already been declared for this job; ignoring")
-				return nil
+				return fmt.Errorf("a different promised exit status has already been declared for this job: %w", err)
 
 			case api.IsErrHavingStatus(err, http.StatusUnprocessableEntity):
-				// Most likely the job is no longer running (cancelled or timed
-				// out) by the time this declaration arrived: a benign race.
-				l.Warnf("Could not declare promised failure (the job may no longer be running); ignoring")
-				return nil
+				return fmt.Errorf("the job is no longer running and cannot accept a promised failure: %w", err)
 			}
 
 			return fmt.Errorf("failed to declare promised job failure: %w", err)

--- a/clicommand/job_promise_failure.go
+++ b/clicommand/job_promise_failure.go
@@ -80,8 +80,10 @@ var JobPromiseFailureCommand = cli.Command{
 		if err != nil {
 			return fmt.Errorf("exit status must be an integer: %w", err)
 		}
-		if exitStatus == 0 {
-			return fmt.Errorf("exit status must be non-zero: a promised failure cannot have a successful (0) exit status")
+		// Only positive exit statuses are meaningful here: 0 is success, and
+		// negative values (such as -1) are reserved for internal use.
+		if exitStatus <= 0 {
+			return fmt.Errorf("exit status must be a positive integer: a promised failure cannot have a zero (successful) or negative exit status")
 		}
 
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))

--- a/clicommand/job_promise_failure.go
+++ b/clicommand/job_promise_failure.go
@@ -93,7 +93,7 @@ var JobPromiseFailureCommand = cli.Command{
 			return err
 		}
 		if redactedValue := redact.String(cfg.Reason, needles); redactedValue != cfg.Reason {
-			l.Warnf("The reason for job %q contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret", cfg.Job)
+			l.Warnf("The promise-failure reason for job %q contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret", cfg.Job)
 			cfg.Reason = redactedValue
 		}
 
@@ -121,9 +121,6 @@ var JobPromiseFailureCommand = cli.Command{
 			// visible to scripts; callers who consider a given case acceptable
 			// can append '|| true'.
 			switch {
-			case api.IsErrHavingStatus(err, http.StatusNotFound):
-				return fmt.Errorf("promised failures are not enabled for this organization: %w", err)
-
 			case api.IsErrHavingStatus(err, http.StatusConflict):
 				return fmt.Errorf("a different promised exit status has already been declared for this job: %w", err)
 

--- a/clicommand/job_promise_failure.go
+++ b/clicommand/job_promise_failure.go
@@ -1,0 +1,139 @@
+package clicommand
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/internal/redact"
+	"github.com/buildkite/roko"
+	"github.com/urfave/cli"
+)
+
+const jobPromiseFailureHelpDescription = `Usage:
+
+    buildkite-agent job promise-failure <exit-status> [options...]
+
+Description:
+
+Declare a promised (early) failure for the current job. This records a
+non-zero exit status that the job is expected to finish with, allowing the
+build to begin failing before the job actually completes. The job keeps
+running and finishes normally; only the build-failing cascade starts early.
+
+Repeated calls with the same exit status are idempotent. Declaring a
+different exit status once one is already recorded is rejected.
+
+This command requires the early-failure feature to be enabled for your
+organization. If it is not, the command logs a warning and exits
+successfully, so it can safely be added to pipelines ahead of rollout.
+
+Example:
+
+    $ buildkite-agent job promise-failure 1
+    $ buildkite-agent job promise-failure 42 --reason "detected failing tests"
+`
+
+type JobPromiseFailureConfig struct {
+	GlobalConfig
+	APIConfig
+
+	ExitStatus   string   `cli:"arg:0" label:"exit status" validate:"required"`
+	Reason       string   `cli:"reason"`
+	Job          string   `cli:"job" validate:"required"`
+	RedactedVars []string `cli:"redacted-vars" normalize:"list"`
+}
+
+var JobPromiseFailureCommand = cli.Command{
+	Name:        "promise-failure",
+	Usage:       "Declare a promised (early) failure for a job",
+	Description: jobPromiseFailureHelpDescription,
+	Flags: slices.Concat(globalFlags(), apiFlags(), []cli.Flag{
+		cli.StringFlag{
+			Name:   "job",
+			Value:  "",
+			Usage:  "The job to declare an early failure for. Defaults to the current job",
+			EnvVar: "BUILDKITE_JOB_ID",
+		},
+		cli.StringFlag{
+			Name:  "reason",
+			Value: "",
+			Usage: "An optional human-readable reason for the promised failure",
+		},
+		RedactedVars,
+	}),
+	Action: func(c *cli.Context) error {
+		ctx, cfg, l, _, done := setupLoggerAndConfig[JobPromiseFailureConfig](context.Background(), c)
+		defer done()
+
+		exitStatus, err := strconv.Atoi(cfg.ExitStatus)
+		if err != nil {
+			return fmt.Errorf("exit status must be an integer: %w", err)
+		}
+		if exitStatus == 0 {
+			return fmt.Errorf("exit status must be non-zero: a promised failure cannot have a successful (0) exit status")
+		}
+
+		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
+
+		needles, _, err := redact.NeedlesFromEnv(cfg.RedactedVars)
+		if err != nil {
+			return err
+		}
+		if redactedValue := redact.String(cfg.Reason, needles); redactedValue != cfg.Reason {
+			l.Warnf("The reason for job %q contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret", cfg.Job)
+			cfg.Reason = redactedValue
+		}
+
+		req := &api.JobPromiseFailureRequest{
+			ExitStatus: exitStatus,
+			Reason:     cfg.Reason,
+		}
+
+		err = roko.NewRetrier(
+			roko.WithMaxAttempts(10),
+			roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
+		).DoWithContext(ctx, func(r *roko.Retrier) error {
+			resp, err := client.PromiseFailure(ctx, cfg.Job, req)
+			if api.BreakOnNonRetryable(r, resp, err) {
+				return err
+			}
+			if err != nil {
+				l.Warnf("%s (%s)", err, r)
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			// These statuses are expected during a gradual rollout and aren't
+			// worth failing the build over, so warn and exit successfully.
+			switch {
+			case api.IsErrHavingStatus(err, http.StatusNotFound):
+				// The early-failure feature is not enabled for this organization.
+				l.Warnf("Promised job failure is not enabled for this organization; skipping declaration")
+				return nil
+
+			case api.IsErrHavingStatus(err, http.StatusConflict):
+				// A different promised exit status was already declared; the
+				// first declaration already took effect.
+				l.Warnf("A different promised exit status has already been declared for this job; ignoring")
+				return nil
+
+			case api.IsErrHavingStatus(err, http.StatusUnprocessableEntity):
+				// Most likely the job is no longer running (cancelled or timed
+				// out) by the time this declaration arrived: a benign race.
+				l.Warnf("Could not declare promised failure (the job may no longer be running); ignoring")
+				return nil
+			}
+
+			return fmt.Errorf("failed to declare promised job failure: %w", err)
+		}
+
+		l.Infof("Declared promised exit status %d for job %s", exitStatus, cfg.Job)
+		return nil
+	},
+}


### PR DESCRIPTION
## Description

Add a `buildkite-agent job promise-failure <exit-status>` command. It lets a running job promise up front that it will finish with a failing exit status, via the new `PUT jobs/:id/promise_failure` Agent API endpoint, so a build can begin failing before the job actually finishes.

The promise is binding: it sets a floor on the job's outcome. If the job is later reported as a success, the promised exit status is recorded instead, so the job still fails. Likewise, if a hard failure was promised but the job reports a soft-failure status, the promised status is kept. Any other reported failure is recorded as reported. (See `effective_exit_status_for` in the agent jobs finish path.)

This follows the existing `buildkite-agent job update` command shape: `roko` retries, secret redaction of `--reason`, and `--job` defaulting to `BUILDKITE_JOB_ID`. The exit status is sent as a JSON integer and validated server-side. Repeated calls with the same status are idempotent; declaring a *different* status once one is already recorded is rejected.

The command is **hidden** until the early-failure feature is generally available (the same approach as the `cache` commands), so we can enable it per-organization without advertising it broadly.

If the API doesn't accept the promise, the command **exits non-zero** with a clear message rather than collapsing to success — that keeps it composable in scripts, where a caller who considers a rejection acceptable can append `|| true`. Each known case gets a tailored error:

- **404** — promised failures aren't enabled for the organization
- **409** — a different promised status was already declared
- **422** — the job is no longer running (cancel/timeout race)
- **401/403** and exhausted retries on **429/5xx/network** also fail

## Context

Implements PB-1911.

## Changes

- `api`: add `api.Client.PromiseFailure` and `JobPromiseFailureRequest` (PUT `jobs/:id/promise_failure`), plus client tests.
- `clicommand`: add the `job promise-failure` command (hidden), register it under the `job` subcommand group, and add it to the config-completeness test.
- `.gitignore`: ignore the `buildkite-agent` build artifact produced by `go build -o buildkite-agent .`.

`buildkite-agent job promise-failure --help`:

```
Usage:

    buildkite-agent job promise-failure <exit-status> [options...]

Description:

Promise the current job will finish with a failing exit status. This records
a non-zero exit status that the job is expected to finish with, allowing the
build to begin failing before the job actually completes.

The promise is binding: it sets a floor on the job's outcome. If the job is
later reported as a success, the promised exit status is recorded instead, so
the job still fails. Likewise, if a hard failure was promised but the job
reports a soft-failure status, the promised status is kept. Any other
reported failure is recorded as reported.

Repeated calls with the same exit status are idempotent. Declaring a
different exit status once one is already recorded is rejected.

The command exits non-zero if the promise is not accepted (for example, if
the job is no longer running, or a different exit status was already
promised). Append '|| true' if you would prefer to ignore that in a script.

Example:

    $ buildkite-agent job promise-failure 1
    $ buildkite-agent job promise-failure 42 --reason "detected failing tests"
```

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

Added unit tests for the new API client method covering the success (204), feature-disabled (404), conflict (409), and job-not-running (422) responses.

## Disclosures / Credits

I used Amp to research the server-side endpoint, design the status handling, and write the implementation and tests, with GPT-5 for a code review pass. I reviewed all of the changes myself.

