### PR TITLE
Clarify OIDC status 1 retry behavior

### DIFF
--- a/clicommand/oidc_request_token.go
+++ b/clicommand/oidc_request_token.go
@@ -75,7 +75,7 @@ Exit statuses:
   410, or 422 response, such as a disallowed audience). Retrying will not
   succeed.
 - 1: any other failure, including transient API or network errors (timeouts,
-  5xx, other 4xx) after exhausting retries. Retrying may succeed.`
+  5xx, other 4xx). Retrying may succeed.`
 )
 
 var OIDCRequestTokenCommand = &cli.Command{


### PR DESCRIPTION
Human comment: This is an AI-generated PR that is a result of reviewing https://github.com/buildkite/docs-private/pull/2057.
Feel free to close but looks like a valid little nitpick from the machine.

## Description

Status 1 from `oidc request-token` does not always mean the command exhausted its retries. Non-retryable 4xx responses such as 408, 421, and 425 can stop after the first attempt.

Remove the inaccurate retry-exhaustion claim while preserving the guidance that retrying may succeed.

## Context

Follow-up to buildkite/docs-private#2057 and buildkite/agent#4272.

## Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

`go test ./clicommand`

## Disclosures / Credits

Amp identified the source wording, made the one-line edit, and ran the targeted test under Karen Sawrey's direction.
