### PR TITLE
Bump gh cli in release script to 2.96.0

### DIFF
--- a/.buildkite/steps/github-release.sh
+++ b/.buildkite/steps/github-release.sh
@@ -25,7 +25,7 @@ if [[ "${GH_TOKEN}" == "" ]]; then
 fi
 
 echo '--- Installing gh CLI'
-GH_VERSION=2.92.0
+GH_VERSION=2.96.0
 curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
   | tar -xz -C /tmp
 install "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh


### PR DESCRIPTION
## Description

Use a newer gh cli for releases.

## Context

Noticed while trying to push a beta.

## Changes

Install v2.96 instead of v2.92.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

Two keystrokes