### PR TITLE
feat: Consume control-plane tracing_exporter for OTLP job export

### DIFF
--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -437,6 +437,10 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	// The agent registration token should never make it into the job environment
 	delete(env, "BUILDKITE_AGENT_TOKEN")
 
+	// Pipeline-supplied OTEL exporter config must not reach bootstrap or commands.
+	// Destination/auth is an operator / control-plane concern only.
+	ignoredOTel := scrubPipelineOTelExporterEnv(env)
+
 	// When in KubernetesExec mode, filter out the Kubernetes plugin,
 	// since it's not a real plugin. agent-stack-k8s reads it but we have no
 	// need for it. Supplying it when not using agent-stack-k8s is a mistake
@@ -456,6 +460,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 	// Wrap setting values in env, so that when any that were already present in
 	// supplied Job env are overwritten, they can be added to ignoredEnv.
 	var ignoredEnv []string
+	ignoredEnv = append(ignoredEnv, ignoredOTel...)
 	setEnv := func(name, value string) {
 		if _, exists := env[name]; exists {
 			ignoredEnv = append(ignoredEnv, name)
@@ -784,6 +789,11 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 	// overwrite the job-provided value so a pipeline cannot enable OTLP export
 	// or choose its destination when the agent operator has not opted in.
 	setEnv("BUILDKITE_JOB_LOGS_OTLP", fmt.Sprint(r.conf.AgentConfiguration.JobLogsOTLP))
+
+	// Apply control-plane OTLP exporter config after BUILDKITE_ENV_FILE is
+	// written, so credentials are available to bootstrap InitOTelTracerProvider
+	// but not persisted in the clean env files or (after executor strip) commands.
+	applyControlPlaneTracingExporter(setEnv, r.conf.Job.TracingExporter)
 
 	setEnv("BUILDKITE_AGENT_DISABLE_WARNINGS_FOR", strings.Join(r.conf.AgentConfiguration.DisableWarningsFor, ","))
 

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -793,7 +793,7 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 	// Apply control-plane OTLP exporter config after BUILDKITE_ENV_FILE is
 	// written, so credentials are available to bootstrap InitOTelTracerProvider
 	// but not persisted in the clean env files or (after executor strip) commands.
-	applyControlPlaneTracingExporter(setEnv, r.conf.Job.TracingExporter)
+	applyControlPlaneTracingExporter(setEnv, r.conf.AgentConfiguration.TracingBackend, r.conf.Job.TracingExporter)
 
 	setEnv("BUILDKITE_AGENT_DISABLE_WARNINGS_FOR", strings.Join(r.conf.AgentConfiguration.DisableWarningsFor, ","))
 

--- a/agent/tracing_exporter.go
+++ b/agent/tracing_exporter.go
@@ -1,12 +1,14 @@
 package agent
 
 import (
+	"maps"
 	"os"
 	"slices"
 	"strings"
 
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/env"
+	"github.com/buildkite/agent/v3/tracetools"
 )
 
 // ControlPlaneOTLPTracingFeature is advertised at registration when this agent
@@ -15,15 +17,14 @@ import (
 const ControlPlaneOTLPTracingFeature = "control-plane-otlp-tracing"
 
 // hostHasOTelExporterConfig reports whether the agent process already has local
-// OTLP exporter configuration. Local operator config takes precedence over
-// control-plane injection.
+// OTLP endpoint or headers. Protocol-only leftovers do not count as a full
+// local override. Local operator config takes precedence over control-plane
+// injection when an endpoint or headers are set.
 func hostHasOTelExporterConfig() bool {
-	for _, key := range env.OTelExporterKeys {
-		if os.Getenv(key) != "" {
-			return true
-		}
-	}
-	return false
+	return os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" ||
+		os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") != "" ||
+		os.Getenv("OTEL_EXPORTER_OTLP_HEADERS") != "" ||
+		os.Getenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS") != ""
 }
 
 // scrubPipelineOTelExporterEnv removes OTLP exporter vars from the job env map
@@ -46,26 +47,26 @@ func encodeOTLPHeaders(headers map[string]string) string {
 	if len(headers) == 0 {
 		return ""
 	}
-	keys := make([]string, 0, len(headers))
-	for k, v := range headers {
+	parts := make([]string, 0, len(headers))
+	for _, k := range slices.Sorted(maps.Keys(headers)) {
+		v := headers[k]
 		if k == "" || v == "" {
 			continue
 		}
-		keys = append(keys, k)
-	}
-	slices.Sort(keys)
-	parts := make([]string, 0, len(keys))
-	for _, k := range keys {
-		parts = append(parts, k+"="+headers[k])
+		parts = append(parts, k+"="+v)
 	}
 	return strings.Join(parts, ",")
 }
 
 // applyControlPlaneTracingExporter sets bootstrap-only OTEL_* vars from the job
-// payload when the control plane supplied tracing_exporter and the agent host
-// has not already configured an exporter. Call this after writing
-// BUILDKITE_ENV_FILE so secrets are not persisted there.
-func applyControlPlaneTracingExporter(setEnv func(name, value string), exporter *api.TracingExporter) {
+// payload when the control plane supplied tracing_exporter, the agent is using
+// the OpenTelemetry backend, and the agent host has not already configured an
+// exporter. Call this after writing BUILDKITE_ENV_FILE so secrets are not
+// persisted there.
+func applyControlPlaneTracingExporter(setEnv func(name, value string), tracingBackend string, exporter *api.TracingExporter) {
+	if tracingBackend != tracetools.BackendOpenTelemetry {
+		return
+	}
 	if exporter == nil || exporter.Endpoint == "" {
 		return
 	}

--- a/agent/tracing_exporter.go
+++ b/agent/tracing_exporter.go
@@ -1,0 +1,87 @@
+package agent
+
+import (
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/env"
+)
+
+// ControlPlaneOTLPTracingFeature is advertised at registration when this agent
+// binary can safely consume job.tracing_exporter (apply to bootstrap-only env
+// and keep credentials out of the command environment / env files).
+const ControlPlaneOTLPTracingFeature = "control-plane-otlp-tracing"
+
+// hostHasOTelExporterConfig reports whether the agent process already has local
+// OTLP exporter configuration. Local operator config takes precedence over
+// control-plane injection.
+func hostHasOTelExporterConfig() bool {
+	for _, key := range env.OTelExporterKeys {
+		if os.Getenv(key) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// scrubPipelineOTelExporterEnv removes OTLP exporter vars from the job env map
+// so a pipeline cannot choose a destination or supply auth headers. Returns the
+// names that were present (for BUILDKITE_IGNORED_ENV).
+func scrubPipelineOTelExporterEnv(jobEnv map[string]string) []string {
+	var ignored []string
+	for _, key := range env.OTelExporterKeys {
+		if _, ok := jobEnv[key]; ok {
+			delete(jobEnv, key)
+			ignored = append(ignored, key)
+		}
+	}
+	return ignored
+}
+
+// encodeOTLPHeaders formats a header map as OTEL_EXPORTER_OTLP_HEADERS expects:
+// comma-separated key=value pairs. Keys are sorted for stable output.
+func encodeOTLPHeaders(headers map[string]string) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(headers))
+	for k, v := range headers {
+		if k == "" || v == "" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+headers[k])
+	}
+	return strings.Join(parts, ",")
+}
+
+// applyControlPlaneTracingExporter sets bootstrap-only OTEL_* vars from the job
+// payload when the control plane supplied tracing_exporter and the agent host
+// has not already configured an exporter. Call this after writing
+// BUILDKITE_ENV_FILE so secrets are not persisted there.
+func applyControlPlaneTracingExporter(setEnv func(name, value string), exporter *api.TracingExporter) {
+	if exporter == nil || exporter.Endpoint == "" {
+		return
+	}
+	if hostHasOTelExporterConfig() {
+		return
+	}
+
+	protocol := exporter.Protocol
+	if protocol == "" {
+		protocol = "http/protobuf"
+	}
+	setEnv("OTEL_EXPORTER_OTLP_PROTOCOL", protocol)
+	// Full traces URL from the control plane (includes /v1/traces).
+	setEnv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", exporter.Endpoint)
+
+	if encoded := encodeOTLPHeaders(exporter.Headers); encoded != "" {
+		setEnv("OTEL_EXPORTER_OTLP_HEADERS", encoded)
+	}
+}

--- a/agent/tracing_exporter_test.go
+++ b/agent/tracing_exporter_test.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/env"
+)
+
+func TestEncodeOTLPHeaders(t *testing.T) {
+	t.Parallel()
+
+	got := encodeOTLPHeaders(map[string]string{
+		"X-Team":        "pipelines",
+		"Authorization": "Bearer secret",
+		"":              "skip",
+		"Empty":         "",
+	})
+	want := "Authorization=Bearer secret,X-Team=pipelines"
+	if got != want {
+		t.Fatalf("encodeOTLPHeaders() = %q, want %q", got, want)
+	}
+}
+
+func TestScrubPipelineOTelExporterEnv(t *testing.T) {
+	t.Parallel()
+
+	jobEnv := map[string]string{
+		"BUILDKITE_COMMAND":           "echo hi",
+		"OTEL_EXPORTER_OTLP_HEADERS":  "Authorization=Bearer pipeline",
+		"OTEL_EXPORTER_OTLP_ENDPOINT": "https://evil.example",
+		"OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+		"OTEL_RESOURCE_ATTRIBUTES":    "keep=me",
+	}
+	ignored := scrubPipelineOTelExporterEnv(jobEnv)
+
+	if _, ok := jobEnv["OTEL_EXPORTER_OTLP_HEADERS"]; ok {
+		t.Fatal("expected OTEL_EXPORTER_OTLP_HEADERS to be scrubbed")
+	}
+	if jobEnv["OTEL_RESOURCE_ATTRIBUTES"] != "keep=me" {
+		t.Fatal("expected non-exporter OTEL vars to remain")
+	}
+	if len(ignored) != 3 {
+		t.Fatalf("ignored = %v, want 3 exporter keys", ignored)
+	}
+}
+
+func TestApplyControlPlaneTracingExporter(t *testing.T) {
+	// Uses t.Setenv — cannot run in parallel with other tests that touch process env.
+	t.Run("applies when host has no OTEL config", func(t *testing.T) {
+		for _, key := range env.OTelExporterKeys {
+			t.Setenv(key, "")
+		}
+
+		got := map[string]string{}
+		setEnv := func(name, value string) { got[name] = value }
+
+		applyControlPlaneTracingExporter(setEnv, &api.TracingExporter{
+			Endpoint: "https://otel.example/v1/traces",
+			Protocol: "http/protobuf",
+			Headers:  map[string]string{"Authorization": "Bearer from-cp"},
+		})
+
+		if got["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] != "https://otel.example/v1/traces" {
+			t.Fatalf("endpoint = %q", got["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"])
+		}
+		if got["OTEL_EXPORTER_OTLP_PROTOCOL"] != "http/protobuf" {
+			t.Fatalf("protocol = %q", got["OTEL_EXPORTER_OTLP_PROTOCOL"])
+		}
+		if got["OTEL_EXPORTER_OTLP_HEADERS"] != "Authorization=Bearer from-cp" {
+			t.Fatalf("headers = %q", got["OTEL_EXPORTER_OTLP_HEADERS"])
+		}
+	})
+
+	t.Run("skips when host already configured", func(t *testing.T) {
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://local.example")
+
+		got := map[string]string{}
+		setEnv := func(name, value string) { got[name] = value }
+
+		applyControlPlaneTracingExporter(setEnv, &api.TracingExporter{
+			Endpoint: "https://otel.example/v1/traces",
+			Headers:  map[string]string{"Authorization": "Bearer from-cp"},
+		})
+
+		if len(got) != 0 {
+			t.Fatalf("expected no control-plane apply when host configured, got %#v", got)
+		}
+	})
+
+	t.Run("skips nil or empty endpoint", func(t *testing.T) {
+		got := map[string]string{}
+		setEnv := func(name, value string) { got[name] = value }
+
+		applyControlPlaneTracingExporter(setEnv, nil)
+		applyControlPlaneTracingExporter(setEnv, &api.TracingExporter{})
+		if len(got) != 0 {
+			t.Fatalf("expected no apply, got %#v", got)
+		}
+	})
+}
+
+func TestStripOTelExporter(t *testing.T) {
+	t.Parallel()
+
+	environ := env.FromSlice([]string{
+		"PATH=/bin",
+		"OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer secret",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://otel.example/v1/traces",
+		"BUILDKITE_JOB_ID=abc",
+	})
+	env.StripOTelExporter(environ)
+
+	if _, ok := environ.Get("OTEL_EXPORTER_OTLP_HEADERS"); ok {
+		t.Fatal("expected headers stripped")
+	}
+	if _, ok := environ.Get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"); ok {
+		t.Fatal("expected endpoint stripped")
+	}
+	if v, _ := environ.Get("BUILDKITE_JOB_ID"); v != "abc" {
+		t.Fatalf("job id = %q", v)
+	}
+}

--- a/agent/tracing_exporter_test.go
+++ b/agent/tracing_exporter_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/env"
+	"github.com/buildkite/agent/v3/tracetools"
 )
 
 func TestEncodeOTLPHeaders(t *testing.T) {
@@ -46,8 +47,7 @@ func TestScrubPipelineOTelExporterEnv(t *testing.T) {
 }
 
 func TestApplyControlPlaneTracingExporter(t *testing.T) {
-	// Uses t.Setenv — cannot run in parallel with other tests that touch process env.
-	t.Run("applies when host has no OTEL config", func(t *testing.T) {
+	t.Run("applies when host has no OTEL config and backend is opentelemetry", func(t *testing.T) {
 		for _, key := range env.OTelExporterKeys {
 			t.Setenv(key, "")
 		}
@@ -55,7 +55,7 @@ func TestApplyControlPlaneTracingExporter(t *testing.T) {
 		got := map[string]string{}
 		setEnv := func(name, value string) { got[name] = value }
 
-		applyControlPlaneTracingExporter(setEnv, &api.TracingExporter{
+		applyControlPlaneTracingExporter(setEnv, tracetools.BackendOpenTelemetry, &api.TracingExporter{
 			Endpoint: "https://otel.example/v1/traces",
 			Protocol: "http/protobuf",
 			Headers:  map[string]string{"Authorization": "Bearer from-cp"},
@@ -72,13 +72,30 @@ func TestApplyControlPlaneTracingExporter(t *testing.T) {
 		}
 	})
 
+	t.Run("skips when tracing backend is not opentelemetry", func(t *testing.T) {
+		got := map[string]string{}
+		setEnv := func(name, value string) { got[name] = value }
+
+		applyControlPlaneTracingExporter(setEnv, tracetools.BackendDatadog, &api.TracingExporter{
+			Endpoint: "https://otel.example/v1/traces",
+			Headers:  map[string]string{"Authorization": "Bearer from-cp"},
+		})
+		applyControlPlaneTracingExporter(setEnv, "", &api.TracingExporter{
+			Endpoint: "https://otel.example/v1/traces",
+		})
+
+		if len(got) != 0 {
+			t.Fatalf("expected no apply without opentelemetry backend, got %#v", got)
+		}
+	})
+
 	t.Run("skips when host already configured", func(t *testing.T) {
 		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://local.example")
 
 		got := map[string]string{}
 		setEnv := func(name, value string) { got[name] = value }
 
-		applyControlPlaneTracingExporter(setEnv, &api.TracingExporter{
+		applyControlPlaneTracingExporter(setEnv, tracetools.BackendOpenTelemetry, &api.TracingExporter{
 			Endpoint: "https://otel.example/v1/traces",
 			Headers:  map[string]string{"Authorization": "Bearer from-cp"},
 		})
@@ -92,8 +109,8 @@ func TestApplyControlPlaneTracingExporter(t *testing.T) {
 		got := map[string]string{}
 		setEnv := func(name, value string) { got[name] = value }
 
-		applyControlPlaneTracingExporter(setEnv, nil)
-		applyControlPlaneTracingExporter(setEnv, &api.TracingExporter{})
+		applyControlPlaneTracingExporter(setEnv, tracetools.BackendOpenTelemetry, nil)
+		applyControlPlaneTracingExporter(setEnv, tracetools.BackendOpenTelemetry, &api.TracingExporter{})
 		if len(got) != 0 {
 			t.Fatalf("expected no apply, got %#v", got)
 		}
@@ -119,5 +136,17 @@ func TestStripOTelExporter(t *testing.T) {
 	}
 	if v, _ := environ.Get("BUILDKITE_JOB_ID"); v != "abc" {
 		t.Fatalf("job id = %q", v)
+	}
+}
+
+func TestOTelExporterKeysAreProtected(t *testing.T) {
+	t.Parallel()
+	for _, key := range env.OTelExporterKeys {
+		if !env.IsProtected(key) {
+			t.Fatalf("%s should be protected", key)
+		}
+		if !env.IsProtectedFromWithinJob(key) {
+			t.Fatalf("%s should be protected from within job", key)
+		}
 	}
 }

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -30,7 +30,20 @@ type Job struct {
 	ChunksFailedCount     int                        `json:"chunks_failed_count"`
 	TraceParent           string                     `json:"traceparent"`
 	TraceState            string                     `json:"tracestate"`
-	Priority              int                        `json:"priority"`
+	// TracingExporter is optional OTLP exporter config injected by the control
+	// plane from the OpenTelemetry notification service. It is a top-level job
+	// field (never job.env) so credentials are not written to BUILDKITE_ENV_FILE.
+	TracingExporter *TracingExporter `json:"tracing_exporter,omitempty"`
+	Priority        int              `json:"priority"`
+}
+
+// TracingExporter is control-plane-supplied OTLP exporter configuration for
+// agent job spans. Protocol is typically "http/protobuf" to match Buildkite's
+// control-plane export path.
+type TracingExporter struct {
+	Endpoint string            `json:"endpoint"`
+	Protocol string            `json:"protocol"`
+	Headers  map[string]string `json:"headers"`
 }
 
 // JobURL returns the URL that deep-links to a specific job on its build page,

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -275,6 +275,12 @@ func (asc AgentStartConfig) Features(ctx context.Context) []string {
 		features = append(features, "propagate-traceparent")
 	}
 
+	// Advertised whenever this binary can safely consume job.tracing_exporter
+	// (bootstrap-only application + command-env stripping). Independent of
+	// whether --tracing-backend is already set, so registration/zero-config
+	// enablement can turn tracing on later.
+	features = append(features, agent.ControlPlaneOTLPTracingFeature)
+
 	if asc.DisconnectAfterJob {
 		features = append(features, "disconnect-after-job")
 	}

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -662,6 +662,11 @@ func setupLoggerAndConfig[T any](ctx context.Context, c *cli.Context, opts ...co
 				_ = traceProvider.Shutdown(flushCtx)
 			}
 		}
+
+		// Drop exporter credentials from the process environment once the
+		// provider is configured (or failed). Otherwise same-UID job commands
+		// can read them from /proc/$PPID/environ even when shell.Env is clean.
+		env.ClearOTelExporterFromProcess()
 	}
 
 	return ctx, cfg, l, loader.File, done

--- a/env/otel_exporter.go
+++ b/env/otel_exporter.go
@@ -1,0 +1,26 @@
+package env
+
+// OTelExporterKeys are standard OTLP exporter environment variables that carry
+// destination and auth. They must not come from pipeline job.env, and must be
+// stripped from the command/hook shell environment after the TracerProvider has
+// been initialized from process env.
+var OTelExporterKeys = []string{
+	"OTEL_EXPORTER_OTLP_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_HEADERS",
+	"OTEL_EXPORTER_OTLP_PROTOCOL",
+	"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+	"OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+}
+
+// StripOTelExporter removes OTLP exporter credentials from environ after the
+// TracerProvider has already been initialized from process env. Hooks and
+// commands must not see these values.
+func StripOTelExporter(environ *Environment) {
+	if environ == nil {
+		return
+	}
+	for _, key := range OTelExporterKeys {
+		environ.Remove(key)
+	}
+}

--- a/env/otel_exporter.go
+++ b/env/otel_exporter.go
@@ -1,5 +1,7 @@
 package env
 
+import "os"
+
 // OTelExporterKeys are standard OTLP exporter environment variables that carry
 // destination and auth. They must not come from pipeline job.env, and must be
 // stripped from the command/hook shell environment after the TracerProvider has
@@ -22,5 +24,14 @@ func StripOTelExporter(environ *Environment) {
 	}
 	for _, key := range OTelExporterKeys {
 		environ.Remove(key)
+	}
+}
+
+// ClearOTelExporterFromProcess unsets OTLP exporter credentials from the
+// current process environment after TracerProvider init so child processes
+// cannot read them via /proc/$PPID/environ.
+func ClearOTelExporterFromProcess() {
+	for _, key := range OTelExporterKeys {
+		_ = os.Unsetenv(key)
 	}
 }

--- a/env/protected.go
+++ b/env/protected.go
@@ -86,6 +86,13 @@ var protectedEnv = map[string]protection{
 	"BUILDKITE_REPO":                        {mutableFromWithinJob: true},
 	"BUILDKITE_SHELL":                       {},
 	"BUILDKITE_SSH_KEYSCAN":                 {},
+	// OTLP exporter destination/auth is operator / control-plane only.
+	"OTEL_EXPORTER_OTLP_ENDPOINT":        {},
+	"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": {},
+	"OTEL_EXPORTER_OTLP_HEADERS":         {},
+	"OTEL_EXPORTER_OTLP_PROTOCOL":        {},
+	"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": {},
+	"OTEL_EXPORTER_OTLP_TRACES_HEADERS":  {},
 }
 
 // checkoutOverrideScope contains checkout-related vars whose write-protection

--- a/internal/agenthttp/debug_redact.go
+++ b/internal/agenthttp/debug_redact.go
@@ -3,14 +3,6 @@ package agenthttp
 import (
 	"bytes"
 	"encoding/json"
-	"regexp"
-)
-
-// tracingExporterHeadersRE matches JSON "headers" objects nested under
-// tracing_exporter in debug HTTP dumps. Values are redacted so vendor tokens
-// are not written to agent logs when --debug-http is enabled.
-var tracingExporterHeadersRE = regexp.MustCompile(
-	`("tracing_exporter"\s*:\s*\{[^}]*"headers"\s*:\s*)\{[^}]*\}`,
 )
 
 func redactTracingExporterHeadersInDump(dump []byte) []byte {
@@ -18,13 +10,43 @@ func redactTracingExporterHeadersInDump(dump []byte) []byte {
 	if !bytes.Contains(dump, []byte(`"tracing_exporter"`)) {
 		return dump
 	}
-
-	// Prefer structured redaction when the dump body is JSON (response body
-	// after headers). Fall back to a conservative regex on the whole dump.
 	if redacted, ok := redactTracingExporterInJSONBody(dump); ok {
 		return redacted
 	}
-	return tracingExporterHeadersRE.ReplaceAll(dump, []byte(`${1}{"[REDACTED]":"[REDACTED]"}`))
+	// If the dump is not parseable JSON (partial dump on error), blank the
+	// headers object with a conservative textual replacement.
+	const needle = `"headers":`
+	out := append([]byte(nil), dump...)
+	searchFrom := 0
+	for {
+		idx := bytes.Index(out[searchFrom:], []byte(`"tracing_exporter"`))
+		if idx < 0 {
+			break
+		}
+		idx += searchFrom
+		headersIdx := bytes.Index(out[idx:], []byte(needle))
+		if headersIdx < 0 {
+			break
+		}
+		headersIdx += idx + len(needle)
+		// Skip whitespace
+		for headersIdx < len(out) && (out[headersIdx] == ' ' || out[headersIdx] == '\t' || out[headersIdx] == '\n' || out[headersIdx] == '\r') {
+			headersIdx++
+		}
+		if headersIdx >= len(out) || out[headersIdx] != '{' {
+			searchFrom = idx + 1
+			continue
+		}
+		end := bytes.IndexByte(out[headersIdx:], '}')
+		if end < 0 {
+			break
+		}
+		end += headersIdx
+		replacement := []byte(`{"[REDACTED]":"[REDACTED]"}`)
+		out = append(out[:headersIdx], append(replacement, out[end+1:]...)...)
+		searchFrom = headersIdx + len(replacement)
+	}
+	return out
 }
 
 func redactTracingExporterInJSONBody(dump []byte) ([]byte, bool) {

--- a/internal/agenthttp/debug_redact.go
+++ b/internal/agenthttp/debug_redact.go
@@ -1,0 +1,78 @@
+package agenthttp
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+)
+
+// tracingExporterHeadersRE matches JSON "headers" objects nested under
+// tracing_exporter in debug HTTP dumps. Values are redacted so vendor tokens
+// are not written to agent logs when --debug-http is enabled.
+var tracingExporterHeadersRE = regexp.MustCompile(
+	`("tracing_exporter"\s*:\s*\{[^}]*"headers"\s*:\s*)\{[^}]*\}`,
+)
+
+func redactTracingExporterHeadersInDump(dump []byte) []byte {
+	// Fast path: no tracing_exporter in the dump.
+	if !bytes.Contains(dump, []byte(`"tracing_exporter"`)) {
+		return dump
+	}
+
+	// Prefer structured redaction when the dump body is JSON (response body
+	// after headers). Fall back to a conservative regex on the whole dump.
+	if redacted, ok := redactTracingExporterInJSONBody(dump); ok {
+		return redacted
+	}
+	return tracingExporterHeadersRE.ReplaceAll(dump, []byte(`${1}{"[REDACTED]":"[REDACTED]"}`))
+}
+
+func redactTracingExporterInJSONBody(dump []byte) ([]byte, bool) {
+	// httputil.DumpResponse format: status line, headers, blank line, body.
+	idx := bytes.Index(dump, []byte("\r\n\r\n"))
+	if idx < 0 {
+		idx = bytes.Index(dump, []byte("\n\n"))
+		if idx < 0 {
+			return nil, false
+		}
+		idx += 2
+	} else {
+		idx += 4
+	}
+	body := dump[idx:]
+	if len(bytes.TrimSpace(body)) == 0 || body[0] != '{' {
+		return nil, false
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, false
+	}
+	rawExporter, ok := payload["tracing_exporter"]
+	if !ok {
+		return nil, false
+	}
+
+	var exporter map[string]any
+	if err := json.Unmarshal(rawExporter, &exporter); err != nil {
+		return nil, false
+	}
+	if headers, ok := exporter["headers"].(map[string]any); ok {
+		for k := range headers {
+			headers[k] = "[REDACTED]"
+		}
+		exporter["headers"] = headers
+	}
+	redactedExporter, err := json.Marshal(exporter)
+	if err != nil {
+		return nil, false
+	}
+	payload["tracing_exporter"] = redactedExporter
+	newBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, false
+	}
+	out := append([]byte(nil), dump[:idx]...)
+	out = append(out, newBody...)
+	return out, true
+}

--- a/internal/agenthttp/debug_redact_test.go
+++ b/internal/agenthttp/debug_redact_test.go
@@ -1,0 +1,34 @@
+package agenthttp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactTracingExporterHeadersInDump(t *testing.T) {
+	t.Parallel()
+
+	dump := []byte("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n" +
+		`{"id":"job-1","tracing_exporter":{"endpoint":"https://otel.example/v1/traces","protocol":"http/protobuf","headers":{"Authorization":"Bearer secret-token"}}}`)
+
+	got := string(redactTracingExporterHeadersInDump(dump))
+	if strings.Contains(got, "Bearer secret-token") {
+		t.Fatalf("expected Authorization value redacted, got:\n%s", got)
+	}
+	if !strings.Contains(got, `"endpoint":"https://otel.example/v1/traces"`) {
+		t.Fatalf("expected endpoint preserved, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[REDACTED]") {
+		t.Fatalf("expected redacted marker, got:\n%s", got)
+	}
+}
+
+func TestRedactTracingExporterHeadersInDump_NoExporter(t *testing.T) {
+	t.Parallel()
+
+	dump := []byte("HTTP/1.1 200 OK\r\n\r\n{\"id\":\"job-1\"}")
+	got := redactTracingExporterHeadersInDump(dump)
+	if string(got) != string(dump) {
+		t.Fatalf("expected unchanged dump without tracing_exporter")
+	}
+}

--- a/internal/agenthttp/do.go
+++ b/internal/agenthttp/do.go
@@ -62,10 +62,11 @@ func Do(l logger.Logger, client *http.Client, req *http.Request, opts ...DoOptio
 
 	if cfg.debugHTTP {
 		responseDump, err := httputil.DumpResponse(resp, true)
+		safeDump := redactTracingExporterHeadersInDump(responseDump)
 		if err != nil {
-			l.Debugf("\nERR: %s\n%s", err, string(responseDump))
+			l.Debugf("\nERR: %s\n%s", err, string(safeDump))
 		} else {
-			l.Debugf("\n%s", string(redactTracingExporterHeadersInDump(responseDump)))
+			l.Debugf("\n%s", string(safeDump))
 		}
 	}
 	if cfg.traceHTTP {

--- a/internal/agenthttp/do.go
+++ b/internal/agenthttp/do.go
@@ -65,7 +65,7 @@ func Do(l logger.Logger, client *http.Client, req *http.Request, opts ...DoOptio
 		if err != nil {
 			l.Debugf("\nERR: %s\n%s", err, string(responseDump))
 		} else {
-			l.Debugf("\n%s", string(responseDump))
+			l.Debugf("\n%s", string(redactTracingExporterHeadersInDump(responseDump)))
 		}
 	}
 	if cfg.traceHTTP {

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -172,6 +172,11 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 	// Create an empty env for us to keep track of our env changes in
 	e.shell.Env = env.FromSlice(os.Environ())
 
+	// OTLP exporter credentials may be present in process env so
+	// InitOTelTracerProvider (at CLI startup) could configure the exporter.
+	// They must not remain visible to hooks, plugins, or the job command.
+	env.StripOTelExporter(e.shell.Env)
+
 	// OTLP job log export lives entirely in the bootstrap process, which is the
 	// single home for this feature. When OpenTelemetry tracing is enabled, log
 	// records carry the span context of the nearest enclosing phase/hook span,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Hosted agents should export OTLP using OpenTelemetry notification-service credentials from the control plane, without vendor tokens in Agent Images and without exposing those credentials to job commands.

This PR consumes the new top-level job field `tracing_exporter` (injected by buildkite/buildkite#31876 on acquire/accept) into bootstrap-only OTEL env, then clears those secrets from process and shell env after TracerProvider init.

Works for normal register→accept and `--acquire-job` (acquire returns the same job payload).

## Context

- Design: [buildkite/buildkite docs/plans/2026-07-31-otel-agent-exporter-injection.md](https://github.com/buildkite/buildkite/blob/cursor/otel-agent-exporter-injection-4795/docs/plans/2026-07-31-otel-agent-exporter-injection.md)
- Control-plane spike: https://github.com/buildkite/buildkite/pull/31876

## Changes

- Parse `api.Job.TracingExporter`
- Advertise `control-plane-otlp-tracing` at registration (capability = can safely consume)
- Apply exporter config after `BUILDKITE_ENV_FILE` write when `--tracing-backend opentelemetry` and host has no local OTEL endpoint/headers
- Scrub pipeline-supplied `OTEL_EXPORTER_*` from job.env; protect those keys from hooks/Job API
- `os.Unsetenv` exporter keys after InitOTel; strip from `shell.Env`
- Redact `tracing_exporter.headers` in `--debug-http` response dumps

## Testing

- [x] Tests have run locally (`go test ./agent/ ./env/ ./api/ ./internal/agenthttp/ ./clicommand/`)
- [x] Code is formatted (`go tool gofumpt -extra -w` on changed files)

## Disclosures / Credits

Implemented with Cursor cloud agent assistance; design agreed in the companion control-plane PR thread.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7dd2cb9-881a-48a0-bfc9-68c961b74795?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7dd2cb9-881a-48a0-bfc9-68c961b74795&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

