### PR TITLE
fix: Map expired artifact to ErrBlobNotFound

### DIFF
--- a/internal/cache/store/nsc.go
+++ b/internal/cache/store/nsc.go
@@ -202,8 +202,11 @@ func (n *NscStore) Download(ctx context.Context, key, filePath string) (*Transfe
 	}
 
 	if result.ExitCode != 0 {
-		// Distinguish a missing artifact from other download failures.
-		if strings.Contains(result.Stderr, "not found") {
+		// Map a missing or expired artifact to ErrBlobNotFound so the restore
+		// treats it as a cache miss (invalidating the stale entry and continuing)
+		// rather than failing the build.
+		if strings.Contains(result.Stderr, "not found") ||
+			strings.Contains(result.Stderr, "has expired") {
 			return nil, fmt.Errorf("%w: nsc key %s: %s", ErrBlobNotFound, key, strings.TrimSpace(result.Stderr))
 		}
 		return nil, fmt.Errorf("nsc download failed with exit code %d: %s", result.ExitCode, result.Stderr)

--- a/internal/cache/store/nsc_test.go
+++ b/internal/cache/store/nsc_test.go
@@ -552,6 +552,19 @@ func TestNscStore_DownloadNotFound(t *testing.T) {
 		}
 	})
 
+	t.Run("stderr expired maps to ErrBlobNotFound", func(t *testing.T) {
+		store := &NscStore{namespace: "ns", run: func(context.Context, string, ...string) (*CommandResult, error) {
+			return &CommandResult{
+				ExitCode: 1,
+				Stderr:   "Failed: the artifact has expired at 2026-07-14T02:06:24Z (request id: cbdorlqepas5e10ldvfvdpog40).",
+			}, nil
+		}}
+		_, err := store.Download(ctx, "valid-key", dest)
+		if !errors.Is(err, ErrBlobNotFound) {
+			t.Fatalf("Download err = %v, want ErrBlobNotFound", err)
+		}
+	})
+
 	t.Run("other failures are not ErrBlobNotFound", func(t *testing.T) {
 		store := &NscStore{namespace: "ns", run: func(context.Context, string, ...string) (*CommandResult, error) {
 			return &CommandResult{ExitCode: 1, Stderr: "connection refused"}, nil


### PR DESCRIPTION
## Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
Map nsc's "the artifact has expired" download error to ErrBlobNotFound (alongside "not found"), so an expired HA cache entry is treated as a cache miss and invalidated instead of failing the build.

## Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->
https://linear.app/buildkite/issue/A-1541/namespace-artifact-expiry-breaks-ha-cache-bust-mechanism

## Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
