### PR TITLE
feat: Consume control-plane OTLP exporter from registration

### DIFF
--- a/agent/agent_configuration.go
+++ b/agent/agent_configuration.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/buildkite/agent/v3/api"
 	"github.com/buildkite/agent/v3/env"
 	"github.com/buildkite/agent/v3/internal/job"
 )
@@ -82,6 +83,7 @@ type AgentConfiguration struct {
 	TracingBackend               string
 	TracingServiceName           string
 	TracingPropagateTraceparent  bool
+	TracingExporter              *api.TracingExporter
 	TraceContextEncoding         string
 	DisableWarningsFor           []string
 	AllowMultipartArtifactUpload bool

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -455,6 +455,15 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 		}
 	}
 
+	// A pipeline only loses the ability to set OTLP exporter env when the control
+	// plane is supplying exporter config for this job. Scrub before writing
+	// BUILDKITE_ENV_FILE / BUILDKITE_ENV_JSON_FILE.
+	exporterApplies := controlPlaneExporterApplies(
+		r.conf.AgentConfiguration.TracingBackend,
+		r.conf.AgentConfiguration.TracingExporter,
+	)
+	ignoredEnv := scrubJobOTelExporterEnv(env, exporterApplies)
+
 	// When in KubernetesExec mode, filter out the Kubernetes plugin,
 	// since it's not a real plugin. agent-stack-k8s reads it but we have no
 	// need for it. Supplying it when not using agent-stack-k8s is a mistake
@@ -473,7 +482,6 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 
 	// Wrap setting values in env, so that when any that were already present in
 	// supplied Job env are overwritten, they can be added to ignoredEnv.
-	var ignoredEnv []string
 	setEnv := func(name, value string) {
 		if _, exists := env[name]; exists {
 			ignoredEnv = append(ignoredEnv, name)
@@ -802,6 +810,14 @@ BUILDKITE_AGENT_JWKS_KEY_ID`
 	// overwrite the job-provided value so a pipeline cannot enable OTLP export
 	// or choose its destination when the agent operator has not opted in.
 	setEnv("BUILDKITE_JOB_LOGS_OTLP", fmt.Sprint(r.conf.AgentConfiguration.JobLogsOTLP))
+
+	// Apply control-plane OTLP exporter config after BUILDKITE_ENV_FILE is
+	// written, so credentials are available to bootstrap InitOTelTracerProvider
+	// but not persisted in the clean env files. Same-UID processes can still
+	// read them from bootstrap environ (same as the agent access token).
+	if exporterApplies {
+		applyControlPlaneTracingExporter(setEnv, r.conf.AgentConfiguration.TracingExporter)
+	}
 
 	setEnv("BUILDKITE_AGENT_DISABLE_WARNINGS_FOR", strings.Join(r.conf.AgentConfiguration.DisableWarningsFor, ","))
 

--- a/agent/job_runner_otel_env_test.go
+++ b/agent/job_runner_otel_env_test.go
@@ -1,0 +1,168 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/env"
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/buildkite/agent/v3/tracetools"
+)
+
+// jobEnvForTest runs createEnvironment and returns the resulting environment.
+func jobEnvForTest(t *testing.T, agentConf AgentConfiguration, jobEnv map[string]string) *env.Environment {
+	t.Helper()
+
+	l := logger.Discard
+	runner := &JobRunner{
+		agentLogger: l,
+		apiClient:   api.NewClient(l, api.Config{}),
+		conf: JobRunnerConfig{
+			Job:                &api.Job{ID: "job-1", Env: jobEnv},
+			AgentConfiguration: agentConf,
+		},
+	}
+
+	envSlice, err := runner.createEnvironment(t.Context())
+	if err != nil {
+		t.Fatalf("createEnvironment() error = %v", err)
+	}
+	return env.FromSlice(envSlice)
+}
+
+func otelAgentConfWithExporter() AgentConfiguration {
+	return AgentConfiguration{
+		TracingBackend: tracetools.BackendOpenTelemetry,
+		TracingExporter: &api.TracingExporter{
+			Endpoint: "https://otel.example/v1/traces",
+			Protocol: "http/protobuf",
+			Headers:  map[string]string{"Authorization": "Bearer from-cp"},
+		},
+	}
+}
+
+// With control-plane exporter config, the agent's values win and the pipeline's
+// are reported as ignored.
+func TestCreateEnvironmentAppliesControlPlaneExporter(t *testing.T) {
+	for _, key := range env.OTelExporterKeys {
+		t.Setenv(key, "")
+	}
+
+	got := jobEnvForTest(t, otelAgentConfWithExporter(), map[string]string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT":        "https://evil.example",
+		"OTEL_EXPORTER_OTLP_TRACES_HEADERS":  "Authorization=Bearer pipeline",
+		"OTEL_EXPORTER_OTLP_TRACES_INSECURE": "true",
+	})
+
+	for key, want := range map[string]string{
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "https://otel.example/v1/traces",
+		"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf",
+		"OTEL_EXPORTER_OTLP_TRACES_HEADERS":  "Authorization=Bearer%20from-cp",
+		env.OTelExporterMarkerEnv:            "true",
+	} {
+		if v, _ := got.Get(key); v != want {
+			t.Errorf("%s = %q, want %q", key, v, want)
+		}
+	}
+
+	// The pipeline's own destination and TLS settings are gone, not merged.
+	for _, key := range []string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_TRACES_INSECURE",
+	} {
+		if v, ok := got.Get(key); ok {
+			t.Errorf("%s = %q, want it scrubbed", key, v)
+		}
+	}
+
+	ignored, _ := got.Get("BUILDKITE_IGNORED_ENV")
+	for _, key := range []string{"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_HEADERS"} {
+		if !strings.Contains(ignored, key) {
+			t.Errorf("BUILDKITE_IGNORED_ENV = %q, want it to mention %s", ignored, key)
+		}
+	}
+}
+
+// Without control-plane exporter config there is no organisation credential in
+// the job environment, so a pipeline keeps whatever exporter env it sets. This
+// is the case for every agent that does not use this feature.
+func TestCreateEnvironmentLeavesPipelineExporterConfigAlone(t *testing.T) {
+	pipelineEnv := map[string]string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT": "https://our-own-collector.example",
+		"OTEL_EXPORTER_OTLP_HEADERS":  "Authorization=Bearer ours",
+	}
+
+	for _, test := range []struct {
+		name string
+		conf AgentConfiguration
+	}{
+		{
+			name: "no tracing configured",
+			conf: AgentConfiguration{},
+		},
+		{
+			name: "opentelemetry backend without control-plane exporter",
+			conf: AgentConfiguration{TracingBackend: tracetools.BackendOpenTelemetry},
+		},
+		{
+			name: "non-opentelemetry backend with an exporter",
+			conf: func() AgentConfiguration {
+				conf := otelAgentConfWithExporter()
+				conf.TracingBackend = tracetools.BackendDatadog
+				return conf
+			}(),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for _, key := range env.OTelExporterKeys {
+				t.Setenv(key, "")
+			}
+
+			got := jobEnvForTest(t, test.conf, pipelineEnv)
+
+			for key, want := range pipelineEnv {
+				if v, _ := got.Get(key); v != want {
+					t.Errorf("%s = %q, want %q", key, v, want)
+				}
+			}
+			if v, ok := got.Get(env.OTelExporterMarkerEnv); ok {
+				t.Errorf("%s = %q, want it unset", env.OTelExporterMarkerEnv, v)
+			}
+		})
+	}
+}
+
+// A host exporter configuration is the operator's choice and must not be
+// replaced by the control plane's.
+func TestCreateEnvironmentHostExporterConfigWins(t *testing.T) {
+	for _, key := range env.OTelExporterKeys {
+		t.Setenv(key, "")
+	}
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://operator-collector.example")
+
+	got := jobEnvForTest(t, otelAgentConfWithExporter(), nil)
+
+	if v, ok := got.Get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"); ok {
+		t.Errorf("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = %q, want no control-plane endpoint", v)
+	}
+	if v, ok := got.Get(env.OTelExporterMarkerEnv); ok {
+		t.Errorf("%s = %q, want it unset", env.OTelExporterMarkerEnv, v)
+	}
+}
+
+// A pipeline must not be able to make bootstrap strip the operator's own
+// exporter configuration by supplying the marker itself.
+func TestCreateEnvironmentDropsPipelineSuppliedMarker(t *testing.T) {
+	for _, key := range env.OTelExporterKeys {
+		t.Setenv(key, "")
+	}
+
+	got := jobEnvForTest(t, AgentConfiguration{}, map[string]string{
+		env.OTelExporterMarkerEnv: "true",
+	})
+
+	if v, ok := got.Get(env.OTelExporterMarkerEnv); ok {
+		t.Errorf("%s = %q, want it dropped", env.OTelExporterMarkerEnv, v)
+	}
+}

--- a/agent/tracing_exporter.go
+++ b/agent/tracing_exporter.go
@@ -1,0 +1,183 @@
+package agent
+
+import (
+	"maps"
+	"net/url"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/env"
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/buildkite/agent/v3/tracetools"
+)
+
+// ControlPlaneOTLPTracingFeature is advertised at registration when this agent
+// binary can consume control-plane OTLP exporter config (apply to bootstrap env
+// and scrub pipeline-supplied exporter keys from job.env).
+const ControlPlaneOTLPTracingFeature = "control-plane-otlp-tracing"
+
+// defaultOTLPProtocol is assumed when registration supplies an exporter without
+// naming a protocol. The control plane exports over HTTP with protobuf, so this
+// matches it rather than the OTel SDK's gRPC default.
+const defaultOTLPProtocol = "http/protobuf"
+
+// ApplyRegistrationTracing merges control-plane tracing policy into the worker's
+// runtime config. Explicit local backend and propagation settings win. When
+// registration supplies an OpenTelemetry exporter, it is stored for bootstrap
+// delivery via process environment variables.
+//
+// Registration can enable tracing on an agent that configured none, so what was
+// accepted is logged: an operator seeing traffic to a collector they did not
+// configure should be able to find out why from the agent log alone.
+func (c *AgentConfiguration) ApplyRegistrationTracing(
+	l logger.Logger,
+	tracing *api.AgentRegistrationTracing,
+	backendLocallyConfigured bool,
+	propagateTraceparentLocallyConfigured bool,
+) {
+	if tracing == nil || tracing.Backend != tracetools.BackendOpenTelemetry {
+		return
+	}
+
+	if !backendLocallyConfigured {
+		c.TracingBackend = tracing.Backend
+	}
+	if c.TracingBackend != tracetools.BackendOpenTelemetry {
+		l.Infof(
+			"Buildkite sent OpenTelemetry tracing configuration for this agent. Ignoring it, because the tracing backend is set to %q locally",
+			c.TracingBackend,
+		)
+		return
+	}
+	if !backendLocallyConfigured {
+		l.Infof("Buildkite enabled OpenTelemetry tracing for this agent")
+	}
+
+	if !propagateTraceparentLocallyConfigured {
+		c.TracingPropagateTraceparent = tracing.PropagateTraceparent
+	}
+
+	if tracing.Exporter == nil || tracing.Exporter.Endpoint == "" {
+		return
+	}
+	c.TracingExporter = tracing.Exporter
+
+	if hostHasOTelExporterConfig() {
+		l.Infof("Buildkite sent an OTLP trace exporter. Ignoring it, because this host sets OTEL_EXPORTER_OTLP_* itself")
+		return
+	}
+
+	protocol := tracing.Exporter.Protocol
+	if protocol == "" {
+		protocol = defaultOTLPProtocol
+	}
+	headers := "no request headers"
+	if len(tracing.Exporter.Headers) > 0 {
+		headers = "request headers supplied by Buildkite"
+	}
+	l.Infof(
+		"Exporting job traces to %s over %s, with %s",
+		exporterEndpointForLog(tracing.Exporter.Endpoint), protocol, headers,
+	)
+}
+
+// exporterEndpointForLog reduces an exporter endpoint to its scheme and host.
+// Some vendors carry an ingest key in the path or query, so those are left out
+// rather than logged.
+func exporterEndpointForLog(endpoint string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Host == "" {
+		return "an unparseable endpoint"
+	}
+	return u.Scheme + "://" + u.Host
+}
+
+// hostHasOTelExporterConfig reports whether the agent process already has a
+// local OTLP endpoint or headers. Protocol-only leftovers do not count as a
+// full local override. Local operator config takes precedence over
+// control-plane injection when an endpoint or headers are set.
+func hostHasOTelExporterConfig() bool {
+	return os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" ||
+		os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") != "" ||
+		os.Getenv("OTEL_EXPORTER_OTLP_HEADERS") != "" ||
+		os.Getenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS") != ""
+}
+
+// controlPlaneExporterApplies reports whether registration exporter config will
+// be injected into a job's bootstrap environment.
+//
+// Everything this feature takes away from a job, namely the job.env scrub and
+// removing exporter values before hooks run, is conditional on this. When the
+// control plane supplies no exporter there is no organisation credential in the
+// job environment to protect, so it is left exactly as it is without this
+// feature and anyone configuring OTLP export themselves is unaffected.
+func controlPlaneExporterApplies(tracingBackend string, exporter *api.TracingExporter) bool {
+	if tracingBackend != tracetools.BackendOpenTelemetry {
+		return false
+	}
+	if exporter == nil || exporter.Endpoint == "" {
+		return false
+	}
+	return !hostHasOTelExporterConfig()
+}
+
+// scrubJobOTelExporterEnv removes the agent-owned exporter marker from job.env
+// always, and the exporter destination, auth, and TLS keys only when the control
+// plane is supplying exporter config for this job. Returns the names removed,
+// for BUILDKITE_IGNORED_ENV.
+func scrubJobOTelExporterEnv(jobEnv map[string]string, exporterApplies bool) []string {
+	scrubbed := env.ScrubOTelExporterMarker(jobEnv)
+	if !exporterApplies {
+		return scrubbed
+	}
+	return append(scrubbed, env.ScrubOTelExporterKeys(jobEnv)...)
+}
+
+// encodeOTLPHeaders formats a header map as OTEL_EXPORTER_OTLP_HEADERS expects:
+// comma-separated key=value pairs with URL-path-escaped values (OTel SDK
+// PathUnescapes on read). Keys are sorted for stable output.
+func encodeOTLPHeaders(headers map[string]string) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(headers))
+	for _, k := range slices.Sorted(maps.Keys(headers)) {
+		v := headers[k]
+		if k == "" || v == "" {
+			continue
+		}
+		parts = append(parts, k+"="+url.PathEscape(v))
+	}
+	return strings.Join(parts, ",")
+}
+
+// applyControlPlaneTracingExporter sets bootstrap OTEL_* vars from registration
+// exporter config, plus the marker telling bootstrap to remove them again before
+// hooks and the command run. Call only when controlPlaneExporterApplies, and
+// after writing BUILDKITE_ENV_FILE so credentials are not persisted there.
+//
+// Only the traces-specific variables are set. Registration configures a traces
+// endpoint, and the OTLP logs and metrics SDKs fall back to the generic
+// variables while honouring their own signal-specific endpoint, so generic
+// headers would let another signal carry this credential elsewhere.
+// Traces-specific values also beat a leftover generic or traces protocol.
+//
+// Same-UID processes can read these values from the bootstrap environ (the
+// same exposure that already applies to BUILDKITE_AGENT_ACCESS_TOKEN).
+func applyControlPlaneTracingExporter(setEnv func(name, value string), exporter *api.TracingExporter) {
+	protocol := exporter.Protocol
+	if protocol == "" {
+		protocol = defaultOTLPProtocol
+	}
+	setEnv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", protocol)
+	// Full traces URL from the control plane (includes /v1/traces).
+	setEnv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", exporter.Endpoint)
+
+	if encoded := encodeOTLPHeaders(exporter.Headers); encoded != "" {
+		setEnv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", encoded)
+	}
+
+	setEnv(env.OTelExporterMarkerEnv, "true")
+}

--- a/agent/tracing_exporter_test.go
+++ b/agent/tracing_exporter_test.go
@@ -1,0 +1,506 @@
+package agent
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/env"
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/buildkite/agent/v3/tracetools"
+)
+
+func TestEncodeOTLPHeaders(t *testing.T) {
+	t.Parallel()
+
+	got := encodeOTLPHeaders(map[string]string{
+		"X-Team":        "pipelines",
+		"Authorization": "Bearer secret,with%chars",
+		"":              "skip",
+		"Empty":         "",
+	})
+	// Values are PathEscaped so commas/percent signs survive OTel's parser.
+	want := "Authorization=Bearer%20secret%2Cwith%25chars,X-Team=pipelines"
+	if got != want {
+		t.Fatalf("encodeOTLPHeaders() = %q, want %q", got, want)
+	}
+}
+
+func TestControlPlaneExporterApplies(t *testing.T) {
+	exporter := &api.TracingExporter{Endpoint: "https://otel.example/v1/traces"}
+
+	tests := []struct {
+		name        string
+		backend     string
+		exporter    *api.TracingExporter
+		hostEnv     map[string]string
+		wantApplies bool
+	}{
+		{
+			name:        "opentelemetry backend with exporter and no host config",
+			backend:     tracetools.BackendOpenTelemetry,
+			exporter:    exporter,
+			wantApplies: true,
+		},
+		{
+			name:        "no exporter supplied",
+			backend:     tracetools.BackendOpenTelemetry,
+			exporter:    nil,
+			wantApplies: false,
+		},
+		{
+			name:        "exporter without endpoint",
+			backend:     tracetools.BackendOpenTelemetry,
+			exporter:    &api.TracingExporter{},
+			wantApplies: false,
+		},
+		{
+			name:        "non-opentelemetry backend",
+			backend:     tracetools.BackendDatadog,
+			exporter:    exporter,
+			wantApplies: false,
+		},
+		{
+			name:        "tracing disabled",
+			backend:     "",
+			exporter:    exporter,
+			wantApplies: false,
+		},
+		{
+			name:        "host endpoint wins",
+			backend:     tracetools.BackendOpenTelemetry,
+			exporter:    exporter,
+			hostEnv:     map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "https://local.example"},
+			wantApplies: false,
+		},
+		{
+			name:        "host traces headers win",
+			backend:     tracetools.BackendOpenTelemetry,
+			exporter:    exporter,
+			hostEnv:     map[string]string{"OTEL_EXPORTER_OTLP_TRACES_HEADERS": "Authorization=Bearer local"},
+			wantApplies: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, key := range env.OTelExporterKeys {
+				t.Setenv(key, "")
+			}
+			for key, value := range test.hostEnv {
+				t.Setenv(key, value)
+			}
+
+			if got := controlPlaneExporterApplies(test.backend, test.exporter); got != test.wantApplies {
+				t.Fatalf("controlPlaneExporterApplies() = %v, want %v", got, test.wantApplies)
+			}
+		})
+	}
+}
+
+// Without control-plane exporter config, a pipeline keeps whatever OTLP exporter
+// env it sets, exactly as it does when this feature is unused.
+func TestScrubJobOTelExporterEnvLeavesPipelineConfigWhenNotApplying(t *testing.T) {
+	t.Parallel()
+
+	jobEnv := map[string]string{
+		"BUILDKITE_COMMAND":           "echo hi",
+		"OTEL_EXPORTER_OTLP_ENDPOINT": "https://our-own-collector.example",
+		"OTEL_EXPORTER_OTLP_HEADERS":  "Authorization=Bearer ours",
+	}
+	scrubbed := scrubJobOTelExporterEnv(jobEnv, false)
+
+	if len(scrubbed) != 0 {
+		t.Fatalf("scrubbed = %v, want nothing removed", scrubbed)
+	}
+	if jobEnv["OTEL_EXPORTER_OTLP_ENDPOINT"] != "https://our-own-collector.example" {
+		t.Fatalf("jobEnv = %#v, want pipeline exporter config kept", jobEnv)
+	}
+}
+
+func TestScrubJobOTelExporterEnvWhenApplying(t *testing.T) {
+	t.Parallel()
+
+	jobEnv := map[string]string{
+		"BUILDKITE_COMMAND":                     "echo hi",
+		"OTEL_EXPORTER_OTLP_HEADERS":            "Authorization=Bearer pipeline",
+		"OTEL_EXPORTER_OTLP_ENDPOINT":           "https://evil.example",
+		"OTEL_EXPORTER_OTLP_PROTOCOL":           "grpc",
+		"OTEL_EXPORTER_OTLP_TRACES_INSECURE":    "true",
+		"OTEL_EXPORTER_OTLP_CERTIFICATE":        "/tmp/attacker-ca.pem",
+		"OTEL_EXPORTER_OTLP_CLIENT_KEY":         "/tmp/key.pem",
+		"OTEL_EXPORTER_OTLP_TRACES_COMPRESSION": "gzip",
+		"OTEL_RESOURCE_ATTRIBUTES":              "keep=me",
+	}
+	scrubbed := scrubJobOTelExporterEnv(jobEnv, true)
+
+	for _, key := range []string{
+		"OTEL_EXPORTER_OTLP_HEADERS",
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_TRACES_INSECURE",
+		"OTEL_EXPORTER_OTLP_CERTIFICATE",
+	} {
+		if _, ok := jobEnv[key]; ok {
+			t.Errorf("expected %s to be scrubbed", key)
+		}
+	}
+	// Compression and resource attributes are neither destination, auth, nor TLS.
+	if jobEnv["OTEL_EXPORTER_OTLP_TRACES_COMPRESSION"] != "gzip" {
+		t.Error("expected compression to remain")
+	}
+	if jobEnv["OTEL_RESOURCE_ATTRIBUTES"] != "keep=me" {
+		t.Error("expected non-exporter OTEL vars to remain")
+	}
+	if len(scrubbed) != 6 {
+		t.Errorf("scrubbed = %v, want 6 exporter keys", scrubbed)
+	}
+}
+
+// The marker drives removal in bootstrap, so a pipeline must never supply it.
+func TestScrubJobOTelExporterEnvAlwaysDropsMarker(t *testing.T) {
+	t.Parallel()
+
+	for _, applies := range []bool{true, false} {
+		jobEnv := map[string]string{env.OTelExporterMarkerEnv: "true"}
+		scrubbed := scrubJobOTelExporterEnv(jobEnv, applies)
+
+		if _, ok := jobEnv[env.OTelExporterMarkerEnv]; ok {
+			t.Fatalf("exporterApplies=%v: expected the marker to be scrubbed", applies)
+		}
+		if len(scrubbed) != 1 {
+			t.Fatalf("exporterApplies=%v: scrubbed = %v, want the marker", applies, scrubbed)
+		}
+	}
+}
+
+func TestOTelExporterMarkerIsProtected(t *testing.T) {
+	t.Parallel()
+
+	if !env.IsProtected(env.OTelExporterMarkerEnv) {
+		t.Errorf("%s should be protected", env.OTelExporterMarkerEnv)
+	}
+	if !env.IsProtectedFromWithinJob(env.OTelExporterMarkerEnv) {
+		t.Errorf("%s should be protected from within job", env.OTelExporterMarkerEnv)
+	}
+}
+
+// Exporter env vars themselves stay unprotected: a job may configure its own
+// OTLP export, and the agent's injected values are removed before hooks run.
+func TestOTelExporterKeysAreNotGloballyProtected(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range env.OTelExporterKeys {
+		if env.IsProtected(key) {
+			t.Errorf("%s should not be globally protected", key)
+		}
+	}
+}
+
+func TestApplyRegistrationTracing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("applies backend, propagate, and exporter", func(t *testing.T) {
+		t.Parallel()
+		conf := AgentConfiguration{}
+		conf.ApplyRegistrationTracing(logger.Discard, &api.AgentRegistrationTracing{
+			Backend:              tracetools.BackendOpenTelemetry,
+			PropagateTraceparent: true,
+			Exporter: &api.TracingExporter{
+				Endpoint: "https://otel.example/v1/traces",
+				Protocol: "http/protobuf",
+				Headers:  map[string]string{"Authorization": "Bearer secret"},
+			},
+		}, false, false)
+
+		if conf.TracingBackend != tracetools.BackendOpenTelemetry {
+			t.Fatalf("TracingBackend = %q", conf.TracingBackend)
+		}
+		if !conf.TracingPropagateTraceparent {
+			t.Fatal("TracingPropagateTraceparent = false")
+		}
+		if conf.TracingExporter == nil || conf.TracingExporter.Endpoint != "https://otel.example/v1/traces" {
+			t.Fatalf("TracingExporter = %#v", conf.TracingExporter)
+		}
+	})
+
+	t.Run("local backend wins", func(t *testing.T) {
+		t.Parallel()
+		conf := AgentConfiguration{TracingBackend: tracetools.BackendDatadog}
+		conf.ApplyRegistrationTracing(logger.Discard, &api.AgentRegistrationTracing{
+			Backend: tracetools.BackendOpenTelemetry,
+			Exporter: &api.TracingExporter{
+				Endpoint: "https://otel.example/v1/traces",
+			},
+		}, true, false)
+
+		if conf.TracingBackend != tracetools.BackendDatadog {
+			t.Fatalf("TracingBackend = %q", conf.TracingBackend)
+		}
+		if conf.TracingExporter != nil {
+			t.Fatalf("TracingExporter = %#v, want nil", conf.TracingExporter)
+		}
+	})
+
+	t.Run("local propagate wins including explicit false", func(t *testing.T) {
+		t.Parallel()
+		conf := AgentConfiguration{TracingPropagateTraceparent: false}
+		conf.ApplyRegistrationTracing(logger.Discard, &api.AgentRegistrationTracing{
+			Backend:              tracetools.BackendOpenTelemetry,
+			PropagateTraceparent: true,
+			Exporter: &api.TracingExporter{
+				Endpoint: "https://otel.example/v1/traces",
+			},
+		}, false, true)
+
+		if conf.TracingPropagateTraceparent {
+			t.Fatal("registration overwrote an explicit local propagate-traceparent=false")
+		}
+		if conf.TracingExporter == nil {
+			t.Fatal("TracingExporter = nil")
+		}
+	})
+
+	t.Run("ignores non-opentelemetry registration backend", func(t *testing.T) {
+		t.Parallel()
+		conf := AgentConfiguration{}
+		conf.ApplyRegistrationTracing(logger.Discard, &api.AgentRegistrationTracing{
+			Backend: tracetools.BackendDatadog,
+			Exporter: &api.TracingExporter{
+				Endpoint: "https://otel.example/v1/traces",
+			},
+		}, false, false)
+		if conf.TracingBackend != "" || conf.TracingExporter != nil {
+			t.Fatalf("unexpected apply: %#v", conf)
+		}
+	})
+
+	t.Run("ignores exporter without endpoint", func(t *testing.T) {
+		t.Parallel()
+		conf := AgentConfiguration{}
+		conf.ApplyRegistrationTracing(logger.Discard, &api.AgentRegistrationTracing{
+			Backend:  tracetools.BackendOpenTelemetry,
+			Exporter: &api.TracingExporter{},
+		}, false, false)
+		if conf.TracingExporter != nil {
+			t.Fatalf("unexpected exporter accept: %#v", conf)
+		}
+	})
+}
+
+// Registration can enable tracing on an agent that configured none, so the agent
+// log has to say what was accepted and where traces are going.
+func TestApplyRegistrationTracingLogging(t *testing.T) {
+	fullExporter := &api.TracingExporter{
+		// A path a vendor might use to carry an ingest key.
+		Endpoint: "https://otel.example/ingest/SECRET_KEY/v1/traces",
+		Protocol: "http/protobuf",
+		Headers:  map[string]string{"Authorization": "Bearer SECRET_HEADER"},
+	}
+
+	tests := []struct {
+		name       string
+		conf       AgentConfiguration
+		tracing    *api.AgentRegistrationTracing
+		backendSet bool
+		hostEnv    map[string]string
+		wantLogged []string
+		wantSilent bool
+	}{
+		{
+			name: "enabled with an exporter",
+			tracing: &api.AgentRegistrationTracing{
+				Backend:  tracetools.BackendOpenTelemetry,
+				Exporter: fullExporter,
+			},
+			wantLogged: []string{
+				"Buildkite enabled OpenTelemetry tracing for this agent",
+				"Exporting job traces to https://otel.example over http/protobuf, with request headers supplied by Buildkite",
+			},
+		},
+		{
+			name: "exporter without headers",
+			tracing: &api.AgentRegistrationTracing{
+				Backend:  tracetools.BackendOpenTelemetry,
+				Exporter: &api.TracingExporter{Endpoint: "https://otel.example/v1/traces"},
+			},
+			wantLogged: []string{
+				"Exporting job traces to https://otel.example over http/protobuf, with no request headers",
+			},
+		},
+		{
+			name:       "local backend wins",
+			conf:       AgentConfiguration{TracingBackend: tracetools.BackendDatadog},
+			backendSet: true,
+			tracing: &api.AgentRegistrationTracing{
+				Backend:  tracetools.BackendOpenTelemetry,
+				Exporter: fullExporter,
+			},
+			wantLogged: []string{`Ignoring it, because the tracing backend is set to "datadog" locally`},
+		},
+		{
+			name: "host exporter config wins",
+			tracing: &api.AgentRegistrationTracing{
+				Backend:  tracetools.BackendOpenTelemetry,
+				Exporter: fullExporter,
+			},
+			hostEnv:    map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "https://operator-collector.example"},
+			wantLogged: []string{"Ignoring it, because this host sets OTEL_EXPORTER_OTLP_* itself"},
+		},
+		{
+			name:       "nothing supplied",
+			tracing:    nil,
+			wantSilent: true,
+		},
+		{
+			name:       "non-opentelemetry registration backend",
+			tracing:    &api.AgentRegistrationTracing{Backend: tracetools.BackendDatadog},
+			wantSilent: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, key := range env.OTelExporterKeys {
+				t.Setenv(key, "")
+			}
+			for key, value := range test.hostEnv {
+				t.Setenv(key, value)
+			}
+
+			buf := logger.NewBuffer()
+			conf := test.conf
+			conf.ApplyRegistrationTracing(buf, test.tracing, test.backendSet, false)
+
+			if test.wantSilent && len(buf.Messages) != 0 {
+				t.Fatalf("expected no log output, got %v", buf.Messages)
+			}
+			logged := strings.Join(buf.Messages, "\n")
+			for _, want := range test.wantLogged {
+				if !strings.Contains(logged, want) {
+					t.Errorf("log missing %q, got:\n%s", want, logged)
+				}
+			}
+			// Neither the credential nor a path that might carry one is loggable.
+			for _, secret := range []string{"SECRET_HEADER", "SECRET_KEY"} {
+				if strings.Contains(logged, secret) {
+					t.Errorf("log leaked %s:\n%s", secret, logged)
+				}
+			}
+		})
+	}
+}
+
+// These lines exist to be seen without extra flags, so they go through a real
+// level-aware ConsoleLogger here rather than logger.Buffer, which ignores levels.
+//
+// Note the level ordering in logger/level.go: NOTICE sits *below* INFO, unlike
+// syslog. Infof prints when level <= INFO, so it is visible at the `start`
+// default of notice as well as at info and debug. Noticef would print when
+// level <= NOTICE, which would hide these lines from anyone running the more
+// verbose-sounding --log-level info.
+func TestApplyRegistrationTracingLogsAtDefaultLogLevel(t *testing.T) {
+	levels := map[string]struct {
+		level       logger.Level
+		wantVisible bool
+	}{
+		"debug":                      {logger.DEBUG, true},
+		"notice (the start default)": {logger.NOTICE, true},
+		"info":                       {logger.INFO, true},
+		"warn":                       {logger.WARN, false},
+	}
+
+	for name, test := range levels {
+		t.Run(name, func(t *testing.T) {
+			for _, key := range env.OTelExporterKeys {
+				t.Setenv(key, "")
+			}
+
+			var buf bytes.Buffer
+			l := logger.NewConsoleLogger(logger.NewTextPrinter(&buf), func(int) {})
+			l.SetLevel(test.level)
+
+			conf := AgentConfiguration{}
+			conf.ApplyRegistrationTracing(l, &api.AgentRegistrationTracing{
+				Backend: tracetools.BackendOpenTelemetry,
+				Exporter: &api.TracingExporter{
+					Endpoint: "https://otel.example/v1/traces",
+					Headers:  map[string]string{"Authorization": "Bearer secret"},
+				},
+			}, false, false)
+
+			got := buf.String()
+			visible := strings.Contains(got, "Buildkite enabled OpenTelemetry tracing") &&
+				strings.Contains(got, "Exporting job traces to https://otel.example")
+			if visible != test.wantVisible {
+				t.Fatalf("visible at %s = %v, want %v; output:\n%s", test.level, visible, test.wantVisible, got)
+			}
+		})
+	}
+}
+
+func TestExporterEndpointForLog(t *testing.T) {
+	t.Parallel()
+
+	for endpoint, want := range map[string]string{
+		"https://otel.example/v1/traces":           "https://otel.example",
+		"https://otel.example:4318/ingest/key?a=b": "https://otel.example:4318",
+		"http://localhost:4318":                    "http://localhost:4318",
+		"not a url":                                "an unparseable endpoint",
+		"":                                         "an unparseable endpoint",
+	} {
+		if got := exporterEndpointForLog(endpoint); got != want {
+			t.Errorf("exporterEndpointForLog(%q) = %q, want %q", endpoint, got, want)
+		}
+	}
+}
+
+func TestApplyControlPlaneTracingExporter(t *testing.T) {
+	t.Parallel()
+
+	got := map[string]string{}
+	setEnv := func(name, value string) { got[name] = value }
+
+	applyControlPlaneTracingExporter(setEnv, &api.TracingExporter{
+		Endpoint: "https://otel.example/v1/traces",
+		Protocol: "http/protobuf",
+		Headers:  map[string]string{"Authorization": "Bearer from-cp"},
+	})
+
+	want := map[string]string{
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "https://otel.example/v1/traces",
+		"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf",
+		"OTEL_EXPORTER_OTLP_TRACES_HEADERS":  "Authorization=Bearer%20from-cp",
+		env.OTelExporterMarkerEnv:            "true",
+	}
+	for name, wantValue := range want {
+		if got[name] != wantValue {
+			t.Errorf("%s = %q, want %q", name, got[name], wantValue)
+		}
+	}
+
+	// Generic variables are shared with the logs and metrics SDKs, which honour
+	// their own signal-specific endpoint. Setting them would let a pipeline-set
+	// OTEL_EXPORTER_OTLP_LOGS_ENDPOINT receive the registration credential.
+	if len(got) != len(want) {
+		t.Errorf("got %#v, want only traces-scoped variables plus the marker", got)
+	}
+}
+
+func TestApplyControlPlaneTracingExporterDefaultsProtocol(t *testing.T) {
+	t.Parallel()
+
+	got := map[string]string{}
+	setEnv := func(name, value string) { got[name] = value }
+
+	applyControlPlaneTracingExporter(setEnv, &api.TracingExporter{
+		Endpoint: "https://otel.example/v1/traces",
+	})
+
+	if got["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"] != "http/protobuf" {
+		t.Errorf("protocol = %q, want http/protobuf", got["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"])
+	}
+	if _, ok := got["OTEL_EXPORTER_OTLP_TRACES_HEADERS"]; ok {
+		t.Error("expected no headers variable when the exporter supplies none")
+	}
+}

--- a/api/agents.go
+++ b/api/agents.go
@@ -21,15 +21,16 @@ type AgentRegisterRequest struct {
 
 // AgentRegisterResponse is the response from the Buildkite Agent API
 type AgentRegisterResponse struct {
-	UUID              string            `json:"id"`
-	Name              string            `json:"name"`
-	AccessToken       string            `json:"access_token"`
-	Endpoint          string            `json:"endpoint"`
-	RequestHeaders    map[string]string `json:"request_headers"`
-	PingInterval      int               `json:"ping_interval"`
-	JobStatusInterval int               `json:"job_status_interval"`
-	HeartbeatInterval int               `json:"heartbeat_interval"`
-	Tags              []string          `json:"meta_data"`
+	UUID              string                    `json:"id"`
+	Name              string                    `json:"name"`
+	AccessToken       string                    `json:"access_token"`
+	Endpoint          string                    `json:"endpoint"`
+	RequestHeaders    map[string]string         `json:"request_headers"`
+	PingInterval      int                       `json:"ping_interval"`
+	JobStatusInterval int                       `json:"job_status_interval"`
+	HeartbeatInterval int                       `json:"heartbeat_interval"`
+	Tags              []string                  `json:"meta_data"`
+	Tracing           *AgentRegistrationTracing `json:"tracing,omitempty"`
 }
 
 // Registers the agent against the Buildkite Agent API. The client for this

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -21,7 +21,7 @@ func TestRegisteringAndConnectingClient(t *testing.T) {
 				return
 			}
 			rw.WriteHeader(http.StatusOK)
-			fmt.Fprint(rw, `{"id":"12-34-56-78-91", "name":"agent-1", "access_token":"alpacas"}`) //nolint:errcheck // The test would still fail
+			fmt.Fprint(rw, `{"id":"12-34-56-78-91","name":"agent-1","access_token":"alpacas","tracing":{"backend":"opentelemetry","propagate_traceparent":true,"exporter":{"endpoint":"https://otel.example/v1/traces","protocol":"http/protobuf","headers":{"Authorization":"Bearer secret"}}}}`) //nolint:errcheck // The test would still fail
 
 		case "/connect":
 			if got, want := authToken(req), "alpacas"; got != want {
@@ -62,6 +62,13 @@ func TestRegisteringAndConnectingClient(t *testing.T) {
 
 	if got, want := reg.AccessToken, "alpacas"; got != want {
 		t.Errorf("regResp.AccessToken = %q, want %q", got, want)
+	}
+
+	if reg.Tracing == nil || reg.Tracing.Backend != "opentelemetry" {
+		t.Errorf("reg.Tracing = %#v, want opentelemetry backend", reg.Tracing)
+	}
+	if reg.Tracing == nil || reg.Tracing.Exporter == nil || reg.Tracing.Exporter.Endpoint != "https://otel.example/v1/traces" {
+		t.Errorf("reg.Tracing.Exporter = %#v", reg.Tracing)
 	}
 
 	if got, want := httpResp.Proto, "HTTP/2.0"; got != want {

--- a/api/tracing.go
+++ b/api/tracing.go
@@ -1,0 +1,17 @@
+package api
+
+// TracingExporter is OTLP exporter configuration supplied by the control plane
+// (registration response). It must never be copied into job.env.
+type TracingExporter struct {
+	Endpoint string            `json:"endpoint"`
+	Protocol string            `json:"protocol"`
+	Headers  map[string]string `json:"headers"`
+}
+
+// AgentRegistrationTracing is tracing policy and optional exporter settings
+// supplied by the control plane at registration.
+type AgentRegistrationTracing struct {
+	Backend              string           `json:"backend"`
+	PropagateTraceparent bool             `json:"propagate_traceparent"`
+	Exporter             *TracingExporter `json:"exporter,omitempty"`
+}

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -242,12 +242,40 @@ func (cfg *AgentStartConfig) checkoutOverrideMode() (env.CheckoutOverrideMode, e
 	return resolveCheckoutOverrideMode(cfg.CheckoutOverrideMode, !cfg.NoCommandEval)
 }
 
+// localTracingEnv records local tracing configuration that later startup steps
+// destroy. UnsetConfigFromEnvironment clears config environment variables so
+// they do not reach bootstrap, and urfave/cli v1's IsSet only reports
+// command-line flags, so presence in the environment has to be captured before
+// config is loaded. Without it an explicit
+// BUILDKITE_TRACING_PROPAGATE_TRACEPARENT=false looks unset and registration
+// policy would overwrite it.
+type localTracingEnv struct {
+	propagateTraceparentSet bool
+}
+
+func captureLocalTracingEnv() localTracingEnv {
+	_, propagateTraceparentSet := os.LookupEnv("BUILDKITE_TRACING_PROPAGATE_TRACEPARENT")
+	return localTracingEnv{propagateTraceparentSet: propagateTraceparentSet}
+}
+
+// propagateTraceparentLocallyConfigured reports whether the operator set
+// traceparent propagation themselves, from any source, including an explicit
+// false.
+func (t localTracingEnv) propagateTraceparentLocallyConfigured(cliSet, configFileSet bool) bool {
+	return cliSet || configFileSet || t.propagateTraceparentSet
+}
+
 func (asc AgentStartConfig) Features(ctx context.Context) []string {
 	if asc.NoFeatureReporting {
 		return []string{}
 	}
 
-	features := make([]string, 0, 9)
+	features := make([]string, 0, 10)
+
+	// Capability: this agent can consume control-plane OTLP exporter config
+	// (bootstrap env application + pipeline scrub). Independent of whether
+	// --tracing-backend is already set, so registration can enable tracing.
+	features = append(features, agent.ControlPlaneOTLPTracingFeature)
 
 	if asc.GitMirrorsPath != "" {
 		features = append(features, "git-mirrors")
@@ -860,6 +888,8 @@ var AgentStartCommand = cli.Command{
 			_, _ = fmt.Fprintf(c.App.ErrWriter, "Couldn't re-exec to remove the registration token from the process command line/environment, continuing anyway: %v\n", err)
 		}
 
+		tracingEnv := captureLocalTracingEnv()
+
 		ctx := context.Background()
 		ctx, cfg, l, configFile, done := setupLoggerAndConfig[AgentStartConfig](ctx, c, withConfigFilePaths(
 			defaultConfigFilePaths(),
@@ -1192,6 +1222,16 @@ var AgentStartCommand = cli.Command{
 			agentConf.ConfigPath = configFile.Path
 		}
 
+		backendLocallyConfigured := agentConf.TracingBackend != ""
+		configFileSetsPropagate := false
+		if configFile != nil {
+			_, configFileSetsPropagate = configFile.Config["tracing-propagate-traceparent"]
+		}
+		propagateTraceparentLocallyConfigured := tracingEnv.propagateTraceparentLocallyConfigured(
+			c.IsSet("tracing-propagate-traceparent"),
+			configFileSetsPropagate,
+		)
+
 		if cfg.LogFormat == "text" {
 			welcomeMessage := "\n" +
 				"%s   _           _ _     _ _    _ _                                _\n" +
@@ -1402,14 +1442,26 @@ var AgentStartCommand = cli.Command{
 				return nil, err
 			}
 
+			workerLogger := l.WithFields(logger.StringField("agent", reg.Name))
+
+			// Per-worker copy so registration tracing policy does not race
+			// across spawned agents.
+			workerAgentConf := agentConf
+			workerAgentConf.ApplyRegistrationTracing(
+				workerLogger,
+				reg.Tracing,
+				backendLocallyConfigured,
+				propagateTraceparentLocallyConfigured,
+			)
+
 			// Create an agent worker to run the agent
 			return agent.NewAgentWorker(
-				l.WithFields(logger.StringField("agent", reg.Name)),
+				workerLogger,
 				reg,
 				mc,
 				apiClient,
 				agent.AgentWorkerConfig{
-					AgentConfiguration: agentConf,
+					AgentConfiguration: workerAgentConf,
 					CancelSignal:       cancelSig,
 					SignalGracePeriod:  signalGracePeriod,
 					Debug:              cfg.Debug,

--- a/clicommand/agent_start_test.go
+++ b/clicommand/agent_start_test.go
@@ -16,6 +16,70 @@ import (
 	"github.com/urfave/cli"
 )
 
+// Registration tracing policy must not override an operator's explicit
+// BUILDKITE_TRACING_PROPAGATE_TRACEPARENT=false. Presence has to be captured
+// before UnsetConfigFromEnvironment clears it, so this covers that ordering.
+func TestCaptureLocalTracingEnvSurvivesConfigUnset(t *testing.T) {
+	t.Setenv("BUILDKITE_TRACING_PROPAGATE_TRACEPARENT", "false")
+
+	tracingEnv := captureLocalTracingEnv()
+
+	// Only this flag is unset, so the shared process environment other tests in
+	// this package rely on is left alone.
+	c := cli.NewContext(cli.NewApp(), nil, nil)
+	c.Command = cli.Command{
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:   "tracing-propagate-traceparent",
+				EnvVar: "BUILDKITE_TRACING_PROPAGATE_TRACEPARENT",
+			},
+		},
+	}
+	if err := UnsetConfigFromEnvironment(c); err != nil {
+		t.Fatalf("UnsetConfigFromEnvironment() error = %v", err)
+	}
+
+	// Guards the ordering: capturing after this point would see nothing.
+	if _, stillSet := os.LookupEnv("BUILDKITE_TRACING_PROPAGATE_TRACEPARENT"); stillSet {
+		t.Fatal("expected UnsetConfigFromEnvironment to clear the variable")
+	}
+	if captureLocalTracingEnv().propagateTraceparentSet {
+		t.Fatal("expected a post-unset capture to see the variable as absent")
+	}
+
+	if !tracingEnv.propagateTraceparentLocallyConfigured(false, false) {
+		t.Fatal("expected the environment value captured before unset to count as local config")
+	}
+
+	// An explicit false must survive registration policy that enables it.
+	conf := agent.AgentConfiguration{TracingPropagateTraceparent: false}
+	conf.ApplyRegistrationTracing(logger.Discard, &api.AgentRegistrationTracing{
+		Backend:              "opentelemetry",
+		PropagateTraceparent: true,
+	}, false, tracingEnv.propagateTraceparentLocallyConfigured(false, false))
+
+	if conf.TracingPropagateTraceparent {
+		t.Fatal("registration overwrote an explicit local propagate-traceparent=false")
+	}
+}
+
+func TestPropagateTraceparentLocallyConfiguredSources(t *testing.T) {
+	t.Parallel()
+
+	if (localTracingEnv{}).propagateTraceparentLocallyConfigured(false, false) {
+		t.Fatal("expected false when no source configures propagation")
+	}
+	if !(localTracingEnv{}).propagateTraceparentLocallyConfigured(true, false) {
+		t.Fatal("expected the command-line flag to count")
+	}
+	if !(localTracingEnv{}).propagateTraceparentLocallyConfigured(false, true) {
+		t.Fatal("expected the config file key to count")
+	}
+	if !(localTracingEnv{propagateTraceparentSet: true}).propagateTraceparentLocallyConfigured(false, false) {
+		t.Fatal("expected the captured environment value to count")
+	}
+}
+
 func setupHooksPath(t *testing.T) (string, func()) {
 	t.Helper()
 

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -662,6 +662,9 @@ func setupLoggerAndConfig[T any](ctx context.Context, c *cli.Context, opts ...co
 				_ = traceProvider.Shutdown(flushCtx)
 			}
 		}
+		// Any control-plane exporter credentials stay in the process environ
+		// until Executor.Run has also finished optional OTLP job-log setup,
+		// which falls back to the generic OTEL_EXPORTER_OTLP_* variables.
 	}
 
 	return ctx, cfg, l, loader.File, done

--- a/env/otel_exporter.go
+++ b/env/otel_exporter.go
@@ -1,0 +1,113 @@
+package env
+
+import "os"
+
+// OTelExporterMarkerEnv records that the agent injected control-plane OTLP
+// exporter configuration into a job's bootstrap environment. Bootstrap uses it
+// to remove those values before hooks and the command run.
+//
+// Without the marker nothing is removed, so an operator's own
+// OTEL_EXPORTER_OTLP_* configuration reaches hooks and commands exactly as it
+// does when this feature is unused.
+const OTelExporterMarkerEnv = "BUILDKITE_OTEL_EXPORTER_FROM_CONTROL_PLANE"
+
+// OTelExporterInjectedKeys are the variables the agent sets from registration
+// exporter config. Only these are removed from a job environment, and only when
+// the marker is present, so operator-supplied configuration survives.
+var OTelExporterInjectedKeys = []string{
+	"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+	"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+}
+
+// OTelExporterKeys are OTLP exporter destination, auth, and TLS variables that a
+// pipeline must not supply while the control plane is delivering exporter
+// config: a job must not redirect the export, attach its own auth, or aim the
+// exporter at a CA it controls.
+//
+// They are scrubbed from job.env only in that case. When the control plane
+// supplies nothing, a pipeline may configure its own exporter as before.
+var OTelExporterKeys = []string{
+	"OTEL_EXPORTER_OTLP_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_HEADERS",
+	"OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+	"OTEL_EXPORTER_OTLP_PROTOCOL",
+	"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+	"OTEL_EXPORTER_OTLP_INSECURE",
+	"OTEL_EXPORTER_OTLP_TRACES_INSECURE",
+	"OTEL_EXPORTER_OTLP_CERTIFICATE",
+	"OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE",
+	"OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE",
+	"OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE",
+	"OTEL_EXPORTER_OTLP_CLIENT_KEY",
+	"OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY",
+}
+
+// ScrubOTelExporterKeys removes OTLP exporter destination, auth, and TLS
+// variables from a job environment map, returning the names that were present so
+// the caller can report them as ignored. Call only when the control plane is
+// supplying exporter config for the job.
+func ScrubOTelExporterKeys(jobEnv map[string]string) []string {
+	return scrubKeys(jobEnv, OTelExporterKeys, normalizeKeyName)
+}
+
+// ScrubOTelExporterMarker removes the agent-owned exporter marker from a job
+// environment map, returning it if it was present. The agent sets the marker
+// itself when it injects exporter config, so a supplied one is never wanted.
+func ScrubOTelExporterMarker(jobEnv map[string]string) []string {
+	return scrubKeys(jobEnv, []string{OTelExporterMarkerEnv}, normalizeKeyName)
+}
+
+// scrubKeys deletes any key of m matching names, comparing under normalize.
+// Windows environment names are case-insensitive, so an exact-key match there
+// could be sidestepped with different casing.
+func scrubKeys(m map[string]string, names []string, normalize func(string) string) []string {
+	unwanted := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		unwanted[normalize(name)] = struct{}{}
+	}
+
+	var scrubbed []string
+	for key := range m {
+		if _, ok := unwanted[normalize(key)]; !ok {
+			continue
+		}
+		delete(m, key)
+		scrubbed = append(scrubbed, key)
+	}
+	return scrubbed
+}
+
+// StripInjectedOTelExporter removes agent-injected exporter values from environ
+// so hooks and the job command cannot read the organisation's credential. It is
+// a no-op unless environ carries the marker, which leaves operator-supplied
+// configuration untouched.
+func StripInjectedOTelExporter(environ *Environment) {
+	if environ == nil {
+		return
+	}
+	if marker, ok := environ.Get(OTelExporterMarkerEnv); !ok || marker != "true" {
+		return
+	}
+	for _, key := range OTelExporterInjectedKeys {
+		environ.Remove(key)
+	}
+	environ.Remove(OTelExporterMarkerEnv)
+}
+
+// ClearInjectedOTelExporterFromProcess unsets agent-injected exporter values
+// from the current process environment, once the TracerProvider and the optional
+// OTLP job logger have read them, so child processes inherit a cleaner environ.
+//
+// Same-UID peers can still have read environ before this point, the same
+// exposure that already applies to BUILDKITE_AGENT_ACCESS_TOKEN.
+func ClearInjectedOTelExporterFromProcess() {
+	if os.Getenv(OTelExporterMarkerEnv) != "true" {
+		return
+	}
+	for _, key := range OTelExporterInjectedKeys {
+		_ = os.Unsetenv(key)
+	}
+	_ = os.Unsetenv(OTelExporterMarkerEnv)
+}

--- a/env/otel_exporter_test.go
+++ b/env/otel_exporter_test.go
@@ -1,0 +1,127 @@
+package env
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestScrubOTelExporterKeys(t *testing.T) {
+	t.Parallel()
+
+	jobEnv := map[string]string{
+		"BUILDKITE_COMMAND":           "echo hi",
+		"OTEL_EXPORTER_OTLP_ENDPOINT": "https://evil.example",
+		"OTEL_EXPORTER_OTLP_HEADERS":  "Authorization=Bearer pipeline",
+		"OTEL_RESOURCE_ATTRIBUTES":    "keep=me",
+	}
+	scrubbed := ScrubOTelExporterKeys(jobEnv)
+
+	if len(scrubbed) != 2 {
+		t.Errorf("scrubbed = %v, want 2 keys", scrubbed)
+	}
+	if len(jobEnv) != 2 || jobEnv["OTEL_RESOURCE_ATTRIBUTES"] != "keep=me" {
+		t.Errorf("jobEnv = %#v", jobEnv)
+	}
+}
+
+// Windows environment names are case-insensitive, so an exact-key match there
+// could be sidestepped with different casing. normalizeKeyName is GOOS-dependent,
+// so drive scrubKeys with the Windows normalizer directly to cover it anywhere.
+func TestScrubKeysUnderCaseInsensitiveNormalization(t *testing.T) {
+	t.Parallel()
+
+	jobEnv := map[string]string{
+		"otel_exporter_otlp_endpoint": "https://evil.example",
+		"Otel_Exporter_Otlp_Headers":  "Authorization=Bearer pipeline",
+		"BUILDKITE_COMMAND":           "echo hi",
+	}
+	scrubbed := scrubKeys(jobEnv, OTelExporterKeys, strings.ToUpper)
+
+	if len(scrubbed) != 2 {
+		t.Errorf("scrubbed = %v, want both mixed-case exporter keys", scrubbed)
+	}
+	if len(jobEnv) != 1 || jobEnv["BUILDKITE_COMMAND"] != "echo hi" {
+		t.Errorf("jobEnv = %#v", jobEnv)
+	}
+}
+
+func TestStripInjectedOTelExporter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removes injected values and the marker when marked", func(t *testing.T) {
+		t.Parallel()
+
+		environ := FromSlice([]string{
+			"PATH=/bin",
+			OTelExporterMarkerEnv + "=true",
+			"OTEL_EXPORTER_OTLP_TRACES_HEADERS=Authorization=Bearer secret",
+			"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://otel.example/v1/traces",
+			"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf",
+			"BUILDKITE_JOB_ID=abc",
+		})
+		StripInjectedOTelExporter(environ)
+
+		for _, key := range append(OTelExporterInjectedKeys, OTelExporterMarkerEnv) {
+			if _, ok := environ.Get(key); ok {
+				t.Errorf("expected %s to be stripped", key)
+			}
+		}
+		if v, _ := environ.Get("BUILDKITE_JOB_ID"); v != "abc" {
+			t.Errorf("BUILDKITE_JOB_ID = %q", v)
+		}
+	})
+
+	// The operator's own exporter config must reach hooks and the command.
+	t.Run("leaves everything alone without the marker", func(t *testing.T) {
+		t.Parallel()
+
+		environ := FromSlice([]string{
+			"OTEL_EXPORTER_OTLP_ENDPOINT=https://operator-collector.example",
+			"OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer operator-own",
+			"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://operator-traces.example",
+		})
+		StripInjectedOTelExporter(environ)
+
+		if environ.Length() != 3 {
+			t.Errorf("environ = %v, want operator config untouched", environ.ToSlice())
+		}
+	})
+
+	t.Run("nil environ", func(t *testing.T) {
+		t.Parallel()
+		StripInjectedOTelExporter(nil)
+	})
+}
+
+func TestClearInjectedOTelExporterFromProcess(t *testing.T) {
+	t.Run("clears when marked", func(t *testing.T) {
+		t.Setenv(OTelExporterMarkerEnv, "true")
+		t.Setenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "Authorization=Bearer secret")
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://operator-collector.example")
+
+		ClearInjectedOTelExporterFromProcess()
+
+		if _, ok := os.LookupEnv("OTEL_EXPORTER_OTLP_TRACES_HEADERS"); ok {
+			t.Error("expected injected headers to be cleared")
+		}
+		if _, ok := os.LookupEnv(OTelExporterMarkerEnv); ok {
+			t.Error("expected the marker to be cleared")
+		}
+		// Only injected keys are cleared, so generic operator config survives for
+		// anything later in the process that reads it.
+		if os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "https://operator-collector.example" {
+			t.Error("expected operator config to be left alone")
+		}
+	})
+
+	t.Run("no-op without the marker", func(t *testing.T) {
+		t.Setenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "Authorization=Bearer operator-own")
+
+		ClearInjectedOTelExporterFromProcess()
+
+		if os.Getenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS") != "Authorization=Bearer operator-own" {
+			t.Error("expected operator config to survive without the marker")
+		}
+	})
+}

--- a/env/protected.go
+++ b/env/protected.go
@@ -92,6 +92,9 @@ var protectedEnv = map[string]protection{
 	"BUILDKITE_REPO":                        {mutableFromWithinJob: true},
 	"BUILDKITE_SHELL":                       {},
 	"BUILDKITE_SSH_KEYSCAN":                 {},
+	// Set by the agent when it injects control-plane OTLP exporter config, and
+	// read by bootstrap before hooks run, so changing it later has no effect.
+	OTelExporterMarkerEnv: {},
 }
 
 // checkoutOverrideScope contains checkout-related vars whose write-protection

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -182,6 +182,12 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 	// Create an empty env for us to keep track of our env changes in
 	e.shell.Env = env.FromSlice(os.Environ())
 
+	// When the agent injected control-plane exporter config, keep it out of the
+	// env hooks and the command see. Operator-supplied OTEL_EXPORTER_OTLP_*
+	// config is left alone. Removal from the process environ waits until after
+	// optional job-log OTLP setup, which falls back to generic variables.
+	env.StripInjectedOTelExporter(e.shell.Env)
+
 	// OTLP job log export lives entirely in the bootstrap process, which is the
 	// single home for this feature. When OpenTelemetry tracing is enabled, log
 	// records carry the span context of the nearest enclosing phase/hook span,
@@ -191,6 +197,12 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 		cleanup := e.setupOTLPJobLogger(ctx)
 		defer cleanup()
 	}
+
+	// Both TracerProvider (CLI startup) and the optional job-log exporter have
+	// now read OTEL_*. Drop injected credentials from the process environ before
+	// hooks and the job command run. Same-UID peers can still have read environ
+	// earlier — same class of exposure as BUILDKITE_AGENT_ACCESS_TOKEN.
+	env.ClearInjectedOTelExporterFromProcess()
 
 	// Initialize the job API, iff the experiment is enabled. Noop otherwise
 	if e.JobAPI {

--- a/internal/job/tracing.go
+++ b/internal/job/tracing.go
@@ -131,9 +131,16 @@ func (e *Executor) otRootSpanName() string {
 // InitOTelTracerProvider creates and globally registers an OpenTelemetry TracerProvider
 // and text map propagator. Caller must call ForceFlush and Shutdown
 // on the returned provider before the process exits.
+//
+// Exporter configuration comes from standard OTEL_EXPORTER_OTLP_* environment
+// variables (including control-plane values applied to bootstrap by the agent).
 func InitOTelTracerProvider(ctx context.Context, serviceName string, extraAttrs []attribute.KeyValue) (*sdktrace.TracerProvider, error) {
-	protocol := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
-	// default to grpc to avoid breaking change
+	// Signal-specific configuration takes precedence over the generic variable.
+	protocol := os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")
+	if protocol == "" {
+		protocol = os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
+	}
+	// default to grpc to avoid breaking change for self-hosted env-based setup
 	if protocol == "" {
 		protocol = "grpc"
 	}

--- a/internal/job/tracing_test.go
+++ b/internal/job/tracing_test.go
@@ -92,3 +92,17 @@ func TestGenericTracingExtrasMatchesEnvDerivedExtras(t *testing.T) {
 		t.Errorf("executor-derived and env-derived extras differ (-executor +env):\n%s", diff)
 	}
 }
+
+func TestInitOTelTracerProviderEnvDefaults(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318")
+
+	ctx := t.Context()
+	tp, err := InitOTelTracerProvider(ctx, "buildkite-agent-test", nil)
+	if err != nil {
+		t.Fatalf("InitOTelTracerProvider() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = tp.Shutdown(ctx)
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Hosted agents that export OTLP currently need vendor tokens baked into Agent Images. This PR consumes control-plane tracing configuration from **registration** — backend, propagate_traceparent, and exporter `{endpoint, protocol, headers}` — and applies it to bootstrap as `OTEL_EXPORTER_OTLP_TRACES_*` environment variables.

Registration config is deliberately traces-scoped. The OTLP logs and metrics SDKs fall back to the generic `OTEL_EXPORTER_OTLP_HEADERS` while honouring their own signal-specific endpoint, so setting generic variables would let another signal carry the credential to a pipeline-chosen destination.

**Everything this takes away from a job is conditional on the control plane actually supplying exporter config for that job.** When it does, the agent injects the traces variables, marks them with `BUILDKITE_OTEL_EXPORTER_FROM_CONTROL_PLANE`, and scrubs pipeline-supplied exporter destination, auth, and TLS keys from `job.env`; bootstrap then removes exactly the injected values before hooks and the command run. When it does not — no org flag, no unrestricted OpenTelemetry service, a non-OpenTelemetry backend, or an operator who has configured an exporter themselves — the job environment is untouched. An operator's own `OTEL_EXPORTER_OTLP_*` config still reaches their build steps, and a pipeline can still configure its own exporter, exactly as today. This matters because an earlier revision stripped those variables unconditionally, which would have silently broken anyone using host-level OTLP config to export telemetry from their own build steps.

Because registration can enable tracing on an agent that configured none, the agent now says so. At the default log level:

```
INFO  stub-agent-1 Buildkite enabled OpenTelemetry tracing for this agent
INFO  stub-agent-1 Exporting job traces to https://otel.vendor.example over http/protobuf, with request headers supplied by Buildkite
```

Both precedence cases are logged too, because an operator debugging the opposite problem needs to see that config was offered and declined:

```
INFO  stub-agent-1 Buildkite sent an OTLP trace exporter. Ignoring it, because this host sets OTEL_EXPORTER_OTLP_* itself
INFO  stub-agent-1 Buildkite sent OpenTelemetry tracing configuration for this agent. Ignoring it, because the tracing backend is set to "datadog" locally
```

Endpoints are reduced to scheme and host, since some vendors carry an ingest key in the path or query, and headers are never logged.

Header values are URL-path-escaped for the OTel SDK parser. Local CLI, environment, and config-file settings still win, including an explicit `propagate_traceparent=false`.

Same-UID processes can read bootstrap environ, including exporter headers, just as they can already read `BUILDKITE_AGENT_ACCESS_TOKEN` and sibling job environ. That existing threat model is accepted here; this PR does not attempt airtight isolation via inherited FDs or transport pinning.

## Context

Companion control-plane PR (merged, behind `Feature::OpenTelemetryTracingAgentExporter`): https://github.com/buildkite/buildkite/pull/31880

Replaces the closed stack that consumed job-level `tracing_exporter`:
- https://github.com/buildkite/agent/pull/4149
- https://github.com/buildkite/agent/pull/4150

Three things reviewers should weigh, none of them accidental:

**This can turn tracing on for agents that never asked for it.** The capability is advertised unconditionally, and when the operator has not set a backend, registration sets it. An agent with no tracing configuration will begin exporting to the org's collector once the flag is enabled. The log lines above exist so that is discoverable.

**Credentials only refresh on restart.** Registration is the only delivery point, so a long-lived agent holds the decrypted vendor header until it restarts. Disabling the flag, deleting the service, or rotating the token does not reach running agents.

**`--job-logs-otlp` does not compose with a registration-supplied exporter.** Traces-scoping means the job-log exporter sees no endpoint and falls back to the SDK's localhost default. Worse, it is installed with a `SimpleProcessor`, so each record burns the OTLP retry budget synchronously on the job's output path: a three-line job takes 60s. That failure mode already exists on `main` for anyone enabling the flag without a destination, but this PR makes it easier to reach. The fix — require an explicit logs endpoint and warn instead of defaulting to localhost — is deferred to its own PR, since it stands alone and benefits everyone using the flag.

`--debug-http` dumps the exporter headers, as it already dumps the registration token and the agent access token, all three requiring `--debug` as well. No field-specific redaction is added here: an earlier revision redacted just this one field, which was inconsistent with the credentials already in those dumps and needed chunked-transfer handling plus a fail-closed path that dropped whole response bodies when there was nothing to redact. Redaction in debug dumps is worth doing generally, as its own change.

## Changes

- Parse registration `tracing` / `exporter`, and advertise `control-plane-otlp-tracing`
- Merge registration policy per worker, honouring CLI, environment, and config-file overrides including an explicit `false`
- Log the accepted backend and exporter destination, and both precedence cases, against the per-worker agent name
- Apply exporter config to bootstrap via `OTEL_EXPORTER_OTLP_TRACES_*` after `BUILDKITE_ENV_FILE` is written, so credentials are not persisted there
- Scrub pipeline-supplied exporter keys from `job.env` and remove the injected values before hooks run, both only when the control plane supplied config
- Prefer `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` over the generic variable in `InitOTelTracerProvider`, per the OTel spec

## Testing
- [x] Tests have run locally for affected packages
- [x] Code is formatted with `go tool gofumpt -extra -w`

Verified by running the same job through `bootstrap` on this branch and on `main`: with host-level OTLP config and no control-plane exporter, both produce an identical job environment; with the marker set, the injected values are gone from the job environment while the operator's own generic config survives. The log output above came from running a real `buildkite-agent start` against a stub API returning the control plane's registration payload, confirming the lines appear at the default log level and that neither the header nor a path-embedded key reaches the log.

## Deployment

Inert until an organisation has `Feature::OpenTelemetryTracingAgentExporter` enabled *and* an unrestricted OpenTelemetry notification service, and until agents are upgraded far enough to advertise `control-plane-otlp-tracing`.

## Rollback

Safe to revert. Disabling the flag stops delivery to newly registering agents, though it does not revoke config already held by running agents, which needs an agent restart. Reverting this PR removes consumption entirely; the merged control-plane change only sends exporter config to agents that advertise the capability, so older agents are unaffected either way.

## Disclosures / Credits

Implemented with Cursor cloud agent assistance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7dd2cb9-881a-48a0-bfc9-68c961b74795?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7dd2cb9-881a-48a0-bfc9-68c961b74795&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

