### PR TITLE
[Backport] Report graceful agent stops to Buildkite

### DIFF
--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -25,6 +25,8 @@ const (
 	PingModeAuto       = "auto" // empty string can be used from tests
 	PingModeStreamOnly = "stream-only"
 	PingModePollOnly   = "poll-only"
+
+	gracefulStopReportTimeout = 5 * time.Second
 )
 
 type AgentWorkerConfig struct {
@@ -98,6 +100,11 @@ type AgentWorker struct {
 	// for an explanation.
 	stopOnce sync.Once // prevents double-closing the channel
 	stop     chan struct{}
+
+	// A graceful stop report is launched by StopGracefully and joined by
+	// Disconnect so the worker does not disconnect before reporting.
+	reportGracefulStopOnce sync.Once
+	reportGracefulStopDone chan struct{}
 
 	// The index of this agent worker
 	spawnIndex int
@@ -206,14 +213,15 @@ func NewAgentWorker(l logger.Logger, reg *api.AgentRegisterResponse, m *metrics.
 			APIClient: apiClient,
 			Logger:    l,
 		},
-		debug:              c.Debug,
-		debugHTTP:          c.DebugHTTP,
-		agentConfiguration: c.AgentConfiguration,
-		stop:               make(chan struct{}),
-		cancelSig:          c.CancelSignal,
-		spawnIndex:         c.SpawnIndex,
-		agentStdout:        c.AgentStdout,
-		state:              agentWorkerStateIdle,
+		debug:                  c.Debug,
+		debugHTTP:              c.DebugHTTP,
+		agentConfiguration:     c.AgentConfiguration,
+		stop:                   make(chan struct{}),
+		reportGracefulStopDone: make(chan struct{}),
+		cancelSig:              c.CancelSignal,
+		spawnIndex:             c.SpawnIndex,
+		agentStdout:            c.AgentStdout,
+		state:                  agentWorkerStateIdle,
 	}
 }
 
@@ -395,6 +403,21 @@ func (a *AgentWorker) internalStop() {
 	})
 }
 
+func (a *AgentWorker) reportGracefulStopToAPI() {
+	defer close(a.reportGracefulStopDone)
+
+	// Reporting must outlive the worker loops, but it remains bounded so an API
+	// failure cannot prevent Disconnect from continuing.
+	reportCtx, cancel := context.WithTimeout(context.Background(), gracefulStopReportTimeout)
+	defer cancel()
+
+	if _, err := a.apiClient.Stop(reportCtx, &api.AgentStopRequest{}); err != nil {
+		a.logger.Warnf("Failed to report graceful stop to Buildkite: %v", err)
+		return
+	}
+	a.logger.Infof("Reported graceful stop to Buildkite")
+}
+
 // StopGracefully stops the agent from accepting new work. It allows the current
 // job to finish without interruption. Does not block.
 func (a *AgentWorker) StopGracefully() {
@@ -406,6 +429,10 @@ func (a *AgentWorker) StopGracefully() {
 	default:
 		// continue below
 	}
+
+	a.reportGracefulStopOnce.Do(func() {
+		go a.reportGracefulStopToAPI()
+	})
 
 	// If we have a job, tell the user that we'll wait for it to finish
 	// before disconnecting
@@ -575,6 +602,12 @@ func (a *AgentWorker) RunJob(ctx context.Context, acceptResponse *api.Job, ignor
 // permanently disconnecting. Don't spend long retrying, because we want to
 // disconnect as fast as possible.
 func (a *AgentWorker) Disconnect(ctx context.Context) error {
+	// If no graceful stop was requested, make the wait below a no-op.
+	a.reportGracefulStopOnce.Do(func() {
+		close(a.reportGracefulStopDone)
+	})
+	<-a.reportGracefulStopDone
+
 	return a.client.Disconnect(ctx)
 }
 

--- a/agent/agent_worker_stop_test.go
+++ b/agent/agent_worker_stop_test.go
@@ -1,0 +1,234 @@
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/logger"
+	"github.com/buildkite/agent/v3/metrics"
+)
+
+const gracefulStopTestSessionToken = "agent-session-token"
+
+type gracefulStopTestServer struct {
+	*httptest.Server
+
+	t            *testing.T
+	stopStatus   int
+	releaseStop  <-chan struct{}
+	stopStarted  chan struct{}
+	disconnected chan struct{}
+
+	stopStartedOnce  sync.Once
+	disconnectedOnce sync.Once
+
+	mu           sync.Mutex
+	events       []string
+	stopRequests []api.AgentStopRequest
+}
+
+func newGracefulStopTestServer(t *testing.T, stopStatus int, releaseStop <-chan struct{}) *gracefulStopTestServer {
+	t.Helper()
+
+	s := &gracefulStopTestServer{
+		t:            t,
+		stopStatus:   stopStatus,
+		releaseStop:  releaseStop,
+		stopStarted:  make(chan struct{}),
+		disconnected: make(chan struct{}),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /stop", s.handleStop)
+	mux.HandleFunc("POST /disconnect", s.handleDisconnect)
+	s.Server = httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return s
+}
+
+func (s *gracefulStopTestServer) checkSessionToken(req *http.Request) {
+	s.t.Helper()
+	if got, want := req.Header.Get("Authorization"), "Token "+gracefulStopTestSessionToken; got != want {
+		s.t.Errorf("Authorization header = %q, want %q", got, want)
+	}
+}
+
+func (s *gracefulStopTestServer) handleStop(rw http.ResponseWriter, req *http.Request) {
+	s.checkSessionToken(req)
+
+	var stopReq api.AgentStopRequest
+	if err := json.NewDecoder(req.Body).Decode(&stopReq); err != nil {
+		s.t.Errorf("decoding graceful stop request: %v", err)
+		http.Error(rw, "invalid request", http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	s.stopRequests = append(s.stopRequests, stopReq)
+	s.mu.Unlock()
+	s.stopStartedOnce.Do(func() { close(s.stopStarted) })
+
+	if s.releaseStop != nil {
+		select {
+		case <-s.releaseStop:
+		case <-req.Context().Done():
+			return
+		}
+	}
+
+	s.mu.Lock()
+	s.events = append(s.events, "stop")
+	s.mu.Unlock()
+	rw.WriteHeader(s.stopStatus)
+}
+
+func (s *gracefulStopTestServer) handleDisconnect(rw http.ResponseWriter, req *http.Request) {
+	s.checkSessionToken(req)
+	s.mu.Lock()
+	s.events = append(s.events, "disconnect")
+	s.mu.Unlock()
+	s.disconnectedOnce.Do(func() { close(s.disconnected) })
+	rw.WriteHeader(http.StatusOK)
+}
+
+func (s *gracefulStopTestServer) snapshot() (events []string, stopRequests []api.AgentStopRequest) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.events), slices.Clone(s.stopRequests)
+}
+
+func newGracefulStopTestWorker(t *testing.T, server *gracefulStopTestServer) (*AgentWorker, *logger.Buffer) {
+	t.Helper()
+
+	l := logger.NewBuffer()
+	return NewAgentWorker(
+		l,
+		&api.AgentRegisterResponse{
+			UUID:        "agent-id",
+			Name:        "agent-name",
+			AccessToken: gracefulStopTestSessionToken,
+			Endpoint:    server.URL,
+		},
+		metrics.NewCollector(logger.Discard, metrics.CollectorConfig{}),
+		api.NewClient(logger.Discard, api.Config{
+			Endpoint: server.URL,
+			Token:    "registration-token",
+		}),
+		AgentWorkerConfig{},
+	), l
+}
+
+func TestAgentWorker_ReportsGracefulStopBeforeDisconnect(t *testing.T) {
+	t.Parallel()
+
+	releaseStop := make(chan struct{})
+	server := newGracefulStopTestServer(t, http.StatusOK, releaseStop)
+	worker, _ := newGracefulStopTestWorker(t, server)
+
+	worker.StopGracefully()
+	worker.StopGracefully()
+	select {
+	case <-server.stopStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for graceful stop request")
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- worker.Disconnect(t.Context())
+	}()
+	select {
+	case <-server.disconnected:
+		t.Fatal("worker disconnected before graceful stop request completed")
+	case err := <-done:
+		t.Fatalf("Disconnect() returned before graceful stop request completed: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseStop)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Disconnect() error = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for agent worker to disconnect")
+	}
+
+	events, stopRequests := server.snapshot()
+	if got, want := events, []string{"stop", "disconnect"}; !slices.Equal(got, want) {
+		t.Errorf("request events = %v, want %v", got, want)
+	}
+	if got, want := len(stopRequests), 1; got != want {
+		t.Fatalf("graceful stop request count = %d, want %d", got, want)
+	}
+	if stopRequests[0].Force {
+		t.Error("graceful stop request Force = true, want false")
+	}
+}
+
+func TestAgentWorker_GracefulStopReportFailureDoesNotPreventDisconnect(t *testing.T) {
+	t.Parallel()
+
+	server := newGracefulStopTestServer(t, http.StatusInternalServerError, nil)
+	worker, l := newGracefulStopTestWorker(t, server)
+
+	worker.StopGracefully()
+	if err := worker.Disconnect(t.Context()); err != nil {
+		t.Fatalf("Disconnect() error = %v, want nil", err)
+	}
+
+	events, _ := server.snapshot()
+	if got, want := events, []string{"stop", "disconnect"}; !slices.Equal(got, want) {
+		t.Errorf("request events = %v, want %v", got, want)
+	}
+	if !slices.ContainsFunc(l.Messages, func(message string) bool {
+		return strings.Contains(message, "Failed to report graceful stop to Buildkite")
+	}) {
+		t.Errorf("log messages = %v, want graceful stop reporting warning", l.Messages)
+	}
+}
+
+func TestAgentWorker_DoesNotReportOtherStops(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		stop func(*AgentWorker)
+	}{
+		{
+			name: "ungraceful stop",
+			stop: (*AgentWorker).StopUngracefully,
+		},
+		{
+			name: "no stop requested",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newGracefulStopTestServer(t, http.StatusOK, nil)
+			worker, _ := newGracefulStopTestWorker(t, server)
+			if test.stop != nil {
+				test.stop(worker)
+			}
+
+			if err := worker.Disconnect(t.Context()); err != nil {
+				t.Fatalf("Disconnect() error = %v, want nil", err)
+			}
+
+			events, _ := server.snapshot()
+			if got, want := events, []string{"disconnect"}; !slices.Equal(got, want) {
+				t.Errorf("request events = %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/agent/agent_worker_test.go
+++ b/agent/agent_worker_test.go
@@ -66,11 +66,12 @@ func TestDisconnect(t *testing.T) {
 	}
 
 	worker := &AgentWorker{
-		logger:             l,
-		agent:              nil,
-		apiClient:          apiClient,
-		client:             client,
-		agentConfiguration: AgentConfiguration{},
+		logger:                 l,
+		agent:                  nil,
+		apiClient:              apiClient,
+		client:                 client,
+		agentConfiguration:     AgentConfiguration{},
+		reportGracefulStopDone: make(chan struct{}),
 	}
 
 	err := worker.Disconnect(t.Context())
@@ -121,11 +122,12 @@ func TestDisconnectRetry(t *testing.T) {
 	}
 
 	worker := &AgentWorker{
-		logger:             l,
-		agent:              nil,
-		apiClient:          apiClient,
-		client:             client,
-		agentConfiguration: AgentConfiguration{},
+		logger:                 l,
+		agent:                  nil,
+		apiClient:              apiClient,
+		client:                 client,
+		agentConfiguration:     AgentConfiguration{},
+		reportGracefulStopDone: make(chan struct{}),
 	}
 
 	err := worker.Disconnect(t.Context())


### PR DESCRIPTION
## Description

Backport of #4270 to v3. The only translation is changing the test imports from the v4 module path to v3; behavior is unchanged.

## Context

https://github.com/buildkite/agent/pull/4270

## Testing

- [ ] Tests have run locally (with `go test ./...`). The new agent tests pass, including with `-race`; the full suite fails in the unchanged `TestUpdateGitMirrorCreatesFromRemoteMirrorAndKeepsCanonicalOrigin` test because macOS doesn't preserve the setgid bit.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

Amp performed the backport, conflict resolution, v3 import translation, and validation.
