### PR TITLE
fix(cache): make expire scope aware (part 2/2)

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -79,22 +79,24 @@ type CacheEntryRetrieveReq struct {
 
 // CacheEntryRetrieveResp describes the cache entry to download.
 type CacheEntryRetrieveResp struct {
-	TargetPaths          []string       `json:"target_paths"`
-	CacheKey             []CacheKeyPart `json:"cache_key"`
-	Blobs                []CacheBlob    `json:"blobs"`
-	ExpiresAt            time.Time      `json:"expires_at"`
-	Store                string         `json:"store"`
-	Fallback             bool           `json:"fallback"`
-	Multipart            bool           `json:"multipart"`
-	DownloadInstructions []string       `json:"download_instructions"`
-	Message              string         `json:"message"`
+	TargetPaths          []string          `json:"target_paths"`
+	CacheKey             []CacheKeyPart    `json:"cache_key"`
+	Blobs                []CacheBlob       `json:"blobs"`
+	ExpiresAt            time.Time         `json:"expires_at"`
+	Store                string            `json:"store"`
+	Fallback             bool              `json:"fallback"`
+	Multipart            bool              `json:"multipart"`
+	DownloadInstructions []string          `json:"download_instructions"`
+	Message              string            `json:"message"`
+	Scopes               map[string]string `json:"scopes,omitempty"`
 }
 
 // CacheEntryExpireReq is the request body for invalidating a cache entry.
 // The address should be the resolved entry, as echoed by the retrieve response.
 type CacheEntryExpireReq struct {
-	TargetPaths []string       `json:"target_paths"`
-	CacheKey    []CacheKeyPart `json:"cache_key"`
+	TargetPaths []string          `json:"target_paths"`
+	CacheKey    []CacheKeyPart    `json:"cache_key"`
+	Scopes      map[string]string `json:"scopes,omitempty"`
 }
 
 // CacheEntryPeekReq is the request body for checking whether an entry exists.

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -242,6 +243,66 @@ func TestCacheEntryRetrieve_Success(t *testing.T) {
 	}
 }
 
+// Pins the retrieve→expire contract at the wire: a literal server payload (not
+// our Go type) with a `scopes` key must decode into resp.Scopes, so the agent
+// can echo it back on expire. A symmetric struct round-trip can't catch a wrong
+// or renamed json tag; a literal payload can.
+func TestCacheEntryRetrieve_DecodesScopesWireKey(t *testing.T) {
+	const body = `{"target_paths":["node_modules"],` +
+		`"cache_key":[{"value":"test-key","mandatory":true}],` +
+		`"blobs":[],"fallback":false,` +
+		`"scopes":{"branch":"main","pipeline":"web-app"}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	client := newTestCacheClient(t, server.URL)
+
+	resp, found, _, err := client.CacheEntryRetrieve(t.Context(), "test-slug", api.CacheEntryRetrieveReq{
+		TargetPaths: []string{"node_modules"},
+		CacheKey:    []api.CacheKeyPart{{Value: "test-key", Mandatory: true}},
+	})
+	if err != nil {
+		t.Fatalf("CacheEntryRetrieve error = %v, want nil", err)
+	}
+	if !found {
+		t.Error("found = false, want true")
+	}
+	if got, want := resp.Scopes, (map[string]string{"branch": "main", "pipeline": "web-app"}); !reflect.DeepEqual(got, want) {
+		t.Errorf("resp.Scopes = %v, want %v", got, want)
+	}
+}
+
+// The omitempty tag must not surface a spurious key: an unscoped retrieve payload
+// (no `scopes`) decodes to a nil map, which the agent then omits on expire.
+func TestCacheEntryRetrieve_UnscopedHasNilScopes(t *testing.T) {
+	const body = `{"target_paths":["node_modules"],"cache_key":[{"value":"test-key","mandatory":true}],"blobs":[]}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	client := newTestCacheClient(t, server.URL)
+
+	resp, _, _, err := client.CacheEntryRetrieve(t.Context(), "test-slug", api.CacheEntryRetrieveReq{
+		TargetPaths: []string{"node_modules"},
+		CacheKey:    []api.CacheKeyPart{{Value: "test-key", Mandatory: true}},
+	})
+	if err != nil {
+		t.Fatalf("CacheEntryRetrieve error = %v, want nil", err)
+	}
+	if resp.Scopes != nil {
+		t.Errorf("resp.Scopes = %v, want nil", resp.Scopes)
+	}
+}
+
 func TestCacheEntryRetrieve_NotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -325,12 +386,18 @@ func TestCacheEntryExpire_Success(t *testing.T) {
 		if !strings.HasSuffix(r.URL.Path, "/cache_registries/test-slug/expire") {
 			t.Errorf("path = %q, want suffix %q", r.URL.Path, "/cache_registries/test-slug/expire")
 		}
-		var req api.CacheEntryExpireReq
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		// Decode into a generic map rather than the typed request, so the
+		// assertions pin the literal wire keys — a symmetric round-trip through
+		// CacheEntryExpireReq would pass even if a json tag were wrong.
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode request body: %v", err)
 		}
-		if len(req.TargetPaths) != 1 || req.TargetPaths[0] != "node_modules" {
-			t.Errorf("req.TargetPaths = %v, want [node_modules]", req.TargetPaths)
+		if paths, ok := body["target_paths"].([]any); !ok || len(paths) != 1 || paths[0] != "node_modules" {
+			t.Errorf("body[\"target_paths\"] = %v, want [node_modules]", body["target_paths"])
+		}
+		if got, want := body["scopes"], map[string]any{"branch": "main"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("body[\"scopes\"] = %v, want %v", got, want)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -344,6 +411,7 @@ func TestCacheEntryExpire_Success(t *testing.T) {
 	_, err := client.CacheEntryExpire(t.Context(), "test-slug", api.CacheEntryExpireReq{
 		TargetPaths: []string{"node_modules"},
 		CacheKey:    []api.CacheKeyPart{{Value: "v1", Mandatory: true}},
+		Scopes:      map[string]string{"branch": "main"},
 	})
 	if err != nil {
 		t.Fatalf("CacheEntryExpire error = %v, want nil", err)

--- a/internal/cache/restore.go
+++ b/internal/cache/restore.go
@@ -285,6 +285,8 @@ func (c *client) invalidateStaleEntry(ctx context.Context, retrieveResp api.Cach
 	req := api.CacheEntryExpireReq{
 		TargetPaths: retrieveResp.TargetPaths,
 		CacheKey:    retrieveResp.CacheKey,
+		// Echo the matched entry's scopes so expire addresses this exact scoped entry.
+		Scopes: retrieveResp.Scopes,
 	}
 	err := roko.NewRetrier(
 		roko.WithMaxAttempts(5),

--- a/internal/cache/restore_test.go
+++ b/internal/cache/restore_test.go
@@ -5,9 +5,12 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/buildkite/agent/v3/api"
 )
 
 func TestCleanPath(t *testing.T) {
@@ -143,5 +146,34 @@ func TestCleanPathWindowsDriveRoot(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "refusing to remove drive root") {
 		t.Errorf("error %q should contain %q", err.Error(), "refusing to remove drive root")
+	}
+}
+
+// A scoped entry lives at a distinct address, so invalidating it requires the
+// matched entry's scopes. invalidateStaleEntry must echo the scopes from the
+// retrieve response into the expire request, or a scoped registry's stale entry
+// can never be busted.
+func TestInvalidateStaleEntryEchoesScopes(t *testing.T) {
+	ctx := t.Context()
+
+	cacheClient, _, _ := setupTestCache(t, "local_file")
+	mockClient := cacheClient.api.(*mockAPIClient)
+
+	scopes := map[string]string{"branch": "main", "pipeline": "app"}
+	retrieveResp := api.CacheEntryRetrieveResp{
+		TargetPaths: []string{"node_modules"},
+		CacheKey:    []api.CacheKeyPart{{Value: "v1-key"}},
+		Scopes:      scopes,
+	}
+
+	if ok := cacheClient.invalidateStaleEntry(ctx, retrieveResp); !ok {
+		t.Fatal("invalidateStaleEntry returned false, want true")
+	}
+
+	if len(mockClient.expireCalls) != 1 {
+		t.Fatalf("expire calls = %d, want 1", len(mockClient.expireCalls))
+	}
+	if got := mockClient.expireCalls[0].Scopes; !reflect.DeepEqual(got, scopes) {
+		t.Errorf("expire request Scopes = %v, want %v", got, scopes)
 	}
 }


### PR DESCRIPTION
## Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
On a scoped cache registry (policy with branch/build/pipeline save scopes), entries live at a distinct scoped address, so that expire request can never match the entry the agent actually restored. The invalidation silently no-ops, the dangling entry keeps being served, and every subsequent restore re-downloads a missing blob — an unrecoverable loop for that key until TTL.

This PR completes the fix by echoing the matched entry's scopes through the round-trip: the paired server change returns the matched entry's scopes on retrieve, and the agent now sends them back on expire so the backend can address (and delete) the exact scoped entry.

## Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->
PR on the bk/bk repo: https://github.com/buildkite/buildkite/pull/31863
Linear: https://linear.app/buildkite/issue/A-1625/make-expire-scope-aware

## Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->
- api.CacheEntryRetrieveResp gains a Scopes map[string]string field (json:"scopes,omitempty") — the matched entry's resolved scope labels, nil when unscoped.
- api.CacheEntryExpireReq gains the same Scopes field (omitempty, so unscoped expire requests are byte-identical on the wire to today).
- invalidateStaleEntry copies retrieveResp.Scopes into the expire request, so the missing-blob self-heal addresses the exact scoped entry that was restored.
- Tests: a focused invalidateStaleEntry test asserting the scopes are echoed into the expire request; the API client wire test asserts scopes round-trips over HTTP. No CLI/argument changes.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
I used claude to write the code
