### PR TITLE
feat: Add branch, step, and pipeline as agent cache-key facts, resolv…

### DIFF
--- a/internal/cache/configuration/key_part.go
+++ b/internal/cache/configuration/key_part.go
@@ -29,8 +29,11 @@ const (
 )
 
 var supportedAgentArgs = map[string]struct{}{
-	"os":   {},
-	"arch": {},
+	"os":       {},
+	"arch":     {},
+	"branch":   {},
+	"step":     {},
+	"pipeline": {},
 }
 
 func (k *KeyPart) UnmarshalYAML(node *yaml.Node) error {
@@ -152,15 +155,20 @@ func (k KeyPart) Resolve(env map[string]string) (string, error) {
 			v = runtime.GOOS
 		case "arch":
 			v = runtime.GOARCH
+		case "branch":
+			v = lookupEnv(env, "BUILDKITE_BRANCH")
+		case "pipeline":
+			v = lookupEnv(env, "BUILDKITE_PIPELINE_SLUG")
+		case "step":
+			v = lookupEnv(env, "BUILDKITE_STEP_KEY")
+			if v == "" {
+				v = lookupEnv(env, "BUILDKITE_STEP_ID")
+			}
 		default:
 			return "", fmt.Errorf("cache_key: unsupported agent fact %q", k.Arg)
 		}
 	case SourceEnv:
-		if env != nil {
-			v = env[k.Arg]
-		} else {
-			v = os.Getenv(k.Arg)
-		}
+		v = lookupEnv(env, k.Arg)
 	case SourceChecksum:
 		// For now, support is for single regular file only. Multi-file checksums, globs, and
 		// directories are not supported. We have NOT yet considered symlinks, special files, or very large
@@ -173,6 +181,15 @@ func (k KeyPart) Resolve(env map[string]string) (string, error) {
 		return "", err
 	}
 	return v, nil
+}
+
+// lookupEnv reads name from the supplied env map, or from the process
+// environment when env is nil. Missing value resolves to "".
+func lookupEnv(env map[string]string, name string) string {
+	if env != nil {
+		return env[name]
+	}
+	return os.Getenv(name)
 }
 
 // sha256File returns the hex-encoded SHA-256 of the file's contents

--- a/internal/cache/configuration/key_part_test.go
+++ b/internal/cache/configuration/key_part_test.go
@@ -27,6 +27,9 @@ func TestKeyPartUnmarshal(t *testing.T) {
 		{name: "literal quoted", yaml: `"v3"`, want: KeyPart{Source: SourceLiteral, Arg: "v3"}},
 		{name: "agent os", yaml: `{ agent: os }`, want: KeyPart{Source: SourceAgent, Arg: "os"}},
 		{name: "agent arch", yaml: `{ agent: arch }`, want: KeyPart{Source: SourceAgent, Arg: "arch"}},
+		{name: "agent branch", yaml: `{ agent: branch }`, want: KeyPart{Source: SourceAgent, Arg: "branch"}},
+		{name: "agent step", yaml: `{ agent: step }`, want: KeyPart{Source: SourceAgent, Arg: "step"}},
+		{name: "agent pipeline", yaml: `{ agent: pipeline }`, want: KeyPart{Source: SourceAgent, Arg: "pipeline"}},
 		{name: "checksum", yaml: `{ checksum: go.mod }`, want: KeyPart{Source: SourceChecksum, Arg: "go.mod"}},
 		{name: "env", yaml: `{ env: GO_VERSION }`, want: KeyPart{Source: SourceEnv, Arg: "GO_VERSION"}},
 		{name: "fallbackLimit on agent", yaml: `{ agent: arch, fallbackLimit: true }`, want: KeyPart{Source: SourceAgent, Arg: "arch", FallbackLimit: true}},
@@ -35,7 +38,6 @@ func TestKeyPartUnmarshal(t *testing.T) {
 
 		// Out of M1 scope -> parse errors.
 		{name: "empty literal", yaml: `""`, wantErr: "literal entry cannot be empty"},
-		{name: "agent pipeline deferred", yaml: `{ agent: pipeline }`, wantErr: "unsupported agent argument"},
 		{name: "agent os_version deferred", yaml: `{ agent: os_version }`, wantErr: "unsupported agent argument"},
 		{name: "checksum array deferred", yaml: `{ checksum: [go.mod, go.sum] }`, wantErr: "single file path"},
 		{name: "cmd deferred", yaml: `{ cmd: ["go", "version"] }`, wantErr: "unknown source"},
@@ -88,6 +90,11 @@ func TestKeyPartResolve(t *testing.T) {
 		{name: "agent arch", part: KeyPart{Source: SourceAgent, Arg: "arch"}, want: runtime.GOARCH},
 		{name: "env from map", part: KeyPart{Source: SourceEnv, Arg: "FOO"}, env: map[string]string{"FOO": "bar"}, want: "bar"},
 		{name: "env missing from map", part: KeyPart{Source: SourceEnv, Arg: "MISSING"}, env: map[string]string{}, want: ""},
+		{name: "agent branch", part: KeyPart{Source: SourceAgent, Arg: "branch"}, env: map[string]string{"BUILDKITE_BRANCH": "main"}, want: "main"},
+		{name: "agent pipeline", part: KeyPart{Source: SourceAgent, Arg: "pipeline"}, env: map[string]string{"BUILDKITE_PIPELINE_SLUG": "my-pipeline"}, want: "my-pipeline"},
+		{name: "agent step from key", part: KeyPart{Source: SourceAgent, Arg: "step"}, env: map[string]string{"BUILDKITE_STEP_KEY": "build", "BUILDKITE_STEP_ID": "01ABC"}, want: "build"},
+		{name: "agent step falls back to id", part: KeyPart{Source: SourceAgent, Arg: "step"}, env: map[string]string{"BUILDKITE_STEP_ID": "01ABC"}, want: "01ABC"},
+		{name: "agent branch missing is empty", part: KeyPart{Source: SourceAgent, Arg: "branch"}, env: map[string]string{}, want: ""},
 		{name: "agent unsupported fact", part: KeyPart{Source: SourceAgent, Arg: "queue"}, wantErr: "unsupported agent fact"},
 	}
 


### PR DESCRIPTION
…ed from job env

## Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

The agent-side `cache_key` parser (A-1293) only supported two `agent` facts — `os` and `arch` — both resolved by runtime detection (`runtime.GOOS`/`runtime.GOARCH`). Users had no curated way to key a cache on job context (branch, step, pipeline) without resorting to raw `{ env: BUILDKITE_* }` entries, which leak env var names into `cache.yml` and can't express multi-variable fallback.

This extends the parser and resolver to accept three backend-supplied job-context facts:

- `{ agent: branch }`   → `BUILDKITE_BRANCH`
- `{ agent: pipeline }` → `BUILDKITE_PIPELINE_SLUG`
- `{ agent: step }`     → `BUILDKITE_STEP_KEY`, falling back to `BUILDKITE_STEP_ID`

Unlike `os`/`arch`, these resolve from the job environment rather than runtime detection.
## Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->
https://linear.app/buildkite/issue/A-1341/agent-keypart-support-agentbranch-agentstep-agentpipeline

## Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->
- `internal/cache/configuration/key_part.go`:
  - Added `branch`, `step`, `pipeline` to `supportedAgentArgs` so the parser accepts and validates them.
  - Added the corresponding cases to `Resolve`'s `agent` switch, reading from the job env (with `step` preferring `BUILDKITE_STEP_KEY` and falling back to `BUILDKITE_STEP_ID`).
  - Extracted a `lookupEnv` helper (env map, or process env when nil; missing → `""`), now shared by these facts and the existing `env` source.
- Tests: parse cases for the three new facts; resolve cases driven by an `env` map, including `step` key-vs-id fallback and missing-var-resolves-to-empty.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
Implemented in colsultation with Claude