### PR TITLE
A-1553: Restore OTel job attributes as resource attributes

### DIFF
--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -20,6 +20,7 @@ import (
 	"github.com/oleiade/reflections"
 	"github.com/urfave/cli"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
 )
 
@@ -614,7 +615,15 @@ func setupLoggerAndConfig[T any](ctx context.Context, c *cli.Context, opts ...co
 				serviceName = snStr
 			}
 		}
-		traceProvider, err := job.InitOTelTracerProvider(ctx, serviceName, nil)
+		// When this process runs within a job (e.g. bootstrap or a subcommand
+		// invoked from a hook), attach the job's attributes to the provider
+		// resource so that every span inherits them, not just the root span.
+		var resourceAttrs []attribute.KeyValue
+		if os.Getenv("BUILDKITE_JOB_ID") != "" {
+			resourceAttrs = job.OTelResourceAttributesFromEnv(env.FromSlice(os.Environ()))
+		}
+
+		traceProvider, err := job.InitOTelTracerProvider(ctx, serviceName, resourceAttrs)
 		if err != nil {
 			l.Warnf("Failed to initialize tracing: %v", err)
 		} else {

--- a/internal/job/tracing.go
+++ b/internal/job/tracing.go
@@ -222,11 +222,58 @@ func (e *Executor) contextWithTraceparentIfEnabled(ctx context.Context) context.
 	return propagation.TraceContext{}.Extract(ctx, carrier)
 }
 
+// jobTracingValues holds the job identity values needed by
+// genericTracingExtras. They can come from the Executor config or, in
+// per-job processes, directly from the environment.
+type jobTracingValues struct {
+	AgentName        string
+	Queue            string
+	OrganizationSlug string
+	PipelineSlug     string
+	Branch           string
+	JobID            string
+}
+
 func GenericTracingExtras(e *Executor, env *env.Environment) map[string]any {
+	return genericTracingExtras(jobTracingValues{
+		AgentName:        e.AgentName,
+		Queue:            e.Queue,
+		OrganizationSlug: e.OrganizationSlug,
+		PipelineSlug:     e.PipelineSlug,
+		Branch:           e.Branch,
+		JobID:            e.JobID,
+	}, env)
+}
+
+// OTelResourceAttributesFromEnv derives the generic tracing attributes from
+// the environment alone, as OpenTelemetry attributes. It is used when
+// initialising the TracerProvider in a per-job process (such as bootstrap),
+// so that job attributes like buildkite.retry become resource attributes
+// inherited by every span, matching agent versions before v3.116.0.
+func OTelResourceAttributesFromEnv(environ *env.Environment) []attribute.KeyValue {
+	get := func(key string) string {
+		v, _ := environ.Get(key)
+		return v
+	}
+	extras := genericTracingExtras(jobTracingValues{
+		AgentName:        get("BUILDKITE_AGENT_NAME"),
+		Queue:            get("BUILDKITE_AGENT_META_DATA_QUEUE"),
+		OrganizationSlug: get("BUILDKITE_ORGANIZATION_SLUG"),
+		PipelineSlug:     get("BUILDKITE_PIPELINE_SLUG"),
+		Branch:           get("BUILDKITE_BRANCH"),
+		JobID:            get("BUILDKITE_JOB_ID"),
+	}, environ)
+	// genericTracingExtras only produces strings and ints, so no attributes
+	// can be dropped for having an unknown type.
+	attrs, _ := toOpenTelemetryAttributes(extras)
+	return attrs
+}
+
+func genericTracingExtras(v jobTracingValues, env *env.Environment) map[string]any {
 	buildID, _ := env.Get("BUILDKITE_BUILD_ID")
 	buildNumber, _ := env.Get("BUILDKITE_BUILD_NUMBER")
 	buildURL, _ := env.Get("BUILDKITE_BUILD_URL")
-	jobURL := api.JobURL(buildURL, e.JobID)
+	jobURL := api.JobURL(buildURL, v.JobID)
 	source, _ := env.Get("BUILDKITE_SOURCE")
 
 	retry := 0
@@ -264,15 +311,15 @@ func GenericTracingExtras(e *Executor, env *env.Environment) map[string]any {
 	}
 
 	result := map[string]any{
-		"buildkite.agent":             e.AgentName,
+		"buildkite.agent":             v.AgentName,
 		"buildkite.version":           version.Version(),
-		"buildkite.queue":             e.Queue,
-		"buildkite.org":               e.OrganizationSlug,
-		"buildkite.pipeline":          e.PipelineSlug,
-		"buildkite.branch":            e.Branch,
+		"buildkite.queue":             v.Queue,
+		"buildkite.org":               v.OrganizationSlug,
+		"buildkite.pipeline":          v.PipelineSlug,
+		"buildkite.branch":            v.Branch,
 		"buildkite.job_label":         jobLabel,
 		"buildkite.job_key":           jobKey,
-		"buildkite.job_id":            e.JobID,
+		"buildkite.job_id":            v.JobID,
 		"buildkite.job_url":           jobURL,
 		"buildkite.build_id":          buildID,
 		"buildkite.build_number":      buildNumber,

--- a/internal/job/tracing_test.go
+++ b/internal/job/tracing_test.go
@@ -1,0 +1,94 @@
+package job
+
+import (
+	"testing"
+
+	"github.com/buildkite/agent/v3/env"
+	"github.com/google/go-cmp/cmp"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestOTelResourceAttributesFromEnv(t *testing.T) {
+	t.Parallel()
+
+	environ := env.FromMap(map[string]string{
+		"BUILDKITE_AGENT_NAME":            "agent-1",
+		"BUILDKITE_AGENT_META_DATA_QUEUE": "default",
+		"BUILDKITE_ORGANIZATION_SLUG":     "acme",
+		"BUILDKITE_PIPELINE_SLUG":         "app",
+		"BUILDKITE_BRANCH":                "main",
+		"BUILDKITE_JOB_ID":                "job-123",
+		"BUILDKITE_BUILD_ID":              "build-456",
+		"BUILDKITE_BUILD_NUMBER":          "42",
+		"BUILDKITE_BUILD_URL":             "https://buildkite.com/acme/app/builds/42",
+		"BUILDKITE_SOURCE":                "webhook",
+		"BUILDKITE_RETRY_COUNT":           "1",
+		"BUILDKITE_LABEL":                 ":go: test",
+	})
+
+	attrs := OTelResourceAttributesFromEnv(environ)
+
+	byKey := make(map[attribute.Key]attribute.Value, len(attrs))
+	for _, attr := range attrs {
+		byKey[attr.Key] = attr.Value
+	}
+
+	wantStrings := map[attribute.Key]string{
+		"buildkite.agent":        "agent-1",
+		"buildkite.queue":        "default",
+		"buildkite.org":          "acme",
+		"buildkite.pipeline":     "app",
+		"buildkite.branch":       "main",
+		"buildkite.job_id":       "job-123",
+		"buildkite.job_label":    ":go: test",
+		"buildkite.build_number": "42",
+	}
+	for key, want := range wantStrings {
+		if got := byKey[key].AsString(); got != want {
+			t.Errorf("attribute %s = %q, want %q", key, got, want)
+		}
+	}
+
+	if got, want := byKey["buildkite.retry"].AsInt64(), int64(1); got != want {
+		t.Errorf("attribute buildkite.retry = %d, want %d", got, want)
+	}
+}
+
+func TestGenericTracingExtrasMatchesEnvDerivedExtras(t *testing.T) {
+	t.Parallel()
+
+	environ := env.FromMap(map[string]string{
+		"BUILDKITE_AGENT_NAME":            "agent-1",
+		"BUILDKITE_AGENT_META_DATA_QUEUE": "default",
+		"BUILDKITE_ORGANIZATION_SLUG":     "acme",
+		"BUILDKITE_PIPELINE_SLUG":         "app",
+		"BUILDKITE_BRANCH":                "main",
+		"BUILDKITE_JOB_ID":                "job-123",
+		"BUILDKITE_RETRY_COUNT":           "1",
+	})
+
+	e := &Executor{
+		ExecutorConfig: ExecutorConfig{
+			AgentName:        "agent-1",
+			Queue:            "default",
+			OrganizationSlug: "acme",
+			PipelineSlug:     "app",
+			Branch:           "main",
+			JobID:            "job-123",
+		},
+	}
+
+	fromExecutor := GenericTracingExtras(e, environ)
+	fromEnv := genericTracingExtras(jobTracingValues{
+		AgentName:        "agent-1",
+		Queue:            "default",
+		OrganizationSlug: "acme",
+		PipelineSlug:     "app",
+		Branch:           "main",
+		JobID:            "job-123",
+	}, environ)
+
+	if diff := cmp.Diff(fromExecutor, fromEnv); diff != "" {
+		t.Errorf("executor-derived and env-derived extras differ (-executor +env):\n%s", diff)
+	}
+}


### PR DESCRIPTION
## Description

Since the TracerProvider refactor in #3880, the `GenericTracingExtras` attributes (`buildkite.retry`, `buildkite.parallel`, `buildkite.rebuilt_from_id`, etc.) are only set as span attributes on the root job span. Before that, they were resource attributes on a per job TracerProvider, so every span in the job trace inherited them.

This broke customers querying these attributes on child spans (environment, checkout, command). See [A-1553](https://linear.app/buildkite/issue/A-1553/pinterest-opentelemetry-retry-fields-no-longer-included-in-all).

## Changes

- `internal/job/tracing.go`: extracted the body of `GenericTracingExtras` into `genericTracingExtras`, shared by two entry points: the existing executor based one, and a new `OTelResourceAttributesFromEnv` that derives the same values purely from env vars (the same env vars the bootstrap CLI flags bind to).
- `clicommand/global.go`: when the process runs within a job (`BUILDKITE_JOB_ID` is set), pass those attributes to `InitOTelTracerProvider` as resource attributes instead of `nil`. This restores the pre v3.116.0 behaviour where all spans carry the job attributes.
- Added unit tests for the env derived attributes, and one asserting executor derived and env derived extras stay in sync.

## Notes

- The extras remain on the root job span as span attributes too. Removing them would be another behaviour change, and the duplication is harmless.
- `agent start`'s own long lived provider is unaffected since it has no `BUILDKITE_JOB_ID`.
- Subcommands invoked within a job env (e.g. `artifact upload` from a hook) also pick up the resource attributes, which is slightly broader than pre #3880 but consistent with what customers expect.

## Testing

- `go build ./...`
- `go test ./internal/job/ ./clicommand/`
- `go tool gofumpt -extra -l`, `golangci-lint run`
