### PR TITLE
fix(cache): verify cache checksum on restore

### DIFF
--- a/internal/cache/integration_test.go
+++ b/internal/cache/integration_test.go
@@ -564,6 +564,62 @@ func TestCacheIntegration_RestoreMissingBlobInvalidates(t *testing.T) {
 	}
 }
 
+// TestCacheIntegration_RestoreDigestMismatchIsMiss proves a blob whose bytes no
+// longer match its content-addressed name is treated as a clean miss: the
+// download is verified before any target folder is touched, so existing files
+// are left intact, nothing is unpacked, and the build continues.
+func TestCacheIntegration_RestoreDigestMismatchIsMiss(t *testing.T) {
+	ctx := t.Context()
+
+	cacheClient, cacheDir, storageDir := setupTestCache(t, "local_file")
+	mockClient := cacheClient.api.(*mockAPIClient)
+
+	// Save so the entry is committed and the blob exists.
+	saveResult, err := cacheClient.Save(ctx, "test-cache")
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if !saveResult.CacheEntryCreated {
+		t.Fatal("expected initial save to create an entry")
+	}
+
+	// Corrupt the stored blob in place: keep its content-addressed name but
+	// replace the bytes, so the fingerprint no longer matches the name.
+	blobPath := filepath.Join(storageDir, saveResult.Archive.Sha256Sum)
+	if err := os.WriteFile(blobPath, []byte("corrupted-not-a-real-archive"), 0o644); err != nil {
+		t.Fatalf("corrupt blob: %v", err)
+	}
+
+	// A sentinel in the target folder must survive: verification happens before
+	// cleaning, so a mismatch never wipes good existing state.
+	sentinel := filepath.Join(cacheDir, "pre-existing.txt")
+	if err := os.WriteFile(sentinel, []byte("keep me"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	// Restore must not error and must report a clean miss.
+	restoreResult, err := cacheClient.Restore(ctx, "test-cache")
+	if err != nil {
+		t.Fatalf("Restore with a corrupt blob should not error, got: %v", err)
+	}
+	if restoreResult.CacheRestored {
+		t.Error("digest mismatch should degrade to CacheRestored=false")
+	}
+	if restoreResult.CacheHit {
+		t.Error("digest mismatch should not be a cache hit")
+	}
+
+	// Existing target files are untouched.
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("pre-existing target file should be untouched, stat: %v", err)
+	}
+
+	// The entry is not invalidated on a mismatch — only skipped for this restore.
+	if len(mockClient.expireCalls) != 0 {
+		t.Errorf("digest mismatch should not invalidate the entry; expire calls = %d, want 0", len(mockClient.expireCalls))
+	}
+}
+
 // TODO: restore fallback-matching coverage (was TestCacheIntegration_RestoreWithFallback,
 // removed in the v2 migration) once agent-side fallback_limit parsing lands and the agent
 // sends mandatory:false parts. Until then the agent only addresses exact matches.

--- a/internal/cache/restore.go
+++ b/internal/cache/restore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -19,6 +20,11 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 )
+
+// ErrDigestMismatch means a downloaded blob's bytes don't hash to the
+// content-addressed name it was fetched under (e.g. a corrupt or half-written
+// upload). Restore treats it as a clean miss and never unpacks the file.
+var ErrDigestMismatch = errors.New("cache blob digest mismatch")
 
 // Restore restores a cache from storage by ID.
 //
@@ -195,6 +201,26 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 			c.callProgress(cacheID, "complete", "Cache miss (missing blob, invalidated stale entry)", 0, 0)
 			return result, nil
 		}
+		if errors.Is(err, ErrDigestMismatch) {
+			// The blob doesn't match its fingerprint. downloadCache verified this
+			// before any target folder was touched, so existing files are intact.
+			// Treat it as a clean miss and let the build continue; leave the entry
+			// in place (it isn't the entry that's wrong, it's the stored bytes).
+			slog.Warn("cache blob digest mismatch, treating as miss",
+				"cache_id", cacheID, "err", err)
+			result.CacheHit = false
+			result.FallbackUsed = false
+			result.CacheRestored = false
+			result.TotalDuration = time.Since(startTime)
+			span.SetAttributes(
+				attribute.Bool("cache.hit", false),
+				attribute.Bool("cache.restored", false),
+				attribute.Bool("cache.digest_mismatch", true),
+			)
+			span.SetStatus(codes.Ok, "cache miss (digest mismatch)")
+			c.callProgress(cacheID, "complete", "Cache miss (blob digest mismatch)", 0, 0)
+			return result, nil
+		}
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to download cache")
 		return result, fmt.Errorf("failed to download cache: %w", err)
@@ -362,9 +388,61 @@ func (c *client) downloadCache(ctx context.Context, retrieveResp api.CacheEntryR
 		attribute.Float64("cache.transfer_speed_mbps", transferInfo.TransferSpeed),
 		attribute.String("cache.request_id", transferInfo.RequestID),
 	)
+
+	// Verify the download matches its content-addressed name before returning it
+	// to the caller, so a bad blob never reaches the target folders.
+	if err := verifyBlobDigest(ctx, archiveFile, retrieveResp.Blobs[0].Digest); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		span.RecordError(err)
+		if errors.Is(err, ErrDigestMismatch) {
+			span.SetAttributes(attribute.Bool("cache.digest_mismatch", true))
+		}
+		span.SetStatus(codes.Error, "cache blob digest verification failed")
+		return "", "", nil, err
+	}
+
 	span.SetStatus(codes.Ok, "download completed")
 
 	return tmpDir, archiveFile, transferInfo, nil
+}
+
+// verifyBlobDigest re-hashes the downloaded archive and confirms it matches the
+// content-addressed name it was fetched under, reusing the streaming SHA-256
+// calculator save uses.
+func verifyBlobDigest(ctx context.Context, archiveFile string, digest api.CacheDigest) error {
+	if digest.Algorithm != "sha256" {
+		return nil
+	}
+	f, err := os.Open(archiveFile)
+	if err != nil {
+		return fmt.Errorf("failed to open archive for digest check: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Hash in chunks, checking ctx between reads, so a cancelled restore aborts
+	// promptly instead of reading the whole archive.
+	sum := archive.NewChecksumSHA256(io.Discard)
+	buf := make([]byte, 1024*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		n, err := f.Read(buf)
+		if n > 0 {
+			_, _ = sum.Write(buf[:n])
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to hash archive for digest check: %w", err)
+		}
+	}
+
+	if got := sum.Sum(); got != digest.Value {
+		return fmt.Errorf("%w: computed %s, expected %s", ErrDigestMismatch, got, digest.Value)
+	}
+	return nil
 }
 
 // extractCache extracts files from a cache archive

--- a/internal/cache/restore_test.go
+++ b/internal/cache/restore_test.go
@@ -2,13 +2,60 @@ package cache
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/buildkite/agent/v3/api"
 )
+
+func TestVerifyBlobDigest(t *testing.T) {
+	dir := t.TempDir()
+	archiveFile := filepath.Join(dir, "archive.zip")
+	content := []byte("hello cache archive")
+	if err := os.WriteFile(archiveFile, content, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	sum := sha256.Sum256(content)
+	digestValue := hex.EncodeToString(sum[:])
+
+	t.Run("matching sha256 passes", func(t *testing.T) {
+		err := verifyBlobDigest(context.Background(), archiveFile, api.CacheDigest{Algorithm: "sha256", Value: digestValue})
+		if err != nil {
+			t.Errorf("verifyBlobDigest = %v, want nil", err)
+		}
+	})
+
+	t.Run("mismatched sha256 is ErrDigestMismatch", func(t *testing.T) {
+		err := verifyBlobDigest(context.Background(), archiveFile, api.CacheDigest{Algorithm: "sha256", Value: "deadbeef"})
+		if !errors.Is(err, ErrDigestMismatch) {
+			t.Errorf("verifyBlobDigest = %v, want ErrDigestMismatch", err)
+		}
+	})
+
+	t.Run("unknown algorithm is skipped, not reported corrupt", func(t *testing.T) {
+		// A non-sha256 digest we can't verify must pass through, not be flagged as
+		// a mismatch — otherwise a future wire format breaks every restore.
+		err := verifyBlobDigest(context.Background(), archiveFile, api.CacheDigest{Algorithm: "blake3", Value: "unverifiable"})
+		if err != nil {
+			t.Errorf("verifyBlobDigest with unknown algorithm = %v, want nil (skip)", err)
+		}
+	})
+
+	t.Run("cancelled context aborts", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := verifyBlobDigest(ctx, archiveFile, api.CacheDigest{Algorithm: "sha256", Value: digestValue})
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("verifyBlobDigest with cancelled ctx = %v, want context.Canceled", err)
+		}
+	})
+}
 
 func TestCleanPath(t *testing.T) {
 	t.Run("removes directory and contents", func(t *testing.T) {


### PR DESCRIPTION
## Description

When we download a cache, its object name in storage **is** the SHA-256 of its contents (content-addressed storage). Until now we trusted that the bytes we downloaded matched that name but never checked — so a corrupt or half-written upload would sail through, we'd wipe the target folders, and the failure would surface later as a confusing "not a valid zip file" error, *after* we'd already destroyed any good existing state.

This adds a verification step on restore: re-hash the downloaded archive and confirm it matches the name it was fetched under, **before** we touch any target folder.

- **On match:** carry on and unpack as normal (unchanged behaviour).
- **On mismatch:** treat it as a clean cache miss — never unpack, leave existing files untouched, let the build continue normally, and emit a log line + span attribute so we can see how often it happens.

The entry is deliberately **not** invalidated on a mismatch: the stored bytes are wrong, not the entry, and this is a read-side safety check only.


## Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->
https://linear.app/buildkite/issue/A-1494/verify-cache-checksum-on-restore

## Changes

- Add `verifyBlobDigest` in `internal/cache/restore.go`, reusing the existing streaming `archive.ChecksumSHA256` calculator that save already uses. Unknown digest algorithms are skipped rather than failed, so a future algorithm can't turn every verifiable cache into a false mismatch.
- Call it in `downloadCache` after the download completes and **before returning to the caller** (i.e. before `cleanPath`); on failure it cleans up the temp dir, records `cache.digest_mismatch` on the span, and returns a new `ErrDigestMismatch` sentinel.
- Handle `ErrDigestMismatch` in `Restore` as a clean miss: `CacheHit=false`, `CacheRestored=false`, no error returned, `slog.Warn` + span attributes for observability, no entry invalidation.
- Add `TestCacheIntegration_RestoreDigestMismatchIsMiss`: corrupts a stored blob's bytes (keeping its content-addressed name), then asserts the restore is a clean miss, a pre-existing sentinel file in the target folder survives, and no expire/invalidate call fires.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
