### PR TITLE
fix: Skip post-fetch mirror scan without URL

### DIFF
--- a/internal/job/checkout_mirror.go
+++ b/internal/job/checkout_mirror.go
@@ -271,10 +271,11 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 		}
 	}()
 
-	if isMainRepository &&
-		attempt != nil &&
+	noURLAttempt := attempt != nil &&
 		attempt.outcome == remoteMirrorOutcomeSkipped &&
-		attempt.skipReason == remoteMirrorSkipNoURL &&
+		attempt.skipReason == remoteMirrorSkipNoURL
+	if isMainRepository &&
+		noURLAttempt &&
 		hasGitCommit(ctx, e.shell, mirrorDir, e.Commit) {
 		// Avoid the global reachability scan when remote mirroring is not configured.
 		e.shell.Commentf("Commit %q exists in mirror", e.Commit)
@@ -391,6 +392,7 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 
 	// Unpinned objects are unsafe through --reference; fail open rather than manage recovery refs.
 	if isMainRepository &&
+		!noURLAttempt &&
 		hasGitCommit(ctx, e.shell, mirrorDir, e.Commit) &&
 		!hasGitCommitReachableFromRef(ctx, e.shell, mirrorDir, e.Commit) {
 		e.shell.Warningf("Commit %q exists in mirror without a durable ref; using canonical repository without it", e.Commit)

--- a/internal/job/checkout_mirror_remote_test.go
+++ b/internal/job/checkout_mirror_remote_test.go
@@ -377,6 +377,52 @@ func TestUpdateGitMirrorNoRemoteURLUsesUnpinnedWarmCommit(t *testing.T) {
 	}
 }
 
+func TestUpdateGitMirrorNoRemoteURLSkipsPostFetchReachabilityScan(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), "")
+	mirrorDir := expectedOnHostMirrorDir(e)
+	cloneOnHostMirrorToPath(t, e.Repository, mirrorDir)
+
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := canonical.CreateRef("canonical", "refs/pull/123/head", commit); err != nil {
+		t.Fatal(err)
+	}
+
+	var commandLog [][]string
+	e.shell = shell.NewTestShell(
+		t,
+		shell.WithSignalGracePeriod(10*time.Millisecond),
+		shell.WithCommandLog(&commandLog),
+	)
+	e.Commit = commit
+	e.PullRequest = "123"
+	e.PipelineProvider = "github"
+	attempt := e.resolveRemoteMirrorAttempt(0)
+	if attempt.outcome != remoteMirrorOutcomeSkipped ||
+		attempt.skipReason != remoteMirrorSkipNoURL {
+		t.Fatalf("attempt = %+v, want no-url skip", attempt)
+	}
+
+	gotDir, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
+	if err != nil {
+		t.Fatalf("updateGitMirror() error = %v", err)
+	}
+	if gotDir != mirrorDir {
+		t.Errorf("mirror dir = %q, want %q", gotDir, mirrorDir)
+	}
+	if !hasGitCommit(t.Context(), e.shell, mirrorDir, commit) {
+		t.Fatal("canonical pull request fetch did not add requested commit")
+	}
+	for _, command := range commandLog {
+		if slices.Contains(command, "for-each-ref") {
+			t.Errorf("post-fetch no-URL path ran global reachability scan: %q", command)
+		}
+	}
+}
+
 func TestGetOrUpdateMirrorDirCloneLockTimeoutFallsBackWithoutMirror(t *testing.T) {
 	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
 	commit, _, err := canonical.PushBranch("canonical", "feature-branch")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The first no-URL mirror hotfix restored the fast path only when the requested commit was already present. When a canonical fetch added a missing commit, checkout still ran the final global `for-each-ref --contains` safety scan. On a production mirror that added another 3 minutes 15 seconds after a one-second fetch.

Skip that final reachability scan for the same resolved `no-url` attempt state. The unpinned-object safeguard remains unchanged whenever a remote mirror URL is configured.

## Context

- [Production build showing the remaining post-fetch delay](https://buildkite.com/buildkite/buildkite/builds/207892/canvas?sid=019fcbf6-f05b-4073-912b-055992a7360e&tab=output)
- Follow-up to [#4171](https://github.com/buildkite/agent/pull/4171)

## Changes

- Reuse the no-URL attempt predicate for both the warm-hit and post-fetch paths.
- Bypass the final global reachability scan only for no-URL attempts.
- Add a PR-ref regression that verifies canonical fetch succeeds without invoking `for-each-ref`.

## Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

Focused warm-hit, post-fetch, URL-repair, and configured-remote retry regressions pass under the race detector.

## Disclosures / Credits

Cursor Agent correlated the second production trace with the remaining code path, implemented the focused correction and regression coverage, and ran independent ship-risk, maintainability, and simplicity reviews.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6f11793-178a-4772-9f71-e334584fc275?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6f11793-178a-4772-9f71-e334584fc275&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

