### PR TITLE
Emit git.remote_mirror.duration_ms as a numeric span attribute

### DIFF
--- a/internal/job/checkout_remote_mirror.go
+++ b/internal/job/checkout_remote_mirror.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildkite/agent/v4/internal/redact"
 	"github.com/buildkite/agent/v4/tracetools"
 	"github.com/buildkite/shellwords"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -315,10 +316,12 @@ func (e *Executor) emitRemoteMirrorTelemetry(span trace.Span, attempt remoteMirr
 	if attempt.skipReason != remoteMirrorSkipNone {
 		attributes["git.remote_mirror.skip_reason"] = string(attempt.skipReason)
 	}
-	if attempt.duration > 0 {
-		attributes["git.remote_mirror.duration_ms"] = strconv.FormatInt(attempt.duration.Milliseconds(), 10)
-	}
 	tracetools.AddAttributes(span, attributes)
+	if attempt.duration > 0 {
+		// Set as a numeric attribute (not a string) so tracing backends can
+		// treat it as a measure rather than a tag.
+		span.SetAttributes(attribute.Int64("git.remote_mirror.duration_ms", attempt.duration.Milliseconds()))
+	}
 
 	message := "Remote Git mirror: outcome=" + attempt.outcome.String() + " site=" + attempt.site.String()
 	if attempt.skipReason != remoteMirrorSkipNone {

--- a/internal/job/checkout_remote_mirror_test.go
+++ b/internal/job/checkout_remote_mirror_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/buildkite/agent/v4/internal/shell"
 	"github.com/buildkite/shellwords"
 	"github.com/google/go-cmp/cmp"
+	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
@@ -329,6 +330,11 @@ func TestRemoteMirrorTelemetrySchema(t *testing.T) {
 			gotAttrs := make(map[string]string)
 			for _, kv := range gotSpan.Attributes() {
 				gotAttrs[string(kv.Key)] = kv.Value.String()
+				if string(kv.Key) == "git.remote_mirror.duration_ms" {
+					if got, want := kv.Value.Type(), attribute.INT64; got != want {
+						t.Errorf("attribute %q type = %v, want %v (numeric so tracing backends can use it as a measure)", kv.Key, got, want)
+					}
+				}
 			}
 			if diff := cmp.Diff(gotAttrs, tc.wantAttrs); diff != "" {
 				t.Errorf("attributes diff (-got +want):\n%s", diff)


### PR DESCRIPTION
## What

Changes `git.remote_mirror.duration_ms` from a string span attribute to a numeric (`attribute.Int64`) one.

## Why

The remote-mirror telemetry added in #4165 stringified the duration (`strconv.FormatInt`) because the old `tracetools.Span` interface only accepted string attributes. Now that spans are raw OTel `trace.Span`, we can set it as an int64 directly.

String-typed durations arrive in tracing backends as tags rather than measures, so they can't be used for aggregation, percentiles, or dashboard formulas (e.g. avg/p95 remote mirror probe latency in Datadog).

## Changes

- `emitRemoteMirrorTelemetry` sets `git.remote_mirror.duration_ms` via `attribute.Int64` instead of adding it to the string attribute map
- `TestRemoteMirrorTelemetrySchema` now asserts the attribute's OTel value type is `INT64`

No behaviour change beyond the attribute type; the attribute key, value, and emission conditions are unchanged.