### PR TITLE
Debounce `buildkite-agent job promise-failure` via the Job API

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -3,8 +3,10 @@ package api
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/buildkite/go-pipeline"
+	"github.com/buildkite/roko"
 )
 
 // Job represents a Buildkite Agent API Job
@@ -158,6 +160,33 @@ func (c *Client) PromiseFailure(ctx context.Context, id string, req *JobPromiseF
 	}
 
 	return c.doRequest(r, nil)
+}
+
+// PromiseFailureWithRetry declares a promised failure for the job, retrying
+// transient errors with the agent's standard backoff. It returns the HTTP
+// status of the most recent response (0 if none was received, e.g. a network
+// error) and an error describing any failure. Retry attempts are logged via
+// warnf.
+func (c *Client) PromiseFailureWithRetry(ctx context.Context, id string, req *JobPromiseFailureRequest, warnf func(string, ...any)) (int, error) {
+	var statusCode int
+	err := roko.NewRetrier(
+		roko.WithMaxAttempts(10),
+		roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
+	).DoWithContext(ctx, func(r *roko.Retrier) error {
+		resp, err := c.PromiseFailure(ctx, id, req)
+		if resp != nil {
+			statusCode = resp.StatusCode
+		}
+		if BreakOnNonRetryable(r, resp, err) {
+			return err
+		}
+		if err != nil {
+			warnf("Couldn't declare promised failure for job %s: %s (%s)", id, err, r)
+			return err
+		}
+		return nil
+	})
+	return statusCode, err
 }
 
 // JobUpdateResponse is the response from updating a job

--- a/clicommand/job_promise_failure.go
+++ b/clicommand/job_promise_failure.go
@@ -2,6 +2,7 @@ package clicommand
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/internal/redact"
+	"github.com/buildkite/agent/v3/internal/socket"
 	"github.com/buildkite/agent/v3/jobapi"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/roko"
@@ -84,98 +86,106 @@ var JobPromiseFailureCommand = cli.Command{
 			return fmt.Errorf("exit status must be a positive integer: a promised failure cannot have a zero (successful) or negative exit status")
 		}
 
-		// A promised failure only makes sense for the current job: the API
-		// authenticates with the job's own token and rejects declarations for
-		// any other job, so we always use BUILDKITE_JOB_ID.
+		// Always target the current job (BUILDKITE_JOB_ID): the API requires a
+		// job token and rejects (403) any other job, and a promised failure only
+		// makes sense for the job that's running.
 		jobID := os.Getenv("BUILDKITE_JOB_ID")
 		if jobID == "" {
 			return fmt.Errorf("BUILDKITE_JOB_ID is not set: this command must be run from within a job")
 		}
 
-		// Debounce repeated calls via the Job API: customers may call this on
-		// every test failure, but each exit status only needs declaring to the
-		// Buildkite API once. The first caller to claim an exit status declares
-		// it; later callers skip without touching the API.
-		if promiseFailureAlreadyClaimed(ctx, l, exitStatus) {
-			return nil
-		}
-
-		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
-
 		needles, _, err := redact.NeedlesFromEnv(cfg.RedactedVars)
 		if err != nil {
 			return err
 		}
-		if redactedValue := redact.String(cfg.Reason, needles); redactedValue != cfg.Reason {
+		reason := cfg.Reason
+		if redactedValue := redact.String(reason, needles); redactedValue != reason {
 			l.Warnf("The promise-failure reason for job %q contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret", jobID)
-			cfg.Reason = redactedValue
+			reason = redactedValue
 		}
 
-		req := &api.JobPromiseFailureRequest{
-			ExitStatus: exitStatus,
-			Reason:     cfg.Reason,
-		}
-
-		err = roko.NewRetrier(
-			roko.WithMaxAttempts(10),
-			roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
-		).DoWithContext(ctx, func(r *roko.Retrier) error {
-			resp, err := client.PromiseFailure(ctx, jobID, req)
-			if api.BreakOnNonRetryable(r, resp, err) {
-				return err
-			}
-			if err != nil {
-				l.Warnf("%s (%s)", err, r)
-				return err
-			}
-			return nil
-		})
+		// Prefer the Job API: it debounces repeated and concurrent calls (this
+		// may be called on every test failure) so the failure is declared at most
+		// once successfully, blocking for an accurate result. Declare directly
+		// only when the Job API can't be used (--no-job-api, or old Windows
+		// without Unix sockets) or can't be reached.
+		client, err := jobapi.NewDefaultClient(ctx)
 		if err != nil {
-			// The promise wasn't accepted. Exit non-zero so the outcome is
-			// visible to scripts; callers who consider a given case acceptable
-			// can append '|| true'.
-			switch {
-			case api.IsErrHavingStatus(err, http.StatusConflict):
-				return fmt.Errorf("a different promised exit status has already been declared for this job: %w", err)
-
-			case api.IsErrHavingStatus(err, http.StatusUnprocessableEntity):
-				return fmt.Errorf("the job is no longer running and cannot accept a promised failure: %w", err)
-			}
-
-			return fmt.Errorf("failed to declare promised job failure: %w", err)
+			l.Debugf("Job API unavailable, declaring promised failure directly: %v", err)
+			return declarePromiseFailureDirectly(ctx, l, cfg, jobID, exitStatus, reason)
 		}
 
-		l.Infof("Declared promised exit status %d for job %s", exitStatus, jobID)
-		return nil
+		err = client.DeclarePromiseFailure(ctx, exitStatus, reason)
+		if err == nil {
+			l.Infof("Declared promised exit status %d for job %s", exitStatus, jobID)
+			return nil
+		}
+
+		// The Job API returned a definitive HTTP error: the Buildkite API
+		// rejected the declaration (409, 422) or was unreachable after retries
+		// (502). Surface it rather than declaring again.
+		var apiErr socket.APIErr
+		if errors.As(err, &apiErr) {
+			return promiseFailureError(apiErr.StatusCode, err)
+		}
+
+		// We couldn't reach the Job API (or its response was lost). Declare
+		// directly so the promise still lands; the endpoint is idempotent for the
+		// same exit status, so a duplicate is safe.
+		l.Warnf("Couldn't reach the Job API to declare the promised failure; declaring it directly: %v", err)
+		return declarePromiseFailureDirectly(ctx, l, cfg, jobID, exitStatus, reason)
 	},
 }
 
-// promiseFailureAlreadyClaimed consults the Job API to debounce repeated
-// promise-failure calls: customers may call this on every test failure, but
-// each exit status only needs declaring to the Buildkite API once.
-//
-// It returns true if this exit status has already been claimed by an earlier
-// call and the caller should skip declaring it. It returns false when the
-// caller should go ahead and declare: either because this is the first call to
-// claim the exit status, or because the Job API isn't usable (--no-job-api, or
-// old Windows versions without Unix-socket support) and we declare directly
-// without debouncing.
-func promiseFailureAlreadyClaimed(ctx context.Context, l logger.Logger, exitStatus int) bool {
-	client, err := jobapi.NewDefaultClient(ctx)
-	if err != nil {
-		l.Debugf("Job API unavailable, declaring promised failure without debouncing: %v", err)
-		return false
+// promiseFailureError wraps err with a human-readable message for the Buildkite
+// API status code. The command exits non-zero so the failure is visible to
+// scripts, which can append '|| true' to ignore it.
+func promiseFailureError(status int, err error) error {
+	switch status {
+	case http.StatusConflict:
+		return fmt.Errorf("a different promised exit status has already been declared for this job: %w", err)
+
+	case http.StatusUnprocessableEntity:
+		return fmt.Errorf("the job is no longer running and cannot accept a promised failure: %w", err)
 	}
 
-	claimed, err := client.PromiseFailureClaim(ctx, exitStatus)
-	if err != nil {
-		l.Warnf("Couldn't reach the Job API to debounce the promised failure; declaring it directly: %v", err)
-		return false
-	}
-	if !claimed {
-		l.Debugf("Promised exit status %d has already been claimed; skipping duplicate", exitStatus)
-		return true
+	return fmt.Errorf("failed to declare promised job failure: %w", err)
+}
+
+// declarePromiseFailureDirectly declares a promised failure straight to the
+// Buildkite API, without debouncing via the Job API. It's used as a fallback
+// when the Job API can't be used or reached.
+func declarePromiseFailureDirectly(ctx context.Context, l logger.Logger, cfg JobPromiseFailureConfig, jobID string, exitStatus int, reason string) error {
+	client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
+
+	req := &api.JobPromiseFailureRequest{
+		ExitStatus: exitStatus,
+		Reason:     reason,
 	}
 
-	return false
+	err := roko.NewRetrier(
+		roko.WithMaxAttempts(10),
+		roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
+	).DoWithContext(ctx, func(r *roko.Retrier) error {
+		resp, err := client.PromiseFailure(ctx, jobID, req)
+		if api.BreakOnNonRetryable(r, resp, err) {
+			return err
+		}
+		if err != nil {
+			l.Warnf("%s (%s)", err, r)
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		status := 0
+		var apiErr *api.ErrorResponse
+		if errors.As(err, &apiErr) {
+			status = apiErr.Response.StatusCode
+		}
+		return promiseFailureError(status, err)
+	}
+
+	l.Infof("Declared promised exit status %d for job %s", exitStatus, jobID)
+	return nil
 }

--- a/clicommand/job_promise_failure.go
+++ b/clicommand/job_promise_failure.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/internal/redact"
-	"github.com/buildkite/agent/v3/internal/socket"
 	"github.com/buildkite/agent/v3/jobapi"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/urfave/cli"
@@ -113,31 +112,35 @@ var JobPromiseFailureCommand = cli.Command{
 			return declarePromiseFailureDirectly(ctx, l, cfg, jobID, exitStatus, reason)
 		}
 
-		outcome, err := client.DeclarePromiseFailure(ctx, exitStatus, reason)
-		if err == nil {
-			if outcome == jobapi.PromiseFailureDebounced {
-				// Log at debug to avoid spamming job logs on repeated calls.
-				l.Debugf("Promised exit status %d already declared for job %s (debounced)", exitStatus, jobID)
-			} else {
-				l.Infof("Declared promised exit status %d for job %s", exitStatus, jobID)
-			}
-			return nil
+		result, err := client.DeclarePromiseFailure(ctx, exitStatus, reason)
+		if err != nil {
+			// We couldn't reach or use the Job API (or its response was lost).
+			// Declare directly so the promise still lands; the endpoint is idempotent
+			// for the same exit status, so a duplicate is safe.
+			l.Warnf("Couldn't reach the Job API to declare the promised failure; declaring it directly: %v", err)
+			return declarePromiseFailureDirectly(ctx, l, cfg, jobID, exitStatus, reason)
 		}
 
-		// The Job API returned a definitive HTTP error: the Buildkite API
-		// rejected the declaration (409, 422) or was unreachable after retries
-		// (502). Surface it rather than declaring again.
-		var apiErr socket.APIErr
-		if errors.As(err, &apiErr) {
-			return promiseFailureError(apiErr.StatusCode, err)
+		if !result.Accepted {
+			return promiseFailureResultError(result)
 		}
 
-		// We couldn't reach the Job API (or its response was lost). Declare
-		// directly so the promise still lands; the endpoint is idempotent for the
-		// same exit status, so a duplicate is safe.
-		l.Warnf("Couldn't reach the Job API to declare the promised failure; declaring it directly: %v", err)
-		return declarePromiseFailureDirectly(ctx, l, cfg, jobID, exitStatus, reason)
+		if result.Outcome == jobapi.PromiseFailureDebounced {
+			// Log at debug to avoid spamming job logs on repeated calls.
+			l.Debugf("Promised exit status %d already declared for job %s (debounced)", exitStatus, jobID)
+		} else {
+			l.Infof("Declared promised exit status %d for job %s", exitStatus, jobID)
+		}
+		return nil
 	},
+}
+
+func promiseFailureResultError(result *jobapi.PromiseFailureResponse) error {
+	err := errors.New(result.Error)
+	if result.Error == "" {
+		err = errors.New("buildkite API rejected the promised failure")
+	}
+	return promiseFailureError(result.UpstreamStatus, err)
 }
 
 // promiseFailureError wraps err with a human-readable message for the Buildkite

--- a/clicommand/job_promise_failure.go
+++ b/clicommand/job_promise_failure.go
@@ -115,9 +115,13 @@ var JobPromiseFailureCommand = cli.Command{
 			return declarePromiseFailureDirectly(ctx, l, cfg, jobID, exitStatus, reason)
 		}
 
-		err = client.DeclarePromiseFailure(ctx, exitStatus, reason)
+		outcome, err := client.DeclarePromiseFailure(ctx, exitStatus, reason)
 		if err == nil {
-			l.Infof("Declared promised exit status %d for job %s", exitStatus, jobID)
+			if outcome == jobapi.PromiseFailureDebounced {
+				l.Infof("Promised exit status %d already declared for job %s (debounced)", exitStatus, jobID)
+			} else {
+				l.Infof("Declared promised exit status %d for job %s", exitStatus, jobID)
+			}
 			return nil
 		}
 

--- a/clicommand/job_promise_failure.go
+++ b/clicommand/job_promise_failure.go
@@ -116,7 +116,8 @@ var JobPromiseFailureCommand = cli.Command{
 		outcome, err := client.DeclarePromiseFailure(ctx, exitStatus, reason)
 		if err == nil {
 			if outcome == jobapi.PromiseFailureDebounced {
-				l.Infof("Promised exit status %d already declared for job %s (debounced)", exitStatus, jobID)
+				// Log at debug to avoid spamming job logs on repeated calls.
+				l.Debugf("Promised exit status %d already declared for job %s (debounced)", exitStatus, jobID)
 			} else {
 				l.Infof("Declared promised exit status %d for job %s", exitStatus, jobID)
 			}

--- a/clicommand/job_promise_failure.go
+++ b/clicommand/job_promise_failure.go
@@ -8,14 +8,12 @@ import (
 	"os"
 	"slices"
 	"strconv"
-	"time"
 
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/internal/redact"
 	"github.com/buildkite/agent/v3/internal/socket"
 	"github.com/buildkite/agent/v3/jobapi"
 	"github.com/buildkite/agent/v3/logger"
-	"github.com/buildkite/roko"
 	"github.com/urfave/cli"
 )
 
@@ -167,26 +165,8 @@ func declarePromiseFailureDirectly(ctx context.Context, l logger.Logger, cfg Job
 		Reason:     reason,
 	}
 
-	err := roko.NewRetrier(
-		roko.WithMaxAttempts(10),
-		roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
-	).DoWithContext(ctx, func(r *roko.Retrier) error {
-		resp, err := client.PromiseFailure(ctx, jobID, req)
-		if api.BreakOnNonRetryable(r, resp, err) {
-			return err
-		}
-		if err != nil {
-			l.Warnf("%s (%s)", err, r)
-			return err
-		}
-		return nil
-	})
+	status, err := client.PromiseFailureWithRetry(ctx, jobID, req, l.Warnf)
 	if err != nil {
-		status := 0
-		var apiErr *api.ErrorResponse
-		if errors.As(err, &apiErr) {
-			status = apiErr.Response.StatusCode
-		}
 		return promiseFailureError(status, err)
 	}
 

--- a/clicommand/job_promise_failure.go
+++ b/clicommand/job_promise_failure.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"slices"
 	"strconv"
 	"time"
 
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/internal/redact"
+	"github.com/buildkite/agent/v3/jobapi"
+	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/roko"
 	"github.com/urfave/cli"
 )
@@ -31,7 +34,9 @@ reports a soft-failure status, the promised status is kept. Any other
 reported failure is recorded as reported.
 
 Repeated calls with the same exit status are idempotent. Declaring a
-different exit status once one is already recorded is rejected.
+different exit status once one is already recorded is rejected. The agent
+debounces repeated calls locally, so each exit status is only declared to
+the Buildkite API once per job, even if you call this on every test failure.
 
 The command exits non-zero if the promise is not accepted (for example, if
 the job is no longer running, or a different exit status was already
@@ -49,7 +54,6 @@ type JobPromiseFailureConfig struct {
 
 	ExitStatus   string   `cli:"arg:0" label:"exit status" validate:"required"`
 	Reason       string   `cli:"reason"`
-	Job          string   `cli:"job" validate:"required"`
 	RedactedVars []string `cli:"redacted-vars" normalize:"list"`
 }
 
@@ -59,12 +63,6 @@ var JobPromiseFailureCommand = cli.Command{
 	Description: jobPromiseFailureHelpDescription,
 	Hidden:      true, // hidden until the early-failure feature is generally available
 	Flags: slices.Concat(globalFlags(), apiFlags(), []cli.Flag{
-		cli.StringFlag{
-			Name:   "job",
-			Value:  "",
-			Usage:  "The job to declare an early failure for. Defaults to the current job",
-			EnvVar: "BUILDKITE_JOB_ID",
-		},
 		cli.StringFlag{
 			Name:  "reason",
 			Value: "",
@@ -86,6 +84,22 @@ var JobPromiseFailureCommand = cli.Command{
 			return fmt.Errorf("exit status must be a positive integer: a promised failure cannot have a zero (successful) or negative exit status")
 		}
 
+		// A promised failure only makes sense for the current job: the API
+		// authenticates with the job's own token and rejects declarations for
+		// any other job, so we always use BUILDKITE_JOB_ID.
+		jobID := os.Getenv("BUILDKITE_JOB_ID")
+		if jobID == "" {
+			return fmt.Errorf("BUILDKITE_JOB_ID is not set: this command must be run from within a job")
+		}
+
+		// Debounce repeated calls via the Job API: customers may call this on
+		// every test failure, but each exit status only needs declaring to the
+		// Buildkite API once. The first caller to claim an exit status declares
+		// it; later callers skip without touching the API.
+		if promiseFailureAlreadyClaimed(ctx, l, exitStatus) {
+			return nil
+		}
+
 		client := api.NewClient(l, loadAPIClientConfig(cfg, "AgentAccessToken"))
 
 		needles, _, err := redact.NeedlesFromEnv(cfg.RedactedVars)
@@ -93,7 +107,7 @@ var JobPromiseFailureCommand = cli.Command{
 			return err
 		}
 		if redactedValue := redact.String(cfg.Reason, needles); redactedValue != cfg.Reason {
-			l.Warnf("The promise-failure reason for job %q contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret", cfg.Job)
+			l.Warnf("The promise-failure reason for job %q contained one or more secrets from environment variables that have been redacted. If this is deliberate, pass --redacted-vars='' or a list of patterns that does not match the variable containing the secret", jobID)
 			cfg.Reason = redactedValue
 		}
 
@@ -106,7 +120,7 @@ var JobPromiseFailureCommand = cli.Command{
 			roko.WithMaxAttempts(10),
 			roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
 		).DoWithContext(ctx, func(r *roko.Retrier) error {
-			resp, err := client.PromiseFailure(ctx, cfg.Job, req)
+			resp, err := client.PromiseFailure(ctx, jobID, req)
 			if api.BreakOnNonRetryable(r, resp, err) {
 				return err
 			}
@@ -131,7 +145,37 @@ var JobPromiseFailureCommand = cli.Command{
 			return fmt.Errorf("failed to declare promised job failure: %w", err)
 		}
 
-		l.Infof("Declared promised exit status %d for job %s", exitStatus, cfg.Job)
+		l.Infof("Declared promised exit status %d for job %s", exitStatus, jobID)
 		return nil
 	},
+}
+
+// promiseFailureAlreadyClaimed consults the Job API to debounce repeated
+// promise-failure calls: customers may call this on every test failure, but
+// each exit status only needs declaring to the Buildkite API once.
+//
+// It returns true if this exit status has already been claimed by an earlier
+// call and the caller should skip declaring it. It returns false when the
+// caller should go ahead and declare: either because this is the first call to
+// claim the exit status, or because the Job API isn't usable (--no-job-api, or
+// old Windows versions without Unix-socket support) and we declare directly
+// without debouncing.
+func promiseFailureAlreadyClaimed(ctx context.Context, l logger.Logger, exitStatus int) bool {
+	client, err := jobapi.NewDefaultClient(ctx)
+	if err != nil {
+		l.Debugf("Job API unavailable, declaring promised failure without debouncing: %v", err)
+		return false
+	}
+
+	claimed, err := client.PromiseFailureClaim(ctx, exitStatus)
+	if err != nil {
+		l.Warnf("Couldn't reach the Job API to debounce the promised failure; declaring it directly: %v", err)
+		return false
+	}
+	if !claimed {
+		l.Debugf("Promised exit status %d has already been claimed; skipping duplicate", exitStatus)
+		return true
+	}
+
+	return false
 }

--- a/internal/job/api.go
+++ b/internal/job/api.go
@@ -3,14 +3,12 @@ package job
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/internal/redact"
 	"github.com/buildkite/agent/v3/internal/socket"
 	"github.com/buildkite/agent/v3/jobapi"
 	"github.com/buildkite/agent/v3/logger"
-	"github.com/buildkite/roko"
 )
 
 // startJobAPI starts the job API server, iff the OS of the box supports it otherwise it returns a
@@ -83,6 +81,8 @@ We'll continue to run your job, but you won't be able to use the Job API`)
 // recent API response (0 if none was received, e.g. a network error) and an
 // error describing any failure.
 func (e *Executor) declarePromiseFailure(ctx context.Context, exitStatus int, reason string) (int, error) {
+	// logger.Discard keeps the access token (in HTTP debug dumps) out of the job
+	// log; retry warnings still go to the shell logger.
 	apiClient := api.NewClient(logger.Discard, api.Config{
 		Endpoint: e.shell.Env.GetString("BUILDKITE_AGENT_ENDPOINT", ""),
 		Token:    e.shell.Env.GetString("BUILDKITE_AGENT_ACCESS_TOKEN", ""),
@@ -93,24 +93,5 @@ func (e *Executor) declarePromiseFailure(ctx context.Context, exitStatus int, re
 		Reason:     reason,
 	}
 
-	var statusCode int
-	err := roko.NewRetrier(
-		roko.WithMaxAttempts(10),
-		roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
-	).DoWithContext(ctx, func(r *roko.Retrier) error {
-		resp, err := apiClient.PromiseFailure(ctx, e.JobID, req)
-		if resp != nil {
-			statusCode = resp.StatusCode
-		}
-		if api.BreakOnNonRetryable(r, resp, err) {
-			return err
-		}
-		if err != nil {
-			e.shell.Warningf("Couldn't declare promised failure for job %s: %s (%s)", e.JobID, err, r)
-			return err
-		}
-		return nil
-	})
-
-	return statusCode, err
+	return apiClient.PromiseFailureWithRetry(ctx, e.JobID, req, e.shell.Warningf)
 }

--- a/internal/job/api.go
+++ b/internal/job/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildkite/agent/v3/internal/socket"
 	"github.com/buildkite/agent/v3/jobapi"
 	"github.com/buildkite/agent/v3/logger"
+	"github.com/buildkite/agent/v3/version"
 )
 
 // startJobAPI starts the job API server, iff the OS of the box supports it otherwise it returns a
@@ -84,8 +85,10 @@ func (e *Executor) declarePromiseFailure(ctx context.Context, exitStatus int, re
 	// logger.Discard keeps the access token (in HTTP debug dumps) out of the job
 	// log; retry warnings still go to the shell logger.
 	apiClient := api.NewClient(logger.Discard, api.Config{
-		Endpoint: e.shell.Env.GetString("BUILDKITE_AGENT_ENDPOINT", ""),
-		Token:    e.shell.Env.GetString("BUILDKITE_AGENT_ACCESS_TOKEN", ""),
+		Endpoint:     e.shell.Env.GetString("BUILDKITE_AGENT_ENDPOINT", ""),
+		Token:        e.shell.Env.GetString("BUILDKITE_AGENT_ACCESS_TOKEN", ""),
+		DisableHTTP2: e.shell.Env.GetBool("BUILDKITE_NO_HTTP2", false),
+		UserAgent:    version.UserAgent(),
 	})
 
 	req := &api.JobPromiseFailureRequest{

--- a/internal/job/api.go
+++ b/internal/job/api.go
@@ -1,11 +1,16 @@
 package job
 
 import (
+	"context"
 	"fmt"
+	"time"
 
+	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/internal/redact"
 	"github.com/buildkite/agent/v3/internal/socket"
 	"github.com/buildkite/agent/v3/jobapi"
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/buildkite/roko"
 )
 
 // startJobAPI starts the job API server, iff the OS of the box supports it otherwise it returns a
@@ -26,7 +31,9 @@ We'll continue to run your job, but you won't be able to use the Job API`)
 		return cleanup, fmt.Errorf("creating job API socket path: %w", err)
 	}
 
-	jobAPIOpts := []jobapi.ServerOpts{}
+	jobAPIOpts := []jobapi.ServerOpts{
+		jobapi.WithPromiseFailureDeclarer(e.declarePromiseFailure),
+	}
 	if e.Debug {
 		jobAPIOpts = append(jobAPIOpts, jobapi.WithDebug())
 	}
@@ -68,4 +75,42 @@ We'll continue to run your job, but you won't be able to use the Job API`)
 			e.shell.Errorf("Error stopping Job API server: %v", err)
 		}
 	}, nil
+}
+
+// declarePromiseFailure declares a promised failure for the current job to the
+// Buildkite API. The Job API server debounces calls, so this runs at most once
+// per successfully-declared exit status. It returns the status code of the most
+// recent API response (0 if none was received, e.g. a network error) and an
+// error describing any failure.
+func (e *Executor) declarePromiseFailure(ctx context.Context, exitStatus int, reason string) (int, error) {
+	apiClient := api.NewClient(logger.Discard, api.Config{
+		Endpoint: e.shell.Env.GetString("BUILDKITE_AGENT_ENDPOINT", ""),
+		Token:    e.shell.Env.GetString("BUILDKITE_AGENT_ACCESS_TOKEN", ""),
+	})
+
+	req := &api.JobPromiseFailureRequest{
+		ExitStatus: exitStatus,
+		Reason:     reason,
+	}
+
+	var statusCode int
+	err := roko.NewRetrier(
+		roko.WithMaxAttempts(10),
+		roko.WithStrategy(roko.ExponentialSubsecond(2*time.Second)),
+	).DoWithContext(ctx, func(r *roko.Retrier) error {
+		resp, err := apiClient.PromiseFailure(ctx, e.JobID, req)
+		if resp != nil {
+			statusCode = resp.StatusCode
+		}
+		if api.BreakOnNonRetryable(r, resp, err) {
+			return err
+		}
+		if err != nil {
+			e.shell.Logger.Warningf("Couldn't declare promised failure for job %s: %s (%s)", e.JobID, err, r)
+			return err
+		}
+		return nil
+	})
+
+	return statusCode, err
 }

--- a/internal/job/api.go
+++ b/internal/job/api.go
@@ -106,7 +106,7 @@ func (e *Executor) declarePromiseFailure(ctx context.Context, exitStatus int, re
 			return err
 		}
 		if err != nil {
-			e.shell.Logger.Warningf("Couldn't declare promised failure for job %s: %s (%s)", e.JobID, err, r)
+			e.shell.Warningf("Couldn't declare promised failure for job %s: %s (%s)", e.JobID, err, r)
 			return err
 		}
 		return nil

--- a/jobapi/client.go
+++ b/jobapi/client.go
@@ -127,13 +127,18 @@ func (c *Client) RedactionCreate(ctx context.Context, text string) (string, erro
 // given exit status and reason to the Buildkite API, blocking until it
 // completes. The server debounces repeated and concurrent calls for the same
 // exit status: concurrent callers share one in-flight call, and once it succeeds
-// later calls return from the cache. A nil error means the promise was accepted.
-// A failed declaration is returned as a socket.APIErr carrying the HTTP status
-// code (the Buildkite API's status when it responded, otherwise 502).
-func (c *Client) DeclarePromiseFailure(ctx context.Context, exitStatus int, reason string) error {
+// later calls return from the cache. On success it returns the outcome
+// (PromiseFailureDeclared or PromiseFailureDebounced). A failed declaration is
+// returned as a socket.APIErr carrying the HTTP status code (the Buildkite API's
+// status when it responded, otherwise 502).
+func (c *Client) DeclarePromiseFailure(ctx context.Context, exitStatus int, reason string) (string, error) {
 	req := PromiseFailureRequest{
 		ExitStatus: exitStatus,
 		Reason:     reason,
 	}
-	return c.client.Do(ctx, http.MethodPost, promiseFailureURL, &req, nil)
+	var resp PromiseFailureResponse
+	if err := c.client.Do(ctx, http.MethodPost, promiseFailureURL, &req, &resp); err != nil {
+		return "", err
+	}
+	return resp.Outcome, nil
 }

--- a/jobapi/client.go
+++ b/jobapi/client.go
@@ -127,18 +127,18 @@ func (c *Client) RedactionCreate(ctx context.Context, text string) (string, erro
 // given exit status and reason to the Buildkite API, blocking until it
 // completes. The server debounces repeated and concurrent calls for the same
 // exit status: concurrent callers share one in-flight call, and once it succeeds
-// later calls return from the cache. On success it returns the outcome
-// (PromiseFailureDeclared or PromiseFailureDebounced). A failed declaration is
-// returned as a socket.APIErr carrying the HTTP status code (the Buildkite API's
-// status when it responded, otherwise 502).
-func (c *Client) DeclarePromiseFailure(ctx context.Context, exitStatus int, reason string) (string, error) {
+// later calls return from the cache. If the Job API handles the request, the
+// returned response describes whether the Buildkite API accepted or rejected the
+// declaration. Errors are reserved for Job API transport/request failures.
+func (c *Client) DeclarePromiseFailure(ctx context.Context, exitStatus int, reason string) (*PromiseFailureResponse, error) {
 	req := PromiseFailureRequest{
 		ExitStatus: exitStatus,
 		Reason:     reason,
 	}
 	var resp PromiseFailureResponse
 	if err := c.client.Do(ctx, http.MethodPost, promiseFailureURL, &req, &resp); err != nil {
-		return "", err
+		return nil, err
 	}
-	return resp.Outcome, nil
+
+	return &resp, nil
 }

--- a/jobapi/client.go
+++ b/jobapi/client.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	envURL        = "http://job/api/current-job/v0/env"
-	workdirURL    = "http://job/api/current-job/v0/workdir"
-	redactionsURL = "http://job/api/current-job/v0/redactions"
+	envURL            = "http://job/api/current-job/v0/env"
+	workdirURL        = "http://job/api/current-job/v0/workdir"
+	redactionsURL     = "http://job/api/current-job/v0/redactions"
+	promiseFailureURL = "http://job/api/current-job/v0/promise-failure"
 )
 
 var (
@@ -120,4 +121,19 @@ func (c *Client) RedactionCreate(ctx context.Context, text string) (string, erro
 		return "", err
 	}
 	return resp.Redacted, nil
+}
+
+// PromiseFailureClaim claims the given exit status for a promised failure. It
+// returns true if this caller is the first to claim the exit status for the job
+// (and so should declare the promised failure to the Buildkite API), or false
+// if the exit status has already been claimed by an earlier call.
+func (c *Client) PromiseFailureClaim(ctx context.Context, exitStatus int) (bool, error) {
+	req := PromiseFailureRequest{
+		ExitStatus: exitStatus,
+	}
+	var resp PromiseFailureResponse
+	if err := c.client.Do(ctx, http.MethodPost, promiseFailureURL, &req, &resp); err != nil {
+		return false, err
+	}
+	return resp.Claimed, nil
 }

--- a/jobapi/client.go
+++ b/jobapi/client.go
@@ -123,17 +123,17 @@ func (c *Client) RedactionCreate(ctx context.Context, text string) (string, erro
 	return resp.Redacted, nil
 }
 
-// PromiseFailureClaim claims the given exit status for a promised failure. It
-// returns true if this caller is the first to claim the exit status for the job
-// (and so should declare the promised failure to the Buildkite API), or false
-// if the exit status has already been claimed by an earlier call.
-func (c *Client) PromiseFailureClaim(ctx context.Context, exitStatus int) (bool, error) {
+// DeclarePromiseFailure asks the Job API to declare a promised failure with the
+// given exit status and reason to the Buildkite API, blocking until it
+// completes. The server debounces repeated and concurrent calls for the same
+// exit status: concurrent callers share one in-flight call, and once it succeeds
+// later calls return from the cache. A nil error means the promise was accepted.
+// A failed declaration is returned as a socket.APIErr carrying the HTTP status
+// code (the Buildkite API's status when it responded, otherwise 502).
+func (c *Client) DeclarePromiseFailure(ctx context.Context, exitStatus int, reason string) error {
 	req := PromiseFailureRequest{
 		ExitStatus: exitStatus,
+		Reason:     reason,
 	}
-	var resp PromiseFailureResponse
-	if err := c.client.Do(ctx, http.MethodPost, promiseFailureURL, &req, &resp); err != nil {
-		return false, err
-	}
-	return resp.Claimed, nil
+	return c.client.Do(ctx, http.MethodPost, promiseFailureURL, &req, nil)
 }

--- a/jobapi/client_test.go
+++ b/jobapi/client_test.go
@@ -19,6 +19,7 @@ import (
 
 type fakeServer struct {
 	env         map[string]string
+	promised    map[int]struct{}
 	sock, token string
 	svr         *http.Server
 }
@@ -31,8 +32,9 @@ func runFakeServer() (svr *fakeServer, err error) {
 			"YZMA":     "Villain",
 			"READONLY": "Should never change",
 		},
-		sock:  filepath.Join(os.TempDir(), fmt.Sprintf("testsocket-%d-%x", os.Getpid(), rand.Int())),
-		token: "to_the_secret_lab",
+		promised: map[int]struct{}{},
+		sock:     filepath.Join(os.TempDir(), fmt.Sprintf("testsocket-%d-%x", os.Getpid(), rand.Int())),
+		token:    "to_the_secret_lab",
 	}
 
 	f.svr = &http.Server{Handler: f}
@@ -54,6 +56,21 @@ func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		_ = socket.WriteError(w, "invalid Authorization header", http.StatusForbidden)
 		return
 	}
+
+	if r.URL.Path == "/api/current-job/v0/promise-failure" {
+		var req PromiseFailureRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			_ = socket.WriteError(w, fmt.Sprintf("decoding request: %v", err), http.StatusBadRequest)
+			return
+		}
+		_, seen := f.promised[req.ExitStatus]
+		f.promised[req.ExitStatus] = struct{}{}
+		if err := json.NewEncoder(w).Encode(&PromiseFailureResponse{Claimed: !seen}); err != nil {
+			_ = socket.WriteError(w, fmt.Sprintf("encoding response: %v", err), http.StatusInternalServerError)
+		}
+		return
+	}
+
 	if r.URL.Path != "/api/current-job/v0/env" {
 		_ = socket.WriteError(w, fmt.Sprintf("not found: %q", r.URL.Path), http.StatusNotFound)
 		return
@@ -122,6 +139,44 @@ func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	default:
 		_ = socket.WriteError(w, fmt.Sprintf("unsupported method %q", r.Method), http.StatusBadRequest)
+	}
+}
+
+func TestClientPromiseFailureClaim(t *testing.T) {
+	t.Parallel()
+
+	svr, err := runFakeServer()
+	if err != nil {
+		t.Fatalf("runFakeServer() = %v", err)
+	}
+	defer svr.Close()
+
+	ctx, canc := context.WithTimeout(t.Context(), 10*time.Second)
+	t.Cleanup(canc)
+
+	cli, err := NewClient(ctx, svr.sock, svr.token)
+	if err != nil {
+		t.Fatalf("NewClient(%q, %q) error = %v", svr.sock, svr.token, err)
+	}
+
+	// The first claim of an exit status returns true; repeated claims of the
+	// same exit status return false, while a different exit status returns true.
+	cases := []struct {
+		exitStatus int
+		want       bool
+	}{
+		{exitStatus: 1, want: true},
+		{exitStatus: 1, want: false},
+		{exitStatus: 2, want: true},
+	}
+	for _, c := range cases {
+		got, err := cli.PromiseFailureClaim(ctx, c.exitStatus)
+		if err != nil {
+			t.Fatalf("cli.PromiseFailureClaim(%d) error = %v", c.exitStatus, err)
+		}
+		if got != c.want {
+			t.Errorf("cli.PromiseFailureClaim(%d) = %t, want %t", c.exitStatus, got, c.want)
+		}
 	}
 }
 

--- a/jobapi/client_test.go
+++ b/jobapi/client_test.go
@@ -70,7 +70,6 @@ func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				Accepted:       false,
 				UpstreamStatus: http.StatusConflict,
 				Error:          "a different exit status was already declared",
-				Terminal:       true,
 			}); err != nil {
 				_ = socket.WriteError(w, fmt.Sprintf("encoding response: %v", err), http.StatusInternalServerError)
 			}

--- a/jobapi/client_test.go
+++ b/jobapi/client_test.go
@@ -68,7 +68,9 @@ func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			_ = socket.WriteError(w, "a different exit status was already declared", http.StatusConflict)
 			return
 		}
-		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(&PromiseFailureResponse{Outcome: PromiseFailureDeclared}); err != nil {
+			_ = socket.WriteError(w, fmt.Sprintf("encoding response: %v", err), http.StatusInternalServerError)
+		}
 		return
 	}
 
@@ -160,15 +162,19 @@ func TestClientDeclarePromiseFailure(t *testing.T) {
 		t.Fatalf("NewClient(%q, %q) error = %v", svr.sock, svr.token, err)
 	}
 
-	// A successful declaration returns no error and forwards the exit status and
-	// reason to the server.
-	if err := cli.DeclarePromiseFailure(ctx, 1, "tests failed"); err != nil {
+	// A successful declaration returns the outcome and no error, and forwards the
+	// exit status and reason to the server.
+	outcome, err := cli.DeclarePromiseFailure(ctx, 1, "tests failed")
+	if err != nil {
 		t.Fatalf("cli.DeclarePromiseFailure(1) error = %v", err)
+	}
+	if outcome != PromiseFailureDeclared {
+		t.Errorf("cli.DeclarePromiseFailure(1) outcome = %q, want %q", outcome, PromiseFailureDeclared)
 	}
 
 	// A rejected declaration surfaces a socket.APIErr carrying the Buildkite API
 	// status code, so the caller can produce an accurate message.
-	err = cli.DeclarePromiseFailure(ctx, 99, "")
+	_, err = cli.DeclarePromiseFailure(ctx, 99, "")
 	var apiErr socket.APIErr
 	if !errors.As(err, &apiErr) {
 		t.Fatalf("cli.DeclarePromiseFailure(99) error = %v, want a socket.APIErr", err)

--- a/jobapi/client_test.go
+++ b/jobapi/client_test.go
@@ -19,7 +19,7 @@ import (
 
 type fakeServer struct {
 	env         map[string]string
-	promised    map[int]struct{}
+	promised    []PromiseFailureRequest
 	sock, token string
 	svr         *http.Server
 }
@@ -32,9 +32,8 @@ func runFakeServer() (svr *fakeServer, err error) {
 			"YZMA":     "Villain",
 			"READONLY": "Should never change",
 		},
-		promised: map[int]struct{}{},
-		sock:     filepath.Join(os.TempDir(), fmt.Sprintf("testsocket-%d-%x", os.Getpid(), rand.Int())),
-		token:    "to_the_secret_lab",
+		sock:  filepath.Join(os.TempDir(), fmt.Sprintf("testsocket-%d-%x", os.Getpid(), rand.Int())),
+		token: "to_the_secret_lab",
 	}
 
 	f.svr = &http.Server{Handler: f}
@@ -63,11 +62,13 @@ func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			_ = socket.WriteError(w, fmt.Sprintf("decoding request: %v", err), http.StatusBadRequest)
 			return
 		}
-		_, seen := f.promised[req.ExitStatus]
-		f.promised[req.ExitStatus] = struct{}{}
-		if err := json.NewEncoder(w).Encode(&PromiseFailureResponse{Claimed: !seen}); err != nil {
-			_ = socket.WriteError(w, fmt.Sprintf("encoding response: %v", err), http.StatusInternalServerError)
+		f.promised = append(f.promised, req)
+		// Exit status 99 stands in for a declaration the Buildkite API rejects.
+		if req.ExitStatus == 99 {
+			_ = socket.WriteError(w, "a different exit status was already declared", http.StatusConflict)
+			return
 		}
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 
@@ -142,7 +143,7 @@ func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func TestClientPromiseFailureClaim(t *testing.T) {
+func TestClientDeclarePromiseFailure(t *testing.T) {
 	t.Parallel()
 
 	svr, err := runFakeServer()
@@ -159,24 +160,29 @@ func TestClientPromiseFailureClaim(t *testing.T) {
 		t.Fatalf("NewClient(%q, %q) error = %v", svr.sock, svr.token, err)
 	}
 
-	// The first claim of an exit status returns true; repeated claims of the
-	// same exit status return false, while a different exit status returns true.
-	cases := []struct {
-		exitStatus int
-		want       bool
-	}{
-		{exitStatus: 1, want: true},
-		{exitStatus: 1, want: false},
-		{exitStatus: 2, want: true},
+	// A successful declaration returns no error and forwards the exit status and
+	// reason to the server.
+	if err := cli.DeclarePromiseFailure(ctx, 1, "tests failed"); err != nil {
+		t.Fatalf("cli.DeclarePromiseFailure(1) error = %v", err)
 	}
-	for _, c := range cases {
-		got, err := cli.PromiseFailureClaim(ctx, c.exitStatus)
-		if err != nil {
-			t.Fatalf("cli.PromiseFailureClaim(%d) error = %v", c.exitStatus, err)
-		}
-		if got != c.want {
-			t.Errorf("cli.PromiseFailureClaim(%d) = %t, want %t", c.exitStatus, got, c.want)
-		}
+
+	// A rejected declaration surfaces a socket.APIErr carrying the Buildkite API
+	// status code, so the caller can produce an accurate message.
+	err = cli.DeclarePromiseFailure(ctx, 99, "")
+	var apiErr socket.APIErr
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("cli.DeclarePromiseFailure(99) error = %v, want a socket.APIErr", err)
+	}
+	if apiErr.StatusCode != http.StatusConflict {
+		t.Errorf("apiErr.StatusCode = %d, want %d", apiErr.StatusCode, http.StatusConflict)
+	}
+
+	want := []PromiseFailureRequest{
+		{ExitStatus: 1, Reason: "tests failed"},
+		{ExitStatus: 99},
+	}
+	if diff := cmp.Diff(want, svr.promised); diff != "" {
+		t.Errorf("recorded promise-failure requests diff (-want +got):\n%s", diff)
 	}
 }
 

--- a/jobapi/client_test.go
+++ b/jobapi/client_test.go
@@ -65,10 +65,18 @@ func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		f.promised = append(f.promised, req)
 		// Exit status 99 stands in for a declaration the Buildkite API rejects.
 		if req.ExitStatus == 99 {
-			_ = socket.WriteError(w, "a different exit status was already declared", http.StatusConflict)
+			if err := json.NewEncoder(w).Encode(&PromiseFailureResponse{
+				Outcome:        PromiseFailureDeclared,
+				Accepted:       false,
+				UpstreamStatus: http.StatusConflict,
+				Error:          "a different exit status was already declared",
+				Terminal:       true,
+			}); err != nil {
+				_ = socket.WriteError(w, fmt.Sprintf("encoding response: %v", err), http.StatusInternalServerError)
+			}
 			return
 		}
-		if err := json.NewEncoder(w).Encode(&PromiseFailureResponse{Outcome: PromiseFailureDeclared}); err != nil {
+		if err := json.NewEncoder(w).Encode(&PromiseFailureResponse{Outcome: PromiseFailureDeclared, Accepted: true}); err != nil {
 			_ = socket.WriteError(w, fmt.Sprintf("encoding response: %v", err), http.StatusInternalServerError)
 		}
 		return
@@ -164,23 +172,29 @@ func TestClientDeclarePromiseFailure(t *testing.T) {
 
 	// A successful declaration returns the outcome and no error, and forwards the
 	// exit status and reason to the server.
-	outcome, err := cli.DeclarePromiseFailure(ctx, 1, "tests failed")
+	result, err := cli.DeclarePromiseFailure(ctx, 1, "tests failed")
 	if err != nil {
 		t.Fatalf("cli.DeclarePromiseFailure(1) error = %v", err)
 	}
-	if outcome != PromiseFailureDeclared {
-		t.Errorf("cli.DeclarePromiseFailure(1) outcome = %q, want %q", outcome, PromiseFailureDeclared)
+	if result.Outcome != PromiseFailureDeclared {
+		t.Errorf("cli.DeclarePromiseFailure(1) outcome = %q, want %q", result.Outcome, PromiseFailureDeclared)
+	}
+	if !result.Accepted {
+		t.Errorf("cli.DeclarePromiseFailure(1) accepted = false, want true")
 	}
 
-	// A rejected declaration surfaces a socket.APIErr carrying the Buildkite API
-	// status code, so the caller can produce an accurate message.
-	_, err = cli.DeclarePromiseFailure(ctx, 99, "")
-	var apiErr socket.APIErr
-	if !errors.As(err, &apiErr) {
-		t.Fatalf("cli.DeclarePromiseFailure(99) error = %v, want a socket.APIErr", err)
+	// A rejected declaration is still a successful Job API response. The response
+	// carries the Buildkite API status code so the caller can produce an accurate
+	// message without guessing where the error came from.
+	result, err = cli.DeclarePromiseFailure(ctx, 99, "")
+	if err != nil {
+		t.Fatalf("cli.DeclarePromiseFailure(99) error = %v, want nil", err)
 	}
-	if apiErr.StatusCode != http.StatusConflict {
-		t.Errorf("apiErr.StatusCode = %d, want %d", apiErr.StatusCode, http.StatusConflict)
+	if result.Accepted {
+		t.Errorf("cli.DeclarePromiseFailure(99) accepted = true, want false")
+	}
+	if result.UpstreamStatus != http.StatusConflict {
+		t.Errorf("result.UpstreamStatus = %d, want %d", result.UpstreamStatus, http.StatusConflict)
 	}
 
 	want := []PromiseFailureRequest{

--- a/jobapi/payloads.go
+++ b/jobapi/payloads.go
@@ -68,3 +68,16 @@ type RedactionCreateRequest struct {
 type RedactionCreateResponse struct {
 	Redacted string `json:"redacted"`
 }
+
+// PromiseFailureRequest is the request body for the POST /promise-failure endpoint
+type PromiseFailureRequest struct {
+	ExitStatus int `json:"exit_status"`
+}
+
+// PromiseFailureResponse is the response body for the POST /promise-failure endpoint
+type PromiseFailureResponse struct {
+	// Claimed is true if this caller is the first to claim the given exit
+	// status for the job, and so is responsible for declaring the promised
+	// failure to the Buildkite API.
+	Claimed bool `json:"claimed"`
+}

--- a/jobapi/payloads.go
+++ b/jobapi/payloads.go
@@ -71,13 +71,6 @@ type RedactionCreateResponse struct {
 
 // PromiseFailureRequest is the request body for the POST /promise-failure endpoint
 type PromiseFailureRequest struct {
-	ExitStatus int `json:"exit_status"`
-}
-
-// PromiseFailureResponse is the response body for the POST /promise-failure endpoint
-type PromiseFailureResponse struct {
-	// Claimed is true if this caller is the first to claim the given exit
-	// status for the job, and so is responsible for declaring the promised
-	// failure to the Buildkite API.
-	Claimed bool `json:"claimed"`
+	ExitStatus int    `json:"exit_status"`
+	Reason     string `json:"reason,omitempty"`
 }

--- a/jobapi/payloads.go
+++ b/jobapi/payloads.go
@@ -89,4 +89,18 @@ const (
 type PromiseFailureResponse struct {
 	// Outcome is PromiseFailureDeclared or PromiseFailureDebounced.
 	Outcome string `json:"outcome"`
+
+	// Accepted reports whether the Buildkite API accepted the promised failure.
+	Accepted bool `json:"accepted"`
+
+	// UpstreamStatus is the Buildkite API status, when one was received.
+	// Network errors that never received a response leave this as 0.
+	UpstreamStatus int `json:"upstream_status,omitempty"`
+
+	// Error is the Buildkite API declaration error, if Accepted is false.
+	Error string `json:"error,omitempty"`
+
+	// Terminal reports whether repeating this declaration is expected to return
+	// the same error, so the result can be cached.
+	Terminal bool `json:"terminal,omitempty"`
 }

--- a/jobapi/payloads.go
+++ b/jobapi/payloads.go
@@ -99,8 +99,4 @@ type PromiseFailureResponse struct {
 
 	// Error is the Buildkite API declaration error, if Accepted is false.
 	Error string `json:"error,omitempty"`
-
-	// Terminal reports whether repeating this declaration is expected to return
-	// the same error, so the result can be cached.
-	Terminal bool `json:"terminal,omitempty"`
 }

--- a/jobapi/payloads.go
+++ b/jobapi/payloads.go
@@ -74,3 +74,19 @@ type PromiseFailureRequest struct {
 	ExitStatus int    `json:"exit_status"`
 	Reason     string `json:"reason,omitempty"`
 }
+
+// Promise failure outcomes, reported in PromiseFailureResponse.Outcome.
+const (
+	// PromiseFailureDeclared means this call declared the exit status to the
+	// Buildkite API.
+	PromiseFailureDeclared = "declared"
+	// PromiseFailureDebounced means an earlier call already declared this exit
+	// status, so this call shared that result without calling the Buildkite API.
+	PromiseFailureDebounced = "debounced"
+)
+
+// PromiseFailureResponse is the response body for the POST /promise-failure endpoint
+type PromiseFailureResponse struct {
+	// Outcome is PromiseFailureDeclared or PromiseFailureDebounced.
+	Outcome string `json:"outcome"`
+}

--- a/jobapi/promise_failure.go
+++ b/jobapi/promise_failure.go
@@ -1,0 +1,35 @@
+package jobapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/buildkite/agent/v3/internal/socket"
+)
+
+// promiseFailure claims an exit status for a promised failure. The first caller
+// to claim a given exit status receives claimed=true and is responsible for
+// declaring the promised failure to the Buildkite API; subsequent callers
+// receive claimed=false so that repeated calls don't hammer the API.
+func (s *Server) promiseFailure(w http.ResponseWriter, r *http.Request) {
+	payload := &PromiseFailureRequest{}
+	if err := json.NewDecoder(r.Body).Decode(payload); err != nil {
+		if err := socket.WriteError(w, fmt.Errorf("failed to decode request body: %w", err), http.StatusBadRequest); err != nil {
+			s.Logger.Errorf("Job API: couldn't write error: %v", err)
+		}
+		return
+	}
+
+	s.mtx.Lock()
+	_, seen := s.promisedFailures[payload.ExitStatus]
+	if !seen {
+		s.promisedFailures[payload.ExitStatus] = struct{}{}
+	}
+	s.mtx.Unlock()
+
+	respBody := &PromiseFailureResponse{Claimed: !seen}
+	if err := json.NewEncoder(w).Encode(respBody); err != nil {
+		s.Logger.Errorf("Job API: couldn't write response: %v", err)
+	}
+}

--- a/jobapi/promise_failure.go
+++ b/jobapi/promise_failure.go
@@ -18,12 +18,20 @@ type promiseFailure struct {
 	err        error         // declaration result; nil means accepted
 }
 
+// terminalStatus reports whether an HTTP status is a definitive client error
+// that won't change on retry (e.g. 409, 422), so the result can be cached. A 429
+// is excluded because it's retryable.
+func terminalStatus(status int) bool {
+	return status >= 400 && status < 500 && status != http.StatusTooManyRequests
+}
+
 // promiseFailure declares a promised failure to the Buildkite API for
 // 'buildkite-agent job promise-failure', debouncing repeated and concurrent
 // calls so each exit status is declared at most once successfully. The first
 // caller declares it (blocking on the API so it can return an accurate result),
-// concurrent callers wait and share that outcome, and callers after a success
-// return from the cache. Failures aren't cached, so a later call can retry.
+// concurrent callers wait and share that outcome, and callers after a success or
+// a terminal failure return from the cache. Transient failures aren't cached, so
+// a later call can retry.
 func (s *Server) promiseFailure(w http.ResponseWriter, r *http.Request) {
 	payload := &PromiseFailureRequest{}
 	if err := json.NewDecoder(r.Body).Decode(payload); err != nil {
@@ -91,9 +99,11 @@ func (s *Server) promiseFailure(w http.ResponseWriter, r *http.Request) {
 		completed = true
 
 		s.mtx.Lock()
-		if pf.err != nil {
-			// Don't cache failures, so a later call can retry. Waiters already
-			// hold pf and still see this result.
+		if pf.err != nil && !terminalStatus(pf.statusCode) {
+			// Evict transient failures (5xx, network, 429) so a later call can
+			// retry. Terminal failures (other 4xx, e.g. 409/422) stay cached so
+			// repeated calls don't keep hitting the Buildkite API. Waiters
+			// already hold pf and still see this result either way.
 			delete(s.promiseFailures, payload.ExitStatus)
 		}
 		close(pf.done)

--- a/jobapi/promise_failure.go
+++ b/jobapi/promise_failure.go
@@ -25,14 +25,17 @@ func terminalStatus(status int) bool {
 	return status >= 400 && status < 500 && status != http.StatusTooManyRequests
 }
 
-// promiseFailure declares a promised failure to the Buildkite API for
+// handlePromiseFailure declares a promised failure to the Buildkite API for
 // 'buildkite-agent job promise-failure', debouncing repeated and concurrent
 // calls so each exit status is declared at most once successfully. The first
 // caller declares it (blocking on the API so it can return an accurate result),
 // concurrent callers wait and share that outcome, and callers after a success or
 // a terminal failure return from the cache. Transient failures aren't cached, so
 // a later call can retry.
-func (s *Server) promiseFailure(w http.ResponseWriter, r *http.Request) {
+//
+// Debouncing keys on exit status only, so for a given exit status the first
+// caller's reason wins and later callers' reasons are ignored.
+func (s *Server) handlePromiseFailure(w http.ResponseWriter, r *http.Request) {
 	payload := &PromiseFailureRequest{}
 	if err := json.NewDecoder(r.Body).Decode(payload); err != nil {
 		if err := socket.WriteError(w, fmt.Errorf("failed to decode request body: %w", err), http.StatusBadRequest); err != nil {

--- a/jobapi/promise_failure.go
+++ b/jobapi/promise_failure.go
@@ -113,5 +113,13 @@ func (s *Server) promiseFailure(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Success: an empty 200, which the client treats as acceptance.
+	// Success. A leading caller (found == false) declared it; any other caller
+	// shared that result without calling the Buildkite API.
+	outcome := PromiseFailureDeclared
+	if found {
+		outcome = PromiseFailureDebounced
+	}
+	if err := json.NewEncoder(w).Encode(&PromiseFailureResponse{Outcome: outcome}); err != nil {
+		s.Logger.Errorf("Job API: couldn't encode or write response: %v", err)
+	}
 }

--- a/jobapi/promise_failure.go
+++ b/jobapi/promise_failure.go
@@ -95,7 +95,6 @@ func (c *promiseFailureCoordinator) Declare(ctx context.Context, req PromiseFail
 			Accepted:       false,
 			UpstreamStatus: http.StatusInternalServerError,
 			Error:          fmt.Sprintf("declaring promised failure panicked: %v", v),
-			Terminal:       false,
 		}
 		c.mu.Lock()
 		delete(c.entries, req.ExitStatus)
@@ -113,12 +112,12 @@ func (c *promiseFailureCoordinator) Declare(ctx context.Context, req PromiseFail
 	}
 	if err != nil {
 		pf.result.Error = err.Error()
-		pf.result.Terminal = terminalStatus(statusCode)
 	}
 	completed = true
+	terminal := terminalStatus(statusCode)
 
 	c.mu.Lock()
-	if !pf.result.Accepted && !pf.result.Terminal {
+	if !pf.result.Accepted && !terminal {
 		// Evict transient failures (5xx, network, 429) so a later call can retry.
 		// Terminal failures (other 4xx, e.g. 409/422) stay cached so repeated
 		// calls don't keep hitting the Buildkite API. Waiters already hold pf and

--- a/jobapi/promise_failure.go
+++ b/jobapi/promise_failure.go
@@ -3,8 +3,10 @@ package jobapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 
 	"github.com/buildkite/agent/v3/internal/socket"
 )
@@ -13,9 +15,24 @@ import (
 // Buildkite API. The first caller declares it; concurrent callers wait on done
 // and share the result.
 type promiseFailure struct {
-	done       chan struct{} // closed when the attempt completes
-	statusCode int           // most recent Buildkite API status (0 if none received)
-	err        error         // declaration result; nil means accepted
+	done   chan struct{}          // closed when the attempt completes
+	result PromiseFailureResponse // declaration result
+}
+
+// promiseFailureCoordinator owns promise-failure coalescing and caching. Each
+// entry is an in-flight declaration or a cached success or terminal failure;
+// transient failures are removed so a later call can retry.
+type promiseFailureCoordinator struct {
+	mu      sync.Mutex
+	entries map[int]*promiseFailure
+	declare PromiseFailureDeclarer
+}
+
+func newPromiseFailureCoordinator(declare PromiseFailureDeclarer) *promiseFailureCoordinator {
+	return &promiseFailureCoordinator{
+		entries: make(map[int]*promiseFailure),
+		declare: declare,
+	}
 }
 
 // terminalStatus reports whether an HTTP status is a definitive client error
@@ -25,9 +42,8 @@ func terminalStatus(status int) bool {
 	return status >= 400 && status < 500 && status != http.StatusTooManyRequests
 }
 
-// handlePromiseFailure declares a promised failure to the Buildkite API for
-// 'buildkite-agent job promise-failure', debouncing repeated and concurrent
-// calls so each exit status is declared at most once successfully. The first
+// Declare declares a promised failure through the configured declarer,
+// coalescing repeated and concurrent calls for the same exit status. The first
 // caller declares it (blocking on the API so it can return an accurate result),
 // concurrent callers wait and share that outcome, and callers after a success or
 // a terminal failure return from the cache. Transient failures aren't cached, so
@@ -35,6 +51,88 @@ func terminalStatus(status int) bool {
 //
 // Debouncing keys on exit status only, so for a given exit status the first
 // caller's reason wins and later callers' reasons are ignored.
+func (c *promiseFailureCoordinator) Declare(ctx context.Context, req PromiseFailureRequest) (result PromiseFailureResponse, err error) {
+	if c == nil || c.declare == nil {
+		return PromiseFailureResponse{}, errors.New("promise-failure coordinator is not configured")
+	}
+
+	c.mu.Lock()
+	pf, found := c.entries[req.ExitStatus]
+	if !found {
+		pf = &promiseFailure{done: make(chan struct{})}
+		c.entries[req.ExitStatus] = pf
+	}
+	c.mu.Unlock()
+
+	if found {
+		// A declaration is already in progress or done; wait for it and share
+		// the outcome, unless this caller gives up first.
+		select {
+		case <-pf.done:
+		case <-ctx.Done():
+			return PromiseFailureResponse{}, ctx.Err()
+		}
+
+		result := pf.result
+		result.Outcome = PromiseFailureDebounced
+		return result, nil
+	}
+
+	// We're the first caller, so we declare while others wait on pf.done. Use a
+	// background context so the declaration isn't abandoned if this caller
+	// disconnects; the waiters depend on it.
+	completed := false
+	defer func() {
+		if completed {
+			return
+		}
+		// If the declarer panics, release waiters with an error and drop the entry
+		// so a later call can retry.
+		// Otherwise pf.done never closes and callers block forever.
+		v := recover()
+		pf.result = PromiseFailureResponse{
+			Outcome:        PromiseFailureDeclared,
+			Accepted:       false,
+			UpstreamStatus: http.StatusInternalServerError,
+			Error:          fmt.Sprintf("declaring promised failure panicked: %v", v),
+			Terminal:       false,
+		}
+		c.mu.Lock()
+		delete(c.entries, req.ExitStatus)
+		close(pf.done)
+		c.mu.Unlock()
+		result = pf.result
+		err = nil
+	}()
+
+	statusCode, err := c.declare(context.Background(), req.ExitStatus, req.Reason)
+	pf.result = PromiseFailureResponse{
+		Outcome:        PromiseFailureDeclared,
+		Accepted:       err == nil,
+		UpstreamStatus: statusCode,
+	}
+	if err != nil {
+		pf.result.Error = err.Error()
+		pf.result.Terminal = terminalStatus(statusCode)
+	}
+	completed = true
+
+	c.mu.Lock()
+	if !pf.result.Accepted && !pf.result.Terminal {
+		// Evict transient failures (5xx, network, 429) so a later call can retry.
+		// Terminal failures (other 4xx, e.g. 409/422) stay cached so repeated
+		// calls don't keep hitting the Buildkite API. Waiters already hold pf and
+		// still see this result either way.
+		delete(c.entries, req.ExitStatus)
+	}
+	close(pf.done)
+	c.mu.Unlock()
+
+	return pf.result, nil
+}
+
+// handlePromiseFailure handles HTTP concerns for 'buildkite-agent job
+// promise-failure'. The coordinator owns declaration, debouncing, and caching.
 func (s *Server) handlePromiseFailure(w http.ResponseWriter, r *http.Request) {
 	payload := &PromiseFailureRequest{}
 	if err := json.NewDecoder(r.Body).Decode(payload); err != nil {
@@ -53,86 +151,19 @@ func (s *Server) handlePromiseFailure(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.declarePromiseFailure == nil {
-		if err := socket.WriteError(w, fmt.Errorf("the Job API server has no promised-failure declarer configured"), http.StatusInternalServerError); err != nil {
-			s.Logger.Errorf("Job API: couldn't write error: %v", err)
-		}
-		return
-	}
-
-	s.mtx.Lock()
-	pf, found := s.promiseFailures[payload.ExitStatus]
-	if !found {
-		pf = &promiseFailure{done: make(chan struct{})}
-		s.promiseFailures[payload.ExitStatus] = pf
-	}
-	s.mtx.Unlock()
-
-	if found {
-		// A declaration is already in progress or done; wait for it and share
-		// the outcome, unless this caller gives up first.
-		select {
-		case <-pf.done:
-		case <-r.Context().Done():
+	result, err := s.promiseFailures.Declare(r.Context(), *payload)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return
 		}
-	} else {
-		// We're the first caller, so we declare while others wait on pf.done.
-		// Use a background context so the declaration isn't abandoned if this
-		// caller disconnects; the waiters depend on it.
-		completed := false
-		defer func() {
-			if completed {
-				return
-			}
-			// If the declarer panics, release waiters with an error and drop the
-			// entry so a later call can retry, then re-panic for the recovery
-			// middleware. Otherwise pf.done never closes and callers block forever.
-			v := recover()
-			pf.statusCode = http.StatusInternalServerError
-			pf.err = fmt.Errorf("declaring promised failure panicked: %v", v)
-			s.mtx.Lock()
-			delete(s.promiseFailures, payload.ExitStatus)
-			close(pf.done)
-			s.mtx.Unlock()
-			panic(v)
-		}()
 
-		pf.statusCode, pf.err = s.declarePromiseFailure(context.Background(), payload.ExitStatus, payload.Reason)
-		completed = true
-
-		s.mtx.Lock()
-		if pf.err != nil && !terminalStatus(pf.statusCode) {
-			// Evict transient failures (5xx, network, 429) so a later call can
-			// retry. Terminal failures (other 4xx, e.g. 409/422) stay cached so
-			// repeated calls don't keep hitting the Buildkite API. Waiters
-			// already hold pf and still see this result either way.
-			delete(s.promiseFailures, payload.ExitStatus)
-		}
-		close(pf.done)
-		s.mtx.Unlock()
-	}
-
-	if pf.err != nil {
-		status := pf.statusCode
-		if status < 400 || status > 599 {
-			// No usable error status (e.g. a network error, or an unexpected
-			// non-error status); report a bad gateway.
-			status = http.StatusBadGateway
-		}
-		if err := socket.WriteError(w, pf.err, status); err != nil {
+		if err := socket.WriteError(w, err, http.StatusInternalServerError); err != nil {
 			s.Logger.Errorf("Job API: couldn't write error: %v", err)
 		}
 		return
 	}
 
-	// Success. A leading caller (found == false) declared it; any other caller
-	// shared that result without calling the Buildkite API.
-	outcome := PromiseFailureDeclared
-	if found {
-		outcome = PromiseFailureDebounced
-	}
-	if err := json.NewEncoder(w).Encode(&PromiseFailureResponse{Outcome: outcome}); err != nil {
+	if err := json.NewEncoder(w).Encode(&result); err != nil {
 		s.Logger.Errorf("Job API: couldn't encode or write response: %v", err)
 	}
 }

--- a/jobapi/promise_failure.go
+++ b/jobapi/promise_failure.go
@@ -1,6 +1,7 @@
 package jobapi
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -8,10 +9,21 @@ import (
 	"github.com/buildkite/agent/v3/internal/socket"
 )
 
-// promiseFailure claims an exit status for a promised failure. The first caller
-// to claim a given exit status receives claimed=true and is responsible for
-// declaring the promised failure to the Buildkite API; subsequent callers
-// receive claimed=false so that repeated calls don't hammer the API.
+// promiseFailure tracks one attempt to declare a given exit status to the
+// Buildkite API. The first caller declares it; concurrent callers wait on done
+// and share the result.
+type promiseFailure struct {
+	done       chan struct{} // closed when the attempt completes
+	statusCode int           // most recent Buildkite API status (0 if none received)
+	err        error         // declaration result; nil means accepted
+}
+
+// promiseFailure declares a promised failure to the Buildkite API for
+// 'buildkite-agent job promise-failure', debouncing repeated and concurrent
+// calls so each exit status is declared at most once successfully. The first
+// caller declares it (blocking on the API so it can return an accurate result),
+// concurrent callers wait and share that outcome, and callers after a success
+// return from the cache. Failures aren't cached, so a later call can retry.
 func (s *Server) promiseFailure(w http.ResponseWriter, r *http.Request) {
 	payload := &PromiseFailureRequest{}
 	if err := json.NewDecoder(r.Body).Decode(payload); err != nil {
@@ -21,15 +33,85 @@ func (s *Server) promiseFailure(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A promised failure must be a positive exit status, so reject anything else
+	// here rather than calling the Buildkite API.
+	if payload.ExitStatus <= 0 {
+		if err := socket.WriteError(w, fmt.Errorf("exit_status must be a positive integer"), http.StatusBadRequest); err != nil {
+			s.Logger.Errorf("Job API: couldn't write error: %v", err)
+		}
+		return
+	}
+
+	if s.declarePromiseFailure == nil {
+		if err := socket.WriteError(w, fmt.Errorf("the Job API server has no promised-failure declarer configured"), http.StatusInternalServerError); err != nil {
+			s.Logger.Errorf("Job API: couldn't write error: %v", err)
+		}
+		return
+	}
+
 	s.mtx.Lock()
-	_, seen := s.promisedFailures[payload.ExitStatus]
-	if !seen {
-		s.promisedFailures[payload.ExitStatus] = struct{}{}
+	pf, found := s.promiseFailures[payload.ExitStatus]
+	if !found {
+		pf = &promiseFailure{done: make(chan struct{})}
+		s.promiseFailures[payload.ExitStatus] = pf
 	}
 	s.mtx.Unlock()
 
-	respBody := &PromiseFailureResponse{Claimed: !seen}
-	if err := json.NewEncoder(w).Encode(respBody); err != nil {
-		s.Logger.Errorf("Job API: couldn't write response: %v", err)
+	if found {
+		// A declaration is already in progress or done; wait for it and share
+		// the outcome, unless this caller gives up first.
+		select {
+		case <-pf.done:
+		case <-r.Context().Done():
+			return
+		}
+	} else {
+		// We're the first caller, so we declare while others wait on pf.done.
+		// Use a background context so the declaration isn't abandoned if this
+		// caller disconnects; the waiters depend on it.
+		completed := false
+		defer func() {
+			if completed {
+				return
+			}
+			// If the declarer panics, release waiters with an error and drop the
+			// entry so a later call can retry, then re-panic for the recovery
+			// middleware. Otherwise pf.done never closes and callers block forever.
+			v := recover()
+			pf.statusCode = http.StatusInternalServerError
+			pf.err = fmt.Errorf("declaring promised failure panicked: %v", v)
+			s.mtx.Lock()
+			delete(s.promiseFailures, payload.ExitStatus)
+			close(pf.done)
+			s.mtx.Unlock()
+			panic(v)
+		}()
+
+		pf.statusCode, pf.err = s.declarePromiseFailure(context.Background(), payload.ExitStatus, payload.Reason)
+		completed = true
+
+		s.mtx.Lock()
+		if pf.err != nil {
+			// Don't cache failures, so a later call can retry. Waiters already
+			// hold pf and still see this result.
+			delete(s.promiseFailures, payload.ExitStatus)
+		}
+		close(pf.done)
+		s.mtx.Unlock()
 	}
+
+	if pf.err != nil {
+		status := pf.statusCode
+		if status < 400 || status > 599 {
+			// No usable error status (e.g. a network error, or an unexpected
+			// non-error status); report a bad gateway.
+			status = http.StatusBadGateway
+		}
+		if err := socket.WriteError(w, pf.err, status); err != nil {
+			s.Logger.Errorf("Job API: couldn't write error: %v", err)
+		}
+		return
+	}
+
+	// Success: an empty 200, which the client treats as acceptance.
 }

--- a/jobapi/routes.go
+++ b/jobapi/routes.go
@@ -33,6 +33,8 @@ func (s *Server) router() chi.Router {
 		r.Put("/workdir", s.setWorkdir)
 
 		r.Post("/redactions", s.createRedaction)
+
+		r.Post("/promise-failure", s.promiseFailure)
 	})
 
 	return r

--- a/jobapi/routes.go
+++ b/jobapi/routes.go
@@ -34,7 +34,7 @@ func (s *Server) router() chi.Router {
 
 		r.Post("/redactions", s.createRedaction)
 
-		r.Post("/promise-failure", s.promiseFailure)
+		r.Post("/promise-failure", s.handlePromiseFailure)
 	})
 
 	return r

--- a/jobapi/server.go
+++ b/jobapi/server.go
@@ -39,6 +39,12 @@ type Server struct {
 	// process exits. Guarded by mtx.
 	pendingWorkdir string
 
+	// promisedFailures records the exit statuses that have already been claimed
+	// for a promised failure, so that repeated calls to
+	// 'buildkite-agent job promise-failure' only declare each exit status to the
+	// Buildkite API once. It is guarded by mtx.
+	promisedFailures map[int]struct{}
+
 	token   string
 	sockSvr *socket.Server
 }
@@ -59,11 +65,12 @@ func NewServer(
 	}
 
 	s := &Server{
-		SocketPath: socketPath,
-		Logger:     logger,
-		environ:    environ,
-		redactors:  redactors,
-		token:      token,
+		SocketPath:       socketPath,
+		Logger:           logger,
+		environ:          environ,
+		redactors:        redactors,
+		promisedFailures: make(map[int]struct{}),
+		token:            token,
 	}
 
 	for _, o := range opts {

--- a/jobapi/server.go
+++ b/jobapi/server.go
@@ -28,7 +28,7 @@ func WithDebug() ServerOpts {
 // tests), the endpoint returns an error.
 func WithPromiseFailureDeclarer(d PromiseFailureDeclarer) ServerOpts {
 	return func(s *Server) {
-		s.declarePromiseFailure = d
+		s.promiseFailures.declare = d
 	}
 }
 
@@ -55,17 +55,8 @@ type Server struct {
 	// process exits. Guarded by mtx.
 	pendingWorkdir string
 
-	// promiseFailures coalesces concurrent and repeated promise-failure calls so
-	// each exit status is declared to the Buildkite API at most once
-	// successfully. Each entry is an in-flight declaration or a cached success or
-	// terminal failure; transient failures are removed so a later call can retry.
-	// Guarded by mtx.
-	promiseFailures map[int]*promiseFailure
-
-	// declarePromiseFailure declares a promised failure to the Buildkite API.
-	// It's nil if the server wasn't configured with a declarer (e.g. in tests),
-	// in which case the /promise-failure endpoint returns an error.
-	declarePromiseFailure PromiseFailureDeclarer
+	// promiseFailures coalesces concurrent and repeated promise-failure calls.
+	promiseFailures *promiseFailureCoordinator
 
 	token   string
 	sockSvr *socket.Server
@@ -91,7 +82,7 @@ func NewServer(
 		Logger:          logger,
 		environ:         environ,
 		redactors:       redactors,
-		promiseFailures: make(map[int]*promiseFailure),
+		promiseFailures: newPromiseFailureCoordinator(nil),
 		token:           token,
 	}
 

--- a/jobapi/server.go
+++ b/jobapi/server.go
@@ -22,6 +22,22 @@ func WithDebug() ServerOpts {
 	}
 }
 
+// WithPromiseFailureDeclarer sets the function the /promise-failure endpoint
+// uses to declare promised failures to the Buildkite API. Debouncing means it's
+// called at most once per successfully-declared exit status. If unset (e.g. in
+// tests), the endpoint returns an error.
+func WithPromiseFailureDeclarer(d PromiseFailureDeclarer) ServerOpts {
+	return func(s *Server) {
+		s.declarePromiseFailure = d
+	}
+}
+
+// PromiseFailureDeclarer declares a promised failure for the current job to the
+// Buildkite API. It returns the status code of the most recent API response (0
+// if none was received, e.g. a network error after exhausting retries) and an
+// error describing any failure. A nil error means the declaration was accepted.
+type PromiseFailureDeclarer func(ctx context.Context, exitStatus int, reason string) (statusCode int, err error)
+
 // Server is a Job API server. It provides an HTTP API with which to interact with the job currently running in the buildkite agent
 // and allows jobs to introspect and mutate their own state
 type Server struct {
@@ -39,11 +55,16 @@ type Server struct {
 	// process exits. Guarded by mtx.
 	pendingWorkdir string
 
-	// promisedFailures records the exit statuses that have already been claimed
-	// for a promised failure, so that repeated calls to
-	// 'buildkite-agent job promise-failure' only declare each exit status to the
-	// Buildkite API once. It is guarded by mtx.
-	promisedFailures map[int]struct{}
+	// promiseFailures coalesces concurrent and repeated promise-failure calls so
+	// each exit status is declared to the Buildkite API at most once
+	// successfully. Each entry is an in-flight or successful declaration; failed
+	// ones are removed so a later call can retry. Guarded by mtx.
+	promiseFailures map[int]*promiseFailure
+
+	// declarePromiseFailure declares a promised failure to the Buildkite API.
+	// It's nil if the server wasn't configured with a declarer (e.g. in tests),
+	// in which case the /promise-failure endpoint returns an error.
+	declarePromiseFailure PromiseFailureDeclarer
 
 	token   string
 	sockSvr *socket.Server
@@ -65,12 +86,12 @@ func NewServer(
 	}
 
 	s := &Server{
-		SocketPath:       socketPath,
-		Logger:           logger,
-		environ:          environ,
-		redactors:        redactors,
-		promisedFailures: make(map[int]struct{}),
-		token:            token,
+		SocketPath:      socketPath,
+		Logger:          logger,
+		environ:         environ,
+		redactors:       redactors,
+		promiseFailures: make(map[int]*promiseFailure),
+		token:           token,
 	}
 
 	for _, o := range opts {

--- a/jobapi/server.go
+++ b/jobapi/server.go
@@ -57,8 +57,9 @@ type Server struct {
 
 	// promiseFailures coalesces concurrent and repeated promise-failure calls so
 	// each exit status is declared to the Buildkite API at most once
-	// successfully. Each entry is an in-flight or successful declaration; failed
-	// ones are removed so a later call can retry. Guarded by mtx.
+	// successfully. Each entry is an in-flight declaration or a cached success or
+	// terminal failure; transient failures are removed so a later call can retry.
+	// Guarded by mtx.
 	promiseFailures map[int]*promiseFailure
 
 	// declarePromiseFailure declares a promised failure to the Buildkite API.

--- a/jobapi/server_test.go
+++ b/jobapi/server_test.go
@@ -501,8 +501,8 @@ func startPromiseFailureServer(t *testing.T, declarer jobapi.PromiseFailureDecla
 }
 
 // promiseFailureRequest POSTs a promise-failure declaration to the Job API and
-// returns the HTTP status code.
-func promiseFailureRequest(t *testing.T, client *http.Client, token string, exitStatus int) int {
+// returns the HTTP status code and, on success, the outcome from the response body.
+func promiseFailureRequest(t *testing.T, client *http.Client, token string, exitStatus int) (int, string) {
 	t.Helper()
 
 	buf := &bytes.Buffer{}
@@ -520,8 +520,16 @@ func promiseFailureRequest(t *testing.T, client *http.Client, token string, exit
 	if err != nil {
 		t.Fatalf("client.Do(req) error = %v", err)
 	}
-	defer resp.Body.Close()
-	return resp.StatusCode
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return resp.StatusCode, ""
+	}
+	var body jobapi.PromiseFailureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	return resp.StatusCode, body.Outcome
 }
 
 func TestPromiseFailure(t *testing.T) {
@@ -538,12 +546,22 @@ func TestPromiseFailure(t *testing.T) {
 		return http.StatusNoContent, nil
 	})
 
-	// The first declaration of an exit status calls the Buildkite API; repeated
-	// calls for the same exit status are debounced (no extra API call), but a
-	// different exit status is declared on its own. All callers see success.
-	for _, exitStatus := range []int{1, 1, 2} {
-		if got := promiseFailureRequest(t, client, token, exitStatus); got != http.StatusOK {
+	// The first declaration of an exit status calls the Buildkite API and reports
+	// "declared"; a repeated call for the same exit status is debounced (no extra
+	// API call) and reports "debounced"; a different exit status is declared on
+	// its own. All callers see success.
+	wantOutcomes := []string{
+		jobapi.PromiseFailureDeclared,
+		jobapi.PromiseFailureDebounced,
+		jobapi.PromiseFailureDeclared,
+	}
+	for i, exitStatus := range []int{1, 1, 2} {
+		got, outcome := promiseFailureRequest(t, client, token, exitStatus)
+		if got != http.StatusOK {
 			t.Errorf("promiseFailureRequest(%d) status = %d, want %d", exitStatus, got, http.StatusOK)
+		}
+		if outcome != wantOutcomes[i] {
+			t.Errorf("promiseFailureRequest(%d) outcome = %q, want %q", exitStatus, outcome, wantOutcomes[i])
 		}
 	}
 
@@ -566,7 +584,7 @@ func TestPromiseFailureInvalidExitStatus(t *testing.T) {
 	// A non-positive exit status is rejected at the boundary, without reaching
 	// the declarer (and therefore the Buildkite API).
 	for _, exitStatus := range []int{0, -1} {
-		if got := promiseFailureRequest(t, client, token, exitStatus); got != http.StatusBadRequest {
+		if got, _ := promiseFailureRequest(t, client, token, exitStatus); got != http.StatusBadRequest {
 			t.Errorf("promiseFailureRequest(%d) status = %d, want %d", exitStatus, got, http.StatusBadRequest)
 		}
 	}
@@ -586,10 +604,10 @@ func TestPromiseFailureNotCachedOnError(t *testing.T) {
 
 	// A failed declaration is surfaced with the Buildkite API's status code, and
 	// isn't cached: a later call for the same exit status retries.
-	if got := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
+	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
 		t.Errorf("first promiseFailureRequest(1) status = %d, want %d", got, http.StatusUnprocessableEntity)
 	}
-	if got := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
+	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
 		t.Errorf("second promiseFailureRequest(1) status = %d, want %d", got, http.StatusUnprocessableEntity)
 	}
 
@@ -615,7 +633,7 @@ func TestPromiseFailureStatusNormalization(t *testing.T) {
 
 	// Both are normalized to 502, so a caller never reads an error as success.
 	for _, exitStatus := range []int{1, 2} {
-		if got := promiseFailureRequest(t, client, token, exitStatus); got != http.StatusBadGateway {
+		if got, _ := promiseFailureRequest(t, client, token, exitStatus); got != http.StatusBadGateway {
 			t.Errorf("promiseFailureRequest(%d) status = %d, want %d", exitStatus, got, http.StatusBadGateway)
 		}
 	}
@@ -634,12 +652,12 @@ func TestPromiseFailurePanicRecovers(t *testing.T) {
 
 	// The first call panics inside the declarer; the recovery middleware turns it
 	// into a 500 rather than leaving the caller (and any waiters) hung.
-	if got := promiseFailureRequest(t, client, token, 1); got != http.StatusInternalServerError {
+	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusInternalServerError {
 		t.Errorf("panicking promiseFailureRequest(1) status = %d, want %d", got, http.StatusInternalServerError)
 	}
 	// The poisoned entry was dropped, so a later call gets a fresh attempt and
 	// succeeds instead of blocking forever.
-	if got := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
+	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
 		t.Errorf("retried promiseFailureRequest(1) status = %d, want %d", got, http.StatusOK)
 	}
 	if got := calls.Load(); got != 2 {
@@ -667,7 +685,7 @@ func TestPromiseFailurePanicConcurrent(t *testing.T) {
 	for range n {
 		go func() {
 			defer wg.Done()
-			if got := promiseFailureRequest(t, client, token, 1); got != http.StatusInternalServerError {
+			if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusInternalServerError {
 				t.Errorf("promiseFailureRequest(1) status = %d, want %d", got, http.StatusInternalServerError)
 			}
 		}()
@@ -700,7 +718,7 @@ func TestPromiseFailureConcurrent(t *testing.T) {
 	for range n {
 		go func() {
 			defer wg.Done()
-			if got := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
+			if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
 				t.Errorf("promiseFailureRequest(1) status = %d, want %d", got, http.StatusOK)
 			}
 		}()
@@ -715,12 +733,17 @@ func TestPromiseFailureConcurrent(t *testing.T) {
 func TestPromiseFailureConcurrentError(t *testing.T) {
 	t.Parallel()
 
-	// The declarer sleeps then fails, so a burst of concurrent callers coalesce
-	// onto the single in-flight attempt and all observe the same failure.
+	// The declarer blocks until released, then fails. Holding the in-flight
+	// attempt open lets a burst of concurrent callers reliably coalesce onto it
+	// and all observe the same failure.
 	var calls atomic.Int64
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startOnce sync.Once
 	client, token := startPromiseFailureServer(t, func(_ context.Context, _ int, _ string) (int, error) {
 		calls.Add(1)
-		time.Sleep(20 * time.Millisecond)
+		startOnce.Do(func() { close(started) })
+		<-release
 		return http.StatusUnprocessableEntity, fmt.Errorf("the job is no longer running")
 	})
 
@@ -730,11 +753,17 @@ func TestPromiseFailureConcurrentError(t *testing.T) {
 	for range n {
 		go func() {
 			defer wg.Done()
-			if got := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
+			if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
 				t.Errorf("concurrent promiseFailureRequest(1) status = %d, want %d", got, http.StatusUnprocessableEntity)
 			}
 		}()
 	}
+
+	// Once the leader is declaring (and holding the entry), give the other
+	// callers time to coalesce onto it, then release the attempt.
+	<-started
+	time.Sleep(100 * time.Millisecond)
+	close(release)
 	wg.Wait()
 
 	// The burst coalesced into a single declaration...
@@ -742,7 +771,7 @@ func TestPromiseFailureConcurrentError(t *testing.T) {
 		t.Errorf("declarer calls during burst = %d, want exactly 1", got)
 	}
 	// ...but because the failure wasn't cached, a later call retries.
-	if got := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
+	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
 		t.Errorf("later promiseFailureRequest(1) status = %d, want %d", got, http.StatusUnprocessableEntity)
 	}
 	if got := calls.Load(); got != 2 {

--- a/jobapi/server_test.go
+++ b/jobapi/server_test.go
@@ -37,12 +37,12 @@ func testEnviron() *env.Environment {
 	return e
 }
 
-func testServer(t *testing.T, e *env.Environment, mux *replacer.Mux) (*jobapi.Server, string, error) {
+func testServer(t *testing.T, e *env.Environment, mux *replacer.Mux, opts ...jobapi.ServerOpts) (*jobapi.Server, string, error) {
 	sockName, err := jobapi.NewSocketPath(os.TempDir())
 	if err != nil {
 		return nil, "", fmt.Errorf("creating socket path: %w", err)
 	}
-	return jobapi.NewServer(shell.TestingLogger{T: t}, sockName, e, mux)
+	return jobapi.NewServer(shell.TestingLogger{T: t}, sockName, e, mux, opts...)
 }
 
 func testSocketClient(socketPath string) *http.Client {
@@ -480,136 +480,273 @@ func TestCreateRedaction(t *testing.T) {
 	}
 }
 
-func TestPromiseFailure(t *testing.T) {
-	t.Parallel()
+// startPromiseFailureServer starts a Job API server with the given promised-
+// failure declarer and returns a socket client and auth token for it.
+func startPromiseFailureServer(t *testing.T, declarer jobapi.PromiseFailureDeclarer) (*http.Client, string) {
+	t.Helper()
 
-	env := testEnviron()
-	srv, token, err := testServer(t, env, replacer.NewMux())
+	srv, token, err := testServer(t, testEnviron(), replacer.NewMux(), jobapi.WithPromiseFailureDeclarer(declarer))
 	if err != nil {
-		t.Fatalf("testServer(t, env) error = %v", err)
+		t.Fatalf("testServer() error = %v", err)
 	}
-
 	if err := srv.Start(); err != nil {
 		t.Fatalf("srv.Start() error = %v", err)
 	}
 	t.Cleanup(func() {
 		if err := srv.Stop(); err != nil {
-			t.Fatalf("srv.Stop() error = %v", err)
+			t.Errorf("srv.Stop() error = %v", err)
 		}
 	})
+	return testSocketClient(srv.SocketPath), token
+}
 
-	client := testSocketClient(srv.SocketPath)
+// promiseFailureRequest POSTs a promise-failure declaration to the Job API and
+// returns the HTTP status code.
+func promiseFailureRequest(t *testing.T, client *http.Client, token string, exitStatus int) int {
+	t.Helper()
 
-	claim := func(exitStatus int) bool {
-		t.Helper()
-
-		buf := &bytes.Buffer{}
-		if err := json.NewEncoder(buf).Encode(&jobapi.PromiseFailureRequest{ExitStatus: exitStatus}); err != nil {
-			t.Fatalf("encoding request: %v", err)
-		}
-
-		req, err := http.NewRequest(http.MethodPost, "http://job/api/current-job/v0/promise-failure", buf)
-		if err != nil {
-			t.Fatalf("creating request: %v", err)
-		}
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-
-		resp, err := client.Do(req)
-		if err != nil {
-			t.Fatalf("client.Do(req) error = %v", err)
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("resp.StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
-		}
-
-		var got jobapi.PromiseFailureResponse
-		if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
-			t.Fatalf("decoding response: %v", err)
-		}
-		return got.Claimed
+	buf := &bytes.Buffer{}
+	if err := json.NewEncoder(buf).Encode(&jobapi.PromiseFailureRequest{ExitStatus: exitStatus}); err != nil {
+		t.Fatalf("encoding request: %v", err)
 	}
 
-	// The first claim of an exit status succeeds; repeated claims of the same
-	// exit status are debounced, but a different exit status can still be
-	// claimed.
-	if got := claim(1); !got {
-		t.Errorf("first claim(1) = %t, want true", got)
+	req, err := http.NewRequest(http.MethodPost, "http://job/api/current-job/v0/promise-failure", buf)
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
 	}
-	if got := claim(1); got {
-		t.Errorf("second claim(1) = %t, want false", got)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do(req) error = %v", err)
 	}
-	if got := claim(2); !got {
-		t.Errorf("first claim(2) = %t, want true", got)
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+func TestPromiseFailure(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu    sync.Mutex
+		calls []int // exit statuses passed to the declarer
+	)
+	client, token := startPromiseFailureServer(t, func(_ context.Context, exitStatus int, _ string) (int, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, exitStatus)
+		return http.StatusNoContent, nil
+	})
+
+	// The first declaration of an exit status calls the Buildkite API; repeated
+	// calls for the same exit status are debounced (no extra API call), but a
+	// different exit status is declared on its own. All callers see success.
+	for _, exitStatus := range []int{1, 1, 2} {
+		if got := promiseFailureRequest(t, client, token, exitStatus); got != http.StatusOK {
+			t.Errorf("promiseFailureRequest(%d) status = %d, want %d", exitStatus, got, http.StatusOK)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if diff := cmp.Diff([]int{1, 2}, calls); diff != "" {
+		t.Errorf("declarer calls diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestPromiseFailureInvalidExitStatus(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	client, token := startPromiseFailureServer(t, func(_ context.Context, _ int, _ string) (int, error) {
+		calls.Add(1)
+		return http.StatusNoContent, nil
+	})
+
+	// A non-positive exit status is rejected at the boundary, without reaching
+	// the declarer (and therefore the Buildkite API).
+	for _, exitStatus := range []int{0, -1} {
+		if got := promiseFailureRequest(t, client, token, exitStatus); got != http.StatusBadRequest {
+			t.Errorf("promiseFailureRequest(%d) status = %d, want %d", exitStatus, got, http.StatusBadRequest)
+		}
+	}
+	if got := calls.Load(); got != 0 {
+		t.Errorf("declarer calls = %d, want 0", got)
+	}
+}
+
+func TestPromiseFailureNotCachedOnError(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	client, token := startPromiseFailureServer(t, func(_ context.Context, _ int, _ string) (int, error) {
+		calls.Add(1)
+		return http.StatusUnprocessableEntity, fmt.Errorf("the job is no longer running")
+	})
+
+	// A failed declaration is surfaced with the Buildkite API's status code, and
+	// isn't cached: a later call for the same exit status retries.
+	if got := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
+		t.Errorf("first promiseFailureRequest(1) status = %d, want %d", got, http.StatusUnprocessableEntity)
+	}
+	if got := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
+		t.Errorf("second promiseFailureRequest(1) status = %d, want %d", got, http.StatusUnprocessableEntity)
+	}
+
+	if got := calls.Load(); got != 2 {
+		t.Errorf("declarer calls = %d, want 2 (failures must not be cached)", got)
+	}
+}
+
+func TestPromiseFailureStatusNormalization(t *testing.T) {
+	t.Parallel()
+
+	// The declarer reports errors with statuses that aren't usable HTTP error
+	// codes: a missing status (network error) and a non-error status.
+	client, token := startPromiseFailureServer(t, func(_ context.Context, exitStatus int, _ string) (int, error) {
+		switch exitStatus {
+		case 1:
+			return 0, fmt.Errorf("network error after retries")
+		case 2:
+			return http.StatusNoContent, fmt.Errorf("error with a non-error status")
+		}
+		return http.StatusNoContent, nil
+	})
+
+	// Both are normalized to 502, so a caller never reads an error as success.
+	for _, exitStatus := range []int{1, 2} {
+		if got := promiseFailureRequest(t, client, token, exitStatus); got != http.StatusBadGateway {
+			t.Errorf("promiseFailureRequest(%d) status = %d, want %d", exitStatus, got, http.StatusBadGateway)
+		}
+	}
+}
+
+func TestPromiseFailurePanicRecovers(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	client, token := startPromiseFailureServer(t, func(_ context.Context, _ int, _ string) (int, error) {
+		if calls.Add(1) == 1 {
+			panic("declarer boom")
+		}
+		return http.StatusNoContent, nil
+	})
+
+	// The first call panics inside the declarer; the recovery middleware turns it
+	// into a 500 rather than leaving the caller (and any waiters) hung.
+	if got := promiseFailureRequest(t, client, token, 1); got != http.StatusInternalServerError {
+		t.Errorf("panicking promiseFailureRequest(1) status = %d, want %d", got, http.StatusInternalServerError)
+	}
+	// The poisoned entry was dropped, so a later call gets a fresh attempt and
+	// succeeds instead of blocking forever.
+	if got := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
+		t.Errorf("retried promiseFailureRequest(1) status = %d, want %d", got, http.StatusOK)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("declarer calls = %d, want 2", got)
+	}
+}
+
+func TestPromiseFailurePanicConcurrent(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	client, token := startPromiseFailureServer(t, func(_ context.Context, _ int, _ string) (int, error) {
+		calls.Add(1)
+		time.Sleep(20 * time.Millisecond)
+		panic("declarer boom")
+	})
+
+	// A burst of callers coalesce onto a leader whose declaration panics. The
+	// leader is recovered to 500 and every waiter must also unblock with 500,
+	// rather than hanging on a channel that's never closed. (If any caller hung,
+	// the wait below would never return and the test would time out.)
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			if got := promiseFailureRequest(t, client, token, 1); got != http.StatusInternalServerError {
+				t.Errorf("promiseFailureRequest(1) status = %d, want %d", got, http.StatusInternalServerError)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := calls.Load(); got < 1 {
+		t.Errorf("declarer calls = %d, want at least 1", got)
 	}
 }
 
 func TestPromiseFailureConcurrent(t *testing.T) {
 	t.Parallel()
 
-	env := testEnviron()
-	srv, token, err := testServer(t, env, replacer.NewMux())
-	if err != nil {
-		t.Fatalf("testServer(t, env) error = %v", err)
-	}
-
-	if err := srv.Start(); err != nil {
-		t.Fatalf("srv.Start() error = %v", err)
-	}
-	t.Cleanup(func() {
-		if err := srv.Stop(); err != nil {
-			t.Fatalf("srv.Stop() error = %v", err)
-		}
+	// The declarer sleeps briefly so concurrent callers pile up behind the first
+	// one and exercise the coalescing wait path.
+	var calls atomic.Int64
+	client, token := startPromiseFailureServer(t, func(_ context.Context, _ int, _ string) (int, error) {
+		calls.Add(1)
+		time.Sleep(20 * time.Millisecond)
+		return http.StatusNoContent, nil
 	})
 
-	client := testSocketClient(srv.SocketPath)
-
-	// Many processes claiming the same exit status concurrently must result in
-	// exactly one claim, so only one declares the promised failure to the
-	// Buildkite API.
+	// Many processes declaring the same exit status concurrently must result in
+	// exactly one declaration to the Buildkite API, while every caller still
+	// sees the successful outcome.
 	const n = 50
-	var (
-		wg      sync.WaitGroup
-		claimed atomic.Int64
-	)
+	var wg sync.WaitGroup
 	wg.Add(n)
 	for range n {
 		go func() {
 			defer wg.Done()
-
-			buf := &bytes.Buffer{}
-			if err := json.NewEncoder(buf).Encode(&jobapi.PromiseFailureRequest{ExitStatus: 1}); err != nil {
-				t.Errorf("encoding request: %v", err)
-				return
-			}
-
-			req, err := http.NewRequest(http.MethodPost, "http://job/api/current-job/v0/promise-failure", buf)
-			if err != nil {
-				t.Errorf("creating request: %v", err)
-				return
-			}
-			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-
-			resp, err := client.Do(req)
-			if err != nil {
-				t.Errorf("client.Do(req) error = %v", err)
-				return
-			}
-
-			var got jobapi.PromiseFailureResponse
-			if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
-				t.Errorf("decoding response: %v", err)
-				return
-			}
-			if got.Claimed {
-				claimed.Add(1)
+			if got := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
+				t.Errorf("promiseFailureRequest(1) status = %d, want %d", got, http.StatusOK)
 			}
 		}()
 	}
 	wg.Wait()
 
-	if got := claimed.Load(); got != 1 {
-		t.Errorf("number of claimed responses = %d, want exactly 1", got)
+	if got := calls.Load(); got != 1 {
+		t.Errorf("declarer calls = %d, want exactly 1", got)
+	}
+}
+
+func TestPromiseFailureConcurrentError(t *testing.T) {
+	t.Parallel()
+
+	// The declarer sleeps then fails, so a burst of concurrent callers coalesce
+	// onto the single in-flight attempt and all observe the same failure.
+	var calls atomic.Int64
+	client, token := startPromiseFailureServer(t, func(_ context.Context, _ int, _ string) (int, error) {
+		calls.Add(1)
+		time.Sleep(20 * time.Millisecond)
+		return http.StatusUnprocessableEntity, fmt.Errorf("the job is no longer running")
+	})
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			if got := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
+				t.Errorf("concurrent promiseFailureRequest(1) status = %d, want %d", got, http.StatusUnprocessableEntity)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// The burst coalesced into a single declaration...
+	if got := calls.Load(); got != 1 {
+		t.Errorf("declarer calls during burst = %d, want exactly 1", got)
+	}
+	// ...but because the failure wasn't cached, a later call retries.
+	if got := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
+		t.Errorf("later promiseFailureRequest(1) status = %d, want %d", got, http.StatusUnprocessableEntity)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("declarer calls after retry = %d, want 2", got)
 	}
 }
 

--- a/jobapi/server_test.go
+++ b/jobapi/server_test.go
@@ -662,40 +662,19 @@ func TestPromiseFailureStatusNormalization(t *testing.T) {
 	}
 }
 
-func TestPromiseFailurePanicRecovers(t *testing.T) {
-	t.Parallel()
-
-	var calls atomic.Int64
-	client, token := startPromiseFailureServer(t, func(_ context.Context, _ int, _ string) (int, error) {
-		if calls.Add(1) == 1 {
-			panic("declarer boom")
-		}
-		return http.StatusNoContent, nil
-	})
-
-	// The first call panics inside the declarer; the recovery middleware turns it
-	// into a 500 rather than leaving the caller (and any waiters) hung.
-	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusInternalServerError {
-		t.Errorf("panicking promiseFailureRequest(1) status = %d, want %d", got, http.StatusInternalServerError)
-	}
-	// The poisoned entry was dropped, so a later call gets a fresh attempt and
-	// succeeds instead of blocking forever.
-	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
-		t.Errorf("retried promiseFailureRequest(1) status = %d, want %d", got, http.StatusOK)
-	}
-	if got := calls.Load(); got != 2 {
-		t.Errorf("declarer calls = %d, want 2", got)
-	}
-}
-
 func TestPromiseFailurePanicConcurrent(t *testing.T) {
 	t.Parallel()
 
 	var calls atomic.Int64
+	var panicking atomic.Bool
+	panicking.Store(true)
 	client, token := startPromiseFailureServer(t, func(_ context.Context, _ int, _ string) (int, error) {
 		calls.Add(1)
-		time.Sleep(20 * time.Millisecond)
-		panic("declarer boom")
+		if panicking.Load() {
+			time.Sleep(20 * time.Millisecond)
+			panic("declarer boom")
+		}
+		return http.StatusNoContent, nil
 	})
 
 	// A burst of callers coalesce onto a leader whose declaration panics. The
@@ -717,6 +696,17 @@ func TestPromiseFailurePanicConcurrent(t *testing.T) {
 
 	if got := calls.Load(); got < 1 {
 		t.Errorf("declarer calls = %d, want at least 1", got)
+	}
+
+	// The panic dropped the entry rather than caching a poisoned result, so a
+	// later call gets a fresh attempt and succeeds.
+	panicking.Store(false)
+	before := calls.Load()
+	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
+		t.Errorf("post-panic promiseFailureRequest(1) status = %d, want %d", got, http.StatusOK)
+	}
+	if got := calls.Load(); got != before+1 {
+		t.Errorf("declarer calls = %d, want %d (a fresh attempt after panic)", got, before+1)
 	}
 }
 
@@ -750,55 +740,6 @@ func TestPromiseFailureConcurrent(t *testing.T) {
 
 	if got := calls.Load(); got != 1 {
 		t.Errorf("declarer calls = %d, want exactly 1", got)
-	}
-}
-
-func TestPromiseFailureConcurrentError(t *testing.T) {
-	t.Parallel()
-
-	// The declarer blocks until released, then fails transiently. Holding the
-	// in-flight attempt open lets a burst of concurrent callers reliably coalesce
-	// onto it and all observe the same failure.
-	var calls atomic.Int64
-	started := make(chan struct{})
-	release := make(chan struct{})
-	var startOnce sync.Once
-	client, token := startPromiseFailureServer(t, func(_ context.Context, _ int, _ string) (int, error) {
-		calls.Add(1)
-		startOnce.Do(func() { close(started) })
-		<-release
-		return http.StatusServiceUnavailable, fmt.Errorf("the Buildkite API is unavailable")
-	})
-
-	const n = 50
-	var wg sync.WaitGroup
-	wg.Add(n)
-	for range n {
-		go func() {
-			defer wg.Done()
-			if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusServiceUnavailable {
-				t.Errorf("concurrent promiseFailureRequest(1) status = %d, want %d", got, http.StatusServiceUnavailable)
-			}
-		}()
-	}
-
-	// Once the leader is declaring (and holding the entry), give the other
-	// callers time to coalesce onto it, then release the attempt.
-	<-started
-	time.Sleep(100 * time.Millisecond)
-	close(release)
-	wg.Wait()
-
-	// The burst coalesced into a single declaration...
-	if got := calls.Load(); got != 1 {
-		t.Errorf("declarer calls during burst = %d, want exactly 1", got)
-	}
-	// ...but because the transient failure wasn't cached, a later call retries.
-	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusServiceUnavailable {
-		t.Errorf("later promiseFailureRequest(1) status = %d, want %d", got, http.StatusServiceUnavailable)
-	}
-	if got := calls.Load(); got != 2 {
-		t.Errorf("declarer calls after retry = %d, want 2", got)
 	}
 }
 

--- a/jobapi/server_test.go
+++ b/jobapi/server_test.go
@@ -593,26 +593,49 @@ func TestPromiseFailureInvalidExitStatus(t *testing.T) {
 	}
 }
 
-func TestPromiseFailureNotCachedOnError(t *testing.T) {
+func TestPromiseFailureNotCachedOnTransientError(t *testing.T) {
 	t.Parallel()
 
 	var calls atomic.Int64
 	client, token := startPromiseFailureServer(t, func(_ context.Context, _ int, _ string) (int, error) {
 		calls.Add(1)
-		return http.StatusUnprocessableEntity, fmt.Errorf("the job is no longer running")
+		return http.StatusServiceUnavailable, fmt.Errorf("the Buildkite API is unavailable")
 	})
 
-	// A failed declaration is surfaced with the Buildkite API's status code, and
+	// A transient failure is surfaced with the Buildkite API's status code, and
 	// isn't cached: a later call for the same exit status retries.
-	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
-		t.Errorf("first promiseFailureRequest(1) status = %d, want %d", got, http.StatusUnprocessableEntity)
+	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusServiceUnavailable {
+		t.Errorf("first promiseFailureRequest(1) status = %d, want %d", got, http.StatusServiceUnavailable)
 	}
-	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
-		t.Errorf("second promiseFailureRequest(1) status = %d, want %d", got, http.StatusUnprocessableEntity)
+	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusServiceUnavailable {
+		t.Errorf("second promiseFailureRequest(1) status = %d, want %d", got, http.StatusServiceUnavailable)
 	}
 
 	if got := calls.Load(); got != 2 {
-		t.Errorf("declarer calls = %d, want 2 (failures must not be cached)", got)
+		t.Errorf("declarer calls = %d, want 2 (transient failures must not be cached)", got)
+	}
+}
+
+func TestPromiseFailureCachedOnTerminalError(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	client, token := startPromiseFailureServer(t, func(_ context.Context, _ int, _ string) (int, error) {
+		calls.Add(1)
+		return http.StatusConflict, fmt.Errorf("a different exit status was already declared")
+	})
+
+	// A terminal failure is cached: a later call for the same exit status returns
+	// the same status without re-hitting the Buildkite API.
+	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusConflict {
+		t.Errorf("first promiseFailureRequest(1) status = %d, want %d", got, http.StatusConflict)
+	}
+	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusConflict {
+		t.Errorf("second promiseFailureRequest(1) status = %d, want %d", got, http.StatusConflict)
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("declarer calls = %d, want 1 (terminal failures must be cached)", got)
 	}
 }
 
@@ -733,9 +756,9 @@ func TestPromiseFailureConcurrent(t *testing.T) {
 func TestPromiseFailureConcurrentError(t *testing.T) {
 	t.Parallel()
 
-	// The declarer blocks until released, then fails. Holding the in-flight
-	// attempt open lets a burst of concurrent callers reliably coalesce onto it
-	// and all observe the same failure.
+	// The declarer blocks until released, then fails transiently. Holding the
+	// in-flight attempt open lets a burst of concurrent callers reliably coalesce
+	// onto it and all observe the same failure.
 	var calls atomic.Int64
 	started := make(chan struct{})
 	release := make(chan struct{})
@@ -744,7 +767,7 @@ func TestPromiseFailureConcurrentError(t *testing.T) {
 		calls.Add(1)
 		startOnce.Do(func() { close(started) })
 		<-release
-		return http.StatusUnprocessableEntity, fmt.Errorf("the job is no longer running")
+		return http.StatusServiceUnavailable, fmt.Errorf("the Buildkite API is unavailable")
 	})
 
 	const n = 50
@@ -753,8 +776,8 @@ func TestPromiseFailureConcurrentError(t *testing.T) {
 	for range n {
 		go func() {
 			defer wg.Done()
-			if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
-				t.Errorf("concurrent promiseFailureRequest(1) status = %d, want %d", got, http.StatusUnprocessableEntity)
+			if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusServiceUnavailable {
+				t.Errorf("concurrent promiseFailureRequest(1) status = %d, want %d", got, http.StatusServiceUnavailable)
 			}
 		}()
 	}
@@ -770,9 +793,9 @@ func TestPromiseFailureConcurrentError(t *testing.T) {
 	if got := calls.Load(); got != 1 {
 		t.Errorf("declarer calls during burst = %d, want exactly 1", got)
 	}
-	// ...but because the failure wasn't cached, a later call retries.
-	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusUnprocessableEntity {
-		t.Errorf("later promiseFailureRequest(1) status = %d, want %d", got, http.StatusUnprocessableEntity)
+	// ...but because the transient failure wasn't cached, a later call retries.
+	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusServiceUnavailable {
+		t.Errorf("later promiseFailureRequest(1) status = %d, want %d", got, http.StatusServiceUnavailable)
 	}
 	if got := calls.Load(); got != 2 {
 		t.Errorf("declarer calls after retry = %d, want 2", got)

--- a/jobapi/server_test.go
+++ b/jobapi/server_test.go
@@ -501,8 +501,8 @@ func startPromiseFailureServer(t *testing.T, declarer jobapi.PromiseFailureDecla
 }
 
 // promiseFailureRequest POSTs a promise-failure declaration to the Job API and
-// returns the HTTP status code and, on success, the outcome from the response body.
-func promiseFailureRequest(t *testing.T, client *http.Client, token string, exitStatus int) (int, string) {
+// returns the HTTP status code and, on success, the response body.
+func promiseFailureRequest(t *testing.T, client *http.Client, token string, exitStatus int) (int, *jobapi.PromiseFailureResponse) {
 	t.Helper()
 
 	buf := &bytes.Buffer{}
@@ -523,13 +523,13 @@ func promiseFailureRequest(t *testing.T, client *http.Client, token string, exit
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return resp.StatusCode, ""
+		return resp.StatusCode, nil
 	}
 	var body jobapi.PromiseFailureResponse
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		t.Fatalf("decoding response: %v", err)
 	}
-	return resp.StatusCode, body.Outcome
+	return resp.StatusCode, &body
 }
 
 func TestPromiseFailure(t *testing.T) {
@@ -556,12 +556,15 @@ func TestPromiseFailure(t *testing.T) {
 		jobapi.PromiseFailureDeclared,
 	}
 	for i, exitStatus := range []int{1, 1, 2} {
-		got, outcome := promiseFailureRequest(t, client, token, exitStatus)
+		got, result := promiseFailureRequest(t, client, token, exitStatus)
 		if got != http.StatusOK {
 			t.Errorf("promiseFailureRequest(%d) status = %d, want %d", exitStatus, got, http.StatusOK)
 		}
-		if outcome != wantOutcomes[i] {
-			t.Errorf("promiseFailureRequest(%d) outcome = %q, want %q", exitStatus, outcome, wantOutcomes[i])
+		if result.Outcome != wantOutcomes[i] {
+			t.Errorf("promiseFailureRequest(%d) outcome = %q, want %q", exitStatus, result.Outcome, wantOutcomes[i])
+		}
+		if !result.Accepted {
+			t.Errorf("promiseFailureRequest(%d) accepted = false, want true", exitStatus)
 		}
 	}
 
@@ -602,13 +605,17 @@ func TestPromiseFailureNotCachedOnTransientError(t *testing.T) {
 		return http.StatusServiceUnavailable, fmt.Errorf("the Buildkite API is unavailable")
 	})
 
-	// A transient failure is surfaced with the Buildkite API's status code, and
-	// isn't cached: a later call for the same exit status retries.
-	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusServiceUnavailable {
-		t.Errorf("first promiseFailureRequest(1) status = %d, want %d", got, http.StatusServiceUnavailable)
+	// A transient failure is surfaced in the response body, and isn't cached: a
+	// later call for the same exit status retries.
+	if got, result := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
+		t.Errorf("first promiseFailureRequest(1) status = %d, want %d", got, http.StatusOK)
+	} else if result.Accepted || result.UpstreamStatus != http.StatusServiceUnavailable || result.Terminal {
+		t.Errorf("first promiseFailureRequest(1) result = %+v, want rejected transient 503", result)
 	}
-	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusServiceUnavailable {
-		t.Errorf("second promiseFailureRequest(1) status = %d, want %d", got, http.StatusServiceUnavailable)
+	if got, result := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
+		t.Errorf("second promiseFailureRequest(1) status = %d, want %d", got, http.StatusOK)
+	} else if result.Accepted || result.UpstreamStatus != http.StatusServiceUnavailable || result.Terminal {
+		t.Errorf("second promiseFailureRequest(1) result = %+v, want rejected transient 503", result)
 	}
 
 	if got := calls.Load(); got != 2 {
@@ -626,12 +633,16 @@ func TestPromiseFailureCachedOnTerminalError(t *testing.T) {
 	})
 
 	// A terminal failure is cached: a later call for the same exit status returns
-	// the same status without re-hitting the Buildkite API.
-	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusConflict {
-		t.Errorf("first promiseFailureRequest(1) status = %d, want %d", got, http.StatusConflict)
+	// the same result without re-hitting the Buildkite API.
+	if got, result := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
+		t.Errorf("first promiseFailureRequest(1) status = %d, want %d", got, http.StatusOK)
+	} else if result.Accepted || result.UpstreamStatus != http.StatusConflict || !result.Terminal || result.Outcome != jobapi.PromiseFailureDeclared {
+		t.Errorf("first promiseFailureRequest(1) result = %+v, want declared terminal 409", result)
 	}
-	if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusConflict {
-		t.Errorf("second promiseFailureRequest(1) status = %d, want %d", got, http.StatusConflict)
+	if got, result := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
+		t.Errorf("second promiseFailureRequest(1) status = %d, want %d", got, http.StatusOK)
+	} else if result.Accepted || result.UpstreamStatus != http.StatusConflict || !result.Terminal || result.Outcome != jobapi.PromiseFailureDebounced {
+		t.Errorf("second promiseFailureRequest(1) result = %+v, want debounced terminal 409", result)
 	}
 
 	if got := calls.Load(); got != 1 {
@@ -654,10 +665,12 @@ func TestPromiseFailureStatusNormalization(t *testing.T) {
 		return http.StatusNoContent, nil
 	})
 
-	// Both are normalized to 502, so a caller never reads an error as success.
+	// Both are reported as rejected, so a caller never reads them as accepted.
 	for _, exitStatus := range []int{1, 2} {
-		if got, _ := promiseFailureRequest(t, client, token, exitStatus); got != http.StatusBadGateway {
-			t.Errorf("promiseFailureRequest(%d) status = %d, want %d", exitStatus, got, http.StatusBadGateway)
+		if got, result := promiseFailureRequest(t, client, token, exitStatus); got != http.StatusOK {
+			t.Errorf("promiseFailureRequest(%d) status = %d, want %d", exitStatus, got, http.StatusOK)
+		} else if result.Accepted || result.UpstreamStatus != map[int]int{1: 0, 2: http.StatusNoContent}[exitStatus] || result.Terminal {
+			t.Errorf("promiseFailureRequest(%d) result = %+v, want rejected transient", exitStatus, result)
 		}
 	}
 }
@@ -678,7 +691,7 @@ func TestPromiseFailurePanicConcurrent(t *testing.T) {
 	})
 
 	// A burst of callers coalesce onto a leader whose declaration panics. The
-	// leader is recovered to 500 and every waiter must also unblock with 500,
+	// leader is recovered to a rejected result and every waiter must also unblock,
 	// rather than hanging on a channel that's never closed. (If any caller hung,
 	// the wait below would never return and the test would time out.)
 	const n = 50
@@ -687,8 +700,10 @@ func TestPromiseFailurePanicConcurrent(t *testing.T) {
 	for range n {
 		go func() {
 			defer wg.Done()
-			if got, _ := promiseFailureRequest(t, client, token, 1); got != http.StatusInternalServerError {
-				t.Errorf("promiseFailureRequest(1) status = %d, want %d", got, http.StatusInternalServerError)
+			if got, result := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
+				t.Errorf("promiseFailureRequest(1) status = %d, want %d", got, http.StatusOK)
+			} else if result.Accepted || result.UpstreamStatus != http.StatusInternalServerError {
+				t.Errorf("promiseFailureRequest(1) result = %+v, want rejected panic result", result)
 			}
 		}()
 	}

--- a/jobapi/server_test.go
+++ b/jobapi/server_test.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -475,6 +477,139 @@ func TestCreateRedaction(t *testing.T) {
 
 	if got, want := writeBuf.String(), "Go from [REDACTED], until you get to Quito.\nFrom [REDACTED], go back to [REDACTED].\n"; got != want {
 		t.Fatalf("writeBuf.String() = %q, want %q", got, want)
+	}
+}
+
+func TestPromiseFailure(t *testing.T) {
+	t.Parallel()
+
+	env := testEnviron()
+	srv, token, err := testServer(t, env, replacer.NewMux())
+	if err != nil {
+		t.Fatalf("testServer(t, env) error = %v", err)
+	}
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("srv.Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := srv.Stop(); err != nil {
+			t.Fatalf("srv.Stop() error = %v", err)
+		}
+	})
+
+	client := testSocketClient(srv.SocketPath)
+
+	claim := func(exitStatus int) bool {
+		t.Helper()
+
+		buf := &bytes.Buffer{}
+		if err := json.NewEncoder(buf).Encode(&jobapi.PromiseFailureRequest{ExitStatus: exitStatus}); err != nil {
+			t.Fatalf("encoding request: %v", err)
+		}
+
+		req, err := http.NewRequest(http.MethodPost, "http://job/api/current-job/v0/promise-failure", buf)
+		if err != nil {
+			t.Fatalf("creating request: %v", err)
+		}
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("client.Do(req) error = %v", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("resp.StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+
+		var got jobapi.PromiseFailureResponse
+		if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+			t.Fatalf("decoding response: %v", err)
+		}
+		return got.Claimed
+	}
+
+	// The first claim of an exit status succeeds; repeated claims of the same
+	// exit status are debounced, but a different exit status can still be
+	// claimed.
+	if got := claim(1); !got {
+		t.Errorf("first claim(1) = %t, want true", got)
+	}
+	if got := claim(1); got {
+		t.Errorf("second claim(1) = %t, want false", got)
+	}
+	if got := claim(2); !got {
+		t.Errorf("first claim(2) = %t, want true", got)
+	}
+}
+
+func TestPromiseFailureConcurrent(t *testing.T) {
+	t.Parallel()
+
+	env := testEnviron()
+	srv, token, err := testServer(t, env, replacer.NewMux())
+	if err != nil {
+		t.Fatalf("testServer(t, env) error = %v", err)
+	}
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("srv.Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := srv.Stop(); err != nil {
+			t.Fatalf("srv.Stop() error = %v", err)
+		}
+	})
+
+	client := testSocketClient(srv.SocketPath)
+
+	// Many processes claiming the same exit status concurrently must result in
+	// exactly one claim, so only one declares the promised failure to the
+	// Buildkite API.
+	const n = 50
+	var (
+		wg      sync.WaitGroup
+		claimed atomic.Int64
+	)
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+
+			buf := &bytes.Buffer{}
+			if err := json.NewEncoder(buf).Encode(&jobapi.PromiseFailureRequest{ExitStatus: 1}); err != nil {
+				t.Errorf("encoding request: %v", err)
+				return
+			}
+
+			req, err := http.NewRequest(http.MethodPost, "http://job/api/current-job/v0/promise-failure", buf)
+			if err != nil {
+				t.Errorf("creating request: %v", err)
+				return
+			}
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Errorf("client.Do(req) error = %v", err)
+				return
+			}
+
+			var got jobapi.PromiseFailureResponse
+			if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+				t.Errorf("decoding response: %v", err)
+				return
+			}
+			if got.Claimed {
+				claimed.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := claimed.Load(); got != 1 {
+		t.Errorf("number of claimed responses = %d, want exactly 1", got)
 	}
 }
 

--- a/jobapi/server_test.go
+++ b/jobapi/server_test.go
@@ -609,12 +609,12 @@ func TestPromiseFailureNotCachedOnTransientError(t *testing.T) {
 	// later call for the same exit status retries.
 	if got, result := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
 		t.Errorf("first promiseFailureRequest(1) status = %d, want %d", got, http.StatusOK)
-	} else if result.Accepted || result.UpstreamStatus != http.StatusServiceUnavailable || result.Terminal {
+	} else if result.Accepted || result.UpstreamStatus != http.StatusServiceUnavailable {
 		t.Errorf("first promiseFailureRequest(1) result = %+v, want rejected transient 503", result)
 	}
 	if got, result := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
 		t.Errorf("second promiseFailureRequest(1) status = %d, want %d", got, http.StatusOK)
-	} else if result.Accepted || result.UpstreamStatus != http.StatusServiceUnavailable || result.Terminal {
+	} else if result.Accepted || result.UpstreamStatus != http.StatusServiceUnavailable {
 		t.Errorf("second promiseFailureRequest(1) result = %+v, want rejected transient 503", result)
 	}
 
@@ -636,12 +636,12 @@ func TestPromiseFailureCachedOnTerminalError(t *testing.T) {
 	// the same result without re-hitting the Buildkite API.
 	if got, result := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
 		t.Errorf("first promiseFailureRequest(1) status = %d, want %d", got, http.StatusOK)
-	} else if result.Accepted || result.UpstreamStatus != http.StatusConflict || !result.Terminal || result.Outcome != jobapi.PromiseFailureDeclared {
+	} else if result.Accepted || result.UpstreamStatus != http.StatusConflict || result.Outcome != jobapi.PromiseFailureDeclared {
 		t.Errorf("first promiseFailureRequest(1) result = %+v, want declared terminal 409", result)
 	}
 	if got, result := promiseFailureRequest(t, client, token, 1); got != http.StatusOK {
 		t.Errorf("second promiseFailureRequest(1) status = %d, want %d", got, http.StatusOK)
-	} else if result.Accepted || result.UpstreamStatus != http.StatusConflict || !result.Terminal || result.Outcome != jobapi.PromiseFailureDebounced {
+	} else if result.Accepted || result.UpstreamStatus != http.StatusConflict || result.Outcome != jobapi.PromiseFailureDebounced {
 		t.Errorf("second promiseFailureRequest(1) result = %+v, want debounced terminal 409", result)
 	}
 
@@ -669,7 +669,7 @@ func TestPromiseFailureStatusNormalization(t *testing.T) {
 	for _, exitStatus := range []int{1, 2} {
 		if got, result := promiseFailureRequest(t, client, token, exitStatus); got != http.StatusOK {
 			t.Errorf("promiseFailureRequest(%d) status = %d, want %d", exitStatus, got, http.StatusOK)
-		} else if result.Accepted || result.UpstreamStatus != map[int]int{1: 0, 2: http.StatusNoContent}[exitStatus] || result.Terminal {
+		} else if result.Accepted || result.UpstreamStatus != map[int]int{1: 0, 2: http.StatusNoContent}[exitStatus] {
 			t.Errorf("promiseFailureRequest(%d) result = %+v, want rejected transient", exitStatus, result)
 		}
 	}


### PR DESCRIPTION
## Description

Debounce repeated `buildkite-agent job promise-failure` calls in the agent so each exit status results in at most one Buildkite API call per job.

Customers are likely to call `promise-failure` from their test suite — potentially on every failing test. Each call spawns a new `buildkite-agent` process and would otherwise make its own API request, all of which the server must authenticate and process before discovering there's nothing new to record. For a suite with thousands of failures that's a lot of useless load on the Agent API.

This change moves the debouncing into the agent. The Job API server owns the declaration: each `promise-failure` invocation POSTs its exit status to the Job API, and the server declares the failure to the Buildkite API at most once per exit status. The first caller for a given exit status declares it, **blocking on the API** so it can return an accurate result; concurrent callers for the same exit status wait and share that outcome; later callers return from the cached success. Terminal failures (4xx other than 429, e.g. 409 or 422) are cached too, so repeated calls don't keep re-sending a declaration the API will always reject; transient failures (5xx, network, 429) aren't cached, so a later call can retry. Because the caller blocks until the result is known, the command exits with an accurate code rather than guessing.

The response reports an `outcome` of `declared` (this call reached the Buildkite API) or `debounced` (it shared an earlier declaration), and the CLI logs the distinction.

The Job API is job-scoped and enabled by default, so the state is naturally per-job (no keying by job ID) and there's no experiment to opt into. When the Job API is unavailable (`--no-job-api`, unsupported Windows) or can't be reached, the command falls back to declaring directly; the endpoint is idempotent for the same exit status, so a duplicate is safe.

This PR also drops the `--job` flag added to the command in #3992. The endpoint requires the job's own token and rejects declarations for any other job, so a promised failure only ever makes sense for the current job — the command now always targets `BUILDKITE_JOB_ID`.

## Context

Follows on from #3992, which added the `buildkite-agent job promise-failure` command.

## Changes

- `jobapi`: the `POST /api/current-job/v0/promise-failure` endpoint now declares the promised failure to the Buildkite API itself, coalescing concurrent and repeated calls so each exit status is declared at most once successfully. The declarer is injected via `WithPromiseFailureDeclarer`. The response carries an `outcome` (`declared`/`debounced`).
- `clicommand`: declare the promised failure through the Job API (blocking for an accurate result) and log whether it was declared or debounced; fall back to declaring directly when the Job API is unavailable or unreachable. Drop the `--job` flag and always target the current job.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

Added server tests over a real socket — sequential (first call declares, repeat is debounced, a different status declares on its own), concurrent (many simultaneous calls of the same status yield exactly one API declaration, all callers see success), error handling (terminal failures are cached, transient failures aren't and can retry; status normalization to 502), and panic safety — plus a client test for `DeclarePromiseFailure`.

## Disclosures / Credits

I used Amp to design and implement the debouncing and tests, with GPT-5 for a code review pass. I reviewed all of the changes myself.

