### PR TITLE
Quiet down logs for assigning priority to agents

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1257,8 +1257,11 @@ var AgentStartCommand = &cli.Command{
 			default:
 				return fmt.Errorf("unknown spawn-with-priority value %s", cfg.SpawnWithPriority)
 			}
-			l.Infof("Assigning priority %s for agent %d", priority, index)
-			registerReq.Priority = priority
+
+			if priority != "" {
+				l.Debugf("Assigning priority %s for agent %d", priority, index)
+				registerReq.Priority = priority
+			}
 
 			regReqs = append(regReqs, registerReq)
 		}


### PR DESCRIPTION
## Description

In https://github.com/buildkite/agent/pull/3821, we promoted the `descending-spawn-priority` experiment into the flag `--spawn-with-priority static|ascending|descending`. However, now, when launching multiple agents with no specific priority, you get logs like:
```
2026-08-07 09:46:08 INFO   Configuration loaded path=.buildkite-agent.cfg
2026-08-07 09:46:08 INFO   Registering agent 1 of 4 with Buildkite...
2026-08-07 09:46:08 INFO   Assigning priority  for agent 1
2026-08-07 09:46:08 INFO   Registering agent 2 of 4 with Buildkite...
2026-08-07 09:46:08 INFO   Assigning priority  for agent 2
2026-08-07 09:46:08 INFO   Registering agent 3 of 4 with Buildkite...
2026-08-07 09:46:08 INFO   Assigning priority  for agent 3
2026-08-07 09:46:08 INFO   Registering agent 4 of 4 with Buildkite...
2026-08-07 09:46:08 INFO   Assigning priority  for agent 4
```

(note that the priority we're assigning is an empty string)

This PR makes it so that:
- The log for `Assigning priority 123 for agent 1` gets demoted to `DEBUG`
- It's only logged if priority is non-default

## Context

It was annoying me.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Disclosures / Credits

This little firecracker of a PR came straight off the top of the dome.
