### PR TITLE
Allow releases from diverged v3 history

### DIFF
--- a/.buildkite/steps/github-release.sh
+++ b/.buildkite/steps/github-release.sh
@@ -69,7 +69,6 @@ release_args=(
   --repo buildkite/agent
   --target "$(git rev-parse HEAD)"
   --generate-notes
-  --fail-on-no-commits
 )
 
 if [[ "${IS_PRERELEASE}" == "1" ]]; then


### PR DESCRIPTION
## Description

Remove `--fail-on-no-commits` from `gh release create` so v3 releases can be cut when consecutive release targets have diverged histories.

The guard caused the v3.136.2 release to abort with `no new commits since the last release`: v3.136.1 contains stabilization reverts, while v3.136.2 continues from the pre-revert v3 history. GitHub can still generate the correct notes for these targets once the guard is removed.

## Context

- Failed release: https://buildkite.com/buildkite/agent-release-stable/builds/236
- Previous release: https://github.com/buildkite/agent/releases/tag/v3.136.1

## Changes

- Retain generated release notes, but stop requiring release targets to have linear commit history.

## Testing

- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)
- `bash -n .buildkite/steps/github-release.sh`
- `git diff --check`
- Confirmed GitHub's release-notes API generates v3.136.2 notes using v3.136.1 as the previous tag.

## Rollback

Revert this PR to restore the linear-history release guard.

## Disclosures / Credits

Amp investigated the failed release, identified the diverged-history interaction, and made the one-line change under direction.
