### PR TITLE
feat: Change ID to Name in the agent to match v2 (follow up on #3993)

### DIFF
--- a/clicommand/cache_restore.go
+++ b/clicommand/cache_restore.go
@@ -34,7 +34,7 @@ Example:
 This will restore all caches defined in .buildkite/cache.yml. You can also restore
 specific caches by providing their IDs:
 
-    $ buildkite-agent cache restore --ids "node"
+    $ buildkite-agent cache restore --names "node"
 
 The cache is retrieved from BUILDKITE_AGENT_CACHE_STORE_URL (or --cache-store-url),
 downloaded directly using the agent's ambient credentials. The registry is
@@ -48,7 +48,7 @@ list of parts; each part is a literal string or one of { agent: os },
 { agent: arch }, { checksum: <file> }, or { env: <VAR> }:
 
     caches:
-      - id: node
+      - name: node
         cache_key:
           - node
           - { agent: os }
@@ -100,7 +100,7 @@ var CacheRestoreCommand = cli.Command{
 			Pipeline:        cfg.Pipeline,
 			Organization:    cfg.Organization,
 			CacheConfigFile: cfg.CacheConfigFile,
-			Ids:             cfg.Ids,
+			Names:           cfg.Names,
 		}
 
 		// Perform cache restore (logging happens inside)

--- a/clicommand/cache_save.go
+++ b/clicommand/cache_save.go
@@ -33,7 +33,7 @@ Example:
 This will save all caches defined in .buildkite/cache.yml. You can also save
 specific caches by providing their IDs:
 
-    $ buildkite-agent cache save --ids "node"
+    $ buildkite-agent cache save --names "node"
 
 The cache is stored at BUILDKITE_AGENT_CACHE_STORE_URL (or --cache-store-url).
 The registry is selected by BUILDKITE_AGENT_CACHE_REGISTRY (or --registry); '~'
@@ -47,7 +47,7 @@ list of parts; each part is a literal string or one of { agent: os },
 { agent: arch }, { checksum: <file> }, or { env: <VAR> }:
 
     caches:
-      - id: node
+      - name: node
         cache_key:
           - node
           - { agent: os }
@@ -97,7 +97,7 @@ var CacheSaveCommand = cli.Command{
 			Pipeline:        cfg.Pipeline,
 			Organization:    cfg.Organization,
 			CacheConfigFile: cfg.CacheConfigFile,
-			Ids:             cfg.Ids,
+			Names:           cfg.Names,
 			Concurrency:     cfg.Concurrency,
 		}
 

--- a/clicommand/cache_shared.go
+++ b/clicommand/cache_shared.go
@@ -5,7 +5,7 @@ import "github.com/urfave/cli"
 // CacheConfig includes cache-related shared options for easy inclusion across
 // cache command config structs (via embedding).
 type CacheConfig struct {
-	Ids             []string `cli:"ids"`
+	Names           []string `cli:"names"`
 	Registry        string   `cli:"registry"`
 	BucketURL       string   `cli:"cache-store-url"`
 	Branch          string   `cli:"branch" validate:"required"`
@@ -18,10 +18,10 @@ type CacheConfig struct {
 func cacheFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringSliceFlag{
-			Name:   "ids",
+			Name:   "names",
 			Value:  &cli.StringSlice{},
-			Usage:  "Cache IDs to process (can be specified multiple times; if empty, processes all caches)",
-			EnvVar: "BUILDKITE_CACHE_IDS",
+			Usage:  "Cache names to process (can be specified multiple times; if empty, processes all caches)",
+			EnvVar: "BUILDKITE_CACHE_NAMES",
 		},
 		cli.StringFlag{
 			Name:   "registry",

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -26,8 +26,8 @@ type Config struct {
 	Organization string
 	// CacheConfigFile is the path to the cache configuration YAML file
 	CacheConfigFile string
-	// Ids is a list of cache IDs (if empty, processes all caches)
-	Ids []string
+	// Names is a list of cache names (if empty, processes all caches)
+	Names []string
 	// Concurrency is the number of concurrent cache operations
 	Concurrency int
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -332,12 +332,12 @@ func TestNewClient_InvalidCacheIDs(t *testing.T) {
 	t.Parallel()
 
 	config := `caches:
-  - id: cache1
+  - name: cache1
     cache_key:
       - test-key-1
     target_paths:
       - path1
-  - id: cache2
+  - name: cache2
     cache_key:
       - test-key-2
     target_paths:
@@ -347,7 +347,7 @@ func TestNewClient_InvalidCacheIDs(t *testing.T) {
 
 	cfg := Config{
 		CacheConfigFile: configFile,
-		Ids:             []string{"cache1", "invalid1", "cache2", "invalid2"},
+		Names:           []string{"cache1", "invalid1", "cache2", "invalid2"},
 		BucketURL:       "s3://test-bucket",
 		Branch:          "main",
 		Pipeline:        "test-pipeline",
@@ -358,7 +358,7 @@ func TestNewClient_InvalidCacheIDs(t *testing.T) {
 	if err == nil {
 		t.Fatalf("newClient(logger.Discard, nil, cfg) error = %v, want non-nil error", err)
 	}
-	if want := "cache IDs not found in configuration"; !strings.Contains(err.Error(), want) {
+	if want := "cache names not found in configuration"; !strings.Contains(err.Error(), want) {
 		t.Fatalf("newClient(logger.Discard, nil, cfg) error = %v, want error containing %q", err, want)
 	}
 	if want := "invalid1"; !strings.Contains(err.Error(), want) {
@@ -373,12 +373,12 @@ func TestNewClient_ValidCacheIDs(t *testing.T) {
 	t.Parallel()
 
 	config := `caches:
-  - id: cache1
+  - name: cache1
     cache_key:
       - test-key-1
     target_paths:
       - path1
-  - id: cache2
+  - name: cache2
     cache_key:
       - test-key-2
     target_paths:
@@ -388,7 +388,7 @@ func TestNewClient_ValidCacheIDs(t *testing.T) {
 
 	cfg := Config{
 		CacheConfigFile: configFile,
-		Ids:             []string{"cache1", "cache2"},
+		Names:           []string{"cache1", "cache2"},
 		BucketURL:       "s3://test-bucket",
 		Branch:          "main",
 		Pipeline:        "test-pipeline",
@@ -411,12 +411,12 @@ func TestNewClient_AllCaches(t *testing.T) {
 	t.Parallel()
 
 	config := `caches:
-  - id: cache1
+  - name: cache1
     cache_key:
       - test-key-1
     target_paths:
       - path1
-  - id: cache2
+  - name: cache2
     cache_key:
       - test-key-2
     target_paths:
@@ -426,7 +426,7 @@ func TestNewClient_AllCaches(t *testing.T) {
 
 	cfg := Config{
 		CacheConfigFile: configFile,
-		Ids:             []string{},
+		Names:           []string{},
 		BucketURL:       "s3://test-bucket",
 		Branch:          "main",
 		Pipeline:        "test-pipeline",

--- a/internal/cache/client.go
+++ b/internal/cache/client.go
@@ -64,7 +64,7 @@ type client struct {
 
 // newClient builds a client from apiClient and cfg: loads and expands the
 // cache configuration file, validates every cache definition, and returns the
-// client together with the cache IDs to operate on (filtered by cfg.Ids if
+// client together with the cache names to operate on (filtered by cfg.Names if
 // non-empty).
 //
 // Returns (nil, nil, nil) when the configuration file has no caches.
@@ -84,7 +84,7 @@ func newClient(l logger.Logger, apiClient cacheAPI, cfg Config) (*client, []stri
 	}
 	for _, c := range expanded {
 		if err := c.Validate(); err != nil {
-			return nil, nil, fmt.Errorf("%w: cache validation failed for ID %s: %w", ErrInvalidConfiguration, c.ID, err)
+			return nil, nil, fmt.Errorf("%w: cache validation failed for name %s: %w", ErrInvalidConfiguration, c.Name, err)
 		}
 	}
 
@@ -114,36 +114,36 @@ func newClient(l logger.Logger, apiClient cacheAPI, cfg Config) (*client, []stri
 		},
 	}
 
-	ids, err := c.resolveCacheIDs(cfg.Ids)
+	names, err := c.resolveCacheNames(cfg.Names)
 	if err != nil {
 		return nil, nil, err
 	}
-	return c, ids, nil
+	return c, names, nil
 }
 
-// resolveCacheIDs returns requested if non-empty (after validating every ID
-// exists), otherwise returns every cache ID configured on the client.
-func (c *client) resolveCacheIDs(requested []string) ([]string, error) {
+// resolveCacheNames returns requested if non-empty (after validating every name
+// exists), otherwise returns every cache name configured on the client.
+func (c *client) resolveCacheNames(requested []string) ([]string, error) {
 	if len(requested) == 0 {
-		ids := make([]string, 0, len(c.caches))
+		names := make([]string, 0, len(c.caches))
 		for _, cc := range c.caches {
-			ids = append(ids, cc.ID)
+			names = append(names, cc.Name)
 		}
-		return ids, nil
+		return names, nil
 	}
 
 	known := make(map[string]bool, len(c.caches))
 	for _, cc := range c.caches {
-		known[cc.ID] = true
+		known[cc.Name] = true
 	}
 	var invalid []string
-	for _, id := range requested {
-		if !known[id] {
-			invalid = append(invalid, id)
+	for _, name := range requested {
+		if !known[name] {
+			invalid = append(invalid, name)
 		}
 	}
 	if len(invalid) > 0 {
-		return nil, fmt.Errorf("cache IDs not found in configuration: %s", strings.Join(invalid, ", "))
+		return nil, fmt.Errorf("cache names not found in configuration: %s", strings.Join(invalid, ", "))
 	}
 	return requested, nil
 }
@@ -160,10 +160,10 @@ func (c *client) callProgress(cacheID, stage, message string, current, total int
 	c.onProgress(cacheID, stage, message, current, total)
 }
 
-// findCache returns the cache definition with the given ID, or ErrCacheNotFound.
-func (c *client) findCache(id string) (*configuration.Cache, error) {
+// findCache returns the cache definition with the given name, or ErrCacheNotFound.
+func (c *client) findCache(name string) (*configuration.Cache, error) {
 	for i := range c.caches {
-		if c.caches[i].ID == id {
+		if c.caches[i].Name == name {
 			return &c.caches[i], nil
 		}
 	}

--- a/internal/cache/configuration/cache.go
+++ b/internal/cache/configuration/cache.go
@@ -7,8 +7,8 @@ import (
 )
 
 type Cache struct {
-	// ID of the cache entry to save.
-	ID string `yaml:"id"`
+	// Name of the cache entry to save.
+	Name string `yaml:"name"`
 	// Key of the cache entry to save, this can be a template string.
 	CacheKey []KeyPart `yaml:"cache_key"`
 	// Target Paths to remove.
@@ -19,11 +19,11 @@ type Cache struct {
 func (c Cache) Validate() error {
 	var errors []string
 
-	// ID validation: alphanumeric and underscore only
-	if strings.TrimSpace(c.ID) == "" {
-		errors = append(errors, "id cannot be empty")
-	} else if !regexp.MustCompile(`^[a-zA-Z0-9_]+$`).MatchString(c.ID) {
-		errors = append(errors, fmt.Sprintf("id '%s' can only contain letters, numbers, and underscores", c.ID))
+	// Name validation: alphanumeric and underscore only
+	if strings.TrimSpace(c.Name) == "" {
+		errors = append(errors, "name cannot be empty")
+	} else if !regexp.MustCompile(`^[a-zA-Z0-9_]+$`).MatchString(c.Name) {
+		errors = append(errors, fmt.Sprintf("name '%s' can only contain letters, numbers, and underscores", c.Name))
 	}
 
 	// Cache Key validation: non-empty
@@ -51,7 +51,7 @@ func (c Cache) Validate() error {
 	}
 
 	if len(errors) > 0 {
-		return fmt.Errorf("cache validation failed for id '%s': %s", c.ID, strings.Join(errors, "; "))
+		return fmt.Errorf("cache validation failed for name '%s': %s", c.Name, strings.Join(errors, "; "))
 	}
 
 	return nil

--- a/internal/cache/configuration/cache_test.go
+++ b/internal/cache/configuration/cache_test.go
@@ -17,7 +17,7 @@ func TestCacheValidate(t *testing.T) {
 		{
 			name: "valid cache",
 			cache: Cache{
-				ID:          "node_modules",
+				Name:        "node_modules",
 				CacheKey:    literalKey,
 				TargetPaths: []string{"node_modules"},
 			},
@@ -26,16 +26,16 @@ func TestCacheValidate(t *testing.T) {
 		{
 			name: "valid cache with underscores and numbers, multiple paths",
 			cache: Cache{
-				ID:          "test_123",
+				Name:        "test_123",
 				CacheKey:    literalKey,
 				TargetPaths: []string{"./dist", "../cache"},
 			},
 			wantErr: false,
 		},
 		{
-			name: "invalid ID with hyphen",
+			name: "invalid name with hyphen",
 			cache: Cache{
-				ID:          "node-modules",
+				Name:        "node-modules",
 				CacheKey:    literalKey,
 				TargetPaths: []string{"node_modules"},
 			},
@@ -43,9 +43,9 @@ func TestCacheValidate(t *testing.T) {
 			errMsg:  "can only contain letters, numbers, and underscores",
 		},
 		{
-			name: "invalid ID with space",
+			name: "invalid name with space",
 			cache: Cache{
-				ID:          "node modules",
+				Name:        "node modules",
 				CacheKey:    literalKey,
 				TargetPaths: []string{"node_modules"},
 			},
@@ -53,29 +53,29 @@ func TestCacheValidate(t *testing.T) {
 			errMsg:  "can only contain letters, numbers, and underscores",
 		},
 		{
-			name: "empty ID",
+			name: "empty Name",
 			cache: Cache{
-				ID:          "",
+				Name:        "",
 				CacheKey:    literalKey,
 				TargetPaths: []string{"node_modules"},
 			},
 			wantErr: true,
-			errMsg:  "id cannot be empty",
+			errMsg:  "name cannot be empty",
 		},
 		{
 			name: "whitespace only ID",
 			cache: Cache{
-				ID:          "   ",
+				Name:        "   ",
 				CacheKey:    literalKey,
 				TargetPaths: []string{"node_modules"},
 			},
 			wantErr: true,
-			errMsg:  "id cannot be empty",
+			errMsg:  "name cannot be empty",
 		},
 		{
 			name: "empty cache_key",
 			cache: Cache{
-				ID:          "valid_id",
+				Name:        "valid_id",
 				CacheKey:    nil,
 				TargetPaths: []string{"node_modules"},
 			},
@@ -85,7 +85,7 @@ func TestCacheValidate(t *testing.T) {
 		{
 			name: "no target paths",
 			cache: Cache{
-				ID:          "valid_id",
+				Name:        "valid_id",
 				CacheKey:    literalKey,
 				TargetPaths: []string{},
 			},
@@ -95,7 +95,7 @@ func TestCacheValidate(t *testing.T) {
 		{
 			name: "empty target path",
 			cache: Cache{
-				ID:          "valid_id",
+				Name:        "valid_id",
 				CacheKey:    literalKey,
 				TargetPaths: []string{""},
 			},
@@ -105,7 +105,7 @@ func TestCacheValidate(t *testing.T) {
 		{
 			name: "target path with null byte",
 			cache: Cache{
-				ID:          "valid_id",
+				Name:        "valid_id",
 				CacheKey:    literalKey,
 				TargetPaths: []string{"invalid\x00path"},
 			},
@@ -115,7 +115,7 @@ func TestCacheValidate(t *testing.T) {
 		{
 			name: "duplicate target paths",
 			cache: Cache{
-				ID:          "valid_id",
+				Name:        "valid_id",
 				CacheKey:    literalKey,
 				TargetPaths: []string{"node_modules", "node_modules"},
 			},

--- a/internal/cache/configuration/file_test.go
+++ b/internal/cache/configuration/file_test.go
@@ -21,13 +21,13 @@ func TestLoadFile_Valid(t *testing.T) {
 	t.Parallel()
 
 	config := `caches:
-  - id: node
+  - name: node
     cache_key:
       - node
       - { checksum: package-lock.json }
     target_paths:
       - node_modules
-  - id: ruby
+  - name: ruby
     cache_key:
       - ruby
       - { checksum: Gemfile.lock }
@@ -43,11 +43,11 @@ func TestLoadFile_Valid(t *testing.T) {
 	if got, want := len(caches), 2; got != want {
 		t.Fatalf("len(caches) = %d, want %d", got, want)
 	}
-	if got, want := caches[0].ID, "node"; got != want {
-		t.Fatalf("caches[0].ID = %q, want %q", got, want)
+	if got, want := caches[0].Name, "node"; got != want {
+		t.Fatalf("caches[0].Name = %q, want %q", got, want)
 	}
-	if got, want := caches[1].ID, "ruby"; got != want {
-		t.Fatalf("caches[1].ID = %q, want %q", got, want)
+	if got, want := caches[1].Name, "ruby"; got != want {
+		t.Fatalf("caches[1].Name = %q, want %q", got, want)
 	}
 }
 
@@ -55,7 +55,7 @@ func TestLoadFile_InvalidYAML(t *testing.T) {
 	t.Parallel()
 
 	config := `caches:
-  - id: node
+  - name: node
     cache_key: test
     target_paths
       - invalid indentation here

--- a/internal/cache/integration_test.go
+++ b/internal/cache/integration_test.go
@@ -281,7 +281,7 @@ func setupTestCache(t *testing.T, storageType string) (cacheClient *client, cach
 		registry:     "~",
 		caches: []configuration.Cache{
 			{
-				ID:          "test-cache",
+				Name:        "test-cache",
 				CacheKey:    []configuration.KeyPart{{Source: configuration.SourceLiteral, Arg: "v1-test-key"}},
 				TargetPaths: []string{cacheDir},
 			},


### PR DESCRIPTION
## Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

follow up on this comment on https://github.com/buildkite/agent/pull/3993#discussion_r3410483454
## Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->
https://linear.app/buildkite/issue/A-1293/agent-cli-parse-v2-cacheyml-and-speak-v2-wire-protocol 
## Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->
renamed the cache entry's id: field to name: and the --ids flag/BUILDKITE_CACHE_IDS env to --names/BUILDKITE_CACHE_NAMES (with matching internal Name/Names/resolveCacheNames renames).

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
