### PR TITLE
Fix setgid preservation

### DIFF
--- a/internal/job/checkout_mirror_remote_test.go
+++ b/internal/job/checkout_mirror_remote_test.go
@@ -69,7 +69,8 @@ func TestUpdateGitMirrorCreatesFromRemoteMirrorAndKeepsCanonicalOrigin(t *testin
 		if got, want := info.Mode().Perm(), os.FileMode(0o777&^osutil.Umask); got != want {
 			t.Errorf("shared mirror mode = %o, want %o", got, want)
 		}
-		if info.Mode()&os.ModeSetgid == 0 {
+		// macOS inherits the parent directory's group without propagating the setgid bit.
+		if runtime.GOOS != "darwin" && info.Mode()&os.ModeSetgid == 0 {
 			t.Errorf("shared mirror mode = %v, want setgid preserved", info.Mode())
 		}
 	}


### PR DESCRIPTION

## Description

There's a bug in the agent integration tests where the tests expect `setgid` behaviour that's linux-only, so tests on macOS fail. This PR fixes that test to to account for the OS it's running on — when `runtime.GOOS == darwin`, we don't check that the child directory's setgid bit.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

Amp-Thread-ID: https://ampcode.com/threads/T-01a05627-2f16-77fb-a5b6-671ee3d78105

