### PR TITLE
Workaround for ETXTBSY flake

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/buildkite/agent/v3/agent/plugin"
 	"github.com/buildkite/agent/v3/api"
@@ -38,7 +37,6 @@ import (
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/agent/v3/tracetools"
 	"github.com/buildkite/go-pipeline"
-	"github.com/buildkite/roko"
 	"github.com/buildkite/shellwords"
 )
 
@@ -551,30 +549,13 @@ func (e *Executor) runWrappedShellScriptHook(ctx context.Context, hookName strin
 		e.shell.Promptf("%s", process.FormatCommand(cleanHookPath, []string{}))
 	}
 
-	const maxHookRetry = 30
-
-	// Run the wrapper script
-	err = roko.NewRetrier(
-		roko.WithStrategy(roko.Constant(100*time.Millisecond)),
-		roko.WithMaxAttempts(maxHookRetry),
-	).DoWithContext(ctx, func(r *roko.Retrier) error {
-		// Run the script and only retry on ETXTBSY.
-		// This error occurs because of an unavoidable race between forking
-		// (which acquires open file descriptors of the parent process) and
-		// writing an executable (the script wrapper).
-		// See https://github.com/golang/go/issues/22315.
+	err = func() error {
 		script, err := e.shell.Script(script.Path(), e.HooksShell)
 		if err != nil {
-			r.Break()
 			return err
 		}
-		err = script.Run(ctx, shell.ShowPrompt(false), shell.WithExtraEnv(hookCfg.Env))
-		if errors.Is(err, syscall.ETXTBSY) {
-			return err
-		}
-		r.Break()
-		return err
-	})
+		return script.Run(ctx, shell.ShowPrompt(false), shell.WithExtraEnv(hookCfg.Env))
+	}()
 	if err != nil {
 		exitCode := shell.ExitCode(err)
 		e.shell.Env.Set("BUILDKITE_LAST_HOOK_EXIT_STATUS", strconv.Itoa(exitCode))
@@ -590,7 +571,8 @@ func (e *Executor) runWrappedShellScriptHook(ctx context.Context, hookName strin
 
 		switch {
 		case errors.Is(err, syscall.ETXTBSY):
-			// If the underlying error is _still_ ETXTBSY, then inspect the file
+			// If the underlying error is _still_ ETXTBSY
+			// (after the retry within script.Run), then inspect the file
 			// to see what process had it open for write, to log something helpful
 			logOpenedHookInfo(e.shell.Logger, e.Debug, hookName, script.Path())
 

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -663,14 +663,29 @@ func (s *Shell) executeCommand(ctx context.Context, cmdCfg process.Config, stdou
 		return nil
 	}
 
-	p := process.New(processLogger, cmdCfg)
-	s.proc.Store(p)
-
-	if err := p.Run(ctx); err != nil {
-		return fmt.Errorf("error running %q: %w", process.FormatCommand(cmdCfg.Path, cmdCfg.Args), err)
+	// This sad retry loop is needed to work around the ETXTBSY race, which is
+	// common when using hook wrappers or other dynamic scripts.
+	// See https://github.com/golang/go/issues/22315
+	attempts := 0
+etxtbsyLoop:
+	for {
+		attempts++
+		p := process.New(processLogger, cmdCfg)
+		s.proc.Store(p)
+		err := p.Run(ctx)
+		if attempts <= 100 && errors.Is(err, syscall.ETXTBSY) {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(100 * time.Millisecond):
+				continue etxtbsyLoop
+			}
+		}
+		if err != nil {
+			return fmt.Errorf("error running %q: %w", process.FormatCommand(cmdCfg.Path, cmdCfg.Args), err)
+		}
+		return p.WaitResult()
 	}
-
-	return p.WaitResult()
 }
 
 // ExitCode extracts an exit code from an error where the platform supports it,


### PR DESCRIPTION
## Description

`TestRunningHookDetectsChangedEnvironment` is flaky because of golang/go#22315. Work around it with a retry loop within shell's `executeCommand`, which replaces the existing retry loop within executor's `runWrappedShellScriptHook`.

## Context

Noticed while running CI for another PR. Was probably obscured by the recently-removed test retry.

## Changes

Add a retry loop within shell's `executeCommand`.
Remove the retry within executor's `runWrappedShellScriptHook`.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

I did not use AI tools at all
