### PR TITLE
Fix commit verification with non-default branches

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -165,6 +165,12 @@ func (e *Executor) checkout(ctx context.Context) error {
 			var errGit *gitError
 
 			switch {
+			case errors.Is(err, ErrCommitVerificationFailed):
+				// A commit that is provably not on its branch won't become valid by
+				// retrying, so fail fast instead of re-cloning through the whole backoff.
+				e.shell.Warningf("Checkout failed! %s", err)
+				r.Break()
+
 			case errors.Is(err, errCheckoutAttemptTimedOut):
 				// The per-attempt timeout fired and git was signal-killed.
 				// Treat this like a generic transient failure: warn, clean

--- a/internal/job/commit_verification.go
+++ b/internal/job/commit_verification.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/buildkite/agent/v3/internal/shell"
+	"github.com/buildkite/roko"
+	"github.com/buildkite/shellwords"
 )
 
 // ErrCommitVerificationFailed indicates that git has definitively determined
@@ -26,48 +29,212 @@ var ErrCommitVerificationUnavailable = errors.New("commit verification unavailab
 func (e *Executor) checkCommitOnBranch(ctx context.Context) error {
 	e.shell.Commentf("Verifying commit %q is on branch %q", e.Commit, e.Branch)
 
+	// The build's branch usually isn't a local ref at this point: the checkout
+	// fetches the commit directly (detached HEAD) and only the repository's
+	// default branch gets a local ref from the clone. Fetch the branch tip into a
+	// dedicated local ref so there's a resolvable ref to check the commit's
+	// ancestry against. Without this, merge-base against the bare branch name fails
+	// to resolve for any non-default branch and the check silently degrades to
+	// "unavailable".
+	//
+	// Resolve the tip through that dedicated ref rather than FETCH_HEAD: with the
+	// operator's fetch flags preserved (below), a configured --append or
+	// --no-write-fetch-head leaves FETCH_HEAD pointing at an earlier fetch (e.g.
+	// the build commit recorded by fetchSource), so rev-parse FETCH_HEAD could
+	// resolve to the build commit itself. merge-base <commit> <commit> then
+	// trivially succeeds and strict verification would accept an off-branch
+	// commit. A refspec with an explicit destination writes the ref regardless of
+	// those flags; the ref is deleted again on return.
+	//
+	// Qualify the source as refs/heads/<branch>: git resolves a bare name against
+	// refs/tags/ before refs/heads/, so a tag sharing the branch's name would pin
+	// the ref to the tag tip and verify the commit against the tag instead of the
+	// branch, letting a commit reachable only from the tag pass.
+	//
+	// Build the fetch argument vector directly rather than going through gitFetch:
+	// gitFetch runs shellwords.Split on every refspec, which mangles a branch name
+	// containing shell metacharacters (quotes are legal in git refs). e.Branch is
+	// externally controlled, so a split ref could target the wrong branch or fail
+	// to parse, silently degrading verification to "unavailable" (warn, never
+	// blocking) and defeating the qualification above.
+	//
+	// Preserve the operator's configured git-fetch flags: they are the supported
+	// way to configure every fetch (e.g. --upload-pack for a server on a custom
+	// path), and the checkout's own clone and source fetch already honour them. A
+	// fetch here that dropped them could fail where those succeed, again degrading
+	// to "unavailable" and letting strict pass. Split the flags (they are meant to
+	// be word-split) but keep the refspec a single unsplit argument.
+	//
+	// Strip the fetch modes that would leave that ref unwritten, though: --dry-run
+	// fetches nothing, --prefetch redirects refs under refs/prefetch/, and
+	// --negotiate-only fetches no packfile. Any of them would make rev-parse of the
+	// ref fail and degrade the check to "unavailable" (a pass under strict), so
+	// drop them from every verification fetch.
+	//
+	// Drop the depth-limiting flags from every verification fetch too, not just
+	// the deepening ones: git rejects --depth (and --shallow-since/--shallow-exclude)
+	// alongside the --deepen and --unshallow the loop below adds, and a configured
+	// --unshallow errors on a clone fetchSource has already completed ("--unshallow
+	// on a complete repository does not make sense"). Either way the fetch exits
+	// non-zero and a genuinely off-branch commit degrades to "unavailable" (a pass
+	// under strict). Reshaping history is the deepening loop's job, so keep the
+	// transport flags but strip the depth-limiting ones everywhere.
+	const branchTipRef = "refs/buildkite-agent/commit-verification-branch-tip"
+	branchRefspec := "+refs/heads/" + e.Branch + ":" + branchTipRef
+	fetchFlags, err := shellwords.Split(e.GitFetchFlags)
+	if err != nil {
+		return fmt.Errorf("%w: unable to parse git-fetch-flags %q: %w", ErrCommitVerificationUnavailable, e.GitFetchFlags, err)
+	}
+	fetchFlags = stripShallowFetchFlags(stripRefSuppressingFetchFlags(fetchFlags))
+	fetchBranch := func(extraFlags ...string) error {
+		args := append([]string{"fetch"}, fetchFlags...)
+		args = append(args, extraFlags...)
+		args = append(args, "--", "origin", branchRefspec)
+		return e.shell.Command("git", args...).Run(ctx)
+	}
+	// The ref is internal to verification; don't leave it behind in the repo.
+	defer func() { _ = e.shell.Command("git", "update-ref", "-d", branchTipRef).Run(ctx) }()
+
+	// Retry the branch-tip fetch a few times: it is the one network dependency the
+	// check adds, and a transient failure would otherwise degrade the whole check
+	// to "unavailable" (warn, never blocking) with no second chance, since
+	// verifyCommit returns nil and the outer checkout retry loop won't re-run it.
+	fetchErr := roko.NewRetrier(
+		roko.WithMaxAttempts(3),
+		roko.WithStrategy(roko.ExponentialSubsecond(time.Second)),
+		roko.WithJitter(),
+	).DoWithContext(ctx, func(*roko.Retrier) error {
+		return fetchBranch()
+	})
+	if fetchErr != nil {
+		return fmt.Errorf("%w: unable to fetch branch %q: %w", ErrCommitVerificationUnavailable, e.Branch, fetchErr)
+	}
+	branchTip, err := e.shell.Command("git", "rev-parse", branchTipRef).RunAndCaptureStdout(ctx)
+	if err != nil {
+		return fmt.Errorf("%w: unable to resolve branch %q: %w", ErrCommitVerificationUnavailable, e.Branch, err)
+	}
+	branchTip = strings.TrimSpace(branchTip)
+
+	// merge-base --is-ancestor walks back from the branch tip: exit 0 means the
+	// commit is reachable from it (definitive, even on a shallow clone), exit 1
+	// means it is not. On a shallow clone a "not an ancestor" result can be a
+	// false negative when the connecting history lies beyond the shallow boundary,
+	// so a negative (or otherwise inconclusive) result is only trusted once the
+	// repository is no longer shallow; until then we deepen the branch and re-check.
 	for _, fetchFlag := range []string{"", "--deepen=50", "--unshallow"} {
 		if fetchFlag != "" {
-			// After the first iteration, try to unshallow the repo (a bit or a lot)
 			e.shell.Commentf("Deepening checkout to verify commit (%s)...", fetchFlag)
-			fetchErr := e.shell.Command("git", "fetch", fetchFlag).Run(ctx)
-			if fetchErr != nil {
+			if fetchErr := fetchBranch(fetchFlag); fetchErr != nil {
 				return fmt.Errorf("%w: unable to verify commit %q on branch %q: %w", ErrCommitVerificationUnavailable, e.Commit, e.Branch, fetchErr)
 			}
 		}
 
-		// Try the ancestry check
-		err := e.shell.Command("git", "merge-base", "--is-ancestor", e.Commit, e.Branch).Run(ctx)
-
-		switch shell.ExitCode(err) {
-		case 0:
-			return nil // verified!
-		case 1:
-			return fmt.Errorf("%w: commit %q is not on branch %q", ErrCommitVerificationFailed, e.Commit, e.Branch)
-		case 128:
-			// unclear — continue below
-		default:
-			return fmt.Errorf("%w: unable to verify commit %q on branch %q: %w", ErrCommitVerificationUnavailable, e.Commit, e.Branch, err)
+		mergeBaseErr := e.shell.Command("git", "merge-base", "--is-ancestor", e.Commit, branchTip).Run(ctx)
+		if mergeBaseErr == nil {
+			return nil // commit is reachable from the branch tip: verified
 		}
-
-		// On the first iteration, check if the checkout is shallow. If it is
-		// not, the 128 exit code reflects some other error.
-		if fetchFlag != "" {
-			continue
+		// A non-exit error (e.g. git failed to spawn) tells us nothing about
+		// ancestry, so treat it as unavailable rather than a definitive failure.
+		if !shell.IsExitError(mergeBaseErr) {
+			return fmt.Errorf("%w: unable to verify commit %q on branch %q: %w", ErrCommitVerificationUnavailable, e.Commit, e.Branch, mergeBaseErr)
 		}
-		output, shallowErr := e.shell.Command("git", "rev-parse", "--is-shallow-repository").RunAndCaptureStdout(ctx)
+		exitCode := shell.ExitCode(mergeBaseErr)
+
+		shallow, shallowErr := e.shell.Command("git", "rev-parse", "--is-shallow-repository").RunAndCaptureStdout(ctx)
 		if shallowErr != nil {
 			return fmt.Errorf("%w: unable to verify commit %q on branch %q: %w", ErrCommitVerificationUnavailable, e.Commit, e.Branch, shallowErr)
 		}
-
-		if strings.TrimSpace(output) != "true" {
-			// Not shallow — this is a genuine error
-			return fmt.Errorf("%w: unable to verify commit %q on branch %q: %w", ErrCommitVerificationUnavailable, e.Commit, e.Branch, err)
+		if strings.TrimSpace(shallow) != "true" {
+			// Full history, so the result is now definitive.
+			if exitCode == 1 {
+				return fmt.Errorf("%w: commit %q is not on branch %q", ErrCommitVerificationFailed, e.Commit, e.Branch)
+			}
+			return fmt.Errorf("%w: unable to verify commit %q on branch %q", ErrCommitVerificationUnavailable, e.Commit, e.Branch)
 		}
+		// Still shallow, so deepen on the next iteration and re-check.
 	}
 
-	// All attempts exhausted — verification is unavailable
+	// All attempts exhausted, so verification is unavailable.
 	return fmt.Errorf("%w: unable to verify commit %q on branch %q after exhausting fetch strategies", ErrCommitVerificationUnavailable, e.Commit, e.Branch)
+}
+
+// stripShallowFetchFlags removes depth-limiting options from a git-fetch flag
+// list. git treats --depth, --deepen, --shallow-since and --shallow-exclude as
+// mutually exclusive with the --deepen/--unshallow fetches checkCommitOnBranch
+// issues, so those fetches must not inherit them from BUILDKITE_GIT_FETCH_FLAGS.
+//
+// Both the "--flag=value" and "--flag value" spellings are handled (the latter
+// also drops the following value token), as are the unambiguous abbreviations
+// git accepts (--dept for --depth, --deep for --deepen, --unsh for --unshallow):
+// a token is dropped when one of the mode names begins with it. The exact-name
+// check this replaced let --dept=1 slip through and re-break the deepen fetch.
+func stripShallowFetchFlags(flags []string) []string {
+	valueModes := []string{"depth", "deepen", "shallow-since", "shallow-exclude"}
+	out := make([]string, 0, len(flags))
+	for i := 0; i < len(flags); i++ {
+		name, isLong := strings.CutPrefix(flags[i], "--")
+		name, _, hasValue := strings.Cut(name, "=")
+		if !isLong || name == "" {
+			out = append(out, flags[i])
+			continue
+		}
+		if strings.HasPrefix("unshallow", name) {
+			continue // boolean, no value token to drop
+		}
+		isValueMode := false
+		for _, m := range valueModes {
+			if strings.HasPrefix(m, name) {
+				isValueMode = true
+				break
+			}
+		}
+		if isValueMode {
+			if !hasValue {
+				i++ // skip the separate value token in the "--flag value" form
+			}
+			continue
+		}
+		out = append(out, flags[i])
+	}
+	return out
+}
+
+// stripRefSuppressingFetchFlags removes git-fetch modes that make a fetch skip
+// or redirect the ref update checkCommitOnBranch relies on: --dry-run performs
+// no fetch and writes no ref, --prefetch rewrites the destination under
+// refs/prefetch/, and --negotiate-only fetches no packfile. Left in
+// BUILDKITE_GIT_FETCH_FLAGS, any of them would leave the branch-tip ref
+// unwritten, so rev-parse fails and the check degrades to "unavailable" (a pass
+// under strict). None of them belong in the verification probe.
+//
+// Unambiguous prefixes are matched too: git accepts --dry for --dry-run and
+// --prefe for --prefetch, so a token is dropped when one of the mode names
+// begins with it. Stripping tokens keeps this version-safe, unlike appending the
+// --no-* forms: --prefetch (git 2.29) and --negotiate-only (2.32) postdate the
+// oldest git the agent runs on, so --no-prefetch/--no-negotiate-only would break
+// fetches there. Legitimate flags like --prune and --negotiation-tip are not
+// prefixes of these names, so they survive.
+func stripRefSuppressingFetchFlags(flags []string) []string {
+	modes := []string{"dry-run", "prefetch", "negotiate-only"}
+	out := make([]string, 0, len(flags))
+	for _, f := range flags {
+		name, isLong := strings.CutPrefix(f, "--")
+		name, _, _ = strings.Cut(name, "=")
+		suppressing := false
+		if isLong && name != "" {
+			for _, m := range modes {
+				if strings.HasPrefix(m, name) {
+					suppressing = true
+					break
+				}
+			}
+		}
+		if suppressing {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
 }
 
 // verifyCommit is called if the user has commit verification enabled. It ensures that the commit we are
@@ -96,8 +263,9 @@ func (e *Executor) verifyCommit(ctx context.Context) error {
 		return nil
 	}
 
-	// Skip if this is a PR build — the commit may be on a merge ref, not the target branch
-	if e.PullRequest != "" {
+	// Skip if this is a PR build: the commit may be on a merge ref, not the target
+	// branch. BUILDKITE_PULL_REQUEST is the string "false" (not empty) on non-PR builds.
+	if e.PullRequest != "" && e.PullRequest != "false" {
 		e.shell.Commentf("Skipping commit verification: pull request build (#%s)", e.PullRequest)
 		return nil
 	}
@@ -122,13 +290,15 @@ func (e *Executor) verifyCommit(ctx context.Context) error {
 		if e.GitCommitVerification == "strict" {
 			return err
 		}
-		e.shell.Warningf("Commit verification failed: %v", err)
+		// err already begins with "commit verification failed", so log it as-is.
+		e.shell.Warningf("%s", err)
 		return nil
 	}
 
 	// Verification unavailable — infrastructure issue, not a security concern.
 	// We always warn but never block, even in strict mode, to avoid users
 	// disabling verification entirely due to infrastructure false positives.
-	e.shell.Warningf("Commit verification unavailable: %v", err)
+	// err already begins with "commit verification unavailable", so log it as-is.
+	e.shell.Warningf("%s", err)
 	return nil
 }

--- a/internal/job/commit_verification_test.go
+++ b/internal/job/commit_verification_test.go
@@ -1,13 +1,151 @@
 package job
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/buildkite/agent/v3/internal/job/githttptest"
 	"github.com/buildkite/agent/v3/internal/shell"
 )
+
+// newFileBackedRepo creates an empty bare git repository served over file://
+// plus a working clone to build history in (the shell is left cd'd into the
+// clone). It returns the shell, the file:// URL, and a helper that commits a
+// one-line file and returns its SHA. A file:// remote is used rather than
+// githttptest because shallow deepening over the test server's stateless-rpc
+// HTTP transport is not reliable across git versions. prefix names the temp
+// directories so failures point at the right fixture.
+func newFileBackedRepo(t *testing.T, ctx context.Context, prefix string) (*shell.Shell, string, func(name string) string) {
+	t.Helper()
+	t.Setenv("GIT_AUTHOR_NAME", "Buildkite Agent")
+	t.Setenv("GIT_AUTHOR_EMAIL", "agent@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "Buildkite Agent")
+	t.Setenv("GIT_COMMITTER_EMAIL", "agent@example.com")
+
+	bareDir, err := os.MkdirTemp("", prefix+"-bare-")
+	if err != nil {
+		t.Fatalf("MkdirTemp error = %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(bareDir) }) //nolint:errcheck // Best-effort cleanup.
+
+	sh, err := shell.New()
+	if err != nil {
+		t.Fatalf("shell.New() error = %v", err)
+	}
+	if err := sh.Command("git", "init", "--bare", bareDir).Run(ctx); err != nil {
+		t.Fatalf("git init --bare error = %v", err)
+	}
+	urlPath := filepath.ToSlash(bareDir)
+	if !strings.HasPrefix(urlPath, "/") {
+		urlPath = "/" + urlPath
+	}
+	repoURL := "file://" + urlPath
+
+	workDir, err := os.MkdirTemp("", prefix+"-work-")
+	if err != nil {
+		t.Fatalf("MkdirTemp error = %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(workDir) }) //nolint:errcheck // Best-effort cleanup.
+	if err := sh.Command("git", "clone", repoURL, workDir).Run(ctx); err != nil {
+		t.Fatalf("git clone error = %v", err)
+	}
+	if err := sh.Chdir(workDir); err != nil {
+		t.Fatalf("Chdir error = %v", err)
+	}
+
+	commit := func(name string) string {
+		if err := os.WriteFile(filepath.Join(workDir, name), []byte(name), 0o600); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+		if err := sh.Command("git", "add", name).Run(ctx); err != nil {
+			t.Fatalf("git add error = %v", err)
+		}
+		if err := sh.Command("git", "commit", "-m", "commit "+name).Run(ctx); err != nil {
+			t.Fatalf("git commit error = %v", err)
+		}
+		sha, err := sh.Command("git", "rev-parse", "HEAD").RunAndCaptureStdout(ctx)
+		if err != nil {
+			t.Fatalf("rev-parse HEAD error = %v", err)
+		}
+		return strings.TrimSpace(sha)
+	}
+
+	return sh, repoURL, commit
+}
+
+// setupFileBackedRepo creates a bare git repository served over file:// with a
+// featureBranch (commits a <- b <- c) and a divergent "other" branch (a <- o).
+// It returns the file:// URL, a deep ancestor of featureBranch (a, beyond a
+// depth=1 clone's boundary), and an off-branch commit (o, present on the remote
+// but not on featureBranch). A file:// remote is used rather than githttptest
+// because shallow deepening over the test server's stateless-rpc HTTP transport
+// is not reliable across git versions.
+func setupFileBackedRepo(t *testing.T, ctx context.Context, featureBranch string) (repoURL, deepAncestor, offBranchCommit string) {
+	t.Helper()
+	sh, repoURL, commit := newFileBackedRepo(t, ctx, "verify")
+
+	// featureBranch: a <- b <- c, where a is two commits below the tip.
+	deepAncestor = commit("a.txt")
+	commit("b.txt")
+	commit("c.txt")
+	if err := sh.Command("git", "branch", "-m", featureBranch).Run(ctx); err != nil {
+		t.Fatalf("git branch -m %q error = %v", featureBranch, err)
+	}
+	if err := sh.Command("git", "push", "origin", featureBranch).Run(ctx); err != nil {
+		t.Fatalf("git push %q error = %v", featureBranch, err)
+	}
+
+	// other: a <- o, diverging from featureBranch so o is not an ancestor of it.
+	if err := sh.Command("git", "checkout", "-b", "other", deepAncestor).Run(ctx); err != nil {
+		t.Fatalf("git checkout -b other error = %v", err)
+	}
+	offBranchCommit = commit("other.txt")
+	if err := sh.Command("git", "push", "origin", "other").Run(ctx); err != nil {
+		t.Fatalf("git push other error = %v", err)
+	}
+
+	return repoURL, deepAncestor, offBranchCommit
+}
+
+// setupTagBranchCollisionRepo creates a bare repo served over file:// where a
+// branch and a tag share the name "release". The branch is a <- b; the tag points
+// at a divergent commit t (a <- t) that is not reachable from the branch. It
+// returns the file:// URL and the off-branch commit the tag points at. This is
+// the ambiguous case: git resolves a bare name against refs/tags/ before
+// refs/heads/, so an unqualified fetch of "release" pins FETCH_HEAD to the tag.
+func setupTagBranchCollisionRepo(t *testing.T, ctx context.Context) (repoURL, offBranchTagCommit string) {
+	t.Helper()
+	sh, repoURL, commit := newFileBackedRepo(t, ctx, "verify-collision")
+
+	// release branch: a <- b.
+	base := commit("a.txt")
+	commit("b.txt")
+	if err := sh.Command("git", "branch", "-m", "release").Run(ctx); err != nil {
+		t.Fatalf("git branch -m release error = %v", err)
+	}
+	if err := sh.Command("git", "push", "origin", "release").Run(ctx); err != nil {
+		t.Fatalf("git push release error = %v", err)
+	}
+
+	// tag "release" on a divergent commit t (a <- t), not reachable from the branch.
+	if err := sh.Command("git", "checkout", "-b", "tagline", base).Run(ctx); err != nil {
+		t.Fatalf("git checkout -b tagline error = %v", err)
+	}
+	offBranchTagCommit = commit("t.txt")
+	if err := sh.Command("git", "tag", "release").Run(ctx); err != nil {
+		t.Fatalf("git tag release error = %v", err)
+	}
+	if err := sh.Command("git", "push", "origin", "refs/tags/release").Run(ctx); err != nil {
+		t.Fatalf("git push tag release error = %v", err)
+	}
+
+	return repoURL, offBranchTagCommit
+}
 
 func TestVerifyCommit(t *testing.T) {
 	// Table-driven tests for the skip conditions — these don't need a real git repo
@@ -141,13 +279,18 @@ func TestVerifyCommit(t *testing.T) {
 			ExecutorConfig: ExecutorConfig{
 				GitCommitVerification: "strict",
 				Commit:                commit,
-				Branch:                "origin/feature",
+				// A plain branch name, as BUILDKITE_BRANCH always is, not a
+				// pre-resolved remote-tracking ref. checkCommitOnBranch fetches it.
+				Branch: "feature",
 			},
 		}
 
-		err = e.verifyCommit(ctx)
-		if err != nil {
-			t.Errorf("verifyCommit() error = %v, want nil", err)
+		// checkCommitOnBranch returns nil only when the commit is genuinely
+		// verified on the branch; an unavailable check returns an error instead.
+		// Asserting nil here proves verification ran, rather than silently
+		// degrading to a warning (which verifyCommit would also report as nil).
+		if err := e.checkCommitOnBranch(ctx); err != nil {
+			t.Errorf("checkCommitOnBranch() error = %v, want nil (verified)", err)
 		}
 	})
 
@@ -239,8 +382,8 @@ func TestVerifyCommit(t *testing.T) {
 			shell: sh,
 			ExecutorConfig: ExecutorConfig{
 				GitCommitVerification: "strict",
-				Commit:                commit,             // commit from feature-a
-				Branch:                "origin/feature-b", // but checking against feature-b
+				Commit:                commit,      // commit from feature-a
+				Branch:                "feature-b", // but checking against feature-b
 			},
 		}
 
@@ -334,19 +477,516 @@ func TestVerifyCommit(t *testing.T) {
 			shell: sh,
 			ExecutorConfig: ExecutorConfig{
 				GitCommitVerification: "warn",
-				Commit:                commit,             // commit from feature-a
-				Branch:                "origin/feature-b", // but checking against feature-b
+				Commit:                commit,      // commit from feature-a
+				Branch:                "feature-b", // but checking against feature-b
 			},
 		}
 
-		// In warn mode, verification failure should NOT return an error
-		err = e.verifyCommit(ctx)
-		if err != nil {
+		// The underlying check must genuinely detect the failure (not merely
+		// degrade to "unavailable"), or warn mode swallowing it below proves nothing.
+		if err := e.checkCommitOnBranch(ctx); !errors.Is(err, ErrCommitVerificationFailed) {
+			t.Fatalf("checkCommitOnBranch() error = %v, want ErrCommitVerificationFailed", err)
+		}
+
+		// In warn mode, that failure must NOT be surfaced as an error.
+		if err := e.verifyCommit(ctx); err != nil {
 			t.Errorf("verifyCommit() in warn mode error = %v, want nil", err)
 		}
 	})
 
 	t.Run("passes after deepening a shallow clone", func(t *testing.T) {
+		ctx := t.Context()
+		repoURL, deepAncestor, _ := setupFileBackedRepo(t, ctx, "feature")
+
+		cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
+		if err != nil {
+			t.Fatalf("MkdirTemp error = %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
+		sh, err := shell.New()
+		if err != nil {
+			t.Fatalf("shell.New() error = %v", err)
+		}
+
+		// Shallow clone with depth=1: the ancestor is beyond the boundary, so the
+		// check must deepen to find it.
+		if err := sh.Command("git", "clone", "--depth=1", "--branch", "feature", repoURL, cloneDir).Run(ctx); err != nil {
+			t.Fatalf("git clone error = %v", err)
+		}
+		if err := sh.Chdir(cloneDir); err != nil {
+			t.Fatalf("Chdir error = %v", err)
+		}
+
+		e := &Executor{
+			shell: sh,
+			ExecutorConfig: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                deepAncestor,
+				Branch:                "feature",
+			},
+		}
+
+		// nil only when truly verified, so this fails if the deepen path regresses
+		// to reporting the commit unavailable.
+		if err := e.checkCommitOnBranch(ctx); err != nil {
+			t.Errorf("checkCommitOnBranch() error = %v, want nil (verified after deepening)", err)
+		}
+	})
+
+	t.Run("fails on a shallow clone when commit is not an ancestor", func(t *testing.T) {
+		ctx := t.Context()
+		repoURL, _, offBranchCommit := setupFileBackedRepo(t, ctx, "feature")
+
+		cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
+		if err != nil {
+			t.Fatalf("MkdirTemp error = %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
+		sh, err := shell.New()
+		if err != nil {
+			t.Fatalf("shell.New() error = %v", err)
+		}
+
+		// Shallow clone of feature, then fetch the off-branch commit at depth=1 so it
+		// is present locally (as the real checkout fetches BUILDKITE_COMMIT) while the
+		// repo stays shallow going into checkCommitOnBranch.
+		if err := sh.Command("git", "clone", "--depth=1", "--branch", "feature", repoURL, cloneDir).Run(ctx); err != nil {
+			t.Fatalf("git clone error = %v", err)
+		}
+		if err := sh.Chdir(cloneDir); err != nil {
+			t.Fatalf("Chdir error = %v", err)
+		}
+		if err := sh.Command("git", "fetch", "--depth=1", "origin", "other").Run(ctx); err != nil {
+			t.Fatalf("git fetch (off-branch commit) error = %v", err)
+		}
+
+		e := &Executor{
+			shell: sh,
+			ExecutorConfig: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                offBranchCommit,
+				Branch:                "feature",
+			},
+		}
+
+		// A shallow clone must not let a genuinely off-branch commit slip through:
+		// deepen/unshallow, then report a definitive failure, not "unavailable".
+		if err := e.checkCommitOnBranch(ctx); !errors.Is(err, ErrCommitVerificationFailed) {
+			t.Errorf("checkCommitOnBranch() error = %v, want ErrCommitVerificationFailed", err)
+		}
+	})
+
+	t.Run("fails on a shallow clone with a configured --depth fetch flag", func(t *testing.T) {
+		// --depth=1 in the configured fetch flags must not reach the deepening
+		// fetches: git rejects --depth alongside --deepen/--unshallow, so an
+		// un-stripped flag would make the deepen fetch exit non-zero and degrade a
+		// genuinely off-branch commit on a shallow clone to "unavailable" (warn,
+		// never blocking under strict) instead of a definitive failure. The
+		// abbreviated spelling git also accepts (--dept) must be stripped too.
+		for _, flag := range []string{"--depth=1", "--dept=1"} {
+			t.Run(flag, func(t *testing.T) {
+				ctx := t.Context()
+				repoURL, _, offBranchCommit := setupFileBackedRepo(t, ctx, "feature")
+
+				cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
+				if err != nil {
+					t.Fatalf("MkdirTemp error = %v", err)
+				}
+				t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
+				sh, err := shell.New()
+				if err != nil {
+					t.Fatalf("shell.New() error = %v", err)
+				}
+
+				// Clone feature at depth=1, then fetch the off-branch commit so it
+				// exists locally while the repo stays shallow.
+				if err := sh.Command("git", "clone", "--depth=1", "--branch", "feature", repoURL, cloneDir).Run(ctx); err != nil {
+					t.Fatalf("git clone error = %v", err)
+				}
+				if err := sh.Chdir(cloneDir); err != nil {
+					t.Fatalf("Chdir error = %v", err)
+				}
+				if err := sh.Command("git", "fetch", "--depth=1", "origin", "other").Run(ctx); err != nil {
+					t.Fatalf("git fetch (off-branch commit) error = %v", err)
+				}
+
+				e := &Executor{
+					shell: sh,
+					ExecutorConfig: ExecutorConfig{
+						GitCommitVerification: "strict",
+						Commit:                offBranchCommit,
+						Branch:                "feature",
+						GitFetchFlags:         flag,
+					},
+				}
+
+				if err := e.checkCommitOnBranch(ctx); !errors.Is(err, ErrCommitVerificationFailed) {
+					t.Errorf("checkCommitOnBranch() error = %v, want ErrCommitVerificationFailed", err)
+				}
+			})
+		}
+	})
+
+	t.Run("fails when a configured --unshallow reaches a completed repo", func(t *testing.T) {
+		// --unshallow (and its abbreviations) must not reach the verification
+		// fetches: once fetchSource has completed the clone, git fetch --unshallow
+		// exits 128 ("--unshallow on a complete repository does not make sense"),
+		// which would degrade a genuinely off-branch commit to "unavailable" (a pass
+		// under strict). A full clone is already complete, so it reproduces that state.
+		for _, flag := range []string{"--unshallow", "--unsh"} {
+			t.Run(flag, func(t *testing.T) {
+				ctx := t.Context()
+				repoURL, _, offBranchCommit := setupFileBackedRepo(t, ctx, "feature")
+
+				cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
+				if err != nil {
+					t.Fatalf("MkdirTemp error = %v", err)
+				}
+				t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
+				sh, err := shell.New()
+				if err != nil {
+					t.Fatalf("shell.New() error = %v", err)
+				}
+				if err := sh.Command("git", "clone", "--branch", "feature", repoURL, cloneDir).Run(ctx); err != nil {
+					t.Fatalf("git clone error = %v", err)
+				}
+				if err := sh.Chdir(cloneDir); err != nil {
+					t.Fatalf("Chdir error = %v", err)
+				}
+				// Bring the off-branch commit across so it exists locally, as fetchSource would.
+				if err := sh.Command("git", "fetch", "origin", "other").Run(ctx); err != nil {
+					t.Fatalf("git fetch (off-branch commit) error = %v", err)
+				}
+
+				e := &Executor{
+					shell: sh,
+					ExecutorConfig: ExecutorConfig{
+						GitCommitVerification: "strict",
+						Commit:                offBranchCommit,
+						Branch:                "feature",
+						GitFetchFlags:         flag,
+					},
+				}
+
+				if err := e.checkCommitOnBranch(ctx); !errors.Is(err, ErrCommitVerificationFailed) {
+					t.Errorf("checkCommitOnBranch() error = %v, want ErrCommitVerificationFailed", err)
+				}
+			})
+		}
+	})
+
+	t.Run("verifies a branch whose name contains shell metacharacters", func(t *testing.T) {
+		ctx := t.Context()
+		// A single quote is a legal git ref character. The branch tip must be
+		// fetched with the ref intact: routing it through a shell-word splitter
+		// would corrupt it, and the check would silently degrade to "unavailable"
+		// (warn, never blocking) instead of catching an off-branch commit.
+		const branch = "quote'branch"
+		repoURL, _, offBranchCommit := setupFileBackedRepo(t, ctx, branch)
+
+		cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
+		if err != nil {
+			t.Fatalf("MkdirTemp error = %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
+		sh, err := shell.New()
+		if err != nil {
+			t.Fatalf("shell.New() error = %v", err)
+		}
+
+		// A full clone brings the off-branch commit's object across, so it exists
+		// locally going into the check (as the real checkout fetches the commit).
+		if err := sh.Command("git", "clone", "--branch", branch, repoURL, cloneDir).Run(ctx); err != nil {
+			t.Fatalf("git clone error = %v", err)
+		}
+		if err := sh.Chdir(cloneDir); err != nil {
+			t.Fatalf("Chdir error = %v", err)
+		}
+
+		e := &Executor{
+			shell: sh,
+			ExecutorConfig: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                offBranchCommit,
+				Branch:                branch,
+			},
+		}
+
+		if err := e.checkCommitOnBranch(ctx); !errors.Is(err, ErrCommitVerificationFailed) {
+			t.Errorf("checkCommitOnBranch() error = %v, want ErrCommitVerificationFailed", err)
+		}
+	})
+
+	t.Run("fails when a same-named tag carries an off-branch commit", func(t *testing.T) {
+		ctx := t.Context()
+		repoURL, offBranchTagCommit := setupTagBranchCollisionRepo(t, ctx)
+
+		cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
+		if err != nil {
+			t.Fatalf("MkdirTemp error = %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
+		sh, err := shell.New()
+		if err != nil {
+			t.Fatalf("shell.New() error = %v", err)
+		}
+
+		// A full clone brings refs/heads/release plus the refs/tags/release object,
+		// so the off-branch commit exists locally going into the check.
+		if err := sh.Command("git", "clone", "--branch", "release", repoURL, cloneDir).Run(ctx); err != nil {
+			t.Fatalf("git clone error = %v", err)
+		}
+		if err := sh.Chdir(cloneDir); err != nil {
+			t.Fatalf("Chdir error = %v", err)
+		}
+
+		e := &Executor{
+			shell: sh,
+			ExecutorConfig: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                offBranchTagCommit,
+				Branch:                "release",
+			},
+		}
+
+		// The fetch must resolve refs/heads/release, not the same-named tag. If it
+		// pinned FETCH_HEAD to the tag tip, this commit (the tag itself) would pass;
+		// qualifying the ref makes it a definitive failure.
+		if err := e.checkCommitOnBranch(ctx); !errors.Is(err, ErrCommitVerificationFailed) {
+			t.Errorf("checkCommitOnBranch() error = %v, want ErrCommitVerificationFailed", err)
+		}
+	})
+
+	t.Run("preserves configured git-fetch flags", func(t *testing.T) {
+		ctx := t.Context()
+		repoURL, _, offBranchCommit := setupFileBackedRepo(t, ctx, "feature")
+
+		cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
+		if err != nil {
+			t.Fatalf("MkdirTemp error = %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
+		sh, err := shell.New()
+		if err != nil {
+			t.Fatalf("shell.New() error = %v", err)
+		}
+		if err := sh.Command("git", "clone", "--branch", "feature", repoURL, cloneDir).Run(ctx); err != nil {
+			t.Fatalf("git clone error = %v", err)
+		}
+		if err := sh.Chdir(cloneDir); err != nil {
+			t.Fatalf("Chdir error = %v", err)
+		}
+
+		// A bogus --upload-pack makes the branch-tip fetch fail, but only if the
+		// configured git-fetch flags actually reach git fetch. If they were dropped,
+		// the fetch would succeed and this off-branch commit would produce a
+		// definitive ErrCommitVerificationFailed; honouring the flag makes the fetch
+		// fail and degrades the check to "unavailable" instead, which is what proves
+		// the flag was passed through.
+		e := &Executor{
+			shell: sh,
+			ExecutorConfig: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                offBranchCommit,
+				Branch:                "feature",
+				GitFetchFlags:         "--upload-pack=/nonexistent/git-upload-pack",
+			},
+		}
+
+		if err := e.checkCommitOnBranch(ctx); !errors.Is(err, ErrCommitVerificationUnavailable) {
+			t.Errorf("checkCommitOnBranch() error = %v, want ErrCommitVerificationUnavailable", err)
+		}
+	})
+
+	t.Run("resolves the branch tip even with an --append fetch flag", func(t *testing.T) {
+		ctx := t.Context()
+		repoURL, _, offBranchCommit := setupFileBackedRepo(t, ctx, "feature")
+
+		cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
+		if err != nil {
+			t.Fatalf("MkdirTemp error = %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
+		sh, err := shell.New()
+		if err != nil {
+			t.Fatalf("shell.New() error = %v", err)
+		}
+		if err := sh.Command("git", "clone", "--branch", "feature", repoURL, cloneDir).Run(ctx); err != nil {
+			t.Fatalf("git clone error = %v", err)
+		}
+		if err := sh.Chdir(cloneDir); err != nil {
+			t.Fatalf("Chdir error = %v", err)
+		}
+
+		// Fetch the off-branch commit so it exists locally AND leaves FETCH_HEAD
+		// pointing at it, mirroring fetchSource recording the build commit before
+		// verification runs.
+		if err := sh.Command("git", "fetch", "origin", "other").Run(ctx); err != nil {
+			t.Fatalf("git fetch (off-branch commit) error = %v", err)
+		}
+
+		// --append makes git append the branch fetch to FETCH_HEAD rather than
+		// overwriting it, so rev-parse FETCH_HEAD would resolve to the earlier entry
+		// (the off-branch build commit) and merge-base <commit> <commit> would pass.
+		// Resolving a dedicated ref instead pins the real branch tip and catches the
+		// off-branch commit.
+		e := &Executor{
+			shell: sh,
+			ExecutorConfig: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                offBranchCommit,
+				Branch:                "feature",
+				GitFetchFlags:         "--append",
+			},
+		}
+
+		if err := e.checkCommitOnBranch(ctx); !errors.Is(err, ErrCommitVerificationFailed) {
+			t.Errorf("checkCommitOnBranch() error = %v, want ErrCommitVerificationFailed", err)
+		}
+	})
+
+	t.Run("fails when a configured fetch mode would suppress the ref update", func(t *testing.T) {
+		// --dry-run writes no ref and --prefetch redirects it under refs/prefetch/;
+		// either would leave the branch-tip ref unresolvable and degrade the check
+		// to "unavailable" (a pass under strict). They must be stripped so the tip
+		// is actually pinned and the off-branch commit is caught. The abbreviated
+		// spellings git also accepts (--dry, --prefe) must be caught as well.
+		for _, flag := range []string{"--dry-run", "--dry", "--prefetch", "--prefe"} {
+			t.Run(flag, func(t *testing.T) {
+				ctx := t.Context()
+				repoURL, _, offBranchCommit := setupFileBackedRepo(t, ctx, "feature")
+
+				cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
+				if err != nil {
+					t.Fatalf("MkdirTemp error = %v", err)
+				}
+				t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
+				sh, err := shell.New()
+				if err != nil {
+					t.Fatalf("shell.New() error = %v", err)
+				}
+				if err := sh.Command("git", "clone", "--branch", "feature", repoURL, cloneDir).Run(ctx); err != nil {
+					t.Fatalf("git clone error = %v", err)
+				}
+				if err := sh.Chdir(cloneDir); err != nil {
+					t.Fatalf("Chdir error = %v", err)
+				}
+				// Bring the off-branch commit across so it exists locally, as the real
+				// checkout's fetchSource would.
+				if err := sh.Command("git", "fetch", "origin", "other").Run(ctx); err != nil {
+					t.Fatalf("git fetch (off-branch commit) error = %v", err)
+				}
+
+				e := &Executor{
+					shell: sh,
+					ExecutorConfig: ExecutorConfig{
+						GitCommitVerification: "strict",
+						Commit:                offBranchCommit,
+						Branch:                "feature",
+						GitFetchFlags:         flag,
+					},
+				}
+
+				if err := e.checkCommitOnBranch(ctx); !errors.Is(err, ErrCommitVerificationFailed) {
+					t.Errorf("checkCommitOnBranch() error = %v, want ErrCommitVerificationFailed", err)
+				}
+			})
+		}
+	})
+
+	t.Run("verifies via --unshallow beyond the deepen boundary", func(t *testing.T) {
+		ctx := t.Context()
+		sh, repoURL, commit := newFileBackedRepo(t, ctx, "verify-unshallow")
+
+		// Put the target at the root, then pile more than (1 + --deepen=50) commits
+		// on top so neither the depth=1 clone nor the first --deepen=50 reaches it,
+		// forcing the check all the way to the --unshallow iteration.
+		deepTarget := commit("root.txt")
+		for range 60 {
+			if err := sh.Command("git", "commit", "--allow-empty", "-m", "filler").Run(ctx); err != nil {
+				t.Fatalf("git commit --allow-empty error = %v", err)
+			}
+		}
+		if err := sh.Command("git", "branch", "-m", "deep").Run(ctx); err != nil {
+			t.Fatalf("git branch -m deep error = %v", err)
+		}
+		if err := sh.Command("git", "push", "origin", "deep").Run(ctx); err != nil {
+			t.Fatalf("git push deep error = %v", err)
+		}
+
+		cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
+		if err != nil {
+			t.Fatalf("MkdirTemp error = %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
+		clone, err := shell.New()
+		if err != nil {
+			t.Fatalf("shell.New() error = %v", err)
+		}
+		if err := clone.Command("git", "clone", "--depth=1", "--branch", "deep", repoURL, cloneDir).Run(ctx); err != nil {
+			t.Fatalf("git clone error = %v", err)
+		}
+		if err := clone.Chdir(cloneDir); err != nil {
+			t.Fatalf("Chdir error = %v", err)
+		}
+
+		e := &Executor{
+			shell: clone,
+			ExecutorConfig: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                deepTarget,
+				Branch:                "deep",
+			},
+		}
+
+		// --deepen=50 can't reach a commit 60 back, so a nil result proves the
+		// --unshallow iteration is what verified it.
+		if err := e.checkCommitOnBranch(ctx); err != nil {
+			t.Errorf("checkCommitOnBranch() error = %v, want nil (verified via --unshallow)", err)
+		}
+	})
+
+	t.Run("does not skip a non-PR build", func(t *testing.T) {
+		ctx := t.Context()
+		// BUILDKITE_PULL_REQUEST is the string "false" (not empty) on ordinary
+		// builds; only a real PR number should skip verification. Point at an
+		// off-branch commit and prove the check still runs and fails rather than
+		// being skipped by the "false" sentinel.
+		repoURL, _, offBranchCommit := setupFileBackedRepo(t, ctx, "feature")
+
+		cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
+		if err != nil {
+			t.Fatalf("MkdirTemp error = %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
+		sh, err := shell.New()
+		if err != nil {
+			t.Fatalf("shell.New() error = %v", err)
+		}
+		if err := sh.Command("git", "clone", "--branch", "feature", repoURL, cloneDir).Run(ctx); err != nil {
+			t.Fatalf("git clone error = %v", err)
+		}
+		if err := sh.Chdir(cloneDir); err != nil {
+			t.Fatalf("Chdir error = %v", err)
+		}
+
+		e := &Executor{
+			shell: sh,
+			ExecutorConfig: ExecutorConfig{
+				GitCommitVerification: "strict",
+				Commit:                offBranchCommit,
+				Branch:                "feature",
+				PullRequest:           "false",
+			},
+		}
+
+		// A skip would return nil; verifyCommit must surface the failure instead.
+		if err := e.verifyCommit(ctx); !errors.Is(err, ErrCommitVerificationFailed) {
+			t.Errorf("verifyCommit() error = %v, want ErrCommitVerificationFailed (a non-PR build must not be skipped)", err)
+		}
+	})
+
+	t.Run("unavailable check does not fail strict mode", func(t *testing.T) {
 		t.Setenv("GIT_AUTHOR_NAME", "Buildkite Agent")
 		t.Setenv("GIT_AUTHOR_EMAIL", "agent@example.com")
 		t.Setenv("GIT_COMMITTER_NAME", "Buildkite Agent")
@@ -357,59 +997,110 @@ func TestVerifyCommit(t *testing.T) {
 		s := githttptest.NewServer()
 		defer s.Close()
 
-		err := s.CreateRepository("verify-shallow")
-		if err != nil {
+		if err := s.CreateRepository("verify-unavailable"); err != nil {
 			t.Fatalf("CreateRepository error = %v", err)
 		}
-
-		_, err = s.InitRepository("verify-shallow")
-		if err != nil {
+		if _, err := s.InitRepository("verify-unavailable"); err != nil {
 			t.Fatalf("InitRepository error = %v", err)
 		}
-
-		// The initial commit from InitRepository is on main.
-		// PushBranch adds one more commit on a feature branch.
-		// We need the initial commit SHA to test — it will be beyond depth=1.
-		commit, _, err := s.PushBranch("verify-shallow", "feature")
+		commit, _, err := s.PushBranch("verify-unavailable", "feature")
 		if err != nil {
 			t.Fatalf("PushBranch error = %v", err)
 		}
 
-		// Get the initial commit (parent of the feature commit) by reading it from the server repo
 		cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
 		if err != nil {
 			t.Fatalf("MkdirTemp error = %v", err)
 		}
 		t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
-
 		sh, err := shell.New()
 		if err != nil {
 			t.Fatalf("shell.New() error = %v", err)
 		}
-
-		// Shallow clone with depth=1 — only gets the tip commit
-		if err := sh.Command("git", "clone", "--depth=1", "--branch", "feature", s.RepoURL("verify-shallow"), cloneDir).Run(ctx); err != nil {
+		if err := sh.Command("git", "clone", s.RepoURL("verify-unavailable"), cloneDir).Run(ctx); err != nil {
 			t.Fatalf("git clone error = %v", err)
 		}
 		if err := sh.Chdir(cloneDir); err != nil {
 			t.Fatalf("Chdir error = %v", err)
 		}
 
-		// The tip commit is the one from PushBranch — it IS on the branch,
-		// but let's verify the shallow clone scenario works at all.
-		// With depth=1, the commit should be present and verifiable.
+		// A branch the remote doesn't have can't be fetched, so ancestry can't be
+		// checked. That is an infrastructure failure, not evidence of an attack.
 		e := &Executor{
 			shell: sh,
 			ExecutorConfig: ExecutorConfig{
 				GitCommitVerification: "strict",
 				Commit:                commit,
-				Branch:                "origin/feature",
+				Branch:                "does-not-exist",
 			},
 		}
 
-		err = e.verifyCommit(ctx)
-		if err != nil {
-			t.Errorf("verifyCommit() error = %v, want nil", err)
+		if err := e.checkCommitOnBranch(ctx); !errors.Is(err, ErrCommitVerificationUnavailable) {
+			t.Fatalf("checkCommitOnBranch() error = %v, want ErrCommitVerificationUnavailable", err)
+		}
+
+		// Even in strict mode, an unavailable check must not fail the build.
+		if err := e.verifyCommit(ctx); err != nil {
+			t.Errorf("verifyCommit() in strict mode with unavailable check error = %v, want nil", err)
 		}
 	})
+}
+
+func TestStripShallowFetchFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil", nil, []string{}},
+		{"transport flags survive", []string{"-v", "--prune", "--upload-pack=/x"}, []string{"-v", "--prune", "--upload-pack=/x"}},
+		{"depth equals form", []string{"--depth=1"}, []string{}},
+		{"depth space form drops the value token", []string{"--depth", "1"}, []string{}},
+		{"deepen and unshallow", []string{"--deepen=50", "--unshallow"}, []string{}},
+		{"shallow-since and shallow-exclude", []string{"--shallow-since=2020-01-01", "--shallow-exclude", "v1.0"}, []string{}},
+		{"depth abbreviation", []string{"--dept=1"}, []string{}},
+		{"depth abbreviation space form", []string{"--dept", "1"}, []string{}},
+		{"deepen abbreviation", []string{"--deep=50"}, []string{}},
+		{"unshallow abbreviation", []string{"--unsh"}, []string{}},
+		{"--filter survives", []string{"--filter=blob:none"}, []string{"--filter=blob:none"}},
+		{"keeps surrounding flags", []string{"-v", "--depth=1", "--prune"}, []string{"-v", "--prune"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripShallowFetchFlags(tt.in)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("stripShallowFetchFlags(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripRefSuppressingFetchFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil", nil, []string{}},
+		{"transport flags survive", []string{"-v", "--prune", "--upload-pack=/x"}, []string{"-v", "--prune", "--upload-pack=/x"}},
+		{"dry-run", []string{"--dry-run"}, []string{}},
+		{"prefetch", []string{"--prefetch"}, []string{}},
+		{"negotiate-only", []string{"--negotiate-only"}, []string{}},
+		{"dry-run abbreviation", []string{"--dry"}, []string{}},
+		{"prefetch abbreviation", []string{"--prefe"}, []string{}},
+		{"negotiate-only abbreviation", []string{"--negotiate"}, []string{}},
+		{"-n is --no-tags, not dry-run, so it survives", []string{"-n"}, []string{"-n"}},
+		{"--prune is not a prefix of these modes", []string{"--prune"}, []string{"--prune"}},
+		{"--negotiation-tip survives", []string{"--negotiation-tip=abc"}, []string{"--negotiation-tip=abc"}},
+		{"--no-* negations survive", []string{"--no-dry-run", "--no-prefetch"}, []string{"--no-dry-run", "--no-prefetch"}},
+		{"keeps surrounding flags", []string{"-v", "--dry-run", "--prune"}, []string{"-v", "--prune"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripRefSuppressingFetchFlags(tt.in)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("stripRefSuppressingFetchFlags(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1771,14 +1772,23 @@ func TestCommitVerificationWithValidCommit(t *testing.T) {
 		MustMock(t, "git").
 		PassthroughToLocalCommand()
 
-	// Expect the normal checkout flow with merge-base --is-ancestor inserted
-	// between fetch and checkout. Since this is a full clone (not shallow),
-	// merge-base succeeds immediately — no rev-parse --is-shallow-repository needed.
+	// Expect the normal checkout flow with commit verification inserted between
+	// fetch and checkout: fetch the branch tip into a dedicated ref (source
+	// refs/heads/main, so a same-named tag can't win the ref lookup) rather than
+	// reading FETCH_HEAD, resolve that ref, then merge-base --is-ancestor against
+	// the SHA. Here the branch (main) tip is the build commit itself, so both
+	// merge-base args are commitHash. Since this is a full clone (not shallow) and
+	// the commit verifies, merge-base succeeds immediately, so no rev-parse
+	// --is-shallow-repository is needed. The dedicated ref is deleted on return.
+	const branchTipRef = "refs/buildkite-agent/commit-verification-branch-tip"
 	git.ExpectAll([][]any{
 		{"clone", "-v", "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"fetch", "-v", "--", "origin", commitHash},
-		{"merge-base", "--is-ancestor", commitHash, "main"},
+		{"fetch", "-v", "--", "origin", "+refs/heads/main:" + branchTipRef},
+		{"rev-parse", branchTipRef},
+		{"merge-base", "--is-ancestor", commitHash, commitHash},
+		{"update-ref", "-d", branchTipRef},
 		{"-c", "advice.detachedHead=false", "checkout", "-f", commitHash},
 		{"clean", "-fdq"},
 		{"--no-pager", "log", "-1", commitHash, "-s", "--no-color", gitShowFormatArg},
@@ -1789,6 +1799,66 @@ func TestCommitVerificationWithValidCommit(t *testing.T) {
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
+}
+
+// TestCommitVerificationRetriesTransientBranchFetch proves the branch-tip fetch
+// survives a transient failure. Without a retry a single fetch blip degrades the
+// check to "unavailable" (warn, never blocking) with no second chance, since the
+// outer checkout retry loop does not re-run a verification that returned nil.
+func TestCommitVerificationRetriesTransientBranchFetch(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewExecutorTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewExecutorTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	commitHash, err := tester.Repo.RevParse("main")
+	if err != nil {
+		t.Fatalf("RevParse(main) error = %v", err)
+	}
+	commitHash = strings.TrimSpace(commitHash)
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_FLAGS=-v",
+		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
+		"BUILDKITE_GIT_FETCH_FLAGS=-v",
+		"BUILDKITE_GIT_COMMIT_VERIFICATION=strict",
+		fmt.Sprintf("BUILDKITE_COMMIT=%s", commitHash),
+	}
+
+	// Fail the first branch-tip fetch (its refspec sources refs/heads/main) to
+	// simulate a transient blip, then let the retry pass through to real git. A
+	// Before error exits the mocked git non-zero, which is what the retrier sees.
+	var branchFetchAttempts atomic.Int32
+	git := tester.MustMock(t, "git").PassthroughToLocalCommand().Before(func(i bintest.Invocation) error {
+		isBranchTipFetch := i.Args[0] == "fetch" && slices.ContainsFunc(i.Args, func(a string) bool {
+			return strings.Contains(a, "refs/heads/main")
+		})
+		if isBranchTipFetch {
+			if branchFetchAttempts.Add(1) == 1 {
+				return fmt.Errorf("simulated transient fetch failure")
+			}
+		}
+		return nil
+	})
+	git.Expect().AtLeastOnce().WithAnyArguments()
+
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
+
+	if err := tester.Run(t, env...); err != nil {
+		t.Fatalf("tester.Run() error = %v, want nil (build should pass after the fetch retries). Output:\n%s", err, tester.Output)
+	}
+	if got := branchFetchAttempts.Load(); got < 2 {
+		t.Errorf("branch-tip fetch attempts = %d, want >= 2 (fetch should retry after a transient failure)", got)
+	}
+	// The retry must let verification actually run, not degrade to "unavailable".
+	if strings.Contains(tester.Output, "verification unavailable") {
+		t.Errorf("verification degraded to unavailable despite the retry; output:\n%s", tester.Output)
+	}
 }
 
 func TestCommitVerificationFailsWithInvalidCommit(t *testing.T) {
@@ -1812,29 +1882,141 @@ func TestCommitVerificationFailsWithInvalidCommit(t *testing.T) {
 		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
 		"BUILDKITE_GIT_FETCH_FLAGS=-v",
 		"BUILDKITE_GIT_COMMIT_VERIFICATION=strict",
+		// The non-PR sentinel. The agent sets this on every ordinary build, so
+		// verification must still run (a naive PullRequest != "" skip would disable
+		// it for almost every build).
+		"BUILDKITE_PULL_REQUEST=false",
 		fmt.Sprintf("BUILDKITE_COMMIT=%s", commitHash),
 	}
 
-	git := tester.
-		MustMock(t, "git").
-		PassthroughToLocalCommand()
-
-	// Expect fetch, then merge-base which should return exit 1 (not ancestor).
-	// No checkout should happen after verification fails.
-	git.ExpectAll([][]any{
-		{"clone", "-v", "--", tester.Repo.Path, "."},
-		{"clean", "-fdq"},
-		{"fetch", "-v", "--", "origin", commitHash},
-		{"merge-base", "--is-ancestor", commitHash, "main"},
-	})
-
+	// Use real git (no mock) and assert on the outcome rather than the exact
+	// command sequence: the build must fail because the commit is not on the branch.
 	agent := tester.MockAgent(t)
-	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).Min(0).Max(bintest.InfiniteTimes).AndExitWith(1)
+	agent.IgnoreUnexpectedInvocations()
 
-	// This should fail — the commit is not on main
+	// This should fail: the commit is not on main.
 	err = tester.Run(t, env...)
 	if err == nil {
 		t.Fatalf("expected build to fail with commit verification error, but it passed")
+	}
+	if !strings.Contains(tester.Output, "is not on branch") {
+		t.Errorf("expected a commit-verification failure in the output, got:\n%s", tester.Output)
+	}
+	// The retry loop fast-breaks on a provably-off-branch commit, so verification
+	// runs once rather than re-cloning through the full backoff (default 6
+	// attempts). checkCommitOnBranch logs "Verifying commit" once per attempt.
+	if got := strings.Count(tester.Output, "Verifying commit"); got != 1 {
+		t.Errorf("commit verification ran %d times, want 1 (fast-break should prevent retries)", got)
+	}
+}
+
+// TestCommitVerificationFailsForCommitNotOnNonDefaultBranch is the regression
+// test for the case the old bare-branch-name check missed: a build on a branch
+// other than the repository default. The clone only materialises the default
+// branch as a local ref, so checking a commit against the bare build-branch name
+// used to resolve to nothing and silently degrade to "unavailable" (warn, never
+// block), even for a commit that is genuinely not on that branch.
+func TestCommitVerificationFailsForCommitNotOnNonDefaultBranch(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewExecutorTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewExecutorTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	// Add a commit on main (the default branch) that diverges from update-test-txt,
+	// so it is genuinely not reachable from that non-default branch.
+	if err := tester.Repo.CheckoutBranch("main"); err != nil {
+		t.Fatalf("CheckoutBranch(main) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tester.Repo.Path, "main-only.txt"), []byte("main only"), 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+	if err := tester.Repo.Add("main-only.txt"); err != nil {
+		t.Fatalf("Add error = %v", err)
+	}
+	if err := tester.Repo.Commit("Commit only on main"); err != nil {
+		t.Fatalf("Commit error = %v", err)
+	}
+	offBranchCommit, err := tester.Repo.RevParse("main")
+	if err != nil {
+		t.Fatalf("RevParse(main) error = %v", err)
+	}
+	offBranchCommit = strings.TrimSpace(offBranchCommit)
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_FLAGS=-v",
+		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
+		"BUILDKITE_GIT_FETCH_FLAGS=-v",
+		"BUILDKITE_GIT_COMMIT_VERIFICATION=strict",
+		"BUILDKITE_BRANCH=update-test-txt",
+		fmt.Sprintf("BUILDKITE_COMMIT=%s", offBranchCommit),
+	}
+
+	// Use real git (no mock) and assert on the outcome rather than the exact
+	// command sequence: the build must fail because the commit is not on the branch.
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).Min(0).Max(bintest.InfiniteTimes).AndExitWith(1)
+	agent.IgnoreUnexpectedInvocations()
+
+	err = tester.Run(t, env...)
+	if err == nil {
+		t.Fatalf("expected build to fail: commit %s is not on branch update-test-txt, but it passed. Output:\n%s", offBranchCommit, tester.Output)
+	}
+	if !strings.Contains(tester.Output, "is not on branch") {
+		t.Errorf("expected a commit-verification failure in the output, got:\n%s", tester.Output)
+	}
+}
+
+// TestCommitVerificationPassesForCommitOnNonDefaultBranch is the happy-path
+// companion to the failure regression above: a valid commit that IS on a
+// non-default branch must verify and let the build proceed. The clone only
+// materialises the default branch as a local ref, so this exercises the
+// branch-tip fetch end-to-end, proving non-default verification passes rather
+// than silently degrading to "unavailable".
+func TestCommitVerificationPassesForCommitOnNonDefaultBranch(t *testing.T) {
+	t.Parallel()
+
+	tester, err := NewExecutorTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewExecutorTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	// The tip of update-test-txt is genuinely on that non-default branch.
+	onBranchCommit, err := tester.Repo.RevParse("update-test-txt")
+	if err != nil {
+		t.Fatalf("RevParse(update-test-txt) error = %v", err)
+	}
+	onBranchCommit = strings.TrimSpace(onBranchCommit)
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_FLAGS=-v",
+		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
+		"BUILDKITE_GIT_FETCH_FLAGS=-v",
+		"BUILDKITE_GIT_COMMIT_VERIFICATION=strict",
+		"BUILDKITE_BRANCH=update-test-txt",
+		fmt.Sprintf("BUILDKITE_COMMIT=%s", onBranchCommit),
+	}
+
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
+
+	if err := tester.Run(t, env...); err != nil {
+		t.Fatalf("tester.Run() error = %v, want nil (commit is on update-test-txt). Output:\n%s", err, tester.Output)
+	}
+	// Verification must actually run and pass, not skip or degrade.
+	if !strings.Contains(tester.Output, "Verifying commit") {
+		t.Errorf("expected verification to run (%q not in output):\n%s", "Verifying commit", tester.Output)
+	}
+	if strings.Contains(tester.Output, "is not on branch") {
+		t.Errorf("verification wrongly reported the commit off-branch; output:\n%s", tester.Output)
+	}
+	if strings.Contains(tester.Output, "verification unavailable") {
+		t.Errorf("verification degraded to unavailable; output:\n%s", tester.Output)
 	}
 }
 


### PR DESCRIPTION
## Description

`checkout.commit_verification` (`BUILDKITE_GIT_COMMIT_VERIFICATION`) verifies that a build's commit is an ancestor of the build's branch before checkout, catching a build pointed at a commit that isn't actually on the claimed branch. Under `strict` it should fail the build; under `warn` it logs and continues.

The check only ever enforced on a repository's default branch. `checkCommitOnBranch` ran `git merge-base --is-ancestor <commit> <branch>` against the bare `BUILDKITE_BRANCH` name, but at verification time only the default branch exists as a local ref (the clone checks it out; the build's own branch is fetched as a detached commit, not a local branch ref). Git does not resolve a bare name like `feature` to `refs/remotes/origin/feature`, so merge-base exited 128 for any non-default branch. That 128 was classified as "unavailable", which is warn-only even under `strict`, so a build on a non-default branch with a commit genuinely not on that branch ran to completion.

The fix fetches the branch tip, pins it to a SHA, and checks ancestry against that SHA instead of the unresolvable bare name. The branch is fetched as `refs/heads/<branch>` so a tag sharing the branch's name can't shadow it, using a direct `git fetch` rather than the shared fetch helper (which word-splits its refspecs and would corrupt a branch name containing shell metacharacters that are legal in git refs). The fetch is retried a few times before giving up, so a transient failure doesn't silently skip verification. Shallow clones are handled by trusting a "not an ancestor" result only once the repo is non-shallow (a shallow clone can report a genuine ancestor as "not an ancestor" when the connecting history is beyond the shallow boundary), deepening as needed. A merge-base that fails to run at all is treated as "unavailable" rather than a definitive failure. The checkout retry loop now fast-breaks on a definitive failure so a provably-off-branch commit fails immediately instead of re-cloning through the full backoff.

A second bug disabled verification on nearly every build: `verifyCommit` skipped whenever `BUILDKITE_PULL_REQUEST` was non-empty, but the agent sets that variable to the string `"false"` (not empty) on every non-PR build. The check therefore returned early before ever running. It now skips only for real pull-request builds, matching how the rest of the checkout treats the `"false"` sentinel.

One behavior was left deliberately unchanged: if fetching the branch keeps failing (branch deleted or renamed on the remote, or the network stays down through the retries), the check reports "unavailable" and does not block, even under `strict`. This matches the existing documented design that infrastructure failures never block verification, so users don't disable it over false positives.

## Context

[Linear](https://linear.app/buildkite/issue/SUP-7566/checkoutcommit-verification-not-blocking-job-when-commit-not-in-branch). Found while testing `checkout.commit_verification: strict` in a pipeline: a build created from a non-default branch with a commit SHA not on that branch allowed the jobs to complete instead of failing.

## Changes

- `internal/job/commit_verification.go`: rewrite `checkCommitOnBranch` to fetch and pin the branch tip (as `refs/heads/<branch>`, via a direct `git fetch` so the ref isn't word-split, and with a bounded retry), check ancestry against the SHA, trust "not an ancestor" only when the repo is non-shallow, and treat a non-exit merge-base error as unavailable.
- `internal/job/commit_verification.go`: skip verification only for real pull-request builds (`BUILDKITE_PULL_REQUEST` is the string `"false"`, not empty, on ordinary builds), and drop a duplicated prefix from the warn-mode log messages.
- `internal/job/checkout.go`: fast-break the checkout retry loop on `ErrCommitVerificationFailed` so a provably-off-branch commit fails immediately.
- Tests: shallow off-branch failure, fast-break (verification runs once, not per retry), unavailable-stays-warn under `strict`, a strengthened warn-mode assertion, a regression test for a build on a non-default branch, a valid commit on a non-default branch that must pass, a non-PR build (`BUILDKITE_PULL_REQUEST=false`) that must still verify, a commit reachable only after `--unshallow`, a transient branch-fetch failure that must retry rather than degrade, and a branch name containing shell metacharacters.
- Tests: the `file://`-backed cases share a fixture helper and use a bare repo served over `file://`, because shallow deepening over the HTTP test server's stateless-rpc transport is not reliable across git versions.

No CLI argument changes.

## Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

I used Claude Code (Opus 4.8) to diagnose the bug, implement the fix and tests, run a structured code review, and address the findings, all under my direction and review. I made the design decisions (including keeping the "unavailable never blocks" behavior under `strict`) and verified the changes fixed the issue with non-default branches.