### PR TITLE
Retry flaky Windows test jobs automatically

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -185,6 +185,10 @@ steps:
         key: test-windows
         command: "bash .buildkite\\steps\\tests.sh"
         parallelism: 2
+        retry:
+          automatic:
+            - exit_status: 1
+              limit: 3
         artifact_paths:
           - junit-*.xml
           - "coverage-*/**"


### PR DESCRIPTION
## Description

The Windows AMD64 test step in [build 14191](https://buildkite.com/buildkite/agent/builds/14191/tests?group_by=test) failed on tests that passed on the other platforms and were classified as flaky. Automatically retrying this step avoids requiring a manual retry for transient test failures.

## Context

https://buildkite.com/buildkite/agent/builds/14191/tests?group_by=test

## Changes

Retry the Windows AMD64 test step up to three times when it exits with status 1.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

`git diff --check` passes. Go tests and formatting are not applicable to this pipeline-only YAML change.

## Affiliation (optional, external contributors)

N/A — Buildkite employee contribution.

## Disclosures / Credits

Amp inspected build 14191, identified the failing Windows test step, and made the pipeline change under my direction.
