### PR TITLE
Pipeline upload: look for secrets within trigger step build.env

### DIFF
--- a/clicommand/pipeline_upload.go
+++ b/clicommand/pipeline_upload.go
@@ -491,6 +491,22 @@ func allEnvVars(o any, f func(p env.Pair)) {
 		for _, s := range x.Steps {
 			allEnvVars(s, f)
 		}
+
+	case *pipeline.TriggerStep:
+		// Include build.env within the trigger step
+		build, _ := x.Contents["build"].(*ordered.MapSA)
+		if build == nil {
+			break
+		}
+		envAny, _ := build.Get("env")
+		if envAny == nil {
+			break
+		}
+		buildEnv, _ := envAny.(*ordered.MapSA)
+		buildEnv.Range(func(k string, v any) error { //nolint:errcheck // No error from Range because its callback never returns an error
+			f(env.Pair{Name: k, Value: fmt.Sprint(v)})
+			return nil
+		})
 	}
 }
 

--- a/clicommand/pipeline_upload_test.go
+++ b/clicommand/pipeline_upload_test.go
@@ -87,6 +87,27 @@ func TestSearchForSecrets(t *testing.T) {
 			wantLog: `pipeline "cat-o-matic.yaml" contains values interpolated from the following secret environment variables: [SEKRET], and cannot be uploaded to Buildkite`,
 		},
 		{
+			desc:    "one step env secret within a trigger",
+			environ: nil,
+			pipeline: &pipeline.Pipeline{
+				Steps: pipeline.Steps{
+					&pipeline.TriggerStep{
+						Contents: map[string]any{
+							"build": ordered.MapFromItems(
+								ordered.TupleSA{
+									Key: "env", Value: ordered.MapFromItems(
+										ordered.TupleSA{Key: "SEKRET", Value: "squirrels"},
+										ordered.TupleSA{Key: "UNRELATED", Value: "horses"},
+									),
+								},
+							),
+						},
+					},
+				},
+			},
+			wantLog: `pipeline "cat-o-matic.yaml" contains values interpolated from the following secret environment variables: [SEKRET], and cannot be uploaded to Buildkite`,
+		},
+		{
 			desc:    "one pipeline env secret",
 			environ: nil,
 			pipeline: &pipeline.Pipeline{


### PR DESCRIPTION
## Description

Trigger steps can contain env blocks too: under `build`. In pipeline upload, include these in the secret search.

## Context

Buildsworth outputted some tokens upon the v4 branch: https://github.com/buildkite/agent/pull/3807#discussion_r3568389182


## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

I happen to know how this works.