### PR TITLE
Run Windows batch hooks through cmd.exe

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -86,19 +86,20 @@ func ParseSignal(sig string) (Signal, error) {
 
 // Configuration for a Process
 type Config struct {
-	PTY               bool
-	Path              string
-	Args              []string
-	Env               []string
-	Stdin             io.Reader
-	Stdout            io.Writer
-	Stderr            io.Writer
-	Dir               string
-	Nice              int // Unix nice value for the child process (0 = default)
-	InterruptSignal   Signal
-	SignalGracePeriod time.Duration
-	Started           chan struct{}
-	Done              chan struct{}
+	PTY                bool
+	Path               string
+	Args               []string
+	WindowsCommandLine string
+	Env                []string
+	Stdin              io.Reader
+	Stdout             io.Writer
+	Stderr             io.Writer
+	Dir                string
+	Nice               int // Unix nice value for the child process (0 = default)
+	InterruptSignal    Signal
+	SignalGracePeriod  time.Duration
+	Started            chan struct{}
+	Done               chan struct{}
 }
 
 // Process is an operating system level process

--- a/internal/process/signal_windows.go
+++ b/internal/process/signal_windows.go
@@ -50,6 +50,7 @@ func (p *Process) setupProcessGroup() {
 	}
 	p.command.SysProcAttr = &windows.SysProcAttr{
 		CreationFlags: windows.CREATE_UNICODE_ENVIRONMENT | windows.CREATE_NEW_PROCESS_GROUP,
+		CmdLine:       p.conf.WindowsCommandLine,
 	}
 	jobHandle, err := newJobObject()
 	if err != nil {

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -267,9 +267,10 @@ retryLoop:
 
 // Command represents a command that can be run in a shell.
 type Command struct {
-	shell   *Shell
-	command string
-	args    []string
+	shell              *Shell
+	command            string
+	args               []string
+	windowsCommandLine string
 }
 
 // Command returns a command that can be run in the shell.
@@ -295,6 +296,9 @@ func (s *Shell) Script(path, commandOverride string) (Command, error) {
 	isSh := filepath.Ext(path) == "" || filepath.Ext(path) == ".sh"
 	isWindows := runtime.GOOS == "windows"
 	isPwsh := filepath.Ext(path) == ".ps1"
+	ext := strings.ToLower(filepath.Ext(path))
+	isBatch := isWindows && (ext == ".bat" || ext == ".cmd")
+	var windowsCommandLine string
 
 	if commandOverride != "" {
 		// first element is the command, all others are args to which we append path
@@ -311,6 +315,14 @@ func (s *Shell) Script(path, commandOverride string) (Command, error) {
 	}
 
 	switch {
+	case isBatch:
+		// Batch files are interpreted by cmd.exe, not executed directly by
+		// CreateProcess. Use a raw command line because cmd.exe's quoting rules
+		// differ from the CommandLineToArgvW rules used by os/exec.
+		command = "cmd.exe"
+		args = []string{"/D", "/V:OFF", "/S", "/C", path}
+		windowsCommandLine = `cmd.exe /D /V:OFF /S /C ""` + path + `""`
+
 	case isWindows && isSh:
 		if s.debug {
 			s.Commentf("Attempting to run %s with Bash for Windows", path)
@@ -386,9 +398,10 @@ func (s *Shell) Script(path, commandOverride string) (Command, error) {
 	}
 
 	return Command{
-		shell:   s,
-		command: command,
-		args:    args,
+		shell:              s,
+		command:            command,
+		args:               args,
+		windowsCommandLine: windowsCommandLine,
 	}, nil
 }
 
@@ -420,6 +433,7 @@ func (c Command) Run(ctx context.Context, opts ...RunCommandOpt) error {
 		c.shell.Errorf("Error building command: %v", err)
 		return err
 	}
+	cmdCfg.WindowsCommandLine = c.windowsCommandLine
 
 	// Merge in any extra env vars.
 	if cfg.extraEnv != nil {

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -141,7 +141,7 @@ func TestRunWindowsBatchScriptWithPipedOutput(t *testing.T) {
 		t.Fatalf("os.Mkdir(%q) = %v", dir, err)
 	}
 	path := filepath.Join(dir, "agent-startup.bat")
-	if err := os.WriteFile(path, []byte("@echo off\r\necho stdout=%BATCH_TEST_VALUE%\r\necho stderr-line 1>&2\r\n"), 0o755); err != nil {
+	if err := os.WriteFile(path, []byte("@echo off\r\necho stdout=%BATCH_TEST_VALUE%\r\n>&2 echo stderr-line\r\n"), 0o755); err != nil {
 		t.Fatalf("os.WriteFile(%q) = %v", path, err)
 	}
 

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -130,6 +130,37 @@ func TestRun(t *testing.T) {
 	}
 }
 
+func TestRunWindowsBatchScriptWithPipedOutput(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("batch scripts require Windows")
+	}
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "hooks with spaces & parentheses (test)")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatalf("os.Mkdir(%q) = %v", dir, err)
+	}
+	path := filepath.Join(dir, "agent-startup.bat")
+	if err := os.WriteFile(path, []byte("@echo off\r\necho stdout=%BATCH_TEST_VALUE%\r\necho stderr-line 1>&2\r\n"), 0o755); err != nil {
+		t.Fatalf("os.WriteFile(%q) = %v", path, err)
+	}
+
+	out := new(bytes.Buffer)
+	sh := newShellForTest(t, shell.WithStdout(out), shell.WithPTY(false))
+	sh.Env.Set("BATCH_TEST_VALUE", "expanded")
+	script, err := sh.Script(path, "")
+	if err != nil {
+		t.Fatalf("sh.Script(%q, %q) = %v", path, "", err)
+	}
+	if err := script.Run(t.Context(), shell.ShowPrompt(false)); err != nil {
+		t.Fatalf("script.Run() = %v", err)
+	}
+
+	if diff := cmp.Diff(out.String(), "stdout=expanded\r\nstderr-line\r\n"); diff != "" {
+		t.Errorf("batch output diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestRunWithStdin(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- execute `.bat` and `.cmd` hook scripts explicitly through `cmd.exe` instead of passing the batch-file path directly to `CreateProcess`
- use a raw Windows command line with `/D /V:OFF /S /C` so cmd's quoting rules preserve hook paths containing spaces and metacharacters
- add a Windows regression test that runs a batch hook from a path containing spaces, `&`, and parentheses while stdout/stderr are copied through a non-file writer

## Why

`TestAgentStartupHookWithRegisteredAgentsEnv` has repeatedly flaked in Windows CI in two closely related ways:

- the batch hook returned success but neither of its two output lines reached the lifecycle-hook logger
- process creation failed with `The handle is invalid` while setting up the batch hook's redirected output handles

The lifecycle hook already closes its `io.Pipe` writer and joins the scanner goroutine before returning, and `exec.Cmd.Wait` waits for the internal output-copy goroutine. The missing lines therefore are not an assertion or scanner timing race.

The shared problem boundary is that `shell.Script` treated `.bat` and `.cmd` files as executables. Go passed the batch path to Windows process creation while also constructing inherited handles for the non-file lifecycle output writer. Batch files are command-processor input, and Go explicitly documents that `cmd.exe`/batch quoting does not follow its normal `CommandLineToArgvW` argument encoding. The fix makes that interpreter boundary explicit and carries the raw cmd command line through the existing process configuration before Windows installs its process-group attributes.

This changes production hook execution rather than serializing the test or adding sleeps/retries. It also applies to pre-bootstrap and wrapped job hooks that share `shell.Script`.

This PR is based independently on `main`; it does not modify or stack on #4197 or #4203.

## Validation

- `go test ./internal/shell ./internal/process ./clicommand`
- `go test -race ./internal/shell ./internal/process ./clicommand`
- focused lifecycle test: `go test ./clicommand -run '^TestAgentStartupHookWithRegisteredAgentsEnv$' -count=500`
- Windows cross-compilation of `internal/shell`, `internal/process`, and `clicommand` test binaries
- `golangci-lint run ./internal/shell ./internal/process ./clicommand`
- `go tool gofumpt -extra -w` on changed files
- `git diff --check`

## Remaining uncertainty

The orb cannot execute Windows binaries, so the new test and repeated Windows suite are the decisive checks in CI. A high-load Linux whole-package repetition also produced an existing lifecycle output-pipe error while many parallel subprocess tests were active; that indicates there may be a second, platform-independent process-pipe stress issue. It does not invalidate the unsupported direct-batch launch fixed here, but if Windows still flakes after this change that lower-level issue should be reduced separately rather than adding retries here.

