### PR TITLE
Improve log URL to point to specific job

### DIFF
--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -77,7 +77,7 @@ func (r *JobRunner) Run(ctx context.Context, ignoreAgentInDispatches *bool) (err
 		return errors.New("job already cancelled before running")
 	}
 
-	r.agentLogger.Infof("Starting job %s for build at %s", r.conf.Job.ID, r.conf.Job.Env["BUILDKITE_BUILD_URL"])
+	r.agentLogger.Infof("Starting job at %s?jid=%s", r.conf.Job.Env["BUILDKITE_BUILD_URL"], r.conf.Job.ID)
 
 	ctx, done := status.AddItem(ctx, "Job Runner", "", nil)
 	defer done()
@@ -457,7 +457,7 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 		r.agentLogger.Errorf("Couldn't mark job as finished: %v", err)
 	}
 
-	r.agentLogger.Infof("Finished job %s for build at %s", r.conf.Job.ID, r.conf.Job.Env["BUILDKITE_BUILD_URL"])
+	r.agentLogger.Infof("Finished job at %s?jid=%s", r.conf.Job.Env["BUILDKITE_BUILD_URL"], r.conf.Job.ID)
 }
 
 // streamJobLogsAfterProcessStart waits for the process to start, then grabs the job output

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -77,7 +77,7 @@ func (r *JobRunner) Run(ctx context.Context, ignoreAgentInDispatches *bool) (err
 		return errors.New("job already cancelled before running")
 	}
 
-	r.agentLogger.Infof("Starting job at %s?jid=%s", r.conf.Job.Env["BUILDKITE_BUILD_URL"], r.conf.Job.ID)
+	r.agentLogger.Infof("Starting job at %s#%s", r.conf.Job.Env["BUILDKITE_BUILD_URL"], r.conf.Job.ID)
 
 	ctx, done := status.AddItem(ctx, "Job Runner", "", nil)
 	defer done()
@@ -457,7 +457,7 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 		r.agentLogger.Errorf("Couldn't mark job as finished: %v", err)
 	}
 
-	r.agentLogger.Infof("Finished job at %s?jid=%s", r.conf.Job.Env["BUILDKITE_BUILD_URL"], r.conf.Job.ID)
+	r.agentLogger.Infof("Finished job at %s#%s", r.conf.Job.Env["BUILDKITE_BUILD_URL"], r.conf.Job.ID)
 }
 
 // streamJobLogsAfterProcessStart waits for the process to start, then grabs the job output


### PR DESCRIPTION
Without this change, the user has to manually create the URL, which is tedious when debugging agents.

## Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

Spotify
