### PR TITLE
Derive fresh checkouts from the per-job mirror snapshot

### DIFF
--- a/docs/git-mirror.md
+++ b/docs/git-mirror.md
@@ -197,6 +197,49 @@ aggressive about removing older commits when you force-push.
 By deleting the whole checkout directory, and then re-cloning it. It's blunt but
 it works, and if you have git mirrors enabled, it's relatively painless.
 
+## Per-job mirror snapshots
+
+For jobs with clean checkout enabled (and a command phase), the agent does not
+reference the mutable mirror directly. Instead, while still holding the
+mirror's update lock, it creates a per-job _snapshot_: a local `--mirror` clone
+of the mirror in a sibling directory. On filesystems with hardlink support the
+snapshot's object files are hardlinks into the mirror, so it is quick to create
+and takes negligible extra space.
+
+The snapshot is immutable for the life of the job and is removed at job
+teardown. Because a hardlinked file survives the original being unlinked, the
+mirror can repack or prune objects while the job runs without corrupting
+anything that references the snapshot. This is what makes the `--reference`
+corruption class above impossible for snapshot-using jobs.
+
+`BUILDKITE_REPO_MIRROR` points at the snapshot for these jobs.
+
+### Cloning the checkout _from_ the snapshot
+
+The snapshot is a complete local copy of the mirror, so a fresh checkout is
+cloned directly from it — `git clone --no-checkout --no-local --reference
+<snapshot> -- <snapshot> .` — and `origin` is immediately rewritten to the
+canonical repository URL. On a warm mirror this removes the checkout's clone
+round-trip to the git host, and the subsequent fetch is skipped when the
+build's commit is already present locally (custom-refspec builds always keep
+their fetch, since fetching a `src:dst` refspec creates local refs that job
+code may read).
+
+`--no-local` is mandatory and appended after user clone flags: without it, a
+local clone bypasses `--reference` and hardlink-ties the checkout's object
+store to the snapshot, which is deleted at job end. `--no-checkout` avoids
+materializing the snapshot's HEAD; the working tree is written exactly once by
+the later checkout of the build's target commit.
+
+Clone flags that need the canonical remote's shape (`--depth`, `--branch`,
+`--single-branch`, `--bundle-uri`, and similar) make the checkout fall back to
+today's canonical clone with the snapshot as `--reference`. Any failure to
+derive from the snapshot falls back to a plain canonical clone: the mirror
+layer is an optimization, never a correctness dependency.
+
+Non-clean checkouts still `--reference` the durable mirror directly, exactly as
+before (see "Why no snapshots if clean checkout is disabled" in the code).
+
 ## Aren't we supposed to update mirrors with `git remote update`?
 
 That's the usual way. `git remote update` updates mirrors, and it updates
@@ -209,16 +252,23 @@ objects needed for a particular job. Eagerly updating everything with
 `git remote update` also almost certainly runs auto maintenance, clearing out
 dangling objects.
 
-## What if we disable auto maintenance when updating the mirror?
+## What about auto maintenance in the mirror?
 
-We could do that (`git fetch --no-auto-maintenance`). Do we want to? This will
-probably need investigating further.
+Implicit maintenance is now disabled in mirrors (`maintenance.auto=false` and
+`gc.auto=0`, set on creation and retrofitted onto existing mirrors on their
+next update). Git's auto-gc normally detaches from the invoking `git fetch`,
+so it could outlive the mirror's update lock and mutate the object store while
+a snapshot was being created or while an unsnapshotted checkout still
+referenced the mirror — the corruption class tracked in
+[#2208](https://github.com/buildkite/agent/issues/2208).
 
-If the mirror only ever grows, then the mirror will become slower and slower as
-Git must process ever more objects, and potentially it could fill the disk.
-
-But it might be preferable to repeatedly deleting and recreating checkout
-directories.
+The mirror still gets maintained: the agent runs `git gc --auto` synchronously
+(with `gc.autoDetach=false`) while holding the update lock, after the fetch and
+before taking the job's snapshot. Git's usual auto-gc thresholds decide whether
+any repacking actually happens, so this is cheap when there is nothing to do.
+When a consolidating repack does run on a large mirror, it extends the time the
+update lock is held — size `--git-mirrors-lock-timeout` accordingly (its
+default is 300 seconds).
 
 ## Did I see something about `--dissociate`?
 

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -354,7 +354,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context, previousAttempts in
 		}()
 	}
 
-	var mirrorDir string
+	var mirror mirrorReference
 
 	// If we can, get a mirror of the git repository to use for reference later
 	if e.GitMirrorsPath != "" && e.Repository != "" {
@@ -365,14 +365,14 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context, previousAttempts in
 		mirrorSpan, mirrorCtx := e.traceOpSpan(ctx, "git.mirror.update")
 		mirrorSpan.SetAttributes(attribute.String("git.repo", redact.URLCredentials(e.Repository)))
 
-		mirrorDir, err = e.getOrUpdateMirrorDir(mirrorCtx, e.Repository, &attempt)
+		mirror, err = e.getOrUpdateMirror(mirrorCtx, e.Repository, &attempt)
 
 		tracetools.FinishWithError(mirrorSpan, err)
 
 		if err != nil {
 			return fmt.Errorf("getting/updating git mirror: %w", err)
 		}
-		e.shell.Env.Set("BUILDKITE_REPO_MIRROR", mirrorDir)
+		e.shell.Env.Set("BUILDKITE_REPO_MIRROR", mirror.dir)
 	}
 
 	// Make sure the build directory exists and that we change directory into it
@@ -398,7 +398,8 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context, previousAttempts in
 	// original user-supplied state, not on flags we auto-add here.
 	userSuppliedCloneFilter := hasPartialFilterFlags(gitCloneFlags)
 
-	if err := e.prepareCheckoutWorkdir(ctx, &attempt, sparse, mirrorDir, gitCloneFlags, userSuppliedCloneFilter); err != nil {
+	derivedFromSnapshot, err := e.prepareCheckoutWorkdir(ctx, &attempt, sparse, mirror, gitCloneFlags, userSuppliedCloneFilter)
+	if err != nil {
 		return err
 	}
 
@@ -439,7 +440,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context, previousAttempts in
 	addBloblessFilter := sparse.active() &&
 		!userSuppliedCloneFilter &&
 		!hasPartialFilterFlags(gitFetchFlags)
-	if err := e.fetchSource(ctx, addBloblessFilter, &attempt); err != nil {
+	if err := e.fetchSource(ctx, addBloblessFilter, derivedFromSnapshot, &attempt); err != nil {
 		return err
 	}
 
@@ -618,19 +619,20 @@ func (e *Executor) updateGitSubmodules(ctx context.Context) (retErr error) {
 	mirrorSubmodules := e.GitMirrorsPath != ""
 	if mirrorSubmodules {
 		for _, repository := range submoduleRepos {
-			// getOrUpdateMirrorDir is shared with the main repo's mirror update, so
+			// getOrUpdateMirror is shared with the main repo's mirror update, so
 			// this produces the same sub-tree of spans; git.repo distinguishes
 			// submodules since the span names repeat.
 			subMirrorSpan, subMirrorCtx := e.traceOpSpan(ctx, "git.mirror.update")
 			subMirrorSpan.SetAttributes(attribute.String("git.repo", redact.URLCredentials(repository)))
 
-			mirrorDir, err := e.getOrUpdateMirrorDir(subMirrorCtx, repository, nil)
+			subMirror, err := e.getOrUpdateMirror(subMirrorCtx, repository, nil)
 
 			tracetools.FinishWithError(subMirrorSpan, err)
 
 			if err != nil {
 				return fmt.Errorf("getting/updating mirror dir for submodules: %w", err)
 			}
+			mirrorDir := subMirror.dir
 
 			// Switch back to the checkout dir, doing other operations from GitMirrorsPath will fail.
 			if err := e.createCheckoutDir(); err != nil {

--- a/internal/job/checkout_fetch.go
+++ b/internal/job/checkout_fetch.go
@@ -42,11 +42,13 @@ const (
 )
 
 // fetchSource fetches the git source for the job. If GitSkipFetchExistingCommits is
-// enabled and the commit already exists locally, the fetch is skipped entirely.
+// enabled, the checkout was derived from a mirror snapshot (and no custom
+// refspec is configured), or a remote mirror reported a hit — and the commit
+// already exists locally — the fetch is skipped entirely.
 // When addBloblessFilter is true, --filter=blob:none is prepended to the fetch
 // flags — the caller decides based on sparse-checkout state and user-supplied
 // filters.
-func (e *Executor) fetchSource(ctx context.Context, addBloblessFilter bool, attempt *remoteMirrorAttempt) (retErr error) {
+func (e *Executor) fetchSource(ctx context.Context, addBloblessFilter, derivedFromSnapshot bool, attempt *remoteMirrorAttempt) (retErr error) {
 	// Start span here so attributes can be set on the in-scope span; covers the
 	// whole fetch including retries (up to 10 attempts, ~2m), not per-attempt.
 	span, ctx := e.traceOpSpan(ctx, "git.fetch")
@@ -79,12 +81,23 @@ func (e *Executor) fetchSource(ctx context.Context, addBloblessFilter bool, atte
 		}
 	}
 
-	// If configured, skip the fetch when the commit already exists locally.
-	// This is useful when a pre-populated git mirror is used with --reference,
-	// as the commit objects are already reachable and fetching is redundant.
+	// Skip the fetch when the commit already exists locally and we have a
+	// reason to expect it to (GitSkipFetchExistingCommits is opt-in trust in a
+	// pre-populated mirror; a snapshot-derived checkout or a remote mirror hit
+	// established local presence earlier in this same checkout). Local
+	// presence is verified here either way — it is the routing decision, while
+	// the later git checkout of the target commit remains the validation that
+	// the objects are actually usable.
+	//
+	// A custom refspec keeps its fetch even for a snapshot-derived checkout:
+	// fetching an explicitly configured refspec can have side effects beyond
+	// object transfer (a src:dst refspec creates local refs that job code may
+	// read), and only the user knows whether those matter. This default-on
+	// optimization must not silently drop them; the opt-in and server-driven
+	// skips above retain their existing behavior.
 	mirrorHit := attempt != nil && attempt.hit()
-	skipFetch := (e.GitSkipFetchExistingCommits || mirrorHit) && e.Commit != "HEAD" &&
-		hasGitCommit(ctx, e.shell, ".git", e.Commit)
+	skipFetch := (e.GitSkipFetchExistingCommits || mirrorHit || (derivedFromSnapshot && kind != refspecCustom)) &&
+		e.Commit != "HEAD" && hasGitCommit(ctx, e.shell, ".git", e.Commit)
 
 	span.SetAttributes(attribute.Bool("git.skipped", skipFetch))
 

--- a/internal/job/checkout_fetch_remote_mirror_test.go
+++ b/internal/job/checkout_fetch_remote_mirror_test.go
@@ -32,7 +32,7 @@ func TestFetchSourceExistingCheckoutRemoteMirrorHitSkipsCanonical(t *testing.T) 
 	e, attempt := newExistingCheckoutRemoteMirrorExecutor(t, checkout, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
 	canonical.Close()
 
-	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+	if err := e.fetchSource(t.Context(), false, false, &attempt); err != nil {
 		t.Fatalf("fetchSource() error = %v", err)
 	}
 	if attempt.outcome != remoteMirrorOutcomeHit {
@@ -57,7 +57,7 @@ func TestFetchSourceExistingCheckoutRemoteMirrorMissLeavesStateUntouchedBeforeCa
 	worktreeBefore := gitOutputForRemoteCheckoutTest(t, checkout, "status", "--porcelain=v1", "--untracked-files=all")
 	e, attempt := newExistingCheckoutRemoteMirrorExecutor(t, checkout, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
 
-	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+	if err := e.fetchSource(t.Context(), false, false, &attempt); err != nil {
 		t.Fatalf("fetchSource() error = %v", err)
 	}
 	if attempt.outcome != remoteMirrorOutcomeMiss {
@@ -96,7 +96,7 @@ func TestFetchSourceExistingCheckoutFilteredLagMissRetargetsPromisor(t *testing.
 	}
 
 	e, attempt := newExistingCheckoutRemoteMirrorExecutor(t, checkout, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
-	if err := e.fetchSource(t.Context(), true, &attempt); err != nil {
+	if err := e.fetchSource(t.Context(), true, false, &attempt); err != nil {
 		t.Fatalf("fetchSource() error = %v", err)
 	}
 	if attempt.outcome != remoteMirrorOutcomeMiss {
@@ -181,7 +181,7 @@ func TestFetchSourceRepairsPreexistingMirrorPromisorOnMiss(t *testing.T) {
 	)
 	e, attempt := newExistingCheckoutRemoteMirrorExecutor(t, checkout, canonical.RepoURL("canonical"), mirrorURL, commit)
 
-	if err := e.fetchSource(t.Context(), true, &attempt); err != nil {
+	if err := e.fetchSource(t.Context(), true, false, &attempt); err != nil {
 		t.Fatalf("fetchSource() error = %v", err)
 	}
 	assertGitConfigForRemoteMirrorTest(t, checkout, "remote.origin.promisor", "true")
@@ -214,7 +214,7 @@ func TestFetchSourceMarkerFailureFallsBackToCanonical(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Remove(configLock) })
 
-	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+	if err := e.fetchSource(t.Context(), false, false, &attempt); err != nil {
 		t.Fatalf("fetchSource() error = %v", err)
 	}
 	if attempt.outcome != remoteMirrorOutcomeError {
@@ -242,7 +242,7 @@ func TestFetchSourceLeavesUnmarkedUserPromisorUntouched(t *testing.T) {
 	)
 	e.GitSkipFetchExistingCommits = true
 
-	if err := e.fetchSource(t.Context(), false, nil); err != nil {
+	if err := e.fetchSource(t.Context(), false, false, nil); err != nil {
 		t.Fatalf("fetchSource() error = %v", err)
 	}
 	assertGitConfigForRemoteMirrorTest(t, checkout, "remote."+userURL+".promisor", "true")
@@ -269,7 +269,7 @@ func TestFetchSourceLeavesSameURLUnmarkedUserPromisorUntouched(t *testing.T) {
 		commit,
 	)
 
-	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+	if err := e.fetchSource(t.Context(), false, false, &attempt); err != nil {
 		t.Fatalf("fetchSource() error = %v", err)
 	}
 	assertGitConfigForRemoteMirrorTest(t, checkout, "remote."+mirrorURL+".promisor", "true")
@@ -486,7 +486,7 @@ func TestFetchSourceExistingCheckoutRetargetsPromisorAndMaterialisesFromCanonica
 	}
 
 	e, attempt := newExistingCheckoutRemoteMirrorExecutor(t, checkout, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
-	if err := e.fetchSource(t.Context(), true, &attempt); err != nil {
+	if err := e.fetchSource(t.Context(), true, false, &attempt); err != nil {
 		t.Fatalf("fetchSource() error = %v", err)
 	}
 	if attempt.outcome != remoteMirrorOutcomeHit {
@@ -529,7 +529,7 @@ func TestFetchSourceExistingPartialCheckoutInheritsOriginFilter(t *testing.T) {
 	}
 
 	e, attempt := newExistingCheckoutRemoteMirrorExecutor(t, checkout, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
-	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+	if err := e.fetchSource(t.Context(), false, false, &attempt); err != nil {
 		t.Fatalf("fetchSource() error = %v", err)
 	}
 	if attempt.outcome != remoteMirrorOutcomeHit {
@@ -571,7 +571,7 @@ func TestFetchSourceExistingCheckoutCancellationDoesNotFallback(t *testing.T) {
 		}
 	}()
 
-	err = e.fetchSource(ctx, true, &attempt)
+	err = e.fetchSource(ctx, true, false, &attempt)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("fetchSource() error = %v, want context.Canceled", err)
 	}
@@ -694,7 +694,7 @@ func TestFetchSourceExistingCheckoutMirrorFailureFallsBack(t *testing.T) {
 				commit,
 			)
 
-			if err := e.fetchSource(t.Context(), true, &attempt); err != nil {
+			if err := e.fetchSource(t.Context(), true, false, &attempt); err != nil {
 				t.Fatalf("fetchSource() error = %v", err)
 			}
 			if attempt.outcome != tc.wantOutcome {

--- a/internal/job/checkout_mirror.go
+++ b/internal/job/checkout_mirror.go
@@ -33,26 +33,38 @@ func remoteMirrorStagingDir(mirrorDir string) string {
 	return filepath.Join(filepath.Dir(mirrorDir), fmt.Sprintf(".remote-mirror-%x", sum[:8]))
 }
 
-func (e *Executor) getOrUpdateMirrorDir(ctx context.Context, repository string, attempt *remoteMirrorAttempt) (string, error) {
-	var mirrorDir string
+// mirrorReference is the on-host mirror directory a checkout may use with
+// --reference. When isSnapshot is true, dir is an immutable per-job snapshot
+// of the durable mirror: it was created while holding the mirror's exclusive
+// lock, is removed at job teardown, and is therefore also safe to clone the
+// checkout from directly without contacting the canonical repository. When
+// isSnapshot is false, dir is the durable, mutable mirror itself (or "" when
+// no mirror is available) and may only be used as a clone reference.
+type mirrorReference struct {
+	dir        string
+	isSnapshot bool
+}
+
+func (e *Executor) getOrUpdateMirror(ctx context.Context, repository string, attempt *remoteMirrorAttempt) (mirrorReference, error) {
 	// Skip updating the Git mirror before using it?
 	if e.GitMirrorsSkipUpdate {
-		mirrorDir = filepath.Join(e.GitMirrorsPath, dirForRepository(repository))
+		mirrorDir := filepath.Join(e.GitMirrorsPath, dirForRepository(repository))
 		e.shell.Commentf("Skipping update and using existing mirror for repository %s at %s.", repository, mirrorDir)
 
 		// Check if specified mirrorDir exists, otherwise the clone will fail.
 		if !osutil.FileExists(mirrorDir) {
 			// Fall back to a clean clone, rather than failing the clone and therefore the build
 			e.shell.Commentf("No existing mirror found for repository %s at %s.", repository, mirrorDir)
-			mirrorDir = ""
+			return mirrorReference{}, nil
 		}
 
 		// If git mirror updates are skipped, we assume there's no change
-		// to the mirror objects, so no need for snapshotting.
-		return mirrorDir, nil
+		// to the mirror objects, so no need for snapshotting. (Snapshotting
+		// would also be unsafe: skipping the update means no lock is taken.)
+		return mirrorReference{dir: mirrorDir}, nil
 	}
 
-	mirrorDir, err := e.updateGitMirror(ctx, repository, attempt)
+	mirror, err := e.updateGitMirror(ctx, repository, attempt)
 	var lockErr ErrTimedOutAcquiringLock
 	if isOnHostRemoteMirrorAttempt(attempt) && errors.As(err, &lockErr) {
 		// The remote mirror is optional. A speculative clone/update holding the
@@ -60,21 +72,21 @@ func (e *Executor) getOrUpdateMirrorDir(ctx context.Context, repository string, 
 		// proceed without an on-host reference.
 		attempt.outcome = remoteMirrorOutcomeTimeout
 		e.shell.Commentf("Timed out waiting for on-host Git mirror; using canonical repository without it")
-		return "", nil
+		return mirrorReference{}, nil
 	}
-	return mirrorDir, err
+	return mirror, err
 }
 
 // updateGitMirror clones a new git mirror (git clone --mirror ...), or updates
 // an existing git mirror to ensure relevant refs are available. It returns a
-// directory path that a checkout can use for the --reference flag. If clean
-// checkouts are enabled, dir will be a path to a snapshot of the mirror,
-// otherwise it will be the mirror.
+// mirrorReference that a checkout can use for the --reference flag. If clean
+// checkouts are enabled, the reference will be a per-job snapshot of the
+// mirror, otherwise it will be the mirror itself.
 //
 // For efficiency reasons, updating an existing mirror is done by fetching
 // specific refspecs rather than using `git remote update` to fetch everything
 // (see https://github.com/buildkite/agent/pull/1112).
-func (e *Executor) updateGitMirror(ctx context.Context, repository string, attempt *remoteMirrorAttempt) (dir string, finalErr error) {
+func (e *Executor) updateGitMirror(ctx context.Context, repository string, attempt *remoteMirrorAttempt) (mirror mirrorReference, finalErr error) {
 	// Create a unique directory for the repository mirror
 	mirrorDir := filepath.Join(e.GitMirrorsPath, dirForRepository(repository))
 	isMainRepository := repository == e.Repository
@@ -84,12 +96,12 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 		e.shell.Commentf("Creating \"%s\"", baseDir)
 		// Actual file permissions will be reduced by umask, and won't be 0o777 unless the user has manually changed the umask to 000
 		if err := os.MkdirAll(baseDir, 0o777); err != nil {
-			return "", err
+			return mirrorReference{}, err
 		}
 	}
 
 	if err := e.shell.Chdir(e.GitMirrorsPath); err != nil {
-		return "", fmt.Errorf("failed to change directory to %q: %w", e.GitMirrorsPath, err)
+		return mirrorReference{}, fmt.Errorf("failed to change directory to %q: %w", e.GitMirrorsPath, err)
 	}
 
 	lockTimeout := time.Second * time.Duration(e.GitMirrorsLockTimeout)
@@ -111,9 +123,9 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			return "", ErrTimedOutAcquiringLock{Name: "clone", Err: err}
+			return mirrorReference{}, ErrTimedOutAcquiringLock{Name: "clone", Err: err}
 		}
-		return "", fmt.Errorf("unable to acquire clone lock: %w", err)
+		return mirrorReference{}, fmt.Errorf("unable to acquire clone lock: %w", err)
 	}
 	defer mirrorCloneLock.Unlock() //nolint:errcheck // Best-effort cleanup - primary unlock checked below.
 
@@ -134,7 +146,7 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 		mirrorFlags, err := shellwords.Split(e.GitCloneMirrorFlags)
 		if err != nil {
 			e.shell.Errorf("Invalid --git-clone-mirror-flags %q (%s)", e.GitCloneMirrorFlags, err)
-			return "", err
+			return mirrorReference{}, err
 		}
 		flags = append(flags, mirrorFlags...)
 
@@ -188,14 +200,17 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 					"remote", "set-url", "origin", repository,
 				).Run(ctx)
 			}
+			if err == nil {
+				err = e.disableMirrorAutoMaintenance(ctx, tempMirrorDir)
+			}
 			hasCommit := false
 			if err == nil {
 				hasCommit = hasGitCommit(ctx, e.shell, tempMirrorDir, e.Commit)
 				if ctxErr := ctx.Err(); ctxErr != nil {
 					if cleanupErr := removeFailedMirror(tempMirrorDir); cleanupErr != nil {
-						return "", errors.Join(ctxErr, cleanupErr)
+						return mirrorReference{}, errors.Join(ctxErr, cleanupErr)
 					}
-					return "", ctxErr
+					return mirrorReference{}, ctxErr
 				}
 				err = os.Rename(tempMirrorDir, mirrorDir)
 			}
@@ -220,7 +235,7 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 				}
 			}
 			if ctxErr := ctx.Err(); ctxErr != nil {
-				return "", ctxErr
+				return mirrorReference{}, ctxErr
 			}
 			var cloneErr *gitError
 			if errors.As(err, &cloneErr) && cloneErr.Type == gitErrorCloneTimeout {
@@ -233,16 +248,19 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 
 		if err := cloneMirror(ctx, nil, repository, mirrorDir); err != nil {
 			if cleanupErr := removeFailedMirror(mirrorDir); cleanupErr != nil {
-				return "", errors.Join(err, cleanupErr)
+				return mirrorReference{}, errors.Join(err, cleanupErr)
 			}
-			return "", err
+			return mirrorReference{}, err
+		}
+		if err := e.disableMirrorAutoMaintenance(ctx, mirrorDir); err != nil {
+			return mirrorReference{}, err
 		}
 		return e.snapshotMirror(ctx, repository, mirrorDir)
 	}
 
 	// If it exists, immediately release the clone lock.
 	if err := mirrorCloneLock.Unlock(); err != nil {
-		return "", fmt.Errorf("unable to release clone lock: %w", err)
+		return mirrorReference{}, fmt.Errorf("unable to release clone lock: %w", err)
 	}
 
 	if e.Debug {
@@ -262,15 +280,22 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			return "", ErrTimedOutAcquiringLock{Name: "update", Err: err}
+			return mirrorReference{}, ErrTimedOutAcquiringLock{Name: "update", Err: err}
 		}
-		return "", fmt.Errorf("unable to acquire update lock: %w", err)
+		return mirrorReference{}, fmt.Errorf("unable to acquire update lock: %w", err)
 	}
 	defer func() {
 		if err := mirrorUpdateLock.Unlock(); err != nil {
 			finalErr = errors.Join(finalErr, fmt.Errorf("unable to release update lock: %w", err))
 		}
 	}()
+
+	// Retrofit mirrors created by earlier agent versions. Idempotent, and must
+	// happen before this job's fetches so they cannot trigger a detached
+	// auto-gc that outlives the lock.
+	if err := e.disableMirrorAutoMaintenance(ctx, mirrorDir); err != nil {
+		return mirrorReference{}, err
+	}
 
 	commitAlreadyPresent := false
 	if isMainRepository {
@@ -296,7 +321,7 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 	// URLs can share one durable mirror directory.
 	urlChanged, err := e.updateRemoteURL(ctx, mirrorDir, repository)
 	if err != nil {
-		return "", fmt.Errorf("setting remote URL: %w", err)
+		return mirrorReference{}, fmt.Errorf("setting remote URL: %w", err)
 	}
 
 	remoteMirrorHit := false
@@ -310,7 +335,7 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 				remoteMirrorOnHostRefspec(e.Commit, e.Branch),
 			)
 			if err != nil {
-				return "", err
+				return mirrorReference{}, err
 			}
 			if hit {
 				// C2: the helper requires both a successful ref write and
@@ -355,7 +380,7 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 				Retry:      retry,
 			})
 		}); err != nil {
-			return "", err
+			return mirrorReference{}, err
 		}
 	}
 	if !isMainRepository {
@@ -370,7 +395,7 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 		if err := e.traceOp(ctx, "git.mirror.fetch", func(ctx context.Context) error {
 			return cmd.Run(ctx)
 		}); err != nil {
-			return "", err
+			return mirrorReference{}, err
 		}
 	}
 
@@ -386,13 +411,25 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 		}
 	}
 
+	// With implicit maintenance disabled, this synchronous run (still under
+	// the update lock, and before the snapshot) is what keeps the mirror's
+	// object store consolidated over time. Failing maintenance is not worth
+	// failing the job over.
+	if err := e.runMirrorAutoMaintenance(ctx, mirrorDir); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return mirrorReference{}, ctxErr
+		}
+		e.shell.Warningf("Couldn't run mirror maintenance: %v", err)
+	}
+
 	return e.snapshotMirror(ctx, repository, mirrorDir)
 }
 
-// snapshotMirror creates a snapshot of the mirror. It returns the directory for
-// the rest of the checkout to use as --reference, which will be the path to a
-// snapshot, unless clean checkout is disabled, in which case it will simply
-// return mirrorDir.
+// snapshotMirror creates a snapshot of the mirror. It returns the reference
+// for the rest of the checkout to use, which will be the path to a snapshot,
+// unless clean checkout is disabled, in which case it will simply refer to
+// mirrorDir. It must be called while holding the mirror's lock, so that the
+// snapshot cannot capture a mirror mid-mutation.
 //
 // This "snapshot" is a clone of the *mirror* in a nearby directory, but on a
 // filesystem that supports hardlinks (most modern filesystems), the git objects
@@ -433,9 +470,9 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 // checkout phase, which could break many git operations in the command phase.
 // Presently we have no way to pass cleanup instructions between containers,
 // which would enable this case.
-func (e *Executor) snapshotMirror(ctx context.Context, repository, mirrorDir string) (string, error) {
+func (e *Executor) snapshotMirror(ctx context.Context, repository, mirrorDir string) (mirrorReference, error) {
 	if !e.CleanCheckout || !e.includePhase("command") {
-		return mirrorDir, nil
+		return mirrorReference{dir: mirrorDir}, nil
 	}
 
 	snapshotBaseDir := filepath.Join(e.GitMirrorsPath, "snapshots")
@@ -445,7 +482,7 @@ func (e *Executor) snapshotMirror(ctx context.Context, repository, mirrorDir str
 		e.shell.Commentf("Creating %q", snapshotBaseDir)
 		// See comment above about umask
 		if err := os.MkdirAll(snapshotBaseDir, 0o777); err != nil {
-			return "", fmt.Errorf("creating base directory for snapshots: %w", err)
+			return mirrorReference{}, fmt.Errorf("creating base directory for snapshots: %w", err)
 		}
 	}
 
@@ -453,10 +490,10 @@ func (e *Executor) snapshotMirror(ctx context.Context, repository, mirrorDir str
 	// MkdirTemp ensures the new dir won't collide with other agents.
 	snapshotDir, err := os.MkdirTemp(snapshotBaseDir, dirForRepository(repository))
 	if err != nil {
-		return "", fmt.Errorf("creating snapshot directory: %w", err)
+		return mirrorReference{}, fmt.Errorf("creating snapshot directory: %w", err)
 	}
 	if err := os.Chmod(snapshotDir, 0o777&^osutil.Umask); err != nil {
-		return "", fmt.Errorf("changing permissions on snapshot directory: %w", err)
+		return mirrorReference{}, fmt.Errorf("changing permissions on snapshot directory: %w", err)
 	}
 
 	// Automatically remove it during teardown
@@ -467,10 +504,54 @@ func (e *Executor) snapshotMirror(ctx context.Context, repository, mirrorDir str
 	if err := e.traceOp(ctx, "git.mirror.snapshot", func(ctx context.Context) error {
 		return gitClone(ctx, e.shell, nil, []string{"--mirror"}, mirrorDir, snapshotDir)
 	}); err != nil {
-		return "", err
+		return mirrorReference{}, err
 	}
 
-	return snapshotDir, nil
+	return mirrorReference{dir: snapshotDir, isSnapshot: true}, nil
+}
+
+// disableMirrorAutoMaintenance persistently prevents git from starting
+// implicit maintenance in the mirror. Auto-maintenance (gc) detaches itself
+// from the invoking command, so it can outlive the mirror's lock and mutate
+// the object store while a snapshot is being created, or while an
+// unsnapshotted checkout still references the mirror — the corruption class
+// tracked in https://github.com/buildkite/agent/issues/2208. Maintenance
+// instead runs synchronously under the lock via runMirrorAutoMaintenance.
+//
+// Both keys are needed: maintenance.auto covers modern command-triggered
+// maintenance (git 2.29+), and gc.auto=0 stops the legacy post-fetch auto-gc
+// path on older gits.
+func (e *Executor) disableMirrorAutoMaintenance(ctx context.Context, mirrorDir string) error {
+	for _, kv := range [][2]string{{"maintenance.auto", "false"}, {"gc.auto", "0"}} {
+		if err := e.shell.Command("git", "--git-dir", mirrorDir, "config", kv[0], kv[1]).Run(ctx); err != nil {
+			return fmt.Errorf("setting %s=%s on mirror: %w", kv[0], kv[1], err)
+		}
+	}
+	return nil
+}
+
+// defaultGitGCAutoThreshold is git's default gc.auto threshold. The mirror
+// persistently sets gc.auto=0 (see disableMirrorAutoMaintenance), so the
+// controlled maintenance run below restores the default threshold for its own
+// invocation only.
+const defaultGitGCAutoThreshold = "6700"
+
+// runMirrorAutoMaintenance runs git's auto-maintenance synchronously. It must
+// be called while holding the mirror's lock: gc.autoDetach=false keeps the
+// work in the foreground so it cannot outlive the lock. Git's usual
+// auto-thresholds (loose object and pack counts) still decide whether any
+// repacking actually happens, so this is cheap when there is nothing to do.
+// Removing old objects is safe even while earlier snapshots are still leased
+// to running jobs, because those snapshots hold hardlinks to the object files.
+func (e *Executor) runMirrorAutoMaintenance(ctx context.Context, mirrorDir string) error {
+	return e.traceOp(ctx, "git.mirror.maintenance", func(ctx context.Context) error {
+		return e.shell.Command(
+			"git", "--git-dir", mirrorDir,
+			"-c", "gc.auto="+defaultGitGCAutoThreshold,
+			"-c", "gc.autoDetach=false",
+			"gc", "--auto",
+		).Run(ctx)
+	})
 }
 
 // updateRemoteURL updates the URL for 'origin' and reports whether the

--- a/internal/job/checkout_mirror_remote_test.go
+++ b/internal/job/checkout_mirror_remote_test.go
@@ -51,10 +51,11 @@ func TestUpdateGitMirrorCreatesFromRemoteMirrorAndKeepsCanonicalOrigin(t *testin
 	}
 	canonical.Close() // Creation must source all objects from the remote mirror.
 
-	mirrorDir, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
+	mirrorDirRef, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
 	if err != nil {
 		t.Fatalf("updateGitMirror() error = %v", err)
 	}
+	mirrorDir := mirrorDirRef.dir
 	if mirrorDir == expectedOnHostMirrorDir(e) {
 		t.Error("clean checkout did not receive a mirror snapshot")
 	}
@@ -131,10 +132,11 @@ func TestUpdateGitMirrorCreationFallsBackToCanonical(t *testing.T) {
 		url:  "http://127.0.0.1:1/mirror.git",
 	}
 
-	mirrorDir, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
+	mirrorDirRef, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
 	if err != nil {
 		t.Fatalf("updateGitMirror() error = %v", err)
 	}
+	mirrorDir := mirrorDirRef.dir
 	if got, want := gitOutputForMirrorTest(t, mirrorDir, "config", "--get", "remote.origin.url"), e.Repository; got != want {
 		t.Errorf("remote.origin.url = %q, want canonical %q", got, want)
 	}
@@ -186,10 +188,11 @@ func TestUpdateGitMirrorKeepsUsefulLaggingCreationClone(t *testing.T) {
 		url:  remoteMirror.RepoURL("mirror"),
 	}
 
-	mirrorDir, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
+	mirrorDirRef, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
 	if err != nil {
 		t.Fatalf("updateGitMirror() error = %v", err)
 	}
+	mirrorDir := mirrorDirRef.dir
 	if attempt.outcome != remoteMirrorOutcomeMiss {
 		t.Errorf("outcome = %q, want miss", attempt.outcome)
 	}
@@ -224,10 +227,11 @@ func TestUpdateGitMirrorUpdateHitUsesNamespacedRefWithoutMovingHeadsOrTags(t *te
 		site: remoteMirrorSiteOnHostMirror,
 		url:  remoteMirror.RepoURL("mirror"),
 	}
-	gotDir, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
+	gotDirRef, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
 	if err != nil {
 		t.Fatalf("updateGitMirror() error = %v", err)
 	}
+	gotDir := gotDirRef.dir
 	if gotDir != mirrorDir {
 		t.Errorf("mirror dir = %q, want %q", gotDir, mirrorDir)
 	}
@@ -387,10 +391,11 @@ func TestUpdateGitMirrorWarmHitUsesUnpinnedCommitWithoutScan(t *testing.T) {
 			attempt := tc.attempt(e)
 			canonical.Close()
 
-			gotDir, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
+			gotDirRef, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
 			if err != nil {
 				t.Fatalf("updateGitMirror() error = %v, want warm mirror fast path", err)
 			}
+			gotDir := gotDirRef.dir
 			if gotDir != mirrorDir {
 				t.Errorf("mirror dir = %q, want %q", gotDir, mirrorDir)
 			}
@@ -435,10 +440,11 @@ func TestUpdateGitMirrorNoRemoteURLPostFetchSkipsReachabilityScan(t *testing.T) 
 		t.Fatalf("attempt = %+v, want no-url skip", attempt)
 	}
 
-	gotDir, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
+	gotDirRef, err := e.updateGitMirror(t.Context(), e.Repository, &attempt)
 	if err != nil {
 		t.Fatalf("updateGitMirror() error = %v", err)
 	}
+	gotDir := gotDirRef.dir
 	if gotDir != mirrorDir {
 		t.Errorf("mirror dir = %q, want %q", gotDir, mirrorDir)
 	}
@@ -452,7 +458,7 @@ func TestUpdateGitMirrorNoRemoteURLPostFetchSkipsReachabilityScan(t *testing.T) 
 	}
 }
 
-func TestGetOrUpdateMirrorDirCloneLockTimeoutFallsBackWithoutMirror(t *testing.T) {
+func TestGetOrUpdateMirrorCloneLockTimeoutFallsBackWithoutMirror(t *testing.T) {
 	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
 	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
 	if err != nil {
@@ -470,10 +476,11 @@ func TestGetOrUpdateMirrorDirCloneLockTimeoutFallsBackWithoutMirror(t *testing.T
 		url:  "https://mirror.example/repo.git",
 	}
 
-	mirrorDir, err := e.getOrUpdateMirrorDir(t.Context(), e.Repository, &attempt)
+	mirror, err := e.getOrUpdateMirror(t.Context(), e.Repository, &attempt)
 	if err != nil {
-		t.Fatalf("getOrUpdateMirrorDir() error = %v, want canonical checkout fallback", err)
+		t.Fatalf("getOrUpdateMirror() error = %v, want canonical checkout fallback", err)
 	}
+	mirrorDir := mirror.dir
 	if mirrorDir != "" {
 		t.Errorf("mirrorDir = %q, want no on-host reference after lock timeout", mirrorDir)
 	}

--- a/internal/job/checkout_snapshot_derive_test.go
+++ b/internal/job/checkout_snapshot_derive_test.go
@@ -1,0 +1,286 @@
+package job
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent/v4/internal/osutil"
+	"github.com/buildkite/agent/v4/internal/shell"
+)
+
+// newSnapshotDeriveExecutor builds an executor configured the way the
+// snapshot-derive path requires: on-host mirrors enabled, clean checkout, and
+// a command phase (so updateGitMirror produces a per-job snapshot).
+func newSnapshotDeriveExecutor(t *testing.T, repository, commit string) *Executor {
+	t.Helper()
+	checkout := t.TempDir()
+	e := New(ExecutorConfig{
+		Repository:            repository,
+		Commit:                commit,
+		Branch:                "feature-branch",
+		PullRequest:           "false",
+		GitMirrorsPath:        t.TempDir(),
+		GitMirrorsLockTimeout: 30,
+		GitCloneMirrorFlags:   "-v",
+		CleanCheckout:         true,
+		Phases:                []string{"checkout", "command"},
+	})
+	e.shell = shell.NewTestShell(t, shell.WithSignalGracePeriod(10*time.Millisecond))
+	e.shell.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", checkout)
+	if err := e.createCheckoutDir(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if e.checkoutRoot != nil {
+			_ = e.checkoutRoot.Close()
+			e.checkoutRoot = nil
+		}
+	})
+	return e
+}
+
+// resolvePathForTest canonicalizes a path for comparison: it resolves
+// symlinks (e.g. /var vs /private/var on macOS) and, on Windows, 8.3 short
+// names (e.g. BUILDK~1) to their long form.
+func resolvePathForTest(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(filepath.FromSlash(path))
+	if err != nil {
+		t.Fatalf("resolving path %q: %v", path, err)
+	}
+	return resolved
+}
+
+// alternatesContainDir reports whether any entry in the alternates file
+// content refers to dir, comparing canonicalized paths (case-insensitively,
+// for Windows).
+func alternatesContainDir(t *testing.T, content, dir string) bool {
+	t.Helper()
+	for _, line := range strings.Split(content, "\n") {
+		entry := strings.TrimSpace(line)
+		if entry == "" {
+			continue
+		}
+		resolved, err := filepath.EvalSymlinks(filepath.FromSlash(entry))
+		if err != nil {
+			continue
+		}
+		if strings.EqualFold(resolved, dir) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPrepareCheckoutWorkdirDerivesFromSnapshotWithoutCanonical(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := newSnapshotDeriveExecutor(t, canonical.RepoURL("canonical"), commit)
+
+	mirror, err := e.getOrUpdateMirror(t.Context(), e.Repository, nil)
+	if err != nil {
+		t.Fatalf("getOrUpdateMirror() error = %v", err)
+	}
+	if !mirror.isSnapshot {
+		t.Fatalf("mirror = %+v, want a per-job snapshot for a clean checkout", mirror)
+	}
+	if err := e.createCheckoutDir(); err != nil {
+		t.Fatal(err)
+	}
+
+	// From here on, the checkout must not need the canonical repository.
+	canonical.Close()
+
+	derived, err := e.prepareCheckoutWorkdir(t.Context(), nil, sparseCheckout{}, mirror, []string{"-v"}, false)
+	if err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if !derived {
+		t.Fatal("prepareCheckoutWorkdir() derived = false, want checkout derived from snapshot")
+	}
+
+	if got, want := gitOutputForMirrorTest(t, filepath.Join(e.shell.Getwd(), ".git"), "config", "--get", "remote.origin.url"), e.Repository; got != want {
+		t.Errorf("remote.origin.url = %q, want canonical %q", got, want)
+	}
+	if !hasGitCommit(t.Context(), e.shell, ".git", commit) {
+		t.Error("derived checkout is missing the build commit")
+	}
+
+	alternates := filepath.Join(e.shell.Getwd(), ".git", "objects", "info", "alternates")
+	content, err := os.ReadFile(alternates)
+	if err != nil {
+		t.Fatalf("derived checkout has no alternates file (--no-local not effective?): %v", err)
+	}
+	// Git canonicalizes the path it writes to the alternates file: forward
+	// slashes and resolved (long) names on Windows, while mirror.dir may use
+	// backslashes and 8.3 short names (e.g. BUILDK~1 from TMP). Resolve both
+	// sides before comparing.
+	if want, got := resolvePathForTest(t, filepath.Join(mirror.dir, "objects")), string(content); !alternatesContainDir(t, got, want) {
+		t.Errorf("alternates = %q, want reference to snapshot objects %q", got, want)
+	}
+
+	// The build branch's remote-tracking ref must not be stale relative to the
+	// build's own commit (syncOriginBranchRef).
+	if got, want := gitOutputForMirrorTest(t, filepath.Join(e.shell.Getwd(), ".git"), "rev-parse", "refs/remotes/origin/feature-branch"), commit; got != want {
+		t.Errorf("refs/remotes/origin/feature-branch = %q, want build commit %q", got, want)
+	}
+
+	// The subsequent fetch is skipped: it must succeed with canonical down.
+	if err := e.fetchSource(t.Context(), false, true, nil); err != nil {
+		t.Fatalf("fetchSource() error = %v, want fetch skipped after snapshot derive", err)
+	}
+}
+
+func TestPrepareCheckoutWorkdirSnapshotDeriveFailureFallsBackToCanonical(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := newSnapshotDeriveExecutor(t, canonical.RepoURL("canonical"), commit)
+
+	// A snapshot path that does not exist: the derive clone fails.
+	mirror := mirrorReference{dir: filepath.Join(t.TempDir(), "missing.git"), isSnapshot: true}
+
+	derived, err := e.prepareCheckoutWorkdir(t.Context(), nil, sparseCheckout{}, mirror, []string{"-v"}, false)
+	if err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v, want fail-open canonical clone", err)
+	}
+	if derived {
+		t.Fatal("prepareCheckoutWorkdir() derived = true, want canonical fallback")
+	}
+	if !hasGitCommit(t.Context(), e.shell, ".git", commit) {
+		t.Error("canonical fallback clone is missing the build commit")
+	}
+	// The broken snapshot must not be retained as a reference.
+	if osutil.FileExists(filepath.Join(e.shell.Getwd(), ".git", "objects", "info", "alternates")) {
+		t.Error("canonical fallback clone retains an alternate into the failed snapshot")
+	}
+}
+
+func TestFetchSourceSnapshotDeriveKeepsCustomRefspecFetch(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out, err := canonical.CreateRef("canonical", "refs/foo/bar", commit); err != nil {
+		t.Fatalf("CreateRef() error = %v\n%s", err, out)
+	}
+	e := newSnapshotDeriveExecutor(t, canonical.RepoURL("canonical"), commit)
+	// A src:dst refspec creates a local ref that job code may read. The
+	// snapshot-derive fetch skip must not apply to custom refspec builds.
+	e.RefSpec = "+refs/foo/bar:refs/foo/bar"
+
+	mirror, err := e.getOrUpdateMirror(t.Context(), e.Repository, nil)
+	if err != nil {
+		t.Fatalf("getOrUpdateMirror() error = %v", err)
+	}
+	if !mirror.isSnapshot {
+		t.Fatalf("mirror = %+v, want a per-job snapshot for a clean checkout", mirror)
+	}
+	if err := e.createCheckoutDir(); err != nil {
+		t.Fatal(err)
+	}
+
+	derived, err := e.prepareCheckoutWorkdir(t.Context(), nil, sparseCheckout{}, mirror, []string{"-v"}, false)
+	if err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if !derived {
+		t.Fatal("prepareCheckoutWorkdir() derived = false, want checkout derived from snapshot")
+	}
+
+	checkoutGitDir := filepath.Join(e.shell.Getwd(), ".git")
+	if gitRefExistsForMirrorTest(checkoutGitDir, "refs/foo/bar") {
+		t.Fatal("refs/foo/bar exists in the derived checkout before fetch; test cannot prove the fetch ran")
+	}
+
+	// Even though the commit is already present via the snapshot, the custom
+	// refspec fetch must still run so its local dst ref is created.
+	if err := e.fetchSource(t.Context(), false, true, nil); err != nil {
+		t.Fatalf("fetchSource() error = %v", err)
+	}
+	if got, want := gitOutputForMirrorTest(t, checkoutGitDir, "rev-parse", "refs/foo/bar"), commit; got != want {
+		t.Errorf("refs/foo/bar = %q, want build commit %q (custom refspec fetch was skipped?)", got, want)
+	}
+}
+
+func TestPrepareCheckoutWorkdirIncompatibleFlagsUseSnapshotAsReferenceOnly(t *testing.T) {
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := newSnapshotDeriveExecutor(t, canonical.RepoURL("canonical"), commit)
+
+	mirror, err := e.getOrUpdateMirror(t.Context(), e.Repository, nil)
+	if err != nil {
+		t.Fatalf("getOrUpdateMirror() error = %v", err)
+	}
+	if !mirror.isSnapshot {
+		t.Fatalf("mirror = %+v, want a per-job snapshot for a clean checkout", mirror)
+	}
+	if err := e.createCheckoutDir(); err != nil {
+		t.Fatal(err)
+	}
+
+	// --depth requires the canonical remote to own the shallow boundary, so
+	// the checkout falls back to today's canonical clone with the snapshot as
+	// a --reference.
+	derived, err := e.prepareCheckoutWorkdir(t.Context(), nil, sparseCheckout{}, mirror, []string{"--depth=1"}, false)
+	if err != nil {
+		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
+	}
+	if derived {
+		t.Fatal("prepareCheckoutWorkdir() derived = true, want canonical clone for shallow flags")
+	}
+	if got, want := gitOutputForMirrorTest(t, filepath.Join(e.shell.Getwd(), ".git"), "config", "--get", "remote.origin.url"), e.Repository; got != want {
+		t.Errorf("remote.origin.url = %q, want canonical %q", got, want)
+	}
+}
+
+func TestCloneFlagsAllowSnapshotDerive(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		flags []string
+		want  bool
+	}{
+		{name: "no flags", flags: nil, want: true},
+		{name: "verbose", flags: []string{"-v"}, want: true},
+		{name: "filter", flags: []string{"--filter=blob:none"}, want: true},
+		{name: "sparse", flags: []string{"--sparse"}, want: true},
+		{name: "no tags", flags: []string{"--no-tags"}, want: true},
+		{name: "config", flags: []string{"--config", "pack.threads=2"}, want: true},
+		{name: "depth", flags: []string{"--depth=1"}, want: false},
+		{name: "depth separate value", flags: []string{"--depth", "1"}, want: false},
+		{name: "shallow since", flags: []string{"--shallow-since=2024-01-01"}, want: false},
+		{name: "single branch", flags: []string{"--single-branch"}, want: false},
+		{name: "branch", flags: []string{"--branch", "main"}, want: false},
+		{name: "branch short", flags: []string{"-b", "main"}, want: false},
+		{name: "origin", flags: []string{"--origin", "upstream"}, want: false},
+		{name: "origin short", flags: []string{"-o", "upstream"}, want: false},
+		{name: "local", flags: []string{"--local"}, want: false},
+		{name: "mirror", flags: []string{"--mirror"}, want: false},
+		{name: "bare", flags: []string{"--bare"}, want: false},
+		{name: "bundle uri", flags: []string{"--bundle-uri=https://example.com/b"}, want: false},
+		{name: "recurse submodules", flags: []string{"--recurse-submodules"}, want: false},
+		{name: "separate git dir", flags: []string{"--separate-git-dir=/elsewhere"}, want: false},
+		{name: "mixed compatible and not", flags: []string{"-v", "--depth=1"}, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := cloneFlagsAllowSnapshotDerive(tc.flags); got != tc.want {
+				t.Errorf("cloneFlagsAllowSnapshotDerive(%v) = %t, want %t", tc.flags, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/job/checkout_workdir.go
+++ b/internal/job/checkout_workdir.go
@@ -15,18 +15,21 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-// prepareCheckoutWorkdir reconciles an existing checkout or clones a fresh one.
-// It intentionally owns the complete existing-vs-fresh decision so checkout.go
-// remains orchestration rather than accumulating another cross-cutting branch.
+// prepareCheckoutWorkdir reconciles an existing checkout or clones a fresh
+// one. It intentionally owns the complete existing-vs-fresh decision so
+// checkout.go remains orchestration rather than accumulating another
+// cross-cutting branch. It reports whether the fresh checkout was derived from
+// the mirror snapshot, in which case the objects for this build's target are
+// already local and the usual fetch can be skipped.
 func (e *Executor) prepareCheckoutWorkdir(
 	ctx context.Context,
 	attempt *remoteMirrorAttempt,
 	sparse sparseCheckout,
-	mirrorDir string,
+	mirror mirrorReference,
 	gitCloneFlags []string,
 	userSuppliedCloneFilter bool,
-) (retErr error) {
-	// On mirrors and dissociation:
+) (derivedFromSnapshot bool, retErr error) {
+	// On mirrors, snapshots and dissociation:
 	//
 	// --reference makes the clone reuse objects from the mirror, using the
 	// .git/objects/info/alternates file. On its own, it won't copy the objects
@@ -37,42 +40,47 @@ func (e *Executor) prepareCheckoutWorkdir(
 	// clone robust against that failure, at the expense of disk space and extra
 	// work up front.
 	//
-	// --dissociate is safer, so it's what we want, but it can be disabled. It
-	// is important even when CleanCheckout is enabled, because auto-maintenance
-	// can happen on the mirror at any time!
+	// A per-job mirror snapshot (see snapshotMirror) removes the fragility a
+	// different way: the snapshot is immutable and outlives the checkout's use
+	// of it, so referencing it is safe without dissociating. It is also a
+	// complete local copy of the mirror, so when one exists, the checkout is
+	// cloned *from* the snapshot rather than from the canonical repository,
+	// eliminating the clone's network round-trip entirely.
 
 	existingGitDir := filepath.Join(e.shell.Getwd(), ".git")
 	if osutil.FileExists(existingGitDir) {
 		if _, err := e.updateRemoteURL(ctx, "", e.Repository); err != nil {
-			return fmt.Errorf("setting origin: %w", err)
+			return false, fmt.Errorf("setting origin: %w", err)
 		}
 
-		if mirrorDir == "" && e.GitMirrorsPath != "" {
+		if mirror.dir == "" && e.GitMirrorsPath != "" {
 			// A bypassed mirror must not remain reachable through a stale alternate.
 			if err := e.traceOp(ctx, "git.dissociate", func(ctx context.Context) error {
 				return e.dissociateIfNeeded(ctx, existingGitDir)
 			}); err != nil {
-				return fmt.Errorf("dissociating bypassed mirror: %w", err)
+				return false, fmt.Errorf("dissociating bypassed mirror: %w", err)
 			}
-		} else if mirrorDir != "" {
+		} else if mirror.dir != "" {
 			switch e.GitMirrorCheckoutMode {
 			case "dissociate":
 				if err := e.traceOp(ctx, "git.dissociate", func(ctx context.Context) error {
 					return e.dissociateIfNeeded(ctx, existingGitDir)
 				}); err != nil {
-					return fmt.Errorf("dissociating existing reference clone: %w", err)
+					return false, fmt.Errorf("dissociating existing reference clone: %w", err)
 				}
 			case "reference":
-				if err := e.reassociateIfNeeded(ctx, existingGitDir, mirrorDir); err != nil {
-					return fmt.Errorf("reassociating existing clone: %w", err)
+				if err := e.reassociateIfNeeded(ctx, existingGitDir, mirror.dir); err != nil {
+					return false, fmt.Errorf("reassociating existing clone: %w", err)
 				}
 			}
 		}
-		return nil
+		return false, nil
 	}
 
-	if mirrorDir != "" {
-		gitCloneFlags = append(gitCloneFlags, "--reference", mirrorDir)
+	deriveFromSnapshot := mirror.isSnapshot && cloneFlagsAllowSnapshotDerive(gitCloneFlags)
+
+	if mirror.dir != "" && !deriveFromSnapshot {
+		gitCloneFlags = append(gitCloneFlags, "--reference", mirror.dir)
 		if e.GitMirrorCheckoutMode == "dissociate" {
 			gitCloneFlags = append(gitCloneFlags, "--dissociate")
 		}
@@ -93,15 +101,31 @@ func (e *Executor) prepareCheckoutWorkdir(
 
 	cloneSpan, cloneCtx := e.traceOpSpan(ctx, "git.clone")
 	mirrorMode := "none"
-	if mirrorDir != "" {
+	if mirror.dir != "" {
 		mirrorMode = e.GitMirrorCheckoutMode
 	}
 	cloneSpan.SetAttributes(
 		attribute.String("git.mirror_mode", mirrorMode),
+		attribute.String("git.clone_source", "canonical"),
 		attribute.Bool("git.sparse", sparse.active()),
 		attribute.Bool("git.blobless_filter", hasPartialFilterFlags(gitCloneFlags)),
 	)
 	defer func() { tracetools.FinishWithError(cloneSpan, retErr) }()
+
+	if deriveFromSnapshot {
+		derived, err := e.deriveCheckoutFromSnapshot(cloneCtx, mirror.dir, gitCloneFlags)
+		if err != nil {
+			return false, err
+		}
+		if derived {
+			cloneSpan.SetAttributes(attribute.String("git.clone_source", "snapshot"))
+			return true, nil
+		}
+		// Fall through to a clean clone from the canonical repository. The
+		// snapshot (or the mirror behind it) may be broken, so don't reference
+		// it: the mirror layer is an optimization, never a correctness
+		// dependency.
+	}
 
 	cloneCheckout := func(
 		gitFlags []string,
@@ -145,9 +169,9 @@ func (e *Executor) prepareCheckoutWorkdir(
 		attempt.duration = time.Since(started)
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			if cleanupErr := e.removeCheckoutDir(); cleanupErr != nil {
-				return errors.Join(ctxErr, cleanupErr)
+				return false, errors.Join(ctxErr, cleanupErr)
 			}
-			return ctxErr
+			return false, ctxErr
 		}
 		if cloneErr == nil {
 			ambientAlternates, _ := e.shell.Env.Get("GIT_ALTERNATE_OBJECT_DIRECTORIES")
@@ -158,13 +182,15 @@ func (e *Executor) prepareCheckoutWorkdir(
 				// if canonical has advanced. Re-cloning every hit would discard
 				// the optimization for the shallow workloads it targets.
 				attempt.outcome = remoteMirrorOutcomeHit
-				return nil
+				cloneSpan.SetAttributes(attribute.String("git.clone_source", "remote-mirror"))
+				return false, nil
 			}
 			attempt.outcome = remoteMirrorOutcomeMiss
 			if !shallowClone {
 				// Keep the useful mirror clone. fetchSource will fetch only
 				// the missing immutable commit from canonical.
-				return nil
+				cloneSpan.SetAttributes(attribute.String("git.clone_source", "remote-mirror"))
+				return false, nil
 			}
 
 			// A canonical fetch into a lagging shallow clone keeps the
@@ -173,10 +199,10 @@ func (e *Executor) prepareCheckoutWorkdir(
 			// Re-clone so canonical owns the shallow boundary in both cases.
 			e.shell.Commentf("Remote Git mirror is lagging for a shallow clone; cloning from canonical repository")
 			if cleanupErr := e.removeCheckoutDir(); cleanupErr != nil {
-				return cleanupErr
+				return false, cleanupErr
 			}
 			if err := e.createCheckoutDir(); err != nil {
-				return err
+				return false, err
 			}
 		} else {
 			var gitErr *gitError
@@ -186,23 +212,143 @@ func (e *Executor) prepareCheckoutWorkdir(
 				attempt.outcome = remoteMirrorOutcomeError
 			}
 			if cleanupErr := e.removeCheckoutDir(); cleanupErr != nil {
-				return errors.Join(cloneErr, cleanupErr)
+				return false, errors.Join(cloneErr, cleanupErr)
 			}
 			if err := e.createCheckoutDir(); err != nil {
-				return errors.Join(cloneErr, err)
+				return false, errors.Join(cloneErr, err)
 			}
 			e.shell.Commentf("Remote Git mirror clone failed; falling back to canonical repository")
 		}
 	}
 
 	if err := cloneCheckout(nil, e.Repository); err != nil {
-		return fmt.Errorf("cloning git repository: %w", err)
+		return false, fmt.Errorf("cloning git repository: %w", err)
 	}
-	return nil
+	return false, nil
 }
 
 func isFreshCloneRemoteMirrorAttempt(attempt *remoteMirrorAttempt) bool {
 	return attempt != nil &&
 		attempt.site == remoteMirrorSiteFreshClone &&
 		attempt.outcome == remoteMirrorOutcomeNotReached
+}
+
+// deriveCheckoutFromSnapshot clones the checkout from the job's immutable
+// mirror snapshot, without contacting the canonical repository. The snapshot
+// is only the transport: origin is rewritten to the canonical repository
+// immediately afterwards, so later fetches (including partial-clone lazy
+// fetches) and job code see the real remote.
+//
+// The local clone succeeding does not by itself prove the build's target is
+// usable — the later checkout of the target commit is the real validation. On
+// failure the partial checkout is removed and (false, nil) is returned so the
+// caller falls back to cloning from canonical: the mirror layer is an
+// optimization, never a correctness dependency.
+func (e *Executor) deriveCheckoutFromSnapshot(ctx context.Context, snapshotDir string, gitCloneFlags []string) (derived bool, retErr error) {
+	e.shell.Commentf("Cloning from mirror snapshot %q", snapshotDir)
+
+	flags := slices.Clone(gitCloneFlags)
+	// These flags are mandatory, and deliberately appended after any
+	// user-supplied flags so they cannot be overridden:
+	//
+	// --no-local: cloning from a local path otherwise uses git's local
+	// hardlink/copy optimization *regardless of --reference*, which would tie
+	// the checkout's object store to the snapshot's files instead of the
+	// alternates mechanism the snapshot lease is built on.
+	//
+	// --no-checkout: the working tree is written exactly once, by the later
+	// git checkout of the build's target commit, instead of first
+	// materializing the snapshot's HEAD.
+	flags = append(flags, "--no-checkout", "--no-local", "--reference", snapshotDir)
+	if e.GitMirrorCheckoutMode == "dissociate" {
+		flags = append(flags, "--dissociate")
+	}
+
+	err := gitClone(ctx, e.shell, nil, flags, snapshotDir, ".")
+	if err == nil {
+		err = e.shell.Command("git", "remote", "set-url", "origin", e.Repository).Run(ctx)
+	}
+	if err == nil {
+		e.syncOriginBranchRef(ctx)
+		return true, nil
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return false, ctxErr
+	}
+	e.shell.Warningf("Clone from mirror snapshot failed (%v); falling back to canonical repository", err)
+	if rmErr := e.removeCheckoutDir(); rmErr != nil {
+		return false, errors.Join(err, rmErr)
+	}
+	if mkErr := e.createCheckoutDir(); mkErr != nil {
+		return false, errors.Join(err, mkErr)
+	}
+	return false, nil
+}
+
+// syncOriginBranchRef points refs/remotes/origin/<branch> at the build's
+// commit when the snapshot's copy is stale or missing. A clone from the
+// canonical repository sees that remote's current refs, but a clone from a
+// mirror snapshot sees whatever the mirror last fetched, and the mirror only
+// guarantees the build's own target. The build branch is the remote-tracking
+// ref job code most commonly reads (e.g. to diff against), so keep it at
+// least as fresh as the build's own commit. Staleness of other remote refs is
+// accepted, documented behavior for snapshot-derived clones.
+//
+// This is best-effort: it only applies to plain branch builds (for a
+// pull-request build the head may not exist on origin at all, and tag or
+// custom-refspec builds don't map to a branch ref), and failures only warn.
+func (e *Executor) syncOriginBranchRef(ctx context.Context) {
+	if e.Commit == "HEAD" || e.Branch == "" || e.RefSpec != "" || e.Tag != "" || e.PullRequest != "false" {
+		return
+	}
+	ref := "refs/remotes/origin/" + e.Branch
+	if !gitCheckRefFormat(ref) || !hasGitCommit(ctx, e.shell, ".git", e.Commit) {
+		return
+	}
+	// Leave the ref alone when it already contains the commit: it is as new
+	// or newer, e.g. a rebuild of an older commit.
+	if err := e.shell.Command("git", "merge-base", "--is-ancestor", e.Commit, ref).Run(ctx, shell.ShowStderr(false)); err == nil {
+		return
+	}
+	if err := e.shell.Command("git", "update-ref", ref, e.Commit).Run(ctx); err != nil {
+		e.shell.Warningf("Could not update %s to %s: %v", ref, e.Commit, err)
+	}
+}
+
+// snapshotDeriveIncompatibleCloneFlags are clone flag prefixes that make a
+// fresh checkout ineligible for cloning from the local mirror snapshot,
+// because they select transport or remote-shape semantics that only the
+// canonical repository provides, or they conflict with the flags
+// deriveCheckoutFromSnapshot appends. Matching is by conservative prefix,
+// since git accepts unambiguous long-option abbreviations; an over-match only
+// means falling back to today's canonical --reference clone.
+var snapshotDeriveIncompatibleCloneFlags = []string{
+	"-b", "--br", // --branch: selects a branch from the canonical remote
+	"--dep",      // --depth: the shallow boundary must be canonical's
+	"--sha",      // --shallow-since / --shallow-exclude
+	"--si",       // --single-branch: depends on the remote's HEAD
+	"-o", "--or", // --origin: the derive rewrites the remote named origin
+	"-l", "--lo", // --local: the exact mode --no-local must suppress
+	"--mi", // --mirror
+	"--ba", // --bare
+	"--bu", // --bundle-uri: bootstraps objects from elsewhere
+}
+
+// cloneFlagsAllowSnapshotDerive reports whether the user-supplied clone flags
+// are compatible with deriving the fresh checkout from the mirror snapshot.
+func cloneFlagsAllowSnapshotDerive(flags []string) bool {
+	// Clone-time recursive submodules resolve URLs and clone while origin
+	// still points at the snapshot, and an external git dir would survive
+	// checkout-directory cleanup on fallback.
+	if hasRecursiveSubmoduleCloneFlags(flags) || hasSeparateGitDirCloneFlag(flags) {
+		return false
+	}
+	for _, flag := range flags {
+		for _, prefix := range snapshotDeriveIncompatibleCloneFlags {
+			if strings.HasPrefix(flag, prefix) {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/internal/job/checkout_workdir_remote_mirror_test.go
+++ b/internal/job/checkout_workdir_remote_mirror_test.go
@@ -52,8 +52,8 @@ func TestPrepareCheckoutWorkdirBypassedMirrorDissociatesStaleAlternate(t *testin
 		url:     "https://127.0.0.1:1/mirror.git",
 		outcome: remoteMirrorOutcomeTimeout,
 	}
-	if err := e.prepareCheckoutWorkdir(
-		t.Context(), &attempt, sparseCheckout{}, "", nil, false,
+	if _, err := e.prepareCheckoutWorkdir(
+		t.Context(), &attempt, sparseCheckout{}, mirrorReference{}, nil, false,
 	); err != nil {
 		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
 	}
@@ -76,14 +76,14 @@ func TestPrepareCheckoutWorkdirRemoteMirrorHitSkipsCanonicalFetch(t *testing.T) 
 	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
 	canonical.Close()
 
-	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", []string{"-v"}, false); err != nil {
+	if _, err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, mirrorReference{}, []string{"-v"}, false); err != nil {
 		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
 	}
 	if attempt.outcome != remoteMirrorOutcomeHit {
 		t.Errorf("outcome = %q, want hit", attempt.outcome)
 	}
 	assertGitConfigForRemoteMirrorTest(t, e.shell.Getwd(), "remote.origin.url", e.Repository)
-	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+	if err := e.fetchSource(t.Context(), false, false, &attempt); err != nil {
 		t.Fatalf("fetchSource() after hit error = %v", err)
 	}
 }
@@ -97,7 +97,7 @@ func TestPrepareCheckoutWorkdirKeepsLaggingMirrorClone(t *testing.T) {
 	}
 	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
 
-	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", []string{"-v"}, false); err != nil {
+	if _, err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, mirrorReference{}, []string{"-v"}, false); err != nil {
 		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
 	}
 	if attempt.outcome != remoteMirrorOutcomeMiss {
@@ -106,7 +106,7 @@ func TestPrepareCheckoutWorkdirKeepsLaggingMirrorClone(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(e.shell.Getwd(), ".git")); err != nil {
 		t.Errorf("useful lagging mirror clone was discarded: %v", err)
 	}
-	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+	if err := e.fetchSource(t.Context(), false, false, &attempt); err != nil {
 		t.Fatalf("canonical delta fetch error = %v", err)
 	}
 	if !hasGitCommit(t.Context(), e.shell, ".git", commit) {
@@ -135,11 +135,11 @@ func TestPrepareCheckoutWorkdirReclonesLaggingShallowMirror(t *testing.T) {
 	commit := gitOutputForRemoteCheckoutTest(t, source, "rev-parse", "HEAD")
 
 	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
-	if err := e.prepareCheckoutWorkdir(
+	if _, err := e.prepareCheckoutWorkdir(
 		t.Context(),
 		&attempt,
 		sparseCheckout{},
-		"",
+		mirrorReference{},
 		[]string{"--dept=1"},
 		false,
 	); err != nil {
@@ -148,7 +148,7 @@ func TestPrepareCheckoutWorkdirReclonesLaggingShallowMirror(t *testing.T) {
 	if attempt.outcome != remoteMirrorOutcomeMiss {
 		t.Fatalf("outcome = %q, want lag miss", attempt.outcome)
 	}
-	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+	if err := e.fetchSource(t.Context(), false, false, &attempt); err != nil {
 		t.Fatalf("fetchSource() error = %v", err)
 	}
 
@@ -190,13 +190,13 @@ func TestPrepareCheckoutWorkdirReclonesShallowReferenceFalseHit(t *testing.T) {
 	cloneOnHostMirrorToPath(t, canonical.RepoURL("canonical"), reference)
 	flags := []string{"--depth=1", "--reference", reference}
 	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
-	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", flags, false); err != nil {
+	if _, err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, mirrorReference{}, flags, false); err != nil {
 		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
 	}
 	if attempt.outcome != remoteMirrorOutcomeMiss {
 		t.Fatalf("outcome = %q, want ambiguous shallow reference treated as miss", attempt.outcome)
 	}
-	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+	if err := e.fetchSource(t.Context(), false, false, &attempt); err != nil {
 		t.Fatalf("fetchSource() error = %v", err)
 	}
 
@@ -233,11 +233,11 @@ func TestPrepareCheckoutWorkdirReclonesShallowAmbientAlternateFalseHit(t *testin
 	cloneOnHostMirrorToPath(t, canonical.RepoURL("canonical"), reference)
 	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
 	e.shell.Env.Set("GIT_ALTERNATE_OBJECT_DIRECTORIES", filepath.Join(reference, "objects"))
-	if err := e.prepareCheckoutWorkdir(
+	if _, err := e.prepareCheckoutWorkdir(
 		t.Context(),
 		&attempt,
 		sparseCheckout{},
-		"",
+		mirrorReference{},
 		[]string{"--depth=1"},
 		false,
 	); err != nil {
@@ -246,7 +246,7 @@ func TestPrepareCheckoutWorkdirReclonesShallowAmbientAlternateFalseHit(t *testin
 	if attempt.outcome != remoteMirrorOutcomeMiss {
 		t.Fatalf("outcome = %q, want ambient alternate shallow hit treated as miss", attempt.outcome)
 	}
-	if err := e.fetchSource(t.Context(), false, &attempt); err != nil {
+	if err := e.fetchSource(t.Context(), false, false, &attempt); err != nil {
 		t.Fatalf("fetchSource() error = %v", err)
 	}
 
@@ -274,11 +274,11 @@ func TestPrepareCheckoutWorkdirRecursiveSubmodulesUseCanonical(t *testing.T) {
 	e.GitCloneFlags = "--recurse-submodules"
 	attempt := e.resolveRemoteMirrorAttempt(0)
 
-	if err := e.prepareCheckoutWorkdir(
+	if _, err := e.prepareCheckoutWorkdir(
 		t.Context(),
 		&attempt,
 		sparseCheckout{},
-		"",
+		mirrorReference{},
 		[]string{"--recurse-submodules"},
 		false,
 	); err != nil {
@@ -312,7 +312,7 @@ func TestPrepareCheckoutWorkdirHidesRemoteURLPromptInDebug(t *testing.T) {
 	}
 	e.shell = debugShell
 
-	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", nil, false); err != nil {
+	if _, err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, mirrorReference{}, nil, false); err != nil {
 		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
 	}
 	if strings.Contains(logs.String(), attempt.url) {
@@ -328,7 +328,7 @@ func TestPrepareCheckoutWorkdirRemoteMirrorFailureFallsBack(t *testing.T) {
 	}
 	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), "http://127.0.0.1:1/mirror.git", commit)
 
-	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", []string{"-v"}, false); err != nil {
+	if _, err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, mirrorReference{}, []string{"-v"}, false); err != nil {
 		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
 	}
 	if attempt.outcome != remoteMirrorOutcomeError {
@@ -356,7 +356,7 @@ func TestPrepareCheckoutWorkdirRemoteMirrorTimeoutFallsBack(t *testing.T) {
 	t.Cleanup(stalled.Close)
 	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), stalled.URL+"/mirror.git", commit)
 
-	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", []string{"-v"}, false); err != nil {
+	if _, err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, mirrorReference{}, []string{"-v"}, false); err != nil {
 		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
 	}
 	if attempt.outcome != remoteMirrorOutcomeTimeout {
@@ -388,7 +388,7 @@ func TestPrepareCheckoutWorkdirAllowsDelayedFirstByteBelowStallGuard(t *testing.
 	t.Cleanup(delayed.Close)
 	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), delayed.URL+"/mirror.git", commit)
 
-	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", []string{"-v"}, false); err != nil {
+	if _, err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, mirrorReference{}, []string{"-v"}, false); err != nil {
 		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
 	}
 	if attempt.outcome != remoteMirrorOutcomeHit {
@@ -420,7 +420,7 @@ func TestPrepareCheckoutWorkdirRemoteMirrorCancellationDoesNotFallback(t *testin
 		case <-ctx.Done():
 		}
 	}()
-	err = e.prepareCheckoutWorkdir(ctx, &attempt, sparseCheckout{}, "", []string{"-v"}, false)
+	_, err = e.prepareCheckoutWorkdir(ctx, &attempt, sparseCheckout{}, mirrorReference{}, []string{"-v"}, false)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("prepareCheckoutWorkdir() error = %v, want context.Canceled", err)
 	}
@@ -450,11 +450,11 @@ func TestPrepareCheckoutWorkdirPartialCloneUsesCanonicalAfterMirrorRemoval(t *te
 	}
 	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
 
-	if err := e.prepareCheckoutWorkdir(
+	if _, err := e.prepareCheckoutWorkdir(
 		t.Context(),
 		&attempt,
 		sparseCheckout{},
-		"",
+		mirrorReference{},
 		[]string{"-v", "--filter=blob:none"},
 		true,
 	); err != nil {
@@ -480,7 +480,7 @@ func TestPrepareCheckoutWorkdirSparseCloneKeepsBloblessShape(t *testing.T) {
 	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
 	sparse := sparseCheckout{paths: []string{"src/"}, mode: SparseCheckoutModeCone}
 
-	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparse, "", []string{"-v"}, false); err != nil {
+	if _, err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparse, mirrorReference{}, []string{"-v"}, false); err != nil {
 		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
 	}
 	if attempt.outcome != remoteMirrorOutcomeHit {
@@ -511,11 +511,11 @@ func TestPrepareCheckoutWorkdirUnsupportedFilterSilentlyTransfersAllObjects(t *t
 	mirror := copyOnHostMirrorHTTPRepo(t, canonical.RepoURL("canonical"), "mirror")
 	e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
 
-	if err := e.prepareCheckoutWorkdir(
+	if _, err := e.prepareCheckoutWorkdir(
 		t.Context(),
 		&attempt,
 		sparseCheckout{},
-		"",
+		mirrorReference{},
 		[]string{"--filter=blob:none"},
 		true,
 	); err != nil {
@@ -593,7 +593,7 @@ func TestPrepareCheckoutWorkdirPreservesCloneConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			e, attempt := newFreshCloneRemoteMirrorExecutor(t, canonical.RepoURL("canonical"), mirror.RepoURL("mirror"), commit)
 			e.GitMirrorCheckoutMode = tc.mirrorMode
-			if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, tc.referenceDir, tc.flags, hasPartialFilterFlags(tc.flags)); err != nil {
+			if _, err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, mirrorReference{dir: tc.referenceDir}, tc.flags, hasPartialFilterFlags(tc.flags)); err != nil {
 				t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
 			}
 			if attempt.outcome != remoteMirrorOutcomeHit && attempt.outcome != remoteMirrorOutcomeMiss {
@@ -673,7 +673,7 @@ func TestPrepareCheckoutWorkdirRequiredSmudgeFailureFallsBackToCanonical(t *test
 		"--config", "filter.testfilter.required=true",
 	}
 
-	if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", flags, false); err != nil {
+	if _, err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, mirrorReference{}, flags, false); err != nil {
 		t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
 	}
 	if attempt.outcome != remoteMirrorOutcomeError {
@@ -749,7 +749,7 @@ func TestPrepareCheckoutWorkdirGitLFSBehavior(t *testing.T) {
 				e.shell.Env.Set("GIT_LFS_SKIP_SMUDGE", "1")
 			}
 
-			if err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, "", nil, false); err != nil {
+			if _, err := e.prepareCheckoutWorkdir(t.Context(), &attempt, sparseCheckout{}, mirrorReference{}, nil, false); err != nil {
 				t.Fatalf("prepareCheckoutWorkdir() error = %v", err)
 			}
 			if enabled {

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -41,6 +41,8 @@ func TestCheckingOutGitHubPullRequests_WithGitMirrors(t *testing.T) {
 	// But assert which ones are called
 	git.ExpectAll([][]any{
 		{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "maintenance.auto", "false"},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "gc.auto", "0"},
 		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", "refs/pull/123/head"},
@@ -87,6 +89,8 @@ func TestCheckingOutLocalGitProject_WithGitMirrors(t *testing.T) {
 	// But assert which ones are called
 	git.ExpectAll([][]any{
 		{"clone", "--mirror", "--config", "pack.threads=35", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "maintenance.auto", "false"},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "gc.auto", "0"},
 		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"fetch", "-v", "--", "origin", "main"},
@@ -133,6 +137,8 @@ func TestCheckingOutLocalGitProjectWithSparseCheckout_WithGitMirrors(t *testing.
 
 	git.ExpectAll([][]any{
 		{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "maintenance.auto", "false"},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "gc.auto", "0"},
 		{"--version"},
 		{"clone", "-v", "--filter=blob:none", "--sparse", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
@@ -184,6 +190,8 @@ func TestCheckingOutLocalGitProjectWithSparseCheckoutNoCone_WithGitMirrors(t *te
 
 	git.ExpectAll([][]any{
 		{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "maintenance.auto", "false"},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "gc.auto", "0"},
 		{"--version"},
 		{"clone", "-v", "--filter=blob:none", "--sparse", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
@@ -258,7 +266,11 @@ func TestCheckingOutLocalGitProjectWithSubmodules_WithGitMirrors(t *testing.T) {
 	// But assert which ones are called
 	git.ExpectAll([][]any{
 		{"clone", "--mirror", "-v", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "maintenance.auto", "false"},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "gc.auto", "0"},
 		{"clone", "--mirror", "-v", "--", submoduleRepo.Path, matchSubDir(tester.GitMirrorsDir)},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "maintenance.auto", "false"},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "gc.auto", "0"},
 		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"submodule", "foreach", "--recursive", "git clean -fdq"},
@@ -335,6 +347,8 @@ func TestCheckingOutLocalGitProjectWithSubmodulesDisabled_WithGitMirrors(t *test
 	// But assert which ones are called
 	git.ExpectAll([][]any{
 		{"clone", "--mirror", "-v", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "maintenance.auto", "false"},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "gc.auto", "0"},
 		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"submodule", "foreach", "--recursive", "git clean -fdq"},
@@ -381,6 +395,8 @@ func TestCheckingOutShallowCloneOfLocalGitProject_WithGitMirrors(t *testing.T) {
 	// But assert which ones are called
 	git.ExpectAll([][]any{
 		{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "maintenance.auto", "false"},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "gc.auto", "0"},
 		{"clone", "--depth=1", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"fetch", "--depth=1", "--", "origin", "main"},
@@ -759,6 +775,8 @@ func TestGitMirrorEnv(t *testing.T) {
 	// But assert which ones are called
 	git.ExpectAll([][]any{
 		{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "maintenance.auto", "false"},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "gc.auto", "0"},
 		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
 		{"fetch", "-v", "--", "origin", "main"},
@@ -840,6 +858,8 @@ func TestCheckingOutWithCustomRefspec_WithGitMirrors(t *testing.T) {
 	// With the fix: the mirror should fetch the custom refspec instead of the branch
 	git.ExpectAll([][]any{
 		{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "maintenance.auto", "false"},
+		{"--git-dir", matchSubDir(tester.GitMirrorsDir), "config", "gc.auto", "0"},
 		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
 		{"clean", "-ffxdq"},
 		{"fetch", "-v", "--prune", "--", "origin", customRef}, // Mirror fetches custom refspec (correct!)


### PR DESCRIPTION
Implements the v4 mirror-first checkout design from [A-1665](https://linear.app/buildkite/issue/A-1665): when on-host git mirrors and clean checkout are enabled, clone the fresh checkout *from* the job's immutable mirror snapshot instead of from the git host.

## What changes

Jobs with mirrors + clean checkout already receive a per-job hardlink snapshot of the mirror, created under the mirror's update lock (#3789). This PR uses that snapshot as the clone source:

- **Derive the checkout locally**: `git clone --no-checkout --no-local --reference <snapshot> -- <snapshot> .`, then immediately rewrite `origin` to the canonical repository URL. `--no-local` and `--no-checkout` are mandatory and appended after user flags so they cannot be overridden (`--no-local` prevents git's local hardlink optimization from tying the checkout's object store to the snapshot, which is deleted at job teardown).
- **Skip the redundant fetch** when the build's commit is already present locally. Presence is the routing decision only; the later `git checkout` of the target commit remains the validation. Custom-refspec builds always keep their fetch, since fetching a `src:dst` refspec creates local refs job code may read.
- **Keep the build branch's remote-tracking ref fresh**: `refs/remotes/origin/<branch>` is advanced to the build commit when the snapshot's copy is stale (best-effort, plain branch builds only).
- **Fix the #2208 corruption class for snapshot creation**: mirrors set `maintenance.auto=false` and `gc.auto=0` (retrofitted onto existing mirrors), so detached auto-gc can no longer mutate the mirror after the lock is released. Maintenance instead runs as a synchronous `git gc --auto` under the update lock, before the snapshot is taken.
- Adds a `git.clone_source` span attribute (`canonical` / `snapshot` / `remote-mirror`) for observability.

On a warm mirror, a clean-checkout job's clone and fetch make no network round-trips to the git host. Local benchmark: ~0.6s snapshot-derived clone vs ~2.8s canonical clone with `--reference`.

## Fail-open behavior

The mirror layer stays an optimization, never a correctness dependency:

- Clone flags that need the canonical remote's shape (`--depth`, `--branch`, `--single-branch`, `--bundle-uri`, `--mirror`, `--bare`, `--origin`, recursive submodules, `--separate-git-dir`, ...) fall back to today's canonical clone with the snapshot as `--reference`. Matching is by conservative prefix; an over-match only means falling back to current behavior.
- Any derive failure removes the partial checkout and falls back to a plain canonical clone, without retaining the possibly-broken snapshot as a reference.

## Scope and accepted tradeoffs

- **Non-clean (persistent) checkouts are unchanged**: they still `--reference` the durable mirror directly, with the pre-existing #2208 exposure. Snapshots for persistent checkouts require an object-ownership story (dissociate-on-teardown or checkout age-out) and are deliberately deferred — see A-1665 for the staging.
- **Split-phase jobs (agent-stack-k8s) are unchanged**: snapshot cleanup is tied to the executor that created it, so jobs without a command phase keep the durable-mirror reference (pre-existing gating from #3789).
- **`gc --auto` under the update lock** can extend lock hold time when git's thresholds trip a consolidating repack (~every `gc.autoPackLimit` fetches). This is the price of making mirror mutation impossible outside the lock. `--git-mirrors-lock-timeout` (default 300s) should exceed the longest checkout, as its usage text already states.
- **Corruption quarantine/staged-rebuild** from the design is not implemented here; recovery remains the existing retry-clean path.

## Testing

- New focused tests: derive with canonical unreachable (proves no network dependency), derive failure falling back to canonical, incompatible flags using the snapshot as reference only, custom-refspec fetch preservation, and a flag-compatibility table.
- Updated exact-argv git-mirror integration fixtures.
- `go test ./...`, `golangci-lint run` (0 issues), `gofumpt -extra` clean.

Docs: `docs/git-mirror.md` gains a section on per-job snapshots and snapshot-derived clones, and the auto-maintenance section now describes the implemented policy.

