### PR TITLE
Revert "Downgrade Go 1.26.5 -> 1.25.12 to fix Windows exit-status flake"

### DIFF
--- a/.buildkite/Dockerfile-compile
+++ b/.buildkite/Dockerfile-compile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.25.12@sha256:fe5d57d3b718e7a4986bae156c2d73f44973bfd313073aed08a4de6692bb6161
+FROM public.ecr.aws/docker/library/golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
 COPY build/ssh.conf /etc/ssh/ssh_config.d/
 
 RUN go install github.com/google/go-licenses@latest

--- a/.buildkite/Dockerfile-e2e
+++ b/.buildkite/Dockerfile-e2e
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.25.12@sha256:fe5d57d3b718e7a4986bae156c2d73f44973bfd313073aed08a4de6692bb6161
+FROM public.ecr.aws/docker/library/golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/agent/v4
 
-go 1.25.12
+go 1.26.5
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.12-20260709200747-435963d16310.1

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.25.12"
+go = "1.26.5"
 golangci-lint = "2.9.0"
 ruby = "3.4.9"
 


### PR DESCRIPTION
### What

Reverts buildkite/agent#4208

### Why

It's evident that Go 1.26 did not cause the problem

[https://buildkite-corp.slack.com/archives/C06J07P1TKM/p1786494788751859?thread_ts=1786182409.662729&cid=C06J07P1TKM](<https://buildkite-corp.slack.com/archives/C06J07P1TKM/p1786494788751859?thread_ts=1786182409.662729&cid=C06J07P1TKM>)

Also Go 1.27 is expected to land this month, which will make Go 1.25 unsupported:

[\[https://go.dev/doc/devel/release#policy](<https://go.dev/doc/devel/release#policy>)