### PR TITLE
Honour cone mode on git older than 2.35

### DIFF
--- a/internal/job/checkout_sparse.go
+++ b/internal/job/checkout_sparse.go
@@ -208,7 +208,10 @@ func (e *Executor) setupSparseCheckout(ctx context.Context, sc sparseCheckout) (
 	args := []string{"sparse-checkout", "set"}
 	if sc.modeFlagSupported {
 		args = append(args, "--"+sc.mode.String())
-	} else if err := e.pinSparseCheckoutMode(ctx, sc); err != nil {
+	} else if err := e.pinConeMode(ctx); err != nil {
+		// Old git has no --cone on `set`. resolveSparseCheckout already rejects
+		// no-cone below minGitSparseCheckoutMode, so the only live path here is
+		// cone — pin it through config before `set` runs without a mode flag.
 		return false, err
 	}
 	// `--` keeps git from parsing a path as an option: paths can come from the
@@ -223,25 +226,18 @@ func (e *Executor) setupSparseCheckout(ctx context.Context, sc sparseCheckout) (
 	return true, nil
 }
 
-// pinSparseCheckoutMode makes the requested mode take effect on git versions
-// whose `sparse-checkout set` has no --cone/--no-cone option, by writing the
-// config git consults instead. `sparse-checkout init` has accepted --cone since
-// git 2.25, comfortably below minGitSparseCheckout.
+// pinConeMode writes core.sparseCheckoutCone=true on git versions whose
+// `sparse-checkout set` has no --cone/--no-cone option. `sparse-checkout init`
+// has accepted --cone since git 2.25, comfortably below minGitSparseCheckout.
 //
 // Without this, the interpretation comes from whatever core.sparseCheckoutCone
 // the repository already has — and `git clone --sparse` on these versions runs
 // `sparse-checkout init` with no --cone, so a cone-mode request quietly gets
 // non-cone pattern matching: paths match a directory of that name at any depth,
 // and top-level files are left out of the working tree.
-func (e *Executor) pinSparseCheckoutMode(ctx context.Context, sc sparseCheckout) error {
-	// Only cone mode reaches here: resolveSparseCheckout falls back to a full
-	// checkout when no-cone is requested on a git this old.
-	if sc.noCone() {
-		return nil
-	}
-
+func (e *Executor) pinConeMode(ctx context.Context) error {
 	e.shell.Commentf("Enabling cone mode via config: this git is older than %s and takes no mode option", minGitSparseCheckoutMode)
-	if err := e.shell.Command("git", "sparse-checkout", "init", "--cone").Run(ctx); err != nil {
+	if err := e.shell.Command("git", "sparse-checkout", "init", "--"+SparseCheckoutModeCone.String()).Run(ctx); err != nil {
 		return fmt.Errorf("enabling sparse checkout cone mode: %w", err)
 	}
 	return nil

--- a/internal/job/checkout_sparse.go
+++ b/internal/job/checkout_sparse.go
@@ -65,13 +65,11 @@ type sparseCheckout struct {
 	paths []string
 	mode  SparseCheckoutMode
 
-	// modeEnforced reports whether mode is what git will actually apply. Below
-	// minGitSparseCheckoutMode the mode option can't be passed, so git falls
-	// back to the repository's core.sparseCheckoutCone, which `git clone
-	// --sparse` leaves unset on those versions — meaning cone mode is requested
-	// but non-cone interpretation is what happens. setupSparseCheckout warns
-	// when that's the case.
-	modeEnforced bool
+	// modeFlagSupported reports whether git accepts the --cone/--no-cone options
+	// on `sparse-checkout set` (git >= minGitSparseCheckoutMode). When it
+	// doesn't, setupSparseCheckout pins the mode through config instead, since
+	// git would otherwise parse the option as just another pattern.
+	modeFlagSupported bool
 }
 
 func (s sparseCheckout) active() bool { return len(s.paths) > 0 }
@@ -177,9 +175,9 @@ func (e *Executor) resolveSparseCheckout(ctx context.Context) (sparseCheckout, e
 	}
 
 	return sparseCheckout{
-		paths:        paths,
-		mode:         mode,
-		modeEnforced: version.atLeast(minGitSparseCheckoutMode),
+		paths:             paths,
+		mode:              mode,
+		modeFlagSupported: version.atLeast(minGitSparseCheckoutMode),
 	}, nil
 }
 
@@ -208,10 +206,10 @@ func (e *Executor) setupSparseCheckout(ctx context.Context, sc sparseCheckout) (
 	e.shell.Commentf("Setting up sparse checkout (%s mode) for paths: %s", sc.mode, strings.Join(sc.paths, ","))
 
 	args := []string{"sparse-checkout", "set"}
-	if sc.modeEnforced {
+	if sc.modeFlagSupported {
 		args = append(args, "--"+sc.mode.String())
-	} else {
-		e.shell.Warningf("This git is older than %s and can't be told which sparse checkout mode to use: the paths will be interpreted using the repository's existing core.sparseCheckoutCone setting, which may not be %s mode. Upgrade git to pin the mode.", minGitSparseCheckoutMode, sc.mode)
+	} else if err := e.pinSparseCheckoutMode(ctx, sc); err != nil {
+		return false, err
 	}
 	// `--` keeps git from parsing a path as an option: paths can come from the
 	// pipeline, and git quietly accepts an unrecognised option as a pattern.
@@ -223,6 +221,30 @@ func (e *Executor) setupSparseCheckout(ctx context.Context, sc sparseCheckout) (
 	}
 
 	return true, nil
+}
+
+// pinSparseCheckoutMode makes the requested mode take effect on git versions
+// whose `sparse-checkout set` has no --cone/--no-cone option, by writing the
+// config git consults instead. `sparse-checkout init` has accepted --cone since
+// git 2.25, comfortably below minGitSparseCheckout.
+//
+// Without this, the interpretation comes from whatever core.sparseCheckoutCone
+// the repository already has — and `git clone --sparse` on these versions runs
+// `sparse-checkout init` with no --cone, so a cone-mode request quietly gets
+// non-cone pattern matching: paths match a directory of that name at any depth,
+// and top-level files are left out of the working tree.
+func (e *Executor) pinSparseCheckoutMode(ctx context.Context, sc sparseCheckout) error {
+	// Only cone mode reaches here: resolveSparseCheckout falls back to a full
+	// checkout when no-cone is requested on a git this old.
+	if sc.noCone() {
+		return nil
+	}
+
+	e.shell.Commentf("Enabling cone mode via config: this git is older than %s and takes no mode option", minGitSparseCheckoutMode)
+	if err := e.shell.Command("git", "sparse-checkout", "init", "--cone").Run(ctx); err != nil {
+		return fmt.Errorf("enabling sparse checkout cone mode: %w", err)
+	}
+	return nil
 }
 
 func (e *Executor) disableSparseCheckoutIfConfigured(ctx context.Context) {

--- a/internal/job/checkout_sparse_test.go
+++ b/internal/job/checkout_sparse_test.go
@@ -113,7 +113,7 @@ func TestSetupSparseCheckout_NoCone(t *testing.T) {
 // are interpreted the way the job asked rather than however the repository was
 // last configured.
 func TestSetupSparseCheckout_PinsModeWithoutModeFlag(t *testing.T) {
-	executor, git, _ := newSparseCheckoutTestExecutor(t)
+	executor, git, out := newSparseCheckoutTestExecutor(t)
 	defer git.Close() //nolint:errcheck // Best-effort cleanup.
 
 	sc := sparseCheckout{paths: []string{"src/"}, mode: SparseCheckoutModeCone}
@@ -122,6 +122,9 @@ func TestSetupSparseCheckout_PinsModeWithoutModeFlag(t *testing.T) {
 
 	if _, err := executor.setupSparseCheckout(t.Context(), sc); err != nil {
 		t.Fatalf("executor.setupSparseCheckout(ctx, sc) error = %v, want nil", err)
+	}
+	if got, want := out.String(), "Enabling cone mode via config: this git is older than 2.35 and takes no mode option"; !strings.Contains(got, want) {
+		t.Errorf("shell output = %q, want to contain %q", got, want)
 	}
 
 	git.Check(t)

--- a/internal/job/checkout_sparse_test.go
+++ b/internal/job/checkout_sparse_test.go
@@ -68,7 +68,7 @@ func TestSetupSparseCheckout_Enable(t *testing.T) {
 	executor, git, out := newSparseCheckoutTestExecutor(t)
 	defer git.Close() //nolint:errcheck // Best-effort cleanup.
 
-	sc := sparseCheckout{paths: []string{".buildkite/", "src/"}, mode: SparseCheckoutModeCone, modeEnforced: true}
+	sc := sparseCheckout{paths: []string{".buildkite/", "src/"}, mode: SparseCheckoutModeCone, modeFlagSupported: true}
 	git.Expect("sparse-checkout", "set", "--cone", "--", ".buildkite/", "src/").AndExitWith(0)
 
 	active, err := executor.setupSparseCheckout(t.Context(), sc)
@@ -89,7 +89,7 @@ func TestSetupSparseCheckout_NoCone(t *testing.T) {
 	executor, git, out := newSparseCheckoutTestExecutor(t)
 	defer git.Close() //nolint:errcheck // Best-effort cleanup.
 
-	sc := sparseCheckout{paths: []string{"/*", "!/docs/"}, mode: SparseCheckoutModeNoCone, modeEnforced: true}
+	sc := sparseCheckout{paths: []string{"/*", "!/docs/"}, mode: SparseCheckoutModeNoCone, modeFlagSupported: true}
 	git.Expect("sparse-checkout", "set", "--no-cone", "--", "/*", "!/docs/").AndExitWith(0)
 
 	active, err := executor.setupSparseCheckout(t.Context(), sc)
@@ -106,24 +106,42 @@ func TestSetupSparseCheckout_NoCone(t *testing.T) {
 	git.Check(t)
 }
 
-// TestSetupSparseCheckout_UnenforcedMode covers git 2.27–2.34, where
+// TestSetupSparseCheckout_PinsModeWithoutModeFlag covers git 2.27–2.34, where
 // `sparse-checkout set` has no --cone option and silently treats an unrecognised
 // one as a pattern. The flag must be omitted so it can't land in the
-// sparse-checkout file, while `--` still guards the paths. Since git will apply
-// whatever mode the repository config says, the build log has to say so rather
-// than claiming the requested mode is in force.
-func TestSetupSparseCheckout_UnenforcedMode(t *testing.T) {
-	executor, git, out := newSparseCheckoutTestExecutor(t)
+// sparse-checkout file; cone mode is pinned through config instead, so the paths
+// are interpreted the way the job asked rather than however the repository was
+// last configured.
+func TestSetupSparseCheckout_PinsModeWithoutModeFlag(t *testing.T) {
+	executor, git, _ := newSparseCheckoutTestExecutor(t)
 	defer git.Close() //nolint:errcheck // Best-effort cleanup.
 
 	sc := sparseCheckout{paths: []string{"src/"}, mode: SparseCheckoutModeCone}
+	git.Expect("sparse-checkout", "init", "--cone").AndExitWith(0)
 	git.Expect("sparse-checkout", "set", "--", "src/").AndExitWith(0)
 
 	if _, err := executor.setupSparseCheckout(t.Context(), sc); err != nil {
 		t.Fatalf("executor.setupSparseCheckout(ctx, sc) error = %v, want nil", err)
 	}
-	if got, want := out.String(), "older than 2.35 and can't be told which sparse checkout mode to use"; !strings.Contains(got, want) {
-		t.Errorf("shell output = %q, want to contain %q", got, want)
+
+	git.Check(t)
+}
+
+func TestSetupSparseCheckout_PinModeFailureIsFatal(t *testing.T) {
+	executor, git, _ := newSparseCheckoutTestExecutor(t)
+	defer git.Close() //nolint:errcheck // Best-effort cleanup.
+
+	sc := sparseCheckout{paths: []string{"src/"}, mode: SparseCheckoutModeCone}
+	git.Expect("sparse-checkout", "init", "--cone").AndExitWith(1)
+	// Continuing would apply the paths under an unknown interpretation.
+	git.Expect("sparse-checkout", "set").WithAnyArguments().NotCalled()
+
+	active, err := executor.setupSparseCheckout(t.Context(), sc)
+	if err == nil {
+		t.Fatalf("executor.setupSparseCheckout(ctx, sc) error = nil, want non-nil")
+	}
+	if active {
+		t.Errorf("executor.setupSparseCheckout(ctx, sc) active = true, want false")
 	}
 
 	git.Check(t)
@@ -131,21 +149,21 @@ func TestSetupSparseCheckout_UnenforcedMode(t *testing.T) {
 
 func TestResolveSparseCheckout_Modes(t *testing.T) {
 	tests := []struct {
-		name             string
-		mode             string
-		gitVersion       string
-		gitVersionExit   int
-		wantActive       bool
-		wantMode         SparseCheckoutMode
-		wantModeEnforced bool
-		wantWarning      string
+		name                  string
+		mode                  string
+		gitVersion            string
+		gitVersionExit        int
+		wantActive            bool
+		wantMode              SparseCheckoutMode
+		wantModeFlagSupported bool
+		wantWarning           string
 	}{
 		{
-			name:             "cone_on_modern_git",
-			gitVersion:       "git version 2.43.0",
-			wantActive:       true,
-			wantMode:         SparseCheckoutModeCone,
-			wantModeEnforced: true,
+			name:                  "cone_on_modern_git",
+			gitVersion:            "git version 2.43.0",
+			wantActive:            true,
+			wantMode:              SparseCheckoutModeCone,
+			wantModeFlagSupported: true,
 		},
 		{
 			// Cone mode is available as soon as `sparse-checkout set` is; below
@@ -157,12 +175,12 @@ func TestResolveSparseCheckout_Modes(t *testing.T) {
 			wantMode:   SparseCheckoutModeCone,
 		},
 		{
-			name:             "no_cone_on_modern_git",
-			mode:             "no-cone",
-			gitVersion:       "git version 2.35.0",
-			wantActive:       true,
-			wantMode:         SparseCheckoutModeNoCone,
-			wantModeEnforced: true,
+			name:                  "no_cone_on_modern_git",
+			mode:                  "no-cone",
+			gitVersion:            "git version 2.35.0",
+			wantActive:            true,
+			wantMode:              SparseCheckoutModeNoCone,
+			wantModeFlagSupported: true,
 		},
 		{
 			// `set` gained --no-cone in 2.35; older git would write the flag into
@@ -212,8 +230,8 @@ func TestResolveSparseCheckout_Modes(t *testing.T) {
 			if got := sc.mode; got != tt.wantMode {
 				t.Errorf("sparseCheckout.mode = %q, want %q", got, tt.wantMode)
 			}
-			if got := sc.modeEnforced; got != tt.wantModeEnforced {
-				t.Errorf("sparseCheckout.modeEnforced = %t, want %t", got, tt.wantModeEnforced)
+			if got := sc.modeFlagSupported; got != tt.wantModeFlagSupported {
+				t.Errorf("sparseCheckout.modeFlagSupported = %t, want %t", got, tt.wantModeFlagSupported)
 			}
 			switch {
 			case tt.wantWarning != "":
@@ -243,14 +261,14 @@ func TestSparseCheckoutLFSInclude(t *testing.T) {
 	}{
 		{
 			name: "cone_paths_scope_lfs",
-			sc:   sparseCheckout{paths: []string{"src/"}, mode: SparseCheckoutModeCone, modeEnforced: true},
+			sc:   sparseCheckout{paths: []string{"src/"}, mode: SparseCheckoutModeCone, modeFlagSupported: true},
 			want: []string{"src/"},
 		},
 		{
 			// `git lfs fetch --include` has no negation and `git lfs checkout` takes
 			// pathspecs, so non-cone patterns must not be reused for LFS.
 			name: "no_cone_patterns_do_not_scope_lfs",
-			sc:   sparseCheckout{paths: []string{"/*", "!/docs/"}, mode: SparseCheckoutModeNoCone, modeEnforced: true},
+			sc:   sparseCheckout{paths: []string{"/*", "!/docs/"}, mode: SparseCheckoutModeNoCone, modeFlagSupported: true},
 		},
 		{
 			name: "inactive_does_not_scope_lfs",

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -282,6 +282,82 @@ func TestCheckingOutLocalGitProjectWithSparseCheckoutFallsBackOnOldGit(t *testin
 	requireCheckoutPath(t, tester.CheckoutDir(), "docs/readme.md", true)
 }
 
+// TestCheckingOutLocalGitProjectWithSparseCheckoutPinsConeOnOldGit covers git
+// 2.27–2.34, where `sparse-checkout set` takes no mode option. It fakes the
+// version the same way as the fallback test above, so real git still does the
+// work: `sparse-checkout init --cone` is a real command in every supported
+// version, and the resulting tree is real cone-mode output.
+//
+// The observable difference is core.sparseCheckoutCone and the top-level file:
+// cone mode includes files alongside the requested directory's ancestors, so
+// test.txt lands in the working tree, whereas the non-cone interpretation that
+// `git clone --sparse` leaves behind on these versions would omit it.
+func TestCheckingOutLocalGitProjectWithSparseCheckoutPinsConeOnOldGit(t *testing.T) {
+	t.Parallel()
+	skipIfGitSparseCheckoutUnsupported(t)
+
+	tester, err := NewExecutorTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewExecutorTester() error = %v", err)
+	}
+	defer tester.Close()
+	addSparseCheckoutFixture(t, tester.Repo)
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_FLAGS=-v --filter=blob:none --sparse",
+		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
+		"BUILDKITE_GIT_FETCH_FLAGS=-v --filter=blob:none",
+		"BUILDKITE_GIT_SPARSE_CHECKOUT_PATHS=src/",
+	}
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("exec.LookPath(git) error = %v", err)
+	}
+
+	git := tester.MustMock(t, "git")
+
+	git.Expect("--version").AndCallFunc(func(c *bintest.Call) {
+		_, _ = fmt.Fprintln(c.Stdout, "git version 2.30.2")
+		c.Exit(0)
+	})
+
+	expect := func(args ...any) *bintest.Expectation {
+		return git.Expect(args...).AndPassthroughToLocalCommand(realGit)
+	}
+
+	expect("clone", "-v", "--filter=blob:none", "--sparse", "--", tester.Repo.Path, ".")
+	expect("clean", "-fdq")
+	expect("fetch", "-v", "--filter=blob:none", "--", "origin", "main")
+	// The mode is pinned through config, and `set` is called without the option
+	// this git would misread as a pattern.
+	expect("sparse-checkout", "init", "--cone")
+	expect("sparse-checkout", "set", "--", "src/")
+	expect("-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD")
+	expect("clean", "-fdq")
+	expect("--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg)
+
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
+
+	tester.RunAndCheck(t, env...)
+
+	checkoutRepo := &gitRepository{Path: tester.CheckoutDir()}
+	cone, err := checkoutRepo.Execute("config", "--get", "core.sparseCheckoutCone")
+	if err != nil {
+		t.Fatalf("git config --get core.sparseCheckoutCone error = %v", err)
+	}
+	if got := strings.TrimSpace(cone); got != "true" {
+		t.Errorf("core.sparseCheckoutCone = %q, want %q", got, "true")
+	}
+
+	requireCheckoutPath(t, tester.CheckoutDir(), "src/main.txt", true)
+	requireCheckoutPath(t, tester.CheckoutDir(), "test.txt", true)
+	requireCheckoutPath(t, tester.CheckoutDir(), "docs/readme.md", false)
+	requireCheckoutPath(t, tester.CheckoutDir(), ".buildkite/pipeline.yml", false)
+}
+
 // TestCheckingOutLocalGitProjectWithSparseCheckoutAutoAddsBlobNoneFilter
 // covers the agent's auto-injection of --filter=blob:none onto the clone when
 // sparse checkout paths are configured but the user did NOT supply any

--- a/internal/job/integration/executor_tester.go
+++ b/internal/job/integration/executor_tester.go
@@ -283,7 +283,12 @@ func (e *ExecutorTester) ExpectGlobalHook(name string) *bintest.Expectation {
 func (e *ExecutorTester) Run(t *testing.T, env ...string) error {
 	t.Helper()
 
+	// Hold cmdLock across setup and Start so Cancel can't observe a nil
+	// Process (and so it blocks until the command is actually running).
+	e.cmdLock.Lock()
+
 	if err := e.flushPendingLocalHooks(); err != nil {
+		e.cmdLock.Unlock()
 		return err
 	}
 
@@ -298,10 +303,10 @@ func (e *ExecutorTester) Run(t *testing.T, env ...string) error {
 
 	path, err := exec.LookPath(e.Name)
 	if err != nil {
+		e.cmdLock.Unlock()
 		return err
 	}
 
-	e.cmdLock.Lock()
 	e.cmd = exec.Command(path, e.Args...)
 
 	buf := &buffer{}
@@ -331,10 +336,9 @@ func (e *ExecutorTester) Run(t *testing.T, env ...string) error {
 }
 
 func (e *ExecutorTester) Cancel() error {
-	// Run does setup (hooks, mocks) before acquiring cmdLock and calling Start,
-	// so Cancel can land while e.cmd / e.cmd.Process is still nil. Wait briefly
-	// for the process rather than nil-dereferencing.
-	deadline := time.Now().Add(5 * time.Second)
+	// Run may not have reached Start yet (caller races a sleep against setup).
+	// Wait for a live Process rather than nil-dereferencing.
+	deadline := time.Now().Add(30 * time.Second)
 	for {
 		e.cmdLock.Lock()
 		if e.cmd != nil && e.cmd.Process != nil {

--- a/internal/job/integration/executor_tester.go
+++ b/internal/job/integration/executor_tester.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/buildkite/agent/v3/clicommand"
 	"github.com/buildkite/agent/v3/env"
@@ -330,10 +331,25 @@ func (e *ExecutorTester) Run(t *testing.T, env ...string) error {
 }
 
 func (e *ExecutorTester) Cancel() error {
-	e.cmdLock.Lock()
-	defer e.cmdLock.Unlock()
-	log.Printf("Killing pid %d", e.cmd.Process.Pid)
-	return e.cmd.Process.Signal(syscall.SIGINT)
+	// Run does setup (hooks, mocks) before acquiring cmdLock and calling Start,
+	// so Cancel can land while e.cmd / e.cmd.Process is still nil. Wait briefly
+	// for the process rather than nil-dereferencing.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		e.cmdLock.Lock()
+		if e.cmd != nil && e.cmd.Process != nil {
+			log.Printf("Killing pid %d", e.cmd.Process.Pid)
+			err := e.cmd.Process.Signal(syscall.SIGINT)
+			e.cmdLock.Unlock()
+			return err
+		}
+		e.cmdLock.Unlock()
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for command to start before cancel")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func (e *ExecutorTester) CheckMocks(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
On git < 2.35, `sparse-checkout set` has no `--cone` flag, so cone mode was not actually enforced after `clone --sparse`. Run `sparse-checkout init --cone` before `set` when that flag is unavailable; fail the checkout if pinning fails.

Behaviour change on git 2.27–2.34: top-level files appear, and paths match only at the top level.

Also fixes a pre-existing nil-deref race in `ExecutorTester.Cancel` that could panic `TestPreExitHooksFireAfterCancel` under load.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

- Cursor cloud agent implemented this change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d0909a3-5e59-54ff-84a1-2f03b2b18562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d0909a3-5e59-54ff-84a1-2f03b2b18562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

