### PR TITLE
Constant-time token comparison

### DIFF
--- a/internal/socket/middleware.go
+++ b/internal/socket/middleware.go
@@ -1,6 +1,7 @@
 package socket
 
 import (
+	"crypto/subtle"
 	"maps"
 	"net/http"
 	"strings"
@@ -64,7 +65,10 @@ func AuthMiddleware(token string, errorLogf func(f string, v ...any)) func(http.
 				return
 			}
 
-			if reqToken != token {
+			// IMO, constant-time comparison is overkill here, as any attacker
+			// would already be on the host as the same user (in order to access
+			// the socket). But it helps keep spurious vuln reports away.
+			if subtle.ConstantTimeCompare([]byte(reqToken), []byte(token)) == 0 {
 				if err := WriteError(w, "invalid authorization token", http.StatusUnauthorized); err != nil {
 					errorLogf("AuthMiddleware: couldn't write error response: %v", err)
 				}


### PR DESCRIPTION
## Description

Reduce spurious vuln reports by comparing the socket token in constant time.

## Context

https://linear.app/buildkite/issue/FODA-1611

## Changes

Use `subtle.ConstantTimeCompare`.

An alternative would be to hash (e.g. SHA) both tokens and compare them in variable time, as that would destroy the relationship between comparison time and token value.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

As suggested in the ticket.