### PR TITLE
Run windows tests on hosted compute + macOS tests in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,8 +4,8 @@ env:
   BUILDKITE_AGENT_CACHE_STORE_URL: "s3://bk-agent-cache-v2-dogfood-445615400570-us-east-1?region=us-east-1"
   AGENT_RUNNERS_LINUX_QUEUE: "${AGENT_RUNNERS_LINUX_QUEUE:-agent-runners-linux-amd64}"
   AGENT_RUNNERS_LINUX_ARM64_QUEUE: "${AGENT_RUNNERS_LINUX_ARM64_QUEUE:-agent-runners-linux-arm64}"
-  AGENT_RUNNERS_WINDOWS_QUEUE: "${AGENT_RUNNERS_WINDOWS_QUEUE:-agent-runners-windows-amd64}"
   AGENT_RUNNERS_MACOS_QUEUE: "${AGENT_RUNNERS_MACOS_QUEUE:-agent-runners-hosted-macos}"
+  AGENT_RUNNERS_WINDOWS_QUEUE: "${AGENT_RUNNERS_WINDOWS_QUEUE:-agent-runners-hosted-windows}"
   AGENT_BUILDERS_QUEUE: "${AGENT_BUILDERS_QUEUE:-elastic-builders}"
   AGENT_BUILDERS_ARM64_QUEUE: "${AGENT_BUILDERS_QUEUE:-elastic-builders}"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,7 @@ env:
   AGENT_RUNNERS_LINUX_QUEUE: "${AGENT_RUNNERS_LINUX_QUEUE:-agent-runners-linux-amd64}"
   AGENT_RUNNERS_LINUX_ARM64_QUEUE: "${AGENT_RUNNERS_LINUX_ARM64_QUEUE:-agent-runners-linux-arm64}"
   AGENT_RUNNERS_WINDOWS_QUEUE: "${AGENT_RUNNERS_WINDOWS_QUEUE:-agent-runners-windows-amd64}"
+  AGENT_RUNNERS_MACOS_QUEUE: "${AGENT_RUNNERS_MACOS_QUEUE:-agent-runners-hosted-macos}"
   AGENT_BUILDERS_QUEUE: "${AGENT_BUILDERS_QUEUE:-elastic-builders}"
   AGENT_BUILDERS_ARM64_QUEUE: "${AGENT_BUILDERS_QUEUE:-elastic-builders}"
 
@@ -182,6 +183,29 @@ steps:
                 - AWS_SECRET_ACCESS_KEY
                 - AWS_SESSION_TOKEN
 
+      - name: ":mac: macOS ARM64 Tests"
+        key: test-macos
+        command: ".buildkite/steps/tests.sh"
+        parallelism: 2
+        artifact_paths:
+          - junit-*.xml
+          - "coverage-*/**"
+        agents:
+          queue: $AGENT_RUNNERS_MACOS_QUEUE
+        plugins:
+          - *assume_cache_role
+          - tests#v1.0.0:
+              suite-slug: buildkite-agent
+              test-runner: gotest
+              result-path: junit.xml
+              install-client: false
+              upload-results: true
+              oidc-lifetime: 7200
+              tags:
+                - "os=darwin"
+                - "arch=arm64"
+                - "race=false"
+
       - name: ":windows: Windows AMD64 Tests"
         key: test-windows
         command: "bash .buildkite\\steps\\tests.sh"
@@ -298,6 +322,7 @@ steps:
           - test-linux-amd64
           - test-race-linux-arm64
           - test-linux-arm64
+          - test-macos
           - test-windows
         allow_dependency_failure: true
         plugins:
@@ -528,6 +553,7 @@ steps:
       - e2e-tests
       - test-docker-amd64
       - test-docker-arm64
+      - test-macos
       - test-windows
     command: ".buildkite/steps/upload-release-steps.sh"
     if: build.env("DRY_RUN") == "true" || build.branch =~ /^(main|.*-.*-stable|v\d+)$$/

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,6 +23,7 @@ steps:
       - .buildkite/steps/check-code-committed.sh
       - .buildkite/cache.yml
       - .buildkite/docker-compose.yml
+      - .buildkite/pipeline.yml
     plugins:
       - &assume_cache_role
         aws-assume-role-with-web-identity#v1.4.0:
@@ -57,6 +58,7 @@ steps:
       - .buildkite/steps/protobuf-tool-versions.sh
       - .buildkite/cache.yml
       - .buildkite/docker-compose.yml
+      - .buildkite/pipeline.yml
     plugins:
       - *assume_cache_role
       - docker-compose#v4.14.0:
@@ -114,6 +116,7 @@ steps:
       - .buildkite/steps/{tests,test-coverage-report}.sh
       - .buildkite/cache.yml
       - .buildkite/docker-compose.yml
+      - .buildkite/pipeline.yml
     steps:
       - name: ":linux: Linux AMD64 Tests"
         key: test-linux-amd64


### PR DESCRIPTION
## Description

We recently added support for windows hosted agents as an enterprise-only feature. it'd be good to dogfood this internally, and have our own builds be tied up in it.

Additionally, macOS tests have been running on developer laptops by proxy for a long time. While we're here, add steps running tests on macos, also against a hosted queue.

## Context

A-1864

## Changes

- Change windows tests to run on a windows hosted queue
- Add macOS tests, running on a macOS hosted queue
- Add `pipeline.yml` to all `if_changed` blocks, ensuring that all steps are run if someone modifies the pipeline definition

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

C'est moi
