### PR TITLE
fix(core): restore FinishJob retries on transport errors

### DIFF
--- a/api/retryable.go
+++ b/api/retryable.go
@@ -20,6 +20,9 @@ var retriableErrorSuffixes = []string{
 	"remote error: handshake failure",
 	io.ErrUnexpectedEOF.Error(),
 	io.EOF.Error(),
+	// Transient HTTP/2 transport failure when a previously pooled connection
+	// has gone away (load balancer idle timeout, server GOAWAY, etc.).
+	"http2: client connection lost",
 }
 
 // IsRetryableStatus returns true if the response's StatusCode is one that we should retry.

--- a/api/retryable_test.go
+++ b/api/retryable_test.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"syscall"
+	"testing"
+
+	"github.com/buildkite/roko"
+)
+
+func TestIsRetryableError(t *testing.T) {
+	t.Parallel()
+
+	http2ConnLost := errors.New("http2: client connection lost")
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "http2 client connection lost",
+			err:  http2ConnLost,
+			want: true,
+		},
+		{
+			name: "http2 client connection lost wrapped in url.Error",
+			err: &url.Error{
+				Op:  "Put",
+				URL: "https://agent.buildkite.com/v3/jobs/abc/finish",
+				Err: http2ConnLost,
+			},
+			want: true,
+		},
+		{
+			name: "connection refused",
+			err:  syscall.ECONNREFUSED,
+			want: true,
+		},
+		{
+			name: "use of closed network connection via url.Error",
+			err: &url.Error{
+				Op:  "Put",
+				URL: "https://example.com",
+				Err: errors.New("use of closed network connection"),
+			},
+			want: true,
+		},
+		{
+			name: "non-retryable application error",
+			err:  errors.New("something went wrong"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsRetryableError(tt.err); got != tt.want {
+				t.Errorf("IsRetryableError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBreakOnNonRetryable_HTTP2ClientConnectionLost(t *testing.T) {
+	t.Parallel()
+
+	retrier := roko.NewRetrier(roko.WithMaxAttempts(3))
+	err := fmt.Errorf(`Put "https://agent.buildkite.com/v3/jobs/abc/finish": %w`,
+		errors.New("http2: client connection lost"))
+
+	if BreakOnNonRetryable(retrier, nil, err) {
+		t.Fatal("BreakOnNonRetryable(...) = true, want false for http2: client connection lost")
+	}
+}
+
+func TestBreakOnNonRetryable_NonRetryableStatus(t *testing.T) {
+	t.Parallel()
+
+	retrier := roko.NewRetrier(roko.WithMaxAttempts(3))
+	resp := &Response{Response: &http.Response{StatusCode: http.StatusUnprocessableEntity}}
+
+	if !BreakOnNonRetryable(retrier, resp, errors.New("unprocessable")) {
+		t.Fatal("BreakOnNonRetryable(...) = false, want true for 422")
+	}
+}
+
+func TestBreakOnNonRetryable_NonRetryable4xx(t *testing.T) {
+	t.Parallel()
+
+	retrier := roko.NewRetrier(roko.WithMaxAttempts(3))
+	resp := &Response{Response: &http.Response{StatusCode: http.StatusForbidden}}
+
+	if !BreakOnNonRetryable(retrier, resp, errors.New("forbidden")) {
+		t.Fatal("BreakOnNonRetryable(...) = false, want true for 403")
+	}
+}

--- a/core/client.go
+++ b/core/client.go
@@ -229,24 +229,11 @@ func (c *Client) FinishJob(ctx context.Context, job *api.Job, finishedAt time.Ti
 	).DoWithContext(ctx, func(retrier *roko.Retrier) error {
 		response, err := c.APIClient.FinishJob(ctx, job, ignoreAgentInDispatches)
 		if err != nil {
-			// If the API returns with a 422, that means that we successfully tried to
-			// finish the job, but Buildkite rejected the finish for some reason. This
-			// can sometimes mean that Buildkite has cancelled the job before we get a
-			// chance to send the final API call (maybe this agent took too long to kill
-			// the process).
-			// The API may also return a 401 when job tokens are enabled.
-			// In either case, we don't want to keep trying to finish the job forever so
-			// we'll just bail out and go find some more work to do.
-			//
-			// Unlike other API calls, we intentionally do not use
-			// api.BreakOnNonRetryable here: finish is critical, so unknown transport
-			// errors (e.g. "http2: client connection lost") must keep retrying.
-			if response != nil && (response.StatusCode == 422 || response.StatusCode == 401) {
-				c.Logger.Warnf("Buildkite rejected the call to finish the job (%s)", err)
-				retrier.Break()
-				return err
+			// Non-retryable responses (e.g. 422, or 401 when job tokens are being used) mean the job has been cancelled or
+			// otherwise already finished. We should stop trying and go find more work to do.
+			if !api.BreakOnNonRetryable(retrier, response, err) {
+				c.Logger.Warnf("%s (%s)", err, retrier)
 			}
-			c.Logger.Warnf("%s (%s)", err, retrier)
 		}
 
 		return err

--- a/core/client.go
+++ b/core/client.go
@@ -229,11 +229,24 @@ func (c *Client) FinishJob(ctx context.Context, job *api.Job, finishedAt time.Ti
 	).DoWithContext(ctx, func(retrier *roko.Retrier) error {
 		response, err := c.APIClient.FinishJob(ctx, job, ignoreAgentInDispatches)
 		if err != nil {
-			// Non-retryable responses (e.g. 422, or 401 when job tokens are being used) mean the job has been cancelled or
-			// otherwise already finished. We should stop trying and go find more work to do.
-			if !api.BreakOnNonRetryable(retrier, response, err) {
-				c.Logger.Warnf("%s (%s)", err, retrier)
+			// If the API returns with a 422, that means that we successfully tried to
+			// finish the job, but Buildkite rejected the finish for some reason. This
+			// can sometimes mean that Buildkite has cancelled the job before we get a
+			// chance to send the final API call (maybe this agent took too long to kill
+			// the process).
+			// The API may also return a 401 when job tokens are enabled.
+			// In either case, we don't want to keep trying to finish the job forever so
+			// we'll just bail out and go find some more work to do.
+			//
+			// Unlike other API calls, we intentionally do not use
+			// api.BreakOnNonRetryable here: finish is critical, so unknown transport
+			// errors (e.g. "http2: client connection lost") must keep retrying.
+			if response != nil && (response.StatusCode == 422 || response.StatusCode == 401) {
+				c.Logger.Warnf("Buildkite rejected the call to finish the job (%s)", err)
+				retrier.Break()
+				return err
 			}
+			c.Logger.Warnf("%s (%s)", err, retrier)
 		}
 
 		return err

--- a/core/client_finish_job_test.go
+++ b/core/client_finish_job_test.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/logger"
+)
+
+type finishJobAPIClient struct {
+	APIClient // panics if unexpected methods are called
+
+	calls    atomic.Int32
+	failOnce error
+	failWith *api.Response
+}
+
+func (f *finishJobAPIClient) FinishJob(context.Context, *api.Job, *bool) (*api.Response, error) {
+	n := f.calls.Add(1)
+	if n == 1 && f.failOnce != nil {
+		return f.failWith, f.failOnce
+	}
+	return &api.Response{Response: &http.Response{StatusCode: http.StatusOK}}, nil
+}
+
+func TestFinishJobRetriesHTTP2ClientConnectionLost(t *testing.T) {
+	t.Parallel()
+
+	fake := &finishJobAPIClient{
+		failOnce: errors.New("http2: client connection lost"),
+	}
+	sleeps := 0
+	client := &Client{
+		APIClient: fake,
+		Logger:    logger.Discard,
+		RetrySleepFunc: func(time.Duration) {
+			sleeps++
+		},
+	}
+
+	err := client.FinishJob(t.Context(), &api.Job{ID: "job-1"}, time.Now(), ProcessExit{Status: 0}, 0, nil)
+	if err != nil {
+		t.Fatalf("FinishJob() error = %v, want nil", err)
+	}
+	if got := fake.calls.Load(); got != 2 {
+		t.Fatalf("FinishJob API calls = %d, want 2 (retry after transport error)", got)
+	}
+	if sleeps != 1 {
+		t.Fatalf("retry sleeps = %d, want 1", sleeps)
+	}
+}
+
+func TestFinishJobDoesNotRetryOn401(t *testing.T) {
+	t.Parallel()
+
+	fake := &finishJobAPIClient{
+		failOnce: errors.New("unauthorized"),
+		failWith: &api.Response{Response: &http.Response{StatusCode: http.StatusUnauthorized}},
+	}
+	client := &Client{
+		APIClient:      fake,
+		Logger:         logger.Discard,
+		RetrySleepFunc: func(time.Duration) {},
+	}
+
+	err := client.FinishJob(t.Context(), &api.Job{ID: "job-1"}, time.Now(), ProcessExit{Status: 0}, 0, nil)
+	if err == nil {
+		t.Fatal("FinishJob() error = nil, want unauthorized")
+	}
+	if got := fake.calls.Load(); got != 1 {
+		t.Fatalf("FinishJob API calls = %d, want 1 (no retry on 401)", got)
+	}
+}


### PR DESCRIPTION
- Only stop finish retries on 401/422 API responses
- Keep retrying unknown transport errors such as http2 connection lost

SUP: #7554

## Description
Successful jobs can exit 0 but then fail the Agent API finish call with a transient transport error such as http2: client connection lost. After the retry-policy cleanup in 3.124.0, FinishJob used BreakOnNonRetryable, which treated that error as non-retryable and gave up after one attempt. The agent then idled/disconnected and the job showed as agent lost (-1).

This PR restores the previous FinishJob retry behavior: only stop on 401/422 responses, and keep retrying unknown transport errors.

Alternative considered: adding http2: client connection lost to the shared IsRetryableError allowlist. That would help other API callers, but would not restore the original finish semantics (retry any non-401/422 failure). Finish is critical enough to keep the more resilient path.

## Context
SUP-7554
Customer report after upgrade from agent 3.114.1 → 3.130.0: finish fails with http2: client connection lost, then idle disconnect marks the job agent lost (-1)
## Changes
Restore FinishJob retry break conditions to 401/422 only in core/client.go
Add regression tests for retrying http2: client connection lost and not retrying 401
## Testing

 Tests have run locally (with go test ./...). Buildkite employees may check this if the pipeline has run automatically.
## Disclosures / Credits
I compared the previous FinishJob retry logic with the post-cleanup version. AI helped revert the deleted behavior and add regression tests.