### PR TITLE
Set last hook exit status for unwrapped hooks

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -531,7 +531,10 @@ func (e *Executor) runUnwrappedHook(ctx context.Context, _ string, hookCfg HookC
 	environ.Set("BUILDKITE_HOOK_PATH", hookCfg.Path)
 	environ.Set("BUILDKITE_HOOK_SCOPE", hookCfg.Scope)
 
-	if err := e.shell.Command(hookCfg.Path).Run(ctx, shell.WithExtraEnv(environ)); err != nil {
+	err := e.shell.Command(hookCfg.Path).Run(ctx, shell.WithExtraEnv(environ))
+	// Store the last hook exit code for subsequent steps, matching wrapped shell hooks.
+	e.shell.Env.Set("BUILDKITE_LAST_HOOK_EXIT_STATUS", strconv.Itoa(shell.ExitCode(err)))
+	if err != nil {
 		return err
 	}
 	// Passing an empty env changes through because in polyglot hook we can't detect

--- a/internal/job/executor_test.go
+++ b/internal/job/executor_test.go
@@ -416,7 +416,7 @@ func TestRunUnwrappedHookSetsLastHookExitStatus(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			e := newCancelTestExecutor(t)
 			hookPath := filepath.Join(t.TempDir(), "hook")
-			hook := []byte(fmt.Sprintf("#!/bin/sh\nexit %d\n", test.exitStatus))
+			hook := []byte(fmt.Sprintf("#!/usr/bin/env python\nimport sys; sys.exit(%d)\n", test.exitStatus))
 			if err := os.WriteFile(hookPath, hook, 0o755); err != nil {
 				t.Fatalf("os.WriteFile(%q) error = %v", hookPath, err)
 			}

--- a/internal/job/executor_test.go
+++ b/internal/job/executor_test.go
@@ -139,41 +139,6 @@ func newCancelTestExecutor(t *testing.T) *Executor {
 	return e
 }
 
-func TestRunUnwrappedHookSetsLastHookExitStatus(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("script hooks aren't supported on Windows")
-	}
-
-	for _, test := range []struct {
-		name       string
-		exitStatus int
-	}{
-		{name: "success", exitStatus: 0},
-		{name: "failure", exitStatus: 7},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			e := newCancelTestExecutor(t)
-			hookPath := filepath.Join(t.TempDir(), "hook")
-			hook := []byte(fmt.Sprintf("#!/bin/sh\nexit %d\n", test.exitStatus))
-			if err := os.WriteFile(hookPath, hook, 0o755); err != nil {
-				t.Fatalf("os.WriteFile(%q) error = %v", hookPath, err)
-			}
-
-			err := e.runUnwrappedHook(t.Context(), "test hook", HookConfig{
-				Name: "test",
-				Path: hookPath,
-				Env:  e.shell.Env,
-			})
-			if got := shell.ExitCode(err); got != test.exitStatus {
-				t.Fatalf("shell.ExitCode(e.runUnwrappedHook()) = %d, want %d", got, test.exitStatus)
-			}
-			if got, ok := e.shell.Env.Get("BUILDKITE_LAST_HOOK_EXIT_STATUS"); !ok || got != strconv.Itoa(test.exitStatus) {
-				t.Errorf("BUILDKITE_LAST_HOOK_EXIT_STATUS = (%q, %v), want (%q, true)", got, ok, strconv.Itoa(test.exitStatus))
-			}
-		})
-	}
-}
-
 // TestSetUpGitLFSSkipSmudge is a regression test for #4041: setUp used to set
 // GIT_LFS_SKIP_SMUDGE=1 unconditionally, disabling git's default LFS smudge for
 // every job. It must only be set when LFS handling is enabled.
@@ -431,6 +396,41 @@ func TestConfigureRepositoryProviderGitCredentials(t *testing.T) {
 			hasRewrite := strings.Contains(config, "url.https://github.com/.insteadof=git@github.com:")
 			if hasRewrite != test.wantGitHubRewrite {
 				t.Errorf("GitHub rewrite present = %t, want %t\n%s", hasRewrite, test.wantGitHubRewrite, config)
+			}
+		})
+	}
+}
+
+func TestRunUnwrappedHookSetsLastHookExitStatus(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script hooks aren't supported on Windows")
+	}
+
+	for _, test := range []struct {
+		name       string
+		exitStatus int
+	}{
+		{name: "success", exitStatus: 0},
+		{name: "failure", exitStatus: 7},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			e := newCancelTestExecutor(t)
+			hookPath := filepath.Join(t.TempDir(), "hook")
+			hook := []byte(fmt.Sprintf("#!/bin/sh\nexit %d\n", test.exitStatus))
+			if err := os.WriteFile(hookPath, hook, 0o755); err != nil {
+				t.Fatalf("os.WriteFile(%q) error = %v", hookPath, err)
+			}
+
+			err := e.runUnwrappedHook(t.Context(), "test hook", HookConfig{
+				Name: "test",
+				Path: hookPath,
+				Env:  e.shell.Env,
+			})
+			if got := shell.ExitCode(err); got != test.exitStatus {
+				t.Fatalf("shell.ExitCode(e.runUnwrappedHook()) = %d, want %d", got, test.exitStatus)
+			}
+			if got, ok := e.shell.Env.Get("BUILDKITE_LAST_HOOK_EXIT_STATUS"); !ok || got != strconv.Itoa(test.exitStatus) {
+				t.Errorf("BUILDKITE_LAST_HOOK_EXIT_STATUS = (%q, %v), want (%q, true)", got, ok, strconv.Itoa(test.exitStatus))
 			}
 		})
 	}

--- a/internal/job/executor_test.go
+++ b/internal/job/executor_test.go
@@ -3,8 +3,11 @@ package job
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -134,6 +137,41 @@ func newCancelTestExecutor(t *testing.T) *Executor {
 	e.shell = sh
 
 	return e
+}
+
+func TestRunUnwrappedHookSetsLastHookExitStatus(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script hooks aren't supported on Windows")
+	}
+
+	for _, test := range []struct {
+		name       string
+		exitStatus int
+	}{
+		{name: "success", exitStatus: 0},
+		{name: "failure", exitStatus: 7},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			e := newCancelTestExecutor(t)
+			hookPath := filepath.Join(t.TempDir(), "hook")
+			hook := []byte(fmt.Sprintf("#!/bin/sh\nexit %d\n", test.exitStatus))
+			if err := os.WriteFile(hookPath, hook, 0o755); err != nil {
+				t.Fatalf("os.WriteFile(%q) error = %v", hookPath, err)
+			}
+
+			err := e.runUnwrappedHook(t.Context(), "test hook", HookConfig{
+				Name: "test",
+				Path: hookPath,
+				Env:  e.shell.Env,
+			})
+			if got := shell.ExitCode(err); got != test.exitStatus {
+				t.Fatalf("shell.ExitCode(e.runUnwrappedHook()) = %d, want %d", got, test.exitStatus)
+			}
+			if got, ok := e.shell.Env.Get("BUILDKITE_LAST_HOOK_EXIT_STATUS"); !ok || got != strconv.Itoa(test.exitStatus) {
+				t.Errorf("BUILDKITE_LAST_HOOK_EXIT_STATUS = (%q, %v), want (%q, true)", got, ok, strconv.Itoa(test.exitStatus))
+			}
+		})
+	}
 }
 
 // TestSetUpGitLFSSkipSmudge is a regression test for #4041: setUp used to set


### PR DESCRIPTION
## Description

Unwrapped hooks (non-shell scripts and binaries) currently do not update `BUILDKITE_LAST_HOOK_EXIT_STATUS`. This differs from wrapped shell hooks and can leave the variable unset or stale for subsequent hooks, even when the unwrapped hook succeeded.

Set the variable from the unwrapped process result so later hooks observe the same exit-status behavior regardless of hook type.

## Context

This surfaced after converting a plugin command hook from Bash to Python. Its pre-exit hook used `BUILDKITE_LAST_HOOK_EXIT_STATUS` to report the command result, but the value was no longer populated after the successful Python hook.

## Changes

- Set `BUILDKITE_LAST_HOOK_EXIT_STATUS` after running an unwrapped hook, using the same `shell.ExitCode` conversion as wrapped hooks.
- Add regression coverage for successful and failing unwrapped hooks.

## Testing

- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

Passed:

```text
go test ./internal/job -run '^TestRunUnwrappedHookSetsLastHookExitStatus$' -count=1
```

## Affiliation (optional, external contributors)

Instacart

## Disclosures / Credits

OpenAI Codex via Pi helped diagnose the behaviour, implement the change, and write the regression test. The PR was then reviewed and refined by a human.
