### PR TITLE
fix: Trust warm mirror hits without reachability scans

### DIFF
--- a/docs/remote-git-mirrors.md
+++ b/docs/remote-git-mirrors.md
@@ -922,8 +922,9 @@ no mirror ref reaches; mirror `gc` may later prune it out from under a
 `--reference` checkout. Proving reachability requires
 `for-each-ref --contains`, a global scan that cost minutes per job on
 production mirrors with hundreds of thousands of refs. Accept the narrow risk
-instead of paying that scan on every warm hit; the namespaced destination ref
-written on every mirror hit still shrinks the unpinned population.
+instead of paying that scan on every warm hit. The namespaced destination ref
+pins every commit the mirror fetch downloads; a commit that is already present
+but unpinned stays unpinned, which is the accepted exposure.
 
 Do not return directly on the remote hit. Record it in the local boolean and let
 the common maintenance and snapshot tail run.

--- a/docs/remote-git-mirrors.md
+++ b/docs/remote-git-mirrors.md
@@ -916,12 +916,14 @@ booleans, skip only the applicable network fetch, and share the existing
 maintenance and snapshot tail. Keep the remote attempt inside the
 `isMainRepository` guard so submodule mirrors remain untouched.
 
-The warm-cache check requires both object presence and reachability from a
-durable ref. A previous fetch can download an object and then fail its
-destination-ref write; if canonical fallback also fails, a presence-only retry
-would skip both sources and hand reference checkouts an object that `gc` may
-remove. Reachability forces the retry to publish the namespaced ref or complete
-the canonical fetch.
+The warm-cache check is presence-only by design (C22). A previous fetch can
+download an object and then fail its destination-ref write, leaving an object
+no mirror ref reaches; mirror `gc` may later prune it out from under a
+`--reference` checkout. Proving reachability requires
+`for-each-ref --contains`, a global scan that cost minutes per job on
+production mirrors with hundreds of thousands of refs. Accept the narrow risk
+instead of paying that scan on every warm hit; the namespaced destination ref
+written on every mirror hit still shrinks the unpinned population.
 
 Do not return directly on the remote hit. Record it in the local boolean and let
 the common maintenance and snapshot tail run.
@@ -958,8 +960,10 @@ mirror; timeout; mirror refuses auth; `--git-mirrors-skip-update` selects a
 checkout-side site instead; submodule mirrors untouched; `refs/heads/*` never
 written by the mirror path; a colliding repository rename is reconciled on a
 remote or warm-cache hit and still runs rename maintenance; clone-lock timeout
-continues canonically without an on-host reference; and cancellation after
-starting mirror work causes no canonical fallback.
+continues canonically without an on-host reference; a warm hit — with or
+without a mirror URL — uses an unpinned commit without any global reachability
+scan (C22); and cancellation after starting mirror work causes no canonical
+fallback.
 
 This first behaviour-changing PR also ships the agent documentation and the
 corresponding `buildkite/docs` update. Later site PRs update those docs rather
@@ -1460,6 +1464,21 @@ immutable commit fetch misses. Origin tracking branch refs are not targeted, and
 R8 still chooses the build by full object ID. Avoiding this would require
 silently changing user fetch semantics for one source. *Comment: at the direct
 mirror fetch in `checkout_fetch.go`.*
+
+**C22 — On-host warm hits trust object presence without proving ref
+reachability.** An unpinned object (interrupted fetch, or a rebuild of a commit
+whose ref was force-pushed away) is lent to `--reference` checkouts and can be
+pruned by mirror `gc`, failing that job with a retryable `bad object` error that
+the checkout retry-clean path heals with a fresh canonical clone. This is a
+deliberate decision, not a gap: the alternative proof is a global
+`for-each-ref --contains` scan that cost minutes per job on production mirrors
+(hundreds of thousands of refs, no commit-graph), and the failure needs an
+unpinned object, a prune past `gc.pruneExpire` (default two weeks), and a
+borrowing checkout to coincide — the same exposure the presence-only check
+shipped with for years before this stack. Do not reintroduce a global
+reachability scan on the checkout path; if stronger pinning is ever needed,
+verify only the expected refs (the namespaced destination ref or the branch
+ref). *Comment: at the warm-cache check in `checkout_mirror.go`.*
 
 ## 11. Gated follow-ups and open questions
 

--- a/internal/job/checkout_mirror.go
+++ b/internal/job/checkout_mirror.go
@@ -272,28 +272,23 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 		}
 	}()
 
-	noURLAttempt := attempt != nil &&
-		attempt.outcome == remoteMirrorOutcomeSkipped &&
-		attempt.skipReason == remoteMirrorSkipNoURL
-	if isMainRepository &&
-		noURLAttempt &&
-		hasGitCommit(ctx, e.shell, mirrorDir, e.Commit) {
-		// Avoid the global reachability scan when remote mirroring is not configured.
-		e.shell.Commentf("Commit %q exists in mirror", e.Commit)
-		return e.snapshotMirror(ctx, repository, mirrorDir)
-	}
-
 	commitAlreadyPresent := false
 	if isMainRepository {
-		// Check again after we get a lock, in case the other process has already updated
-		if hasGitCommit(ctx, e.shell, mirrorDir, e.Commit) &&
-			hasGitCommitReachableFromRef(ctx, e.shell, mirrorDir, e.Commit) {
+		// Check again after we get a lock, in case the other process has already updated.
+		//
+		// Presence-only by design (C22): proving the object is also reachable from a
+		// mirror ref requires a global `for-each-ref --contains` scan, which costs
+		// minutes on large mirrors. An unpinned object pruned by mirror gc fails one
+		// job with a retryable git error that the retry-clean path heals.
+		if hasGitCommit(ctx, e.shell, mirrorDir, e.Commit) {
 			e.shell.Commentf("Commit %q exists in mirror", e.Commit)
 			commitAlreadyPresent = true
 		}
 	}
 
-	e.shell.Commentf("Updating existing repository mirror to find commit %s", e.Commit)
+	if !commitAlreadyPresent {
+		e.shell.Commentf("Updating existing repository mirror to find commit %s", e.Commit)
+	}
 
 	// Update the origin of the repository so we can gracefully handle
 	// repository renames. This must happen before a remote-mirror hit can skip
@@ -389,15 +384,6 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 		if err := e.shell.Command("git", "--git-dir", mirrorDir, "gc").Run(ctx); err != nil {
 			e.shell.Warningf("Couldn't run git gc: %v", err)
 		}
-	}
-
-	// Unpinned objects are unsafe through --reference; fail open rather than manage recovery refs.
-	if isMainRepository &&
-		!noURLAttempt &&
-		hasGitCommit(ctx, e.shell, mirrorDir, e.Commit) &&
-		!hasGitCommitReachableFromRef(ctx, e.shell, mirrorDir, e.Commit) {
-		e.shell.Warningf("Commit %q exists in mirror without a durable ref; using canonical repository without it", e.Commit)
-		return "", nil
 	}
 
 	return e.snapshotMirror(ctx, repository, mirrorDir)

--- a/internal/job/checkout_mirror.go
+++ b/internal/job/checkout_mirror.go
@@ -274,7 +274,7 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 
 	commitAlreadyPresent := false
 	if isMainRepository {
-		// Check again after we get a lock, in case the other process has already updated.
+		// Another process may have fetched the commit while we waited for the lock.
 		//
 		// Presence-only by design (C22): proving the object is also reachable from a
 		// mirror ref requires a global `for-each-ref --contains` scan, which costs

--- a/internal/job/checkout_mirror_remote_test.go
+++ b/internal/job/checkout_mirror_remote_test.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"net/http/httputil"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,7 +13,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -327,57 +324,89 @@ func TestUpdateGitMirrorWarmHitRepairsCollidingCanonicalOrigin(t *testing.T) {
 	}
 }
 
-func TestUpdateGitMirrorNoRemoteURLUsesUnpinnedWarmCommit(t *testing.T) {
-	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
-	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), "")
-	mirrorDir := expectedOnHostMirrorDir(e)
-	cloneOnHostMirrorToPath(t, e.Repository, mirrorDir)
+func TestUpdateGitMirrorWarmHitUsesUnpinnedCommitWithoutScan(t *testing.T) {
+	tests := []struct {
+		name    string
+		attempt func(e *Executor) remoteMirrorAttempt
+	}{
+		{
+			name: "no remote mirror URL",
+			attempt: func(e *Executor) remoteMirrorAttempt {
+				attempt := e.resolveRemoteMirrorAttempt(0)
+				if attempt.outcome != remoteMirrorOutcomeSkipped ||
+					attempt.skipReason != remoteMirrorSkipNoURL {
+					t.Fatalf("attempt = %+v, want no-url skip", attempt)
+				}
+				return attempt
+			},
+		},
+		{
+			name: "remote mirror URL configured",
+			attempt: func(e *Executor) remoteMirrorAttempt {
+				// Port 1 is never contacted: a warm hit skips all fetches.
+				return remoteMirrorAttempt{
+					site: remoteMirrorSiteOnHostMirror,
+					url:  "https://127.0.0.1:1/mirror.git",
+				}
+			},
+		},
+	}
 
-	parent := gitOutputForMirrorTest(t, mirrorDir, "rev-parse", "refs/heads/main")
-	tree := gitOutputForMirrorTest(t, mirrorDir, "rev-parse", "refs/heads/main^{tree}")
-	commit := gitOutputForMirrorTest(
-		t,
-		mirrorDir,
-		"commit-tree", tree,
-		"-p", parent,
-		"-m", "Unpinned warm commit",
-	)
-	if !hasGitCommit(t.Context(), e.shell, mirrorDir, commit) {
-		t.Fatal("test commit is absent from mirror")
-	}
-	if hasGitCommitReachableFromRef(t.Context(), e.shell, mirrorDir, commit) {
-		t.Fatal("test commit unexpectedly reachable from a ref")
-	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+			e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), "")
+			mirrorDir := expectedOnHostMirrorDir(e)
+			cloneOnHostMirrorToPath(t, e.Repository, mirrorDir)
 
-	var commandLog [][]string
-	e.shell = shell.NewTestShell(
-		t,
-		shell.WithSignalGracePeriod(10*time.Millisecond),
-		shell.WithCommandLog(&commandLog),
-	)
-	e.Commit = commit
-	attempt := e.resolveRemoteMirrorAttempt(0)
-	if attempt.outcome != remoteMirrorOutcomeSkipped ||
-		attempt.skipReason != remoteMirrorSkipNoURL {
-		t.Fatalf("attempt = %+v, want no-url skip", attempt)
-	}
-	canonical.Close()
+			parent := gitOutputForMirrorTest(t, mirrorDir, "rev-parse", "refs/heads/main")
+			tree := gitOutputForMirrorTest(t, mirrorDir, "rev-parse", "refs/heads/main^{tree}")
+			commit := gitOutputForMirrorTest(
+				t,
+				mirrorDir,
+				"commit-tree", tree,
+				"-p", parent,
+				"-m", "Unpinned warm commit",
+			)
+			if !hasGitCommit(t.Context(), e.shell, mirrorDir, commit) {
+				t.Fatal("test commit is absent from mirror")
+			}
+			if pinning := gitOutputForMirrorTest(
+				t, mirrorDir, "for-each-ref", "--format=%(refname)", "--contains", commit,
+			); pinning != "" {
+				t.Fatalf("test commit unexpectedly reachable from refs: %q", pinning)
+			}
 
-	gotDir, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
-	if err != nil {
-		t.Fatalf("updateGitMirror() error = %v, want warm mirror fast path", err)
-	}
-	if gotDir != mirrorDir {
-		t.Errorf("mirror dir = %q, want %q", gotDir, mirrorDir)
-	}
-	for _, command := range commandLog {
-		if slices.Contains(command, "for-each-ref") {
-			t.Errorf("warm mirror fast path ran global reachability scan: %q", command)
-		}
+			var commandLog [][]string
+			e.shell = shell.NewTestShell(
+				t,
+				shell.WithSignalGracePeriod(10*time.Millisecond),
+				shell.WithCommandLog(&commandLog),
+			)
+			e.Commit = commit
+			attempt := tc.attempt(e)
+			canonical.Close()
+
+			gotDir, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
+			if err != nil {
+				t.Fatalf("updateGitMirror() error = %v, want warm mirror fast path", err)
+			}
+			if gotDir != mirrorDir {
+				t.Errorf("mirror dir = %q, want %q", gotDir, mirrorDir)
+			}
+			if attempt.outcome == remoteMirrorOutcomeHit {
+				t.Error("warm hit counted as a remote mirror hit")
+			}
+			for _, command := range commandLog {
+				if slices.Contains(command, "for-each-ref") {
+					t.Errorf("warm mirror fast path ran global reachability scan: %q", command)
+				}
+			}
+		})
 	}
 }
 
-func TestUpdateGitMirrorNoRemoteURLSkipsPostFetchReachabilityScan(t *testing.T) {
+func TestUpdateGitMirrorPostFetchSkipsReachabilityScan(t *testing.T) {
 	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
 	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), "")
 	mirrorDir := expectedOnHostMirrorDir(e)
@@ -521,79 +550,45 @@ func TestUpdateGitMirrorRefWriteFailureDoesNotCountAsHit(t *testing.T) {
 	}
 }
 
-func TestUpdateGitMirrorRetryDoesNotTrustUnpinnedCommit(t *testing.T) {
+func TestPrepareCheckoutWorkdirBypassedMirrorDissociatesStaleAlternate(t *testing.T) {
 	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
-	canonicalURL, err := url.Parse(canonical.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	canonicalProxy := httputil.NewSingleHostReverseProxy(canonicalURL)
-	var canonicalAvailable atomic.Bool
-	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if !canonicalAvailable.Load() {
-			http.Error(w, "canonical unavailable", http.StatusServiceUnavailable)
-			return
-		}
-		canonicalProxy.ServeHTTP(w, req)
-	}))
-	t.Cleanup(proxy.Close)
-
-	e := newOnHostMirrorExecutor(t, proxy.URL+"/canonical.git", "")
-	mirrorDir := expectedOnHostMirrorDir(e)
-	cloneOnHostMirrorToPath(t, canonical.RepoURL("canonical"), mirrorDir)
-
-	mainRef := exec.Command("git", "ls-remote", canonical.RepoURL("canonical"), "refs/heads/main")
-	mainOutput, err := mainRef.Output()
-	if err != nil {
-		t.Fatal(err)
-	}
-	mainCommit := strings.Fields(string(mainOutput))[0]
-
 	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
 	if err != nil {
 		t.Fatal(err)
 	}
-	remoteMirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
-	e.GitRemoteMirrorURL = remoteMirror.RepoURL("mirror")
-	if _, err := canonical.CreateRef("canonical", "refs/heads/feature-branch", mainCommit); err != nil {
-		t.Fatal(err)
-	}
-	conflict := filepath.Join(mirrorDir, "refs", "buildkite-agent", "remote-mirror")
-	if err := os.MkdirAll(filepath.Dir(conflict), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(conflict, []byte(commit+"\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), commit)
+	mirrorDir := expectedOnHostMirrorDir(e)
+	cloneOnHostMirrorToPath(t, e.Repository, mirrorDir)
 
-	e.Commit = commit
-	attempt := remoteMirrorAttempt{site: remoteMirrorSiteOnHostMirror, url: remoteMirror.RepoURL("mirror")}
-	if _, err := e.updateGitMirror(t.Context(), e.Repository, &attempt); err == nil {
-		t.Fatal("updateGitMirror() error = nil, want canonical fallback failure")
-	}
-	if !hasGitCommit(t.Context(), e.shell, mirrorDir, commit) {
-		t.Fatal("failed destination ref did not leave the fetched object for retry regression")
-	}
-	if err := os.Remove(conflict); err != nil {
-		t.Fatal(err)
-	}
-
-	canonicalAvailable.Store(true)
-	checkoutDir := t.TempDir()
-	runGitForMirrorTest(t, "", "clone", "--reference", mirrorDir, "--", e.Repository, checkoutDir)
-	alternates := filepath.Join(checkoutDir, ".git", "objects", "info", "alternates")
+	checkout := t.TempDir()
+	runGitForMirrorTest(t, "", "clone", "--reference", mirrorDir, "--", e.Repository, checkout)
+	alternates := filepath.Join(checkout, ".git", "objects", "info", "alternates")
 	if !osutil.FileExists(alternates) {
 		t.Fatal("reference checkout has no alternates file")
 	}
-	e.shell.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", checkoutDir)
-	e.GitMirrorCheckoutMode = "reference"
-	e.GitSkipFetchExistingCommits = true
-
-	if err := e.defaultCheckoutPhase(t.Context(), 1); err == nil {
-		t.Fatal("defaultCheckoutPhase() retry error = nil, want canonical fetch failure for force-pushed commit")
+	if err := e.shell.Chdir(checkout); err != nil {
+		t.Fatal(err)
 	}
+	e.GitMirrorCheckoutMode = "reference"
+
+	// A lock timeout bypasses the mirror: mirrorDir is empty while
+	// GitMirrorsPath remains configured.
+	attempt := remoteMirrorAttempt{
+		site:    remoteMirrorSiteOnHostMirror,
+		url:     "https://127.0.0.1:1/mirror.git",
+		outcome: remoteMirrorOutcomeTimeout,
+	}
+	if err := e.prepareCheckoutWorkdir(
+		t.Context(), &attempt, sparseCheckout{}, "", nil, false,
+	); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+
 	if osutil.FileExists(alternates) {
-		t.Fatal("unsafe checkout alternate remains after mirror bypass")
+		t.Fatal("bypassed mirror remains reachable through a stale alternate")
+	}
+	if !hasGitCommit(t.Context(), e.shell, filepath.Join(checkout, ".git"), commit) {
+		t.Fatal("dissociation lost objects the checkout depends on")
 	}
 }
 

--- a/internal/job/checkout_mirror_remote_test.go
+++ b/internal/job/checkout_mirror_remote_test.go
@@ -406,7 +406,7 @@ func TestUpdateGitMirrorWarmHitUsesUnpinnedCommitWithoutScan(t *testing.T) {
 	}
 }
 
-func TestUpdateGitMirrorPostFetchSkipsReachabilityScan(t *testing.T) {
+func TestUpdateGitMirrorNoRemoteURLPostFetchSkipsReachabilityScan(t *testing.T) {
 	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
 	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), "")
 	mirrorDir := expectedOnHostMirrorDir(e)
@@ -547,48 +547,6 @@ func TestUpdateGitMirrorRefWriteFailureDoesNotCountAsHit(t *testing.T) {
 	}
 	if got, want := gitOutputForMirrorTest(t, mirrorDir, "rev-parse", "refs/heads/feature-branch"), commit; got != want {
 		t.Errorf("canonical fallback branch = %q, want %q", got, want)
-	}
-}
-
-func TestPrepareCheckoutWorkdirBypassedMirrorDissociatesStaleAlternate(t *testing.T) {
-	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
-	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
-	if err != nil {
-		t.Fatal(err)
-	}
-	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), commit)
-	mirrorDir := expectedOnHostMirrorDir(e)
-	cloneOnHostMirrorToPath(t, e.Repository, mirrorDir)
-
-	checkout := t.TempDir()
-	runGitForMirrorTest(t, "", "clone", "--reference", mirrorDir, "--", e.Repository, checkout)
-	alternates := filepath.Join(checkout, ".git", "objects", "info", "alternates")
-	if !osutil.FileExists(alternates) {
-		t.Fatal("reference checkout has no alternates file")
-	}
-	if err := e.shell.Chdir(checkout); err != nil {
-		t.Fatal(err)
-	}
-	e.GitMirrorCheckoutMode = "reference"
-
-	// A lock timeout bypasses the mirror: mirrorDir is empty while
-	// GitMirrorsPath remains configured.
-	attempt := remoteMirrorAttempt{
-		site:    remoteMirrorSiteOnHostMirror,
-		url:     "https://127.0.0.1:1/mirror.git",
-		outcome: remoteMirrorOutcomeTimeout,
-	}
-	if err := e.prepareCheckoutWorkdir(
-		t.Context(), &attempt, sparseCheckout{}, "", nil, false,
-	); err != nil {
-		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
-	}
-
-	if osutil.FileExists(alternates) {
-		t.Fatal("bypassed mirror remains reachable through a stale alternate")
-	}
-	if !hasGitCommit(t.Context(), e.shell, filepath.Join(checkout, ".git"), commit) {
-		t.Fatal("dissociation lost objects the checkout depends on")
 	}
 }
 

--- a/internal/job/checkout_workdir_remote_mirror_test.go
+++ b/internal/job/checkout_workdir_remote_mirror_test.go
@@ -24,6 +24,48 @@ import (
 	"github.com/buildkite/shellwords"
 )
 
+func TestPrepareCheckoutWorkdirBypassedMirrorDissociatesStaleAlternate(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), commit)
+	mirrorDir := expectedOnHostMirrorDir(e)
+	cloneOnHostMirrorToPath(t, e.Repository, mirrorDir)
+
+	checkout := t.TempDir()
+	runGitForMirrorTest(t, "", "clone", "--reference", mirrorDir, "--", e.Repository, checkout)
+	alternates := filepath.Join(checkout, ".git", "objects", "info", "alternates")
+	if !osutil.FileExists(alternates) {
+		t.Fatal("reference checkout has no alternates file")
+	}
+	if err := e.shell.Chdir(checkout); err != nil {
+		t.Fatal(err)
+	}
+	e.GitMirrorCheckoutMode = "reference"
+
+	// A lock timeout bypasses the mirror: mirrorDir is empty while
+	// GitMirrorsPath remains configured.
+	attempt := remoteMirrorAttempt{
+		site:    remoteMirrorSiteOnHostMirror,
+		url:     "https://127.0.0.1:1/mirror.git",
+		outcome: remoteMirrorOutcomeTimeout,
+	}
+	if err := e.prepareCheckoutWorkdir(
+		t.Context(), &attempt, sparseCheckout{}, "", nil, false,
+	); err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+
+	if osutil.FileExists(alternates) {
+		t.Fatal("bypassed mirror remains reachable through a stale alternate")
+	}
+	if !hasGitCommit(t.Context(), e.shell, filepath.Join(checkout, ".git"), commit) {
+		t.Fatal("dissociation lost objects the checkout depends on")
+	}
+}
+
 func TestPrepareCheckoutWorkdirRemoteMirrorHitSkipsCanonicalFetch(t *testing.T) {
 	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
 	commit, _, err := canonical.PushBranch("canonical", "feature-branch")

--- a/internal/job/git.go
+++ b/internal/job/git.go
@@ -103,20 +103,6 @@ func hasGitCommit(ctx context.Context, sh *shell.Shell, gitDir, commit string) b
 	return true
 }
 
-func hasGitCommitReachableFromRef(ctx context.Context, sh *shell.Shell, gitDir, commit string) bool {
-	extraEnv := env.New()
-	extraEnv.Set("GIT_NO_LAZY_FETCH", "1")
-	output, err := sh.Command(
-		"git", "--git-dir", gitDir, "for-each-ref",
-		"--format=%(refname)", "--contains", commit,
-	).RunAndCaptureStdout(
-		ctx,
-		shell.ShowStderr(false),
-		shell.WithExtraEnv(extraEnv),
-	)
-	return err == nil && strings.TrimSpace(output) != ""
-}
-
 func gitCheckout(ctx context.Context, sh *shell.Shell, gitCheckoutFlags, reference string) error {
 	individualCheckoutFlags, err := shellwords.Split(gitCheckoutFlags)
 	if err != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Checkout of large repositories with on-host mirrors stalled for minutes on `git for-each-ref --contains` reachability scans in `updateGitMirror` — observed at 3m15s per job on the buildkite/buildkite mirror, both with and without a remote mirror URL configured. The two prior hotfixes ([#4171](https://github.com/buildkite/agent/pull/4171), [#4172](https://github.com/buildkite/agent/pull/4172)) only exempted the no-URL paths.

This removes the reachability guard entirely and returns warm hits to the presence-only check the agent shipped with for years. That deliberately re-accepts a narrow pre-existing risk: an object present in the mirror but reachable from no mirror ref can be lent to a `--reference` checkout and later pruned by mirror gc. The failure needs an unpinned object (interrupted fetch, or rebuilding a force-pushed-away commit), a prune past `gc.pruneExpire` (default two weeks), and a borrowing checkout to coincide — and it fails one job with a retryable `bad object` error that the existing retry-clean path heals with a fresh canonical clone. The alternative (proving reachability) is inherently a global scan whose cost scales with the repository size the mirror feature exists to serve. The decision is recorded as caveat C22 in `docs/remote-git-mirrors.md`, with guidance to verify only expected refs if stronger pinning is ever wanted.

## Context

- [Production job with remote mirror enabled: 3m17s gap between mirror fetch and clone](https://buildkite.com/buildkite/buildkite/builds/208214/canvas?sid=019fd0b1-e294-4817-a047-efbc458f14db&tab=output)
- Follow-up to [#4171](https://github.com/buildkite/agent/pull/4171) and [#4172](https://github.com/buildkite/agent/pull/4172), which fixed the same stall for jobs without `BUILDKITE_GIT_REMOTE_MIRROR_URL`

## Changes

- Delete `hasGitCommitReachableFromRef` and both call sites (warm-hit check and post-fetch guard).
- Delete both no-URL carve-outs from the prior hotfixes — presence-only now applies uniformly, removing the per-path reasoning that caused three incident rounds.
- Warm hits now flow through the shared `updateRemoteURL` tail instead of returning early, so repository-rename repair runs on warm hits. This also fixes the stale-origin edge Codex flagged on #4171.
- Gate the "Updating existing repository mirror" log message so warm hits no longer log a misleading update.
- Replace the deleted unpinned-retry regression with a table-driven warm-hit test (no-URL and URL-configured) asserting no `for-each-ref` runs, plus a unit test preserving coverage of the bypassed-mirror alternate dissociation.
- Record the accepted risk as caveat C22 in `docs/remote-git-mirrors.md`.

## Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

The full `TestUpdateGitMirror*`, `TestPrepareCheckoutWorkdir*`, and `TestGetOrUpdateMirrorDir*` suites pass under the race detector.

Known trade-offs called out by review, both inside the accepted decision: a present-but-unpinned object is no longer re-pinned by a mirror fetch (it stays unpinned for its gc window), and warm hits on mirrors with colliding canonical URLs (lossy `dirForRepository`) now pay the rename-repair `fsck`/`gc` that the early return previously skipped.

## Disclosures / Credits

Cursor Agent diagnosed the production stalls from job-log timestamps, implemented the removal after the trade-off was decided by a human, and ran independent ship-risk, maintainability, and simplicity reviews.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6f11793-178a-4772-9f71-e334584fc275?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6f11793-178a-4772-9f71-e334584fc275&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

