### PR TITLE
feat(cache): namespace archive entries by anchor via a manifest (backport to v3)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/puzpuzpuz/xsync/v2 v2.5.1
 	github.com/qri-io/jsonschema v0.2.1
 	github.com/urfave/cli v1.22.17
-	github.com/wolfeidau/quickzip v1.0.2
+	github.com/wolfeidau/quickzip v1.0.3
 	go.opentelemetry.io/contrib/propagators/aws v1.44.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.44.0
 	go.opentelemetry.io/contrib/propagators/jaeger v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -423,8 +423,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.13 h1:A2wsiTbvp63ilDaWmsk2wjx6xZdxQOvpiNl
 github.com/vmihailenco/msgpack/v4 v4.3.13/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.2 h1:gnjoVuB/kljJ5wICEEOpx98oXMWPLj22G67Vbd1qPqc=
 github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/wolfeidau/quickzip v1.0.2 h1:QPc4CVE8ECYng87o63C4t6+6ihZk1howyrZWwklKjq8=
-github.com/wolfeidau/quickzip v1.0.2/go.mod h1:ZDvxJMzI2iVp6CavOqxFq1tORhRyuxCDFw4HO25RbuA=
+github.com/wolfeidau/quickzip v1.0.3 h1:ThEzyN1RccCCeZqDvF7mM8gZxveOFaUTIinAA/HvsgU=
+github.com/wolfeidau/quickzip v1.0.3/go.mod h1:ZDvxJMzI2iVp6CavOqxFq1tORhRyuxCDFw4HO25RbuA=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=

--- a/internal/cache/archive/archive.go
+++ b/internal/cache/archive/archive.go
@@ -3,12 +3,8 @@ package archive
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"hash"
 	"io"
-	"os"
-	"path/filepath"
-	"strings"
 	"time"
 )
 
@@ -25,35 +21,6 @@ type ArchiveInfo struct {
 	WrittenBytes   int64
 	WrittenEntries int64
 	Duration       time.Duration
-}
-
-// isUnderHome checks if the given path is under the user's home directory.
-// It first gets the absolute path of the given path, then gets the user's
-// home directory, and finally checks if the absolute path starts with the
-// home directory path.
-func isUnderHome(path string) (bool, error) {
-	if path == "" {
-		return false, fmt.Errorf("path is empty")
-	}
-
-	// Get absolute path
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return false, fmt.Errorf("failed to get absolute path: %w", err)
-	}
-
-	// Get user's home directory
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return false, fmt.Errorf("failed to get home directory: %w", err)
-	}
-
-	// Clean both paths to normalize them
-	cleanPath := filepath.Clean(absPath)
-	cleanHome := filepath.Clean(homeDir)
-
-	// Check if the path starts with home directory
-	return strings.HasPrefix(cleanPath, cleanHome), nil
 }
 
 type ChecksumSHA256 struct {

--- a/internal/cache/archive/archive_test.go
+++ b/internal/cache/archive/archive_test.go
@@ -3,69 +3,16 @@ package archive
 import (
 	"bytes"
 	"crypto/sha256"
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+
+	"github.com/buildkite/agent/v3/internal/cache/internal/trace"
+	"github.com/klauspost/compress/zip"
 )
-
-func TestIsUnderHome(t *testing.T) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatalf("failed to get home directory: %v", err)
-	}
-
-	tests := []struct {
-		name     string
-		path     string
-		expected bool
-		wantErr  bool
-	}{
-		{
-			name:     "path under home directory",
-			path:     filepath.Join(homeDir, "documents"),
-			expected: true,
-			wantErr:  false,
-		},
-		{
-			name:     "path not under home directory",
-			path:     "/tmp/test",
-			expected: false,
-			wantErr:  false,
-		},
-		// TODO: investigate how we can override the home directory for testing
-		// {
-		// 	name:     "relative path under home",
-		// 	path:     "~/documents",
-		// 	expected: true,
-		// 	wantErr:  false,
-		// },
-		{
-			name:     "empty path",
-			path:     "",
-			expected: false,
-			wantErr:  true,
-		},
-		{
-			name:     "path with symlinks",
-			path:     filepath.Join(homeDir, "..", filepath.Base(homeDir)),
-			expected: true,
-			wantErr:  false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := isUnderHome(tt.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("isUnderHome() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if result != tt.expected {
-				t.Errorf("isUnderHome() = %v, want %v", result, tt.expected)
-			}
-		})
-	}
-}
 
 func TestChecksumSHA256_Sum(t *testing.T) {
 	tests := []struct {
@@ -115,5 +62,664 @@ func TestChecksumSHA256_Sum(t *testing.T) {
 				t.Errorf("Sum() = %v, want %v", result, tt.expected)
 			}
 		})
+	}
+}
+
+func mustTrace(t *testing.T) {
+	t.Helper()
+	if _, err := trace.NewProvider(t.Context(), "noop", "test", "0.0.1"); err != nil {
+		t.Fatalf("trace.NewProvider: %v", err)
+	}
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func openArchive(t *testing.T, info *ArchiveInfo) *os.File {
+	t.Helper()
+	f, err := os.Open(info.ArchivePath)
+	if err != nil {
+		t.Fatalf("os.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	return f
+}
+
+func readArchiveManifest(t *testing.T, info *ArchiveInfo) Manifest {
+	t.Helper()
+	f := openArchive(t, info)
+	reader, err := zip.NewReader(f, info.Size)
+	if err != nil {
+		t.Fatalf("zip.NewReader: %v", err)
+	}
+	manifest, err := readManifest(reader)
+	if err != nil {
+		t.Fatalf("readManifest: %v", err)
+	}
+	return manifest
+}
+
+// TestV2_AbsolutePathRoundTrip covers absolute paths — the case v1 could not
+// handle (quickzip cannot chroot at a bare root) and the reason this change
+// unblocks A-1533. Runs on Windows too: the anchor is the drive root there.
+func TestV2_AbsolutePathRoundTrip(t *testing.T) {
+	mustTrace(t)
+	setHomeDir(t, t.TempDir())
+
+	absDir := t.TempDir()
+	writeTestFile(t, filepath.Join(absDir, "a.txt"), "hello")
+	writeTestFile(t, filepath.Join(absDir, "sub", "b.txt"), "world")
+
+	info, err := BuildArchive(t.Context(), []string{absDir}, "abs")
+	if err != nil {
+		t.Fatalf("BuildArchive: %v", err)
+	}
+	defer func() { _ = os.Remove(info.ArchivePath) }()
+
+	if got := readArchiveManifest(t, info).Mappings["_0"]; !isRootAnchor(got) {
+		t.Errorf("manifest _0 anchor = %q, want a root anchor", got)
+	}
+
+	// Wipe the source and restore it back into the same absolute location.
+	if err := os.RemoveAll(absDir); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	if _, err := ExtractFiles(t.Context(), openArchive(t, info), info.Size, []string{absDir}); err != nil {
+		t.Fatalf("ExtractFiles: %v", err)
+	}
+
+	assertFileContent(t, filepath.Join(absDir, "a.txt"), "hello")
+	assertFileContent(t, filepath.Join(absDir, "sub", "b.txt"), "world")
+}
+
+// TestV2_EmptyAbsoluteDirectoryRestored checks that an empty root-anchored
+// directory survives a round trip — the chroot-root entry must be retained, not
+// dropped, or restore recreates nothing.
+func TestV2_EmptyAbsoluteDirectoryRestored(t *testing.T) {
+	mustTrace(t)
+	setHomeDir(t, t.TempDir())
+
+	absDir := t.TempDir() // absolute, outside home, empty
+
+	info, err := BuildArchive(t.Context(), []string{absDir}, "empty")
+	if err != nil {
+		t.Fatalf("BuildArchive: %v", err)
+	}
+	defer func() { _ = os.Remove(info.ArchivePath) }()
+
+	if err := os.RemoveAll(absDir); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	if _, err := ExtractFiles(t.Context(), openArchive(t, info), info.Size, []string{absDir}); err != nil {
+		t.Fatalf("ExtractFiles: %v", err)
+	}
+
+	fi, err := os.Stat(absDir)
+	if err != nil {
+		t.Fatalf("empty directory should be recreated: %v", err)
+	}
+	if !fi.IsDir() {
+		t.Errorf("%q should be a directory", absDir)
+	}
+}
+
+// TestV2_DirectorySymlinkRestored checks that an absolute target that is a
+// symlink to a directory is retained as a symlink rather than dropped.
+func TestV2_DirectorySymlinkRestored(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating a directory symlink needs privileges on Windows")
+	}
+	mustTrace(t)
+	setHomeDir(t, t.TempDir())
+
+	realDir := t.TempDir()
+	writeTestFile(t, filepath.Join(realDir, "f.txt"), "hi")
+
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	info, err := BuildArchive(t.Context(), []string{link}, "symlink")
+	if err != nil {
+		t.Fatalf("BuildArchive: %v", err)
+	}
+	defer func() { _ = os.Remove(info.ArchivePath) }()
+
+	if err := os.Remove(link); err != nil {
+		t.Fatalf("Remove link: %v", err)
+	}
+
+	if _, err := ExtractFiles(t.Context(), openArchive(t, info), info.Size, []string{link}); err != nil {
+		t.Fatalf("ExtractFiles: %v", err)
+	}
+
+	target, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("symlink should be recreated: %v", err)
+	}
+	if target != realDir {
+		t.Errorf("symlink target = %q, want %q", target, realDir)
+	}
+}
+
+// TestV2_AbsolutePathUnderHomeIsPinned checks that an absolute path that
+// happens to sit under $HOME is *pinned* (root-anchored), not portable: only a
+// leading "~" is portable. A pinned path must restore to its exact
+// original location even after $HOME changes, rather than following the new
+// home (which would silently drop the entries).
+func TestV2_AbsolutePathUnderHomeIsPinned(t *testing.T) {
+	mustTrace(t)
+
+	homeA := t.TempDir()
+	setHomeDir(t, homeA)
+
+	// Configure the path as an absolute path under home (not "~/...").
+	absUnderHome := filepath.Join(homeA, ".gradle")
+	writeTestFile(t, filepath.Join(absUnderHome, "caches", "x.bin"), "data")
+
+	info, err := BuildArchive(t.Context(), []string{absUnderHome}, "gradle")
+	if err != nil {
+		t.Fatalf("BuildArchive: %v", err)
+	}
+	defer func() { _ = os.Remove(info.ArchivePath) }()
+
+	anchor := readArchiveManifest(t, info).Mappings["_0"]
+	if anchor == AnchorHome {
+		t.Errorf("absolute path under $HOME must be pinned, got anchor %q (AnchorHome)", anchor)
+	}
+	if !isRootAnchor(anchor) {
+		t.Errorf("expected a root anchor, got %q", anchor)
+	}
+
+	// Change $HOME. The pinned path must still restore to its ORIGINAL absolute
+	// location (under homeA), not the new home.
+	setHomeDir(t, t.TempDir())
+
+	if err := os.RemoveAll(absUnderHome); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	if _, err := ExtractFiles(t.Context(), openArchive(t, info), info.Size, []string{absUnderHome}); err != nil {
+		t.Fatalf("ExtractFiles: %v", err)
+	}
+
+	assertFileContent(t, filepath.Join(absUnderHome, "caches", "x.bin"), "data")
+}
+
+// TestV2_TargetOverlap checks BuildArchive rejects overlapping targets and
+// accepts non-overlapping ones across nesting, symlink, and spelling shapes.
+func TestV2_TargetOverlap(t *testing.T) {
+	mustTrace(t)
+
+	tests := []struct {
+		name    string
+		symlink bool // needs symlink privileges
+		setup   func(t *testing.T, base string) []string
+		wantErr bool
+	}{
+		{
+			name: "nested",
+			setup: func(t *testing.T, base string) []string {
+				writeTestFile(t, filepath.Join(base, "cache", "sub", "x"), "data")
+				return []string{filepath.Join(base, "cache"), filepath.Join(base, "cache", "sub")}
+			},
+			wantErr: true,
+		},
+		{
+			name: "tilde and absolute spelling of one dir",
+			setup: func(t *testing.T, base string) []string {
+				setHomeDir(t, base)
+				writeTestFile(t, filepath.Join(base, "cache", "x"), "data")
+				return []string{"~/cache", filepath.Join(base, "cache")}
+			},
+			wantErr: true,
+		},
+		{
+			name:    "symlink alias to the same dir",
+			symlink: true,
+			setup: func(t *testing.T, base string) []string {
+				real := filepath.Join(base, "real")
+				writeTestFile(t, filepath.Join(real, "sub", "x"), "data")
+				mustSymlink(t, real, filepath.Join(base, "alias"))
+				return []string{filepath.Join(real, "sub"), filepath.Join(base, "alias", "sub")}
+			},
+			wantErr: true,
+		},
+		{
+			name:    "symlinked parent, lexically nested",
+			symlink: true,
+			setup: func(t *testing.T, base string) []string {
+				cacheDir := filepath.Join(base, "cache")
+				if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+					t.Fatalf("MkdirAll: %v", err)
+				}
+				writeTestFile(t, filepath.Join(base, "other", "sub", "x"), "data")
+				mustSymlink(t, filepath.Join(base, "other"), filepath.Join(cacheDir, "link"))
+				return []string{cacheDir, filepath.Join(cacheDir, "link", "sub")}
+			},
+			wantErr: true,
+		},
+		{
+			// A final symlink is archived as the link, not its referent.
+			name:    "final symlink does not overlap its referent",
+			symlink: true,
+			setup: func(t *testing.T, base string) []string {
+				real := filepath.Join(base, "real")
+				writeTestFile(t, filepath.Join(real, "sub", "x"), "data")
+				alias := filepath.Join(base, "alias")
+				mustSymlink(t, real, alias)
+				return []string{alias, filepath.Join(real, "sub")}
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.symlink && runtime.GOOS == "windows" {
+				t.Skip("creating a symlink needs privileges on Windows")
+			}
+			paths := tt.setup(t, t.TempDir())
+			_, err := BuildArchive(t.Context(), paths, "overlap")
+			switch {
+			case tt.wantErr && (err == nil || !strings.Contains(err.Error(), "overlap")):
+				t.Errorf("BuildArchive(%v) = %v, want overlap error", paths, err)
+			case !tt.wantErr && err != nil:
+				t.Errorf("BuildArchive(%v) = %v, want no error", paths, err)
+			}
+		})
+	}
+}
+
+// mustSymlink creates a symlink or fails the test.
+func mustSymlink(t *testing.T, target, link string) {
+	t.Helper()
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+}
+
+// TestPathsOverlap covers the case-sensitivity switch of the overlap
+// comparison portably (the case-insensitive branch is what Windows uses).
+func TestPathsOverlap(t *testing.T) {
+	sep := string(filepath.Separator)
+	a := filepath.Join(sep, "a", "Cache")
+	lower := filepath.Join(sep, "a", "cache")
+	nested := filepath.Join(sep, "a", "x", "y")
+	parent := filepath.Join(sep, "a", "x")
+	sibling := filepath.Join(sep, "a", "z")
+
+	tests := []struct {
+		name            string
+		a, b            string
+		caseInsensitive bool
+		want            bool
+	}{
+		{"case variant, case-sensitive", a, lower, false, false},
+		{"case variant, case-insensitive", a, lower, true, true},
+		{"nested", parent, nested, false, true},
+		{"nested reversed", nested, parent, false, true},
+		{"siblings", parent, sibling, false, false},
+	}
+	for _, tt := range tests {
+		if got := pathsOverlap(tt.a, tt.b, tt.caseInsensitive); got != tt.want {
+			t.Errorf("%s: pathsOverlap(%q,%q,%v) = %v, want %v", tt.name, tt.a, tt.b, tt.caseInsensitive, got, tt.want)
+		}
+	}
+}
+
+// TestV2_TargetOverlapCaseVariant covers case-only differences via BuildArchive,
+// adapting to the host filesystem's case behaviour (existing targets).
+func TestV2_TargetOverlapCaseVariant(t *testing.T) {
+	mustTrace(t)
+
+	tests := []struct{ name, upper, lower string }{
+		{"leaf", "Cache", "cache"},
+		{"numeric leaf under a cased parent", filepath.Join("Cache", "2024"), filepath.Join("cache", "2024")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setHomeDir(t, t.TempDir())
+			base := t.TempDir()
+			upper := filepath.Join(base, tt.upper)
+			writeTestFile(t, filepath.Join(upper, "x.bin"), "data")
+
+			_, err := BuildArchive(t.Context(), []string{upper, filepath.Join(base, tt.lower)}, "case")
+			if caseInsensitiveFS(t, base) {
+				if err == nil || !strings.Contains(err.Error(), "overlap") {
+					t.Errorf("case-insensitive: BuildArchive = %v, want overlap error", err)
+				}
+			} else if err != nil {
+				t.Errorf("case-sensitive: BuildArchive = %v, want no error", err)
+			}
+		})
+	}
+}
+
+// TestOverlappingPathsAbsentCaseVariant covers a fresh restore: case-variant
+// targets that don't exist yet must overlap iff the filesystem folds case.
+func TestOverlappingPathsAbsentCaseVariant(t *testing.T) {
+	base := t.TempDir()
+	want := caseInsensitiveFS(t, base)
+	_, _, ok := OverlappingPaths([]string{
+		filepath.Join(base, "Cache"),
+		filepath.Join(base, "cache"),
+	})
+	if ok != want {
+		t.Errorf("OverlappingPaths overlap = %v, want %v (case-insensitive=%v)", ok, want, want)
+	}
+}
+
+// TestOverlappingPathsReadOnlyCaseVariant covers existing case-variant targets
+// whose destination is read-only (0555), so the writable probe (MkdirTemp)
+// fails — file identity must still detect the overlap. The numeric-leaf variant
+// exercises re-casing an ancestor rather than the (all-digit) leaf.
+func TestOverlappingPathsReadOnlyCaseVariant(t *testing.T) {
+	tests := []struct{ name, upper, lower string }{
+		{"lettered leaf", "Cache", "cache"},
+		{"numeric leaf under a cased parent", filepath.Join("Cache", "123"), filepath.Join("cache", "123")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := t.TempDir()
+			if !caseInsensitiveFS(t, base) {
+				t.Skip("requires a case-insensitive filesystem")
+			}
+			upper := filepath.Join(base, tt.upper)
+			if err := os.MkdirAll(upper, 0o755); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			// Make the target read-only so MkdirTemp inside it fails; detection
+			// must fall back to file identity.
+			if err := os.Chmod(upper, 0o555); err != nil {
+				t.Fatalf("Chmod: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Chmod(upper, 0o755) })
+
+			if _, _, ok := OverlappingPaths([]string{upper, filepath.Join(base, tt.lower)}); !ok {
+				t.Error("case-variant targets in a read-only dir should overlap via identity")
+			}
+		})
+	}
+}
+
+// caseInsensitiveFS reports whether dir's filesystem folds case, via a marker.
+func caseInsensitiveFS(t *testing.T, dir string) bool {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "Marker"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	a, e1 := os.Stat(filepath.Join(dir, "Marker"))
+	b, e2 := os.Stat(filepath.Join(dir, "marker"))
+	return e1 == nil && e2 == nil && os.SameFile(a, b)
+}
+
+// TestV2_HomePortability proves a "~" cache saved under one home directory
+// restores under a different home directory.
+func TestV2_HomePortability(t *testing.T) {
+	mustTrace(t)
+
+	homeA := t.TempDir()
+	setHomeDir(t, homeA)
+	writeTestFile(t, filepath.Join(homeA, ".cache", "x.txt"), "data")
+
+	info, err := BuildArchive(t.Context(), []string{"~/.cache"}, "home")
+	if err != nil {
+		t.Fatalf("BuildArchive: %v", err)
+	}
+	defer func() { _ = os.Remove(info.ArchivePath) }()
+
+	if got := readArchiveManifest(t, info).Mappings["_0"]; got != AnchorHome {
+		t.Errorf("manifest _0 anchor = %q, want %q", got, AnchorHome)
+	}
+
+	// Restore into a different home directory.
+	homeB := t.TempDir()
+	setHomeDir(t, homeB)
+
+	if _, err := ExtractFiles(t.Context(), openArchive(t, info), info.Size, []string{"~/.cache"}); err != nil {
+		t.Fatalf("ExtractFiles: %v", err)
+	}
+
+	assertFileContent(t, filepath.Join(homeB, ".cache", "x.txt"), "data")
+}
+
+// TestV2_ExtractMatchesSpellingVariantsAndSkipsUnconfigured checks that restore
+// matches on the normalised resolved path (so "~/.cache" matches a config that
+// spells it as an absolute path) and skips namespaces absent from local config.
+func TestV2_ExtractMatchesSpellingVariantsAndSkipsUnconfigured(t *testing.T) {
+	mustTrace(t)
+
+	home := t.TempDir()
+	setHomeDir(t, home)
+	writeTestFile(t, filepath.Join(home, ".cache", "keep.txt"), "keep")
+	writeTestFile(t, filepath.Join(home, ".other", "drop.txt"), "drop")
+
+	info, err := BuildArchive(t.Context(), []string{"~/.cache", "~/.other"}, "multi")
+	if err != nil {
+		t.Fatalf("BuildArchive: %v", err)
+	}
+	defer func() { _ = os.Remove(info.ArchivePath) }()
+
+	if err := os.RemoveAll(filepath.Join(home, ".cache")); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(home, ".other")); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	// Configure only .cache, spelled as an absolute path rather than "~/.cache".
+	if _, err := ExtractFiles(t.Context(), openArchive(t, info), info.Size, []string{filepath.Join(home, ".cache")}); err != nil {
+		t.Fatalf("ExtractFiles: %v", err)
+	}
+
+	assertFileContent(t, filepath.Join(home, ".cache", "keep.txt"), "keep")
+
+	if _, err := os.Stat(filepath.Join(home, ".other", "drop.txt")); !os.IsNotExist(err) {
+		t.Errorf(".other should not be restored (not in local config), stat err = %v", err)
+	}
+}
+
+// TestV2_UnrecognizedFormatSoftFails ensures a v1-style archive (no manifest)
+// is detected and reported as ErrUnrecognizedFormat rather than extracted.
+func TestV2_UnrecognizedFormatSoftFails(t *testing.T) {
+	mustTrace(t)
+
+	tmp, err := os.CreateTemp(t.TempDir(), "v1-*.zip")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	defer func() { _ = tmp.Close() }()
+
+	zw := zip.NewWriter(tmp)
+	w, err := zw.Create("cache/file.txt")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := w.Write([]byte("legacy")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	stat, err := tmp.Stat()
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+
+	if err := Validate(tmp.Name(), stat.Size()); !errors.Is(err, ErrUnrecognizedFormat) {
+		t.Errorf("Validate err = %v, want ErrUnrecognizedFormat", err)
+	}
+
+	if _, err := ExtractFiles(t.Context(), tmp, stat.Size(), []string{"cache"}); !errors.Is(err, ErrUnrecognizedFormat) {
+		t.Errorf("ExtractFiles err = %v, want ErrUnrecognizedFormat", err)
+	}
+}
+
+// TestV2_UnrecognizedAnchorSoftFails ensures a manifest whose anchor value
+// falls outside {~, /, .} soft-fails as ErrUnrecognizedFormat, the same as an
+// absent manifest or bad version, instead of causing a hard failure partway
+// through extraction.
+func TestV2_UnrecognizedAnchorSoftFails(t *testing.T) {
+	mustTrace(t)
+
+	tmp, err := os.CreateTemp(t.TempDir(), "bad-anchor-*.zip")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	defer func() { _ = tmp.Close() }()
+
+	zw := zip.NewWriter(tmp)
+	if err := writeManifest(zw, Manifest{
+		Version:  ManifestVersion,
+		Mappings: map[string]string{"_0": "?"},
+	}); err != nil {
+		t.Fatalf("writeManifest: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	stat, err := tmp.Stat()
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+
+	if err := Validate(tmp.Name(), stat.Size()); !errors.Is(err, ErrUnrecognizedFormat) {
+		t.Errorf("Validate err = %v, want ErrUnrecognizedFormat", err)
+	}
+
+	if _, err := ExtractFiles(t.Context(), tmp, stat.Size(), []string{"cache"}); !errors.Is(err, ErrUnrecognizedFormat) {
+		t.Errorf("ExtractFiles err = %v, want ErrUnrecognizedFormat", err)
+	}
+}
+
+// TestV2_AbsoluteFileRoundTrip covers a root-anchored target that is a single
+// file (not a directory) — its chroot-root entry must round-trip as a file.
+func TestV2_AbsoluteFileRoundTrip(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("absolute (root-anchored) target_paths are not supported on Windows")
+	}
+	mustTrace(t)
+	setHomeDir(t, t.TempDir())
+
+	file := filepath.Join(t.TempDir(), "cache-file") // absolute, outside home
+	writeTestFile(t, file, "payload")
+
+	info, err := BuildArchive(t.Context(), []string{file}, "absfile")
+	if err != nil {
+		t.Fatalf("BuildArchive: %v", err)
+	}
+	defer func() { _ = os.Remove(info.ArchivePath) }()
+
+	if got := readArchiveManifest(t, info).Mappings["_0"]; got != "/" {
+		t.Errorf("manifest _0 anchor = %q, want %q", got, "/")
+	}
+
+	if err := os.Remove(file); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	if _, err := ExtractFiles(t.Context(), openArchive(t, info), info.Size, []string{file}); err != nil {
+		t.Fatalf("ExtractFiles: %v", err)
+	}
+
+	assertFileContent(t, file, "payload")
+}
+
+// TestV2_TrailingSlashHomeRoundTrips guards against $HOME carrying a trailing
+// slash: anchor bases must be normalised so restore's containment check doesn't
+// spuriously reject a valid "~"-anchored entry.
+func TestV2_TrailingSlashHomeRoundTrips(t *testing.T) {
+	mustTrace(t)
+
+	home := t.TempDir()
+	setHomeDir(t, home+string(os.PathSeparator)) // trailing slash
+	writeTestFile(t, filepath.Join(home, ".cache", "x.txt"), "data")
+
+	info, err := BuildArchive(t.Context(), []string{"~/.cache"}, "trailing")
+	if err != nil {
+		t.Fatalf("BuildArchive: %v", err)
+	}
+	defer func() { _ = os.Remove(info.ArchivePath) }()
+
+	if err := os.RemoveAll(filepath.Join(home, ".cache")); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	if _, err := ExtractFiles(t.Context(), openArchive(t, info), info.Size, []string{"~/.cache"}); err != nil {
+		t.Fatalf("ExtractFiles: %v", err)
+	}
+
+	assertFileContent(t, filepath.Join(home, ".cache", "x.txt"), "data")
+}
+
+// TestDiscardNameContained ensures discarded entries can never escape the
+// throwaway directory, even when the entry name contains "/", "\" or ".."
+// segments (a crafted-archive Windows extraction escape).
+func TestDiscardNameContained(t *testing.T) {
+	discardDir := t.TempDir()
+
+	names := []string{
+		".buildkite/cache-manifest.json",
+		"../../etc/passwd",
+		`..\..\victim`,
+		`_9/..\..\..\Windows\System32\evil`,
+		"",
+		"a/b/c",
+	}
+
+	for _, name := range names {
+		got := discardName(discardDir, name)
+		if !isUnder(got, discardDir) {
+			t.Errorf("discardName(%q) = %q, escapes discardDir %q", name, got, discardDir)
+		}
+		// The mapped name must be a single component directly under discardDir.
+		if filepath.Dir(got) != filepath.Clean(discardDir) {
+			t.Errorf("discardName(%q) = %q, not a direct child of %q", name, got, discardDir)
+		}
+	}
+}
+
+// TestIsUnder locks the containment logic, including roots that already end in
+// a separator (the POSIX root, and — exercised on Windows — a volume root).
+func TestIsUnder(t *testing.T) {
+	sep := string(filepath.Separator)
+	tests := []struct {
+		p, root string
+		want    bool
+	}{
+		{filepath.Join(sep, "a", "b"), sep, true}, // separator-terminated root
+		{sep, sep, true}, // equal to root
+		{filepath.Join(sep, "home", "user", "x"), filepath.Join(sep, "home", "user"), true},
+		{filepath.Join(sep, "home", "user2"), filepath.Join(sep, "home", "user"), false}, // prefix sibling, not under
+		{filepath.Join(sep, "home", "user"), filepath.Join(sep, "home", "user"), true},
+	}
+	for _, tt := range tests {
+		if got := isUnder(tt.p, tt.root); got != tt.want {
+			t.Errorf("isUnder(%q, %q) = %v, want %v", tt.p, tt.root, got, tt.want)
+		}
+	}
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile %q: %v", path, err)
+	}
+	if string(got) != want {
+		t.Errorf("content of %q = %q, want %q", path, string(got), want)
 	}
 }

--- a/internal/cache/archive/create.go
+++ b/internal/cache/archive/create.go
@@ -3,17 +3,22 @@ package archive
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/buildkite/agent/v3/internal/cache/internal/trace"
+	"github.com/klauspost/compress/zip"
 	"github.com/klauspost/compress/zstd"
 	"github.com/wolfeidau/quickzip"
 	"go.opentelemetry.io/otel/attribute"
 )
 
+// BuildArchive builds a cache archive for the given target paths.
 func BuildArchive(ctx context.Context, paths []string, key string) (*ArchiveInfo, error) {
 	_, span := trace.Start(ctx, "BuildArchive")
 	defer span.End()
@@ -33,61 +38,65 @@ func BuildArchive(ctx context.Context, paths []string, key string) (*ArchiveInfo
 		_ = archiveFile.Close()
 	}()
 
+	// Wrap the file in an io.Writer which records the sha256sum of the archive.
 	checksummer := NewChecksumSHA256(archiveFile)
-
-	// wrap the file in an io.Writer which records the sha256sum of the file
-	arc, err := quickzip.NewArchiver(
-		checksummer,
-		quickzip.WithArchiverMethod(zstd.ZipMethodWinZip),
-		quickzip.WithArchiverBufferSize(bufferSize),
-		quickzip.WithModifiedEpoch(modified),
-		quickzip.WithSkipOwnership(skipOwnership),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create archiver: %w", err)
-	}
+	zw := zip.NewWriter(checksummer)
 
 	mappings, err := PathsToMappings(paths)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get mappings: %w", err)
 	}
 
+	// Resolve each mapping's on-disk layout, skipping paths that don't exist.
+	// The manifest records only the namespaces actually written.
+	type plan struct {
+		mapping Mapping
+		chroot  string
+		prefix  string
+	}
+	plans := make([]plan, 0, len(mappings))
+	manifest := Manifest{Version: ManifestVersion, Mappings: make(map[string]string, len(mappings))}
+
 	for _, mapping := range mappings {
-		_, err := os.Stat(mapping.ResolvedPath)
-		if err != nil {
+		if _, err := os.Stat(mapping.ResolvedPath()); err != nil {
 			if os.IsNotExist(err) {
-				slog.Warn("file does not exist", "path", mapping.ResolvedPath)
+				slog.Warn("cache path does not exist, skipping", "path", mapping.Path, "resolved", mapping.ResolvedPath())
 				continue
 			}
 			return nil, fmt.Errorf("failed to stat file: %w", err)
 		}
 
-		_, err = isUnderHome(mapping.ResolvedPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed directory (%s) outside home directory: %w", mapping.ResolvedPath, err)
-		}
+		chroot, prefix := mapping.archiveLayout()
 
-		files := make(map[string]os.FileInfo)
-		err = filepath.Walk(mapping.ResolvedPath, func(filename string, fi os.FileInfo, err error) error {
-			files[filename] = fi
-			return nil
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to walk path: %s with error: %w", mapping.ResolvedPath, err)
-		}
-
-		slog.Debug("chroot", "chroot", mapping.Chroot, "path", mapping.ResolvedPath)
-
-		err = arc.Archive(context.Background(), mapping.Chroot, files)
-		if err != nil {
-			return nil, fmt.Errorf("failed to archive path: %s with error: %w", mapping.ResolvedPath, err)
-		}
+		plans = append(plans, plan{mapping: mapping, chroot: chroot, prefix: prefix})
+		manifest.Mappings[mapping.Namespace] = mapping.Anchor
 	}
 
-	writtenBytes, writtenEntries := arc.Written()
+	// Reject overlapping targets: they archive shared files twice and collide on
+	// one restore destination. Restore re-checks the re-resolved paths.
+	resolved := make([]string, len(plans))
+	for i, p := range plans {
+		resolved[i] = p.mapping.ResolvedPath()
+	}
+	if i, j, ok := OverlappingPaths(resolved); ok {
+		return nil, fmt.Errorf("cache target_paths overlap: %q and %q resolve to nested or aliased locations; remove the redundant one", plans[i].mapping.Path, plans[j].mapping.Path)
+	}
 
-	err = arc.Close()
-	if err != nil {
+	if err := writeManifest(zw, manifest); err != nil {
+		return nil, err
+	}
+
+	var writtenBytes, writtenEntries int64
+	for _, p := range plans {
+		b, e, err := archiveMapping(ctx, zw, p.mapping.ResolvedPath(), p.chroot, p.prefix, modified)
+		if err != nil {
+			return nil, fmt.Errorf("failed to archive path %q: %w", p.mapping.Path, err)
+		}
+		writtenBytes += b
+		writtenEntries += e
+	}
+
+	if err := zw.Close(); err != nil {
 		return nil, fmt.Errorf("failed to close archive: %w", err)
 	}
 
@@ -109,4 +118,94 @@ func BuildArchive(ctx context.Context, paths []string, key string) (*ArchiveInfo
 		WrittenEntries: writtenEntries,
 		Duration:       time.Since(start),
 	}, nil
+}
+
+// archiveMapping archives a single target path into a temporary zip via
+// quickzip, then copies each entry into the final archive with its namespace prefix.
+// Entries are copied raw (already compressed), so there is no second compression pass.
+func archiveMapping(ctx context.Context, zw *zip.Writer, resolvedPath, chroot, prefix string, modified time.Time) (writtenBytes, writtenEntries int64, err error) {
+	tmp, err := os.CreateTemp("", "cache-ns-*.zip")
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to create namespace archive: %w", err)
+	}
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+	}()
+
+	arc, err := quickzip.NewArchiver(
+		tmp,
+		quickzip.WithArchiverMethod(zstd.ZipMethodWinZip),
+		quickzip.WithArchiverBufferSize(bufferSize),
+		quickzip.WithModifiedEpoch(modified),
+		quickzip.WithSkipOwnership(skipOwnership),
+	)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to create archiver: %w", err)
+	}
+
+	files := make(map[string]os.FileInfo)
+	err = filepath.Walk(resolvedPath, func(filename string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		files[filename] = fi
+		return nil
+	})
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to walk path %q: %w", resolvedPath, err)
+	}
+
+	if err := arc.Archive(ctx, chroot, files); err != nil {
+		return 0, 0, fmt.Errorf("failed to archive path %q: %w", resolvedPath, err)
+	}
+	writtenBytes, writtenEntries = arc.Written()
+	if err := arc.Close(); err != nil {
+		return 0, 0, fmt.Errorf("failed to close namespace archive: %w", err)
+	}
+
+	stat, err := tmp.Stat()
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to stat namespace archive: %w", err)
+	}
+
+	reader, err := zip.NewReader(tmp, stat.Size())
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to read namespace archive: %w", err)
+	}
+
+	for _, f := range reader.File {
+		hdr := f.FileHeader
+
+		// A "." entry is quickzip's name for the chroot root, which only appears
+		// when the target IS its anchor base (a bare "~" or "."). Name it after
+		// the namespace; splitNamespace drops a namespace-only entry on extract,
+		// so the base dir's own mode isn't restored — harmless, since home and
+		// cwd always already exist. prefix ends in "/" (a dir entry to klauspost),
+		// so trim it for a non-directory root.
+		switch {
+		case path.Clean(f.Name) != ".":
+			hdr.Name = prefix + f.Name
+		case hdr.Mode().IsDir():
+			hdr.Name = prefix
+		default:
+			hdr.Name = strings.TrimSuffix(prefix, "/")
+		}
+
+		w, err := zw.CreateRaw(&hdr)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to create archive entry %q: %w", hdr.Name, err)
+		}
+
+		rc, err := f.OpenRaw()
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to open raw entry %q: %w", f.Name, err)
+		}
+
+		if _, err := io.Copy(w, rc); err != nil {
+			return 0, 0, fmt.Errorf("failed to copy entry %q: %w", f.Name, err)
+		}
+	}
+
+	return writtenBytes, writtenEntries, nil
 }

--- a/internal/cache/archive/create_test.go
+++ b/internal/cache/archive/create_test.go
@@ -11,6 +11,44 @@ import (
 	"github.com/buildkite/agent/v3/internal/cache/internal/trace"
 )
 
+func TestArchiveLayoutRootAnchor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX \"/\" path literals; Windows root anchors are drive roots")
+	}
+
+	// A child of "/" chroots at the volume root like any other anchor (quickzip
+	// >= v1.0.3 can chroot at a bare root, so entries come out as
+	// "<namespace>/<path under root>/..." with no special-casing here).
+	tests := []struct {
+		resolved   string
+		namespace  string
+		wantPrefix string
+	}{
+		{"/cache-file", "_0", "_0/"},
+		{"/opt/cache", "_1", "_1/"},
+	}
+	for _, tt := range tests {
+		chroot, prefix := (Mapping{Namespace: tt.namespace, Anchor: "/", base: "/", resolved: tt.resolved}).archiveLayout()
+		if chroot != "/" {
+			t.Errorf("archiveLayout(%q) chroot = %q, want %q", tt.resolved, chroot, "/")
+		}
+		if prefix != tt.wantPrefix {
+			t.Errorf("archiveLayout(%q) prefix = %q, want %q", tt.resolved, prefix, tt.wantPrefix)
+		}
+	}
+}
+
+// TestPathsToMappingsRejectsVolumeRoot covers the validation moved out of
+// archiveLayout: a bare volume/filesystem root target is rejected at resolution time
+func TestPathsToMappingsRejectsVolumeRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses the POSIX \"/\" root literal; Windows roots are drive roots")
+	}
+	if _, err := PathsToMappings([]string{"/"}); err == nil {
+		t.Error("expected an error caching the volume/filesystem root")
+	}
+}
+
 func TestBuildArchive(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		// The expected sha256/size encode unix file modes and LF line
@@ -34,11 +72,49 @@ func TestBuildArchive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildArchive: %v", err)
 	}
-	if got, want := archiveInfo.Sha256sum, "3f194172652432099ffc528f81ea6ce1687780287cba1d1a9587f5c26c72aeac"; got != want {
-		t.Errorf("Sha256sum = %v, want %v", got, want)
+	if archiveInfo.Size <= 0 {
+		t.Errorf("Size = %v, want > 0", archiveInfo.Size)
 	}
-	if got, want := archiveInfo.Size, int64(1228); got != want {
-		t.Errorf("Size = %v, want %v", got, want)
+	if archiveInfo.Sha256sum == "" {
+		t.Error("Sha256sum should not be empty")
+	}
+	defer func() { _ = os.Remove(archiveInfo.ArchivePath) }()
+
+	// Content-addressing relies on the archive being byte-for-byte
+	// deterministic for the same inputs.
+	second, err := BuildArchive(t.Context(), []string{"testdata"}, "test")
+	if err != nil {
+		t.Fatalf("BuildArchive (second): %v", err)
+	}
+	defer func() { _ = os.Remove(second.ArchivePath) }()
+	if archiveInfo.Sha256sum != second.Sha256sum {
+		t.Errorf("archive is not deterministic: %v != %v", archiveInfo.Sha256sum, second.Sha256sum)
+	}
+
+	zipFile, err := os.Open(archiveInfo.ArchivePath)
+	if err != nil {
+		t.Fatalf("os.Open: %v", err)
+	}
+	defer func() { _ = zipFile.Close() }()
+
+	entries, err := ListArchive(t.Context(), zipFile, archiveInfo.Size)
+	if err != nil {
+		t.Fatalf("ListArchive: %v", err)
+	}
+	if !slices.Contains(entries, ManifestPath) {
+		t.Errorf("entries does not contain manifest %q: %v", ManifestPath, entries)
+	}
+	// "testdata" is a relative path, so it is namespaced under _0 with the "."
+	// anchor.
+	foundNamespaced := false
+	for _, e := range entries {
+		if strings.HasPrefix(e, "_0/testdata/") {
+			foundNamespaced = true
+			break
+		}
+	}
+	if !foundNamespaced {
+		t.Errorf("entries does not contain any _0/testdata/ entry: %v", entries)
 	}
 
 	homeDir, err := os.UserHomeDir()
@@ -130,11 +206,11 @@ func TestBuildAndExtractArchive_MultipleHomeDirPaths(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListArchive: %v", err)
 	}
-	if !slices.Contains(entries, ".go-build/cache.txt") {
-		t.Errorf("entries does not contain %q: %v", ".go-build/cache.txt", entries)
+	if !slices.Contains(entries, "_0/.go-build/cache.txt") {
+		t.Errorf("entries does not contain %q: %v", "_0/.go-build/cache.txt", entries)
 	}
-	if !slices.Contains(entries, "go/pkg/mod/module.txt") {
-		t.Errorf("entries does not contain %q: %v", "go/pkg/mod/module.txt", entries)
+	if !slices.Contains(entries, "_1/go/pkg/mod/module.txt") {
+		t.Errorf("entries does not contain %q: %v", "_1/go/pkg/mod/module.txt", entries)
 	}
 
 	_, err = zipFile.Seek(0, 0)
@@ -208,8 +284,8 @@ func TestBuildArchive_MissingPathOnFilesystem(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListArchive: %v", err)
 	}
-	if !slices.Contains(entries, ".go-build/cache.txt") {
-		t.Errorf("entries does not contain %q: %v", ".go-build/cache.txt", entries)
+	if !slices.Contains(entries, "_0/.go-build/cache.txt") {
+		t.Errorf("entries does not contain %q: %v", "_0/.go-build/cache.txt", entries)
 	}
 
 	for _, entry := range entries {
@@ -260,11 +336,11 @@ func TestExtractArchive_MissingPathInArchive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListArchive: %v", err)
 	}
-	if !slices.Contains(entries, ".go-build/cache.txt") {
-		t.Errorf("entries does not contain %q: %v", ".go-build/cache.txt", entries)
+	if !slices.Contains(entries, "_0/.go-build/cache.txt") {
+		t.Errorf("entries does not contain %q: %v", "_0/.go-build/cache.txt", entries)
 	}
-	if slices.Contains(entries, "go/pkg/mod/") {
-		t.Errorf("entries should not contain %q: %v", "go/pkg/mod/", entries)
+	if slices.Contains(entries, "_0/go/pkg/mod/") {
+		t.Errorf("entries should not contain %q: %v", "_0/go/pkg/mod/", entries)
 	}
 
 	_, err = zipFile.Seek(0, 0)

--- a/internal/cache/archive/extract.go
+++ b/internal/cache/archive/extract.go
@@ -2,6 +2,8 @@ package archive
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"os"
@@ -36,37 +38,100 @@ func ListArchive(ctx context.Context, zipFile *os.File, zipFileLen int64) ([]str
 	return entries, nil
 }
 
+// ExtractFiles extracts a cache archive to the given target paths.
 func ExtractFiles(ctx context.Context, zipFile *os.File, zipFileLen int64, paths []string) (*ArchiveInfo, error) {
 	_, span := trace.Start(ctx, "ExtractFiles")
 	defer span.End()
 
 	start := time.Now()
 
+	reader, err := zip.NewReader(zipFile, zipFileLen)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open zip reader: %w", err)
+	}
+
+	manifest, err := readManifest(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	// Normalise the configured target paths so archive destinations can be
+	// matched against them regardless of spelling ("~/cache" vs "$HOME/cache").
+	configPaths := make([]string, len(paths))
+	for i, p := range paths {
+		resolved, err := ResolveConfigPath(p)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve config path %q: %w", p, err)
+		}
+		configPaths[i] = resolved
+	}
+
+	// Entries that are not restored (the manifest, and namespaces absent from
+	// local config) are routed to a throwaway directory that is removed when we
+	// return, since quickzip's path mapper cannot skip an entry outright.
+	discardDir, err := os.MkdirTemp("", "cache-extract-discard-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create discard directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(discardDir) }()
+
+	discard := func(name string) string {
+		return discardName(discardDir, name)
+	}
+
 	extract, err := quickzip.NewExtractorFromReader(zipFile, zipFileLen)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create extractor: %w", err)
 	}
 
-	mappings, err := PathsToMappings(paths)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create mappings: %w", err)
-	}
-
 	foundPaths := make(map[string]bool)
 
 	err = extract.ExtractWithPathMapper(ctx, func(file *zip.File) (string, error) {
-		// Zip entry names always use forward slashes (per the zip spec),
-		// but mapping.RelativePath comes from filepath.Rel and may use the
-		// OS native separator (backslash on Windows). Normalise the mapping
-		// to forward slashes for the comparison.
-		for _, mapping := range mappings {
-			if strings.HasPrefix(file.Name, filepath.ToSlash(mapping.RelativePath)) {
-				foundPaths[mapping.Path] = true
-				return filepath.Join(mapping.Chroot, file.Name), nil
-			}
+		if file.Name == ManifestPath {
+			return discard(file.Name), nil
 		}
 
-		return "", fmt.Errorf("failed to find path mapping for: %s", file.Name)
+		namespace, rest, ok := splitNamespace(file.Name)
+		if !ok {
+			slog.Warn("archive entry has no namespace, skipping", "entry", file.Name)
+			return discard(file.Name), nil
+		}
+
+		anchor, ok := manifest.Mappings[namespace]
+		if !ok {
+			slog.Warn("archive entry namespace not in manifest, skipping", "entry", file.Name)
+			return discard(file.Name), nil
+		}
+
+		base, err := resolveAnchor(anchor)
+		if err != nil {
+			return "", err
+		}
+
+		dest := filepath.Clean(filepath.Join(base, filepath.FromSlash(rest)))
+
+		// Containment: an entry must stay within its own anchor. This rejects
+		// zip-slip payloads (e.g. "_0/../../etc/passwd") before they escape.
+		if !isUnder(dest, base) {
+			return "", fmt.Errorf("entry %q escapes its anchor %q", file.Name, base)
+		}
+
+		// Restore an entry only if it falls under a configured target; otherwise discard
+		// it (as it is a namespace this job didn't ask for). Targets can't overlap here, so an
+		// entry matches at most one.
+		matched := -1
+		for i, cfg := range configPaths {
+			if isUnder(dest, cfg) {
+				matched = i
+				break
+			}
+		}
+		if matched == -1 {
+			return discard(file.Name), nil
+		}
+		foundPaths[paths[matched]] = true
+
+		return dest, nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract zip file: %w", err)
@@ -93,4 +158,36 @@ func ExtractFiles(ctx context.Context, zipFile *os.File, zipFileLen int64, paths
 		WrittenEntries: countExtracted,
 		Duration:       time.Since(start),
 	}, nil
+}
+
+// discardName maps a not-restored entry (the manifest, or an unconfigured
+// namespace) to an opaque, separator-free path under discardDir. Hashing keeps
+// it inside discardDir even if the name contains "/", "\" or ".." segments.
+func discardName(discardDir, name string) string {
+	sum := sha256.Sum256([]byte(name))
+	return filepath.Join(discardDir, hex.EncodeToString(sum[:]))
+}
+
+// splitNamespace splits an entry name into its leading namespace ("_0") and
+// the anchor-relative remainder. Zip entry names always use forward slashes.
+func splitNamespace(name string) (namespace, rest string, ok bool) {
+	i := strings.IndexByte(name, '/')
+	if i <= 0 || i == len(name)-1 {
+		return "", "", false
+	}
+	return name[:i], name[i+1:], true
+}
+
+// isUnder reports whether p is root itself or a path beneath it.
+func isUnder(p, root string) bool {
+	if p == root {
+		return true
+	}
+	// A root that already ends in a separator — the POSIX root "/" or a Windows
+	// volume root like "C:\" — needs no extra separator. Otherwise require one
+	// so "/home/user2" isn't treated as under "/home/user".
+	if strings.HasSuffix(root, string(filepath.Separator)) {
+		return strings.HasPrefix(p, root)
+	}
+	return strings.HasPrefix(p, root+string(filepath.Separator))
 }

--- a/internal/cache/archive/manifest.go
+++ b/internal/cache/archive/manifest.go
@@ -1,0 +1,87 @@
+package archive
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/klauspost/compress/zip"
+)
+
+const (
+	// ManifestPath is the reserved archive entry.
+	// Extraction reads it but never writes it to disk.
+	ManifestPath = ".buildkite/cache-manifest.json"
+	// ManifestVersion is the archive format version this agent reads and writes.
+	ManifestVersion = 2
+)
+
+// ErrUnrecognizedFormat is returned when an archive has no readable manifest
+var ErrUnrecognizedFormat = errors.New("unrecognized cache archive format")
+
+// Manifest maps each namespace in an archive to its anchor.
+type Manifest struct {
+	Version  int               `json:"version"`
+	Mappings map[string]string `json:"mappings"`
+}
+
+// writeManifest converts manifest into json, creates a
+// new zip/archive file and writes the manifest to that file.
+func writeManifest(zw *zip.Writer, manifest Manifest) error {
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	w, err := zw.Create(ManifestPath)
+	if err != nil {
+		return fmt.Errorf("failed to create manifest entry: %w", err)
+	}
+
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("failed to write manifest: %w", err)
+	}
+
+	return nil
+}
+
+// readManifest extracts and validates the manifest from an archive. It
+// returns ErrUnrecognizedFormat when the manifest is absent or invalid.
+func readManifest(reader *zip.Reader) (Manifest, error) {
+	for _, f := range reader.File {
+		if f.Name != ManifestPath {
+			continue
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			return Manifest{}, fmt.Errorf("failed to open manifest: %w", err)
+		}
+		defer func() { _ = rc.Close() }()
+
+		data, err := io.ReadAll(rc)
+		if err != nil {
+			return Manifest{}, fmt.Errorf("failed to read manifest: %w", err)
+		}
+
+		var manifest Manifest
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			return Manifest{}, fmt.Errorf("%w: invalid manifest json: %w", ErrUnrecognizedFormat, err)
+		}
+
+		if manifest.Version != ManifestVersion {
+			return Manifest{}, fmt.Errorf("%w: manifest version %d", ErrUnrecognizedFormat, manifest.Version)
+		}
+
+		for namespace, anchor := range manifest.Mappings {
+			// The pinned-absolute anchor is a volume/filesystem root ("/" or a
+			// Windows drive root), so accept any root.
+			if anchor != AnchorHome && anchor != AnchorCWD && !isRootAnchor(anchor) {
+				return Manifest{}, fmt.Errorf("%w: unrecognized anchor %q for namespace %q", ErrUnrecognizedFormat, anchor, namespace)
+			}
+		}
+		return manifest, nil
+	}
+	return Manifest{}, fmt.Errorf("%w: no manifest entry", ErrUnrecognizedFormat)
+}

--- a/internal/cache/archive/mappings.go
+++ b/internal/cache/archive/mappings.go
@@ -7,86 +7,164 @@ import (
 	"strings"
 )
 
-// Mapping represents a mapping of a file path to a destination path, including
-// the chroot path and whether the path is relative or not.
+// Anchor identifies where a mapping's stored paths are re-resolved at restore time.
+// It is deliberately a symbol rather than a resolved path so caches stay portable.
+const (
+	// AnchorHome marks paths configured with a leading "~" (or "~/"). Restore
+	// re-expands them against the restoring environment's home directory.
+	AnchorHome = "~"
+	// AnchorCWD marks relative paths. Restore resolves them against the job's
+	// working directory.
+	AnchorCWD = "."
+	// Absolute paths are pinned to a volume/filesystem root ("/" on POSIX, a
+	// drive root like "C:\" on Windows); those anchors are produced by
+	// volumeRoot and recognised by isRootAnchor rather than a named constant.
+)
+
+// Mapping describes how one configured target path maps into an archive: a
+// numbered namespace ("_0", "_1", ...) whose entries are relative to the anchor.
 type Mapping struct {
-	Path         string
-	ResolvedPath string
-	RelativePath string
-	Chroot       string
-	Relative     bool
+	// Path is the target path exactly as configured.
+	Path string
+	// Namespace is the archive prefix that isolates this mapping's entries ("_0").
+	Namespace string
+	// Anchor is the portable symbol stored in the manifest (see consts above).
+	Anchor string
+	// base is the absolute directory Anchor resolves to on a machine.
+	base string
+	// resolved is the absolute path the target resolves to on this machine.
+	resolved string
 }
 
-// PathsToMappings takes a slice of file paths and returns a slice of Mapping structs,
-// which contain information about the destination path, chroot path, and whether
-// the path is relative or not. It handles paths starting with "~/" by replacing
-// them with the user's home directory.
+// ResolvedPath is the absolute path on this machine the target resolves to.
+func (m Mapping) ResolvedPath() string { return m.resolved }
+
+// archiveLayout returns the directory quickzip archives from (chroot) and the
+// entry-name prefix prepended so each stored entry is "<namespace>/..". Every
+// anchor chroots at its base (home, cwd, or the volume root), so quickzip names
+// entries relative to that base and the prefix only adds the namespace.
+func (m Mapping) archiveLayout() (chroot, prefix string) {
+	return m.base, m.Namespace + "/"
+}
+
+// homeDir returns the cleaned home directory (os.UserHomeDir returns $HOME
+// verbatim), keeping save and restore resolution consistent.
+func homeDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Clean(home), nil
+}
+
+// workingDir returns the cleaned working directory.
+func workingDir() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get working directory: %w", err)
+	}
+	return filepath.Clean(cwd), nil
+}
+
+// PathsToMappings resolves each configured target path into a Mapping.
 func PathsToMappings(paths []string) ([]Mapping, error) {
-	pathMappings := make([]Mapping, 0, len(paths))
-
-	for _, path := range paths {
-		mapping := Mapping{
-			Path:         path,
-			ResolvedPath: path,
-			RelativePath: path,
-			Relative:     true,
-		}
-
-		homedir, err := os.UserHomeDir()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get home directory: %w", err)
-		}
-
-		if strings.HasPrefix(path, "~/") {
-			mapping.ResolvedPath = filepath.Join(homedir, path[2:])
-			mapping.Relative = false
-
-			rel, err := filepath.Rel(homedir, mapping.ResolvedPath)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get relative path: %w", err)
-			}
-
-			mapping.RelativePath = rel
-		} else if filepath.IsAbs(path) && strings.HasPrefix(path, homedir) {
-			mapping.Relative = false
-
-			rel, err := filepath.Rel(homedir, path)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get relative path: %w", err)
-			}
-
-			mapping.RelativePath = rel
-		}
-
-		chroot, err := chrootPath(mapping.ResolvedPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get chroot path: %w", err)
-		}
-
-		mapping.Chroot = chroot
-
-		pathMappings = append(pathMappings, mapping)
+	home, err := homeDir()
+	if err != nil {
+		return nil, err
 	}
 
-	return pathMappings, nil
+	cwd, err := workingDir()
+	if err != nil {
+		return nil, err
+	}
+
+	mappings := make([]Mapping, 0, len(paths))
+	for i, path := range paths {
+		anchor, base, resolved := classifyAndResolvePath(path, home, cwd)
+		// A target can't be a bare volume/filesystem root ("/", "C:\", or a UNC
+		// share "\\server\share"). resolved may drop the trailing separator that
+		// base (the volume root) keeps — notably for UNC — so compare cleaned.
+		if isRootAnchor(anchor) && filepath.Clean(resolved) == filepath.Clean(base) {
+			return nil, fmt.Errorf("cannot cache the volume/filesystem root %q", resolved)
+		}
+		mappings = append(mappings, Mapping{
+			Path:      path,
+			Namespace: fmt.Sprintf("_%d", i),
+			Anchor:    anchor,
+			base:      base,
+			resolved:  resolved,
+		})
+	}
+
+	return mappings, nil
 }
 
-func ResolveHomeDir(path string) (string, error) {
-	if strings.HasPrefix(path, "~/") {
-		homedir, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("failed to get home directory: %w", err)
-		}
-		return filepath.Join(homedir, path[2:]), nil
+// classifyAndResolvePath determines a configured path's anchor, the absolute
+// base directory that anchor resolves to, and the absolute path the target
+// resolves to in the current environment.
+func classifyAndResolvePath(path, home, cwd string) (anchor, base, resolved string) {
+	switch {
+	case path == "~" || strings.HasPrefix(path, "~/"):
+		rest := strings.TrimPrefix(strings.TrimPrefix(path, "~"), "/")
+		return AnchorHome, home, filepath.Join(home, rest)
+
+	case filepath.IsAbs(path):
+		resolved := filepath.Clean(path)
+		// Absolute paths are pinned — never follow $HOME, even under it. The
+		// anchor is the volume root, so a Windows drive is retained.
+		root := volumeRoot(resolved)
+		return root, root, resolved
+
+	default:
+		return AnchorCWD, cwd, filepath.Join(cwd, path)
 	}
-	return path, nil
 }
 
-func chrootPath(path string) (string, error) {
-	if filepath.IsAbs(path) {
-		return os.UserHomeDir()
+// volumeRoot returns the volume/filesystem root of an absolute path: "/" on
+// POSIX, a drive root ("C:\") on Windows. This is the pinned-absolute anchor.
+func volumeRoot(p string) string {
+	return filepath.VolumeName(p) + string(filepath.Separator)
+}
+
+// isRootAnchor reports whether an anchor is a volume/filesystem root ("/" or
+// "C:\") — the pinned-absolute anchor produced by volumeRoot.
+func isRootAnchor(anchor string) bool {
+	return anchor != "" && anchor == volumeRoot(anchor)
+}
+
+// resolveAnchor returns the absolute base directory an anchor expands to in the
+// current environment. It is the inverse of the anchor classification done in
+// PathsToMappings and is used at restore time to re-root a stored entry.
+func resolveAnchor(anchor string) (string, error) {
+	switch {
+	case anchor == AnchorHome:
+		return homeDir()
+	case anchor == AnchorCWD:
+		return workingDir()
+	case isRootAnchor(anchor):
+		// A volume/filesystem root ("/" or "C:\") is already an absolute base.
+		return anchor, nil
+	default:
+		return "", fmt.Errorf("unknown anchor %q", anchor)
+	}
+}
+
+// ResolveConfigPath normalises a configured target path to the absolute,
+// cleaned path it refers to on this machine, using the same classification as
+// PathsToMappings.
+func ResolveConfigPath(path string) (string, error) {
+	var home, cwd string
+	var err error
+	switch {
+	case path == "~" || strings.HasPrefix(path, "~/"):
+		home, err = homeDir()
+	case !filepath.IsAbs(path):
+		cwd, err = workingDir()
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve config path %q: %w", path, err)
 	}
 
-	// get the current working directory
-	return os.Getwd()
+	_, _, resolved := classifyAndResolvePath(path, home, cwd)
+	return resolved, nil
 }

--- a/internal/cache/archive/mappings_test.go
+++ b/internal/cache/archive/mappings_test.go
@@ -3,111 +3,99 @@ package archive
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
-func TestPathsToMappings_AbsolutePathUnderHome(t *testing.T) {
+func TestPathsToMappings(t *testing.T) {
 	home := t.TempDir()
 	setHomeDir(t, home)
 
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+
+	// "/opt/cache" is only absolute on POSIX; on Windows an absolute path needs
+	// a volume, so build one from the temp dir's volume.
+	absPath := "/opt/cache"
+	if runtime.GOOS == "windows" {
+		absPath = filepath.VolumeName(home) + `\opt\cache`
+	}
+
 	paths := []string{
+		"~/.npm",
+		absPath,
+		"node_modules",
 		filepath.Join(home, ".go-build"),
-		filepath.Join(home, "go", "pkg", "mod"),
 	}
 
 	mappings, err := PathsToMappings(paths)
 	if err != nil {
 		t.Fatalf("PathsToMappings: %v", err)
 	}
-	if len(mappings) != 2 {
-		t.Fatalf("len(mappings) = %d, want 2", len(mappings))
+	if len(mappings) != 4 {
+		t.Fatalf("len(mappings) = %d, want 4", len(mappings))
 	}
 
-	if got, want := mappings[0].RelativePath, ".go-build"; got != want {
-		t.Errorf("mappings[0].RelativePath = %v, want %v", got, want)
-	}
-	if got, want := mappings[0].ResolvedPath, filepath.Join(home, ".go-build"); got != want {
-		t.Errorf("mappings[0].ResolvedPath = %v, want %v", got, want)
-	}
-	if mappings[0].Relative {
-		t.Errorf("mappings[0].Relative = true, want false")
+	tests := []struct {
+		namespace    string
+		anchor       string
+		resolvedPath string
+	}{
+		{"_0", AnchorHome, filepath.Join(home, ".npm")},
+		{"_1", volumeRoot(filepath.Clean(absPath)), filepath.Clean(absPath)},
+		{"_2", AnchorCWD, filepath.Join(cwd, "node_modules")},
+		// An absolute path under $HOME is pinned (root-anchored), not portable:
+		// only a leading "~" is portable.
+		{"_3", volumeRoot(filepath.Join(home, ".go-build")), filepath.Join(home, ".go-build")},
 	}
 
-	if got, want := mappings[1].RelativePath, filepath.Join("go", "pkg", "mod"); got != want {
-		t.Errorf("mappings[1].RelativePath = %v, want %v", got, want)
-	}
-	if got, want := mappings[1].ResolvedPath, filepath.Join(home, "go", "pkg", "mod"); got != want {
-		t.Errorf("mappings[1].ResolvedPath = %v, want %v", got, want)
-	}
-	if mappings[1].Relative {
-		t.Errorf("mappings[1].Relative = true, want false")
+	for i, want := range tests {
+		got := mappings[i]
+		if got.Namespace != want.namespace {
+			t.Errorf("mappings[%d].Namespace = %q, want %q", i, got.Namespace, want.namespace)
+		}
+		if got.Anchor != want.anchor {
+			t.Errorf("mappings[%d].Anchor = %q, want %q", i, got.Anchor, want.anchor)
+		}
+		if got.ResolvedPath() != want.resolvedPath {
+			t.Errorf("mappings[%d].ResolvedPath() = %q, want %q", i, got.ResolvedPath(), want.resolvedPath)
+		}
 	}
 }
 
-func TestResolveHomeDir(t *testing.T) {
-	homeDir, err := os.UserHomeDir()
+// TestResolveConfigPath pins the resolver used by both restore matching and
+// cleanup. The bare-"~" case: it must resolve to $HOME
+// (consistent with how save classifies it), not stay a literal "~".
+func TestResolveConfigPath(t *testing.T) {
+	home := t.TempDir()
+	setHomeDir(t, home)
+
+	cwd, err := os.Getwd()
 	if err != nil {
-		t.Fatalf("os.UserHomeDir: %v", err)
+		t.Fatalf("os.Getwd: %v", err)
 	}
 
 	tests := []struct {
 		name     string
 		path     string
 		expected string
-		wantErr  bool
 	}{
-		{
-			name:     "path with tilde prefix",
-			path:     "~/documents/test.txt",
-			expected: filepath.Join(homeDir, "documents/test.txt"),
-			wantErr:  false,
-		},
-		{
-			name:     "path without tilde",
-			path:     "/absolute/path/test.txt",
-			expected: "/absolute/path/test.txt",
-			wantErr:  false,
-		},
-		{
-			name:     "empty path",
-			path:     "",
-			expected: "",
-			wantErr:  false,
-		},
-		{
-			name:     "tilde only",
-			path:     "~",
-			expected: "~",
-			wantErr:  false,
-		},
-		{
-			name:     "relative path",
-			path:     "./test.txt",
-			expected: "./test.txt",
-			wantErr:  false,
-		},
-		{
-			name:     "path with multiple tildes",
-			path:     "~/path/~/test.txt",
-			expected: filepath.Join(homeDir, "path/~/test.txt"),
-			wantErr:  false,
-		},
+		{"bare tilde resolves to home", "~", home},
+		{"tilde prefix", "~/documents/test.txt", filepath.Join(home, "documents/test.txt")},
+		{"absolute path", filepath.Join(home, "x"), filepath.Join(home, "x")},
+		{"relative path", filepath.Join("sub", "test.txt"), filepath.Join(cwd, "sub", "test.txt")},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := ResolveHomeDir(tt.path)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				return
-			}
+			result, err := ResolveConfigPath(tt.path)
 			if err != nil {
-				t.Fatalf("ResolveHomeDir: %v", err)
+				t.Fatalf("ResolveConfigPath: %v", err)
 			}
 			if result != tt.expected {
-				t.Errorf("ResolveHomeDir() = %v, want %v", result, tt.expected)
+				t.Errorf("ResolveConfigPath(%q) = %v, want %v", tt.path, result, tt.expected)
 			}
 		})
 	}

--- a/internal/cache/archive/overlap.go
+++ b/internal/cache/archive/overlap.go
@@ -1,0 +1,107 @@
+package archive
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Overlap detection over a set of resolved target paths. It is shared by both
+// save (create.go rejects overlapping targets up front) and restore
+// (restore.go re-checks the re-resolved paths, since portable anchors can
+// converge on a different machine).
+
+// OverlappingPaths returns the indices of the first pair of resolved paths that
+// are nested or equal — by lexical and canonical spelling, case-folded on
+// case-insensitive filesystems — or ok=false if none overlap.
+func OverlappingPaths(paths []string) (i, j int, ok bool) {
+	canonical := make([]string, len(paths))
+	insensitive := make([]bool, len(paths))
+	for k, p := range paths {
+		canonical[k] = canonicalizeForOverlap(p)
+		insensitive[k] = pathCaseInsensitive(p)
+	}
+	for a := 0; a < len(paths); a++ {
+		for b := a + 1; b < len(paths); b++ {
+			ci := insensitive[a] || insensitive[b]
+			if pathsOverlap(paths[a], paths[b], ci) || pathsOverlap(canonical[a], canonical[b], ci) {
+				return a, b, true
+			}
+		}
+	}
+	return 0, 0, false
+}
+
+// pathsOverlap reports whether two paths are nested or equal, folding case when
+// caseInsensitive (isUnder stays case-sensitive for its other callers).
+func pathsOverlap(a, b string, caseInsensitive bool) bool {
+	if caseInsensitive {
+		a, b = strings.ToLower(a), strings.ToLower(b)
+	}
+	return isUnder(a, b) || isUnder(b, a)
+}
+
+// ~/Cache and ~/cache are the same directory on a case-insensitive FS (so they collide)
+// but distinct on a case-sensitive one.
+// pathCaseInsensitive reports whether the filesystem that will hold p folds
+// case. When p already exists it decides from p's own casing by identity, otherwise it
+// creates a temp entry in the nearest existing directory and re-cases it. Assumed
+// case-sensitive if it can't confirm.
+func pathCaseInsensitive(p string) bool {
+	if orig, err := os.Lstat(p); err == nil {
+		seg := strings.Split(p, string(filepath.Separator))
+		for i := len(seg) - 1; i >= 0; i-- {
+			if recase(seg[i]) == seg[i] {
+				continue
+			}
+			seg[i] = recase(seg[i])
+			alt, err2 := os.Lstat(strings.Join(seg, string(filepath.Separator)))
+			return err2 == nil && os.SameFile(orig, alt)
+		}
+	}
+
+	dir := p
+	for {
+		if fi, err := os.Stat(dir); err == nil && fi.IsDir() {
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false // no existing ancestor directory
+		}
+		dir = parent
+	}
+
+	// The "bk-case-probe-" prefix guarantees a letter to re-case (MkdirTemp's
+	// random suffix is numeric).
+	marker, err := os.MkdirTemp(dir, "bk-case-probe-")
+	if err != nil {
+		return false
+	}
+	defer func() { _ = os.Remove(marker) }()
+
+	orig, err1 := os.Stat(marker)
+	alt, err2 := os.Stat(filepath.Join(dir, recase(filepath.Base(marker))))
+	return err1 == nil && err2 == nil && os.SameFile(orig, alt)
+}
+
+// recase returns s with its case flipped (upper, else lower). It returns s
+// unchanged when there is no letter to re-case.
+func recase(s string) string {
+	if up := strings.ToUpper(s); up != s {
+		return up
+	}
+	return strings.ToLower(s)
+}
+
+// canonicalizeForOverlap resolves symlinks in a path's parent but preserves the
+// final component — matching filepath.Walk, which archives a final symlink as
+// the link, not its referent. Falls back to the lexical path on error.
+func canonicalizeForOverlap(p string) string {
+	dir, base := filepath.Split(p)
+	realDir, err := filepath.EvalSymlinks(filepath.Clean(dir))
+	if err != nil {
+		return p
+	}
+	return filepath.Join(realDir, base)
+}

--- a/internal/cache/archive/validate.go
+++ b/internal/cache/archive/validate.go
@@ -1,0 +1,27 @@
+package archive
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/klauspost/compress/zip"
+)
+
+// Validate reports whether a downloaded archive is a readable v2 archive,
+// returning ErrUnrecognizedFormat otherwise. It checks that the manifest is
+// present and readable — not that the entry bodies are intact. Content-digest
+// verification is out of scope here.
+func Validate(archiveFile string, archiveSize int64) error {
+	f, err := os.Open(archiveFile)
+	if err != nil {
+		return fmt.Errorf("failed to open archive file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	reader, err := zip.NewReader(f, archiveSize)
+	if err != nil {
+		return fmt.Errorf("failed to open zip reader: %w", err)
+	}
+	_, err = readManifest(reader)
+	return err
+}

--- a/internal/cache/configuration/cache.go
+++ b/internal/cache/configuration/cache.go
@@ -2,6 +2,7 @@ package configuration
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -53,6 +54,8 @@ func (c Cache) Validate() error {
 				errors = append(errors, fmt.Sprintf("target_paths[%d] cannot be empty", i))
 			case !isValidPath(targetPath):
 				errors = append(errors, fmt.Sprintf("target_paths[%d] is not valid: '%s'", i, targetPath))
+			case isWholeAnchorTarget(targetPath):
+				errors = append(errors, fmt.Sprintf("target_paths[%d] '%s' refers to an entire home, working, or root directory; cache a subdirectory instead", i, targetPath))
 			}
 			if _, dup := seen[targetPath]; dup {
 				errors = append(errors, fmt.Sprintf("target_paths[%d] '%s' is duplicated (target_paths is a set)", i, targetPath))
@@ -66,6 +69,26 @@ func (c Cache) Validate() error {
 	}
 
 	return nil
+}
+
+// isWholeAnchorTarget reports whether p names an entire anchor root — the home
+// directory ("~"), the working directory ("."), or a filesystem/volume root —
+// rather than a path within one. Caching a whole home/cwd/root breaks restore,
+// which refuses to clean those directories (see cleanPath's protectedDirs), so
+// it is rejected up front.
+func isWholeAnchorTarget(p string) bool {
+	switch filepath.Clean(p) {
+	case "~", ".", string(filepath.Separator):
+		return true
+	}
+	if filepath.IsAbs(p) {
+		c := filepath.Clean(p)
+		vol := filepath.VolumeName(c) // a bare volume root such as "C:\" on Windows
+		if c == vol+string(filepath.Separator) || c == vol {
+			return true
+		}
+	}
+	return false
 }
 
 // isValidPath checks if a path is valid (doesn't contain null bytes or other invalid characters).

--- a/internal/cache/configuration/cache_test.go
+++ b/internal/cache/configuration/cache_test.go
@@ -1,6 +1,7 @@
 package configuration
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -147,6 +148,26 @@ func TestCacheValidate(t *testing.T) {
 			wantErr: true,
 			errMsg:  "is duplicated",
 		},
+		{
+			name: "bare home target path",
+			cache: Cache{
+				Name:        "valid_id",
+				CacheKey:    literalKey,
+				TargetPaths: []string{"~"},
+			},
+			wantErr: true,
+			errMsg:  "refers to an entire home, working, or root directory",
+		},
+		{
+			name: "bare cwd target path",
+			cache: Cache{
+				Name:        "valid_id",
+				CacheKey:    literalKey,
+				TargetPaths: []string{"."},
+			},
+			wantErr: true,
+			errMsg:  "refers to an entire home, working, or root directory",
+		},
 	}
 
 	for _, tt := range tests {
@@ -213,5 +234,23 @@ func TestIsValidPath(t *testing.T) {
 				t.Errorf("isValidPath() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestCacheValidateRejectsUNCShareRoot covers the Windows-only case: a UNC share
+// root such as `\\server\share` is a bare volume root (filepath.Clean leaves it
+// equal to the volume name, without a trailing separator) and must be rejected.
+func TestCacheValidateRejectsUNCShareRoot(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("UNC share roots are Windows-only")
+	}
+	c := Cache{
+		Name:        "valid_id",
+		CacheKey:    []KeyPart{{Source: SourceLiteral, Arg: "v1"}},
+		TargetPaths: []string{`\\server\share`},
+	}
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "refers to an entire home, working, or root directory") {
+		t.Errorf("Validate() = %v, want whole-anchor rejection for a UNC share root", err)
 	}
 }

--- a/internal/cache/integration_test.go
+++ b/internal/cache/integration_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"archive/zip"
 	"context"
 	"crypto/rand"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -561,6 +563,297 @@ func TestCacheIntegration_RestoreMissingBlobInvalidates(t *testing.T) {
 	}
 	if !resaveResult.CacheEntryCreated {
 		t.Error("expected re-save to re-create the invalidated entry")
+	}
+}
+
+// TestCacheIntegration_SaveAndRestoreRegularFile exercises the full client path
+// for a target that is a single regular file (not a directory).
+func TestCacheIntegration_SaveAndRestoreRegularFile(t *testing.T) {
+	ctx := t.Context()
+
+	cacheClient, cacheDir, _ := setupTestCache(t, "local_file")
+
+	// Reconfigure the cache to target a single regular file. cacheDir is a
+	// relative path, so the file is cwd-anchored and this runs cross-platform.
+	file := filepath.Join(cacheDir, "single.txt")
+	if err := os.WriteFile(file, []byte("file-cache-data"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cacheClient.caches[0].TargetPaths = []string{file}
+
+	if _, err := cacheClient.Save(ctx, "test-cache"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Corrupt the file so a successful restore must clean + replace it.
+	if err := os.WriteFile(file, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("WriteFile (stale): %v", err)
+	}
+
+	result, err := cacheClient.Restore(ctx, "test-cache")
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if !result.CacheRestored {
+		t.Fatal("expected the regular-file cache to be restored")
+	}
+
+	got, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "file-cache-data" {
+		t.Errorf("restored content = %q, want %q", string(got), "file-cache-data")
+	}
+}
+
+// TestCacheIntegration_SaveAndRestoreSymlinkTarget drives a symlink cache
+// target through the full client path. Restore's cleanup must unlink the
+// symlink (not follow it): it must not recurse into or chmod the referent, and
+// must recreate the symlink. Covers the client cleanup path the archive-only
+// symlink test bypasses.
+func TestCacheIntegration_SaveAndRestoreSymlinkTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating a symlink needs privileges on Windows")
+	}
+	ctx := t.Context()
+
+	cacheClient, _, _ := setupTestCache(t, "local_file")
+
+	base := t.TempDir()
+	realDir := filepath.Join(base, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realDir, "keep.txt"), []byte("referent"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	link := filepath.Join(base, "link")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	cacheClient.caches[0].TargetPaths = []string{link}
+
+	if _, err := cacheClient.Save(ctx, "test-cache"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Repoint the symlink at a different, mode-0700 directory before restore. A
+	// correct restore unlinks the stale symlink and recreates it → realDir,
+	// without recursing into or chmod-ing the stale referent.
+	otherDir := filepath.Join(base, "other")
+	if err := os.MkdirAll(otherDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(otherDir, "untouched.txt"), []byte("stay"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Chmod(otherDir, 0o700); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	if err := os.Remove(link); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if err := os.Symlink(otherDir, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	result, err := cacheClient.Restore(ctx, "test-cache")
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if !result.CacheRestored {
+		t.Fatal("expected the symlink cache to be restored")
+	}
+
+	// The symlink is recreated pointing at the original referent.
+	if got, err := os.Readlink(link); err != nil {
+		t.Fatalf("symlink should be restored: %v", err)
+	} else if got != realDir {
+		t.Errorf("symlink target = %q, want %q", got, realDir)
+	}
+
+	// The stale referent is untouched — cleanup unlinked the symlink and neither
+	// recursed into it (content intact) nor chmod-ed it (mode still 0700).
+	if content, err := os.ReadFile(filepath.Join(otherDir, "untouched.txt")); err != nil || string(content) != "stay" {
+		t.Errorf("stale referent content = %q (err %v), want %q", content, err, "stay")
+	}
+	if fi, err := os.Stat(otherDir); err != nil {
+		t.Fatalf("Stat otherDir: %v", err)
+	} else if fi.Mode().Perm() != 0o700 {
+		t.Errorf("stale referent mode = %v, want 0700 (cleanup must not chmod a symlink's referent)", fi.Mode().Perm())
+	}
+}
+
+// TestCacheIntegration_RestoreOverlapAfterHomeChange covers a portable anchor
+// converging onto another target at restore: save ["~/cache", homeB/cache] with
+// HOME=homeA (no overlap), then restore with HOME=homeB, where "~/cache"
+// re-resolves to homeB/cache and collides with the pinned target. Restore must
+// detect the overlap on the re-resolved paths and soft-fail to a miss, without
+// cleaning or extracting.
+func TestCacheIntegration_RestoreOverlapAfterHomeChange(t *testing.T) {
+	ctx := t.Context()
+
+	cacheClient, _, _ := setupTestCache(t, "local_file")
+
+	homeA := t.TempDir()
+	homeB := t.TempDir()
+	setHome := func(h string) {
+		t.Setenv("HOME", h)
+		t.Setenv("USERPROFILE", h)
+	}
+
+	// Both targets exist at save time so neither is skipped.
+	if err := os.WriteFile(filepath.Join(mkdir(t, filepath.Join(homeA, "cache")), "x"), []byte("a"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	sentinel := filepath.Join(mkdir(t, filepath.Join(homeB, "cache")), "y")
+	if err := os.WriteFile(sentinel, []byte("b"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cacheClient.caches[0].TargetPaths = []string{"~/cache", filepath.Join(homeB, "cache")}
+
+	setHome(homeA) // "~/cache" -> homeA/cache; no overlap with homeB/cache
+	if _, err := cacheClient.Save(ctx, "test-cache"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	setHome(homeB) // "~/cache" now re-resolves to homeB/cache -> overlaps the pinned target
+	result, err := cacheClient.Restore(ctx, "test-cache")
+	if err != nil {
+		t.Fatalf("Restore with overlapping re-resolved targets should not error: %v", err)
+	}
+	if result.CacheRestored {
+		t.Error("overlapping targets at restore should soft-fail to a miss")
+	}
+
+	// Soft-failed before cleanup, so the target's content is untouched.
+	if content, err := os.ReadFile(sentinel); err != nil || string(content) != "b" {
+		t.Errorf("target should be untouched, content=%q err=%v", content, err)
+	}
+}
+
+// mkdir creates dir (and parents) and returns it, failing the test on error.
+func mkdir(t *testing.T, dir string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	return dir
+}
+
+// TestCacheIntegration_RestoreUnrecognizedFormatInvalidates covers the clean-break migration path:
+// the entry still exists but points at an archive this agent can't read.
+// Restore must degrade to a cache miss AND invalidate the stale entry,
+// so a subsequent save can re-upload a v2 archive instead of being blocked by CacheEntryPeekExists.
+func TestCacheIntegration_RestoreUnrecognizedFormatInvalidates(t *testing.T) {
+	ctx := t.Context()
+
+	cacheClient, _, storageDir := setupTestCache(t, "local_file")
+	mockClient := cacheClient.api.(*mockAPIClient)
+
+	// Save so the entry is committed and a blob exists.
+	saveResult, err := cacheClient.Save(ctx, "test-cache")
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Overwrite the stored blob (named by its digest; a .attrs.json sidecar sits
+	// alongside it) with a v1-style archive that has no manifest.
+	writeManifestlessArchive(t, filepath.Join(storageDir, saveResult.Archive.Sha256Sum))
+
+	// Restore must not error, must report a miss, and must invalidate the entry.
+	restoreResult, err := cacheClient.Restore(ctx, "test-cache")
+	if err != nil {
+		t.Fatalf("Restore with unrecognized format should not error, got: %v", err)
+	}
+	if restoreResult.CacheRestored {
+		t.Error("unrecognized format should degrade to CacheRestored=false")
+	}
+	if restoreResult.CacheHit {
+		t.Error("unrecognized format should not be a cache hit")
+	}
+	if len(mockClient.expireCalls) != 1 {
+		t.Fatalf("expire calls = %d, want 1", len(mockClient.expireCalls))
+	}
+
+	// A subsequent save must re-upload, proving the entry was invalidated.
+	resaveResult, err := cacheClient.Save(ctx, "test-cache")
+	if err != nil {
+		t.Fatalf("re-Save: %v", err)
+	}
+	if !resaveResult.CacheEntryCreated {
+		t.Error("expected re-save to re-create the invalidated entry")
+	}
+}
+
+// TestCacheIntegration_RestoreCorruptArchiveInvalidates covers a blob that is
+// not a valid archive at all (corrupted/truncated in storage). Like the
+// unrecognized-format case, restore must degrade to a miss and invalidate the
+// entry rather than failing the job.
+func TestCacheIntegration_RestoreCorruptArchiveInvalidates(t *testing.T) {
+	ctx := t.Context()
+
+	cacheClient, _, storageDir := setupTestCache(t, "local_file")
+	mockClient := cacheClient.api.(*mockAPIClient)
+
+	saveResult, err := cacheClient.Save(ctx, "test-cache")
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Corrupt the stored blob so it is no longer a valid zip.
+	if err := os.WriteFile(filepath.Join(storageDir, saveResult.Archive.Sha256Sum), []byte("not a zip file"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	restoreResult, err := cacheClient.Restore(ctx, "test-cache")
+	if err != nil {
+		t.Fatalf("Restore with corrupt archive should not error, got: %v", err)
+	}
+	if restoreResult.CacheRestored {
+		t.Error("corrupt archive should degrade to CacheRestored=false")
+	}
+	if restoreResult.CacheHit {
+		t.Error("corrupt archive should not be a cache hit")
+	}
+	if len(mockClient.expireCalls) != 1 {
+		t.Fatalf("expire calls = %d, want 1", len(mockClient.expireCalls))
+	}
+
+	// A subsequent save must re-upload, proving the entry was invalidated.
+	resaveResult, err := cacheClient.Save(ctx, "test-cache")
+	if err != nil {
+		t.Fatalf("re-Save: %v", err)
+	}
+	if !resaveResult.CacheEntryCreated {
+		t.Error("expected re-save to re-create the invalidated entry")
+	}
+}
+
+// writeManifestlessArchive overwrites path with a plain zip that has no v2
+// manifest entry, simulating a v1/foreign archive.
+func writeManifestlessArchive(t *testing.T, path string) {
+	t.Helper()
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	zw := zip.NewWriter(f)
+	w, err := zw.Create("cache/file.txt")
+	if err != nil {
+		t.Fatalf("zip Create: %v", err)
+	}
+	if _, err := w.Write([]byte("legacy")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip Close: %v", err)
 	}
 }
 

--- a/internal/cache/restore.go
+++ b/internal/cache/restore.go
@@ -213,14 +213,69 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 		Concurrency:      transferInfo.Concurrency,
 	}
 
+	// Check the archive is a readable format before touching the filesystem.
+	if err := archive.Validate(archiveFile, transferInfo.BytesTransferred); err != nil {
+		// A bad cache must never block a build: an unrecognized or otherwise
+		// unreadable archive degrades to a miss and invalidates the entry
+		// (targets untouched — this runs before cleaning).
+		unrecognized := errors.Is(err, archive.ErrUnrecognizedFormat)
+		slog.Warn("cache archive failed verification, treating as miss and invalidating entry",
+			"cache_id", cacheID, "unrecognized_format", unrecognized, "err", err)
+		invalidated := c.invalidateStaleEntry(ctx, retrieveResp)
+		result.CacheHit = false
+		result.FallbackUsed = false
+		result.CacheRestored = false
+		result.TotalDuration = time.Since(startTime)
+		span.SetAttributes(
+			attribute.Bool("cache.hit", false),
+			attribute.Bool("cache.restored", false),
+			attribute.Bool("cache.unrecognized_format", unrecognized),
+			attribute.Bool("cache.invalidated", invalidated),
+		)
+		span.SetStatus(codes.Ok, "cache miss (archive failed verification)")
+		c.callProgress(cacheID, "complete", "Cache miss (archive failed verification, invalidated stale entry)", 0, 0)
+		return result, nil
+	}
+
+	// Portable anchors (~, .) re-resolve here, so targets that didn't overlap at
+	// save can converge (e.g. "~/cache" and "/home/b/cache" when HOME=/home/b).
+	// Re-check the resolved paths and soft-fail before touching the filesystem.
+	resolvedTargets := make([]string, len(cacheConfig.TargetPaths))
+	for i, path := range cacheConfig.TargetPaths {
+		resolved, err := archive.ResolveConfigPath(path)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "failed to resolve target path")
+			return result, fmt.Errorf("failed to resolve target path %q: %w", path, err)
+		}
+		resolvedTargets[i] = resolved
+	}
+	if a, b, ok := archive.OverlappingPaths(resolvedTargets); ok {
+		slog.Warn("configured cache targets overlap after re-resolving anchors, treating as miss",
+			"cache_id", cacheID, "target_a", cacheConfig.TargetPaths[a], "target_b", cacheConfig.TargetPaths[b])
+		result.CacheHit = false
+		result.FallbackUsed = false
+		result.CacheRestored = false
+		result.TotalDuration = time.Since(startTime)
+		span.SetAttributes(
+			attribute.Bool("cache.hit", false),
+			attribute.Bool("cache.restored", false),
+			attribute.Bool("cache.targets_overlap", true),
+		)
+		span.SetStatus(codes.Ok, "cache miss (targets overlap at restore)")
+		c.callProgress(cacheID, "complete", "Cache miss (targets overlap at restore)", 0, 0)
+		return result, nil
+	}
+
 	c.callProgress(cacheID, "cleaning", "Cleaning paths", 0, 0)
 
 	for _, path := range cacheConfig.TargetPaths {
-		extractedPath, err := archive.ResolveHomeDir(path)
+		// Resolve exactly as save/restore matching does.
+		extractedPath, err := archive.ResolveConfigPath(path)
 		if err != nil {
 			span.RecordError(err)
-			span.SetStatus(codes.Error, "failed to resolve home dir")
-			return result, fmt.Errorf("failed to resolve home dir for %q: %w", path, err)
+			span.SetStatus(codes.Error, "failed to resolve target path")
+			return result, fmt.Errorf("failed to resolve target path %q: %w", path, err)
 		}
 
 		slog.Debug("cleaning path", "path", path, "extractedPath", extractedPath)
@@ -415,26 +470,39 @@ func cleanPath(ctx context.Context, dir string) error {
 
 	clean := filepath.Clean(dir)
 
-	// Refuse to delete root or current directory
+	// Cheap lexical guards for degenerate spellings.
 	if clean == "." || clean == string(os.PathSeparator) {
 		return fmt.Errorf("cleanPath: refusing to remove %q", clean)
 	}
-
-	// On Windows, also check for drive roots like "C:\"
-	if runtime.GOOS == "windows" && len(clean) == 3 && clean[1] == ':' && clean[2] == '\\' {
-		return fmt.Errorf("cleanPath: refusing to remove drive root %q", clean)
-	}
-
-	// Refuse to delete home directory
-	if home, err := os.UserHomeDir(); err == nil {
-		if clean == filepath.Clean(home) {
-			return fmt.Errorf("cleanPath: refusing to remove home directory %q", clean)
+	if runtime.GOOS == "windows" {
+		if len(clean) == 3 && clean[1] == ':' && clean[2] == '\\' {
+			return fmt.Errorf("cleanPath: refusing to remove drive root %q", clean)
+		}
+		// UNC share root (\\server\share): filepath.Clean leaves it equal to the
+		// volume name with no trailing separator, so the drive-root check above
+		// misses it — reject it so cleanup never recurses the whole share.
+		if vol := filepath.VolumeName(clean); vol != "" && clean == vol {
+			return fmt.Errorf("cleanPath: refusing to remove volume root %q", clean)
 		}
 	}
+	// A final symlink is only unlinked by RemoveAll, so the guards below run only
+	// for a real (non-symlink) target; os.Lstat doesn't dereference it.
+	if lstat, err := os.Lstat(clean); err == nil && lstat.Mode()&os.ModeSymlink == 0 {
+		// Refuse if the target is, or is an ancestor of, a protected dir (cwd,
+		// home, root) — removing it would delete that dir too. By file identity,
+		// so symlinked parents and case variants count, not just an exact match.
+		for _, p := range protectedDirs() {
+			if pathContains(lstat, p) {
+				return fmt.Errorf("cleanPath: refusing to remove %q (it is or contains protected directory %q)", clean, p)
+			}
+		}
 
-	// Module cache has 0555 directories; make them writable in order to remove content.
-	if err := makeTreeWritable(ctx, clean); err != nil {
-		return err
+		// Module cache has 0555 directories; make them writable before removal.
+		if lstat.IsDir() {
+			if err := makeTreeWritable(ctx, clean); err != nil {
+				return err
+			}
+		}
 	}
 
 	// Check context again before potentially long RemoveAll
@@ -447,6 +515,34 @@ func cleanPath(ctx context.Context, dir string) error {
 	}
 
 	return nil
+}
+
+// protectedDirs returns directories cleanPath must never remove: the filesystem
+// root, the working directory, and the user's home directory.
+func protectedDirs() []string {
+	dirs := []string{string(os.PathSeparator)}
+	if cwd, err := os.Getwd(); err == nil {
+		dirs = append(dirs, cwd)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, home)
+	}
+	return dirs
+}
+
+// pathContains reports whether the file described by info is dir itself or an
+// ancestor of it.
+func pathContains(info os.FileInfo, dir string) bool {
+	for cur := filepath.Clean(dir); ; {
+		if ci, err := os.Stat(cur); err == nil && os.SameFile(info, ci) {
+			return true
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur { // reached the root
+			return false
+		}
+		cur = parent
+	}
 }
 
 // makeTreeWritable walks `clean` and chmods every directory to 0755 so that

--- a/internal/cache/restore_test.go
+++ b/internal/cache/restore_test.go
@@ -97,6 +97,22 @@ func TestCleanPath(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects resolved current directory", func(t *testing.T) {
+		// target_paths: ["."] resolves to the absolute cwd before cleanup; the
+		// guard must catch that too, not just the literal ".".
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("os.Getwd: %v", err)
+		}
+		err = cleanPath(t.Context(), cwd)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "refusing to remove") {
+			t.Errorf("error %q should contain %q", err.Error(), "refusing to remove")
+		}
+	})
+
 	t.Run("rejects home directory", func(t *testing.T) {
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -107,8 +123,68 @@ func TestCleanPath(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), "refusing to remove home directory") {
-			t.Errorf("error %q should contain %q", err.Error(), "refusing to remove home directory")
+		if !strings.Contains(err.Error(), "refusing to remove") {
+			t.Errorf("error %q should contain %q", err.Error(), "refusing to remove")
+		}
+	})
+
+	t.Run("removes a regular file", func(t *testing.T) {
+		// A file target must be removable; makeTreeWritable's os.OpenRoot only
+		// works on directories, so cleanPath must skip it for files.
+		file := filepath.Join(t.TempDir(), "cache-file")
+		if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := cleanPath(t.Context(), file); err != nil {
+			t.Fatalf("cleanPath: %v", err)
+		}
+		if _, err := os.Stat(file); !os.IsNotExist(err) {
+			t.Errorf("file should be removed, stat err = %v", err)
+		}
+	})
+
+	t.Run("removes a final symlink without following it to a protected dir", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink creation needs privileges on Windows")
+		}
+		// A final symlink is only unlinked by RemoveAll, so removing it is safe
+		// even when it points at the cwd — the referent must be left intact and
+		// removal must not be refused (nor the referent's tree chmod-ed).
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("os.Getwd: %v", err)
+		}
+		link := filepath.Join(t.TempDir(), "alias")
+		if err := os.Symlink(cwd, link); err != nil {
+			t.Fatalf("Symlink: %v", err)
+		}
+		if err := cleanPath(t.Context(), link); err != nil {
+			t.Fatalf("removing a symlink to cwd should be safe, got: %v", err)
+		}
+		if _, err := os.Lstat(link); !os.IsNotExist(err) {
+			t.Errorf("symlink should be removed, got err=%v", err)
+		}
+		if _, err := os.Stat(cwd); err != nil {
+			t.Errorf("cwd (the referent) must be left intact: %v", err)
+		}
+	})
+
+	t.Run("rejects an ancestor of the working directory", func(t *testing.T) {
+		// A target that contains the cwd (e.g. "/work" while cwd is "/work/job")
+		// must be refused — RemoveAll would recursively delete the cwd too.
+		base := t.TempDir()
+		job := filepath.Join(base, "job")
+		if err := os.MkdirAll(job, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		t.Chdir(job) // cwd is now base/job; restored automatically after the test
+
+		err := cleanPath(t.Context(), base)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "refusing to remove") {
+			t.Errorf("error %q should contain %q", err.Error(), "refusing to remove")
 		}
 	})
 
@@ -132,6 +208,42 @@ func TestCleanPath(t *testing.T) {
 	})
 }
 
+// TestPathContains covers the ancestor/equality logic behind cleanPath's
+// protected-directory guard.
+func TestPathContains(t *testing.T) {
+	base := t.TempDir()
+	parent := filepath.Join(base, "work")
+	child := filepath.Join(parent, "job")
+	sibling := filepath.Join(base, "other")
+	for _, d := range []string{child, sibling} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+	}
+
+	parentInfo, err := os.Stat(parent)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	childInfo, err := os.Stat(child)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+
+	if !pathContains(parentInfo, parent) {
+		t.Error("a directory should contain itself")
+	}
+	if !pathContains(parentInfo, child) {
+		t.Error("parent should contain its descendant")
+	}
+	if pathContains(parentInfo, sibling) {
+		t.Error("parent should not contain a sibling")
+	}
+	if pathContains(childInfo, parent) {
+		t.Error("child should not contain its parent")
+	}
+}
+
 func TestCleanPathWindowsDriveRoot(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows-specific test")
@@ -143,5 +255,21 @@ func TestCleanPathWindowsDriveRoot(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "refusing to remove drive root") {
 		t.Errorf("error %q should contain %q", err.Error(), "refusing to remove drive root")
+	}
+}
+
+func TestCleanPathWindowsUNCShareRoot(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("UNC share roots are Windows-only")
+	}
+
+	// A UNC share root cleans to the volume name with no trailing separator, so
+	// the drive-root guard misses it — cleanup must still refuse it.
+	err := cleanPath(t.Context(), `\\server\share`)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to remove") {
+		t.Errorf("error %q should contain %q", err.Error(), "refusing to remove")
 	}
 }


### PR DESCRIPTION
Backports #4120 to `v3`.

## Description

Moves the cache archive format from **v1** (a single flat namespace where the zip entry name is the sole routing key) to **v2** (each configured `target_path` gets its own numbered namespace `_N/`, plus a reserved `.buildkite/cache-manifest.json` that maps each namespace to its **anchor** — a symbol `~` / `/` / `.`, not a resolved path).

See #4120 for full design rationale and trade-offs.

## Backport notes

- Cherry-picked the 8 constituent (non-merge) commits from #4120 individually, in original order.
- Translated `github.com/buildkite/agent/v4/...` import paths and OTel tracer name strings back to `github.com/buildkite/agent/v3/...` (this package doesn't touch urfave/cli, so no CLI-layer translation was needed).
- Resolved a `go.mod`/`go.sum` conflict from the `quickzip` v1.0.2→v1.0.3 bump by keeping v3's `urfave/cli` (v1) line and dropping the incoming `urfave/cli/v3` line.
- Verified the 8 cherry-picked commits' cumulative diff has zero delta against the full PR diff (confirming no content was missed and no unrelated `main` drift was pulled in via the PR's merge commits).
- No experiment flag gates this on `main`, so none was added here.

## Sequencing note

On `main`, a later checksum-verification change (`fix(cache): verify cache checksum on restore` / `refactor(cache): move digest verification to digest.go`) was built on top of this v2 manifest rewrite. That change was already backported to `v3` independently as #4195 (open, based on `v3` before this PR), adapted to the old v1-format `restore.go`. Whichever of this PR and #4195 merges second will need a small rebase to reconcile `restore.go`.

## Testing

- `go build ./...`
- `go vet ./internal/cache/... ./clicommand/...`
- `gofmt -l internal/cache/` (clean)
- `go test ./internal/cache/...` and `go test ./clicommand/... -run Cache` — all passing