### PR TITLE
Fix issue with ssh-key not reading from shell env BUILDKITE_GIT_SSH_KEY on checkout

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -1208,7 +1208,16 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context) (retErr error) {
 // Only the default checkout phase invokes this; custom checkout hooks must
 // arrange their own credentials.
 func (e *Executor) prepareGitSSHKey() (sshKeyPath string, cleanup func() error, retErr error) {
-	if e.GitSSHKey == "" {
+	// Prefer the current value in the shell environment so that secrets
+	// materialised at runtime by fetchAndSetSecrets are honoured, even when
+	// no environment/pre-checkout hook has run to refresh e.GitSSHKey via
+	// applyEnvironmentChanges. Fall back to the config field for callers
+	// that populate it directly without touching shell.Env (chiefly tests).
+	gitSSHKey, ok := e.shell.Env.Get("BUILDKITE_GIT_SSH_KEY")
+	if !ok {
+		gitSSHKey = e.GitSSHKey
+	}
+	if gitSSHKey == "" {
 		return "", nil, nil
 	}
 
@@ -1242,7 +1251,7 @@ func (e *Executor) prepareGitSSHKey() (sshKeyPath string, cleanup func() error, 
 	sshKeyPath = filepath.Join(sshKeyDir, "id")
 	// Most SSH key parsers require a trailing newline; tolerate either form
 	// of input and always write a single one.
-	keyBytes := []byte(strings.TrimRight(e.GitSSHKey, "\n") + "\n")
+	keyBytes := []byte(strings.TrimRight(gitSSHKey, "\n") + "\n")
 	if err := os.WriteFile(sshKeyPath, keyBytes, 0o600); err != nil {
 		return "", nil, fmt.Errorf("writing ssh key file: %w", err)
 	}

--- a/internal/job/checkout_test.go
+++ b/internal/job/checkout_test.go
@@ -246,6 +246,67 @@ func TestPrepareGitSSHKey(t *testing.T) {
 		}
 	})
 
+	t.Run("uses shell env value when config field is empty", func(t *testing.T) {
+		checkoutParent := t.TempDir()
+		checkoutPath := filepath.Join(checkoutParent, "checkout")
+		sh.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", checkoutPath)
+		sh.Env.Set("BUILDKITE_GIT_SSH_KEY", "runtime-injected-key")
+		sh.Env.Remove("GIT_SSH_COMMAND")
+		t.Cleanup(func() { sh.Env.Remove("BUILDKITE_GIT_SSH_KEY") })
+
+		// e.GitSSHKey is deliberately empty — this mirrors the real case where
+		// a cluster secret writes BUILDKITE_GIT_SSH_KEY to the shell env after
+		// bootstrap has already parsed its config.
+		executor := &Executor{shell: sh}
+
+		sshKeyPath, cleanup, err := executor.prepareGitSSHKey()
+		if err != nil {
+			t.Fatalf("executor.prepareGitSSHKey() error = %v, want nil", err)
+		}
+		if cleanup == nil {
+			t.Fatal("executor.prepareGitSSHKey() cleanup = nil, want non-nil")
+		}
+		t.Cleanup(func() { _ = cleanup() })
+
+		contents, err := os.ReadFile(sshKeyPath)
+		if err != nil {
+			t.Fatalf("os.ReadFile(%q) error = %v, want nil", sshKeyPath, err)
+		}
+		if got, want := string(contents), "runtime-injected-key\n"; got != want {
+			t.Fatalf("ssh key contents = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("shell env value takes precedence over config field", func(t *testing.T) {
+		checkoutParent := t.TempDir()
+		checkoutPath := filepath.Join(checkoutParent, "checkout")
+		sh.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", checkoutPath)
+		sh.Env.Set("BUILDKITE_GIT_SSH_KEY", "shell-env-key")
+		sh.Env.Remove("GIT_SSH_COMMAND")
+		t.Cleanup(func() { sh.Env.Remove("BUILDKITE_GIT_SSH_KEY") })
+
+		executor := &Executor{
+			shell: sh,
+			ExecutorConfig: ExecutorConfig{
+				GitSSHKey: "stale-config-key",
+			},
+		}
+
+		sshKeyPath, cleanup, err := executor.prepareGitSSHKey()
+		if err != nil {
+			t.Fatalf("executor.prepareGitSSHKey() error = %v, want nil", err)
+		}
+		t.Cleanup(func() { _ = cleanup() })
+
+		contents, err := os.ReadFile(sshKeyPath)
+		if err != nil {
+			t.Fatalf("os.ReadFile(%q) error = %v, want nil", sshKeyPath, err)
+		}
+		if got, want := string(contents), "shell-env-key\n"; got != want {
+			t.Fatalf("ssh key contents = %q, want %q", got, want)
+		}
+	})
+
 	t.Run("creates key file with default ssh command when none exists", func(t *testing.T) {
 		checkoutParent := t.TempDir()
 		checkoutPath := filepath.Join(checkoutParent, "checkout")


### PR DESCRIPTION
## Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

## Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

## Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

## Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
