### PR TITLE
Add docs section to PR template for docs bot to consume

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,29 @@ List of what the PR changes. If the PR changes the CLI arguments, consider addin
 Can skip if changes are simple or clear from the commit messages.
 -->
 
+## Documentation and publication
+
+<!--
+The following details help our docs writer bot decide whether and how to draft docs for this change.
+-->
+
+**Does this change need public documentation?**
+
+- [ ] Yes
+- [ ] No
+- [ ] Unsure
+
+**Is this change safe to document publicly when this PR merges?**
+
+- [ ] Yes
+- [ ] No, the documentation must be held
+- [ ] It can be documented as a limited-availability or preview feature
+- [ ] Not applicable (docs not needed)
+
+**Publication notes:**
+
+<!-- If documentation must be held or needs availability language, explain what reviewers should know and when it can be published. -->
+
 ## Testing
 - [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
 - [ ] Code is formatted (with `go tool gofumpt -extra -w .`)


### PR DESCRIPTION
### Description

This is not a code change.

We've had some issues in the past where our docs writer bot documented a code change which wasn't ready to be made public yet. This change adds two points to the PR template, asking the author to note if docs are needed, and if those docs can be published immediately or not. The bot will use that information when it reviews the PR.

### Context

SUP-7756