### PR TITLE
Avoid overriding BUILDKITE_GIT_SPARSE_CHECKOUT_PATHS when agent has no sparse config

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -623,7 +623,10 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 	setEnv("BUILDKITE_GIT_CHECKOUT_FLAGS", r.conf.AgentConfiguration.GitCheckoutFlags)
 	setEnv("BUILDKITE_GIT_CLONE_FLAGS", r.conf.AgentConfiguration.GitCloneFlags)
 	setEnv("BUILDKITE_GIT_FETCH_FLAGS", r.conf.AgentConfiguration.GitFetchFlags)
-	setEnv("BUILDKITE_GIT_SPARSE_CHECKOUT_PATHS", strings.Join(r.conf.AgentConfiguration.GitSparseCheckoutPaths, ","))
+
+	if len(r.conf.AgentConfiguration.GitSparseCheckoutPaths) > 0 {
+		setEnv("BUILDKITE_GIT_SPARSE_CHECKOUT_PATHS", strings.Join(r.conf.AgentConfiguration.GitSparseCheckoutPaths, ","))
+	}
 	setEnv("BUILDKITE_GIT_CLONE_MIRROR_FLAGS", r.conf.AgentConfiguration.GitCloneMirrorFlags)
 	setEnv("BUILDKITE_GIT_MIRROR_CHECKOUT_MODE", r.conf.AgentConfiguration.GitMirrorCheckoutMode)
 	setEnv("BUILDKITE_GIT_CLEAN_FLAGS", r.conf.AgentConfiguration.GitCleanFlags)


### PR DESCRIPTION
## Description

When the backend ships `BUILDKITE_GIT_SPARSE_CHECKOUT_PATHS` in the job env, the agent  was silently replacing it with the agent-side config value — which, on a default   agent, is an empty string. The bootstrap then read `""`, found no paths, and fall back to a full checkout.
 
 After this change:
  - Agent operator sets `--git-sparse-checkout-paths` → agent config wins (unchanged).
  - Backend sends the env var, agent has no sparse config → server value flows
    through to the bootstrap as intended.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

Used claude to review the code change. 