### PR TITLE
Prepare v4 for stable release

### DIFF
--- a/.buildkite/pipeline.release-experimental.yml
+++ b/.buildkite/pipeline.release-experimental.yml
@@ -50,39 +50,6 @@ steps:
           volumes:
             - "/yum.buildkite.com"
 
-  - group: ":redhat: Publish Edge RPM Package to Buildkite Packages"
-    steps:
-      - name: ":redhat: Publish Edge {{matrix.pkg_arch}} RPM Package to Buildkite Packages"
-        plugins:
-          - publish-to-packages#v2.2.0:
-              artifacts: "rpm/buildkite-agent_*_{{matrix.pkg_arch}}.rpm"
-              registry: "buildkite/agent-rpm-experimental"
-              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
-              attestations:
-                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
-                - "buildkite-agent-rpm-packages.package-attestation.json"
-        soft_fail: true
-        matrix:
-          setup:
-            go_arch:
-              - "amd64"
-              - "386"
-              - "arm64"
-              - "ppc64"
-              - "ppc64le"
-              - "riscv64"
-            pkg_arch:
-              - "SKIP_FAKE_ARCH"
-          adjustments:
-            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
-            - with: { go_arch: "386", pkg_arch: "i386" }
-            - with: { go_arch: "arm64", pkg_arch: "aarch64" }
-            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
-            - with: { go_arch: "ppc64le", pkg_arch: "ppc64le" }
-            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
-            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
-              skip: true
-
   - name: ":debian: Publish Edge Debian Package"
     command: ".buildkite/steps/publish-debian-package.sh"
     env:
@@ -113,43 +80,6 @@ steps:
       automatic:
         - exit_status: 1
           limit: 3
-
-  - group: ":debian: Publish Edge Debian Package to Buildkite Packages"
-    steps:
-      - name: ":debian: Publish Edge {{matrix.pkg_arch}} Debian Package to Buildkite Packages"
-        plugins:
-          - publish-to-packages#v2.2.0:
-              artifacts: "deb/buildkite-agent_*_{{matrix.pkg_arch}}.deb"
-              registry: "buildkite/agent-deb-experimental"
-              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
-              attestations:
-                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
-                - "buildkite-agent-debian-packages.package-attestation.json"
-        soft_fail: true
-        matrix:
-          setup:
-            go_arch:
-              - "amd64"
-              - "386"
-              - "arm"
-              - "armhf"
-              - "arm64"
-              - "ppc64"
-              - "ppc64le"
-              - "riscv64"
-            pkg_arch:
-              - "SKIP_FAKE_ARCH"
-          adjustments:
-            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
-            - with: { go_arch: "386", pkg_arch: "i386" }
-            - with: { go_arch: "arm", pkg_arch: "arm" }
-            - with: { go_arch: "armhf", pkg_arch: "armhf" }
-            - with: { go_arch: "arm64", pkg_arch: "arm64" }
-            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
-            - with: { go_arch: "ppc64le", pkg_arch: "ppc64el" }
-            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
-            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
-              skip: true
 
   - group: ":docker: Publish Edge Docker Images"
     steps:

--- a/.buildkite/pipeline.release-oldstable.yml
+++ b/.buildkite/pipeline.release-oldstable.yml
@@ -78,39 +78,6 @@ steps:
         - exit_status: 1
           limit: 3
 
-  - group: ":redhat: Publish Oldstable RPM Package to Buildkite Packages"
-    steps:
-      - name: ":redhat: Publish Oldstable {{matrix.pkg_arch}} RPM Package to Buildkite Packages"
-        plugins:
-          - publish-to-packages#v2.2.0:
-              artifacts: "rpm/buildkite-agent_*_{{matrix.pkg_arch}}.rpm"
-              registry: "buildkite/agent-rpm-oldstable"
-              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
-              attestations:
-                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
-                - "buildkite-agent-rpm-packages.package-attestation.json"
-        soft_fail: true
-        matrix:
-          setup:
-            go_arch:
-              - "amd64"
-              - "386"
-              - "arm64"
-              - "ppc64"
-              - "ppc64le"
-              - "riscv64"
-            pkg_arch:
-              - "SKIP_FAKE_ARCH"
-          adjustments:
-            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
-            - with: { go_arch: "386", pkg_arch: "i386" }
-            - with: { go_arch: "arm64", pkg_arch: "aarch64" }
-            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
-            - with: { go_arch: "ppc64le", pkg_arch: "ppc64le" }
-            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
-            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
-              skip: true
-
   - name: ":debian: Publish Oldstable Debian Package"
     command: ".buildkite/steps/publish-debian-package.sh"
     env:
@@ -137,43 +104,6 @@ steps:
           mount-buildkite-agent: true
           tmpfs:
             - "/root/.gnupg"
-
-  - group: ":debian: Publish Oldstable Debian Package to Buildkite Packages"
-    steps:
-      - name: ":debian: Publish Oldstable {{matrix.pkg_arch}} Debian Package to Buildkite Packages"
-        plugins:
-          - publish-to-packages#v2.2.0:
-              artifacts: "deb/buildkite-agent_*_{{matrix.pkg_arch}}.deb"
-              registry: "buildkite/agent-deb-oldstable"
-              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
-              attestations:
-                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
-                - "buildkite-agent-debian-packages.package-attestation.json"
-        soft_fail: true
-        matrix:
-          setup:
-            go_arch:
-              - "amd64"
-              - "386"
-              - "arm"
-              - "armhf"
-              - "arm64"
-              - "ppc64"
-              - "ppc64le"
-              - "riscv64"
-            pkg_arch:
-              - "SKIP_FAKE_ARCH"
-          adjustments:
-            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
-            - with: { go_arch: "386", pkg_arch: "i386" }
-            - with: { go_arch: "arm", pkg_arch: "arm" }
-            - with: { go_arch: "armhf", pkg_arch: "armhf" }
-            - with: { go_arch: "arm64", pkg_arch: "arm64" }
-            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
-            - with: { go_arch: "ppc64le", pkg_arch: "ppc64el" }
-            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
-            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
-              skip: true
 
   - group: ":docker: Publish Oldstable Docker Images"
     steps:

--- a/.buildkite/pipeline.release-oldstable.yml
+++ b/.buildkite/pipeline.release-oldstable.yml
@@ -26,7 +26,6 @@ steps:
           mount-buildkite-agent: true
 
   - name: ":octocat: :rocket: Create Github Release (if necessary)"
-    skip: "TODO(v4 release): unskip when v3 no longer stable"
     command: ".buildkite/steps/github-release.sh"
     env:
       CODENAME: "oldstable"
@@ -207,7 +206,6 @@ steps:
   - wait
 
   - name: ":beer: Publish Oldstable Homebrew Package"
-    skip: "TODO(v4 release): unskip when v3 no longer stable"
     command: ".buildkite/steps/release-homebrew.sh"
     artifact_paths: "pkg/*.rb;pkg/*.json"
     env:

--- a/.buildkite/pipeline.release-stable.yml
+++ b/.buildkite/pipeline.release-stable.yml
@@ -78,39 +78,6 @@ steps:
         - exit_status: 1
           limit: 3
 
-  - group: ":redhat: Publish RPM Package to Buildkite Packages"
-    steps:
-      - name: ":redhat: Publish {{matrix.pkg_arch}} RPM Package to Buildkite Packages"
-        plugins:
-          - publish-to-packages#v2.2.0:
-              artifacts: "rpm/buildkite-agent_*_{{matrix.pkg_arch}}.rpm"
-              registry: "buildkite/agent-rpm"
-              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
-              attestations:
-                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
-                - "buildkite-agent-rpm-packages.package-attestation.json"
-        soft_fail: true
-        matrix:
-          setup:
-            go_arch:
-              - "amd64"
-              - "386"
-              - "arm64"
-              - "ppc64"
-              - "ppc64le"
-              - "riscv64"
-            pkg_arch:
-              - "SKIP_FAKE_ARCH"
-          adjustments:
-            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
-            - with: { go_arch: "386", pkg_arch: "i386" }
-            - with: { go_arch: "arm64", pkg_arch: "aarch64" }
-            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
-            - with: { go_arch: "ppc64le", pkg_arch: "ppc64le" }
-            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
-            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
-              skip: true
-
   - name: ":debian: Publish Debian Package"
     command: ".buildkite/steps/publish-debian-package.sh"
     env:
@@ -137,43 +104,6 @@ steps:
           mount-buildkite-agent: true
           tmpfs:
             - "/root/.gnupg"
-
-  - group: ":debian: Publish Debian Package to Buildkite Packages"
-    steps:
-      - name: ":debian: Publish {{matrix.pkg_arch}} Debian Package to Buildkite Packages"
-        plugins:
-          - publish-to-packages#v2.2.0:
-              artifacts: "deb/buildkite-agent_*_{{matrix.pkg_arch}}.deb"
-              registry: "buildkite/agent-deb"
-              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
-              attestations:
-                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
-                - "buildkite-agent-debian-packages.package-attestation.json"
-        soft_fail: true
-        matrix:
-          setup:
-            go_arch:
-              - "amd64"
-              - "386"
-              - "arm"
-              - "armhf"
-              - "arm64"
-              - "ppc64"
-              - "ppc64le"
-              - "riscv64"
-            pkg_arch:
-              - "SKIP_FAKE_ARCH"
-          adjustments:
-            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
-            - with: { go_arch: "386", pkg_arch: "i386" }
-            - with: { go_arch: "arm", pkg_arch: "arm" }
-            - with: { go_arch: "armhf", pkg_arch: "armhf" }
-            - with: { go_arch: "arm64", pkg_arch: "arm64" }
-            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
-            - with: { go_arch: "ppc64le", pkg_arch: "ppc64el" }
-            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
-            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
-              skip: true
 
   - group: ":docker: Publish Docker Images"
     steps:

--- a/.buildkite/pipeline.release-unstable.yml
+++ b/.buildkite/pipeline.release-unstable.yml
@@ -78,39 +78,6 @@ steps:
         - exit_status: 1
           limit: 3
 
-  - group: ":redhat: Publish Unstable RPM Package to Buildkite Packages"
-    steps:
-      - name: ":redhat: Publish Unstable {{matrix.pkg_arch}} RPM Package to Buildkite Packages"
-        plugins:
-          - publish-to-packages#v2.2.0:
-              artifacts: "rpm/buildkite-agent_*_{{matrix.pkg_arch}}.rpm"
-              registry: "buildkite/agent-rpm-unstable"
-              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
-              attestations:
-                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
-                - "buildkite-agent-rpm-packages.package-attestation.json"
-        soft_fail: true
-        matrix:
-          setup:
-            go_arch:
-              - "amd64"
-              - "386"
-              - "arm64"
-              - "ppc64"
-              - "ppc64le"
-              - "riscv64"
-            pkg_arch:
-              - "SKIP_FAKE_ARCH"
-          adjustments:
-            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
-            - with: { go_arch: "386", pkg_arch: "i386" }
-            - with: { go_arch: "arm64", pkg_arch: "aarch64" }
-            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
-            - with: { go_arch: "ppc64le", pkg_arch: "ppc64le" }
-            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
-            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
-              skip: true
-
   - name: ":debian: Publish Unstable Debian Package"
     command: ".buildkite/steps/publish-debian-package.sh"
     env:
@@ -137,43 +104,6 @@ steps:
           mount-buildkite-agent: true
           tmpfs:
             - "/root/.gnupg"
-
-  - group: ":debian: Publish Unstable Debian Package to Buildkite Packages"
-    steps:
-      - name: ":debian: Publish Unstable {{matrix.pkg_arch}} Debian Package to Buildkite Packages"
-        plugins:
-          - publish-to-packages#v2.2.0:
-              artifacts: "deb/buildkite-agent_*_{{matrix.pkg_arch}}.deb"
-              registry: "buildkite/agent-deb-unstable"
-              artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
-              attestations:
-                - "buildkite-agent-linux-{{matrix.go_arch}}.build-attestation.json"
-                - "buildkite-agent-debian-packages.package-attestation.json"
-        soft_fail: true
-        matrix:
-          setup:
-            go_arch:
-              - "amd64"
-              - "386"
-              - "arm"
-              - "armhf"
-              - "arm64"
-              - "ppc64"
-              - "ppc64le"
-              - "riscv64"
-            pkg_arch:
-              - "SKIP_FAKE_ARCH"
-          adjustments:
-            - with: { go_arch: "amd64", pkg_arch: "x86_64" }
-            - with: { go_arch: "386", pkg_arch: "i386" }
-            - with: { go_arch: "arm", pkg_arch: "arm" }
-            - with: { go_arch: "armhf", pkg_arch: "armhf" }
-            - with: { go_arch: "arm64", pkg_arch: "arm64" }
-            - with: { go_arch: "ppc64", pkg_arch: "ppc64" }
-            - with: { go_arch: "ppc64le", pkg_arch: "ppc64el" }
-            - with: { go_arch: "riscv64", pkg_arch: "riscv64" }
-            - with: { pkg_arch: "SKIP_FAKE_ARCH" }
-              skip: true
 
   - group: ":docker: Publish Unstable Docker Images"
     steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -412,10 +412,6 @@ steps:
       - set-metadata
     command: ".buildkite/steps/build-debian-packages.sh"
     artifact_paths: "deb/**/*"
-    plugins:
-      - generate-provenance-attestation#v1.1.0:
-          artifacts: "deb/*"
-          attestation_name: "buildkite-agent-debian-packages.package-attestation.json"
 
   - name: ":redhat: RPM Package build"
     key: build-rpm-packages
@@ -424,10 +420,6 @@ steps:
       - set-metadata
     command: ".buildkite/steps/build-rpm-packages.sh"
     artifact_paths: "rpm/**/*"
-    plugins:
-      - generate-provenance-attestation#v1.1.0:
-          artifacts: "rpm/*"
-          attestation_name: "buildkite-agent-rpm-packages.package-attestation.json"
 
   - name: ":github: Build Github Release"
     key: build-github-release

--- a/.buildkite/steps/upload-release-steps.sh
+++ b/.buildkite/steps/upload-release-steps.sh
@@ -74,28 +74,22 @@ output_steps_yaml() {
   wait_step
 
   case "${agent_version}" in
-    *beta*|*rc*)
+    *alpha*|*beta*|*rc*)
       trigger_step \
         "beta ${agent_version}" \
         "agent-release-beta"
       ;;
 
     4.*)
-      # This case shouldn't be reached while the v4 branch version string
-      # includes "beta".
-      trigger_step \
-        "beta ${agent_version}" \
-        "agent-release-beta"
-      ;;
-
-    3.*)
-      # TODO(v4 release): move stable release to v4
-      trigger_step \
-        "oldstable ${agent_version}" \
-        "agent-release-oldstable"
       trigger_step \
         "stable ${agent_version}" \
         "agent-release-stable"
+      ;;
+
+    3.*)
+      trigger_step \
+        "oldstable ${agent_version}" \
+        "agent-release-oldstable"
       ;;
   esac
 }

--- a/.buildkite/steps/upload-release-steps.sh
+++ b/.buildkite/steps/upload-release-steps.sh
@@ -111,7 +111,7 @@ edge_steps_yaml | buildkite-agent pipeline upload
 
 # If there is already a release (which means a tag), we want to avoid trying to create
 # another one, as this will fail and cause partial broken releases
-if [[ "${DRY_RUN:-false}" == "false" ]] && git ls-remote --tags origin | grep "refs/tags/v${agent_version}" ; then
+if [[ "${DRY_RUN:-false}" == "false" ]] && git ls-remote --exit-code --tags origin "refs/tags/v${agent_version}" > /dev/null; then
   echo "Tag refs/tags/v${agent_version} already exists"
   exit 0
 fi


### PR DESCRIPTION
## Description

We're preparing to release v4.0.0 as the stable release, and to do that we need to make some changes to the release pipeline. This PR makes it so that making a v4.0.0 tag will release it to stable, and further 3.x releases will go to oldstable.

Once this PR is merged, **we should not make further releases until v4.**

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

It's me