### PR TITLE
chore: resolve default cache configuration file

### DIFF
--- a/clicommand/cache_restore.go
+++ b/clicommand/cache_restore.go
@@ -18,7 +18,8 @@ const cacheRestoreHelpDescription = `Usage:
 Description:
 
 Restores files from the cache for the current job based on the cache configuration
-defined in your cache config file (defaults to .buildkite/cache.yml).
+defined in your cache config file (defaults to .buildkite/cache.yml or
+.buildkite/cache.yaml).
 
 The cache configuration file defines which files or directories should be restored
 and their associated cache key. An entry is restored when its target_paths
@@ -33,8 +34,8 @@ Example:
 
     $ buildkite-agent cache restore
 
-This will restore all caches defined in .buildkite/cache.yml. You can also restore
-specific caches by providing their IDs:
+This will restore all caches defined in the cache configuration file.
+You can also restore specific caches by providing their IDs:
 
     $ buildkite-agent cache restore --names "node"
 
@@ -101,6 +102,11 @@ var CacheRestoreCommand = cli.Command{
 		apiCfg := loadAPIClientConfig(cfg, "AgentAccessToken")
 		apiClient := api.NewClient(l, apiCfg)
 
+		cacheConfigFile, err := resolveCacheConfigFile(cfg.CacheConfigFile)
+		if err != nil {
+			return err
+		}
+
 		// Build cache configuration
 		cacheCfg := cache.Config{
 			Registry:        cfg.Registry,
@@ -108,7 +114,7 @@ var CacheRestoreCommand = cli.Command{
 			Branch:          cfg.Branch,
 			Pipeline:        cfg.Pipeline,
 			Organization:    cfg.Organization,
-			CacheConfigFile: cfg.CacheConfigFile,
+			CacheConfigFile: cacheConfigFile,
 			Names:           cfg.Names,
 		}
 

--- a/clicommand/cache_save.go
+++ b/clicommand/cache_save.go
@@ -18,7 +18,8 @@ const cacheSaveHelpDescription = `Usage:
 Description:
 
 Saves files to the cache for the current build based on the cache configuration
-defined in your cache config file (defaults to .buildkite/cache.yml).
+defined in your cache config file (defaults to .buildkite/cache.yml or
+.buildkite/cache.yaml).
 
 The cache configuration file defines which files or directories should be cached
 and their associated cache key.
@@ -30,8 +31,8 @@ Example:
 
     $ buildkite-agent cache save
 
-This will save all caches defined in .buildkite/cache.yml. You can also save
-specific caches by providing their IDs:
+This will save all caches defined in the cache configuration file.
+You can also save specific caches by providing their IDs:
 
     $ buildkite-agent cache save --names "node"
 
@@ -91,6 +92,11 @@ var CacheSaveCommand = cli.Command{
 
 		apiClient := api.NewClient(l, apiCfg)
 
+		cacheConfigFile, err := resolveCacheConfigFile(cfg.CacheConfigFile)
+		if err != nil {
+			return err
+		}
+
 		// Build cache configuration
 		cacheCfg := cache.Config{
 			Registry:        cfg.Registry,
@@ -98,7 +104,7 @@ var CacheSaveCommand = cli.Command{
 			Branch:          cfg.Branch,
 			Pipeline:        cfg.Pipeline,
 			Organization:    cfg.Organization,
-			CacheConfigFile: cfg.CacheConfigFile,
+			CacheConfigFile: cacheConfigFile,
 			Names:           cfg.Names,
 			Concurrency:     cfg.Concurrency,
 		}

--- a/clicommand/cache_shared.go
+++ b/clicommand/cache_shared.go
@@ -1,6 +1,13 @@
 package clicommand
 
-import "github.com/urfave/cli"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/urfave/cli"
+)
 
 // CacheConfig includes cache-related shared options for easy inclusion across
 // cache command config structs (via embedding).
@@ -55,8 +62,8 @@ func cacheFlags() []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:   "cache-config-file",
-			Value:  ".buildkite/cache.yml",
-			Usage:  "Path to the cache configuration YAML file",
+			Value:  "",
+			Usage:  "Path to the cache configuration YAML file (defaults to .buildkite/cache.yml or .buildkite/cache.yaml)",
 			EnvVar: "BUILDKITE_CACHE_CONFIG_FILE",
 		},
 		cli.IntFlag{
@@ -65,5 +72,38 @@ func cacheFlags() []cli.Flag {
 			Usage:  "Number of concurrent cache operations",
 			EnvVar: "BUILDKITE_CACHE_CONCURRENCY",
 		},
+	}
+}
+
+// defaultCacheConfigPaths lists the candidate cache configuration files, in
+// precedence order, used when --cache-config-file is not provided.
+var defaultCacheConfigPaths = []string{
+	filepath.FromSlash(".buildkite/cache.yml"),
+	filepath.FromSlash(".buildkite/cache.yaml"),
+}
+
+// resolveCacheConfigFile returns the cache configuration path to load. An
+// explicitly provided path is used as-is. Otherwise it searches the default
+// locations, returning the one that exists and erroring if more than one, or
+// none, are present.
+func resolveCacheConfigFile(explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+
+	var exists []string
+	for _, path := range defaultCacheConfigPaths {
+		if _, err := os.Stat(path); err == nil {
+			exists = append(exists, path)
+		}
+	}
+
+	switch len(exists) {
+	case 0:
+		return "", fmt.Errorf("could not find a default cache configuration file; tried %s", strings.Join(defaultCacheConfigPaths, ", "))
+	case 1:
+		return exists[0], nil
+	default:
+		return "", fmt.Errorf("found multiple cache configuration files: %s; please keep only 1 configuration file present", strings.Join(exists, ", "))
 	}
 }

--- a/clicommand/cache_shared_test.go
+++ b/clicommand/cache_shared_test.go
@@ -1,0 +1,113 @@
+package clicommand
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveCacheConfigFile(t *testing.T) {
+	t.Run("explicit path is used as-is", func(t *testing.T) {
+		got, err := resolveCacheConfigFile("custom/cache.yml")
+		if err != nil {
+			t.Fatalf("resolveCacheConfigFile() error = %v", err)
+		}
+		if want := "custom/cache.yml"; got != want {
+			t.Errorf("resolveCacheConfigFile() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("explicit path skips default search", func(t *testing.T) {
+		dir := t.TempDir()
+		// Create both defaults; an explicit path must still win.
+		writeFile(t, filepath.Join(dir, ".buildkite", "cache.yml"))
+		writeFile(t, filepath.Join(dir, ".buildkite", "cache.yaml"))
+		chdir(t, dir)
+
+		got, err := resolveCacheConfigFile("custom/cache.yml")
+		if err != nil {
+			t.Fatalf("resolveCacheConfigFile() error = %v", err)
+		}
+		if want := "custom/cache.yml"; got != want {
+			t.Errorf("resolveCacheConfigFile() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("finds .yml when only .yml exists", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, ".buildkite", "cache.yml"))
+		chdir(t, dir)
+
+		got, err := resolveCacheConfigFile("")
+		if err != nil {
+			t.Fatalf("resolveCacheConfigFile() error = %v", err)
+		}
+		if want := filepath.FromSlash(".buildkite/cache.yml"); got != want {
+			t.Errorf("resolveCacheConfigFile() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("finds .yaml when only .yaml exists", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, ".buildkite", "cache.yaml"))
+		chdir(t, dir)
+
+		got, err := resolveCacheConfigFile("")
+		if err != nil {
+			t.Fatalf("resolveCacheConfigFile() error = %v", err)
+		}
+		if want := filepath.FromSlash(".buildkite/cache.yaml"); got != want {
+			t.Errorf("resolveCacheConfigFile() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("errors when both .yml and .yaml exist", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, ".buildkite", "cache.yml"))
+		writeFile(t, filepath.Join(dir, ".buildkite", "cache.yaml"))
+		chdir(t, dir)
+
+		_, err := resolveCacheConfigFile("")
+		if err == nil {
+			t.Fatal("resolveCacheConfigFile() error = nil, want error")
+		}
+	})
+
+	t.Run("errors when neither exists", func(t *testing.T) {
+		chdir(t, t.TempDir())
+
+		_, err := resolveCacheConfigFile("")
+		if err == nil {
+			t.Fatal("resolveCacheConfigFile() error = nil, want error")
+		}
+	})
+}
+
+// writeFile creates an empty file at path, including any parent directories.
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("os.MkdirAll(%q) = %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("os.WriteFile(%q) = %v", path, err)
+	}
+}
+
+// chdir changes into dir for the duration of the test, restoring the previous
+// working directory on cleanup.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd() = %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("os.Chdir(%q) = %v", dir, err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(prev); err != nil {
+			t.Errorf("os.Chdir(%q) = %v", prev, err)
+		}
+	})
+}


### PR DESCRIPTION
## Description

When an explicit cache configuration file is not provided, resolve the default to either `.buildkite/cache.yml` OR `.buildkite/cache.yaml`
<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

## Context

Solves A-1399
<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

## Changes

If a default file doesn't exist, and an explicit file is not provided, the command will exit early instead of when file fails to open.
<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

## Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

Claude
<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
