### PR TITLE
Fix unknown Kubernetes container exit statuses

### DIFF
--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -52,6 +52,10 @@ func TestOrderedClients(t *testing.T) {
 	default:
 		t.Fatalf("runner should be done when all clients have exited")
 	}
+
+	if got, want := runner.WaitStatus().ExitStatus(), 0; got != want {
+		t.Errorf("runner.WaitStatus().ExitStatus() = %d, want %d", got, want)
+	}
 }
 
 func TestLivenessCheck(t *testing.T) {
@@ -160,6 +164,42 @@ func TestWaitStatusNonZero(t *testing.T) {
 	}
 }
 
+func TestWaitStatusUnknown(t *testing.T) {
+	runner := newRunner(t, 2)
+
+	client0 := &Client{ID: 0, SocketPath: runner.conf.SocketPath}
+	client1 := &Client{ID: 1, SocketPath: runner.conf.SocketPath}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	for _, client := range []*Client{client0, client1} {
+		if err := connect(ctx, client); err != nil {
+			t.Errorf("connect(ctx, client) error = %v", err)
+		}
+		t.Cleanup(client.Close)
+	}
+
+	if err := client0.Exit(0); err != nil {
+		t.Errorf("client0.Exit(0) error = %v", err)
+	}
+	if err := runner.Terminate(); err != nil {
+		t.Errorf("runner.Terminate() error = %v", err)
+	}
+
+	if got, want := runner.WaitStatus().ExitStatus(), unknownContainerExitStatus; got != want {
+		t.Errorf("runner.WaitStatus().ExitStatus() = %d, want %d", got, want)
+	}
+}
+
+func TestWaitStatusUnknownState(t *testing.T) {
+	runner := &Runner{clients: []*clientResult{{State: ClientState(99)}}}
+
+	if got, want := runner.WaitStatus().ExitStatus(), unknownContainerExitStatus; got != want {
+		t.Errorf("runner.WaitStatus().ExitStatus() = %d, want %d", got, want)
+	}
+}
+
 func TestInterruptBeforeStart(t *testing.T) {
 	runner := newRunner(t, 2)
 	ctx, cancel := context.WithCancel(t.Context())
@@ -236,7 +276,7 @@ func TestInterruptAfterStart(t *testing.T) {
 }
 
 func TestTerminateAfterStart(t *testing.T) {
-	runner := newRunner(t, 2)
+	runner := newRunner(t, 1)
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 	client0 := &Client{ID: 0, SocketPath: runner.conf.SocketPath}
@@ -265,6 +305,10 @@ func TestTerminateAfterStart(t *testing.T) {
 	}
 
 	<-terminated
+
+	if got, want := runner.WaitStatus().ExitStatus(), unknownContainerExitStatus; got != want {
+		t.Errorf("runner.WaitStatus().ExitStatus() = %d, want %d", got, want)
+	}
 }
 
 func newRunner(t *testing.T, clientCount int) *Runner {

--- a/kubernetes/runner.go
+++ b/kubernetes/runner.go
@@ -23,7 +23,10 @@ func init() {
 	gob.Register(new(syscall.WaitStatus))
 }
 
-const defaultSocketPath = "/workspace/buildkite.sock"
+const (
+	defaultSocketPath          = "/workspace/buildkite.sock"
+	unknownContainerExitStatus = 137
+)
 
 type RunnerConfig struct {
 	SocketPath         string
@@ -227,16 +230,22 @@ func (r *Runner) WaitStatus() process.WaitStatus {
 		exitStatus, state := client.ExitStatus, client.State
 		client.mu.Unlock()
 
-		if exitStatus != 0 {
-			return waitStatus{Code: exitStatus}
-		}
-
-		// use an unusual status code to distinguish unusual states
 		switch state {
+		case StateExited:
+			if exitStatus != 0 {
+				return waitStatus{Code: exitStatus}
+			}
 		case StateLost:
 			return waitStatus{Code: -7}
 		case StateNotYetConnected:
 			return waitStatus{Code: -10}
+		default:
+			// During agent shutdown, a long-running post-command hook can outlast
+			// the signal grace period. The runner then stops before the connected
+			// client reports its terminal status. Match Kubernetes' synthetic exit
+			// status rather than treating the zero-value exit status as success.
+			// Any future client state is also unknown by default.
+			return waitStatus{Code: unknownContainerExitStatus}
 		}
 	}
 	return waitStatus{}


### PR DESCRIPTION
## Description

Fix a race during Kubernetes job shutdown where the runner can terminate before the command container sends its `Exit` RPC. In that case, the container remains connected but its zero-value exit status was reported to Buildkite as a genuine success.

The runner now returns a synthetic exit status of `137` when the container's terminal status is unavailable.

This follows Kubernetes' convention for previously running containers that can no longer be located:

- [Kubelet synthesising exit code 137](https://github.com/kubernetes/kubernetes/blob/faba7e6a94df833524a619874172cd77fdeaf760/pkg/kubelet/kubelet_pods.go#L2393-L2403)
- [`ContainerStatusUnknown` definition](https://github.com/kubernetes/kubernetes/blob/faba7e6a94df833524a619874172cd77fdeaf760/pkg/kubelet/container/runtime.go#L307-L308)

Explicitly reported exit statuses, including exit `0`, remain unchanged.

## Context
- https://buildkite.com/jamie-21-july-2026/buildkite-testing/builds/7/summary shows a sample passing build, that should have failed

## Changes

- Return synthetic exit status `137` when a connected Kubernetes client never reports its terminal status.
- Preserve explicit successful and non-zero exit statuses.
- Add single- and multi-container regression coverage.

## Testing

- [x] Full test suite passed locally: 2,706 tests passed, 10 skipped.
- [x] Kubernetes package tests passed.
- [x] `golangci-lint run` passed with zero issues.
- [x] Code is formatted with `gofumpt`.
- [x] https://buildkite.com/jamie-21-july-2026/buildkite-testing/builds/10/summary

## Deployment / Rollback

No configuration or migration is required. This ships with the agent binary and can be rolled back by reverting this change.

## Disclosures / Credits

OpenAI Codex investigated the failure mode, implemented the change and regression tests, and ran verification under Jamie Monserrate's direction.
