### PR TITLE
Update job log size warning

### DIFF
--- a/agent/log_streamer.go
+++ b/agent/log_streamer.go
@@ -120,9 +120,9 @@ func (ls *LogStreamer) Process(ctx context.Context, output []byte) error {
 		// (This check is also performed on the server side.)
 		if ls.bytes > ls.conf.MaxSizeBytes && !ls.warnedAboutSize {
 			ls.logger.Warnf("The job log has reached %s in size, which has "+
-				"exceeded the maximum size (%s). Further logs may be dropped "+
-				"by the server, and a future version of the agent will stop "+
-				"sending logs at this point.",
+				"exceeded the maximum size (%s). Buildkite cancels jobs whose "+
+				"logs exceed this limit, and a future version of the agent "+
+				"will stop sending logs at this point.",
 				humanize.IBytes(ls.bytes), humanize.IBytes(ls.conf.MaxSizeBytes))
 			ls.warnedAboutSize = true
 			// In a future version, this will error out, e.g.:


### PR DESCRIPTION
Update stale wording when job log exceed 1 GiB limit.

## Testing

- [x] Existing tests passed
  No test asserts on this string.

## Disclosures / Credits

Claude Code authored, I reviewed and directed the change.