### PR TITLE
fix(cache-restore): retry s3 Download on 412

### DIFF
--- a/internal/cache/store/s3.go
+++ b/internal/cache/store/s3.go
@@ -2,7 +2,9 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -20,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	smithymiddleware "github.com/aws/smithy-go/middleware"
 	"github.com/buildkite/agent/v3/internal/cache/internal/trace"
+	"github.com/buildkite/roko"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -99,6 +102,53 @@ func OptionsFromURL(s3url string) (*Options, error) {
 	}
 
 	return opts, nil
+}
+
+// objectDownloader is the subset of manager.Downloader used by downloadWithRetry,
+// declared so the retry loop can be tested with a fake.
+type objectDownloader interface {
+	Download(ctx context.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*manager.Downloader)) (int64, error) //nolint:staticcheck // SA1019: pending migration to transfermanager
+}
+
+// isPreconditionFailed reports whether err is an S3 412 PreconditionFailed,
+// which happens when the object's ETag changes mid-download (e.g. a concurrent
+// restore's TTL-refresh CopyObject) and invalidates the SDK's If-Match guard.
+func isPreconditionFailed(err error) bool {
+	var respErr *awshttp.ResponseError
+	if errors.As(err, &respErr) {
+		return respErr.HTTPStatusCode() == http.StatusPreconditionFailed
+	}
+	return false
+}
+
+// downloadWithRetry runs the multipart download, retrying on S3 412
+// PreconditionFailed (a concurrent restore's TTL-refresh CopyObject changed the
+// object's ETag and invalidated the SDK's If-Match guard). Returns bytes written.
+func downloadWithRetry(ctx context.Context, r *roko.Retrier, d objectDownloader, destPath string, in *s3.GetObjectInput, opts ...func(*manager.Downloader)) (int64, error) { //nolint:staticcheck // SA1019: pending migration to transfermanager
+	var bytesWritten int64
+	err := r.DoWithContext(ctx, func(r *roko.Retrier) error {
+		destFile, err := os.Create(destPath)
+		if err != nil {
+			r.Break()
+			return fmt.Errorf("failed to create destination file %s: %w", destPath, err)
+		}
+		defer func() { _ = destFile.Close() }()
+
+		n, err := d.Download(ctx, destFile, in, opts...)
+		if err != nil {
+			if isPreconditionFailed(err) {
+				slog.Warn("cache download hit 412 (concurrent ETag change), retrying",
+					"key", aws.ToString(in.Key), "retrier", r.String())
+				return err // retryable
+			}
+			r.Break()
+			return err
+		}
+
+		bytesWritten = n
+		return nil
+	})
+	return bytesWritten, err
 }
 
 // S3Blob implements the Blob interface using AWS S3
@@ -318,25 +368,21 @@ func (b *S3Blob) Download(ctx context.Context, key, destPath string) (*TransferI
 	// Get the full key with prefix
 	fullKey := b.getFullKey(key)
 
-	// Create the destination file - must support WriteAt for parallel downloads
-	destFile, err := os.Create(destPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create destination file %s: %w", destPath, err)
-	}
-	defer func() {
-		_ = destFile.Close()
-	}()
-
 	slog.Debug("starting S3 download",
 		"key", fullKey,
 		"concurrency", b.downloadConcurrency,
 	)
 
-	// Track number of GetObject requests (parts) made during download
 	var partCount atomic.Int32
 
-	// Download the file from S3 using parallel range requests
-	bytesWritten, err := b.downloader.Download(ctx, destFile, &s3.GetObjectInput{ //nolint:staticcheck // SA1019: pending migration to transfermanager
+	// Download the file from S3 using parallel range requests, retrying on a
+	// 412 PreconditionFailed caused by a concurrent restore's ETag change.
+	retrier := roko.NewRetrier(
+		roko.WithMaxAttempts(3),
+		roko.WithStrategy(roko.ExponentialSubsecond(200*time.Millisecond)),
+		roko.WithJitterRange(0, 250*time.Millisecond),
+	)
+	bytesWritten, err := downloadWithRetry(ctx, retrier, b.downloader, destPath, &s3.GetObjectInput{
 		Bucket: aws.String(b.bucketName),
 		Key:    aws.String(fullKey),
 	}, func(d *manager.Downloader) { //nolint:staticcheck // SA1019: pending migration to transfermanager

--- a/internal/cache/store/s3_test.go
+++ b/internal/cache/store/s3_test.go
@@ -1,10 +1,21 @@
 package store
 
 import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/buildkite/roko"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -391,4 +402,111 @@ func TestResolveTransferSettings(t *testing.T) {
 			}
 		})
 	}
+}
+
+// responseErrorWithStatus builds a synthetic *awshttp.ResponseError carrying the
+// given HTTP status code, matching what the SDK surfaces on a failed request.
+func responseErrorWithStatus(status int) error {
+	return &awshttp.ResponseError{
+		ResponseError: &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{Response: &http.Response{StatusCode: status}},
+			Err:      fmt.Errorf("status %d", status),
+		},
+	}
+}
+
+// fakeDownloader is a test double for objectDownloader. It returns the result
+// for each successive call from results (the last entry repeats if exhausted),
+// writing payload to the destination on success so callers can assert bytes.
+type fakeDownloader struct {
+	calls   int
+	results []fakeDownloadResult
+}
+
+type fakeDownloadResult struct {
+	err     error
+	payload []byte
+}
+
+func (f *fakeDownloader) Download(_ context.Context, w io.WriterAt, _ *s3.GetObjectInput, _ ...func(*manager.Downloader)) (int64, error) { //nolint:staticcheck // SA1019: pending migration to transfermanager
+	res := f.results[min(f.calls, len(f.results)-1)]
+	f.calls++
+	if res.err != nil {
+		return 0, res.err
+	}
+	n, err := w.WriteAt(res.payload, 0)
+	return int64(n), err
+}
+
+// testRetrier builds a retrier that runs instantly (no real sleeps) so the
+// retry-loop tests are deterministic and fast.
+func testRetrier() *roko.Retrier {
+	return roko.NewRetrier(
+		roko.WithMaxAttempts(3),
+		roko.WithStrategy(roko.Constant(0)),
+		roko.WithSleepFunc(func(time.Duration) {}),
+	)
+}
+
+func TestDownloadWithRetry(t *testing.T) {
+	payload := []byte("cache-contents")
+
+	t.Run("retries 412 then succeeds", func(t *testing.T) {
+		destPath := filepath.Join(t.TempDir(), "dest")
+		fake := &fakeDownloader{results: []fakeDownloadResult{
+			{err: responseErrorWithStatus(http.StatusPreconditionFailed)},
+			{payload: payload},
+		}}
+
+		n, err := downloadWithRetry(t.Context(), testRetrier(), fake, destPath, &s3.GetObjectInput{})
+		if err != nil {
+			t.Fatalf("downloadWithRetry: unexpected error: %v", err)
+		}
+		if fake.calls != 2 {
+			t.Errorf("downloader called %d times, want 2", fake.calls)
+		}
+		if n != int64(len(payload)) {
+			t.Errorf("bytes written = %d, want %d", n, len(payload))
+		}
+		got, err := os.ReadFile(destPath)
+		if err != nil {
+			t.Fatalf("read dest: %v", err)
+		}
+		if string(got) != string(payload) {
+			t.Errorf("dest content = %q, want %q", got, payload)
+		}
+	})
+
+	t.Run("persistent 412 exhausts attempts", func(t *testing.T) {
+		destPath := filepath.Join(t.TempDir(), "dest")
+		fake := &fakeDownloader{results: []fakeDownloadResult{
+			{err: responseErrorWithStatus(http.StatusPreconditionFailed)},
+		}}
+
+		_, err := downloadWithRetry(t.Context(), testRetrier(), fake, destPath, &s3.GetObjectInput{})
+		if err == nil {
+			t.Fatal("downloadWithRetry: expected error, got nil")
+		}
+		if !isPreconditionFailed(err) {
+			t.Errorf("error %v is not a 412 PreconditionFailed", err)
+		}
+		if fake.calls != 3 {
+			t.Errorf("downloader called %d times, want 3", fake.calls)
+		}
+	})
+
+	t.Run("non-412 error fails without retry", func(t *testing.T) {
+		destPath := filepath.Join(t.TempDir(), "dest")
+		fake := &fakeDownloader{results: []fakeDownloadResult{
+			{err: responseErrorWithStatus(http.StatusInternalServerError)},
+		}}
+
+		_, err := downloadWithRetry(t.Context(), testRetrier(), fake, destPath, &s3.GetObjectInput{})
+		if err == nil {
+			t.Fatal("downloadWithRetry: expected error, got nil")
+		}
+		if fake.calls != 1 {
+			t.Errorf("downloader called %d times, want 1", fake.calls)
+		}
+	})
 }


### PR DESCRIPTION
## Description

(cache restore): retry s3 GetObject on status `412` `PreconditionFailed`

This error occurs on the s3 multipart downloader when the object's ETtag changes mid-download (which can happen when a concurrent restore's TTL-refresh CopyObject changes the object).

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

## Context

Resolves A-1452
<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

## Changes

Retries the s3 GetObject
<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)
Buildkite
<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits
Claude
<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
