### PR TITLE
Allow releases after stable branches diverge

### DIFF
--- a/.buildkite/steps/github-release.sh
+++ b/.buildkite/steps/github-release.sh
@@ -89,8 +89,6 @@ else
   echo "--- 🚀 ${AGENT_VERSION}"
 
   buildkite-agent meta-data set github_release_type "stable"
-
-  release_args+=(--fail-on-no-commits)
 fi
 
 buildkite-agent meta-data set github_release_version "${AGENT_VERSION}"


### PR DESCRIPTION
## Description

The v4.0.0 release failed with `no new commits since the last release` because `gh release create --fail-on-no-commits` compares the latest non-prerelease, v3.137.2, with `main`. GitHub reports the independently maintained v3 and v4 histories as diverged, which the CLI incorrectly treats as having no new commits.

Remove that flag so the stable release can proceed. The release uploader already skips publication when the exact version tag exists, which retains the intended duplicate-release protection.

## Context

- [Failed v4.0.0 build](https://buildkite.com/buildkite/agent/builds/14181)
- [Known GitHub CLI issue](https://github.com/cli/cli/issues/10847)

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

Me + Amp
