### PR TITLE
A-1624: Wait for automatic mirror maintenance

### DIFF
--- a/internal/job/checkout_mirror.go
+++ b/internal/job/checkout_mirror.go
@@ -14,6 +14,18 @@ import (
 	"github.com/buildkite/shellwords"
 )
 
+// gitMirrorFetchFlags returns the global Git flags used when updating a mirror.
+// Keep automatic maintenance enabled, but wait for it to finish before releasing
+// the update lock or creating a snapshot. gc.autoDetach covers older Git versions
+// that run auto-gc instead of `git maintenance`.
+func gitMirrorFetchFlags(mirrorDir string) []string {
+	return []string{
+		"-c", "maintenance.autoDetach=false",
+		"-c", "gc.autoDetach=false",
+		"--git-dir", mirrorDir,
+	}
+}
+
 func (e *Executor) getOrUpdateMirrorDir(ctx context.Context, repository string) (string, error) {
 	var mirrorDir string
 	// Skip updating the Git mirror before using it?
@@ -188,7 +200,7 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string) (dir 
 		if err := e.traceOp(ctx, "git.mirror.fetch", func(ctx context.Context) error {
 			return gitFetch(ctx, gitFetchArgs{
 				Shell:      e.shell,
-				GitFlags:   fmt.Sprintf("--git-dir=%s", mirrorDir),
+				GitFlags:   gitMirrorFetchFlags(mirrorDir),
 				Repository: "origin",
 				RefSpecs:   refspecs,
 				Retry:      retry,
@@ -205,7 +217,7 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string) (dir 
 		// a clean host or with a clean checkout.)
 		// TODO: Investigate getting the ref from the main repo and passing
 		// that in here.
-		cmd := e.shell.Command("git", "--git-dir", mirrorDir, "fetch", "origin")
+		cmd := e.shell.Command("git", append(gitMirrorFetchFlags(mirrorDir), "fetch", "origin")...)
 		if err := e.traceOp(ctx, "git.mirror.fetch", func(ctx context.Context) error {
 			return cmd.Run(ctx)
 		}); err != nil {

--- a/internal/job/git.go
+++ b/internal/job/git.go
@@ -290,7 +290,7 @@ func gitRepack(ctx context.Context, sh *shell.Shell, args ...string) error {
 
 type gitFetchArgs struct {
 	Shell         *shell.Shell // The shell to run the command in
-	GitFlags      string       // Global git flags to pass to the command
+	GitFlags      []string     // Global git flags to pass to the command
 	GitFetchFlags string       // Flags to pass to the fetch command
 	Repository    string       // The remote to fetch from
 	Retry         bool         // Whether to retry the fetch on certain errors
@@ -299,16 +299,7 @@ type gitFetchArgs struct {
 
 func gitFetch(ctx context.Context, args gitFetchArgs) error {
 	// Build the command: git [global gitFlags] fetch [fetchFlags] -- [repository] [refspecs...]
-	commandArgs := []string{}
-
-	if args.GitFlags != "" {
-		parts, err := shellwords.Split(args.GitFlags)
-		if err != nil {
-			return fmt.Errorf("failed to parse gitFlags: %w", err)
-		}
-		commandArgs = append(commandArgs, parts...)
-	}
-
+	commandArgs := append([]string{}, args.GitFlags...)
 	commandArgs = append(commandArgs, "fetch")
 
 	if args.GitFetchFlags != "" {

--- a/internal/job/git_test.go
+++ b/internal/job/git_test.go
@@ -328,6 +328,7 @@ func TestGitFetch(t *testing.T) {
 
 	if err := gitFetch(ctx, gitFetchArgs{
 		Shell:         sh,
+		GitFlags:      gitMirrorFetchFlags("/tmp/mirror with spaces"),
 		GitFetchFlags: "--foo --bar",
 		Repository:    "repo",
 		RefSpecs:      []string{"ref1", "ref2"},
@@ -335,7 +336,13 @@ func TestGitFetch(t *testing.T) {
 		t.Fatalf(`gitFetch(ctx, gitFetchArgs{Shell: sh, GitFetchFlags: "--foo --bar", Remote: "repo", RefSpecs: []string{"ref1", "ref2"}} = %v`, err)
 	}
 
-	wantLog := [][]string{{absoluteGit, "fetch", "--foo", "--bar", "--", "repo", "ref1", "ref2"}}
+	wantLog := [][]string{{
+		absoluteGit,
+		"-c", "maintenance.autoDetach=false",
+		"-c", "gc.autoDetach=false",
+		"--git-dir", "/tmp/mirror with spaces",
+		"fetch", "--foo", "--bar", "--", "repo", "ref1", "ref2",
+	}}
 	if diff := cmp.Diff(gotLog, wantLog); diff != "" {
 		t.Errorf("executed commands diff (-got +want):\n%s", diff)
 	}


### PR DESCRIPTION
## Description

Git can start automatic maintenance from `git fetch` in a detached process. The agent would then release its mirror update lock and return while repacking was still in progress, allowing Hosted Agent cache generations to capture both the old and new packfiles and inflate rapidly.

This keeps automatic maintenance enabled, but makes it synchronous for agent-owned mirror fetches. Both `maintenance.autoDetach=false` and the older `gc.autoDetach=false` fallback are scoped to the individual Git command, so maintenance completes under the existing update lock before the agent snapshots or returns the mirror.

We deliberately do not disable automatic maintenance: the prior mirror-cache design work concluded that doing so would let long-lived mirrors grow without bound.

## Context

- [Linear A-1624](https://linear.app/buildkite/issue/A-1624/detached-git-repacking-inflates-hosted-agent-mirror-cache-generations)
- [Namespace confirmation that detached repack/GC is not awaited](https://buildkite-corp.slack.com/archives/C05MQ1W710X/p1785422947926829?thread_ts=1785394688.799909)
- [Git caching analysis](https://app.notion.com/p/33bb8dbc2c8980e2a8b3c9d2da08b700?pvs=1)
- [Hosted Agent mirror volume data](https://app.notion.com/p/24db8dbc2c8981449caadbda85119ef6?pvs=1)
- [Prior decision to retain automatic mirror maintenance](https://github.com/buildkite/agent/pull/2223)
- [Mirror snapshots introduced to isolate checkouts from mirror mutation](https://github.com/buildkite/agent/pull/3789)

## Changes

- Add shared foreground-maintenance Git flags for mirror fetches.
- Apply them to both main-repository and submodule mirror updates.
- Pass global Git flags as an argument slice, preserving mirror paths containing spaces.
- Assert the exact foreground-maintenance command in the Git fetch regression test.

## Testing

- [x] Tests have run locally with `go test ./...` (with local `tag.gpgSign` disabled only for the test process).
- [x] Code is formatted with `go tool gofumpt -extra -w .`.
- [x] Pinned `golangci-lint` 2.9.0 reports `0 issues`.

## Deployment

No configuration or migration is required. This takes effect when an agent release containing the change reaches Hosted Agents. We should watch `git.mirror.fetch` duration, `git.mirror.lock_wait.update` timeouts, and mirror generation sizes because repack time will now be attributed to the fetch that triggered it.

## Rollback

Revert this PR to restore detached automatic maintenance. The change does not alter mirror data formats or persist configuration.

## Affiliation (optional, external contributors)

Buildkite.

## Disclosures / Credits

OpenAI Codex researched the code history and internal Linear, Slack, and Notion context; implemented the change and regression coverage; ran validation; and drafted this PR under Jamie's direction.
