### PR TITLE
fix: remove archiveInfo.ArchivePath after upload

### DIFF
--- a/internal/cache/save.go
+++ b/internal/cache/save.go
@@ -199,6 +199,9 @@ func (c *client) Save(ctx context.Context, cacheID string) (SaveResult, error) {
 		span.SetStatus(codes.Error, "failed to build archive")
 		return result, fmt.Errorf("failed to build archive: %w", err)
 	}
+	defer func() {
+		_ = os.Remove(archiveInfo.ArchivePath)
+	}()
 
 	// Populate archive metrics
 	result.Archive = ArchiveMetrics{


### PR DESCRIPTION
## Description

fixes the bug found during testing where the cache save path did not delete the temporary archive after upload, leaking a temp .zip per save until the OS cleans TMPDIR.

## Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->
https://linear.app/buildkite/issue/A-1489/clean-up-temp-archive-after-cache-save-upload

## Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
