### PR TITLE
feat: Support fallbackLimit for agent keyPart

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -32,7 +32,7 @@ var ErrCacheEntryNotFound = errors.New("cache entry not found")
 var cacheTracer = otel.Tracer("github.com/buildkite/agent/v3/api/cache")
 
 // CacheKeyPart is one element of the structured cache_key sent on the wire.
-// Every part ships with mandatory=true for now; fallback ability lands later.
+// Mandatory parts must match for a cache hit.
 type CacheKeyPart struct {
 	Value     string `json:"value"`
 	Mandatory bool   `json:"mandatory"`

--- a/clicommand/cache_restore.go
+++ b/clicommand/cache_restore.go
@@ -21,8 +21,9 @@ defined in your cache config file (defaults to .buildkite/cache.yml).
 
 The cache configuration file defines which files or directories should be restored
 and their associated cache key. An entry is restored when its target_paths
-(an order-insensitive set) and cache_key match exactly. Fallback matching is not
-enabled yet — every key part is treated as mandatory.
+(an order-insensitive set) and the mandatory parts of its cache_key match. By
+default every key part is mandatory; mark a part with fallbackLimit: true to make
+every part after it optional.
 
 Note: This feature is currently in development and subject to change. It is not
 yet available to all customers.
@@ -45,14 +46,19 @@ Configuration File Format:
 
 The cache configuration file should be in YAML format. cache_key is an ordered
 list of parts; each part is a literal string or one of { agent: os },
-{ agent: arch }, { checksum: <file> }, or { env: <VAR> }:
+{ agent: arch }, { checksum: <file> }, or { env: <VAR> }. Any one part may also
+set fallbackLimit: true to make every part after it optional for fallback
+matching (the marked part itself stays mandatory). In the example below an exact
+match is preferred, but if the lockfile changed, an entry matching node + os + arch
+is still restored, as the fallback is specified on arch, making node + os + arch mandatory, 
+but making checksum optional:
 
     caches:
       - name: node
         cache_key:
           - node
           - { agent: os }
-          - { agent: arch }
+          - { agent: arch, fallbackLimit: true }
           - { checksum: package-lock.json }
         target_paths:
           - node_modules

--- a/internal/cache/configuration/cache.go
+++ b/internal/cache/configuration/cache.go
@@ -31,6 +31,17 @@ func (c Cache) Validate() error {
 		errors = append(errors, "cache_key cannot be empty")
 	}
 
+	// At most one cache_key part may declare fallbackLimit.
+	fallbackLimits := 0
+	for _, part := range c.CacheKey {
+		if part.FallbackLimit {
+			fallbackLimits++
+		}
+	}
+	if fallbackLimits > 1 {
+		errors = append(errors, "cache_key: fallbackLimit may be set on at most one part")
+	}
+
 	// TargetPaths validation: non-empty set of valid, unique paths
 	if len(c.TargetPaths) == 0 {
 		errors = append(errors, "at least one target_paths entry must be specified")

--- a/internal/cache/configuration/cache_test.go
+++ b/internal/cache/configuration/cache_test.go
@@ -73,6 +73,31 @@ func TestCacheValidate(t *testing.T) {
 			errMsg:  "name cannot be empty",
 		},
 		{
+			name: "single fallbackLimit is valid",
+			cache: Cache{
+				Name: "node_modules",
+				CacheKey: []KeyPart{
+					{Source: SourceLiteral, Arg: "v1", FallbackLimit: true},
+					{Source: SourceEnv, Arg: "FOO"},
+				},
+				TargetPaths: []string{"node_modules"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple fallbackLimit is invalid",
+			cache: Cache{
+				Name: "node_modules",
+				CacheKey: []KeyPart{
+					{Source: SourceLiteral, Arg: "v1", FallbackLimit: true},
+					{Source: SourceEnv, Arg: "FOO", FallbackLimit: true},
+				},
+				TargetPaths: []string{"node_modules"},
+			},
+			wantErr: true,
+			errMsg:  "fallbackLimit may be set on at most one part",
+		},
+		{
 			name: "empty cache_key",
 			cache: Cache{
 				Name:        "valid_id",

--- a/internal/cache/configuration/key_part.go
+++ b/internal/cache/configuration/key_part.go
@@ -15,6 +15,9 @@ import (
 type KeyPart struct {
 	Arg    string
 	Source Source
+	// FallbackLimit marks the fallback boundary: this part and every part before
+	// it are mandatory; parts after it are optional. At most one part may set it.
+	FallbackLimit bool
 }
 type Source string
 
@@ -52,11 +55,29 @@ func (k *KeyPart) unmarshalMapping(node *yaml.Node) error {
 	if err := node.Decode(&fields); err != nil {
 		return fmt.Errorf("cache_key: invalid entry: %w", err)
 	}
-	if len(fields) != 1 {
-		return fmt.Errorf("cache_key: invalid entry length: %d", len(fields))
+
+	// fallbackLimit is an optional modifier alongside the single source.
+	hasFallbackLimit := false
+	if raw, ok := fields["fallbackLimit"]; ok {
+		if err := raw.Decode(&k.FallbackLimit); err != nil {
+			return fmt.Errorf("cache_key: fallbackLimit must be a boolean")
+		}
+		hasFallbackLimit = true
+	}
+
+	// Exactly one source key; fallbackLimit is a modifier, not a source.
+	sourceCount := len(fields)
+	if hasFallbackLimit {
+		sourceCount--
+	}
+	if sourceCount != 1 {
+		return fmt.Errorf("cache_key: entry must name exactly one source (plus optional fallbackLimit)")
 	}
 
 	for src, val := range fields {
+		if src == "fallbackLimit" {
+			continue
+		}
 		switch Source(src) {
 		case SourceAgent:
 			if val.Kind != yaml.ScalarNode {
@@ -90,19 +111,31 @@ func (k *KeyPart) unmarshalMapping(node *yaml.Node) error {
 }
 
 // ResolveCacheKey resolves each KeyPart to its concrete value and returns the
-// flat wire shape the backend expects. Every part is mandatory in M1 (fallback
-// semantics land separately), which is why Mandatory is hard-coded true.
+// flat wire shape the backend expects. A part is mandatory iff it is at or
+// before the part declaring fallbackLimit; parts after it are optional. When no
+// part declares fallbackLimit, every part is mandatory. At most one part may
+// declare it (enforced by Validate).
 func ResolveCacheKey(keyParts []KeyPart, env map[string]string) ([]api.CacheKeyPart, error) {
 	if len(keyParts) == 0 {
 		return nil, fmt.Errorf("cache_key cannot be empty")
 	}
+
+	// Default boundary = last part → every part mandatory.
+	limit := len(keyParts) - 1
+	for i, keyPart := range keyParts {
+		if keyPart.FallbackLimit {
+			limit = i
+			break
+		}
+	}
+
 	out := make([]api.CacheKeyPart, len(keyParts))
 	for i, keyPart := range keyParts {
 		resolvedKeyPart, err := keyPart.Resolve(env)
 		if err != nil {
 			return nil, fmt.Errorf("cache_key[%d]: %w", i, err)
 		}
-		out[i] = api.CacheKeyPart{Value: resolvedKeyPart, Mandatory: true}
+		out[i] = api.CacheKeyPart{Value: resolvedKeyPart, Mandatory: i <= limit}
 	}
 	return out, nil
 }

--- a/internal/cache/configuration/key_part_test.go
+++ b/internal/cache/configuration/key_part_test.go
@@ -29,6 +29,9 @@ func TestKeyPartUnmarshal(t *testing.T) {
 		{name: "agent arch", yaml: `{ agent: arch }`, want: KeyPart{Source: SourceAgent, Arg: "arch"}},
 		{name: "checksum", yaml: `{ checksum: go.mod }`, want: KeyPart{Source: SourceChecksum, Arg: "go.mod"}},
 		{name: "env", yaml: `{ env: GO_VERSION }`, want: KeyPart{Source: SourceEnv, Arg: "GO_VERSION"}},
+		{name: "fallbackLimit on agent", yaml: `{ agent: arch, fallbackLimit: true }`, want: KeyPart{Source: SourceAgent, Arg: "arch", FallbackLimit: true}},
+		{name: "fallbackLimit on checksum", yaml: `{ checksum: go.mod, fallbackLimit: true }`, want: KeyPart{Source: SourceChecksum, Arg: "go.mod", FallbackLimit: true}},
+		{name: "fallbackLimit false is a no-op", yaml: `{ agent: arch, fallbackLimit: false }`, want: KeyPart{Source: SourceAgent, Arg: "arch", FallbackLimit: false}},
 
 		// Out of M1 scope -> parse errors.
 		{name: "empty literal", yaml: `""`, wantErr: "literal entry cannot be empty"},
@@ -37,8 +40,9 @@ func TestKeyPartUnmarshal(t *testing.T) {
 		{name: "checksum array deferred", yaml: `{ checksum: [go.mod, go.sum] }`, wantErr: "single file path"},
 		{name: "cmd deferred", yaml: `{ cmd: ["go", "version"] }`, wantErr: "unknown source"},
 		{name: "unknown source", yaml: `{ bogus: x }`, wantErr: "unknown source"},
-		{name: "fallbackLimit deferred", yaml: `{ agent: arch, fallbackLimit: true }`, wantErr: "invalid entry length"},
-		{name: "empty map", yaml: `{}`, wantErr: "invalid entry length"},
+		{name: "fallbackLimit non-bool", yaml: `{ agent: arch, fallbackLimit: 7 }`, wantErr: "fallbackLimit must be a boolean"},
+		{name: "fallbackLimit without source", yaml: `{ fallbackLimit: true }`, wantErr: "exactly one source"},
+		{name: "empty map", yaml: `{}`, wantErr: "exactly one source"},
 		{name: "sequence", yaml: `[a, b]`, wantErr: "must be a string or a { source: arg } map"},
 	}
 
@@ -185,6 +189,50 @@ func TestResolveCacheKey(t *testing.T) {
 			if got[i] != want[i] {
 				t.Fatalf("ResolveCacheKey()[%d] = %+v, want %+v", i, got[i], want[i])
 			}
+		}
+	})
+
+	t.Run("fallbackLimit splits mandatory from optional", func(t *testing.T) {
+		t.Parallel()
+		parts := []KeyPart{
+			{Source: SourceLiteral, Arg: "node"},
+			{Source: SourceAgent, Arg: "os", FallbackLimit: true},
+			{Source: SourceEnv, Arg: "FOO"},
+		}
+		got, err := ResolveCacheKey(parts, map[string]string{"FOO": "bar"})
+		if err != nil {
+			t.Fatalf("ResolveCacheKey() unexpected error = %v", err)
+		}
+
+		// The part declaring fallbackLimit (os) is itself mandatory;
+		// only parts after it are optional.
+		want := []api.CacheKeyPart{
+			{Value: "node", Mandatory: true},
+			{Value: runtime.GOOS, Mandatory: true},
+			{Value: "bar", Mandatory: false},
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("ResolveCacheKey()[%d] = %+v, want %+v", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("fallbackLimit on first part makes only later parts optional", func(t *testing.T) {
+		t.Parallel()
+		parts := []KeyPart{
+			{Source: SourceLiteral, Arg: "node", FallbackLimit: true},
+			{Source: SourceAgent, Arg: "os"},
+		}
+		got, err := ResolveCacheKey(parts, nil)
+		if err != nil {
+			t.Fatalf("ResolveCacheKey() unexpected error = %v", err)
+		}
+		if !got[0].Mandatory {
+			t.Fatalf("got[0].Mandatory = false, want true")
+		}
+		if got[1].Mandatory {
+			t.Fatalf("got[1].Mandatory = true, want false")
 		}
 	})
 


### PR DESCRIPTION
## Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
Building on the changes introduces in [A-1293](https://linear.app/buildkite/issue/A-1293/agent-cli-parse-v2-cacheyml-and-speak-v2-wire-protocol)

The v2 cache wire protocol marks each `cache_key` part as `mandatory` or optional: mandatory parts must match for a cache hit, while optional parts can be dropped in a fallback lookup so a near-match can still be restored. Until now the agent hard-coded every resolved part to `mandatory: true`, so users had no way to express partial fallback (e.g. "reuse yesterday's `node_modules` even if the lockfile changed").

This adds a `fallbackLimit: true` modifier to `cache.yml` that lets users draw the fallback boundary themselves. The marked part is the *last mandatory* part; every part after it is optional. With no `fallbackLimit` anywhere, all parts remian mandatory. 



## Context
<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->
https://linear.app/buildkite/issue/A-1342/agent-keypart-support-fallbacklimit

## Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->
- **Parser** (`internal/cache/configuration/key_part.go`): `fallbackLimit` is accepted as an optional modifier alongside the single source key on any object-form `KeyPart`. `fallbackLimit: false` is a documented no-op; a non-bool value is a parse error; an entry with zero or more-than-one source key is rejected.
- **Validation** (`internal/cache/configuration/cache.go`): at most one part may declare `fallbackLimit` — this cross-part rule lives in `Validate()` since `UnmarshalYAML` only sees one part at a time.
- **Config→wire normalization** (`ResolveCacheKey`): computes the boundary index from the part declaring `fallbackLimit` (default: last part) and sets `Mandatory: i <= limit` per part.
- **Docs/comments**: refreshed the stale "fallback not enabled / always mandatory" notes in `api/cache.go` and the `cache restore --help` text, and added a `fallbackLimit` example to the help.
- **Tests**: parse cases (`true`/`false`/non-bool/source-less), boundary normalization (middle and first part), and the multiple-`fallbackLimit` validation error.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
Implemented in consultation with Claude.
