### PR TITLE
e2e tests: Include job logs in agent logs

### DIFF
--- a/internal/e2e/testcase.go
+++ b/internal/e2e/testcase.go
@@ -341,6 +341,7 @@ func (tc *testCase) startAgent(extraArgs ...string) *exec.Cmd {
 	args := append([]string{
 		"start",
 		"--debug",
+		"--write-job-logs-to-stdout",
 		"--token", agentToken,
 		"--name", tc.fullName,
 		"--queue", tc.queue.Key,


### PR DESCRIPTION
## Description

When an e2e test fails, the failed pipeline is still deleted, which makes the job logs inaccessible. This flag includes the job logs in the agent's stdout.

## Context

Noticed while (struggling with) debugging e2e tests.

## Changes

Add `--write-job-logs-to-stdout` to the agent being run for each e2e test.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)


## Disclosures / Credits

I did not use AI tools to write this 1 line