### PR TITLE
Correct inaccurate CLI flag descriptions

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -574,7 +574,7 @@ var AgentStartCommand = &cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:    "no-ssh-keyscan",
-			Usage:   "Don't automatically run ssh-keyscan before checkout (default: false)",
+			Usage:   "Require known SSH host keys for the default checkout instead of accepting new keys (flag retained for compatibility; default: false)",
 			Sources: cli.EnvVars("BUILDKITE_NO_SSH_KEYSCAN"),
 		},
 		&cli.BoolFlag{
@@ -661,7 +661,7 @@ var AgentStartCommand = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:    "spawn-with-priority",
-			Usage:   `Assign priorities to every spawned agent (when using --spawn or --spawn-per-cpu). Pass "static" (1, 1, 1, ...), "ascending" (1, 2, 3, ...), or "descending" (-1, -2, -3, ...). Descending helps jobs be assigned across all hosts when the value of --spawn varies between hosts`,
+			Usage:   `Assign priorities to every spawned agent (when using --spawn or --spawn-per-cpu). Pass "static" (the configured --priority for every agent, or no priority if unset), "ascending" (1, 2, 3, ...), or "descending" (-1, -2, -3, ...). Descending helps jobs be assigned across all hosts when the value of --spawn varies between hosts`,
 			Value:   "static",
 			Sources: cli.EnvVars("BUILDKITE_AGENT_SPAWN_WITH_PRIORITY"),
 		},
@@ -1100,7 +1100,7 @@ var AgentStartCommand = &cli.Command{
 		}
 
 		if !agentConf.SSHKeyscan {
-			l.Infof("Automatic ssh-keyscan has been disabled")
+			l.Infof("Strict SSH host key checking has been enabled")
 		}
 
 		if !agentConf.CommandEval {

--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -574,7 +574,7 @@ var AgentStartCommand = &cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:    "no-ssh-keyscan",
-			Usage:   "Require known SSH host keys for the default checkout instead of accepting new keys (flag retained for compatibility; default: false)",
+			Usage:   "Require known SSH host keys for the default checkout instead of accepting new keys (default: false)",
 			Sources: cli.EnvVars("BUILDKITE_NO_SSH_KEYSCAN"),
 		},
 		&cli.BoolFlag{

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -330,7 +330,7 @@ var BootstrapCommand = &cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:    "ssh-keyscan",
-			Usage:   "Automatically run ssh-keyscan before checkout (default: true)",
+			Usage:   "Accept new SSH host keys for the default checkout instead of requiring known hosts (flag retained for compatibility; default: true)",
 			Value:   true,
 			Sources: cli.EnvVars("BUILDKITE_SSH_KEYSCAN"),
 		},

--- a/clicommand/bootstrap.go
+++ b/clicommand/bootstrap.go
@@ -330,7 +330,7 @@ var BootstrapCommand = &cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:    "ssh-keyscan",
-			Usage:   "Accept new SSH host keys for the default checkout instead of requiring known hosts (flag retained for compatibility; default: true)",
+			Usage:   "Accept new SSH host keys for the default checkout instead of requiring known hosts (default: true)",
 			Value:   true,
 			Sources: cli.EnvVars("BUILDKITE_SSH_KEYSCAN"),
 		},

--- a/clicommand/cancel_signal.go
+++ b/clicommand/cancel_signal.go
@@ -27,7 +27,7 @@ var (
 	cancelCleanupTimeoutFlag = &cli.DurationFlag{
 		Name:    "cancel-cleanup-timeout",
 		Value:   defaultCancelCleanupTimeout,
-		Usage:   "The amount of time given to the agent after the process exits or is killed to upload logs and artifacts",
+		Usage:   "Extra time for a stopping agent to upload logs and artifacts after a job process exits or is killed, before the agent forcefully exits",
 		Sources: cli.EnvVars("BUILDKITE_CANCEL_CLEANUP_TIMEOUT"),
 	}
 )

--- a/internal/job/config.go
+++ b/internal/job/config.go
@@ -192,7 +192,7 @@ type ExecutorConfig struct {
 	// A custom destination to upload artifacts to (for example, s3://...)
 	ArtifactUploadDestination string `env:"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"`
 
-	// Whether ssh-keyscan is run on ssh hosts before checkout
+	// Whether new SSH host keys are accepted during checkout
 	SSHKeyscan bool
 
 	// The shell used to execute commands


### PR DESCRIPTION
## Description

Correct three CLI usage strings that feed Buildkite's generated documentation so they describe the v4 behavior accurately.

## Context

A docs review found that the help text still described old or incorrect behavior for spawned-agent priorities, SSH host key checking, and cancellation cleanup timeouts.

## Changes

- Describe `spawn-with-priority=static` as reusing `--priority`, or assigning no priority when unset.
- Describe the `ssh-keyscan` flags in terms of accepting new versus requiring known SSH host keys during the default checkout.
- Clarify that `cancel-cleanup-timeout` extends a stopping agent's forced-exit deadline and does not limit normal job cancellation cleanup.
- Update the related SSH startup log and executor configuration comment.

## Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

Targeted verification: `go test ./clicommand` and `go build ./...`.

## Affiliation (optional, external contributors)

Buildkite.

## Disclosures / Credits

Amp implemented and verified these documentation corrections under developer direction.