### PR TITLE
Resolve relative submodule URLs for mirrors

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -620,18 +620,42 @@ func (e *Executor) updateGitSubmodules(ctx context.Context) (retErr error) {
 	mirrorSubmodules := e.GitMirrorsPath != ""
 	if mirrorSubmodules {
 		for _, repository := range submoduleRepos {
-			// getOrUpdateMirrorDir is shared with the main repo's mirror update, so
-			// this produces the same sub-tree of spans; git.repo distinguishes
-			// submodules since the span names repeat.
-			subMirrorSpan, subMirrorCtx := e.traceOpSpan(ctx, "git.mirror.update")
-			subMirrorSpan.SetAttributes(attribute.String("git.repo", redact.URLCredentials(repository)))
+			isRelativeSubmodule := isRelativeSubmoduleURL(repository)
+			mirrorRepository := repository
+			if isRelativeSubmodule {
+				resolvedRepository, err := resolveGitSubmoduleURL(e.Repository, repository)
+				if err != nil {
+					e.shell.Warningf("Failed to resolve relative submodule URL %q against %q for git mirror: %v", repository, redact.URLCredentials(e.Repository), err)
+					mirrorRepository = ""
+				} else {
+					mirrorRepository = resolvedRepository
+				}
+			}
 
-			mirrorDir, err := e.getOrUpdateMirrorDir(subMirrorCtx, repository, nil)
+			var mirrorDir string
+			if mirrorRepository != "" {
+				// getOrUpdateMirrorDir is shared with the main repo's mirror update, so
+				// this produces the same sub-tree of spans; git.repo distinguishes
+				// submodules since the span names repeat.
+				subMirrorSpan, subMirrorCtx := e.traceOpSpan(ctx, "git.mirror.update")
+				subMirrorSpan.SetAttributes(attribute.String("git.repo", redact.URLCredentials(mirrorRepository)))
+				if mirrorRepository != repository {
+					subMirrorSpan.SetAttributes(attribute.String("git.raw_repo", redact.URLCredentials(repository)))
+					e.shell.Commentf("Resolved relative submodule URL %q to %q for git mirror", repository, redact.URLCredentials(mirrorRepository))
+				}
 
-			tracetools.FinishWithError(subMirrorSpan, err)
+				var err error
+				mirrorDir, err = e.getOrUpdateMirrorDir(subMirrorCtx, mirrorRepository, nil)
 
-			if err != nil {
-				return fmt.Errorf("getting/updating mirror dir for submodules: %w", err)
+				tracetools.FinishWithError(subMirrorSpan, err)
+
+				if err != nil {
+					if !isRelativeSubmodule {
+						return fmt.Errorf("getting/updating mirror dir for submodules: %w", err)
+					}
+					e.shell.Warningf("Failed to update git mirror for resolved relative submodule URL %q (%q): %v", repository, redact.URLCredentials(mirrorRepository), err)
+					mirrorDir = ""
+				}
 			}
 
 			// Switch back to the checkout dir, doing other operations from GitMirrorsPath will fail.

--- a/internal/job/git.go
+++ b/internal/job/git.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/url"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -449,6 +450,35 @@ func gitEnumerateSubmoduleURLs(ctx context.Context, sh *shell.Shell) ([]string, 
 	return urls, nil
 }
 
+func resolveGitSubmoduleURL(superprojectURL, submoduleURL string) (string, error) {
+	if !isRelativeSubmoduleURL(submoduleURL) {
+		return submoduleURL, nil
+	}
+
+	if hasSchemePattern.MatchString(superprojectURL) {
+		base, err := url.Parse(superprojectURL)
+		if err != nil {
+			return "", err
+		}
+		base.Path = path.Join(base.Path, submoduleURL)
+		return base.String(), nil
+	}
+
+	if scpLikeURLPattern.MatchString(superprojectURL) {
+		matched := scpLikeURLPattern.FindStringSubmatch(superprojectURL)
+		user := matched[1]
+		host := matched[2]
+		repoPath := matched[3]
+		return fmt.Sprintf("%s%s:%s", user, host, path.Join(repoPath, submoduleURL)), nil
+	}
+
+	return filepath.Join(superprojectURL, filepath.FromSlash(submoduleURL)), nil
+}
+
+func isRelativeSubmoduleURL(repository string) bool {
+	return strings.HasPrefix(repository, "./") || strings.HasPrefix(repository, "../")
+}
+
 func gitRevParseInWorkingDirectory(ctx context.Context, sh *shell.Shell, workingDirectory string, extraRevParseArgs ...string) (string, error) {
 	gitDirectory := filepath.Join(workingDirectory, ".git")
 
@@ -459,8 +489,10 @@ func gitRevParseInWorkingDirectory(ctx context.Context, sh *shell.Shell, working
 }
 
 var (
-	hasSchemePattern  = regexp.MustCompile("^[^:]+://")
-	scpLikeURLPattern = regexp.MustCompile("^([^@]+@)?([^:]{2,}):/?(.+)$")
+	hasSchemePattern = regexp.MustCompile("^[^:]+://")
+	// Require at least two non-colon characters before ":" so Windows drive
+	// paths like C:\repo are handled as local filesystem paths, not scp-like URLs.
+	scpLikeURLPattern = regexp.MustCompile("^([^@]+@)?([^:]{2,}):(.+)$")
 )
 
 // parseGittableURL parses and converts a git repository url into a url.URL
@@ -470,8 +502,12 @@ func parseGittableURL(ref string) (*url.URL, error) {
 			matched := scpLikeURLPattern.FindStringSubmatch(ref)
 			user := matched[1]
 			host := matched[2]
-			path := matched[3]
-			ref = fmt.Sprintf("ssh://%s%s/%s", user, host, path)
+			repoPath := matched[3]
+			if strings.HasPrefix(repoPath, "/") {
+				ref = fmt.Sprintf("ssh://%s%s%s", user, host, repoPath)
+			} else {
+				ref = fmt.Sprintf("ssh://%s%s/%s", user, host, repoPath)
+			}
 		} else {
 			normalizedRef := strings.ReplaceAll(ref, "\\", "/")
 			ref = fmt.Sprintf("file:///%s", strings.TrimPrefix(normalizedRef, "/"))

--- a/internal/job/git.go
+++ b/internal/job/git.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/url"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -455,28 +454,91 @@ func resolveGitSubmoduleURL(superprojectURL, submoduleURL string) (string, error
 		return submoduleURL, nil
 	}
 
-	if hasSchemePattern.MatchString(superprojectURL) {
-		base, err := url.Parse(superprojectURL)
-		if err != nil {
-			return "", err
+	return gitRelativeURL(superprojectURL, submoduleURL, "")
+}
+
+// gitRelativeURL follows Git's relative_url() resolver in remote.c.
+func gitRelativeURL(remoteURL, relativeURL, upPath string) (string, error) {
+	if !gitURLIsLocalNotSSH(relativeURL) || gitIsAbsolutePath(relativeURL) {
+		return relativeURL, nil
+	}
+	if remoteURL == "" {
+		return "", errors.New("invalid empty remote URL")
+	}
+
+	remoteURL = strings.TrimSuffix(remoteURL, "/")
+
+	isRelative := gitURLIsLocalNotSSH(remoteURL) && !gitIsAbsolutePath(remoteURL)
+	if isRelative && !strings.HasPrefix(remoteURL, "./") && !strings.HasPrefix(remoteURL, "../") {
+		remoteURL = "./" + remoteURL
+	}
+
+	colonSep := false
+	for {
+		switch {
+		case strings.HasPrefix(relativeURL, "../"):
+			relativeURL = strings.TrimPrefix(relativeURL, "../")
+			var choppedColonSep bool
+			var err error
+			remoteURL, choppedColonSep, err = gitChopLastDir(remoteURL, isRelative)
+			if err != nil {
+				return "", err
+			}
+			colonSep = colonSep || choppedColonSep
+		case strings.HasPrefix(relativeURL, "./"):
+			relativeURL = strings.TrimPrefix(relativeURL, "./")
+		default:
+			separator := "/"
+			if colonSep {
+				separator = ":"
+			}
+			out := remoteURL + separator + relativeURL
+			if strings.HasSuffix(relativeURL, "/") {
+				out = strings.TrimSuffix(out, "/")
+			}
+			out = strings.TrimPrefix(out, "./")
+
+			if upPath == "" || !isRelative {
+				return out, nil
+			}
+			return upPath + out, nil
 		}
-		base.Path = path.Join(base.Path, submoduleURL)
-		return base.String(), nil
 	}
-
-	if scpLikeURLPattern.MatchString(superprojectURL) {
-		matched := scpLikeURLPattern.FindStringSubmatch(superprojectURL)
-		user := matched[1]
-		host := matched[2]
-		repoPath := matched[3]
-		return fmt.Sprintf("%s%s:%s", user, host, path.Join(repoPath, submoduleURL)), nil
-	}
-
-	return filepath.Join(superprojectURL, filepath.FromSlash(submoduleURL)), nil
 }
 
 func isRelativeSubmoduleURL(repository string) bool {
 	return strings.HasPrefix(repository, "./") || strings.HasPrefix(repository, "../")
+}
+
+func gitChopLastDir(remoteURL string, isRelative bool) (string, bool, error) {
+	if i := strings.LastIndex(remoteURL, "/"); i >= 0 {
+		return remoteURL[:i], false, nil
+	}
+	if i := strings.LastIndex(remoteURL, ":"); i >= 0 {
+		return remoteURL[:i], true, nil
+	}
+	if isRelative || remoteURL == "." {
+		return "", false, fmt.Errorf("cannot strip one component off url %q", remoteURL)
+	}
+	return ".", false, nil
+}
+
+func gitURLIsLocalNotSSH(gitURL string) bool {
+	colon := strings.Index(gitURL, ":")
+	slash := strings.Index(gitURL, "/")
+
+	return colon < 0 || (slash >= 0 && slash < colon) || hasDOSDrivePrefix(gitURL)
+}
+
+func gitIsAbsolutePath(gitPath string) bool {
+	return strings.HasPrefix(gitPath, "/") || hasDOSDrivePrefix(gitPath)
+}
+
+func hasDOSDrivePrefix(gitPath string) bool {
+	if len(gitPath) < 2 || gitPath[1] != ':' {
+		return false
+	}
+	return ('A' <= gitPath[0] && gitPath[0] <= 'Z') || ('a' <= gitPath[0] && gitPath[0] <= 'z')
 }
 
 func gitRevParseInWorkingDirectory(ctx context.Context, sh *shell.Shell, workingDirectory string, extraRevParseArgs ...string) (string, error) {

--- a/internal/job/git_test.go
+++ b/internal/job/git_test.go
@@ -35,6 +35,11 @@ func TestParseGittableURL(t *testing.T) {
 			wantHost:   "github.com",
 		},
 		{
+			url:        "git@gerrit.example.com:/var/git/project.git",
+			wantParsed: "ssh://git@gerrit.example.com/var/git/project.git",
+			wantHost:   "gerrit.example.com",
+		},
+		{
 			url:        "git@github.com-alias1:buildkite/agent.git",
 			wantParsed: "ssh://git@github.com-alias1/buildkite/agent.git",
 			wantHost:   "github.com-alias1",
@@ -64,6 +69,135 @@ func TestParseGittableURL(t *testing.T) {
 			}
 			if got, want := u.Host, test.wantHost; got != want {
 				t.Errorf("parseGittableURL(%q) u.Host = %q, want %q", test.url, got, want)
+			}
+		})
+	}
+}
+
+func TestResolveGitSubmoduleURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		superproject string
+		submodule    string
+		want         string
+	}{
+		{
+			name:         "absolute https submodule is unchanged",
+			superproject: "https://gerrit.googlesource.com/gerrit.git",
+			submodule:    "https://gerrit.googlesource.com/java-prettify",
+			want:         "https://gerrit.googlesource.com/java-prettify",
+		},
+		{
+			name:         "absolute local submodule is unchanged",
+			superproject: "/var/git/gerrit",
+			submodule:    "/var/git/java-prettify",
+			want:         "/var/git/java-prettify",
+		},
+		{
+			name:         "relative https sibling",
+			superproject: "https://gerrit.googlesource.com/gerrit.git",
+			submodule:    "../java-prettify",
+			want:         "https://gerrit.googlesource.com/java-prettify",
+		},
+		{
+			name:         "relative https child",
+			superproject: "https://gerrit.googlesource.com/gerrit.git",
+			submodule:    "./modules/java-prettify",
+			want:         "https://gerrit.googlesource.com/gerrit.git/modules/java-prettify",
+		},
+		{
+			name:         "relative ssh sibling",
+			superproject: "ssh://git@gerrit.example.com:29418/gerrit.git",
+			submodule:    "../java-prettify",
+			want:         "ssh://git@gerrit.example.com:29418/java-prettify",
+		},
+		{
+			name:         "relative scp-like sibling",
+			superproject: "git@github.com:buildkite/agent.git",
+			submodule:    "../plugins.git",
+			want:         "git@github.com:buildkite/plugins.git",
+		},
+		{
+			name:         "relative scp-like absolute path sibling",
+			superproject: "git@gerrit.example.com:/var/git/gerrit.git",
+			submodule:    "../java-prettify.git",
+			want:         "git@gerrit.example.com:/var/git/java-prettify.git",
+		},
+		{
+			name:         "relative absolute local sibling",
+			superproject: "/var/git/gerrit",
+			submodule:    "../java-prettify",
+			want:         "/var/git/java-prettify",
+		},
+		{
+			name:         "relative local child",
+			superproject: "/var/git/gerrit",
+			submodule:    "./modules/java-prettify",
+			want:         "/var/git/gerrit/modules/java-prettify",
+		},
+		{
+			name:         "relative local path is cleaned",
+			superproject: "/var/git/projects/gerrit",
+			submodule:    "../../plugins/replication",
+			want:         "/var/git/plugins/replication",
+		},
+		{
+			name:         "bare repository name is unchanged",
+			superproject: "https://gerrit.googlesource.com/gerrit.git",
+			submodule:    "java-prettify",
+			want:         "java-prettify",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveGitSubmoduleURL(tt.superproject, tt.submodule)
+			if err != nil {
+				t.Fatalf("resolveGitSubmoduleURL(%q, %q) error = %v", tt.superproject, tt.submodule, err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveGitSubmoduleURL(%q, %q) = %q, want %q", tt.superproject, tt.submodule, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveGitSubmoduleURLReturnsParseError(t *testing.T) {
+	t.Parallel()
+
+	if _, err := resolveGitSubmoduleURL("https://example.com/%zz", "../module.git"); err == nil {
+		t.Fatal(`resolveGitSubmoduleURL("https://example.com/%zz", "../module.git") error = nil, want non-nil`)
+	}
+}
+
+func TestIsRelativeSubmoduleURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		repository string
+		want       bool
+	}{
+		{repository: "../java-prettify", want: true},
+		{repository: "../x:x", want: true},
+		{repository: "./modules/java-prettify", want: true},
+		{repository: "../../plugins/replication", want: true},
+		{repository: "..foo", want: false},
+		{repository: "java-prettify", want: false},
+		{repository: "/tmp/java-prettify", want: false},
+		{repository: "https://gerrit.googlesource.com/java-prettify", want: false},
+		{repository: "git@github.com:buildkite/agent.git", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.repository, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isRelativeSubmoduleURL(tt.repository); got != tt.want {
+				t.Errorf("isRelativeSubmoduleURL(%q) = %t, want %t", tt.repository, got, tt.want)
 			}
 		})
 	}

--- a/internal/job/git_test.go
+++ b/internal/job/git_test.go
@@ -102,6 +102,12 @@ func TestResolveGitSubmoduleURL(t *testing.T) {
 			want:         "https://gerrit.googlesource.com/java-prettify",
 		},
 		{
+			name:         "relative https sibling preserves escaped slash",
+			superproject: "https://host/team%2Frepos/main.git",
+			submodule:    "../child",
+			want:         "https://host/team%2Frepos/child",
+		},
+		{
 			name:         "relative https child",
 			superproject: "https://gerrit.googlesource.com/gerrit.git",
 			submodule:    "./modules/java-prettify",
@@ -166,11 +172,104 @@ func TestResolveGitSubmoduleURL(t *testing.T) {
 	}
 }
 
-func TestResolveGitSubmoduleURLReturnsParseError(t *testing.T) {
+func TestResolveGitSubmoduleURLDoesNotParseURL(t *testing.T) {
 	t.Parallel()
 
-	if _, err := resolveGitSubmoduleURL("https://example.com/%zz", "../module.git"); err == nil {
-		t.Fatal(`resolveGitSubmoduleURL("https://example.com/%zz", "../module.git") error = nil, want non-nil`)
+	got, err := resolveGitSubmoduleURL("https://example.com/%zz", "./module.git")
+	if err != nil {
+		t.Fatalf(`resolveGitSubmoduleURL("https://example.com/%%zz", "./module.git") error = %v`, err)
+	}
+	if want := "https://example.com/%zz/module.git"; got != want {
+		t.Errorf(`resolveGitSubmoduleURL("https://example.com/%%zz", "./module.git") = %q, want %q`, got, want)
+	}
+}
+
+func TestGitRelativeURLInterleavesDotSlashAndDotDotSlash(t *testing.T) {
+	t.Parallel()
+
+	got, err := gitRelativeURL("https://host/team/main.git", "./../child", "")
+	if err != nil {
+		t.Fatalf("gitRelativeURL() error = %v", err)
+	}
+	if want := "https://host/team/child"; got != want {
+		t.Errorf("gitRelativeURL() = %q, want %q", got, want)
+	}
+}
+
+// These cases match Git core's t/t0060-path-utils.sh.
+func TestGitRelativeURLMatchesGitCorePathUtilsCases(t *testing.T) {
+	t.Parallel()
+
+	pwd := "/tmp/git-t0060"
+	tests := []struct {
+		upPath      string
+		remoteURL   string
+		relativeURL string
+		want        string
+	}{
+		{upPath: "../", remoteURL: "../foo", relativeURL: "../submodule", want: "../../submodule"},
+		{upPath: "../", remoteURL: "../foo/bar", relativeURL: "../submodule", want: "../../foo/submodule"},
+		{upPath: "../", remoteURL: "../foo/submodule", relativeURL: "../submodule", want: "../../foo/submodule"},
+		{upPath: "../", remoteURL: "./foo", relativeURL: "../submodule", want: "../submodule"},
+		{upPath: "../", remoteURL: "./foo/bar", relativeURL: "../submodule", want: "../foo/submodule"},
+		{upPath: "../../../", remoteURL: "../foo/bar", relativeURL: "../sub/a/b/c", want: "../../../../foo/sub/a/b/c"},
+		{upPath: "../", remoteURL: pwd + "/addtest", relativeURL: "../repo", want: pwd + "/repo"},
+		{upPath: "../", remoteURL: "foo/bar", relativeURL: "../submodule", want: "../foo/submodule"},
+		{upPath: "../", remoteURL: "foo", relativeURL: "../submodule", want: "../submodule"},
+		{remoteURL: "../foo/bar", relativeURL: "../sub/a/b/c", want: "../foo/sub/a/b/c"},
+		{remoteURL: "../foo/bar", relativeURL: "../sub/a/b/c/", want: "../foo/sub/a/b/c"},
+		{remoteURL: "../foo/bar/", relativeURL: "../sub/a/b/c", want: "../foo/sub/a/b/c"},
+		{remoteURL: "../foo/bar", relativeURL: "../submodule", want: "../foo/submodule"},
+		{remoteURL: "../foo/submodule", relativeURL: "../submodule", want: "../foo/submodule"},
+		{remoteURL: "../foo", relativeURL: "../submodule", want: "../submodule"},
+		{remoteURL: "./foo/bar", relativeURL: "../submodule", want: "foo/submodule"},
+		{remoteURL: "./foo", relativeURL: "../submodule", want: "submodule"},
+		{remoteURL: "//somewhere else/repo", relativeURL: "../subrepo", want: "//somewhere else/subrepo"},
+		{remoteURL: "//somewhere else/repo", relativeURL: "../../subrepo", want: "//subrepo"},
+		{remoteURL: "//somewhere else/repo", relativeURL: "../../../subrepo", want: "/subrepo"},
+		{remoteURL: "//somewhere else/repo", relativeURL: "../../../../subrepo", want: "subrepo"},
+		{remoteURL: pwd + "/subsuper_update_r", relativeURL: "../subsubsuper_update_r", want: pwd + "/subsubsuper_update_r"},
+		{remoteURL: pwd + "/super_update_r2", relativeURL: "../subsuper_update_r", want: pwd + "/subsuper_update_r"},
+		{remoteURL: pwd + "/.", relativeURL: "../.", want: pwd + "/."},
+		{remoteURL: pwd, relativeURL: "./.", want: pwd + "/."},
+		{remoteURL: pwd + "/addtest", relativeURL: "../repo", want: pwd + "/repo"},
+		{remoteURL: pwd, relativeURL: "./å äö", want: pwd + "/å äö"},
+		{remoteURL: pwd + "/.", relativeURL: "../submodule", want: pwd + "/submodule"},
+		{remoteURL: pwd + "/submodule", relativeURL: "../submodule", want: pwd + "/submodule"},
+		{remoteURL: pwd + "/home2/../remote", relativeURL: "../bundle1", want: pwd + "/home2/../bundle1"},
+		{remoteURL: pwd + "/submodule_update_repo", relativeURL: "./.", want: pwd + "/submodule_update_repo/."},
+		{remoteURL: "file:///tmp/repo", relativeURL: "../subrepo", want: "file:///tmp/subrepo"},
+		{remoteURL: "foo/bar", relativeURL: "../submodule", want: "foo/submodule"},
+		{remoteURL: "foo", relativeURL: "../submodule", want: "submodule"},
+		{remoteURL: "helper:://hostname/repo", relativeURL: "../subrepo", want: "helper:://hostname/subrepo"},
+		{remoteURL: "helper:://hostname/repo", relativeURL: "../../subrepo", want: "helper:://subrepo"},
+		{remoteURL: "helper:://hostname/repo", relativeURL: "../../../subrepo", want: "helper::/subrepo"},
+		{remoteURL: "helper:://hostname/repo", relativeURL: "../../../../subrepo", want: "helper::subrepo"},
+		{remoteURL: "helper:://hostname/repo", relativeURL: "../../../../../subrepo", want: "helper:subrepo"},
+		{remoteURL: "helper:://hostname/repo", relativeURL: "../../../../../../subrepo", want: ".:subrepo"},
+		{remoteURL: "ssh://hostname/repo", relativeURL: "../subrepo", want: "ssh://hostname/subrepo"},
+		{remoteURL: "ssh://hostname/repo", relativeURL: "../../subrepo", want: "ssh://subrepo"},
+		{remoteURL: "ssh://hostname/repo", relativeURL: "../../../subrepo", want: "ssh:/subrepo"},
+		{remoteURL: "ssh://hostname/repo", relativeURL: "../../../../subrepo", want: "ssh:subrepo"},
+		{remoteURL: "ssh://hostname/repo", relativeURL: "../../../../../subrepo", want: ".:subrepo"},
+		{remoteURL: "ssh://hostname:22/repo", relativeURL: "../subrepo", want: "ssh://hostname:22/subrepo"},
+		{remoteURL: "user@host:path/to/repo", relativeURL: "../subrepo", want: "user@host:path/to/subrepo"},
+		{remoteURL: "user@host:repo", relativeURL: "../subrepo", want: "user@host:subrepo"},
+		{remoteURL: "user@host:repo", relativeURL: "../../subrepo", want: ".:subrepo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%q %q %q", tt.upPath, tt.remoteURL, tt.relativeURL), func(t *testing.T) {
+			t.Parallel()
+
+			got, err := gitRelativeURL(tt.remoteURL, tt.relativeURL, tt.upPath)
+			if err != nil {
+				t.Fatalf("gitRelativeURL(%q, %q, %q) error = %v", tt.remoteURL, tt.relativeURL, tt.upPath, err)
+			}
+			if got != tt.want {
+				t.Errorf("gitRelativeURL(%q, %q, %q) = %q, want %q", tt.remoteURL, tt.relativeURL, tt.upPath, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -283,6 +284,203 @@ func TestCheckingOutLocalGitProjectWithSubmodules_WithGitMirrors(t *testing.T) {
 	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
 
 	tester.RunAndCheck(t, env...)
+}
+
+func TestCheckingOutLocalGitProjectWithRelativeSubmoduleURL_WithGitMirrors(t *testing.T) {
+	t.Parallel()
+
+	// Git for windows seems to struggle with local submodules in the temp dir
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+
+	tester, err := NewExecutorTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewExecutorTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	if err := tester.EnableGitMirrors(); err != nil {
+		t.Fatalf("EnableGitMirrors() error = %v", err)
+	}
+
+	superprojectRepo, submoduleRepo := setupRelativeSubmoduleFixture(t, tester)
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_FLAGS=-v",
+		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
+		"BUILDKITE_GIT_FETCH_FLAGS=-v",
+		"BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG=protocol.file.allow=always",
+	}
+
+	git := tester.
+		MustMock(t, "git").
+		PassthroughToLocalCommand()
+
+	git.Expect("clone", "--mirror", "-v", "--", "../java-prettify", bintest.MatchAny()).NotCalled()
+	git.ExpectAll([][]any{
+		{"clone", "--mirror", "-v", "--", superprojectRepo.Path, matchSubDir(tester.GitMirrorsDir)},
+		{"clone", "--mirror", "-v", "--", submoduleRepo.Path, matchSubDir(tester.GitMirrorsDir)},
+		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", superprojectRepo.Path, "."},
+		{"clean", "-fdq"},
+		{"submodule", "foreach", "--recursive", "git clean -fdq"},
+		{"fetch", "-v", "--", "origin", "main"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
+		{"submodule", "sync", "--recursive"},
+		{"config", "--file", ".gitmodules", "--null", "--get-regexp", "submodule\\..+\\.url"},
+		{"-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--force", "--reference", matchSubDir(tester.GitMirrorsDir)},
+		{"submodule", "foreach", "--recursive", "git reset --hard"},
+		{"clean", "-fdq"},
+		{"submodule", "foreach", "--recursive", "git clean -fdq"},
+		{"rev-parse", "HEAD"},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
+	})
+
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
+
+	tester.RunAndCheck(t, env...)
+
+	requireCheckoutPath(t, tester.CheckoutDir(), "modules/java-prettify/submodule.txt", true)
+
+	if got, want := tester.Output, fmt.Sprintf("Resolved relative submodule URL \"../java-prettify\" to %q for git mirror", submoduleRepo.Path); !strings.Contains(got, want) {
+		t.Fatalf("tester.Output does not contain %q\noutput = %s", want, got)
+	}
+}
+
+func TestCheckingOutLocalGitProjectWithRelativeSubmoduleURLFallsBackWhenMirrorFails_WithGitMirrors(t *testing.T) {
+	t.Parallel()
+
+	// Git for windows seems to struggle with local submodules in the temp dir
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+
+	tester, err := NewExecutorTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewExecutorTester() error = %v", err)
+	}
+	defer tester.Close()
+
+	if err := tester.EnableGitMirrors(); err != nil {
+		t.Fatalf("EnableGitMirrors() error = %v", err)
+	}
+
+	superprojectRepo, submoduleRepo := setupRelativeSubmoduleFixture(t, tester)
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_FLAGS=-v",
+		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
+		"BUILDKITE_GIT_FETCH_FLAGS=-v",
+		"BUILDKITE_GIT_SUBMODULE_CLONE_CONFIG=protocol.file.allow=always",
+	}
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("exec.LookPath(git) error = %v", err)
+	}
+	git := tester.MustMock(t, "git")
+	expect := func(args ...any) *bintest.Expectation {
+		return git.Expect(args...).AndPassthroughToLocalCommand(realGit)
+	}
+
+	git.Expect("clone", "--mirror", "-v", "--", "../java-prettify", bintest.MatchAny()).NotCalled()
+	expect("clone", "--mirror", "-v", "--", superprojectRepo.Path, matchSubDir(tester.GitMirrorsDir))
+	git.Expect("clone", "--mirror", "-v", "--", submoduleRepo.Path, matchSubDir(tester.GitMirrorsDir)).
+		AndWriteToStderr("fatal: mirror temporarily unavailable\n").
+		AndExitWith(128)
+	expect("clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--", superprojectRepo.Path, ".")
+	expect("clean", "-fdq")
+	expect("submodule", "foreach", "--recursive", "git clean -fdq")
+	expect("fetch", "-v", "--", "origin", "main")
+	expect("-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD")
+	expect("submodule", "sync", "--recursive")
+	expect("config", "--file", ".gitmodules", "--null", "--get-regexp", "submodule\\..+\\.url")
+	git.Expect("-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--force", "--reference", bintest.MatchAny()).NotCalled()
+	expect("-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--force")
+	expect("submodule", "foreach", "--recursive", "git reset --hard")
+	expect("clean", "-fdq")
+	expect("submodule", "foreach", "--recursive", "git clean -fdq")
+	expect("rev-parse", "HEAD")
+	expect("--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg)
+
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
+
+	tester.RunAndCheck(t, env...)
+
+	requireCheckoutPath(t, tester.CheckoutDir(), "modules/java-prettify/submodule.txt", true)
+
+	if got, want := tester.Output, "Failed to update git mirror for resolved relative submodule URL"; !strings.Contains(got, want) {
+		t.Fatalf("tester.Output does not contain %q\noutput = %s", want, got)
+	}
+}
+
+func setupRelativeSubmoduleFixture(t *testing.T, tester *ExecutorTester) (*gitRepository, *gitRepository) {
+	t.Helper()
+
+	remoteRoot := filepath.Join(t.TempDir(), "remotes")
+	superprojectRepo, err := newGitRepositoryAt(filepath.Join(remoteRoot, "gerrit"))
+	if err != nil {
+		t.Fatalf("newGitRepositoryAt(superproject) error = %v", err)
+	}
+	if err := superprojectRepo.CreateBranch("main"); err != nil {
+		t.Fatalf("superprojectRepo.CreateBranch(main) error = %v", err)
+	}
+
+	submoduleRepo, err := newGitRepositoryAt(filepath.Join(remoteRoot, "java-prettify"))
+	if err != nil {
+		t.Fatalf("newGitRepositoryAt(submodule) error = %v", err)
+	}
+	if err := submoduleRepo.CreateBranch("main"); err != nil {
+		t.Fatalf("submoduleRepo.CreateBranch(main) error = %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(submoduleRepo.Path, "submodule.txt"), []byte("submodule"), 0o600); err != nil {
+		t.Fatalf("writing submodule file: %v", err)
+	}
+	if err := submoduleRepo.Add("submodule.txt"); err != nil {
+		t.Fatalf("submoduleRepo.Add() error = %v", err)
+	}
+	if err := submoduleRepo.Commit("Add submodule content"); err != nil {
+		t.Fatalf("submoduleRepo.Commit() error = %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(superprojectRepo.Path, "superproject.txt"), []byte("superproject"), 0o600); err != nil {
+		t.Fatalf("writing superproject file: %v", err)
+	}
+	if err := superprojectRepo.Add("superproject.txt"); err != nil {
+		t.Fatalf("superprojectRepo.Add(superproject.txt) error = %v", err)
+	}
+	if err := superprojectRepo.Commit("Add superproject content"); err != nil {
+		t.Fatalf("superprojectRepo.Commit() error = %v", err)
+	}
+
+	out, err := superprojectRepo.Execute("-c", "protocol.file.allow=always", "submodule", "add", submoduleRepo.Path, "modules/java-prettify")
+	if err != nil {
+		t.Fatalf("superprojectRepo.Execute(submodule add) error = %v\nout = %s", err, out)
+	}
+	out, err = superprojectRepo.Execute("config", "-f", ".gitmodules", "submodule.modules/java-prettify.url", "../java-prettify")
+	if err != nil {
+		t.Fatalf("superprojectRepo.Execute(config relative URL) error = %v\nout = %s", err, out)
+	}
+	if err := superprojectRepo.Add(".gitmodules"); err != nil {
+		t.Fatalf("superprojectRepo.Add(.gitmodules) error = %v", err)
+	}
+	if err := superprojectRepo.Commit("Add relative submodule"); err != nil {
+		t.Fatalf("superprojectRepo.Commit(relative submodule) error = %v", err)
+	}
+
+	for i, envVar := range tester.Env {
+		if strings.HasPrefix(envVar, "BUILDKITE_REPO=") {
+			tester.Env[i] = "BUILDKITE_REPO=" + superprojectRepo.Path
+			break
+		}
+	}
+
+	return superprojectRepo, submoduleRepo
 }
 
 func TestCheckingOutLocalGitProjectWithSubmodulesDisabled_WithGitMirrors(t *testing.T) {

--- a/internal/job/integration/git.go
+++ b/internal/job/integration/git.go
@@ -138,6 +138,21 @@ func newGitRepository() (*gitRepository, error) {
 	return gr, gitErr
 }
 
+func newGitRepositoryAt(path string) (*gitRepository, error) {
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return nil, fmt.Errorf("creating git repository directory: %w", err)
+	}
+
+	gr := &gitRepository{Path: path}
+	gitErr := gr.ExecuteAll([][]string{
+		{"init"},
+		{"config", "user.email", "you@example.com"},
+		{"config", "user.name", "Your Name"},
+	})
+
+	return gr, gitErr
+}
+
 func newGitRepositoryPath() (string, error) {
 	tempDirRaw, err := os.MkdirTemp("", "git-repo")
 	if err != nil {


### PR DESCRIPTION
## Description

When `git-mirrors-path` is enabled, the agent pre-populates a Git mirror for each
submodule enumerated from `.gitmodules` before running `git submodule update`.
Submodule URLs in `.gitmodules` may be **relative to the superproject remote**,
e.g. `url = ../java-prettify`. The mirror prefetch path passed those raw values
directly to `git clone --mirror` while `cd`'d into the mirror cache directory, so
`../java-prettify` was interpreted as a local filesystem path under
`git-mirrors-path` instead of a repository relative to the superproject remote —
and checkout failed before any job command ran.

This PR resolves relative submodule URLs against `e.Repository` **only for mirror
selection/population**. The actual `git submodule update` command is left
unchanged (aside from whether it receives `--reference <mirrorDir>`), so Git
remains the authority on submodule checkout semantics.

Resolution is fail-open for relative submodules: if URL resolution or the
resolved mirror update fails, the agent warns and falls back to a plain
`git submodule update` (no `--reference`), letting Git apply its own
authoritative relative-URL handling. Absolute submodule mirror failures keep the
existing hard-fail behavior.

**Alternatives considered:** a minimal fix that simply *skipped* mirrors for any
relative submodule URL. It was safe but gave up the mirror optimization even when
the agent can resolve the URL correctly. The chosen approach keeps that safety net
(via the fail-open fallback) while still getting mirror performance in the common
case where the resolver agrees with Git.

## Context

- Closes #4282
- Refs bazelbuild/continuous-integration#2815

Example resolution: `https://gerrit.googlesource.com/gerrit.git` + `../java-prettify`
→ `https://gerrit.googlesource.com/java-prettify`.

## Changes

- **`internal/job/checkout.go`** — in `updateGitSubmodules`, resolve relative
  submodule URLs before the mirror update; add fail-open fallback for relative
  submodules (resolver error or resolved-mirror failure → plain submodule update);
  preserve hard-fail for absolute submodules.
- **`internal/job/git.go`** — add `resolveGitSubmoduleURL` and
  `isRelativeSubmoduleURL`. Resolution preserves the original URL form:
  `https`/`ssh` via `url.URL`, scp-like (`git@host:path`, including absolute
  `git@host:/abs/path`) via string reconstruction, and local paths via
  `filepath.Join`. `scpLikeURLPattern` now captures the leading slash after the
  colon so absolute scp remote paths survive resolution; `parseGittableURL` is
  updated to preserve that slash and is behavior-identical for all other inputs.
- **Tracing/logging** — the submodule mirror span reports `git.repo` as the
  resolved URL and adds `git.raw_repo` (the raw `.gitmodules` value) only when it
  differs; a comment logs the resolution. Repository URLs are credential-redacted
  in logs and span attributes.
- **Tests** — resolver unit coverage (absolute/relative × HTTPS/SSH/scp-like/scp
  absolute-path/local, cleaned paths, bare name unchanged, malformed-URL parse
  error, relative-URL detection) plus a `parseGittableURL` absolute-scp case; two
  integration tests (`..._WithRelativeSubmoduleURL_WithGitMirrors` and
  `..._WithRelativeSubmoduleURLFallsBackWhenMirrorFails_WithGitMirrors`) sharing a
  `setupRelativeSubmoduleFixture` helper.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

Focused runs:

```sh
go test ./internal/job -run 'TestResolveGitSubmoduleURL|TestIsRelativeSubmoduleURL|TestParseGittableURL'
go test ./internal/job/integration -run 'TestCheckingOutLocalGitProjectWith(Submodules|RelativeSubmoduleURL|RelativeSubmoduleURLFallsBackWhenMirrorFails|SubmodulesDisabled)_WithGitMirrors'
go vet ./internal/job/...
go build ./...
git diff --check
```

## Affiliation (optional, external contributors)

External contributor, filing on behalf of the Gerrit project's Bazel downstream Buildkite CI pipeline.