### PR TITLE
Nice the command subprocess so k8s boostrap can't be starved of CPU

### DIFF
--- a/clicommand/kubernetes_bootstrap.go
+++ b/clicommand/kubernetes_bootstrap.go
@@ -225,6 +225,7 @@ var KubernetesBootstrapCommand = cli.Command{
 			Stderr:            io.MultiWriter(os.Stderr, socket),
 			Dir:               buildPath,
 			PTY:               runInPTY,
+			Nice:              5, // Lower priority for bootstrap subprocess so kubernetes-bootstrap's StatusLoop stays responsive
 			InterruptSignal:   cancelSignal,
 			SignalGracePeriod: signalGracePeriod,
 		})

--- a/internal/process/main_nice_test.go
+++ b/internal/process/main_nice_test.go
@@ -12,6 +12,14 @@ import (
 
 func init() {
 	extraTestMainCases["tester-nice"] = func() {
+		// Wait for a byte on stdin before reading priority.
+		// The parent writes this byte after postStart has applied Setpriority,
+		// avoiding a race where we read priority before it's been set.
+		buf := make([]byte, 1)
+		if _, err := os.Stdin.Read(buf); err != nil {
+			log.Fatalf("waiting for start signal: %v", err)
+		}
+
 		prio, err := syscall.Getpriority(syscall.PRIO_PROCESS, 0)
 		if err != nil {
 			log.Fatalf("Getpriority: %v", err)

--- a/internal/process/main_nice_test.go
+++ b/internal/process/main_nice_test.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package process_test
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"syscall"
+)
+
+func init() {
+	extraTestMainCases["tester-nice"] = func() {
+		prio, err := syscall.Getpriority(syscall.PRIO_PROCESS, 0)
+		if err != nil {
+			log.Fatalf("Getpriority: %v", err)
+		}
+		fmt.Printf("nice=%d", prio)
+		os.Exit(0)
+	}
+}

--- a/internal/process/main_nice_test.go
+++ b/internal/process/main_nice_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"syscall"
 )
 
@@ -14,6 +15,11 @@ func init() {
 		prio, err := syscall.Getpriority(syscall.PRIO_PROCESS, 0)
 		if err != nil {
 			log.Fatalf("Getpriority: %v", err)
+		}
+		// On Linux, getpriority returns 20 - nice (always non-negative).
+		// On macOS/others, it returns the nice value directly.
+		if runtime.GOOS == "linux" {
+			prio = 20 - prio
 		}
 		fmt.Printf("nice=%d", prio)
 		os.Exit(0)

--- a/internal/process/main_test.go
+++ b/internal/process/main_test.go
@@ -76,6 +76,14 @@ func TestMain(m *testing.M) {
 		fmt.Printf("SIG %v", <-signals)
 		os.Exit(0)
 
+	case "tester-nice":
+		prio, err := syscall.Getpriority(syscall.PRIO_PROCESS, 0)
+		if err != nil {
+			log.Fatalf("Getpriority: %v", err)
+		}
+		fmt.Printf("nice=%d", prio)
+		os.Exit(0)
+
 	case "tester-pgid":
 		pid := syscall.Getpid()
 		pgid, err := process.GetPgid(pid)

--- a/internal/process/main_test.go
+++ b/internal/process/main_test.go
@@ -13,8 +13,15 @@ import (
 	"github.com/buildkite/agent/v3/internal/process"
 )
 
+var extraTestMainCases = map[string]func(){}
+
 // Invoked by `go test`, switch between helper and running tests based on env
 func TestMain(m *testing.M) {
+	if fn, ok := extraTestMainCases[os.Getenv("TEST_MAIN")]; ok {
+		fn()
+		return // fn is expected to call os.Exit
+	}
+
 	switch os.Getenv("TEST_MAIN") {
 	case "tester":
 		for line := range strings.SplitSeq(strings.TrimSuffix(longTestOutput, "\n"), "\n") {
@@ -74,14 +81,6 @@ func TestMain(m *testing.M) {
 		)
 		fmt.Println("Ready")
 		fmt.Printf("SIG %v", <-signals)
-		os.Exit(0)
-
-	case "tester-nice":
-		prio, err := syscall.Getpriority(syscall.PRIO_PROCESS, 0)
-		if err != nil {
-			log.Fatalf("Getpriority: %v", err)
-		}
-		fmt.Printf("nice=%d", prio)
 		os.Exit(0)
 
 	case "tester-pgid":

--- a/internal/process/nice_test.go
+++ b/internal/process/nice_test.go
@@ -48,7 +48,9 @@ func TestProcessNiceValue(t *testing.T) {
 	if _, err := stdinW.Write([]byte("g")); err != nil {
 		t.Fatalf("writing start signal: %v", err)
 	}
-	stdinW.Close()
+	if err := stdinW.Close(); err != nil {
+		t.Fatalf("closing stdin pipe: %v", err)
+	}
 
 	if err := <-errCh; err != nil {
 		t.Fatalf("p.Run(ctx) = %v", err)

--- a/internal/process/nice_test.go
+++ b/internal/process/nice_test.go
@@ -5,6 +5,7 @@ package process_test
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -17,18 +18,39 @@ func TestProcessNiceValue(t *testing.T) {
 	t.Parallel()
 
 	stdout := &bytes.Buffer{}
+	stdinR, stdinW := io.Pipe()
+	started := make(chan struct{})
 
 	p := process.New(logger.Discard, process.Config{
-		Path:   os.Args[0],
-		Env:    []string{"TEST_MAIN=tester-nice"},
-		Stdout: stdout,
-		Nice:   5,
+		Path:    os.Args[0],
+		Env:     []string{"TEST_MAIN=tester-nice"},
+		Stdout:  stdout,
+		Stdin:   stdinR,
+		Nice:    5,
+		Started: started,
 	})
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
-	if err := p.Run(ctx); err != nil {
+	// Run the process in the background.
+	errCh := make(chan error, 1)
+	go func() { errCh <- p.Run(ctx) }()
+
+	// Wait for the process to start (postStart has applied Setpriority).
+	select {
+	case <-started:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for process to start")
+	}
+
+	// Signal the child that it's safe to read its priority.
+	if _, err := stdinW.Write([]byte("g")); err != nil {
+		t.Fatalf("writing start signal: %v", err)
+	}
+	stdinW.Close()
+
+	if err := <-errCh; err != nil {
 		t.Fatalf("p.Run(ctx) = %v", err)
 	}
 

--- a/internal/process/nice_test.go
+++ b/internal/process/nice_test.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+package process_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent/v3/internal/process"
+	"github.com/buildkite/agent/v3/logger"
+)
+
+func TestProcessNiceValue(t *testing.T) {
+	t.Parallel()
+
+	stdout := &bytes.Buffer{}
+
+	p := process.New(logger.Discard, process.Config{
+		Path:   os.Args[0],
+		Env:    []string{"TEST_MAIN=tester-nice"},
+		Stdout: stdout,
+		Nice:   5,
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	if err := p.Run(ctx); err != nil {
+		t.Fatalf("p.Run(ctx) = %v", err)
+	}
+
+	// The child process reports its own nice value via syscall.Getpriority.
+	if got, want := stdout.String(), "nice=5"; got != want {
+		t.Errorf("child process reported %q, want %q", got, want)
+	}
+}

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -88,6 +88,7 @@ type Config struct {
 	Stdout            io.Writer
 	Stderr            io.Writer
 	Dir               string
+	Nice              int // Unix nice value for the child process (0 = default)
 	InterruptSignal   Signal
 	SignalGracePeriod time.Duration
 	Started           chan struct{}

--- a/internal/process/signal_notwindows.go
+++ b/internal/process/signal_notwindows.go
@@ -27,7 +27,12 @@ func (p *Process) setupProcessGroup() {
 }
 
 func (p *Process) postStart() error {
-	// a no-op on non-windows
+	if p.conf.Nice != 0 {
+		p.logger.Debugf("[Process] Setting nice value %d on PID %d", p.conf.Nice, p.pid())
+		if err := syscall.Setpriority(syscall.PRIO_PROCESS, p.pid(), p.conf.Nice); err != nil {
+			p.logger.Warnf("[Process] Failed to set nice value %d on PID %d: %v", p.conf.Nice, p.pid(), err)
+		}
+	}
 	return nil
 }
 

--- a/internal/process/signal_notwindows.go
+++ b/internal/process/signal_notwindows.go
@@ -28,9 +28,9 @@ func (p *Process) setupProcessGroup() {
 
 func (p *Process) postStart() error {
 	if p.conf.Nice != 0 {
-		p.logger.Debugf("[Process] Setting nice value %d on PID %d", p.conf.Nice, p.pid())
-		if err := syscall.Setpriority(syscall.PRIO_PROCESS, p.pid(), p.conf.Nice); err != nil {
-			p.logger.Warnf("[Process] Failed to set nice value %d on PID %d: %v", p.conf.Nice, p.pid(), err)
+		p.logger.Debugf("[Process] Setting nice value %d on PGID %d", p.conf.Nice, p.pid())
+		if err := syscall.Setpriority(syscall.PRIO_PGRP, p.pid(), p.conf.Nice); err != nil {
+			p.logger.Warnf("[Process] Failed to set nice value %d on PGID %d: %v", p.conf.Nice, p.pid(), err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Description

When a CPU-intensive command consumes all available CPU within a K8s command container, it can starve the kubernetes-bootstrap process of scheduler cycles. The StatusLoop goroutine can't complete its once-per-second RPC call to the Runner, LastHeardFrom exceeds the 30-second ClientLostTimeout, and the Runner marks the client as StateLost. The customer sees "container stopped communicating without exiting normally" even though nothing was OOM-killed.

To address this, we launch the `buildkite-agent bootstrap` process at `nice 5` so that the root process has priority on the CPU. That should help prevent a heavy command workload from starving out the status check and causing the agent to be "lost."

## Context

SUP-7567

## Changes

As above.

## Testing
- [X] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [X] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

I used Claude to plan, implement, and test the change.