### PR TITLE
[A-1515] Improve job log URL and deduplicate url computation

### DIFF
--- a/agent/json_job_logger.go
+++ b/agent/json_job_logger.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -27,7 +26,7 @@ func NewJSONJobLogger(conf JobRunnerConfig) JSONJobLogger {
 		logger.StringField("queue", job.Env["BUILDKITE_AGENT_META_DATA_QUEUE"]),
 		logger.StringField("build_id", job.Env["BUILDKITE_BUILD_ID"]),
 		logger.StringField("build_number", job.Env["BUILDKITE_BUILD_NUMBER"]),
-		logger.StringField("job_url", fmt.Sprintf("%s#%s", job.Env["BUILDKITE_BUILD_URL"], job.ID)),
+		logger.StringField("job_url", job.URL()),
 		logger.StringField("build_url", job.Env["BUILDKITE_BUILD_URL"]),
 		logger.StringField("job_id", job.ID),
 		logger.StringField("step_key", job.Env["BUILDKITE_STEP_KEY"]),

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -77,7 +77,7 @@ func (r *JobRunner) Run(ctx context.Context, ignoreAgentInDispatches *bool) (err
 		return errors.New("job already cancelled before running")
 	}
 
-	r.agentLogger.Infof("Starting job at %s#%s", r.conf.Job.Env["BUILDKITE_BUILD_URL"], r.conf.Job.ID)
+	r.agentLogger.Infof("Starting job at %s", r.conf.Job.URL())
 
 	ctx, done := status.AddItem(ctx, "Job Runner", "", nil)
 	defer done()
@@ -457,7 +457,7 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 		r.agentLogger.Errorf("Couldn't mark job as finished: %v", err)
 	}
 
-	r.agentLogger.Infof("Finished job at %s#%s", r.conf.Job.Env["BUILDKITE_BUILD_URL"], r.conf.Job.ID)
+	r.agentLogger.Infof("Finished job at %s", r.conf.Job.URL())
 }
 
 // streamJobLogsAfterProcessStart waits for the process to start, then grabs the job output

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -77,7 +77,7 @@ func (r *JobRunner) Run(ctx context.Context, ignoreAgentInDispatches *bool) (err
 		return errors.New("job already cancelled before running")
 	}
 
-	r.agentLogger.Infof("Starting job %s for build at %s", r.conf.Job.ID, r.conf.Job.Env["BUILDKITE_BUILD_URL"])
+	r.agentLogger.Infof("Starting job at %s?jid=%s", r.conf.Job.Env["BUILDKITE_BUILD_URL"], r.conf.Job.ID)
 
 	ctx, done := status.AddItem(ctx, "Job Runner", "", nil)
 	defer done()
@@ -457,7 +457,7 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 		r.agentLogger.Errorf("Couldn't mark job as finished: %v", err)
 	}
 
-	r.agentLogger.Infof("Finished job %s for build at %s", r.conf.Job.ID, r.conf.Job.Env["BUILDKITE_BUILD_URL"])
+	r.agentLogger.Infof("Finished job at %s?jid=%s", r.conf.Job.Env["BUILDKITE_BUILD_URL"], r.conf.Job.ID)
 }
 
 // streamJobLogsAfterProcessStart waits for the process to start, then grabs the job output

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -77,7 +77,7 @@ func (r *JobRunner) Run(ctx context.Context, ignoreAgentInDispatches *bool) (err
 		return errors.New("job already cancelled before running")
 	}
 
-	r.agentLogger.Infof("Starting job at %s?jid=%s", r.conf.Job.Env["BUILDKITE_BUILD_URL"], r.conf.Job.ID)
+	r.agentLogger.Infof("Starting job at %s#%s", r.conf.Job.Env["BUILDKITE_BUILD_URL"], r.conf.Job.ID)
 
 	ctx, done := status.AddItem(ctx, "Job Runner", "", nil)
 	defer done()
@@ -457,7 +457,7 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 		r.agentLogger.Errorf("Couldn't mark job as finished: %v", err)
 	}
 
-	r.agentLogger.Infof("Finished job at %s?jid=%s", r.conf.Job.Env["BUILDKITE_BUILD_URL"], r.conf.Job.ID)
+	r.agentLogger.Infof("Finished job at %s#%s", r.conf.Job.Env["BUILDKITE_BUILD_URL"], r.conf.Job.ID)
 }
 
 // streamJobLogsAfterProcessStart waits for the process to start, then grabs the job output

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -33,6 +33,17 @@ type Job struct {
 	Priority              int                        `json:"priority"`
 }
 
+// JobURL returns the URL that deep-links to a specific job on its build page,
+// e.g. "https://buildkite.com/org/pipeline/builds/42#0190abcd-...".
+func JobURL(buildURL, jobID string) string {
+	return fmt.Sprintf("%s#%s", buildURL, jobID)
+}
+
+// URL returns the URL that deep-links to this job on its build page.
+func (j *Job) URL() string {
+	return JobURL(j.Env["BUILDKITE_BUILD_URL"], j.ID)
+}
+
 type JobState struct {
 	State string `json:"state,omitempty"`
 }

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -13,6 +13,24 @@ import (
 	"github.com/buildkite/agent/v3/logger"
 )
 
+func TestJobURL(t *testing.T) {
+	const buildURL = "https://buildkite.com/my-org/my-pipeline/builds/42"
+	const jobID = "b078e2d2-86e9-4c12-bf3b-612a8058d0a4"
+	const want = buildURL + "#" + jobID
+
+	if got := api.JobURL(buildURL, jobID); got != want {
+		t.Errorf("JobURL(%q, %q) = %q, want %q", buildURL, jobID, got, want)
+	}
+
+	job := &api.Job{
+		ID:  jobID,
+		Env: map[string]string{"BUILDKITE_BUILD_URL": buildURL},
+	}
+	if got := job.URL(); got != want {
+		t.Errorf("job.URL() = %q, want %q", got, want)
+	}
+}
+
 func TestPromiseFailure(t *testing.T) {
 	const jobID = "b078e2d2-86e9-4c12-bf3b-612a8058d0a4"
 	const accessToken = "llamas"

--- a/internal/job/tracing.go
+++ b/internal/job/tracing.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/env"
 	"github.com/buildkite/agent/v3/tracetools"
 	"github.com/buildkite/agent/v3/version"
@@ -228,7 +229,7 @@ func GenericTracingExtras(e *Executor, env *env.Environment) map[string]any {
 	buildID, _ := env.Get("BUILDKITE_BUILD_ID")
 	buildNumber, _ := env.Get("BUILDKITE_BUILD_NUMBER")
 	buildURL, _ := env.Get("BUILDKITE_BUILD_URL")
-	jobURL := fmt.Sprintf("%s#%s", buildURL, e.JobID)
+	jobURL := api.JobURL(buildURL, e.JobID)
 	source, _ := env.Get("BUILDKITE_SOURCE")
 
 	retry := 0


### PR DESCRIPTION
Building on #4076 (thanks @mitchhentgesspotify!), make Job URL in logs actually usable. Also implement shared `job.URL()` to deduplicate this exact behaviour across the codebase.

### Before
```
Starting job at https://buildkite.com/my-org/my-pipeline/builds/42?jid=b078e2d2-86e9-4c12-bf3b-612a8058d0a4
```


### After
```
Starting job at https://buildkite.com/my-org/my-pipeline/builds/42#b078e2d2-86e9-4c12-bf3b-612a8058d0a4
```

## Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go tool gofumpt -extra -w .`)
