### PR TITLE
Fix shell cancellation test synchronization

### DIFF
--- a/internal/shell/main_test.go
+++ b/internal/shell/main_test.go
@@ -16,6 +16,13 @@ import (
 var errMissingFilename = errors.New("missing file name")
 
 func TestMain(m *testing.M) {
+	if os.Getenv("TEST_MAIN_CONTEXT_CANCEL_READY") == "1" {
+		fmt.Println("ready")
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+
 	// leakStdoutGrandchild must be checked before leakStdout: the grandchild
 	// inherits the parent's environment (which still carries the leak-stdout
 	// marker), so keying the grandchild branch first prevents infinite respawn.

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -192,42 +192,51 @@ func TestContextCancelInterrupts(t *testing.T) {
 				opts = append(opts, shell.WithInterruptSignal(test.interruptSignal))
 			}
 
+			cmd := test.cmdWindows
+			ready := make(chan struct{})
+			runOpts := []shell.RunCommandOpt{shell.WithStarted(ready)}
+			if runtime.GOOS != "windows" {
+				// Starting a shell script does not mean it has started its sleep
+				// child yet. Have the process itself report when it is ready for
+				// signals so cancellation cannot race script startup.
+				cmd = os.Args[0]
+				runOpts = []shell.RunCommandOpt{
+					shell.WithExtraEnv(env.FromMap(map[string]string{"TEST_MAIN_CONTEXT_CANCEL_READY": "1"})),
+				}
+				opts = append(opts,
+					shell.WithStdout(replacer.New(io.Discard, []string{"ready"}, func([]byte) []byte {
+						close(ready)
+						return nil
+					})),
+				)
+			}
+
 			sh, err := shell.New(opts...)
 			if err != nil {
 				t.Fatalf("shell.New(%v) error = %v", opts, err)
 			}
-
 			sh.Logger = shell.DiscardLogger
 
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
-			// Wait for the process to start before cancelling the context.
-			// This is more reliable than time.Sleep, but still not perfect.
-			started := make(chan struct{})
-
 			go func() {
 				select {
 				case <-time.After(1 * time.Minute):
-					t.Errorf("timeout waiting for process to start")
-				case <-started:
-					// TODO: figure out why this still needs a sleep to be
-					// reliable.
-					time.Sleep(100 * time.Millisecond)
+					t.Errorf("timeout waiting for process to become ready")
+				case <-ready:
+					if runtime.GOOS == "windows" {
+						time.Sleep(100 * time.Millisecond)
+					}
 					// Now cancel the context, which should cause the interrupt.
 					cancel()
 				}
 			}()
 
-			cmd := "fixtures/sleep60.sh"
-			if runtime.GOOS == "windows" {
-				cmd = test.cmdWindows
-			}
-
 			// The process returns an exit error, except on Windows. 🙄
 			wantSignaled := runtime.GOOS != "windows"
 
-			err = sh.Command(cmd).Run(ctx, shell.WithStarted(started))
+			err = sh.Command(cmd).Run(ctx, runOpts...)
 			if got, want := shell.IsExitSignaled(err), wantSignaled; got != want {
 				t.Errorf("sh.Command(%q).Run(ctx) = %v, want shell.IsExitSignaled(err) = %t", cmd, err, want)
 			}


### PR DESCRIPTION
## Description

Fixes the ARM64 race-test timing flake in `TestContextCancelInterrupts/SIGINT` without changing production cancellation behavior.

`WithStarted` only establishes that `/bin/sh` has started; it does not establish that the script has launched `sleep`. Cancelling in that startup window can leave the non-interactive shell/process group alive until the 10-second grace-period SIGKILL, producing `killed` instead of `interrupt`.

On Unix, the test now executes a test helper process that writes a readiness marker only after it is running and ready to receive signals. Cancellation waits for that marker, eliminating the startup race and the arbitrary 100ms delay. Windows retains its existing batch-file path and timing because its Ctrl-Break behavior differs.

## Context

Observed independently in PR #4203's ARM64 race job:
https://buildkite.com/buildkite/agent/builds/13851#019fdfe9-3b64-49d3-9cb5-3dea0b8c500a

The failing case took 10.12s, matching the configured 10-second signal grace period before fallback SIGKILL. `internal/job/integration` passed in the same job.

## Changes

- add a Unix test helper that reports explicit signal readiness and then blocks
- synchronize context cancellation on that readiness marker
- preserve the existing Windows test path
- leave `internal/process` and production signaling unchanged

## Testing

- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

Targeted validation:

- `go test -race ./internal/shell -run '^TestContextCancelInterrupts$' -count=100`
- `go test -race ./internal/process -run '^TestProcessWithSlowHandlerKilledWhenContextDone$' -count=50`
- `go test -race ./internal/shell ./internal/process`
- `go test ./internal/shell`
- `golangci-lint run ./internal/shell/...`

## Disclosures / Credits

Amp investigated the failure, implemented the test synchronization change, and ran the validation and local review with direction from Lachlan Donald.