### PR TITLE
[SUP-7744]: Update artifact retention period from six months to 90 days

### DIFF
--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -27,7 +27,7 @@ You can specify an alternate destination on Amazon S3, Google Cloud Storage
 or Artifactory as per the examples below. This may be specified in the
 'destination' argument, or in the 'BUILDKITE_ARTIFACT_UPLOAD_DESTINATION'
 environment variable.  Otherwise, artifacts are uploaded to a
-Buildkite-managed Amazon S3 bucket, where they’re retained for six months.
+Buildkite-managed Amazon S3 bucket, where they’re retained for 90 days.
 
 Example:
 

--- a/clicommand/artifact_upload.go
+++ b/clicommand/artifact_upload.go
@@ -27,7 +27,7 @@ You can specify an alternate destination on Amazon S3, Google Cloud Storage
 or Artifactory as per the examples below. This may be specified in the
 'destination' argument, or in the 'BUILDKITE_ARTIFACT_UPLOAD_DESTINATION'
 environment variable.  Otherwise, artifacts are uploaded to a
-Buildkite-managed Amazon S3 bucket, where they’re retained for 90 days.
+Buildkite-managed Amazon S3 bucket.
 
 Example:
 


### PR DESCRIPTION
## Description

Corrects the artifact retention period stated in the `buildkite-agent artifact upload` CLI help text. It said "six months," but the actual Buildkite-managed artifact storage retention policy is 90 days.

## Changes

- `clicommand/artifact_upload.go`: updated retention text from "six months" to "90 days"