### PR TITLE
[A-1756] Apply request headers from streaming pings

### DIFF
--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1062,6 +1063,101 @@ func TestAgentWorker_Streaming_Disconnect(t *testing.T) {
 
 	if err := worker.Start(t.Context(), nil); err != nil {
 		t.Errorf("worker.Start() error = %v, want nil", err)
+	}
+	if got, want := agent.Pings, 0; got != want {
+		t.Errorf("agent.Pings = %d, want %d", got, want)
+	}
+}
+
+func TestAgentWorker_Streaming_RequestHeadersRestartStream(t *testing.T) {
+	t.Parallel()
+
+	const (
+		agentSessionToken = "alpacas"
+		headerKey         = "Buildkite-Hello"
+		headerValue       = "world"
+	)
+
+	server := NewFakeAPIServer(WithStreaming)
+	defer server.Close()
+
+	agent := server.AddAgent(agentSessionToken)
+	agent.PingHandler = func(*http.Request) (api.Ping, error) {
+		return api.Ping{}, errors.New("too many pings")
+	}
+
+	var connections atomic.Int32
+	agent.PingStreamHandler = func(ctx context.Context, req *connect.Request[agentedgev1.StreamPingsRequest], resp *connect.ServerStream[agentedgev1.StreamPingsResponse]) error {
+		switch connection := connections.Add(1); connection {
+		case 1:
+			if got := req.Header().Get(headerKey); got != "" {
+				t.Errorf("first stream header = %q, want empty", got)
+			}
+			return resp.Send(&agentedgev1.StreamPingsResponse{
+				Action: &agentedgev1.StreamPingsResponse_Resume{},
+				RequestHeaders: &agentedgev1.RequestHeaders{
+					Values: map[string]string{headerKey: headerValue},
+				},
+			})
+
+		case 2:
+			if got := req.Header().Get(headerKey); got != headerValue {
+				t.Errorf("second stream header = %q, want %q", got, headerValue)
+			}
+			// Repeating the current headers must not restart the stream before
+			// the following message clears them.
+			if err := resp.Send(&agentedgev1.StreamPingsResponse{
+				Action: &agentedgev1.StreamPingsResponse_Resume{},
+				RequestHeaders: &agentedgev1.RequestHeaders{
+					Values: map[string]string{headerKey: headerValue},
+				},
+			}); err != nil {
+				return err
+			}
+			return resp.Send(&agentedgev1.StreamPingsResponse{
+				Action:         &agentedgev1.StreamPingsResponse_Resume{},
+				RequestHeaders: &agentedgev1.RequestHeaders{},
+			})
+
+		case 3:
+			if got := req.Header().Get(headerKey); got != "" {
+				t.Errorf("third stream header = %q, want empty", got)
+			}
+			return resp.Send(&agentedgev1.StreamPingsResponse{
+				Action: &agentedgev1.StreamPingsResponse_Disconnect{},
+			})
+
+		default:
+			return connect.NewError(connect.CodeInternal, fmt.Errorf("unexpected stream connection %d", connection))
+		}
+	}
+
+	l := logger.NewConsoleLogger(logger.NewTestPrinter(t), func(int) {})
+	worker := NewAgentWorker(
+		l,
+		&api.AgentRegisterResponse{
+			UUID:              uuid.New().String(),
+			Name:              "agent-1",
+			AccessToken:       agentSessionToken,
+			Endpoint:          server.URL,
+			PingInterval:      1,
+			JobStatusInterval: 5,
+			HeartbeatInterval: 60,
+		},
+		metrics.NewCollector(logger.Discard, metrics.CollectorConfig{}),
+		api.NewClient(logger.Discard, api.Config{
+			Endpoint: server.URL,
+			Token:    "llamas",
+		}),
+		AgentWorkerConfig{},
+	)
+	worker.noWaitBetweenPingsForTesting = true
+
+	if err := worker.Start(t.Context(), nil); err != nil {
+		t.Errorf("worker.Start() error = %v, want nil", err)
+	}
+	if got, want := connections.Load(), int32(3); got != want {
+		t.Errorf("stream connections = %d, want %d", got, want)
 	}
 	if got, want := agent.Pings, 0; got != want {
 		t.Errorf("agent.Pings = %d, want %d", got, want)

--- a/agent/integration/job_environment_integration_test.go
+++ b/agent/integration/job_environment_integration_test.go
@@ -183,23 +183,19 @@ func TestNoCacheSettings_DoesNotLogMessage(t *testing.T) {
 }
 
 func TestBuildkiteRequestHeaders(t *testing.T) {
-	t.Parallel()
-
 	// create a mock agent API
 	e := createTestAgentEndpoint()
 	server := e.server()
 	defer server.Close()
 
 	// create a client with server-specified headers
+	t.Setenv("BUILDKITE_REQUEST_HEADER_BUILDKITE_HELLO", "world")
 	l := logger.NewConsoleLogger(logger.NewTestPrinter(t), func(int) {})
 	client := api.NewClient(l, api.Config{
 		Endpoint:  server.URL,
 		Token:     "llamasrock",
 		DebugHTTP: true,
 	})
-	headers := client.ServerSpecifiedRequestHeaders()
-	// That getter isn't designed to modify the headers, but all's fair in test setup code and war.
-	headers.Set("Buildkite-Hello", "world")
 
 	mb := mockBootstrap(t)
 	defer mb.CheckAndClose(t) //nolint:errcheck // bintest logs to t

--- a/api/client.go
+++ b/api/client.go
@@ -8,12 +8,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/buildkite/agent/v4/internal/agenthttp"
@@ -72,7 +75,8 @@ type Client struct {
 	logger logger.Logger
 
 	// server-specified HTTP request headers to include in all requests
-	requestHeaders http.Header
+	requestHeadersMu sync.RWMutex
+	requestHeaders   http.Header
 }
 
 // NewClient returns a new Buildkite Agent API Client.
@@ -141,7 +145,7 @@ func requestHeadersFromEnv(environ []string) http.Header {
 // request headers and the logger.
 func (c *Client) New(conf Config) *Client {
 	client := NewClient(c.logger, conf)
-	client.requestHeaders = c.requestHeaders
+	client.requestHeaders = c.requestHeadersSnapshot()
 	return client
 }
 
@@ -153,7 +157,7 @@ func (c *Client) Config() Config {
 // ServerSpecifiedRequestHeaders returns the HTTP headers that the Buildkite register/ping
 // APIs have advised the client to send in all requests.
 func (c *Client) ServerSpecifiedRequestHeaders() http.Header {
-	return c.requestHeaders
+	return c.requestHeadersSnapshot()
 }
 
 // FromAgentRegisterResponse returns a new instance using the access token and endpoint
@@ -177,26 +181,44 @@ func (c *Client) FromAgentRegisterResponse(reg *AgentRegisterResponse) *Client {
 	return newClient
 }
 
-func (c *Client) setRequestHeaders(headers map[string]string) {
+// setRequestHeaders replaces the current headers when headers is non-nil and
+// reports whether the effective set of permitted headers changed.
+func (c *Client) setRequestHeaders(headers map[string]string) bool {
 	if headers == nil {
-		return
+		return false
 	}
 
-	c.requestHeaders = make(http.Header)
+	next := make(http.Header)
 	for k, v := range headers {
 		if !strings.HasPrefix(k, "Buildkite-") {
 			continue
 		}
-		c.requestHeaders.Set(k, v)
+		next.Set(k, v)
 	}
 
-	if c.logger.Level() <= logger.DEBUG {
-		for k, values := range c.requestHeaders {
+	c.requestHeadersMu.Lock()
+	changed := !maps.EqualFunc(c.requestHeaders, next, slices.Equal)
+	if changed {
+		c.requestHeaders = next
+	}
+	c.requestHeadersMu.Unlock()
+
+	if changed && c.logger.Level() <= logger.DEBUG {
+		for k, values := range next {
 			for _, v := range values {
 				c.logger.Debugf("Server-specified request header: %s: %s", k, v)
 			}
 		}
 	}
+
+	return changed
+}
+
+func (c *Client) requestHeadersSnapshot() http.Header {
+	c.requestHeadersMu.RLock()
+	defer c.requestHeadersMu.RUnlock()
+
+	return c.requestHeaders.Clone()
 }
 
 // FromPing returns a new instance using a new endpoint from a ping response
@@ -254,7 +276,7 @@ func (c *Client) newRequest(
 	}
 
 	// add any request headers specified by the server during register/ping
-	for k, values := range c.requestHeaders {
+	for k, values := range c.requestHeadersSnapshot() {
 		for _, v := range values {
 			req.Header.Add(k, v)
 		}
@@ -288,7 +310,7 @@ func (c *Client) newFormRequest(ctx context.Context, method, urlStr string, body
 	}
 
 	// add any request headers specified by the server during register/ping
-	for k, values := range c.requestHeaders {
+	for k, values := range c.requestHeadersSnapshot() {
 		for _, v := range values {
 			req.Header.Add(k, v)
 		}

--- a/api/pings_streaming.go
+++ b/api/pings_streaming.go
@@ -38,7 +38,7 @@ func (c *Client) StreamPings(ctx context.Context, agentID string, opts ...connec
 	h := callInfo.RequestHeader()
 
 	// Add any request headers specified by the server during register/ping
-	for k, values := range c.requestHeaders {
+	for k, values := range c.requestHeadersSnapshot() {
 		for _, v := range values {
 			h.Add(k, v)
 		}
@@ -61,10 +61,29 @@ func (c *Client) StreamPings(ctx context.Context, agentID string, opts ...connec
 	return func(yield func(*agentedgev1.StreamPingsResponse, error) bool) {
 		defer stream.Close() //nolint:errcheck // Best-effort cleanup
 		for stream.Receive() {
-			if !yield(stream.Msg(), nil) {
+			msg := stream.Msg()
+
+			headersDidChange := false
+			if headers := msg.GetRequestHeaders(); headers != nil {
+				values := headers.GetValues()
+				if values == nil {
+					values = map[string]string{}
+				}
+				headersDidChange = c.setRequestHeaders(values)
+			}
+
+			// Always yield the action before restarting so that a message
+			// containing both an action and new headers doesn't lose the action.
+			if !yield(msg, nil) {
+				return
+			}
+
+			if headersDidChange {
+				// Restart the stream to pick up the new headers
 				return
 			}
 		}
+
 		if err := stream.Err(); err != nil {
 			yield(nil, err)
 		}

--- a/api/proto/agentedge.proto
+++ b/api/proto/agentedge.proto
@@ -2,13 +2,13 @@ syntax = "proto3";
 
 package agentedge.v1;
 
-import "buf/validate/validate.proto";
-
 message StreamPingsRequest {
   string agent_id = 1;
 }
 
 message StreamPingsResponse {
+  reserved 1;
+  reserved "endpoint";
 
   oneof action {
     ResumeAction resume = 2;
@@ -16,6 +16,12 @@ message StreamPingsResponse {
     DisconnectAction disconnect = 4;
     JobAssignedAction job_assigned = 5;
   }
+
+  RequestHeaders request_headers = 6;
+}
+
+message RequestHeaders {
+  map<string, string> values = 1;
 }
 
 message ResumeAction {}

--- a/api/proto/gen/agentedge.pb.go
+++ b/api/proto/gen/agentedge.pb.go
@@ -7,7 +7,6 @@
 package agentedgev1
 
 import (
-	_ "buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -74,9 +73,10 @@ type StreamPingsResponse struct {
 	//	*StreamPingsResponse_Pause
 	//	*StreamPingsResponse_Disconnect
 	//	*StreamPingsResponse_JobAssigned
-	Action        isStreamPingsResponse_Action `protobuf_oneof:"action"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Action         isStreamPingsResponse_Action `protobuf_oneof:"action"`
+	RequestHeaders *RequestHeaders              `protobuf:"bytes,6,opt,name=request_headers,json=requestHeaders,proto3" json:"request_headers,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *StreamPingsResponse) Reset() {
@@ -152,6 +152,13 @@ func (x *StreamPingsResponse) GetJobAssigned() *JobAssignedAction {
 	return nil
 }
 
+func (x *StreamPingsResponse) GetRequestHeaders() *RequestHeaders {
+	if x != nil {
+		return x.RequestHeaders
+	}
+	return nil
+}
+
 type isStreamPingsResponse_Action interface {
 	isStreamPingsResponse_Action()
 }
@@ -180,6 +187,50 @@ func (*StreamPingsResponse_Disconnect) isStreamPingsResponse_Action() {}
 
 func (*StreamPingsResponse_JobAssigned) isStreamPingsResponse_Action() {}
 
+type RequestHeaders struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Values        map[string]string      `protobuf:"bytes,1,rep,name=values,proto3" json:"values,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequestHeaders) Reset() {
+	*x = RequestHeaders{}
+	mi := &file_agentedge_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequestHeaders) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequestHeaders) ProtoMessage() {}
+
+func (x *RequestHeaders) ProtoReflect() protoreflect.Message {
+	mi := &file_agentedge_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequestHeaders.ProtoReflect.Descriptor instead.
+func (*RequestHeaders) Descriptor() ([]byte, []int) {
+	return file_agentedge_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *RequestHeaders) GetValues() map[string]string {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
 type ResumeAction struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -188,7 +239,7 @@ type ResumeAction struct {
 
 func (x *ResumeAction) Reset() {
 	*x = ResumeAction{}
-	mi := &file_agentedge_proto_msgTypes[2]
+	mi := &file_agentedge_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -200,7 +251,7 @@ func (x *ResumeAction) String() string {
 func (*ResumeAction) ProtoMessage() {}
 
 func (x *ResumeAction) ProtoReflect() protoreflect.Message {
-	mi := &file_agentedge_proto_msgTypes[2]
+	mi := &file_agentedge_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -213,7 +264,7 @@ func (x *ResumeAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeAction.ProtoReflect.Descriptor instead.
 func (*ResumeAction) Descriptor() ([]byte, []int) {
-	return file_agentedge_proto_rawDescGZIP(), []int{2}
+	return file_agentedge_proto_rawDescGZIP(), []int{3}
 }
 
 type PauseAction struct {
@@ -225,7 +276,7 @@ type PauseAction struct {
 
 func (x *PauseAction) Reset() {
 	*x = PauseAction{}
-	mi := &file_agentedge_proto_msgTypes[3]
+	mi := &file_agentedge_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -237,7 +288,7 @@ func (x *PauseAction) String() string {
 func (*PauseAction) ProtoMessage() {}
 
 func (x *PauseAction) ProtoReflect() protoreflect.Message {
-	mi := &file_agentedge_proto_msgTypes[3]
+	mi := &file_agentedge_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -250,7 +301,7 @@ func (x *PauseAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseAction.ProtoReflect.Descriptor instead.
 func (*PauseAction) Descriptor() ([]byte, []int) {
-	return file_agentedge_proto_rawDescGZIP(), []int{3}
+	return file_agentedge_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *PauseAction) GetReason() string {
@@ -269,7 +320,7 @@ type DisconnectAction struct {
 
 func (x *DisconnectAction) Reset() {
 	*x = DisconnectAction{}
-	mi := &file_agentedge_proto_msgTypes[4]
+	mi := &file_agentedge_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -281,7 +332,7 @@ func (x *DisconnectAction) String() string {
 func (*DisconnectAction) ProtoMessage() {}
 
 func (x *DisconnectAction) ProtoReflect() protoreflect.Message {
-	mi := &file_agentedge_proto_msgTypes[4]
+	mi := &file_agentedge_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -294,7 +345,7 @@ func (x *DisconnectAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DisconnectAction.ProtoReflect.Descriptor instead.
 func (*DisconnectAction) Descriptor() ([]byte, []int) {
-	return file_agentedge_proto_rawDescGZIP(), []int{4}
+	return file_agentedge_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *DisconnectAction) GetReason() string {
@@ -313,7 +364,7 @@ type JobAssignedAction struct {
 
 func (x *JobAssignedAction) Reset() {
 	*x = JobAssignedAction{}
-	mi := &file_agentedge_proto_msgTypes[5]
+	mi := &file_agentedge_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -325,7 +376,7 @@ func (x *JobAssignedAction) String() string {
 func (*JobAssignedAction) ProtoMessage() {}
 
 func (x *JobAssignedAction) ProtoReflect() protoreflect.Message {
-	mi := &file_agentedge_proto_msgTypes[5]
+	mi := &file_agentedge_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -338,7 +389,7 @@ func (x *JobAssignedAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JobAssignedAction.ProtoReflect.Descriptor instead.
 func (*JobAssignedAction) Descriptor() ([]byte, []int) {
-	return file_agentedge_proto_rawDescGZIP(), []int{5}
+	return file_agentedge_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *JobAssignedAction) GetJob() *Job {
@@ -357,7 +408,7 @@ type Job struct {
 
 func (x *Job) Reset() {
 	*x = Job{}
-	mi := &file_agentedge_proto_msgTypes[6]
+	mi := &file_agentedge_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -369,7 +420,7 @@ func (x *Job) String() string {
 func (*Job) ProtoMessage() {}
 
 func (x *Job) ProtoReflect() protoreflect.Message {
-	mi := &file_agentedge_proto_msgTypes[6]
+	mi := &file_agentedge_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -382,7 +433,7 @@ func (x *Job) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Job.ProtoReflect.Descriptor instead.
 func (*Job) Descriptor() ([]byte, []int) {
-	return file_agentedge_proto_rawDescGZIP(), []int{6}
+	return file_agentedge_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *Job) GetId() string {
@@ -396,17 +447,23 @@ var File_agentedge_proto protoreflect.FileDescriptor
 
 const file_agentedge_proto_rawDesc = "" +
 	"\n" +
-	"\x0fagentedge.proto\x12\fagentedge.v1\x1a\x1bbuf/validate/validate.proto\"/\n" +
+	"\x0fagentedge.proto\x12\fagentedge.v1\"/\n" +
 	"\x12StreamPingsRequest\x12\x19\n" +
-	"\bagent_id\x18\x01 \x01(\tR\aagentId\"\x90\x02\n" +
+	"\bagent_id\x18\x01 \x01(\tR\aagentId\"\xe7\x02\n" +
 	"\x13StreamPingsResponse\x124\n" +
 	"\x06resume\x18\x02 \x01(\v2\x1a.agentedge.v1.ResumeActionH\x00R\x06resume\x121\n" +
 	"\x05pause\x18\x03 \x01(\v2\x19.agentedge.v1.PauseActionH\x00R\x05pause\x12@\n" +
 	"\n" +
 	"disconnect\x18\x04 \x01(\v2\x1e.agentedge.v1.DisconnectActionH\x00R\n" +
 	"disconnect\x12D\n" +
-	"\fjob_assigned\x18\x05 \x01(\v2\x1f.agentedge.v1.JobAssignedActionH\x00R\vjobAssignedB\b\n" +
-	"\x06action\"\x0e\n" +
+	"\fjob_assigned\x18\x05 \x01(\v2\x1f.agentedge.v1.JobAssignedActionH\x00R\vjobAssigned\x12E\n" +
+	"\x0frequest_headers\x18\x06 \x01(\v2\x1c.agentedge.v1.RequestHeadersR\x0erequestHeadersB\b\n" +
+	"\x06actionJ\x04\b\x01\x10\x02R\bendpoint\"\x8d\x01\n" +
+	"\x0eRequestHeaders\x12@\n" +
+	"\x06values\x18\x01 \x03(\v2(.agentedge.v1.RequestHeaders.ValuesEntryR\x06values\x1a9\n" +
+	"\vValuesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x0e\n" +
 	"\fResumeAction\"%\n" +
 	"\vPauseAction\x12\x16\n" +
 	"\x06reason\x18\x01 \x01(\tR\x06reason\"*\n" +
@@ -432,29 +489,33 @@ func file_agentedge_proto_rawDescGZIP() []byte {
 	return file_agentedge_proto_rawDescData
 }
 
-var file_agentedge_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_agentedge_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_agentedge_proto_goTypes = []any{
 	(*StreamPingsRequest)(nil),  // 0: agentedge.v1.StreamPingsRequest
 	(*StreamPingsResponse)(nil), // 1: agentedge.v1.StreamPingsResponse
-	(*ResumeAction)(nil),        // 2: agentedge.v1.ResumeAction
-	(*PauseAction)(nil),         // 3: agentedge.v1.PauseAction
-	(*DisconnectAction)(nil),    // 4: agentedge.v1.DisconnectAction
-	(*JobAssignedAction)(nil),   // 5: agentedge.v1.JobAssignedAction
-	(*Job)(nil),                 // 6: agentedge.v1.Job
+	(*RequestHeaders)(nil),      // 2: agentedge.v1.RequestHeaders
+	(*ResumeAction)(nil),        // 3: agentedge.v1.ResumeAction
+	(*PauseAction)(nil),         // 4: agentedge.v1.PauseAction
+	(*DisconnectAction)(nil),    // 5: agentedge.v1.DisconnectAction
+	(*JobAssignedAction)(nil),   // 6: agentedge.v1.JobAssignedAction
+	(*Job)(nil),                 // 7: agentedge.v1.Job
+	nil,                         // 8: agentedge.v1.RequestHeaders.ValuesEntry
 }
 var file_agentedge_proto_depIdxs = []int32{
-	2, // 0: agentedge.v1.StreamPingsResponse.resume:type_name -> agentedge.v1.ResumeAction
-	3, // 1: agentedge.v1.StreamPingsResponse.pause:type_name -> agentedge.v1.PauseAction
-	4, // 2: agentedge.v1.StreamPingsResponse.disconnect:type_name -> agentedge.v1.DisconnectAction
-	5, // 3: agentedge.v1.StreamPingsResponse.job_assigned:type_name -> agentedge.v1.JobAssignedAction
-	6, // 4: agentedge.v1.JobAssignedAction.job:type_name -> agentedge.v1.Job
-	0, // 5: agentedge.v1.AgentEdgeService.StreamPings:input_type -> agentedge.v1.StreamPingsRequest
-	1, // 6: agentedge.v1.AgentEdgeService.StreamPings:output_type -> agentedge.v1.StreamPingsResponse
-	6, // [6:7] is the sub-list for method output_type
-	5, // [5:6] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	3, // 0: agentedge.v1.StreamPingsResponse.resume:type_name -> agentedge.v1.ResumeAction
+	4, // 1: agentedge.v1.StreamPingsResponse.pause:type_name -> agentedge.v1.PauseAction
+	5, // 2: agentedge.v1.StreamPingsResponse.disconnect:type_name -> agentedge.v1.DisconnectAction
+	6, // 3: agentedge.v1.StreamPingsResponse.job_assigned:type_name -> agentedge.v1.JobAssignedAction
+	2, // 4: agentedge.v1.StreamPingsResponse.request_headers:type_name -> agentedge.v1.RequestHeaders
+	8, // 5: agentedge.v1.RequestHeaders.values:type_name -> agentedge.v1.RequestHeaders.ValuesEntry
+	7, // 6: agentedge.v1.JobAssignedAction.job:type_name -> agentedge.v1.Job
+	0, // 7: agentedge.v1.AgentEdgeService.StreamPings:input_type -> agentedge.v1.StreamPingsRequest
+	1, // 8: agentedge.v1.AgentEdgeService.StreamPings:output_type -> agentedge.v1.StreamPingsResponse
+	8, // [8:9] is the sub-list for method output_type
+	7, // [7:8] is the sub-list for method input_type
+	7, // [7:7] is the sub-list for extension type_name
+	7, // [7:7] is the sub-list for extension extendee
+	0, // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_agentedge_proto_init() }
@@ -474,7 +535,7 @@ func file_agentedge_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agentedge_proto_rawDesc), len(file_agentedge_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/buildkite/agent/v4
 go 1.26.5
 
 require (
-	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.12-20260709200747-435963d16310.1
 	cloud.google.com/go/compute/metadata v0.9.0
 	cloud.google.com/go/kms v1.33.0
 	connectrpc.com/connect v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.12-20260709200747-435963d16310.1 h1:6nlcxMOui23ZRVAfJM451duu79P1npA5JRdZqMilrrQ=
-buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.12-20260709200747-435963d16310.1/go.mod h1:TCt1lluMFnctISJXvkIQ4x3ABrPuUKCWKyjKdkJNBpw=
 cloud.google.com/go v0.123.0 h1:2NAUJwPR47q+E35uaJeYoNhuNEM9kM8SjgRgdeOJUSE=
 cloud.google.com/go v0.123.0/go.mod h1:xBoMV08QcqUGuPW65Qfm1o9Y4zKZBpGS+7bImXLTAZU=
 cloud.google.com/go/auth v0.22.0 h1:Xp9wAKkLoeaYb5pYZZoQGz4E9sdPxIbzS3gywZE3ciQ=


### PR DESCRIPTION
## Description

Ping-stream responses can now include updated server-specified request headers. Without applying these updates, a streaming agent may continue using stale routing information for subsequent Agent API requests.

This change applies headers received from the stream and reconnects when the effective header set changes, ensuring the next streaming request includes them. Any action accompanying the update is delivered before reconnecting.

Polling pings already apply server-specified request headers. This brings streaming pings in line with that behaviour, including distinguishing between:

- absent headers, which leave the current headers unchanged; and
- an explicitly empty header set, which clears them.

## Context

https://github.com/buildkite/buildkite/pull/32972
INC-1228
A-1756

## Changes

- Update the protobuf definitions for streaming pings to include request headers to be reflected
- Restart the ping stream when its effective request headers change.
- Synchronise access to request headers shared by concurrent API requests.
- Return header snapshots rather than exposing mutable internal state.
- Cover adding, retaining, and clearing headers across stream connections.

## Testing

- [x] Tests have run locally (with `go test ./...`). Relevant packages pass with `go test ./api ./agent ./agent/integration`; the full suite currently has an unrelated failure in `internal/job`.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

Me + Amp