### PR TITLE
Clarify redaction failures without Job API

### DIFF
--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -3,6 +3,7 @@ package clicommand
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -155,7 +156,15 @@ var OIDCRequestTokenCommand = cli.Command{
 		if !cfg.SkipRedaction {
 			jobClient, err := jobapi.NewDefaultClient(ctx)
 			if err != nil {
-				return fmt.Errorf("failed to create Job API client: %w", err)
+				reason := "the Job API client could not be created"
+				if errors.Is(err, jobapi.ErrJobAPIUnavailable) {
+					reason = "the Job API is unavailable on this machine. On older Windows versions, including Windows Server 2016, the Job API is unavailable because Unix domain sockets are not supported"
+				}
+				return fmt.Errorf(
+					"automatic OIDC token redaction requires the Job API, but %s. OIDC token was not printed. To request it anyway, explicitly opt out of redaction with --skip-redaction or BUILDKITE_AGENT_OIDC_REQUEST_TOKEN_SKIP_TOKEN_REDACTION=true: %w",
+					reason,
+					err,
+				)
 			}
 
 			if err := AddToRedactor(ctx, l, jobClient, token.Token); err != nil {

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -156,13 +156,12 @@ var OIDCRequestTokenCommand = cli.Command{
 		if !cfg.SkipRedaction {
 			jobClient, err := jobapi.NewDefaultClient(ctx)
 			if err != nil {
-				reason := "the Job API client could not be created"
+				err = fmt.Errorf("the Job API client could not be created (error: %w)", err)
 				if errors.Is(err, jobapi.ErrJobAPIUnavailable) {
-					reason = "the Job API is unavailable on this machine. On older Windows versions, including Windows Server 2016, the Job API is unavailable because Unix domain sockets are not supported"
+					err = fmt.Errorf("the Job API is unavailable on this machine, as it requires Unix domain sockets to function. On Windows, Unix domain sockets require Windows build 17063 or newer (Windows 10 version 1803 / Windows Server 2019 onwards)")
 				}
 				return fmt.Errorf(
-					"automatic OIDC token redaction requires the Job API, but %s. OIDC token was not printed. To request it anyway, explicitly opt out of redaction with --skip-redaction or BUILDKITE_AGENT_OIDC_REQUEST_TOKEN_SKIP_TOKEN_REDACTION=true: %w",
-					reason,
+					"automatic OIDC token redaction requires the Job API, but %w. The command failed instead of outputting the token because it could leak in logs without redaction. To output the token anyway, explicitly opt out of redaction with --skip-redaction or BUILDKITE_AGENT_OIDC_REQUEST_TOKEN_SKIP_TOKEN_REDACTION=true",
 					err,
 				)
 			}

--- a/clicommand/oidc_request_token_test.go
+++ b/clicommand/oidc_request_token_test.go
@@ -69,7 +69,7 @@ func TestOIDCRequestToken(t *testing.T) {
 
 		for _, want := range []string{
 			"automatic OIDC token redaction requires the Job API",
-			"OIDC token was not printed",
+			"could leak in logs without redaction",
 			"--skip-redaction",
 			"BUILDKITE_AGENT_OIDC_REQUEST_TOKEN_SKIP_TOKEN_REDACTION=true",
 		} {

--- a/clicommand/oidc_request_token_test.go
+++ b/clicommand/oidc_request_token_test.go
@@ -68,9 +68,10 @@ func TestOIDCRequestToken(t *testing.T) {
 		}
 
 		for _, want := range []string{
-			"automatic OIDC token redaction requires the Job API, but the Job API client could not be created",
+			"automatic OIDC token redaction requires the Job API",
 			"OIDC token was not printed",
-			"To request it anyway, explicitly opt out of redaction with --skip-redaction or BUILDKITE_AGENT_OIDC_REQUEST_TOKEN_SKIP_TOKEN_REDACTION=true",
+			"--skip-redaction",
+			"BUILDKITE_AGENT_OIDC_REQUEST_TOKEN_SKIP_TOKEN_REDACTION=true",
 		} {
 			if got := err.Error(); !strings.Contains(got, want) {
 				t.Fatalf("runOIDCRequestTokenCommand() error = %q, want containing %q", got, want)

--- a/clicommand/oidc_request_token_test.go
+++ b/clicommand/oidc_request_token_test.go
@@ -1,0 +1,94 @@
+package clicommand
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli"
+)
+
+func newOIDCRequestTokenTestServer(t *testing.T, jobID, token string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		wantPath := fmt.Sprintf("/jobs/%s/oidc/tokens", url.PathEscape(jobID))
+		if req.URL.Path != wantPath {
+			http.Error(rw, fmt.Sprintf("got path %q, want %q", req.URL.Path, wantPath), http.StatusNotFound)
+			return
+		}
+
+		_, _ = fmt.Fprintf(rw, `{"token":%q}`, token)
+	}))
+}
+
+func runOIDCRequestTokenCommand(t *testing.T, serverURL string, args ...string) (string, error) {
+	t.Helper()
+
+	app := cli.NewApp()
+	app.Commands = []cli.Command{OIDCRequestTokenCommand}
+
+	var out bytes.Buffer
+	app.Writer = &out
+
+	runArgs := []string{
+		"buildkite-agent",
+		"request-token",
+		"--endpoint", serverURL,
+		"--agent-access-token", "agent-access-token",
+		"--job", "job-123",
+	}
+	runArgs = append(runArgs, args...)
+
+	err := app.Run(runArgs)
+	return out.String(), err
+}
+
+func TestOIDCRequestToken(t *testing.T) {
+	const oidcToken = "oidc-token"
+
+	server := newOIDCRequestTokenTestServer(t, "job-123", oidcToken)
+	defer server.Close()
+
+	t.Run("requires explicit opt out when redaction cannot be set up", func(t *testing.T) {
+		t.Setenv("BUILDKITE_AGENT_JOB_API_SOCKET", "")
+		t.Setenv("BUILDKITE_AGENT_JOB_API_TOKEN", "")
+
+		out, err := runOIDCRequestTokenCommand(t, server.URL)
+		if err == nil {
+			t.Fatal("runOIDCRequestTokenCommand() error = nil, want non-nil")
+		}
+
+		if out != "" {
+			t.Fatalf("runOIDCRequestTokenCommand() output = %q, want empty", out)
+		}
+
+		for _, want := range []string{
+			"automatic OIDC token redaction requires the Job API, but the Job API client could not be created",
+			"OIDC token was not printed",
+			"To request it anyway, explicitly opt out of redaction with --skip-redaction or BUILDKITE_AGENT_OIDC_REQUEST_TOKEN_SKIP_TOKEN_REDACTION=true",
+		} {
+			if got := err.Error(); !strings.Contains(got, want) {
+				t.Fatalf("runOIDCRequestTokenCommand() error = %q, want containing %q", got, want)
+			}
+		}
+	})
+
+	t.Run("prints token when redaction is explicitly skipped", func(t *testing.T) {
+		t.Setenv("BUILDKITE_AGENT_JOB_API_SOCKET", "")
+		t.Setenv("BUILDKITE_AGENT_JOB_API_TOKEN", "")
+
+		out, err := runOIDCRequestTokenCommand(t, server.URL, "--skip-redaction")
+		if err != nil {
+			t.Fatalf("runOIDCRequestTokenCommand() error = %v, want nil", err)
+		}
+
+		if want := oidcToken + "\n"; out != want {
+			t.Fatalf("runOIDCRequestTokenCommand() output = %q, want %q", out, want)
+		}
+	})
+}

--- a/clicommand/secret_get.go
+++ b/clicommand/secret_get.go
@@ -116,7 +116,15 @@ func secretGet(ctx context.Context, cfg SecretGetConfig, w io.Writer, l logger.L
 	if !cfg.SkipRedaction {
 		jobClient, err := jobapi.NewDefaultClient(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to create Job API client: %w", err)
+			reason := "the Job API client could not be created"
+			if errors.Is(err, jobapi.ErrJobAPIUnavailable) {
+				reason = "the Job API is unavailable on this machine. On older Windows versions, including Windows Server 2016, the Job API is unavailable because Unix domain sockets are not supported"
+			}
+			return fmt.Errorf(
+				"automatic secret redaction requires the Job API, but %s. secret values were not printed. To request it anyway, explicitly opt out of redaction with --skip-redaction or BUILDKITE_AGENT_SECRET_GET_SKIP_SECRET_REDACTION=true: %w",
+				reason,
+				err,
+			)
 		}
 
 		for _, secret := range fetchedSecrets {

--- a/clicommand/secret_get.go
+++ b/clicommand/secret_get.go
@@ -116,13 +116,12 @@ func secretGet(ctx context.Context, cfg SecretGetConfig, w io.Writer, l logger.L
 	if !cfg.SkipRedaction {
 		jobClient, err := jobapi.NewDefaultClient(ctx)
 		if err != nil {
-			reason := "the Job API client could not be created"
+			err = fmt.Errorf("the Job API client could not be created (error: %w)", err)
 			if errors.Is(err, jobapi.ErrJobAPIUnavailable) {
-				reason = "the Job API is unavailable on this machine. On older Windows versions, including Windows Server 2016, the Job API is unavailable because Unix domain sockets are not supported"
+				err = fmt.Errorf("the Job API is unavailable on this machine, as it requires Unix domain sockets to function. On Windows, Unix domain sockets require Windows build 17063 or newer (Windows 10 version 1803 / Windows Server 2019 onwards)")
 			}
 			return fmt.Errorf(
-				"automatic secret redaction requires the Job API, but %s. secret values were not printed. To request it anyway, explicitly opt out of redaction with --skip-redaction or BUILDKITE_AGENT_SECRET_GET_SKIP_SECRET_REDACTION=true: %w",
-				reason,
+				"automatic secret redaction requires the Job API, but %w. The command failed instead of outputting secret values because they could leak in logs without redaction. To output the secret values anyway, explicitly opt out of redaction with --skip-redaction or BUILDKITE_AGENT_SECRET_GET_SKIP_SECRET_REDACTION=true",
 				err,
 			)
 		}

--- a/clicommand/secret_get_test.go
+++ b/clicommand/secret_get_test.go
@@ -198,7 +198,7 @@ func TestSecretGet(t *testing.T) {
 
 		for _, want := range []string{
 			"automatic secret redaction requires the Job API",
-			"secret values were not printed",
+			"could leak in logs without redaction",
 			"--skip-redaction",
 			"BUILDKITE_AGENT_SECRET_GET_SKIP_SECRET_REDACTION=true",
 		} {

--- a/clicommand/secret_get_test.go
+++ b/clicommand/secret_get_test.go
@@ -175,4 +175,36 @@ func TestSecretGet(t *testing.T) {
 			t.Fatalf("err.Error() = %q, want containing %q", got, want)
 		}
 	})
+
+	t.Run("requires explicit opt out when redaction cannot be set up", func(t *testing.T) {
+		t.Setenv("BUILDKITE_AGENT_JOB_API_SOCKET", "")
+		t.Setenv("BUILDKITE_AGENT_JOB_API_TOKEN", "")
+
+		server := newSecretGetTestServer(t, map[string]string{"deploy_key": "shhsecret"})
+		defer server.Close()
+
+		cfg := baseSecretGetConfig(server.URL, []string{"deploy_key"}, "default")
+		cfg.SkipRedaction = false
+
+		var out bytes.Buffer
+		err := secretGet(t.Context(), cfg, &out, logger.NewBuffer())
+		if err == nil {
+			t.Fatal("secretGet(t.Context(), cfg, &out, logger.NewBuffer()) error = nil, want non-nil")
+		}
+
+		if out.String() != "" {
+			t.Fatalf("out.String() = %q, want empty", out.String())
+		}
+
+		for _, want := range []string{
+			"automatic secret redaction requires the Job API",
+			"secret values were not printed",
+			"--skip-redaction",
+			"BUILDKITE_AGENT_SECRET_GET_SKIP_SECRET_REDACTION=true",
+		} {
+			if got := err.Error(); !strings.Contains(got, want) {
+				t.Fatalf("err.Error() = %q, want containing %q", got, want)
+			}
+		}
+	})
 }

--- a/jobapi/client.go
+++ b/jobapi/client.go
@@ -15,6 +15,8 @@ const (
 )
 
 var (
+	// ErrJobAPIUnavailable is returned when the current machine cannot support the Job API.
+	ErrJobAPIUnavailable = errors.New("job API is unavailable on this machine")
 	errNoJobAPISocketEnv = errors.New("BUILDKITE_AGENT_JOB_API_SOCKET empty or undefined")
 	errNoJobAPITokenEnv  = errors.New("BUILDKITE_AGENT_JOB_API_TOKEN empty or undefined")
 )
@@ -37,6 +39,10 @@ func NewDefaultClient(ctx context.Context) (*Client, error) {
 
 // DefaultSocketPath returns the socket path and access token, if available.
 func DefaultSocketPath() (path, token string, err error) {
+	if !socket.Available() {
+		return "", "", ErrJobAPIUnavailable
+	}
+
 	path = os.Getenv("BUILDKITE_AGENT_JOB_API_SOCKET")
 	if path == "" {
 		return "", "", errNoJobAPISocketEnv


### PR DESCRIPTION
## Description

Older Windows versions such as Windows Server 2016 cannot use the Job API because Unix domain sockets are unavailable. OIDC token and secret redaction both depend on the Job API, so this change keeps failing closed by default while making the failure explicit and actionable.

## Context

Linear: https://linear.app/buildkite/issue/A-1290/elastic-oidc-support-for-older-windows-versions-2016

## Changes

- Return a sentinel `jobapi.ErrJobAPIUnavailable` when the current machine cannot support the Job API.
- Check socket availability before reading the default Job API socket/token environment variables.
- Improve `oidc request-token` and `secret get` errors so users know output was not printed and can opt out with `--skip-redaction` or the command-specific environment variable.
- Add coverage for OIDC token redaction setup failures and skipped redaction, plus secret redaction setup failures.

## Testing

- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go tool gofumpt -extra -w .`)

Ran focused tests locally:

```sh
mise exec -- go test ./clicommand ./jobapi
```

Formatted touched files with `gofmt`.

Manually smoke-tested OIDC token requests on Unix and Windows Server 2016. Verified the Unix redaction path, the Windows fail-closed error path, and the explicit `--skip-redaction` opt-out path.

## Affiliation (optional, external contributors)

Buildkite

## Disclosures / Credits

I used OpenAI Codex to help implement and refactor this change.
