### PR TITLE
oidc request-token: distinct exit status 77 when the API refuses

### DIFF
--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -32,13 +32,16 @@ type OIDCTokenConfig struct {
 }
 
 // OIDCTokenRefusedExitStatus is the exit status when the Buildkite API
-// positively refused to issue an OIDC token (a 4xx response such as 401, 403,
-// 404, or 422 — for example an audience disallowed by organization policy).
+// positively refused to issue an OIDC token: a 400, 401, 403, 404, 410, or
+// 422 response — for example an audience disallowed by organization policy.
 // Retrying such a request will not succeed.
 //
-// All other failures — exhausted retries on 429/5xx, timeout-like statuses
-// (408, 425), network timeouts, and other transport errors — exit with the
-// generic status 1 and may succeed if retried later.
+// All other failures — exhausted retries on 5xx, any other 4xx (408, 421,
+// 425, 429, nonstandard proxy statuses), network timeouts, and other
+// transport errors — exit with the generic status 1 and may succeed if
+// retried later. Ambiguity deliberately biases toward the transient exit
+// status: a spurious 1 costs callers a pointless retry, whereas a spurious 77
+// makes them abandon a credential they could have obtained.
 //
 // This exit status is a contract consumed by other tools (at least
 // github.com/buildkite/test-engine-client, which uses it to decide whether an
@@ -68,10 +71,11 @@ Requests and prints an OIDC token from Buildkite that claims the Job ID
 Exit statuses:
 
 - 0: the token was obtained and printed.
-- 77: the Buildkite API refused to issue the token (a 4xx response such as a
-  disallowed audience). Retrying will not succeed.
+- 77: the Buildkite API refused to issue the token (a 400, 401, 403, 404,
+  410, or 422 response, such as a disallowed audience). Retrying will not
+  succeed.
 - 1: any other failure, including transient API or network errors (timeouts,
-  5xx, 408/425/429) after exhausting retries. Retrying may succeed.`
+  5xx, other 4xx) after exhausting retries. Retrying may succeed.`
 )
 
 var OIDCRequestTokenCommand = &cli.Command{
@@ -233,20 +237,27 @@ var OIDCRequestTokenCommand = &cli.Command{
 }
 
 // oidcTokenRefused reports whether err represents the Buildkite API positively
-// refusing to issue an OIDC token: a 4xx API response that indicates retrying
-// will not succeed. Timeout-like and rate-limiting 4xx statuses (408, 425,
-// 429) are excluded: they can succeed if retried, so they must exit with the
-// generic transient status even when the retrier chose not to retry them.
-// 5xx and transport errors are transient by definition.
+// refusing to issue an OIDC token: an API response status that indicates
+// retrying will not succeed. Only statuses that definitively represent a
+// refusal are listed; every other status — including timeout-like or
+// connection-scoped 4xx (408, 421, 425, 429) and anything nonstandard from an
+// intermediary — is treated as transient, because a spurious transient
+// classification merely costs the caller a retry, while a spurious refusal
+// makes it abandon a credential it could have obtained.
 func oidcTokenRefused(err error) bool {
 	var errResp *api.ErrorResponse
 	if !errors.As(err, &errResp) || errResp.Response == nil {
 		return false
 	}
-	switch code := errResp.Response.StatusCode; code {
-	case http.StatusRequestTimeout, http.StatusTooEarly, http.StatusTooManyRequests:
-		return false
+	switch errResp.Response.StatusCode {
+	case http.StatusBadRequest, // 400
+		http.StatusUnauthorized,        // 401
+		http.StatusForbidden,           // 403
+		http.StatusNotFound,            // 404
+		http.StatusGone,                // 410
+		http.StatusUnprocessableEntity: // 422
+		return true
 	default:
-		return code >= 400 && code < 500
+		return false
 	}
 }

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"time"
 
@@ -30,6 +31,20 @@ type OIDCTokenConfig struct {
 	SubjectClaim   string   `cli:"subject-claim"`
 }
 
+// OIDCTokenRefusedExitStatus is the exit status when the Buildkite API
+// positively refused to issue an OIDC token (a non-retryable 4xx response such
+// as 401, 403, 404, or 422 — for example an audience disallowed by
+// organization policy). Retrying such a request will not succeed.
+//
+// All other failures — exhausted retries on 429/5xx, timeouts, and other
+// transport errors — exit with the generic status 1 and may succeed if
+// retried later.
+//
+// This exit status is a contract consumed by other tools (at least
+// github.com/buildkite/test-engine-client, which uses it to decide whether an
+// OTLP relay credential failure is terminal). Do not change or reuse it.
+const OIDCTokenRefusedExitStatus = 77
+
 const (
 	backoffSeconds       = 2
 	maxAttempts          = 5
@@ -48,7 +63,15 @@ Example:
     $ buildkite-agent oidc request-token --audience sts.amazonaws.com
 
 Requests and prints an OIDC token from Buildkite that claims the Job ID
-(amongst other things) and the audience "sts.amazonaws.com".`
+(amongst other things) and the audience "sts.amazonaws.com".
+
+Exit statuses:
+
+- 0: the token was obtained and printed.
+- 77: the Buildkite API refused to issue the token (a non-retryable 4xx
+  response, such as a disallowed audience). Retrying will not succeed.
+- 1: any other failure, including transient API or network errors after
+  exhausting retries. Retrying may succeed.`
 )
 
 var OIDCRequestTokenCommand = &cli.Command{
@@ -145,9 +168,14 @@ var OIDCRequestTokenCommand = &cli.Command{
 		})
 		if err != nil {
 			if len(cfg.Audience) > 0 {
-				return fmt.Errorf("could not obtain OIDC token for audience %s: %w", cfg.Audience, err)
+				err = fmt.Errorf("could not obtain OIDC token for audience %s: %w", cfg.Audience, err)
+			} else {
+				err = fmt.Errorf("could not obtain OIDC token for default audience: %w", err)
 			}
-			return fmt.Errorf("could not obtain OIDC token for default audience: %w", err)
+			if oidcTokenRefused(err) {
+				return NewExitError(OIDCTokenRefusedExitStatus, err)
+			}
+			return err
 		}
 
 		if !cfg.SkipRedaction {
@@ -202,4 +230,17 @@ var OIDCRequestTokenCommand = &cli.Command{
 
 		return nil
 	},
+}
+
+// oidcTokenRefused reports whether err represents the Buildkite API positively
+// refusing to issue an OIDC token: a non-retryable 4xx API response. This is
+// the same classification api.BreakOnNonRetryable uses to stop retrying, minus
+// the failures (429, 5xx, transport errors) that could succeed if retried.
+func oidcTokenRefused(err error) bool {
+	var errResp *api.ErrorResponse
+	if !errors.As(err, &errResp) || errResp.Response == nil {
+		return false
+	}
+	code := errResp.Response.StatusCode
+	return code >= 400 && code < 500 && code != http.StatusTooManyRequests
 }

--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -32,13 +32,13 @@ type OIDCTokenConfig struct {
 }
 
 // OIDCTokenRefusedExitStatus is the exit status when the Buildkite API
-// positively refused to issue an OIDC token (a non-retryable 4xx response such
-// as 401, 403, 404, or 422 — for example an audience disallowed by
-// organization policy). Retrying such a request will not succeed.
+// positively refused to issue an OIDC token (a 4xx response such as 401, 403,
+// 404, or 422 — for example an audience disallowed by organization policy).
+// Retrying such a request will not succeed.
 //
-// All other failures — exhausted retries on 429/5xx, timeouts, and other
-// transport errors — exit with the generic status 1 and may succeed if
-// retried later.
+// All other failures — exhausted retries on 429/5xx, timeout-like statuses
+// (408, 425), network timeouts, and other transport errors — exit with the
+// generic status 1 and may succeed if retried later.
 //
 // This exit status is a contract consumed by other tools (at least
 // github.com/buildkite/test-engine-client, which uses it to decide whether an
@@ -68,10 +68,10 @@ Requests and prints an OIDC token from Buildkite that claims the Job ID
 Exit statuses:
 
 - 0: the token was obtained and printed.
-- 77: the Buildkite API refused to issue the token (a non-retryable 4xx
-  response, such as a disallowed audience). Retrying will not succeed.
-- 1: any other failure, including transient API or network errors after
-  exhausting retries. Retrying may succeed.`
+- 77: the Buildkite API refused to issue the token (a 4xx response such as a
+  disallowed audience). Retrying will not succeed.
+- 1: any other failure, including transient API or network errors (timeouts,
+  5xx, 408/425/429) after exhausting retries. Retrying may succeed.`
 )
 
 var OIDCRequestTokenCommand = &cli.Command{
@@ -233,14 +233,20 @@ var OIDCRequestTokenCommand = &cli.Command{
 }
 
 // oidcTokenRefused reports whether err represents the Buildkite API positively
-// refusing to issue an OIDC token: a non-retryable 4xx API response. This is
-// the same classification api.BreakOnNonRetryable uses to stop retrying, minus
-// the failures (429, 5xx, transport errors) that could succeed if retried.
+// refusing to issue an OIDC token: a 4xx API response that indicates retrying
+// will not succeed. Timeout-like and rate-limiting 4xx statuses (408, 425,
+// 429) are excluded: they can succeed if retried, so they must exit with the
+// generic transient status even when the retrier chose not to retry them.
+// 5xx and transport errors are transient by definition.
 func oidcTokenRefused(err error) bool {
 	var errResp *api.ErrorResponse
 	if !errors.As(err, &errResp) || errResp.Response == nil {
 		return false
 	}
-	code := errResp.Response.StatusCode
-	return code >= 400 && code < 500 && code != http.StatusTooManyRequests
+	switch code := errResp.Response.StatusCode; code {
+	case http.StatusRequestTimeout, http.StatusTooEarly, http.StatusTooManyRequests:
+		return false
+	default:
+		return code >= 400 && code < 500
+	}
 }

--- a/clicommand/oidc_request_token_test.go
+++ b/clicommand/oidc_request_token_test.go
@@ -157,13 +157,18 @@ func TestOIDCTokenRefused(t *testing.T) {
 		err  error
 		want bool
 	}{
+		{name: "400 bad request", err: errorResponse(http.StatusBadRequest), want: true},
 		{name: "401 unauthorized", err: errorResponse(http.StatusUnauthorized), want: true},
 		{name: "403 forbidden", err: errorResponse(http.StatusForbidden), want: true},
+		{name: "404 not found", err: errorResponse(http.StatusNotFound), want: true},
+		{name: "410 gone", err: errorResponse(http.StatusGone), want: true},
 		{name: "422 unprocessable", err: errorResponse(http.StatusUnprocessableEntity), want: true},
 		{name: "wrapped 422", err: fmt.Errorf("could not obtain OIDC token: %w", errorResponse(http.StatusUnprocessableEntity)), want: true},
 		{name: "408 request timeout", err: errorResponse(http.StatusRequestTimeout), want: false},
+		{name: "421 misdirected request", err: errorResponse(http.StatusMisdirectedRequest), want: false},
 		{name: "425 too early", err: errorResponse(http.StatusTooEarly), want: false},
 		{name: "429 too many requests", err: errorResponse(http.StatusTooManyRequests), want: false},
+		{name: "unlisted 4xx (418)", err: errorResponse(http.StatusTeapot), want: false},
 		{name: "500 internal server error", err: errorResponse(http.StatusInternalServerError), want: false},
 		{name: "504 gateway timeout", err: errorResponse(http.StatusGatewayTimeout), want: false},
 		{name: "transport error", err: errors.New("net/http: request canceled"), want: false},

--- a/clicommand/oidc_request_token_test.go
+++ b/clicommand/oidc_request_token_test.go
@@ -161,6 +161,8 @@ func TestOIDCTokenRefused(t *testing.T) {
 		{name: "403 forbidden", err: errorResponse(http.StatusForbidden), want: true},
 		{name: "422 unprocessable", err: errorResponse(http.StatusUnprocessableEntity), want: true},
 		{name: "wrapped 422", err: fmt.Errorf("could not obtain OIDC token: %w", errorResponse(http.StatusUnprocessableEntity)), want: true},
+		{name: "408 request timeout", err: errorResponse(http.StatusRequestTimeout), want: false},
+		{name: "425 too early", err: errorResponse(http.StatusTooEarly), want: false},
 		{name: "429 too many requests", err: errorResponse(http.StatusTooManyRequests), want: false},
 		{name: "500 internal server error", err: errorResponse(http.StatusInternalServerError), want: false},
 		{name: "504 gateway timeout", err: errorResponse(http.StatusGatewayTimeout), want: false},

--- a/clicommand/oidc_request_token_test.go
+++ b/clicommand/oidc_request_token_test.go
@@ -2,6 +2,7 @@ package clicommand
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/buildkite/agent/v4/api"
 	"github.com/urfave/cli/v3"
 )
 
@@ -98,6 +100,80 @@ func TestOIDCRequestToken(t *testing.T) {
 			t.Fatalf("runOIDCRequestTokenCommand() output = %q, want %q", out, want)
 		}
 	})
+}
+
+// A non-retryable 4xx means the API positively refused to issue a token, so
+// the command must not retry, and must exit with the documented distinct
+// status so callers (e.g. test-engine-client) can tell a refusal apart from a
+// transient failure without parsing stderr.
+func TestOIDCRequestTokenRefusalExitsWithDistinctStatus(t *testing.T) {
+	var requests atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		requests.Add(1)
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = fmt.Fprint(rw, `{"message":"audience not allowed"}`)
+	}))
+	defer server.Close()
+
+	_, err := runOIDCRequestTokenCommand(t, server.URL)
+	if err == nil {
+		t.Fatal("runOIDCRequestTokenCommand() error = nil, want non-nil")
+	}
+
+	eerr := new(ExitError)
+	if !errors.As(err, &eerr) {
+		t.Fatalf("runOIDCRequestTokenCommand() error = %v (%T), want ExitError", err, err)
+	}
+	if got, want := eerr.Code(), OIDCTokenRefusedExitStatus; got != want {
+		t.Errorf("ExitError.Code() = %d, want %d", got, want)
+	}
+	if got, want := err.Error(), "audience not allowed"; !strings.Contains(got, want) {
+		t.Errorf("error = %q, want containing %q", got, want)
+	}
+
+	if got, want := requests.Load(), int32(1); got != want {
+		t.Errorf("server received %d requests, want %d (refusals must not be retried)", got, want)
+	}
+}
+
+func TestOIDCTokenRefused(t *testing.T) {
+	errorResponse := func(status int) error {
+		return &api.ErrorResponse{
+			Response: &http.Response{
+				StatusCode: status,
+				Request: &http.Request{
+					Method: "POST",
+					URL:    &url.URL{Scheme: "https", Host: "agent.buildkite.com", Path: "/v3/jobs/job-123/oidc/tokens"},
+				},
+			},
+			Message: "message",
+		}
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "401 unauthorized", err: errorResponse(http.StatusUnauthorized), want: true},
+		{name: "403 forbidden", err: errorResponse(http.StatusForbidden), want: true},
+		{name: "422 unprocessable", err: errorResponse(http.StatusUnprocessableEntity), want: true},
+		{name: "wrapped 422", err: fmt.Errorf("could not obtain OIDC token: %w", errorResponse(http.StatusUnprocessableEntity)), want: true},
+		{name: "429 too many requests", err: errorResponse(http.StatusTooManyRequests), want: false},
+		{name: "500 internal server error", err: errorResponse(http.StatusInternalServerError), want: false},
+		{name: "504 gateway timeout", err: errorResponse(http.StatusGatewayTimeout), want: false},
+		{name: "transport error", err: errors.New("net/http: request canceled"), want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := oidcTokenRefused(test.err); got != test.want {
+				t.Errorf("oidcTokenRefused(%v) = %t, want %t", test.err, got, test.want)
+			}
+		})
+	}
 }
 
 // An intermediary in front of the API can answer with an HTML error page and a


### PR DESCRIPTION
`buildkite-agent oidc request-token` exits 1 for every failure, so callers can't tell a terminal refusal (the API will never issue this token) from a transient failure (retrying may succeed) without parsing stderr, which is fragile. This PR exits with status **77** when the API positively refuses: a non-retryable 4xx (401, 403, 404, 422 — e.g. an audience disallowed by org policy). It mirrors the classification `api.BreakOnNonRetryable` already uses to stop retrying — no new taxonomy. Exhausted retries on 429/5xx, timeouts, and transport errors still exit 1. Stderr output is unchanged.

77 is sysexits `EX_NOPERM` (fits the policy-refusal meaning) and avoids codes the agent already assigns semantics to (27/28 acquire-job, 100 meta-data exists, 125 executor setup, 128+signal). Alternatives considered: parsing stderr in callers (fragile, rejected) and structured `--output json` errors (heavier; can still be added later).

## Context

- Motivation: test-engine-client's OTLP relay mints suite-scoped OIDC tokens via this command. During an OIDC endpoint incident (504s/timeouts) bktec hard-failed otherwise healthy jobs. bktec will retry token failures in the background by default, but wants to keep hard-failing fast when the failure is a refusal that will never succeed. The exported constant's doc comment marks this exit status as a contract.
- Resolves side 1 of https://linear.app/buildkite/issue/TE-6799 (internal)
- Slack (internal): https://buildkite-corp.slack.com/archives/C0BJYPY4Q7K/p1787708848057439

## Changes

- `clicommand/oidc_request_token.go`: exported `OIDCTokenRefusedExitStatus = 77`; classify the final error via `api.ErrorResponse` status and return `NewExitError(77, err)` for non-429 4xx; document exit statuses in the command description.
- Tests: refusal (422) exits via `ExitError(77)` after exactly one request; table test pinning the classification (401/403/422 → refused; 429/5xx/transport → not).

## Testing
- [x] Tests have run locally (with `go test ./...`). (`go test ./clicommand/` passes locally; full suite left to CI.)
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

Implemented with Amp (https://ampcode.com), driven and reviewed by @pda.
