### PR TITLE
Remove tracetools.AddAttributes; use typed span attributes

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"runtime"
 	"slices"
-	"strconv"
 	"time"
 
 	"github.com/buildkite/agent/v4/internal/experiments"
@@ -17,6 +16,7 @@ import (
 	"github.com/buildkite/agent/v4/tracetools"
 	"github.com/buildkite/roko"
 	"github.com/buildkite/shellwords"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // CheckoutPhase creates the build directory and makes sure we're running the
@@ -327,12 +327,12 @@ func (e *Executor) runDefaultCheckoutAttempt(ctx context.Context, previousAttemp
 // previousAttempts is the count of prior checkout attempts.
 func (e *Executor) defaultCheckoutPhase(ctx context.Context, previousAttempts int) (retErr error) {
 	span, spanCtx := tracetools.StartSpanFromContext(ctx, "repo-checkout", e.TracingBackend)
-	tracetools.AddAttributes(span, map[string]string{
-		"checkout.repo_name": redact.URLCredentials(e.Repository),
-		"checkout.refspec":   e.RefSpec,
-		"checkout.commit":    e.Commit,
-		"checkout.attempt":   strconv.Itoa(previousAttempts + 1),
-	})
+	span.SetAttributes(
+		attribute.String("checkout.repo_name", redact.URLCredentials(e.Repository)),
+		attribute.String("checkout.refspec", e.RefSpec),
+		attribute.String("checkout.commit", e.Commit),
+		attribute.Int("checkout.attempt", previousAttempts+1),
+	)
 	defer func() { tracetools.FinishWithError(span, retErr) }()
 
 	attempt := e.resolveRemoteMirrorAttempt(previousAttempts)
@@ -358,12 +358,12 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context, previousAttempts in
 
 	// If we can, get a mirror of the git repository to use for reference later
 	if e.GitMirrorsPath != "" && e.Repository != "" {
-		tracetools.AddAttributes(span, map[string]string{"checkout.is_using_git_mirrors": "true"})
+		span.SetAttributes(attribute.Bool("checkout.is_using_git_mirrors", true))
 
 		var err error
 
 		mirrorSpan, mirrorCtx := e.traceOpSpan(ctx, "git.mirror.update")
-		tracetools.AddAttributes(mirrorSpan, map[string]string{"git.repo": redact.URLCredentials(e.Repository)})
+		mirrorSpan.SetAttributes(attribute.String("git.repo", redact.URLCredentials(e.Repository)))
 
 		mirrorDir, err = e.getOrUpdateMirrorDir(mirrorCtx, e.Repository, &attempt)
 
@@ -454,10 +454,10 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context, previousAttempts in
 	if sparse.active() {
 		sparseMode = sparse.mode.String()
 	}
-	tracetools.AddAttributes(sparseSpan, map[string]string{
-		"git.path_count":  strconv.Itoa(len(sparse.paths)),
-		"git.sparse_mode": sparseMode,
-	})
+	sparseSpan.SetAttributes(
+		attribute.Int("git.path_count", len(sparse.paths)),
+		attribute.String("git.sparse_mode", sparseMode),
+	)
 
 	sparseCheckoutActive, err := e.setupSparseCheckout(sparseCtx, sparse)
 
@@ -582,7 +582,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context, previousAttempts in
 // with a plain clean update.
 func (e *Executor) updateGitSubmodules(ctx context.Context) (retErr error) {
 	submodulesSpan, ctx := e.traceOpSpan(ctx, "git.submodules")
-	tracetools.AddAttributes(submodulesSpan, map[string]string{"git.mirrored": strconv.FormatBool(e.GitMirrorsPath != "")})
+	submodulesSpan.SetAttributes(attribute.Bool("git.mirrored", e.GitMirrorsPath != ""))
 	defer func() { tracetools.FinishWithError(submodulesSpan, retErr) }()
 
 	// `submodule sync` will ensure the .git/config
@@ -613,7 +613,7 @@ func (e *Executor) updateGitSubmodules(ctx context.Context) (retErr error) {
 		return nil
 	}
 
-	tracetools.AddAttributes(submodulesSpan, map[string]string{"git.count": strconv.Itoa(len(submoduleRepos))})
+	submodulesSpan.SetAttributes(attribute.Int("git.count", len(submoduleRepos)))
 
 	mirrorSubmodules := e.GitMirrorsPath != ""
 	if mirrorSubmodules {
@@ -622,7 +622,7 @@ func (e *Executor) updateGitSubmodules(ctx context.Context) (retErr error) {
 			// this produces the same sub-tree of spans; git.repo distinguishes
 			// submodules since the span names repeat.
 			subMirrorSpan, subMirrorCtx := e.traceOpSpan(ctx, "git.mirror.update")
-			tracetools.AddAttributes(subMirrorSpan, map[string]string{"git.repo": redact.URLCredentials(repository)})
+			subMirrorSpan.SetAttributes(attribute.String("git.repo", redact.URLCredentials(repository)))
 
 			mirrorDir, err := e.getOrUpdateMirrorDir(subMirrorCtx, repository, nil)
 

--- a/internal/job/checkout_fetch.go
+++ b/internal/job/checkout_fetch.go
@@ -10,13 +10,13 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/buildkite/agent/v4/internal/shell"
 	"github.com/buildkite/agent/v4/tracetools"
 	"github.com/buildkite/shellwords"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const remoteMirrorPromisorMarkerKey = "buildkite.remote-mirror-promisor"
@@ -67,10 +67,10 @@ func (e *Executor) fetchSource(ctx context.Context, addBloblessFilter bool, atte
 		kind = refspecBranch
 	}
 
-	tracetools.AddAttributes(span, map[string]string{
-		"git.pull_request": strconv.FormatBool(e.PullRequest != "false"),
-		"git.refspec_kind": string(kind),
-	})
+	span.SetAttributes(
+		attribute.Bool("git.pull_request", e.PullRequest != "false"),
+		attribute.String("git.refspec_kind", string(kind)),
+	)
 
 	if err := e.repairInterruptedRemoteMirrorPromisors(ctx); err != nil {
 		return &gitError{
@@ -86,7 +86,7 @@ func (e *Executor) fetchSource(ctx context.Context, addBloblessFilter bool, atte
 	skipFetch := (e.GitSkipFetchExistingCommits || mirrorHit) && e.Commit != "HEAD" &&
 		hasGitCommit(ctx, e.shell, ".git", e.Commit)
 
-	tracetools.AddAttributes(span, map[string]string{"git.skipped": strconv.FormatBool(skipFetch)})
+	span.SetAttributes(attribute.Bool("git.skipped", skipFetch))
 
 	if skipFetch {
 		e.shell.Commentf("Commit %q already exists locally, skipping fetch", e.Commit)

--- a/internal/job/checkout_mirror.go
+++ b/internal/job/checkout_mirror.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/buildkite/agent/v4/internal/shell"
 	"github.com/buildkite/agent/v4/tracetools"
 	"github.com/buildkite/shellwords"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 func remoteMirrorOnHostRefspec(commit, branch string) string {
@@ -106,7 +106,7 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 
 	mirrorCloneLock, err := e.shell.LockFile(cloneCtx, mirrorDir+".clonelock")
 
-	tracetools.AddAttributes(cloneLockSpan, map[string]string{"git.timed_out": strconv.FormatBool(errors.Is(err, context.DeadlineExceeded))})
+	cloneLockSpan.SetAttributes(attribute.Bool("git.timed_out", errors.Is(err, context.DeadlineExceeded)))
 	tracetools.FinishWithError(cloneLockSpan, err)
 
 	if err != nil {
@@ -257,7 +257,7 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 
 	mirrorUpdateLock, err := e.shell.LockFile(updateCtx, mirrorDir+".updatelock")
 
-	tracetools.AddAttributes(updateLockSpan, map[string]string{"git.timed_out": strconv.FormatBool(errors.Is(err, context.DeadlineExceeded))})
+	updateLockSpan.SetAttributes(attribute.Bool("git.timed_out", errors.Is(err, context.DeadlineExceeded)))
 	tracetools.FinishWithError(updateLockSpan, err)
 
 	if err != nil {

--- a/internal/job/checkout_remote_mirror.go
+++ b/internal/job/checkout_remote_mirror.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/buildkite/agent/v4/internal/osutil"
 	"github.com/buildkite/agent/v4/internal/redact"
-	"github.com/buildkite/agent/v4/tracetools"
 	"github.com/buildkite/shellwords"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -309,19 +308,17 @@ func (e *Executor) fetchCommitFromRemoteMirror(
 }
 
 func (e *Executor) emitRemoteMirrorTelemetry(span trace.Span, attempt remoteMirrorAttempt) {
-	attributes := map[string]string{
-		"git.remote_mirror.outcome": attempt.outcome.String(),
-		"git.remote_mirror.site":    attempt.site.String(),
+	attributes := []attribute.KeyValue{
+		attribute.String("git.remote_mirror.outcome", attempt.outcome.String()),
+		attribute.String("git.remote_mirror.site", attempt.site.String()),
 	}
 	if attempt.skipReason != remoteMirrorSkipNone {
-		attributes["git.remote_mirror.skip_reason"] = string(attempt.skipReason)
+		attributes = append(attributes, attribute.String("git.remote_mirror.skip_reason", string(attempt.skipReason)))
 	}
-	tracetools.AddAttributes(span, attributes)
 	if attempt.duration > 0 {
-		// Set as a numeric attribute (not a string) so tracing backends can
-		// treat it as a measure rather than a tag.
-		span.SetAttributes(attribute.Int64("git.remote_mirror.duration_ms", attempt.duration.Milliseconds()))
+		attributes = append(attributes, attribute.Int64("git.remote_mirror.duration_ms", attempt.duration.Milliseconds()))
 	}
+	span.SetAttributes(attributes...)
 
 	message := "Remote Git mirror: outcome=" + attempt.outcome.String() + " site=" + attempt.site.String()
 	if attempt.skipReason != remoteMirrorSkipNone {

--- a/internal/job/checkout_trace_test.go
+++ b/internal/job/checkout_trace_test.go
@@ -270,12 +270,12 @@ func assertSpanAttr(t *testing.T, s sdktrace.ReadOnlySpan, key, want string) {
 	}
 }
 
-// spanAttr returns the string value of the named attribute, and whether it
-// was present.
+// spanAttr returns the rendered value of the named attribute (regardless of
+// its type), and whether it was present.
 func spanAttr(s sdktrace.ReadOnlySpan, key string) (string, bool) {
 	for _, kv := range s.Attributes() {
 		if string(kv.Key) == key {
-			return kv.Value.AsString(), true
+			return kv.Value.String(), true
 		}
 	}
 	return "", false

--- a/internal/job/checkout_trace_test.go
+++ b/internal/job/checkout_trace_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildkite/agent/v4/internal/shell"
 	"github.com/buildkite/agent/v4/tracetools"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
@@ -23,6 +24,7 @@ func TestTraceGitCheckout_EmitsSpans(t *testing.T) {
 
 	repoCheckout := findOnlySpan(t, spans, "repo-checkout")
 	assertSpanAttr(t, repoCheckout, "checkout.attempt", "1")
+	assertSpanAttrType(t, repoCheckout, "checkout.attempt", attribute.INT64)
 
 	// A fresh clone into an empty checkout dir exercises these spans, all
 	// nested directly under repo-checkout.
@@ -268,6 +270,22 @@ func assertSpanAttr(t *testing.T, s sdktrace.ReadOnlySpan, key, want string) {
 	if !ok || got != want {
 		t.Fatalf("span %q attribute %q = %q (present=%t), want %q", s.Name(), key, got, ok, want)
 	}
+}
+
+// assertSpanAttrType asserts the named span attribute is present and has the
+// given OTel value type, so wire-type changes are caught even though
+// assertSpanAttr compares rendered values.
+func assertSpanAttrType(t *testing.T, s sdktrace.ReadOnlySpan, key string, want attribute.Type) {
+	t.Helper()
+	for _, kv := range s.Attributes() {
+		if string(kv.Key) == key {
+			if got := kv.Value.Type(); got != want {
+				t.Fatalf("span %q attribute %q type = %v, want %v", s.Name(), key, got, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("span %q attribute %q not present", s.Name(), key)
 }
 
 // spanAttr returns the rendered value of the named attribute (regardless of

--- a/internal/job/checkout_workdir.go
+++ b/internal/job/checkout_workdir.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/buildkite/agent/v4/internal/osutil"
 	"github.com/buildkite/agent/v4/internal/shell"
 	"github.com/buildkite/agent/v4/tracetools"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // prepareCheckoutWorkdir reconciles an existing checkout or clones a fresh one.
@@ -96,11 +96,11 @@ func (e *Executor) prepareCheckoutWorkdir(
 	if mirrorDir != "" {
 		mirrorMode = e.GitMirrorCheckoutMode
 	}
-	tracetools.AddAttributes(cloneSpan, map[string]string{
-		"git.mirror_mode":     mirrorMode,
-		"git.sparse":          strconv.FormatBool(sparse.active()),
-		"git.blobless_filter": strconv.FormatBool(hasPartialFilterFlags(gitCloneFlags)),
-	})
+	cloneSpan.SetAttributes(
+		attribute.String("git.mirror_mode", mirrorMode),
+		attribute.Bool("git.sparse", sparse.active()),
+		attribute.Bool("git.blobless_filter", hasPartialFilterFlags(gitCloneFlags)),
+	)
 	defer func() { tracetools.FinishWithError(cloneSpan, retErr) }()
 
 	cloneCheckout := func(

--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -40,6 +40,7 @@ import (
 	"github.com/buildkite/agent/v4/tracetools"
 	"github.com/buildkite/go-pipeline"
 	"github.com/buildkite/shellwords"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // Executor represents the phases of execution in a Buildkite Job. It's run as
@@ -448,12 +449,14 @@ func (e *Executor) executeHook(ctx context.Context, hookCfg HookConfig) (retErr 
 	spanName := fmt.Sprintf("%s %s hook", hookCfg.Scope, hookCfg.Name)
 	span, ctx := tracetools.StartSpanFromContext(ctx, spanName, e.TracingBackend)
 	defer func() { tracetools.FinishWithError(span, retErr) }()
-	tracetools.AddAttributes(span, map[string]string{
-		"hook.type":    hookCfg.Scope,
-		"hook.name":    hookCfg.Name,
-		"hook.command": hookCfg.Path,
-	})
-	tracetools.AddAttributes(span, hookCfg.SpanAttributes)
+	span.SetAttributes(
+		attribute.String("hook.type", hookCfg.Scope),
+		attribute.String("hook.name", hookCfg.Name),
+		attribute.String("hook.command", hookCfg.Path),
+	)
+	for k, v := range hookCfg.SpanAttributes {
+		span.SetAttributes(attribute.String(k, v))
+	}
 	defer e.otlpLogSpan(ctx)()
 
 	hookName := hookCfg.Scope
@@ -1249,10 +1252,10 @@ func (e *Executor) CommandPhase(ctx context.Context) (hookErr, commandErr error)
 func (e *Executor) defaultCommandPhase(ctx context.Context) (retErr error) {
 	span, ctx := tracetools.StartSpanFromContext(ctx, "default command hook", e.TracingBackend)
 	defer func() { tracetools.FinishWithError(span, retErr) }()
-	tracetools.AddAttributes(span, map[string]string{
-		"hook.name": "command",
-		"hook.type": "default",
-	})
+	span.SetAttributes(
+		attribute.String("hook.name", "command"),
+		attribute.String("hook.type", "default"),
+	)
 	defer e.otlpLogSpan(ctx)()
 
 	// Flush the redactors before the OTLP span restore above runs, so any
@@ -1271,7 +1274,7 @@ func (e *Executor) defaultCommandPhase(ctx context.Context) (retErr error) {
 	scriptFileName := strings.ReplaceAll(e.Command, "\n", "")
 	pathToCommand, err := filepath.Abs(filepath.Join(e.shell.Getwd(), scriptFileName))
 	commandIsScript := err == nil && osutil.FileExists(pathToCommand)
-	tracetools.AddAttributes(span, map[string]string{"hook.command": pathToCommand})
+	span.SetAttributes(attribute.String("hook.command", pathToCommand))
 
 	// If the command isn't a script, then it's something we need
 	// to eval. But before we even try running it, we should double

--- a/tracetools/span.go
+++ b/tracetools/span.go
@@ -44,13 +44,6 @@ func StartSpanFromContext(ctx context.Context, operation, tracingBackend string)
 	}
 }
 
-// AddAttributes adds the given map of string attributes to the span.
-func AddAttributes(span trace.Span, attributes map[string]string) {
-	for k, v := range attributes {
-		span.SetAttributes(attribute.String(k, v))
-	}
-}
-
 // FinishWithError records error information on the span (if err isn't nil) and
 // ends the span.
 func FinishWithError(span trace.Span, err error) {

--- a/tracetools/span_test.go
+++ b/tracetools/span_test.go
@@ -2,7 +2,6 @@ package tracetools
 
 import (
 	"errors"
-	"slices"
 	"testing"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -50,24 +49,6 @@ func (t *TestOtelSpan) AddEvent(name string, _ ...trace.EventOption) {
 
 func newTestOtelSpan() *TestOtelSpan {
 	return &TestOtelSpan{events: []string{}, attributes: []attribute.KeyValue{}}
-}
-
-func TestAddAttributes(t *testing.T) {
-	t.Parallel()
-
-	span := newTestOtelSpan()
-
-	if got := len(span.attributes); got != 0 {
-		t.Errorf("span.attributes = %v, want 0", got)
-	}
-
-	AddAttributes(span, map[string]string{"colour": "blue", "flavour": "bittersweet"})
-	if got, want := span.attributes, attribute.String("colour", "blue"); !slices.Contains(got, want) {
-		t.Errorf("span.attributes = %v, want containing %v", got, want)
-	}
-	if got, want := span.attributes, attribute.String("flavour", "bittersweet"); !slices.Contains(got, want) {
-		t.Errorf("span.attributes = %v, want containing %v", got, want)
-	}
 }
 
 func TestFinishWithError(t *testing.T) {


### PR DESCRIPTION
## What

Deletes `tracetools.AddAttributes(span, map[string]string)` and migrates all call sites to `span.SetAttributes(attribute.X(...))` with properly typed attributes.

## Why

The `map[string]string` helper made stringification the path of least resistance: every numeric or boolean span attribute in the checkout code was `strconv`-formatted because the signature demanded it (see #4192 for one instance). The cache and artifact packages, which set typed attributes directly, never had this bug. Removing the helper makes the wrong thing impossible rather than merely detectable — writing a string where a number belongs now requires deliberately typing `attribute.String`.

## Type corrections included

| Attribute | Before | After |
|---|---|---|
| `checkout.attempt` | string | Int |
| `git.count` | string | Int |
| `git.path_count` | string | Int |
| `git.timed_out` | string | Bool |
| `git.skipped` | string | Bool |
| `git.mirrored` | string | Bool |
| `git.sparse` | string | Bool |
| `git.blobless_filter` | string | Bool |
| `git.pull_request` | string | Bool |
| `checkout.is_using_git_mirrors` | string | Bool |

All attribute keys, values, and emission conditions are unchanged; only the wire types differ. Datadog facet queries like `@git.timed_out:true` work identically for boolean attributes.

## Notes

- `tracetools` is exported from the `github.com/buildkite/agent/v4` module, so this is technically a breaking API change — v4 being in beta makes now the time.
- The one dynamic-map call site (`hookCfg.SpanAttributes`, user-supplied hook span attributes) keeps a small inline loop of `attribute.String`.