### PR TITLE
fix: check for `--ensure_minimum` when refreshExpiry

### DIFF
--- a/internal/cache/store/nsc.go
+++ b/internal/cache/store/nsc.go
@@ -275,7 +275,8 @@ func (n *NscStore) refreshExpiry(ctx context.Context, key string) {
 // exit non-zero for its --help.
 func (n *NscStore) extendSupported(ctx context.Context) bool {
 	result, err := n.run(ctx, "", "nsc", "artifact", "extend", "--help")
-	return err == nil && result.ExitCode == 0
+	return err == nil && result.ExitCode == 0 &&
+		strings.Contains(result.Stdout, "--ensure_minimum")
 }
 
 type CommandResult struct {

--- a/internal/cache/store/nsc_test.go
+++ b/internal/cache/store/nsc_test.go
@@ -363,6 +363,47 @@ func TestNscStore_UpdatesCLIWhenExtendUnsupported(t *testing.T) {
 	}
 }
 
+func TestNscStore_UpdatesCLIWhenExtendHelpLacksEnsureMinimum(t *testing.T) {
+	ctx := t.Context()
+	dest := filepath.Join(t.TempDir(), "out.txt")
+
+	var calls [][]string
+	respond := func(args []string) (*CommandResult, error) {
+		if isCommand(args, "nsc", "artifact", "extend", "--help") {
+			return &CommandResult{
+				ExitCode: 0,
+				Stdout: "Artifact-related activities.\n" +
+					"Usage:\n  nsc artifact [command]\n" +
+					"Available Commands:\n" +
+					"  download   Download an artifact.\n" +
+					"  upload     Upload an artifact.\n",
+			}, nil
+		}
+		return &CommandResult{}, nil
+	}
+	store := &NscStore{namespace: "ns", run: recordingRunner(&calls, respond)}
+
+	if _, err := store.Download(ctx, "key", dest); err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+
+	var updated, extended bool
+	for _, c := range calls {
+		if isCommand(c, "nsc", "version", "update") {
+			updated = true
+		}
+		if isCommand(c, "nsc", "artifact", "extend", "key") {
+			extended = true
+		}
+	}
+	if !updated {
+		t.Error("expected nsc version update to run when extend --help exits 0 but omits --ensure_minimum")
+	}
+	if !extended {
+		t.Error("expected nsc artifact extend to run after updating the CLI")
+	}
+}
+
 func TestNscStore_DownloadSucceedsWhenRefreshFails(t *testing.T) {
 	ctx := t.Context()
 	dest := filepath.Join(t.TempDir(), "out.txt")


### PR DESCRIPTION
## Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

On an NSC (Namespace) cache restore, the cache download succeeded but refreshing
the cache's TTL failed with a non-fatal warning: `failed to refresh cache TTL, continuing (non-fatal) ... unknown flag: --ensure_minimum` because the TTL was never extended, frequently-accessed caches could still expire.
The problem was that `extendSupported` only checked that `nsc artifact extend --help` *exited 0* — i.e. that the `artifact extend` subcommand exists — not that the `--ensure_minimum` flag exists. On the nsc versions currently on Buildkite hosted agents, `nsc artifact extend --help` exits 0 (older builds fall back to printing the parent `nsc artifact` help, newer-but-in-between builds have `extend` without the flag), so the capability check passed, the `nsc version update` contingency was skipped, and the subsequent extend failed with `unknown flag: --ensure_minimum`.

## Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->
https://linear.app/buildkite/issue/A-1517/nsc-cache-restore-fails-to-refresh-ttl-with-unknown-ensure-minimum

## Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
