### PR TITLE
A-1376 part 1: e2e test for basic cache read/write

### DIFF
--- a/internal/e2e/cache_test.go
+++ b/internal/e2e/cache_test.go
@@ -1,0 +1,34 @@
+//go:build e2e
+
+// Note to external contributors: Many test cases in this file require
+// access to specific Buildkite organization resources and may not work
+// in your local environment. These tests can be safely skipped during
+// local development.
+
+package e2e
+
+import (
+	"testing"
+)
+
+// Test that an agent can save a cache and restore it (with round-tripped
+// content) in a dependent step, using a customer-managed S3 cache store.
+//
+// Test name structure is load-bearing: the IAM trust policy on the role
+// assumed by the fixture's aws-assume-role-with-web-identity plugin pins
+// pipeline_slug to a prefix, so the test name must produce a slug starting
+// with that prefix (Buildkite converts underscores to hyphens during slug
+// derivation, and the slug is lower(t.Name() + "-" + jobID)). The trust
+// policy allows "testcache*" to cover this and future cache test variants.
+func TestCacheBasicSaveRestore(t *testing.T) {
+	ctx := t.Context()
+
+	tc := newTestCase(t, "cache_save_restore.yaml")
+
+	tc.startAgent()
+	build := tc.triggerBuild()
+	state := tc.waitForBuild(ctx, build)
+	if got, want := state, "passed"; got != want {
+		t.Errorf("Build state = %q, want %q", got, want)
+	}
+}

--- a/internal/e2e/fixtures/cache_save_restore.yaml
+++ b/internal/e2e/fixtures/cache_save_restore.yaml
@@ -1,0 +1,37 @@
+# cache save/restore round-trip against the customer-managed S3 bucket.
+# Region is pinned in the URL (cache S3 client defaults to us-east-1).
+# The cache config is shared via a base64 env var; its cache_key embeds
+# BUILDKITE_BUILD_ID so each build gets a unique, freshly-created entry.
+env:
+  BUILDKITE_AGENT_CACHE_STORE_URL: s3://buildkite-agent-e2e-tests-shared/cache-e2e-test?region=us-west-2
+  CACHE_CONFIG_B64: "{{ fixture "includes/cache_config.yml" | b64enc }}"
+agents:
+  queue: {{ .queue }}
+steps:
+  - key: save
+    plugins:
+      - aws-assume-role-with-web-identity#v1.4.0:
+          role-arn: arn:aws:iam::172840064832:role/pipeline-agent-e2e-testing-buildkite-agent-e2e
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+    commands:
+      - mkdir -p cache-src
+      - echo "hello cache" > cache-src/file.txt
+      - echo "$$CACHE_CONFIG_B64" | base64 -d > cache.yml
+      - {{ .buildkite_agent_binary }} cache save --cache-config-file cache.yml
+  - key: restore
+    depends_on: save
+    plugins:
+      - aws-assume-role-with-web-identity#v1.4.0:
+          role-arn: arn:aws:iam::172840064832:role/pipeline-agent-e2e-testing-buildkite-agent-e2e
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+    commands:
+      - echo "$$CACHE_CONFIG_B64" | base64 -d > cache.yml
+      - {{ .buildkite_agent_binary }} cache restore --cache-config-file cache.yml
+      - test -f cache-src/file.txt
+      - if [[ $(cat cache-src/file.txt) == "hello cache" ]]; then exit 0; else exit 1; fi

--- a/internal/e2e/fixtures/includes/cache_config.yml
+++ b/internal/e2e/fixtures/includes/cache_config.yml
@@ -1,0 +1,7 @@
+caches:
+  - name: relative_paths
+    cache_key:
+      - cache-e2e-relative
+      - { env: BUILDKITE_BUILD_ID }
+    target_paths:
+      - cache-src

--- a/internal/e2e/testcase.go
+++ b/internal/e2e/testcase.go
@@ -6,6 +6,7 @@ import (
 	"cmp"
 	"context"
 	"embed"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
@@ -57,6 +58,26 @@ func nopCleanup() error { return nil }
 //go:embed fixtures
 var fixturesFS embed.FS
 
+// fixtureFuncs are template helpers available to fixture pipeline templates.
+// They let a fixture inline the contents of another fixture file (e.g. a shared
+// cache config) so it doesn't have to be duplicated across steps. Pairing
+// fixture with b64enc lets a fixture carry a whole file in a single env var
+// (decode it at runtime with `base64 -d`), avoiding fragile heredoc indentation.
+var fixtureFuncs = template.FuncMap{
+	// fixture returns the raw contents of a file under fixtures/.
+	"fixture": func(name string) (string, error) {
+		b, err := fixturesFS.ReadFile(path.Join("fixtures", name))
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	},
+	// b64enc base64-encodes s so it can be embedded as a single-line scalar.
+	"b64enc": func(s string) string {
+		return base64.StdEncoding.EncodeToString([]byte(s))
+	},
+}
+
 // testCase bundles the information needed to run an end-to-end test.
 // Note that it embeds testing.TB - each test should create its own testCase.
 type testCase struct {
@@ -85,7 +106,7 @@ func newTestCase(t testing.TB, file string) *testCase {
 		t.Fatalf("fixturesFS.ReadFile(%q) error = %v", file, err)
 	}
 
-	tmpl, err := template.New("pipeline").Parse(string(pipelineCfgTmpl))
+	tmpl, err := template.New("pipeline").Funcs(fixtureFuncs).Parse(string(pipelineCfgTmpl))
 	if err != nil {
 		t.Fatalf("template.New(pipeline).Parse(%q) error = %v", pipelineCfgTmpl, err)
 	}


### PR DESCRIPTION
## Description

Added a basic e2e test to assert the happy path of buildkite cache save/restore working

## Context

part of A-1376


## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

LLM and brain