### PR TITLE
updateGitMirror: use double checked locking

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -489,6 +489,15 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string) (dir 
 		e.shell.Commentf("Acquiring mirror repository update lock")
 	}
 
+	if isMainRepository {
+		// Check if the commit is in the mirror before acquiring the lock
+		// This is an operation that is safe to perform concurrently.
+		if hasGitCommit(ctx, e.shell, mirrorDir, e.Commit) {
+			e.shell.Commentf("Commit %q exists in mirror", e.Commit)
+			return e.snapshotMirror(ctx, repository, mirrorDir)
+		}
+	}
+
 	// Lock the mirror dir to prevent concurrent updates
 	updateCtx, canc := context.WithTimeout(ctx, lockTimeout)
 	defer canc()


### PR DESCRIPTION
Currently `updateGitMirror` acquire the mirror lock before checking for the existence of the revision.

But `git rev-parse` should be safe to run concurrently, so before locking it's worth checking if the commit is present, which should be safe to do without the lock.

When running builds with large number of jobs, and large server with many agents on them, it's not rare that several agents are looking for the same revision, hence reducing contention on that path is worth it.

Ideally, while we're blocked on the lock, we could occasionally check if the commit has been fetched, but it's a more invasive change.