### PR TITLE
[A-1469] Re-exec agent start to hide the registration token from proc inspection

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -832,11 +832,30 @@ var AgentStartCommand = cli.Command{
 		},
 	),
 	Action: func(c *cli.Context) error {
+		// If a plaintext registration token was passed via the command line
+		// or environment, re-exec (on Unix) with the token passed over a pipe
+		// instead, so it isn't readable in /proc/PID/cmdline or
+		// /proc/PID/environ for the life of the agent. On success this
+		// replaces the process and never returns.
+		if err := reexecToScrubRegistrationToken(); err != nil {
+			_, _ = fmt.Fprintf(c.App.ErrWriter, "Couldn't re-exec to remove the registration token from the process command line/environment, continuing anyway: %v\n", err)
+		}
+
 		ctx := context.Background()
 		ctx, cfg, l, configFile, done := setupLoggerAndConfig[AgentStartConfig](ctx, c, withConfigFilePaths(
 			defaultConfigFilePaths(),
 		))
 		defer done()
+
+		// Resolve indirect registration tokens (fd://N from the re-exec
+		// above, or file://PATH) into the real token.
+		if isIndirectToken(cfg.Token) {
+			token, err := resolveRegistrationToken(cfg.Token)
+			if err != nil {
+				return fmt.Errorf("failed to resolve registration token %q: %w", cfg.Token, err)
+			}
+			cfg.Token = token
+		}
 
 		// used later to force the shutdown of the agent
 		ctx, cancel := context.WithCancel(ctx)

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -38,7 +38,7 @@ var (
 	AgentRegisterTokenFlag = cli.StringFlag{
 		Name:   "token",
 		Value:  "",
-		Usage:  "Your account agent token",
+		Usage:  "Your cluster token or unclustered registration token. Prefix with file:// to read the token from a file, or fd:// to read it from an inherited file descriptor",
 		EnvVar: "BUILDKITE_AGENT_TOKEN",
 	}
 

--- a/clicommand/register_token.go
+++ b/clicommand/register_token.go
@@ -1,0 +1,134 @@
+package clicommand
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// The agent registration token is a long-lived secret, so we try to avoid
+// leaving it anywhere another process on the same host could read it. If it's
+// passed via the command line or environment, it's visible in
+// /proc/PID/cmdline (world-readable) and /proc/PID/environ (readable by any
+// process running as the same user - which jobs typically are) for the
+// lifetime of the agent, because those reflect the state at exec time.
+//
+// To mitigate this, "agent start" supports two indirect token references in
+// addition to a plain token value:
+//
+//   - file://PATH: read the token from the file at PATH.
+//   - fd://N: read the token from (inherited) file descriptor N.
+//
+// On Unix, when a plaintext token is detected in the command line or
+// environment, the agent re-execs itself with the token passed over a pipe as
+// fd://N instead (see reexecToScrubRegistrationToken), which replaces the
+// exec-time cmdline and environ with token-free versions.
+
+const registrationTokenEnvVar = "BUILDKITE_AGENT_TOKEN"
+
+// maxTokenFileSize is a sanity limit when reading tokens from files or file
+// descriptors.
+const maxTokenFileSize = 64 * 1024
+
+// isIndirectToken reports whether the token value is a reference to a token
+// (file:// or fd://) rather than the token itself.
+func isIndirectToken(token string) bool {
+	return strings.HasPrefix(token, "file://") || strings.HasPrefix(token, "fd://")
+}
+
+// resolveRegistrationToken resolves fd:// and file:// token references into
+// the actual token. Plain token values are returned unchanged.
+func resolveRegistrationToken(token string) (string, error) {
+	switch {
+	case strings.HasPrefix(token, "fd://"):
+		fd, err := strconv.ParseUint(strings.TrimPrefix(token, "fd://"), 10, 31)
+		if err != nil {
+			return "", fmt.Errorf("invalid token file descriptor %q: %w", token, err)
+		}
+
+		f := os.NewFile(uintptr(fd), "buildkite-agent-token")
+		if f == nil {
+			return "", fmt.Errorf("invalid token file descriptor %q", token)
+		}
+		defer f.Close() //nolint:errcheck // File is only read.
+
+		b, err := io.ReadAll(io.LimitReader(f, maxTokenFileSize))
+		if err != nil {
+			return "", fmt.Errorf("couldn't read token from file descriptor %d: %w", fd, err)
+		}
+
+		return strings.TrimSpace(string(b)), nil
+
+	case strings.HasPrefix(token, "file://"):
+		path := strings.TrimPrefix(token, "file://")
+
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("couldn't read token from file: %w", err)
+		}
+
+		return strings.TrimSpace(string(b)), nil
+
+	default:
+		return token, nil
+	}
+}
+
+// registrationTokenFromArgs scans command line arguments for the registration
+// token flag (-token/--token, space- or =-separated) and returns its value.
+// If the flag appears multiple times, the last value wins, matching flag
+// parsing behaviour.
+func registrationTokenFromArgs(args []string) (token string, found bool) {
+	for i := 0; i < len(args); i++ {
+		switch arg := args[i]; {
+		case arg == "-token" || arg == "--token":
+			if i+1 < len(args) {
+				token, found = args[i+1], true
+				i++
+			}
+		case strings.HasPrefix(arg, "-token="):
+			token, found = strings.TrimPrefix(arg, "-token="), true
+		case strings.HasPrefix(arg, "--token="):
+			token, found = strings.TrimPrefix(arg, "--token="), true
+		}
+	}
+	return token, found
+}
+
+// replaceTokenInArgs returns a copy of args with the value of every
+// registration token flag replaced with the given replacement.
+func replaceTokenInArgs(args []string, replacement string) []string {
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		switch arg := args[i]; {
+		case arg == "-token" || arg == "--token":
+			out = append(out, arg)
+			if i+1 < len(args) {
+				out = append(out, replacement)
+				i++
+			}
+		case strings.HasPrefix(arg, "-token="):
+			out = append(out, "-token="+replacement)
+		case strings.HasPrefix(arg, "--token="):
+			out = append(out, "--token="+replacement)
+		default:
+			out = append(out, arg)
+		}
+	}
+	return out
+}
+
+// scrubTokenFromEnviron returns a copy of environ (in "KEY=value" form) with
+// any BUILDKITE_AGENT_TOKEN entries removed.
+func scrubTokenFromEnviron(environ []string) []string {
+	out := make([]string, 0, len(environ))
+	for _, kv := range environ {
+		if strings.HasPrefix(kv, registrationTokenEnvVar+"=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}

--- a/clicommand/register_token_test.go
+++ b/clicommand/register_token_test.go
@@ -1,0 +1,228 @@
+package clicommand
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestIsIndirectToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		token string
+		want  bool
+	}{
+		{token: "bkt_llamas", want: false},
+		{token: "", want: false},
+		{token: "file:///etc/buildkite-agent/token", want: true},
+		{token: "fd://3", want: true},
+		{token: "fdish-token", want: false},
+	}
+
+	for _, test := range tests {
+		if got, want := isIndirectToken(test.token), test.want; got != want {
+			t.Errorf("isIndirectToken(%q) = %t, want %t", test.token, got, want)
+		}
+	}
+}
+
+func TestRegistrationTokenFromArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		args      []string
+		wantToken string
+		wantFound bool
+	}{
+		{
+			name: "no token flag",
+			args: []string{"buildkite-agent", "start", "--spawn", "2"},
+		},
+		{
+			name:      "space separated",
+			args:      []string{"buildkite-agent", "start", "--token", "llamas"},
+			wantToken: "llamas",
+			wantFound: true,
+		},
+		{
+			name:      "equals separated",
+			args:      []string{"buildkite-agent", "start", "--token=llamas"},
+			wantToken: "llamas",
+			wantFound: true,
+		},
+		{
+			name:      "single dash",
+			args:      []string{"buildkite-agent", "start", "-token", "llamas"},
+			wantToken: "llamas",
+			wantFound: true,
+		},
+		{
+			name:      "single dash equals",
+			args:      []string{"buildkite-agent", "start", "-token=alpacas"},
+			wantToken: "alpacas",
+			wantFound: true,
+		},
+		{
+			name:      "last occurrence wins",
+			args:      []string{"buildkite-agent", "start", "--token", "llamas", "--token=alpacas"},
+			wantToken: "alpacas",
+			wantFound: true,
+		},
+		{
+			name: "trailing flag with no value",
+			args: []string{"buildkite-agent", "start", "--token"},
+		},
+		{
+			name:      "empty value",
+			args:      []string{"buildkite-agent", "start", "--token", ""},
+			wantToken: "",
+			wantFound: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			token, found := registrationTokenFromArgs(test.args)
+			if got, want := token, test.wantToken; got != want {
+				t.Errorf("registrationTokenFromArgs(%q) token = %q, want %q", test.args, got, want)
+			}
+			if got, want := found, test.wantFound; got != want {
+				t.Errorf("registrationTokenFromArgs(%q) found = %t, want %t", test.args, got, want)
+			}
+		})
+	}
+}
+
+func TestReplaceTokenInArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "space separated",
+			args: []string{"buildkite-agent", "start", "--token", "llamas", "--spawn", "2"},
+			want: []string{"buildkite-agent", "start", "--token", "fd://3", "--spawn", "2"},
+		},
+		{
+			name: "equals separated",
+			args: []string{"buildkite-agent", "start", "--token=llamas"},
+			want: []string{"buildkite-agent", "start", "--token=fd://3"},
+		},
+		{
+			name: "single dash",
+			args: []string{"buildkite-agent", "start", "-token", "llamas", "-token=alpacas"},
+			want: []string{"buildkite-agent", "start", "-token", "fd://3", "-token=fd://3"},
+		},
+		{
+			name: "no token flag",
+			args: []string{"buildkite-agent", "start"},
+			want: []string{"buildkite-agent", "start"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := replaceTokenInArgs(test.args, "fd://3")
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("replaceTokenInArgs(%q, fd://3) diff (-got +want):\n%s", test.args, diff)
+			}
+		})
+	}
+}
+
+func TestScrubTokenFromEnviron(t *testing.T) {
+	t.Parallel()
+
+	environ := []string{
+		"HOME=/home/llama",
+		"BUILDKITE_AGENT_TOKEN=secret",
+		"BUILDKITE_AGENT_TOKENISH=not-scrubbed",
+		"PATH=/usr/bin",
+	}
+	want := []string{
+		"HOME=/home/llama",
+		"BUILDKITE_AGENT_TOKENISH=not-scrubbed",
+		"PATH=/usr/bin",
+	}
+	if diff := cmp.Diff(scrubTokenFromEnviron(environ), want); diff != "" {
+		t.Errorf("scrubTokenFromEnviron diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestResolveRegistrationToken_Plain(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveRegistrationToken("bkt_llamas")
+	if err != nil {
+		t.Fatalf("resolveRegistrationToken(bkt_llamas) error = %v", err)
+	}
+	if want := "bkt_llamas"; got != want {
+		t.Errorf("resolveRegistrationToken(bkt_llamas) = %q, want %q", got, want)
+	}
+}
+
+func TestResolveRegistrationToken_File(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(path, []byte("bkt_llamas\n"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(%q) = %v", path, err)
+	}
+
+	got, err := resolveRegistrationToken("file://" + path)
+	if err != nil {
+		t.Fatalf("resolveRegistrationToken(file://%s) error = %v", path, err)
+	}
+	if want := "bkt_llamas"; got != want {
+		t.Errorf("resolveRegistrationToken(file://%s) = %q, want %q", path, got, want)
+	}
+}
+
+func TestResolveRegistrationToken_FileMissing(t *testing.T) {
+	t.Parallel()
+
+	if _, err := resolveRegistrationToken("file:///nonexistent/token"); err == nil {
+		t.Error("resolveRegistrationToken(file:///nonexistent/token) error = nil, want error")
+	}
+}
+
+func TestResolveRegistrationToken_FD(t *testing.T) {
+	t.Parallel()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() = %v", err)
+	}
+	if _, err := w.WriteString("bkt_llamas"); err != nil {
+		t.Fatalf("w.WriteString = %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("w.Close() = %v", err)
+	}
+
+	got, err := resolveRegistrationToken("fd://" + strconv.FormatUint(uint64(r.Fd()), 10))
+	if err != nil {
+		t.Fatalf("resolveRegistrationToken(fd://) error = %v", err)
+	}
+	if want := "bkt_llamas"; got != want {
+		t.Errorf("resolveRegistrationToken(fd://) = %q, want %q", got, want)
+	}
+}
+
+func TestResolveRegistrationToken_BadFD(t *testing.T) {
+	t.Parallel()
+
+	if _, err := resolveRegistrationToken("fd://not-a-number"); err == nil {
+		t.Error("resolveRegistrationToken(fd://not-a-number) error = nil, want error")
+	}
+}

--- a/clicommand/register_token_unix.go
+++ b/clicommand/register_token_unix.go
@@ -1,0 +1,97 @@
+//go:build unix
+
+package clicommand
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// reexecToScrubRegistrationToken checks whether a plaintext registration
+// token was passed via the command line or environment, and if so, re-execs
+// the agent with the token passed over a pipe (as --token fd://N) instead.
+//
+// This exists because /proc/PID/cmdline and /proc/PID/environ expose the
+// *exec-time* command line and environment for the life of the process:
+// unsetting the variable after startup doesn't remove it from /proc, and jobs
+// typically run as the same user as the agent, so they can read both. Since
+// exec (as opposed to fork+exec) replaces the process image in place, the
+// re-exec'd agent keeps the same PID with a token-free cmdline and environ.
+//
+// On success this function never returns. It returns nil when no re-exec is
+// needed, and an error if the re-exec was attempted but failed (in which case
+// the caller may continue running with the token exposed).
+func reexecToScrubRegistrationToken() error {
+	argToken, argFound := registrationTokenFromArgs(os.Args)
+	envToken := os.Getenv(registrationTokenEnvVar)
+
+	argPlain := argFound && argToken != "" && !isIndirectToken(argToken)
+	envPlain := envToken != "" && !isIndirectToken(envToken)
+
+	if !argPlain && !envPlain {
+		// Nothing secret in the command line or environment.
+		return nil
+	}
+
+	// The effective token follows flag-beats-env precedence. If the flag is
+	// present but indirect (file:// or fd://), it wins and there's no secret
+	// to pipe: we only need to scrub the unused env var.
+	var secret string
+	switch {
+	case argPlain:
+		secret = argToken
+	case !argFound:
+		secret = envToken
+	}
+
+	args := os.Args
+	var tokenPipe *os.File
+
+	if secret != "" {
+		r, w, err := os.Pipe()
+		if err != nil {
+			return fmt.Errorf("creating token pipe: %w", err)
+		}
+		tokenPipe = r
+
+		// The token is far smaller than the pipe buffer, so this write
+		// completes without a reader.
+		if _, err := w.WriteString(secret); err != nil {
+			return fmt.Errorf("writing token to pipe: %w", err)
+		}
+		if err := w.Close(); err != nil {
+			return fmt.Errorf("closing token pipe: %w", err)
+		}
+
+		// os.Pipe creates both ends with CLOEXEC set. The read end must
+		// survive the exec; the write end should not (and its buffered
+		// contents remain readable regardless).
+		if _, err := unix.FcntlInt(r.Fd(), unix.F_SETFD, 0); err != nil {
+			return fmt.Errorf("clearing CLOEXEC on token pipe: %w", err)
+		}
+
+		ref := fmt.Sprintf("fd://%d", r.Fd())
+		if argFound {
+			args = replaceTokenInArgs(args, ref)
+		} else {
+			args = append(append([]string{}, args...), "--token", ref)
+		}
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("finding executable: %w", err)
+	}
+
+	err = syscall.Exec(exe, args, scrubTokenFromEnviron(os.Environ()))
+	if err != nil {
+		// This block will always execute, because syscall.Exec doesn't return if there's no error
+		tokenPipe.Close() //nolint:errcheck // best-effort cleanup
+		return fmt.Errorf("re-exec %q: %w", exe, err)
+	}
+
+	return nil // unreachable
+}

--- a/clicommand/register_token_windows.go
+++ b/clicommand/register_token_windows.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+package clicommand
+
+// reexecToScrubRegistrationToken is a no-op on non-Unix platforms: there's no
+// exec(2) equivalent to replace the process image in place, and no /proc
+// exposing the exec-time command line and environment to other processes.
+func reexecToScrubRegistrationToken() error {
+	return nil
+}


### PR DESCRIPTION
## Description

On Linux, `/proc/PID/cmdline` is world-readable and `/proc/PID/environ` is readable by any process running as the same user, and both reflect the state at exec time. Since jobs typically run as the same user as the agent, a token passed via `--token` or `BUILDKITE_AGENT_TOKEN` was readable by job processes for the life of the agent.

When agent start detects a plaintext token in its arguments or environment, it now re-execs itself with the token passed over a pipe (`--token fd://N`) and scrubbed from both. exec-in-place preserves the PID, so process supervision is unaffected. The token also accepts `file://PATH`, which avoids this particular exposure window entirely.


## Context

A-1469

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

This one was partly me, partly fable. good to have you back, buddy.
