### PR TITLE
A-1542: Rename cache_key fallbackLimit to fallback_limit

### DIFF
--- a/clicommand/cache_restore.go
+++ b/clicommand/cache_restore.go
@@ -24,7 +24,7 @@ defined in your cache config file (defaults to .buildkite/cache.yml or
 The cache configuration file defines which files or directories should be restored
 and their associated cache key. An entry is restored when its target_paths
 (an order-insensitive set) and the mandatory parts of its cache_key match. By
-default every key part is mandatory; mark a part with fallbackLimit: true to make
+default every key part is mandatory; mark a part with fallback_limit: true to make
 every part after it optional.
 
 Note: This feature is currently in development and subject to change. It is not
@@ -49,7 +49,7 @@ Configuration File Format:
 The cache configuration file should be in YAML format. cache_key is an ordered
 list of parts; each part is a literal string or one of { agent: os },
 { agent: arch }, { checksum: <file> }, or { env: <VAR> }. Any one part may also
-set fallbackLimit: true to make every part after it optional for fallback
+set fallback_limit: true to make every part after it optional for fallback
 matching (the marked part itself stays mandatory). In the example below an exact
 match is preferred, but if the lockfile changed, an entry matching node + os + arch
 is still restored, as the fallback is specified on arch, making node + os + arch mandatory, 
@@ -60,7 +60,7 @@ but making checksum optional:
         cache_key:
           - node
           - { agent: os }
-          - { agent: arch, fallbackLimit: true }
+          - { agent: arch, fallback_limit: true }
           - { checksum: package-lock.json }
         target_paths:
           - node_modules

--- a/internal/cache/configuration/cache.go
+++ b/internal/cache/configuration/cache.go
@@ -31,7 +31,7 @@ func (c Cache) Validate() error {
 		errors = append(errors, "cache_key cannot be empty")
 	}
 
-	// At most one cache_key part may declare fallbackLimit.
+	// At most one cache_key part may declare fallback_limit.
 	fallbackLimits := 0
 	for _, part := range c.CacheKey {
 		if part.FallbackLimit {
@@ -39,7 +39,7 @@ func (c Cache) Validate() error {
 		}
 	}
 	if fallbackLimits > 1 {
-		errors = append(errors, "cache_key: fallbackLimit may be set on at most one part")
+		errors = append(errors, "cache_key: fallback_limit may be set on at most one part")
 	}
 
 	// TargetPaths validation: non-empty set of valid, unique paths

--- a/internal/cache/configuration/cache_test.go
+++ b/internal/cache/configuration/cache_test.go
@@ -73,7 +73,7 @@ func TestCacheValidate(t *testing.T) {
 			errMsg:  "name cannot be empty",
 		},
 		{
-			name: "single fallbackLimit is valid",
+			name: "single fallback_limit is valid",
 			cache: Cache{
 				Name: "node_modules",
 				CacheKey: []KeyPart{
@@ -85,7 +85,7 @@ func TestCacheValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "multiple fallbackLimit is invalid",
+			name: "multiple fallback_limit is invalid",
 			cache: Cache{
 				Name: "node_modules",
 				CacheKey: []KeyPart{
@@ -95,7 +95,7 @@ func TestCacheValidate(t *testing.T) {
 				TargetPaths: []string{"node_modules"},
 			},
 			wantErr: true,
-			errMsg:  "fallbackLimit may be set on at most one part",
+			errMsg:  "fallback_limit may be set on at most one part",
 		},
 		{
 			name: "empty cache_key",

--- a/internal/cache/configuration/key_part.go
+++ b/internal/cache/configuration/key_part.go
@@ -59,26 +59,26 @@ func (k *KeyPart) unmarshalMapping(node *yaml.Node) error {
 		return fmt.Errorf("cache_key: invalid entry: %w", err)
 	}
 
-	// fallbackLimit is an optional modifier alongside the single source.
+	// fallback_limit is an optional modifier alongside the single source.
 	hasFallbackLimit := false
-	if raw, ok := fields["fallbackLimit"]; ok {
+	if raw, ok := fields["fallback_limit"]; ok {
 		if err := raw.Decode(&k.FallbackLimit); err != nil {
-			return fmt.Errorf("cache_key: fallbackLimit must be a boolean")
+			return fmt.Errorf("cache_key: fallback_limit must be a boolean")
 		}
 		hasFallbackLimit = true
 	}
 
-	// Exactly one source key; fallbackLimit is a modifier, not a source.
+	// Exactly one source key; fallback_limit is a modifier, not a source.
 	sourceCount := len(fields)
 	if hasFallbackLimit {
 		sourceCount--
 	}
 	if sourceCount != 1 {
-		return fmt.Errorf("cache_key: entry must name exactly one source (plus optional fallbackLimit)")
+		return fmt.Errorf("cache_key: entry must name exactly one source (plus optional fallback_limit)")
 	}
 
 	for src, val := range fields {
-		if src == "fallbackLimit" {
+		if src == "fallback_limit" {
 			continue
 		}
 		switch Source(src) {
@@ -115,8 +115,8 @@ func (k *KeyPart) unmarshalMapping(node *yaml.Node) error {
 
 // ResolveCacheKey resolves each KeyPart to its concrete value and returns the
 // flat wire shape the backend expects. A part is mandatory iff it is at or
-// before the part declaring fallbackLimit; parts after it are optional. When no
-// part declares fallbackLimit, every part is mandatory. At most one part may
+// before the part declaring fallback_limit; parts after it are optional. When no
+// part declares fallback_limit, every part is mandatory. At most one part may
 // declare it (enforced by Validate).
 func ResolveCacheKey(keyParts []KeyPart, env map[string]string) ([]api.CacheKeyPart, error) {
 	if len(keyParts) == 0 {

--- a/internal/cache/configuration/key_part_test.go
+++ b/internal/cache/configuration/key_part_test.go
@@ -32,9 +32,9 @@ func TestKeyPartUnmarshal(t *testing.T) {
 		{name: "agent pipeline", yaml: `{ agent: pipeline }`, want: KeyPart{Source: SourceAgent, Arg: "pipeline"}},
 		{name: "checksum", yaml: `{ checksum: go.mod }`, want: KeyPart{Source: SourceChecksum, Arg: "go.mod"}},
 		{name: "env", yaml: `{ env: GO_VERSION }`, want: KeyPart{Source: SourceEnv, Arg: "GO_VERSION"}},
-		{name: "fallbackLimit on agent", yaml: `{ agent: arch, fallbackLimit: true }`, want: KeyPart{Source: SourceAgent, Arg: "arch", FallbackLimit: true}},
-		{name: "fallbackLimit on checksum", yaml: `{ checksum: go.mod, fallbackLimit: true }`, want: KeyPart{Source: SourceChecksum, Arg: "go.mod", FallbackLimit: true}},
-		{name: "fallbackLimit false is a no-op", yaml: `{ agent: arch, fallbackLimit: false }`, want: KeyPart{Source: SourceAgent, Arg: "arch", FallbackLimit: false}},
+		{name: "fallback_limit on agent", yaml: `{ agent: arch, fallback_limit: true }`, want: KeyPart{Source: SourceAgent, Arg: "arch", FallbackLimit: true}},
+		{name: "fallback_limit on checksum", yaml: `{ checksum: go.mod, fallback_limit: true }`, want: KeyPart{Source: SourceChecksum, Arg: "go.mod", FallbackLimit: true}},
+		{name: "fallback_limit false is a no-op", yaml: `{ agent: arch, fallback_limit: false }`, want: KeyPart{Source: SourceAgent, Arg: "arch", FallbackLimit: false}},
 
 		// Out of M1 scope -> parse errors.
 		{name: "empty literal", yaml: `""`, wantErr: "literal entry cannot be empty"},
@@ -42,8 +42,8 @@ func TestKeyPartUnmarshal(t *testing.T) {
 		{name: "checksum array deferred", yaml: `{ checksum: [go.mod, go.sum] }`, wantErr: "single file path"},
 		{name: "cmd deferred", yaml: `{ cmd: ["go", "version"] }`, wantErr: "unknown source"},
 		{name: "unknown source", yaml: `{ bogus: x }`, wantErr: "unknown source"},
-		{name: "fallbackLimit non-bool", yaml: `{ agent: arch, fallbackLimit: 7 }`, wantErr: "fallbackLimit must be a boolean"},
-		{name: "fallbackLimit without source", yaml: `{ fallbackLimit: true }`, wantErr: "exactly one source"},
+		{name: "fallback_limit non-bool", yaml: `{ agent: arch, fallback_limit: 7 }`, wantErr: "fallback_limit must be a boolean"},
+		{name: "fallback_limit without source", yaml: `{ fallback_limit: true }`, wantErr: "exactly one source"},
 		{name: "empty map", yaml: `{}`, wantErr: "exactly one source"},
 		{name: "sequence", yaml: `[a, b]`, wantErr: "must be a string or a { source: arg } map"},
 	}
@@ -199,7 +199,7 @@ func TestResolveCacheKey(t *testing.T) {
 		}
 	})
 
-	t.Run("fallbackLimit splits mandatory from optional", func(t *testing.T) {
+	t.Run("fallback_limit splits mandatory from optional", func(t *testing.T) {
 		t.Parallel()
 		parts := []KeyPart{
 			{Source: SourceLiteral, Arg: "node"},
@@ -211,7 +211,7 @@ func TestResolveCacheKey(t *testing.T) {
 			t.Fatalf("ResolveCacheKey() unexpected error = %v", err)
 		}
 
-		// The part declaring fallbackLimit (os) is itself mandatory;
+		// The part declaring fallback_limit (os) is itself mandatory;
 		// only parts after it are optional.
 		want := []api.CacheKeyPart{
 			{Value: "node", Mandatory: true},
@@ -225,7 +225,7 @@ func TestResolveCacheKey(t *testing.T) {
 		}
 	})
 
-	t.Run("fallbackLimit on first part makes only later parts optional", func(t *testing.T) {
+	t.Run("fallback_limit on first part makes only later parts optional", func(t *testing.T) {
 		t.Parallel()
 		parts := []KeyPart{
 			{Source: SourceLiteral, Arg: "node", FallbackLimit: true},

--- a/internal/cache/integration_test.go
+++ b/internal/cache/integration_test.go
@@ -565,7 +565,7 @@ func TestCacheIntegration_RestoreMissingBlobInvalidates(t *testing.T) {
 }
 
 // TODO: restore fallback-matching coverage (was TestCacheIntegration_RestoreWithFallback,
-// removed in the v2 migration) once agent-side fallbackLimit parsing lands and the agent
+// removed in the v2 migration) once agent-side fallback_limit parsing lands and the agent
 // sends mandatory:false parts. Until then the agent only addresses exact matches.
 
 func TestCacheIntegration_LargeFileChecksum(t *testing.T) {

--- a/internal/e2e/cache_test.go
+++ b/internal/e2e/cache_test.go
@@ -50,11 +50,11 @@ func TestCacheFilesystemIntegrity(t *testing.T) {
 	}
 }
 
-// Test that a cache_key's fallbackLimit makes trailing parts optional on
+// Test that a cache_key's fallback_limit makes trailing parts optional on
 // restore. Two caches share a BUILD_ID-anchored key but differ in a trailing
 // CACHE_VARIANT part that changes between save and restore: the cache that
-// declares fallbackLimit on BUILD_ID falls back to the BUILD_ID match and
-// restores, while the cache without fallbackLimit treats the variant mismatch
+// declares fallback_limit on BUILD_ID falls back to the BUILD_ID match and
+// restores, while the cache without fallback_limit treats the variant mismatch
 // as a hard miss.
 func TestCacheKeyFallback(t *testing.T) {
 	ctx := t.Context()

--- a/internal/e2e/fixtures/cache_fallback.yaml
+++ b/internal/e2e/fixtures/cache_fallback.yaml
@@ -1,7 +1,7 @@
-# cache key fallbackLimit behavior. Two caches share a BUILD_ID-anchored key
-# but differ in an optional CACHE_VARIANT part: one declares fallbackLimit on
+# cache key fallback_limit behavior. Two caches share a BUILD_ID-anchored key
+# but differ in an optional CACHE_VARIANT part: one declares fallback_limit on
 # BUILD_ID (variant optional), the other does not (variant mandatory). The
-# variant changes between save and restore, so only the fallbackLimit cache
+# variant changes between save and restore, so only the fallback_limit cache
 # falls back to the BUILD_ID match; the other is a hard miss.
 env:
   BUILDKITE_AGENT_CACHE_STORE_URL: s3://buildkite-agent-e2e-tests-shared/cache-e2e-test?region=us-west-2
@@ -42,9 +42,9 @@ steps:
       - {{ .buildkite_agent_binary }} cache restore --cache-config-file cache.yml
       - |
         set -euo pipefail
-        # fallbackLimit makes CACHE_VARIANT optional, so the v1/v2 mismatch
+        # fallback_limit makes CACHE_VARIANT optional, so the v1/v2 mismatch
         # falls back to the BUILD_ID match and restores the saved content.
         [[ "$(cat fallback-src/file.txt)" == "fallback payload" ]]
-        # Without fallbackLimit every part is mandatory, so the variant
+        # Without fallback_limit every part is mandatory, so the variant
         # mismatch is a hard miss and nothing is restored.
         [[ ! -e nofallback-src ]]

--- a/internal/e2e/fixtures/includes/cache_fallback_config.yml
+++ b/internal/e2e/fixtures/includes/cache_fallback_config.yml
@@ -2,7 +2,7 @@ caches:
   - name: with_fallback
     cache_key:
       - cache-e2e-fallback
-      - { env: BUILDKITE_BUILD_ID, fallbackLimit: true }
+      - { env: BUILDKITE_BUILD_ID, fallback_limit: true }
       - { env: CACHE_VARIANT }
     target_paths:
       - fallback-src


### PR DESCRIPTION
Renames the Cache v2 `cache_key` option `fallbackLimit` to `fallback_limit`, matching the snake_case convention used by the rest of the config (`cache_key`, `target_paths`, etc.).

- No backward-compatible alias: `fallbackLimit` is dropped entirely (Cache v2 is pre-GA, so the break is acceptable).
- Updates parsing, error messages, help text, tests, and e2e fixtures.

Fixes A-1542
