### PR TITLE
Default git commit verification to strict in v4

### DIFF
--- a/agent/integration/job_environment_integration_test.go
+++ b/agent/integration/job_environment_integration_test.go
@@ -760,18 +760,18 @@ func TestCheckoutScopedJobEnvOverrideHonorsCheckoutOverrideMode(t *testing.T) {
 		},
 		// Commit verification is an enum (not a flag) but is checkout-override
 		// scoped, so it follows the same mode rules. With v4's strict default, none
-		// lets the backend job env select warn instead.
+		// lets the backend job env turn verification off instead.
 		{
 			name:    "none_allows_job_env_to_override_default_commit_verification",
 			varName: "BUILDKITE_GIT_COMMIT_VERIFICATION",
 			jobEnv: map[string]string{
-				"BUILDKITE_GIT_COMMIT_VERIFICATION": "warn",
+				"BUILDKITE_GIT_COMMIT_VERIFICATION": "off",
 			},
 			agentCfg: agent.AgentConfiguration{
 				GitCommitVerification: "strict",
 				CheckoutOverrideMode:  env.CheckoutOverrideNone,
 			},
-			wantEnvValue: "warn",
+			wantEnvValue: "off",
 		},
 		{
 			name:    "none_allows_job_env_to_override_commit_verification",
@@ -780,7 +780,7 @@ func TestCheckoutScopedJobEnvOverrideHonorsCheckoutOverrideMode(t *testing.T) {
 				"BUILDKITE_GIT_COMMIT_VERIFICATION": "strict",
 			},
 			agentCfg: agent.AgentConfiguration{
-				GitCommitVerification: "warn",
+				GitCommitVerification: "off",
 				CheckoutOverrideMode:  env.CheckoutOverrideNone,
 			},
 			wantEnvValue: "strict",
@@ -792,10 +792,10 @@ func TestCheckoutScopedJobEnvOverrideHonorsCheckoutOverrideMode(t *testing.T) {
 				"BUILDKITE_GIT_COMMIT_VERIFICATION": "strict",
 			},
 			agentCfg: agent.AgentConfiguration{
-				GitCommitVerification: "warn",
+				GitCommitVerification: "off",
 				CheckoutOverrideMode:  env.CheckoutOverrideStrict,
 			},
-			wantEnvValue:       "warn",
+			wantEnvValue:       "off",
 			wantIgnoredEnvVars: []string{"BUILDKITE_GIT_COMMIT_VERIFICATION"},
 		},
 		{
@@ -807,10 +807,10 @@ func TestCheckoutScopedJobEnvOverrideHonorsCheckoutOverrideMode(t *testing.T) {
 				"BUILDKITE_GIT_COMMIT_VERIFICATION": "strict",
 			},
 			agentCfg: agent.AgentConfiguration{
-				GitCommitVerification: "warn",
+				GitCommitVerification: "off",
 				CheckoutOverrideMode:  env.CheckoutOverrideFromJob,
 			},
-			wantEnvValue:       "warn",
+			wantEnvValue:       "off",
 			wantIgnoredEnvVars: []string{"BUILDKITE_GIT_COMMIT_VERIFICATION"},
 		},
 	}

--- a/agent/integration/job_environment_integration_test.go
+++ b/agent/integration/job_environment_integration_test.go
@@ -759,19 +759,19 @@ func TestCheckoutScopedJobEnvOverrideHonorsCheckoutOverrideMode(t *testing.T) {
 			wantIgnoredEnvVars: []string{"BUILDKITE_GIT_CHECKOUT_TIMEOUT"},
 		},
 		// Commit verification is an enum (not a flag) but is checkout-override
-		// scoped, so it follows the same mode rules. The first case is the reported
-		// scenario: agent leaves it unset, the pipeline requests strict, and none
-		// lets the job env win so verification actually runs.
+		// scoped, so it follows the same mode rules. With v4's strict default, none
+		// lets the backend job env select warn instead.
 		{
-			name:    "none_allows_job_env_to_enable_commit_verification_when_agent_unset",
+			name:    "none_allows_job_env_to_override_default_commit_verification",
 			varName: "BUILDKITE_GIT_COMMIT_VERIFICATION",
 			jobEnv: map[string]string{
-				"BUILDKITE_GIT_COMMIT_VERIFICATION": "strict",
+				"BUILDKITE_GIT_COMMIT_VERIFICATION": "warn",
 			},
 			agentCfg: agent.AgentConfiguration{
-				CheckoutOverrideMode: env.CheckoutOverrideNone,
+				GitCommitVerification: "strict",
+				CheckoutOverrideMode:  env.CheckoutOverrideNone,
 			},
-			wantEnvValue: "strict",
+			wantEnvValue: "warn",
 		},
 		{
 			name:    "none_allows_job_env_to_override_commit_verification",

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -820,9 +820,10 @@ var AgentStartCommand = &cli.Command{
 			}
 		}
 
-		// Validate the commit verification option input
-		if v := cfg.GitCommitVerification; v != "" && v != "strict" && v != "warn" {
-			return fmt.Errorf("invalid value for --git-commit-verification: %q (must be \"strict\" or \"warn\")", v)
+		// The config file is loaded after CLI flag validation, so validate its
+		// commit verification value here as well.
+		if err := validateGitCommitVerification(cfg.GitCommitVerification); err != nil {
+			return err
 		}
 
 		// Force some settings if on Windows (these aren't supported yet)

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -199,8 +199,13 @@ var (
 )
 
 func validateGitCommitVerification(value string) error {
-	if value != "strict" && value != "warn" {
-		return fmt.Errorf("invalid value for --git-commit-verification: %q (must be \"strict\" or \"warn\")", value)
+	if value != job.GitCommitVerificationStrict && value != job.GitCommitVerificationOff {
+		return fmt.Errorf(
+			"invalid value for --git-commit-verification: %q (must be %q or %q)",
+			value,
+			job.GitCommitVerificationStrict,
+			job.GitCommitVerificationOff,
+		)
 	}
 	return nil
 }
@@ -254,8 +259,8 @@ var (
 
 	GitCommitVerificationFlag = &cli.StringFlag{
 		Name:             "git-commit-verification",
-		Value:            "strict",
-		Usage:            "Verify that the commit being built exists on the specified branch; one of strict or warn",
+		Value:            job.GitCommitVerificationStrict,
+		Usage:            "Verify that the commit being built exists on the specified branch; one of strict or off",
 		Sources:          cli.EnvVars("BUILDKITE_GIT_COMMIT_VERIFICATION"),
 		ValidateDefaults: true,
 		Validator:        validateGitCommitVerification,

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -198,6 +198,13 @@ var (
 	}
 )
 
+func validateGitCommitVerification(value string) error {
+	if value != "strict" && value != "warn" {
+		return fmt.Errorf("invalid value for --git-commit-verification: %q (must be \"strict\" or \"warn\")", value)
+	}
+	return nil
+}
+
 // Git related flags shared between agent start and bootstrap
 var (
 	SkipCheckoutFlag = &cli.BoolFlag{
@@ -246,9 +253,12 @@ var (
 	}
 
 	GitCommitVerificationFlag = &cli.StringFlag{
-		Name:    "git-commit-verification",
-		Usage:   "Enable git commit verification",
-		Sources: cli.EnvVars("BUILDKITE_GIT_COMMIT_VERIFICATION"),
+		Name:             "git-commit-verification",
+		Value:            "strict",
+		Usage:            "Verify that the commit being built exists on the specified branch; one of strict or warn",
+		Sources:          cli.EnvVars("BUILDKITE_GIT_COMMIT_VERIFICATION"),
+		ValidateDefaults: true,
+		Validator:        validateGitCommitVerification,
 	}
 
 	GitFetchFlagsFlag = &cli.StringFlag{

--- a/clicommand/global_test.go
+++ b/clicommand/global_test.go
@@ -45,13 +45,17 @@ func TestGitCommitVerificationFlag(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			flag := *GitCommitVerificationFlag
-			flag.Sources = cli.ValueSourceChain{}
+			flag := &cli.StringFlag{
+				Name:             GitCommitVerificationFlag.Name,
+				Value:            GitCommitVerificationFlag.Value,
+				ValidateDefaults: GitCommitVerificationFlag.ValidateDefaults,
+				Validator:        GitCommitVerificationFlag.Validator,
+			}
 
 			var got string
 			command := &cli.Command{
 				Name:  "test",
-				Flags: []cli.Flag{&flag},
+				Flags: []cli.Flag{flag},
 				Action: func(_ context.Context, command *cli.Command) error {
 					got = command.String("git-commit-verification")
 					return nil

--- a/clicommand/global_test.go
+++ b/clicommand/global_test.go
@@ -1,10 +1,12 @@
 package clicommand
 
 import (
+	"context"
 	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/urfave/cli/v3"
 )
 
 func TestAllFlagEnvs(t *testing.T) {
@@ -21,5 +23,47 @@ func TestAllFlagEnvs(t *testing.T) {
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("allFlagEnvs(EnvDumpCommand) diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestGitCommitVerificationFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "defaults to strict",
+			want: "strict",
+		},
+		{
+			name: "can be overridden with warn",
+			args: []string{"--git-commit-verification", "warn"},
+			want: "warn",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			flag := *GitCommitVerificationFlag
+			flag.Sources = cli.ValueSourceChain{}
+
+			var got string
+			command := &cli.Command{
+				Name:  "test",
+				Flags: []cli.Flag{&flag},
+				Action: func(_ context.Context, command *cli.Command) error {
+					got = command.String("git-commit-verification")
+					return nil
+				},
+			}
+
+			if err := command.Run(t.Context(), append([]string{"test"}, test.args...)); err != nil {
+				t.Fatalf("command.Run() error = %v", err)
+			}
+			if got != test.want {
+				t.Errorf("git-commit-verification = %q, want %q", got, test.want)
+			}
+		})
 	}
 }

--- a/clicommand/global_test.go
+++ b/clicommand/global_test.go
@@ -37,9 +37,9 @@ func TestGitCommitVerificationFlag(t *testing.T) {
 			want: "strict",
 		},
 		{
-			name: "can be overridden with warn",
-			args: []string{"--git-commit-verification", "warn"},
-			want: "warn",
+			name: "can be overridden with off",
+			args: []string{"--git-commit-verification", "off"},
+			want: "off",
 		},
 	}
 

--- a/env/protected.go
+++ b/env/protected.go
@@ -103,7 +103,7 @@ var protectedEnv = map[string]protection{
 // Locking matters because git is riddled with shell injections, so letting a job
 // set git flags would otherwise be a way to bypass protections like
 // no-command-eval (which is why disabling command-eval forces the mode to
-// strict). BUILDKITE_GIT_COMMIT_VERIFICATION is an enum ("", "warn", "strict"),
+// strict). BUILDKITE_GIT_COMMIT_VERIFICATION is an enum ("warn", "strict"),
 // not an injection vector, but the backend exposes it under `checkout:` alongside
 // the flag vars, so it's governed by the mode too: only none lets a job's own
 // checkout config (pipeline/step env, secrets) turn verification on, matching the

--- a/env/protected.go
+++ b/env/protected.go
@@ -105,10 +105,10 @@ var protectedEnv = map[string]protection{
 // no-command-eval (which is why disabling command-eval forces the mode to
 // strict). BUILDKITE_GIT_COMMIT_VERIFICATION is an enum ("warn", "strict"),
 // not an injection vector, but the backend exposes it under `checkout:` alongside
-// the flag vars, so it's governed by the mode too: only none lets a job's own
-// checkout config (pipeline/step env, secrets) turn verification on, matching the
-// other checkout settings. Vars here must not also appear in protectedEnv; the
-// two maps are disjoint.
+// the flag vars, so it's governed by the mode too: only none lets the backend job
+// env and secrets select the verification mode, matching the other checkout
+// settings. Vars here must not also appear in protectedEnv; the two maps are
+// disjoint.
 var checkoutOverrideScope = map[string]struct{}{
 	"BUILDKITE_GIT_CHECKOUT_FLAGS":              {},
 	"BUILDKITE_GIT_CHECKOUT_TIMEOUT":            {},

--- a/env/protected.go
+++ b/env/protected.go
@@ -103,7 +103,7 @@ var protectedEnv = map[string]protection{
 // Locking matters because git is riddled with shell injections, so letting a job
 // set git flags would otherwise be a way to bypass protections like
 // no-command-eval (which is why disabling command-eval forces the mode to
-// strict). BUILDKITE_GIT_COMMIT_VERIFICATION is an enum ("warn", "strict"),
+// strict). BUILDKITE_GIT_COMMIT_VERIFICATION is an enum ("strict", "off"),
 // not an injection vector, but the backend exposes it under `checkout:` alongside
 // the flag vars, so it's governed by the mode too: only none lets the backend job
 // env and secrets select the verification mode, matching the other checkout

--- a/internal/job/commit_verification.go
+++ b/internal/job/commit_verification.go
@@ -237,14 +237,9 @@ func stripRefSuppressingFetchFlags(flags []string) []string {
 	return out
 }
 
-// verifyCommit is called if the user has commit verification enabled. It ensures that the commit we are
-// asked to build exists and is reachable on the branch we are given.
+// verifyCommit ensures that the commit we are asked to build exists and is
+// reachable on the branch we are given.
 func (e *Executor) verifyCommit(ctx context.Context) error {
-	// Skip if not enabled
-	if e.GitCommitVerification == "" {
-		return nil
-	}
-
 	// Skip if commit is HEAD (nothing to verify)
 	if e.Commit == "HEAD" {
 		e.shell.Commentf("Skipping commit verification: commit is HEAD")
@@ -287,12 +282,11 @@ func (e *Executor) verifyCommit(ctx context.Context) error {
 
 	// Definitive failure — commit is provably not on the branch
 	if errors.Is(err, ErrCommitVerificationFailed) {
-		if e.GitCommitVerification == "strict" {
-			return err
+		if e.GitCommitVerification == "warn" {
+			e.shell.Warningf("Commit verification failed: %v", err)
+			return nil
 		}
-		// err already begins with "commit verification failed", so log it as-is.
-		e.shell.Warningf("%s", err)
-		return nil
+		return err
 	}
 
 	// Verification unavailable — infrastructure issue, not a security concern.

--- a/internal/job/commit_verification.go
+++ b/internal/job/commit_verification.go
@@ -283,7 +283,7 @@ func (e *Executor) verifyCommit(ctx context.Context) error {
 	// Definitive failure — commit is provably not on the branch
 	if errors.Is(err, ErrCommitVerificationFailed) {
 		if e.GitCommitVerification == "warn" {
-			e.shell.Warningf("Commit verification failed: %v", err)
+			e.shell.Warningf("%s", err)
 			return nil
 		}
 		return err

--- a/internal/job/commit_verification.go
+++ b/internal/job/commit_verification.go
@@ -21,6 +21,13 @@ var ErrCommitVerificationFailed = errors.New("commit verification failed")
 // This is NOT evidence of an attack — it's an infrastructure problem.
 var ErrCommitVerificationUnavailable = errors.New("commit verification unavailable")
 
+const (
+	// GitCommitVerificationStrict checks branch ancestry and blocks a definitive mismatch.
+	GitCommitVerificationStrict = "strict"
+	// GitCommitVerificationOff skips branch ancestry verification entirely.
+	GitCommitVerificationOff = "off"
+)
+
 // checkCommitOnBranch performs the actual git ancestry check, handling shallow
 // clones by deepening or unshallowing as needed. It returns:
 //   - nil if the commit is verified on the branch
@@ -240,6 +247,23 @@ func stripRefSuppressingFetchFlags(flags []string) []string {
 // verifyCommit ensures that the commit we are asked to build exists and is
 // reachable on the branch we are given.
 func (e *Executor) verifyCommit(ctx context.Context) error {
+	switch e.GitCommitVerification {
+	case GitCommitVerificationOff:
+		e.shell.Commentf("Skipping commit verification: mode is off")
+		return nil
+	case GitCommitVerificationStrict, "":
+		// The zero value is treated as strict for programmatic ExecutorConfig
+		// consumers. The CLI rejects empty values, and only explicit off skips.
+		// Continue below.
+	default:
+		return fmt.Errorf(
+			"invalid git commit verification mode %q (must be %q or %q)",
+			e.GitCommitVerification,
+			GitCommitVerificationStrict,
+			GitCommitVerificationOff,
+		)
+	}
+
 	// Skip if commit is HEAD (nothing to verify)
 	if e.Commit == "HEAD" {
 		e.shell.Commentf("Skipping commit verification: commit is HEAD")
@@ -282,16 +306,11 @@ func (e *Executor) verifyCommit(ctx context.Context) error {
 
 	// Definitive failure — commit is provably not on the branch
 	if errors.Is(err, ErrCommitVerificationFailed) {
-		if e.GitCommitVerification == "warn" {
-			e.shell.Warningf("%s", err)
-			return nil
-		}
 		return err
 	}
 
-	// Verification unavailable — infrastructure issue, not a security concern.
-	// We always warn but never block, even in strict mode, to avoid users
-	// disabling verification entirely due to infrastructure false positives.
+	// Verification unavailable — infrastructure issue, not a definitive mismatch.
+	// We always warn but never block, even in strict mode.
 	// err already begins with "commit verification unavailable", so log it as-is.
 	e.shell.Warningf("%s", err)
 	return nil

--- a/internal/job/commit_verification_test.go
+++ b/internal/job/commit_verification_test.go
@@ -370,18 +370,27 @@ func TestVerifyCommit(t *testing.T) {
 			t.Fatalf("git fetch error = %v", err)
 		}
 
-		e := &Executor{
-			shell: sh,
-			ExecutorConfig: ExecutorConfig{
-				GitCommitVerification: "strict",
-				Commit:                commit,      // commit from feature-a
-				Branch:                "feature-b", // but checking against feature-b
-			},
-		}
+		for _, mode := range []struct {
+			name  string
+			value string
+		}{
+			{name: "strict mode", value: "strict"},
+			{name: "empty mode fails closed", value: ""},
+		} {
+			t.Run(mode.name, func(t *testing.T) {
+				e := &Executor{
+					shell: sh,
+					ExecutorConfig: ExecutorConfig{
+						GitCommitVerification: mode.value,
+						Commit:                commit,      // commit from feature-a
+						Branch:                "feature-b", // but checking against feature-b
+					},
+				}
 
-		err = e.verifyCommit(ctx)
-		if err == nil {
-			t.Errorf("verifyCommit() error = nil, want error about commit not on branch")
+				if err := e.verifyCommit(ctx); !errors.Is(err, ErrCommitVerificationFailed) {
+					t.Errorf("verifyCommit() with mode %q error = %v, want ErrCommitVerificationFailed", mode.value, err)
+				}
+			})
 		}
 	})
 

--- a/internal/job/commit_verification_test.go
+++ b/internal/job/commit_verification_test.go
@@ -154,6 +154,14 @@ func TestVerifyCommit(t *testing.T) {
 		config ExecutorConfig
 	}{
 		{
+			name: "skips when verification is off",
+			config: ExecutorConfig{
+				GitCommitVerification: GitCommitVerificationOff,
+				Commit:                "abc123",
+				Branch:                "main",
+			},
+		},
+		{
 			name: "skips when commit is HEAD",
 			config: ExecutorConfig{
 				GitCommitVerification: "strict",
@@ -374,7 +382,7 @@ func TestVerifyCommit(t *testing.T) {
 			name  string
 			value string
 		}{
-			{name: "strict mode", value: "strict"},
+			{name: "strict mode", value: GitCommitVerificationStrict},
 			{name: "empty mode fails closed", value: ""},
 		} {
 			t.Run(mode.name, func(t *testing.T) {
@@ -391,107 +399,6 @@ func TestVerifyCommit(t *testing.T) {
 					t.Errorf("verifyCommit() with mode %q error = %v, want ErrCommitVerificationFailed", mode.value, err)
 				}
 			})
-		}
-	})
-
-	t.Run("warn mode logs warning but does not fail", func(t *testing.T) {
-		t.Setenv("GIT_AUTHOR_NAME", "Buildkite Agent")
-		t.Setenv("GIT_AUTHOR_EMAIL", "agent@example.com")
-		t.Setenv("GIT_COMMITTER_NAME", "Buildkite Agent")
-		t.Setenv("GIT_COMMITTER_EMAIL", "agent@example.com")
-
-		ctx := t.Context()
-
-		s := githttptest.NewServer()
-		defer s.Close()
-
-		err := s.CreateRepository("verify-warn-mode")
-		if err != nil {
-			t.Fatalf("CreateRepository error = %v", err)
-		}
-
-		_, err = s.InitRepository("verify-warn-mode")
-		if err != nil {
-			t.Fatalf("InitRepository error = %v", err)
-		}
-
-		commit, _, err := s.PushBranch("verify-warn-mode", "feature-a")
-		if err != nil {
-			t.Fatalf("PushBranch(feature-a) error = %v", err)
-		}
-
-		// Create feature-b with unique content so the branches genuinely diverge
-		workDir, err := os.MkdirTemp("", "verify-commit-work-")
-		if err != nil {
-			t.Fatalf("MkdirTemp error = %v", err)
-		}
-		t.Cleanup(func() { os.RemoveAll(workDir) }) //nolint:errcheck // Best-effort cleanup.
-
-		setupSh, err := shell.New()
-		if err != nil {
-			t.Fatalf("shell.New() error = %v", err)
-		}
-		if err := setupSh.Command("git", "clone", s.RepoURL("verify-warn-mode"), workDir).Run(ctx); err != nil {
-			t.Fatalf("git clone error = %v", err)
-		}
-		if err := setupSh.Chdir(workDir); err != nil {
-			t.Fatalf("Chdir error = %v", err)
-		}
-		if err := setupSh.Command("git", "checkout", "-b", "feature-b").Run(ctx); err != nil {
-			t.Fatalf("git checkout error = %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(workDir, "unique-b.txt"), []byte("unique content for branch b"), 0o644); err != nil {
-			t.Fatalf("WriteFile error = %v", err)
-		}
-		if err := setupSh.Command("git", "add", "unique-b.txt").Run(ctx); err != nil {
-			t.Fatalf("git add error = %v", err)
-		}
-		if err := setupSh.Command("git", "commit", "-m", "unique commit on feature-b").Run(ctx); err != nil {
-			t.Fatalf("git commit error = %v", err)
-		}
-		if err := setupSh.Command("git", "push", "origin", "feature-b").Run(ctx); err != nil {
-			t.Fatalf("git push error = %v", err)
-		}
-
-		cloneDir, err := os.MkdirTemp("", "verify-commit-test-")
-		if err != nil {
-			t.Fatalf("MkdirTemp error = %v", err)
-		}
-		t.Cleanup(func() { os.RemoveAll(cloneDir) }) //nolint:errcheck // Best-effort cleanup.
-
-		sh, err := shell.New()
-		if err != nil {
-			t.Fatalf("shell.New() error = %v", err)
-		}
-
-		if err := sh.Command("git", "clone", s.RepoURL("verify-warn-mode"), cloneDir).Run(ctx); err != nil {
-			t.Fatalf("git clone error = %v", err)
-		}
-		if err := sh.Chdir(cloneDir); err != nil {
-			t.Fatalf("Chdir error = %v", err)
-		}
-		if err := sh.Command("git", "fetch", "origin", "feature-a:refs/remotes/origin/feature-a", "feature-b:refs/remotes/origin/feature-b").Run(ctx); err != nil {
-			t.Fatalf("git fetch error = %v", err)
-		}
-
-		e := &Executor{
-			shell: sh,
-			ExecutorConfig: ExecutorConfig{
-				GitCommitVerification: "warn",
-				Commit:                commit,      // commit from feature-a
-				Branch:                "feature-b", // but checking against feature-b
-			},
-		}
-
-		// The underlying check must genuinely detect the failure (not merely
-		// degrade to "unavailable"), or warn mode swallowing it below proves nothing.
-		if err := e.checkCommitOnBranch(ctx); !errors.Is(err, ErrCommitVerificationFailed) {
-			t.Fatalf("checkCommitOnBranch() error = %v, want ErrCommitVerificationFailed", err)
-		}
-
-		// In warn mode, that failure must NOT be surfaced as an error.
-		if err := e.verifyCommit(ctx); err != nil {
-			t.Errorf("verifyCommit() in warn mode error = %v, want nil", err)
 		}
 	})
 

--- a/internal/job/commit_verification_test.go
+++ b/internal/job/commit_verification_test.go
@@ -154,14 +154,6 @@ func TestVerifyCommit(t *testing.T) {
 		config ExecutorConfig
 	}{
 		{
-			name: "skips when verification is disabled",
-			config: ExecutorConfig{
-				GitCommitVerification: "",
-				Commit:                "abc123",
-				Branch:                "main",
-			},
-		},
-		{
 			name: "skips when commit is HEAD",
 			config: ExecutorConfig{
 				GitCommitVerification: "strict",

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -128,7 +128,7 @@ type ExecutorConfig struct {
 	// SSH private key to use for git checkout operations
 	GitSSHKey string `env:"BUILDKITE_GIT_SSH_KEY"`
 
-	// Enable git commit verification
+	// Controls git commit verification behavior
 	GitCommitVerification string `env:"BUILDKITE_GIT_COMMIT_VERIFICATION"`
 
 	// Config key=value pairs to pass to "git" when submodule init commands are invoked

--- a/internal/job/config_test.go
+++ b/internal/job/config_test.go
@@ -219,8 +219,8 @@ func TestReadFromEnvironmentRefreshesCommitVerification(t *testing.T) {
 
 	// Commit verification is checkout-scoped, so an allowed within-job source
 	// (from-job or none) must refresh the executor field: verifyCommit reads
-	// GitCommitVerification, not the env, so a stale field would silently skip the
-	// requested verification. strict must keep the agent-config value.
+	// GitCommitVerification, not the env, so a stale field would use the wrong
+	// verification policy. strict must keep the agent-config value.
 	t.Run("from-job refreshes the field", func(t *testing.T) {
 		t.Parallel()
 
@@ -241,7 +241,7 @@ func TestReadFromEnvironmentRefreshesCommitVerification(t *testing.T) {
 
 		config := &ExecutorConfig{
 			CheckoutOverrideMode:  env.CheckoutOverrideStrict,
-			GitCommitVerification: "warn",
+			GitCommitVerification: "off",
 		}
 		environ := env.FromSlice([]string{"BUILDKITE_GIT_COMMIT_VERIFICATION=strict"})
 
@@ -249,7 +249,7 @@ func TestReadFromEnvironmentRefreshesCommitVerification(t *testing.T) {
 		if len(changes) != 0 {
 			t.Errorf("changes = %v, want none", changes)
 		}
-		if got, want := config.GitCommitVerification, "warn"; got != want {
+		if got, want := config.GitCommitVerification, "off"; got != want {
 			t.Errorf("config.GitCommitVerification = %q, want %q", got, want)
 		}
 	})

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -1112,19 +1112,26 @@ func TestCheckingOutLocalGitProjectWithShortCommitHash(t *testing.T) {
 		t.Fatalf("tester.Repo.RevParse(%q) error = %v, want nil", "HEAD", err)
 	}
 	shortCommitHash := commitHash[:7]
+	branchTip := strings.TrimSpace(commitHash)
 
 	git := tester.
 		MustMock(t, "git").
 		PassthroughToLocalCommand()
 
 	// Git should attempt to fetch the shortHash, but fail. Then fallback to fetching
-	// all the heads and tags and checking out the short commit hash.
+	// all the heads and tags, verify the commit against main, and check out the
+	// short commit hash.
+	const branchTipRef = "refs/buildkite-agent/commit-verification-branch-tip"
 	git.ExpectAll([][]any{
 		{"config", "--get-all", "remote.origin.url"},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", shortCommitHash},
 		{"config", "remote.origin.fetch"},
 		{"fetch", "-v", "--prune", "--", "origin", "+refs/heads/*:refs/remotes/origin/*", "+refs/tags/*:refs/tags/*"},
+		{"fetch", "-v", "--prune", "--", "origin", "+refs/heads/main:" + branchTipRef},
+		{"rev-parse", branchTipRef},
+		{"merge-base", "--is-ancestor", shortCommitHash, branchTip},
+		{"update-ref", "-d", branchTipRef},
 		{"-c", "advice.detachedHead=false", "checkout", "-f", shortCommitHash},
 		{"clean", "-ffxdq"},
 		{"rev-parse", shortCommitHash},


### PR DESCRIPTION
## Description

Make Git commit verification a secure default in agent v4.

The agent now uses `strict` when `git-commit-verification` is not configured. Operators can explicitly select `off` to skip verification entirely. The supported v4 modes are `strict` and `off`; `warn`, empty values, and other unsupported CLI values are rejected.

The zero value in a programmatically constructed executor configuration remains fail-closed and behaves as `strict`. Verification that cannot be completed because of an infrastructure problem remains warning-only, preserving the existing availability behavior.

## Context

- [A-1592: Consider git commit verification strict as default in v4](https://linear.app/buildkite/issue/A-1592/consider-git-commit-verification-strict-as-default-in-v4)
- Companion documentation: [buildkite/docs#3145](https://github.com/buildkite/docs/pull/3145)

## Changes

- Default `--git-commit-verification` to `strict`.
- Accept `strict` and `off` from flags, environment variables, and config files.
- Make `off` skip branch-tip fetching and the ancestry check entirely.
- Reject empty and unsupported CLI values instead of treating them as disabled.
- Treat an empty programmatic executor value as `strict` and reject other unrecognized executor values.

## Design decision: explicit off mode

This PR changes both the default and the supported modes. Agent v4 enables verification by default with `strict`, while `off` provides an explicit escape hatch for operators who cannot run the verification fetch and ancestry checks.

In `strict` mode, a definitive branch/commit mismatch fails the job. If the check is unavailable because of an infrastructure problem, the agent warns and continues. Existing skip conditions for `HEAD`, tags, pull requests, custom refspecs, and builds without a branch remain unchanged.

## Testing

Tested that I was able to disable the verification
<img width="624" height="106" alt="Screenshot 2026-08-05 at 11 26 53 am" src="https://github.com/user-attachments/assets/6fc28c4c-076c-480b-a26a-d0b9426da5e6" />

And when the verification is enabled, it fails properly
<img width="980" height="308" alt="Screenshot 2026-08-05 at 11 27 09 am" src="https://github.com/user-attachments/assets/95372e85-4991-48fb-9fcd-822fe5cc9a2e" />


## Deployment

This is an intentional v4 behavior change. Operators who need to disable verification must set `git-commit-verification="off"` or `BUILDKITE_GIT_COMMIT_VERIFICATION=off`. Existing `warn` or empty configurations must be changed to either `strict` or `off`. There are no data migrations.

## Rollback

Revert this PR to restore the previous empty default and `warn` behavior.

## Affiliation (optional, external contributors)

Buildkite.

## Disclosures / Credits

OpenAI Codex implemented the change and tests under Jamie Monserrate's direction.
