### PR TITLE
fix(cache): set flag as name singular

### DIFF
--- a/clicommand/cache_restore.go
+++ b/clicommand/cache_restore.go
@@ -35,9 +35,9 @@ Example:
     $ buildkite-agent cache restore
 
 This will restore all caches defined in the cache configuration file.
-You can also restore specific caches by providing their IDs:
+You can also restore specific caches by providing their names:
 
-    $ buildkite-agent cache restore --names "node"
+    $ buildkite-agent cache restore --name "node"
 
 The cache is retrieved from BUILDKITE_AGENT_CACHE_STORE_URL (or --cache-store-url),
 downloaded directly using the agent's ambient credentials. The registry is

--- a/clicommand/cache_save.go
+++ b/clicommand/cache_save.go
@@ -32,9 +32,9 @@ Example:
     $ buildkite-agent cache save
 
 This will save all caches defined in the cache configuration file.
-You can also save specific caches by providing their IDs:
+You can also save specific caches by providing their names:
 
-    $ buildkite-agent cache save --names "node"
+    $ buildkite-agent cache save --name "node"
 
 The cache is stored at BUILDKITE_AGENT_CACHE_STORE_URL (or --cache-store-url).
 The registry is selected by BUILDKITE_AGENT_CACHE_REGISTRY (or --registry); '~'

--- a/clicommand/cache_shared.go
+++ b/clicommand/cache_shared.go
@@ -12,7 +12,7 @@ import (
 // CacheConfig includes cache-related shared options for easy inclusion across
 // cache command config structs (via embedding).
 type CacheConfig struct {
-	Names           []string `cli:"names"`
+	Names           []string `cli:"name"`
 	Registry        string   `cli:"registry"`
 	BucketURL       string   `cli:"cache-store-url"`
 	Branch          string   `cli:"branch" validate:"required"`
@@ -25,9 +25,9 @@ type CacheConfig struct {
 func cacheFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringSliceFlag{
-			Name:   "names",
+			Name:   "name",
 			Value:  &cli.StringSlice{},
-			Usage:  "Cache names to process (can be specified multiple times; if empty, processes all caches)",
+			Usage:  "Cache name to process (can be specified multiple times; if empty, processes all caches)",
 			EnvVar: "BUILDKITE_CACHE_NAMES",
 		},
 		cli.StringFlag{


### PR DESCRIPTION
## Description

(cache restore/save commands) changes the flag `--names` to `--name`
<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

## Context

Solves A-1413

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

## Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

Claude
<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
