### PR TITLE
A-1474: Remove --organization, --pipeline, --branch flags from cache subcommand

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -56,13 +56,10 @@ type CacheBlob struct {
 
 // CacheEntryCreateReq is the request body for creating (storing) a cache entry.
 type CacheEntryCreateReq struct {
-	TargetPaths  []string       `json:"target_paths"`
-	CacheKey     []CacheKeyPart `json:"cache_key"`
-	Blobs        []CacheBlob    `json:"blobs"`
-	Pipeline     string         `json:"pipeline"`
-	Branch       string         `json:"branch"`
-	Organization string         `json:"owner"`
-	Platform     string         `json:"platform"`
+	TargetPaths []string       `json:"target_paths"`
+	CacheKey    []CacheKeyPart `json:"cache_key"`
+	Blobs       []CacheBlob    `json:"blobs"`
+	Platform    string         `json:"platform"`
 }
 
 // CacheEntryCreateResp describes how to upload the new cache entry. The storage

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -180,10 +180,7 @@ func TestCacheEntryCreate_Success(t *testing.T) {
 			FileSize:    1024,
 			Compression: "zstd",
 		}},
-		Platform:     "linux/amd64",
-		Pipeline:     "test-pipeline",
-		Branch:       "main",
-		Organization: "test-org",
+		Platform: "linux/amd64",
 	})
 	if err != nil {
 		t.Fatalf("CacheEntryCreate error = %v, want nil", err)

--- a/clicommand/cache_restore.go
+++ b/clicommand/cache_restore.go
@@ -70,12 +70,7 @@ Cache Restoration Results:
 The command will report one of three outcomes for each cache:
   - Cache hit: Exact key match found and restored
   - Fallback used: No exact match, but a fallback key was found and restored
-  - Cache miss: No matching cache found
-
-The command automatically uses the following environment variables when available:
-  - BUILDKITE_BRANCH (for branch scoping)
-  - BUILDKITE_PIPELINE_SLUG (for pipeline scoping)
-  - BUILDKITE_ORGANIZATION_SLUG (for organization scoping)`
+  - Cache miss: No matching cache found`
 
 type CacheRestoreConfig struct {
 	GlobalConfig
@@ -111,9 +106,6 @@ var CacheRestoreCommand = cli.Command{
 		cacheCfg := cache.Config{
 			Registry:        cfg.Registry,
 			BucketURL:       cfg.BucketURL,
-			Branch:          cfg.Branch,
-			Pipeline:        cfg.Pipeline,
-			Organization:    cfg.Organization,
 			CacheConfigFile: cacheConfigFile,
 			Names:           cfg.Names,
 		}

--- a/clicommand/cache_save.go
+++ b/clicommand/cache_save.go
@@ -55,12 +55,7 @@ list of parts; each part is a literal string or one of { agent: os },
           - { agent: arch }
           - { checksum: package-lock.json }
         target_paths:
-          - node_modules
-
-The command automatically uses the following environment variables when available:
-  - BUILDKITE_BRANCH (for branch scoping)
-  - BUILDKITE_PIPELINE_SLUG (for pipeline scoping)
-  - BUILDKITE_ORGANIZATION_SLUG (for organization scoping)`
+          - node_modules`
 
 type CacheSaveConfig struct {
 	GlobalConfig
@@ -101,9 +96,6 @@ var CacheSaveCommand = cli.Command{
 		cacheCfg := cache.Config{
 			Registry:        cfg.Registry,
 			BucketURL:       cfg.BucketURL,
-			Branch:          cfg.Branch,
-			Pipeline:        cfg.Pipeline,
-			Organization:    cfg.Organization,
 			CacheConfigFile: cacheConfigFile,
 			Names:           cfg.Names,
 			Concurrency:     cfg.Concurrency,

--- a/clicommand/cache_shared.go
+++ b/clicommand/cache_shared.go
@@ -15,9 +15,6 @@ type CacheConfig struct {
 	Names           []string `cli:"name"`
 	Registry        string   `cli:"registry"`
 	BucketURL       string   `cli:"cache-store-url"`
-	Branch          string   `cli:"branch" validate:"required"`
-	Pipeline        string   `cli:"pipeline" validate:"required"`
-	Organization    string   `cli:"organization" validate:"required"`
 	CacheConfigFile string   `cli:"cache-config-file"`
 	Concurrency     int      `cli:"concurrency"`
 }
@@ -41,24 +38,6 @@ func cacheFlags() []cli.Flag {
 			Value:  "",
 			Usage:  "The URL of the cache store (e.g., s3://bucket-name); uploads/downloads use ambient credentials",
 			EnvVar: "BUILDKITE_AGENT_CACHE_STORE_URL",
-		},
-		cli.StringFlag{
-			Name:   "branch",
-			Value:  "",
-			Usage:  "Which branch should the cache be associated with",
-			EnvVar: "BUILDKITE_BRANCH",
-		},
-		cli.StringFlag{
-			Name:   "pipeline",
-			Value:  "",
-			Usage:  "The pipeline slug for this cache",
-			EnvVar: "BUILDKITE_PIPELINE_SLUG",
-		},
-		cli.StringFlag{
-			Name:   "organization",
-			Value:  "",
-			Usage:  "The organization slug for this cache",
-			EnvVar: "BUILDKITE_ORGANIZATION_SLUG",
 		},
 		cli.StringFlag{
 			Name:   "cache-config-file",

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -18,12 +18,6 @@ type Config struct {
 	Registry string
 	// BucketURL is the URL of the bucket (e.g., s3://bucket-name)
 	BucketURL string
-	// Branch is the branch associated with the cache
-	Branch string
-	// Pipeline is the pipeline slug for this cache
-	Pipeline string
-	// Organization is the organization slug for this cache
-	Organization string
 	// CacheConfigFile is the path to the cache configuration YAML file
 	CacheConfigFile string
 	// Names is a list of cache names (if empty, processes all caches)

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -349,9 +349,6 @@ func TestNewClient_InvalidCacheIDs(t *testing.T) {
 		CacheConfigFile: configFile,
 		Names:           []string{"cache1", "invalid1", "cache2", "invalid2"},
 		BucketURL:       "s3://test-bucket",
-		Branch:          "main",
-		Pipeline:        "test-pipeline",
-		Organization:    "test-org",
 	}
 
 	_, _, err := newClient(logger.Discard, nil, cfg)
@@ -390,9 +387,6 @@ func TestNewClient_ValidCacheIDs(t *testing.T) {
 		CacheConfigFile: configFile,
 		Names:           []string{"cache1", "cache2"},
 		BucketURL:       "s3://test-bucket",
-		Branch:          "main",
-		Pipeline:        "test-pipeline",
-		Organization:    "test-org",
 	}
 
 	client, cacheIDs, err := newClient(logger.Discard, nil, cfg)
@@ -428,9 +422,6 @@ func TestNewClient_AllCaches(t *testing.T) {
 		CacheConfigFile: configFile,
 		Names:           []string{},
 		BucketURL:       "s3://test-bucket",
-		Branch:          "main",
-		Pipeline:        "test-pipeline",
-		Organization:    "test-org",
 	}
 
 	client, cacheIDs, err := newClient(logger.Discard, nil, cfg)

--- a/internal/cache/client.go
+++ b/internal/cache/client.go
@@ -50,16 +50,13 @@ var (
 // bucket and the expanded, validated cache definitions used by every call.
 // Safe for concurrent use; honours context cancellation.
 type client struct {
-	api          cacheAPI
-	bucketURL    string
-	format       string
-	branch       string
-	pipeline     string
-	organization string
-	platform     string
-	registry     string
-	caches       []configuration.Cache
-	onProgress   ProgressCallback
+	api        cacheAPI
+	bucketURL  string
+	format     string
+	platform   string
+	registry   string
+	caches     []configuration.Cache
+	onProgress ProgressCallback
 }
 
 // newClient builds a client from apiClient and cfg: loads and expands the
@@ -96,15 +93,12 @@ func newClient(l logger.Logger, apiClient cacheAPI, cfg Config) (*client, []stri
 	}
 
 	c := &client{
-		api:          apiClient,
-		bucketURL:    cfg.BucketURL,
-		format:       "zip",
-		branch:       cfg.Branch,
-		pipeline:     cfg.Pipeline,
-		organization: cfg.Organization,
-		platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
-		registry:     registry,
-		caches:       expanded,
+		api:       apiClient,
+		bucketURL: cfg.BucketURL,
+		format:    "zip",
+		platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		registry:  registry,
+		caches:    expanded,
 		onProgress: func(cacheID, stage, message string, _, _ int) {
 			l.WithFields(
 				logger.StringField("cache_id", cacheID),

--- a/internal/cache/integration_test.go
+++ b/internal/cache/integration_test.go
@@ -37,9 +37,6 @@ type mockCacheEntry struct {
 	committed       bool
 	expiresAt       time.Time
 	platform        string
-	pipeline        string
-	branch          string
-	organization    string
 }
 
 // cacheAddr builds the v2 entry address from the order-insensitive target_paths
@@ -125,9 +122,6 @@ func (m *mockAPIClient) CacheEntryCreate(ctx context.Context, registry string, r
 		committed:       false,
 		expiresAt:       time.Now().Add(7 * 24 * time.Hour),
 		platform:        req.Platform,
-		pipeline:        req.Pipeline,
-		branch:          req.Branch,
-		organization:    req.Organization,
 	}
 
 	reg.cache[cacheAddr(req.TargetPaths, req.CacheKey)] = entry
@@ -271,14 +265,11 @@ func setupTestCache(t *testing.T, storageType string) (cacheClient *client, cach
 
 	// Create cache client
 	c := &client{
-		api:          mockClient,
-		bucketURL:    bucketURL,
-		format:       "zip",
-		branch:       "main",
-		pipeline:     "test-pipeline",
-		organization: "test-org",
-		platform:     "linux/amd64",
-		registry:     "~",
+		api:       mockClient,
+		bucketURL: bucketURL,
+		format:    "zip",
+		platform:  "linux/amd64",
+		registry:  "~",
 		caches: []configuration.Cache{
 			{
 				Name:        "test-cache",

--- a/internal/cache/restore.go
+++ b/internal/cache/restore.go
@@ -69,9 +69,6 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 
 	span.SetAttributes(
 		attribute.String("cache.id", cacheID),
-		attribute.String("cache.branch", c.branch),
-		attribute.String("cache.pipeline", c.pipeline),
-		attribute.String("cache.organization", c.organization),
 		attribute.String("cache.platform", c.platform),
 	)
 

--- a/internal/cache/save.go
+++ b/internal/cache/save.go
@@ -62,9 +62,6 @@ func (c *client) Save(ctx context.Context, cacheID string) (SaveResult, error) {
 
 	span.SetAttributes(
 		attribute.String("cache.id", cacheID),
-		attribute.String("cache.branch", c.branch),
-		attribute.String("cache.pipeline", c.pipeline),
-		attribute.String("cache.organization", c.organization),
 		attribute.String("cache.platform", c.platform),
 		attribute.String("cache.format", c.format),
 	)
@@ -246,10 +243,7 @@ func (c *client) Save(ctx context.Context, cacheID string) (SaveResult, error) {
 				FileSize:    archiveInfo.Size,
 				Compression: c.format,
 			}},
-			Platform:     c.platform,
-			Pipeline:     c.pipeline,
-			Branch:       c.branch,
-			Organization: c.organization,
+			Platform: c.platform,
 		})
 		if api.BreakOnNonRetryable(r, createApiResp, err) {
 			return err


### PR DESCRIPTION
## Summary

Removes the `--organization`, `--pipeline`, and `--branch` flags from `buildkite-agent cache save`/`restore`, and stops sending `pipeline`/`branch`/`owner` on the cache v2 wire. The backend now derives this metadata from the authenticated agent job identity.

Closes A-1474.

## Why

Per the [Cache Policy Design x Use Cases](https://www.notion.so/buildkite/Cache-Policy-Design-x-Use-Cases-364b8dbc2c89808fa6cfe99d056d05c5) decision, cache scope must track the **verified agent identity**, not a client-supplied flag or request-body value.

## Backend dependency (now satisfied)

The cache v2 `PUT /cache_registries/{registry}/store` endpoint used to **require** `pipeline`/`branch`/`owner` in the request body (400 otherwise). buildkite/buildkite#30835 changed it to derive these from the agent job identity and is **deployed to production**. This PR is the agent-side half.

## Changes

- Remove `Branch`/`Pipeline`/`Organization` from `CacheConfig` and delete the three flags (`clicommand/cache_shared.go`, `cache_save.go`, `cache_restore.go`).
- Remove `pipeline`/`branch`/`owner` from `CacheEntryCreateReq` and the internal plumbing (`api/cache.go`, `internal/cache/*`). `platform` is still sent.
- Update tests.

## Verification

- `go build ./...`, `go test ./api/... ./internal/cache/... ./clicommand/...`, `gofumpt` + `golangci-lint` clean.
- CI build #13055 (incl. the `agent-e2e-tests` trigger, `async: false`) **passed** against the deployed backend — the same agent code failed as #13047 before the backend deploy, confirming the fix.
