### PR TITLE
Execute Windows batch hooks through the system command processor

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -86,9 +86,11 @@ func ParseSignal(sig string) (Signal, error) {
 
 // Configuration for a Process
 type Config struct {
-	PTY               bool
-	Path              string
-	Args              []string
+	PTY  bool
+	Path string
+	Args []string
+	// WindowsCmdLine bypasses os/exec argument quoting when non-empty.
+	WindowsCmdLine    string
 	Env               []string
 	Stdin             io.Reader
 	Stdout            io.Writer

--- a/internal/process/signal_windows.go
+++ b/internal/process/signal_windows.go
@@ -50,6 +50,7 @@ func (p *Process) setupProcessGroup() {
 	}
 	p.command.SysProcAttr = &windows.SysProcAttr{
 		CreationFlags: windows.CREATE_UNICODE_ENVIRONMENT | windows.CREATE_NEW_PROCESS_GROUP,
+		CmdLine:       p.conf.WindowsCmdLine,
 	}
 	jobHandle, err := newJobObject()
 	if err != nil {

--- a/internal/shell/lookpath.go
+++ b/internal/shell/lookpath.go
@@ -51,3 +51,7 @@ func LookPath(file, path, fileExtensions string) (string, error) {
 	}
 	return "", &exec.Error{Name: file, Err: exec.ErrNotFound}
 }
+
+func systemCommandProcessor() (string, error) {
+	return "cmd.exe", nil
+}

--- a/internal/shell/lookpath_windows.go
+++ b/internal/shell/lookpath_windows.go
@@ -9,10 +9,13 @@
 package shell
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/sys/windows"
 )
 
 func chkStat(file string) error {
@@ -88,4 +91,12 @@ func LookPath(file, path, fileExtensions string) (string, error) {
 		}
 	}
 	return "", &exec.Error{file, exec.ErrNotFound}
+}
+
+func systemCommandProcessor() (string, error) {
+	systemDirectory, err := windows.GetSystemDirectory()
+	if err != nil {
+		return "", fmt.Errorf("finding Windows system directory: %w", err)
+	}
+	return filepath.Join(systemDirectory, "cmd.exe"), nil
 }

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -267,9 +267,10 @@ retryLoop:
 
 // Command represents a command that can be run in a shell.
 type Command struct {
-	shell   *Shell
-	command string
-	args    []string
+	shell          *Shell
+	command        string
+	args           []string
+	windowsCmdLine string
 }
 
 // Command returns a command that can be run in the shell.
@@ -295,6 +296,9 @@ func (s *Shell) Script(path, commandOverride string) (Command, error) {
 	isSh := filepath.Ext(path) == "" || filepath.Ext(path) == ".sh"
 	isWindows := runtime.GOOS == "windows"
 	isPwsh := filepath.Ext(path) == ".ps1"
+	ext := strings.ToLower(filepath.Ext(path))
+	isBatch := isWindows && (ext == ".bat" || ext == ".cmd")
+	var windowsCmdLine string
 
 	if commandOverride != "" {
 		// first element is the command, all others are args to which we append path
@@ -311,6 +315,21 @@ func (s *Shell) Script(path, commandOverride string) (Command, error) {
 	}
 
 	switch {
+	case isBatch:
+		// Batch files are interpreted by cmd.exe, not executed directly by
+		// CreateProcess. Use a raw command line because cmd.exe's quoting rules
+		// differ from the CommandLineToArgvW rules used by os/exec.
+		if strings.Contains(path, "%") {
+			return Command{}, fmt.Errorf("cannot run Windows batch script %q: path contains '%%', which cmd.exe expands", path)
+		}
+		cmdPath, err := systemCommandProcessor()
+		if err != nil {
+			return Command{}, fmt.Errorf("finding command processor for Windows batch script: %w", err)
+		}
+		command = cmdPath
+		args = []string{"/D", "/V:OFF", "/S", "/C", path}
+		windowsCmdLine = `"` + command + `" /D /V:OFF /S /C ""` + path + `""`
+
 	case isWindows && isSh:
 		if s.debug {
 			s.Commentf("Attempting to run %s with Bash for Windows", path)
@@ -386,9 +405,10 @@ func (s *Shell) Script(path, commandOverride string) (Command, error) {
 	}
 
 	return Command{
-		shell:   s,
-		command: command,
-		args:    args,
+		shell:          s,
+		command:        command,
+		args:           args,
+		windowsCmdLine: windowsCmdLine,
 	}, nil
 }
 
@@ -420,6 +440,7 @@ func (c Command) Run(ctx context.Context, opts ...RunCommandOpt) error {
 		c.shell.Errorf("Error building command: %v", err)
 		return err
 	}
+	cmdCfg.WindowsCmdLine = c.windowsCmdLine
 
 	// Merge in any extra env vars.
 	if cfg.extraEnv != nil {

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -165,6 +165,27 @@ func TestRunWindowsBatchScriptWithPipedOutput(t *testing.T) {
 	}
 }
 
+func TestRunWindowsBatchScriptPreservesExitCode(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("batch scripts require Windows")
+	}
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "nonzero.cmd")
+	if err := os.WriteFile(path, []byte("@exit /b 23\r\n"), 0o755); err != nil {
+		t.Fatalf("os.WriteFile(%q) = %v", path, err)
+	}
+
+	sh := newShellForTest(t, shell.WithPTY(false))
+	script, err := sh.Script(path, "")
+	if err != nil {
+		t.Fatalf("sh.Script(%q, %q) = %v", path, "", err)
+	}
+	if err := script.Run(t.Context(), shell.ShowPrompt(false)); shell.ExitCode(err) != 23 {
+		t.Fatalf("shell.ExitCode(script.Run()) = %d, want 23 (error: %v)", shell.ExitCode(err), err)
+	}
+}
+
 func TestWindowsBatchScriptRejectsPercentInPath(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("batch scripts require Windows")

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -138,7 +138,7 @@ func TestRunWindowsBatchScriptWithPipedOutput(t *testing.T) {
 
 	for _, ext := range []string{".bat", ".CMD"} {
 		t.Run(ext, func(t *testing.T) {
-			dir := filepath.Join(t.TempDir(), "hooks with spaces & parentheses (test)")
+			dir := filepath.Join(t.TempDir(), "hooks with spaces & parentheses (test) ! caret ^")
 			if err := os.Mkdir(dir, 0o755); err != nil {
 				t.Fatalf("os.Mkdir(%q) = %v", dir, err)
 			}

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -130,6 +130,55 @@ func TestRun(t *testing.T) {
 	}
 }
 
+func TestRunWindowsBatchScriptWithPipedOutput(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("batch scripts require Windows")
+	}
+	t.Parallel()
+
+	for _, ext := range []string{".bat", ".CMD"} {
+		t.Run(ext, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), "hooks with spaces & parentheses (test)")
+			if err := os.Mkdir(dir, 0o755); err != nil {
+				t.Fatalf("os.Mkdir(%q) = %v", dir, err)
+			}
+			path := filepath.Join(dir, "agent-startup"+ext)
+			if err := os.WriteFile(path, []byte("@echo off\r\necho stdout=%BATCH_TEST_VALUE%\r\n>&2 echo stderr-line\r\n"), 0o755); err != nil {
+				t.Fatalf("os.WriteFile(%q) = %v", path, err)
+			}
+
+			out := new(bytes.Buffer)
+			sh := newShellForTest(t, shell.WithStdout(out), shell.WithPTY(false))
+			sh.Env.Set("BATCH_TEST_VALUE", "expanded")
+			script, err := sh.Script(path, "")
+			if err != nil {
+				t.Fatalf("sh.Script(%q, %q) = %v", path, "", err)
+			}
+			if err := script.Run(t.Context(), shell.ShowPrompt(false)); err != nil {
+				t.Fatalf("script.Run() = %v", err)
+			}
+
+			if diff := cmp.Diff(out.String(), "stdout=expanded\r\nstderr-line\r\n"); diff != "" {
+				t.Errorf("batch output diff (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWindowsBatchScriptRejectsPercentInPath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("batch scripts require Windows")
+	}
+	t.Parallel()
+
+	sh := newShellForTest(t)
+	path := filepath.Join(t.TempDir(), "%TEMP%", "agent-startup.bat")
+	_, err := sh.Script(path, "")
+	if err == nil || !strings.Contains(err.Error(), "path contains '%'") {
+		t.Fatalf("sh.Script(%q, %q) error = %v, want percent-path error", path, "", err)
+	}
+}
+
 func TestRunWithStdin(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- execute default Windows `.bat` and `.cmd` hooks through the Windows command processor
- resolve `cmd.exe` from the Windows system directory rather than `PATH`
- preserve `cmd.exe` quoting for script paths containing spaces and shell metacharacters
- reject script paths containing `%` rather than allowing environment-variable expansion to select a different path

## Why

The agent currently passes default Windows batch hooks to `CreateProcessW` as if they were executable images. This usually works because Windows has an undocumented compatibility behavior that converts a `.bat` or `.cmd` application into a `cmd.exe /c` invocation. [Rust documents the same behavior](https://doc.rust-lang.org/std/process/index.html#batch-file-special-handling), warns that it may be removed, and handles batch files explicitly.

That implicit behavior is not the supported Windows contract. Microsoft's [`CreateProcessW` documentation](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw) says that callers must start the command interpreter to run a batch file. Go's [`os/exec.Command` documentation](https://pkg.go.dev/os/exec#Command) also calls out `cmd.exe` and batch files as exceptions to its normal Windows argument quoting and directs callers to provide the appropriate raw command line.

This change makes that contract explicit at the shared `internal/shell` boundary. Default lifecycle, bootstrap, repository, and plugin batch hooks run through the trusted system command processor with cmd-specific quoting, while explicit `HooksShell` overrides remain unchanged.

Literal `%` is legal in a Windows path but is expanded by `cmd.exe` even inside quotes. Until there is a verified literal encoding for script paths, the agent rejects these paths with an actionable error rather than potentially executing a different path.

## Validation

- `go test ./internal/shell ./internal/process ./clicommand`
- `go test -race ./internal/shell ./internal/process ./clicommand`
- `golangci-lint run ./internal/shell ./internal/process ./clicommand`
- Windows cross-compilation of `internal/shell` and `internal/process` test binaries
- Windows runtime coverage for `.bat` and `.cmd`, piped stdout/stderr, non-zero exit propagation, environment expansion, paths containing spaces, `&`, parentheses, `!`, and `^`, and deterministic rejection of `%` in paths


