### PR TITLE
Concurrently register spawn

### DIFF
--- a/api/agents.go
+++ b/api/agents.go
@@ -46,9 +46,6 @@ func (c *Client) Register(ctx context.Context, regReq *AgentRegisterRequest) (*A
 		return nil, resp, err
 	}
 
-	// If Buildkite told us to use Buildkite-* request headers, store those
-	c.setRequestHeaders(a.RequestHeaders)
-
 	return a, resp, err
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -166,7 +166,12 @@ func (c *Client) FromAgentRegisterResponse(reg *AgentRegisterResponse) *Client {
 		conf.Endpoint = reg.Endpoint
 	}
 
-	return c.New(conf)
+	newClient := c.New(conf)
+
+	// If Buildkite told us to use Buildkite-* request headers, store those
+	newClient.setRequestHeaders(reg.RequestHeaders)
+
+	return newClient
 }
 
 func (c *Client) setRequestHeaders(headers map[string]string) {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -28,6 +28,7 @@ import (
 	"github.com/buildkite/agent/v3/core"
 	"github.com/buildkite/agent/v3/internal/agentapi"
 	"github.com/buildkite/agent/v3/internal/awslib"
+	"github.com/buildkite/agent/v3/internal/concurrently"
 	awssigner "github.com/buildkite/agent/v3/internal/cryptosigner/aws"
 	gcpsigner "github.com/buildkite/agent/v3/internal/cryptosigner/gcp"
 	"github.com/buildkite/agent/v3/internal/experiments"
@@ -1302,41 +1303,54 @@ var AgentStartCommand = cli.Command{
 
 		// Spawning multiple agents doesn't work if the agent is being
 		// booted in acquisition mode
-		if cfg.Spawn > 1 && cfg.AcquireJob != "" {
-			return errors.New("you can't spawn multiple agents and acquire a job at the same time")
+		if cfg.AcquireJob != "" {
+			if cfg.Spawn != 1 {
+				return errors.New("you can't spawn multiple agents and acquire a job at the same time")
+			}
+		} else { // not acquire-job mode
+			if cfg.Spawn < 1 {
+				return fmt.Errorf("invalid spawn %d, must be at least 1", cfg.Spawn)
+			}
 		}
 
-		var workers []*agent.AgentWorker
+		// Create register requests.
+		regReqs := make([]api.AgentRegisterRequest, 0, cfg.Spawn)
 
-		for i := 1; i <= cfg.Spawn; i++ {
+		for i := range cfg.Spawn {
+			index := i + 1
 			if cfg.Spawn == 1 {
 				l.Infof("Registering agent with Buildkite...")
 			} else {
-				l.Infof("Registering agent %d of %d with Buildkite...", i, cfg.Spawn)
+				l.Infof("Registering agent %d of %d with Buildkite...", index, cfg.Spawn)
 			}
 
 			// Handle per-spawn name interpolation, replacing %spawn with the spawn index
-			registerReq.Name = strings.ReplaceAll(cfg.Name, "%spawn", strconv.Itoa(i))
+			registerReq.Name = strings.ReplaceAll(cfg.Name, "%spawn", strconv.Itoa(index))
 
 			if cfg.SpawnWithPriority {
-				p := i
+				p := index
 				if experiments.IsEnabled(ctx, experiments.DescendingSpawnPriority) {
 					// This experiment helps jobs be assigned across all hosts
 					// in cases where the value of --spawn varies between hosts.
-					p = -i
+					p = -index
 				}
-				l.Infof("Assigning priority %d for agent %d", p, i)
+				l.Infof("Assigning priority %d for agent %d", p, index)
 				registerReq.Priority = strconv.Itoa(p)
 			}
 
+			regReqs = append(regReqs, registerReq)
+		}
+
+		// Send register requests.
+		workers, err := concurrently.Map(ctx, regReqs, func(ctx context.Context, i int, regReq api.AgentRegisterRequest) (*agent.AgentWorker, error) {
 			// Register the agent with the buildkite API
-			reg, err := client.Register(ctx, registerReq)
+			reg, err := client.Register(ctx, regReq)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			// Create an agent worker to run the agent
-			workers = append(workers, agent.NewAgentWorker(
+			return agent.NewAgentWorker(
 				l.WithFields(logger.StringField("agent", reg.Name)),
 				reg,
 				mc,
@@ -1347,10 +1361,13 @@ var AgentStartCommand = cli.Command{
 					SignalGracePeriod:  signalGracePeriod,
 					Debug:              cfg.Debug,
 					DebugHTTP:          cfg.DebugHTTP,
-					SpawnIndex:         i,
+					SpawnIndex:         i + 1,
 					AgentStdout:        os.Stdout,
 				},
-			))
+			), nil
+		})
+		if err != nil {
+			return err
 		}
 
 		// Setup the agent pool that spawns agent workers
@@ -1411,7 +1428,6 @@ var AgentStartCommand = cli.Command{
 
 		default:
 			return err
-
 		}
 	},
 }

--- a/internal/concurrently/map.go
+++ b/internal/concurrently/map.go
@@ -1,0 +1,96 @@
+// Package concurrently has helpers for writing concurrent code.
+package concurrently
+
+import (
+	"context"
+	"runtime"
+	"sync"
+)
+
+// Option funcs alter how the concurrent algorithms behave.
+type Option func(*config)
+
+// WithWorkerCount overrides the default worker count for the operation.
+// If n ≤ 0, it uses the default worker count.
+func WithWorkerCount(n int) Option {
+	if n <= 0 {
+		return func(c *config) { c.workerCount = nil }
+	}
+	return func(c *config) { c.workerCount = &n }
+}
+
+type config struct {
+	workerCount *int
+}
+
+// Map transforms an input slice into an output slice via a function f.
+// It calls f as concurrently as reasonably possible (up to GOMAXPROCS by
+// default).
+func Map[In, Out any, InS ~[]In](ctx context.Context, in InS, f func(context.Context, int, In) (Out, error), opts ...Option) ([]Out, error) {
+	// Short circuits for len(in) ≤ 1
+	switch len(in) {
+	case 0:
+		return nil, nil
+	case 1:
+		o, err := f(ctx, 0, in[0])
+		return []Out{o}, err
+	}
+
+	cfg := &config{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	workerCount := min(len(in), runtime.GOMAXPROCS(0))
+	if cfg.workerCount != nil {
+		workerCount = *cfg.workerCount
+	}
+
+	// Lock around concurrent accesses to out, in case of misalignment
+	// (suppose Out = byte, then each write writes 7 other elements on a 64-bit
+	// machine).
+	var outMu sync.Mutex
+	out := make([]Out, len(in))
+	type workUnit struct {
+		in  In
+		idx int
+	}
+	workCh := make(chan workUnit)
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
+	var wg sync.WaitGroup
+	for range workerCount {
+		wg.Go(func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case work, open := <-workCh:
+					if !open {
+						return
+					}
+					o, err := f(ctx, work.idx, work.in)
+					if err != nil {
+						cancel(err)
+						return
+					}
+					outMu.Lock()
+					out[work.idx] = o
+					outMu.Unlock()
+				}
+			}
+		})
+	}
+	for i, x := range in {
+		select {
+		case <-ctx.Done():
+			return out, context.Cause(ctx)
+		case workCh <- workUnit{in: x, idx: i}:
+			// continue
+		}
+	}
+	close(workCh)
+	wg.Wait()
+
+	return out, context.Cause(ctx)
+}


### PR DESCRIPTION
## Description

The workers are already started concurrently, but they weren't _registered_ concurrently - until now!

## Context

It annoyed me.

## Changes

- Add a `concurrently` package and a generic `Map` function. I'm sure we can reuse this. I'm also sure there are plenty of packages out there that could do this for us but wanted to write it out myself.
- Use `concurrently.Map` to perform concurrent register calls.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

I did not use any AI tools to write this code.