### PR TITLE
Conditionally refresh cache TTL on restore (A-1454)

### DIFF
--- a/internal/cache/store/s3.go
+++ b/internal/cache/store/s3.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithy "github.com/aws/smithy-go"
 	smithymiddleware "github.com/aws/smithy-go/middleware"
 	"github.com/buildkite/agent/v3/internal/cache/internal/trace"
 	"github.com/buildkite/roko"
@@ -110,13 +111,21 @@ type objectDownloader interface {
 	Download(ctx context.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*manager.Downloader)) (int64, error) //nolint:staticcheck // SA1019: pending migration to transfermanager
 }
 
-// isPreconditionFailed reports whether err is an S3 412 PreconditionFailed,
-// which happens when the object's ETag changes mid-download (e.g. a concurrent
-// restore's TTL-refresh CopyObject) and invalidates the SDK's If-Match guard.
+// isPreconditionFailed reports whether err is an S3 412 PreconditionFailed. It
+// arises in two places: a download whose object ETag changes mid-transfer (a
+// concurrent restore's TTL-refresh CopyObject invalidates the SDK's If-Match
+// guard), surfaced as an *awshttp.ResponseError with HTTP status 412; and a
+// self-CopyObject whose CopySourceIfUnmodifiedSince precondition signals the
+// object was modified too recently to refresh, surfaced as a smithy.APIError
+// with code "PreconditionFailed". Both carriers are matched.
 func isPreconditionFailed(err error) bool {
 	var respErr *awshttp.ResponseError
 	if errors.As(err, &respErr) {
 		return respErr.HTTPStatusCode() == http.StatusPreconditionFailed
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorCode() == "PreconditionFailed"
 	}
 	return false
 }
@@ -358,6 +367,15 @@ func (b *S3Blob) Upload(ctx context.Context, filePath, key string) (*TransferInf
 	}, nil
 }
 
+// restoreRefreshInterval is the minimum age (time since last modification)
+// before a restore refreshes a cache object's lifecycle expiration via a
+// self-CopyObject that resets LastModified. Objects modified more recently are
+// left untouched (the copy is skipped by S3 via a precondition), so an
+// actively-restored cache is refreshed at most about once per interval instead
+// of on every restore. The actual S3 bucket lifecycle window isn't known to the
+// agent, so this is a heuristic: keep it comfortably below that window.
+const restoreRefreshInterval = 12 * time.Hour
+
 // Download downloads a file from S3 using parallel range requests for large files
 func (b *S3Blob) Download(ctx context.Context, key, destPath string) (*TransferInfo, error) {
 	ctx, span := trace.Start(ctx, "S3Blob.Download")
@@ -427,23 +445,30 @@ func (b *S3Blob) Download(ctx context.Context, key, destPath string) (*TransferI
 		attribute.Int("concurrency", b.downloadConcurrency),
 	)
 
-	// Copy the object to itself to reset the LastModified timestamp,
-	// which extends the lifecycle expiration.
+	// Refresh the object's lifecycle expiration by copying it to itself, which
+	// resets LastModified. The if-unmodified-since precondition makes S3 skip the
+	// copy (412) when the object was modified within restoreRefreshInterval, so a
+	// hot cache isn't rewritten on every restore. The refresh is best-effort: any
+	// failure (incl. objects over S3's 5GB CopyObject limit) must not fail the
+	// restore.
 	copySource := fmt.Sprintf("%s/%s", b.bucketName, fullKey)
 	_, err = b.client.CopyObject(ctx, &s3.CopyObjectInput{
-		Bucket:            aws.String(b.bucketName),
-		Key:               aws.String(fullKey),
-		CopySource:        aws.String(copySource),
-		MetadataDirective: "REPLACE",
+		Bucket:                      aws.String(b.bucketName),
+		Key:                         aws.String(fullKey),
+		CopySource:                  aws.String(copySource),
+		MetadataDirective:           "REPLACE",
+		CopySourceIfUnmodifiedSince: aws.Time(time.Now().Add(-restoreRefreshInterval)),
 	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to refresh object expiration: %w", err)
+	switch {
+	case err == nil:
+		slog.Debug("refreshed object expiration", "key", fullKey, "bucket", b.bucketName)
+	case isPreconditionFailed(err):
+		slog.Debug("skipping cache TTL refresh, blob modified recently",
+			"key", fullKey, "bucket", b.bucketName)
+	default:
+		slog.Warn("failed to refresh object expiration, continuing (non-fatal)",
+			"key", fullKey, "bucket", b.bucketName, "error", err)
 	}
-
-	slog.Debug("refreshed object expiration",
-		"key", fullKey,
-		"bucket", b.bucketName,
-	)
 
 	return &TransferInfo{
 		BytesTransferred: bytesWritten,

--- a/internal/cache/store/s3.go
+++ b/internal/cache/store/s3.go
@@ -111,13 +111,16 @@ type objectDownloader interface {
 	Download(ctx context.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*manager.Downloader)) (int64, error) //nolint:staticcheck // SA1019: pending migration to transfermanager
 }
 
-// isPreconditionFailed reports whether err is an S3 412 PreconditionFailed. It
-// arises in two places: a download whose object ETag changes mid-transfer (a
-// concurrent restore's TTL-refresh CopyObject invalidates the SDK's If-Match
-// guard), surfaced as an *awshttp.ResponseError with HTTP status 412; and a
-// self-CopyObject whose CopySourceIfUnmodifiedSince precondition signals the
-// object was modified too recently to refresh, surfaced as a smithy.APIError
-// with code "PreconditionFailed". Both carriers are matched.
+// isPreconditionFailed returns true when an error is an S3 412 PreconditionFailed.
+// This happens when:
+//
+//  1. The ETag of an object changes mid-restore (e.g. A TTL-refresh CopyObject by
+//     a concurrent restore invalidates the If-Match guard).
+//     This presents as an *awshttp.ResponseError with HTTP status code 412.
+//
+//  2. The CopySourceIfUnmodifiedSince precondition was not met when performing a
+//     self-CopyObject, indicating that the object was modified too recently.
+//     This presents as a smithy.APIError with code "PreconditionFailed".
 func isPreconditionFailed(err error) bool {
 	var respErr *awshttp.ResponseError
 	if errors.As(err, &respErr) {
@@ -367,14 +370,14 @@ func (b *S3Blob) Upload(ctx context.Context, filePath, key string) (*TransferInf
 	}, nil
 }
 
-// restoreRefreshInterval is the minimum age (time since last modification)
-// before a restore refreshes a cache object's lifecycle expiration via a
-// self-CopyObject that resets LastModified. Objects modified more recently are
-// left untouched (the copy is skipped by S3 via a precondition), so an
-// actively-restored cache is refreshed at most about once per interval instead
-// of on every restore. The actual S3 bucket lifecycle window isn't known to the
-// agent, so this is a heuristic: keep it comfortably below that window.
-const restoreRefreshInterval = 12 * time.Hour
+// restoreRefreshMinInterval is the minimum time-since-LastModified
+// before a restore operation extends a cache object's effective TTL
+// by refreshing its LastModified timestamp with a self-CopyObject operation.
+//
+// Objects modified within this interval are left untouched using the
+// S3 CopySourceIfUnmodifiedSince precondition so that a heavily-restored
+// cache object is refreshed at most once per interval.
+const restoreRefreshMinInterval = 12 * time.Hour
 
 // Download downloads a file from S3 using parallel range requests for large files
 func (b *S3Blob) Download(ctx context.Context, key, destPath string) (*TransferInfo, error) {
@@ -445,19 +448,22 @@ func (b *S3Blob) Download(ctx context.Context, key, destPath string) (*TransferI
 		attribute.Int("concurrency", b.downloadConcurrency),
 	)
 
-	// Refresh the object's lifecycle expiration by copying it to itself, which
-	// resets LastModified. The if-unmodified-since precondition makes S3 skip the
-	// copy (412) when the object was modified within restoreRefreshInterval, so a
-	// hot cache isn't rewritten on every restore. The refresh is best-effort: any
-	// failure (incl. objects over S3's 5GB CopyObject limit) must not fail the
-	// restore.
+	// Extend an object's effective TTL by performing CopyObject on itself to
+	// refresh its LastModified timestamp.
+	//
+	// The CopySourceIfUnmodifiedSince precondition aborts the operation with an
+	// HTTP status code 412 if the object's LastModified timestamp falls within
+	// restoreRefreshMinInterval.
+	//
+	// This refresh is best-effort only: any failure (incl. objects exceeding
+	// S3's 5GB CopyObject limit) must not cause the overall restore operation to fail.
 	copySource := fmt.Sprintf("%s/%s", b.bucketName, fullKey)
 	_, err = b.client.CopyObject(ctx, &s3.CopyObjectInput{
 		Bucket:                      aws.String(b.bucketName),
 		Key:                         aws.String(fullKey),
 		CopySource:                  aws.String(copySource),
 		MetadataDirective:           "REPLACE",
-		CopySourceIfUnmodifiedSince: aws.Time(time.Now().Add(-restoreRefreshInterval)),
+		CopySourceIfUnmodifiedSince: aws.Time(time.Now().Add(-restoreRefreshMinInterval)),
 	})
 	switch {
 	case err == nil:

--- a/internal/cache/store/s3_test.go
+++ b/internal/cache/store/s3_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithy "github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/buildkite/roko"
 	"github.com/google/go-cmp/cmp"
@@ -277,6 +279,49 @@ func TestOptionsFromURL(t *testing.T) {
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("OptionsFromURL mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIsPreconditionFailed(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "precondition failed API error (CopyObject refresh)",
+			err:  &smithy.GenericAPIError{Code: "PreconditionFailed", Message: "At least one of the pre-conditions you specified did not hold"},
+			want: true,
+		},
+		{
+			name: "412 response error (download ETag change)",
+			err:  responseErrorWithStatus(http.StatusPreconditionFailed),
+			want: true,
+		},
+		{
+			name: "different API error code",
+			err:  &smithy.GenericAPIError{Code: "NoSuchKey", Message: "The specified key does not exist"},
+			want: false,
+		},
+		{
+			name: "non-412 response error",
+			err:  responseErrorWithStatus(http.StatusInternalServerError),
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPreconditionFailed(tt.err)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("isPreconditionFailed mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

The S3 cache restore path refreshes a cache object's lifecycle expiration by copying the object to itself (source == dest, `MetadataDirective: REPLACE`), which resets its `LastModified` so the bucket lifecycle rule doesn't expire it.

**Before:** that self-copy ran on _every_ restore. It's a synchronous full-object server-side rewrite — about 27s of blocking work for a 2GB cache — and it hard-errors on objects above S3's 5GB CopyObject limit, failing the whole restore (and the pipeline).

**After:** the self-copy still fires on every restore, but it now carries a `CopySourceIfUnmodifiedSince` precondition set to `now - restoreRefreshInterval`. S3 evaluates the precondition server-side and returns `412 PreconditionFailed` — skipping the copy — whenever the object was modified within the interval. So a hot cache is rewritten at most about once per `restoreRefreshInterval` instead of on every restore. And if the copy does run and fails for any other reason — including the >5GB case — the restore continues normally; the failure is logged as a warning instead of aborting.

**How:** the decision is entirely server-side via the precondition; there's no `HeadObject` and no dependency on the backend `expires_at` (which is decoupled from the actual S3 lifecycle policy and so isn't a reliable signal). The `CopyObject` result is classified into three branches: success (refreshed), `412 PreconditionFailed` (skipped, modified recently — a small `isPreconditionFailed` helper detects it via smithy's `APIError` code), and any other error (soft-fail: log a warning and continue). All three paths return normally.

`restoreRefreshInterval` is a single tunable const, currently `12 * time.Hour`. The actual bucket lifecycle window isn't known to the agent, so this is a heuristic — keep it comfortably below that window.

## Context

Linear ticket: [A-1454](https://linear.app/buildkite/issue/A-1454). The per-restore CopyObject was identified as the largest single cost in the cache-restore investigation.

## Changes

- `internal/cache/store/s3.go`: add the `restoreRefreshInterval` const and the `isPreconditionFailed` helper; in `Download`, issue the self-copy with a `CopySourceIfUnmodifiedSince` precondition and branch on the result (success / 412 skipped / soft-fail on any other error).
- `internal/cache/store/s3_test.go`: table-driven unit tests for `isPreconditionFailed`.

## Testing
- [x] Tests have run locally (`go test ./internal/cache/...` passes; `go build ./...` and `go vet ./internal/cache/...` clean).
- [x] Code is formatted.

## Disclosures / Credits

Implemented with Claude Code.

