### PR TITLE
[v3] Retry flaky Windows test jobs automatically

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -131,6 +131,10 @@ steps:
         key: test-windows
         command: "bash .buildkite\\steps\\tests.sh"
         parallelism: 2
+        retry:
+          automatic:
+            - exit_status: 1
+              limit: 3
         artifact_paths:
           - junit-*.xml
           - "coverage-*/**"


### PR DESCRIPTION
## Description

Backport of #4310 to the v3 branch.

## Context

https://buildkite.com/buildkite/agent/builds/14191/tests?group_by=test

## Changes

No translation was needed: v3 has the same Windows AMD64 test step, which now retries exit status 1 up to three times.

## Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [ ] Code is formatted (with `go tool gofumpt -extra -w .`)

`git diff --check` passes. Go tests and formatting are not applicable to this pipeline-only YAML change.

## Affiliation (optional, external contributors)

N/A — Buildkite employee contribution.

## Disclosures / Credits

Amp backported #4310 under my direction.
