### PR TITLE
Redact Go-escaped needles

### DIFF
--- a/clicommand/env_dump.go
+++ b/clicommand/env_dump.go
@@ -56,6 +56,7 @@ var EnvDumpCommand = cli.Command{
 		}
 
 		enc := json.NewEncoder(c.App.Writer)
+		enc.SetEscapeHTML(false) // HTML escapes may interfere with secret redaction
 		if cfg.Format == "json-pretty" {
 			enc.SetIndent("", "  ")
 		}

--- a/clicommand/env_get.go
+++ b/clicommand/env_get.go
@@ -128,6 +128,7 @@ func envGetAction(c *cli.Context) error {
 
 	case "json", "json-pretty":
 		enc := json.NewEncoder(c.App.Writer)
+		enc.SetEscapeHTML(false) // HTML escapes may interfere with secret redaction
 		if c.String("format") == "json-pretty" {
 			enc.SetIndent("", "  ")
 		}

--- a/clicommand/env_set.go
+++ b/clicommand/env_set.go
@@ -155,6 +155,7 @@ func envSetAction(c *cli.Context) error {
 
 	case "json", "json-pretty":
 		enc := json.NewEncoder(c.App.Writer)
+		enc.SetEscapeHTML(false) // HTML escapes may interfere with secret redaction
 		if c.String("output-format") == "json-pretty" {
 			enc.SetIndent("", "  ")
 		}

--- a/clicommand/env_unset.go
+++ b/clicommand/env_unset.go
@@ -139,6 +139,7 @@ func envUnsetAction(c *cli.Context) error {
 
 	case "json", "json-pretty":
 		enc := json.NewEncoder(c.App.Writer)
+		enc.SetEscapeHTML(false) // HTML escapes may interfere with secret redaction
 		if c.String("output-format") == "json-pretty" {
 			enc.SetIndent("", "  ")
 		}

--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -303,6 +303,9 @@ var PipelineUploadCommand = cli.Command{
 			case "json":
 				enc := json.NewEncoder(c.App.Writer)
 				enc.SetIndent("", "  ")
+				// HTML escapes make dry-run output harder to read, and we don't
+				// expect the output to appear in a JS context within HTML.
+				enc.SetEscapeHTML(false)
 				dryRunEnc = enc.Encode
 
 			case "yaml":
@@ -563,6 +566,14 @@ func searchForSecrets(
 		shortValues[name] = struct{}{}
 	}
 
+	// Add GoEscaped versions (where different).
+	for _, pair := range matched {
+		escVal := redact.GoEscaped(pair.Value)
+		if pair.Value != escVal {
+			matched = append(matched, env.Pair{Name: pair.Name, Value: escVal})
+		}
+	}
+
 	// Create a slice of values to search the pipeline for.
 	needles := make([]string, 0, len(matched))
 	for _, pair := range matched {
@@ -583,7 +594,11 @@ func searchForSecrets(
 	})
 
 	// Encode the pipeline as JSON into the searcher.
-	if err := json.NewEncoder(searcher).Encode(pp); err != nil {
+	// Disable HTML escapes, because these replacements might hinder the search,
+	// and we ultimately discard the output.
+	enc := json.NewEncoder(searcher)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(pp); err != nil {
 		return fmt.Errorf("couldn’t scan the %q pipeline for redacted variables. This parsed pipeline could not be serialized, ensure the pipeline YAML is valid, or ignore interpolated secrets for this upload by passing --redacted-vars=''. (%w)", src, err)
 	}
 

--- a/clicommand/secret_get.go
+++ b/clicommand/secret_get.go
@@ -147,7 +147,11 @@ func secretGet(ctx context.Context, cfg SecretGetConfig, w io.Writer, l logger.L
 		return nil
 
 	case cfg.Format == "json" || (cfg.Format == "default" && len(cfg.Keys) > 1):
-		if err := json.NewEncoder(w).Encode(secretsMap); err != nil {
+		// Disable escapes for HTML here, since we don't expect w to be fed to
+		// a browser, and it potentially interferes with secret redaction.
+		enc := json.NewEncoder(w)
+		enc.SetEscapeHTML(false)
+		if err := enc.Encode(secretsMap); err != nil {
 			return fmt.Errorf("failed to write JSON response: %w", err)
 		}
 

--- a/clicommand/workdir_set.go
+++ b/clicommand/workdir_set.go
@@ -93,6 +93,7 @@ func workdirSetAction(c *cli.Context) error {
 
 	case "json":
 		enc := json.NewEncoder(c.App.Writer)
+		enc.SetEscapeHTML(false) // HTML escapes may interfere with secret redaction
 		if err := enc.Encode(jobapi.WorkdirSetResponse{Workdir: workdir}); err != nil {
 			return fmt.Errorf("error marshalling JSON: %w", err)
 		}

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -726,7 +726,7 @@ func (e *Executor) addOutputRedactors() {
 	// But does a particular string stop being a secret if we learn new secret strings?
 	// For produence, we use Add.
 	for _, pair := range toRedact {
-		e.redactors.Add(pair.Value)
+		e.redactors.Add(pair.Value, redact.GoEscaped(pair.Value))
 	}
 }
 
@@ -985,7 +985,7 @@ func (e *Executor) fetchAndSetSecrets(ctx context.Context) error {
 	for _, pipelineSecret := range pipelineSecrets {
 		if secretValue, exists := secretValuesByKey[pipelineSecret.Key]; exists {
 			// Always register the secret value for redaction regardless of env var setting
-			e.redactors.Add(secretValue)
+			e.redactors.Add(secretValue, redact.GoEscaped(secretValue))
 
 			// Set the environment variable only if environment_variable is specified and non-nil
 			if pipelineSecret.EnvironmentVariable != "" {
@@ -1395,6 +1395,7 @@ func (e *Executor) setupRedactors(log shell.Logger, environ *env.Environment, st
 	for _, pair := range varsToRedact {
 		needles = append(needles, pair.Value)
 	}
+	needles = redact.AppendGoEscaped(needles)
 
 	stdoutRedactor := replacer.New(stdout, needles, redact.Redacted)
 	e.redactors.Append(stdoutRedactor)

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/buildkite/agent/v3/env"
@@ -61,7 +62,24 @@ func NeedlesFromEnv(patterns []string) (values, short []string, err error) {
 
 // New returns a replacer configured to write to dst, and redact all needles.
 func New(dst io.Writer, needles []string) *replacer.Replacer {
-	return replacer.New(dst, needles, Redacted)
+	return replacer.New(dst, AppendGoEscaped(needles), Redacted)
+}
+
+// GoEscaped is like [strconv.Quote], but without the surrounding double quotes.
+func GoEscaped(s string) string {
+	q := strconv.Quote(s)
+	return q[1 : len(q)-1]
+}
+
+// AppendGoEscaped appends the [GoEscaped] versions of needles, as needed, to
+// catch values printed via %q.
+func AppendGoEscaped(needles []string) []string {
+	for _, n := range needles {
+		if n2 := GoEscaped(n); n != n2 {
+			needles = append(needles, n2)
+		}
+	}
+	return needles
 }
 
 // MatchAny reports if the name matches any of the patterns.

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -98,6 +98,12 @@ func TestRedactString(t *testing.T) {
 			input:   "secret 1 secret 2 secret 3 s",
 			want:    "[REDACTED] [REDACTED] [REDACTED] s",
 		},
+		{
+			name:    "needle with newline in two forms",
+			needles: []string{"secret\n1"},
+			input:   "secret\n1 secret\\n1 s",
+			want:    "[REDACTED] [REDACTED] s",
+		},
 	}
 
 	for _, test := range tests {

--- a/jobapi/redactions.go
+++ b/jobapi/redactions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/buildkite/agent/v3/internal/redact"
 	"github.com/buildkite/agent/v3/internal/socket"
 )
 
@@ -18,7 +19,7 @@ func (s *Server) createRedaction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.mtx.Lock()
-	s.redactors.Add(payload.Redact)
+	s.redactors.Add(payload.Redact, redact.GoEscaped(payload.Redact))
 	s.mtx.Unlock()
 
 	respBody := &RedactionCreateResponse{Redacted: payload.Redact}


### PR DESCRIPTION
## Description

Alternative to #4088, that also catches multiline secrets that might have passed through Go `%q` formatting within commands, etc.

Buildsworth also liked to point out that the JSON encoder defaults to escaping a couple of HTML-sensitive chars, which could interfere with the secret redactor, so I have gone around disabling the HTML escaping in situations where the output is more likely to end up in log output than in a JS context.

## Context

https://linear.app/buildkite/issue/SUP-7552/private-ssh-key-leaked-in-logs

## Changes

- Add `GoEscaped` and `AppendGoEscaped` helpers to `redact`
- When creating a replacer with `redact.New`, add `GoEscaped` versions of the needles
- When adding new needles in executor / pipeline upload, also add `GoEscaped` versions
- Disable HTML escaping in several places

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

Straight from the top of my dome