### PR TITLE
A-1610: Fall back to /bin/sh when bash is absent

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -1272,6 +1272,11 @@ func (e *Executor) defaultCommandPhase(ctx context.Context) (retErr error) {
 		return fmt.Errorf("no shell set for job")
 	}
 
+	if fallback := shFallback(interpreter, e.shell.AbsolutePath); fallback != nil {
+		e.shell.Warningf("Couldn't find bash. Falling back to %s. Commands that rely on bash features may fail.", fallback[0])
+		interpreter = fallback
+	}
+
 	// Windows CMD.EXE is horrible and can't handle newline delimited commands. We write
 	// a batch script so that it works, but we don't like it
 	if strings.ToUpper(filepath.Base(interpreter[0])) == "CMD.EXE" {
@@ -1356,6 +1361,25 @@ func (e *Executor) defaultCommandPhase(ctx context.Context) (retErr error) {
 
 	err = e.shell.Command(cmd[0], cmd[1:]...).Run(ctx, shell.ShowPrompt(false))
 	return err
+}
+
+// shFallback returns a replacement interpreter that uses sh when the given
+// interpreter relies on finding bash via PATH but no bash is available, such
+// as in minimal (e.g. Alpine-based) images. This is only the case for the
+// default shell on systems without /bin/bash; interpreters with explicit
+// paths are left alone. It returns nil when no fallback is needed or possible.
+func shFallback(interpreter []string, absPath func(string) (string, error)) []string {
+	if len(interpreter) < 2 || interpreter[0] != "/usr/bin/env" || interpreter[1] != "bash" {
+		return nil
+	}
+	if _, err := absPath("bash"); err == nil {
+		return nil
+	}
+	shPath, err := absPath("sh")
+	if err != nil {
+		return nil
+	}
+	return append([]string{shPath}, interpreter[2:]...)
 }
 
 /*

--- a/internal/job/executor_test.go
+++ b/internal/job/executor_test.go
@@ -303,3 +303,66 @@ func TestCancelDoesNotSetTimedOutWhenMarkerMissing(t *testing.T) {
 		t.Errorf("BUILDKITE_JOB_TIMED_OUT was set despite missing marker file, want unset")
 	}
 }
+
+func TestShFallback(t *testing.T) {
+	t.Parallel()
+
+	pathWith := func(available ...string) func(string) (string, error) {
+		return func(executable string) (string, error) {
+			for _, a := range available {
+				if executable == a {
+					return "/bin/" + a, nil
+				}
+			}
+			return "", errors.New("not found")
+		}
+	}
+
+	tests := []struct {
+		name        string
+		interpreter []string
+		absPath     func(string) (string, error)
+		want        []string
+	}{
+		{
+			name:        "no fallback when bash is on PATH",
+			interpreter: []string{"/usr/bin/env", "bash", "-e", "-c"},
+			absPath:     pathWith("bash", "sh"),
+			want:        nil,
+		},
+		{
+			name:        "falls back to sh when bash is absent",
+			interpreter: []string{"/usr/bin/env", "bash", "-e", "-c"},
+			absPath:     pathWith("sh"),
+			want:        []string{"/bin/sh", "-e", "-c"},
+		},
+		{
+			name:        "no fallback for explicit bash path",
+			interpreter: []string{"/bin/bash", "-e", "-c"},
+			absPath:     pathWith("sh"),
+			want:        nil,
+		},
+		{
+			name:        "no fallback for other interpreters",
+			interpreter: []string{"/usr/bin/env", "zsh", "-e", "-c"},
+			absPath:     pathWith("sh"),
+			want:        nil,
+		},
+		{
+			name:        "no fallback when sh is also absent",
+			interpreter: []string{"/usr/bin/env", "bash", "-e", "-c"},
+			absPath:     pathWith(),
+			want:        nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := shFallback(test.interpreter, test.absPath)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("shFallback() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

The default job command shell assumes bash exists. In minimal images (e.g. Alpine-based) that don't ship bash, jobs fail outright before running anything. Hook scripts already handle this: when they have no shebang and bash is missing, the agent warns and falls back to `sh`. This applies the same idea to the job command.

`DefaultShell()` is unchanged. Instead, at the command phase, when the interpreter is the PATH-dependent default (`/usr/bin/env bash …`) and the job's environment has no bash, the agent warns and runs commands with `sh` (keeping the `-e -c` flags).

Because the check happens at execution time against the executor's final environment, setups that expose bash via `PATH` from env hooks (e.g. NixOS, Guix) keep resolving bash exactly as before. Interpreters with explicit paths (e.g. `/bin/bash`) are left alone, and the fallback only activates where the job previously could not run at all.

Context: [A-1610](https://linear.app/buildkite/issue/A-1610/agent-invocation-fails-with-unknown-subcommand-error)

## Changes

- Add `shFallback` in the executor: swap `/usr/bin/env bash …` for `sh` at the command phase when bash is not resolvable in the job environment, with a warning matching the existing hook fallback
- Add table tests covering fallback and non-fallback cases
