### PR TITLE
Fix pre-exit cancellation test timing flake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,12 +58,6 @@ Non-obvious environment/run caveats:
   `.buildkite/build/ssh.conf` to be present at `/etc/ssh/ssh_config.d/` (mirroring
   `.buildkite/Dockerfile-compile`). If this test fails with unresolved aliases, copy it:
   `sudo cp .buildkite/build/ssh.conf /etc/ssh/ssh_config.d/`
-- Cold-cache flakiness: `internal/job/integration` tests spawn many `bintest` mock
-  binaries that are compiled on first use. On a completely cold Go build cache, the
-  timing-sensitive `TestPreExitHooksFireAfterCancel` (500ms sleep before cancel) can
-  panic/fail. Warming the build cache first (e.g. `go build ./...` or simply running the
-  package once) makes the full suite pass reliably. This is a pre-existing test timing
-  assumption, not a product bug.
 
 Running the app end-to-end without a Buildkite token — build the binary, then use
 `bootstrap` to run a job locally (invoke the freshly built `./buildkite-agent`, since a

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync"
 	"testing"
+	"time"
 
 	"github.com/buildkite/agent/v4/internal/job"
 	"github.com/buildkite/agent/v4/internal/shell"
@@ -899,21 +899,35 @@ func TestPreExitHooksFireAfterCancel(t *testing.T) {
 		<-commandFinished
 	})
 
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		if err := tester.Run(t, "BUILDKITE_COMMAND=blocking-command"); err == nil {
-			t.Errorf(`tester.Run(t, "BUILDKITE_COMMAND=blocking-command") = %v, want non-nil error`, err)
-		}
-		t.Logf("Command finished")
-	})
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- tester.Run(t, "BUILDKITE_COMMAND=blocking-command")
+	}()
 
-	<-commandStarted
+	select {
+	case <-commandStarted:
+	case err := <-runDone:
+		close(commandFinished)
+		t.Fatalf("tester.Run() finished before command started: %v", err)
+	case <-time.After(30 * time.Second):
+		close(commandFinished)
+		_ = tester.Cancel()
+		t.Fatal("timed out waiting for command to start")
+	}
+
 	if err := tester.Cancel(); err != nil {
 		t.Errorf("tester.Cancel() = %v", err)
 	}
 
-	t.Logf("Waiting for command to finish")
-	wg.Wait()
+	select {
+	case err := <-runDone:
+		if err == nil {
+			t.Error("tester.Run() = nil, want non-nil error")
+		}
+	case <-time.After(30 * time.Second):
+		close(commandFinished)
+		t.Fatal("timed out waiting for command to finish after cancel")
+	}
 	close(commandFinished)
 
 	tester.CheckMocks(t)

--- a/internal/job/integration/hooks_integration_test.go
+++ b/internal/job/integration/hooks_integration_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/buildkite/agent/v4/internal/job"
 	"github.com/buildkite/agent/v4/internal/shell"
@@ -893,21 +892,29 @@ func TestPreExitHooksFireAfterCancel(t *testing.T) {
 	tester.ExpectGlobalHook("pre-exit").Once()
 	tester.ExpectLocalHook("pre-exit").Once()
 
+	commandStarted := make(chan struct{})
+	commandFinished := make(chan struct{})
+	tester.MustMock(t, "blocking-command").Expect().Once().AndCallFunc(func(*bintest.Call) {
+		close(commandStarted)
+		<-commandFinished
+	})
+
 	var wg sync.WaitGroup
 	wg.Go(func() {
-		if err := tester.Run(t, "BUILDKITE_COMMAND=sleep 5"); err == nil {
-			t.Errorf(`tester.Run(t, "BUILDKITE_COMMAND=sleep 5") = %v, want non-nil error`, err)
+		if err := tester.Run(t, "BUILDKITE_COMMAND=blocking-command"); err == nil {
+			t.Errorf(`tester.Run(t, "BUILDKITE_COMMAND=blocking-command") = %v, want non-nil error`, err)
 		}
 		t.Logf("Command finished")
 	})
 
-	time.Sleep(time.Millisecond * 500)
+	<-commandStarted
 	if err := tester.Cancel(); err != nil {
 		t.Errorf("tester.Cancel() = %v", err)
 	}
 
 	t.Logf("Waiting for command to finish")
 	wg.Wait()
+	close(commandFinished)
 
 	tester.CheckMocks(t)
 }


### PR DESCRIPTION
## Summary

- replace the fixed 500 ms delay in `TestPreExitHooksFireAfterCancel` with an observable bintest command-start signal
- keep the mocked command blocked until cancellation has completed, ensuring cancellation exercises the command and pre-exit path
- remove the obsolete cold-cache flake note from `AGENTS.md`

## Why

The test previously started bootstrap in a goroutine, slept for 500 ms, and sent SIGINT. `ExecutorTester.Cancel` only guarantees that the outer bootstrap process exists; it does not prove bootstrap has reached command execution. Under cold build caches, bintest mock compilation and job setup can take longer than 500 ms, so cancellation can arrive before the executor's pre-exit path is active and the hook expectations remain unmet.

The replacement waits until a dedicated bintest command is actually invoked. That is the behavior-level synchronization point proving the job is in its command phase before cancellation.

This is an independent fix based on `main`; it is not stacked on or part of #4197. It addresses the unrelated failure observed in the ARM64 race build: https://buildkite.com/buildkite/agent/builds/13842

## Validation

- `go test ./internal/job/integration -run '^TestPreExitHooksFireAfterCancel$' -count=10`
- `go test -race ./internal/job/integration -run '^TestPreExitHooksFireAfterCancel$' -count=10`
- empty temporary `GOCACHE`: `go test -race ./internal/job/integration -run '^TestPreExitHooksFireAfterCancel$' -count=1`
- `go test ./internal/job/integration`
- `golangci-lint run ./internal/job/integration`
- `git diff --check`
