### PR TITLE
Support post-registration hook and inject agent env into lifecycle hooks

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -26,6 +26,7 @@ import (
 	"github.com/buildkite/agent/v3/agent"
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/core"
+	"github.com/buildkite/agent/v3/env"
 	"github.com/buildkite/agent/v3/internal/agentapi"
 	"github.com/buildkite/agent/v3/internal/awslib"
 	"github.com/buildkite/agent/v3/internal/concurrently"
@@ -1349,9 +1350,14 @@ var AgentStartCommand = cli.Command{
 				return nil, err
 			}
 
+			agentLog := l.WithFields(logger.StringField("agent", reg.Name))
+			if err := agentPostRegistrationHook(agentLog, cfg, reg); err != nil {
+				return nil, fmt.Errorf("failed to run post-registration hook for agent %q: %w", reg.Name, err)
+			}
+
 			// Create an agent worker to run the agent
 			return agent.NewAgentWorker(
-				l.WithFields(logger.StringField("agent", reg.Name)),
+				agentLog,
 				reg,
 				mc,
 				apiClient,
@@ -1544,17 +1550,34 @@ func (ps *poolSignals) handleLoop(ctx context.Context, signals chan os.Signal) {
 }
 
 func agentStartupHook(log logger.Logger, cfg AgentStartConfig) error {
-	return agentLifecycleHook("agent-startup", log, cfg)
+	return agentLifecycleHook("agent-startup", log, cfg, nil)
+}
+
+func agentPostRegistrationHook(log logger.Logger, cfg AgentStartConfig, reg *api.AgentRegisterResponse) error {
+	return agentLifecycleHook("post-registration", log, cfg, agentPostRegistrationHookEnv(reg))
 }
 
 func agentShutdownHook(log logger.Logger, cfg AgentStartConfig) {
-	_ = agentLifecycleHook("agent-shutdown", log, cfg)
+	_ = agentLifecycleHook("agent-shutdown", log, cfg, nil)
+}
+
+func agentPostRegistrationHookEnv(reg *api.AgentRegisterResponse) *env.Environment {
+	environ := env.New()
+	if reg == nil {
+		return environ
+	}
+
+	environ.Set("BUILDKITE_AGENT_ID", reg.UUID)
+	environ.Set("BUILDKITE_AGENT_NAME", reg.Name)
+	environ.Set("BUILDKITE_AGENT_META_DATA", strings.Join(reg.Tags, ","))
+
+	return environ
 }
 
 // agentLifecycleHook looks for a hook script in the hooks path
 // and executes it if found. Output (stdout + stderr) is streamed into the main
 // agent logger. Exit status failure is logged and returned for the caller to handle
-func agentLifecycleHook(hookName string, log logger.Logger, cfg AgentStartConfig) error {
+func agentLifecycleHook(hookName string, log logger.Logger, cfg AgentStartConfig, hookEnv *env.Environment) error {
 	// search for hook (including .bat & .ps1 files on Windows)
 	hooks := []string{}
 	p, err := hook.Find(nil, cfg.HooksPath, hookName)
@@ -1593,6 +1616,8 @@ func agentLifecycleHook(hookName string, log logger.Logger, cfg AgentStartConfig
 		log.Errorf("creating shell for %q hook: %v", hookName, err)
 		return err
 	}
+
+	sh.Env.Merge(hookEnv)
 
 	var wg sync.WaitGroup
 	wg.Go(func() {

--- a/clicommand/agent_start_test.go
+++ b/clicommand/agent_start_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/core"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/google/go-cmp/cmp"
@@ -40,6 +41,22 @@ func writeAgentHook(t *testing.T, dir, hookName, msg string) string {
 		t.Fatalf("%+v", err)
 	}
 	t.Log("Providing the path with file created")
+	return filepath
+}
+
+func writeAgentHookScript(t *testing.T, dir, hookName, script string) string {
+	t.Helper()
+
+	filename := hookName
+	if runtime.GOOS == "windows" {
+		filename = hookName + ".bat"
+	}
+
+	filepath := filepath.Join(dir, filename)
+	t.Logf("Creating %q", filepath)
+	if err := os.WriteFile(filepath, []byte(script), 0o755); err != nil {
+		t.Fatalf("%+v", err)
+	}
 	return filepath
 }
 
@@ -146,6 +163,62 @@ func TestAgentStartupHookWithAdditionalPaths(t *testing.T) {
 			t.Errorf("log.Messages diff (-got +want):\n%s", diff)
 		}
 	})
+}
+
+func TestAgentPostRegistrationHook(t *testing.T) {
+	t.Parallel()
+
+	cfg := func(hooksPath string) AgentStartConfig {
+		return AgentStartConfig{
+			HooksPath:    hooksPath,
+			GlobalConfig: GlobalConfig{NoColor: true},
+		}
+	}
+	prompt := "$"
+	if runtime.GOOS == "windows" {
+		prompt = ">"
+	}
+
+	hooksPath, closer := setupHooksPath(t)
+	defer closer()
+
+	var script string
+	if runtime.GOOS == "windows" {
+		script = `@echo off
+echo id=%BUILDKITE_AGENT_ID%
+echo name=%BUILDKITE_AGENT_NAME%
+echo meta=%BUILDKITE_AGENT_META_DATA%`
+	} else {
+		script = `echo id=$BUILDKITE_AGENT_ID
+echo name=$BUILDKITE_AGENT_NAME
+echo meta=$BUILDKITE_AGENT_META_DATA`
+	}
+	filepath := writeAgentHookScript(t, hooksPath, "post-registration", script)
+
+	regs := []*api.AgentRegisterResponse{
+		{UUID: "agent-123", Name: "test-agent-1", Tags: []string{"queue=default", "os=linux"}},
+		{UUID: "agent-456", Name: "test-agent-2", Tags: []string{"queue=priority", "os=linux"}},
+	}
+
+	log := logger.NewBuffer()
+	for _, reg := range regs {
+		if err := agentPostRegistrationHook(log, cfg(hooksPath), reg); err != nil {
+			t.Fatalf("%+v", log.Messages)
+		}
+	}
+
+	if diff := cmp.Diff(log.Messages, []string{
+		"[info] " + prompt + " " + filepath,
+		"[info] id=agent-123",
+		"[info] name=test-agent-1",
+		"[info] meta=queue=default,os=linux",
+		"[info] " + prompt + " " + filepath,
+		"[info] id=agent-456",
+		"[info] name=test-agent-2",
+		"[info] meta=queue=priority,os=linux",
+	}); diff != "" {
+		t.Errorf("log.Messages diff (-got +want):\n%s", diff)
+	}
 }
 
 func TestAgentShutdownHook(t *testing.T) {


### PR DESCRIPTION
### Motivation

- Add the ability to run a `post-registration` hook after an agent registers, with the agent-specific environment available to the hook. 
- Ensure lifecycle hook execution can receive custom environment variables so hooks can use registration metadata like agent ID, name, and tags.

### Description

- Added import of the `env` package and a new `agentPostRegistrationHook` which builds an environment and delegates to the generic lifecycle handler. 
- Call `agentPostRegistrationHook` immediately after successful agent registration and use a per-agent logger (`agentLog`) for context. 
- Changed `agentLifecycleHook` signature to accept `hookEnv *env.Environment` and merge that environment into the shell before running hooks. 
- Added helper `agentPostRegistrationHookEnv` to populate `BUILDKITE_AGENT_ID`, `BUILDKITE_AGENT_NAME`, and `BUILDKITE_AGENT_META_DATA` from the registration response. 
- Updated `agentStartupHook` and `agentShutdownHook` calls to pass `nil` for the new env parameter and added test helpers (`writeAgentHookScript`) and a new unit test `TestAgentPostRegistrationHook` to validate the behavior.

### Testing

- Ran unit tests with `go test ./...` and the test suite passed. 
- Exercised `TestAgentPostRegistrationHook`, `TestAgentStartupHook`, and `TestAgentShutdownHook` which succeeded and validated hook output and environment injection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a370dca7918832f9c58bfabef357635)