### PR TITLE
[v3] Fix lint after golangci-lint upgrade

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,6 +16,7 @@ steps:
     if_changed:
       - go.{mod,sum}
       - "**.go"
+      - .buildkite/Dockerfile-lint
       - .buildkite/steps/check-code-committed.sh
     plugins:
       - docker-compose#v4.14.0:

--- a/internal/socket/server_test.go
+++ b/internal/socket/server_test.go
@@ -110,8 +110,8 @@ func TestServerHandler(t *testing.T) {
 
 	cli := &http.Client{
 		Transport: &http.Transport{
-			Dial: func(string, string) (net.Conn, error) {
-				return net.Dial("unix", sockPath)
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
 			},
 		},
 	}


### PR DESCRIPTION
## Description

Backport of #4314 to prevent the golangci-lint v2.13 upgrade in #4299 from breaking the v3 build. No v3-specific translation was required.

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

`go test ./internal/socket` and `golangci-lint v2.13.2 run ./internal/socket/...` pass.

## Disclosures / Credits

Amp performed the backport under Kate Sy's direction.
