### PR TITLE
A-1547: Add --job-context-dir to configure job coordination file locations

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -50,6 +50,7 @@ type AgentConfiguration struct {
 	RunInPty                        bool
 	KubernetesExec                  bool
 	KubernetesContainerStartTimeout time.Duration
+	JobContextDir                   string
 
 	SigningJWKSFile  string // Where to find the key to sign pipeline uploads with (passed through to jobs, they might be uploading pipelines)
 	SigningJWKSKeyID string // The key ID to sign pipeline uploads with

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -553,6 +553,7 @@ func (a *AgentWorker) RunJob(ctx context.Context, acceptResponse *api.Job, ignor
 		AgentStdout:                     a.agentStdout,
 		KubernetesExec:                  a.agentConfiguration.KubernetesExec,
 		KubernetesContainerStartTimeout: a.agentConfiguration.KubernetesContainerStartTimeout,
+		JobContextDir:                   a.agentConfiguration.JobContextDir,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize job: %w", err)

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -90,6 +90,14 @@ type JobRunnerConfig struct {
 	// It's useful to be configured in situations like huge container image cold download.
 	KubernetesContainerStartTimeout time.Duration
 
+	// JobContextDir is the directory for files the agent uses to coordinate
+	// with the processes running the job: the job env files, the job timeout
+	// marker file, and, in Kubernetes mode, the coordination socket. If
+	// empty, it defaults to kubernetes.DefaultContextDir in Kubernetes mode,
+	// or the system temporary directory otherwise. In Kubernetes mode it must
+	// be on a volume shared by all containers in the pod.
+	JobContextDir string
+
 	// Stdout of the parent agent process. Used for job log stdout writing arg, for simpler containerized log collection.
 	AgentStdout io.Writer
 }
@@ -212,7 +220,9 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient *api.Client, c
 		},
 	)
 
-	r.envShellFile, r.envJSONFile, err = createJobEnvFiles(r.agentLogger, r.conf.Job.ID, conf.KubernetesExec)
+	contextDir := jobContextDir(conf)
+
+	r.envShellFile, r.envJSONFile, err = createJobEnvFiles(r.agentLogger, r.conf.Job.ID, contextDir)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +231,7 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient *api.Client, c
 	// disk if the job is cancelled because of a Buildkite job-level timeout
 	// (see Cancel). The bootstrap subprocess reads this path from the
 	// BUILDKITE_AGENT_JOB_TIMEOUT_FILE env var.
-	r.jobTimeoutFilePath = jobTimeoutFilePath(r.conf.Job.ID, conf.KubernetesExec)
+	r.jobTimeoutFilePath = jobTimeoutFilePath(r.conf.Job.ID, contextDir)
 
 	env, err := r.createEnvironment(ctx)
 	if err != nil {
@@ -338,6 +348,7 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient *api.Client, c
 			return nil, fmt.Errorf("failed to parse BUILDKITE_CONTAINER_COUNT: %w", err)
 		}
 		r.process = kubernetes.NewRunner(r.agentLogger, kubernetes.RunnerConfig{
+			SocketPath:         kubernetes.SocketPath(jobContextDir(conf)),
 			Stdout:             r.jobLogs,
 			Stderr:             r.jobLogs,
 			ClientCount:        containerCount,
@@ -980,13 +991,22 @@ func (r *JobRunner) onUploadHeaderTime(ctx context.Context, cursor, total int, t
 	}
 }
 
-func createJobEnvFiles(l logger.Logger, jobID string, kubernetesExec bool) (shellFile, jsonFile *os.File, err error) {
-	// Use /workspace in Kubernetes mode for shared volume access between containers
-	tempDir := os.TempDir()
-	if kubernetesExec {
-		tempDir = "/workspace"
+// jobContextDir returns the directory for files the agent creates to
+// coordinate with the processes running the job (the env files, the job
+// timeout marker file, and, in Kubernetes mode, the coordination socket). In
+// Kubernetes mode these files are read by other containers in the pod, so the
+// directory must be on a volume shared by all containers in the pod.
+func jobContextDir(conf JobRunnerConfig) string {
+	if conf.JobContextDir != "" {
+		return conf.JobContextDir
 	}
+	if conf.KubernetesExec {
+		return kubernetes.DefaultContextDir
+	}
+	return os.TempDir()
+}
 
+func createJobEnvFiles(l logger.Logger, jobID, tempDir string) (shellFile, jsonFile *os.File, err error) {
 	// tempDir is not guaranteed to exist
 	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
 		// Actual file permissions will be reduced by umask, and won't be 0o777 unless the user has manually changed the umask to 000
@@ -1017,10 +1037,6 @@ func createJobEnvFiles(l logger.Logger, jobID string, kubernetesExec bool) (shel
 // because of a Buildkite job-level timeout. The file is not created until
 // the timeout actually fires; the bootstrap detects the timeout by checking
 // whether the file exists.
-func jobTimeoutFilePath(jobID string, kubernetesExec bool) string {
-	tempDir := os.TempDir()
-	if kubernetesExec {
-		tempDir = "/workspace"
-	}
+func jobTimeoutFilePath(jobID, tempDir string) string {
 	return filepath.Join(tempDir, fmt.Sprintf("job-timeout-%s", jobID))
 }

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -348,7 +348,7 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient *api.Client, c
 			return nil, fmt.Errorf("failed to parse BUILDKITE_CONTAINER_COUNT: %w", err)
 		}
 		r.process = kubernetes.NewRunner(r.agentLogger, kubernetes.RunnerConfig{
-			SocketPath:         kubernetes.SocketPath(jobContextDir(conf)),
+			SocketPath:         kubernetes.SocketPath(contextDir),
 			Stdout:             r.jobLogs,
 			Stderr:             r.jobLogs,
 			ClientCount:        containerCount,
@@ -1006,22 +1006,22 @@ func jobContextDir(conf JobRunnerConfig) string {
 	return os.TempDir()
 }
 
-func createJobEnvFiles(l logger.Logger, jobID, tempDir string) (shellFile, jsonFile *os.File, err error) {
-	// tempDir is not guaranteed to exist
-	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
+func createJobEnvFiles(l logger.Logger, jobID, contextDir string) (shellFile, jsonFile *os.File, err error) {
+	// contextDir is not guaranteed to exist
+	if _, err := os.Stat(contextDir); os.IsNotExist(err) {
 		// Actual file permissions will be reduced by umask, and won't be 0o777 unless the user has manually changed the umask to 000
-		if err = os.MkdirAll(tempDir, 0o777); err != nil {
+		if err = os.MkdirAll(contextDir, 0o777); err != nil {
 			return nil, nil, err
 		}
 	}
 
-	shellFile, err = os.CreateTemp(tempDir, fmt.Sprintf("job-env-%s", jobID))
+	shellFile, err = os.CreateTemp(contextDir, fmt.Sprintf("job-env-%s", jobID))
 	if err != nil {
 		return nil, nil, err
 	}
 	l.Debugf("[JobRunner] Created env file (shell format): %s", shellFile.Name())
 
-	jsonFile, err = os.CreateTemp(tempDir, fmt.Sprintf("job-env-json-%s", jobID))
+	jsonFile, err = os.CreateTemp(contextDir, fmt.Sprintf("job-env-json-%s", jobID))
 	if err != nil {
 		_ = shellFile.Close()
 		_ = os.Remove(shellFile.Name())
@@ -1032,11 +1032,11 @@ func createJobEnvFiles(l logger.Logger, jobID, tempDir string) (shellFile, jsonF
 	return shellFile, jsonFile, nil
 }
 
-// jobTimeoutFilePath returns a deterministic path within the job temp
+// jobTimeoutFilePath returns a deterministic path within the job context
 // directory used to signal to the bootstrap that the job was cancelled
 // because of a Buildkite job-level timeout. The file is not created until
 // the timeout actually fires; the bootstrap detects the timeout by checking
 // whether the file exists.
-func jobTimeoutFilePath(jobID, tempDir string) string {
-	return filepath.Join(tempDir, fmt.Sprintf("job-timeout-%s", jobID))
+func jobTimeoutFilePath(jobID, contextDir string) string {
+	return filepath.Join(contextDir, fmt.Sprintf("job-timeout-%s", jobID))
 }

--- a/agent/job_runner_test.go
+++ b/agent/job_runner_test.go
@@ -66,14 +66,55 @@ func TestValidateJobValue(t *testing.T) {
 func TestJobTimeoutFilePath(t *testing.T) {
 	t.Parallel()
 
-	got := jobTimeoutFilePath("abc123", false)
+	got := jobTimeoutFilePath("abc123", jobContextDir(JobRunnerConfig{}))
 	want := filepath.Join(os.TempDir(), "job-timeout-abc123")
 	if got != want {
-		t.Errorf("jobTimeoutFilePath(%q, false) = %q, want %q", "abc123", got, want)
+		t.Errorf("jobTimeoutFilePath(%q, jobContextDir({})) = %q, want %q", "abc123", got, want)
 	}
 
-	if got, want := jobTimeoutFilePath("abc123", true), filepath.Join("/workspace", "job-timeout-abc123"); got != want {
-		t.Errorf("jobTimeoutFilePath(%q, true) = %q, want %q", "abc123", got, want)
+	k8sDir := jobContextDir(JobRunnerConfig{KubernetesExec: true})
+	if got, want := jobTimeoutFilePath("abc123", k8sDir), filepath.Join("/workspace", "job-timeout-abc123"); got != want {
+		t.Errorf("jobTimeoutFilePath(%q, %q) = %q, want %q", "abc123", k8sDir, got, want)
+	}
+}
+
+func TestJobContextDir(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		conf JobRunnerConfig
+		want string
+	}{
+		{
+			name: "default",
+			conf: JobRunnerConfig{},
+			want: os.TempDir(),
+		},
+		{
+			name: "explicit_dir",
+			conf: JobRunnerConfig{JobContextDir: "/var/lib/buildkite/job"},
+			want: "/var/lib/buildkite/job",
+		},
+		{
+			name: "kubernetes_default",
+			conf: JobRunnerConfig{KubernetesExec: true},
+			want: "/workspace",
+		},
+		{
+			name: "kubernetes_explicit_dir",
+			conf: JobRunnerConfig{
+				KubernetesExec: true,
+				JobContextDir:  "/buildkite-shared",
+			},
+			want: "/buildkite-shared",
+		},
+	}
+
+	for _, tc := range tests {
+		if got := jobContextDir(tc.conf); got != tc.want {
+			t.Errorf("%s: jobContextDir(%+v) = %q, want %q", tc.name, tc.conf, got, tc.want)
+		}
 	}
 }
 

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -210,6 +210,7 @@ type AgentStartConfig struct {
 	StrictSingleHooks               bool          `cli:"strict-single-hooks"`
 	KubernetesExec                  bool          `cli:"kubernetes-exec"`
 	KubernetesContainerStartTimeout time.Duration `cli:"kubernetes-container-start-timeout"`
+	JobContextDir                   string        `cli:"job-context-dir" normalize:"filepath"`
 	TraceContextEncoding            string        `cli:"trace-context-encoding"`
 	NoMultipartArtifactUpload       bool          `cli:"no-multipart-artifact-upload"`
 	ArtifactUploadConcurrency       int           `cli:"artifact-upload-concurrency"`
@@ -795,6 +796,7 @@ var AgentStartCommand = cli.Command{
 			EnvVar: "BUILDKITE_KUBERNETES_CONTAINER_START_TIMEOUT",
 			Value:  5 * time.Minute,
 		},
+		JobContextDirFlag,
 
 		// Other shared flags
 		RedactedVars,
@@ -1171,6 +1173,7 @@ var AgentStartCommand = cli.Command{
 			ArtifactUploadConcurrency:       cfg.ArtifactUploadConcurrency,
 			KubernetesExec:                  cfg.KubernetesExec,
 			KubernetesContainerStartTimeout: cfg.KubernetesContainerStartTimeout,
+			JobContextDir:                   cfg.JobContextDir,
 			PingMode:                        cfg.PingMode,
 
 			SigningJWKSFile:  cfg.SigningJWKSFile,

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -113,9 +113,12 @@ var (
 		Usage: "The directory for files the agent uses to coordinate with the " +
 			"processes running the job: the job env files, the job timeout marker " +
 			"file, and, in Kubernetes mode, the coordination socket " +
-			"(buildkite.sock). In Kubernetes mode this defaults to /workspace and " +
-			"must be on a volume mounted by all containers in the pod; otherwise " +
-			"it defaults to the system temporary directory",
+			"(buildkite.sock). With agent-stack-k8s, leave this unset: the stack " +
+			"manages the shared /workspace volume that Kubernetes mode defaults " +
+			"to. When running --kubernetes-exec under your own orchestration, set " +
+			"this on every container to the path where the shared volume is " +
+			"mounted in that container. Outside Kubernetes mode it defaults to " +
+			"the system temporary directory and rarely needs changing",
 		EnvVar: "BUILDKITE_JOB_CONTEXT_DIR",
 	}
 

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -108,6 +108,17 @@ var (
 		EnvVar: "BUILDKITE_CONTAINER_ID",
 	}
 
+	JobContextDirFlag = cli.StringFlag{
+		Name: "job-context-dir",
+		Usage: "The directory for files the agent uses to coordinate with the " +
+			"processes running the job: the job env files, the job timeout marker " +
+			"file, and, in Kubernetes mode, the coordination socket " +
+			"(buildkite.sock). In Kubernetes mode this defaults to /workspace and " +
+			"must be on a volume mounted by all containers in the pod; otherwise " +
+			"it defaults to the system temporary directory",
+		EnvVar: "BUILDKITE_JOB_CONTEXT_DIR",
+	}
+
 	KubernetesLogCollectionGracePeriodFlag = cli.DurationFlag{
 		Name:   "kubernetes-log-collection-grace-period",
 		Usage:  "Deprecated, do not use",

--- a/clicommand/kubernetes_bootstrap.go
+++ b/clicommand/kubernetes_bootstrap.go
@@ -123,6 +123,16 @@ var KubernetesBootstrapCommand = cli.Command{
 			environ.Set(name, val)
 		}
 
+		// The registration env contains file paths that the agent computed in
+		// its own mount namespace. The shared volume may be mounted at a
+		// different path in this container, so rebase them onto the local job
+		// context directory.
+		contextDir := cfg.JobContextDir
+		if contextDir == "" {
+			contextDir = kubernetes.DefaultContextDir
+		}
+		rebaseJobContextPaths(environ, contextDir)
+
 		// Capture parameters from the agent that affect how the subprocess
 		// should be run: build path, PTY, cancel signal, and signal grace period.
 		buildPath := environ.GetString("BUILDKITE_BUILD_PATH", "/workspace/build")
@@ -279,6 +289,38 @@ var KubernetesBootstrapCommand = cli.Command{
 	},
 }
 
+// jobContextFileVars are env vars holding paths of files that live directly
+// in the job context directory (see the --job-context-dir flag).
+var jobContextFileVars = []string{
+	"BUILDKITE_ENV_FILE",
+	"BUILDKITE_ENV_JSON_FILE",
+	"BUILDKITE_AGENT_JOB_TIMEOUT_FILE",
+}
+
+// rebaseJobContextPaths rewrites the jobContextFileVars in environ to point
+// into contextDir, keeping their base names.
+//
+// The agent sends these vars as absolute paths computed in its own mount
+// namespace, and an absolute path is only meaningful in the namespace that
+// created it. Since the agent creates all of these files directly in its job
+// context directory, joining the base name onto this container's context
+// directory yields the local path of the same file on the shared volume.
+//
+// When every container mounts the shared volume at the same path (the
+// supported configuration, and the only one agent-stack-k8s produces), this
+// is a no-op. It matters only when the volume is mounted at different paths
+// per container: the socket is still found via the local
+// BUILDKITE_JOB_CONTEXT_DIR (see existingEnvPriority), so without this
+// rebasing the job would connect fine and then fail on unreachable env file
+// paths.
+func rebaseJobContextPaths(environ *env.Environment, contextDir string) {
+	for _, name := range jobContextFileVars {
+		if val, has := environ.Get(name); has && val != "" {
+			environ.Set(name, filepath.Join(contextDir, filepath.Base(val)))
+		}
+	}
+}
+
 // existingEnvPriority lists existing env vars (the ones this process started
 // with) that should take priority over the registration response env. This is
 // vaguely similar to the "protectedEnv" map, but is distinct and inverted.
@@ -299,10 +341,11 @@ var existingEnvPriority = map[string]struct{}{
 	"BUILDKITE_COMMAND": {},
 	// BUILDKITE_CONTAINER_ID is preserved in case of Hyrum's Law.
 	"BUILDKITE_CONTAINER_ID": {},
-	// BUILDKITE_JOB_CONTEXT_DIR is set by the k8s stack on each container.
-	// The shared volume holding the socket and job context files may be
-	// mounted at a different path in each container, so the local value must
-	// win over the agent container's value.
+	// BUILDKITE_JOB_CONTEXT_DIR is set per container by whatever builds the
+	// pod (self-managed --kubernetes-exec setups; agent-stack-k8s does not
+	// set it and relies on the /workspace default). Each container's value
+	// describes where the shared volume is mounted locally, so it must win
+	// over the agent container's value.
 	"BUILDKITE_JOB_CONTEXT_DIR": {},
 	// BUILDKITE_SOCKETS_PATH is set by agent-stack-k8s and varies by container
 	// name.

--- a/clicommand/kubernetes_bootstrap.go
+++ b/clicommand/kubernetes_bootstrap.go
@@ -29,6 +29,7 @@ intended to be used directly.`
 type KubernetesBootstrapConfig struct {
 	KubernetesContainerID                int           `cli:"kubernetes-container-id"`
 	KubernetesBootstrapConnectionTimeout time.Duration `cli:"kubernetes-bootstrap-connection-timeout"`
+	JobContextDir                        string        `cli:"job-context-dir" normalize:"filepath"`
 
 	// Global flags for debugging, etc
 	LogLevel    string   `cli:"log-level"`
@@ -44,6 +45,7 @@ var KubernetesBootstrapCommand = cli.Command{
 	Description: kubernetesBootstrapHelpDescription,
 	Flags: []cli.Flag{
 		KubernetesContainerIDFlag,
+		JobContextDirFlag,
 		cli.DurationFlag{
 			Name: "kubernetes-bootstrap-connection-timeout",
 			Usage: "This is intended to be used only by the Buildkite k8s stack " +
@@ -70,7 +72,10 @@ var KubernetesBootstrapCommand = cli.Command{
 		defer cancel()
 
 		// Connect the socket.
-		socket := &kubernetes.Client{ID: cfg.KubernetesContainerID}
+		socket := &kubernetes.Client{
+			ID:         cfg.KubernetesContainerID,
+			SocketPath: kubernetes.SocketPath(cfg.JobContextDir),
+		}
 
 		// Registration passes down the env vars the agent normally sets on the
 		// subprocess, but in this case the bootstrap is in a separate
@@ -294,6 +299,11 @@ var existingEnvPriority = map[string]struct{}{
 	"BUILDKITE_COMMAND": {},
 	// BUILDKITE_CONTAINER_ID is preserved in case of Hyrum's Law.
 	"BUILDKITE_CONTAINER_ID": {},
+	// BUILDKITE_JOB_CONTEXT_DIR is set by the k8s stack on each container.
+	// The shared volume holding the socket and job context files may be
+	// mounted at a different path in each container, so the local value must
+	// win over the agent container's value.
+	"BUILDKITE_JOB_CONTEXT_DIR": {},
 	// BUILDKITE_SOCKETS_PATH is set by agent-stack-k8s and varies by container
 	// name.
 	"BUILDKITE_SOCKETS_PATH": {},

--- a/clicommand/kubernetes_bootstrap_test.go
+++ b/clicommand/kubernetes_bootstrap_test.go
@@ -1,0 +1,82 @@
+package clicommand
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/buildkite/agent/v3/env"
+)
+
+func TestRebaseJobContextPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		environ    []string
+		contextDir string
+		want       map[string]string
+	}{
+		{
+			name: "differing_mount_paths",
+			environ: []string{
+				"BUILDKITE_ENV_FILE=/workspace/job-env-abc123",
+				"BUILDKITE_ENV_JSON_FILE=/workspace/job-env-json-abc123",
+				"BUILDKITE_AGENT_JOB_TIMEOUT_FILE=/workspace/job-timeout-abc123",
+			},
+			contextDir: "/buildkite-shared",
+			want: map[string]string{
+				"BUILDKITE_ENV_FILE":               filepath.Join("/buildkite-shared", "job-env-abc123"),
+				"BUILDKITE_ENV_JSON_FILE":          filepath.Join("/buildkite-shared", "job-env-json-abc123"),
+				"BUILDKITE_AGENT_JOB_TIMEOUT_FILE": filepath.Join("/buildkite-shared", "job-timeout-abc123"),
+			},
+		},
+		{
+			name: "same_mount_path_is_unchanged",
+			environ: []string{
+				"BUILDKITE_ENV_FILE=" + filepath.Join("/workspace", "job-env-abc123"),
+			},
+			contextDir: "/workspace",
+			want: map[string]string{
+				"BUILDKITE_ENV_FILE": filepath.Join("/workspace", "job-env-abc123"),
+			},
+		},
+		{
+			name: "unrelated_vars_are_untouched",
+			environ: []string{
+				"BUILDKITE_COMMAND=echo hello",
+			},
+			contextDir: "/buildkite-shared",
+			want: map[string]string{
+				"BUILDKITE_COMMAND": "echo hello",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			environ := env.FromSlice(tc.environ)
+			rebaseJobContextPaths(environ, tc.contextDir)
+
+			for name, want := range tc.want {
+				if got, _ := environ.Get(name); got != want {
+					t.Errorf("environ.Get(%q) = %q, want %q", name, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRebaseJobContextPathsLeavesAbsentVarsAbsent(t *testing.T) {
+	t.Parallel()
+
+	environ := env.FromSlice([]string{"BUILDKITE_COMMAND=echo hello"})
+	rebaseJobContextPaths(environ, "/buildkite-shared")
+
+	for _, name := range jobContextFileVars {
+		if _, has := environ.Get(name); has {
+			t.Errorf("environ.Get(%q) exists, want absent", name)
+		}
+	}
+}

--- a/env/protected.go
+++ b/env/protected.go
@@ -76,6 +76,7 @@ var protectedEnv = map[string]protection{
 	"BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG":  {},
 	"BUILDKITE_HOOKS_PATH":                  {},
 	"BUILDKITE_HOOKS_SHELL":                 {},
+	"BUILDKITE_JOB_CONTEXT_DIR":             {},
 	"BUILDKITE_KUBERNETES_EXEC":             {},
 	"BUILDKITE_LOCAL_HOOKS_ENABLED":         {},
 	"BUILDKITE_PLUGINS_ALWAYS_CLONE_FRESH":  {mutableFromWithinJob: true},

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -29,7 +29,7 @@ var errNotConnected = errors.New("client not connected")
 // Callers should use context.WithTimeout to control the connection timeout.
 func (c *Client) Connect(ctx context.Context) (*RegisterResponse, error) {
 	if c.SocketPath == "" {
-		c.SocketPath = defaultSocketPath
+		c.SocketPath = SocketPath("")
 	}
 
 	// Retry until the context is cancelled. The high maxAttempts is a safety net

--- a/kubernetes/runner.go
+++ b/kubernetes/runner.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/rpc"
 	"os"
+	"path/filepath"
 	"sync"
 	"syscall"
 	"time"
@@ -24,9 +25,26 @@ func init() {
 }
 
 const (
-	defaultSocketPath          = "/workspace/buildkite.sock"
+	// socketName is the name of the coordination socket file within the job
+	// context directory.
+	socketName = "buildkite.sock"
+
+	// DefaultContextDir is the job context directory used when no other
+	// directory is configured. It must be on a volume shared by all
+	// containers in the pod.
+	DefaultContextDir = "/workspace"
+
 	unknownContainerExitStatus = 137
 )
+
+// SocketPath returns the path of the coordination socket within the given job
+// context directory. An empty dir means DefaultContextDir.
+func SocketPath(dir string) string {
+	if dir == "" {
+		dir = DefaultContextDir
+	}
+	return filepath.Join(dir, socketName)
+}
 
 type RunnerConfig struct {
 	SocketPath         string
@@ -40,7 +58,7 @@ type RunnerConfig struct {
 // NewRunner returns a runner, implementing the agent's jobRunner interface.
 func NewRunner(l logger.Logger, c RunnerConfig) *Runner {
 	if c.SocketPath == "" {
-		c.SocketPath = defaultSocketPath
+		c.SocketPath = SocketPath("")
 	}
 	clients := make([]*clientResult, c.ClientCount)
 	for i := range c.ClientCount {


### PR DESCRIPTION
Adds a `--job-context-dir` flag (`BUILDKITE_JOB_CONTEXT_DIR`) to `agent start` and `kubernetes-bootstrap` to configure the directory for job coordination files. Based on #4090 by @aeijdenberg-canva, thanks Adam for the contribution. Tracked as [A-1547](https://linear.app/buildkite/issue/A-1547).

Closes #4090.

## Context

The agent and the processes running a job coordinate through a small set of files: the job env snapshot (`BUILDKITE_ENV_FILE` / `BUILDKITE_ENV_JSON_FILE`), the job timeout marker (`BUILDKITE_AGENT_JOB_TIMEOUT_FILE`), and, in Kubernetes mode, the socket that `kubernetes-bootstrap` connects to (`buildkite.sock`). Their directory was hardcoded: `/workspace` in Kubernetes mode, the system temp dir otherwise.

## Who this is for

* **agent-stack-k8s users**: no change. The stack manages the shared `/workspace` volume that Kubernetes mode defaults to; leave the flag unset.
* **Self-managed `--kubernetes-exec` orchestration**: set `BUILDKITE_JOB_CONTEXT_DIR` on every container to the path where the shared volume is mounted in that container. This removes the last hardcoded `/workspace` in the agent binary, which can collide with images that claim that path.
* **Ordinary self-hosted agents**: rarely needed. It relocates the env and timeout files out of the system temp dir (previously only movable via `TMPDIR`).

Defaults are unchanged in all modes.

## Changes

Two commits:

1. The original commit from #4090, rebased onto main. Conflicts with the checkout override work in `env/protected.go` and the container exit status change in `kubernetes/runner.go` were resolved during the rebase.
2. Follow-ups:
   * `kubernetes-bootstrap` now rebases `BUILDKITE_ENV_FILE`, `BUILDKITE_ENV_JSON_FILE` and `BUILDKITE_AGENT_JOB_TIMEOUT_FILE` onto its own context directory. The agent sends these as absolute paths computed in its own mount namespace, so a container mounting the shared volume at a different path would connect to the socket fine and then fail on unreachable env file paths.
   * Reuse the `contextDir` computed in `NewJobRunner` for the socket path, and rename the `tempDir` parameters to `contextDir` since the directory is no longer necessarily the system temp dir.
   * Document the intended audience in the flag help, and correct the `existingEnvPriority` comment (agent-stack-k8s does not set `BUILDKITE_JOB_CONTEXT_DIR`).

Note on scope: mounting the shared volume at the same path in every container remains the supported configuration, since `BUILDKITE_BUILD_PATH` also crosses containers as an absolute path. The env file rebasing is defence in depth and a no-op when paths match.

## Testing

* New unit test `TestRebaseJobContextPaths` covers differing mount paths, same path no-op, and absent vars
* Tests have run locally (with `go test ./...`)
* Code is formatted (with `go tool gofumpt -extra -w .`) and `golangci-lint run` reports no issues on the touched packages
