### PR TITLE
feat: Refresh reused checkouts from remote mirrors

### DIFF
--- a/docs/git-mirror.md
+++ b/docs/git-mirror.md
@@ -46,8 +46,11 @@ URLs rotate, and prevents lagging mirror data from overwriting canonical
 The remote mirror URL and credentials are supplied by Buildkite. The URL is not
 written into the on-host mirror configuration or retained in checkout
 configuration after a completed fetch. An interrupted filtered fetch can leave
-promisor keys that the next fetch repairs. For full requirements, caveats, and
-rollout decisions, see [`remote-git-mirrors.md`](remote-git-mirrors.md).
+promisor keys. Before fetching, the agent records a credential-free digest
+marker so the next fetch repairs only the matching agent-created section and
+leaves unmarked user promisor configuration unchanged. For full requirements,
+caveats, and rollout decisions, see
+[`remote-git-mirrors.md`](remote-git-mirrors.md).
 
 ## Mirrors? `--mirror`? 🪞
 

--- a/docs/git-mirror.md
+++ b/docs/git-mirror.md
@@ -29,6 +29,14 @@ as an optional upstream for the on-host mirror:
 - a lagging, unavailable, or unauthorised remote mirror fails open to the
   canonical repository while the checkout is still active.
 
+When no on-host mirror update is configured and a checkout already exists, the
+agent fetches the exact build commit into that checkout from the remote mirror.
+A confirmed hit skips the redundant canonical commit fetch. A miss, timeout, or
+transport failure leaves the checkout in place and falls back to canonical;
+cancellation does not start new fallback work. Filtered fetches retarget their
+promisor configuration to canonical `origin`, so later lazy object reads never
+depend on the one-shot mirror URL.
+
 The shared mirror directory remains keyed by the canonical repository URL and
 its persisted `origin` is always canonical. This keeps the cache compatible with
 older agents sharing the same volume, avoids cache fragmentation when mirror

--- a/docs/git-mirror.md
+++ b/docs/git-mirror.md
@@ -44,9 +44,10 @@ URLs rotate, and prevents lagging mirror data from overwriting canonical
 `refs/heads/*`.
 
 The remote mirror URL and credentials are supplied by Buildkite. The URL is not
-written into the on-host mirror or checkout configuration. For full
-requirements, caveats, and rollout decisions, see
-[`remote-git-mirrors.md`](remote-git-mirrors.md).
+written into the on-host mirror configuration or retained in checkout
+configuration after a completed fetch. An interrupted filtered fetch can leave
+promisor keys that the next fetch repairs. For full requirements, caveats, and
+rollout decisions, see [`remote-git-mirrors.md`](remote-git-mirrors.md).
 
 ## Mirrors? `--mirror`? 🪞
 

--- a/docs/git-mirror.md
+++ b/docs/git-mirror.md
@@ -48,9 +48,10 @@ written into the on-host mirror configuration or retained in checkout
 configuration after a completed fetch. An interrupted filtered fetch can leave
 promisor keys. Before fetching, the agent records a credential-free digest
 marker so the next fetch repairs only the matching agent-created section and
-leaves unmarked user promisor configuration unchanged. For full requirements,
-caveats, and rollout decisions, see
-[`remote-git-mirrors.md`](remote-git-mirrors.md).
+leaves unmarked user promisor configuration unchanged. If config for the exact
+mirror URL already exists without that marker, the agent preserves it and uses
+the canonical repository. For full requirements, caveats, and rollout
+decisions, see [`remote-git-mirrors.md`](remote-git-mirrors.md).
 
 ## Mirrors? `--mirror`? 🪞
 

--- a/docs/remote-git-mirrors.md
+++ b/docs/remote-git-mirrors.md
@@ -990,7 +990,7 @@ An existing partial clone has a second source of effective fetch behavior:
 but a direct-URL mirror fetch does not. When no explicit fetch filter or
 `--no-filter` override is present, append the stored origin filter to the mirror
 attempt so the transfer shape still matches canonical. Detect Git's accepted
-`--fil*` and `--no-fil*` long-option abbreviations too; otherwise an inherited
+`--fi*` and `--no-fi*` long-option abbreviations too; otherwise an inherited
 filter can silently override the operator's effective flag.
 
 **Then retarget the promisor the fetch wrote on every outcome — do not just
@@ -1042,9 +1042,14 @@ cancel. A checkout already partial under a *different* filter has its
 given the fetch it just took was filtered the new way.
 
 Normal cancellation cleanup is not enough for process death or host reboot.
-Before every later fetch, scan URL-named promisor sections left by interrupted
-attempts, establish canonical `origin` ownership, and remove them—even when the
-backend mirror URL has since been removed or rotated.
+Before the mirror fetch, write a local config marker containing a
+credential-free digest of the exact mirror URL. Remove it only after promisor
+cleanup completes. Before every later fetch, use that marker to find the
+matching URL-named promisor section left by an interrupted attempt, establish
+canonical `origin` ownership, and remove it—even when the backend mirror URL has
+since been removed or rotated. A marker with no matching section is the safe
+crash window before Git wrote promisor state and is simply cleared. Unmarked
+URL-named promisors are user-owned and remain untouched.
 
 If that bounded config repair fails, the checkout is no longer safe to preserve:
 the mirror may remain registered as an unbounded promisor. Classify the failure
@@ -1064,7 +1069,9 @@ leave canonical promisor ownership; a sparse pipeline's mirror fetch carries
 `--filter=blob:none`; an existing origin filter is inherited unless
 `--no-filter` (including accepted abbreviations) is explicit; cleanup failure
 cleans and retries canonically; no `remote.<mirrorURL>.*` survives any successful
-cleanup; and —
+cleanup; marker write failure falls back canonically; marker-only interruption
+is cleared; marked repair leaves unrelated and unmarked user promisor sections
+untouched; and —
 the one that matters — after a
 hit on a checkout that was **not** previously a partial clone, with the mirror
 then deleted, the worktree materialises. A config-shape assertion passes on the

--- a/docs/remote-git-mirrors.md
+++ b/docs/remote-git-mirrors.md
@@ -1042,14 +1042,16 @@ cancel. A checkout already partial under a *different* filter has its
 given the fetch it just took was filtered the new way.
 
 Normal cancellation cleanup is not enough for process death or host reboot.
-Before the mirror fetch, write a local config marker containing a
-credential-free digest of the exact mirror URL. Remove it only after promisor
-cleanup completes. Before every later fetch, use that marker to find the
-matching URL-named promisor section left by an interrupted attempt, establish
-canonical `origin` ownership, and remove it—even when the backend mirror URL has
-since been removed or rotated. A marker with no matching section is the safe
-crash window before Git wrote promisor state and is simply cleared. Unmarked
-URL-named promisors are user-owned and remain untouched.
+Before the mirror fetch, confirm no unmarked config section already exists for
+the exact mirror URL; if one does, treat it as user-owned and use canonical.
+Otherwise write a local config marker containing a credential-free digest of
+that URL. Remove it only after promisor cleanup completes. Before every later
+fetch, use that marker to find the matching URL-named promisor section left by
+an interrupted attempt, establish canonical `origin` ownership, and remove
+it—even when the backend mirror URL has since been removed or rotated. A marker
+with no matching section is the safe crash window before Git wrote promisor
+state and is simply cleared. Other unmarked URL-named promisors are user-owned
+and remain untouched.
 
 If that bounded config repair fails, the checkout is no longer safe to preserve:
 the mirror may remain registered as an unbounded promisor. Classify the failure
@@ -1071,7 +1073,8 @@ leave canonical promisor ownership; a sparse pipeline's mirror fetch carries
 cleans and retries canonically; no `remote.<mirrorURL>.*` survives any successful
 cleanup; marker write failure falls back canonically; marker-only interruption
 is cleared; marked repair leaves unrelated and unmarked user promisor sections
-untouched; and —
+untouched; a same-URL unmarked user section bypasses the mirror without losing
+any of its keys; and —
 the one that matters — after a
 hit on a checkout that was **not** previously a partial clone, with the mirror
 then deleted, the worktree materialises. A config-shape assertion passes on the

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -211,6 +211,18 @@ func (e *Executor) checkout(ctx context.Context) error {
 				// 94 chosen by fair die roll
 				return &shell.ExitError{Code: 94, Err: err}
 
+			case errors.As(err, &errGit) && errGit.Type == gitErrorFetchRetryClean:
+				// Cleanup failures can wrap cancellation; remove unsafe state first.
+				if errGit.WasRetried {
+					e.shell.Warningf("Checkout failed! %s", err)
+					r.Break()
+				} else {
+					e.shell.Warningf("Checkout failed! %s (%s)", err, r)
+				}
+				if err := e.removeCheckoutDir(); err != nil {
+					e.shell.Warningf("Failed to remove checkout dir while cleaning up after a checkout error: %v", err)
+				}
+
 			case errors.Is(err, context.Canceled):
 				e.shell.Warningf("Checkout was cancelled")
 				r.Break()
@@ -232,7 +244,7 @@ func (e *Executor) checkout(ctx context.Context) error {
 
 				switch errGit.Type {
 				case gitErrorClean, gitErrorCleanSubmodules, gitErrorClone, gitErrorCloneTimeout,
-					gitErrorCheckoutRetryClean, gitErrorFetchRetryClean,
+					gitErrorCheckoutRetryClean,
 					gitErrorFetchBadObject, gitErrorFetchRefNotOnRemote:
 					// Checkout can fail because of corrupted files in the checkout which can leave the agent in a state where it
 					// keeps failing. This removes the checkout dir, which means the next checkout will be a lot slower (clone vs

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -222,6 +222,9 @@ func (e *Executor) checkout(ctx context.Context) error {
 				if err := e.removeCheckoutDir(); err != nil {
 					e.shell.Warningf("Failed to remove checkout dir while cleaning up after a checkout error: %v", err)
 				}
+				if err := e.createCheckoutDir(); err != nil {
+					return err
+				}
 
 			case errors.Is(err, context.Canceled):
 				e.shell.Warningf("Checkout was cancelled")

--- a/internal/job/checkout_fetch.go
+++ b/internal/job/checkout_fetch.go
@@ -212,6 +212,22 @@ func (e *Executor) fetchExistingCheckoutFromRemoteMirror(
 	attempt *remoteMirrorAttempt,
 	gitFetchFlags string,
 ) (bool, error) {
+	hasURLConfig, err := e.hasRemoteMirrorURLConfig(ctx, attempt.url)
+	if err != nil {
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+		attempt.outcome = remoteMirrorOutcomeError
+		e.shell.Warningf("Could not inspect remote Git mirror state; falling back to canonical")
+		return false, nil
+	}
+	if hasURLConfig {
+		attempt.outcome = remoteMirrorOutcomeSkipped
+		attempt.skipReason = remoteMirrorSkipURLConfigConflict
+		e.shell.Commentf("Remote Git mirror URL already has user-owned config; falling back to canonical")
+		return false, nil
+	}
+
 	if err := e.markRemoteMirrorPromisor(ctx, attempt.url); err != nil {
 		if ctx.Err() != nil {
 			return false, ctx.Err()
@@ -256,6 +272,27 @@ func remoteMirrorPromisorKey(mirrorURL, name string) string {
 
 func remoteMirrorPromisorMarker(mirrorURL string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(mirrorURL)))
+}
+
+func (e *Executor) hasRemoteMirrorURLConfig(ctx context.Context, mirrorURL string) (bool, error) {
+	output, err := e.runSilentLocalGitConfigOutput(ctx, "--get-regexp", `^remote\..*\..*$`)
+	if err != nil {
+		if shell.IsExitError(err) && shell.ExitCode(err) == 1 {
+			return false, nil
+		}
+		return false, err
+	}
+	for line := range strings.SplitSeq(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		key := strings.TrimPrefix(fields[0], "remote.")
+		if variable := strings.LastIndexByte(key, '.'); variable > 0 && key[:variable] == mirrorURL {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (e *Executor) markRemoteMirrorPromisor(ctx context.Context, mirrorURL string) error {

--- a/internal/job/checkout_fetch.go
+++ b/internal/job/checkout_fetch.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"net/url"
@@ -16,6 +17,8 @@ import (
 	"github.com/buildkite/agent/v3/internal/shell"
 	"github.com/buildkite/shellwords"
 )
+
+const remoteMirrorPromisorMarkerKey = "buildkite.remote-mirror-promisor"
 
 // refspecKind is the category of git refspec a fetch targets.
 type refspecKind string
@@ -177,35 +180,9 @@ func (e *Executor) fetchSource(ctx context.Context, addBloblessFilter bool, atte
 			if err != nil {
 				return fmt.Errorf("preparing remote mirror fetch: %w", err)
 			}
-			e.shell.Commentf("Fetch commit from remote Git mirror")
-			// C21: preserve the caller's effective fetch flags. Explicit
-			// ref-mutating flags such as --tags may therefore reflect the
-			// mirror's lagging view, while the build commit remains the
-			// backend-provided immutable object ID.
-			hit, fetchErr := e.fetchCommitFromRemoteMirror(
-				ctx,
-				attempt,
-				".git",
-				mirrorFetchFlags,
-				e.Commit,
-			)
-			// Cleanup is bounded but deliberately detached: cancellation can
-			// race with any individual config command, and leaving the one-shot
-			// mirror as a promisor is not a safe cancellation state.
-			cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-			cleanupErr := e.finishRemoteMirrorPromisor(cleanupCtx, attempt.url)
-			cancelCleanup()
-			if cleanupErr != nil {
-				return &gitError{
-					error: fmt.Errorf(
-						"cleaning up unsafe remote mirror promisor state: %w",
-						errors.Join(fetchErr, cleanupErr),
-					),
-					Type: gitErrorFetchRetryClean,
-				}
-			}
-			if fetchErr != nil {
-				return fetchErr
+			hit, err := e.fetchExistingCheckoutFromRemoteMirror(ctx, attempt, mirrorFetchFlags)
+			if err != nil {
+				return err
 			}
 			if hit {
 				// C4: FETCH_HEAD records the non-secret mirror URL. No
@@ -230,8 +207,71 @@ func isExistingCheckoutRemoteMirrorAttempt(attempt *remoteMirrorAttempt) bool {
 		attempt.outcome == remoteMirrorOutcomeNotReached
 }
 
+func (e *Executor) fetchExistingCheckoutFromRemoteMirror(
+	ctx context.Context,
+	attempt *remoteMirrorAttempt,
+	gitFetchFlags string,
+) (bool, error) {
+	if err := e.markRemoteMirrorPromisor(ctx, attempt.url); err != nil {
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+		attempt.outcome = remoteMirrorOutcomeError
+		e.shell.Warningf("Could not mark remote Git mirror state; falling back to canonical")
+		return false, nil
+	}
+
+	e.shell.Commentf("Fetch commit from remote Git mirror")
+	// C21: preserve the caller's effective fetch flags. Explicit ref-mutating
+	// flags such as --tags may reflect the mirror's lagging view, while the
+	// build commit remains the backend-provided immutable object ID.
+	hit, fetchErr := e.fetchCommitFromRemoteMirror(
+		ctx,
+		attempt,
+		".git",
+		gitFetchFlags,
+		e.Commit,
+	)
+	// Cleanup is bounded but deliberately detached: cancellation can race with
+	// any individual config command, and leaving the one-shot mirror as a
+	// promisor is not a safe cancellation state.
+	cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	cleanupErr := e.finishRemoteMirrorPromisor(cleanupCtx, attempt.url)
+	cancelCleanup()
+	if cleanupErr != nil {
+		return false, &gitError{
+			error: fmt.Errorf(
+				"cleaning up unsafe remote mirror promisor state: %w",
+				errors.Join(fetchErr, cleanupErr),
+			),
+			Type: gitErrorFetchRetryClean,
+		}
+	}
+	return hit, fetchErr
+}
+
 func remoteMirrorPromisorKey(mirrorURL, name string) string {
 	return "remote." + mirrorURL + "." + name
+}
+
+func remoteMirrorPromisorMarker(mirrorURL string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(mirrorURL)))
+}
+
+func (e *Executor) markRemoteMirrorPromisor(ctx context.Context, mirrorURL string) error {
+	return e.runSilentLocalGitConfig(
+		ctx,
+		remoteMirrorPromisorMarkerKey,
+		remoteMirrorPromisorMarker(mirrorURL),
+	)
+}
+
+func (e *Executor) clearRemoteMirrorPromisorMarker(ctx context.Context) error {
+	_, marked, err := e.localGitConfigValue(ctx, remoteMirrorPromisorMarkerKey)
+	if err != nil || !marked {
+		return err
+	}
+	return e.runSilentLocalGitConfig(ctx, "--unset-all", remoteMirrorPromisorMarkerKey)
 }
 
 func (e *Executor) prepareRemoteMirrorFetch(
@@ -265,13 +305,21 @@ func (e *Executor) finishRemoteMirrorPromisor(
 	ctx context.Context,
 	mirrorURL string,
 ) error {
+	marker, marked, err := e.localGitConfigValue(ctx, remoteMirrorPromisorMarkerKey)
+	if err != nil {
+		return fmt.Errorf("reading remote mirror promisor marker: %w", err)
+	}
+	if !marked || marker != remoteMirrorPromisorMarker(mirrorURL) {
+		return nil
+	}
+
 	promisorKey := remoteMirrorPromisorKey(mirrorURL, "promisor")
 	promisor, hasPromisor, err := e.localGitConfigValue(ctx, promisorKey)
 	if err != nil {
 		return fmt.Errorf("reading remote mirror promisor config: %w", err)
 	}
 	if !hasPromisor || promisor == "" {
-		return nil
+		return e.clearRemoteMirrorPromisorMarker(ctx)
 	}
 
 	filterKey := remoteMirrorPromisorKey(mirrorURL, "partialclonefilter")
@@ -300,7 +348,7 @@ func (e *Executor) finishRemoteMirrorPromisor(
 		return fmt.Errorf("removing remote mirror promisor config: %w", err)
 	}
 
-	return nil
+	return e.clearRemoteMirrorPromisorMarker(ctx)
 }
 
 func (e *Executor) repairInterruptedRemoteMirrorPromisors(ctx context.Context) error {
@@ -317,18 +365,24 @@ func (e *Executor) repairInterruptedRemoteMirrorPromisors(ctx context.Context) e
 		if err != nil {
 			return err
 		}
-		// Avoid adding a Git invocation to every ordinary checkout. Git writes
-		// URL remotes with this section shape for direct filtered fetches.
-		if !strings.Contains(string(config), `[remote "http`) ||
-			!strings.Contains(string(config), "promisor") {
+		// Avoid adding a Git invocation to checkouts the agent did not mark.
+		if !strings.Contains(string(config), "remote-mirror-promisor") {
 			return nil
 		}
+	}
+
+	marker, marked, err := e.localGitConfigValue(ctx, remoteMirrorPromisorMarkerKey)
+	if err != nil {
+		return err
+	}
+	if !marked {
+		return nil
 	}
 
 	output, err := e.runSilentLocalGitConfigOutput(ctx, "--get-regexp", `^remote\..*\.promisor$`)
 	if err != nil {
 		if shell.IsExitError(err) && shell.ExitCode(err) == 1 {
-			return nil
+			return e.clearRemoteMirrorPromisorMarker(ctx)
 		}
 		return err
 	}
@@ -342,11 +396,15 @@ func (e *Executor) repairInterruptedRemoteMirrorPromisors(ctx context.Context) e
 		if err != nil || (remoteURL.Scheme != "https" && remoteURL.Scheme != "http") || remoteURL.Host == "" {
 			continue
 		}
+		if remoteMirrorPromisorMarker(remoteName) != marker {
+			continue
+		}
 		if err := e.finishRemoteMirrorPromisor(ctx, remoteName); err != nil {
 			return err
 		}
+		return nil
 	}
-	return nil
+	return e.clearRemoteMirrorPromisorMarker(ctx)
 }
 
 func (e *Executor) localGitConfigValue(ctx context.Context, key string) (string, bool, error) {

--- a/internal/job/checkout_fetch.go
+++ b/internal/job/checkout_fetch.go
@@ -4,10 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/buildkite/agent/v3/internal/shell"
+	"github.com/buildkite/shellwords"
 )
 
 // refspecKind is the category of git refspec a fetch targets.
@@ -60,6 +67,13 @@ func (e *Executor) fetchSource(ctx context.Context, addBloblessFilter bool, atte
 		"git.pull_request": strconv.FormatBool(e.PullRequest != "false"),
 		"git.refspec_kind": string(kind),
 	})
+
+	if err := e.repairInterruptedRemoteMirrorPromisors(ctx); err != nil {
+		return &gitError{
+			error: fmt.Errorf("repairing interrupted remote mirror promisor state: %w", err),
+			Type:  gitErrorFetchRetryClean,
+		}
+	}
 
 	// If configured, skip the fetch when the commit already exists locally.
 	// This is useful when a pre-populated git mirror is used with --reference,
@@ -158,6 +172,48 @@ func (e *Executor) fetchSource(ctx context.Context, addBloblessFilter bool, atte
 		}
 
 	default: // refspecCommit
+		if isExistingCheckoutRemoteMirrorAttempt(attempt) {
+			mirrorFetchFlags, err := e.prepareRemoteMirrorFetch(ctx, gitFetchFlags)
+			if err != nil {
+				return fmt.Errorf("preparing remote mirror fetch: %w", err)
+			}
+			e.shell.Commentf("Fetch commit from remote Git mirror")
+			// C21: preserve the caller's effective fetch flags. Explicit
+			// ref-mutating flags such as --tags may therefore reflect the
+			// mirror's lagging view, while the build commit remains the
+			// backend-provided immutable object ID.
+			hit, fetchErr := e.fetchCommitFromRemoteMirror(
+				ctx,
+				attempt,
+				".git",
+				mirrorFetchFlags,
+				e.Commit,
+			)
+			// Cleanup is bounded but deliberately detached: cancellation can
+			// race with any individual config command, and leaving the one-shot
+			// mirror as a promisor is not a safe cancellation state.
+			cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			cleanupErr := e.finishRemoteMirrorPromisor(cleanupCtx, attempt.url)
+			cancelCleanup()
+			if cleanupErr != nil {
+				return &gitError{
+					error: fmt.Errorf(
+						"cleaning up unsafe remote mirror promisor state: %w",
+						errors.Join(fetchErr, cleanupErr),
+					),
+					Type: gitErrorFetchRetryClean,
+				}
+			}
+			if fetchErr != nil {
+				return fetchErr
+			}
+			if hit {
+				// C4: FETCH_HEAD records the non-secret mirror URL. No
+				// mirror-eligible flow reads it, so retain Git's normal write.
+				return nil
+			}
+		}
+
 		// Otherwise fetch and checkout the commit directly.
 		e.shell.Commentf("Fetch and checkout commit")
 		if err := gitFetchWithFallback(ctx, e.shell, gitFetchFlags, e.Commit); err != nil {
@@ -166,6 +222,164 @@ func (e *Executor) fetchSource(ctx context.Context, addBloblessFilter bool, atte
 	}
 
 	return nil
+}
+
+func isExistingCheckoutRemoteMirrorAttempt(attempt *remoteMirrorAttempt) bool {
+	return attempt != nil &&
+		attempt.site == remoteMirrorSiteExistingCheckout &&
+		attempt.outcome == remoteMirrorOutcomeNotReached
+}
+
+func remoteMirrorPromisorKey(mirrorURL, name string) string {
+	return "remote." + mirrorURL + "." + name
+}
+
+func (e *Executor) prepareRemoteMirrorFetch(
+	ctx context.Context,
+	gitFetchFlags string,
+) (string, error) {
+	parts, err := shellwords.Split(gitFetchFlags)
+	if err != nil {
+		return "", err
+	}
+	if hasPartialFilterFlags(parts) || hasNoPartialFilterFlag(parts) {
+		return gitFetchFlags, nil
+	}
+	filter, hasFilter, err := e.localGitConfigValue(ctx, "remote.origin.partialclonefilter")
+	if err != nil {
+		return "", err
+	}
+	if !hasFilter || filter == "" {
+		return gitFetchFlags, nil
+	}
+	return strings.TrimSpace(gitFetchFlags + " " + shellwords.Quote("--filter="+filter)), nil
+}
+
+func hasNoPartialFilterFlag(flags []string) bool {
+	return slices.ContainsFunc(flags, func(flag string) bool {
+		return strings.HasPrefix(flag, "--no-fi")
+	})
+}
+
+func (e *Executor) finishRemoteMirrorPromisor(
+	ctx context.Context,
+	mirrorURL string,
+) error {
+	promisorKey := remoteMirrorPromisorKey(mirrorURL, "promisor")
+	promisor, hasPromisor, err := e.localGitConfigValue(ctx, promisorKey)
+	if err != nil {
+		return fmt.Errorf("reading remote mirror promisor config: %w", err)
+	}
+	if !hasPromisor || promisor == "" {
+		return nil
+	}
+
+	filterKey := remoteMirrorPromisorKey(mirrorURL, "partialclonefilter")
+	filter, hasFilter, err := e.localGitConfigValue(ctx, filterKey)
+	if err != nil {
+		return fmt.Errorf("reading remote mirror partial-clone config: %w", err)
+	}
+
+	// A filtered fetch can write missing objects before it reports failure or
+	// cancellation. Configure canonical ownership before removing mirror
+	// ownership on every outcome so an interruption cannot strand those objects.
+	if err := e.shell.Command(
+		"git", "config", "--local", "remote.origin.promisor", "true",
+	).Run(ctx, shell.AlwaysHidePrompt(), shell.ShowStderr(false)); err != nil {
+		return fmt.Errorf("configuring origin promisor: %w", err)
+	}
+	if hasFilter {
+		if err := e.shell.Command(
+			"git", "config", "--local", "remote.origin.partialclonefilter", filter,
+		).Run(ctx, shell.AlwaysHidePrompt(), shell.ShowStderr(false)); err != nil {
+			return fmt.Errorf("configuring origin partial clone filter: %w", err)
+		}
+	}
+
+	if err := e.runSilentLocalGitConfig(ctx, "--remove-section", "remote."+mirrorURL); err != nil {
+		return fmt.Errorf("removing remote mirror promisor config: %w", err)
+	}
+
+	return nil
+}
+
+func (e *Executor) repairInterruptedRemoteMirrorPromisors(ctx context.Context) error {
+	gitPath := filepath.Join(e.shell.Getwd(), ".git")
+	gitInfo, err := os.Stat(gitPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if gitInfo.IsDir() {
+		config, err := os.ReadFile(filepath.Join(gitPath, "config"))
+		if err != nil {
+			return err
+		}
+		// Avoid adding a Git invocation to every ordinary checkout. Git writes
+		// URL remotes with this section shape for direct filtered fetches.
+		if !strings.Contains(string(config), `[remote "http`) ||
+			!strings.Contains(string(config), "promisor") {
+			return nil
+		}
+	}
+
+	output, err := e.runSilentLocalGitConfigOutput(ctx, "--get-regexp", `^remote\..*\.promisor$`)
+	if err != nil {
+		if shell.IsExitError(err) && shell.ExitCode(err) == 1 {
+			return nil
+		}
+		return err
+	}
+	for line := range strings.SplitSeq(output, "\n") {
+		key, _, ok := strings.Cut(strings.TrimSpace(line), " ")
+		if !ok {
+			continue
+		}
+		remoteName := strings.TrimSuffix(strings.TrimPrefix(key, "remote."), ".promisor")
+		remoteURL, err := url.Parse(remoteName)
+		if err != nil || (remoteURL.Scheme != "https" && remoteURL.Scheme != "http") || remoteURL.Host == "" {
+			continue
+		}
+		if err := e.finishRemoteMirrorPromisor(ctx, remoteName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *Executor) localGitConfigValue(ctx context.Context, key string) (string, bool, error) {
+	value, err := e.runSilentLocalGitConfigOutput(ctx, "--get", key)
+	if err != nil {
+		if shell.IsExitError(err) && shell.ExitCode(err) == 1 {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return strings.TrimSpace(value), true, nil
+}
+
+func (e *Executor) runSilentLocalGitConfig(ctx context.Context, args ...string) error {
+	_, err := e.runSilentLocalGitConfigOutput(ctx, args...)
+	return err
+}
+
+func (e *Executor) runSilentLocalGitConfigOutput(ctx context.Context, args ...string) (string, error) {
+	commandArgs := append([]string{"config", "--local"}, args...)
+	gitPath, err := e.shell.AbsolutePath("git")
+	if err != nil {
+		return "", errors.New("resolving git for silent config command")
+	}
+	cmd := exec.CommandContext(ctx, gitPath, commandArgs...)
+	cmd.Dir = e.shell.Getwd()
+	cmd.Env = e.shell.Env.ToSlice()
+	output, err := cmd.Output()
+	if err != nil {
+		// Do not return argv or stderr: mirror-keyed config includes the URL.
+		return "", fmt.Errorf("silent git config failed: %w", err)
+	}
+	return string(output), nil
 }
 
 // gitFetchWithFallback runs git fetch for refspecs; when it fails for a recoverable reason, it retries by fetching

--- a/internal/job/checkout_fetch_remote_mirror_test.go
+++ b/internal/job/checkout_fetch_remote_mirror_test.go
@@ -3,6 +3,7 @@ package job
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -141,6 +142,19 @@ func TestPrepareRemoteMirrorFetchHonorsExplicitFilterFlags(t *testing.T) {
 	}
 }
 
+func TestRemoteMirrorPromisorMarkerDoesNotContainCredentials(t *testing.T) {
+	mirrorURL := "https://token:secret@mirror.example/repo.git"
+	marker := remoteMirrorPromisorMarker(mirrorURL)
+	if strings.Contains(marker, mirrorURL) ||
+		strings.Contains(marker, "token") ||
+		strings.Contains(marker, "secret") {
+		t.Errorf("remoteMirrorPromisorMarker() = %q, want credential-free digest", marker)
+	}
+	if len(marker) != sha256.Size*2 {
+		t.Errorf("remoteMirrorPromisorMarker() length = %d, want %d", len(marker), sha256.Size*2)
+	}
+}
+
 func TestFetchSourceRepairsPreexistingMirrorPromisorOnMiss(t *testing.T) {
 	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
 	if err := canonical.ConfigureRepository("canonical", "uploadpack.allowFilter", "true"); err != nil {
@@ -158,6 +172,13 @@ func TestFetchSourceRepairsPreexistingMirrorPromisorOnMiss(t *testing.T) {
 	runGitForMirrorTest(t, checkout, "config", "core.repositoryformatversion", "1")
 	runGitForMirrorTest(t, checkout, "config", "remote."+mirrorURL+".promisor", "true")
 	runGitForMirrorTest(t, checkout, "config", "remote."+mirrorURL+".partialclonefilter", "blob:none")
+	runGitForMirrorTest(
+		t,
+		checkout,
+		"config",
+		remoteMirrorPromisorMarkerKey,
+		remoteMirrorPromisorMarker(mirrorURL),
+	)
 	e, attempt := newExistingCheckoutRemoteMirrorExecutor(t, checkout, canonical.RepoURL("canonical"), mirrorURL, commit)
 
 	if err := e.fetchSource(t.Context(), true, &attempt); err != nil {
@@ -168,14 +189,85 @@ func TestFetchSourceRepairsPreexistingMirrorPromisorOnMiss(t *testing.T) {
 	if got := gitConfigForRemoteMirrorTest(t, checkout, "remote."+mirrorURL+".promisor"); got != "" {
 		t.Errorf("pre-existing mirror promisor remains after repair: %q", got)
 	}
+	if got := gitConfigForRemoteMirrorTest(t, checkout, remoteMirrorPromisorMarkerKey); got != "" {
+		t.Errorf("remote mirror promisor marker remains after repair: %q", got)
+	}
+}
+
+func TestFetchSourceMarkerFailureFallsBackToCanonical(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, attempt := newExistingCheckoutRemoteMirrorExecutor(
+		t,
+		checkout,
+		canonical.RepoURL("canonical"),
+		"https://127.0.0.1:1/mirror.git",
+		commit,
+	)
+	configLock := filepath.Join(checkout, ".git", "config.lock")
+	if err := os.WriteFile(configLock, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(configLock) })
+
+	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+		t.Fatalf("fetchSource() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeError {
+		t.Errorf("outcome = %q, want error", attempt.outcome)
+	}
+	if !hasGitCommit(t.Context(), e.shell, ".git", commit) {
+		t.Error("canonical fallback did not fetch requested commit")
+	}
+}
+
+func TestFetchSourceLeavesUnmarkedUserPromisorUntouched(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+	commit := gitOutputForRemoteCheckoutTest(t, checkout, "rev-parse", "refs/remotes/origin/main")
+	userURL := "https://user.example/repo.git"
+	runGitForMirrorTest(t, checkout, "config", "core.repositoryformatversion", "1")
+	runGitForMirrorTest(t, checkout, "config", "remote."+userURL+".promisor", "true")
+	runGitForMirrorTest(t, checkout, "config", "remote."+userURL+".partialclonefilter", "blob:none")
+	e, _ := newExistingCheckoutRemoteMirrorExecutor(
+		t,
+		checkout,
+		canonical.RepoURL("canonical"),
+		"",
+		commit,
+	)
+	e.GitSkipFetchExistingCommits = true
+
+	if err := e.fetchSource(t.Context(), false, nil); err != nil {
+		t.Fatalf("fetchSource() error = %v", err)
+	}
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote."+userURL+".promisor", "true")
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote."+userURL+".partialclonefilter", "blob:none")
+	if got := gitConfigForRemoteMirrorTest(t, checkout, "remote.origin.promisor"); got != "" {
+		t.Errorf("remote.origin.promisor = %q, want user promisor ownership unchanged", got)
+	}
 }
 
 func TestRepairInterruptedRemoteMirrorPromisorAfterURLRemoval(t *testing.T) {
 	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
 	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
 	oldMirrorURL := "https://old-mirror.example/repo.git"
+	userURL := "https://user.example/repo.git"
 	runGitForMirrorTest(t, checkout, "config", "remote."+oldMirrorURL+".promisor", "true")
 	runGitForMirrorTest(t, checkout, "config", "remote."+oldMirrorURL+".partialclonefilter", "blob:none")
+	runGitForMirrorTest(t, checkout, "config", "remote."+userURL+".promisor", "true")
+	runGitForMirrorTest(t, checkout, "config", "remote."+userURL+".partialclonefilter", "tree:0")
+	runGitForMirrorTest(
+		t,
+		checkout,
+		"config",
+		remoteMirrorPromisorMarkerKey,
+		remoteMirrorPromisorMarker(oldMirrorURL),
+	)
 	e, _ := newExistingCheckoutRemoteMirrorExecutor(
 		t,
 		checkout,
@@ -191,6 +283,38 @@ func TestRepairInterruptedRemoteMirrorPromisorAfterURLRemoval(t *testing.T) {
 	assertGitConfigForRemoteMirrorTest(t, checkout, "remote.origin.partialclonefilter", "blob:none")
 	if got := gitConfigForRemoteMirrorTest(t, checkout, "remote."+oldMirrorURL+".promisor"); got != "" {
 		t.Errorf("old mirror promisor remains after repair: %q", got)
+	}
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote."+userURL+".promisor", "true")
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote."+userURL+".partialclonefilter", "tree:0")
+	if got := gitConfigForRemoteMirrorTest(t, checkout, remoteMirrorPromisorMarkerKey); got != "" {
+		t.Errorf("remote mirror promisor marker remains after repair: %q", got)
+	}
+}
+
+func TestRepairInterruptedRemoteMirrorPromisorClearsMarkerWithoutPromisor(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+	oldMirrorURL := "https://old-mirror.example/repo.git"
+	runGitForMirrorTest(
+		t,
+		checkout,
+		"config",
+		remoteMirrorPromisorMarkerKey,
+		remoteMirrorPromisorMarker(oldMirrorURL),
+	)
+	e, _ := newExistingCheckoutRemoteMirrorExecutor(
+		t,
+		checkout,
+		canonical.RepoURL("canonical"),
+		"",
+		strings.Repeat("a", 40),
+	)
+
+	if err := e.repairInterruptedRemoteMirrorPromisors(t.Context()); err != nil {
+		t.Fatalf("repairInterruptedRemoteMirrorPromisors() error = %v", err)
+	}
+	if got := gitConfigForRemoteMirrorTest(t, checkout, remoteMirrorPromisorMarkerKey); got != "" {
+		t.Errorf("orphaned remote mirror promisor marker remains: %q", got)
 	}
 }
 
@@ -253,6 +377,13 @@ func TestFinishRemoteMirrorPromisorHidesURLCommandsInDebug(t *testing.T) {
 	mirrorURL := "https://token:secret@mirror.example/repo.git"
 	runGitForMirrorTest(t, checkout, "config", "remote."+mirrorURL+".promisor", "true")
 	runGitForMirrorTest(t, checkout, "config", "remote."+mirrorURL+".partialclonefilter", "blob:none")
+	runGitForMirrorTest(
+		t,
+		checkout,
+		"config",
+		remoteMirrorPromisorMarkerKey,
+		remoteMirrorPromisorMarker(mirrorURL),
+	)
 
 	e, _ := newExistingCheckoutRemoteMirrorExecutor(
 		t,

--- a/internal/job/checkout_fetch_remote_mirror_test.go
+++ b/internal/job/checkout_fetch_remote_mirror_test.go
@@ -252,6 +252,38 @@ func TestFetchSourceLeavesUnmarkedUserPromisorUntouched(t *testing.T) {
 	}
 }
 
+func TestFetchSourceLeavesSameURLUnmarkedUserPromisorUntouched(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+	commit := gitOutputForRemoteCheckoutTest(t, checkout, "rev-parse", "refs/remotes/origin/main")
+	mirrorURL := "https://127.0.0.1:1/mirror.git"
+	runGitForMirrorTest(t, checkout, "config", "core.repositoryformatversion", "1")
+	runGitForMirrorTest(t, checkout, "config", "remote."+mirrorURL+".promisor", "true")
+	runGitForMirrorTest(t, checkout, "config", "remote."+mirrorURL+".partialclonefilter", "blob:none")
+	runGitForMirrorTest(t, checkout, "config", "remote."+mirrorURL+".user-owned", "keep")
+	e, attempt := newExistingCheckoutRemoteMirrorExecutor(
+		t,
+		checkout,
+		canonical.RepoURL("canonical"),
+		mirrorURL,
+		commit,
+	)
+
+	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+		t.Fatalf("fetchSource() error = %v", err)
+	}
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote."+mirrorURL+".promisor", "true")
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote."+mirrorURL+".partialclonefilter", "blob:none")
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote."+mirrorURL+".user-owned", "keep")
+	if got := gitConfigForRemoteMirrorTest(t, checkout, "remote.origin.promisor"); got != "" {
+		t.Errorf("remote.origin.promisor = %q, want user promisor ownership unchanged", got)
+	}
+	if attempt.outcome != remoteMirrorOutcomeSkipped ||
+		attempt.skipReason != remoteMirrorSkipURLConfigConflict {
+		t.Errorf("remote mirror attempt = %+v, want URL config conflict skip", attempt)
+	}
+}
+
 func TestRepairInterruptedRemoteMirrorPromisorAfterURLRemoval(t *testing.T) {
 	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
 	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))

--- a/internal/job/checkout_fetch_remote_mirror_test.go
+++ b/internal/job/checkout_fetch_remote_mirror_test.go
@@ -219,6 +219,34 @@ func TestRepairInterruptedRemoteMirrorPromisorSupportsGitFile(t *testing.T) {
 	}
 }
 
+func TestResolveRemoteMirrorAttemptSkipsGitFileCheckout(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	checkout := filepath.Join(t.TempDir(), "checkout")
+	separateGitDir := filepath.Join(t.TempDir(), "checkout.git")
+	runGitForMirrorTest(
+		t,
+		"",
+		"clone",
+		"--separate-git-dir", separateGitDir,
+		canonical.RepoURL("canonical"),
+		checkout,
+	)
+	e, _ := newExistingCheckoutRemoteMirrorExecutor(
+		t,
+		checkout,
+		canonical.RepoURL("canonical"),
+		"https://mirror.example/repo.git",
+		strings.Repeat("a", 40),
+	)
+	e.shell.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", checkout)
+
+	attempt := e.resolveRemoteMirrorAttempt(0)
+	if attempt.outcome != remoteMirrorOutcomeSkipped ||
+		attempt.skipReason != remoteMirrorSkipSeparateGitDir {
+		t.Errorf("resolveRemoteMirrorAttempt() = %+v, want separate-git-dir skip", attempt)
+	}
+}
+
 func TestFinishRemoteMirrorPromisorHidesURLCommandsInDebug(t *testing.T) {
 	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
 	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
@@ -444,8 +472,11 @@ func TestCheckoutCancellationCleanupFailureRemovesCheckout(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("checkout() error = %v, want context.Canceled", err)
 	}
-	if osutil.FileExists(checkout) {
-		t.Fatal("checkout with unsafe promisor remains after cancellation cleanup failure")
+	if !osutil.FileExists(checkout) {
+		t.Fatal("checkout directory was not recreated for teardown hooks")
+	}
+	if osutil.FileExists(filepath.Join(checkout, ".git")) {
+		t.Fatal("unsafe Git state remains after cancellation cleanup failure")
 	}
 }
 
@@ -536,6 +567,12 @@ func newExistingCheckoutRemoteMirrorExecutor(
 	if err := e.shell.Chdir(checkout); err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		if e.checkoutRoot != nil {
+			_ = e.checkoutRoot.Close()
+			e.checkoutRoot = nil
+		}
+	})
 	return e, remoteMirrorAttempt{
 		site: remoteMirrorSiteExistingCheckout,
 		url:  mirrorURL,

--- a/internal/job/checkout_fetch_remote_mirror_test.go
+++ b/internal/job/checkout_fetch_remote_mirror_test.go
@@ -1,0 +1,595 @@
+package job
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent/v3/internal/osutil"
+	"github.com/buildkite/agent/v3/internal/process"
+	"github.com/buildkite/agent/v3/internal/shell"
+)
+
+func TestFetchSourceExistingCheckoutRemoteMirrorHitSkipsCanonical(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+
+	e, attempt := newExistingCheckoutRemoteMirrorExecutor(t, checkout, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+	canonical.Close()
+
+	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+		t.Fatalf("fetchSource() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeHit {
+		t.Errorf("outcome = %q, want hit", attempt.outcome)
+	}
+	if !hasGitCommit(t.Context(), e.shell, ".git", commit) {
+		t.Errorf("existing checkout does not contain mirror commit %s", commit)
+	}
+}
+
+func TestFetchSourceExistingCheckoutRemoteMirrorMissLeavesStateUntouchedBeforeCanonicalFetch(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configBefore := readRemoteMirrorTestFile(t, filepath.Join(checkout, ".git", "config"))
+	refsBefore := gitOutputForRemoteCheckoutTest(t, checkout, "show-ref")
+	worktreeBefore := gitOutputForRemoteCheckoutTest(t, checkout, "status", "--porcelain=v1", "--untracked-files=all")
+	e, attempt := newExistingCheckoutRemoteMirrorExecutor(t, checkout, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+
+	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+		t.Fatalf("fetchSource() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeMiss {
+		t.Errorf("outcome = %q, want miss", attempt.outcome)
+	}
+	if got := readRemoteMirrorTestFile(t, filepath.Join(checkout, ".git", "config")); got != configBefore {
+		t.Errorf(".git/config changed on mirror miss\nbefore:\n%s\nafter:\n%s", configBefore, got)
+	}
+	if got := gitOutputForRemoteCheckoutTest(t, checkout, "show-ref"); got != refsBefore {
+		t.Errorf("refs changed on exact-SHA mirror miss\nbefore:\n%s\nafter:\n%s", refsBefore, got)
+	}
+	if got := gitOutputForRemoteCheckoutTest(t, checkout, "status", "--porcelain=v1", "--untracked-files=all"); got != worktreeBefore {
+		t.Errorf("worktree changed on mirror miss\nbefore:\n%s\nafter:\n%s", worktreeBefore, got)
+	}
+	if !hasGitCommit(t.Context(), e.shell, ".git", commit) {
+		t.Error("canonical fallback did not fetch requested commit")
+	}
+}
+
+func TestFetchSourceExistingCheckoutFilteredLagMissRetargetsPromisor(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	if err := canonical.ConfigureRepository("canonical", "uploadpack.allowFilter", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := canonical.ConfigureRepository("canonical", "uploadpack.allowAnySHA1InWant", "true"); err != nil {
+		t.Fatal(err)
+	}
+	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	if err := mirror.ConfigureRepository("mirror", "uploadpack.allowFilter", "true"); err != nil {
+		t.Fatal(err)
+	}
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e, attempt := newExistingCheckoutRemoteMirrorExecutor(t, checkout, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+	if err := e.fetchSource(t.Context(), true, &attempt); err != nil {
+		t.Fatalf("fetchSource() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeMiss {
+		t.Errorf("outcome = %q, want miss", attempt.outcome)
+	}
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote.origin.promisor", "true")
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote.origin.partialclonefilter", "blob:none")
+	if got := gitConfigForRemoteMirrorTest(t, checkout, "remote."+attempt.url+".promisor"); got != "" {
+		t.Errorf("mirror promisor remains after lag miss: %q", got)
+	}
+	if !hasGitCommit(t.Context(), e.shell, ".git", commit) {
+		t.Error("canonical fallback did not fetch lagging commit")
+	}
+}
+
+func TestPrepareRemoteMirrorFetchHonorsExplicitFilterFlags(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+	runGitForMirrorTest(t, checkout, "config", "remote.origin.partialclonefilter", "blob:none")
+	e, _ := newExistingCheckoutRemoteMirrorExecutor(
+		t,
+		checkout,
+		canonical.RepoURL("canonical"),
+		"https://mirror.example/repo.git",
+		strings.Repeat("a", 40),
+	)
+
+	for _, flags := range []string{
+		"-v --no-filter",
+		"-v --no-fi",
+		"-v --no-fil",
+		"-v --filter=tree:0",
+		"-v --fi=tree:0",
+		"-v --fil=tree:0",
+	} {
+		got, err := e.prepareRemoteMirrorFetch(t.Context(), flags)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != flags {
+			t.Errorf("mirror fetch flags = %q, want explicit flags %q preserved", got, flags)
+		}
+	}
+}
+
+func TestFetchSourceRepairsPreexistingMirrorPromisorOnMiss(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	if err := canonical.ConfigureRepository("canonical", "uploadpack.allowFilter", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := canonical.ConfigureRepository("canonical", "uploadpack.allowAnySHA1InWant", "true"); err != nil {
+		t.Fatal(err)
+	}
+	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mirrorURL := "http://127.0.0.1:1/mirror.git"
+	runGitForMirrorTest(t, checkout, "config", "core.repositoryformatversion", "1")
+	runGitForMirrorTest(t, checkout, "config", "remote."+mirrorURL+".promisor", "true")
+	runGitForMirrorTest(t, checkout, "config", "remote."+mirrorURL+".partialclonefilter", "blob:none")
+	e, attempt := newExistingCheckoutRemoteMirrorExecutor(t, checkout, canonical.RepoURL("canonical"), mirrorURL, commit)
+
+	if err := e.fetchSource(t.Context(), true, &attempt); err != nil {
+		t.Fatalf("fetchSource() error = %v", err)
+	}
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote.origin.promisor", "true")
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote.origin.partialclonefilter", "blob:none")
+	if got := gitConfigForRemoteMirrorTest(t, checkout, "remote."+mirrorURL+".promisor"); got != "" {
+		t.Errorf("pre-existing mirror promisor remains after repair: %q", got)
+	}
+}
+
+func TestRepairInterruptedRemoteMirrorPromisorAfterURLRemoval(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+	oldMirrorURL := "https://old-mirror.example/repo.git"
+	runGitForMirrorTest(t, checkout, "config", "remote."+oldMirrorURL+".promisor", "true")
+	runGitForMirrorTest(t, checkout, "config", "remote."+oldMirrorURL+".partialclonefilter", "blob:none")
+	e, _ := newExistingCheckoutRemoteMirrorExecutor(
+		t,
+		checkout,
+		canonical.RepoURL("canonical"),
+		"",
+		strings.Repeat("a", 40),
+	)
+
+	if err := e.repairInterruptedRemoteMirrorPromisors(t.Context()); err != nil {
+		t.Fatalf("repairInterruptedRemoteMirrorPromisors() error = %v", err)
+	}
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote.origin.promisor", "true")
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote.origin.partialclonefilter", "blob:none")
+	if got := gitConfigForRemoteMirrorTest(t, checkout, "remote."+oldMirrorURL+".promisor"); got != "" {
+		t.Errorf("old mirror promisor remains after repair: %q", got)
+	}
+}
+
+func TestRepairInterruptedRemoteMirrorPromisorSupportsGitFile(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	checkout := filepath.Join(t.TempDir(), "checkout")
+	separateGitDir := filepath.Join(t.TempDir(), "checkout.git")
+	runGitForMirrorTest(
+		t,
+		"",
+		"clone",
+		"--separate-git-dir", separateGitDir,
+		canonical.RepoURL("canonical"),
+		checkout,
+	)
+	e, _ := newExistingCheckoutRemoteMirrorExecutor(
+		t,
+		checkout,
+		canonical.RepoURL("canonical"),
+		"",
+		strings.Repeat("a", 40),
+	)
+
+	if err := e.repairInterruptedRemoteMirrorPromisors(t.Context()); err != nil {
+		t.Fatalf("repairInterruptedRemoteMirrorPromisors() with gitfile error = %v", err)
+	}
+}
+
+func TestFinishRemoteMirrorPromisorHidesURLCommandsInDebug(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+	mirrorURL := "https://token:secret@mirror.example/repo.git"
+	runGitForMirrorTest(t, checkout, "config", "remote."+mirrorURL+".promisor", "true")
+	runGitForMirrorTest(t, checkout, "config", "remote."+mirrorURL+".partialclonefilter", "blob:none")
+
+	e, _ := newExistingCheckoutRemoteMirrorExecutor(
+		t,
+		checkout,
+		canonical.RepoURL("canonical"),
+		mirrorURL,
+		strings.Repeat("a", 40),
+	)
+	logs := &bytes.Buffer{}
+	commandOutput := &process.Buffer{}
+	debugShell, err := shell.New(
+		shell.WithDebug(true),
+		shell.WithEnv(e.shell.Env),
+		shell.WithLogger(shell.NewWriterLogger(logs, false, nil)),
+		shell.WithStdout(commandOutput),
+		shell.WithWD(checkout),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.shell = debugShell
+
+	if err := e.finishRemoteMirrorPromisor(t.Context(), mirrorURL); err != nil {
+		t.Fatalf("finishRemoteMirrorPromisor() error = %v", err)
+	}
+	if strings.Contains(logs.String(), mirrorURL) || strings.Contains(logs.String(), "secret") {
+		t.Errorf("debug job log leaks mirror URL credentials: %q", logs.String())
+	}
+}
+
+func TestSilentMirrorConfigFailureDoesNotExposeURL(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+	mirrorURL := "https://token:secret@mirror.example/repo.git"
+	e, _ := newExistingCheckoutRemoteMirrorExecutor(
+		t,
+		checkout,
+		canonical.RepoURL("canonical"),
+		mirrorURL,
+		strings.Repeat("a", 40),
+	)
+
+	err := e.runSilentLocalGitConfig(t.Context(), "--remove-section", "remote."+mirrorURL)
+	if err == nil {
+		t.Fatal("runSilentLocalGitConfig() error = nil, want missing-section failure")
+	}
+	if strings.Contains(err.Error(), mirrorURL) || strings.Contains(err.Error(), "secret") {
+		t.Errorf("silent git config error leaks mirror URL credentials: %q", err)
+	}
+}
+
+func TestFetchSourceExistingCheckoutRetargetsPromisorAndMaterialisesFromCanonical(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	if err := canonical.ConfigureRepository("canonical", "uploadpack.allowFilter", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := canonical.ConfigureRepository("canonical", "uploadpack.allowAnySHA1InWant", "true"); err != nil {
+		t.Fatal(err)
+	}
+	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	if err := mirror.ConfigureRepository("mirror", "uploadpack.allowFilter", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	e, attempt := newExistingCheckoutRemoteMirrorExecutor(t, checkout, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+	if err := e.fetchSource(t.Context(), true, &attempt); err != nil {
+		t.Fatalf("fetchSource() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeHit {
+		t.Errorf("outcome = %q, want hit", attempt.outcome)
+	}
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote.origin.promisor", "true")
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote.origin.partialclonefilter", "blob:none")
+	if got := gitConfigForRemoteMirrorTest(t, checkout, "remote."+attempt.url+".promisor"); got != "" {
+		t.Errorf("mirror promisor remains configured: %q", got)
+	}
+	if got := gitConfigForRemoteMirrorTest(t, checkout, "remote."+attempt.url+".partialclonefilter"); got != "" {
+		t.Errorf("mirror partial-clone filter remains configured: %q", got)
+	}
+
+	mirror.Close()
+	runGitForMirrorTest(t, checkout, "checkout", "--force", commit)
+	got := readRemoteMirrorTestFile(t, filepath.Join(checkout, "newfile.txt"))
+	if got != "This is a new file." {
+		t.Errorf("materialised file = %q, want mirror-fetched pointer resolved from canonical", got)
+	}
+}
+
+func TestFetchSourceExistingPartialCheckoutInheritsOriginFilter(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	if err := canonical.ConfigureRepository("canonical", "uploadpack.allowFilter", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := canonical.ConfigureRepository("canonical", "uploadpack.allowAnySHA1InWant", "true"); err != nil {
+		t.Fatal(err)
+	}
+	checkout := filepath.Join(t.TempDir(), "checkout")
+	runGitForMirrorTest(t, "", "clone", "--filter=blob:none", canonical.RepoURL("canonical"), checkout)
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	if err := mirror.ConfigureRepository("mirror", "uploadpack.allowFilter", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	e, attempt := newExistingCheckoutRemoteMirrorExecutor(t, checkout, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+		t.Fatalf("fetchSource() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeHit {
+		t.Errorf("outcome = %q, want hit", attempt.outcome)
+	}
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote.origin.partialclonefilter", "blob:none")
+
+	mirror.Close()
+	runGitForMirrorTest(t, checkout, "checkout", "--force", commit)
+	if got := readRemoteMirrorTestFile(t, filepath.Join(checkout, "newfile.txt")); got != "This is a new file." {
+		t.Errorf("materialised file = %q, want inherited filter to lazy-fetch from canonical", got)
+	}
+}
+
+func TestFetchSourceExistingCheckoutCancellationDoesNotFallback(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	requested := make(chan struct{})
+	var requestedOnce sync.Once
+	hung := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		requestedOnce.Do(func() { close(requested) })
+		<-req.Context().Done()
+	}))
+	t.Cleanup(hung.Close)
+
+	e, attempt := newExistingCheckoutRemoteMirrorExecutor(t, checkout, canonical.RepoURL("canonical"), hung.URL+"/mirror.git", commit)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	go func() {
+		select {
+		case <-requested:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	err = e.fetchSource(ctx, true, &attempt)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("fetchSource() error = %v, want context.Canceled", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeNotReached {
+		t.Errorf("outcome = %q, want not reached", attempt.outcome)
+	}
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote.origin.promisor", "true")
+	assertGitConfigForRemoteMirrorTest(t, checkout, "remote.origin.partialclonefilter", "blob:none")
+	if got := gitConfigForRemoteMirrorTest(t, checkout, "remote."+attempt.url+".promisor"); got != "" {
+		t.Errorf("mirror promisor remains after cancellation: %q", got)
+	}
+}
+
+func TestCheckoutCancellationCleanupFailureRemovesCheckout(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	requested := make(chan struct{})
+	var requestedOnce sync.Once
+	hung := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		requestedOnce.Do(func() { close(requested) })
+		<-req.Context().Done()
+	}))
+	t.Cleanup(hung.Close)
+
+	e, _ := newExistingCheckoutRemoteMirrorExecutor(
+		t,
+		checkout,
+		canonical.RepoURL("canonical"),
+		hung.URL+"/mirror.git",
+		commit,
+	)
+	e.GitFetchFlags += " --filter=blob:none"
+	e.GitCleanFlags = "-fdq"
+	e.shell.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", checkout)
+	e.shell.Env.Set("GIT_SSL_NO_VERIFY", "true")
+	if attempt := e.resolveRemoteMirrorAttempt(0); attempt.site != remoteMirrorSiteExistingCheckout {
+		t.Fatalf("resolveRemoteMirrorAttempt() = %+v, want existing checkout", attempt)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	lockResult := make(chan error, 1)
+	go func() {
+		select {
+		case <-requested:
+			lockResult <- os.WriteFile(filepath.Join(checkout, ".git", "config.lock"), nil, 0o600)
+			cancel()
+		case <-ctx.Done():
+			lockResult <- ctx.Err()
+		}
+	}()
+
+	err = e.checkout(ctx)
+	if lockErr := <-lockResult; lockErr != nil {
+		t.Fatalf("creating config lock: %v; checkout error: %v", lockErr, err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("checkout() error = %v, want context.Canceled", err)
+	}
+	if osutil.FileExists(checkout) {
+		t.Fatal("checkout with unsafe promisor remains after cancellation cleanup failure")
+	}
+}
+
+func TestFetchSourceExistingCheckoutMirrorFailureFallsBack(t *testing.T) {
+	tests := []struct {
+		name        string
+		mirrorURL   func(*testing.T) string
+		wantOutcome remoteMirrorOutcome
+	}{
+		{
+			name: "transport error",
+			mirrorURL: func(*testing.T) string {
+				return "http://127.0.0.1:1/mirror.git"
+			},
+			wantOutcome: remoteMirrorOutcomeError,
+		},
+		{
+			name: "timeout",
+			mirrorURL: func(t *testing.T) string {
+				oldTimeout := remoteMirrorProbeTimeout
+				remoteMirrorProbeTimeout = 20 * time.Millisecond
+				t.Cleanup(func() { remoteMirrorProbeTimeout = oldTimeout })
+				server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+					<-req.Context().Done()
+				}))
+				t.Cleanup(server.Close)
+				return server.URL + "/mirror.git"
+			},
+			wantOutcome: remoteMirrorOutcomeTimeout,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+			if err := canonical.ConfigureRepository("canonical", "uploadpack.allowFilter", "true"); err != nil {
+				t.Fatal(err)
+			}
+			if err := canonical.ConfigureRepository("canonical", "uploadpack.allowAnySHA1InWant", "true"); err != nil {
+				t.Fatal(err)
+			}
+			checkout := cloneExistingCheckoutForRemoteMirrorTest(t, canonical.RepoURL("canonical"))
+			commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+			if err != nil {
+				t.Fatal(err)
+			}
+			e, attempt := newExistingCheckoutRemoteMirrorExecutor(
+				t,
+				checkout,
+				canonical.RepoURL("canonical"),
+				tc.mirrorURL(t),
+				commit,
+			)
+
+			if err := e.fetchSource(t.Context(), true, &attempt); err != nil {
+				t.Fatalf("fetchSource() error = %v", err)
+			}
+			if attempt.outcome != tc.wantOutcome {
+				t.Errorf("outcome = %q, want %q", attempt.outcome, tc.wantOutcome)
+			}
+			if !hasGitCommit(t.Context(), e.shell, ".git", commit) {
+				t.Error("canonical fallback did not fetch requested commit")
+			}
+			if got := gitConfigForRemoteMirrorTest(t, checkout, "remote."+attempt.url+".promisor"); got != "" {
+				t.Errorf("mirror promisor remains after fallback: %q", got)
+			}
+			if got := gitConfigForRemoteMirrorTest(t, checkout, "remote."+attempt.url+".partialclonefilter"); got != "" {
+				t.Errorf("mirror partial-clone filter remains after fallback: %q", got)
+			}
+		})
+	}
+}
+
+func newExistingCheckoutRemoteMirrorExecutor(
+	t *testing.T,
+	checkout, canonicalURL, mirrorURL, commit string,
+) (*Executor, remoteMirrorAttempt) {
+	t.Helper()
+	e := New(ExecutorConfig{
+		Repository:         canonicalURL,
+		GitRemoteMirrorURL: mirrorURL,
+		Commit:             commit,
+		Branch:             "feature-branch",
+		PullRequest:        "false",
+		GitFetchFlags:      "-v --prune",
+	})
+	e.shell = shell.NewTestShell(t, shell.WithSignalGracePeriod(10*time.Millisecond))
+	if err := e.shell.Chdir(checkout); err != nil {
+		t.Fatal(err)
+	}
+	return e, remoteMirrorAttempt{
+		site: remoteMirrorSiteExistingCheckout,
+		url:  mirrorURL,
+	}
+}
+
+func cloneExistingCheckoutForRemoteMirrorTest(t *testing.T, repository string) string {
+	t.Helper()
+	checkout := filepath.Join(t.TempDir(), "checkout")
+	runGitForMirrorTest(t, "", "clone", repository, checkout)
+	return checkout
+}
+
+func gitOutputForRemoteCheckoutTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		if len(out) == 0 {
+			return ""
+		}
+		t.Fatalf("git %v error = %v", args, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func gitConfigForRemoteMirrorTest(t *testing.T, dir, key string) string {
+	t.Helper()
+	cmd := exec.Command("git", "config", "--local", "--get", key)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return ""
+		}
+		t.Fatalf("git config --get %q error = %v", key, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func assertGitConfigForRemoteMirrorTest(t *testing.T, dir, key, want string) {
+	t.Helper()
+	if got := gitConfigForRemoteMirrorTest(t, dir, key); got != want {
+		t.Errorf("git config %s = %q, want %q", key, got, want)
+	}
+}
+
+func readRemoteMirrorTestFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/internal/job/checkout_remote_mirror.go
+++ b/internal/job/checkout_remote_mirror.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/url"
+	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -161,6 +162,10 @@ func (e *Executor) resolveRemoteMirrorAttempt(previousAttempts int) remoteMirror
 	default:
 		attempt.site = remoteMirrorSiteFreshClone
 	}
+	if attempt.site == remoteMirrorSiteExistingCheckout && e.checkoutUsesGitFile() {
+		// External Git dirs survive worktree cleanup, so failures cannot be quarantined.
+		return skip(remoteMirrorSkipSeparateGitDir)
+	}
 	if attempt.site == remoteMirrorSiteFreshClone {
 		cloneFlags, err := shellwords.Split(e.GitCloneFlags)
 		if err == nil && hasRecursiveSubmoduleCloneFlags(cloneFlags) {
@@ -201,6 +206,15 @@ func hasSeparateGitDirCloneFlag(flags []string) bool {
 func (e *Executor) checkoutAlreadyExists() bool {
 	checkoutPath, ok := e.shell.Env.Get("BUILDKITE_BUILD_CHECKOUT_PATH")
 	return ok && osutil.FileExists(filepath.Join(checkoutPath, ".git"))
+}
+
+func (e *Executor) checkoutUsesGitFile() bool {
+	checkoutPath, ok := e.shell.Env.Get("BUILDKITE_BUILD_CHECKOUT_PATH")
+	if !ok {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(checkoutPath, ".git"))
+	return err == nil && !info.IsDir()
 }
 
 func remoteMirrorGitFlags(ctx context.Context) []string {

--- a/internal/job/checkout_remote_mirror.go
+++ b/internal/job/checkout_remote_mirror.go
@@ -97,6 +97,7 @@ const (
 	remoteMirrorSkipNotFirstAttempt     remoteMirrorSkipReason = "not-first-attempt"
 	remoteMirrorSkipRecursiveSubmodules remoteMirrorSkipReason = "recursive-submodules"
 	remoteMirrorSkipSeparateGitDir      remoteMirrorSkipReason = "separate-git-dir"
+	remoteMirrorSkipURLConfigConflict   remoteMirrorSkipReason = "url-config-conflict"
 )
 
 type remoteMirrorAttempt struct {

--- a/internal/job/git.go
+++ b/internal/job/git.go
@@ -150,16 +150,14 @@ func gitCheckout(ctx context.Context, sh *shell.Shell, gitCheckoutFlags, referen
 	return nil
 }
 
-// hasPartialFilterFlags returns true if flags contains a
-// --filter=<spec> or --filter <spec> option.
+// hasPartialFilterFlags returns true if flags contains a filter option,
+// including Git's accepted --fi* long-option abbreviations.
 func hasPartialFilterFlags(flags []string) bool {
 	for i, f := range flags {
-		// Check for --filter=<spec>
-		if strings.HasPrefix(f, "--filter=") {
+		if strings.HasPrefix(f, "--fi") && strings.Contains(f, "=") {
 			return true
 		}
-		// The --filter <spec> form only counts when a value actually follows it
-		if f == "--filter" && i+1 < len(flags) {
+		if strings.HasPrefix(f, "--fi") && i+1 < len(flags) {
 			return true
 		}
 	}

--- a/internal/job/githttptest/githttptest.go
+++ b/internal/job/githttptest/githttptest.go
@@ -58,6 +58,19 @@ func (s *Server) CreateRepository(repoName string) error {
 	return nil
 }
 
+func (s *Server) ConfigureRepository(repoName, key, value string) error {
+	repoPath := filepath.Join(s.repositories, repoName)
+	if _, err := os.Stat(repoPath); err != nil {
+		return fmt.Errorf("repository %q: %w", repoName, err)
+	}
+	cmd := exec.Command("git", "config", key, value)
+	cmd.Dir = repoPath
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("configuring repository %q: %w\n%s", repoName, err, out)
+	}
+	return nil
+}
+
 func (s *Server) InitRepository(repoName string) ([]byte, error) {
 	tempDir, err := os.MkdirTemp("", "git-init-")
 	if err != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fetch the immutable build commit from the remote mirror into a reused checkout before falling back to canonical. This is PR 3 based on #4161.

A mirror miss never deletes the checkout. Unsafe promisor-cleanup failure quarantines the checkout's Git state, recreates an empty workdir for teardown hooks, and lets the next mirror-ineligible attempt clone canonically.

## Context

The explicit mirror URL makes the bounded source deterministic despite customer `insteadOf` rules. That requires filter inheritance and one-shot promisor cleanup without mutating user-owned promisor configuration.

## Changes

- Attempt only immutable commit fetches and skip canonical fetch only after a local hit.
- Preserve effective fetch flags, including Git-accepted `--fi*` and `--no-fi*` abbreviations.
- Inherit origin filters only without an explicit override.
- Establish canonical promisor ownership before removing mirror ownership on every outcome.
- Write a credential-free digest marker before mirror fetches and repair only the matching agent-created promisor after interruption, URL removal, or rotation.
- Leave unmarked and unrelated user promisor configuration untouched; clear marker-only crash windows safely.
- Preserve pre-existing unmarked config for the exact mirror URL by skipping the mirror and using canonical.
- Fall back to canonical when marker setup or ownership inspection fails.
- Route cleanup failure through clean canonical retry, prioritising quarantine over cancellation handling.
- Keep gitfile-backed reused checkouts canonical because external Git directories cannot be safely quarantined with the worktree.
- Recreate an empty checkout directory after quarantine so teardown hooks retain a valid working directory.
- Run mirror-keyed config commands silently with checkout PATH resolution, preventing URL-bearing argv/stderr leaks.
- Preserve cancellation without starting canonical fallback.

Filtered Git fetches can transiently write URL-named promisor keys. Completed fetches remove the keys and marker; the next fetch repairs only matching marked state left by process interruption.

F2 mirror-routed lazy materialisation remains outside this stack; lazy reads use canonical `origin`.

## Testing

Real Git-over-HTTP tests cover hit, lag, failure, timeout, cancellation, automatic/inherited/abbreviated filters, marked repair after URL removal, preservation of unmarked user promisors including an exact-URL section with extra keys, marker-only crash recovery, marker privacy and setup failure, canonical materialisation, credential-safe config failures, checkout PATH, state preservation, and debug suppression. Regression tests additionally force cancellation plus config-lock cleanup failure, verify unsafe Git state is removed while the teardown workdir remains, and keep real `--separate-git-dir` checkouts mirror-ineligible.

## Disclosures / Credits

Implemented with Cursor under human direction. Independent review drove all-outcome and restart recovery, scoped ownership marking, exact-URL collision handling, option parity, safe retry, gitfile/PATH correctness, teardown invariants, and logging hardening.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6f11793-178a-4772-9f71-e334584fc275?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6f11793-178a-4772-9f71-e334584fc275&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

