### PR TITLE
Gate GIT_LFS_SKIP_SMUDGE on git-lfs-enabled flag

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -916,9 +916,11 @@ func (e *Executor) setUp(ctx context.Context) (retErr error) {
 	// Disable any interactive Git/SSH prompting
 	e.shell.Env.Set("GIT_TERMINAL_PROMPT", "0")
 
-	// Force-set GIT_LFS_SKIP_SMUDGE=1 before any git operations so LFS
-	// objects are not downloaded automatically during checkout.
-	e.shell.Env.Set("GIT_LFS_SKIP_SMUDGE", "1")
+	// Suppress automatic LFS smudge only when LFS is enabled, so the checkout
+	// phase can materialise objects explicitly; otherwise git's default applies.
+	if e.GitLFSEnabled {
+		e.shell.Env.Set("GIT_LFS_SKIP_SMUDGE", "1")
+	}
 
 	// Fetch and set secrets before environment hook execution
 	if e.Secrets != "" {

--- a/internal/job/executor_test.go
+++ b/internal/job/executor_test.go
@@ -123,6 +123,48 @@ func newCancelTestExecutor(t *testing.T) *Executor {
 	return e
 }
 
+// TestSetUpGitLFSSkipSmudge is a regression test for #4041: setUp used to set
+// GIT_LFS_SKIP_SMUDGE=1 unconditionally, disabling git's default LFS smudge for
+// every job. It must only be set when LFS handling is enabled.
+func TestSetUpGitLFSSkipSmudge(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name       string
+		lfsEnabled bool
+		wantSkip   bool
+	}{
+		{name: "lfs disabled leaves smudge enabled", lfsEnabled: false, wantSkip: false},
+		{name: "lfs enabled skips smudge", lfsEnabled: true, wantSkip: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			e := New(ExecutorConfig{GitLFSEnabled: test.lfsEnabled})
+
+			sh, err := shell.New(shell.WithEnv(env.New()))
+			if err != nil {
+				t.Fatalf("shell.New() error = %v, want nil", err)
+			}
+			// setUp requires a checkout path; supply one so it doesn't error.
+			sh.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", t.TempDir())
+			e.shell = sh
+
+			if err := e.setUp(t.Context()); err != nil {
+				t.Fatalf("e.setUp() error = %v, want nil", err)
+			}
+
+			got, ok := e.shell.Env.Get("GIT_LFS_SKIP_SMUDGE")
+			if ok != test.wantSkip {
+				t.Errorf("GIT_LFS_SKIP_SMUDGE present = %v, want %v", ok, test.wantSkip)
+			}
+			if test.wantSkip && got != "1" {
+				t.Errorf("GIT_LFS_SKIP_SMUDGE = %q, want %q", got, "1")
+			}
+		})
+	}
+}
+
 // TestCancelSetsJobCancelledEnv verifies the precedent set in #3213: any
 // cancellation surfaces BUILDKITE_JOB_CANCELLED=true to the post-command hook.
 func TestCancelSetsJobCancelledEnv(t *testing.T) {


### PR DESCRIPTION
## Description

v3.130.0 set `GIT_LFS_SKIP_SMUDGE=1` unconditionally in `setUp`, which disabled git's default LFS smudge filter for every job. Because the compensating agent-managed LFS path (`git lfs fetch`/`checkout`) only runs when `BUILDKITE_GIT_LFS_ENABLED` is set, and the backend does not yet emit that flag, checkouts silently ended up with only LFS pointer files instead of real content. The variable was also set on the whole job shell env, so it leaked into user commands and broke downstream git-lfs tooling (e.g. Carthage).

This gates the `GIT_LFS_SKIP_SMUDGE=1` set behind `GitLFSEnabled`. When LFS is not enabled (the default), the variable is left untouched and git's native smudge behaviour applies again, restoring pre-3.130.0 behaviour. When LFS is enabled, the suppression still happens so the agent-managed path stays in control of materialising objects.

Considered leaving the set in place but always re-materialising; rejected because that would change default behaviour for everyone and still run LFS work no one opted into.

## Context

- Fixes #4041
- Regression introduced by #3909 (first shipped in v3.130.0)
- The backend flag that opts jobs in (`checkout.lfs: true` -> `BUILDKITE_GIT_LFS_ENABLED`) is not yet merged to main, so today LFS is driven entirely by git's native smudge (implicit LFS), which this restores.

## Changes

- `internal/job/executor.go`: only set `GIT_LFS_SKIP_SMUDGE=1` when `GitLFSEnabled` is true.
- `internal/job/executor_test.go`: add `TestSetUpGitLFSSkipSmudge`, a table-driven regression test asserting the env var is present only when LFS is enabled. Verified it fails against the previous unconditional code.

No follow-up in this PR (tracked separately): scoping the variable to the checkout git commands rather than the job-wide env, so enabling LFS does not disable smudge for the user's own job scripts.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

`go test ./internal/job/...` passes (246 tests); `go vet` and `golangci-lint run ./internal/job/` are clean.

## Disclosures / Credits

Claude Code (Opus 4.8) investigated the regression across the agent and backend repos, implemented the fix, and wrote the regression test under my direction and review.