### PR TITLE
Fix delayed disconnect-after-job in streaming ping mode

### DIFF
--- a/agent/agent_worker_debouncer.go
+++ b/agent/agent_worker_debouncer.go
@@ -59,6 +59,10 @@ func (a *AgentWorker) runDebouncer(ctx context.Context, bat *baton, outCh chan<-
 	// pending is true when the action is pending, false otherwise
 	var pending bool
 
+	// lastActionWasJob is true when the most recently sent action included a
+	// job to run. Used for disconnect-after-job, below.
+	var lastActionWasJob bool
+
 	// Is the stream healthy?
 	// If so, take the baton (which blocks the ping loop).
 	// If not, return the baton (unblocking the ping loop).
@@ -139,12 +143,26 @@ func (a *AgentWorker) runDebouncer(ctx context.Context, bat *baton, outCh chan<-
 
 			// continue below to send it
 
-		case <-lastActionResult: // most recent action has completed
+		case err := <-lastActionResult: // most recent action has completed
 			a.logger.Debugf("[runDebouncer] Last action has completed")
 			// Set the channel variable to nil so we don't spinloop.
 			// (Operations on a nil channel block forever.)
 			lastActionResult = nil
 			actionInProgress = false
+
+			// In disconnect-after-job mode, the action handler loop only
+			// disconnects when it handles the next action after running a job
+			// (this gives a pending "pause" the chance to keep the agent
+			// alive). The ping loop pings the backend immediately after a job,
+			// so it produces that next action promptly, but the stream might
+			// not deliver another message for a while. So if a job just ran
+			// and nothing else is pending, synthesise an idle action to let
+			// the action handler loop disconnect promptly.
+			if a.agentConfiguration.DisconnectAfterJob && lastActionWasJob && err == nil && !pending {
+				a.logger.Debugf("[runDebouncer] Job ran in disconnect-after-job mode; enqueueing a synthetic idle action")
+				pending = true
+				pendingAction = ""
+			}
 
 			// continue below to send a pending message
 		}
@@ -169,6 +187,7 @@ func (a *AgentWorker) runDebouncer(ctx context.Context, bat *baton, outCh chan<-
 		case outCh <- newMsg:
 			// sent!
 			pending = false
+			lastActionWasJob = newMsg.jobID != ""
 			if newMsg.jobID != "" {
 				pendingJobs = pendingJobs[1:]
 				pending = len(pendingJobs) > 0

--- a/agent/agent_worker_debouncer.go
+++ b/agent/agent_worker_debouncer.go
@@ -150,6 +150,12 @@ func (a *AgentWorker) runDebouncer(ctx context.Context, bat *baton, outCh chan<-
 			lastActionResult = nil
 			actionInProgress = false
 
+			// If the action errored, there's nothing special to do; fall
+			// through to (maybe) sending the next pending action.
+			if err != nil {
+				break // out of the select
+			}
+
 			// In disconnect-after-job mode, the action handler loop only
 			// disconnects when it handles the next action after running a job
 			// (this gives a pending "pause" the chance to keep the agent
@@ -158,7 +164,12 @@ func (a *AgentWorker) runDebouncer(ctx context.Context, bat *baton, outCh chan<-
 			// not deliver another message for a while. So if a job just ran
 			// and nothing else is pending, synthesise an idle action to let
 			// the action handler loop disconnect promptly.
-			if a.agentConfiguration.DisconnectAfterJob && lastActionWasJob && err == nil && !pending {
+			//
+			// This only covers disconnect-after-job. An acquire-job agent runs
+			// its single job before these loops even start (see
+			// AgentWorker.Start), so that job never passes through the
+			// debouncer and lastActionWasJob is never set for it.
+			if a.agentConfiguration.DisconnectAfterJob && lastActionWasJob && !pending {
 				a.logger.Debugf("[runDebouncer] Job ran in disconnect-after-job mode; enqueueing a synthetic idle action")
 				pending = true
 				pendingAction = ""

--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -1293,6 +1293,105 @@ func TestAgentWorker_Streaming_DisconnectAfterJob_Start_Pause_Unpause(t *testing
 	}
 }
 
+func TestAgentWorker_Streaming_DisconnectAfterJob_PromptDisconnect(t *testing.T) {
+	t.Parallel()
+
+	buildPath := filepath.Join(os.TempDir(), t.Name(), "build")
+	hooksPath := filepath.Join(os.TempDir(), t.Name(), "hooks")
+	if err := errors.Join(os.MkdirAll(buildPath, 0o777), os.MkdirAll(hooksPath, 0o777)); err != nil {
+		t.Fatalf("Couldn't create directories: %v", err)
+	}
+	t.Cleanup(func() {
+		os.RemoveAll(filepath.Join(os.TempDir(), t.Name())) //nolint:errcheck // Best-effort cleanup
+	})
+
+	server := NewFakeAPIServer(WithStreaming)
+	t.Cleanup(server.Close)
+
+	job := server.AddJob(map[string]string{
+		"BUILDKITE_COMMAND": "echo echo",
+	})
+
+	// Pre-register the agent.
+	const agentSessionToken = "alpacas"
+	agent := server.AddAgent(agentSessionToken)
+	// Unblock the fake server's stream handler at the end of the test.
+	// (Registered after server.Close so that it runs first.)
+	t.Cleanup(func() { close(agent.PingStream) })
+	agent.PingHandler = func(*http.Request) (api.Ping, error) {
+		return api.Ping{}, errors.New("too many pings")
+	}
+	go func() {
+		// Send the job, then nothing else: the agent shouldn't depend on
+		// receiving another stream message to disconnect after the job.
+		agent.PingStream <- &agentedgev1.StreamPingsResponse{
+			Action: &agentedgev1.StreamPingsResponse_JobAssigned{
+				JobAssigned: &agentedgev1.JobAssignedAction{
+					Job: &agentedgev1.Job{
+						Id: job.Job.ID,
+					},
+				},
+			},
+		}
+	}()
+
+	server.Assign(agent, job)
+
+	l := logger.NewConsoleLogger(logger.NewTestPrinter(t), func(int) {})
+
+	worker := NewAgentWorker(
+		l,
+		&api.AgentRegisterResponse{
+			UUID:              uuid.New().String(),
+			Name:              "agent-1",
+			AccessToken:       "alpacas",
+			Endpoint:          server.URL,
+			PingInterval:      1,
+			JobStatusInterval: 1,
+			HeartbeatInterval: 10,
+		},
+		metrics.NewCollector(logger.Discard, metrics.CollectorConfig{}),
+		api.NewClient(logger.Discard, api.Config{
+			Endpoint: server.URL,
+			Token:    "llamas",
+		}),
+		AgentWorkerConfig{
+			SpawnIndex: 1,
+			AgentConfiguration: AgentConfiguration{
+				BootstrapScript:    dummyBootstrap,
+				BuildPath:          buildPath,
+				HooksPath:          hooksPath,
+				DisconnectAfterJob: true,
+			},
+		},
+	)
+	worker.noWaitBetweenPingsForTesting = true
+
+	done := make(chan error, 1)
+	go func() {
+		done <- worker.Start(t.Context(), nil)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("worker.Start() = %v", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("worker.Start() did not return: disconnect-after-job stalled waiting for the next stream message")
+	}
+
+	if got, want := agent.Pings, 0; got != want {
+		t.Errorf("agent.Pings = %d, want %d", got, want)
+	}
+	if got, want := agent.IgnoreInDispatches, true; got != want {
+		t.Errorf("agent.IgnoreInDispatches = %t, want %t", got, want)
+	}
+	if got, want := job.State, JobStateFinished; got != want {
+		t.Errorf("job.State = %q, want %q", got, want)
+	}
+}
+
 func TestAgentWorker_Streaming_UnrecoverableError_Fallback(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

In `--disconnect-after-job` mode with the streaming ping protocol (the default since ping mode `auto` prefers streaming), the agent can idle for up to a minute after its job finishes before actually disconnecting.

The action handler loop deliberately evaluates the disconnect-after-job condition only when handling the *next* action after a job, so that a pending "pause" can keep the agent alive (93768548). The classical ping loop accounts for this by skipping the ping interval and pinging immediately after a job (605ff871), producing that next action promptly. Streaming mode has no equivalent: nothing arrives until the server pushes another message, and the client has no read deadline on the ping stream, so the agent just sits there — in our production setup, consistently ~57–60 seconds per job, which dominates the runtime of short jobs on ephemeral one-job-per-container agents.

Observed timeline (agent v3.127.2):

```
13:43:55  Ping stream connection established
13:43:58  Finished job ... (exit 0)
13:44:55  Job ran, and disconnect-after-job is enabled. Disconnecting...
```

This PR fixes it in the debouncer, which is the component that knows whether another action (such as a pause received during the job) is already pending: when a job action completes successfully in disconnect-after-job mode and nothing else is pending, it synthesises an idle action so the action handler loop can disconnect immediately. This mirrors poll mode's "ping once right after the job" behaviour, so the two modes now have aligned semantics — including the (pre-existing, identical in poll mode) race where a pause pushed after the job finishes may arrive too late.

Alternatives considered:

- Returning from the action loop directly after `AcceptAndRunJob` — simpler, but loses the deliberate pause-keeps-agent-alive semantics from 93768548.
- A client-side read deadline / local timer on the stream — heavier-handed, and changes behaviour for all agents rather than just disconnect-after-job.
- (As a user-side workaround, `--ping-mode=poll-only` avoids the issue on current releases.)

## Context

Found while operating the JuliaGPU Buildkite cluster, which runs untrusted open-source PR workloads on self-hosted hardware. To isolate jobs from one another, each agent runs inside a Docker container and `--disconnect-after-job` is what drives the recycle: the agent exits after its single job, the container exits with it, and systemd brings up a fresh container for the next job. With the streaming linger, that per-job recycle gained a ~60s tax, reducing a single-queue agent to roughly one 3-second job per minute. No GitHub issue filed; happy to open one if preferred.

## Changes

- `agent/agent_worker_debouncer.go`: track whether the most recently dispatched action carried a job; when it completes without error in disconnect-after-job mode and no other action is pending, synthesise an idle action. Pause/resume debouncing and ignore-in-dispatches behaviour are unchanged.
- `agent/agent_worker_test.go`: add `TestAgentWorker_Streaming_DisconnectAfterJob_PromptDisconnect`, which streams a job assignment and then goes quiet. Without the fix the worker never disconnects (in production it waits for the server's next keepalive); with it, it disconnects immediately. The existing streaming disconnect-after-job test didn't catch this because its fake server pushes follow-up messages right after the job.

No CLI changes.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Affiliation (optional, external contributors)

JuliaGPU / JuliaHub — this affects the CI infrastructure for the Julia GPU ecosystem.

## Disclosures / Credits

Claude Code (Claude Fable 5) diagnosed the issue from production logs, and wrote the fix and the regression test; I reviewed the change. The fix is verified by the regression test (which hangs without it), not yet by a production deployment.