### PR TITLE
Downgrade Go 1.26.5 -> 1.25.12 to fix Windows exit-status flake

### DIFF
--- a/.buildkite/Dockerfile-compile
+++ b/.buildkite/Dockerfile-compile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
+FROM public.ecr.aws/docker/library/golang:1.25.12@sha256:fe5d57d3b718e7a4986bae156c2d73f44973bfd313073aed08a4de6692bb6161
 COPY build/ssh.conf /etc/ssh/ssh_config.d/
 
 RUN go install github.com/google/go-licenses@latest

--- a/.buildkite/Dockerfile-e2e
+++ b/.buildkite/Dockerfile-e2e
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
+FROM public.ecr.aws/docker/library/golang:1.25.12@sha256:fe5d57d3b718e7a4986bae156c2d73f44973bfd313073aed08a4de6692bb6161
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/agent/v4
 
-go 1.26.5
+go 1.25.12
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260709200747-435963d16310.1

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.26.5"
+go = "1.25.12"
 golangci-lint = "2.9.0"
 ruby = "3.4.9"
 


### PR DESCRIPTION
## What

Downgrades Go from 1.26.5 to 1.25.12 in `go.mod`, `mise.toml`, and both `.buildkite` Dockerfiles (image digest verified against ECR Public).

## Why

Since the Go 1.26.5 bump (#4134 — first seen in its merge build, [13445](https://buildkite.com/buildkite/agent/builds/13445)), Windows AMD64 CI has intermittently failed with:

```
*os.SyscallError: GetExitCodeProcess: The handle is invalid.
```

returned from `Cmd.Wait` after the process has already exited. This matches the `Cmd.Wait`/`watchCtx` process-handle lifetime races tracked in golang/go#78046. Go 1.26 introduced new process-handle machinery in `os`/`os/exec` consistent with this failure mode; Go 1.25 predates it and doesn't exhibit the flake.

The upstream fixes have landed on Go master for 1.27 but have **not** been backported to any released 1.26.x (1.26.5 is the latest). Rather than working around an unreadable exit status in our process package (risking reporting a failed command as successful), downgrade until a fixed Go is released.

## Notes

- 1.25.12 is the current patch release of the supported 1.25 line, so we stay on a security-supported toolchain.
- **This is a stopgap**: we should re-upgrade directly to Go 1.27 once it's released with the golang/go#78046 fixes.
- Companion PR #4207 fixes the other (unrelated) Windows CI flake: lifecycle-hook output truncated by a too-short post-exit `WaitDelay`.

## Validation

With a local Go 1.25.12 toolchain (`GOTOOLCHAIN=local`): `go build ./...`, `GOOS=windows GOARCH=amd64 go build ./...`, `go vet ./...`, `go mod tidy` (no-op), and `go test ./internal/process/ ./internal/shell/` all pass.
