### PR TITLE
Parallelize end-to-end tests

### DIFF
--- a/.buildkite/steps/e2e-tests.sh
+++ b/.buildkite/steps/e2e-tests.sh
@@ -15,4 +15,6 @@ else
 	export CI_E2E_TESTS_AGENT_PATH="${PWD}/${ARTIFACT}"
 fi
 
-go tool gotestsum --junitfile junit.xml -- -tags e2e ./internal/e2e/...
+# Each test provisions its own queue, pipeline, and agent. Run isolated tests
+# concurrently, but cap parallelism to avoid overwhelming shared services.
+go tool gotestsum --junitfile junit.xml -- -tags e2e -parallel 4 ./internal/e2e/...

--- a/internal/e2e/artifact_test.go
+++ b/internal/e2e/artifact_test.go
@@ -13,6 +13,8 @@ import (
 
 // Test that an agent can upload and download an artifact across different steps in the same build
 func TestArtifactUploadDownload(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 
 	tc := newTestCase(t, "artifact_upload_download.yaml")
@@ -27,6 +29,8 @@ func TestArtifactUploadDownload(t *testing.T) {
 
 // Test that an agent can upload and download artifact to/from a customer-managed S3 bucket
 func TestArtifactUploadDownload_CustomBucket(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 	tc := newTestCase(t, "artifact_custom_s3_bucket.yaml")
 
@@ -42,6 +46,8 @@ func TestArtifactUploadDownload_CustomBucket(t *testing.T) {
 // Test that we can upload/download artifact using a custom GCS bucket.
 // Everything that gets uploaded here gets auto removed in 30 days.
 func TestArtifactUploadDownload_GCS(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 	tc := newTestCase(t, "artifact_custom_gcs_bucket.yaml")
 
@@ -57,6 +63,8 @@ func TestArtifactUploadDownload_GCS(t *testing.T) {
 // Test that an agent can upload and download many artifacts (100 files).
 // This exercises the batch creator iterator producing multiple batches (batch size = 30).
 func TestArtifactUploadMany(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 
 	tc := newTestCase(t, "artifact_upload_many.yaml")
@@ -72,6 +80,8 @@ func TestArtifactUploadMany(t *testing.T) {
 // Test that artifact upload with --glob-resolve-follow-symlinks follows symlinked directories.
 // Regression test for https://github.com/buildkite/agent/issues/3826
 func TestArtifactUploadFollowSymlinks(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 
 	tc := newTestCase(t, "artifact_upload_symlink_glob.yaml")
@@ -88,6 +98,8 @@ func TestArtifactUploadFollowSymlinks(t *testing.T) {
 // container.
 // Everything that gets uploaded here gets auto removed in 30 days.
 func TestArtifactUploadDownload_Azure(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 	tc := newTestCase(t, "artifact_custom_azure_storage.yaml")
 
@@ -114,6 +126,8 @@ func TestArtifactUploadDownload_Azure(t *testing.T) {
 // name must produce a slug starting with that prefix (Buildkite converts
 // underscores to hyphens during slug derivation).
 func TestArtifactUploadDownload_CustomBucket_Multipart(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 	tc := newTestCase(t, "artifact_multipart_s3_download.yaml")
 

--- a/internal/e2e/basic_test.go
+++ b/internal/e2e/basic_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestBasicE2E(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 	tc := newTestCase(t, "basic_e2e.yaml")
 
@@ -32,6 +34,8 @@ func TestBasicE2E(t *testing.T) {
 }
 
 func TestBasicE2E_PollOnly(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 	tc := newTestCase(t, "basic_e2e.yaml")
 
@@ -54,6 +58,8 @@ func TestBasicE2E_PollOnly(t *testing.T) {
 }
 
 func TestBasicE2E_StreamOnly(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 	tc := newTestCase(t, "basic_e2e.yaml")
 

--- a/internal/e2e/cache_test.go
+++ b/internal/e2e/cache_test.go
@@ -21,6 +21,8 @@ import (
 // derivation, and the slug is lower(t.Name() + "-" + jobID)). The trust
 // policy allows "testcache*" to cover this and future cache test variants.
 func TestCacheBasicSaveRestore(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 
 	tc := newTestCase(t, "cache_save_restore.yaml")
@@ -38,6 +40,8 @@ func TestCacheBasicSaveRestore(t *testing.T) {
 // The restore step deletes the targets before restoring so the assertions
 // prove the cache, not leftover state from the save step.
 func TestCacheFilesystemIntegrity(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 
 	tc := newTestCase(t, "cache_filesystem_integrity.yaml")
@@ -57,6 +61,8 @@ func TestCacheFilesystemIntegrity(t *testing.T) {
 // restores, while the cache without fallback_limit treats the variant mismatch
 // as a hard miss.
 func TestCacheKeyFallback(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 
 	tc := newTestCase(t, "cache_fallback.yaml")
@@ -74,6 +80,8 @@ func TestCacheKeyFallback(t *testing.T) {
 // and invalidates the stale entry, so a subsequent save re-uploads and a final
 // restore hits. The fixture nukes the blob from S3 between save and restore.
 func TestCacheMissingBlobReupload(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 
 	tc := newTestCase(t, "cache_missing_blob_reupload.yaml")

--- a/internal/e2e/job_update_timeout_test.go
+++ b/internal/e2e/job_update_timeout_test.go
@@ -10,6 +10,8 @@ import (
 // minutes to 1 minute via `job update timeout`, then sleeps for 5 minutes,
 // exceeds the new timeout and fails.
 func TestJobUpdateTimeout(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 	tc := newTestCase(t, "job_update_timeout.yaml")
 

--- a/internal/e2e/plugin_test.go
+++ b/internal/e2e/plugin_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestPluginE2E(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 	tc := newTestCase(t, "repeated_plugin.yaml")
 


### PR DESCRIPTION
## Description

The end-to-end test step has grown from a 1.1-minute median in December to 5.2 minutes in August as the suite expanded to 16 tests. Each test already provisions an isolated pipeline, queue, agent, and temporary directories, but the Go tests were running serially.

Run the independent tests concurrently, capped at four, so the suite retains bounded pressure on the Buildkite API and shared runner services.

## Context

The latest baseline [agent build 13866](https://buildkite.com/buildkite/agent/builds/13866) spent 5.3 minutes in [e2e build 2163](https://buildkite.com/buildkite/agent-e2e-tests/builds/2163). The median across recent main builds is 5.2 minutes.

The one-minute `TestJobUpdateTimeout` remains unchanged, but can now overlap with the other tests.

## Measured impact

[PR build 13868](https://buildkite.com/buildkite/agent/builds/13868) passed, with [e2e build 2165](https://buildkite.com/buildkite/agent-e2e-tests/builds/2165) completing in **3.4 minutes**:

- **1.9 minutes / 36% faster** than the latest 5.3-minute main baseline.
- **1.8 minutes / 35% faster** than the recent 5.2-minute main median.

## Changes

- Opt all 16 runnable e2e tests into `t.Parallel()`.
- Limit the CI test process to four concurrent tests with `-parallel 4`.

## Testing

- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

The e2e-tagged package compiles with the pinned Go 1.25.12 toolchain:

```
go test -tags e2e -c ./internal/e2e
```

The full credentialed e2e suite passed in the Buildkite run linked above.

Also checked:

```
bash -n .buildkite/steps/e2e-tests.sh
git diff --check
```

## Disclosures / Credits

Amp analyzed the Buildkite timing history, identified the serialization bottleneck, implemented the bounded parallelism change, and performed the local validation.