### PR TITLE
feat: Clone fresh checkouts from remote mirrors

### DIFF
--- a/docs/git-mirror.md
+++ b/docs/git-mirror.md
@@ -37,6 +37,20 @@ cancellation does not start new fallback work. Filtered fetches retarget their
 promisor configuration to canonical `origin`, so later lazy object reads never
 depend on the one-shot mirror URL.
 
+For a fresh checkout with no active on-host mirror update, the agent performs a
+real `git clone` from the remote mirror with the same clone flags it would use
+for canonical, then immediately repoints `origin` to canonical. This preserves
+depth, partial-clone, sparse, single-branch, no-tags, reference, and dissociate
+semantics. A lagging non-shallow clone is kept and completed with the canonical
+commit fetch. Lagging shallow clones and shallow clones whose apparent hit comes
+from an alternate are removed and cloned canonically so canonical owns the
+shallow boundary. Recursive-submodule and separate-Git-directory clone modes
+also stay canonical in this initial implementation. A failed clone is removed
+and retried canonically. The agent does not
+suppress LFS smudging specifically for the mirror—if the mirror cannot serve a
+required filter, the clone fails loudly and the canonical fallback produces the
+correct worktree.
+
 The shared mirror directory remains keyed by the canonical repository URL and
 its persisted `origin` is always canonical. This keeps the cache compatible with
 older agents sharing the same volume, avoids cache fragmentation when mirror
@@ -52,6 +66,9 @@ leaves unmarked user promisor configuration unchanged. If config for the exact
 mirror URL already exists without that marker, the agent preserves it and uses
 the canonical repository. For full requirements, caveats, and rollout
 decisions, see [`remote-git-mirrors.md`](remote-git-mirrors.md).
+
+Remote mirror optimization requires Git 2.45.0 or newer. Initial Windows support
+is best-effort and rough-edged; the canonical checkout path remains supported.
 
 ## Mirrors? `--mirror`? 🪞
 

--- a/docs/remote-git-mirrors.md
+++ b/docs/remote-git-mirrors.md
@@ -1159,10 +1159,10 @@ retains the mirror tip as an extra shallow root and can make more history
 reachable than a canonical clone with the same depth. Ask Git whether the
 resulting repository is shallow rather than reimplementing its accepted option
 spellings and abbreviations. If a shallow clone misses the commit, re-clone
-canonically. Also re-clone a shallow apparent hit when an alternates file is
-present: `hasGitCommit` follows alternates, so the target may come from a newer
-reference repository rather than the lagging mirror. This is the smallest
-reliable way to preserve R3.
+canonically. Also re-clone a shallow apparent hit when an alternates file or
+`GIT_ALTERNATE_OBJECT_DIRECTORIES` is present: `hasGitCommit` follows both, so
+the target may come from a newer reference repository rather than the lagging
+mirror. This is the smallest reliable way to preserve R3.
 
 Clone flags may also initialize submodules before `origin` is repointed.
 `--recurse-submodules` and its `--recursive` alias resolve relative
@@ -1237,7 +1237,7 @@ code that caused it no longer exists.
   vacuously. Include a lagging depth case using a Git-accepted abbreviated flag
   that compares shallow boundaries and reachable commits after canonical
   fallback, plus a shallow-reference case where the target exists only through
-  alternates.
+  an alternates file and through `GIT_ALTERNATE_OBJECT_DIRECTORIES`.
 - **Assert the avoided operation directly.** For existing/fresh mirror hits,
   assert that no canonical commit-fetch request occurs while allowing separately
   expected verification requests. A zero-byte assertion is insufficient because

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
 	"slices"
 	"strconv"
@@ -403,104 +402,8 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context, previousAttempts in
 	// original user-supplied state, not on flags we auto-add here.
 	userSuppliedCloneFilter := hasPartialFilterFlags(gitCloneFlags)
 
-	// On mirrors and dissociation:
-	//
-	// --reference makes the clone reuse objects from the mirror, using the
-	// .git/objects/info/alternates file. On its own, it won't copy the objects
-	// from the mirror, just refer to them. This becomes a problem if they
-	// disappear, which happens during routine normal use of the mirror.
-	//
-	// --dissociate makes copies of the objects from the mirror, which makes the
-	// clone robust against that failure, at the expense of disk space and extra
-	// work up front.
-	//
-	// --dissociate is safer, so it's what we want, but it can be disabled. It
-	// is important even when CleanCheckout is enabled, because auto-maintenance
-	// can happen on the mirror at any time!
-
-	// Does the git directory exist?
-	existingGitDir := filepath.Join(e.shell.Getwd(), ".git")
-	if osutil.FileExists(existingGitDir) {
-		// Ensure the origin matches the configured repo, so we can
-		// gracefully handle repository renames.
-		if _, err := e.updateRemoteURL(ctx, "", e.Repository); err != nil {
-			return fmt.Errorf("setting origin: %w", err)
-		}
-
-		if mirrorDir == "" && e.GitMirrorsPath != "" {
-			// A bypassed mirror must not remain reachable through a stale alternate.
-			if err := e.traceOp(ctx, "git.dissociate", func(ctx context.Context) error {
-				return e.dissociateIfNeeded(ctx, existingGitDir)
-			}); err != nil {
-				return fmt.Errorf("dissociating bypassed mirror: %w", err)
-			}
-		} else if mirrorDir != "" {
-			switch e.GitMirrorCheckoutMode {
-			case "dissociate":
-				// If the existing repo is still relying on the reference, then
-				// "dissociate" it (git repack, and delete the alternates file).
-				if err := e.traceOp(ctx, "git.dissociate", func(ctx context.Context) error {
-					return e.dissociateIfNeeded(ctx, existingGitDir)
-				}); err != nil {
-					return fmt.Errorf("dissociating existing reference clone: %w", err)
-				}
-			case "reference":
-				// If the existing repo does not have a reference to the mirror,
-				// create one. Existing objects don't need cleaning up.
-				if err := e.reassociateIfNeeded(ctx, existingGitDir, mirrorDir); err != nil {
-					return fmt.Errorf("reassociating existing clone: %w", err)
-				}
-			}
-		}
-
-	} else { // the .git directory does not already exist
-
-		// Compute the clone flags. For mirrors we need --reference, and usually
-		// --dissociate.
-		if mirrorDir != "" {
-			gitCloneFlags = append(gitCloneFlags, "--reference", mirrorDir)
-			if e.GitMirrorCheckoutMode == "dissociate" {
-				gitCloneFlags = append(gitCloneFlags, "--dissociate")
-			}
-		}
-
-		// When sparse checkout applies, add two clone flags:
-		//   --sparse             clone in sparse mode
-		//   --filter=blob:none   make it a partial clone, so blobs outside the
-		//                        sparse set aren't downloaded up front
-		// Each flag is added only if the user hasn't already supplied their own.
-		if sparse.active() {
-			if slices.Contains(gitCloneFlags, "--sparse") {
-				e.shell.Commentf("Sparse checkout is configured and BUILDKITE_GIT_CLONE_FLAGS already contains a --sparse flag (preserving user-supplied sparse checkout).")
-			} else {
-				gitCloneFlags = append(gitCloneFlags, "--sparse")
-			}
-			if userSuppliedCloneFilter {
-				e.shell.Commentf("Sparse checkout is configured and BUILDKITE_GIT_CLONE_FLAGS already contains a --filter (preserving user-supplied filter).")
-			} else {
-				gitCloneFlags = append(gitCloneFlags, "--filter=blob:none")
-			}
-		}
-
-		// Do the clone.
-		cloneSpan, cloneCtx := e.traceOpSpan(ctx, "git.clone")
-		mirrorMode := "none"
-		if mirrorDir != "" {
-			mirrorMode = e.GitMirrorCheckoutMode
-		}
-		cloneSpan.AddAttributes(map[string]string{
-			"git.mirror_mode":     mirrorMode,
-			"git.sparse":          strconv.FormatBool(sparse.active()),
-			"git.blobless_filter": strconv.FormatBool(hasPartialFilterFlags(gitCloneFlags)),
-		})
-
-		cloneErr := gitClone(cloneCtx, e.shell, nil, gitCloneFlags, e.Repository, ".")
-
-		cloneSpan.FinishWithError(cloneErr)
-
-		if cloneErr != nil {
-			return fmt.Errorf("cloning git repository: %w", cloneErr)
-		}
+	if err := e.prepareCheckoutWorkdir(ctx, &attempt, sparse, mirrorDir, gitCloneFlags, userSuppliedCloneFilter); err != nil {
+		return err
 	}
 
 	// Git clean prior to checkout, we do this even if submodules have been

--- a/internal/job/checkout_workdir.go
+++ b/internal/job/checkout_workdir.go
@@ -149,7 +149,9 @@ func (e *Executor) prepareCheckoutWorkdir(
 			return ctxErr
 		}
 		if cloneErr == nil {
-			alternateObjects := osutil.FileExists(filepath.Join(e.shell.Getwd(), ".git", "objects", "info", "alternates"))
+			ambientAlternates, _ := e.shell.Env.Get("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+			alternateObjects := ambientAlternates != "" ||
+				osutil.FileExists(filepath.Join(e.shell.Getwd(), ".git", "objects", "info", "alternates"))
 			if hasCommit && (!shallowClone || !alternateObjects) {
 				// C1: a shallow hit keeps the mirror snapshot's boundary even
 				// if canonical has advanced. Re-cloning every hit would discard

--- a/internal/job/checkout_workdir.go
+++ b/internal/job/checkout_workdir.go
@@ -1,0 +1,205 @@
+package job
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/buildkite/agent/v3/internal/osutil"
+	"github.com/buildkite/agent/v3/internal/shell"
+)
+
+// prepareCheckoutWorkdir reconciles an existing checkout or clones a fresh one.
+// It intentionally owns the complete existing-vs-fresh decision so checkout.go
+// remains orchestration rather than accumulating another cross-cutting branch.
+func (e *Executor) prepareCheckoutWorkdir(
+	ctx context.Context,
+	attempt *remoteMirrorAttempt,
+	sparse sparseCheckout,
+	mirrorDir string,
+	gitCloneFlags []string,
+	userSuppliedCloneFilter bool,
+) (retErr error) {
+	// On mirrors and dissociation:
+	//
+	// --reference makes the clone reuse objects from the mirror, using the
+	// .git/objects/info/alternates file. On its own, it won't copy the objects
+	// from the mirror, just refer to them. This becomes a problem if they
+	// disappear, which happens during routine normal use of the mirror.
+	//
+	// --dissociate makes copies of the objects from the mirror, which makes the
+	// clone robust against that failure, at the expense of disk space and extra
+	// work up front.
+	//
+	// --dissociate is safer, so it's what we want, but it can be disabled. It
+	// is important even when CleanCheckout is enabled, because auto-maintenance
+	// can happen on the mirror at any time!
+
+	existingGitDir := filepath.Join(e.shell.Getwd(), ".git")
+	if osutil.FileExists(existingGitDir) {
+		if _, err := e.updateRemoteURL(ctx, "", e.Repository); err != nil {
+			return fmt.Errorf("setting origin: %w", err)
+		}
+
+		if mirrorDir == "" && e.GitMirrorsPath != "" {
+			// A bypassed mirror must not remain reachable through a stale alternate.
+			if err := e.traceOp(ctx, "git.dissociate", func(ctx context.Context) error {
+				return e.dissociateIfNeeded(ctx, existingGitDir)
+			}); err != nil {
+				return fmt.Errorf("dissociating bypassed mirror: %w", err)
+			}
+		} else if mirrorDir != "" {
+			switch e.GitMirrorCheckoutMode {
+			case "dissociate":
+				if err := e.traceOp(ctx, "git.dissociate", func(ctx context.Context) error {
+					return e.dissociateIfNeeded(ctx, existingGitDir)
+				}); err != nil {
+					return fmt.Errorf("dissociating existing reference clone: %w", err)
+				}
+			case "reference":
+				if err := e.reassociateIfNeeded(ctx, existingGitDir, mirrorDir); err != nil {
+					return fmt.Errorf("reassociating existing clone: %w", err)
+				}
+			}
+		}
+		return nil
+	}
+
+	if mirrorDir != "" {
+		gitCloneFlags = append(gitCloneFlags, "--reference", mirrorDir)
+		if e.GitMirrorCheckoutMode == "dissociate" {
+			gitCloneFlags = append(gitCloneFlags, "--dissociate")
+		}
+	}
+
+	if sparse.active() {
+		if slices.Contains(gitCloneFlags, "--sparse") {
+			e.shell.Commentf("Sparse checkout is configured and BUILDKITE_GIT_CLONE_FLAGS already contains a --sparse flag (preserving user-supplied sparse checkout).")
+		} else {
+			gitCloneFlags = append(gitCloneFlags, "--sparse")
+		}
+		if userSuppliedCloneFilter {
+			e.shell.Commentf("Sparse checkout is configured and BUILDKITE_GIT_CLONE_FLAGS already contains a --filter (preserving user-supplied filter).")
+		} else {
+			gitCloneFlags = append(gitCloneFlags, "--filter=blob:none")
+		}
+	}
+
+	cloneSpan, cloneCtx := e.traceOpSpan(ctx, "git.clone")
+	mirrorMode := "none"
+	if mirrorDir != "" {
+		mirrorMode = e.GitMirrorCheckoutMode
+	}
+	cloneSpan.AddAttributes(map[string]string{
+		"git.mirror_mode":     mirrorMode,
+		"git.sparse":          strconv.FormatBool(sparse.active()),
+		"git.blobless_filter": strconv.FormatBool(hasPartialFilterFlags(gitCloneFlags)),
+	})
+	defer func() { cloneSpan.FinishWithError(retErr) }()
+
+	cloneCheckout := func(
+		gitFlags []string,
+		repository string,
+		runOpts ...shell.RunCommandOpt,
+	) error {
+		return gitClone(cloneCtx, e.shell, gitFlags, gitCloneFlags, repository, ".", runOpts...)
+	}
+	if isFreshCloneRemoteMirrorAttempt(attempt) {
+		started := time.Now()
+		// C3: a mirror without filter support silently performs a full
+		// transfer. Preserve Git's clone semantics and expose the cost through
+		// telemetry rather than reconstructing clone capability negotiation.
+		cloneErr := cloneCheckout(
+			remoteMirrorBulkGitFlags(ctx),
+			attempt.url,
+			shell.AlwaysHidePrompt(),
+		)
+		if cloneErr == nil {
+			// C1/C14: refs initially reflect the mirror, but durable origin is
+			// canonical and a killed process self-heals on the next checkout.
+			cloneErr = e.shell.Command(
+				"git", "remote", "set-url", "origin", e.Repository,
+			).Run(ctx)
+		}
+		shallowClone := false
+		if cloneErr == nil {
+			shallow, err := e.shell.Command(
+				"git", "rev-parse", "--is-shallow-repository",
+			).RunAndCaptureStdout(ctx)
+			if err != nil {
+				cloneErr = fmt.Errorf("determining whether mirror clone is shallow: %w", err)
+			} else {
+				shallowClone = strings.TrimSpace(shallow) == "true"
+			}
+		}
+		hasCommit := false
+		if cloneErr == nil {
+			hasCommit = hasGitCommit(ctx, e.shell, ".git", e.Commit)
+		}
+		attempt.duration = time.Since(started)
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if cleanupErr := e.removeCheckoutDir(); cleanupErr != nil {
+				return errors.Join(ctxErr, cleanupErr)
+			}
+			return ctxErr
+		}
+		if cloneErr == nil {
+			alternateObjects := osutil.FileExists(filepath.Join(e.shell.Getwd(), ".git", "objects", "info", "alternates"))
+			if hasCommit && (!shallowClone || !alternateObjects) {
+				// C1: a shallow hit keeps the mirror snapshot's boundary even
+				// if canonical has advanced. Re-cloning every hit would discard
+				// the optimization for the shallow workloads it targets.
+				attempt.outcome = remoteMirrorOutcomeHit
+				return nil
+			}
+			attempt.outcome = remoteMirrorOutcomeMiss
+			if !shallowClone {
+				// Keep the useful mirror clone. fetchSource will fetch only
+				// the missing immutable commit from canonical.
+				return nil
+			}
+
+			// A canonical fetch into a lagging shallow clone keeps the
+			// mirror's old shallow boundary and can expose extra history.
+			// Alternates can also make a missing mirror commit look present.
+			// Re-clone so canonical owns the shallow boundary in both cases.
+			e.shell.Commentf("Remote Git mirror is lagging for a shallow clone; cloning from canonical repository")
+			if cleanupErr := e.removeCheckoutDir(); cleanupErr != nil {
+				return cleanupErr
+			}
+			if err := e.createCheckoutDir(); err != nil {
+				return err
+			}
+		} else {
+			var gitErr *gitError
+			if errors.As(cloneErr, &gitErr) && gitErr.Type == gitErrorCloneTimeout {
+				attempt.outcome = remoteMirrorOutcomeTimeout
+			} else {
+				attempt.outcome = remoteMirrorOutcomeError
+			}
+			if cleanupErr := e.removeCheckoutDir(); cleanupErr != nil {
+				return errors.Join(cloneErr, cleanupErr)
+			}
+			if err := e.createCheckoutDir(); err != nil {
+				return errors.Join(cloneErr, err)
+			}
+			e.shell.Commentf("Remote Git mirror clone failed; falling back to canonical repository")
+		}
+	}
+
+	if err := cloneCheckout(nil, e.Repository); err != nil {
+		return fmt.Errorf("cloning git repository: %w", err)
+	}
+	return nil
+}
+
+func isFreshCloneRemoteMirrorAttempt(attempt *remoteMirrorAttempt) bool {
+	return attempt != nil &&
+		attempt.site == remoteMirrorSiteFreshClone &&
+		attempt.outcome == remoteMirrorOutcomeNotReached
+}

--- a/internal/job/checkout_workdir_remote_mirror_test.go
+++ b/internal/job/checkout_workdir_remote_mirror_test.go
@@ -167,6 +167,56 @@ func TestPrepareCheckoutWorkdirReclonesShallowReferenceFalseHit(t *testing.T) {
 	}
 }
 
+func TestPrepareCheckoutWorkdirReclonesShallowAmbientAlternateFalseHit(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	if err := canonical.SetDefaultBranch("canonical", "main"); err != nil {
+		t.Fatal(err)
+	}
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	if err := mirror.SetDefaultBranch("mirror", "main"); err != nil {
+		t.Fatal(err)
+	}
+
+	source := filepath.Join(t.TempDir(), "source")
+	runGitForMirrorTest(t, "", "clone", canonical.RepoURL("canonical"), source)
+	if err := os.WriteFile(filepath.Join(source, "second.txt"), []byte("second\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForMirrorTest(t, source, "add", "second.txt")
+	runGitForMirrorTest(t, source, "commit", "-m", "Advance main")
+	runGitForMirrorTest(t, source, "push", "origin", "main")
+	commit := gitOutputForRemoteCheckoutTest(t, source, "rev-parse", "HEAD")
+
+	reference := filepath.Join(t.TempDir(), "reference.git")
+	cloneOnHostMirrorToPath(t, canonical.RepoURL("canonical"), reference)
+	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+	e.shell.Env.Set("GIT_ALTERNATE_OBJECT_DIRECTORIES", filepath.Join(reference, "objects"))
+	if err := e.prepareCheckoutWorkdir(
+		t.Context(),
+		&attempt,
+		sparseCheckout{},
+		"",
+		[]string{"--depth=1"},
+		false,
+	); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeMiss {
+		t.Fatalf("outcome = %q, want ambient alternate shallow hit treated as miss", attempt.outcome)
+	}
+	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+		t.Fatalf("fetchSource() error = %v", err)
+	}
+
+	control := filepath.Join(t.TempDir(), "canonical-control")
+	runGitForMirrorTest(t, "", "clone", "--depth=1", canonical.RepoURL("canonical"), control)
+	gotShallow := readRemoteMirrorTestFile(t, filepath.Join(e.shell.Getwd(), ".git", "shallow"))
+	wantShallow := readRemoteMirrorTestFile(t, filepath.Join(control, ".git", "shallow"))
+	if gotShallow != wantShallow {
+		t.Errorf("shallow boundary = %q, want canonical boundary %q", gotShallow, wantShallow)
+	}
+}
+
 func TestPrepareCheckoutWorkdirRecursiveSubmodulesUseCanonical(t *testing.T) {
 	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
 	commit, _, err := canonical.PushBranch("canonical", "feature-branch")

--- a/internal/job/checkout_workdir_remote_mirror_test.go
+++ b/internal/job/checkout_workdir_remote_mirror_test.go
@@ -1,0 +1,684 @@
+package job
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent/v3/internal/osutil"
+	"github.com/buildkite/agent/v3/internal/process"
+	"github.com/buildkite/agent/v3/internal/shell"
+	"github.com/buildkite/shellwords"
+)
+
+func TestPrepareCheckoutWorkdirRemoteMirrorHitSkipsCanonicalFetch(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+	canonical.Close()
+
+	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", []string{"-v"}, false); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeHit {
+		t.Errorf("outcome = %q, want hit", attempt.outcome)
+	}
+	assertGitConfigForRemoteMirrorTest(t, e.shell.Getwd(), "remote.origin.url", e.Repository)
+	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+		t.Fatalf("fetchSource() after hit error = %v", err)
+	}
+}
+
+func TestPrepareCheckoutWorkdirKeepsLaggingMirrorClone(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+
+	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", []string{"-v"}, false); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeMiss {
+		t.Errorf("outcome = %q, want miss", attempt.outcome)
+	}
+	if _, err := os.Stat(filepath.Join(e.shell.Getwd(), ".git")); err != nil {
+		t.Errorf("useful lagging mirror clone was discarded: %v", err)
+	}
+	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+		t.Fatalf("canonical delta fetch error = %v", err)
+	}
+	if !hasGitCommit(t.Context(), e.shell, ".git", commit) {
+		t.Error("canonical delta fetch did not add requested commit")
+	}
+}
+
+func TestPrepareCheckoutWorkdirReclonesLaggingShallowMirror(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	if err := canonical.SetDefaultBranch("canonical", "main"); err != nil {
+		t.Fatal(err)
+	}
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	if err := mirror.SetDefaultBranch("mirror", "main"); err != nil {
+		t.Fatal(err)
+	}
+
+	source := filepath.Join(t.TempDir(), "source")
+	runGitForMirrorTest(t, "", "clone", canonical.RepoURL("canonical"), source)
+	if err := os.WriteFile(filepath.Join(source, "second.txt"), []byte("second\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForMirrorTest(t, source, "add", "second.txt")
+	runGitForMirrorTest(t, source, "commit", "-m", "Advance main")
+	runGitForMirrorTest(t, source, "push", "origin", "main")
+	commit := gitOutputForRemoteCheckoutTest(t, source, "rev-parse", "HEAD")
+
+	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+	if err := e.prepareCheckoutWorkdir(
+		t.Context(),
+		&attempt,
+		sparseCheckout{},
+		"",
+		[]string{"--dept=1"},
+		false,
+	); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeMiss {
+		t.Fatalf("outcome = %q, want lag miss", attempt.outcome)
+	}
+	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+		t.Fatalf("fetchSource() error = %v", err)
+	}
+
+	control := filepath.Join(t.TempDir(), "canonical-control")
+	runGitForMirrorTest(t, "", "clone", "--depth=1", canonical.RepoURL("canonical"), control)
+	gotShallow := readRemoteMirrorTestFile(t, filepath.Join(e.shell.Getwd(), ".git", "shallow"))
+	wantShallow := readRemoteMirrorTestFile(t, filepath.Join(control, ".git", "shallow"))
+	if gotShallow != wantShallow {
+		t.Errorf("shallow boundary = %q, want canonical boundary %q", gotShallow, wantShallow)
+	}
+	gotCount := gitOutputForRemoteCheckoutTest(t, e.shell.Getwd(), "rev-list", "--count", commit)
+	wantCount := gitOutputForRemoteCheckoutTest(t, control, "rev-list", "--count", commit)
+	if gotCount != wantCount {
+		t.Errorf("reachable commit count = %s, want canonical shallow count %s", gotCount, wantCount)
+	}
+}
+
+func TestPrepareCheckoutWorkdirReclonesShallowReferenceFalseHit(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	if err := canonical.SetDefaultBranch("canonical", "main"); err != nil {
+		t.Fatal(err)
+	}
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	if err := mirror.SetDefaultBranch("mirror", "main"); err != nil {
+		t.Fatal(err)
+	}
+
+	source := filepath.Join(t.TempDir(), "source")
+	runGitForMirrorTest(t, "", "clone", canonical.RepoURL("canonical"), source)
+	if err := os.WriteFile(filepath.Join(source, "second.txt"), []byte("second\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForMirrorTest(t, source, "add", "second.txt")
+	runGitForMirrorTest(t, source, "commit", "-m", "Advance main")
+	runGitForMirrorTest(t, source, "push", "origin", "main")
+	commit := gitOutputForRemoteCheckoutTest(t, source, "rev-parse", "HEAD")
+
+	reference := filepath.Join(t.TempDir(), "reference.git")
+	cloneOnHostMirrorToPath(t, canonical.RepoURL("canonical"), reference)
+	flags := []string{"--depth=1", "--reference", reference}
+	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", flags, false); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeMiss {
+		t.Fatalf("outcome = %q, want ambiguous shallow reference treated as miss", attempt.outcome)
+	}
+	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+		t.Fatalf("fetchSource() error = %v", err)
+	}
+
+	control := filepath.Join(t.TempDir(), "canonical-control")
+	runGitForMirrorTest(t, "", "clone", "--depth=1", "--reference", reference, canonical.RepoURL("canonical"), control)
+	gotShallow := readRemoteMirrorTestFile(t, filepath.Join(e.shell.Getwd(), ".git", "shallow"))
+	wantShallow := readRemoteMirrorTestFile(t, filepath.Join(control, ".git", "shallow"))
+	if gotShallow != wantShallow {
+		t.Errorf("shallow boundary = %q, want canonical boundary %q", gotShallow, wantShallow)
+	}
+}
+
+func TestPrepareCheckoutWorkdirRecursiveSubmodulesUseCanonical(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, _ := newFreshCloneRemoteMirrorExecutor(
+		t,
+		canonical.RepoURL("canonical"),
+		"https://mirror.example/repo.git",
+		commit,
+	)
+	e.GitCloneFlags = "--recurse-submodules"
+	attempt := e.resolveRemoteMirrorAttempt(0)
+
+	if err := e.prepareCheckoutWorkdir(
+		t.Context(),
+		&attempt,
+		sparseCheckout{},
+		"",
+		[]string{"--recurse-submodules"},
+		false,
+	); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeSkipped || attempt.skipReason != remoteMirrorSkipRecursiveSubmodules {
+		t.Errorf("attempt = (%q, %q), want skipped recursive-submodules", attempt.outcome, attempt.skipReason)
+	}
+	assertGitConfigForRemoteMirrorTest(t, e.shell.Getwd(), "remote.origin.url", e.Repository)
+}
+
+func TestPrepareCheckoutWorkdirHidesRemoteURLPromptInDebug(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+	logs := &bytes.Buffer{}
+	commandOutput := &process.Buffer{}
+	debugShell, err := shell.New(
+		shell.WithDebug(true),
+		shell.WithEnv(e.shell.Env),
+		shell.WithLogger(shell.NewWriterLogger(logs, false, nil)),
+		shell.WithStdout(commandOutput),
+		shell.WithWD(e.shell.Getwd()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.shell = debugShell
+
+	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", nil, false); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if strings.Contains(logs.String(), attempt.url) {
+		t.Errorf("debug job log contains remote mirror URL prompt: %q", logs.String())
+	}
+}
+
+func TestPrepareCheckoutWorkdirRemoteMirrorFailureFallsBack(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), "http://127.0.0.1:1/mirror.git", commit)
+
+	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", []string{"-v"}, false); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeError {
+		t.Errorf("outcome = %q, want error", attempt.outcome)
+	}
+	assertGitConfigForRemoteMirrorTest(t, e.shell.Getwd(), "remote.origin.url", e.Repository)
+	if !hasGitCommit(t.Context(), e.shell, ".git", commit) {
+		t.Error("canonical fallback clone does not contain requested commit")
+	}
+}
+
+func TestPrepareCheckoutWorkdirRemoteMirrorTimeoutFallsBack(t *testing.T) {
+	oldLowSpeedTime := remoteMirrorLowSpeedTime
+	remoteMirrorLowSpeedTime = 1
+	t.Cleanup(func() { remoteMirrorLowSpeedTime = oldLowSpeedTime })
+
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stalled := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		<-req.Context().Done()
+	}))
+	t.Cleanup(stalled.Close)
+	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), stalled.URL+"/mirror.git", commit)
+
+	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", []string{"-v"}, false); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeTimeout {
+		t.Errorf("outcome = %q, want timeout", attempt.outcome)
+	}
+	assertGitConfigForRemoteMirrorTest(t, e.shell.Getwd(), "remote.origin.url", e.Repository)
+}
+
+func TestPrepareCheckoutWorkdirAllowsDelayedFirstByteBelowStallGuard(t *testing.T) {
+	oldLowSpeedTime := remoteMirrorLowSpeedTime
+	remoteMirrorLowSpeedTime = 1
+	t.Cleanup(func() { remoteMirrorLowSpeedTime = oldLowSpeedTime })
+
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	target, err := url.Parse(mirror.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	delayed := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		proxy.ServeHTTP(rw, req)
+	}))
+	t.Cleanup(delayed.Close)
+	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), delayed.URL+"/mirror.git", commit)
+
+	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", []string{"-v"}, false); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeHit {
+		t.Errorf("outcome = %q, want hit below low-speed time", attempt.outcome)
+	}
+}
+
+func TestPrepareCheckoutWorkdirRemoteMirrorCancellationDoesNotFallback(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	requested := make(chan struct{})
+	var requestedOnce sync.Once
+	hung := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		requestedOnce.Do(func() { close(requested) })
+		<-req.Context().Done()
+	}))
+	t.Cleanup(hung.Close)
+	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), hung.URL+"/mirror.git", commit)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	go func() {
+		select {
+		case <-requested:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	err = e.prepareCheckoutWorkdir(ctx, &attempt, sparseCheckout{}, "", []string{"-v"}, false)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v, want context.Canceled", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeNotReached {
+		t.Errorf("outcome = %q, want not reached", attempt.outcome)
+	}
+	if _, err := os.Stat(filepath.Join(e.shell.Getwd(), ".git")); !os.IsNotExist(err) {
+		t.Error("cancelled mirror clone started canonical fallback")
+	}
+}
+
+func TestPrepareCheckoutWorkdirPartialCloneUsesCanonicalAfterMirrorRemoval(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	if err := canonical.ConfigureRepository("canonical", "uploadpack.allowFilter", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := canonical.ConfigureRepository("canonical", "uploadpack.allowAnySHA1InWant", "true"); err != nil {
+		t.Fatal(err)
+	}
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	if err := mirror.ConfigureRepository("mirror", "uploadpack.allowFilter", "true"); err != nil {
+		t.Fatal(err)
+	}
+	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+
+	if err := e.prepareCheckoutWorkdir(
+		t.Context(),
+		&attempt,
+		sparseCheckout{},
+		"",
+		[]string{"-v", "--filter=blob:none"},
+		true,
+	); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	mirror.Close()
+	runGitForMirrorTest(t, e.shell.Getwd(), "checkout", "--force", commit)
+	if got := readRemoteMirrorTestFile(t, filepath.Join(e.shell.Getwd(), "newfile.txt")); got != "This is a new file." {
+		t.Errorf("materialised file = %q, want canonical lazy fetch", got)
+	}
+}
+
+func TestPrepareCheckoutWorkdirSparseCloneKeepsBloblessShape(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	if err := mirror.ConfigureRepository("mirror", "uploadpack.allowFilter", "true"); err != nil {
+		t.Fatal(err)
+	}
+	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+	sparse := sparseCheckout{paths: []string{"src/"}, mode: SparseCheckoutModeCone}
+
+	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparse, "", []string{"-v"}, false); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeHit {
+		t.Fatalf("outcome = %q, want hit", attempt.outcome)
+	}
+
+	control := filepath.Join(t.TempDir(), "canonical-sparse")
+	runGitForMirrorTest(t, "", "clone", "--sparse", "--filter=blob:none", canonical.RepoURL("canonical"), control)
+	for _, key := range []string{
+		"core.sparseCheckout",
+		"core.sparseCheckoutCone",
+		"remote.origin.partialclonefilter",
+	} {
+		got := gitConfigForRemoteMirrorTest(t, e.shell.Getwd(), key)
+		want := gitConfigForRemoteMirrorTest(t, control, key)
+		if got != want {
+			t.Errorf("%s = %q, want canonical sparse clone value %q", key, got, want)
+		}
+	}
+}
+
+func TestPrepareCheckoutWorkdirUnsupportedFilterSilentlyTransfersAllObjects(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+
+	if err := e.prepareCheckoutWorkdir(
+		t.Context(),
+		&attempt,
+		sparseCheckout{},
+		"",
+		[]string{"--filter=blob:none"},
+		true,
+	); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeHit {
+		t.Fatalf("outcome = %q, want hit despite unsupported filter", attempt.outcome)
+	}
+	missing := gitOutputForRemoteCheckoutTest(t, e.shell.Getwd(), "rev-list", "--objects", "--all", "--missing=print")
+	for _, line := range strings.Split(missing, "\n") {
+		if strings.HasPrefix(line, "?") {
+			t.Fatalf("unsupported filter left a missing object %q; want silent full transfer", line)
+		}
+	}
+}
+
+func newFreshCloneRemoteMirrorExecutor(
+	t *testing.T,
+	canonicalURL, mirrorURL, commit string,
+) (*Executor, remoteMirrorAttempt) {
+	t.Helper()
+	checkout := t.TempDir()
+	e := New(ExecutorConfig{
+		Repository:         canonicalURL,
+		GitRemoteMirrorURL: mirrorURL,
+		Commit:             commit,
+		Branch:             "feature-branch",
+		PullRequest:        "false",
+		GitFetchFlags:      "-v --prune",
+	})
+	e.shell = shell.NewTestShell(t, shell.WithSignalGracePeriod(10*time.Millisecond))
+	e.shell.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", checkout)
+	if err := e.createCheckoutDir(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if e.checkoutRoot != nil {
+			_ = e.checkoutRoot.Close()
+			e.checkoutRoot = nil
+		}
+	})
+	return e, remoteMirrorAttempt{
+		site: remoteMirrorSiteFreshClone,
+		url:  mirrorURL,
+	}
+}
+
+func TestPrepareCheckoutWorkdirPreservesCloneConfig(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+	if err := mirror.ConfigureRepository("mirror", "uploadpack.allowFilter", "true"); err != nil {
+		t.Fatal(err)
+	}
+	referenceMirror := filepath.Join(t.TempDir(), "reference.git")
+	cloneOnHostMirrorToPath(t, canonical.RepoURL("canonical"), referenceMirror)
+
+	tests := []struct {
+		name         string
+		flags        []string
+		referenceDir string
+		mirrorMode   string
+	}{
+		{name: "depth", flags: []string{"--depth=1"}},
+		{name: "filter", flags: []string{"--filter=blob:none"}},
+		{name: "single branch", flags: []string{"--single-branch"}},
+		{name: "no tags", flags: []string{"--no-tags"}},
+		{name: "reference", referenceDir: referenceMirror, mirrorMode: "reference"},
+		{name: "dissociate", referenceDir: referenceMirror, mirrorMode: "dissociate"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+			e.GitMirrorCheckoutMode = tc.mirrorMode
+			if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, tc.referenceDir, tc.flags, hasPartialFilterFlags(tc.flags)); err != nil {
+				t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+			}
+			if attempt.outcome != remoteMirrorOutcomeHit && attempt.outcome != remoteMirrorOutcomeMiss {
+				t.Fatalf("outcome = %q, want successful mirror clone (hit or lag miss)", attempt.outcome)
+			}
+			if got := gitConfigForRemoteMirrorTest(t, e.shell.Getwd(), "remote.origin.url"); got != canonical.RepoURL("canonical") {
+				t.Errorf("origin = %q, want canonical", got)
+			}
+
+			control := filepath.Join(t.TempDir(), "canonical-control")
+			cloneArgs := append([]string{"clone"}, tc.flags...)
+			if tc.referenceDir != "" {
+				cloneArgs = append(cloneArgs, "--reference", tc.referenceDir)
+				if tc.mirrorMode == "dissociate" {
+					cloneArgs = append(cloneArgs, "--dissociate")
+				}
+			}
+			cloneArgs = append(cloneArgs, canonical.RepoURL("canonical"), control)
+			runGitForMirrorTest(t, "", cloneArgs...)
+			for _, key := range []string{
+				"remote.origin.fetch",
+				"remote.origin.tagOpt",
+				"remote.origin.promisor",
+				"remote.origin.partialclonefilter",
+			} {
+				got := gitConfigForRemoteMirrorTest(t, e.shell.Getwd(), key)
+				want := gitConfigForRemoteMirrorTest(t, control, key)
+				if got != want {
+					t.Errorf("%s = %q, want canonical clone value %q", key, got, want)
+				}
+			}
+			gotShallow := gitOutputForRemoteCheckoutTest(t, e.shell.Getwd(), "rev-parse", "--is-shallow-repository")
+			wantShallow := gitOutputForRemoteCheckoutTest(t, control, "rev-parse", "--is-shallow-repository")
+			if gotShallow != wantShallow {
+				t.Errorf("shallow repository = %q, want canonical clone value %q", gotShallow, wantShallow)
+			}
+			gotAlternates := osutil.FileExists(filepath.Join(e.shell.Getwd(), ".git", "objects", "info", "alternates"))
+			wantAlternates := osutil.FileExists(filepath.Join(control, ".git", "objects", "info", "alternates"))
+			if gotAlternates != wantAlternates {
+				t.Errorf("alternates present = %t, want canonical clone value %t", gotAlternates, wantAlternates)
+			}
+		})
+	}
+}
+
+func TestPrepareCheckoutWorkdirRequiredSmudgeFailureFallsBackToCanonical(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test smudge shim is POSIX-only")
+	}
+
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	source := filepath.Join(t.TempDir(), "source")
+	runGitForMirrorTest(t, "", "clone", canonical.RepoURL("canonical"), source)
+	runGitForMirrorTest(t, source, "checkout", "-B", "main", "origin/main")
+	if err := os.WriteFile(filepath.Join(source, ".gitattributes"), []byte("*.bin filter=testfilter\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "asset.bin"), []byte("pointer-content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForMirrorTest(t, source, "add", ".gitattributes", "asset.bin")
+	runGitForMirrorTest(t, source, "commit", "-m", "Add filtered asset")
+	runGitForMirrorTest(t, source, "push", "origin", "HEAD:refs/heads/main")
+	commit := gitOutputForRemoteCheckoutTest(t, source, "rev-parse", "HEAD")
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
+
+	state := filepath.Join(t.TempDir(), "smudge-attempted")
+	script := filepath.Join(t.TempDir(), "smudge")
+	body := "#!/bin/sh\nif [ ! -e " + shellwords.Quote(state) + " ]; then : > " + shellwords.Quote(state) + "; exit 1; fi\ncat\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
+	flags := []string{
+		"--branch=main",
+		"--config", "filter.testfilter.smudge=" + script,
+		"--config", "filter.testfilter.required=true",
+	}
+
+	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", flags, false); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if attempt.outcome != remoteMirrorOutcomeError {
+		t.Errorf("outcome = %q, want mirror clone error", attempt.outcome)
+	}
+	if got := readRemoteMirrorTestFile(t, filepath.Join(e.shell.Getwd(), "asset.bin")); got != "pointer-content" {
+		t.Errorf("asset content = %q, want canonical fallback to materialise it", got)
+	}
+}
+
+func TestPrepareCheckoutWorkdirGitLFSBehavior(t *testing.T) {
+	if err := exec.Command("git", "lfs", "version").Run(); err != nil {
+		t.Skip("git-lfs is not installed")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GIT_LFS_SKIP_SMUDGE", "0")
+	runGitForMirrorTest(t, "", "lfs", "install", "--skip-repo")
+	t.Setenv("GIT_AUTHOR_NAME", "Buildkite Agent")
+	t.Setenv("GIT_AUTHOR_EMAIL", "agent@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "Buildkite Agent")
+	t.Setenv("GIT_COMMITTER_EMAIL", "agent@example.com")
+
+	canonical := filepath.Join(t.TempDir(), "canonical.git")
+	runGitForMirrorTest(t, "", "init", "--bare", canonical)
+	source := filepath.Join(t.TempDir(), "source")
+	runGitForMirrorTest(t, "", "init", "--initial-branch=main", source)
+	runGitForMirrorTest(t, source, "lfs", "install", "--local")
+	runGitForMirrorTest(t, source, "lfs", "track", "*.bin")
+	asset := bytes.Repeat([]byte("lfs-content-"), 10_000)
+	if err := os.WriteFile(filepath.Join(source, "asset.bin"), asset, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForMirrorTest(t, source, "add", ".gitattributes", "asset.bin")
+	runGitForMirrorTest(t, source, "commit", "-m", "Add LFS asset")
+	runGitForMirrorTest(t, source, "remote", "add", "origin", canonical)
+	runGitForMirrorTest(t, source, "push", "origin", "main")
+	runGitForMirrorTest(t, source, "lfs", "push", "origin", "--all")
+	runGitForMirrorTest(t, "", "--git-dir", canonical, "symbolic-ref", "HEAD", "refs/heads/main")
+	commit := gitOutputForRemoteCheckoutTest(t, source, "rev-parse", "HEAD")
+
+	mirror := copyOnHostMirrorHTTPRepo(t, canonical, "mirror")
+	if err := mirror.SetDefaultBranch("mirror", "main"); err != nil {
+		t.Fatal(err)
+	}
+	control := filepath.Join(t.TempDir(), "canonical-control")
+	runGitForMirrorTest(t, "", "clone", canonical, control)
+	controlInfo, err := os.Stat(filepath.Join(control, "asset.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := controlInfo.Size(), int64(len(asset)); got != want {
+		t.Fatalf("canonical control asset size = %d, want %d", got, want)
+	}
+
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("enabled=%t", enabled), func(t *testing.T) {
+			e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical, mirror.RepoURL("mirror"), commit)
+			e.GitLFSEnabled = enabled
+			e.shell.Env.Set("HOME", home)
+			e.shell.Env.Set("GIT_CONFIG_GLOBAL", filepath.Join(home, ".gitconfig"))
+			e.shell.Env.Set("GIT_CONFIG_COUNT", "3")
+			e.shell.Env.Set("GIT_CONFIG_KEY_0", "filter.lfs.smudge")
+			e.shell.Env.Set("GIT_CONFIG_VALUE_0", "git-lfs smudge -- %f")
+			e.shell.Env.Set("GIT_CONFIG_KEY_1", "filter.lfs.process")
+			e.shell.Env.Set("GIT_CONFIG_VALUE_1", "git-lfs filter-process")
+			e.shell.Env.Set("GIT_CONFIG_KEY_2", "filter.lfs.required")
+			e.shell.Env.Set("GIT_CONFIG_VALUE_2", "true")
+			if enabled {
+				// This is existing executor behavior, not a mirror-specific
+				// workaround. The later LFS phase materialises from canonical.
+				e.shell.Env.Set("GIT_LFS_SKIP_SMUDGE", "1")
+			}
+
+			if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", nil, false); err != nil {
+				t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+			}
+			if enabled {
+				if attempt.outcome != remoteMirrorOutcomeHit {
+					t.Errorf("outcome = %q, want hit with existing skip-smudge behavior", attempt.outcome)
+				}
+				if err := gitLFSFetchCheckout(t.Context(), gitLFSFetchCheckoutArgs{Shell: e.shell}); err != nil {
+					t.Fatalf("gitLFSFetchCheckout() error = %v", err)
+				}
+			} else if attempt.outcome != remoteMirrorOutcomeError {
+				t.Errorf("outcome = %q, want loud mirror LFS error and canonical fallback", attempt.outcome)
+			}
+
+			info, err := os.Stat(filepath.Join(e.shell.Getwd(), "asset.bin"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantSize := int64(len(asset))
+			if got := info.Size(); got != wantSize {
+				t.Errorf("asset size = %d, want %d (enabled=%t)", got, wantSize, enabled)
+			}
+		})
+	}
+}

--- a/internal/job/githttptest/githttptest.go
+++ b/internal/job/githttptest/githttptest.go
@@ -71,6 +71,16 @@ func (s *Server) ConfigureRepository(repoName, key, value string) error {
 	return nil
 }
 
+func (s *Server) SetDefaultBranch(repoName, branch string) error {
+	repoPath := filepath.Join(s.repositories, repoName)
+	cmd := exec.Command("git", "symbolic-ref", "HEAD", "refs/heads/"+branch)
+	cmd.Dir = repoPath
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("setting default branch for repository %q: %w\n%s", repoName, err, out)
+	}
+	return nil
+}
+
 func (s *Server) InitRepository(repoName string) ([]byte, error) {
 	tempDir, err := os.MkdirTemp("", "git-init-")
 	if err != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Clone fresh checkouts from the remote mirror, then restore canonical `origin`.

A hit skips redundant canonical commit acquisition. Useful non-shallow lagging clones are retained; lagging shallow and alternate-backed apparent hits re-clone canonically.

## Context

A real clone preserves Git’s clone semantics. Remote mirrors require Git 2.45+; initial Windows support is best-effort and rough-edged.

A confirmed shallow hit keeps the mirror snapshot’s boundary. If canonical has advanced beyond the build commit, that can differ from today’s canonical clone-plus-fetch boundary; re-cloning every shallow hit would remove the required optimization for shallow workloads. Configured depth and the exact backend commit remain preserved.

## Changes

- Extract existing workdir reconciliation and cloning.
- Clone with complete flags and debug-proof hidden URL prompts.
- Restore canonical `origin` and locally confirm the immutable commit.
- Ask Git whether the clone is shallow, covering accepted option abbreviations.
- Re-clone lagging shallow clones and shallow apparent hits backed by `.git/objects/info/alternates` or `GIT_ALTERNATE_OBJECT_DIRECTORIES`.
- Keep useful non-shallow lagging clones and fetch only the missing delta.
- Keep recursive-submodule and separate-Git-directory clone modes canonical.
- Preserve cancellation, partial/sparse/single-branch/no-tags/reference/dissociate and existing LFS behavior.

F1 packfile/bundle URI offload and F2 mirror-routed lazy materialisation remain gated follow-ups.

## Testing

Real Git fixtures and race tests cover hit, lag, failure, timeout, cancellation, delayed first byte, partial/sparse behavior, clone flag parity, unsupported filters, LFS, shallow abbreviation and both file-backed and ambient-alternate false hits, recursive and separate-Git-directory bypass, and debug prompt hiding. Focused workdir tests, the full `internal/job` package, package race coverage, lint, and the full Buildkite pipeline pass.

## Disclosures / Credits

Implemented with Cursor under human direction. Independent review drove native shallow detection, explicit snapshot-boundary acceptance, file-backed and ambient-alternates handling, eligibility boundaries, and logging hardening.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6f11793-178a-4772-9f71-e334584fc275?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6f11793-178a-4772-9f71-e334584fc275&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

