### PR TITLE
A-1533: harden cache target path validation and extraction

### DIFF
--- a/internal/cache/archive/archive.go
+++ b/internal/cache/archive/archive.go
@@ -3,12 +3,8 @@ package archive
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"hash"
 	"io"
-	"os"
-	"path/filepath"
-	"strings"
 	"time"
 )
 
@@ -25,35 +21,6 @@ type ArchiveInfo struct {
 	WrittenBytes   int64
 	WrittenEntries int64
 	Duration       time.Duration
-}
-
-// isUnderHome checks if the given path is under the user's home directory.
-// It first gets the absolute path of the given path, then gets the user's
-// home directory, and finally checks if the absolute path starts with the
-// home directory path.
-func isUnderHome(path string) (bool, error) {
-	if path == "" {
-		return false, fmt.Errorf("path is empty")
-	}
-
-	// Get absolute path
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return false, fmt.Errorf("failed to get absolute path: %w", err)
-	}
-
-	// Get user's home directory
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return false, fmt.Errorf("failed to get home directory: %w", err)
-	}
-
-	// Clean both paths to normalize them
-	cleanPath := filepath.Clean(absPath)
-	cleanHome := filepath.Clean(homeDir)
-
-	// Check if the path starts with home directory
-	return strings.HasPrefix(cleanPath, cleanHome), nil
 }
 
 type ChecksumSHA256 struct {

--- a/internal/cache/archive/archive_test.go
+++ b/internal/cache/archive/archive_test.go
@@ -3,69 +3,8 @@ package archive
 import (
 	"bytes"
 	"crypto/sha256"
-	"os"
-	"path/filepath"
 	"testing"
 )
-
-func TestIsUnderHome(t *testing.T) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatalf("failed to get home directory: %v", err)
-	}
-
-	tests := []struct {
-		name     string
-		path     string
-		expected bool
-		wantErr  bool
-	}{
-		{
-			name:     "path under home directory",
-			path:     filepath.Join(homeDir, "documents"),
-			expected: true,
-			wantErr:  false,
-		},
-		{
-			name:     "path not under home directory",
-			path:     "/tmp/test",
-			expected: false,
-			wantErr:  false,
-		},
-		// TODO: investigate how we can override the home directory for testing
-		// {
-		// 	name:     "relative path under home",
-		// 	path:     "~/documents",
-		// 	expected: true,
-		// 	wantErr:  false,
-		// },
-		{
-			name:     "empty path",
-			path:     "",
-			expected: false,
-			wantErr:  true,
-		},
-		{
-			name:     "path with symlinks",
-			path:     filepath.Join(homeDir, "..", filepath.Base(homeDir)),
-			expected: true,
-			wantErr:  false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := isUnderHome(tt.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("isUnderHome() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if result != tt.expected {
-				t.Errorf("isUnderHome() = %v, want %v", result, tt.expected)
-			}
-		})
-	}
-}
 
 func TestChecksumSHA256_Sum(t *testing.T) {
 	tests := []struct {

--- a/internal/cache/archive/create.go
+++ b/internal/cache/archive/create.go
@@ -62,11 +62,6 @@ func BuildArchive(ctx context.Context, paths []string, key string) (*ArchiveInfo
 			return nil, fmt.Errorf("failed to stat file: %w", err)
 		}
 
-		_, err = isUnderHome(mapping.ResolvedPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed directory (%s) outside home directory: %w", mapping.ResolvedPath, err)
-		}
-
 		files := make(map[string]os.FileInfo)
 		err = filepath.Walk(mapping.ResolvedPath, func(filename string, fi os.FileInfo, err error) error {
 			files[filename] = fi

--- a/internal/cache/archive/extract.go
+++ b/internal/cache/archive/extract.go
@@ -36,6 +36,17 @@ func ListArchive(ctx context.Context, zipFile *os.File, zipFileLen int64) ([]str
 	return entries, nil
 }
 
+// entryMatchesMapping reports whether a zip entry belongs to a mapping,
+// matching on whole path components so that e.g. entry "cache2/file" does not
+// match the mapping for "cache". Zip entry names always use forward slashes
+// (per the zip spec), but relativePath comes from filepath.Rel or user
+// configuration and may use the OS native separator or contain "./" or
+// trailing-slash noise, so it is cleaned and normalised before comparison.
+func entryMatchesMapping(entryName, relativePath string) bool {
+	rel := filepath.ToSlash(filepath.Clean(relativePath))
+	return entryName == rel || strings.HasPrefix(entryName, rel+"/")
+}
+
 func ExtractFiles(ctx context.Context, zipFile *os.File, zipFileLen int64, paths []string) (*ArchiveInfo, error) {
 	_, span := trace.Start(ctx, "ExtractFiles")
 	defer span.End()
@@ -55,15 +66,22 @@ func ExtractFiles(ctx context.Context, zipFile *os.File, zipFileLen int64, paths
 	foundPaths := make(map[string]bool)
 
 	err = extract.ExtractWithPathMapper(ctx, func(file *zip.File) (string, error) {
-		// Zip entry names always use forward slashes (per the zip spec),
-		// but mapping.RelativePath comes from filepath.Rel and may use the
-		// OS native separator (backslash on Windows). Normalise the mapping
-		// to forward slashes for the comparison.
 		for _, mapping := range mappings {
-			if strings.HasPrefix(file.Name, filepath.ToSlash(mapping.RelativePath)) {
-				foundPaths[mapping.Path] = true
-				return filepath.Join(mapping.Chroot, file.Name), nil
+			if !entryMatchesMapping(file.Name, mapping.RelativePath) {
+				continue
 			}
+
+			// Entry names come from the archive and are untrusted: refuse
+			// entries whose cleaned destination (e.g. via "..") would land
+			// outside the mapping's target path.
+			destination := filepath.Join(mapping.Chroot, filepath.FromSlash(file.Name))
+			target := filepath.Join(mapping.Chroot, mapping.RelativePath)
+			if !IsUnder(destination, target) {
+				return "", fmt.Errorf("archive entry %q escapes target path %q", file.Name, mapping.Path)
+			}
+
+			foundPaths[mapping.Path] = true
+			return destination, nil
 		}
 
 		return "", fmt.Errorf("failed to find path mapping for: %s", file.Name)

--- a/internal/cache/archive/extract_test.go
+++ b/internal/cache/archive/extract_test.go
@@ -1,0 +1,119 @@
+package archive
+
+import (
+	stdzip "archive/zip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/agent/v3/internal/cache/internal/trace"
+)
+
+func TestEntryMatchesMapping(t *testing.T) {
+	tests := []struct {
+		name         string
+		entryName    string
+		relativePath string
+		want         bool
+	}{
+		{
+			name:         "entry under mapping",
+			entryName:    "cache/file.txt",
+			relativePath: "cache",
+			want:         true,
+		},
+		{
+			name:         "entry equals mapping (single-file target)",
+			entryName:    "cache",
+			relativePath: "cache",
+			want:         true,
+		},
+		{
+			name:         "sibling with shared name prefix does not match",
+			entryName:    "cache2/file.txt",
+			relativePath: "cache",
+			want:         false,
+		},
+		{
+			name:         "trailing slash in mapping",
+			entryName:    "cache/file.txt",
+			relativePath: "cache/",
+			want:         true,
+		},
+		{
+			name:         "dot-slash prefix in mapping",
+			entryName:    "cache/file.txt",
+			relativePath: "./cache",
+			want:         true,
+		},
+		{
+			name:         "nested mapping path",
+			entryName:    "go/pkg/mod/module.txt",
+			relativePath: filepath.Join("go", "pkg", "mod"),
+			want:         true,
+		},
+		{
+			name:         "unrelated entry",
+			entryName:    "other/file.txt",
+			relativePath: "cache",
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := entryMatchesMapping(tt.entryName, tt.relativePath); got != tt.want {
+				t.Errorf("entryMatchesMapping(%q, %q) = %v, want %v", tt.entryName, tt.relativePath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractFiles_RejectsEscapingEntries(t *testing.T) {
+	_, err := trace.NewProvider(t.Context(), "noop", "test", "0.0.1")
+	if err != nil {
+		t.Fatalf("trace.NewProvider: %v", err)
+	}
+
+	// Craft an archive whose entry matches the "cache" mapping prefix but
+	// traverses out of it.
+	zipPath := filepath.Join(t.TempDir(), "evil.zip")
+	f, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatalf("os.Create: %v", err)
+	}
+	zw := stdzip.NewWriter(f)
+	w, err := zw.Create("cache/../../escape.txt")
+	if err != nil {
+		t.Fatalf("zip Create: %v", err)
+	}
+	if _, err := w.Write([]byte("escaped")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip Close: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	zipFile, err := os.Open(zipPath)
+	if err != nil {
+		t.Fatalf("os.Open: %v", err)
+	}
+	defer func() { _ = zipFile.Close() }()
+
+	stat, err := zipFile.Stat()
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+
+	_, err = ExtractFiles(t.Context(), zipFile, stat.Size(), []string{"cache"})
+	if err == nil {
+		t.Fatal("ExtractFiles: expected error for escaping entry, got nil")
+	}
+	if !strings.Contains(err.Error(), "escapes target path") {
+		t.Errorf("error %q should contain %q", err.Error(), "escapes target path")
+	}
+}

--- a/internal/cache/archive/mappings.go
+++ b/internal/cache/archive/mappings.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -17,58 +18,105 @@ type Mapping struct {
 	Relative     bool
 }
 
-// PathsToMappings takes a slice of file paths and returns a slice of Mapping structs,
-// which contain information about the destination path, chroot path, and whether
-// the path is relative or not. It handles paths starting with "~/" by replacing
-// them with the user's home directory.
+// PathsToMappings takes a slice of file paths and returns a slice of Mapping
+// structs, which contain information about the destination path, chroot path,
+// and whether the path is relative or not.
+//
+// Paths are anchored as follows:
+//   - "~/..." and absolute paths under the home directory are stored
+//     home-relative (chroot is the home directory), so home caches stay
+//     portable across agents running as different users.
+//   - Other absolute paths are not supported.
+//   - Everything else is relative to the current working directory.
 func PathsToMappings(paths []string) ([]Mapping, error) {
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+
 	pathMappings := make([]Mapping, 0, len(paths))
-
 	for _, path := range paths {
-		mapping := Mapping{
-			Path:         path,
-			ResolvedPath: path,
-			RelativePath: path,
-			Relative:     true,
-		}
-
-		homedir, err := os.UserHomeDir()
+		mapping, err := pathToMapping(path, homedir)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get home directory: %w", err)
+			return nil, err
 		}
-
-		if strings.HasPrefix(path, "~/") {
-			mapping.ResolvedPath = filepath.Join(homedir, path[2:])
-			mapping.Relative = false
-
-			rel, err := filepath.Rel(homedir, mapping.ResolvedPath)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get relative path: %w", err)
-			}
-
-			mapping.RelativePath = rel
-		} else if filepath.IsAbs(path) && strings.HasPrefix(path, homedir) {
-			mapping.Relative = false
-
-			rel, err := filepath.Rel(homedir, path)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get relative path: %w", err)
-			}
-
-			mapping.RelativePath = rel
-		}
-
-		chroot, err := chrootPath(mapping.ResolvedPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get chroot path: %w", err)
-		}
-
-		mapping.Chroot = chroot
-
 		pathMappings = append(pathMappings, mapping)
 	}
 
 	return pathMappings, nil
+}
+
+func pathToMapping(path, homedir string) (Mapping, error) {
+	mapping := Mapping{
+		Path:         path,
+		ResolvedPath: path,
+		RelativePath: path,
+		Relative:     true,
+	}
+
+	switch {
+	case strings.HasPrefix(path, "~/"):
+		mapping.ResolvedPath = filepath.Join(homedir, path[2:])
+		if !IsUnder(mapping.ResolvedPath, homedir) {
+			return Mapping{}, fmt.Errorf("path escapes the home directory: %s", path)
+		}
+		mapping.Relative = false
+		mapping.Chroot = homedir
+
+		rel, err := filepath.Rel(homedir, mapping.ResolvedPath)
+		if err != nil {
+			return Mapping{}, fmt.Errorf("failed to get relative path: %w", err)
+		}
+		mapping.RelativePath = rel
+
+	case filepath.IsAbs(path) && IsUnder(path, homedir):
+		mapping.Relative = false
+		mapping.Chroot = homedir
+
+		rel, err := filepath.Rel(homedir, path)
+		if err != nil {
+			return Mapping{}, fmt.Errorf("failed to get relative path: %w", err)
+		}
+		mapping.RelativePath = rel
+
+	case filepath.IsAbs(path):
+		return Mapping{}, fmt.Errorf("absolute paths outside the home directory are not supported: %s", path)
+
+	default:
+		// On Windows, rooted ("\etc" or "/etc") and drive-relative
+		// ("C:cache") paths are not absolute, but they are not relative to
+		// the working directory either: their meaning depends on the
+		// process's current drive and directory state.
+		if runtime.GOOS == "windows" && (filepath.VolumeName(path) != "" || strings.HasPrefix(path, `\`) || strings.HasPrefix(path, "/")) {
+			return Mapping{}, fmt.Errorf("rooted and drive-relative paths are not supported on Windows: %s", path)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			return Mapping{}, fmt.Errorf("failed to get working directory: %w", err)
+		}
+
+		// Relative paths must stay within the working directory: the
+		// archiver cannot include files outside the chroot, so a
+		// parent-relative path like "../cache" could never be saved.
+		if !IsUnder(filepath.Join(cwd, path), cwd) {
+			return Mapping{}, fmt.Errorf("relative path escapes the working directory: %s", path)
+		}
+		mapping.Chroot = cwd
+	}
+
+	return mapping, nil
+}
+
+// IsUnder reports whether path is dir itself or a descendant of dir. Unlike a
+// plain prefix check, it does not treat a sibling like "/home/user2" as being
+// under "/home/user".
+func IsUnder(path, dir string) bool {
+	rel, err := filepath.Rel(dir, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
 }
 
 func ResolveHomeDir(path string) (string, error) {
@@ -80,13 +128,4 @@ func ResolveHomeDir(path string) (string, error) {
 		return filepath.Join(homedir, path[2:]), nil
 	}
 	return path, nil
-}
-
-func chrootPath(path string) (string, error) {
-	if filepath.IsAbs(path) {
-		return os.UserHomeDir()
-	}
-
-	// get the current working directory
-	return os.Getwd()
 }

--- a/internal/cache/archive/mappings_test.go
+++ b/internal/cache/archive/mappings_test.go
@@ -3,6 +3,8 @@ package archive
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -41,6 +43,84 @@ func TestPathsToMappings_AbsolutePathUnderHome(t *testing.T) {
 	}
 	if mappings[1].Relative {
 		t.Errorf("mappings[1].Relative = true, want false")
+	}
+}
+
+func TestPathsToMappings_AbsolutePathOutsideHomeRejected(t *testing.T) {
+	home := t.TempDir()
+	setHomeDir(t, home)
+
+	outside := filepath.Join(t.TempDir(), "opt", "cache")
+
+	_, err := PathsToMappings([]string{outside})
+	if err == nil {
+		t.Fatal("PathsToMappings: expected error for absolute path outside home, got nil")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("error %q should contain %q", err.Error(), "not supported")
+	}
+}
+
+func TestPathsToMappings_ParentRelativeRejected(t *testing.T) {
+	home := t.TempDir()
+	setHomeDir(t, home)
+
+	for _, path := range []string{"..", filepath.Join("..", "cache")} {
+		_, err := PathsToMappings([]string{path})
+		if err == nil {
+			t.Errorf("PathsToMappings(%q): expected error for parent-relative path, got nil", path)
+			continue
+		}
+		if !strings.Contains(err.Error(), "escapes the working directory") {
+			t.Errorf("error %q should contain %q", err.Error(), "escapes the working directory")
+		}
+	}
+}
+
+func TestPathsToMappings_HomeEscapeRejected(t *testing.T) {
+	home := t.TempDir()
+	setHomeDir(t, home)
+
+	_, err := PathsToMappings([]string{"~/../shared/cache"})
+	if err == nil {
+		t.Fatal("PathsToMappings: expected error for path escaping home, got nil")
+	}
+	if !strings.Contains(err.Error(), "escapes the home directory") {
+		t.Errorf("error %q should contain %q", err.Error(), "escapes the home directory")
+	}
+}
+
+func TestPathsToMappings_RootedPathsOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("only relevant on Windows")
+	}
+
+	home := t.TempDir()
+	setHomeDir(t, home)
+
+	for _, path := range []string{`\etc`, "/etc", "C:cache"} {
+		_, err := PathsToMappings([]string{path})
+		if err == nil {
+			t.Errorf("PathsToMappings(%q): expected error for rooted path on Windows, got nil", path)
+		}
+	}
+}
+
+func TestPathsToMappings_SiblingOfHomeIsNotHomeRelative(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "user")
+	setHomeDir(t, home)
+
+	// A sibling directory sharing the home path as a string prefix must not
+	// be treated as home-relative: it is outside home and must be rejected.
+	sibling := filepath.Join(base, "user2", "cache")
+
+	_, err := PathsToMappings([]string{sibling})
+	if err == nil {
+		t.Fatal("PathsToMappings: expected error for sibling of home, got nil")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("error %q should contain %q", err.Error(), "not supported")
 	}
 }
 

--- a/internal/cache/paths.go
+++ b/internal/cache/paths.go
@@ -1,0 +1,191 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/buildkite/agent/v3/internal/cache/archive"
+)
+
+// checkPathsExist validates that all paths exist on the filesystem
+func checkPathsExist(paths []string) error {
+	if len(paths) == 0 {
+		return fmt.Errorf("no paths provided")
+	}
+
+	for _, path := range paths {
+		resolved, err := archive.ResolveHomeDir(path)
+		if err != nil {
+			return fmt.Errorf("failed to resolve home dir for %q: %w", path, err)
+		}
+
+		if _, err := os.Stat(resolved); os.IsNotExist(err) {
+			return fmt.Errorf("path does not exist: %s", path)
+		}
+	}
+
+	return nil
+}
+
+// validateTargetPaths checks that every target path is supported by the
+// archive mapping rules and would be accepted by cleanPath. Save and Restore
+// both run it at their validating stage: Save so it never creates an entry
+// that could not be restored, Restore so an invalid path fails the whole
+// operation before anything is destructively cleaned.
+func validateTargetPaths(paths []string) error {
+	if _, err := archive.PathsToMappings(paths); err != nil {
+		return err
+	}
+
+	for _, path := range paths {
+		extractedPath, err := archive.ResolveHomeDir(path)
+		if err != nil {
+			return fmt.Errorf("failed to resolve home dir for %q: %w", path, err)
+		}
+		if _, err := validateCleanPath(extractedPath); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateCleanPath checks that dir is safe to remove and returns its cleaned
+// form. It refuses paths whose removal could be catastrophic: the filesystem
+// root, drive roots, the home directory, top-level directories such as /etc,
+// and relative paths escaping the working directory.
+func validateCleanPath(dir string) (string, error) {
+	if dir == "" {
+		return "", fmt.Errorf("cleanPath: empty directory path")
+	}
+
+	clean := filepath.Clean(dir)
+
+	// Refuse to delete root or current directory
+	if clean == "." || clean == string(os.PathSeparator) {
+		return "", fmt.Errorf("cleanPath: refusing to remove %q", clean)
+	}
+
+	// On Windows, also check for drive roots like "C:\"
+	if runtime.GOOS == "windows" && len(clean) == 3 && clean[1] == ':' && clean[2] == '\\' {
+		return "", fmt.Errorf("cleanPath: refusing to remove drive root %q", clean)
+	}
+
+	// Refuse to delete home directory
+	if home, err := os.UserHomeDir(); err == nil {
+		if clean == filepath.Clean(home) {
+			return "", fmt.Errorf("cleanPath: refusing to remove home directory %q", clean)
+		}
+	}
+
+	// Absolute paths may point anywhere on the filesystem, so refuse to
+	// delete top-level directories such as /etc or /usr: require absolute
+	// paths to be at least two components deep.
+	if filepath.IsAbs(clean) {
+		root := filepath.VolumeName(clean) + string(os.PathSeparator)
+		rel, err := filepath.Rel(root, clean)
+		if err != nil || !strings.Contains(rel, string(os.PathSeparator)) {
+			return "", fmt.Errorf("cleanPath: refusing to remove top-level path %q", clean)
+		}
+	}
+
+	// On Windows a rooted path like "\etc" or a drive-relative path like
+	// "C:cache" is not absolute, but not relative to the working directory
+	// either; refuse it.
+	if runtime.GOOS == "windows" && !filepath.IsAbs(clean) && (filepath.VolumeName(clean) != "" || strings.HasPrefix(clean, string(os.PathSeparator))) {
+		return "", fmt.Errorf("cleanPath: refusing to remove rooted path %q", clean)
+	}
+
+	// Refuse to delete the working directory or any of its ancestors
+	// (e.g. ".." or an absolute path containing the working directory),
+	// which would delete the working directory itself.
+	abs, err := filepath.Abs(clean)
+	if err != nil {
+		return "", fmt.Errorf("cleanPath: failed to resolve %q: %w", clean, err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("cleanPath: failed to get working directory: %w", err)
+	}
+	if archive.IsUnder(cwd, abs) {
+		return "", fmt.Errorf("cleanPath: refusing to remove the working directory or an ancestor of it: %q", clean)
+	}
+
+	return clean, nil
+}
+
+// cleanPath removes a directory tree for a configured cache path.
+// It handles Go module cache directories that have 0555 permissions by
+// making them writable before removal.
+func cleanPath(ctx context.Context, dir string) error {
+	clean, err := validateCleanPath(dir)
+	if err != nil {
+		return err
+	}
+
+	// Module cache has 0555 directories; make them writable in order to remove content.
+	if err := makeTreeWritable(ctx, clean); err != nil {
+		return err
+	}
+
+	// Check context again before potentially long RemoveAll
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	if err := os.RemoveAll(clean); err != nil {
+		return fmt.Errorf("cleanPath: failed to remove %q: %w", clean, err)
+	}
+
+	return nil
+}
+
+// makeTreeWritable walks `clean` and chmods every directory to 0755 so that
+// the subsequent os.RemoveAll can delete read-only entries (e.g. Go module
+// cache). The os.Root handle is closed before returning so that the caller
+// can remove `clean` on platforms (Windows) that disallow removing a
+// directory with an open handle.
+func makeTreeWritable(ctx context.Context, clean string) error {
+	root, err := os.OpenRoot(clean)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("cleanPath: open root %q: %w", clean, err)
+	}
+	defer func() { _ = root.Close() }()
+
+	err = fs.WalkDir(root.FS(), ".", func(relPath string, info fs.DirEntry, walkErr error) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if walkErr != nil {
+			slog.Debug("cleanPath: error walking path", "path", relPath, "err", walkErr)
+			return nil
+		}
+
+		if info.IsDir() {
+			if chmodErr := root.Chmod(relPath, 0o755); chmodErr != nil {
+				return fmt.Errorf("chmod %q: %w", relPath, chmodErr)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		return fmt.Errorf("cleanPath: error preparing %q for removal: %w", clean, err)
+	}
+	return nil
+}

--- a/internal/cache/paths_test.go
+++ b/internal/cache/paths_test.go
@@ -61,6 +61,44 @@ func TestCleanPath(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects top-level absolute paths", func(t *testing.T) {
+		paths := []string{"/etc", "/usr", "/opt"}
+		if runtime.GOOS == "windows" {
+			paths = []string{`C:\Windows`, `D:\data`}
+		}
+		for _, path := range paths {
+			err := cleanPath(t.Context(), path)
+			if err == nil {
+				t.Fatalf("cleanPath(%q): expected error, got nil", path)
+			}
+			if !strings.Contains(err.Error(), "refusing to remove top-level path") {
+				t.Errorf("error %q should contain %q", err.Error(), "refusing to remove top-level path")
+			}
+		}
+	})
+
+	t.Run("rejects working directory and its ancestors", func(t *testing.T) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Getwd: %v", err)
+		}
+		for _, path := range []string{"..", filepath.Join("..", ".."), cwd, filepath.Dir(cwd)} {
+			_, err := validateCleanPath(path)
+			if err == nil {
+				t.Fatalf("validateCleanPath(%q): expected error, got nil", path)
+			}
+			if !strings.Contains(err.Error(), "refusing to remove") {
+				t.Errorf("error %q should contain %q", err.Error(), "refusing to remove")
+			}
+		}
+	})
+
+	t.Run("accepts sibling paths (only ancestors are refused)", func(t *testing.T) {
+		if _, err := validateCleanPath(filepath.Join("..", "sibling-cache")); err != nil {
+			t.Fatalf("validateCleanPath: %v", err)
+		}
+	})
+
 	t.Run("succeeds on non-existent path", func(t *testing.T) {
 		if err := cleanPath(t.Context(), "/nonexistent/path/that/does/not/exist"); err != nil {
 			t.Fatalf("cleanPath: %v", err)
@@ -128,6 +166,56 @@ func TestCleanPath(t *testing.T) {
 		}
 		if !errors.Is(err, context.Canceled) {
 			t.Errorf("expected context.Canceled, got %v", err)
+		}
+	})
+}
+
+func TestValidateTargetPaths(t *testing.T) {
+	t.Run("fails when any target path is unsafe to clean", func(t *testing.T) {
+		err := validateTargetPaths([]string{filepath.Join("some", "dir"), "."})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "refusing to remove") {
+			t.Errorf("error %q should contain %q", err.Error(), "refusing to remove")
+		}
+	})
+
+	t.Run("fails for top-level absolute paths", func(t *testing.T) {
+		path := "/etc"
+		if runtime.GOOS == "windows" {
+			path = `C:\Windows`
+		}
+		err := validateTargetPaths([]string{path})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("fails for absolute paths outside the home directory", func(t *testing.T) {
+		err := validateTargetPaths([]string{filepath.Join(t.TempDir(), "opt", "cache")})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "not supported") {
+			t.Errorf("error %q should contain %q", err.Error(), "not supported")
+		}
+	})
+
+	t.Run("fails for parent-relative paths", func(t *testing.T) {
+		err := validateTargetPaths([]string{filepath.Join("..", "outside")})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "escapes the working directory") {
+			t.Errorf("error %q should contain %q", err.Error(), "escapes the working directory")
+		}
+	})
+
+	t.Run("accepts safe paths", func(t *testing.T) {
+		paths := []string{filepath.Join("some", "dir"), "~/cache"}
+		if err := validateTargetPaths(paths); err != nil {
+			t.Fatalf("validateTargetPaths(%v): %v", paths, err)
 		}
 	})
 }

--- a/internal/cache/restore.go
+++ b/internal/cache/restore.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/buildkite/agent/v3/api"
@@ -100,6 +98,16 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 	)
 
 	c.callProgress(cacheID, "validating", "Validating cache configuration", 0, 0)
+
+	// Validate every target path before doing any work: unsupported paths
+	// (e.g. absolute paths outside the home directory on Windows) and paths
+	// that the destructive clean step would refuse must fail up front, so no
+	// path is removed when a later one is invalid.
+	if err := validateTargetPaths(cacheConfig.TargetPaths); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "invalid target paths")
+		return result, fmt.Errorf("invalid target paths: %w", err)
+	}
 
 	c.callProgress(cacheID, "checking_exists", "Checking if cache exists", 0, 0)
 
@@ -403,91 +411,4 @@ func (c *client) extractCache(ctx context.Context, archiveFile string, archiveSi
 	span.SetStatus(codes.Ok, "extraction completed")
 
 	return archiveInfo, nil
-}
-
-// cleanPath removes a directory tree for a configured cache path.
-// It handles Go module cache directories that have 0555 permissions by
-// making them writable before removal.
-func cleanPath(ctx context.Context, dir string) error {
-	if dir == "" {
-		return fmt.Errorf("cleanPath: empty directory path")
-	}
-
-	clean := filepath.Clean(dir)
-
-	// Refuse to delete root or current directory
-	if clean == "." || clean == string(os.PathSeparator) {
-		return fmt.Errorf("cleanPath: refusing to remove %q", clean)
-	}
-
-	// On Windows, also check for drive roots like "C:\"
-	if runtime.GOOS == "windows" && len(clean) == 3 && clean[1] == ':' && clean[2] == '\\' {
-		return fmt.Errorf("cleanPath: refusing to remove drive root %q", clean)
-	}
-
-	// Refuse to delete home directory
-	if home, err := os.UserHomeDir(); err == nil {
-		if clean == filepath.Clean(home) {
-			return fmt.Errorf("cleanPath: refusing to remove home directory %q", clean)
-		}
-	}
-
-	// Module cache has 0555 directories; make them writable in order to remove content.
-	if err := makeTreeWritable(ctx, clean); err != nil {
-		return err
-	}
-
-	// Check context again before potentially long RemoveAll
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
-
-	if err := os.RemoveAll(clean); err != nil {
-		return fmt.Errorf("cleanPath: failed to remove %q: %w", clean, err)
-	}
-
-	return nil
-}
-
-// makeTreeWritable walks `clean` and chmods every directory to 0755 so that
-// the subsequent os.RemoveAll can delete read-only entries (e.g. Go module
-// cache). The os.Root handle is closed before returning so that the caller
-// can remove `clean` on platforms (Windows) that disallow removing a
-// directory with an open handle.
-func makeTreeWritable(ctx context.Context, clean string) error {
-	root, err := os.OpenRoot(clean)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil
-		}
-		return fmt.Errorf("cleanPath: open root %q: %w", clean, err)
-	}
-	defer func() { _ = root.Close() }()
-
-	err = fs.WalkDir(root.FS(), ".", func(relPath string, info fs.DirEntry, walkErr error) error {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		if walkErr != nil {
-			slog.Debug("cleanPath: error walking path", "path", relPath, "err", walkErr)
-			return nil
-		}
-
-		if info.IsDir() {
-			if chmodErr := root.Chmod(relPath, 0o755); chmodErr != nil {
-				return fmt.Errorf("chmod %q: %w", relPath, chmodErr)
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return err
-		}
-		return fmt.Errorf("cleanPath: error preparing %q for removal: %w", clean, err)
-	}
-	return nil
 }

--- a/internal/cache/save.go
+++ b/internal/cache/save.go
@@ -102,6 +102,17 @@ func (c *client) Save(ctx context.Context, cacheID string) (SaveResult, error) {
 		return result, fmt.Errorf("invalid cache paths: %w", err)
 	}
 
+	// Validate that all target paths are supported by the archive mapping
+	// rules and restorable (restore refuses to clean paths like "." or the
+	// home directory), so unsupported paths fail here rather than surfacing
+	// as an archive error, being masked by an already-existing cache entry,
+	// or producing entries that can never be restored.
+	if err := validateTargetPaths(cacheConfig.TargetPaths); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "invalid cache paths")
+		return result, fmt.Errorf("invalid cache paths: %w", err)
+	}
+
 	c.callProgress(cacheID, "checking_exists", "Checking if cache already exists", 0, 0)
 
 	// Check if cache already exists
@@ -354,31 +365,6 @@ func (c *client) Save(ctx context.Context, cacheID string) (SaveResult, error) {
 	c.callProgress(cacheID, "complete", "Cache saved successfully", 0, 0)
 
 	return result, nil
-}
-
-// checkPathsExist validates that all paths exist on the filesystem
-func checkPathsExist(paths []string) error {
-	if len(paths) == 0 {
-		return fmt.Errorf("no paths provided")
-	}
-
-	for _, path := range paths {
-		// Handle ~ expansion
-		if len(path) > 0 && path[0] == '~' {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return fmt.Errorf("failed to get home directory: %w", err)
-			}
-			path = homeDir + path[1:]
-		}
-
-		// Check if the path exists
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			return fmt.Errorf("path does not exist: %s", path)
-		}
-	}
-
-	return nil
 }
 
 // validateCacheStore validates the cache store configuration


### PR DESCRIPTION
Part of A-1533 (multi-PR change).

Safety hardening for cache save/restore path handling. No behavior change for supported paths (`~/...`, absolute under `$HOME`, CWD-relative); unsupported or unsafe forms now fail early with clear errors instead of failing late or behaving unsafely.

- Reject absolute paths outside `$HOME` at mapping time (previously failed late in `BuildArchive`), `~/../` escapes, parent-relative paths escaping CWD, and Windows rooted/drive-relative paths
- Fix home-prefix matching so a sibling like `/home/user2` is not treated as under `/home/user`
- Harden extraction: whole-component entry matching (entry `cache2/x` no longer matches target `cache`) and zip-slip containment checks for untrusted archive entries
- Validate all target paths in Save and Restore before any download or destructive cleanup
- Cleanup refuses filesystem roots, `$HOME`, top-level dirs, and CWD or its ancestors
- Path validation/cleanup moved into `internal/cache/paths.go`

Support for absolute `target_paths` outside `$HOME` will land in a follow-up PR, implemented via an archive manifest format change.