### PR TITLE
Log when a custom endpoint is used

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -36,6 +36,7 @@ import (
 	"github.com/buildkite/agent/v4/internal/job/hook"
 	"github.com/buildkite/agent/v4/internal/osutil"
 	"github.com/buildkite/agent/v4/internal/process"
+	"github.com/buildkite/agent/v4/internal/redact"
 	"github.com/buildkite/agent/v4/internal/shell"
 	"github.com/buildkite/agent/v4/logger"
 	"github.com/buildkite/agent/v4/metrics"
@@ -1092,6 +1093,10 @@ var AgentStartCommand = &cli.Command{
 
 		if exps := experiments.KnownAndEnabled(ctx); len(exps) > 0 {
 			l.WithFields(logger.StringField("experiments", fmt.Sprintf("%v", exps))).Infof("Experiments are enabled")
+		}
+
+		if cfg.Endpoint != DefaultEndpoint {
+			l.Infof("Connecting to custom endpoint %s", redact.URLCredentials(cfg.Endpoint))
 		}
 
 		if !agentConf.SSHKeyscan {


### PR DESCRIPTION
## Description

I often have an agent running for local dev, and i switch it between using production buildkite (`agent-edge.buildkite.com/v3`) and local dev (`agent-edge.buildkite.localhost/v3`) pretty frequently. Every once in a while, i'll test something and think "man, why isn't this job running?", and the answer is because my agents are connected to the wrong endpoint. This PR makes it slightly easier to see when this happens.

## Context

It came to me in a dream

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

Certified human generated slop.
