### PR TITLE
[A-1776] Align hosted agents cache expiry with registry

### DIFF
--- a/internal/cache/store/nsc.go
+++ b/internal/cache/store/nsc.go
@@ -23,11 +23,13 @@ const nscScheme = "nsc"
 
 // nscDefaultExpiry is the artifact lifetime used both when uploading a cache
 // entry (--expires_in) and when refreshing it on access (--ensure_minimum).
+// Keep this aligned with CacheRegistry::Entry::DEFAULT_EXPIRES in the Buildkite
+// backend.
 // Cache entries are content-addressed and short-lived, so we cap storage growth
 // rather than relying on NSC's no-expiry default. Every restore pushes the
 // expiry back out to this duration from now, keeping hot caches alive while
 // letting cold ones expire.
-const nscDefaultExpiry = "24h"
+const nscDefaultExpiry = "72h"
 
 // commandRunner executes an external command. It is a seam so tests can assert
 // the arguments passed to the nsc CLI without invoking the real binary.

--- a/internal/cache/store/nsc_test.go
+++ b/internal/cache/store/nsc_test.go
@@ -265,7 +265,7 @@ func TestNscStore_PassesNamespace(t *testing.T) {
 		t.Fatalf("Upload: %v", err)
 	}
 
-	wantArgs := []string{"nsc", "artifact", "upload", testFile, "key", "--expires_in", "24h", "--namespace", "my-namespace"}
+	wantArgs := []string{"nsc", "artifact", "upload", testFile, "key", "--expires_in", "72h", "--namespace", "my-namespace"}
 	if diff := cmp.Diff(wantArgs, captured); diff != "" {
 		t.Errorf("upload args mismatch (-want +got):\n%s", diff)
 	}
@@ -316,7 +316,7 @@ func TestNscStore_RefreshesTTLOnDownload(t *testing.T) {
 		t.Fatalf("Download: %v", err)
 	}
 
-	wantExtend := []string{"nsc", "artifact", "extend", "key", "--ensure_minimum", "24h", "--namespace", "my-namespace"}
+	wantExtend := []string{"nsc", "artifact", "extend", "key", "--ensure_minimum", "72h", "--namespace", "my-namespace"}
 	var gotExtend []string
 	for _, c := range calls {
 		if isCommand(c, "nsc", "artifact", "extend") && !isCommand(c, "nsc", "artifact", "extend", "--help") {


### PR DESCRIPTION
## Description

Hosted Agents cache artifacts expired after 24 hours while their cache registry entries remained valid for three days. This extends Hosted Agents artifact retention to 72 hours so cold cache blobs remain available for the registry entry's initial lifetime.

## Context

https://linear.app/buildkite/issue/A-1776/align-namespace-artifact-expiry-with-cache-registry-expiry-on-save

## Changes

- Use a 72-hour expiry for uploads and restore-time extensions to Hosted Agents storage
- Keep command-level tests pinned to the three-day retention period.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

`go test ./internal/cache/store ./internal/cache` passes. `go test ./...` otherwise passes but reports `TestPolyglotScriptHooksCanBeRun` failing because Ruby is not installed in the test environment.

## Disclosures / Credits

Implemented with Amp, directed and reviewed by Kate Sy.
