### PR TITLE
A-1494: Verify cache checksum on restore (backport to v3)

### DIFF
--- a/internal/cache/digest.go
+++ b/internal/cache/digest.go
@@ -1,0 +1,85 @@
+package cache
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/buildkite/agent/v3/api"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+)
+
+// ErrDigestMismatch means a downloaded blob's bytes don't hash to the
+// content-addressed name it was fetched under (e.g. a corrupt or half-written
+// upload). Restore treats it as a clean miss and never unpacks the file.
+var ErrDigestMismatch = errors.New("cache blob digest mismatch")
+
+// verifyBlobDigest re-hashes the downloaded archive and confirms it matches
+// the content-addressed name it was fetched under.
+//
+// This re-reads the file the download just wrote. We considered hashing the
+// bytes in the same pass as the download to avoid the second read, but the
+// blob stores don't expose a sequential byte stream: the S3 downloader writes
+// parts concurrently and out of order via io.WriterAt, and the nsc store
+// shells out to a CLI that writes the file itself. In practice the second
+// read is cheap anyway; the file was written moments earlier, so it is
+// served from the OS page cache, and the SHA-256 cost is the same wherever
+// the bytes are hashed.
+func verifyBlobDigest(ctx context.Context, archiveFile string, digest api.CacheDigest) error {
+	tracer := otel.Tracer("github.com/buildkite/agent/v3/internal/cache")
+	ctx, span := tracer.Start(ctx, "verifyBlobDigest")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("cache.digest_algorithm", digest.Algorithm))
+
+	if digest.Algorithm != "sha256" {
+		span.SetStatus(codes.Ok, "unsupported digest algorithm, verification skipped")
+		return nil
+	}
+
+	f, err := os.Open(archiveFile)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "failed to open archive")
+		return fmt.Errorf("failed to open archive for digest check: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, &contextReader{ctx: ctx, r: f}); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "failed to hash archive")
+		return fmt.Errorf("failed to hash archive for digest check: %w", err)
+	}
+
+	if got := hex.EncodeToString(h.Sum(nil)); got != digest.Value {
+		err := fmt.Errorf("%w: computed %s, expected %s", ErrDigestMismatch, got, digest.Value)
+		span.RecordError(err)
+		span.SetAttributes(attribute.Bool("cache.digest_mismatch", true))
+		span.SetStatus(codes.Error, "digest mismatch")
+		return err
+	}
+
+	span.SetStatus(codes.Ok, "digest verified")
+	return nil
+}
+
+// contextReader wraps an io.Reader so a cancelled restore aborts between reads
+// instead of hashing the whole archive.
+type contextReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (c *contextReader) Read(p []byte) (int, error) {
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return c.r.Read(p)
+}

--- a/internal/cache/digest_test.go
+++ b/internal/cache/digest_test.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildkite/agent/v3/api"
+)
+
+func TestVerifyBlobDigest(t *testing.T) {
+	dir := t.TempDir()
+	archiveFile := filepath.Join(dir, "archive.zip")
+	content := []byte("hello cache archive")
+	if err := os.WriteFile(archiveFile, content, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	sum := sha256.Sum256(content)
+	digestValue := hex.EncodeToString(sum[:])
+
+	t.Run("matching sha256 passes", func(t *testing.T) {
+		err := verifyBlobDigest(t.Context(), archiveFile, api.CacheDigest{Algorithm: "sha256", Value: digestValue})
+		if err != nil {
+			t.Errorf("verifyBlobDigest = %v, want nil", err)
+		}
+	})
+
+	t.Run("mismatched sha256 is ErrDigestMismatch", func(t *testing.T) {
+		err := verifyBlobDigest(t.Context(), archiveFile, api.CacheDigest{Algorithm: "sha256", Value: "deadbeef"})
+		if !errors.Is(err, ErrDigestMismatch) {
+			t.Errorf("verifyBlobDigest = %v, want ErrDigestMismatch", err)
+		}
+	})
+
+	t.Run("unknown algorithm is skipped, not reported corrupt", func(t *testing.T) {
+		// A non-sha256 digest we can't verify must pass through, not be flagged as
+		// a mismatch — otherwise a future wire format breaks every restore.
+		err := verifyBlobDigest(t.Context(), archiveFile, api.CacheDigest{Algorithm: "blake3", Value: "unverifiable"})
+		if err != nil {
+			t.Errorf("verifyBlobDigest with unknown algorithm = %v, want nil (skip)", err)
+		}
+	})
+
+	t.Run("cancelled context aborts", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		err := verifyBlobDigest(ctx, archiveFile, api.CacheDigest{Algorithm: "sha256", Value: digestValue})
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("verifyBlobDigest with cancelled ctx = %v, want context.Canceled", err)
+		}
+	})
+}

--- a/internal/cache/integration_test.go
+++ b/internal/cache/integration_test.go
@@ -857,6 +857,62 @@ func writeManifestlessArchive(t *testing.T, path string) {
 	}
 }
 
+// TestCacheIntegration_RestoreDigestMismatchIsMiss proves a blob whose bytes no
+// longer match its content-addressed name is treated as a clean miss: the
+// download is verified before any target folder is touched, so existing files
+// are left intact, nothing is unpacked, and the build continues.
+func TestCacheIntegration_RestoreDigestMismatchIsMiss(t *testing.T) {
+	ctx := t.Context()
+
+	cacheClient, cacheDir, storageDir := setupTestCache(t, "local_file")
+	mockClient := cacheClient.api.(*mockAPIClient)
+
+	// Save so the entry is committed and the blob exists.
+	saveResult, err := cacheClient.Save(ctx, "test-cache")
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if !saveResult.CacheEntryCreated {
+		t.Fatal("expected initial save to create an entry")
+	}
+
+	// Corrupt the stored blob in place: keep its content-addressed name but
+	// replace the bytes, so the fingerprint no longer matches the name.
+	blobPath := filepath.Join(storageDir, saveResult.Archive.Sha256Sum)
+	if err := os.WriteFile(blobPath, []byte("corrupted-not-a-real-archive"), 0o644); err != nil {
+		t.Fatalf("corrupt blob: %v", err)
+	}
+
+	// A sentinel in the target folder must survive: verification happens before
+	// cleaning, so a mismatch never wipes good existing state.
+	sentinel := filepath.Join(cacheDir, "pre-existing.txt")
+	if err := os.WriteFile(sentinel, []byte("keep me"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	// Restore must not error and must report a clean miss.
+	restoreResult, err := cacheClient.Restore(ctx, "test-cache")
+	if err != nil {
+		t.Fatalf("Restore with a corrupt blob should not error, got: %v", err)
+	}
+	if restoreResult.CacheRestored {
+		t.Error("digest mismatch should degrade to CacheRestored=false")
+	}
+	if restoreResult.CacheHit {
+		t.Error("digest mismatch should not be a cache hit")
+	}
+
+	// Existing target files are untouched.
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("pre-existing target file should be untouched, stat: %v", err)
+	}
+
+	// The entry is not invalidated on a mismatch — only skipped for this restore.
+	if len(mockClient.expireCalls) != 0 {
+		t.Errorf("digest mismatch should not invalidate the entry; expire calls = %d, want 0", len(mockClient.expireCalls))
+	}
+}
+
 // TODO: restore fallback-matching coverage (was TestCacheIntegration_RestoreWithFallback,
 // removed in the v2 migration) once agent-side fallback_limit parsing lands and the agent
 // sends mandatory:false parts. Until then the agent only addresses exact matches.

--- a/internal/cache/integration_test.go
+++ b/internal/cache/integration_test.go
@@ -857,30 +857,52 @@ func writeManifestlessArchive(t *testing.T, path string) {
 	}
 }
 
-// TestCacheIntegration_RestoreDigestMismatchIsMiss proves a blob whose bytes no
-// longer match its content-addressed name is treated as a clean miss: the
-// download is verified before any target folder is touched, so existing files
-// are left intact, nothing is unpacked, and the build continues.
-func TestCacheIntegration_RestoreDigestMismatchIsMiss(t *testing.T) {
+// TestCacheIntegration_RestorePoisonedBlobIsMiss is the flagship cache
+// poisoning case: a perfectly valid archive planted under another entry's
+// content-addressed name. Extraction would succeed silently if attempted, so
+// the digest check is the only defence. A poisoned blob must be a clean miss:
+// verified before any target folder is touched, never unpacked, existing files
+// left intact, and the build continues. The entry is expired so a subsequent
+// save replaces the bad blob instead of missing until TTL.
+func TestCacheIntegration_RestorePoisonedBlobIsMiss(t *testing.T) {
 	ctx := t.Context()
 
 	cacheClient, cacheDir, storageDir := setupTestCache(t, "local_file")
 	mockClient := cacheClient.api.(*mockAPIClient)
 
-	// Save so the entry is committed and the blob exists.
+	// Build the poisoned blob: a valid archive of the same target path that
+	// carries a file an attacker wants planted.
+	backdoor := filepath.Join(cacheDir, "backdoor.sh")
+	if err := os.WriteFile(backdoor, []byte("#!/bin/sh\necho pwned\n"), 0o755); err != nil {
+		t.Fatalf("write backdoor: %v", err)
+	}
+	poisonedSave, err := cacheClient.Save(ctx, "test-cache")
+	if err != nil {
+		t.Fatalf("Save poisoned variant: %v", err)
+	}
+	poisonedBlob, err := os.ReadFile(filepath.Join(storageDir, poisonedSave.Archive.Sha256Sum))
+	if err != nil {
+		t.Fatalf("read poisoned blob: %v", err)
+	}
+
+	// Reset to a clean registry and save the legitimate cache.
+	if err := os.Remove(backdoor); err != nil {
+		t.Fatalf("remove backdoor: %v", err)
+	}
+	mockClient.registries["~"].cache = make(map[string]*mockCacheEntry)
 	saveResult, err := cacheClient.Save(ctx, "test-cache")
 	if err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 	if !saveResult.CacheEntryCreated {
-		t.Fatal("expected initial save to create an entry")
+		t.Fatal("expected save to create an entry")
 	}
 
-	// Corrupt the stored blob in place: keep its content-addressed name but
-	// replace the bytes, so the fingerprint no longer matches the name.
+	// Poison the store: keep the legitimate blob's content-addressed name but
+	// swap in the poisoned bytes, so the fingerprint no longer matches the name.
 	blobPath := filepath.Join(storageDir, saveResult.Archive.Sha256Sum)
-	if err := os.WriteFile(blobPath, []byte("corrupted-not-a-real-archive"), 0o644); err != nil {
-		t.Fatalf("corrupt blob: %v", err)
+	if err := os.WriteFile(blobPath, poisonedBlob, 0o644); err != nil {
+		t.Fatalf("poison blob: %v", err)
 	}
 
 	// A sentinel in the target folder must survive: verification happens before
@@ -893,7 +915,7 @@ func TestCacheIntegration_RestoreDigestMismatchIsMiss(t *testing.T) {
 	// Restore must not error and must report a clean miss.
 	restoreResult, err := cacheClient.Restore(ctx, "test-cache")
 	if err != nil {
-		t.Fatalf("Restore with a corrupt blob should not error, got: %v", err)
+		t.Fatalf("Restore with a poisoned blob should not error, got: %v", err)
 	}
 	if restoreResult.CacheRestored {
 		t.Error("digest mismatch should degrade to CacheRestored=false")
@@ -902,14 +924,32 @@ func TestCacheIntegration_RestoreDigestMismatchIsMiss(t *testing.T) {
 		t.Error("digest mismatch should not be a cache hit")
 	}
 
+	// The poisoned archive was never unpacked.
+	if _, err := os.Stat(backdoor); !os.IsNotExist(err) {
+		t.Errorf("poisoned archive must never be extracted; stat backdoor: %v", err)
+	}
+
 	// Existing target files are untouched.
 	if _, err := os.Stat(sentinel); err != nil {
 		t.Errorf("pre-existing target file should be untouched, stat: %v", err)
 	}
 
-	// The entry is not invalidated on a mismatch — only skipped for this restore.
-	if len(mockClient.expireCalls) != 0 {
-		t.Errorf("digest mismatch should not invalidate the entry; expire calls = %d, want 0", len(mockClient.expireCalls))
+	// The unverifiable entry is expired, targeting the resolved entry address.
+	if len(mockClient.expireCalls) != 1 {
+		t.Fatalf("expire calls = %d, want 1", len(mockClient.expireCalls))
+	}
+	expired := mockClient.expireCalls[0]
+	if len(expired.CacheKey) != 1 || expired.CacheKey[0].Value != "v1-test-key" {
+		t.Errorf("expire targeted cache_key %+v, want single part v1-test-key", expired.CacheKey)
+	}
+
+	// A subsequent save must re-upload, proving the entry was invalidated.
+	resaveResult, err := cacheClient.Save(ctx, "test-cache")
+	if err != nil {
+		t.Fatalf("re-Save: %v", err)
+	}
+	if !resaveResult.CacheEntryCreated {
+		t.Error("expected re-save to re-create the invalidated entry")
 	}
 }
 

--- a/internal/cache/restore.go
+++ b/internal/cache/restore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -19,6 +20,11 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 )
+
+// ErrDigestMismatch means a downloaded blob's bytes don't hash to the
+// content-addressed name it was fetched under (e.g. a corrupt or half-written
+// upload). Restore treats it as a clean miss and never unpacks the file.
+var ErrDigestMismatch = errors.New("cache blob digest mismatch")
 
 // Restore restores a cache from storage by ID.
 //
@@ -193,6 +199,26 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 			)
 			span.SetStatus(codes.Ok, "cache miss (missing blob)")
 			c.callProgress(cacheID, "complete", "Cache miss (missing blob, invalidated stale entry)", 0, 0)
+			return result, nil
+		}
+		if errors.Is(err, ErrDigestMismatch) {
+			// The blob doesn't match its fingerprint. downloadCache verified this
+			// before any target folder was touched, so existing files are intact.
+			// Treat it as a clean miss and let the build continue; leave the entry
+			// in place (it isn't the entry that's wrong, it's the stored bytes).
+			slog.Warn("cache blob digest mismatch, treating as miss",
+				"cache_id", cacheID, "err", err)
+			result.CacheHit = false
+			result.FallbackUsed = false
+			result.CacheRestored = false
+			result.TotalDuration = time.Since(startTime)
+			span.SetAttributes(
+				attribute.Bool("cache.hit", false),
+				attribute.Bool("cache.restored", false),
+				attribute.Bool("cache.digest_mismatch", true),
+			)
+			span.SetStatus(codes.Ok, "cache miss (digest mismatch)")
+			c.callProgress(cacheID, "complete", "Cache miss (blob digest mismatch)", 0, 0)
 			return result, nil
 		}
 		span.RecordError(err)
@@ -417,9 +443,61 @@ func (c *client) downloadCache(ctx context.Context, retrieveResp api.CacheEntryR
 		attribute.Float64("cache.transfer_speed_mbps", transferInfo.TransferSpeed),
 		attribute.String("cache.request_id", transferInfo.RequestID),
 	)
+
+	// Verify the download matches its content-addressed name before returning it
+	// to the caller, so a bad blob never reaches the target folders.
+	if err := verifyBlobDigest(ctx, archiveFile, retrieveResp.Blobs[0].Digest); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		span.RecordError(err)
+		if errors.Is(err, ErrDigestMismatch) {
+			span.SetAttributes(attribute.Bool("cache.digest_mismatch", true))
+		}
+		span.SetStatus(codes.Error, "cache blob digest verification failed")
+		return "", "", nil, err
+	}
+
 	span.SetStatus(codes.Ok, "download completed")
 
 	return tmpDir, archiveFile, transferInfo, nil
+}
+
+// verifyBlobDigest re-hashes the downloaded archive and confirms it matches the
+// content-addressed name it was fetched under, reusing the streaming SHA-256
+// calculator save uses.
+func verifyBlobDigest(ctx context.Context, archiveFile string, digest api.CacheDigest) error {
+	if digest.Algorithm != "sha256" {
+		return nil
+	}
+	f, err := os.Open(archiveFile)
+	if err != nil {
+		return fmt.Errorf("failed to open archive for digest check: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Hash in chunks, checking ctx between reads, so a cancelled restore aborts
+	// promptly instead of reading the whole archive.
+	sum := archive.NewChecksumSHA256(io.Discard)
+	buf := make([]byte, 1024*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		n, err := f.Read(buf)
+		if n > 0 {
+			_, _ = sum.Write(buf[:n])
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to hash archive for digest check: %w", err)
+		}
+	}
+
+	if got := sum.Sum(); got != digest.Value {
+		return fmt.Errorf("%w: computed %s, expected %s", ErrDigestMismatch, got, digest.Value)
+	}
+	return nil
 }
 
 // extractCache extracts files from a cache archive

--- a/internal/cache/restore.go
+++ b/internal/cache/restore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -20,11 +19,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 )
-
-// ErrDigestMismatch means a downloaded blob's bytes don't hash to the
-// content-addressed name it was fetched under (e.g. a corrupt or half-written
-// upload). Restore treats it as a clean miss and never unpacks the file.
-var ErrDigestMismatch = errors.New("cache blob digest mismatch")
 
 // Restore restores a cache from storage by ID.
 //
@@ -204,10 +198,11 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 		if errors.Is(err, ErrDigestMismatch) {
 			// The blob doesn't match its fingerprint. downloadCache verified this
 			// before any target folder was touched, so existing files are intact.
-			// Treat it as a clean miss and let the build continue; leave the entry
-			// in place (it isn't the entry that's wrong, it's the stored bytes).
-			slog.Warn("cache blob digest mismatch, treating as miss",
+			// The blob will never verify, so expire the entry to let a subsequent
+			// save re-upload it, and let the build continue with a clean miss.
+			slog.Warn("cache blob digest mismatch, treating as miss and invalidating entry",
 				"cache_id", cacheID, "err", err)
+			invalidated := c.invalidateStaleEntry(ctx, retrieveResp)
 			result.CacheHit = false
 			result.FallbackUsed = false
 			result.CacheRestored = false
@@ -216,9 +211,10 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 				attribute.Bool("cache.hit", false),
 				attribute.Bool("cache.restored", false),
 				attribute.Bool("cache.digest_mismatch", true),
+				attribute.Bool("cache.invalidated", invalidated),
 			)
 			span.SetStatus(codes.Ok, "cache miss (digest mismatch)")
-			c.callProgress(cacheID, "complete", "Cache miss (blob digest mismatch)", 0, 0)
+			c.callProgress(cacheID, "complete", "Cache miss (blob digest mismatch, invalidated entry)", 0, 0)
 			return result, nil
 		}
 		span.RecordError(err)
@@ -356,7 +352,7 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 }
 
 // invalidateStaleEntry uses the retrieve response to expire a cache entry whose
-// blob is missing, so a subsequent save re-uploads it.
+// blob is missing or fails digest verification, so a subsequent save re-uploads it.
 func (c *client) invalidateStaleEntry(ctx context.Context, retrieveResp api.CacheEntryRetrieveResp) bool {
 	if len(retrieveResp.TargetPaths) == 0 || len(retrieveResp.CacheKey) == 0 {
 		slog.Warn("cannot invalidate stale cache entry: retrieve response missing resolved address")
@@ -459,45 +455,6 @@ func (c *client) downloadCache(ctx context.Context, retrieveResp api.CacheEntryR
 	span.SetStatus(codes.Ok, "download completed")
 
 	return tmpDir, archiveFile, transferInfo, nil
-}
-
-// verifyBlobDigest re-hashes the downloaded archive and confirms it matches the
-// content-addressed name it was fetched under, reusing the streaming SHA-256
-// calculator save uses.
-func verifyBlobDigest(ctx context.Context, archiveFile string, digest api.CacheDigest) error {
-	if digest.Algorithm != "sha256" {
-		return nil
-	}
-	f, err := os.Open(archiveFile)
-	if err != nil {
-		return fmt.Errorf("failed to open archive for digest check: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	// Hash in chunks, checking ctx between reads, so a cancelled restore aborts
-	// promptly instead of reading the whole archive.
-	sum := archive.NewChecksumSHA256(io.Discard)
-	buf := make([]byte, 1024*1024)
-	for {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		n, err := f.Read(buf)
-		if n > 0 {
-			_, _ = sum.Write(buf[:n])
-		}
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("failed to hash archive for digest check: %w", err)
-		}
-	}
-
-	if got := sum.Sum(); got != digest.Value {
-		return fmt.Errorf("%w: computed %s, expected %s", ErrDigestMismatch, got, digest.Value)
-	}
-	return nil
 }
 
 // extractCache extracts files from a cache archive

--- a/internal/cache/restore_test.go
+++ b/internal/cache/restore_test.go
@@ -2,13 +2,60 @@ package cache
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/buildkite/agent/v3/api"
 )
+
+func TestVerifyBlobDigest(t *testing.T) {
+	dir := t.TempDir()
+	archiveFile := filepath.Join(dir, "archive.zip")
+	content := []byte("hello cache archive")
+	if err := os.WriteFile(archiveFile, content, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	sum := sha256.Sum256(content)
+	digestValue := hex.EncodeToString(sum[:])
+
+	t.Run("matching sha256 passes", func(t *testing.T) {
+		err := verifyBlobDigest(context.Background(), archiveFile, api.CacheDigest{Algorithm: "sha256", Value: digestValue})
+		if err != nil {
+			t.Errorf("verifyBlobDigest = %v, want nil", err)
+		}
+	})
+
+	t.Run("mismatched sha256 is ErrDigestMismatch", func(t *testing.T) {
+		err := verifyBlobDigest(context.Background(), archiveFile, api.CacheDigest{Algorithm: "sha256", Value: "deadbeef"})
+		if !errors.Is(err, ErrDigestMismatch) {
+			t.Errorf("verifyBlobDigest = %v, want ErrDigestMismatch", err)
+		}
+	})
+
+	t.Run("unknown algorithm is skipped, not reported corrupt", func(t *testing.T) {
+		// A non-sha256 digest we can't verify must pass through, not be flagged as
+		// a mismatch — otherwise a future wire format breaks every restore.
+		err := verifyBlobDigest(context.Background(), archiveFile, api.CacheDigest{Algorithm: "blake3", Value: "unverifiable"})
+		if err != nil {
+			t.Errorf("verifyBlobDigest with unknown algorithm = %v, want nil (skip)", err)
+		}
+	})
+
+	t.Run("cancelled context aborts", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := verifyBlobDigest(ctx, archiveFile, api.CacheDigest{Algorithm: "sha256", Value: digestValue})
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("verifyBlobDigest with cancelled ctx = %v, want context.Canceled", err)
+		}
+	})
+}
 
 func TestCleanPath(t *testing.T) {
 	t.Run("removes directory and contents", func(t *testing.T) {

--- a/internal/cache/restore_test.go
+++ b/internal/cache/restore_test.go
@@ -2,60 +2,13 @@ package cache
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
-
-	"github.com/buildkite/agent/v3/api"
 )
-
-func TestVerifyBlobDigest(t *testing.T) {
-	dir := t.TempDir()
-	archiveFile := filepath.Join(dir, "archive.zip")
-	content := []byte("hello cache archive")
-	if err := os.WriteFile(archiveFile, content, 0o600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-	sum := sha256.Sum256(content)
-	digestValue := hex.EncodeToString(sum[:])
-
-	t.Run("matching sha256 passes", func(t *testing.T) {
-		err := verifyBlobDigest(context.Background(), archiveFile, api.CacheDigest{Algorithm: "sha256", Value: digestValue})
-		if err != nil {
-			t.Errorf("verifyBlobDigest = %v, want nil", err)
-		}
-	})
-
-	t.Run("mismatched sha256 is ErrDigestMismatch", func(t *testing.T) {
-		err := verifyBlobDigest(context.Background(), archiveFile, api.CacheDigest{Algorithm: "sha256", Value: "deadbeef"})
-		if !errors.Is(err, ErrDigestMismatch) {
-			t.Errorf("verifyBlobDigest = %v, want ErrDigestMismatch", err)
-		}
-	})
-
-	t.Run("unknown algorithm is skipped, not reported corrupt", func(t *testing.T) {
-		// A non-sha256 digest we can't verify must pass through, not be flagged as
-		// a mismatch — otherwise a future wire format breaks every restore.
-		err := verifyBlobDigest(context.Background(), archiveFile, api.CacheDigest{Algorithm: "blake3", Value: "unverifiable"})
-		if err != nil {
-			t.Errorf("verifyBlobDigest with unknown algorithm = %v, want nil (skip)", err)
-		}
-	})
-
-	t.Run("cancelled context aborts", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		err := verifyBlobDigest(ctx, archiveFile, api.CacheDigest{Algorithm: "sha256", Value: digestValue})
-		if !errors.Is(err, context.Canceled) {
-			t.Errorf("verifyBlobDigest with cancelled ctx = %v, want context.Canceled", err)
-		}
-	})
-}
 
 func TestCleanPath(t *testing.T) {
 	t.Run("removes directory and contents", func(t *testing.T) {


### PR DESCRIPTION
## What

Backports #4187 to `v3`.

Verifies a downloaded cache blob's SHA256 digest against its content-addressed name before anything touches the target folders. A mismatch is treated as a clean miss: nothing is unpacked, existing files stay intact, and the build continues. The entry is also expired so a subsequent save replaces the bad blob. A warning and tracing attributes record the mismatch.

## Translation notes

- Rewrote `github.com/buildkite/agent/v4/...` import paths (and the OpenTelemetry tracer name string) to `v3`.
- `v3`'s `internal/cache/integration_test.go` lacks several v4-only tests added between the two backported commits' anchor points (symlink-target restore, single-file targets, home-directory overlap detection, unrecognized-format/corrupt-archive invalidation). Cherry-pick's 3-way merge had no matching context for those, so I took only the digest-verification test out of each conflict and left the unrelated v4-only tests out, rather than pulling them into this backport.
- No other v3-vs-v4 behavioral differences applied here — this change is internal to `internal/cache` and doesn't touch CLI/urfave code.

## Testing

- `go test ./internal/cache/...` passes.
- `go vet ./internal/cache/...` and `gofmt -l` are clean.
- Final diffstat matches upstream PR #4187 exactly (273 insertions, 1 deletion across `digest.go`, `digest_test.go`, `integration_test.go`, `restore.go`).

Closes nothing on its own; backport of #4187 (closes #4169 upstream).