### PR TITLE
feat: Populate on-host mirrors from remote mirrors

### DIFF
--- a/docs/git-mirror.md
+++ b/docs/git-mirror.md
@@ -17,6 +17,29 @@ How do we do this? By:
 - Mirroring the repository in a central location (the git mirror directory), and
 - Making each checkout use a `--reference` clone of the mirror.
 
+## Server-provided remote mirrors
+
+When a pipeline has a server-provided remote Git mirror URL, the agent uses it
+as an optional upstream for the on-host mirror:
+
+- a missing on-host mirror is cloned from the remote mirror and immediately has
+  `origin` reset to the pipeline's canonical repository;
+- an existing on-host mirror fetches the build's exact immutable object ID from
+  the remote mirror into a `refs/buildkite-agent/remote-mirror/*` ref;
+- a lagging, unavailable, or unauthorised remote mirror fails open to the
+  canonical repository while the checkout is still active.
+
+The shared mirror directory remains keyed by the canonical repository URL and
+its persisted `origin` is always canonical. This keeps the cache compatible with
+older agents sharing the same volume, avoids cache fragmentation when mirror
+URLs rotate, and prevents lagging mirror data from overwriting canonical
+`refs/heads/*`.
+
+The remote mirror URL and credentials are supplied by Buildkite. The URL is not
+written into the on-host mirror or checkout configuration. For full
+requirements, caveats, and rollout decisions, see
+[`remote-git-mirrors.md`](remote-git-mirrors.md).
+
 ## Mirrors? `--mirror`? 🪞
 
 You're probably familiar with `git clone`: this gives you a copy of a repo you

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -412,7 +412,14 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context, previousAttempts in
 			return fmt.Errorf("setting origin: %w", err)
 		}
 
-		if mirrorDir != "" {
+		if mirrorDir == "" && e.GitMirrorsPath != "" {
+			// A bypassed mirror must not remain reachable through a stale alternate.
+			if err := e.traceOp(ctx, "git.dissociate", func(ctx context.Context) error {
+				return e.dissociateIfNeeded(ctx, existingGitDir)
+			}); err != nil {
+				return fmt.Errorf("dissociating bypassed mirror: %w", err)
+			}
+		} else if mirrorDir != "" {
 			switch e.GitMirrorCheckoutMode {
 			case "dissociate":
 				// If the existing repo is still relying on the reference, then

--- a/internal/job/checkout_mirror.go
+++ b/internal/job/checkout_mirror.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"os"
@@ -11,8 +12,25 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/v3/internal/osutil"
+	"github.com/buildkite/agent/v3/internal/shell"
 	"github.com/buildkite/shellwords"
 )
+
+func remoteMirrorOnHostRefspec(commit, branch string) string {
+	branchComponent := badCharsRE.ReplaceAllString(branch, "-")
+	return "+" + commit + ":refs/buildkite-agent/remote-mirror/" + branchComponent
+}
+
+func isOnHostRemoteMirrorAttempt(attempt *remoteMirrorAttempt) bool {
+	return attempt != nil &&
+		attempt.site == remoteMirrorSiteOnHostMirror &&
+		attempt.outcome == remoteMirrorOutcomeNotReached
+}
+
+func remoteMirrorStagingDir(mirrorDir string) string {
+	sum := sha256.Sum256([]byte(mirrorDir))
+	return filepath.Join(filepath.Dir(mirrorDir), fmt.Sprintf(".remote-mirror-%x", sum[:8]))
+}
 
 func (e *Executor) getOrUpdateMirrorDir(ctx context.Context, repository string, attempt *remoteMirrorAttempt) (string, error) {
 	var mirrorDir string
@@ -33,7 +51,17 @@ func (e *Executor) getOrUpdateMirrorDir(ctx context.Context, repository string, 
 		return mirrorDir, nil
 	}
 
-	return e.updateGitMirror(ctx, repository, attempt)
+	mirrorDir, err := e.updateGitMirror(ctx, repository, attempt)
+	var lockErr ErrTimedOutAcquiringLock
+	if isOnHostRemoteMirrorAttempt(attempt) && errors.As(err, &lockErr) {
+		// The remote mirror is optional. A speculative clone/update holding the
+		// shared lock must not make another job fail when canonical checkout can
+		// proceed without an on-host reference.
+		attempt.outcome = remoteMirrorOutcomeTimeout
+		e.shell.Commentf("Timed out waiting for on-host Git mirror; using canonical repository without it")
+		return "", nil
+	}
+	return mirrorDir, err
 }
 
 // updateGitMirror clones a new git mirror (git clone --mirror ...), or updates
@@ -88,6 +116,16 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 	}
 	defer mirrorCloneLock.Unlock() //nolint:errcheck // Best-effort cleanup - primary unlock checked below.
 
+	stagingDir := remoteMirrorStagingDir(mirrorDir)
+	var stagingCleanupErr error
+	if osutil.FileExists(stagingDir) {
+		e.shell.Commentf("Removing interrupted remote mirror staging dir %q", stagingDir)
+		if err := os.RemoveAll(stagingDir); err != nil {
+			stagingCleanupErr = fmt.Errorf("removing interrupted remote mirror staging dir %q: %w", stagingDir, err)
+			e.shell.Warningf("%v", stagingCleanupErr)
+		}
+	}
+
 	// If we don't have a mirror, we need to clone it
 	if !osutil.FileExists(mirrorDir) {
 		e.shell.Commentf("Cloning a mirror of the repository to %q", mirrorDir)
@@ -98,16 +136,106 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 			return "", err
 		}
 		flags = append(flags, mirrorFlags...)
-		if err := e.traceOp(ctx, "git.mirror.clone", func(ctx context.Context) error {
-			return gitClone(ctx, e.shell, nil, flags, repository, mirrorDir)
-		}); err != nil {
-			e.shell.Commentf("Removing mirror dir %q due to failed clone", mirrorDir)
-			if err := os.RemoveAll(mirrorDir); err != nil {
-				e.shell.Errorf("Failed to remove %q (%s)", mirrorDir, err)
+
+		cloneMirror := func(
+			ctx context.Context,
+			gitFlags []string,
+			source, destination string,
+			runOpts ...shell.RunCommandOpt,
+		) error {
+			return e.traceOp(ctx, "git.mirror.clone", func(ctx context.Context) error {
+				return gitClone(ctx, e.shell, gitFlags, flags, source, destination, runOpts...)
+			})
+		}
+		removeFailedMirror := func(path string) error {
+			if !osutil.FileExists(path) {
+				return nil
+			}
+			e.shell.Commentf("Removing mirror dir %q due to failed clone", path)
+			if err := os.RemoveAll(path); err != nil {
+				return fmt.Errorf("removing failed mirror %q: %w", path, err)
+			}
+			return nil
+		}
+
+		if isOnHostRemoteMirrorAttempt(attempt) {
+			started := time.Now()
+			tempMirrorDir := stagingDir
+			// A prior process may have been killed while cloning. The clone
+			// lock makes this deterministic staging directory exclusive.
+			err := stagingCleanupErr
+			if err == nil {
+				// Match direct git-clone directory creation: apply the process
+				// umask and inherit parent setgid/default ACLs.
+				err = os.Mkdir(tempMirrorDir, 0o777)
+			}
+			if err == nil {
+				err = cloneMirror(
+					ctx,
+					remoteMirrorBulkGitFlags(ctx),
+					attempt.url,
+					tempMirrorDir,
+					shell.AlwaysHidePrompt(),
+				)
+			}
+			if err == nil {
+				// C16: agents predating remote mirrors may share this mirror.
+				// Canonicalize the temporary repository before atomically
+				// publishing it to the shared mixed-version cache.
+				err = e.shell.Command(
+					"git", "--git-dir", tempMirrorDir,
+					"remote", "set-url", "origin", repository,
+				).Run(ctx)
+			}
+			hasCommit := false
+			if err == nil {
+				hasCommit = hasGitCommit(ctx, e.shell, tempMirrorDir, e.Commit)
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					if cleanupErr := removeFailedMirror(tempMirrorDir); cleanupErr != nil {
+						return "", errors.Join(ctxErr, cleanupErr)
+					}
+					return "", ctxErr
+				}
+				err = os.Rename(tempMirrorDir, mirrorDir)
+			}
+			attempt.duration = time.Since(started)
+			if err == nil {
+				if hasCommit {
+					attempt.outcome = remoteMirrorOutcomeHit
+				} else {
+					// A lagging clone is still useful: the checkout's canonical
+					// --reference clone transfers only the missing delta.
+					attempt.outcome = remoteMirrorOutcomeMiss
+				}
+				return e.snapshotMirror(ctx, repository, mirrorDir)
+			}
+
+			if stagingCleanupErr == nil && tempMirrorDir != "" {
+				if cleanupErr := removeFailedMirror(tempMirrorDir); cleanupErr != nil {
+					// Staging is independent of the canonical destination.
+					// Preserve the cleanup failure in the log, but still let
+					// the optional mirror optimization fail open.
+					e.shell.Warningf("Failed to clean remote mirror staging before canonical fallback: %v", cleanupErr)
+				}
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return "", ctxErr
+			}
+			var cloneErr *gitError
+			if errors.As(err, &cloneErr) && cloneErr.Type == gitErrorCloneTimeout {
+				attempt.outcome = remoteMirrorOutcomeTimeout
+			} else {
+				attempt.outcome = remoteMirrorOutcomeError
+			}
+			e.shell.Commentf("Remote Git mirror clone failed; falling back to canonical repository")
+		}
+
+		if err := cloneMirror(ctx, nil, repository, mirrorDir); err != nil {
+			if cleanupErr := removeFailedMirror(mirrorDir); cleanupErr != nil {
+				return "", errors.Join(err, cleanupErr)
 			}
 			return "", err
 		}
-
 		return e.snapshotMirror(ctx, repository, mirrorDir)
 	}
 
@@ -143,24 +271,50 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 		}
 	}()
 
+	commitAlreadyPresent := false
 	if isMainRepository {
 		// Check again after we get a lock, in case the other process has already updated
-		if hasGitCommit(ctx, e.shell, mirrorDir, e.Commit) {
+		if hasGitCommit(ctx, e.shell, mirrorDir, e.Commit) &&
+			hasGitCommitReachableFromRef(ctx, e.shell, mirrorDir, e.Commit) {
 			e.shell.Commentf("Commit %q exists in mirror", e.Commit)
-			return e.snapshotMirror(ctx, repository, mirrorDir)
+			commitAlreadyPresent = true
 		}
 	}
 
 	e.shell.Commentf("Updating existing repository mirror to find commit %s", e.Commit)
 
 	// Update the origin of the repository so we can gracefully handle
-	// repository renames.
+	// repository renames. This must happen before a remote-mirror hit can skip
+	// the canonical fetch: dirForRepository is lossy, so distinct canonical
+	// URLs can share one durable mirror directory.
 	urlChanged, err := e.updateRemoteURL(ctx, mirrorDir, repository)
 	if err != nil {
 		return "", fmt.Errorf("setting remote URL: %w", err)
 	}
 
-	if isMainRepository {
+	remoteMirrorHit := false
+	if isMainRepository && !commitAlreadyPresent {
+		if isOnHostRemoteMirrorAttempt(attempt) {
+			hit, err := e.fetchCommitFromRemoteMirror(
+				ctx,
+				attempt,
+				mirrorDir,
+				"--no-tags",
+				remoteMirrorOnHostRefspec(e.Commit, e.Branch),
+			)
+			if err != nil {
+				return "", err
+			}
+			if hit {
+				// C2: the helper requires both a successful ref write and
+				// local object presence. Keep going through rename
+				// maintenance instead of returning early.
+				remoteMirrorHit = true
+			}
+		}
+	}
+
+	if isMainRepository && !commitAlreadyPresent && !remoteMirrorHit {
 		var refspecs []string
 		var retry bool
 
@@ -196,8 +350,8 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 		}); err != nil {
 			return "", err
 		}
-	} else { // not the main repo.
-
+	}
+	if !isMainRepository {
 		// This is a mirror of a submodule.
 		// Update without specifying particular ref, since we don't know which
 		// ref is needed for the main build.
@@ -223,6 +377,14 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 		if err := e.shell.Command("git", "--git-dir", mirrorDir, "gc").Run(ctx); err != nil {
 			e.shell.Warningf("Couldn't run git gc: %v", err)
 		}
+	}
+
+	// Unpinned objects are unsafe through --reference; fail open rather than manage recovery refs.
+	if isMainRepository &&
+		hasGitCommit(ctx, e.shell, mirrorDir, e.Commit) &&
+		!hasGitCommitReachableFromRef(ctx, e.shell, mirrorDir, e.Commit) {
+		e.shell.Warningf("Commit %q exists in mirror without a durable ref; using canonical repository without it", e.Commit)
+		return "", nil
 	}
 
 	return e.snapshotMirror(ctx, repository, mirrorDir)

--- a/internal/job/checkout_mirror_remote_test.go
+++ b/internal/job/checkout_mirror_remote_test.go
@@ -610,6 +610,12 @@ func newOnHostMirrorExecutor(t *testing.T, repository, commit string) *Executor 
 		GitCloneMirrorFlags:   "-v",
 	})
 	e.shell = shell.NewTestShell(t, shell.WithSignalGracePeriod(10*time.Millisecond))
+	t.Cleanup(func() {
+		if e.checkoutRoot != nil {
+			_ = e.checkoutRoot.Close()
+			e.checkoutRoot = nil
+		}
+	})
 	return e
 }
 

--- a/internal/job/checkout_mirror_remote_test.go
+++ b/internal/job/checkout_mirror_remote_test.go
@@ -1,0 +1,689 @@
+package job
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent/v3/internal/job/githttptest"
+	"github.com/buildkite/agent/v3/internal/osutil"
+	"github.com/buildkite/agent/v3/internal/process"
+	"github.com/buildkite/agent/v3/internal/shell"
+)
+
+func TestUpdateGitMirrorCreatesFromRemoteMirrorAndKeepsCanonicalOrigin(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+
+	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), commit)
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(e.GitMirrorsPath, os.ModeSetgid|0o775); err != nil {
+			t.Fatal(err)
+		}
+	}
+	e.CleanCheckout = true
+	e.Phases = []string{"checkout", "command"}
+	stagingDir := remoteMirrorStagingDir(expectedOnHostMirrorDir(e))
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stagingDir, "interrupted-clone"), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	attempt := remoteMirrorAttempt{
+		site: remoteMirrorSiteOnHostMirror,
+		url:  mirror.RepoURL("mirror"),
+	}
+	canonical.Close() // Creation must source all objects from the remote mirror.
+
+	mirrorDir, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
+	if err != nil {
+		t.Fatalf("updateGitMirror() error = %v", err)
+	}
+	if mirrorDir == expectedOnHostMirrorDir(e) {
+		t.Error("clean checkout did not receive a mirror snapshot")
+	}
+	if got, want := gitOutputForMirrorTest(t, expectedOnHostMirrorDir(e), "config", "--get", "remote.origin.url"), e.Repository; got != want {
+		t.Errorf("shared remote.origin.url = %q, want canonical %q", got, want)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(expectedOnHostMirrorDir(e))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := info.Mode().Perm(), os.FileMode(0o777&^osutil.Umask); got != want {
+			t.Errorf("shared mirror mode = %o, want %o", got, want)
+		}
+		if info.Mode()&os.ModeSetgid == 0 {
+			t.Errorf("shared mirror mode = %v, want setgid preserved", info.Mode())
+		}
+	}
+	if got, want := gitOutputForMirrorTest(t, mirrorDir, "rev-parse", commit), commit; got != want {
+		t.Errorf("mirror commit = %q, want %q", got, want)
+	}
+	if attempt.outcome != remoteMirrorOutcomeHit {
+		t.Errorf("outcome = %q, want hit", attempt.outcome)
+	}
+	if _, err := os.Stat(stagingDir); !os.IsNotExist(err) {
+		t.Errorf("staging dir remains after publication: %v", err)
+	}
+}
+
+func TestUpdateGitMirrorCreationHidesRemoteURLPromptInDebug(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+
+	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), commit)
+	logs := &bytes.Buffer{}
+	commandOutput := &process.Buffer{}
+	debugShell, err := shell.New(
+		shell.WithDebug(true),
+		shell.WithEnv(e.shell.Env),
+		shell.WithLogger(shell.NewWriterLogger(logs, false, nil)),
+		shell.WithStdout(commandOutput),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.shell = debugShell
+	attempt := remoteMirrorAttempt{
+		site: remoteMirrorSiteOnHostMirror,
+		url:  mirror.RepoURL("mirror"),
+	}
+
+	if _, err := e.updateGitMirror(t.Context(), e.Repository, &attempt); err != nil {
+		t.Fatalf("updateGitMirror() error = %v", err)
+	}
+	if strings.Contains(logs.String(), attempt.url) {
+		t.Errorf("debug job log contains remote mirror URL prompt: %q", logs.String())
+	}
+}
+
+func TestUpdateGitMirrorCreationFallsBackToCanonical(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), commit)
+	attempt := remoteMirrorAttempt{
+		site: remoteMirrorSiteOnHostMirror,
+		url:  "http://127.0.0.1:1/mirror.git",
+	}
+
+	mirrorDir, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
+	if err != nil {
+		t.Fatalf("updateGitMirror() error = %v", err)
+	}
+	if got, want := gitOutputForMirrorTest(t, mirrorDir, "config", "--get", "remote.origin.url"), e.Repository; got != want {
+		t.Errorf("remote.origin.url = %q, want canonical %q", got, want)
+	}
+	if attempt.outcome != remoteMirrorOutcomeError {
+		t.Errorf("outcome = %q, want error", attempt.outcome)
+	}
+}
+
+func TestUpdateGitMirrorCreationClassifiesStalledMirrorAsTimeout(t *testing.T) {
+	oldLowSpeedTime := remoteMirrorLowSpeedTime
+	remoteMirrorLowSpeedTime = 1
+	t.Cleanup(func() { remoteMirrorLowSpeedTime = oldLowSpeedTime })
+
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stalled := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		<-req.Context().Done()
+	}))
+	t.Cleanup(stalled.Close)
+
+	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), commit)
+	attempt := remoteMirrorAttempt{
+		site: remoteMirrorSiteOnHostMirror,
+		url:  stalled.URL + "/mirror.git",
+	}
+
+	if _, err := e.updateGitMirror(t.Context(), e.Repository, &attempt); err != nil {
+		t.Fatalf("updateGitMirror() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeTimeout {
+		t.Errorf("outcome = %q, want timeout", attempt.outcome)
+	}
+}
+
+func TestUpdateGitMirrorKeepsUsefulLaggingCreationClone(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	remoteMirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), commit)
+	attempt := remoteMirrorAttempt{
+		site: remoteMirrorSiteOnHostMirror,
+		url:  remoteMirror.RepoURL("mirror"),
+	}
+
+	mirrorDir, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
+	if err != nil {
+		t.Fatalf("updateGitMirror() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeMiss {
+		t.Errorf("outcome = %q, want miss", attempt.outcome)
+	}
+	if hasGitCommit(t.Context(), e.shell, mirrorDir, commit) {
+		t.Error("lagging creation clone unexpectedly contains requested commit")
+	}
+	if got, want := gitOutputForMirrorTest(t, mirrorDir, "config", "--get", "remote.origin.url"), e.Repository; got != want {
+		t.Errorf("remote.origin.url = %q, want canonical %q", got, want)
+	}
+	if !gitRefExistsForMirrorTest(mirrorDir, "refs/heads/main") {
+		t.Error("lagging creation clone discarded useful main branch objects")
+	}
+}
+
+func TestUpdateGitMirrorUpdateHitUsesNamespacedRefWithoutMovingHeadsOrTags(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), "")
+	mirrorDir := expectedOnHostMirrorDir(e)
+	cloneOnHostMirrorToPath(t, canonical.RepoURL("canonical"), mirrorDir)
+
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteMirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	if _, err := remoteMirror.CreateRef("mirror", "refs/tags/lagged-tag", commit); err != nil {
+		t.Fatal(err)
+	}
+
+	e.Commit = commit
+	attempt := remoteMirrorAttempt{
+		site: remoteMirrorSiteOnHostMirror,
+		url:  remoteMirror.RepoURL("mirror"),
+	}
+	gotDir, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
+	if err != nil {
+		t.Fatalf("updateGitMirror() error = %v", err)
+	}
+	if gotDir != mirrorDir {
+		t.Errorf("mirror dir = %q, want %q", gotDir, mirrorDir)
+	}
+	if attempt.outcome != remoteMirrorOutcomeHit {
+		t.Errorf("outcome = %q, want hit", attempt.outcome)
+	}
+	_, namespacedRef, _ := strings.Cut(remoteMirrorOnHostRefspec(commit, e.Branch), ":")
+	if got, want := gitOutputForMirrorTest(t, mirrorDir, "rev-parse", namespacedRef), commit; got != want {
+		t.Errorf("namespaced ref = %q, want %q", got, want)
+	}
+	if gitRefExistsForMirrorTest(mirrorDir, "refs/heads/feature-branch") {
+		t.Error("remote mirror update wrote refs/heads/feature-branch")
+	}
+	if gitRefExistsForMirrorTest(mirrorDir, "refs/tags/lagged-tag") {
+		t.Error("remote mirror update auto-followed a lagged tag despite --no-tags")
+	}
+
+	checkout := filepath.Join(t.TempDir(), "checkout")
+	runGitForMirrorTest(t, "", "clone", "--reference", mirrorDir, canonical.RepoURL("canonical"), checkout)
+	countObjects := gitOutputForMirrorTest(t, filepath.Join(checkout, ".git"), "count-objects", "-v")
+	if !strings.Contains(countObjects, "count: 0") || !strings.Contains(countObjects, "in-pack: 0") {
+		t.Errorf("reference clone copied objects from canonical:\n%s", countObjects)
+	}
+}
+
+func TestUpdateGitMirrorUpdateHitRepairsCollidingCanonicalOrigin(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical.one")
+	if err := canonical.CreateRepository("canonical-one"); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := canonical.InitRepository("canonical-one"); err != nil {
+		t.Fatalf("InitRepository() error = %v\n%s", err, out)
+	}
+	oldURL := canonical.RepoURL("canonical.one")
+	newURL := canonical.RepoURL("canonical-one")
+	if dirForRepository(oldURL) != dirForRepository(newURL) {
+		t.Fatalf("test URLs do not collide: %q and %q", oldURL, newURL)
+	}
+
+	newCommit, _, err := canonical.PushBranch("canonical-one", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := newOnHostMirrorExecutor(t, newURL, newCommit)
+	mirrorDir := expectedOnHostMirrorDir(e)
+	cloneOnHostMirrorToPath(t, oldURL, mirrorDir)
+	remoteMirror := copyOnHostMirrorHTTPRepo(t, newURL, "mirror")
+	attempt := remoteMirrorAttempt{
+		site: remoteMirrorSiteOnHostMirror,
+		url:  remoteMirror.RepoURL("mirror"),
+	}
+
+	if _, err := e.updateGitMirror(t.Context(), e.Repository, &attempt); err != nil {
+		t.Fatalf("updateGitMirror() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeHit {
+		t.Fatalf("outcome = %q, want hit", attempt.outcome)
+	}
+	if got := gitOutputForMirrorTest(t, mirrorDir, "config", "--get", "remote.origin.url"); got != newURL {
+		t.Errorf("remote.origin.url = %q, want repaired canonical %q", got, newURL)
+	}
+}
+
+func TestUpdateGitMirrorWarmHitRepairsCollidingCanonicalOrigin(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical.one")
+	if err := canonical.CreateRepository("canonical-one"); err != nil {
+		t.Fatal(err)
+	}
+	oldURL := canonical.RepoURL("canonical.one")
+	newURL := canonical.RepoURL("canonical-one")
+	if dirForRepository(oldURL) != dirForRepository(newURL) {
+		t.Fatalf("test URLs do not collide: %q and %q", oldURL, newURL)
+	}
+
+	e := newOnHostMirrorExecutor(t, newURL, "")
+	mirrorDir := expectedOnHostMirrorDir(e)
+	cloneOnHostMirrorToPath(t, oldURL, mirrorDir)
+	runGitForMirrorTest(t, mirrorDir, "push", "--mirror", newURL)
+	e.Commit = gitOutputForMirrorTest(t, mirrorDir, "rev-parse", "refs/heads/main")
+	attempt := remoteMirrorAttempt{
+		site: remoteMirrorSiteOnHostMirror,
+		url:  "https://mirror.example/repo.git",
+	}
+
+	if _, err := e.updateGitMirror(t.Context(), e.Repository, &attempt); err != nil {
+		t.Fatalf("updateGitMirror() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeNotReached {
+		t.Fatalf("outcome = %q, want notReached warm hit", attempt.outcome)
+	}
+	if got := gitOutputForMirrorTest(t, mirrorDir, "config", "--get", "remote.origin.url"); got != newURL {
+		t.Errorf("remote.origin.url = %q, want repaired canonical %q", got, newURL)
+	}
+}
+
+func TestGetOrUpdateMirrorDirCloneLockTimeoutFallsBackWithoutMirror(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), commit)
+	e.GitMirrorsLockTimeout = 0
+	lock, err := e.shell.LockFile(t.Context(), expectedOnHostMirrorDir(e)+".clonelock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = lock.Unlock() })
+	attempt := remoteMirrorAttempt{
+		site: remoteMirrorSiteOnHostMirror,
+		url:  "https://mirror.example/repo.git",
+	}
+
+	mirrorDir, err := e.getOrUpdateMirrorDir(t.Context(), e.Repository, &attempt)
+	if err != nil {
+		t.Fatalf("getOrUpdateMirrorDir() error = %v, want canonical checkout fallback", err)
+	}
+	if mirrorDir != "" {
+		t.Errorf("mirrorDir = %q, want no on-host reference after lock timeout", mirrorDir)
+	}
+	if attempt.outcome != remoteMirrorOutcomeTimeout {
+		t.Errorf("outcome = %q, want timeout", attempt.outcome)
+	}
+}
+
+func TestUpdateGitMirrorUpdateMissFallsBackToCanonical(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	remoteMirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+
+	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), "")
+	mirrorDir := expectedOnHostMirrorDir(e)
+	cloneOnHostMirrorToPath(t, canonical.RepoURL("canonical"), mirrorDir)
+
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.Commit = commit
+	attempt := remoteMirrorAttempt{
+		site: remoteMirrorSiteOnHostMirror,
+		url:  remoteMirror.RepoURL("mirror"),
+	}
+
+	if _, err := e.updateGitMirror(t.Context(), e.Repository, &attempt); err != nil {
+		t.Fatalf("updateGitMirror() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeMiss {
+		t.Errorf("outcome = %q, want miss", attempt.outcome)
+	}
+	if got, want := gitOutputForMirrorTest(t, mirrorDir, "rev-parse", commit), commit; got != want {
+		t.Errorf("canonical fallback commit = %q, want %q", got, want)
+	}
+	if got, want := gitOutputForMirrorTest(t, mirrorDir, "rev-parse", "refs/heads/feature-branch"), commit; got != want {
+		t.Errorf("canonical branch ref = %q, want %q", got, want)
+	}
+}
+
+func TestUpdateGitMirrorRefWriteFailureDoesNotCountAsHit(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), "")
+	mirrorDir := expectedOnHostMirrorDir(e)
+	cloneOnHostMirrorToPath(t, canonical.RepoURL("canonical"), mirrorDir)
+
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteMirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	conflictParent := filepath.Join(mirrorDir, "refs", "buildkite-agent")
+	if err := os.MkdirAll(conflictParent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existingCommit := gitOutputForMirrorTest(t, mirrorDir, "rev-parse", "refs/heads/main")
+	if err := os.WriteFile(filepath.Join(conflictParent, "remote-mirror"), []byte(existingCommit+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	e.Commit = commit
+	attempt := remoteMirrorAttempt{
+		site: remoteMirrorSiteOnHostMirror,
+		url:  remoteMirror.RepoURL("mirror"),
+	}
+	if _, err := e.updateGitMirror(t.Context(), e.Repository, &attempt); err != nil {
+		t.Fatalf("updateGitMirror() error = %v", err)
+	}
+	if attempt.outcome == remoteMirrorOutcomeHit {
+		t.Fatal("ref-write failure counted as a remote mirror hit")
+	}
+	if got, want := gitOutputForMirrorTest(t, mirrorDir, "rev-parse", "refs/heads/feature-branch"), commit; got != want {
+		t.Errorf("canonical fallback branch = %q, want %q", got, want)
+	}
+}
+
+func TestUpdateGitMirrorRetryDoesNotTrustUnpinnedCommit(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	canonicalURL, err := url.Parse(canonical.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalProxy := httputil.NewSingleHostReverseProxy(canonicalURL)
+	var canonicalAvailable atomic.Bool
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if !canonicalAvailable.Load() {
+			http.Error(w, "canonical unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		canonicalProxy.ServeHTTP(w, req)
+	}))
+	t.Cleanup(proxy.Close)
+
+	e := newOnHostMirrorExecutor(t, proxy.URL+"/canonical.git", "")
+	mirrorDir := expectedOnHostMirrorDir(e)
+	cloneOnHostMirrorToPath(t, canonical.RepoURL("canonical"), mirrorDir)
+
+	mainRef := exec.Command("git", "ls-remote", canonical.RepoURL("canonical"), "refs/heads/main")
+	mainOutput, err := mainRef.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mainCommit := strings.Fields(string(mainOutput))[0]
+
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteMirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	if _, err := canonical.CreateRef("canonical", "refs/heads/feature-branch", mainCommit); err != nil {
+		t.Fatal(err)
+	}
+	conflict := filepath.Join(mirrorDir, "refs", "buildkite-agent", "remote-mirror")
+	if err := os.MkdirAll(filepath.Dir(conflict), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(conflict, []byte(commit+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	e.Commit = commit
+	attempt := remoteMirrorAttempt{site: remoteMirrorSiteOnHostMirror, url: remoteMirror.RepoURL("mirror")}
+	if _, err := e.updateGitMirror(t.Context(), e.Repository, &attempt); err == nil {
+		t.Fatal("updateGitMirror() error = nil, want canonical fallback failure")
+	}
+	if !hasGitCommit(t.Context(), e.shell, mirrorDir, commit) {
+		t.Fatal("failed destination ref did not leave the fetched object for retry regression")
+	}
+	if err := os.Remove(conflict); err != nil {
+		t.Fatal(err)
+	}
+
+	canonicalAvailable.Store(true)
+	checkoutDir := t.TempDir()
+	runGitForMirrorTest(t, "", "clone", "--reference", mirrorDir, "--", e.Repository, checkoutDir)
+	alternates := filepath.Join(checkoutDir, ".git", "objects", "info", "alternates")
+	if !osutil.FileExists(alternates) {
+		t.Fatal("reference checkout has no alternates file")
+	}
+	e.shell.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", checkoutDir)
+	e.GitMirrorCheckoutMode = "reference"
+	e.GitSkipFetchExistingCommits = true
+
+	if err := e.defaultCheckoutPhase(t.Context(), 1); err == nil {
+		t.Fatal("defaultCheckoutPhase() retry error = nil, want canonical fetch failure for force-pushed commit")
+	}
+	if osutil.FileExists(alternates) {
+		t.Fatal("unsafe checkout alternate remains after mirror bypass")
+	}
+}
+
+func TestUpdateGitMirrorExistingCommitDoesNotContactRemoteMirror(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), commit)
+	mirrorDir := expectedOnHostMirrorDir(e)
+	cloneOnHostMirrorToPath(t, canonical.RepoURL("canonical"), mirrorDir)
+	stagingDir := remoteMirrorStagingDir(mirrorDir)
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stagingDir, "interrupted-clone"), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	attempt := remoteMirrorAttempt{
+		site: remoteMirrorSiteOnHostMirror,
+		url:  "http://127.0.0.1:1/mirror.git",
+	}
+
+	if _, err := e.updateGitMirror(t.Context(), e.Repository, &attempt); err != nil {
+		t.Fatalf("updateGitMirror() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeNotReached {
+		t.Errorf("outcome = %q, want not reached", attempt.outcome)
+	}
+	if _, err := os.Stat(stagingDir); !os.IsNotExist(err) {
+		t.Errorf("stale staging dir remains beside valid mirror: %v", err)
+	}
+}
+
+func TestUpdateGitMirrorReclaimsStagingWithoutRemoteAttempt(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), commit)
+	mirrorDir := expectedOnHostMirrorDir(e)
+	cloneOnHostMirrorToPath(t, canonical.RepoURL("canonical"), mirrorDir)
+	stagingDir := remoteMirrorStagingDir(mirrorDir)
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stagingDir, "interrupted-clone"), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := e.updateGitMirror(t.Context(), e.Repository, nil); err != nil {
+		t.Fatalf("updateGitMirror() error = %v", err)
+	}
+	if _, err := os.Stat(stagingDir); !os.IsNotExist(err) {
+		t.Errorf("stale staging dir remains without remote attempt: %v", err)
+	}
+}
+
+func TestUpdateGitMirrorCancellationDoesNotFallbackToCanonical(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	requested := make(chan struct{})
+	var requestedOnce sync.Once
+	hung := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		requestedOnce.Do(func() { close(requested) })
+		<-req.Context().Done()
+	}))
+	t.Cleanup(hung.Close)
+
+	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), commit)
+	attempt := remoteMirrorAttempt{
+		site: remoteMirrorSiteOnHostMirror,
+		url:  hung.URL + "/mirror.git",
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	go func() {
+		select {
+		case <-requested:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	_, err = e.updateGitMirror(ctx, e.Repository, &attempt)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("updateGitMirror() error = %v, want context.Canceled", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeNotReached {
+		t.Errorf("outcome = %q, want not reached", attempt.outcome)
+	}
+	if osutil.FileExists(expectedOnHostMirrorDir(e)) {
+		t.Error("cancelled remote mirror clone fell back to canonical")
+	}
+}
+
+func newOnHostMirrorExecutor(t *testing.T, repository, commit string) *Executor {
+	t.Helper()
+	e := New(ExecutorConfig{
+		Repository:            repository,
+		Commit:                commit,
+		Branch:                "feature-branch",
+		PullRequest:           "false",
+		GitMirrorsPath:        t.TempDir(),
+		GitMirrorsLockTimeout: 30,
+		GitCloneMirrorFlags:   "-v",
+	})
+	e.shell = shell.NewTestShell(t, shell.WithSignalGracePeriod(10*time.Millisecond))
+	return e
+}
+
+func newOnHostMirrorHTTPRepo(t *testing.T, name string) *githttptest.Server {
+	t.Helper()
+	t.Setenv("GIT_AUTHOR_NAME", "Buildkite Agent")
+	t.Setenv("GIT_AUTHOR_EMAIL", "agent@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "Buildkite Agent")
+	t.Setenv("GIT_COMMITTER_EMAIL", "agent@example.com")
+
+	server := githttptest.NewServer()
+	t.Cleanup(server.Close)
+	if err := server.CreateRepository(name); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := server.InitRepository(name); err != nil {
+		t.Fatalf("InitRepository() error = %v\n%s", err, out)
+	}
+	return server
+}
+
+func copyOnHostMirrorHTTPRepo(t *testing.T, sourceURL, name string) *githttptest.Server {
+	t.Helper()
+	server := githttptest.NewServer()
+	t.Cleanup(server.Close)
+	if err := server.CreateRepository(name); err != nil {
+		t.Fatal(err)
+	}
+	tmp := t.TempDir()
+	runGitForMirrorTest(t, "", "clone", "--mirror", sourceURL, tmp)
+	runGitForMirrorTest(t, tmp, "push", "--mirror", server.RepoURL(name))
+	return server
+}
+
+func cloneOnHostMirrorToPath(t *testing.T, sourceURL, path string) {
+	t.Helper()
+	runGitForMirrorTest(t, "", "clone", "--mirror", sourceURL, path)
+}
+
+func expectedOnHostMirrorDir(e *Executor) string {
+	return filepath.Join(e.GitMirrorsPath, dirForRepository(e.Repository))
+}
+
+func runGitForMirrorTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v error = %v\n%s", args, err, out)
+	}
+}
+
+func gitOutputForMirrorTest(t *testing.T, gitDir string, args ...string) string {
+	t.Helper()
+	commandArgs := append([]string{"--git-dir", gitDir}, args...)
+	cmd := exec.Command("git", commandArgs...)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v error = %v", commandArgs, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func gitRefExistsForMirrorTest(gitDir, ref string) bool {
+	cmd := exec.Command("git", "--git-dir", gitDir, "show-ref", "--verify", "--quiet", ref)
+	return cmd.Run() == nil
+}
+
+func TestRemoteMirrorOnHostRefspec(t *testing.T) {
+	t.Parallel()
+	commit := strings.Repeat("a", 40)
+	got := remoteMirrorOnHostRefspec(commit, "feature/foo")
+	want := "+" + commit + ":refs/buildkite-agent/remote-mirror/feature-foo"
+	if got != want {
+		t.Errorf("remoteMirrorOnHostRefspec() = %q, want %q", got, want)
+	}
+}

--- a/internal/job/git.go
+++ b/internal/job/git.go
@@ -103,6 +103,20 @@ func hasGitCommit(ctx context.Context, sh *shell.Shell, gitDir, commit string) b
 	return true
 }
 
+func hasGitCommitReachableFromRef(ctx context.Context, sh *shell.Shell, gitDir, commit string) bool {
+	extraEnv := env.New()
+	extraEnv.Set("GIT_NO_LAZY_FETCH", "1")
+	output, err := sh.Command(
+		"git", "--git-dir", gitDir, "for-each-ref",
+		"--format=%(refname)", "--contains", commit,
+	).RunAndCaptureStdout(
+		ctx,
+		shell.ShowStderr(false),
+		shell.WithExtraEnv(extraEnv),
+	)
+	return err == nil && strings.TrimSpace(output) != ""
+}
+
 func gitCheckout(ctx context.Context, sh *shell.Shell, gitCheckoutFlags, reference string) error {
 	individualCheckoutFlags, err := shellwords.Split(gitCheckoutFlags)
 	if err != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Populate and refresh the shared on-host mirror from the server-provided remote mirror before falling back to canonical. This is PR 2 based on #4160.

## Context

The shared mirror’s durable `origin` and canonical heads remain canonical for mixed-version agents. Remote objects are pinned in a namespaced ref without moving canonical refs.

## Changes

- Create mirrors through shared-permission staging, canonicalize `origin`, and atomically publish.
- Reclaim interrupted staging and fail open to canonical if optional cleanup fails.
- Refresh by exact SHA with `--no-tags` and hidden URL prompts.
- Require warm objects to be reachable from a durable ref, preventing failed ref writes from becoming retry hits.
- Reconcile canonical `origin` on remote and warm hits before shared rename maintenance.
- Skip the redundant canonical exact-SHA checkout fetch after an on-host hit.
- Bypass mirrors containing an unpinned build object and dissociate reused checkouts from stale alternates before canonical fetch.
- Continue canonical checkout without an on-host reference on lock timeout.
- Preserve locks, snapshots, submodules, skip-update, cancellation, and reference/dissociate modes.

## Testing

Real Git-over-HTTP tests cover atomic creation, permissions, staging, lag, timeout, namespaced refs, tag/head isolation, fallback, warm/remote collision repair, failed ref write plus canonical force-push plus reused-checkout retry, lock contention, prompt hiding, and cancellation. The retry regression verifies the stale alternate is removed before canonical fetch; test executors close checkout roots for Windows cleanup.

## Disclosures / Credits

Implemented with Cursor under human direction. Independent review drove atomic publication, durable reachability, retry alternate cleanup, warm-hit maintenance, and contention fallback.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6f11793-178a-4772-9f71-e334584fc275?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6f11793-178a-4772-9f71-e334584fc275&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

