### PR TITLE
A-1376 part 4: e2e test cache fallback logic

### DIFF
--- a/internal/e2e/cache_test.go
+++ b/internal/e2e/cache_test.go
@@ -49,3 +49,22 @@ func TestCacheFilesystemIntegrity(t *testing.T) {
 		t.Errorf("Build state = %q, want %q", got, want)
 	}
 }
+
+// Test that a cache_key's fallbackLimit makes trailing parts optional on
+// restore. Two caches share a BUILD_ID-anchored key but differ in a trailing
+// CACHE_VARIANT part that changes between save and restore: the cache that
+// declares fallbackLimit on BUILD_ID falls back to the BUILD_ID match and
+// restores, while the cache without fallbackLimit treats the variant mismatch
+// as a hard miss.
+func TestCacheKeyFallback(t *testing.T) {
+	ctx := t.Context()
+
+	tc := newTestCase(t, "cache_fallback.yaml")
+
+	tc.startAgent()
+	build := tc.triggerBuild()
+	state := tc.waitForBuild(ctx, build)
+	if got, want := state, "passed"; got != want {
+		t.Errorf("Build state = %q, want %q", got, want)
+	}
+}

--- a/internal/e2e/fixtures/cache_fallback.yaml
+++ b/internal/e2e/fixtures/cache_fallback.yaml
@@ -1,0 +1,50 @@
+# cache key fallbackLimit behavior. Two caches share a BUILD_ID-anchored key
+# but differ in an optional CACHE_VARIANT part: one declares fallbackLimit on
+# BUILD_ID (variant optional), the other does not (variant mandatory). The
+# variant changes between save and restore, so only the fallbackLimit cache
+# falls back to the BUILD_ID match; the other is a hard miss.
+env:
+  BUILDKITE_AGENT_CACHE_STORE_URL: s3://buildkite-agent-e2e-tests-shared/cache-e2e-test?region=us-west-2
+  CACHE_CONFIG_B64: "{{ fixture "includes/cache_fallback_config.yml" | b64enc }}"
+agents:
+  queue: {{ .queue }}
+steps:
+  - key: save
+    env:
+      CACHE_VARIANT: v1
+    plugins:
+      - aws-assume-role-with-web-identity#v1.4.0:
+          role-arn: arn:aws:iam::172840064832:role/pipeline-agent-e2e-testing-buildkite-agent-e2e
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+    commands:
+      - mkdir -p fallback-src nofallback-src
+      - echo "fallback payload" > fallback-src/file.txt
+      - echo "nofallback payload" > nofallback-src/file.txt
+      - echo "$$CACHE_CONFIG_B64" | base64 -d > cache.yml
+      - {{ .buildkite_agent_binary }} cache save --cache-config-file cache.yml
+  - key: restore
+    depends_on: save
+    env:
+      CACHE_VARIANT: v2
+    plugins:
+      - aws-assume-role-with-web-identity#v1.4.0:
+          role-arn: arn:aws:iam::172840064832:role/pipeline-agent-e2e-testing-buildkite-agent-e2e
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+    commands:
+      - rm -rf fallback-src nofallback-src
+      - echo "$$CACHE_CONFIG_B64" | base64 -d > cache.yml
+      - {{ .buildkite_agent_binary }} cache restore --cache-config-file cache.yml
+      - |
+        set -euo pipefail
+        # fallbackLimit makes CACHE_VARIANT optional, so the v1/v2 mismatch
+        # falls back to the BUILD_ID match and restores the saved content.
+        [[ "$(cat fallback-src/file.txt)" == "fallback payload" ]]
+        # Without fallbackLimit every part is mandatory, so the variant
+        # mismatch is a hard miss and nothing is restored.
+        [[ ! -e nofallback-src ]]

--- a/internal/e2e/fixtures/includes/cache_fallback_config.yml
+++ b/internal/e2e/fixtures/includes/cache_fallback_config.yml
@@ -1,0 +1,15 @@
+caches:
+  - name: with_fallback
+    cache_key:
+      - cache-e2e-fallback
+      - { env: BUILDKITE_BUILD_ID, fallbackLimit: true }
+      - { env: CACHE_VARIANT }
+    target_paths:
+      - fallback-src
+  - name: without_fallback
+    cache_key:
+      - cache-e2e-nofallback
+      - { env: BUILDKITE_BUILD_ID }
+      - { env: CACHE_VARIANT }
+    target_paths:
+      - nofallback-src


### PR DESCRIPTION
## Description

Add e2e test to cover cache fallback logic. And that's the end of e2e test coverage I think. 

## Context

part of A-1376

## Disclosures / Credits

Clanker and meat bag