### PR TITLE
A-1437: TTL refresh on hosted cache object

### DIFF
--- a/internal/cache/store/nsc.go
+++ b/internal/cache/store/nsc.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"os/exec"
@@ -20,13 +21,12 @@ import (
 // nscScheme is the URL scheme that routes an agent-managed cache store to NSC.
 const nscScheme = "nsc"
 
-// nscDefaultExpiry is the default artifact expiry passed to nsc artifact upload.
+// nscDefaultExpiry is the artifact lifetime used both when uploading a cache
+// entry (--expires_in) and when refreshing it on access (--ensure_minimum).
 // Cache entries are content-addressed and short-lived, so we cap storage growth
-// rather than relying on NSC's no-expiry default.
-//
-// TODO: 24h is a temporary stopgap. We ultimately want parity with the S3 path,
-// where the expiry can be extended (e.g. refreshed on cache hits) instead of a
-// fixed lifetime.
+// rather than relying on NSC's no-expiry default. Every restore pushes the
+// expiry back out to this duration from now, keeping hot caches alive while
+// letting cold ones expire.
 const nscDefaultExpiry = "24h"
 
 // commandRunner executes an external command. It is a seam so tests can assert
@@ -221,12 +221,57 @@ func (n *NscStore) Download(ctx context.Context, key, filePath string) (*Transfe
 		attribute.String("nsc_key", key),
 	)
 
+	// Refresh the artifact's TTL on access so hot caches stay alive, mirroring
+	// the S3 store's self-CopyObject refresh. Unlike CopyObject this is cheap,
+	// so we refresh on every restore rather than gating it behind a minimum
+	// interval.
+	n.refreshExpiry(ctx, key)
+
 	return &TransferInfo{
 		BytesTransferred: bytesTransferred,
 		TransferSpeed:    averageSpeed,
 		RequestID:        "", // NSC doesn't expose request IDs
 		Duration:         duration,
 	}, nil
+}
+
+// refreshExpiry pushes the artifact's expiry out to at least nscDefaultExpiry
+// from now via `nsc artifact extend --ensure_minimum`. Using --ensure_minimum
+// (rather than the additive --by) makes the refresh idempotent, so calling it
+// on every restore keeps a hot cache alive without growing its expiry unbounded.
+//
+// This is best-effort: any failure is logged and swallowed so a restore never
+// fails because its TTL could not be refreshed.
+func (n *NscStore) refreshExpiry(ctx context.Context, key string) {
+	if !n.extendSupported(ctx) {
+		// `nsc artifact extend` is still being rolled out by Namespace. Update
+		// the nsc CLI as a contingency so the command becomes available.
+		slog.Debug("nsc artifact extend unavailable, updating nsc CLI")
+		if _, err := n.run(ctx, "", "nsc", "version", "update"); err != nil {
+			slog.Warn("failed to update nsc CLI, skipping cache TTL refresh (non-fatal)",
+				"key", key, "error", err)
+			return
+		}
+	}
+
+	result, err := n.run(ctx, "", n.artifactArgs("extend", key, "--ensure_minimum", nscDefaultExpiry)...)
+	switch {
+	case err != nil:
+		slog.Warn("failed to refresh cache TTL, continuing (non-fatal)", "key", key, "error", err)
+	case result.ExitCode != 0:
+		slog.Warn("failed to refresh cache TTL, continuing (non-fatal)",
+			"key", key, "exit_code", result.ExitCode, "stderr", result.Stderr)
+	default:
+		slog.Debug("refreshed cache TTL", "key", key)
+	}
+}
+
+// extendSupported reports whether the installed nsc CLI supports
+// `nsc artifact extend`. During Namespace's rollout of this command, older CLIs
+// exit non-zero for its --help.
+func (n *NscStore) extendSupported(ctx context.Context) bool {
+	result, err := n.run(ctx, "", "nsc", "artifact", "extend", "--help")
+	return err == nil && result.ExitCode == 0
 }
 
 type CommandResult struct {

--- a/internal/cache/store/nsc_test.go
+++ b/internal/cache/store/nsc_test.go
@@ -270,6 +270,116 @@ func TestNscStore_PassesNamespace(t *testing.T) {
 	}
 }
 
+// isCommand reports whether args starts with the given nsc subcommand tokens.
+func isCommand(args []string, tokens ...string) bool {
+	if len(args) < len(tokens) {
+		return false
+	}
+	for i, tok := range tokens {
+		if args[i] != tok {
+			return false
+		}
+	}
+	return true
+}
+
+// recordingRunner records every command invocation and delegates the result to
+// respond. When respond is nil, every command succeeds. Download commands write
+// their destination file so the store's os.Stat succeeds.
+func recordingRunner(calls *[][]string, respond func(args []string) (*CommandResult, error)) commandRunner {
+	return func(_ context.Context, _ string, args ...string) (*CommandResult, error) {
+		*calls = append(*calls, args)
+
+		if isCommand(args, "nsc", "artifact", "download") {
+			// download args: nsc artifact download <key> <filePath> ...
+			if err := os.WriteFile(args[4], []byte("data"), 0o600); err != nil {
+				return nil, err
+			}
+		}
+
+		if respond != nil {
+			return respond(args)
+		}
+		return &CommandResult{}, nil
+	}
+}
+
+func TestNscStore_RefreshesTTLOnDownload(t *testing.T) {
+	ctx := t.Context()
+	dest := filepath.Join(t.TempDir(), "out.txt")
+
+	var calls [][]string
+	store := &NscStore{namespace: "my-namespace", run: recordingRunner(&calls, nil)}
+
+	if _, err := store.Download(ctx, "key", dest); err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+
+	wantExtend := []string{"nsc", "artifact", "extend", "key", "--ensure_minimum", "24h", "--namespace", "my-namespace"}
+	var gotExtend []string
+	for _, c := range calls {
+		if isCommand(c, "nsc", "artifact", "extend") && !isCommand(c, "nsc", "artifact", "extend", "--help") {
+			gotExtend = c
+		}
+	}
+	if diff := cmp.Diff(wantExtend, gotExtend); diff != "" {
+		t.Errorf("extend args mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestNscStore_UpdatesCLIWhenExtendUnsupported(t *testing.T) {
+	ctx := t.Context()
+	dest := filepath.Join(t.TempDir(), "out.txt")
+
+	var calls [][]string
+	respond := func(args []string) (*CommandResult, error) {
+		// Simulate an old CLI: `nsc artifact extend --help` exits non-zero.
+		if isCommand(args, "nsc", "artifact", "extend", "--help") {
+			return &CommandResult{ExitCode: 1}, nil
+		}
+		return &CommandResult{}, nil
+	}
+	store := &NscStore{namespace: "ns", run: recordingRunner(&calls, respond)}
+
+	if _, err := store.Download(ctx, "key", dest); err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+
+	var updated, extended bool
+	for _, c := range calls {
+		if isCommand(c, "nsc", "version", "update") {
+			updated = true
+		}
+		if isCommand(c, "nsc", "artifact", "extend", "key") {
+			extended = true
+		}
+	}
+	if !updated {
+		t.Error("expected nsc version update to run when extend is unsupported")
+	}
+	if !extended {
+		t.Error("expected nsc artifact extend to run after updating the CLI")
+	}
+}
+
+func TestNscStore_DownloadSucceedsWhenRefreshFails(t *testing.T) {
+	ctx := t.Context()
+	dest := filepath.Join(t.TempDir(), "out.txt")
+
+	respond := func(args []string) (*CommandResult, error) {
+		if isCommand(args, "nsc", "artifact", "extend", "key") {
+			return &CommandResult{ExitCode: 1, Stderr: "boom"}, nil
+		}
+		return &CommandResult{}, nil
+	}
+	var calls [][]string
+	store := &NscStore{namespace: "ns", run: recordingRunner(&calls, respond)}
+
+	if _, err := store.Download(ctx, "key", dest); err != nil {
+		t.Fatalf("Download should succeed despite a failed TTL refresh: %v", err)
+	}
+}
+
 func TestNewNscStore_RequiresNamespace(t *testing.T) {
 	if _, err := NewNscStore("nsc://"); err == nil {
 		t.Error(`NewNscStore("nsc://"): expected error, got nil`)


### PR DESCRIPTION
## Description

For hosted cache, after restoring a cache, refresh its TTL. 

## Context

A-1437

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

Buildkite

## Disclosures / Credits

Clanker and human brain