### PR TITLE
docs: fix 7 typos in comments and documentation

### DIFF
--- a/agent/pipeline_uploader.go
+++ b/agent/pipeline_uploader.go
@@ -41,18 +41,18 @@ type PipelineUploader struct {
 // 3. Status Route: /jobs/:job_uuid/pipelines/:upload_uuid
 //
 // In this method, the agent will first upload the pipeline to the Async Route.
-// Then, depending on the response it will behave differetly
+// Then, depending on the response it will behave differently
 //
-// 1. The Async Route responds 202: poll the Status Route until the upload has beed "applied"
+// 1. The Async Route responds 202: poll the Status Route until the upload has been "applied"
 // 2. The Async Route responds with other 2xx: exit, the upload succeeded synchronously (possibly after retry)
 // 3. The Async Route responds with other xxx: retry uploading the pipeline to the Async Route
 //
-// Note that the Sync Route is not used by this version of the agent at all. Typically, the Aysnc
+// Note that the Sync Route is not used by this version of the agent at all. Typically, the Async
 // Route will return 202 whether or not the pipeline upload has been processed.
 //
 // However, the API has the option to treat the Async Route as if it were the Sync Route by
-// returning a 2xx that's not a 202. This will tigger option 2. While the API currently does not do
-// this, we want to maintain the flexbitity to do so in the future. If that is implemented, the
+// returning a 2xx that's not a 202. This will trigger option 2. While the API currently does not do
+// this, we want to maintain the flexibility to do so in the future. If that is implemented, the
 // Status Route will not be polled, and either the Async Route will be retried until a (non 202) 2xx
 // is returned from the API, or the method will exit early with no error. This reiterates option 2.
 //

--- a/logger/log.go
+++ b/logger/log.go
@@ -275,7 +275,7 @@ var Discard = &ConsoleLogger{
 	},
 }
 
-// TestPrinter is a log printer than calls the Logf method of a [testing.T]
+// TestPrinter is a log printer that calls the Logf method of a [testing.T]
 // or [testing.B].
 type TestPrinter struct {
 	tb testing.TB

--- a/status/status.go
+++ b/status/status.go
@@ -225,7 +225,7 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 // AddItem adds an item to be displayed on the status page. On each page load,
 // the item's callback is called, and the data returned used to fill the
 // HTML template in tmpl. The title should be unique (among items under this
-// parent.
+// parent).
 func AddItem(parent context.Context, title, tmpl string, cb func(context.Context) (any, error)) (context.Context, func()) {
 	if cb == nil {
 		cb = func(context.Context) (any, error) { return nil, nil }


### PR DESCRIPTION
## Summary

Fix 7 typos across 3 files, all in Go doc/inline comments:

- **agent/pipeline_uploader.go**: `differetly` -> `differently`
- **agent/pipeline_uploader.go**: `beed` -> `been`
- **agent/pipeline_uploader.go**: `Aysnc` -> `Async`
- **agent/pipeline_uploader.go**: `tigger` -> `trigger`
- **agent/pipeline_uploader.go**: `flexbitity` -> `flexibility`
- **status/status.go**: unbalanced parenthesis in the `AddItem` doc comment - `parent.` -> `parent).`
- **logger/log.go**: `a log printer than calls` -> `a log printer that calls`

No functional changes - comments/documentation only. No identifiers were renamed (notably `pollForPiplineUploadStatus` was left alone on purpose, since renaming it would be a code change rather than a doc fix - happy to follow up separately if you'd like it corrected).

Gofumpt formatting is unaffected because only comment text changed.