### PR TITLE
Automatically acquire jobs from JAT tokens

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -224,6 +224,21 @@ func (cfg *AgentStartConfig) checkoutOverrideMode() (env.CheckoutOverrideMode, e
 	return resolveCheckoutOverrideMode(cfg.CheckoutOverrideMode, !cfg.NoCommandEval)
 }
 
+func (cfg *AgentStartConfig) acquireJobFromToken() error {
+	jobUUID, isJobAcquisitionToken, err := jobAcquisitionTokenJobUUID(cfg.Token)
+	if err != nil {
+		return fmt.Errorf("invalid job acquisition token: %w", err)
+	}
+	if !isJobAcquisitionToken {
+		return nil
+	}
+	if cfg.AcquireJob != "" && cfg.AcquireJob != jobUUID {
+		return fmt.Errorf("--acquire-job %q does not match job %q in job acquisition token", cfg.AcquireJob, jobUUID)
+	}
+	cfg.AcquireJob = jobUUID
+	return nil
+}
+
 func (asc AgentStartConfig) Features(ctx context.Context) []string {
 	if asc.NoFeatureReporting {
 		return []string{}
@@ -782,6 +797,10 @@ var AgentStartCommand = &cli.Command{
 				return fmt.Errorf("failed to resolve registration token %q: %w", cfg.Token, err)
 			}
 			cfg.Token = token
+		}
+
+		if err := cfg.acquireJobFromToken(); err != nil {
+			return err
 		}
 
 		// used later to force the shutdown of the agent

--- a/clicommand/agent_start_test.go
+++ b/clicommand/agent_start_test.go
@@ -1,6 +1,7 @@
 package clicommand
 
 import (
+	"encoding/base64"
 	"errors"
 	"os"
 	"path/filepath"
@@ -23,6 +24,46 @@ func TestAgentStartFeatures_OpenTelemetryTracing(t *testing.T) {
 	features := AgentStartConfig{OpenTelemetryTracing: true}.Features(t.Context())
 	if !slices.Contains(features, "opentelemetry-tracing") {
 		t.Fatalf("Features() = %v, want opentelemetry-tracing", features)
+	}
+}
+
+func TestAgentStartAcquireJobFromToken(t *testing.T) {
+	t.Parallel()
+
+	const jobUUID = "0198dfd7-b7a3-723f-a647-1f54f491f334"
+	jobAcquisitionToken := func(subject string) string {
+		payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"` + subject + `"}`))
+		return jobAcquisitionTokenPrefix + "e30." + payload + ".signature"
+	}
+
+	tests := []struct {
+		name       string
+		token      string
+		acquireJob string
+		want       string
+		wantErr    bool
+	}{
+		{name: "registration token is unchanged", token: "bkt_llamas"},
+		{name: "JAT sets acquire job", token: jobAcquisitionToken(jobUUID), want: jobUUID},
+		{name: "matching explicit acquire job", token: jobAcquisitionToken(jobUUID), acquireJob: jobUUID, want: jobUUID},
+		{name: "conflicting explicit acquire job", token: jobAcquisitionToken(jobUUID), acquireJob: "0198dfd7-b7a3-723f-a647-1f54f491f335", want: "0198dfd7-b7a3-723f-a647-1f54f491f335", wantErr: true},
+		{name: "malformed JAT", token: jobAcquisitionTokenPrefix + "not-a-jwt", wantErr: true},
+		{name: "JAT with invalid subject", token: jobAcquisitionToken("not-a-uuid"), wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := AgentStartConfig{Token: test.token, AcquireJob: test.acquireJob}
+			err := cfg.acquireJobFromToken()
+			if (err != nil) != test.wantErr {
+				t.Fatalf("acquireJobFromToken() error = %v, want error %t", err, test.wantErr)
+			}
+			if got := cfg.AcquireJob; got != test.want {
+				t.Errorf("AcquireJob = %q, want %q", got, test.want)
+			}
+		})
 	}
 }
 

--- a/clicommand/register_token.go
+++ b/clicommand/register_token.go
@@ -1,11 +1,15 @@
 package clicommand
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 // The agent registration token is a long-lived secret, so we try to avoid
@@ -26,7 +30,10 @@ import (
 // fd://N instead (see reexecToScrubRegistrationToken), which replaces the
 // exec-time cmdline and environ with token-free versions.
 
-const registrationTokenEnvVar = "BUILDKITE_AGENT_TOKEN"
+const (
+	registrationTokenEnvVar   = "BUILDKITE_AGENT_TOKEN"
+	jobAcquisitionTokenPrefix = "bkjat_"
+)
 
 // maxTokenFileSize is a sanity limit when reading tokens from files or file
 // descriptors.
@@ -74,6 +81,37 @@ func resolveRegistrationToken(token string) (string, error) {
 	default:
 		return token, nil
 	}
+}
+
+// jobAcquisitionTokenJobUUID extracts the job UUID from a Job Acquisition
+// Token. The token's signature is validated by Buildkite during registration;
+// decoding it here only selects the agent's acquisition mode.
+func jobAcquisitionTokenJobUUID(token string) (string, bool, error) {
+	if !strings.HasPrefix(token, jobAcquisitionTokenPrefix) {
+		return "", false, nil
+	}
+
+	parts := strings.Split(strings.TrimPrefix(token, jobAcquisitionTokenPrefix), ".")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", true, fmt.Errorf("expected a three-part JWT")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", true, fmt.Errorf("couldn't decode JWT payload: %w", err)
+	}
+
+	var claims struct {
+		Subject string `json:"sub"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", true, fmt.Errorf("couldn't decode JWT claims: %w", err)
+	}
+	if _, err := uuid.Parse(claims.Subject); err != nil {
+		return "", true, fmt.Errorf("invalid job UUID in JWT subject: %w", err)
+	}
+
+	return claims.Subject, true, nil
 }
 
 // registrationTokenFromArgs scans command line arguments for the registration


### PR DESCRIPTION
## Description

Recognize `bkjat_` Job Acquisition Tokens and automatically enter acquire mode using the job UUID from the JWT `sub` claim. The token is decoded locally only to select acquire mode; Buildkite still validates its signature and authorization during registration.

An explicitly configured `--acquire-job` remains supported, but must match the JAT's job UUID.

Fixes: A-1697

## Context

- https://github.com/buildkite/buildkite/pull/32347

## Changes

- Decode and validate the job UUID from JAT payloads.
- Configure acquire mode automatically after resolving direct or indirect registration tokens.
- Reject malformed JATs and conflicting explicit job UUIDs.
- Cover regular tokens, valid JATs, malformed JATs, and conflicting acquisition settings.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

Additional focused validation:
- `go test ./clicommand -count=1`
- `go vet ./clicommand`

## Affiliation (optional, external contributors)

Buildkite

## Disclosures / Credits

Amp implemented and tested this change under my direction.
