### PR TITLE
Add Ubuntu 26.04

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -356,6 +356,7 @@ steps:
             - "ubuntu-20.04"
             - "ubuntu-22.04"
             - "ubuntu-24.04"
+            - "ubuntu-26.04"
             - "sidecar"
 
   - group: ":docker: Docker Image Tests"
@@ -386,6 +387,7 @@ steps:
               - ubuntu-20.04
               - ubuntu-22.04
               - ubuntu-24.04
+              - ubuntu-26.04
               - sidecar
 
       - name: ":docker: {{matrix.variant}} arm64 image test"
@@ -414,6 +416,7 @@ steps:
               - ubuntu-20.04
               - ubuntu-22.04
               - ubuntu-24.04
+              - ubuntu-26.04
               - sidecar
 
   # --- end Docker Image tests ---

--- a/.buildkite/steps/build-docker-image.sh
+++ b/.buildkite/steps/build-docker-image.sh
@@ -4,7 +4,7 @@ set -Eeufo pipefail
 
 ## This script can be run locally like this:
 ##
-## .buildkite/steps/build-docker-image.sh (alpine|alpine-k8s|ubuntu-20.04|ubuntu-22.04|ubuntu-24.04|sidecar) (image tag) (codename) (version)
+## .buildkite/steps/build-docker-image.sh (alpine|alpine-k8s|ubuntu-20.04|ubuntu-22.04|ubuntu-24.04|ubuntu-26.04|sidecar) (image tag) (codename) (version)
 ## e.g: .buildkite/steps/build-docker-image.sh alpine buildkiteci/agent:lox-manual-build stable 3.1.1
 ##
 ## You can then publish that image with
@@ -21,7 +21,7 @@ codename="${3:-}"
 version="${4:-}"
 push="${PUSH_IMAGE:-true}"
 
-if [[ ! "$variant" =~ ^(alpine|alpine-k8s|ubuntu-20\.04|ubuntu-22\.04|ubuntu-24\.04|sidecar)$ ]]; then
+if [[ ! "$variant" =~ ^(alpine|alpine-k8s|ubuntu-20\.04|ubuntu-22\.04|ubuntu-24\.04|ubuntu-26\.04|sidecar)$ ]]; then
   echo "Unknown docker variant $variant"
   exit 1
 fi

--- a/.buildkite/steps/extract-agent-version-metadata.sh
+++ b/.buildkite/steps/extract-agent-version-metadata.sh
@@ -12,6 +12,7 @@ docker_alpine_k8s_image_tag="$registry:alpine-k8s-build-${BUILDKITE_BUILD_NUMBER
 docker_ubuntu_focal_image_tag="$registry:ubuntu-20.04-build-${BUILDKITE_BUILD_NUMBER}"
 docker_ubuntu_jammy_image_tag="$registry:ubuntu-22.04-build-${BUILDKITE_BUILD_NUMBER}"
 docker_ubuntu_noble_image_tag="$registry:ubuntu-24.04-build-${BUILDKITE_BUILD_NUMBER}"
+docker_ubuntu_resolute_image_tag="$registry:ubuntu-26.04-build-${BUILDKITE_BUILD_NUMBER}"
 
 docker_sidecar_image_tag="$registry:sidecar-build-${BUILDKITE_BUILD_NUMBER}"
 
@@ -27,6 +28,7 @@ echo "Docker Alpine Image Tag: $docker_alpine_image_tag"
 echo "Docker Ubuntu 20.04 Image Tag: $docker_ubuntu_focal_image_tag"
 echo "Docker Ubuntu 22.04 Image Tag: $docker_ubuntu_jammy_image_tag"
 echo "Docker Ubuntu 24.04 Image Tag: $docker_ubuntu_noble_image_tag"
+echo "Docker Ubuntu 26.04 Image Tag: $docker_ubuntu_resolute_image_tag"
 echo "Docker Sidecar Image Tag: $docker_sidecar_image_tag"
 echo "Is prerelease? $is_prerelease"
 
@@ -38,5 +40,6 @@ buildkite-agent meta-data set "agent-docker-image-alpine-k8s" "$docker_alpine_k8
 buildkite-agent meta-data set "agent-docker-image-ubuntu-20.04" "$docker_ubuntu_focal_image_tag"
 buildkite-agent meta-data set "agent-docker-image-ubuntu-22.04" "$docker_ubuntu_jammy_image_tag"
 buildkite-agent meta-data set "agent-docker-image-ubuntu-24.04" "$docker_ubuntu_noble_image_tag"
+buildkite-agent meta-data set "agent-docker-image-ubuntu-26.04" "$docker_ubuntu_resolute_image_tag"
 buildkite-agent meta-data set "agent-docker-image-sidecar" "$docker_sidecar_image_tag"
 buildkite-agent meta-data set "agent-is-prerelease" "$is_prerelease"

--- a/.buildkite/steps/publish-docker-images.sh
+++ b/.buildkite/steps/publish-docker-images.sh
@@ -62,7 +62,7 @@ esac
 version="$(buildkite-agent meta-data get "agent-version")"
 build="$(buildkite-agent meta-data get "agent-version-build")"
 
-for variant in "alpine" "alpine-k8s" "ubuntu-20.04" "ubuntu-22.04" "ubuntu-24.04" "sidecar" ; do
+for variant in "alpine" "alpine-k8s" "ubuntu-20.04" "ubuntu-22.04" "ubuntu-24.04" "ubuntu-26.04" "sidecar" ; do
   echo "--- Getting docker image tag for $variant from build meta data"
   source_image="$(buildkite-agent meta-data get "agent-docker-image-${variant}")"
   echo "Docker Image Tag for ${variant}: ${source_image}"

--- a/.buildkite/steps/upload-release-steps.sh
+++ b/.buildkite/steps/upload-release-steps.sh
@@ -34,6 +34,7 @@ trigger_step() {
         'agent-docker-image-ubuntu-20.04': "${agent_docker_image_ubuntu_focal}"
         'agent-docker-image-ubuntu-22.04': "${agent_docker_image_ubuntu_jammy}"
         'agent-docker-image-ubuntu-24.04': "${agent_docker_image_ubuntu_noble}"
+        'agent-docker-image-ubuntu-26.04': "${agent_docker_image_ubuntu_resolute}"
         agent-docker-image-sidecar: "${agent_docker_image_sidecar}"
         agent-is-prerelease: "${agent_is_prerelease}"
       env:
@@ -107,6 +108,7 @@ agent_docker_image_alpine_k8s=$(buildkite-agent meta-data get "agent-docker-imag
 agent_docker_image_ubuntu_focal=$(buildkite-agent meta-data get "agent-docker-image-ubuntu-20.04")
 agent_docker_image_ubuntu_jammy=$(buildkite-agent meta-data get "agent-docker-image-ubuntu-22.04")
 agent_docker_image_ubuntu_noble=$(buildkite-agent meta-data get "agent-docker-image-ubuntu-24.04")
+agent_docker_image_ubuntu_resolute=$(buildkite-agent meta-data get "agent-docker-image-ubuntu-26.04")
 
 agent_docker_image_sidecar=$(buildkite-agent meta-data get "agent-docker-image-sidecar")
 agent_is_prerelease=$(buildkite-agent meta-data get "agent-is-prerelease")

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
       - /packaging/docker/ubuntu-20.04
       - /packaging/docker/ubuntu-22.04
       - /packaging/docker/ubuntu-24.04
+      - /packaging/docker/ubuntu-26.04
     schedule:
       interval: weekly
     groups:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ For example, agent version 3.45.6 is published as:
 - Ubuntu 20.04 LTS (x86_64), supported to end of standard support for 20.04
 - Ubuntu 22.04 LTS (x86_64), supported to end of standard support for 22.04
 - Ubuntu 24.04 LTS (x86_64), supported to end of standard support for 24.04
+- Ubuntu 26.04 LTS (x86_64), supported to end of standard support for 26.04
 
 ## Starting
 

--- a/packaging/docker/ubuntu-26.04/Dockerfile
+++ b/packaging/docker/ubuntu-26.04/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.4
+
+FROM public.ecr.aws/buildkite/agent-base:ubuntu-resolute@sha256:f83df853163c8db3af8fe052399a48fcad35307b6ca640f0ecb23b432f5d3e65
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV BUILDKITE_AGENT_CONFIG=/buildkite/buildkite-agent.cfg \
+    PATH="/usr/local/bin:${PATH}"
+
+RUN mkdir -p /buildkite/builds /buildkite/hooks /buildkite/plugins \
+    && curl -Lfs -o /usr/local/bin/ssh-env-config.sh https://raw.githubusercontent.com/buildkite/docker-ssh-env-config/master/ssh-env-config.sh \
+    && chmod +x /usr/local/bin/ssh-env-config.sh
+
+COPY ./buildkite-agent.cfg /buildkite/buildkite-agent.cfg
+COPY ./buildkite-agent-$TARGETOS-$TARGETARCH /usr/local/bin/buildkite-agent
+COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint
+
+VOLUME /buildkite
+ENTRYPOINT ["buildkite-agent-entrypoint"]
+CMD ["start"]

--- a/packaging/docker/ubuntu-26.04/buildkite-agent.cfg
+++ b/packaging/docker/ubuntu-26.04/buildkite-agent.cfg
@@ -1,0 +1,74 @@
+# The token from your Buildkite "Agents" page
+#token="xxx"
+
+# The name of the agent
+name="%hostname-%spawn"
+
+# The number of agents to spawn in parallel (default is "1")
+# spawn=1
+
+# The priority of the agent (higher priorities are assigned work first)
+# priority=1
+
+# Tags for the agent (default is "queue=default")
+# tags="key1=val2,key2=val2"
+
+# Include the host's EC2 meta-data as tags (instance-id, instance-type, and ami-id)
+# tags-from-ec2-meta-data=true
+
+# Include the host's EC2 tags as tags
+# tags-from-ec2-tags=true
+
+# Include the host's ECS meta-data as tags (container-name, image, and task-arn)
+# tags-from-ecs-meta-data=true
+
+# Include the host's Google Cloud instance meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
+# tags-from-gcp-meta-data=true
+
+# Include the host's Google Cloud instance labels as tags
+# tags-from-gcp-labels=true
+
+# Path to a custom bootstrap command to run. By default this is `buildkite-agent bootstrap`.
+# This allows you to override the entire execution of a job. Generally you should use hooks instead!
+# See https://buildkite.com/docs/agent/hooks
+# bootstrap-script=""
+
+# Path to where the builds will run from
+build-path="/buildkite/builds"
+
+# Directory where the hook scripts are found
+hooks-path="/buildkite/hooks"
+
+# Any additional directories where hook scripts are found
+# additional-hooks-path="/hook/path/a,/hook/path/b"
+
+# Directory where plugins will be installed
+plugins-path="/buildkite/plugins"
+
+# Flags to pass to the `git clone` command
+# git-clone-flags=-v
+
+# Flags to pass to the `git clean` command
+# git-clean-flags=-ffxdq
+
+# Do not run jobs within a pseudo terminal
+# no-pty=true
+
+# Don't automatically accept new SSH host keys
+# no-ssh-keyscan=true
+
+# Don't allow this agent to run arbitrary console commands
+# no-command-eval=true
+
+# Don't allow this agent to run plugins
+# no-plugins=true
+
+# Enable debug mode
+# debug=true
+
+# Don't show colors in logging
+# no-color=true
+
+# Enable OpenTelemetry metrics export over OTLP.
+# Configure the endpoint and protocol with the standard OTEL_EXPORTER_OTLP_* env vars.
+# opentelemetry-metrics=true

--- a/packaging/docker/ubuntu-26.04/entrypoint.sh
+++ b/packaging/docker/ubuntu-26.04/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR=/docker-entrypoint.d
+
+if [[ -d "$DIR" ]] ; then
+  echo "Executing scripts in $DIR"
+  /bin/run-parts --exit-on-error "$DIR"
+fi
+
+exec /usr/bin/tini -- ssh-env-config.sh /usr/local/bin/buildkite-agent "$@"


### PR DESCRIPTION
## Description

Adds Ubuntu 26.04 to the available distros the Agent image is built on

## Context

This came through as a request to Support. Linear SUP-7796. 
## Changes

Adds Ubuntu 26.04 to the list for docker builds, and standard Agent images

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Affiliation (optional, external contributors)

N/A

## Disclosures / Credits

I did not use AI tools at all
