### PR TITLE
[WIP] Remove client timeout for ping streams

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -68,6 +68,10 @@ type Client struct {
 	// HTTP client used to communicate with the API.
 	client *http.Client
 
+	// HTTP client used for streaming responses. It shares the API client's
+	// transport but has no whole-response timeout.
+	streamingClient *http.Client
+
 	// The logger used
 	logger logger.Logger
 
@@ -87,9 +91,10 @@ func NewClient(l logger.Logger, conf Config) *Client {
 
 	if conf.HTTPClient != nil {
 		return &Client{
-			logger: l,
-			client: conf.HTTPClient,
-			conf:   conf,
+			logger:          l,
+			client:          conf.HTTPClient,
+			streamingClient: withoutTimeout(conf.HTTPClient),
+			conf:            conf,
 		}
 	}
 
@@ -103,12 +108,20 @@ func NewClient(l logger.Logger, conf Config) *Client {
 		clientOptions = append(clientOptions, agenthttp.WithTimeout(conf.Timeout))
 	}
 
+	client := agenthttp.NewClient(clientOptions...)
 	return &Client{
-		logger:         l,
-		client:         agenthttp.NewClient(clientOptions...),
-		conf:           conf,
-		requestHeaders: requestHeadersFromEnv(os.Environ()),
+		logger:          l,
+		client:          client,
+		streamingClient: withoutTimeout(client),
+		conf:            conf,
+		requestHeaders:  requestHeadersFromEnv(os.Environ()),
 	}
+}
+
+func withoutTimeout(client *http.Client) *http.Client {
+	streamingClient := *client
+	streamingClient.Timeout = 0
+	return &streamingClient
 }
 
 func requestHeadersFromEnv(environ []string) http.Header {

--- a/api/pings_streaming.go
+++ b/api/pings_streaming.go
@@ -23,7 +23,7 @@ func (c *Client) StreamPings(ctx context.Context, agentID string, opts ...connec
 	u.Path = "/"
 
 	cl := agentedgev1connect.NewAgentEdgeServiceClient(
-		c.client,
+		c.streamingClient,
 		u.String(),
 		connect.WithGRPC(),
 		connect.WithClientOptions(opts...),

--- a/api/pings_streaming_test.go
+++ b/api/pings_streaming_test.go
@@ -1,0 +1,80 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/buildkite/agent/v4/api"
+	agentedgev1 "github.com/buildkite/agent/v4/api/proto/gen"
+	"github.com/buildkite/agent/v4/api/proto/gen/agentedgev1connect"
+	"github.com/buildkite/agent/v4/logger"
+)
+
+type delayedPingStreamHandler struct{}
+
+func (delayedPingStreamHandler) StreamPings(_ context.Context, _ *connect.Request[agentedgev1.StreamPingsRequest], stream *connect.ServerStream[agentedgev1.StreamPingsResponse]) error {
+	if err := stream.Send(resumePing()); err != nil {
+		return err
+	}
+	time.Sleep(150 * time.Millisecond)
+	return stream.Send(resumePing())
+}
+
+func TestStreamPingsDoesNotUseAPIClientTimeout(t *testing.T) {
+	path, handler := agentedgev1connect.NewAgentEdgeServiceHandler(delayedPingStreamHandler{})
+	mux := http.NewServeMux()
+	mux.Handle(path, handler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := api.NewClient(logger.Discard, api.Config{
+		Endpoint: server.URL + "/v3",
+		Timeout:  50 * time.Millisecond,
+	})
+	stream, err := client.StreamPings(t.Context(), "agent-id")
+	if err != nil {
+		t.Fatalf("client.StreamPings: %v", err)
+	}
+
+	var messages int
+	for _, err := range stream {
+		if err != nil {
+			t.Fatalf("stream error: %v", err)
+		}
+		messages++
+	}
+	if got, want := messages, 2; got != want {
+		t.Errorf("stream message count = %d, want %d", got, want)
+	}
+}
+
+func TestAPIRequestsStillUseClientTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(150 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := api.NewClient(logger.Discard, api.Config{
+		Endpoint: server.URL + "/",
+		Timeout:  50 * time.Millisecond,
+	})
+	_, _, err := client.Ping(t.Context())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("client.Ping error = %v, want context deadline exceeded", err)
+	}
+}
+
+func resumePing() *agentedgev1.StreamPingsResponse {
+	return &agentedgev1.StreamPingsResponse{
+		Action: &agentedgev1.StreamPingsResponse_Resume{
+			Resume: &agentedgev1.ResumeAction{},
+		},
+	}
+}


### PR DESCRIPTION
## Description

This change goes along with a serverside change that controls stream lifetime from the backend, meaning buildkite will be able to make streams last longer without having to update the agent


## Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

## Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

## Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go tool gofumpt -extra -w .`)

<!--
Note: if the tests fail to run locally, please let us know!
-->

## Affiliation (optional, external contributors)

<!--
If you're contributing from outside Buildkite and are comfortable sharing, let us know your company or organisation — it helps us prioritise review and may accelerate a response.
-->

## Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
