### PR TITLE
fix: let k8s command containers override BUILDKITE_SHELL/HOOKS_SHELL via podSpec env, falling back to the agent's value when unset

### DIFF
--- a/clicommand/kubernetes_bootstrap.go
+++ b/clicommand/kubernetes_bootstrap.go
@@ -93,11 +93,26 @@ var KubernetesBootstrapCommand = cli.Command{
 		// given some higher-priority info from agent-stack-k8s or the
 		// container's default setup.
 		environ := env.FromSlice(os.Environ())
+
+		// Snapshot which containerShellPriority vars the command container set
+		// itself, before the loop below starts writing registration values into
+		// environ.
+		containerSetShell := make(map[string]bool, len(containerShellPriority))
+		for name := range containerShellPriority {
+			if _, set := environ.Get(name); set {
+				containerSetShell[name] = true
+			}
+		}
+
 		for name, val := range env.SeqSlice(regResp.Env) {
 			if _, skip := existingEnvPriority[name]; skip {
 				continue
 			}
 			if strings.HasPrefix(name, "KUBERNETES_") {
+				continue
+			}
+			if containerSetShell[name] {
+				// The command container set its own shell; keep it.
 				continue
 			}
 			environ.Set(name, val)
@@ -290,4 +305,12 @@ var existingEnvPriority = map[string]struct{}{
 	"SHLVL":    {},
 	"TERM":     {},
 	// "KUBERNETES_*": {}, // implemented as a strings.HasPrefix check
+}
+
+// containerShellPriority lists shell-selection vars where the command
+// container's own value wins if it sets one, else the agent's value is used
+// (the container's image may lack the agent's shell path, e.g. distroless).
+var containerShellPriority = map[string]struct{}{
+	"BUILDKITE_SHELL":       {},
+	"BUILDKITE_HOOKS_SHELL": {},
 }


### PR DESCRIPTION


## Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
This adds a `containerShellPriority` set (`BUILDKITE_SHELL`, `BUILDKITE_HOOKS_SHELL`). For these shell-selection vars, a command container's own value — set via its podSpec `env[]` - wins over the agent's registration
value, but falls back to the registration value when the container sets none.

The reasoning: the shell that actually exists depends on the command container's image (e.g. a distroless image may have no `/bin/sh`), and these are protected vars, so they can't be set via job env, hooks, or plugins - the container's `env[]` is the only per-container lever. Unlike `existingEnvPriority`, a container that sets no shell falls back to the agent's value (the operator's `--shell`, or its default) rather than being left unset.


## Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

https://linear.app/buildkite/issue/A-1463

## Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
