### PR TITLE
[Backport] Add systemd watchdog notification support

### DIFF
--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/buildkite/agent/v3/internal/systemdnotify"
 	"github.com/buildkite/agent/v3/logger"
 	"github.com/buildkite/agent/v3/status"
 
@@ -20,13 +21,18 @@ import (
 type AgentPool struct {
 	workers     []*AgentWorker
 	idleTimeout time.Duration
+	watchdog    watchdogNotifier
+	watchdogErr error
 }
 
 // NewAgentPool returns a new AgentPool.
 func NewAgentPool(workers []*AgentWorker, config *AgentConfiguration) *AgentPool {
+	watchdog, watchdogErr := systemdnotify.New()
 	return &AgentPool{
 		workers:     workers,
 		idleTimeout: config.DisconnectAfterIdleTimeout,
+		watchdog:    watchdog,
+		watchdogErr: watchdogErr,
 	}
 }
 
@@ -57,6 +63,29 @@ func (ap *AgentPool) StartStatusServer(ctx context.Context, l logger.Logger, add
 
 // Start kicks off the parallel AgentWorkers and waits for them to finish.
 func (r *AgentPool) Start(ctx context.Context) error {
+	if r.watchdogErr != nil {
+		return fmt.Errorf("configure systemd watchdog: %w", r.watchdogErr)
+	}
+
+	if r.watchdog != nil {
+		if watchdogInterval := r.watchdog.WatchdogInterval(); watchdogInterval > 0 {
+			var l logger.Logger = logger.Discard
+			if len(r.workers) > 0 {
+				l = r.workers[0].logger
+			}
+			watchdogCtx, stopWatchdog := context.WithCancel(ctx)
+			var watchdogWG sync.WaitGroup
+			watchdogWG.Go(func() {
+				r.runWatchdog(watchdogCtx, l, watchdogInterval)
+			})
+			defer func() {
+				stopWatchdog()
+				watchdogWG.Wait()
+			}()
+			l.Noticef("Systemd watchdog enabled with a %s timeout", watchdogInterval)
+		}
+	}
+
 	ctx, setStat, done := status.AddSimpleItem(ctx, "Agent Pool")
 	defer done()
 	setStat("🏃 Spawning workers...")
@@ -89,13 +118,25 @@ func runWorker(ctx context.Context, worker *AgentWorker, idleMon *idleMonitor) e
 
 	// Connect the worker to the API
 	if err := worker.Connect(ctx); err != nil {
+		if ctx.Err() != nil {
+			worker.watchdogMarkStopped()
+		} else {
+			worker.watchdogMarkFailed(err)
+		}
 		return err
 	}
 	// Ensure the worker is disconnected at the end of this function.
 	defer worker.Disconnect(ctx) //nolint:errcheck // Error is logged within core/client
 
 	// Starts the agent worker and wait for it to finish.
-	return worker.Start(ctx, idleMon)
+	worker.watchdogMarkRunning()
+	err := worker.Start(ctx, idleMon)
+	if err == nil || ctx.Err() != nil {
+		worker.watchdogMarkStopped()
+	} else {
+		worker.watchdogMarkFailed(err)
+	}
+	return err
 }
 
 // StopGracefully stops all workers in the pool gracefully.

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -22,18 +22,20 @@ type AgentPool struct {
 	workers     []*AgentWorker
 	idleTimeout time.Duration
 	watchdog    watchdogNotifier
-	watchdogErr error
 }
 
 // NewAgentPool returns a new AgentPool.
-func NewAgentPool(workers []*AgentWorker, config *AgentConfiguration) *AgentPool {
-	watchdog, watchdogErr := systemdnotify.New()
+func NewAgentPool(workers []*AgentWorker, config *AgentConfiguration) (*AgentPool, error) {
+	watchdog, err := systemdnotify.New()
+	if err != nil {
+		return nil, fmt.Errorf("configure systemd watchdog: %w", err)
+	}
+
 	return &AgentPool{
 		workers:     workers,
 		idleTimeout: config.DisconnectAfterIdleTimeout,
 		watchdog:    watchdog,
-		watchdogErr: watchdogErr,
-	}
+	}, nil
 }
 
 func (ap *AgentPool) StartStatusServer(ctx context.Context, l logger.Logger, addr string) {
@@ -63,10 +65,6 @@ func (ap *AgentPool) StartStatusServer(ctx context.Context, l logger.Logger, add
 
 // Start kicks off the parallel AgentWorkers and waits for them to finish.
 func (r *AgentPool) Start(ctx context.Context) error {
-	if r.watchdogErr != nil {
-		return fmt.Errorf("configure systemd watchdog: %w", r.watchdogErr)
-	}
-
 	if r.watchdog != nil {
 		if watchdogInterval := r.watchdog.WatchdogInterval(); watchdogInterval > 0 {
 			var l logger.Logger = logger.Discard

--- a/agent/agent_pool.go
+++ b/agent/agent_pool.go
@@ -116,9 +116,7 @@ func runWorker(ctx context.Context, worker *AgentWorker, idleMon *idleMonitor) e
 
 	// Connect the worker to the API
 	if err := worker.Connect(ctx); err != nil {
-		if ctx.Err() != nil {
-			worker.watchdogMarkStopped()
-		} else {
+		if !errors.Is(err, context.Canceled) {
 			worker.watchdogMarkFailed(err)
 		}
 		return err
@@ -128,10 +126,9 @@ func runWorker(ctx context.Context, worker *AgentWorker, idleMon *idleMonitor) e
 
 	// Starts the agent worker and wait for it to finish.
 	worker.watchdogMarkRunning()
+	defer worker.watchdogMarkStopped()
 	err := worker.Start(ctx, idleMon)
-	if err == nil || ctx.Err() != nil {
-		worker.watchdogMarkStopped()
-	} else {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		worker.watchdogMarkFailed(err)
 	}
 	return err

--- a/agent/agent_watchdog.go
+++ b/agent/agent_watchdog.go
@@ -66,6 +66,8 @@ func (a *AgentWorker) watchdogHealth(now time.Time) error {
 }
 
 func (ap *AgentPool) runWatchdog(ctx context.Context, l logger.Logger, watchdogInterval time.Duration) {
+	ap.notifyWatchdog(l, time.Now())
+
 	// systemd recommends notifying every half of the configured interval.
 	ticker := time.NewTicker(watchdogInterval / 2)
 	defer ticker.Stop()

--- a/agent/agent_watchdog.go
+++ b/agent/agent_watchdog.go
@@ -26,7 +26,6 @@ func (a *AgentWorker) watchdogMarkStopped() {
 	defer a.stats.Unlock()
 
 	a.stats.watchdogRunningSince = time.Time{}
-	a.stats.watchdogErr = nil
 }
 
 func (a *AgentWorker) watchdogMarkFailed(err error) {

--- a/agent/agent_watchdog.go
+++ b/agent/agent_watchdog.go
@@ -78,11 +78,11 @@ func (ap *AgentPool) runWatchdog(ctx context.Context, l logger.Logger, watchdogI
 func (ap *AgentPool) runWatchdogLoop(ctx context.Context, l logger.Logger, ticks <-chan time.Time) {
 	for {
 		select {
-		case now, ok := <-ticks:
+		case _, ok := <-ticks:
 			if !ok {
 				return
 			}
-			ap.notifyWatchdog(l, now)
+			ap.notifyWatchdog(l, time.Now())
 		case <-ctx.Done():
 			return
 		}

--- a/agent/agent_watchdog.go
+++ b/agent/agent_watchdog.go
@@ -1,0 +1,109 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/buildkite/agent/v3/logger"
+)
+
+type watchdogNotifier interface {
+	Watchdog() error
+	WatchdogInterval() time.Duration
+}
+
+func (a *AgentWorker) watchdogMarkRunning() {
+	a.stats.Lock()
+	defer a.stats.Unlock()
+
+	a.stats.watchdogRunningSince = time.Now()
+	a.stats.watchdogErr = nil
+}
+
+func (a *AgentWorker) watchdogMarkStopped() {
+	a.stats.Lock()
+	defer a.stats.Unlock()
+
+	a.stats.watchdogRunningSince = time.Time{}
+	a.stats.watchdogErr = nil
+}
+
+func (a *AgentWorker) watchdogMarkFailed(err error) {
+	a.stats.Lock()
+	defer a.stats.Unlock()
+
+	a.stats.watchdogRunningSince = time.Time{}
+	a.stats.watchdogErr = err
+}
+
+func (a *AgentWorker) watchdogHealth(now time.Time) error {
+	a.stats.Lock()
+	defer a.stats.Unlock()
+
+	if a.stats.watchdogErr != nil {
+		return fmt.Errorf("worker %d failed: %w", a.spawnIndex, a.stats.watchdogErr)
+	}
+	if a.stats.watchdogRunningSince.IsZero() {
+		// Workers that are still connecting or have intentionally stopped do
+		// not contribute to pool health.
+		return nil
+	}
+
+	lastSuccessfulContact := a.stats.lastHeartbeat
+	if lastSuccessfulContact.Before(a.stats.watchdogRunningSince) {
+		// Connect succeeded immediately before the worker started, so use it
+		// as the heartbeat grace period until the first heartbeat succeeds.
+		lastSuccessfulContact = a.stats.watchdogRunningSince
+	}
+	// A worker remains healthy through one delayed or in-flight heartbeat.
+	maxContactAge := 2 * time.Duration(a.agent.HeartbeatInterval) * time.Second
+	age := now.Sub(lastSuccessfulContact)
+	if age > maxContactAge {
+		return fmt.Errorf("worker %d has not successfully contacted Buildkite for %s", a.spawnIndex, age.Round(time.Second))
+	}
+	return nil
+}
+
+func (ap *AgentPool) runWatchdog(ctx context.Context, l logger.Logger, watchdogInterval time.Duration) {
+	// systemd recommends notifying every half of the configured interval.
+	ticker := time.NewTicker(watchdogInterval / 2)
+	defer ticker.Stop()
+
+	ap.runWatchdogLoop(ctx, l, ticker.C)
+}
+
+func (ap *AgentPool) runWatchdogLoop(ctx context.Context, l logger.Logger, ticks <-chan time.Time) {
+	for {
+		select {
+		case now, ok := <-ticks:
+			if !ok {
+				return
+			}
+			ap.notifyWatchdog(l, now)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (ap *AgentPool) notifyWatchdog(l logger.Logger, now time.Time) {
+	if err := ap.watchdogHealth(now); err != nil {
+		l.Warnf("Buildkite heartbeat has not succeeded; not sending systemd watchdog notification: %v", err)
+		return
+	}
+	if err := ap.watchdog.Watchdog(); err != nil {
+		l.Warnf("Failed to notify systemd watchdog: %v", err)
+		return
+	}
+	l.Debugf("Notified systemd watchdog")
+}
+
+func (ap *AgentPool) watchdogHealth(now time.Time) error {
+	for _, worker := range ap.workers {
+		if err := worker.watchdogHealth(now); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/agent/agent_watchdog_test.go
+++ b/agent/agent_watchdog_test.go
@@ -289,14 +289,3 @@ func TestAgentPoolWatchdogLoopStops(t *testing.T) {
 		t.Fatal("watchdog loop did not stop after context cancellation")
 	}
 }
-
-func TestAgentPoolRejectsInvalidSystemdWatchdogConfiguration(t *testing.T) {
-	t.Parallel()
-
-	want := errors.New("invalid watchdog configuration")
-	pool := &AgentPool{watchdogErr: want}
-	err := pool.Start(t.Context())
-	if !errors.Is(err, want) {
-		t.Fatalf("Start() error = %v, want error wrapping %v", err, want)
-	}
-}

--- a/agent/agent_watchdog_test.go
+++ b/agent/agent_watchdog_test.go
@@ -129,6 +129,27 @@ func TestAgentWorkerSuccessfulHeartbeatDoesNotReviveFailedWorker(t *testing.T) {
 	}
 }
 
+func TestAgentWorkerStoppedPreservesWatchdogFailure(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("failed")
+	worker := &AgentWorker{
+		agent: &api.AgentRegisterResponse{HeartbeatInterval: 60},
+	}
+	worker.watchdogMarkRunning()
+	worker.watchdogMarkFailed(want)
+	worker.watchdogMarkStopped()
+
+	if err := worker.watchdogHealth(time.Now()); !errors.Is(err, want) {
+		t.Errorf("watchdogHealth() error = %v, want error wrapping %v", err, want)
+	}
+
+	worker.watchdogMarkRunning()
+	if err := worker.watchdogHealth(time.Now()); err != nil {
+		t.Errorf("watchdogHealth() after restart error = %v, want nil", err)
+	}
+}
+
 func TestAgentWorkerHeartbeatRecordsOnlySuccessfulBuildkiteContact(t *testing.T) {
 	t.Parallel()
 

--- a/agent/agent_watchdog_test.go
+++ b/agent/agent_watchdog_test.go
@@ -1,0 +1,288 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/logger"
+)
+
+type fakeWatchdogNotifier struct {
+	interval time.Duration
+
+	mu       sync.Mutex
+	watchdog int
+	watchErr error
+}
+
+func (n *fakeWatchdogNotifier) Watchdog() error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.watchdog++
+	return n.watchErr
+}
+
+func (n *fakeWatchdogNotifier) WatchdogInterval() time.Duration {
+	return n.interval
+}
+
+func (n *fakeWatchdogNotifier) watchdogCount() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.watchdog
+}
+
+func TestAgentWorkerWatchdogHealth(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	failure := errors.New("heartbeat rejected")
+	tests := []struct {
+		name                 string
+		heartbeatInterval    int
+		lastHeartbeat        time.Time
+		watchdogRunningSince time.Time
+		watchdogErr          error
+		wantError            string
+	}{
+		{
+			name:              "connecting or stopped worker",
+			heartbeatInterval: 60,
+		},
+		{
+			name:                 "running worker within two heartbeat intervals",
+			heartbeatInterval:    60,
+			lastHeartbeat:        now.Add(-119 * time.Second),
+			watchdogRunningSince: now.Add(-3 * time.Minute),
+		},
+		{
+			name:                 "running worker beyond two heartbeat intervals",
+			heartbeatInterval:    60,
+			lastHeartbeat:        now.Add(-121 * time.Second),
+			watchdogRunningSince: now.Add(-3 * time.Minute),
+			wantError:            "has not successfully contacted Buildkite",
+		},
+		{
+			name:              "failed worker",
+			heartbeatInterval: 60,
+			watchdogErr:       failure,
+			wantError:         failure.Error(),
+		},
+		{
+			name:                 "running worker awaiting its first heartbeat",
+			heartbeatInterval:    60,
+			watchdogRunningSince: now.Add(-time.Minute),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			worker := &AgentWorker{
+				spawnIndex: 3,
+				agent: &api.AgentRegisterResponse{
+					HeartbeatInterval: test.heartbeatInterval,
+				},
+				stats: agentStats{
+					lastHeartbeat:        test.lastHeartbeat,
+					watchdogRunningSince: test.watchdogRunningSince,
+					watchdogErr:          test.watchdogErr,
+				},
+			}
+			err := worker.watchdogHealth(now)
+			if test.wantError == "" {
+				if err != nil {
+					t.Errorf("watchdogHealth() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Errorf("watchdogHealth() error = %v, want error containing %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestAgentWorkerSuccessfulHeartbeatDoesNotReviveFailedWorker(t *testing.T) {
+	t.Parallel()
+
+	worker := &AgentWorker{
+		agent: &api.AgentRegisterResponse{HeartbeatInterval: 60},
+	}
+	worker.watchdogMarkFailed(errors.New("failed"))
+	worker.stats.Lock()
+	worker.stats.lastHeartbeat = time.Now()
+	worker.stats.Unlock()
+
+	if err := worker.watchdogHealth(time.Now()); err == nil {
+		t.Fatal("watchdogHealth() error = nil, want failed worker error")
+	}
+}
+
+func TestAgentWorkerHeartbeatRecordsOnlySuccessfulBuildkiteContact(t *testing.T) {
+	t.Parallel()
+
+	var rejectHeartbeat atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if rejectHeartbeat.Load() {
+			http.Error(w, "heartbeat rejected", http.StatusUnauthorized)
+			return
+		}
+
+		var heartbeat api.Heartbeat
+		if err := json.NewDecoder(r.Body).Decode(&heartbeat); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		heartbeat.ReceivedAt = time.Now().Format(time.RFC3339Nano)
+		if err := json.NewEncoder(w).Encode(heartbeat); err != nil {
+			t.Errorf("Encode(heartbeat) error = %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	worker := &AgentWorker{
+		agent: &api.AgentRegisterResponse{HeartbeatInterval: 60},
+		apiClient: api.NewClient(logger.Discard, api.Config{
+			Endpoint: server.URL,
+			Token:    "test-token",
+		}),
+		logger: logger.Discard,
+		stats: agentStats{
+			lastHeartbeat:        time.Now().Add(-time.Minute),
+			watchdogRunningSince: time.Now().Add(-2 * time.Minute),
+		},
+	}
+	lastSuccessfulContact := func() time.Time {
+		worker.stats.Lock()
+		defer worker.stats.Unlock()
+		return worker.stats.lastHeartbeat
+	}
+
+	beforeSuccess := lastSuccessfulContact()
+	if err := worker.Heartbeat(t.Context()); err != nil {
+		t.Fatalf("Heartbeat() error = %v, want nil", err)
+	}
+	afterSuccess := lastSuccessfulContact()
+	if !afterSuccess.After(beforeSuccess) {
+		t.Errorf("lastSuccessfulContact after successful heartbeat = %s, want after %s", afterSuccess, beforeSuccess)
+	}
+
+	rejectHeartbeat.Store(true)
+	if err := worker.Heartbeat(t.Context()); err == nil {
+		t.Fatal("Heartbeat() error = nil, want heartbeat rejection")
+	}
+	if got := lastSuccessfulContact(); got != afterSuccess {
+		t.Errorf("lastSuccessfulContact after rejected heartbeat = %s, want unchanged %s", got, afterSuccess)
+	}
+}
+
+func TestAgentPoolWatchdogNotifiesForHealthyWorkers(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	worker := &AgentWorker{
+		agent: &api.AgentRegisterResponse{HeartbeatInterval: 60},
+		stats: agentStats{
+			lastHeartbeat:        now,
+			watchdogRunningSince: now.Add(-time.Minute),
+		},
+	}
+	notifier := &fakeWatchdogNotifier{}
+	pool := &AgentPool{
+		workers:  []*AgentWorker{worker},
+		watchdog: notifier,
+	}
+
+	pool.notifyWatchdog(logger.Discard, now.Add(time.Minute))
+	if got := notifier.watchdogCount(); got != 1 {
+		t.Errorf("Watchdog() calls = %d, want 1", got)
+	}
+}
+
+func TestAgentPoolWatchdogSkipsUnhealthyWorkers(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	notifier := &fakeWatchdogNotifier{}
+	pool := &AgentPool{
+		workers: []*AgentWorker{{
+			agent: &api.AgentRegisterResponse{HeartbeatInterval: 60},
+			stats: agentStats{
+				lastHeartbeat:        now.Add(-121 * time.Second),
+				watchdogRunningSince: now.Add(-3 * time.Minute),
+			},
+		}},
+		watchdog: notifier,
+	}
+	pool.notifyWatchdog(logger.Discard, now)
+	if got := notifier.watchdogCount(); got != 0 {
+		t.Errorf("Watchdog() calls = %d, want 0", got)
+	}
+}
+
+func TestAgentPoolWatchdogContinuesAfterNotificationError(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	notifier := &fakeWatchdogNotifier{
+		watchErr: errors.New("send failed"),
+	}
+	pool := &AgentPool{
+		workers: []*AgentWorker{{
+			agent: &api.AgentRegisterResponse{HeartbeatInterval: 60},
+			stats: agentStats{
+				lastHeartbeat:        now,
+				watchdogRunningSince: now.Add(-time.Minute),
+			},
+		}},
+		watchdog: notifier,
+	}
+
+	pool.notifyWatchdog(logger.Discard, now)
+	pool.notifyWatchdog(logger.Discard, now)
+	if got := notifier.watchdogCount(); got != 2 {
+		t.Errorf("Watchdog() calls = %d, want 2", got)
+	}
+}
+
+func TestAgentPoolWatchdogLoopStops(t *testing.T) {
+	t.Parallel()
+
+	pool := &AgentPool{}
+	ticks := make(chan time.Time)
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		pool.runWatchdogLoop(ctx, logger.Discard, ticks)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watchdog loop did not stop after context cancellation")
+	}
+}
+
+func TestAgentPoolRejectsInvalidSystemdWatchdogConfiguration(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("invalid watchdog configuration")
+	pool := &AgentPool{watchdogErr: want}
+	err := pool.Start(t.Context())
+	if !errors.Is(err, want) {
+		t.Fatalf("Start() error = %v, want error wrapping %v", err, want)
+	}
+}

--- a/agent/agent_watchdog_test.go
+++ b/agent/agent_watchdog_test.go
@@ -256,6 +256,20 @@ func TestAgentPoolWatchdogContinuesAfterNotificationError(t *testing.T) {
 	}
 }
 
+func TestAgentPoolWatchdogNotifiesImmediately(t *testing.T) {
+	t.Parallel()
+
+	notifier := &fakeWatchdogNotifier{}
+	pool := &AgentPool{watchdog: notifier}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	pool.runWatchdog(ctx, logger.Discard, time.Hour)
+	if got := notifier.watchdogCount(); got != 1 {
+		t.Errorf("Watchdog() calls = %d, want 1", got)
+	}
+}
+
 func TestAgentPoolWatchdogLoopStops(t *testing.T) {
 	t.Parallel()
 

--- a/agent/agent_worker.go
+++ b/agent/agent_worker.go
@@ -61,6 +61,9 @@ type agentStats struct {
 
 	// The last error that occurred during heartbeat, or nil if it was successful
 	lastHeartbeatError error
+
+	watchdogRunningSince time.Time
+	watchdogErr          error
 }
 
 type AgentWorker struct {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -1458,7 +1458,10 @@ var AgentStartCommand = cli.Command{
 		}
 
 		// Setup the agent pool that spawns agent workers
-		pool := agent.NewAgentPool(workers, &agentConf)
+		pool, err := agent.NewAgentPool(workers, &agentConf)
+		if err != nil {
+			return err
+		}
 
 		// Agent-wide shutdown hook. Once per agent, for all workers on the agent.
 		defer agentShutdownHook(l, cfg, workers)

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/buildkite/interpolate v0.1.5
 	github.com/buildkite/roko v1.4.0
 	github.com/buildkite/shellwords v1.0.1
+	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/creack/pty v1.1.19
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dustin/go-humanize v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 h1:kHaBemcxl8o/pQ5VM1
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
+github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
+github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.19 h1:tUN6H7LWqNx4hQVxomd0CVsDwaDr9gaRQaI4GpSmrsA=

--- a/internal/systemdnotify/backend_linux.go
+++ b/internal/systemdnotify/backend_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package systemdnotify
+
+import (
+	"os"
+	"time"
+
+	"github.com/coreos/go-systemd/v22/daemon"
+)
+
+type systemdBackend struct{}
+
+func newBackend() backend {
+	return systemdBackend{}
+}
+
+func (systemdBackend) notifyEnabled() bool {
+	return os.Getenv("NOTIFY_SOCKET") != ""
+}
+
+func (systemdBackend) notify(state string) (bool, error) {
+	return daemon.SdNotify(false, state)
+}
+
+func (systemdBackend) watchdogInterval() (time.Duration, error) {
+	return daemon.SdWatchdogEnabled(false)
+}

--- a/internal/systemdnotify/backend_other.go
+++ b/internal/systemdnotify/backend_other.go
@@ -1,0 +1,23 @@
+//go:build !linux
+
+package systemdnotify
+
+import "time"
+
+type noopBackend struct{}
+
+func newBackend() backend {
+	return noopBackend{}
+}
+
+func (noopBackend) notifyEnabled() bool {
+	return false
+}
+
+func (noopBackend) notify(string) (bool, error) {
+	return false, nil
+}
+
+func (noopBackend) watchdogInterval() (time.Duration, error) {
+	return 0, nil
+}

--- a/internal/systemdnotify/notifier.go
+++ b/internal/systemdnotify/notifier.go
@@ -1,0 +1,70 @@
+// Package systemdnotify reports service liveness to systemd.
+package systemdnotify
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+const watchdogState = "WATCHDOG=1"
+
+type backend interface {
+	notifyEnabled() bool
+	notify(state string) (bool, error)
+	watchdogInterval() (time.Duration, error)
+}
+
+// Notifier reports agent liveness to its systemd service manager. It is inert
+// when the systemd watchdog is disabled.
+type Notifier struct {
+	backend          backend
+	watchdogDuration time.Duration
+}
+
+// New returns a notifier configured from the current systemd environment.
+func New() (*Notifier, error) {
+	return newNotifier(newBackend())
+}
+
+func newNotifier(b backend) (*Notifier, error) {
+	watchdogDuration, err := b.watchdogInterval()
+	if err != nil {
+		return nil, fmt.Errorf("read systemd watchdog configuration: %w", err)
+	}
+
+	notifyEnabled := b.notifyEnabled()
+	if watchdogDuration > 0 && !notifyEnabled {
+		return nil, errors.New("systemd watchdog is enabled but NOTIFY_SOCKET is not set")
+	}
+
+	return &Notifier{
+		backend:          b,
+		watchdogDuration: watchdogDuration,
+	}, nil
+}
+
+// WatchdogInterval returns the maximum time systemd permits between watchdog
+// notifications. A zero duration means the watchdog is disabled.
+func (n *Notifier) WatchdogInterval() time.Duration {
+	return n.watchdogDuration
+}
+
+// Watchdog tells systemd that the agent remains healthy.
+func (n *Notifier) Watchdog() error {
+	if n.watchdogDuration <= 0 {
+		return nil
+	}
+	return n.notify(watchdogState)
+}
+
+func (n *Notifier) notify(state string) error {
+	sent, err := n.backend.notify(state)
+	if err != nil {
+		return fmt.Errorf("send systemd notification %q: %w", state, err)
+	}
+	if !sent {
+		return fmt.Errorf("send systemd notification %q: notification socket is unavailable", state)
+	}
+	return nil
+}

--- a/internal/systemdnotify/notifier_test.go
+++ b/internal/systemdnotify/notifier_test.go
@@ -1,0 +1,109 @@
+package systemdnotify
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeBackend struct {
+	enabled   bool
+	interval  time.Duration
+	watchErr  error
+	notifyOK  bool
+	notifyErr error
+	states    []string
+}
+
+func (b *fakeBackend) notifyEnabled() bool {
+	return b.enabled
+}
+
+func (b *fakeBackend) notify(state string) (bool, error) {
+	b.states = append(b.states, state)
+	return b.notifyOK, b.notifyErr
+}
+
+func (b *fakeBackend) watchdogInterval() (time.Duration, error) {
+	return b.interval, b.watchErr
+}
+
+func TestNotifierDisabled(t *testing.T) {
+	t.Parallel()
+
+	b := &fakeBackend{}
+	n, err := newNotifier(b)
+	if err != nil {
+		t.Fatalf("newNotifier() error = %v, want nil", err)
+	}
+
+	if err := n.Watchdog(); err != nil {
+		t.Errorf("disabled notifier returned error: %v", err)
+	}
+	if len(b.states) != 0 {
+		t.Errorf("disabled notifier sent states %q, want none", b.states)
+	}
+}
+
+func TestNotifierWatchdog(t *testing.T) {
+	t.Parallel()
+
+	b := &fakeBackend{
+		enabled:  true,
+		interval: 3 * time.Minute,
+		notifyOK: true,
+	}
+	n, err := newNotifier(b)
+	if err != nil {
+		t.Fatalf("newNotifier() error = %v, want nil", err)
+	}
+
+	if got, want := n.WatchdogInterval(), 3*time.Minute; got != want {
+		t.Errorf("WatchdogInterval() = %v, want %v", got, want)
+	}
+	if err := n.Watchdog(); err != nil {
+		t.Fatalf("Watchdog() error = %v, want nil", err)
+	}
+	if got, want := b.states, []string{watchdogState}; !slices.Equal(got, want) {
+		t.Errorf("notification states = %q, want %q", got, want)
+	}
+}
+
+func TestNotifierRejectsWatchdogWithoutSocket(t *testing.T) {
+	t.Parallel()
+
+	_, err := newNotifier(&fakeBackend{interval: time.Minute})
+	if err == nil || !strings.Contains(err.Error(), "NOTIFY_SOCKET") {
+		t.Fatalf("newNotifier() error = %v, want error mentioning NOTIFY_SOCKET", err)
+	}
+}
+
+func TestNotifierReportsConfigurationError(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("invalid watchdog interval")
+	_, err := newNotifier(&fakeBackend{watchErr: want})
+	if !errors.Is(err, want) {
+		t.Fatalf("newNotifier() error = %v, want error wrapping %v", err, want)
+	}
+}
+
+func TestNotifierReportsSendFailure(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("socket unavailable")
+	n, err := newNotifier(&fakeBackend{
+		enabled:   true,
+		interval:  time.Minute,
+		notifyErr: want,
+	})
+	if err != nil {
+		t.Fatalf("newNotifier() error = %v, want nil", err)
+	}
+
+	if err := n.Watchdog(); !errors.Is(err, want) {
+		t.Errorf("Watchdog() error = %v, want error wrapping %v", err, want)
+	}
+}


### PR DESCRIPTION
## Description

Backport of [#4175](https://github.com/buildkite/agent/pull/4175) to `v3`. It adds opt-in systemd watchdog support and only sends notifications while every running worker remains healthy and successfully contacts Buildkite.

## Context

See [#4175](https://github.com/buildkite/agent/pull/4175) for the full description and testing context.

## Changes

The behavior matches the merged v4 change. Agent module imports use the v3 path.

## Testing

- [x] Tests have run locally (with `go test ./...`). 
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)
- [x] `golangci-lint run`

## Disclosures / Credits

jj-duplicate
