### PR TITLE
Enable container-aware parallel Git checkout

### DIFF
--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -6,6 +6,7 @@ import (
 	"iter"
 	"os"
 	"reflect"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -234,7 +235,7 @@ var (
 
 	GitCloneFlagsFlag = &cli.StringFlag{
 		Name:    "git-clone-flags",
-		Value:   "-v -c checkout.workers=0",
+		Value:   fmt.Sprintf("-v -c checkout.workers=%d", runtime.GOMAXPROCS(0)),
 		Usage:   "Flags to pass to \"git clone\" command",
 		Sources: cli.EnvVars("BUILDKITE_GIT_CLONE_FLAGS"),
 	}

--- a/clicommand/global.go
+++ b/clicommand/global.go
@@ -234,7 +234,7 @@ var (
 
 	GitCloneFlagsFlag = &cli.StringFlag{
 		Name:    "git-clone-flags",
-		Value:   "-v",
+		Value:   "-v -c checkout.workers=0",
 		Usage:   "Flags to pass to \"git clone\" command",
 		Sources: cli.EnvVars("BUILDKITE_GIT_CLONE_FLAGS"),
 	}

--- a/clicommand/global_test.go
+++ b/clicommand/global_test.go
@@ -2,6 +2,8 @@ package clicommand
 
 import (
 	"context"
+	"fmt"
+	"runtime"
 	"slices"
 	"testing"
 
@@ -67,6 +69,57 @@ func TestGitCommitVerificationFlag(t *testing.T) {
 			}
 			if got != test.want {
 				t.Errorf("git-commit-verification = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestGitCloneFlagsFlag(t *testing.T) {
+	if got, want := GitCloneFlagsFlag.Value, fmt.Sprintf("-v -c checkout.workers=%d", runtime.GOMAXPROCS(0)); got != want {
+		t.Errorf("GitCloneFlagsFlag.Value = %q, want %q", got, want)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "environment overrides default",
+			want: "--no-checkout",
+		},
+		{
+			name: "command line overrides environment",
+			args: []string{"--git-clone-flags", "--filter=blob:none"},
+			want: "--filter=blob:none",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("BUILDKITE_GIT_CLONE_FLAGS", "--no-checkout")
+
+			flag := &cli.StringFlag{
+				Name:    GitCloneFlagsFlag.Name,
+				Value:   GitCloneFlagsFlag.Value,
+				Sources: cli.EnvVars("BUILDKITE_GIT_CLONE_FLAGS"),
+			}
+
+			var got string
+			command := &cli.Command{
+				Name:  "test",
+				Flags: []cli.Flag{flag},
+				Action: func(_ context.Context, command *cli.Command) error {
+					got = command.String("git-clone-flags")
+					return nil
+				},
+			}
+
+			if err := command.Run(t.Context(), append([]string{"test"}, test.args...)); err != nil {
+				t.Fatalf("command.Run() error = %v", err)
+			}
+			if got != test.want {
+				t.Errorf("git-clone-flags = %q, want %q", got, test.want)
 			}
 		})
 	}

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -41,7 +41,7 @@ func TestCheckingOutGitHubPullRequests_WithGitMirrors(t *testing.T) {
 	// But assert which ones are called
 	git.ExpectAll([][]any{
 		{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
-		{"clone", "-v", "-c", "checkout.workers=0", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
+		{"clone", "-v", "-c", fmt.Sprintf("checkout.workers=%d", runtime.GOMAXPROCS(0)), "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", "refs/pull/123/head"},
 		{"rev-parse", "FETCH_HEAD"},
@@ -840,7 +840,7 @@ func TestCheckingOutWithCustomRefspec_WithGitMirrors(t *testing.T) {
 	// With the fix: the mirror should fetch the custom refspec instead of the branch
 	git.ExpectAll([][]any{
 		{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
-		{"clone", "-v", "-c", "checkout.workers=0", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
+		{"clone", "-v", "-c", fmt.Sprintf("checkout.workers=%d", runtime.GOMAXPROCS(0)), "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", customRef}, // Mirror fetches custom refspec (correct!)
 		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -41,7 +41,7 @@ func TestCheckingOutGitHubPullRequests_WithGitMirrors(t *testing.T) {
 	// But assert which ones are called
 	git.ExpectAll([][]any{
 		{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
-		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
+		{"clone", "-v", "-c", "checkout.workers=0", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", "refs/pull/123/head"},
 		{"rev-parse", "FETCH_HEAD"},
@@ -840,7 +840,7 @@ func TestCheckingOutWithCustomRefspec_WithGitMirrors(t *testing.T) {
 	// With the fix: the mirror should fetch the custom refspec instead of the branch
 	git.ExpectAll([][]any{
 		{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
-		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
+		{"clone", "-v", "-c", "checkout.workers=0", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", customRef}, // Mirror fetches custom refspec (correct!)
 		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -1621,7 +1621,7 @@ func TestCheckingOutWithSSHKeyscan(t *testing.T) {
 	git := tester.MustMock(t, "git")
 	git.IgnoreUnexpectedInvocations()
 
-	git.Expect("clone", "-v", "--", "git@github.com:buildkite/agent.git", ".").
+	git.Expect("clone", "-v", "-c", "checkout.workers=0", "--", "git@github.com:buildkite/agent.git", ".").
 		AndExitWith(0)
 
 	env := []string{
@@ -1661,7 +1661,7 @@ func TestCheckingOutWithSSHKeyscanAndUnscannableRepo(t *testing.T) {
 	git := tester.MustMock(t, "git")
 	git.IgnoreUnexpectedInvocations()
 
-	git.Expect("clone", "-v", "--", "https://github.com/buildkite/bash-example.git", ".").
+	git.Expect("clone", "-v", "-c", "checkout.workers=0", "--", "https://github.com/buildkite/bash-example.git", ".").
 		AndExitWith(0)
 
 	env := []string{
@@ -1915,7 +1915,7 @@ func TestGitCheckoutWithCommitResolved(t *testing.T) {
 	git := tester.MustMock(t, "git").PassthroughToLocalCommand()
 
 	git.ExpectAll([][]any{
-		{"clone", "-v", "--", tester.Repo.Path, "."},
+		{"clone", "-v", "-c", "checkout.workers=0", "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", "main"},
 		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
@@ -1943,7 +1943,7 @@ func TestGitCheckoutWithoutCommitResolved(t *testing.T) {
 	git := tester.MustMock(t, "git").PassthroughToLocalCommand()
 
 	git.ExpectAll([][]any{
-		{"clone", "-v", "--", tester.Repo.Path, "."},
+		{"clone", "-v", "-c", "checkout.workers=0", "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", "main"},
 		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
@@ -1971,7 +1971,7 @@ func TestGitCheckoutWithoutCommitResolvedAndNoMetaData(t *testing.T) {
 	git := tester.MustMock(t, "git").PassthroughToLocalCommand()
 
 	git.ExpectAll([][]any{
-		{"clone", "-v", "--", tester.Repo.Path, "."},
+		{"clone", "-v", "-c", "checkout.workers=0", "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", "main"},
 		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -1621,7 +1621,7 @@ func TestCheckingOutWithSSHKeyscan(t *testing.T) {
 	git := tester.MustMock(t, "git")
 	git.IgnoreUnexpectedInvocations()
 
-	git.Expect("clone", "-v", "-c", "checkout.workers=0", "--", "git@github.com:buildkite/agent.git", ".").
+	git.Expect("clone", "-v", "-c", fmt.Sprintf("checkout.workers=%d", runtime.GOMAXPROCS(0)), "--", "git@github.com:buildkite/agent.git", ".").
 		AndExitWith(0)
 
 	env := []string{
@@ -1661,7 +1661,7 @@ func TestCheckingOutWithSSHKeyscanAndUnscannableRepo(t *testing.T) {
 	git := tester.MustMock(t, "git")
 	git.IgnoreUnexpectedInvocations()
 
-	git.Expect("clone", "-v", "-c", "checkout.workers=0", "--", "https://github.com/buildkite/bash-example.git", ".").
+	git.Expect("clone", "-v", "-c", fmt.Sprintf("checkout.workers=%d", runtime.GOMAXPROCS(0)), "--", "https://github.com/buildkite/bash-example.git", ".").
 		AndExitWith(0)
 
 	env := []string{
@@ -1915,7 +1915,7 @@ func TestGitCheckoutWithCommitResolved(t *testing.T) {
 	git := tester.MustMock(t, "git").PassthroughToLocalCommand()
 
 	git.ExpectAll([][]any{
-		{"clone", "-v", "-c", "checkout.workers=0", "--", tester.Repo.Path, "."},
+		{"clone", "-v", "-c", fmt.Sprintf("checkout.workers=%d", runtime.GOMAXPROCS(0)), "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", "main"},
 		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
@@ -1943,7 +1943,7 @@ func TestGitCheckoutWithoutCommitResolved(t *testing.T) {
 	git := tester.MustMock(t, "git").PassthroughToLocalCommand()
 
 	git.ExpectAll([][]any{
-		{"clone", "-v", "-c", "checkout.workers=0", "--", tester.Repo.Path, "."},
+		{"clone", "-v", "-c", fmt.Sprintf("checkout.workers=%d", runtime.GOMAXPROCS(0)), "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", "main"},
 		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
@@ -1971,7 +1971,7 @@ func TestGitCheckoutWithoutCommitResolvedAndNoMetaData(t *testing.T) {
 	git := tester.MustMock(t, "git").PassthroughToLocalCommand()
 
 	git.ExpectAll([][]any{
-		{"clone", "-v", "-c", "checkout.workers=0", "--", tester.Repo.Path, "."},
+		{"clone", "-v", "-c", fmt.Sprintf("checkout.workers=%d", runtime.GOMAXPROCS(0)), "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", "main"},
 		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},

--- a/internal/job/integration/executor_tester.go
+++ b/internal/job/integration/executor_tester.go
@@ -94,6 +94,7 @@ func NewExecutorTester(ctx context.Context) (*ExecutorTester, error) {
 		Repo: repo,
 		Env: []string{
 			"HOME=" + homeDir,
+			fmt.Sprintf("GOMAXPROCS=%d", runtime.GOMAXPROCS(0)),
 			"BUILDKITE_BIN_PATH=" + pathDir,
 			"BUILDKITE_BUILD_PATH=" + buildDir,
 			"BUILDKITE_HOOKS_PATH=" + hooksDir,


### PR DESCRIPTION
## Description

Enable Git's parallel checkout for fresh worktree clones, while bounding its worker count to the agent's effective CPU parallelism:

```text
-v -c checkout.workers=<runtime.GOMAXPROCS(0)>
```

The repository builds with Go 1.25.12, whose default `GOMAXPROCS` is aware of Linux cgroup CPU bandwidth limits. Passing that positive value prevents Git's `checkout.workers=0` host-logical-CPU detection from over-parallelizing checkout in CPU-limited containers. This uses the Go runtime's existing behavior without bespoke cgroup parsing, an `automaxprocs` dependency, or changing the agent scheduler.

## Context

This revision addresses the cgroup correctness concern raised in review on #4197. Go 1.25's behavior is documented in the [release notes](https://go.dev/doc/go1.25#container-aware-gomaxprocs) and [Go blog](https://go.dev/blog/container-aware-gomaxprocs).

## Changes

- Fresh worktree clones persist a positive `checkout.workers` value derived from `runtime.GOMAXPROCS(0)`.
- Explicit `BUILDKITE_GIT_CLONE_FLAGS` and `--git-clone-flags` values still replace the default entirely.
- Bare mirror clone flags remain unchanged because mirror clones do not materialize a worktree.
- Integration subprocesses inherit the test process's effective `GOMAXPROCS`, keeping worker-count assertions deterministic.

On non-Linux and unconstrained systems, `GOMAXPROCS` safely resolves from the runtime's normal CPU/affinity behavior. Go uses cgroup CPU quota limits, not shares/weights (or Kubernetes CPU requests). Explicit `GOMAXPROCS` or `GODEBUG=containermaxprocs=0` configuration remains authoritative. The clone default is a process-start snapshot, so a later in-place quota resize does not rewrite it; Go may also floor its cgroup-derived default at two workers.

## Testing

- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

Passed locally with Go 1.25.12:

- `go test ./clicommand -count=1`
- `go test ./internal/job/... -skip '^TestPolyglotScriptHooksCanBeRun$' -count=1`
- `GOMAXPROCS=2 go test ./clicommand -run '^TestGitCloneFlagsFlag$' -count=1`
- `GOMAXPROCS=2 go test ./internal/job/integration -run '<affected checkout tests>' -count=1`
- `golangci-lint run` (0 issues)
- `go tool gofumpt -extra -d .` (clean)

A full local run was attempted. The orb lacks Ruby for `TestPolyglotScriptHooksCanBeRun`; it also encountered the existing transient agent-shutdown pipe test failure on the first broad run, which passed when rerun as the full `clicommand` package. CI will provide the complete environment-backed run.

## Disclosures / Credits

Amp implemented and tested the update under Lachlan Donald's direction, including a separate expert review of the container/runtime behavior and test robustness.