### PR TITLE
Honor OTEL_RESOURCE_ATTRIBUTES across agent telemetry

### DIFF
--- a/internal/job/otlp_job_logger.go
+++ b/internal/job/otlp_job_logger.go
@@ -3,6 +3,7 @@ package job
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/v4/version"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
@@ -84,11 +86,22 @@ func newOTLPJobLogger(ctx context.Context, e *Executor) (*otlpJobLogger, error) 
 	if serviceName == "" {
 		serviceName = "buildkite-agent"
 	}
-	resources := resource.NewWithAttributes(semconv.SchemaURL,
-		semconv.ServiceNameKey.String(serviceName),
-		semconv.ServiceVersionKey.String(version.Version()),
-		semconv.DeploymentEnvironmentKey.String("ci"),
+	resources, err := resource.New(ctx,
+		resource.WithFromEnv(),
+		resource.WithSchemaURL(semconv.SchemaURL),
+		// Explicit agent attributes take precedence over attributes from the environment.
+		resource.WithAttributes(
+			semconv.ServiceNameKey.String(serviceName),
+			semconv.ServiceVersionKey.String(version.Version()),
+			semconv.DeploymentEnvironmentKey.String("ci"),
+		),
 	)
+	if err != nil {
+		if !errors.Is(err, resource.ErrPartialResource) {
+			return nil, fmt.Errorf("creating OpenTelemetry log resource: %w", err)
+		}
+		otel.Handle(err)
+	}
 	provider := sdklog.NewLoggerProvider(
 		// Job logs must not be silently dropped when the SDK batch queue fills.
 		// Back-pressure the command output on the exporter instead.

--- a/internal/job/tracing.go
+++ b/internal/job/tracing.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -107,7 +108,18 @@ func InitOTelTracerProvider(ctx context.Context, serviceName string, extraAttrs 
 	}
 	attributes = append(attributes, extraAttrs...)
 
-	resources := resource.NewWithAttributes(semconv.SchemaURL, attributes...)
+	resources, err := resource.New(ctx,
+		resource.WithFromEnv(),
+		resource.WithSchemaURL(semconv.SchemaURL),
+		// Explicit agent attributes take precedence over attributes from the environment.
+		resource.WithAttributes(attributes...),
+	)
+	if err != nil {
+		if !errors.Is(err, resource.ErrPartialResource) {
+			return nil, fmt.Errorf("creating OpenTelemetry trace resource: %w", err)
+		}
+		otel.Handle(err)
+	}
 	tracerProvider := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(resources),

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/buildkite/agent/v4/logger"
 	"github.com/buildkite/agent/v4/version"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
@@ -142,12 +143,22 @@ func (c *Collector) newMeterProvider(ctx context.Context, protocol string) (*sdk
 		return nil, err
 	}
 
-	resources := resource.NewWithAttributes(
-		semconv.SchemaURL,
-		semconv.ServiceNameKey.String(c.config.ServiceName),
-		semconv.ServiceVersionKey.String(version.Version()),
-		semconv.DeploymentEnvironmentKey.String("ci"),
+	resources, err := resource.New(ctx,
+		resource.WithFromEnv(),
+		resource.WithSchemaURL(semconv.SchemaURL),
+		// Explicit agent attributes take precedence over attributes from the environment.
+		resource.WithAttributes(
+			semconv.ServiceNameKey.String(c.config.ServiceName),
+			semconv.ServiceVersionKey.String(version.Version()),
+			semconv.DeploymentEnvironmentKey.String("ci"),
+		),
 	)
+	if err != nil {
+		if !errors.Is(err, resource.ErrPartialResource) {
+			return nil, fmt.Errorf("creating OpenTelemetry metrics resource: %w", err)
+		}
+		otel.Handle(err)
+	}
 
 	return sdkmetric.NewMeterProvider(
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter)),


### PR DESCRIPTION
## Description

The agent documents `OTEL_RESOURCE_ATTRIBUTES` as supported, but its primary job tracing and agent metrics resources were built only from hard-coded attributes.

Read standard environment resource attributes in job tracing, agent metrics, and OTLP job logging. Explicit agent attributes are applied last, so values such as `service.name`, `service.version`, `deployment.environment`, and Buildkite job attributes retain precedence. Invalid environment entries are reported through OpenTelemetry's error handler while valid entries and explicit attributes remain usable.

## Context

Aligns these telemetry paths with the existing cache tracing resource setup and the documented agent configuration.

## Changes

- Read `OTEL_RESOURCE_ATTRIBUTES` when creating trace, metric, and log resources.
- Preserve explicit agent attribute precedence on key conflicts.
- Continue with partial resources when malformed environment entries are encountered.

## Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

`go build ./...`, `go test ./internal/job`, and `go test ./metrics` pass locally.

## Affiliation (optional, external contributors)

Buildkite.

## Disclosures / Credits

Amp implemented and verified this change under user direction.
