### PR TITLE
[Backport] e2e tests: Include job logs in agent logs

### DIFF
--- a/internal/e2e/testcase.go
+++ b/internal/e2e/testcase.go
@@ -341,6 +341,7 @@ func (tc *testCase) startAgent(extraArgs ...string) *exec.Cmd {
 	args := append([]string{
 		"start",
 		"--debug",
+		"--write-job-logs-to-stdout",
 		"--token", agentToken,
 		"--name", tc.fullName,
 		"--queue", tc.queue.Key,


### PR DESCRIPTION
## Description
 
Backport of #4176 to v3.

## Context

See #4176.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

`jj duplicate`