### PR TITLE
Do "stable" Homebrew release for "prerelease" (betas)

### DIFF
--- a/.buildkite/steps/release-homebrew.sh
+++ b/.buildkite/steps/release-homebrew.sh
@@ -48,11 +48,18 @@ GITHUB_RELEASE_ACCESS_TOKEN="$(aws ssm get-parameter \
   --query Parameter.Value \
   --region us-east-1)"
 
-if [[ "${GITHUB_RELEASE_TYPE}" != "stable" ]]; then
-  BREW_RELEASE_TYPE="devel"
-else
+case "${GITHUB_RELEASE_TYPE}" in
+stable)
   BREW_RELEASE_TYPE="stable"
-fi
+  ;;
+prerelease)
+  # Beta release to a versioned Homebrew formula
+  BREW_RELEASE_TYPE="stable"
+  ;;
+*)
+  BREW_RELEASE_TYPE="devel"
+  ;;
+esac
 
 BINARY_NAME_AMD64="buildkite-agent-darwin-amd64-${AGENT_VERSION}.tar.gz"
 DOWNLOAD_URL_AMD64="https://github.com/buildkite/agent/releases/download/v${GITHUB_RELEASE_VERSION}/${BINARY_NAME_AMD64}"


### PR DESCRIPTION
## Description

The script wasn't releasing v4 beta versions into the v4 Homebrew file, because the "GitHub release type" meta-data had `prerelease` instead of `stable`. This fixes that.

## Context

Found while manually installing the agent locally.

## Changes

Accept `prerelease` as well as `stable` for the GitHub release type when doing a Homebrew release.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

hack hack hack hack hack