### PR TITLE
Suggestions for #4044

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -762,7 +762,7 @@ func (e *Executor) getOrUpdateMirrorDir(ctx context.Context, repository string) 
 
 // fetchSource fetches the git source for the job. If GitSkipFetchExistingCommits is
 // enabled and the commit already exists locally, the fetch is skipped entirely.
-func (e *Executor) fetchSource(ctx context.Context, autoAddBloblessFilter bool) error {
+func (e *Executor) fetchSource(ctx context.Context, addBloblessFilter bool) error {
 	// If configured, skip the fetch when the commit already exists locally.
 	// This is useful when a pre-populated git mirror is used with --reference,
 	// as the commit objects are already reachable and fetching is redundant.
@@ -773,7 +773,7 @@ func (e *Executor) fetchSource(ctx context.Context, autoAddBloblessFilter bool) 
 	}
 
 	gitFetchFlags := e.GitFetchFlags
-	if autoAddBloblessFilter {
+	if addBloblessFilter {
 		gitFetchFlags = "--filter=blob:none " + gitFetchFlags
 	}
 
@@ -911,8 +911,8 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (retErr error) {
 		return fmt.Errorf("creating checkout dir: %w", err)
 	}
 
-	// If sparse checkout paths are present, plan the sparse checkout.
-	sparsePlan := e.planSparseCheckout(ctx)
+	// Resolve the cone paths to check out (nil means a full checkout).
+	sparsePaths := e.resolveSparseCheckout(ctx)
 
 	// On mirrors and dissociation:
 	//
@@ -970,12 +970,13 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (retErr error) {
 			}
 		}
 
-		// If sparse checkout will actually apply, use a partial clone so blobs
-		// outside the sparse set aren't downloaded up front. Only when the user
-		// hasn't already supplied a --filter — git takes the last --filter on the
-		// command line and would silently override theirs.
-		if sparsePlan.supported {
-			if hasSparseCheckoutFlag(gitCloneFlags) {
+		// When sparse checkout applies, add two clone flags:
+		//   --sparse             clone in sparse mode
+		//   --filter=blob:none   make it a partial clone, so blobs outside the
+		//                        sparse set aren't downloaded up front
+		// Each flag is added only if the user hasn't already supplied their own.
+		if len(sparsePaths) > 0 {
+			if slices.Contains(gitCloneFlags, "--sparse") {
 				e.shell.Commentf("Sparse checkout is configured and BUILDKITE_GIT_CLONE_FLAGS already contains a --sparse flag (preserving user-supplied sparse checkout).")
 			} else {
 				gitCloneFlags = append(gitCloneFlags, "--sparse")
@@ -1014,10 +1015,10 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (retErr error) {
 		}
 	}
 
-	autoAddBloblessFilter := sparsePlan.supported &&
+	addBloblessFilter := len(sparsePaths) > 0 &&
 		!strings.Contains(e.GitCloneFlags, "--filter") &&
 		!strings.Contains(e.GitFetchFlags, "--filter")
-	if err := e.fetchSource(ctx, autoAddBloblessFilter); err != nil {
+	if err := e.fetchSource(ctx, addBloblessFilter); err != nil {
 		return err
 	}
 
@@ -1025,7 +1026,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (retErr error) {
 		return err
 	}
 
-	sparseCheckoutActive, err := e.setupSparseCheckout(ctx, sparsePlan)
+	sparseCheckoutActive, err := e.setupSparseCheckout(ctx, sparsePaths)
 	if err != nil {
 		return err
 	}

--- a/internal/job/checkout_sparse.go
+++ b/internal/job/checkout_sparse.go
@@ -12,40 +12,29 @@ import (
 	"github.com/buildkite/agent/v3/internal/shell"
 )
 
-// sparseCheckoutPlan is the decision, made once at the top of the checkout,
-// about whether sparse checkout applies to this build. Data only — all state
-// mutation happens in setupSparseCheckout.
-type sparseCheckoutPlan struct {
-	paths     []string // cleaned; empty when sparse checkout is not requested
-	supported bool     // requested AND `sparse-checkout set --cone` is available (git >= 2.27)
-}
-
-// planSparseCheckout resolves whether sparse checkout can be applied to this
-// build. Called once, before the clone, so the pre-clone --filter decision
-// and the post-fetch `sparse-checkout set --cone` call share the same answer
-// without running `git --version` twice. Runs `git --version` only when
-// sparse checkout was actually requested.
-func (e *Executor) planSparseCheckout(ctx context.Context) sparseCheckoutPlan {
+// resolveSparseCheckout returns the cone paths to check out for this build, or
+// nil to check out the full tree — either because no paths were requested or
+// because git is too old (< 2.27).
+func (e *Executor) resolveSparseCheckout(ctx context.Context) []string {
 	paths := cleanGitSparseCheckoutPaths(e.GitSparseCheckoutPaths)
 	if len(paths) == 0 {
-		return sparseCheckoutPlan{}
+		return nil
 	}
 
-	// 2.27 is the floor because setupSparseCheckout calls
-	// `git sparse-checkout set --cone <paths>` in a single call. Cone mode
-	// shipped in 2.26 but `--cone` was only accepted on the `init` subcommand
-	// then; `set --cone` landed in 2.27. On 2.26.x that call fails, so we
-	// fall back to a full checkout rather than carrying the older two-step.
+	// We require git >= 2.27 because setupSparseCheckout runs
+	// `git sparse-checkout set --cone <paths>` which is only supported by
+	// 2.27 and newer. On older git versions, fall back to a full checkout
+	// by returning nil.
 	ok, err := gitVersionAtLeast(ctx, e.shell, 2, 27)
 	if err != nil {
 		e.shell.Warningf("Sparse checkout requires git >= 2.27; falling back to full checkout (%v)", err)
-		return sparseCheckoutPlan{paths: paths}
+		return nil
 	}
 	if !ok {
 		e.shell.Warningf("Sparse checkout requires git >= 2.27; falling back to full checkout")
-		return sparseCheckoutPlan{paths: paths}
+		return nil
 	}
-	return sparseCheckoutPlan{paths: paths, supported: true}
+	return paths
 }
 
 func cleanGitSparseCheckoutPaths(paths []string) []string {
@@ -127,19 +116,19 @@ func (e *Executor) disableSparseCheckoutIfConfigured(ctx context.Context) {
 	}
 }
 
-// setupSparseCheckout applies a resolved plan to configure (or disable)
-// git sparse checkout for the current working tree. It returns true if
-// sparse checkout was successfully applied for this build, so callers can
-// adjust later behaviour (e.g. skip submodule init, which requires the full
-// tree).
-func (e *Executor) setupSparseCheckout(ctx context.Context, plan sparseCheckoutPlan) (bool, error) {
-	if len(plan.paths) == 0 || !plan.supported {
+// setupSparseCheckout configures git sparse checkout for the given cone paths.
+// When sparsePaths is empty it does a full checkout instead, disabling any
+// prior sparse checkout configuration. It returns true when sparse checkout is
+// applied, so callers can skip steps that need the full tree (e.g. submodule
+// init).
+func (e *Executor) setupSparseCheckout(ctx context.Context, sparsePaths []string) (bool, error) {
+	if len(sparsePaths) == 0 {
 		e.disableSparseCheckoutIfConfigured(ctx)
 		return false, nil
 	}
 
-	e.shell.Commentf("Setting up sparse checkout for paths: %s", strings.Join(plan.paths, ","))
-	args := append([]string{"sparse-checkout", "set", "--cone"}, plan.paths...)
+	e.shell.Commentf("Setting up sparse checkout for paths: %s", strings.Join(sparsePaths, ","))
+	args := append([]string{"sparse-checkout", "set", "--cone"}, sparsePaths...)
 	if err := e.shell.Command("git", args...).Run(ctx); err != nil {
 		return false, fmt.Errorf("setting sparse checkout paths: %w", err)
 	}

--- a/internal/job/checkout_sparse_test.go
+++ b/internal/job/checkout_sparse_test.go
@@ -58,13 +58,12 @@ func TestSetupSparseCheckout_Enable(t *testing.T) {
 
 	git.Expect("sparse-checkout", "set", "--cone", ".buildkite/", "src/").AndExitWith(0)
 
-	plan := sparseCheckoutPlan{paths: []string{".buildkite/", "src/"}, supported: true}
-	active, err := executor.setupSparseCheckout(t.Context(), plan)
+	active, err := executor.setupSparseCheckout(t.Context(), []string{".buildkite/", "src/"})
 	if err != nil {
-		t.Fatalf("executor.setupSparseCheckout(ctx, plan) error = %v, want nil", err)
+		t.Fatalf("executor.setupSparseCheckout(ctx, sparsePaths) error = %v, want nil", err)
 	}
 	if !active {
-		t.Fatalf("executor.setupSparseCheckout(ctx, plan) active = false, want true")
+		t.Fatalf("executor.setupSparseCheckout(ctx, sparsePaths) active = false, want true")
 	}
 	if got, want := out.String(), "Setting up sparse checkout for paths: .buildkite/,src/"; !strings.Contains(got, want) {
 		t.Fatalf("shell output = %q, want to contain %q", got, want)
@@ -83,13 +82,12 @@ func TestSetupSparseCheckout_DisableWithPriorSparseConfig(t *testing.T) {
 	git.Expect("config", "--worktree", "--list").AndWriteToStdout("").AndExitWith(0)
 	git.Expect("config", "--unset", "extensions.worktreeConfig").AndExitWith(0)
 
-	plan := sparseCheckoutPlan{paths: []string{"src/"}, supported: false}
-	active, err := executor.setupSparseCheckout(t.Context(), plan)
+	active, err := executor.setupSparseCheckout(t.Context(), nil)
 	if err != nil {
-		t.Fatalf("executor.setupSparseCheckout(ctx, plan) error = %v, want nil", err)
+		t.Fatalf("executor.setupSparseCheckout(ctx, sparsePaths) error = %v, want nil", err)
 	}
 	if active {
-		t.Fatalf("executor.setupSparseCheckout(ctx, plan) active = true, want false")
+		t.Fatalf("executor.setupSparseCheckout(ctx, sparsePaths) active = true, want false")
 	}
 	if got, want := out.String(), "Disabling sparse checkout from previous build"; !strings.Contains(got, want) {
 		t.Fatalf("shell output = %q, want to contain %q", got, want)
@@ -108,9 +106,8 @@ func TestSetupSparseCheckout_DisablePreservesOtherWorktreeConfig(t *testing.T) {
 	git.Expect("config", "--worktree", "--list").AndWriteToStdout("user.something=value\n").AndExitWith(0)
 	git.Expect("config", "--unset", "extensions.worktreeConfig").NotCalled()
 
-	plan := sparseCheckoutPlan{paths: []string{"src/"}, supported: false}
-	if _, err := executor.setupSparseCheckout(t.Context(), plan); err != nil {
-		t.Fatalf("executor.setupSparseCheckout(ctx, plan) error = %v, want nil", err)
+	if _, err := executor.setupSparseCheckout(t.Context(), nil); err != nil {
+		t.Fatalf("executor.setupSparseCheckout(ctx, sparsePaths) error = %v, want nil", err)
 	}
 
 	git.Check(t)
@@ -123,9 +120,8 @@ func TestSetupSparseCheckout_DisableWithoutPriorSparseConfig(t *testing.T) {
 	git.Expect("config").WithAnyArguments().NotCalled()
 	git.Expect("sparse-checkout").WithAnyArguments().NotCalled()
 
-	plan := sparseCheckoutPlan{paths: []string{"src/"}, supported: false}
-	if _, err := executor.setupSparseCheckout(t.Context(), plan); err != nil {
-		t.Fatalf("executor.setupSparseCheckout(ctx, plan) error = %v, want nil", err)
+	if _, err := executor.setupSparseCheckout(t.Context(), nil); err != nil {
+		t.Fatalf("executor.setupSparseCheckout(ctx, sparsePaths) error = %v, want nil", err)
 	}
 
 	git.Check(t)
@@ -139,12 +135,9 @@ func TestSetupSparseCheckout_VersionFallback(t *testing.T) {
 	git.Expect("--version").AndWriteToStdout("git version 2.25.4").AndExitWith(0)
 	git.Expect("sparse-checkout").WithAnyArguments().NotCalled()
 
-	plan := executor.planSparseCheckout(t.Context())
-	if plan.supported {
-		t.Fatalf("planSparseCheckout(ctx).supported = true, want false")
-	}
-	if len(plan.paths) != 1 || plan.paths[0] != "src/" {
-		t.Fatalf("planSparseCheckout(ctx).paths = %#v, want [\"src/\"]", plan.paths)
+	paths := executor.resolveSparseCheckout(t.Context())
+	if len(paths) != 0 {
+		t.Fatalf("resolveSparseCheckout(ctx) = %#v, want nil (fallback to full checkout)", paths)
 	}
 	if got, want := out.String(), "Sparse checkout requires git >= 2.27; falling back to full checkout"; !strings.Contains(got, want) {
 		t.Fatalf("shell output = %q, want to contain %q", got, want)
@@ -159,18 +152,28 @@ func TestSetupSparseCheckout_VersionFallbackDisablesPriorSparseConfig(t *testing
 	executor.GitSparseCheckoutPaths = []string{"src/"}
 	createSparseCheckoutFile(t, executor.shell.Getwd())
 
+	// Old git: resolveSparseCheckout warns and returns nil paths, then
+	// setupSparseCheckout disables the prior sparse config left on disk.
+	git.Expect("--version").AndWriteToStdout("git version 2.25.4").AndExitWith(0)
 	git.Expect("config", "--get", "core.sparseCheckout").AndWriteToStdout("true\n").AndExitWith(0)
 	git.Expect("sparse-checkout", "disable").AndExitWith(0)
 	git.Expect("config", "--worktree", "--list").AndWriteToStdout("").AndExitWith(0)
 	git.Expect("config", "--unset", "extensions.worktreeConfig").AndExitWith(0)
 
-	plan := sparseCheckoutPlan{paths: []string{"src/"}, supported: false}
-	active, err := executor.setupSparseCheckout(t.Context(), plan)
+	sparsePaths := executor.resolveSparseCheckout(t.Context())
+	if len(sparsePaths) != 0 {
+		t.Fatalf("resolveSparseCheckout(ctx) = %#v, want nil (fallback to full checkout)", sparsePaths)
+	}
+
+	active, err := executor.setupSparseCheckout(t.Context(), sparsePaths)
 	if err != nil {
-		t.Fatalf("executor.setupSparseCheckout(ctx, plan) error = %v, want nil", err)
+		t.Fatalf("executor.setupSparseCheckout(ctx, sparsePaths) error = %v, want nil", err)
 	}
 	if active {
-		t.Fatalf("executor.setupSparseCheckout(ctx, plan) active = true, want false")
+		t.Fatalf("executor.setupSparseCheckout(ctx, sparsePaths) active = true, want false")
+	}
+	if got, want := out.String(), "Sparse checkout requires git >= 2.27; falling back to full checkout"; !strings.Contains(got, want) {
+		t.Fatalf("shell output = %q, want to contain %q", got, want)
 	}
 	if got, want := out.String(), "Disabling sparse checkout from previous build"; !strings.Contains(got, want) {
 		t.Fatalf("shell output = %q, want to contain %q", got, want)

--- a/internal/job/git.go
+++ b/internal/job/git.go
@@ -92,26 +92,16 @@ func gitCheckout(ctx context.Context, sh *shell.Shell, gitCheckoutFlags, referen
 	return nil
 }
 
-// hasPartialCloneFilter reports whether the given clone flags already include
-// any --filter=<spec> or --filter <spec> option. The caller (sparse checkout
-// setup) uses this to avoid stacking its own --filter=blob:none on top of a
-// user-supplied filter, since git takes the last --filter on the command line
-// and would silently override the user's choice.
+// hasPartialCloneFilter returns true if flags contains a
+// --filter=<spec> or --filter <spec> option.
 func hasPartialCloneFilter(flags []string) bool {
 	for i, f := range flags {
+		// Check for --filter=<spec>
 		if strings.HasPrefix(f, "--filter=") {
 			return true
 		}
+		// The --filter <spec> form only counts when a value actually follows it
 		if f == "--filter" && i+1 < len(flags) {
-			return true
-		}
-	}
-	return false
-}
-
-func hasSparseCheckoutFlag(flags []string) bool {
-	for _, f := range flags {
-		if f == "--sparse" {
 			return true
 		}
 	}

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -158,7 +158,7 @@ func TestCheckingOutLocalGitProject(t *testing.T) {
 }
 
 // TestCheckingOutLocalGitProjectWithSparseCheckoutFallsBackOnOldGit exercises
-// the fallback path in planSparseCheckout when git is older than 2.27 (below
+// the fallback path in resolveSparseCheckout when git is older than 2.27 (below
 // the cone-mode floor). It overrides `git --version` via AndCallFunc to
 // report an old git version, while every other invocation passes through to
 // the real binary.
@@ -250,8 +250,8 @@ func TestCheckingOutLocalGitProjectWithSparseCheckoutFallsBackOnOldGit(t *testin
 // sparse checkout paths are configured but the user did NOT supply any
 // --filter in BUILDKITE_GIT_CLONE_FLAGS. The other sparse integration tests
 // all pre-supply --filter=blob:none, which short-circuits the auto-add and
-// therefore doesn't exercise enableCloneFlagsForSparseCheckout's "add it"
-// branch.
+// therefore doesn't exercise the "add it" branch of the clone-flag logic in
+// defaultCheckoutPhase.
 func TestCheckingOutLocalGitProjectWithSparseCheckoutAutoAddsBlobNoneFilter(t *testing.T) {
 	t.Parallel()
 	skipIfGitSparseCheckoutUnsupported(t)


### PR DESCRIPTION
Suggestions for #4044

- Replace **sparseCheckoutPlan** struct with a plain **[]string**
- Rename **planSparseCheckout** → **resolveSparseCheckout**, which now returns just **[]string** or **nil** when no paths have been requested or git is too old.
- Update **setupSparseCheckout** to take sparsePaths **[]string** instead of a **plan**. Empty/nil means full checkout (disabling any prior sparse config).
- Replace **hasSparseCheckoutFlag** with inline **slices.Contains(gitCloneFlags, "--sparse")**  
- Update tests and tighten up commentary