### PR TITLE
PS-2124: GCS artifact upload to bucket root no longer uses a leading-slash key

### DIFF
--- a/internal/artifact/gs_uploader.go
+++ b/internal/artifact/gs_uploader.go
@@ -178,9 +178,11 @@ func (u *gsUploaderWork) DoWork(_ context.Context) (*api.ArtifactPartETag, error
 }
 
 func (u *GSUploader) artifactPath(artifact *api.Artifact) string {
-	parts := []string{u.BucketPath, artifact.Path}
+	if u.BucketPath == "" {
+		return artifact.Path
+	}
 
-	return strings.Join(parts, "/")
+	return path.Join(u.BucketPath, artifact.Path)
 }
 
 func (u *GSUploader) contentDisposition(a *api.Artifact) string {

--- a/internal/artifact/gs_uploader_test.go
+++ b/internal/artifact/gs_uploader_test.go
@@ -1,7 +1,10 @@
 package artifact
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/buildkite/agent/v3/api"
 )
 
 func TestParseGSDestination(t *testing.T) {
@@ -24,5 +27,85 @@ func TestParseGSDestination(t *testing.T) {
 		if bucket != tc.bucket || path != tc.path {
 			t.Errorf("ParseGSDestination(%q) = (%q, %q), want (%q, %q)", tc.dest, bucket, path, tc.bucket, tc.path)
 		}
+	}
+}
+
+func TestGSUploaderArtifactPath(t *testing.T) {
+	tests := []struct {
+		name         string
+		bucketPath   string
+		artifactPath string
+		want         string
+	}{
+		{
+			name:         "empty bucket path, top-level artifact",
+			bucketPath:   "",
+			artifactPath: "index.html",
+			want:         "index.html",
+		},
+		{
+			name:         "empty bucket path, nested artifact",
+			bucketPath:   "",
+			artifactPath: "nested/index.html",
+			want:         "nested/index.html",
+		},
+		{
+			name:         "non-empty bucket path, top-level artifact",
+			bucketPath:   "prefix",
+			artifactPath: "index.html",
+			want:         "prefix/index.html",
+		},
+		{
+			name:         "non-empty bucket path, nested artifact",
+			bucketPath:   "artifacts/build",
+			artifactPath: "nested/index.html",
+			want:         "artifacts/build/nested/index.html",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := &GSUploader{BucketName: "my-bucket", BucketPath: tc.bucketPath}
+			got := u.artifactPath(&api.Artifact{Path: tc.artifactPath})
+			if got != tc.want {
+				t.Errorf("artifactPath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGSUploaderArtifactPathNoLeadingSlash is a regression guard for the
+// bucket-root upload bug: an empty BucketPath must not produce a leading slash
+// or a double slash in the object key.
+func TestGSUploaderArtifactPathNoLeadingSlash(t *testing.T) {
+	u := &GSUploader{BucketName: "my-bucket", BucketPath: ""}
+	got := u.artifactPath(&api.Artifact{Path: "index.html"})
+	if strings.HasPrefix(got, "/") {
+		t.Errorf("artifactPath() = %q, must not start with a slash", got)
+	}
+	if strings.Contains(got, "//") {
+		t.Errorf("artifactPath() = %q, must not contain a double slash", got)
+	}
+}
+
+// TestGSUploaderUploadKeyMatchesURL asserts that, for a bucket-root
+// destination, the object name used at upload (artifactPath) equals the key
+// portion of the generated download URL (after the host and bucket name), so
+// the two can never diverge again.
+func TestGSUploaderUploadKeyMatchesURL(t *testing.T) {
+	bucket, bucketPath := ParseGSDestination("gs://my-bucket")
+	u := &GSUploader{BucketName: bucket, BucketPath: bucketPath}
+	artifact := &api.Artifact{Path: "index.html"}
+
+	uploadKey := u.artifactPath(artifact)
+
+	url := u.URL(artifact)
+	prefix := "https://storage.googleapis.com/" + bucket + "/"
+	urlKey, ok := strings.CutPrefix(url, prefix)
+	if !ok {
+		t.Fatalf("URL() = %q, want prefix %q", url, prefix)
+	}
+
+	if uploadKey != urlKey {
+		t.Errorf("upload key %q does not match URL key %q (URL %q)", uploadKey, urlKey, url)
 	}
 }

--- a/internal/artifact/gs_uploader_test.go
+++ b/internal/artifact/gs_uploader_test.go
@@ -1,6 +1,7 @@
 package artifact
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -90,22 +91,39 @@ func TestGSUploaderArtifactPathNoLeadingSlash(t *testing.T) {
 // TestGSUploaderUploadKeyMatchesURL asserts that, for a bucket-root
 // destination, the object name used at upload (artifactPath) equals the key
 // portion of the generated download URL (after the host and bucket name), so
-// the two can never diverge again.
+// the two can never diverge again. Both the trailing-slash and no-slash forms
+// of a bucket-root destination are covered.
 func TestGSUploaderUploadKeyMatchesURL(t *testing.T) {
-	bucket, bucketPath := ParseGSDestination("gs://my-bucket")
-	u := &GSUploader{BucketName: bucket, BucketPath: bucketPath}
-	artifact := &api.Artifact{Path: "index.html"}
-
-	uploadKey := u.artifactPath(artifact)
-
-	url := u.URL(artifact)
-	prefix := "https://storage.googleapis.com/" + bucket + "/"
-	urlKey, ok := strings.CutPrefix(url, prefix)
-	if !ok {
-		t.Fatalf("URL() = %q, want prefix %q", url, prefix)
+	// URL() reads BUILDKITE_GCS_ACCESS_HOST and BUILDKITE_GCS_PATH_PREFIX via
+	// os.LookupEnv; the expected prefix below assumes the default environment,
+	// so unset them for the duration of the test.
+	for _, key := range []string{"BUILDKITE_GCS_ACCESS_HOST", "BUILDKITE_GCS_PATH_PREFIX"} {
+		if orig, ok := os.LookupEnv(key); ok {
+			os.Unsetenv(key) //nolint:errcheck // Best-effort.
+			t.Cleanup(func() {
+				os.Setenv(key, orig) //nolint:errcheck // Best-effort restore.
+			})
+		}
 	}
 
-	if uploadKey != urlKey {
-		t.Errorf("upload key %q does not match URL key %q (URL %q)", uploadKey, urlKey, url)
+	for _, dest := range []string{"gs://my-bucket", "gs://my-bucket/"} {
+		t.Run(dest, func(t *testing.T) {
+			bucket, bucketPath := ParseGSDestination(dest)
+			u := &GSUploader{BucketName: bucket, BucketPath: bucketPath}
+			artifact := &api.Artifact{Path: "index.html"}
+
+			uploadKey := u.artifactPath(artifact)
+
+			url := u.URL(artifact)
+			prefix := "https://storage.googleapis.com/" + bucket + "/"
+			urlKey, ok := strings.CutPrefix(url, prefix)
+			if !ok {
+				t.Fatalf("URL() = %q, want prefix %q", url, prefix)
+			}
+
+			if uploadKey != urlKey {
+				t.Errorf("upload key %q does not match URL key %q (URL %q)", uploadKey, urlKey, url)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

When an artifact is uploaded to a Google Cloud Storage destination with **no path component** — i.e. the bucket root, such as `gs://my-bucket` or `gs://my-bucket/` — the agent stored the object under a key with a **leading slash** (e.g. `/index.html`) but generated the download URL **without** it (e.g. `https://storage.googleapis.com/my-bucket/index.html`). The link pointed at key `index.html` while the object was actually stored at `/index.html`, so GCS returned *"Requested entity was not found."* This affected every artifact uploaded to a bucket root (`index.html` for static sites being the common case).

Root cause: with an empty `BucketPath`, `GSUploader.artifactPath` built the key with a raw `strings.Join([]string{"", "index.html"}, "/")` → `/index.html`, while `URL()` runs the same value through `path.Join`, which calls `path.Clean` and strips the leading slash — so the upload key and the URL key diverged.

The fix brings `GSUploader.artifactPath` in line with the existing `S3Uploader.artifactPath` reference implementation: guard the empty `BucketPath` and use `path.Join`, so the object name and the URL are constructed consistently and can't diverge again. AWS S3 and Azure Blob Storage were already immune.

Alternatives considered: also stripping a trailing slash in `ParseGSDestination` (to mirror `ParseS3Destination`). Not needed — the empty-path guard already covers `gs://my-bucket/` (parses to an empty path), and `path.Join` cleans a trailing slash on any non-empty prefix — so it was left out to keep the change minimal.

## Changes

- `internal/artifact/gs_uploader.go`: `artifactPath` now returns `artifact.Path` unchanged when `BucketPath` is empty, otherwise `path.Join(BucketPath, artifact.Path)` — removing the leading slash and aligning object-key construction with the download URL.
- `internal/artifact/gs_uploader_test.go`: added tests covering empty vs non-empty `BucketPath`, a regression guard against leading/double slashes, and an assertion that the upload key matches the key portion of the generated URL — exercised over both bucket-root forms (`gs://my-bucket` and `gs://my-bucket/`) with `BUILDKITE_GCS_ACCESS_HOST` / `BUILDKITE_GCS_PATH_PREFIX` unset so the assertion runs against the default environment.

No CLI argument or behaviour changes for uploads under a sub-path.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

Claude Code (Opus 4.8) investigated the bug, then wrote both the fix and the unit tests test-first (TDD), under my direction and review.

