### PR TITLE
Fix lint after golangci-lint upgrade

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,6 +18,7 @@ steps:
     if_changed:
       - go.{mod,sum}
       - "**.go"
+      - .buildkite/Dockerfile-lint
       - .buildkite/steps/check-code-committed.sh
       - .buildkite/cache.yml
       - .buildkite/docker-compose.yml

--- a/internal/socket/server_test.go
+++ b/internal/socket/server_test.go
@@ -110,8 +110,8 @@ func TestServerHandler(t *testing.T) {
 
 	cli := &http.Client{
 		Transport: &http.Transport{
-			Dial: func(string, string) (net.Conn, error) {
-				return net.Dial("unix", sockPath)
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
 			},
 		},
 	}


### PR DESCRIPTION
## Description

The golangci-lint v2.13 upgrade exposed deprecated `http.Transport.Dial` usage and broke the main build. The linter image update itself did not run lint because `Dockerfile-lint` was missing from the step's change filters.

## Context

https://buildkite.com/buildkite/agent/builds/14218

## Changes

- Use the context-aware `DialContext` hook in the socket server test.
- Run lint when `.buildkite/Dockerfile-lint` changes.

## Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

`go test ./internal/socket` and `golangci-lint v2.13.2 run ./internal/socket/...` pass. The full suite was attempted but this orb cannot create signed commits in test repositories and does not have Ruby installed; CI will run it in the configured environment.

## Disclosures / Credits

Amp traced the build failure and implemented the fix under Kate Sy's direction.
