### PR TITLE
[A-1511] Redact repo URL credentials in repo-checkout OTel span

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/buildkite/agent/v3/internal/experiments"
 	"github.com/buildkite/agent/v3/internal/osutil"
+	"github.com/buildkite/agent/v3/internal/redact"
 	"github.com/buildkite/agent/v3/internal/shell"
 	"github.com/buildkite/agent/v3/tracetools"
 	"github.com/buildkite/roko"
@@ -288,7 +289,7 @@ func (e *Executor) runDefaultCheckoutAttempt(ctx context.Context) error {
 func (e *Executor) defaultCheckoutPhase(ctx context.Context) (retErr error) {
 	span, _ := tracetools.StartSpanFromContext(ctx, "repo-checkout", e.TracingBackend)
 	span.AddAttributes(map[string]string{
-		"checkout.repo_name": e.Repository,
+		"checkout.repo_name": redact.URLCredentials(e.Repository),
 		"checkout.refspec":   e.RefSpec,
 		"checkout.commit":    e.Commit,
 	})

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -26,11 +27,23 @@ const LengthMin = 6
 // Redacted ignores its input and returns "[REDACTED]".
 func Redacted([]byte) []byte { return []byte("[REDACTED]") }
 
+// hasScheme matches URLs that begin with a "scheme://" prefix
+var hasScheme = regexp.MustCompile(`^[^:]+://`)
+
 // URLCredentials returns rawURL with any embedded password masked. URLs
-// without one (including SCP-style SSH remotes) are returned unchanged.
+// without one are returned unchanged; an unparsable scheme-based URL returns a
+// placeholder to avoid leaking a credential it may contain.
 func URLCredentials(rawURL string) string {
 	u, err := url.Parse(rawURL)
-	if err != nil || u.User == nil {
+	if err != nil {
+		if hasScheme.MatchString(rawURL) {
+			// Avoid returning the unparsed as it may contain an embedded
+			// credential that we were unable to mask.
+			return "(invalid URL)"
+		}
+		return rawURL
+	}
+	if u.User == nil {
 		return rawURL
 	}
 	if _, hasPassword := u.User.Password(); !hasPassword {

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net/url"
 	"os"
 	"path"
 	"slices"
@@ -24,6 +25,19 @@ const LengthMin = 6
 
 // Redacted ignores its input and returns "[REDACTED]".
 func Redacted([]byte) []byte { return []byte("[REDACTED]") }
+
+// URLCredentials returns rawURL with any embedded password masked. URLs
+// without one (including SCP-style SSH remotes) are returned unchanged.
+func URLCredentials(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.User == nil {
+		return rawURL
+	}
+	if _, hasPassword := u.User.Password(); !hasPassword {
+		return rawURL
+	}
+	return u.Redacted()
+}
 
 // String is a convenience wrapper for redacting small strings.
 // This is fine to call repeatedly with many separate strings, but avoid using

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -116,3 +116,35 @@ func TestRedactString(t *testing.T) {
 		})
 	}
 }
+
+// TestURLCredentials asserts that an embedded password is masked while URLs
+// without a secret, ssh:// SSH remotes and relative submodule paths pass
+// through unchanged.
+func TestURLCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "https with creds", in: "https://x-access-token:ghs_secret@github.com/org/repo.git", want: "https://x-access-token:xxxxx@github.com/org/repo.git"},
+		{name: "https with creds but no user", in: "https://:ghs_secret@github.com/org/repo.git", want: "https://:xxxxx@github.com/org/repo.git"},
+		{name: "https no creds", in: "https://github.com/org/repo.git", want: "https://github.com/org/repo.git"},
+		{name: "https user only", in: "https://user@github.com/org/repo.git", want: "https://user@github.com/org/repo.git"},
+		{name: "scp-style ssh", in: "git@github.com:org/repo.git", want: "git@github.com:org/repo.git"},
+		{name: "ssh scheme", in: "ssh://git@github.com/org/repo.git", want: "ssh://git@github.com/org/repo.git"},
+		{name: "relative submodule", in: "../relative/submodule", want: "../relative/submodule"},
+		{name: "empty", in: "", want: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := URLCredentials(test.in); got != test.want {
+				t.Errorf("URLCredentials(%q) = %q, want %q", test.in, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -136,6 +136,8 @@ func TestURLCredentials(t *testing.T) {
 		{name: "ssh scheme", in: "ssh://git@github.com/org/repo.git", want: "ssh://git@github.com/org/repo.git"},
 		{name: "relative submodule", in: "../relative/submodule", want: "../relative/submodule"},
 		{name: "empty", in: "", want: ""},
+		{name: "unparsable scheme url with creds", in: "https://x-access-token:ghs_secret@github.com/org/repo.git\x7f", want: "(invalid URL)"},
+		{name: "unparsable schemeless ref", in: "git@github.com:org/repo.git\x7f", want: "git@github.com:org/repo.git\x7f"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Changes

Redact password in `checkout.repo_name` repository URL when emitting a `repo-checkout` OTel span to prevent sensitive credentials from accidentally leaking.

Implementing this ahead of a PR that will use this heavily.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)
