### PR TITLE
feat: Add `--reject-parse-warnings` flag to fail pipeline upload on p…

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -622,7 +622,11 @@ func (cfg *PipelineUploadConfig) handleParseError(l logger.Logger, src string, e
 	}
 
 	if cfg.RejectParseWarnings {
-		return NewExitError(1, fmt.Errorf("pipeline %q had parsing warnings, and --reject-parse-warnings is enabled:\n%v", src, w))
+return NewExitError(1, fmt.Errorf(
+	"pipeline %q parsed with warnings; refusing upload because --reject-parse-warnings is enabled:\n%v",
+	src,
+	w,
+))
 	}
 
 	l.Warnf("There were some issues with the pipeline input - pipeline upload will proceed, but might not succeed:\n%v", w)

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -622,11 +622,11 @@ func (cfg *PipelineUploadConfig) handleParseError(l logger.Logger, src string, e
 	}
 
 	if cfg.RejectParseWarnings {
-return NewExitError(1, fmt.Errorf(
-	"pipeline %q parsed with warnings; refusing upload because --reject-parse-warnings is enabled:\n%v",
-	src,
-	w,
-))
+		return NewExitError(1, fmt.Errorf(
+			"pipeline %q parsed with warnings; refusing upload because --reject-parse-warnings is enabled:\n%v",
+			src,
+			w,
+		))
 	}
 
 	l.Warnf("There were some issues with the pipeline input - pipeline upload will proceed, but might not succeed:\n%v", w)

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -80,14 +80,15 @@ type PipelineUploadConfig struct {
 	GlobalConfig
 	APIConfig
 
-	FilePaths       []string `cli:"arg:*" label:"upload paths"`
-	Replace         bool     `cli:"replace"`
-	Job             string   `cli:"job"` // required, but not in dry-run mode
-	DryRun          bool     `cli:"dry-run"`
-	DryRunFormat    string   `cli:"format"`
-	NoInterpolation bool     `cli:"no-interpolation"`
-	RedactedVars    []string `cli:"redacted-vars" normalize:"list"`
-	RejectSecrets   bool     `cli:"reject-secrets"`
+	FilePaths           []string `cli:"arg:*" label:"upload paths"`
+	Replace             bool     `cli:"replace"`
+	Job                 string   `cli:"job"` // required, but not in dry-run mode
+	DryRun              bool     `cli:"dry-run"`
+	DryRunFormat        string   `cli:"format"`
+	NoInterpolation     bool     `cli:"no-interpolation"`
+	RedactedVars        []string `cli:"redacted-vars" normalize:"list"`
+	RejectSecrets       bool     `cli:"reject-secrets"`
+	RejectParseWarnings bool     `cli:"reject-parse-warnings"`
 
 	// Used for if_changed processing
 	ApplyIfChanged   bool   `cli:"apply-if-changed"`
@@ -139,6 +140,11 @@ var PipelineUploadCommand = cli.Command{
 			Name:   "reject-secrets",
 			Usage:  "When true, fail the pipeline upload early if the pipeline contains secrets (default: false)",
 			EnvVar: "BUILDKITE_AGENT_PIPELINE_UPLOAD_REJECT_SECRETS",
+		},
+		cli.BoolFlag{
+			Name:   "reject-parse-warnings",
+			Usage:  "When true, fail the pipeline upload if any warnings are encountered while parsing or interpolating the pipeline, rather than logging them and continuing with the upload (default: false)",
+			EnvVar: "BUILDKITE_AGENT_PIPELINE_UPLOAD_REJECT_PARSE_WARNINGS",
 		},
 		cli.BoolTFlag{
 			Name:   "apply-if-changed",
@@ -333,12 +339,8 @@ var PipelineUploadCommand = cli.Command{
 			// For each pipeline in the input (could be multiple)...
 			count := 1
 			for result, err := range cfg.parseAndInterpolate(ctx, input.name, input.file, environ) {
-				if err != nil {
-					w := warning.As(err)
-					if w == nil {
-						return err
-					}
-					l.Warnf("There were some issues with the pipeline input - pipeline upload will proceed, but might not succeed:\n%v", w)
+				if abort := cfg.handleParseError(l, input.name, err); abort != nil {
+					return abort
 				}
 
 				if len(cfg.RedactedVars) > 0 {
@@ -607,6 +609,26 @@ func searchForSecrets(
 	return nil
 }
 
+// handleParseError decides what to do with an error yielded by
+// parseAndInterpolate for the pipeline.
+func (cfg *PipelineUploadConfig) handleParseError(l logger.Logger, src string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	w := warning.As(err)
+	if w == nil {
+		return err
+	}
+
+	if cfg.RejectParseWarnings {
+		return NewExitError(1, fmt.Errorf("pipeline %q had parsing warnings, and --reject-parse-warnings is enabled:\n%v", src, w))
+	}
+
+	l.Warnf("There were some issues with the pipeline input - pipeline upload will proceed, but might not succeed:\n%v", w)
+	return nil
+}
+
 func (cfg *PipelineUploadConfig) parseAndInterpolate(ctx context.Context, src string, input io.Reader, environ *env.Environment) iter.Seq2[*pipeline.Pipeline, error] {
 	return func(yield func(*pipeline.Pipeline, error) bool) {
 		for result, err := range pipeline.ParseAll(input) {
@@ -629,11 +651,22 @@ func (cfg *PipelineUploadConfig) parseAndInterpolate(ctx context.Context, src st
 					result.Env.Set(tracetools.EnvVarTraceContextKey, tracing)
 				}
 
+				// At this point err is either nil or a parse warning.
+				parseWarning := err
+
 				// Do the interpolation.
 				preferRuntimeEnv := experiments.IsEnabled(ctx, experiments.InterpolationPrefersRuntimeEnv)
-				err = result.Interpolate(environ, preferRuntimeEnv)
-				if err != nil {
-					err = fmt.Errorf("pipeline interpolation of %q failed: %w", src, err)
+				switch interpolationErr := result.Interpolate(environ, preferRuntimeEnv); {
+				case interpolationErr == nil:
+					err = parseWarning
+				case warning.Is(interpolationErr): // Combine interpolation warnings with parse warnings.
+					err = interpolationErr
+					if parseWarning != nil {
+						err = warning.Wrap(parseWarning, interpolationErr)
+					}
+
+				default:
+					err = fmt.Errorf("pipeline interpolation of %q failed: %w", src, interpolationErr)
 				}
 				// yield below
 			}

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -1,6 +1,7 @@
 package clicommand
 
 import (
+	"errors"
 	"os"
 	"runtime"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/go-pipeline"
 	"github.com/buildkite/go-pipeline/ordered"
+	"github.com/buildkite/go-pipeline/warning"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -263,6 +265,144 @@ steps:
 
 			if diff := cmp.Diff(gotCommands, test.wantCommands); diff != "" {
 				t.Errorf("commands diff (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestParseWarningsSurviveInterpolation checks that a parse-level warning is reported as a *Warning by parseAndInterpolate
+// regardless of whether interpolation is enabled.
+func TestParseWarningsSurviveInterpolation(t *testing.T) {
+	t.Parallel()
+	const pipelineYAML = `---
+steps:
+- llamas
+`
+
+	tests := []struct {
+		name          string
+		interpolation bool
+	}{
+		{name: "with interpolation", interpolation: true},
+		{name: "without interpolation", interpolation: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &PipelineUploadConfig{
+				NoInterpolation: !test.interpolation,
+				RedactedVars:    []string{},
+			}
+			ctx := t.Context()
+			environ := env.FromMap(map[string]string{})
+
+			var gotWarning bool
+			for _, err := range cfg.parseAndInterpolate(ctx, "test", strings.NewReader(pipelineYAML), environ) {
+				if err == nil {
+					continue
+				}
+				if w := warning.As(err); w != nil {
+					gotWarning = true
+					continue
+				}
+				t.Errorf("parseAndInterpolate yielded a non-warning error = %v; want a *Warning", err)
+			}
+
+			if !gotWarning {
+				t.Errorf("parseAndInterpolate(interpolation=%v) yielded no warning for %q; want a parse warning", test.interpolation, pipelineYAML)
+			}
+		})
+	}
+}
+
+// TestHandleParseError covers the bail-out decision for errors yielded by
+// parseAndInterpolate: hard errors always abort, warnings abort only when
+// --reject-parse-warnings is set, and otherwise warnings are logged and the
+// upload proceeds.
+func TestHandleParseError(t *testing.T) {
+	t.Parallel()
+
+	parseWarning := warning.Newf("unknown step type %q", "llamas")
+	hardError := errors.New("pipeline parsing failed")
+
+	tests := []struct {
+		desc                string
+		rejectParseWarnings bool
+		err                 error
+		wantAbort           bool
+		wantExitCode        int
+		wantLogContains     string
+	}{
+		{
+			desc:      "nil error proceeds",
+			err:       nil,
+			wantAbort: false,
+		},
+		{
+			desc:      "hard error aborts regardless of flag",
+			err:       hardError,
+			wantAbort: true,
+		},
+		{
+			desc:                "hard error aborts even with reject enabled",
+			err:                 hardError,
+			rejectParseWarnings: true,
+			wantAbort:           true,
+		},
+		{
+			desc:            "warning is logged and proceeds by default",
+			err:             parseWarning,
+			wantAbort:       false,
+			wantLogContains: "pipeline upload will proceed",
+		},
+		{
+			desc:                "warning aborts when reject enabled",
+			err:                 parseWarning,
+			rejectParseWarnings: true,
+			wantAbort:           true,
+			wantExitCode:        1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &PipelineUploadConfig{RejectParseWarnings: test.rejectParseWarnings}
+			l := logger.NewBuffer()
+
+			got := cfg.handleParseError(l, "test.yaml", test.err)
+
+			if test.wantAbort && got == nil {
+				t.Fatalf("handleParseError(...) = nil; want non-nil (abort)")
+			}
+			if !test.wantAbort && got != nil {
+				t.Fatalf("handleParseError(...) = %v; want nil (proceed)", got)
+			}
+
+			if test.wantExitCode != 0 {
+				var exitErr *ExitError
+				if !errors.As(got, &exitErr) {
+					t.Fatalf("handleParseError(...) = %v; want an *ExitError", got)
+				}
+				if exitErr.Code() != test.wantExitCode {
+					t.Errorf("ExitError code = %d; want %d", exitErr.Code(), test.wantExitCode)
+				}
+			}
+
+			var loggedWarning string
+			for _, m := range l.Messages {
+				if strings.HasPrefix(m, "[warn] ") {
+					loggedWarning = m
+				}
+			}
+			switch {
+			case test.wantLogContains == "" && loggedWarning != "":
+				t.Errorf("unexpected warning logged: %q", loggedWarning)
+			case test.wantLogContains != "" && !strings.Contains(loggedWarning, test.wantLogContains):
+				t.Errorf("warning log = %q; want it to contain %q", loggedWarning, test.wantLogContains)
 			}
 		})
 	}


### PR DESCRIPTION
…arse warnings

## Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
This adds an opt-in `--reject-parse-warnings` flag (env: `BUILDKITE_AGENT_PIPELINE_UPLOAD_REJECT_PARSE_WARNINGS`) that makes the upload fail (exit 1) when parsing or interpolation produces any warning, instead of logging and continuing. Defaults to `false`, so existing behaviour is unchanged.

## Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->
https://linear.app/buildkite/issue/A-1238/add-config-option-to-fail-pipeline-upload-on-parsing-warnings-as-well

## Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->
- New `--reject-parse-warnings` flag on `buildkite-agent pipeline upload`.
- Fix `parseAndInterpolate` so parse warnings are preserved through interpolation (and combined with interpolation warnings).
- Extract the warning/error handling into `handleParseError` for clarity and testability.
- Tests: `TestParseWarningsSurviveInterpolation` (warning survives with and without interpolation) and `TestHandleParseError` (hard errors always abort; warnings abort only when the flag is set, otherwise log-and-continue).

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

Claude helped write the test and with naming the flag 🎏 

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
