### PR TITLE
[Backport] [A-1755] Die cleanly when heartbeats fail

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -265,16 +265,20 @@ func (a *AgentWorker) Start(ctx context.Context, idleMon *idleMonitor) (startErr
 	}
 	defer a.metricsCollector.Stop() //nolint:errcheck // Best-effort cleanup
 
-	// There are as many as 4 different loops that send 1 error here each.
-	errCh := make(chan error, 4)
-
 	// Use this context to control the heartbeat loop.
 	heartbeatCtx, stopHeartbeats := context.WithCancel(ctx)
-	defer stopHeartbeats()
+	heartbeatDone := make(chan struct{})
+	var heartbeatErr error
 
-	// Start the heartbeat loop but don't wait for it to return (yet).
+	// Start the heartbeat loop. Stop and wait for it on every return path.
 	go func() {
-		errCh <- a.runHeartbeatLoop(heartbeatCtx)
+		defer close(heartbeatDone)
+		heartbeatErr = a.runHeartbeatLoop(heartbeatCtx)
+	}()
+	defer func() {
+		stopHeartbeats()
+		<-heartbeatDone
+		startErr = errors.Join(startErr, heartbeatErr)
 	}()
 
 	// If the agent is booted in acquisition mode, acquire that particular job
@@ -314,10 +318,10 @@ func (a *AgentWorker) Start(ctx context.Context, idleMon *idleMonitor) (startErr
 
 	// Based on configuration, we have our choice of ping loop,
 	// streaming loop+debouncer loop, or both.
-	pingLoop := func() {
-		errCh <- a.runPingLoop(ctx, bat, fromPingLoopCh)
+	pingLoop := func() error {
+		return a.runPingLoop(ctx, bat, fromPingLoopCh)
 	}
-	streamingLoop := func() {
+	streamingLoop := func() error {
 		err := a.runStreamingPingLoop(ctx, fromStreamingLoopCh)
 		if err != nil {
 			switch a.agentConfiguration.PingMode {
@@ -337,25 +341,25 @@ func (a *AgentWorker) Start(ctx context.Context, idleMon *idleMonitor) (startErr
 				err = nil
 			}
 		}
-		errCh <- err
+		return err
 	}
-	debouncerLoop := func() {
-		errCh <- a.runDebouncer(ctx, bat, fromDebouncerCh, fromStreamingLoopCh)
+	debouncerLoop := func() error {
+		return a.runDebouncer(ctx, bat, fromDebouncerCh, fromStreamingLoopCh)
 	}
 
-	var loops []func()
+	var loops []func() error
 	switch a.agentConfiguration.PingMode {
 	case "", PingModeAuto: // note: "" can happen in some tests
-		loops = []func(){pingLoop, streamingLoop, debouncerLoop}
+		loops = []func() error{pingLoop, streamingLoop, debouncerLoop}
 		<-bat.Acquire()
 		bat.Acquired(actorDebouncer)
 
 	case PingModePollOnly:
-		loops = []func(){pingLoop}
+		loops = []func() error{pingLoop}
 		fromDebouncerCh = nil // prevent action loop listening to streaming side
 
 	case PingModeStreamOnly:
-		loops = []func(){streamingLoop, debouncerLoop}
+		loops = []func() error{streamingLoop, debouncerLoop}
 		fromPingLoopCh = nil // prevent action loop listening to ping side
 		<-bat.Acquire()
 		bat.Acquired(actorDebouncer)
@@ -365,29 +369,22 @@ func (a *AgentWorker) Start(ctx context.Context, idleMon *idleMonitor) (startErr
 	}
 
 	// There's always an action handler.
-	actionLoop := func() {
-		errCh <- a.runActionLoop(ctx, idleMon, fromPingLoopCh, fromDebouncerCh)
+	actionLoop := func() error {
+		return a.runActionLoop(ctx, idleMon, fromPingLoopCh, fromDebouncerCh)
 	}
 	loops = append(loops, actionLoop)
 
 	// Start the loops and block until they have all stopped.
+	loopErrs := make([]error, len(loops))
 	var wg sync.WaitGroup
-	for _, l := range loops {
-		wg.Go(l)
+	for i, loop := range loops {
+		wg.Go(func() {
+			loopErrs[i] = loop()
+		})
 	}
 	wg.Wait()
 
-	// The source loops have ended, so stop the heartbeat loop.
-	stopHeartbeats()
-
-	// Block until all loops have returned, then join the errors.
-	// (Note that errors.Join does the right thing with nil.)
-	// All loops are context aware, so no need to wait on ctx here.
-	var err error
-	for range len(loops) + 1 { // loops + heartbeat loop
-		err = errors.Join(err, <-errCh)
-	}
-	return err
+	return errors.Join(loopErrs...)
 }
 
 func (a *AgentWorker) internalStop() {

--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -1021,6 +1021,61 @@ func TestAgentWorker_UnrecoverableErrorInPing(t *testing.T) {
 	}
 }
 
+func TestAgentWorker_UnrecoverableErrorInHeartbeatStopsAutoPingMode(t *testing.T) {
+	t.Parallel()
+
+	const agentSessionToken = "alpacas"
+
+	server := NewFakeAPIServer(WithStreaming)
+	defer server.Close()
+
+	agent := server.AddAgent(agentSessionToken)
+	defer close(agent.PingStream)
+	agent.HeartbeatHandler = func(rw http.ResponseWriter, _ *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(rw, encodeMsg("agent not found"))
+	}
+
+	apiClient := api.NewClient(logger.Discard, api.Config{
+		Endpoint: server.URL,
+		Token:    "llamas",
+	})
+
+	l := logger.NewConsoleLogger(logger.NewTestPrinter(t), func(int) {})
+	worker := NewAgentWorker(
+		l,
+		&api.AgentRegisterResponse{
+			UUID:              uuid.New().String(),
+			Name:              "agent-1",
+			AccessToken:       agentSessionToken,
+			Endpoint:          server.URL,
+			PingInterval:      1,
+			JobStatusInterval: 5,
+			HeartbeatInterval: 1,
+		},
+		metrics.NewCollector(logger.Discard, metrics.CollectorConfig{}),
+		apiClient,
+		AgentWorkerConfig{
+			AgentConfiguration: AgentConfiguration{PingMode: PingModeAuto},
+		},
+	)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- worker.Start(t.Context(), nil)
+	}()
+
+	select {
+	case err := <-done:
+		if !isUnrecoverable(err) {
+			t.Errorf("worker.Start() = %v, want an unrecoverable error", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker.Start() did not return after an unrecoverable heartbeat error")
+	}
+}
+
 func TestAgentWorker_Streaming_Disconnect(t *testing.T) {
 	t.Parallel()
 

--- a/agent/fake_api_server_test.go
+++ b/agent/fake_api_server_test.go
@@ -49,7 +49,8 @@ type FakeAgent struct {
 	Heartbeats         int
 	IgnoreInDispatches bool
 
-	PingHandler func(*http.Request) (api.Ping, error)
+	PingHandler      func(*http.Request) (api.Ping, error)
+	HeartbeatHandler http.HandlerFunc
 
 	// PingStream is a simple way of providing streaming responses concurrently.
 	// It is used for the default handler.
@@ -428,6 +429,10 @@ func (fs *FakeAPIServer) handleHeartbeat(rw http.ResponseWriter, req *http.Reque
 	}
 
 	agent.Heartbeats++
+	if agent.HeartbeatHandler != nil {
+		agent.HeartbeatHandler(rw, req)
+		return
+	}
 
 	var hb api.Heartbeat
 	if err := json.NewDecoder(req.Body).Decode(&hb); err != nil {


### PR DESCRIPTION
## Description

Backport of [#4271](https://github.com/buildkite/agent/pull/4271) to `v3`. It prevents unrecoverable heartbeat failures in `ping-mode=auto` from leaving Agent v3 processes running indefinitely.

## Context

See [#4271](https://github.com/buildkite/agent/pull/4271) for the full description and investigation context.

## Changes

The change applied cleanly with no v3-specific behavioural changes.

## Testing

- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

Prepared and validated with Amp as a v3 backport of the merged v4 change.
