### PR TITLE
[Backport] Describe and retry undecodable API responses

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -458,7 +458,9 @@ func (a *AgentWorker) Heartbeat(ctx context.Context) error {
 	beat, err := roko.DoFunc(ctx, r, func(r *roko.Retrier) (*api.Heartbeat, error) {
 		b, resp, err := a.apiClient.Heartbeat(ctx)
 		if err != nil {
-			if resp != nil && !api.IsRetryableStatus(resp) {
+			// A response we couldn't decode is not the API telling us to stop,
+			// whatever status it arrived with, so check the error as well.
+			if resp != nil && !api.IsRetryableStatus(resp) && !api.IsRetryableError(err) {
 				r.Break()
 				return nil, &errUnrecoverable{action: "Heartbeat", response: resp, err: err}
 			}

--- a/agent/agent_worker_ping.go
+++ b/agent/agent_worker_ping.go
@@ -223,7 +223,9 @@ func (a *AgentWorker) Ping(ctx context.Context) (jobID, action string, err error
 		// If the ping has a non-retryable status, we have to kill the agent, there's no way of recovering
 		// The reason we do this after the disconnect check is because the backend can (and does) send disconnect actions in
 		// responses with non-retryable statuses
-		if resp != nil && !api.IsRetryableStatus(resp) {
+		// A response we couldn't decode is not the API telling us to stop, whatever
+		// status it arrived with, so check the error as well
+		if resp != nil && !api.IsRetryableStatus(resp) && !api.IsRetryableError(pingErr) {
 			return "", action, &errUnrecoverable{action: "Ping", response: resp, err: pingErr}
 		}
 

--- a/api/client.go
+++ b/api/client.go
@@ -24,6 +24,9 @@ import (
 const (
 	defaultEndpoint  = "https://agent-edge.buildkite.com/v3"
 	defaultUserAgent = "buildkite-agent/api"
+
+	// Maximum bytes of a response body to quote in an error message.
+	maxErrorBodySnippet = 512
 )
 
 // Config is configuration for the API Client
@@ -340,8 +343,11 @@ func (c *Client) doRequest(req *http.Request, v any) (*Response, error) {
 				return response, errors.New("msgpack not supported")
 			}
 
-			if err = json.NewDecoder(resp.Body).Decode(v); err != nil {
-				return response, fmt.Errorf("failed to decode JSON response: %w", err)
+			// Keep the start of the body as it is decoded, so that a decode
+			// failure can report what the response actually contained.
+			head := &headWriter{limit: maxErrorBodySnippet}
+			if err = json.NewDecoder(io.TeeReader(resp.Body, head)).Decode(v); err != nil {
+				return response, newUndecodableResponseError(resp, head.String(), err)
 			}
 		}
 	}
@@ -353,6 +359,11 @@ func (c *Client) doRequest(req *http.Request, v any) (*Response, error) {
 type ErrorResponse struct {
 	Response *http.Response // HTTP response that caused this error
 	Message  string         `json:"message"` // error message
+
+	// Details of a response body that wasn't an API error message. Taken from the
+	// response, never decoded from it, hence `json:"-"`.
+	ContentType string `json:"-"`
+	Snippet     string `json:"-"`
 }
 
 func (r *ErrorResponse) Error() string {
@@ -364,7 +375,90 @@ func (r *ErrorResponse) Error() string {
 		s = fmt.Sprintf("%s: %v", s, r.Message)
 	}
 
+	if r.Snippet != "" {
+		s = fmt.Sprintf("%s: non-JSON body (content-type %q) starting with %q", s, r.ContentType, r.Snippet)
+	}
+
 	return s
+}
+
+// UndecodableResponseError is returned when a response had a success status but
+// a body that could not be decoded. Usually this means something other than the
+// Buildkite Agent API answered the request - a proxy, load balancer, or CDN
+// serving its own error page - which makes it worth retrying. See
+// IsRetryableError.
+type UndecodableResponseError struct {
+	Method      string // request method
+	URL         string // request URL, after any redirects
+	Status      string // response status
+	ContentType string // response content type
+	Snippet     string // start of the response body; empty when it could hold credentials
+	Err         error  // the decoding error
+}
+
+func (e *UndecodableResponseError) Error() string {
+	s := fmt.Sprintf("%s %s: %s: could not decode response body", e.Method, e.URL, e.Status)
+
+	if e.ContentType != "" {
+		s = fmt.Sprintf("%s (content-type %q)", s, e.ContentType)
+	}
+
+	s = fmt.Sprintf("%s: %v", s, e.Err)
+
+	if e.Snippet != "" {
+		s = fmt.Sprintf("%s: body starts with %q", s, e.Snippet)
+	}
+
+	return s
+}
+
+func (e *UndecodableResponseError) Unwrap() error { return e.Err }
+
+func newUndecodableResponseError(r *http.Response, head string, err error) *UndecodableResponseError {
+	e := &UndecodableResponseError{
+		Status:      r.Status,
+		ContentType: r.Header.Get("Content-Type"),
+		Err:         err,
+	}
+
+	if r.Request != nil {
+		e.Method = r.Request.Method
+		e.URL = r.Request.URL.String()
+	}
+
+	// A body that didn't claim to be JSON came from something that isn't the
+	// Agent API, so quoting it leaks none of our credentials. A malformed JSON
+	// body did come from the API and could contain a token, so it stays out.
+	if !isJSONContent(e.ContentType) {
+		// head is capped by the caller; drop a trailing partial rune.
+		e.Snippet = strings.ToValidUTF8(head, "")
+	}
+
+	return e
+}
+
+// headWriter keeps the first limit bytes written to it, and discards the rest.
+type headWriter struct {
+	buf   bytes.Buffer
+	limit int
+}
+
+func (w *headWriter) Write(p []byte) (int, error) {
+	if rem := w.limit - w.buf.Len(); rem > 0 {
+		w.buf.Write(p[:min(rem, len(p))]) //nolint:errcheck // bytes.Buffer.Write never errors.
+	}
+	return len(p), nil
+}
+
+func (w *headWriter) String() string { return w.buf.String() }
+
+// truncate shortens s to at most limit bytes, marking it when it does.
+func truncate(s string, limit int) string {
+	if len(s) <= limit {
+		return s
+	}
+	// Cutting at a byte offset can split a multi-byte rune; drop the remnant.
+	return strings.ToValidUTF8(s[:limit], "") + "…"
 }
 
 func IsErrHavingStatus(err error, code int) bool {
@@ -377,15 +471,21 @@ func checkResponse(r *http.Response) error {
 		return nil
 	}
 
-	errorResponse := &ErrorResponse{Response: r}
+	contentType := r.Header.Get("Content-Type")
+	errorResponse := &ErrorResponse{Response: r, ContentType: contentType}
 	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		return errorResponse
 	}
-	if data != nil {
+	if len(data) > 0 {
 		// Unmarshaling the error JSON is best-effort, but we could consider
 		// reporting unmarshaling problems.
-		json.Unmarshal(data, errorResponse) //nolint:errcheck // ^^
+		if err := json.Unmarshal(data, errorResponse); err != nil && !isJSONContent(contentType) {
+			// Not an API error message: most likely an error page from a proxy,
+			// load balancer, or CDN in front of the API. It's the only clue as to
+			// what really answered, and holds none of our credentials.
+			errorResponse.Snippet = truncate(string(data), maxErrorBodySnippet)
+		}
 	}
 
 	return errorResponse

--- a/api/retryable.go
+++ b/api/retryable.go
@@ -38,9 +38,24 @@ func IsRetryableStatus(r *Response) bool {
 	}
 }
 
+// isUndecodableResponse reports whether err is (or wraps) an
+// UndecodableResponseError.
+func isUndecodableResponse(err error) bool {
+	var undecodable *UndecodableResponseError
+	return errors.As(err, &undecodable)
+}
+
 // Looks at a bunch of connection related errors, and returns true if the error
 // matches one of them.
 func IsRetryableError(err error) bool {
+	// A response we couldn't decode is usually an error page from a proxy, load
+	// balancer, or CDN in front of the API, and it can arrive with any status,
+	// including a 2xx. Either way the API's real answer is lost, so the only way
+	// to get it is to ask again.
+	if isUndecodableResponse(err) {
+		return true
+	}
+
 	var neterr net.Error
 	if errors.As(err, &neterr) {
 		if neterr.Timeout() {
@@ -70,10 +85,11 @@ func IsRetryableError(err error) bool {
 }
 
 // BreakOnNonRetryable calls r.Break() if the error from an API call is not
-// worth retrying. An error is retryable if the response has a retryable status
-// code (429, 5xx) or if there was no response and the error is a retryable
-// network-level error (connection reset, timeout, etc.). All other errors
-// — including all non-429 4xx status codes — cause a break.
+// worth retrying. An error is retryable if the response body could not be
+// decoded, if the response has a retryable status code (429, 5xx), or if there
+// was no response and the error is a retryable network-level error (connection
+// reset, timeout, etc.). All other errors — including all non-429 4xx status
+// codes — cause a break.
 //
 // This should be called inside roko retry callbacks after every API call.
 // If err is nil, this is a no-op.
@@ -82,6 +98,11 @@ func IsRetryableError(err error) bool {
 // information when the retrier is about to give up.
 func BreakOnNonRetryable(r *roko.Retrier, resp *Response, err error) (broke bool) {
 	if err == nil {
+		return false
+	}
+	// An undecodable response is retryable whatever status it arrived with, so
+	// classify the error before the response.
+	if isUndecodableResponse(err) {
 		return false
 	}
 	if resp != nil {

--- a/api/undecodable_response_test.go
+++ b/api/undecodable_response_test.go
@@ -1,0 +1,225 @@
+package api_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/buildkite/roko"
+)
+
+const gatewayErrorPage = `<html>
+<head><title>502 Bad Gateway</title></head>
+<body><center><h1>502 Bad Gateway</h1></center></body>
+</html>`
+
+// An intermediary (proxy, load balancer, CDN) answering with an HTML error page
+// and a success status is indistinguishable from the API returning nonsense. The
+// error has to name the request and what came back, otherwise all a job log gets
+// is "invalid character '<' looking for beginning of value".
+func TestOIDCTokenErrorDescribesUndecodableResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("Content-Type", "text/html; charset=utf-8")
+		rw.WriteHeader(http.StatusOK)
+		fmt.Fprint(rw, gatewayErrorPage) //nolint:errcheck // The test would still fail
+	}))
+	defer server.Close()
+
+	c := api.NewClient(logger.Discard, api.Config{Endpoint: server.URL, Token: "llamas"})
+	_, resp, err := c.OIDCToken(t.Context(), &api.OIDCTokenRequest{Job: "job-123"})
+	if err == nil {
+		t.Fatal("c.OIDCToken(...) error = nil, want non-nil")
+	}
+
+	var undecodable *api.UndecodableResponseError
+	if !errors.As(err, &undecodable) {
+		t.Fatalf("c.OIDCToken(...) error = %v (%T), want an *api.UndecodableResponseError", err, err)
+	}
+
+	for _, want := range []string{
+		"POST",
+		server.URL + "/jobs/job-123/oidc/tokens",
+		"200 OK",
+		"text/html",
+		"502 Bad Gateway", // the snippet
+	} {
+		if got := err.Error(); !strings.Contains(got, want) {
+			t.Errorf("c.OIDCToken(...) error = %q, want containing %q", got, want)
+		}
+	}
+
+	// The response is still handed back for callers that inspect it.
+	if resp == nil {
+		t.Fatal("c.OIDCToken(...) response = nil, want non-nil")
+	}
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Errorf("resp.StatusCode = %d, want %d", got, want)
+	}
+}
+
+// A body that claims to be JSON but doesn't parse came from the API itself, so it
+// can hold credentials. Report everything except the body.
+func TestUndecodableJSONResponseErrorOmitsBody(t *testing.T) {
+	t.Parallel()
+
+	const secret = "bkaj_supersecrettoken"
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		fmt.Fprintf(rw, `{"token":%q`, secret) //nolint:errcheck // Deliberately truncated JSON
+	}))
+	defer server.Close()
+
+	c := api.NewClient(logger.Discard, api.Config{Endpoint: server.URL, Token: "llamas"})
+	_, _, err := c.OIDCToken(t.Context(), &api.OIDCTokenRequest{Job: "job-123"})
+	if err == nil {
+		t.Fatal("c.OIDCToken(...) error = nil, want non-nil")
+	}
+
+	if got := err.Error(); strings.Contains(got, secret) {
+		t.Errorf("c.OIDCToken(...) error = %q, want it to not contain the response body", got)
+	}
+
+	for _, want := range []string{"200 OK", "application/json"} {
+		if got := err.Error(); !strings.Contains(got, want) {
+			t.Errorf("c.OIDCToken(...) error = %q, want containing %q", got, want)
+		}
+	}
+}
+
+// Non-2xx responses go down a different path (checkResponse), which used to
+// discard the body entirely.
+func TestErrorResponseIncludesNonJSONBody(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("Content-Type", "text/html; charset=utf-8")
+		rw.WriteHeader(http.StatusBadGateway)
+		fmt.Fprint(rw, gatewayErrorPage) //nolint:errcheck // The test would still fail
+	}))
+	defer server.Close()
+
+	c := api.NewClient(logger.Discard, api.Config{Endpoint: server.URL, Token: "llamas"})
+	_, _, err := c.OIDCToken(t.Context(), &api.OIDCTokenRequest{Job: "job-123"})
+	if err == nil {
+		t.Fatal("c.OIDCToken(...) error = nil, want non-nil")
+	}
+
+	for _, want := range []string{"502 Bad Gateway", "text/html"} {
+		if got := err.Error(); !strings.Contains(got, want) {
+			t.Errorf("c.OIDCToken(...) error = %q, want containing %q", got, want)
+		}
+	}
+}
+
+func TestErrorResponseNonJSONBodyIsCapped(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("Content-Type", "text/html")
+		rw.WriteHeader(http.StatusBadGateway)
+		fmt.Fprint(rw, "<html>"+strings.Repeat("x", 4096)+"</html>") //nolint:errcheck // The test would still fail
+	}))
+	defer server.Close()
+
+	c := api.NewClient(logger.Discard, api.Config{Endpoint: server.URL, Token: "llamas"})
+	_, _, err := c.OIDCToken(t.Context(), &api.OIDCTokenRequest{Job: "job-123"})
+	if err == nil {
+		t.Fatal("c.OIDCToken(...) error = nil, want non-nil")
+	}
+
+	// The whole message, not just the snippet, has to stay log-sized.
+	if got, want := len(err.Error()), 1024; got > want {
+		t.Errorf("len(c.OIDCToken(...) error) = %d, want <= %d: %q", got, want, err)
+	}
+	if got, want := err.Error(), "…"; !strings.Contains(got, want) {
+		t.Errorf("c.OIDCToken(...) error = %q, want containing a truncation marker %q", got, want)
+	}
+}
+
+// A JSON error body from the API keeps its message, and gains no snippet.
+func TestErrorResponseKeepsAPIMessage(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusUnprocessableEntity)
+		fmt.Fprint(rw, `{"message":"audience is not allowed"}`) //nolint:errcheck // The test would still fail
+	}))
+	defer server.Close()
+
+	c := api.NewClient(logger.Discard, api.Config{Endpoint: server.URL, Token: "llamas"})
+	_, _, err := c.OIDCToken(t.Context(), &api.OIDCTokenRequest{Job: "job-123"})
+	if err == nil {
+		t.Fatal("c.OIDCToken(...) error = nil, want non-nil")
+	}
+
+	if got, want := err.Error(), "audience is not allowed"; !strings.Contains(got, want) {
+		t.Errorf("c.OIDCToken(...) error = %q, want containing %q", got, want)
+	}
+	if got, want := err.Error(), "non-JSON body"; strings.Contains(got, want) {
+		t.Errorf("c.OIDCToken(...) error = %q, want it to not contain %q", got, want)
+	}
+}
+
+// A big error page shouldn't dump kilobytes into a job log.
+func TestUndecodableResponseSnippetIsCapped(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("Content-Type", "text/html")
+		rw.WriteHeader(http.StatusOK)
+		fmt.Fprint(rw, "<html>"+strings.Repeat("x", 4096)+"</html>") //nolint:errcheck // The test would still fail
+	}))
+	defer server.Close()
+
+	c := api.NewClient(logger.Discard, api.Config{Endpoint: server.URL, Token: "llamas"})
+	_, _, err := c.OIDCToken(t.Context(), &api.OIDCTokenRequest{Job: "job-123"})
+
+	var undecodable *api.UndecodableResponseError
+	if !errors.As(err, &undecodable) {
+		t.Fatalf("c.OIDCToken(...) error = %v (%T), want an *api.UndecodableResponseError", err, err)
+	}
+
+	if got, want := len(undecodable.Snippet), 512; got > want {
+		t.Errorf("len(undecodable.Snippet) = %d, want <= %d", got, want)
+	}
+	if got, want := undecodable.Snippet, "<html>"; !strings.HasPrefix(got, want) {
+		t.Errorf("undecodable.Snippet = %q, want it to start with %q", got, want)
+	}
+}
+
+func TestUndecodableResponseIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	err := error(&api.UndecodableResponseError{
+		Method: "POST",
+		URL:    "https://agent.buildkite.com/v3/jobs/abc/oidc/tokens",
+		Status: "200 OK",
+		Err:    errors.New("invalid character '<' looking for beginning of value"),
+	})
+
+	if !api.IsRetryableError(err) {
+		t.Error("api.IsRetryableError(&UndecodableResponseError{}) = false, want true")
+	}
+
+	if !api.IsRetryableError(fmt.Errorf("requesting OIDC token: %w", err)) {
+		t.Error("api.IsRetryableError(wrapped UndecodableResponseError) = false, want true")
+	}
+
+	// The success status must not be read as "this request is settled": the whole
+	// point is that we never got a usable answer.
+	retrier := roko.NewRetrier(roko.WithMaxAttempts(3))
+	resp := &api.Response{Response: &http.Response{StatusCode: http.StatusOK}}
+	if api.BreakOnNonRetryable(retrier, resp, err) {
+		t.Error("api.BreakOnNonRetryable(...) = true, want false for an undecodable 200 response")
+	}
+}

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -146,11 +146,9 @@ var OIDCRequestTokenCommand = cli.Command{
 		})
 		if err != nil {
 			if len(cfg.Audience) > 0 {
-				l.Errorf("Could not obtain OIDC token for audience %s", cfg.Audience)
-			} else {
-				l.Errorf("Could not obtain OIDC token for default audience")
+				return fmt.Errorf("could not obtain OIDC token for audience %s: %w", cfg.Audience, err)
 			}
-			return err
+			return fmt.Errorf("could not obtain OIDC token for default audience: %w", err)
 		}
 
 		if !cfg.SkipRedaction {

--- a/clicommand/oidc_request_token_test.go
+++ b/clicommand/oidc_request_token_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/urfave/cli"
@@ -92,4 +93,41 @@ func TestOIDCRequestToken(t *testing.T) {
 			t.Fatalf("runOIDCRequestTokenCommand() output = %q, want %q", out, want)
 		}
 	})
+}
+
+// An intermediary in front of the API can answer with an HTML error page and a
+// 2xx status. That used to fail the job on the first attempt, because a success
+// status was read as "settled", so the retrier broke instead of retrying.
+func TestOIDCRequestTokenRetriesUndecodableResponse(t *testing.T) {
+	t.Setenv("BUILDKITE_AGENT_JOB_API_SOCKET", "")
+	t.Setenv("BUILDKITE_AGENT_JOB_API_TOKEN", "")
+
+	const oidcToken = "oidc-token"
+	var requests atomic.Int32
+
+	// The first attempt gets a gateway error page with a 200; the second gets the
+	// real thing. Note the retrier's first backoff is a real 1s sleep.
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if requests.Add(1) == 1 {
+			rw.Header().Set("Content-Type", "text/html")
+			rw.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(rw, "<html><head><title>502 Bad Gateway</title></head></html>")
+			return
+		}
+		_, _ = fmt.Fprintf(rw, `{"token":%q}`, oidcToken)
+	}))
+	defer server.Close()
+
+	out, err := runOIDCRequestTokenCommand(t, server.URL, "--skip-redaction")
+	if err != nil {
+		t.Fatalf("runOIDCRequestTokenCommand() error = %v, want nil", err)
+	}
+
+	if want := oidcToken + "\n"; out != want {
+		t.Fatalf("runOIDCRequestTokenCommand() output = %q, want %q", out, want)
+	}
+
+	if got, want := requests.Load(), int32(2); got != want {
+		t.Errorf("server received %d requests, want %d", got, want)
+	}
 }


### PR DESCRIPTION

## Description

Backport #4239 to v3.

## Context

See #4239

## Changes

#4239, with two import paths changed to refer to v3.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

`jj duplicate`