### PR TITLE
Add experimental Origin CloneKit mirror seeding

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -18,6 +18,25 @@ If an experiment doesn't exist, no error will be raised.
 
 ## Available Experiments
 
+### `origin-clonekit`
+
+Seeds a missing on-host Git mirror using Cursor Origin's CloneKit pack data.
+Requires `BUILDKITE_GIT_MIRRORS_PATH` and a repository URL of the form
+`https://origin.cursor.com/owner/repo.git`. The backend-provided remote mirror
+URL takes precedence over the canonical repository URL. Credentials come only
+from the agent's repository credential helper; SSH authentication is not supported.
+
+Only the first checkout attempt of a fresh checkout is eligible. Existing mirrors,
+submodule mirrors, skipped mirror updates, hook-rewritten repositories and custom
+mirror clone flags retain their normal behavior. Downloads and verification have
+a 30-second budget; failures fall back directly to canonical Git in the same
+attempt. Cancellation does not start fallback. Canonical Git remains authoritative
+for the build commit. Disable the experiment to restore normal mirror creation;
+already-created mirrors remain usable.
+
+**Status:** Experimental, HTTPS Origin only. Uses primary artifact URLs, not the
+optional S3 delivery URLs. No top-up fetch or verification bypass is provided.
+
 ### `agent-api`
 
 This exposes a local API for interacting with the agent process.

--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -22,14 +22,23 @@ If an experiment doesn't exist, no error will be raised.
 
 Seeds a missing on-host Git mirror using Cursor Origin's CloneKit pack data.
 Requires `BUILDKITE_GIT_MIRRORS_PATH` and a repository URL of the form
-`https://origin.cursor.com/owner/repo.git`. The backend-provided remote mirror
-URL takes precedence over the canonical repository URL. Credentials come only
-from the agent's repository credential helper; SSH authentication is not supported.
+`https://origin.cursor.com/git/owner/repo.git` or
+`https://origin.cursor.com/owner/repo.git`. The URL is preserved for credential
+lookup and manifest requests; use the backend-provided form for managed credentials.
+The backend-provided remote mirror URL takes precedence over the canonical
+repository URL. Manifest credentials come only from the agent's repository
+credential helper; SSH authentication is not supported.
+
+The experiment does not configure credentials for the subsequent canonical Git
+checkout. Self-hosted Origin jobs must retain working operator-provided Git auth
+or explicitly opt into `BUILDKITE_USE_REPOSITORY_PROVIDER_GIT_CREDENTIALS=true`,
+with repository access enabled in the backend.
 
 Only the first checkout attempt of a fresh checkout is eligible. Existing mirrors,
 submodule mirrors, skipped mirror updates, hook-rewritten repositories and custom
-mirror clone flags retain their normal behavior. Downloads and verification have
-a 30-second budget; failures fall back directly to canonical Git in the same
+mirror clone flags retain their normal behavior (the default `-v` and empty mirror
+flags are eligible). Downloads and verification have a 30-second budget;
+failures fall back directly to canonical Git in the same
 attempt. Cancellation does not start fallback. Canonical Git remains authoritative
 for the build commit. Disable the experiment to restore normal mirror creation;
 already-created mirrors remain usable.

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -25,6 +25,7 @@ const (
 	// Available experiments
 	AgentAPI                       = "agent-api"
 	InterpolationPrefersRuntimeEnv = "interpolation-prefers-runtime-env"
+	OriginCloneKit                 = "origin-clonekit"
 	PTYRaw                         = "pty-raw"
 	LegacyPostHookOrder            = "legacy-post-hook-order"
 	ZipPlugins                     = "zip-plugins"
@@ -53,6 +54,7 @@ var (
 	Available = map[string]struct{}{
 		AgentAPI:                       {},
 		InterpolationPrefersRuntimeEnv: {},
+		OriginCloneKit:                 {},
 		LegacyPostHookOrder:            {},
 		PTYRaw:                         {},
 		ZipPlugins:                     {},

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -336,6 +336,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context, previousAttempts in
 	defer func() { tracetools.FinishWithError(span, retErr) }()
 
 	attempt := e.resolveRemoteMirrorAttempt(previousAttempts)
+	attempt.cloneKitURL = e.originCloneKitSource(ctx, previousAttempts)
 	defer func() { e.emitRemoteMirrorTelemetry(span, attempt) }()
 
 	// Adopt the repo-checkout child ctx so git.* spans nest under it.

--- a/internal/job/checkout_mirror.go
+++ b/internal/job/checkout_mirror.go
@@ -159,6 +159,20 @@ func (e *Executor) updateGitMirror(ctx context.Context, repository string, attem
 			return nil
 		}
 
+		if attempt != nil && attempt.cloneKitURL != "" && stagingCleanupErr == nil {
+			// Only one speculative accelerator: a failed CloneKit attempt goes
+			// straight to canonical Git, not a second remote-mirror clone.
+			attempt.outcome = remoteMirrorOutcomeSkipped
+			attempt.skipReason = remoteMirrorSkipCloneKit
+			hit, err := e.tryOriginCloneKit(ctx, attempt.cloneKitURL, repository, stagingDir, mirrorDir)
+			if err != nil {
+				return "", err
+			}
+			if hit {
+				return e.snapshotMirror(ctx, repository, mirrorDir)
+			}
+		}
+
 		if isOnHostRemoteMirrorAttempt(attempt) {
 			started := time.Now()
 			tempMirrorDir := stagingDir

--- a/internal/job/checkout_origin_clonekit.go
+++ b/internal/job/checkout_origin_clonekit.go
@@ -1,0 +1,439 @@
+package job
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/buildkite/agent/v4/internal/experiments"
+	"github.com/buildkite/agent/v4/internal/osutil"
+	"github.com/buildkite/agent/v4/internal/shell"
+	"github.com/buildkite/agent/v4/tracetools"
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/sync/errgroup"
+)
+
+const cloneKitAnchor = "refs/buildkite-agent/origin-clonekit/anchor"
+
+var (
+	cloneKitRepoPath = regexp.MustCompile(`^/[A-Za-z0-9_][A-Za-z0-9_.-]*/[A-Za-z0-9_][A-Za-z0-9_.-]*\.git$`)
+	cloneKitPackPath = regexp.MustCompile(`^objects/pack/pack-([0-9a-f]{40})\.(pack|idx|rev)$`)
+	errCloneKitMiss  = errors.New("clonekit manifest unavailable")
+)
+
+func (e *Executor) originCloneKitSource(ctx context.Context, previousAttempts int) string {
+	if !experiments.IsEnabled(ctx, experiments.OriginCloneKit) || previousAttempts != 0 ||
+		e.GitMirrorsPath == "" || e.GitMirrorsSkipUpdate || e.GitCloneMirrorFlags != "" ||
+		e.Repository != e.canonicalRepository || e.checkoutAlreadyExists() {
+		return ""
+	}
+	source := e.GitRemoteMirrorURL
+	if source == "" {
+		source = e.Repository
+	}
+	u, err := url.Parse(source)
+	if err != nil || u.Scheme != "https" || u.Host != "origin.cursor.com" || u.User != nil ||
+		u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.RawPath != "" || !cloneKitRepoPath.MatchString(u.Path) {
+		return ""
+	}
+	return source
+}
+
+// tryOriginCloneKit owns only unpublished staging, under the mirror clone lock.
+// All errors crossing this boundary are intentionally URL/credential-free.
+func (e *Executor) tryOriginCloneKit(parent context.Context, source, repository, staging, destination string) (bool, error) {
+	span, ctx := e.traceOpSpan(parent, "origin-clonekit")
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	started := time.Now()
+	stage, outcome := "credentials", "error"
+	sourceKind := "canonical"
+	if source == e.GitRemoteMirrorURL {
+		sourceKind = "remote-mirror"
+	}
+	defer func() {
+		span.SetAttributes(attribute.String("outcome", outcome), attribute.String("stage", stage), attribute.String("source", sourceKind), attribute.Bool("fallback", outcome != "hit" && parent.Err() == nil), attribute.Float64("duration_seconds", time.Since(started).Seconds()))
+		tracetools.FinishWithError(span, nil)
+		e.shell.Commentf("Origin CloneKit: %s (%s)", outcome, stage)
+	}()
+	err := func() error {
+		u, _ := url.Parse(source) // eligibility checked before acquiring the clone lock
+		input := "protocol=https\nhost=" + u.Host + "\npath=" + strings.TrimPrefix(u.Path, "/") + "\n\n"
+		args := append(remoteMirrorGitFlags(ctx), "credential", "fill")
+		credentials, err := e.shell.CloneWithStdin(strings.NewReader(input)).Command("git", args...).RunAndCaptureStdout(ctx, shell.AlwaysHidePrompt(), shell.ShowStderr(false))
+		if err != nil {
+			return errors.New("credential lookup failed")
+		}
+		var username, password string
+		for _, line := range strings.Split(credentials, "\n") {
+			if v, ok := strings.CutPrefix(line, "username="); ok {
+				username = v
+			}
+			if v, ok := strings.CutPrefix(line, "password="); ok {
+				password = v
+			}
+		}
+		if username == "" || password == "" || (username == "fail" && password == "fail") {
+			return errors.New("credentials unavailable")
+		}
+		client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+		stage = "manifest"
+		t := time.Now()
+		m, err := fetchCloneKitManifest(ctx, client, source+"/clone-kit", username, password)
+		span.SetAttributes(attribute.Float64("manifest_seconds", time.Since(t).Seconds()))
+		if err != nil {
+			return err
+		}
+		stage = "prepare"
+		if err := os.Mkdir(staging, 0o777); err != nil {
+			return errors.New("create staging failed")
+		}
+		runGit := func(args ...string) error {
+			_, err := e.shell.Command("git", args...).RunAndCaptureStdout(ctx, shell.AlwaysHidePrompt(), shell.ShowStderr(false))
+			if err != nil {
+				return errors.New("seed git operation failed")
+			}
+			return nil
+		}
+		if err := runGit("init", "--bare", "--object-format=sha1", "--initial-branch=main", staging); err != nil {
+			return err
+		}
+		stage = "download"
+		t = time.Now()
+		g, downloadCtx := errgroup.WithContext(ctx)
+		var bytes int64
+		for _, file := range m.Files {
+			bytes += file.Size
+			if file.Name == "pack" {
+				span.SetAttributes(attribute.Int("ranges", cloneKitRangeCount(file.Size)))
+			}
+			g.Go(func() error {
+				return downloadCloneKitFile(downloadCtx, client, file, filepath.Join(staging, file.Name+".download"))
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return err
+		}
+		span.SetAttributes(attribute.Float64("download_seconds", time.Since(t).Seconds()), attribute.Int64("bytes", bytes))
+		stage = "verify"
+		t = time.Now()
+		for _, file := range m.Files {
+			if err := verifyCloneKitFile(ctx, file, m.PackChunks, filepath.Join(staging, file.Name+".download")); err != nil {
+				return err
+			}
+		}
+		for _, file := range m.Files {
+			// Paths have been validated, but derive destinations from the pack ID.
+			name := "pack-" + m.packID + "." + file.Name
+			// Mirror caches may be shared by agents running as different users.
+			// Match Git's read-only pack permissions, respecting the host umask.
+			if err := os.Chmod(filepath.Join(staging, file.Name+".download"), 0o444&^osutil.Umask); err != nil {
+				return errors.New("set pack permissions failed")
+			}
+			if err := os.Rename(filepath.Join(staging, file.Name+".download"), filepath.Join(staging, "objects", "pack", name)); err != nil {
+				return errors.New("install pack data failed")
+			}
+		}
+		if err := runGit("--git-dir", staging, "cat-file", "-e", m.TipCommit+"^{commit}"); err != nil {
+			return err
+		}
+		if err := runGit("--git-dir", staging, "fsck", "--connectivity-only", "--no-dangling", m.TipCommit); err != nil {
+			return err
+		}
+		if err := runGit("--git-dir", staging, "update-ref", cloneKitAnchor, m.TipCommit); err != nil {
+			return err
+		}
+		span.SetAttributes(attribute.Float64("verify_seconds", time.Since(t).Seconds()))
+		stage = "publish"
+		for _, config := range [][2]string{{"remote.origin.url", repository}, {"remote.origin.fetch", "+refs/*:refs/*"}, {"remote.origin.mirror", "true"}, {"remote.origin.tagOpt", "--no-tags"}} {
+			if err := runGit("--git-dir", staging, "config", config[0], config[1]); err != nil {
+				return err
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := os.Rename(staging, destination); err != nil {
+			return errors.New("publish seed failed")
+		}
+		return nil
+	}()
+	if err == nil {
+		outcome = "hit"
+		return true, nil
+	}
+	if errors.Is(err, errCloneKitMiss) {
+		outcome = "miss"
+	}
+	if ctx.Err() != nil {
+		outcome = "timeout"
+	}
+	// Every worker and Git process has completed before staging can be removed.
+	if cleanupErr := os.RemoveAll(staging); cleanupErr != nil {
+		stage = "cleanup"
+		// Canonical destination is independent. Leave interrupted staging for
+		// next clone-lock acquisition and continue canonical checkout.
+	}
+	if parent.Err() != nil {
+		outcome = "cancelled"
+		return false, parent.Err()
+	}
+	return false, nil
+}
+
+type cloneKitFile struct {
+	Name   string `json:"name"`
+	Path   string `json:"path"`
+	URL    string `json:"url"`
+	Size   int64  `json:"size"`
+	SHA256 string `json:"sha256"`
+}
+
+type cloneKitChunks struct {
+	ChunkSize int64    `json:"chunk_size"`
+	SHA256s   []string `json:"sha256s"`
+}
+
+type cloneKitManifest struct {
+	Version    int             `json:"version"`
+	RepoID     string          `json:"repo_id"`
+	TipCommit  string          `json:"tip_commit"`
+	Files      []cloneKitFile  `json:"files"`
+	PackChunks *cloneKitChunks `json:"pack_chunks"`
+	packID     string
+}
+
+func fetchCloneKitManifest(ctx context.Context, client *http.Client, endpoint, username, password string) (*cloneKitManifest, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, errors.New("invalid manifest request")
+	}
+	req.SetBasicAuth(username, password)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.New("manifest request failed")
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == 404 || resp.StatusCode == 410 {
+		return nil, errCloneKitMiss
+	}
+	if resp.StatusCode != 200 {
+		return nil, errors.New("manifest status rejected")
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, (1<<20)+1))
+	if err != nil || len(body) > 1<<20 {
+		return nil, errors.New("manifest body rejected")
+	}
+	// encoding/json otherwise silently accepts duplicate keys (last value wins).
+	if !json.Valid(body) || !cloneKitUniqueKeys(json.NewDecoder(bytes.NewReader(body)), 0) {
+		return nil, errors.New("ambiguous manifest JSON")
+	}
+	var m cloneKitManifest
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil, errors.New("invalid manifest JSON")
+	}
+	if err := m.validate(); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func cloneKitUniqueKeys(d *json.Decoder, depth int) bool {
+	if depth > 64 {
+		return false
+	}
+	token, err := d.Token()
+	if err != nil {
+		return false
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return true
+	}
+	keys := make(map[string]bool)
+	for d.More() {
+		if delim == '{' {
+			key, err := d.Token()
+			if err != nil {
+				return false
+			}
+			s, ok := key.(string)
+			s = strings.ToLower(s) // encoding/json also matches struct fields case-insensitively
+			if !ok || keys[s] {
+				return false
+			}
+			keys[s] = true
+		}
+		if !cloneKitUniqueKeys(d, depth+1) {
+			return false
+		}
+	}
+	_, err = d.Token()
+	return err == nil
+}
+
+func cloneKitDigest(s string) bool {
+	b, err := hex.DecodeString(s)
+	return err == nil && len(b) == sha256.Size && s == strings.ToLower(s)
+}
+
+func (m *cloneKitManifest) validate() error {
+	invalid := errors.New("invalid clonekit manifest")
+	id, err := uuid.Parse(m.RepoID)
+	if err != nil || id == uuid.Nil || id.String() != m.RepoID || m.Version != 1 || !fullSHA1ObjectID.MatchString(m.TipCommit) || len(m.Files) != 3 {
+		return invalid
+	}
+	seen := make(map[string]bool)
+	var packSize int64
+	for _, f := range m.Files {
+		parts := cloneKitPackPath.FindStringSubmatch(f.Path)
+		if len(parts) != 3 || parts[2] != f.Name || seen[f.Name] || !cloneKitDigest(f.SHA256) || f.Size <= 0 {
+			return invalid
+		}
+		if m.packID != "" && m.packID != parts[1] {
+			return invalid
+		}
+		m.packID = parts[1]
+		seen[f.Name] = true
+		cap := int64(4 << 30)
+		if f.Name == "pack" {
+			cap = 64 << 30
+			packSize = f.Size
+		}
+		if f.Size > cap {
+			return invalid
+		}
+		u, err := url.Parse(f.URL)
+		if err != nil || u.Scheme != "https" || u.Host == "" || u.User != nil || u.Fragment != "" {
+			return invalid
+		}
+	}
+	if c := m.PackChunks; c != nil {
+		if c.ChunkSize <= 0 || c.ChunkSize > 64<<30 || int64(len(c.SHA256s)) != (packSize-1)/c.ChunkSize+1 {
+			return invalid
+		}
+		for _, digest := range c.SHA256s {
+			if !cloneKitDigest(digest) {
+				return invalid
+			}
+		}
+	}
+	return nil
+}
+
+func cloneKitRangeCount(size int64) int {
+	if size < 64<<20 {
+		return 1
+	}
+	return int(min(int64(32), size/(8<<20)))
+}
+
+func downloadCloneKitFile(ctx context.Context, client *http.Client, file cloneKitFile, path string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		return errors.New("create download failed")
+	}
+	defer func() { _ = f.Close() }() // error path; successful writes explicitly close below
+	if err := f.Truncate(file.Size); err != nil {
+		return errors.New("size download failed")
+	}
+	n := 1
+	if file.Name == "pack" {
+		n = cloneKitRangeCount(file.Size)
+	}
+	g, ctx := errgroup.WithContext(ctx)
+	for i := range n {
+		start, end := int64(i)*file.Size/int64(n), int64(i+1)*file.Size/int64(n)-1
+		g.Go(func() error {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, file.URL, nil)
+			if err != nil {
+				return errors.New("invalid artifact request")
+			}
+			req.Header.Set("Accept-Encoding", "identity")
+			status := http.StatusOK
+			if n > 1 {
+				req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+				status = http.StatusPartialContent
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				return errors.New("artifact request failed")
+			}
+			defer func() { _ = resp.Body.Close() }()
+			length := end - start + 1
+			if resp.StatusCode != status || resp.ContentLength != length || (resp.Header.Get("Content-Encoding") != "" && resp.Header.Get("Content-Encoding") != "identity") {
+				return errors.New("artifact response rejected")
+			}
+			if n > 1 && resp.Header.Get("Content-Range") != fmt.Sprintf("bytes %d-%d/%d", start, end, file.Size) {
+				return errors.New("artifact range rejected")
+			}
+			if _, err := io.CopyN(io.NewOffsetWriter(f, start), resp.Body, length); err != nil {
+				return errors.New("artifact transfer failed")
+			}
+			var extra [1]byte
+			if n, err := resp.Body.Read(extra[:]); n != 0 || err != io.EOF {
+				return errors.New("artifact length rejected")
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return errors.New("close download failed")
+	}
+	return nil
+}
+
+func verifyCloneKitFile(ctx context.Context, file cloneKitFile, chunks *cloneKitChunks, path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return errors.New("open verification failed")
+	}
+	defer func() { _ = f.Close() }() // read-only handle
+	size, hashes := file.Size, []string{file.SHA256}
+	if file.Name == "pack" && chunks != nil {
+		size, hashes = chunks.ChunkSize, chunks.SHA256s
+	}
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(8)
+	for i, digest := range hashes {
+		g.Go(func() error {
+			h := sha256.New()
+			r := io.NewSectionReader(f, int64(i)*size, min(size, file.Size-int64(i)*size))
+			buf := make([]byte, 64<<10)
+			for {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				n, err := r.Read(buf)
+				h.Write(buf[:n])
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					return errors.New("read verification failed")
+				}
+			}
+			if hex.EncodeToString(h.Sum(nil)) != digest {
+				return errors.New("artifact digest mismatch")
+			}
+			return nil
+		})
+	}
+	return g.Wait()
+}

--- a/internal/job/checkout_origin_clonekit.go
+++ b/internal/job/checkout_origin_clonekit.go
@@ -29,15 +29,20 @@ import (
 const cloneKitAnchor = "refs/buildkite-agent/origin-clonekit/anchor"
 
 var (
-	cloneKitRepoPath = regexp.MustCompile(`^/[A-Za-z0-9_][A-Za-z0-9_.-]*/[A-Za-z0-9_][A-Za-z0-9_.-]*\.git$`)
+	cloneKitRepoPath = regexp.MustCompile(`^/(git/)?[A-Za-z0-9_][A-Za-z0-9_.-]*/[A-Za-z0-9_][A-Za-z0-9_.-]*\.git$`)
 	cloneKitPackPath = regexp.MustCompile(`^objects/pack/pack-([0-9a-f]{40})\.(pack|idx|rev)$`)
 	errCloneKitMiss  = errors.New("clonekit manifest unavailable")
 )
 
 func (e *Executor) originCloneKitSource(ctx context.Context, previousAttempts int) string {
 	if !experiments.IsEnabled(ctx, experiments.OriginCloneKit) || previousAttempts != 0 ||
-		e.GitMirrorsPath == "" || e.GitMirrorsSkipUpdate || e.GitCloneMirrorFlags != "" ||
+		e.GitMirrorsPath == "" || e.GitMirrorsSkipUpdate ||
 		e.Repository != e.canonicalRepository || e.checkoutAlreadyExists() {
+		return ""
+	}
+	// The CLI defaults to -v; it changes output, not the mirror's contents.
+	// Other custom flags may change repository semantics and remain ineligible.
+	if e.GitCloneMirrorFlags != "" && e.GitCloneMirrorFlags != "-v" {
 		return ""
 	}
 	source := e.GitRemoteMirrorURL

--- a/internal/job/checkout_origin_clonekit_integration_test.go
+++ b/internal/job/checkout_origin_clonekit_integration_test.go
@@ -1,0 +1,170 @@
+package job
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/agent/v4/internal/osutil"
+	"github.com/buildkite/agent/v4/internal/self"
+	"github.com/buildkite/agent/v4/internal/shell"
+)
+
+type cloneKitTestTransport func(*http.Request) (*http.Response, error)
+
+func (f cloneKitTestTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestOriginCloneKitMirrorLifecycle(t *testing.T) {
+	// No parallelism: substitute the default HTTP transport only for this test.
+	canonical := newOnHostMirrorHTTPRepo(t, "canonical")
+	commit, _, err := canonical.PushBranch("canonical", "feature-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	packRepo := filepath.Join(t.TempDir(), "pack.git")
+	runGitForMirrorTest(t, "", "clone", "--mirror", canonical.RepoURL("canonical"), packRepo)
+	runGitForMirrorTest(t, packRepo, "-c", "pack.writeReverseIndex=true", "repack", "-ad")
+	m := validCloneKitManifest()
+	m.TipCommit, m.PackChunks, m.Files = commit, nil, nil
+	data := make(map[string][]byte)
+	entries, err := os.ReadDir(filepath.Join(packRepo, "objects", "pack"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		name := strings.TrimPrefix(filepath.Ext(entry.Name()), ".")
+		if name != "pack" && name != "idx" && name != "rev" {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(packRepo, "objects", "pack", entry.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		data[name] = b
+		m.Files = append(m.Files, cloneKitFile{Name: name, Path: "objects/pack/" + entry.Name(), Size: int64(len(b)), SHA256: cloneKitTestDigest(string(b)), URL: "https://cdn.example/" + name + "?secret=presigned-secret"})
+	}
+	if err := m.validate(); err != nil {
+		t.Fatal(err)
+	}
+	helper := filepath.Join(t.TempDir(), "helper")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\ncat > \"$CLONEKIT_CREDENTIAL_INPUT\"\nprintf 'username=test-user\\npassword=repository-secret\\n'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, mode := range []string{"hit", "miss", "corrupt", "cancel"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(self.OverridePath(t.Context(), helper))
+			defer cancel()
+			e := newOnHostMirrorExecutor(t, canonical.RepoURL("canonical"), commit)
+			e.CleanCheckout = true
+			e.Phases = []string{"checkout", "command"}
+			input := filepath.Join(t.TempDir(), "input")
+			e.shell.Env.Set("CLONEKIT_CREDENTIAL_INPUT", input)
+			var logs bytes.Buffer
+			e.shell, err = shell.New(shell.WithEnv(e.shell.Env), shell.WithDebug(true), shell.WithStdout(&logs), shell.WithLogger(shell.NewWriterLogger(&logs, false, nil)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, "/clone-kit") {
+					user, password, ok := r.BasicAuth()
+					if !ok || user != "test-user" || password != "repository-secret" {
+						t.Error("manifest auth missing")
+					}
+					if mode == "cancel" {
+						cancel()
+						<-r.Context().Done()
+						return
+					}
+					if mode == "miss" {
+						http.NotFound(w, r)
+						return
+					}
+					_ = json.NewEncoder(w).Encode(m)
+					return
+				}
+				if r.Header.Get("Authorization") != "" {
+					t.Error("repository auth leaked to artifact")
+				}
+				b := bytes.Clone(data[strings.TrimPrefix(r.URL.Path, "/")])
+				if mode == "corrupt" && len(b) > 0 {
+					b[0] ^= 1
+				}
+				w.Header().Set("Content-Length", fmt.Sprint(len(b)))
+				_, _ = w.Write(b)
+			}))
+			defer server.Close()
+			old := http.DefaultTransport
+			http.DefaultTransport = cloneKitTestTransport(func(r *http.Request) (*http.Response, error) {
+				c := r.Clone(r.Context())
+				c.URL.Host = strings.TrimPrefix(server.URL, "https://")
+				return server.Client().Transport.RoundTrip(c)
+			})
+			defer func() { http.DefaultTransport = old }()
+			attempt := remoteMirrorAttempt{site: remoteMirrorSiteOnHostMirror, url: "https://must-not-be-used.example/repo.git", cloneKitURL: "https://origin.cursor.com/acme/repo.git"}
+			dir, err := e.updateGitMirror(ctx, e.Repository, &attempt)
+			if mode == "cancel" {
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("error=%v, want cancellation", err)
+				}
+				if _, err := os.Stat(expectedOnHostMirrorDir(e)); !os.IsNotExist(err) {
+					t.Fatal("canonical fallback started on cancellation")
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				gitOutputForMirrorTest(t, dir, "fsck", "--full", "--no-dangling")
+				checkout := filepath.Join(t.TempDir(), "checkout")
+				runGitForMirrorTest(t, "", "clone", "--reference", dir, e.Repository, checkout)
+				runGitForMirrorTest(t, checkout, "checkout", "--force", commit)
+				gitOutputForRemoteCheckoutTest(t, checkout, "fsck", "--full", "--no-dangling")
+				if gitOutputForRemoteCheckoutTest(t, checkout, "rev-parse", "HEAD") != commit {
+					t.Fatal("wrong checkout commit")
+				}
+				if got := gitOutputForMirrorTest(t, expectedOnHostMirrorDir(e), "config", "remote.origin.url"); got != e.Repository {
+					t.Fatal("canonical origin not preserved")
+				}
+				if mode == "hit" {
+					if gitOutputForMirrorTest(t, dir, "rev-parse", cloneKitAnchor) != commit {
+						t.Fatal("snapshot lost anchor")
+					}
+					if gitOutputForMirrorTest(t, dir, "symbolic-ref", "HEAD") != "refs/heads/main" {
+						t.Fatal("invalid HEAD")
+					}
+					if runtime.GOOS != "windows" {
+						for _, f := range m.Files {
+							info, err := os.Stat(filepath.Join(dir, filepath.FromSlash(f.Path)))
+							if err != nil {
+								t.Fatal(err)
+							}
+							if info.Mode().Perm() != 0o444&^osutil.Umask {
+								t.Fatal("pack permissions do not respect shared-cache umask")
+							}
+						}
+					}
+				}
+			}
+			if _, err := os.Stat(remoteMirrorStagingDir(expectedOnHostMirrorDir(e))); !os.IsNotExist(err) {
+				t.Fatal("staging remains")
+			}
+			for _, secret := range []string{"repository-secret", "presigned-secret"} {
+				if strings.Contains(logs.String(), secret) {
+					t.Fatal("secret logged")
+				}
+			}
+			b, err := os.ReadFile(input)
+			if err != nil || !strings.Contains(string(b), "path=acme/repo.git\n") || strings.Contains(string(b), "clone-kit") {
+				t.Fatal("wrong credential target")
+			}
+		})
+	}
+}

--- a/internal/job/checkout_origin_clonekit_test.go
+++ b/internal/job/checkout_origin_clonekit_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildkite/agent/v4/env"
 	"github.com/buildkite/agent/v4/internal/experiments"
 	"github.com/buildkite/agent/v4/internal/shell"
 )
@@ -83,7 +84,7 @@ func TestOriginCloneKitSource(t *testing.T) {
 	ctx, _ := experiments.Enable(t.Context(), experiments.OriginCloneKit)
 	canonical := "https://origin.cursor.com/acme/repo.git"
 	newExecutor := func() *Executor {
-		sh, err := shell.New()
+		sh, err := shell.New(shell.WithEnv(env.New()))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/job/checkout_origin_clonekit_test.go
+++ b/internal/job/checkout_origin_clonekit_test.go
@@ -1,0 +1,323 @@
+package job
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/buildkite/agent/v4/internal/experiments"
+	"github.com/buildkite/agent/v4/internal/shell"
+)
+
+const cloneKitTestPackID = "0123456789abcdef0123456789abcdef01234567"
+
+func cloneKitTestDigest(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+func validCloneKitManifest() cloneKitManifest {
+	files := make([]cloneKitFile, 0, 3)
+	for _, name := range []string{"pack", "idx", "rev"} {
+		files = append(files, cloneKitFile{
+			Name: name, Path: "objects/pack/pack-" + cloneKitTestPackID + "." + name,
+			URL: "https://objects.example/" + name, Size: 1, SHA256: cloneKitTestDigest(name),
+		})
+	}
+	return cloneKitManifest{
+		Version: 1, RepoID: "123e4567-e89b-12d3-a456-426614174000",
+		TipCommit: strings.Repeat("a", 40), Files: files,
+		PackChunks: &cloneKitChunks{ChunkSize: 1, SHA256s: []string{cloneKitTestDigest("pack")}},
+	}
+}
+
+func TestCloneKitManifestValidate(t *testing.T) {
+	tests := map[string]func(*cloneKitManifest){
+		"version":          func(m *cloneKitManifest) { m.Version = 2 },
+		"uuid":             func(m *cloneKitManifest) { m.RepoID = "not-a-uuid" },
+		"tip SHA1":         func(m *cloneKitManifest) { m.TipCommit = strings.Repeat("A", 40) },
+		"missing file":     func(m *cloneKitManifest) { m.Files = m.Files[:2] },
+		"duplicate kind":   func(m *cloneKitManifest) { m.Files[2].Name = "idx" },
+		"mismatched SHA1":  func(m *cloneKitManifest) { m.Files[2].Path = "objects/pack/pack-" + strings.Repeat("b", 40) + ".rev" },
+		"wrong path kind":  func(m *cloneKitManifest) { m.Files[2].Path = "objects/pack/pack-" + cloneKitTestPackID + ".idx" },
+		"unsafe path":      func(m *cloneKitManifest) { m.Files[0].Path = "../pack-" + cloneKitTestPackID + ".pack" },
+		"zero size":        func(m *cloneKitManifest) { m.Files[0].Size = 0 },
+		"oversize sidecar": func(m *cloneKitManifest) { m.Files[1].Size = (4 << 30) + 1 },
+		"oversize pack":    func(m *cloneKitManifest) { m.Files[0].Size = (64 << 30) + 1 },
+		"digest":           func(m *cloneKitManifest) { m.Files[0].SHA256 = strings.Repeat("A", 64) },
+		"URL scheme":       func(m *cloneKitManifest) { m.Files[0].URL = "http://objects.example/pack" },
+		"URL credentials":  func(m *cloneKitManifest) { m.Files[0].URL = "https://secret@objects.example/pack" },
+		"URL fragment":     func(m *cloneKitManifest) { m.Files[0].URL += "#fragment" },
+		"chunk size":       func(m *cloneKitManifest) { m.PackChunks.ChunkSize = 0 },
+		"chunk count":      func(m *cloneKitManifest) { m.PackChunks.SHA256s = nil },
+		"chunk digest":     func(m *cloneKitManifest) { m.PackChunks.SHA256s[0] = "bad" },
+	}
+	m := validCloneKitManifest()
+	if err := m.validate(); err != nil || m.packID != cloneKitTestPackID {
+		t.Fatalf("valid manifest: error = %v, packID = %q", err, m.packID)
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			m := validCloneKitManifest()
+			mutate(&m)
+			if err := m.validate(); err == nil {
+				t.Fatal("validate() error = nil, want invalid manifest")
+			}
+		})
+	}
+}
+
+func TestOriginCloneKitSource(t *testing.T) {
+	ctx, _ := experiments.Enable(t.Context(), experiments.OriginCloneKit)
+	canonical := "https://origin.cursor.com/acme/repo.git"
+	newExecutor := func() *Executor {
+		sh, err := shell.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return &Executor{ExecutorConfig: ExecutorConfig{Repository: canonical, GitMirrorsPath: t.TempDir()}, canonicalRepository: canonical, shell: sh}
+	}
+	if got := newExecutor().originCloneKitSource(ctx, 0); got != canonical {
+		t.Fatalf("eligible source = %q, want %q", got, canonical)
+	}
+
+	tests := map[string]func(*Executor) (context.Context, int){
+		"disabled":          func(e *Executor) (context.Context, int) { return t.Context(), 0 },
+		"later attempt":     func(e *Executor) (context.Context, int) { return ctx, 1 },
+		"no mirrors":        func(e *Executor) (context.Context, int) { e.GitMirrorsPath = ""; return ctx, 0 },
+		"skip update":       func(e *Executor) (context.Context, int) { e.GitMirrorsSkipUpdate = true; return ctx, 0 },
+		"clone flags":       func(e *Executor) (context.Context, int) { e.GitCloneMirrorFlags = "--depth=1"; return ctx, 0 },
+		"canonical changed": func(e *Executor) (context.Context, int) { e.Repository += "?changed"; return ctx, 0 },
+		"wrong host": func(e *Executor) (context.Context, int) {
+			e.Repository = "https://evil.example/acme/repo.git"
+			e.canonicalRepository = e.Repository
+			return ctx, 0
+		},
+		"host suffix": func(e *Executor) (context.Context, int) {
+			e.Repository = "https://origin.cursor.com.evil/acme/repo.git"
+			e.canonicalRepository = e.Repository
+			return ctx, 0
+		},
+		"SSH": func(e *Executor) (context.Context, int) {
+			e.Repository = "git@origin.cursor.com:acme/repo.git"
+			e.canonicalRepository = e.Repository
+			return ctx, 0
+		},
+		"reuse": func(e *Executor) (context.Context, int) {
+			checkout := t.TempDir()
+			if err := os.Mkdir(filepath.Join(checkout, ".git"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			e.shell.Env.Set("BUILDKITE_BUILD_CHECKOUT_PATH", checkout)
+			return ctx, 0
+		},
+	}
+	for name, alter := range tests {
+		t.Run(name, func(t *testing.T) {
+			e := newExecutor()
+			gotCtx, attempt := alter(e)
+			if got := e.originCloneKitSource(gotCtx, attempt); got != "" {
+				t.Errorf("source = %q, want empty", got)
+			}
+		})
+	}
+
+	e := newExecutor()
+	e.Repository, e.canonicalRepository = "git@github.com:acme/repo.git", "git@github.com:acme/repo.git"
+	e.GitRemoteMirrorURL = canonical
+	if got := e.originCloneKitSource(ctx, 0); got != canonical {
+		t.Errorf("SSH canonical with HTTPS mirror = %q, want %q", got, canonical)
+	}
+}
+
+func TestCloneKitRangeCount(t *testing.T) {
+	for _, test := range []struct {
+		size int64
+		want int
+	}{
+		{1, 1}, {(64 << 20) - 1, 1}, {64 << 20, 8}, {65 << 20, 8}, {256 << 20, 32}, {64 << 30, 32},
+	} {
+		if got := cloneKitRangeCount(test.size); got != test.want {
+			t.Errorf("cloneKitRangeCount(%d) = %d, want %d", test.size, got, test.want)
+		}
+	}
+}
+
+func TestDownloadCloneKitFileRangesAndAuthentication(t *testing.T) {
+	const size = int64(64 << 20)
+	var mu sync.Mutex
+	var ranges []string
+	s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.Header.Get("Authorization") != "" || r.Header.Get("Accept-Encoding") != "identity" {
+			t.Errorf("request method/auth/encoding = %q/%q/%q", r.Method, r.Header.Get("Authorization"), r.Header.Get("Accept-Encoding"))
+		}
+		var start, end int64
+		if _, err := fmt.Sscanf(r.Header.Get("Range"), "bytes=%d-%d", &start, &end); err != nil {
+			t.Errorf("Range = %q: %v", r.Header.Get("Range"), err)
+			return
+		}
+		mu.Lock()
+		ranges = append(ranges, r.Header.Get("Range"))
+		mu.Unlock()
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, size))
+		w.Header().Set("Content-Length", fmt.Sprint(end-start+1))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = io.CopyN(w, zeroReader{}, end-start+1)
+	}))
+	t.Cleanup(s.Close)
+	path := filepath.Join(t.TempDir(), "pack")
+	if err := downloadCloneKitFile(t.Context(), s.Client(), cloneKitFile{Name: "pack", URL: s.URL, Size: size}, path); err != nil {
+		t.Fatal(err)
+	}
+	wantRanges := make(map[string]bool)
+	for i := int64(0); i < 8; i++ {
+		wantRanges[fmt.Sprintf("bytes=%d-%d", i*(8<<20), (i+1)*(8<<20)-1)] = true
+	}
+	for _, got := range ranges {
+		delete(wantRanges, got)
+	}
+	if len(ranges) != 8 || len(wantRanges) != 0 {
+		t.Errorf("ranges = %v", ranges)
+	}
+	if info, err := os.Stat(path); err != nil || info.Size() != size {
+		t.Errorf("download size: info=%v error=%v", info, err)
+	}
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) { clear(p); return len(p), nil }
+
+func TestDownloadCloneKitFileRejectsResponses(t *testing.T) {
+	tests := map[string]func(http.ResponseWriter){
+		"status": func(w http.ResponseWriter) { w.WriteHeader(http.StatusPartialContent) },
+		"length": func(w http.ResponseWriter) {
+			w.Header().Set("Content-Length", "2")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("xx"))
+		},
+		"short body": func(w http.ResponseWriter) {
+			w.Header().Set("Content-Length", "3")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("x"))
+		},
+	}
+	for name, respond := range tests {
+		t.Run(name, func(t *testing.T) {
+			var requests atomic.Int32
+			s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { requests.Add(1); respond(w) }))
+			defer s.Close()
+			err := downloadCloneKitFile(t.Context(), s.Client(), cloneKitFile{Name: "idx", URL: s.URL, Size: 3}, filepath.Join(t.TempDir(), "file"))
+			if err == nil {
+				t.Fatal("error = nil, want response rejection")
+			}
+			if requests.Load() != 1 {
+				t.Errorf("requests = %d, want 1 (no retries)", requests.Load())
+			}
+		})
+	}
+}
+
+func TestDownloadCloneKitFileCancellation(t *testing.T) {
+	started := make(chan struct{})
+	s := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) { close(started); <-r.Context().Done() }))
+	defer s.Close()
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		done <- downloadCloneKitFile(ctx, s.Client(), cloneKitFile{Name: "idx", URL: s.URL, Size: 1}, filepath.Join(t.TempDir(), "file"))
+	}()
+	<-started
+	cancel()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("error = nil after cancellation")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("download did not observe cancellation")
+	}
+}
+
+func TestVerifyCloneKitFileWholeAndChunks(t *testing.T) {
+	data := []byte("abcdefgh")
+	path := filepath.Join(t.TempDir(), "pack")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file := cloneKitFile{Name: "pack", Size: int64(len(data)), SHA256: cloneKitTestDigest(string(data))}
+	if err := verifyCloneKitFile(t.Context(), file, nil, path); err != nil {
+		t.Fatalf("whole hash: %v", err)
+	}
+	chunks := &cloneKitChunks{ChunkSize: 3, SHA256s: []string{cloneKitTestDigest("abc"), cloneKitTestDigest("def"), cloneKitTestDigest("gh")}}
+	if err := verifyCloneKitFile(t.Context(), file, chunks, path); err != nil {
+		t.Fatalf("chunk hashes: %v", err)
+	}
+	chunks.SHA256s[1] = cloneKitTestDigest("bad")
+	if err := verifyCloneKitFile(t.Context(), file, chunks, path); err == nil {
+		t.Fatal("bad chunk hash accepted")
+	}
+	file.SHA256 = cloneKitTestDigest("bad")
+	if err := verifyCloneKitFile(t.Context(), file, nil, path); err == nil {
+		t.Fatal("bad whole hash accepted")
+	}
+}
+
+func TestFetchCloneKitManifestBoundary(t *testing.T) {
+	m := validCloneKitManifest()
+	body, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, body string
+		status     int
+		valid      bool
+	}{
+		{"valid", string(body), 200, true},
+		{"additive", strings.TrimSuffix(string(body), "}") + `,"future":{"values":[1,2]}}`, 200, true},
+		{"duplicate", strings.TrimSuffix(string(body), "}") + `,"version":1}`, 200, false},
+		{"case duplicate", strings.TrimSuffix(string(body), "}") + `,"VERSION":1}`, 200, false},
+		{"malformed", `{`, 200, false},
+		{"oversize", strings.Repeat(" ", (1<<20)+1), 200, false},
+		{"miss", "", 404, false},
+		{"unauthorized", "repository-secret", 401, false},
+		{"redirect", "", 302, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				user, pass, ok := r.BasicAuth()
+				if !ok || user != "user" || pass != "repository-secret" {
+					t.Error("manifest credentials missing")
+				}
+				if tc.status == 302 {
+					w.Header().Set("Location", "https://forbidden.example/secret")
+				}
+				w.WriteHeader(tc.status)
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer s.Close()
+			client := s.Client()
+			client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+			_, err := fetchCloneKitManifest(t.Context(), client, s.URL+"?secret=presigned-secret", "user", "repository-secret")
+			if (err == nil) != tc.valid {
+				t.Fatalf("error=%v valid=%v", err, tc.valid)
+			}
+			if err != nil && (strings.Contains(err.Error(), "repository-secret") || strings.Contains(err.Error(), "presigned-secret")) {
+				t.Fatal("secret in error")
+			}
+		})
+	}
+}

--- a/internal/job/checkout_origin_clonekit_test.go
+++ b/internal/job/checkout_origin_clonekit_test.go
@@ -88,10 +88,14 @@ func TestOriginCloneKitSource(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		return &Executor{ExecutorConfig: ExecutorConfig{Repository: canonical, GitMirrorsPath: t.TempDir()}, canonicalRepository: canonical, shell: sh}
+		return &Executor{ExecutorConfig: ExecutorConfig{Repository: canonical, GitMirrorsPath: t.TempDir(), GitCloneMirrorFlags: "-v"}, canonicalRepository: canonical, shell: sh}
 	}
-	if got := newExecutor().originCloneKitSource(ctx, 0); got != canonical {
-		t.Fatalf("eligible source = %q, want %q", got, canonical)
+	for _, flags := range []string{"", "-v"} {
+		e := newExecutor()
+		e.GitCloneMirrorFlags = flags
+		if got := e.originCloneKitSource(ctx, 0); got != canonical {
+			t.Fatalf("eligible source with flags %q = %q, want %q", flags, got, canonical)
+		}
 	}
 
 	tests := map[string]func(*Executor) (context.Context, int){
@@ -100,6 +104,7 @@ func TestOriginCloneKitSource(t *testing.T) {
 		"no mirrors":        func(e *Executor) (context.Context, int) { e.GitMirrorsPath = ""; return ctx, 0 },
 		"skip update":       func(e *Executor) (context.Context, int) { e.GitMirrorsSkipUpdate = true; return ctx, 0 },
 		"clone flags":       func(e *Executor) (context.Context, int) { e.GitCloneMirrorFlags = "--depth=1"; return ctx, 0 },
+		"additional flags":  func(e *Executor) (context.Context, int) { e.GitCloneMirrorFlags = "-v --depth=1"; return ctx, 0 },
 		"canonical changed": func(e *Executor) (context.Context, int) { e.Repository += "?changed"; return ctx, 0 },
 		"wrong host": func(e *Executor) (context.Context, int) {
 			e.Repository = "https://evil.example/acme/repo.git"
@@ -137,9 +142,26 @@ func TestOriginCloneKitSource(t *testing.T) {
 
 	e := newExecutor()
 	e.Repository, e.canonicalRepository = "git@github.com:acme/repo.git", "git@github.com:acme/repo.git"
-	e.GitRemoteMirrorURL = canonical
-	if got := e.originCloneKitSource(ctx, 0); got != canonical {
-		t.Errorf("SSH canonical with HTTPS mirror = %q, want %q", got, canonical)
+	for _, path := range []string{"acme/repo.git", "git/acme/repo.git"} {
+		e.GitRemoteMirrorURL = "https://origin.cursor.com/" + path
+		if got := e.originCloneKitSource(ctx, 0); got != e.GitRemoteMirrorURL {
+			t.Errorf("SSH canonical with HTTPS mirror = %q, want unchanged %q", got, e.GitRemoteMirrorURL)
+		}
+	}
+	for _, source := range []string{
+		"https://origin.cursor.com/other/acme/repo.git",
+		"https://origin.cursor.com/git/git/acme/repo.git",
+		"https://origin.cursor.com/git/../repo.git",
+		"https://origin.cursor.com/%67it/acme/repo.git",
+		"https://origin.cursor.com/git/acme/repo.git?token=secret",
+		"https://origin.cursor.com/git/acme/repo.git#fragment",
+		"https://user@origin.cursor.com/git/acme/repo.git",
+		"https://origin.cursor.com:443/git/acme/repo.git",
+	} {
+		e.GitRemoteMirrorURL = source
+		if got := e.originCloneKitSource(ctx, 0); got != "" {
+			t.Errorf("source %q admitted as %q", source, got)
+		}
 	}
 }
 

--- a/internal/job/checkout_remote_mirror.go
+++ b/internal/job/checkout_remote_mirror.go
@@ -100,12 +100,16 @@ const (
 	remoteMirrorSkipRecursiveSubmodules remoteMirrorSkipReason = "recursive-submodules"
 	remoteMirrorSkipSeparateGitDir      remoteMirrorSkipReason = "separate-git-dir"
 	remoteMirrorSkipURLConfigConflict   remoteMirrorSkipReason = "url-config-conflict"
+	remoteMirrorSkipCloneKit            remoteMirrorSkipReason = "origin-clonekit"
 )
 
 type remoteMirrorAttempt struct {
 	site       remoteMirrorSite
 	url        string
 	skipReason remoteMirrorSkipReason
+	// cloneKitURL is independently eligible for cold on-host mirror creation.
+	// It never grants a remote-mirror hit or bypasses canonical commit fetching.
+	cloneKitURL string
 
 	outcome  remoteMirrorOutcome
 	duration time.Duration

--- a/internal/job/integration/checkout_origin_clonekit_integration_test.go
+++ b/internal/job/integration/checkout_origin_clonekit_integration_test.go
@@ -1,0 +1,49 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/buildkite/bintest/v3"
+)
+
+func TestOriginCloneKitWithDefaultMirrorFlags(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{"acme/repo.git", "git/acme/repo.git"} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			tester, err := NewExecutorTester(mainCtx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tester.Close()
+			if err := tester.EnableGitMirrors(); err != nil {
+				t.Fatal(err)
+			}
+			repository := "https://origin.cursor.com/" + path
+
+			git := tester.MustMock(t, "git")
+			git.IgnoreUnexpectedInvocations()
+			// Reach the credential boundary without making external requests. A failed
+			// lookup must fall back to the canonical mirror clone in the same attempt.
+			git.Expect("-c", "credential.useHttpPath=true", "-c", "credential.helper=",
+				"-c", bintest.MatchAny(), "-c", "http.extraHeader=", "-c", "protocol.version=2",
+				"credential", "fill").
+				WithStdin("protocol=https\nhost=origin.cursor.com\npath=" + path + "\n\n").
+				AndExitWith(1)
+			git.Expect("clone", "--mirror", "-v", "--", repository, bintest.MatchAny()).AndExitWith(0)
+
+			// Deliberately do not override BUILDKITE_GIT_CLONE_MIRROR_FLAGS: exercise
+			// the real bootstrap CLI default, rather than a zero-value ExecutorConfig.
+			tester.RunAndCheck(t,
+				"BUILDKITE_AGENT_EXPERIMENT=origin-clonekit",
+				"BUILDKITE_REPO="+repository,
+				"BUILDKITE_SSH_KEYSCAN=false",
+			)
+			if !strings.Contains(tester.Output, "Origin CloneKit: error (credentials)") {
+				t.Fatalf("CloneKit was not attempted with default mirror flags:\n%s", tester.Output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add `--experiment origin-clonekit` to seed a missing on-host Git mirror from Cursor Origin's CloneKit endpoint, rather than transferring the initial object database through Git.

Requires `BUILDKITE_GIT_MIRRORS_PATH` and an HTTPS Origin repository, either canonical or supplied through the existing backend remote mirror URL. Remote mirroring is not required for a canonical Origin repository. SSH authentication is out of scope initially. Both `/git/owner/repo.git` and `/owner/repo.git` are admitted without rewriting the URL; use the backend-provided `/git/` form for current managed credentials. The default `-v` mirror flags are eligible; other nonempty custom mirror flags are skipped.

Requiring on-host mirrors is a deliberate scope decision for this first experiment, not a CloneKit protocol requirement. This PR measures cold-mirror creation benefits; agents without `BUILDKITE_GIT_MIRRORS_PATH` get no acceleration. Direct fresh-checkout support could also benefit from CloneKit, but is deferred to avoid adding temporary-seed ownership, pack adoption and crash recovery, or paying the potentially significant repacking cost of `--dissociate`.

The experiment uses the existing clone lock, staging directory, atomic publication and snapshot lifecycle. Pack data is downloaded with bounded concurrency and mandatory checksums; a private ref supplies the negotiation anchor. Canonical Git still selects and fetches the build commit. An unsuccessful attempt falls back directly to canonical Git within the same checkout attempt, with a 30-second budget and no fallback on cancellation.

Existing mirrors and reused checkouts keep their existing behavior. There is no new backend contract, direct-checkout pack adoption, S3 selection or verification bypass.

## Context

Live Origin testing informed the protocol and anchor handling. Local Buildkite jobs have validated real Origin App-backed credentials and canonical checkout with explicit managed-helper opt-in. The corrected head passed live CloneKit cold-seed and mirror-reuse jobs using the real local Buildkite backend, an existing Origin App installation and the default `-v` mirror flags. Cold checkout reported `Origin CloneKit: hit (publish)`; both jobs checked out the pinned revision with the canonical `/git/` URL and passed full `git fsck`. A separate fresh-HOME job without canonical Git auth confirmed manifest authentication succeeds independently, then canonical clone fails as expected. Representative multi-GB performance remains unvalidated. Self-hosted canonical checkout still needs existing operator Git auth or explicit `BUILDKITE_USE_REPOSITORY_PROVIDER_GIT_CREDENTIALS=true` with backend repository access enabled; this experiment does not silently change that policy.

### Public documentation
- [ ] Ready for public documentation - document and publish
- [x] Not ready for public docs - document and hold
- [ ] Not applicable - docs not needed

`EXPERIMENTS.md` documents enablement and limitations.

## Testing
- [x] Tests have run locally (with `go test ./...`).
- [x] Code is formatted (with `gofumpt -extra`).

CloneKit race tests pass; golangci-lint reports zero issues. Windows amd64 and macOS arm64 test binaries cross-compile (not runtime-tested). Tests cover manifest validation, transfer completeness, checksum failure, credential isolation, cancellation, canonical fallback and a real Git reference checkout with `fsck`.

Exploratory live benchmark: three fixed-order OFF→ON cold-checkout pairs on the same clean agent revision, host, Git 2.55.0 and pinned repository revision, with fresh HOME/build/mirror directories each run. Checkout medians were 6.975s without the experiment and 5.426s with it; all six jobs passed integrity checks. Timing spans pre-checkout→post-checkout, including mirror creation and downstream canonical checkout, but excludes queue/setup and the extra fsck command. This was one ~72 MB pack, not a randomized or representative multi-GB benchmark; no general speedup claim follows.

## Disclosures / Credits

Amp wrote the implementation and tests, updated the plan, and performed local auto-review. Cursor's production bootstrap script and live Origin endpoint testing informed the design.
