### PR TITLE
feat: add experimental Docker bootstrap supervisor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /vendor/pkg
 .bundle
 .envrc
+.envrc.*
 /.agent.conf
 /.agent.*.conf
 /.buildkite-agent.cfg

--- a/agent/docker_bootstrap_test.go
+++ b/agent/docker_bootstrap_test.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/agent/v4/api"
+	envutil "github.com/buildkite/agent/v4/env"
+	"github.com/buildkite/agent/v4/internal/dockerbootstrap"
+)
+
+func TestDockerBootstrapStepRejection(t *testing.T) {
+	for _, image := range []string{`"ubuntu"`, `""`, `null`, `42`, `{}`} {
+		for _, script := range []string{"/usr/bin/buildkite-agent docker-bootstrap", "/usr/bin/buildkite-agent bootstrap"} {
+			t.Run(script+image, func(t *testing.T) {
+				var job api.Job
+				if err := json.Unmarshal([]byte(`{"step":{"command":"true","image":`+image+`}}`), &job); err != nil {
+					t.Fatal(err)
+				}
+				conf := JobRunnerConfig{Job: &job, AgentConfiguration: AgentConfiguration{BootstrapScript: script}}
+				err := validateDockerBootstrapStep(conf)
+				if want := strings.Contains(script, "docker-bootstrap"); (err != nil) != want {
+					t.Fatalf("rejection=%v, want %t", err, want)
+				}
+			})
+		}
+	}
+	conf := JobRunnerConfig{Job: &api.Job{}, AgentConfiguration: AgentConfiguration{BootstrapScript: "buildkite-agent docker-bootstrap"}}
+	if err := validateDockerBootstrapStep(conf); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDockerJobContextIsolation(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "agent-context")
+	first, err := createDockerJobContext(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := createDockerJobContext(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second || filepath.Dir(first) != base || filepath.Dir(second) != base {
+		t.Fatal("job contexts not isolated")
+	}
+	info, err := os.Stat(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Fatal("job context accessible to other users")
+	}
+	for _, invalid := range []string{"", ".", "/", "/tmp", os.TempDir()} {
+		if _, err := createDockerJobContext(invalid); err == nil {
+			t.Errorf("accepted context root %q", invalid)
+		}
+	}
+}
+
+func TestDockerContextCannotBeSpoofedByJobEnvironment(t *testing.T) {
+	r := controlPlaneTestRunner(t, map[string]string{dockerbootstrap.ContextEnv: "/tmp/other-job"}, AgentConfiguration{})
+	r.dockerContextDir = "/private/real-job"
+	got, err := r.createEnvironment(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	environ := envutil.FromSlice(got)
+	if value, _ := environ.Get(dockerbootstrap.ContextEnv); value != r.dockerContextDir {
+		t.Fatal("job overrode private context")
+	}
+	ignored, _ := environ.Get("BUILDKITE_IGNORED_ENV")
+	if !strings.Contains(ignored, dockerbootstrap.ContextEnv) {
+		t.Fatal("spoofed value not recorded as ignored")
+	}
+}

--- a/agent/docker_bootstrap_test.go
+++ b/agent/docker_bootstrap_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -51,7 +52,8 @@ func TestDockerJobContextIsolation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm()&0o077 != 0 {
+	// Windows synthesizes mode bits; they do not describe directory ACLs.
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
 		t.Fatal("job context accessible to other users")
 	}
 	for _, invalid := range []string{"", ".", "/", "/tmp", os.TempDir()} {

--- a/agent/docker_bootstrap_test.go
+++ b/agent/docker_bootstrap_test.go
@@ -1,12 +1,19 @@
 package agent
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/buildkite/agent/v4/logger"
+	"github.com/buildkite/agent/v4/metrics"
 
 	"github.com/buildkite/agent/v4/api"
 	envutil "github.com/buildkite/agent/v4/env"
@@ -77,5 +84,81 @@ func TestDockerContextCannotBeSpoofedByJobEnvironment(t *testing.T) {
 	ignored, _ := environ.Get("BUILDKITE_IGNORED_ENV")
 	if !strings.Contains(ignored, dockerbootstrap.ContextEnv) {
 		t.Fatal("spoofed value not recorded as ignored")
+	}
+}
+
+func TestUsesDockerBootstrap(t *testing.T) {
+	for _, tc := range []struct {
+		script           string
+		kubernetes, want bool
+	}{
+		{"/usr/bin/buildkite-agent docker-bootstrap", false, true},
+		{"buildkite-agent docker-bootstrap --image example", false, true},
+		{"/usr/bin/buildkite-agent docker-bootstrap", true, false},
+		{"/usr/bin/wrapper", false, false},
+		{"buildkite-agent", false, false},
+		{"docker-bootstrap --image example", false, false},
+		{"", false, false},
+		{"buildkite-agent '", false, false},
+	} {
+		t.Run(tc.script, func(t *testing.T) {
+			conf := JobRunnerConfig{KubernetesExec: tc.kubernetes, AgentConfiguration: AgentConfiguration{BootstrapScript: tc.script}}
+			if got := usesDockerBootstrap(conf); got != tc.want {
+				t.Fatalf("got %t want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDockerStepRejectionThroughRun(t *testing.T) {
+	var finished api.JobFinishRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/jobs/test-job/start":
+		case "/jobs/test-job/finish":
+			if err := json.NewDecoder(req.Body).Decode(&finished); err != nil {
+				t.Error(err)
+			}
+		default:
+			t.Errorf("unexpected request %s", req.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	var job api.Job
+	if err := json.Unmarshal([]byte(`{"id":"test-job","env":{},"step":{"command":"true","image":"ubuntu"},"chunks_max_size_bytes":1024}`), &job); err != nil {
+		t.Fatal(err)
+	}
+	conf := JobRunnerConfig{
+		Job: &job, JobContextDir: filepath.Join(t.TempDir(), "context"),
+		AgentConfiguration: AgentConfiguration{BootstrapScript: "missing-agent docker-bootstrap", BuildPath: t.TempDir()},
+		MetricsScope:       metrics.NewCollector(logger.Discard, metrics.CollectorConfig{}).Scope(nil),
+	}
+	r, err := NewJobRunner(t.Context(), logger.Discard, api.NewClient(logger.Discard, api.Config{Endpoint: server.URL}), conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var logs bytes.Buffer
+	r.logStreamer = NewLogStreamer(logger.Discard, func(_ context.Context, c *api.Chunk) error { _, err := logs.Write(c.Data); return err }, LogStreamerConfig{Concurrency: 1, MaxChunkSizeBytes: 1024})
+	dir := r.dockerContextDir
+	if err := os.WriteFile(r.jobTimeoutFilePath, []byte("timeout"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Run(t.Context(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if finished.ExitStatus != "-1" || finished.SignalReason != SignalReasonProcessRunError {
+		t.Fatalf("finish: %+v", finished)
+	}
+	if !strings.Contains(logs.String(), "step image is rejected") {
+		t.Fatalf("missing rejection log: %s", logs.String())
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("private context not removed: %v", err)
+	}
+	select {
+	case <-r.process.Started():
+		t.Fatal("bootstrap started for rejected job")
+	default:
 	}
 }

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildkite/agent/v4/api"
 	"github.com/buildkite/agent/v4/core"
 	envutil "github.com/buildkite/agent/v4/env"
+	"github.com/buildkite/agent/v4/internal/dockerbootstrap"
 	"github.com/buildkite/agent/v4/internal/experiments"
 	"github.com/buildkite/agent/v4/internal/process"
 	"github.com/buildkite/agent/v4/internal/shell"
@@ -149,6 +150,9 @@ type JobRunner struct {
 	// to the bootstrap subprocess via BUILDKITE_AGENT_JOB_TIMEOUT_FILE.
 	jobTimeoutFilePath string
 
+	// Set only for the Docker bootstrap; removed after coordination files.
+	dockerContextDir string
+
 	// droppedRemoteMirrorURL records a backend-provided mirror removed from the
 	// bootstrap environment because it did not match --allowed-repositories.
 	// createEnvironment runs before jobLogs exists, so Run emits the warning.
@@ -219,6 +223,19 @@ func NewJobRunner(ctx context.Context, l logger.Logger, apiClient *api.Client, c
 	)
 
 	contextDir := jobContextDir(conf)
+	if usesDockerBootstrap(conf) {
+		contextDir, err = createDockerJobContext(conf.JobContextDir)
+		if err != nil {
+			return nil, err
+		}
+		r.dockerContextDir = contextDir
+		// Construction may fail before Run gets a chance to clean up.
+		defer func() {
+			if r.process == nil {
+				_ = os.RemoveAll(contextDir)
+			}
+		}()
+	}
 
 	r.envShellFile, r.envJSONFile, err = createJobEnvFiles(r.agentLogger, r.conf.Job.ID, contextDir)
 	if err != nil {
@@ -437,6 +454,7 @@ func (r *JobRunner) createEnvironment(ctx context.Context) ([]string, error) {
 		}
 		env[name] = value
 	}
+	setEnv(dockerbootstrap.ContextEnv, r.dockerContextDir)
 	// For some checkout env vars, we allow the Job env (if present) to have
 	// higher precedence than the agent configuration, unless the checkout-override
 	// mode locks them. Only checkout-scoped vars are passed here.
@@ -971,6 +989,38 @@ func jobContextDir(conf JobRunnerConfig) string {
 		return kubernetes.DefaultContextDir
 	}
 	return os.TempDir()
+}
+
+// The prototype integrates through the existing bootstrap-script seam. Wrapper
+// scripts are not supported: JobRunner must recognize the command to allocate
+// private coordination files and enforce the step-image policy.
+func usesDockerBootstrap(conf JobRunnerConfig) bool {
+	args, err := shellwords.Split(conf.AgentConfiguration.BootstrapScript)
+	return !conf.KubernetesExec && err == nil && len(args) >= 2 && args[1] == "docker-bootstrap"
+}
+
+func validateDockerBootstrapStep(conf JobRunnerConfig) error {
+	if usesDockerBootstrap(conf) {
+		if _, present := conf.Job.Step.RemainingFields["image"]; present {
+			return fmt.Errorf("docker bootstrap setup failed (125): step image is rejected by agent-only policy; pipeline image selection is not supported yet")
+		}
+	}
+	return nil
+}
+
+func createDockerJobContext(base string) (string, error) {
+	base = filepath.Clean(base)
+	if !filepath.IsAbs(base) || base == string(filepath.Separator) || base == filepath.Clean(os.TempDir()) || base == "/tmp" {
+		return "", fmt.Errorf("docker-bootstrap requires --job-context-dir set to a dedicated absolute per-agent directory")
+	}
+	if err := os.MkdirAll(base, 0o700); err != nil {
+		return "", fmt.Errorf("create Docker job context root: %w", err)
+	}
+	dir, err := os.MkdirTemp(base, "docker-job-")
+	if err != nil {
+		return "", fmt.Errorf("create private Docker job context: %w", err)
+	}
+	return dir, nil
 }
 
 func createJobEnvFiles(l logger.Logger, jobID, contextDir string) (shellFile, jsonFile *os.File, err error) {

--- a/agent/job_runner.go
+++ b/agent/job_runner.go
@@ -150,7 +150,7 @@ type JobRunner struct {
 	// to the bootstrap subprocess via BUILDKITE_AGENT_JOB_TIMEOUT_FILE.
 	jobTimeoutFilePath string
 
-	// Set only for the Docker bootstrap; removed after coordination files.
+	// Must remain until all coordination files have been removed.
 	dockerContextDir string
 
 	// droppedRemoteMirrorURL records a backend-provided mirror removed from the
@@ -991,9 +991,8 @@ func jobContextDir(conf JobRunnerConfig) string {
 	return os.TempDir()
 }
 
-// The prototype integrates through the existing bootstrap-script seam. Wrapper
-// scripts are not supported: JobRunner must recognize the command to allocate
-// private coordination files and enforce the step-image policy.
+// Wrapper scripts cannot be recognized here, so they bypass Docker context
+// allocation and image rejection and are unsupported.
 func usesDockerBootstrap(conf JobRunnerConfig) bool {
 	args, err := shellwords.Split(conf.AgentConfiguration.BootstrapScript)
 	return !conf.KubernetesExec && err == nil && len(args) >= 2 && args[1] == "docker-bootstrap"

--- a/agent/run_job.go
+++ b/agent/run_job.go
@@ -212,6 +212,13 @@ func (r *JobRunner) Run(ctx context.Context, ignoreAgentInDispatches *bool) (err
 		}
 	}
 
+	if err := validateDockerBootstrapStep(r.conf); err != nil {
+		_, _ = fmt.Fprintln(r.jobLogs, err)
+		exit.Status = -1 // Same mapping as bootstrap setup failure (125).
+		exit.SignalReason = SignalReasonProcessRunError
+		return nil
+	}
+
 	// Kick off log streaming and job status checking when the process starts.
 	wg.Go(func() { r.streamJobLogsAfterProcessStart(cctx) })
 	wg.Go(func() { r.jobCancellationChecker(cctx) })
@@ -436,6 +443,12 @@ func (r *JobRunner) cleanup(ctx context.Context, wg *sync.WaitGroup, exit core.P
 	if r.jobTimeoutFilePath != "" {
 		if err := os.Remove(r.jobTimeoutFilePath); err != nil && !os.IsNotExist(err) {
 			r.agentLogger.Warnf("[JobRunner] Error cleaning up job timeout file: %s", err)
+		}
+	}
+
+	if r.dockerContextDir != "" {
+		if err := os.Remove(r.dockerContextDir); err != nil && !os.IsNotExist(err) {
+			r.agentLogger.Warnf("[JobRunner] Error cleaning up Docker job context: %s", err)
 		}
 	}
 

--- a/clicommand/commands.go
+++ b/clicommand/commands.go
@@ -11,6 +11,7 @@ var BuildkiteAgentCommands = []*cli.Command{
 	// These commands are special. The have a different lifecycle to the others
 	AgentStartCommand,
 	BootstrapCommand,
+	DockerBootstrapCommand,
 	KubernetesBootstrapCommand,
 
 	// These are in alphabetical order

--- a/clicommand/config_completeness_test.go
+++ b/clicommand/config_completeness_test.go
@@ -28,6 +28,7 @@ var commandConfigPairs = []configCommandPair{
 	{Config: ArtifactUploadConfig{}, Command: ArtifactUploadCommand},
 	{Config: BuildCancelConfig{}, Command: BuildCancelCommand},
 	{Config: BootstrapConfig{}, Command: BootstrapCommand},
+	{Config: DockerBootstrapConfig{}, Command: DockerBootstrapCommand},
 	{Config: CacheRestoreConfig{}, Command: CacheRestoreCommand},
 	{Config: CacheSaveConfig{}, Command: CacheSaveCommand},
 	{Config: EnvDumpConfig{}, Command: EnvDumpCommand},

--- a/clicommand/docker_bootstrap.go
+++ b/clicommand/docker_bootstrap.go
@@ -1,0 +1,89 @@
+package clicommand
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+	"time"
+
+	"github.com/buildkite/agent/v4/internal/dockerbootstrap"
+	"github.com/buildkite/agent/v4/internal/process"
+	"github.com/buildkite/agent/v4/internal/self"
+	"github.com/urfave/cli/v3"
+)
+
+type DockerBootstrapConfig struct {
+	Image            string        `cli:"image"`
+	DockerPath       string        `cli:"docker-path"`
+	CleanupMargin    time.Duration `cli:"cleanup-margin"`
+	OperationTimeout time.Duration `cli:"operation-timeout"`
+	PullTimeout      time.Duration `cli:"pull-timeout"`
+}
+
+var DockerBootstrapCommand = &cli.Command{
+	Name:     "docker-bootstrap",
+	Usage:    "Run the job bootstrap in a disposable local Docker container (experimental)",
+	Category: categoryInternal,
+	Description: `Usage:
+
+    buildkite-agent docker-bootstrap [options...]
+
+Experimental Linux-only supervisor for the normal job bootstrap. Configure agent
+start with --bootstrap-script="/usr/bin/buildkite-agent docker-bootstrap" and a
+dedicated --job-context-dir. Policy flags are accepted only as command arguments.
+The default image is public; private registry authentication is not yet supported.`,
+	Flags: []cli.Flag{
+		// No environment sources: these are operator policy, not job inputs.
+		&cli.StringFlag{Name: "image", Value: dockerbootstrap.DefaultImage, Usage: "Agent-controlled bootstrap image"},
+		&cli.StringFlag{Name: "docker-path", Value: "/usr/bin/docker", Usage: "Absolute path to the Docker CLI"},
+		&cli.DurationFlag{Name: "cleanup-margin", Value: 5 * time.Second, Usage: "Time reserved within the agent cancellation timeout for removal"},
+		&cli.DurationFlag{Name: "operation-timeout", Value: 30 * time.Second, Usage: "Timeout for Docker setup operations"},
+		&cli.DurationFlag{Name: "pull-timeout", Value: 10 * time.Minute, Usage: "Timeout for pulling the bootstrap image"},
+	},
+	Action: func(ctx context.Context, c *cli.Command) error {
+		// Read flags directly: the general config loader also reads inherited
+		// config-file settings, which are not trusted Docker policy inputs.
+		cfg := DockerBootstrapConfig{
+			Image: c.String("image"), DockerPath: c.String("docker-path"),
+			CleanupMargin: c.Duration("cleanup-margin"), OperationTimeout: c.Duration("operation-timeout"), PullTimeout: c.Duration("pull-timeout"),
+		}
+		if runtime.GOOS != "linux" {
+			return cli.Exit("docker-bootstrap requires a Linux host", dockerbootstrap.SetupFailure)
+		}
+		sig := os.Getenv("BUILDKITE_CANCEL_SIGNAL")
+		if sig == "" || sig == "SIGKILL" {
+			sig = "SIGTERM"
+		}
+		parsed, err := process.ParseSignal(sig)
+		if err != nil {
+			return cli.Exit(err, dockerbootstrap.SetupFailure)
+		}
+		ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT, syscall.Signal(parsed))
+		defer stop()
+		// The public default image needs no registry credentials. Private
+		// registry authentication is deliberately deferred to the MVP.
+		configDir, err := os.MkdirTemp("", "buildkite-docker-config-")
+		if err != nil {
+			return cli.Exit(err, dockerbootstrap.SetupFailure)
+		}
+		defer func() { _ = os.RemoveAll(configDir) }()
+		runner := dockerbootstrap.Runner{
+			Client: dockerbootstrap.CLI{Path: cfg.DockerPath, ConfigDir: configDir},
+			Stdout: os.Stdout, Stderr: os.Stderr,
+		}
+		code, err := runner.Run(ctx, dockerbootstrap.Config{
+			Image: cfg.Image, Binary: self.Path(ctx), Environment: os.Environ(),
+			CleanupMargin: cfg.CleanupMargin, OperationTimeout: cfg.OperationTimeout, PullTimeout: cfg.PullTimeout,
+		})
+		if err != nil {
+			return cli.Exit(fmt.Sprintf("Docker bootstrap: %v", err), dockerbootstrap.SetupFailure)
+		}
+		if code != 0 {
+			return cli.Exit("", code)
+		}
+		return nil
+	},
+}

--- a/clicommand/docker_bootstrap.go
+++ b/clicommand/docker_bootstrap.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"syscall"
 	"time"
@@ -17,6 +18,11 @@ import (
 
 // DockerBootstrapConfig retains cli tags for config completeness checks only.
 type DockerBootstrapConfig struct {
+	PullPolicy       string        `cli:"pull-policy"`
+	DockerConfig     string        `cli:"docker-config"`
+	HelperEnvFile    string        `cli:"docker-helper-env-file"`
+	HelperPath       string        `cli:"docker-helper-path"`
+	User             string        `cli:"user"`
 	Image            string        `cli:"image"`
 	DockerPath       string        `cli:"docker-path"`
 	CleanupMargin    time.Duration `cli:"cleanup-margin"`
@@ -35,9 +41,14 @@ var DockerBootstrapCommand = &cli.Command{
 Experimental Linux-only supervisor for the normal job bootstrap. Configure agent
 start with --bootstrap-script="/usr/bin/buildkite-agent docker-bootstrap" and a
 dedicated --job-context-dir. Policy flags are accepted only as command arguments.
-The default image is public; private registry authentication is not yet supported.`,
+Registry credentials are read only from an operator-supplied --docker-config.`,
 	Flags: []cli.Flag{
 		// Job environment must not select operator policy.
+		&cli.StringFlag{Name: "pull-policy", Value: "missing", Usage: "Image pull policy: always, missing, or never"},
+		&cli.StringFlag{Name: "docker-config", Usage: "Absolute host Docker configuration directory for registry authentication"},
+		&cli.StringFlag{Name: "docker-helper-env-file", Usage: "Private host JSON file of credential helper environment variables"},
+		&cli.StringFlag{Name: "docker-helper-path", Usage: "Absolute host PATH entries for registry credential helpers"},
+		&cli.StringFlag{Name: "user", Usage: "Container numeric UID:GID (default: host agent UID:GID)"},
 		&cli.StringFlag{Name: "image", Value: dockerbootstrap.DefaultImage, Usage: "Agent-controlled bootstrap image"},
 		&cli.StringFlag{Name: "docker-path", Value: "/usr/bin/docker", Usage: "Absolute path to the Docker CLI"},
 		&cli.DurationFlag{Name: "cleanup-margin", Value: 5 * time.Second, Usage: "Time reserved within the agent cancellation timeout for removal"},
@@ -48,6 +59,7 @@ The default image is public; private registry authentication is not yet supporte
 		// The general config loader would also trust inherited config-file settings.
 		cfg := DockerBootstrapConfig{
 			Image: c.String("image"), DockerPath: c.String("docker-path"),
+			PullPolicy: c.String("pull-policy"), DockerConfig: c.String("docker-config"), HelperEnvFile: c.String("docker-helper-env-file"), HelperPath: c.String("docker-helper-path"), User: c.String("user"),
 			CleanupMargin: c.Duration("cleanup-margin"), OperationTimeout: c.Duration("operation-timeout"), PullTimeout: c.Duration("pull-timeout"),
 		}
 		if runtime.GOOS != "linux" {
@@ -69,11 +81,26 @@ The default image is public; private registry authentication is not yet supporte
 			return cli.Exit(err, dockerbootstrap.SetupFailure)
 		}
 		defer func() { _ = os.RemoveAll(configDir) }()
+		auth, err := dockerbootstrap.LoadAuthentication(cfg.DockerConfig, cfg.HelperEnvFile, cfg.HelperPath)
+		if err != nil {
+			return cli.Exit(err, dockerbootstrap.SetupFailure)
+		}
+		authDir := ""
+		if auth.Config != nil {
+			authDir = filepath.Join(configDir, "auth")
+			if err := os.Mkdir(authDir, 0o700); err != nil {
+				return cli.Exit(err, dockerbootstrap.SetupFailure)
+			}
+			if err := os.WriteFile(filepath.Join(authDir, "config.json"), auth.Config, 0o600); err != nil {
+				return cli.Exit(err, dockerbootstrap.SetupFailure)
+			}
+		}
 		runner := dockerbootstrap.Runner{
-			Client: dockerbootstrap.CLI{Path: cfg.DockerPath, ConfigDir: configDir},
+			Client: dockerbootstrap.CLI{Path: cfg.DockerPath, ConfigDir: configDir, AuthConfigDir: authDir, HelperPath: cfg.HelperPath, HelperEnvironment: auth.Environment},
 			Stdout: os.Stdout, Stderr: os.Stderr,
 		}
 		code, err := runner.Run(ctx, dockerbootstrap.Config{
+			PullPolicy: cfg.PullPolicy, DockerConfig: cfg.DockerConfig, HelperEnvFile: cfg.HelperEnvFile, User: cfg.User, RedactedValues: auth.Secrets,
 			Image: cfg.Image, Binary: self.Path(ctx), Environment: os.Environ(),
 			CleanupMargin: cfg.CleanupMargin, OperationTimeout: cfg.OperationTimeout, PullTimeout: cfg.PullTimeout,
 		})

--- a/clicommand/docker_bootstrap.go
+++ b/clicommand/docker_bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+// DockerBootstrapConfig retains cli tags for config completeness checks only.
 type DockerBootstrapConfig struct {
 	Image            string        `cli:"image"`
 	DockerPath       string        `cli:"docker-path"`
@@ -36,7 +37,7 @@ start with --bootstrap-script="/usr/bin/buildkite-agent docker-bootstrap" and a
 dedicated --job-context-dir. Policy flags are accepted only as command arguments.
 The default image is public; private registry authentication is not yet supported.`,
 	Flags: []cli.Flag{
-		// No environment sources: these are operator policy, not job inputs.
+		// Job environment must not select operator policy.
 		&cli.StringFlag{Name: "image", Value: dockerbootstrap.DefaultImage, Usage: "Agent-controlled bootstrap image"},
 		&cli.StringFlag{Name: "docker-path", Value: "/usr/bin/docker", Usage: "Absolute path to the Docker CLI"},
 		&cli.DurationFlag{Name: "cleanup-margin", Value: 5 * time.Second, Usage: "Time reserved within the agent cancellation timeout for removal"},
@@ -44,8 +45,7 @@ The default image is public; private registry authentication is not yet supporte
 		&cli.DurationFlag{Name: "pull-timeout", Value: 10 * time.Minute, Usage: "Timeout for pulling the bootstrap image"},
 	},
 	Action: func(ctx context.Context, c *cli.Command) error {
-		// Read flags directly: the general config loader also reads inherited
-		// config-file settings, which are not trusted Docker policy inputs.
+		// The general config loader would also trust inherited config-file settings.
 		cfg := DockerBootstrapConfig{
 			Image: c.String("image"), DockerPath: c.String("docker-path"),
 			CleanupMargin: c.Duration("cleanup-margin"), OperationTimeout: c.Duration("operation-timeout"), PullTimeout: c.Duration("pull-timeout"),
@@ -63,8 +63,7 @@ The default image is public; private registry authentication is not yet supporte
 		}
 		ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT, syscall.Signal(parsed))
 		defer stop()
-		// The public default image needs no registry credentials. Private
-		// registry authentication is deliberately deferred to the MVP.
+		// An empty config prevents use of host registry credentials.
 		configDir, err := os.MkdirTemp("", "buildkite-docker-config-")
 		if err != nil {
 			return cli.Exit(err, dockerbootstrap.SetupFailure)

--- a/docs/docker-validation.md
+++ b/docs/docker-validation.md
@@ -1,0 +1,189 @@
+# Docker bootstrap manual validation
+
+Use [docker-validation.yml](docker-validation.yml) in the YAML editor of a
+dedicated development pipeline. The steps use the `docker-bootstrap-dev` queue
+and the default Ubuntu image's Python interpreter. No repository scripts or
+hook changes are required.
+
+## 1. Prepare the development agent
+
+Run these tests with only the development agent consuming the test queue, and
+no other Docker bootstrap builds running on its machine. Keep the agent terminal
+open so you can see its cancellation messages.
+
+For the latest diagnostics, install the newly built Linux ARM64 binary inside
+the Orb machine while the development agent is stopped. Replace the example
+machine name `docker-test-vm` below with your own. From macOS:
+
+```sh
+orb push -m docker-test-vm /tmp/buildkite-agent-docker-bootstrap-linux-arm64
+orb -m docker-test-vm
+```
+
+In the Linux shell:
+
+```sh
+sudo install -m 755 ~/buildkite-agent-docker-bootstrap-linux-arm64 /usr/local/bin/buildkite-agent
+```
+
+Restart your existing agent command with these additional settings:
+
+```text
+--cancel-signal=SIGTERM
+--cancel-signal-timeout=20s
+```
+
+Keep `--job-context-dir` and the `docker-bootstrap` bootstrap-script setting.
+Keep the supervisor's default `--cleanup-margin=5s`. That gives the inner
+bootstrap a 15-second grace period and reserves time for supervisor cleanup.
+Do not change these values through pipeline environment variables.
+
+## 2. Install the validation pipeline
+
+Paste the entire contents of [docker-validation.yml](docker-validation.yml)
+into the pipeline's YAML editor and save it. Change every queue value if your
+development agent uses a different queue. Do not add a step-level `image`.
+
+Disable any pipeline-level policy that automatically cancels an older build
+when you create another build. Complete one test build before starting the next.
+
+The `BOOTSTRAP_TEST` build variable selects the test. Use that exact name:
+job-defined `DOCKER_*` variables are rejected by this prototype. The conditionals
+are evaluated when the pipeline is uploaded, so set the variable when creating
+the build, not within a command.
+
+## 3. Validate ordinary exit codes
+
+Create a new build and enter this under Environment Variables:
+
+```text
+BOOTSTRAP_TEST=exits
+```
+
+Wait for all six command jobs to finish. Inspect each job's reported exit status
+in its job details or final command log; do not rely on build colour alone.
+
+| Step | Expected exit status | Expected behavior |
+| --- | --- | --- |
+| Exit 0 | 0 | Pass |
+| Exit 1 | 1 | Expected soft failure |
+| Exit 42 | 42 | Expected soft failure |
+| Explicit exit 137 | 137 | Expected soft failure; no signal was sent |
+| Explicit exit 143 | 143 | Expected soft failure; no signal was sent |
+| Exit 255 | 255 | Expected soft failure |
+
+Each nonzero step only soft-fails its expected code. Still check the numeric
+status: an incorrect zero would also appear successful. Explicit exits 137 and
+143 must not be treated as evidence of an OOM or signal termination.
+
+Code 125 is deliberately excluded: this agent reserves it for bootstrap setup
+failure and maps it to reported status -1 with reason `process_run_error`. It is
+not an ordinary exit-code round-trip test.
+
+From a second macOS terminal, check that all test containers have been removed:
+
+```sh
+orb -m docker-test-vm docker ps -a \
+  --filter label=com.buildkite.bootstrap=docker \
+  --format 'table {{.ID}}\t{{.Status}}\t{{.Names}}'
+```
+
+Expected: only the table header. Use `-a` so stopped-but-not-removed containers
+are visible too.
+
+## 4. Validate graceful cancellation
+
+Create a separate build with:
+
+```text
+BOOTSTRAP_TEST=graceful
+```
+
+1. Open the running job and wait for `READY: cancel this job now` in its log.
+2. Run the Docker listing above and record the running container ID.
+3. Use the running job's **Cancel** action in Buildkite. Leave the agent running.
+4. Look for `GRACEFUL: received signal 15` and `GRACEFUL: cleanup complete`.
+5. Wait for the job to finish, then repeat the Docker listing.
+
+Pass criteria: the signal handler runs, its cleanup message reaches the job log,
+the command exits 143, Buildkite records cancellation rather than a normal pass,
+and the container is removed. The agent remains connected and can accept another
+job. The supervisor should not need to print its forced-removal message.
+
+The handler sleeps for one second, so this should finish well before the grace
+deadline after the agent receives cancellation. Allow for polling between the UI
+click and the agent receiving the request.
+
+This exercises application cleanup in a signal handler. It does not yet validate
+post-command/pre-exit hooks or artifact uploads during cancellation.
+
+## 5. Validate cancellation of an uncooperative command
+
+Create another build with:
+
+```text
+BOOTSTRAP_TEST=forced
+```
+
+1. Wait for `READY: ignoring SIGTERM and SIGINT; cancel this job now`.
+2. Record the running container ID using the Docker listing.
+3. Cancel the running job in Buildkite, leaving the agent running.
+4. Observe the job and agent logs until cancellation completes.
+5. Repeat the Docker listing, including `-a`.
+
+The command ignores graceful cancellation. Escalation should occur near the
+15-second inner grace deadline, measured from the agent receiving cancellation,
+and cleanup should complete within its 20-second outer budget.
+
+If the supervisor performs escalation, expect:
+
+```text
+Docker bootstrap cancellation grace expired; forcing container removal
+```
+
+That supervisor path returns 137. The inner bootstrap can also kill the command
+at its own deadline and finish first, so absence of that exact log message does
+not by itself mean escalation failed. Record the actual exit status and logs;
+do not infer which process sent SIGKILL from exit status 137 alone.
+
+Pass criteria: the job terminates despite ignoring SIGTERM, Buildkite records
+cancellation, no container remains, and the agent stays usable. A remaining
+running or stopped container, a supervisor killed before cleanup, or a cleanup
+failure diagnostic is a failure to investigate.
+
+## 6. Confirm recovery and record results
+
+Run `BOOTSTRAP_TEST=exits` again after the cancellation tests. This checks that
+the same agent can accept and complete subsequent jobs.
+
+Record the build URL, test mode, reported exit statuses, cancellation log
+messages, approximate duration, and whether the final Docker listing was empty.
+If a container remains, preserve its ID and inspect its state before removing it:
+
+```sh
+orb -m docker-test-vm docker inspect --format '{{json .State}}' CONTAINER_ID
+```
+
+These tests validate exit reporting, command cancellation, and container cleanup.
+Checkout failures, cancellation during pull/start, hooks, artifacts, lock
+compatibility, and backend delivery of step images remain separate tests.
+
+## Recorded validation
+
+Manual validation on ARM64 Ubuntu Noble under OrbStack used a 20-second
+cancellation timeout and the default 5-second supervisor cleanup margin.
+
+| Test | Observed result |
+| --- | --- |
+| Graceful cancellation | Process exited 143 approximately two seconds after cancellation, with no process signal reported. |
+| Forced cancellation | Process exited 137 approximately 16 seconds after cancellation. The job log explicitly confirmed supervisor-forced container removal. No stopped containers remained. |
+| Recovery on the same agent | All six jobs returned exactly 0, 1, 42, 137, 143, and 255, with `Signal: nil`. The final filtered `docker ps -a` output was empty. |
+
+These results establish command exit reporting, graceful termination timing,
+supervisor escalation, container removal, and continued operation after
+cancellation. They do not yet establish hook or artifact behavior during
+cancellation.
+
+References: [Buildkite conditionals](https://buildkite.com/docs/pipelines/configure/conditionals),
+[soft failures](https://buildkite.com/docs/pipelines/configure/soft-fail), and
+[canceling jobs](https://buildkite.com/docs/pipelines/configure/canceling-builds).

--- a/docs/docker-validation.md
+++ b/docs/docker-validation.md
@@ -191,7 +191,9 @@ References: [Buildkite conditionals](https://buildkite.com/docs/pipelines/config
 ## Prototype image refresh and crash recovery
 
 The prototype pulls an image only when it is missing locally. A cached mutable
-tag is reused until the operator refreshes it; there is no pull-policy flag yet.
+tag is reused until the operator refreshes it. Set `--pull-policy=always` in the
+bootstrap-script to refresh before each job, or `--pull-policy=never` to prohibit
+pulls. A failed `always` pull fails the job even when the image is cached.
 Between jobs, refresh the default image on the Docker host with:
 
 ```sh
@@ -206,3 +208,79 @@ and running container may survive. Automatic reconciliation is deferred. Inspect
 leftovers using `docker ps -a --filter label=com.buildkite.bootstrap=docker` and
 the job/agent labels; confirm the job is no longer active before removing its
 specific container with `docker rm --force CONTAINER_ID`.
+
+## Pull policy, registry credentials, and container user
+
+Configure operator flags in the bootstrap-script, for example:
+
+```sh
+buildkite-agent start \
+  --build-path=/var/lib/buildkite-agent/builds \
+  --plugins-path=/var/lib/buildkite-agent/plugins \
+  --job-context-dir=/var/lib/buildkite-agent/docker-context \
+  --bootstrap-script='/usr/bin/buildkite-agent docker-bootstrap --pull-policy=always --docker-config=/var/lib/buildkite-agent/registry'
+```
+
+Provision the dedicated registry directory with mode 0700 and use
+`docker --config /var/lib/buildkite-agent/registry login REGISTRY --username USER --password-stdin`
+to supply credentials through stdin. Keep `config.json` mode 0600, outside all
+job-mounted paths. Container operations cannot access this configuration.
+
+For credential helpers, install the helper on the host and configure `credHelpers`
+or `credsStore` in that file. If needed, add `--docker-helper-path` with absolute
+PATH entries and `--docker-helper-env-file` pointing to a mode 0600 JSON object:
+
+```json
+{"HOME":"/var/lib/buildkite-agent/registry-helper","AWS_PROFILE":"buildkite-pull"}
+```
+
+These values go only to pull helpers. Provision referenced credential files on
+the host outside job mounts. Helpers must not include credentials in error text.
+
+The default container identity now matches the host agent UID:GID. Use fresh
+build/plugin directories when validating migration from root execution; the
+supervisor does not repair existing file ownership. `--user=0:0` opts into root.
+A different non-root UID requires a root host agent and pre-provisioned writable
+build/plugin paths. Each container receives a private writable home and minimal
+user/group lookup files; arbitrary image accounts and supplementary groups are
+not preserved.
+
+Linux-only integration tests are opt-in and require the local Docker socket:
+
+```sh
+CGO_ENABLED=0 go build -o /tmp/buildkite-agent-test .
+DOCKER_BOOTSTRAP_TEST_BINARY=/tmp/buildkite-agent-test \
+  go test ./internal/dockerbootstrap -run TestDockerUserIntegration -v
+```
+
+The hosted image must already be cached for the user test. It checks non-root
+and explicit root execution, repository hook environment propagation, writable
+home, user/group lookup, repeated workspace use, file ownership, and cleanup.
+Run as an unprivileged agent user to exercise the non-root default.
+
+Private-registry integration tests also accept `DOCKER_BOOTSTRAP_TEST_IMAGE` and
+`DOCKER_BOOTSTRAP_TEST_AUTH` (a private Docker config directory). Use a disposable
+registry requiring basic authentication and seed the hosted image under a unique
+test tag. These tests remove that tag from the local image cache to exercise
+missing-image behavior; do not point them at an image used by other workloads.
+The helper test requires the fixture's inline basic-auth credentials.
+
+```sh
+DOCKER_BOOTSTRAP_TEST_BINARY=/tmp/buildkite-agent-test \
+DOCKER_BOOTSTRAP_TEST_IMAGE=127.0.0.1:5000/bootstrap:validation \
+DOCKER_BOOTSTRAP_TEST_AUTH=/private/test-registry-config \
+  go test ./internal/dockerbootstrap -run 'TestDocker(Registry|CredentialHelper)Integration' -v
+```
+
+Live ARM64 OrbStack validation confirmed authenticated pulls, cached policies,
+credential rejection, host credential helper execution, and cancellation during
+helper resolution. Default non-root execution also passed the real pipeline's
+checkout/artifact round trip and metahook ordering/failure tests. Build and plugin
+files belonged to the host agent UID:GID. Graceful cancellation completed with
+exit 143; forced cancellation logged supervisor-forced removal. No bootstrap
+containers remained. The source and generated credential
+configurations were not mounted into jobs. Rootless/user-namespace mappings and
+migration of existing root-owned workspaces remain outside this validation.
+A root-host test also verified a distinct non-root UID:GID with pre-provisioned
+workspace ownership, including private-context access and cleanup. An unwritable
+workspace failed with a user-permission diagnostic before bootstrap started.

--- a/docs/docker-validation.md
+++ b/docs/docker-validation.md
@@ -284,3 +284,42 @@ migration of existing root-owned workspaces remain outside this validation.
 A root-host test also verified a distinct non-root UID:GID with pre-provisioned
 workspace ownership, including private-context access and cleanup. An unwritable
 workspace failed with a user-permission diagnostic before bootstrap started.
+
+## Per-job networks
+
+Each execution creates `buildkite_job_<random-id>` and
+`buildkite_network_<random-id>` with the same suffix. The job log includes the
+network name. Inspect resources on the agent's Docker host:
+
+```sh
+docker ps -a --filter label=com.buildkite.bootstrap=docker
+docker network ls --filter label=com.buildkite.bootstrap=docker
+```
+
+After all test jobs finish, both lists should be empty. While jobs are running,
+each container should belong to exactly one dedicated bridge, with no published
+ports.
+
+With the hosted image cached, run the opt-in Linux integration test:
+
+```sh
+CGO_ENABLED=0 go build -o /tmp/buildkite-agent-test .
+DOCKER_BOOTSTRAP_TEST_BINARY=/tmp/buildkite-agent-test \
+  go test ./internal/dockerbootstrap -run 'TestDocker(Network|User)Integration' -v
+```
+
+The network test starts two concurrent jobs and requires outbound HTTPS access
+to `https://example.com`. Both jobs start TCP listeners. The test confirms that
+each listener is reachable locally, but connections to the other job's container
+IP fail in both directions. It then cancels one job gracefully and forces the
+other to stop, checking that both containers and networks disappear. The user
+test also exercises successful exits and permission failures with network cleanup.
+
+Live ARM64 OrbStack validation passed these checks. Unit tests cover partial
+network creation, cancellation during creation, missing resources, cleanup
+failures, and reserved time for network removal.
+
+These checks do not establish isolation from host services, cloud metadata, or
+internal networks. DNS/proxy overrides, custom CAs, VPN routes, IPv6, and MTU
+compatibility remain unvalidated. Abrupt supervisor termination can leave networks
+behind; stale-resource reconciliation remains deferred.

--- a/docs/docker-validation.md
+++ b/docs/docker-validation.md
@@ -187,3 +187,22 @@ cancellation.
 References: [Buildkite conditionals](https://buildkite.com/docs/pipelines/configure/conditionals),
 [soft failures](https://buildkite.com/docs/pipelines/configure/soft-fail), and
 [canceling jobs](https://buildkite.com/docs/pipelines/configure/canceling-builds).
+
+## Prototype image refresh and crash recovery
+
+The prototype pulls an image only when it is missing locally. A cached mutable
+tag is reused until the operator refreshes it; there is no pull-policy flag yet.
+Between jobs, refresh the default image on the Docker host with:
+
+```sh
+docker pull buildkite/agent-base:ubuntu-noble-hosted
+```
+
+The next job resolves the refreshed tag to an immutable image ID. Existing jobs
+continue using their already-selected image.
+
+SIGKILL of the supervisor bypasses cleanup. Its separate Docker CLI process group
+and running container may survive. Automatic reconciliation is deferred. Inspect
+leftovers using `docker ps -a --filter label=com.buildkite.bootstrap=docker` and
+the job/agent labels; confirm the job is no longer active before removing its
+specific container with `docker rm --force CONTAINER_ID`.

--- a/docs/docker-validation.yml
+++ b/docs/docker-validation.yml
@@ -1,0 +1,71 @@
+# Paste into a dedicated pipeline's YAML editor. Change the queue if needed.
+# Set BOOTSTRAP_TEST in New Build > Environment Variables:
+#   exits (default), graceful, or forced
+steps:
+  - group: "Docker exit codes"
+    if: 'build.env("BOOTSTRAP_TEST") == null || build.env("BOOTSTRAP_TEST") == "exits"'
+    steps:
+      - label: "Exit 0"
+        agents: { queue: docker-bootstrap-dev }
+        command: "test -f /.dockerenv && exit 0"
+      - label: "Exit 1"
+        agents: { queue: docker-bootstrap-dev }
+        command: "test -f /.dockerenv || exit 99; exit 1"
+        soft_fail: [{ exit_status: 1 }]
+      - label: "Exit 42"
+        agents: { queue: docker-bootstrap-dev }
+        command: "test -f /.dockerenv || exit 99; exit 42"
+        soft_fail: [{ exit_status: 42 }]
+      - label: "Explicit exit 137 (no signal)"
+        agents: { queue: docker-bootstrap-dev }
+        command: "test -f /.dockerenv || exit 99; exit 137"
+        soft_fail: [{ exit_status: 137 }]
+      - label: "Explicit exit 143 (no signal)"
+        agents: { queue: docker-bootstrap-dev }
+        command: "test -f /.dockerenv || exit 99; exit 143"
+        soft_fail: [{ exit_status: 143 }]
+      - label: "Exit 255"
+        agents: { queue: docker-bootstrap-dev }
+        command: "test -f /.dockerenv || exit 99; exit 255"
+        soft_fail: [{ exit_status: 255 }]
+
+  - label: "Cancel gracefully after READY"
+    if: 'build.env("BOOTSTRAP_TEST") == "graceful"'
+    agents: { queue: docker-bootstrap-dev }
+    timeout_in_minutes: 5
+    command: |
+      test -f /.dockerenv
+      exec python3 -u - <<'PY'
+      import signal
+      import sys
+      import time
+
+      def cancel(signum, frame):
+          print("GRACEFUL: received signal", signum, flush=True)
+          time.sleep(1)
+          print("GRACEFUL: cleanup complete", flush=True)
+          sys.exit(143)
+
+      signal.signal(signal.SIGTERM, cancel)
+      signal.signal(signal.SIGINT, cancel)
+      print("READY: cancel this job now", flush=True)
+      while True:
+          time.sleep(1)
+      PY
+
+  - label: "Cancel stubborn command after READY"
+    if: 'build.env("BOOTSTRAP_TEST") == "forced"'
+    agents: { queue: docker-bootstrap-dev }
+    timeout_in_minutes: 5
+    command: |
+      test -f /.dockerenv
+      exec python3 -u - <<'PY'
+      import signal
+      import time
+
+      signal.signal(signal.SIGTERM, signal.SIG_IGN)
+      signal.signal(signal.SIGINT, signal.SIG_IGN)
+      print("READY: ignoring SIGTERM and SIGINT; cancel this job now", flush=True)
+      while True:
+          time.sleep(1)
+      PY

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -2,9 +2,11 @@
 
 ## Status
 
-Implementation plan with an agreed first-milestone scope. No implementation
-exists yet. Later phases describe the intended supported feature, not requirements
-for the first milestone.
+Implementation plan with an agreed first-milestone scope. An initial CLI prototype
+is implemented; a real pipeline smoke test has passed on an OrbStack Linux
+machine, including the container marker and absence of the host Docker socket.
+Live cancellation and broader lifecycle validation are still pending. Later phases describe
+the intended supported feature, not requirements for the first milestone.
 
 First-milestone decisions:
 
@@ -19,6 +21,48 @@ First-milestone decisions:
 - Defer local Linux/OrbStack setup and live Docker validation initially. Start
   with unit tests and Linux builds; live validation remains required to complete
   the executable prototype.
+
+### Running the initial prototype
+
+On a Linux host with a local Docker Engine and a statically linked Linux agent:
+
+```sh
+buildkite-agent start \
+  --job-context-dir=/var/lib/buildkite-agent/docker-context \
+  --bootstrap-script='/usr/bin/buildkite-agent docker-bootstrap'
+```
+
+The agent executable in `--bootstrap-script` must be the development binary.
+An agent token and the normal agent configuration are still required. The Docker
+CLI defaults to `/usr/bin/docker`; override it with `--docker-path` inside the
+bootstrap-script argument if needed. Other prototype arguments are `--image`,
+`--cleanup-margin`, `--operation-timeout`, and `--pull-timeout`. None read policy
+from job environment variables or inherited agent configuration files.
+
+Current implementation details and limits:
+
+- `docker start --attach` performs attach, exit-observer registration, start, and
+  wait in one CLI invocation. Separate CLI processes cannot guarantee that
+  ordering for fast-exiting auto-removed containers.
+- The local endpoint is fixed to `unix:///var/run/docker.sock`. Docker uses an
+  empty private configuration directory; public images and images already in
+  the daemon's cache are supported. Private registry authentication is deferred.
+- Job-defined `DOCKER_*` variables are rejected because name-only environment
+  transport would also apply them to the host Docker client.
+- The image's configured user is used. The default image runs as root; UID/GID
+  mapping is deferred. Bind-mounted build outputs can therefore be root-owned.
+- Job API sockets use a container-private tmpfs. Only existing agent API socket
+  files are mounted for agent-level lock commands.
+- Wrapper scripts around `docker-bootstrap` are not supported: JobRunner must
+  recognize the command to allocate private coordination files and reject step
+  images. Host `PATH`, `HOME`, and other unavailable host paths are omitted.
+- Startup and attachment errors map to setup failures when state is available.
+  Once auto-removal has discarded that state, the CLI exit code is retained;
+  some Docker client failures can therefore remain indistinguishable from a
+  bootstrap exit. Exact signal reporting and reliable OOM reporting are deferred.
+- A real pipeline smoke test has passed on OrbStack Linux. Live cancellation,
+  failure handling, hooks, artifacts, and lock compatibility still require
+  validation before treating this as an end-to-end validated milestone.
 
 ## Objective
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,872 @@
+# Docker Bootstrap Plan
+
+## Status
+
+Implementation plan with an agreed first-milestone scope. No implementation
+exists yet. Later phases describe the intended supported feature, not requirements
+for the first milestone.
+
+First-milestone decisions:
+
+- Use the Docker CLI and one agent-configured image, defaulting to
+  `buildkite/agent-base:ubuntu-noble-hosted`, maintained in
+  <https://github.com/buildkite/agent-base-images>.
+- Always mount the host agent binary read-only.
+- Reject steps that specify `image` as a setup failure (exit 125). Pipeline image
+  selection, resource controls, and per-job networks are deferred.
+- Preserve container exit codes without inferring signals; retain JobRunner's
+  cancellation reason. OOM diagnostics are best-effort.
+- Defer local Linux/OrbStack setup and live Docker validation initially. Start
+  with unit tests and Linux builds; live validation remains required to complete
+  the executable prototype.
+
+## Objective
+
+Run each Buildkite job's bootstrap lifecycle inside a disposable Docker
+container while keeping the long-lived Buildkite agent on the host.
+
+The container runs the existing `buildkite-agent bootstrap` command so the
+current plugin, checkout, hook, command, artifact, environment, and exit-status
+semantics remain in one implementation.
+
+```text
+Linux host
+└── buildkite-agent start
+    └── JobRunner
+        └── buildkite-agent docker-bootstrap
+            └── disposable Docker container
+                └── buildkite-agent bootstrap
+                    ├── plugin setup
+                    ├── checkout
+                    ├── hooks
+                    ├── command
+                    └── artifact upload
+```
+
+This is a job-container model. It is different from wrapping only the command
+phase with a Docker plugin: the checkout and the rest of the bootstrap lifecycle
+also run in the container.
+
+## Why this fits the existing agent
+
+The agent already exposes the required interception point. `agent start`
+launches a configurable `--bootstrap-script` for every job. `JobRunner` supplies
+the job environment and working directory, captures stdout and stderr, forwards
+cancellation, and consumes the subprocess exit status.
+
+The first implementation should use this interface:
+
+```text
+--bootstrap-script="/usr/bin/buildkite-agent docker-bootstrap"
+```
+
+The new `docker-bootstrap` command acts as a host-side container supervisor. It
+starts a container whose command is the existing:
+
+```text
+buildkite-agent bootstrap
+```
+
+This avoids copying or forking the job executor.
+
+Relevant code:
+
+- `agent/job_runner.go`: constructs and supervises the bootstrap process.
+- `agent/run_job.go`: maps process completion, cancellation, and setup failures
+  to job results.
+- `clicommand/agent_start.go`: defines and defaults `--bootstrap-script`.
+- `clicommand/bootstrap.go`: constructs the normal job executor.
+- `internal/job/executor.go`: runs plugins, checkout, hooks, the command, and
+  artifact upload.
+- `clicommand/kubernetes_bootstrap.go`: useful prior art for launching the real
+  bootstrap in another execution environment and forwarding cancellation. Its
+  `rebaseJobContextPaths` helper, `BUILDKITE_BIN_PATH` override, and checkout
+  path handling are directly reusable here.
+- `internal/process/process.go` and `internal/process/signal_notwindows.go`:
+  the interrupt-then-group-SIGKILL sequence that bounds how long the supervisor
+  has to clean up after cancellation.
+
+## Initial scope
+
+The first release should have deliberately narrow semantics:
+
+- Linux hosts only.
+- A local Docker Engine reachable by the agent.
+- One bootstrap container per job.
+- An agent-configured default image, with the step-level `image` attribute
+  honoured only when agent policy allows it. See "Image selection".
+- All normal bootstrap phases run in the container.
+- The `pre-bootstrap` hook remains on the host and runs before Docker starts.
+- The agent must be started with `--job-context-dir` set to a dedicated
+  per-agent directory. See "Job-context directory" below for why the default
+  is unsafe to mount.
+- Attached stdout and stderr feed the existing job log streamer.
+- The container's exit status becomes the bootstrap exit status.
+- Containers are always removed after completion.
+- The host Docker socket is not mounted into the job container by default.
+- Service containers and Docker-in-Docker are deferred until the base
+  lifecycle is reliable. Pipeline-selected images are in scope for the MVP,
+  gated by agent policy, but not the first milestone.
+
+## Proposed components
+
+### `docker-bootstrap` command
+
+Add a new internal CLI command:
+
+```text
+buildkite-agent docker-bootstrap
+```
+
+Suggested files:
+
+```text
+clicommand/docker_bootstrap.go
+clicommand/docker_bootstrap_test.go
+internal/dockerbootstrap/runner.go
+internal/dockerbootstrap/runner_test.go
+```
+
+Register the command in `clicommand/commands.go`.
+
+Keep CLI parsing separate from lifecycle logic. The CLI command should load
+configuration and signals; an internal runner should own Docker operations,
+state transitions, cleanup, and exit-status handling.
+
+### Bootstrap image
+
+The image contract should require:
+
+- A `buildkite-agent` binary compatible with the host agent.
+- Git, SSH, CA certificates, and a supported shell.
+- Any interpreters required by organization-level hooks.
+- A writable temporary directory.
+- A valid user and working directory.
+
+Pipeline-selected images are arbitrary user images and will not contain
+`buildkite-agent`. The supervisor must therefore bind-mount the host agent
+binary read-only into the container and point `BUILDKITE_BIN_PATH` at that
+location. This is the required approach, not a prototype shortcut. The agent is
+a statically linked Go binary, so it runs unchanged on glibc and musl images.
+An agent-provided default image may additionally bake the binary in, but the
+mount is always applied so the host and container versions can never drift.
+
+The supervisor should validate the image before running the bootstrap: the
+mounted agent binary must be executable by the container user, and `git` and a
+supported shell must be on `PATH`. Report these as a clear image-contract
+failure rather than letting the checkout phase fail with a confusing error.
+
+Use Docker's `--init` support, or an equivalent minimal init in the image, so
+signals are forwarded and orphaned child processes are reaped correctly.
+
+## Configuration
+
+Start with host-controlled configuration. Do not allow arbitrary job
+environment variables to supply raw Docker options.
+
+Proposed settings:
+
+```text
+docker-bootstrap-image
+docker-bootstrap-image-policy
+docker-bootstrap-image-allowlist
+docker-bootstrap-image-require-digest
+docker-bootstrap-pull-policy
+docker-bootstrap-user
+docker-bootstrap-memory
+docker-bootstrap-cpus
+docker-bootstrap-pids-limit
+docker-bootstrap-docker-socket
+docker-bootstrap-additional-volume
+docker-bootstrap-additional-env
+```
+
+During the prototype use arguments embedded in `--bootstrap-script` for
+host-controlled policy. Do not read policy from unprotected environment variables:
+the supervisor inherits job-supplied values. If Docker execution becomes a first-class
+agent mode, promote them to normal `agent start` configuration and flags.
+
+Image selection is agent-controlled by default. Pipelines may choose the image
+through the step-level `image` attribute only when the agent operator opts in.
+The policy, allowlist, plumbing, and signing requirements are covered in "Image
+selection" below.
+
+## Image selection
+
+The pipeline YAML already supports a step-level `image` attribute, currently
+honoured only on hosted agents where it sets the container image for the whole
+job. That is the same job-container model as this design, so self-hosted Docker
+mode should honour the same attribute rather than introduce a new one.
+
+### Where the value comes from
+
+The agent decodes each job's step into `pipeline.CommandStep` from
+`github.com/buildkite/go-pipeline`. As of v0.18.0 that struct has no typed
+`image` field; an `image` key in the accept-job payload lands in the untyped
+`RemainingFields` map, and nothing in the agent reads it.
+
+Before implementation, confirm with the backend team:
+
+- That the step payload delivered to self-hosted agents includes `image` rather
+  than consuming it server-side for hosted compute only. The existing cache
+  warning keyed on `BUILDKITE_COMPUTE_TYPE == "self-hosted"` in
+  `agent/run_job.go` shows hosted-oriented attributes do already reach
+  self-hosted agents, so this is likely but must be verified.
+- Whether the backend also exposes the value as a job environment variable. The
+  agent currently references no image-related variable.
+
+Add a typed `Image string` field to `CommandStep` in go-pipeline rather than
+reading `RemainingFields`. This validates the value once and makes it available
+to signing.
+
+### Signing
+
+Pipeline signing covers command, env, plugins, matrix, and repository URL, plus
+secrets and checkout when non-empty (`signature/pipeline_invariants.go` in
+go-pipeline, verified in `agent/verify_job.go`). `image` is not signed. With
+signing enabled, an altered job payload could therefore swap the image without
+invalidating the signature, and that image runs with the job token and the build
+path mounted.
+
+Add `image` to the signed fields, included only when non-empty so existing
+signatures remain valid, and add the corresponding comparison in
+`verifyJob`. This go-pipeline change must ship before pipeline-selected images
+are enabled by default in any agent configuration.
+
+### Resolution and precedence
+
+1. `docker-bootstrap-image` is the agent default. It is used only when the step
+   sets no image.
+2. A step image is honoured only when `docker-bootstrap-image-policy` allows it:
+   - `agent-only` (default): a step image is rejected.
+   - `allowlist`: the step image must match an entry in
+     `docker-bootstrap-image-allowlist`, a list of registry or repository
+     patterns such as `123456789012.dkr.ecr.us-east-1.amazonaws.com/ci/*` or
+     `ghcr.io/example-org/*`.
+   - `any`: any image is accepted. Intended for isolated or single-tenant
+     agents only.
+3. When `docker-bootstrap-image-require-digest` is set, a step image must be
+   pinned by digest. Mutable tags are rejected.
+4. A step image that is present but rejected by policy fails the job with a
+   message naming the image and the policy that rejected it. Never fall back
+   silently to the default image: silent fallback hides misconfiguration and
+   runs the job in an image the author did not ask for.
+5. Rejection is a setup failure and exits with code 125 so `JobRunner` maps it
+   to an agent-side failure, not a command failure. That keeps retry behaviour
+   sensible.
+
+### Plumbing
+
+`JobRunner` sees the decoded step, but the supervisor only sees the
+environment. `JobRunner` should place the requested image into an agent-set
+variable, proposed as `BUILDKITE_JOB_IMAGE`, using `setEnv`. `setEnv` always
+overwrites and records any job-supplied value in `BUILDKITE_IGNORED_ENV`, so a
+pipeline environment variable cannot smuggle an image past the policy. Add the
+variable to the protected list in `env/protected.go`.
+
+The supervisor owns policy evaluation, defaulting, pull, and registry
+authentication, because it is the Docker-aware component. It logs the resolved
+image reference and digest at the top of the job log so users can see which
+image ran.
+
+### Operational notes
+
+- Pre-pull the default image at agent start so the fallback path does not pay
+  a cold pull on the first job.
+- Registry authentication becomes per-registry once pipelines choose images.
+  See "Registry authentication".
+- Pull policy matters more with mutable tags. Default to pulling when the tag is
+  not present locally, and document that `always` is the safer choice when the
+  allowlist permits tags.
+- The image contract in "Bootstrap image" applies to pipeline-selected images
+  too: git, a shell, SSH, and CA certificates must be present, and the agent
+  binary is mounted from the host.
+
+## Per-job lifecycle
+
+The supervisor should implement an explicit lifecycle:
+
+```text
+created → pulling → configured → starting → running → stopping → removed
+```
+
+For each job:
+
+1. Validate the platform, Docker client, and daemon connectivity.
+2. Resolve the image: take the step image from `BUILDKITE_JOB_IMAGE` if set,
+   apply the image policy and allowlist, otherwise use the agent default. Exit
+   125 on rejection.
+3. Derive a unique container name from the job ID plus a random suffix.
+4. Pull or inspect the image according to the configured pull policy, using
+   credentials for the resolved image's registry.
+5. Build the environment, mounts, labels, resource limits, and security options.
+6. Create the container with `buildkite-agent bootstrap` as its command.
+7. Attach stdout and stderr before starting it, avoiding early output loss.
+8. Start the container and wait for completion or cancellation.
+9. Inspect the container state and collect its actual exit status.
+10. Translate infrastructure failures separately from bootstrap failures where
+    possible.
+11. Force-remove the container and any per-job network in a deferred,
+    idempotent cleanup path.
+
+Every operation should have a bounded timeout. Cleanup must still run when image
+pull, create, attach, start, inspect, or cancellation fails partway through.
+
+## Docker client strategy
+
+There are two reasonable implementation stages.
+
+### Stage 1: Docker CLI
+
+Use the installed `docker` CLI for a small prototype. Prefer argument arrays
+over shell command strings. Do not place secret values in command-line
+arguments.
+
+The supervisor needs more than a simple `docker run --rm` call. It should use an
+explicit create/attach/start/inspect/remove sequence so it can:
+
+- Attach before start.
+- Identify the exact container during cancellation.
+- Distinguish client errors from container exit codes.
+- Inspect OOM and runtime state.
+- Reliably remove a container if the local Docker CLI process is interrupted.
+
+### Stage 2: Docker Engine API
+
+Adopt a Go Docker Engine client if the feature progresses beyond a prototype.
+The API provides structured create, attach, wait, signal, inspect, and remove
+operations without parsing CLI output or relying on shell escaping.
+
+The tradeoff is an additional dependency and API compatibility surface. Make
+that change only after the execution contract is proven.
+
+## Environment propagation
+
+The bootstrap container must receive the environment assembled by `JobRunner`.
+This includes job metadata, command configuration, API credentials, checkout
+settings, tracing context, plugin definitions, and paths to coordination files.
+
+`JobRunner` builds the subprocess environment as the host agent's own
+environment plus the job environment, with no marker separating the two. The
+supervisor therefore needs an explicit selection rule rather than "everything
+`JobRunner` set". Propose:
+
+1. Every variable named in `BUILDKITE_ENV_JSON_FILE`. This is the job
+   environment as the agent assembled it.
+2. Every `BUILDKITE_*` variable present in the supervisor's environment. This
+   picks up values that are deliberately kept out of the env files, notably
+   `BUILDKITE_AGENT_ACCESS_TOKEN` and the agent API request headers.
+3. Control-plane OpenTelemetry exporter variables (`OTEL_EXPORTER_OTLP_*`),
+   which `JobRunner` also adds after the env files are written.
+4. An agent-configured allowlist (`docker-bootstrap-additional-env`) for
+   anything else, such as proxy settings.
+
+Host-only variables such as `PATH`, `HOME`, `USER`, `TMPDIR`, and
+`BUILDKITE_JOB_LOG_TMPFILE` must not be forwarded unless the container is given
+an equivalent path. `BUILDKITE_JOB_LOG_TMPFILE` in particular is set on the
+agent process itself when `--enable-job-log-tmpfile` is on; either mount the
+file or drop the variable so hooks do not see a path that does not exist.
+
+Do not serialize secret values into Docker command arguments. With the Docker
+CLI, pass environment variable names using repeated `--env NAME` options and let
+Docker inherit their values from `docker-bootstrap`. With the Engine API, pass
+the environment directly in the create request.
+
+Validate environment names before passing them to Docker. Preserve values
+exactly, including whitespace. Add tests for multiline and non-ASCII values.
+
+The parent also exposes job environment files and a job-timeout marker through:
+
+```text
+BUILDKITE_ENV_FILE
+BUILDKITE_ENV_JSON_FILE
+BUILDKITE_AGENT_JOB_TIMEOUT_FILE
+```
+
+Their containing job-context directory must be mounted into the container at
+the same absolute path. A read-only bind mount is sufficient: host-side creation
+of a timeout marker remains visible through the mount.
+
+### Job-context directory
+
+In non-Kubernetes mode `jobContextDir` in `agent/job_runner.go` falls back to
+`os.TempDir()`, so env files and the timeout marker are written directly into
+the host `/tmp` alongside every other job's files. Mounting that directory into
+the container is unacceptable for two reasons:
+
+- It would shadow the container's own `/tmp` with a read-only host directory.
+- It would expose other concurrent jobs' env files, which contain user-supplied
+  pipeline environment, to this job.
+
+The agent already has a `--job-context-dir` flag. The Docker mode must require
+it to point at a dedicated per-agent directory, and JobRunner should
+create a per-job subdirectory beneath it before writing coordination files so
+only this job's files are mounted. Reuse `rebaseJobContextPaths` from
+the Kubernetes bootstrap if the in-container path ever differs from the host
+path.
+
+## Filesystem layout and mounts
+
+Initially mount important paths at the same absolute path on the host and in the
+container. This avoids path translation throughout the existing bootstrap.
+
+| Host path | Container mode | Purpose |
+| --- | --- | --- |
+| Build path | read/write | Checkout and build output |
+| Plugins path | read/write | Plugin checkout and cache |
+| Hooks paths | read-only where compatible | Agent hooks |
+| Job-context directory | read-only | Environment and timeout files |
+| Git mirrors path | read/write, when configured | `BUILDKITE_GIT_MIRRORS_PATH` and its lock files |
+| Additional hooks paths | read-only, one mount per entry | `BUILDKITE_ADDITIONAL_HOOKS_PATHS` is a list |
+| Per-job sockets path | read/write | Job API socket |
+| Agent API socket | read/write, single file | `buildkite-agent lock` and other agent-level commands |
+| Job log tempfile | read-only, optional | Only when `--enable-job-log-tmpfile` is set |
+| SSH agent socket | optional | SSH authentication |
+| CA and credential paths | optional, read-only | Enterprise trust and repository access |
+
+Override container-specific values such as `BUILDKITE_BIN_PATH`, `PATH`, `HOME`,
+and the sockets path when their inherited host values are not valid inside the
+image.
+
+### PTY and terminal handling
+
+`agent start` runs the bootstrap in a PTY by default (`RunInPty`), so the
+supervisor itself runs under a PTY, and the inner bootstrap will also allocate
+PTYs for hooks and the command unless `BUILDKITE_PTY=false` is propagated. The
+supervisor must decide explicitly whether the container gets a TTY:
+
+- With a TTY, Docker merges stdout and stderr into one stream, matching what a
+  PTY-mode bootstrap produces today.
+- Without a TTY, stdout and stderr arrive as separate multiplexed streams. Both
+  feed the same `JobRunner` writer, so nothing is lost, but interleaving can
+  differ from the host behaviour.
+
+Default to a TTY when the agent is in PTY mode and no TTY otherwise, propagate
+`BUILDKITE_PTY` unchanged, and set `TERM` and the terminal size for the
+container so ANSI output matches the non-Docker path.
+
+### File ownership
+
+A container running as root can leave root-owned files in the host build path.
+The design must make this behavior explicit.
+
+Support an agent-controlled container user. Test both:
+
+- Running as the image's configured user for image compatibility.
+- Running as the host agent UID and GID for bind-mount ownership compatibility.
+
+Neither behavior works universally, so the selected policy must be configurable
+and validated during container startup.
+
+## Job API
+
+The normal bootstrap starts the per-job Job API. Because the bootstrap and job
+commands live in the same container, no host-to-container RPC protocol is
+required.
+
+Give each job a private writable sockets directory and set the bootstrap's
+socket configuration to that path. Agent subcommands, hooks, and plugins inside
+the same container can then use the existing Unix socket normally.
+
+A private directory is required, not merely preferred: `jobapi.NewSocketPath`
+names the socket `<pid>-<random>.sock` using the bootstrap's PID. Every
+container has its own PID namespace, so with `--init` the bootstrap is the same
+low PID in every job and a shared directory would produce colliding names.
+
+Do not expose the Job API socket to other jobs or unrelated host processes.
+
+The agent-level API socket is a separate concern. `buildkite-agent lock` and
+related commands connect to `agent-<pid>` under the shared sockets path via
+`agentapi.DefaultSocketPath`. If jobs use these commands, that single socket
+file must be bind-mounted into the container at the path the bootstrap will
+compute from `BUILDKITE_SOCKETS_PATH`, or the supervisor must set the sockets
+path so both the private Job API directory and the agent socket resolve. Treat
+lock support as a compatibility requirement for the MVP.
+
+## Cancellation and signals
+
+Cancellation is the highest-risk part of the implementation. Terminating the
+local `docker` CLI process does not guarantee that the container stops.
+
+When `docker-bootstrap` receives the configured cancellation signal:
+
+1. Mark the job as cancelling and reject duplicate cancellation work.
+2. Signal the bootstrap process in the container, allowing command cleanup,
+   post-command hooks, artifact upload where applicable, and pre-exit hooks.
+3. Wait for the existing cancellation grace period.
+4. Stop or kill the container if it remains active.
+5. Inspect the final state where possible.
+6. Remove the container unconditionally.
+
+### Nested grace periods
+
+`JobRunner.Cancel` sends the cancel signal to the supervisor's process group and
+then SIGKILLs the whole group once `CancelSignalTimeout` elapses. The inner
+bootstrap receives the same value via `BUILDKITE_CANCEL_SIGNAL_TIMEOUT` and uses
+it as the grace period for its own command. Without intervention the
+supervisor, its `docker` CLI children, and the container's bootstrap all run out
+of time at the same instant, and the supervisor is killed before any deferred
+cleanup runs.
+
+The supervisor must therefore:
+
+- Hand the container a shorter `BUILDKITE_CANCEL_SIGNAL_TIMEOUT` than it was
+  given, reserving a fixed margin (for example 5 seconds, configurable) for
+  stop, inspect, and remove.
+- Refuse to start when the configured agent timeout is smaller than the margin,
+  with a clear error, rather than silently running with no headroom.
+- Set daemon-side auto-remove (`AutoRemove` / `--rm`) on the container at
+  create time. The daemon completes removal even if the supervisor is
+  SIGKILLed. Explicit removal remains the primary path; auto-remove is the
+  backstop.
+
+Note the tradeoff: with auto-remove the container disappears immediately on
+exit, so the supervisor must use `docker wait` (or the Engine API wait) to
+obtain the exit code. Register exit observation before starting the container
+and test fast exits explicitly. Final inspection is best-effort; correctness
+must not depend on inspecting a container after it has been removed.
+
+Test cancellation during image pull, create, bootstrap setup, checkout, command,
+artifact upload, and post-command cleanup.
+
+The existing bootstrap setup-failure exit code `125` must remain meaningful to
+`JobRunner`. Be careful because the Docker CLI also uses exit codes in the
+125–127 range for client and invocation failures. Inspection or structured
+Engine API errors should distinguish these cases.
+
+## Logs and exit status
+
+Attach container stdout and stderr to the current bootstrap process stdout and
+stderr. The existing `JobRunner` log buffer and uploader should remain unaware
+that Docker is involved.
+
+The supervisor should report concise infrastructure diagnostics for:
+
+- Docker daemon unavailable.
+- Image pull failure.
+- Container create or start failure.
+- Attach failure.
+- Bootstrap binary missing.
+- Container OOM kill.
+- Container runtime failure.
+- Lost daemon connection.
+- Forced termination after cancellation timeout.
+
+Do not print the full environment, registry credentials, Docker authorization
+configuration, or secret-bearing create requests.
+
+On normal completion, return the inner bootstrap exit status unchanged. Preserve
+the agent's existing distinction between a user command failure and an
+infrastructure failure that prevented the command from running.
+
+### Signal-death reporting
+
+`runJob` in `agent/run_job.go` populates the reported signal from
+`WaitStatus().Signaled()`. Docker's container exit code does not reliably
+distinguish an explicit `exit 143` from termination by SIGTERM, and inspect does
+not provide a general signal-termination field.
+
+For the first milestone, preserve the container exit code unchanged. Do not
+re-raise a signal based on `128+n`, and do not change JobRunner's global exit
+mapping. JobRunner retains its existing cancellation reason independently of
+signal reporting. Collect OOM diagnostics when available, but treat them as
+best-effort because auto-remove can race with inspection.
+
+Exact signal reporting is deferred until there is a reliable explicit reporting
+mechanism from the inner bootstrap.
+
+## Docker socket policy
+
+The job container must not receive the host Docker socket by default.
+
+Support an explicit agent-side policy:
+
+```text
+docker-bootstrap-docker-socket=none   # default
+docker-bootstrap-docker-socket=host
+```
+
+`host` bind-mounts:
+
+```text
+/var/run/docker.sock:/var/run/docker.sock
+```
+
+This gives the job control of the host Docker daemon and is normally equivalent
+to root access to the host. It is a compatibility feature, not an isolation
+feature. A pipeline-provided environment variable must never be able to enable
+it when the agent has disabled it.
+
+Be explicit with adopters about the consequence of the default: the `docker`
+and `docker-compose` Buildkite plugins, which most existing pipelines use, need
+a Docker daemon and will fail under `none`. Operators choosing `none` are
+choosing to run only pipelines that do not build or run containers themselves,
+until a `dind` mode exists.
+
+A future `dind` mode could provide a private per-job Docker daemon. Treat that as
+a separate project because it introduces daemon readiness, storage, networking,
+resource accounting, and nested-container cleanup concerns.
+
+## Networking
+
+Create a uniquely named Docker network per job, even before service containers
+are supported. This provides a clean future path for job-scoped services and
+avoids coupling jobs through the default bridge.
+
+The initial network policy should provide outbound connectivity and no published
+host ports. Evaluate controls for access to:
+
+- Host management endpoints.
+- Cloud instance metadata services.
+- Other job containers and networks.
+- Internal networks not required by the build.
+
+DNS, proxies, custom certificate authorities, VPN routes, IPv6, and MTU behavior
+must be included in integration testing.
+
+Check `BUILDKITE_AGENT_ENDPOINT` and any proxy variables during validation.
+Some deployments point the agent at a localhost proxy or sidecar. That address
+is unreachable from the container's network namespace, so the supervisor should
+fail fast with a clear message or, where appropriate, rewrite loopback to the
+host gateway address.
+
+## Resource and security controls
+
+Enforce resource limits from host-controlled agent configuration:
+
+- CPU quota.
+- Memory and swap.
+- PID count.
+- File descriptor limits.
+- Temporary storage expectations.
+- Stop timeout.
+
+Prefer safe defaults where compatible:
+
+- Drop unnecessary Linux capabilities.
+- Enable `no-new-privileges`.
+- Use Docker's default seccomp profile.
+- Do not use privileged mode.
+- Do not use host PID, IPC, user, or network namespaces.
+- Do not permit arbitrary device mounts.
+- Do not permit arbitrary raw Docker option strings from jobs.
+
+Docker shares the host kernel. This design reduces accidental host pollution and
+improves job cleanup, but it is not a virtual-machine security boundary.
+
+## Registry authentication
+
+Registry credentials are host-side configuration and must not become part of the
+job environment.
+
+For the CLI prototype, use a private temporary Docker configuration directory or
+an existing agent-owned credential helper. Remove temporary authentication data
+after pull. Do not mount the host's general Docker configuration into the job
+container unless explicitly required.
+
+Credentials are resolved per registry from the resolved image reference. The
+allowlist in "Image selection" bounds which registries a pipeline can reach, so
+operators only need to configure credentials for registries they have allowed.
+
+## Cleanup and reconciliation
+
+Label every resource with stable ownership metadata:
+
+```text
+com.buildkite.agent=true
+com.buildkite.agent-id=<agent-id>
+com.buildkite.agent-name=<agent-name>
+com.buildkite.owner=<hostname>/<spawn-index>
+com.buildkite.job-id=<job-id>
+com.buildkite.bootstrap=docker
+```
+
+Normal cleanup should remove the container and per-job network regardless of job
+success or failure.
+
+Agent or host crashes can bypass deferred cleanup. Before starting a new Docker
+job, reconcile stale resources owned by the same agent.
+
+The agent ID is issued at registration and changes every time the agent
+restarts, so it cannot be the reconciliation key: a restarted agent would never
+match the previous process's orphans. Reconcile on a stable owner label such as
+agent name or hostname plus spawn index, and keep `agent-id` only for
+diagnostics. Because several workers on one host share a daemon, reconciliation
+must also confirm the container's job is not currently running (for example by
+checking the job ID against the agent's active jobs or requiring the container
+to be older than a threshold and in an exited state) before removing it.
+
+Cleanup must be idempotent: a missing container or network is already clean, not
+an error that should fail an otherwise completed job.
+
+## Observability
+
+Add structured fields and metrics without logging secrets:
+
+- Job ID and container ID.
+- Image reference and resolved digest.
+- Pull, create, start, bootstrap, stop, and cleanup durations.
+- Container exit code and OOM state.
+- Graceful versus forced cancellation.
+- Cleanup and stale-resource reconciliation failures.
+
+Use separate error categories for Docker infrastructure failures and normal
+bootstrap failures so retry policies can distinguish them.
+
+## Testing strategy
+
+### Unit tests
+
+- Configuration defaults and validation.
+- Image policy: `agent-only` rejects a step image, `allowlist` pattern
+  matching, `any`, digest requirement, and no silent fallback to the default.
+- `BUILDKITE_JOB_IMAGE` cannot be set from the job environment.
+- Container names, labels, and network names.
+- Environment-name handling without exposing values.
+- Mount construction and protected paths.
+- Docker socket disabled by default.
+- Container user selection.
+- Lifecycle transitions.
+- Exit-status mapping.
+- Cancellation escalation.
+- Idempotent cleanup after every partial state.
+- Redaction of error messages and diagnostic output.
+
+Use a small Docker client interface so lifecycle tests can inject deterministic
+pull, create, attach, start, wait, inspect, signal, and remove failures.
+
+### Docker integration tests
+
+Gate integration tests on an explicitly enabled local Docker daemon. The
+existing real-agent end-to-end harness in `internal/e2e`, driven by
+`.buildkite/pipeline.e2e.yml`, is the natural home for these rather than a new
+harness. Cover:
+
+- A successful command.
+- A non-zero command exit.
+- Plugin, checkout, hook, command, and artifact phases.
+- Environment mutations made by hooks.
+- Job API use from a hook or command.
+- Multiline and non-ASCII environment values.
+- Graceful cancellation and post-command cleanup.
+- Forced cancellation after timeout.
+- Cancellation during image pull and checkout.
+- Missing image, bad entrypoint, and unavailable daemon.
+- A step-selected image that lacks `git`, failing with an image-contract error.
+- A step-selected image rejected by policy exiting 125 with the reason in the
+  job log.
+- OOM termination.
+- Parallel jobs with unique resources.
+- File ownership in bind-mounted paths.
+- Agent restart followed by stale-resource reconciliation.
+- Absence of the host Docker socket by default.
+- Presence of the socket only when enabled by agent policy.
+- No secret values in process arguments or supervisor logs.
+- `buildkite-agent lock` from inside a job.
+- Cancellation with the shortest supported grace period, verifying the
+  supervisor still removes the container before it is SIGKILLed.
+- Explicit exits such as 143 preserved without fabricating a signal; cancellation
+  retains the correct job-result reason.
+- Git mirrors enabled, with a mirror shared across two concurrent jobs.
+
+## Delivery phases
+
+### Phase 1: executable prototype
+
+- Add `docker-bootstrap` as an internal command.
+- Use the Docker CLI.
+- Use one agent-configured image, defaulting to
+  `buildkite/agent-base:ubuntu-noble-hosted`, with the host binary mounted.
+- Reject any step specifying `image` before launching Docker. Detect presence
+  in the decoded step in JobRunner, including invalid or empty values; the
+  prototype does not need the Phase 2 typed go-pipeline field to reject it.
+- Bind-mount the minimum required paths.
+- Attach logs and propagate normal exit codes.
+- Implement graceful stop, forced kill, and unconditional removal.
+- Exercise it through the existing `--bootstrap-script` setting.
+
+Success criteria: a local job completes plugin, checkout, command, hook, and
+artifact behavior inside the container, and cancellation leaves no running
+container.
+
+### Phase 2: supported MVP
+
+- Add complete configuration validation.
+- Add pull policies and per-registry authentication.
+- Add step-level `image` support: typed field in go-pipeline, `image` in the
+  signed fields, `BUILDKITE_JOB_IMAGE` plumbing, and the policy and allowlist.
+- Add UID/GID handling.
+- Add resource limits and baseline security options.
+- Add per-job networks.
+- Add labels and stale-resource reconciliation.
+- Add Docker-gated end-to-end tests.
+- Document compatibility differences and operating requirements.
+
+Success criteria: concurrent production-like jobs complete reliably, failures
+are diagnosable, and all tested shutdown paths clean up their resources.
+
+### Phase 3: first-class execution mode
+
+If the MVP proves useful, replace the configured bootstrap-script convention
+with a native agent execution setting. Implement a Docker-backed job process
+alongside the existing local process and Kubernetes runner.
+
+This phase should preserve the same container contract rather than changing job
+semantics. It primarily improves configuration, typed infrastructure errors,
+daemon lifecycle handling, and observability.
+
+### Phase 4: optional extensions
+
+Consider independently:
+
+- Job-scoped service containers.
+- Private Docker-in-Docker daemons.
+- Read-only root filesystems and declared writable paths.
+- Ephemeral named volumes instead of host build-path mounts.
+- Shared read-only caches with explicit trust boundaries.
+
+Do not make these extensions prerequisites for the single-container bootstrap.
+
+## Key risks and decisions
+
+Resolve these before declaring the feature supported:
+
+1. **Image authority:** decided as agent-policy-gated step `image`, defaulting
+   to `agent-only`. Remaining open items are backend delivery of the field to
+   self-hosted agents and the go-pipeline signing change.
+2. **Docker socket:** whether host-daemon compatibility is allowed and how it is
+   visibly marked as unsafe.
+3. **File ownership:** image user versus host UID/GID behavior.
+4. **Workspace storage:** host bind mount versus ephemeral Docker volume.
+5. **Agent binary:** baked-in version versus a read-only host binary mount.
+6. **Environment transport:** Docker CLI inheritance versus Engine API.
+7. **Cancellation:** exact signal, nested grace-period margin, escalation, and
+   reliable exit reporting without inferring signals.
+8. **Infrastructure failures:** how they map to Buildkite retry behavior.
+9. **Network policy:** metadata, host, and internal-network access.
+10. **Compatibility:** which existing hooks and plugins rely on host-only paths,
+    binaries, sockets, or services.
+
+## Recommended first milestone
+
+Build the smallest end-to-end vertical slice:
+
+1. Default image `buildkite/agent-base:ubuntu-noble-hosted`, with the host
+   agent binary mounted read-only.
+2. A `docker-bootstrap` command selected through `--bootstrap-script`.
+3. Same-path mounts for the build and per-job job-context directories, with
+   `--job-context-dir` required.
+4. Environment propagation by variable name using the selection rule above.
+5. Explicit create, attach, start, wait, inspect, and remove operations, with
+   daemon-side auto-remove as a backstop.
+6. Signal forwarding with a reduced inner grace period, timed stop-to-kill
+   escalation, and unchanged container exit codes without signal inference.
+7. Unit tests for success, command failure, step-image rejection, cancellation,
+   and cleanup, plus a Linux build. Defer live Docker validation and OrbStack
+   machine setup initially; these remain required before milestone completion.
+8. No Docker socket, custom volumes, service containers, or pipeline-selected
+   image in the first milestone. Reject steps specifying `image` with a clear
+   setup-failure message and exit 125 until Phase 2 enables policy-gated selection.
+
+That milestone validates the architectural seam and the hard lifecycle behavior
+before expanding the configuration or security surface.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,8 +5,11 @@
 Implementation plan with an agreed first-milestone scope. An initial CLI prototype
 is implemented; a real pipeline smoke test has passed on an OrbStack Linux
 machine, including the container marker and absence of the host Docker socket.
-Live cancellation and broader lifecycle validation are still pending. Later phases describe
-the intended supported feature, not requirements for the first milestone.
+Manual validation has also confirmed exit-code preservation, graceful
+cancellation, supervisor-forced removal, and subsequent agent recovery. See the
+[validation runbook and results](docker-validation.md). Broader lifecycle
+validation remains pending. Later phases describe the intended supported feature,
+not requirements for the first milestone.
 
 First-milestone decisions:
 
@@ -60,9 +63,10 @@ Current implementation details and limits:
   Once auto-removal has discarded that state, the CLI exit code is retained;
   some Docker client failures can therefore remain indistinguishable from a
   bootstrap exit. Exact signal reporting and reliable OOM reporting are deferred.
-- A real pipeline smoke test has passed on OrbStack Linux. Live cancellation,
-  failure handling, hooks, artifacts, and lock compatibility still require
-  validation before treating this as an end-to-end validated milestone.
+- Real pipeline smoke, exit-code, cancellation, cleanup, and recovery tests have
+  passed on OrbStack Linux. Setup failure handling, hooks, artifacts, and lock
+  compatibility still require validation before treating this as an end-to-end
+  validated milestone.
 
 ## Objective
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -43,7 +43,9 @@ scripts are unsupported because JobRunner must recognize the subcommand to
 allocate private job context and enforce image rejection. The Docker
 CLI defaults to `/usr/bin/docker`; override it with `--docker-path` inside the
 bootstrap-script argument if needed. Other prototype arguments are `--image`,
-`--cleanup-margin`, `--operation-timeout`, and `--pull-timeout`. None read policy
+`--cleanup-margin`, `--operation-timeout`, `--pull-timeout`, `--pull-policy`,
+`--docker-config`, `--docker-helper-path`, `--docker-helper-env-file`, and `--user`.
+None read policy
 from job environment variables or inherited agent configuration files.
 
 Current implementation details and limits:
@@ -52,18 +54,17 @@ Current implementation details and limits:
   wait in one CLI invocation. Separate CLI processes cannot guarantee that
   ordering for fast-exiting auto-removed containers.
 - The local endpoint is fixed to `unix:///var/run/docker.sock`. Docker uses an
-  empty private configuration directory; public images and images already in
-  the daemon's cache are supported. Private registry authentication is deferred.
+  empty private configuration for container operations. Pulls can use
+  operator-provided registry credentials; see "Registry authentication".
 - Job-defined `DOCKER_*` variables are rejected because name-only environment
   transport would also apply them to the host Docker client. This includes common
   pipeline settings such as `DOCKER_BUILDKIT` and `DOCKER_DEFAULT_PLATFORM`; remove
   these from prototype jobs. Narrower compatibility needs separate environment
   transport or a verified exception list.
-- The image's configured user is used. The default image runs as root; UID/GID
-  mapping is deferred. Bind-mounted build outputs can therefore be root-owned.
-  The private context directory is mode 0700 and env files are mode 0600, owned
-  by the host agent. A different non-root image UID may not read them. Phase 2
-  must test access with matching UIDs and rootless user namespace mappings.
+- Containers default to the host agent's numeric UID:GID. `--user=UID:GID`
+  overrides it; `--user=0:0` explicitly runs as root. Private context remains
+  mode 0700 with mode 0600 env files. Rootless/user-namespace mappings are not
+  supported by this ownership contract yet; see "File ownership".
 - Job API sockets use a container-private tmpfs. Only existing agent API socket
   files are mounted for agent-level lock commands.
 - Wrapper scripts around `docker-bootstrap` are not supported: JobRunner must
@@ -514,16 +515,31 @@ container so ANSI output matches the non-Docker path.
 
 ### File ownership
 
-A container running as root can leave root-owned files in the host build path.
-The design must make this behavior explicit.
+The default UID:GID matches the host agent. The image's `USER` is overridden.
+Operators can select a numeric identity with `--user=UID:GID`; names are not
+accepted. A root host agent defaults to root, and `--user=0:0` is an explicit
+compatibility option that can produce root-owned workspace files.
 
-Support an agent-controlled container user. Test both:
+Each job receives a private tmpfs home owned by that UID:GID. Minimal read-only
+`/etc/passwd` and `/etc/group` files provide root and the selected identity
+(`buildkite` for a non-root UID). Image-specific accounts and supplementary host
+groups are not preserved. This deliberately avoids inheriting the host Docker
+group; images requiring their original account database need separate support.
 
-- Running as the image's configured user for image compatibility.
-- Running as the host agent UID and GID for bind-mount ownership compatibility.
+A root host agent can grant the selected UID ownership of the private job context
+and coordination files. An unprivileged host agent can select its own UID or
+explicit root; selecting another non-root UID fails before Docker starts.
+Generated identity files are removed during supervisor cleanup.
 
-Neither behavior works universally, so the selected policy must be configurable
-and validated during container startup.
+Before bootstrap, the entrypoint checks context readability and write/search
+access to home, build, plugin, mirror, and existing checkout directories. Existing
+workspaces are never recursively chowned. Operators must provision compatible
+ownership or new directories when migrating from root execution. Nested files
+with incompatible ownership can still fail during checkout or plugin reuse.
+
+The mounted binary must be executable by the selected identity. Rootless Docker
+and daemon user-namespace remapping require additional ownership mapping and
+remain outside the validated support boundary.
 
 ## Job API
 
@@ -723,17 +739,38 @@ improves job cleanup, but it is not a virtual-machine security boundary.
 
 ## Registry authentication
 
-Registry credentials are host-side configuration and must not become part of the
-job environment.
+Image policy is operator-only: `--pull-policy=missing` is the default, `always`
+pulls before every job, and `never` requires a cached image. `always` fails on
+pull failure even when cached. Every successful resolution pins the container to
+the inspected immutable image ID. No policy is accepted from job environment.
 
-For the CLI prototype, use a private temporary Docker configuration directory or
-an existing agent-owned credential helper. Remove temporary authentication data
-after pull. Do not mount the host's general Docker configuration into the job
-container unless explicitly required.
+`--docker-config=/absolute/directory` reads a Docker `config.json` provisioned
+using `docker login --password-stdin`. The file must be accessible only to its
+owner (normally mode 0600). Without this option no host credentials are loaded.
+Only `auths`, `credsStore`, and `credHelpers` are copied into a temporary private
+configuration. Proxy injection, custom headers, and CLI plugin settings are not
+copied. The temporary configuration is removed when the supervisor exits.
 
-Credentials are resolved per registry from the resolved image reference. The
-allowlist in "Image selection" bounds which registries a pipeline can reach, so
-operators only need to configure credentials for registries they have allowed.
+Only pull commands receive the authentication configuration. Other Docker
+operations use an empty configuration. Neither configuration is mounted into the
+job. Mounts overlapping the source credential directory or helper environment
+file, including through symlinks, are rejected.
+
+Credential helper executables run on the host. `--docker-helper-path` supplies an
+absolute search path; otherwise the fixed system search path is used.
+`--docker-helper-env-file=/absolute/file.json` supplies a mode 0600 JSON object of
+string environment values, such as a helper's HOME or cloud credentials. These
+values are supplied only during pulls. No job environment is inherited by helpers;
+Docker control variables and PATH cannot be set through this file. Provision
+helper programs and their credential files outside job-mounted directories.
+
+Static registry secrets and helper environment values are included in diagnostic
+redaction. Helpers must not print dynamically retrieved credentials in failure
+messages. TLS trust is configured on the Docker daemon; remote Docker endpoints
+and arbitrary inherited Docker client settings remain unsupported.
+
+Step-selected images remain deferred. When introduced, agent image policy must
+bound the registries reachable using these credentials.
 
 ## Cleanup and reconciliation
 
@@ -888,10 +925,10 @@ These results are live validation, not an automated Docker integration suite.
 ### Phase 2: supported MVP
 
 - Add complete configuration validation.
-- Add pull policies and per-registry authentication.
+- [x] Operator pull policies and per-registry authentication, including helpers.
 - Add step-level `image` support: typed field in go-pipeline, `image` in the
   signed fields, `BUILDKITE_JOB_IMAGE` plumbing, and the policy and allowlist.
-- Add UID/GID handling.
+- [x] Host UID:GID default, numeric overrides, private home, and access checks.
 - Add resource limits and baseline security options.
 - Add per-job networks.
 - Add labels and stale-resource reconciliation.
@@ -932,7 +969,8 @@ Resolve these before declaring the feature supported:
    self-hosted agents and the go-pipeline signing change.
 2. **Docker socket:** whether host-daemon compatibility is allowed and how it is
    visibly marked as unsafe.
-3. **File ownership:** image user versus host UID/GID behavior.
+3. **File ownership:** migration of existing root-owned paths and support for
+   rootless/user-namespace mappings.
 4. **Workspace storage:** host bind mount versus ephemeral Docker volume.
 5. **Agent binary:** baked-in version versus a read-only host binary mount.
 6. **Environment transport:** Docker CLI inheritance versus Engine API.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -23,9 +23,8 @@ First-milestone decisions:
   selection, resource controls, and per-job networks are deferred.
 - Preserve container exit codes without inferring signals; retain JobRunner's
   cancellation reason. OOM diagnostics are best-effort.
-- Defer local Linux/OrbStack setup and live Docker validation initially. Start
-  with unit tests and Linux builds; live validation remains required to complete
-  the executable prototype.
+- Initial unit tests and Linux builds have been supplemented by live OrbStack
+  validation; the Phase 1 checklist records completed and remaining coverage.
 
 ### Running the initial prototype
 
@@ -38,7 +37,10 @@ buildkite-agent start \
 ```
 
 The agent executable in `--bootstrap-script` must be the development binary.
-An agent token and the normal agent configuration are still required. The Docker
+An agent token and the normal agent configuration are still required. Invoke
+`buildkite-agent docker-bootstrap` directly in `--bootstrap-script`; wrapper
+scripts are unsupported because JobRunner must recognize the subcommand to
+allocate private job context and enforce image rejection. The Docker
 CLI defaults to `/usr/bin/docker`; override it with `--docker-path` inside the
 bootstrap-script argument if needed. Other prototype arguments are `--image`,
 `--cleanup-margin`, `--operation-timeout`, and `--pull-timeout`. None read policy
@@ -53,9 +55,15 @@ Current implementation details and limits:
   empty private configuration directory; public images and images already in
   the daemon's cache are supported. Private registry authentication is deferred.
 - Job-defined `DOCKER_*` variables are rejected because name-only environment
-  transport would also apply them to the host Docker client.
+  transport would also apply them to the host Docker client. This includes common
+  pipeline settings such as `DOCKER_BUILDKIT` and `DOCKER_DEFAULT_PLATFORM`; remove
+  these from prototype jobs. Narrower compatibility needs separate environment
+  transport or a verified exception list.
 - The image's configured user is used. The default image runs as root; UID/GID
   mapping is deferred. Bind-mounted build outputs can therefore be root-owned.
+  The private context directory is mode 0700 and env files are mode 0600, owned
+  by the host agent. A different non-root image UID may not read them. Phase 2
+  must test access with matching UIDs and rootless user namespace mappings.
 - Job API sockets use a container-private tmpfs. Only existing agent API socket
   files are mounted for agent-level lock commands.
 - Wrapper scripts around `docker-bootstrap` are not supported: JobRunner must
@@ -242,6 +250,10 @@ The policy, allowlist, plumbing, and signing requirements are covered in "Image
 selection" below.
 
 ## Image selection
+
+This section describes Phase 2. Phase 1 instead rejects the presence of any step
+`image` in JobRunner, before starting the supervisor; it does not consume
+`BUILDKITE_JOB_IMAGE` or evaluate the future image policy.
 
 The pipeline YAML already supports a step-level `image` attribute, currently
 honoured only on hosted agents where it sets the container image for the whole
@@ -473,6 +485,11 @@ container. This avoids path translation throughout the existing bootstrap.
 | Job log tempfile | read-only, optional | Only when `--enable-job-log-tmpfile` is set |
 | SSH agent socket | optional | SSH authentication |
 | CA and credential paths | optional, read-only | Enterprise trust and repository access |
+
+The Docker entrypoint prepends the mounted binary directory to the image PATH
+before bootstrap starts. This ensures ordinary hook and plugin invocations use
+the mounted agent even if the image contains another agent binary. Hooks that
+explicitly change PATH or invoke an absolute image binary can still override it.
 
 Override container-specific values such as `BUILDKITE_BIN_PATH`, `PATH`, `HOME`,
 and the sockets path when their inherited host values are not valid inside the
@@ -719,6 +736,15 @@ allowlist in "Image selection" bounds which registries a pipeline can reach, so
 operators only need to configure credentials for registries they have allowed.
 
 ## Cleanup and reconciliation
+
+The prototype labels containers with job ID, agent ID, and agent name when
+available, in addition to the static bootstrap labels. These aid diagnosis;
+automatic reconciliation and a stable owner key are still Phase 2 work.
+
+A supervisor killed with SIGKILL cannot run deferred cleanup. Docker CLI children
+are in separate process groups and may survive along with the running container.
+`--rm` only helps once the container exits; it does not stop an orphaned running
+job. Abrupt agent/host termination therefore requires operator cleanup today.
 
 Label every resource with stable ownership metadata:
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -20,7 +20,7 @@ First-milestone decisions:
   <https://github.com/buildkite/agent-base-images>.
 - Always mount the host agent binary read-only.
 - Reject steps that specify `image` as a setup failure (exit 125). Pipeline image
-  selection, resource controls, and per-job networks are deferred.
+  selection and resource controls remain deferred. Phase 2 adds per-job networks.
 - Preserve container exit codes without inferring signals; retain JobRunner's
   cancellation reason. OOM diagnostics are best-effort.
 - Initial unit tests and Linux builds have been supplemented by live OrbStack
@@ -692,12 +692,17 @@ resource accounting, and nested-container cleanup concerns.
 
 ## Networking
 
-Create a uniquely named Docker network per job, even before service containers
-are supported. This provides a clean future path for job-scoped services and
-avoids coupling jobs through the default bridge.
+Each job uses a dedicated Docker bridge network. The container name
+`buildkite_job_<random-id>` and network name `buildkite_network_<random-id>`
+share a cryptographically random 24-character hexadecimal suffix, generated for
+each execution attempt. Both resources carry the bootstrap, job, and agent labels.
+Service containers remain deferred.
 
-The initial network policy should provide outbound connectivity and no published
-host ports. Evaluate controls for access to:
+The network permits outbound connectivity and publishes no host ports. Separate
+bridges isolate direct container traffic between jobs under Docker's normal
+firewall configuration. They do not block access to host services, cloud metadata,
+or reachable internal networks. Host firewall and egress policy remain operator
+responsibilities. Evaluate additional controls for access to:
 
 - Host management endpoints.
 - Cloud instance metadata services.
@@ -794,8 +799,17 @@ com.buildkite.job-id=<job-id>
 com.buildkite.bootstrap=docker
 ```
 
-Normal cleanup should remove the container and per-job network regardless of job
-success or failure.
+Normal cleanup removes the container first, then its network, on success,
+failure, or cancellation. Cleanup is registered before network creation so an
+ambiguous creation failure still triggers removal. Container removal gets at most
+half of the cleanup margin, reserving time for network removal within the same
+overall deadline. Failed removal is checked against an exact-name resource list;
+unconfirmed cleanup is logged and turns an otherwise successful job into a setup
+failure.
+
+Networks have no automatic removal option. A killed supervisor can leave an
+empty network even when its container is auto-removed; until reconciliation lands,
+operators must remove these stale resources.
 
 Agent or host crashes can bypass deferred cleanup. Before starting a new Docker
 job, reconcile stale resources owned by the same agent.
@@ -930,7 +944,7 @@ These results are live validation, not an automated Docker integration suite.
   signed fields, `BUILDKITE_JOB_IMAGE` plumbing, and the policy and allowlist.
 - [x] Host UID:GID default, numeric overrides, private home, and access checks.
 - Add resource limits and baseline security options.
-- Add per-job networks.
+- [x] Per-job bridge networks with labelled ownership and bounded cleanup.
 - Add labels and stale-resource reconciliation.
 - Add Docker-gated end-to-end tests.
 - Document compatibility differences and operating requirements.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -6,10 +6,12 @@ Implementation plan with an agreed first-milestone scope. An initial CLI prototy
 is implemented; a real pipeline smoke test has passed on an OrbStack Linux
 machine, including the container marker and absence of the host Docker socket.
 Manual validation has also confirmed exit-code preservation, graceful
-cancellation, supervisor-forced removal, and subsequent agent recovery. See the
-[validation runbook and results](docker-validation.md). Broader lifecycle
-validation remains pending. Later phases describe the intended supported feature,
-not requirements for the first milestone.
+cancellation, supervisor-forced removal, and subsequent agent recovery. Live
+pipeline validation has also confirmed checkout, artifact upload/download, and
+plugin hook ordering and failure propagation inside Docker. See the Phase 1
+validation checklist below and the [validation runbook and results](docker-validation.md).
+Broader compatibility validation remains pending. Later phases describe the
+intended supported feature, not requirements for the first milestone.
 
 First-milestone decisions:
 
@@ -63,10 +65,10 @@ Current implementation details and limits:
   Once auto-removal has discarded that state, the CLI exit code is retained;
   some Docker client failures can therefore remain indistinguishable from a
   bootstrap exit. Exact signal reporting and reliable OOM reporting are deferred.
-- Real pipeline smoke, exit-code, cancellation, cleanup, and recovery tests have
-  passed on OrbStack Linux. Setup failure handling, hooks, artifacts, and lock
-  compatibility still require validation before treating this as an end-to-end
-  validated milestone.
+- Real pipeline smoke, exit-code, cancellation, cleanup, recovery, checkout,
+  artifact, and plugin hook tests have passed on OrbStack Linux. Host-configured
+  and repository hooks, broader setup failure handling, hook and artifact behavior
+  during cancellation, and lock compatibility still require validation.
 
 ## Objective
 
@@ -836,6 +838,26 @@ harness. Cover:
 Success criteria: a local job completes plugin, checkout, command, hook, and
 artifact behavior inside the container, and cancellation leaves no running
 container.
+
+Live validation on ARM64 Ubuntu Noble under OrbStack:
+
+- [x] Checkout and command execution inside Docker.
+- [x] Automatic artifact upload, followed by download and content verification
+  in a second Docker job.
+- [x] Plugin loading and hook execution using `improbable-eng/metahook#v0.4.1`.
+  Assertions verified `pre-checkout`, `post-checkout`, `pre-command`, command,
+  `post-command`, `pre-artifact`, `post-artifact`, and `pre-exit` in order, all
+  within the same container. Artifact hooks created and verified an uploaded file.
+- [x] A `pre-command` hook exiting 42 prevented command execution, preserved the
+  failure status, and still ran `pre-exit` successfully.
+- [x] Exit-code preservation, graceful and forced cancellation, and agent recovery.
+- [x] No running or stopped bootstrap containers remained after the tested jobs.
+- [ ] Host-configured and repository hook compatibility.
+- [ ] Hook environment mutation coverage beyond the plugin's own setup.
+- [ ] Hook and artifact behavior during cancellation.
+
+Plugin tests require an explicit `--plugins-path` in the host agent configuration.
+These results are live validation, not an automated Docker integration suite.
 
 ### Phase 2: supported MVP
 

--- a/env/protected.go
+++ b/env/protected.go
@@ -60,6 +60,7 @@ type protection struct {
 // protected reconfigurable vars set mutableFromWithinJob here, and checkout-
 // scoped vars are added to checkoutOverrideScope below.
 var protectedEnv = map[string]protection{
+	"BUILDKITE_DOCKER_BOOTSTRAP_CONTEXT":    {},
 	"BUILDKITE_AGENT_ACCESS_TOKEN":          {},
 	"BUILDKITE_AGENT_DEBUG":                 {},
 	"BUILDKITE_AGENT_ENDPOINT":              {},

--- a/internal/dockerbootstrap/auth.go
+++ b/internal/dockerbootstrap/auth.go
@@ -1,0 +1,128 @@
+package dockerbootstrap
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Authentication is loaded from operator files, never the inherited job environment.
+type Authentication struct {
+	Config      []byte
+	Environment map[string]string
+	Secrets     []string
+}
+
+func LoadAuthentication(directory, envFile, helperPath string) (Authentication, error) {
+	var result Authentication
+	if directory == "" {
+		if envFile != "" || helperPath != "" {
+			return result, fmt.Errorf("credential helper options require --docker-config")
+		}
+		return result, nil
+	}
+	if !filepath.IsAbs(directory) {
+		return result, fmt.Errorf("docker-config must be an absolute directory")
+	}
+	if helperPath != "" {
+		for _, path := range filepath.SplitList(helperPath) {
+			if !filepath.IsAbs(path) {
+				return result, fmt.Errorf("docker-helper-path requires absolute directories")
+			}
+		}
+	}
+	data, err := readCredentialFile(filepath.Join(directory, "config.json"))
+	if err != nil {
+		return result, err
+	}
+	var config struct {
+		Auths map[string]struct {
+			Auth          string `json:"auth,omitempty"`
+			Username      string `json:"username,omitempty"`
+			Password      string `json:"password,omitempty"`
+			IdentityToken string `json:"identitytoken,omitempty"`
+			RegistryToken string `json:"registrytoken,omitempty"`
+		} `json:"auths,omitempty"`
+		CredsStore  string            `json:"credsStore,omitempty"`
+		CredHelpers map[string]string `json:"credHelpers,omitempty"`
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		return result, fmt.Errorf("docker config must contain valid JSON")
+	}
+	for _, auth := range config.Auths {
+		for _, value := range []string{auth.Auth, auth.Password, auth.IdentityToken, auth.RegistryToken} {
+			if value != "" {
+				result.Secrets = append(result.Secrets, value)
+			}
+		}
+		if decoded, err := base64.StdEncoding.DecodeString(auth.Auth); err == nil && len(decoded) > 0 {
+			result.Secrets = append(result.Secrets, string(decoded))
+			if _, password, ok := strings.Cut(string(decoded), ":"); ok && password != "" {
+				result.Secrets = append(result.Secrets, password)
+			}
+		}
+	}
+	// Proxy injection, CLI plugins, and custom headers are not registry credentials.
+	result.Config, err = json.Marshal(config)
+	if err != nil {
+		return result, err
+	}
+	if envFile != "" {
+		data, err := readCredentialFile(envFile)
+		if err != nil {
+			return result, err
+		}
+		if err := json.Unmarshal(data, &result.Environment); err != nil {
+			return result, fmt.Errorf("helper environment must be a JSON object of string values")
+		}
+		for name, value := range result.Environment {
+			if !envName.MatchString(name) || strings.HasPrefix(name, "DOCKER_") || name == "PATH" || strings.ContainsRune(value, 0) {
+				return result, fmt.Errorf("invalid helper environment; Docker settings and PATH cannot be overridden")
+			}
+			if value != "" {
+				result.Secrets = append(result.Secrets, value)
+			}
+		}
+	}
+	return result, nil
+}
+
+func readCredentialFile(path string) ([]byte, error) {
+	if !filepath.IsAbs(path) {
+		return nil, fmt.Errorf("credential file paths must be absolute")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("read credential file: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
+		return nil, fmt.Errorf("credential files must be regular files accessible only to their owner")
+	}
+	return os.ReadFile(path)
+}
+
+func rejectCredentialMount(source string, cfg Config) error {
+	if cfg.DockerConfig == "" && cfg.HelperEnvFile == "" {
+		return nil
+	}
+	resolved, err := filepath.EvalSymlinks(source)
+	if err != nil {
+		return err
+	}
+	for _, secret := range []string{cfg.DockerConfig, cfg.HelperEnvFile} {
+		if secret == "" {
+			continue
+		}
+		target, err := filepath.EvalSymlinks(secret)
+		if err != nil {
+			return fmt.Errorf("resolve credential location: %w", err)
+		}
+		if within(target, resolved) || within(resolved, target) {
+			return fmt.Errorf("docker mount overlaps host registry credentials")
+		}
+	}
+	return nil
+}

--- a/internal/dockerbootstrap/auth_test.go
+++ b/internal/dockerbootstrap/auth_test.go
@@ -1,0 +1,128 @@
+package dockerbootstrap
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestAuthenticationIsolation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permissions and shell fixture")
+	}
+	dir := t.TempDir()
+	encoded := base64.StdEncoding.EncodeToString([]byte("tester:synthetic-password"))
+	config := `{"auths":{"registry.test":{"auth":"` + encoded + `"}},"credsStore":"test","proxies":{"default":{"httpProxy":"secret-proxy"}},"HttpHeaders":{"secret":"header"}}`
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	envFile := filepath.Join(dir, "helpers.json")
+	if err := os.WriteFile(envFile, []byte(`{"HELPER_SECRET":"synthetic-helper-secret"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	auth, err := LoadAuthentication(dir, envFile, "/usr/bin:/bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(auth.Config), "proxies") || strings.Contains(string(auth.Config), "HttpHeaders") {
+		t.Fatal("non-authentication settings copied")
+	}
+	path := filepath.Join(t.TempDir(), "docker")
+	script := `#!/bin/sh
+printf '%s\n' "$@"
+printf 'HELPER:%s\n' "${HELPER_SECRET-unset}"
+printf 'JOB:%s\n' "${JOB_SECRET-unset}"
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HELPER_SECRET", "job-spoof")
+	empty := t.TempDir()
+	client := CLI{Path: path, ConfigDir: empty, AuthConfigDir: dir, HelperPath: "/usr/bin:/bin", HelperEnvironment: auth.Environment}
+	for _, action := range []string{"pull", "create", "info"} {
+		var out bytes.Buffer
+		env := map[string]string(nil)
+		if action == "create" {
+			env = map[string]string{"JOB_SECRET": "job-value"}
+		}
+		if _, err := client.Run(t.Context(), []string{action, "image"}, env, &out, &out); err != nil {
+			t.Fatal(err)
+		}
+		result := out.String()
+		if action == "pull" {
+			if !strings.Contains(result, "\n"+dir+"\n") || !strings.Contains(result, "HELPER:synthetic-helper-secret") || !strings.Contains(result, "JOB:unset") {
+				t.Fatalf("pull environment: %s", result)
+			}
+		} else if !strings.Contains(result, "\n"+empty+"\n") || !strings.Contains(result, "HELPER:unset") {
+			t.Fatalf("runtime environment: %s", result)
+		}
+	}
+}
+
+func TestAuthenticationValidation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permissions")
+	}
+	dir := t.TempDir()
+	for _, content := range []string{"invalid", `{"auths":42}`} {
+		if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LoadAuthentication(dir, "", ""); err == nil {
+			t.Fatal("accepted invalid config")
+		}
+	}
+	if err := os.Chmod(filepath.Join(dir, "config.json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadAuthentication(dir, "", ""); err == nil {
+		t.Fatal("accepted public credentials")
+	}
+	if _, err := LoadAuthentication("relative", "", ""); err == nil {
+		t.Fatal("accepted relative config")
+	}
+	if _, err := LoadAuthentication("", "/helpers.json", ""); err == nil {
+		t.Fatal("accepted helpers without config")
+	}
+}
+
+func TestCredentialsCannotBeMounted(t *testing.T) {
+	cfg := testConfig(t)
+	dir := t.TempDir()
+	cfg.DockerConfig = dir
+	for _, source := range []string{dir, filepath.Dir(dir)} {
+		if err := rejectCredentialMount(source, cfg); err == nil {
+			t.Fatal("accepted credential mount")
+		}
+	}
+	link := filepath.Join(t.TempDir(), "credentials")
+	if err := os.Symlink(dir, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := rejectCredentialMount(link, cfg); err == nil {
+		t.Fatal("accepted symlink credential mount")
+	}
+	if err := rejectCredentialMount(t.TempDir(), cfg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRegistryDiagnosticRedaction(t *testing.T) {
+	secret := "synthetic-registry-secret"
+	f := &fakeClient{run: func(_ context.Context, _ []string, _ map[string]string, _, stderr io.Writer) (int, error) {
+		_, _ = fmt.Fprintln(stderr, "credential failure:", secret)
+		return 1, fmt.Errorf("helper failed: %s", secret)
+	}}
+	client := withDiagnostics(f, nil, secret)
+	_, err := client.Run(t.Context(), []string{"pull", "registry.test/image"}, nil, io.Discard, io.Discard)
+	if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("unsafe diagnostic: %v", err)
+	}
+}

--- a/internal/dockerbootstrap/client.go
+++ b/internal/dockerbootstrap/client.go
@@ -1,0 +1,52 @@
+package dockerbootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// Clienter separates lifecycle decisions from Docker subprocess execution.
+// Run returns a process exit code; errors indicate failure to execute or a
+// cancelled operation. Callers decide which commands return container status.
+type Clienter interface {
+	Run(context.Context, []string, map[string]string, io.Writer, io.Writer) (int, error)
+}
+
+// CLI deliberately ignores inherited Docker configuration and environment.
+// The supervisor inherits job variables, including potentially DOCKER_HOST and
+// DOCKER_CONFIG. Only operator-supplied arguments may select these settings.
+type CLI struct {
+	Path      string
+	ConfigDir string
+}
+
+func (c CLI) Run(ctx context.Context, args []string, env map[string]string, stdout, stderr io.Writer) (int, error) {
+	if !filepath.IsAbs(c.Path) || !filepath.IsAbs(c.ConfigDir) {
+		return 0, fmt.Errorf("docker executable and configuration paths must be absolute")
+	}
+	argv := append([]string{"--host", "unix:///var/run/docker.sock", "--config", c.ConfigDir}, args...)
+	cmd := exec.CommandContext(ctx, c.Path, argv...)
+	// A minimal environment also avoids loading host credentials or job-selected
+	// Docker helpers. --env NAME reads the selected container values from here.
+	cmd.Env = []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
+	for name, value := range env {
+		cmd.Env = append(cmd.Env, name+"="+value)
+	}
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+	cmd.WaitDelay = time.Second
+	isolateProcess(cmd)
+	err := cmd.Run()
+	if ctx.Err() != nil {
+		return 0, ctx.Err()
+	}
+	var exit *exec.ExitError
+	if errors.As(err, &exit) {
+		return exit.ExitCode(), nil
+	}
+	return 0, err
+}

--- a/internal/dockerbootstrap/client.go
+++ b/internal/dockerbootstrap/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -20,19 +21,43 @@ type Clienter interface {
 // CLI excludes inherited configuration because the supervisor receives untrusted
 // job variables that could redirect Docker or select host credentials.
 type CLI struct {
-	Path      string
-	ConfigDir string
+	Path              string
+	ConfigDir         string
+	AuthConfigDir     string
+	HelperPath        string
+	HelperEnvironment map[string]string
 }
 
 func (c CLI) Run(ctx context.Context, args []string, env map[string]string, stdout, stderr io.Writer) (int, error) {
 	if !filepath.IsAbs(c.Path) || !filepath.IsAbs(c.ConfigDir) {
 		return 0, fmt.Errorf("docker executable and configuration paths must be absolute")
 	}
-	argv := append([]string{"--host", "unix:///var/run/docker.sock", "--config", c.ConfigDir}, args...)
+	configDir := c.ConfigDir
+	path := "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	isPull := len(args) > 0 && args[0] == "pull"
+	if isPull && c.AuthConfigDir != "" {
+		if !filepath.IsAbs(c.AuthConfigDir) {
+			return 0, fmt.Errorf("docker authentication directory must be absolute")
+		}
+		configDir = c.AuthConfigDir
+		if c.HelperPath != "" {
+			path = c.HelperPath
+		}
+	}
+	argv := append([]string{"--host", "unix:///var/run/docker.sock", "--config", configDir}, args...)
 	cmd := exec.CommandContext(ctx, c.Path, argv...)
 	// --env NAME requires container values in the client environment; prepare
 	// rejects Docker control variables before they reach this boundary.
-	cmd.Env = []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
+	cmd.Env = []string{"PATH=" + path}
+	// Registry helpers receive operator credentials only during pulls, never jobs.
+	if isPull && c.AuthConfigDir != "" {
+		for name, value := range c.HelperEnvironment {
+			if strings.HasPrefix(name, "DOCKER_") || name == "PATH" {
+				return 0, fmt.Errorf("helper environment cannot override Docker settings or PATH")
+			}
+			cmd.Env = append(cmd.Env, name+"="+value)
+		}
+	}
 	for name, value := range env {
 		cmd.Env = append(cmd.Env, name+"="+value)
 	}

--- a/internal/dockerbootstrap/client.go
+++ b/internal/dockerbootstrap/client.go
@@ -10,16 +10,15 @@ import (
 	"time"
 )
 
-// Clienter separates lifecycle decisions from Docker subprocess execution.
-// Run returns a process exit code; errors indicate failure to execute or a
-// cancelled operation. Callers decide which commands return container status.
+// Clienter allows lifecycle tests to inject Docker failures.
+// Run reports nonzero exits as codes; errors indicate execution or cancellation
+// failures. The caller interprets whether the code belongs to Docker or the job.
 type Clienter interface {
 	Run(context.Context, []string, map[string]string, io.Writer, io.Writer) (int, error)
 }
 
-// CLI deliberately ignores inherited Docker configuration and environment.
-// The supervisor inherits job variables, including potentially DOCKER_HOST and
-// DOCKER_CONFIG. Only operator-supplied arguments may select these settings.
+// CLI excludes inherited configuration because the supervisor receives untrusted
+// job variables that could redirect Docker or select host credentials.
 type CLI struct {
 	Path      string
 	ConfigDir string
@@ -31,8 +30,8 @@ func (c CLI) Run(ctx context.Context, args []string, env map[string]string, stdo
 	}
 	argv := append([]string{"--host", "unix:///var/run/docker.sock", "--config", c.ConfigDir}, args...)
 	cmd := exec.CommandContext(ctx, c.Path, argv...)
-	// A minimal environment also avoids loading host credentials or job-selected
-	// Docker helpers. --env NAME reads the selected container values from here.
+	// --env NAME requires container values in the client environment; prepare
+	// rejects Docker control variables before they reach this boundary.
 	cmd.Env = []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
 	for name, value := range env {
 		cmd.Env = append(cmd.Env, name+"="+value)

--- a/internal/dockerbootstrap/client_test.go
+++ b/internal/dockerbootstrap/client_test.go
@@ -1,0 +1,80 @@
+package dockerbootstrap
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCLIEnvironmentAndArguments(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	t.Setenv("DOCKER_HOST", "tcp://untrusted:2375")
+	t.Setenv("DOCKER_CONFIG", "/untrusted")
+	t.Setenv("HOST_SECRET", "host-only")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "docker")
+	const script = `#!/bin/sh
+printf '%s\n' "$@"
+printf 'MULTILINE:%s\n' "$MULTILINE"
+printf 'HOST_SECRET:%s\n' "${HOST_SECRET-unset}"
+printf 'DOCKER_HOST:%s\n' "${DOCKER_HOST-unset}"
+exit 42
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	value := "secret\n世界  "
+	code, err := (CLI{Path: path, ConfigDir: dir}).Run(t.Context(), []string{"create", "--env", "MULTILINE", DefaultImage}, map[string]string{"MULTILINE": value}, &out, &out)
+	if err != nil || code != 42 {
+		t.Fatalf("got (%d, %v)", code, err)
+	}
+	want := "--host\nunix:///var/run/docker.sock\n--config\n" + dir + "\ncreate\n--env\nMULTILINE\n" + DefaultImage + "\nMULTILINE:" + value + "\nHOST_SECRET:unset\nDOCKER_HOST:unset\n"
+	if out.String() != want {
+		t.Fatalf("unexpected client arguments/environment: %q", out.String())
+	}
+}
+
+func TestCLICancellation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "docker")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nsleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	var out bytes.Buffer
+	_, err := (CLI{Path: path, ConfigDir: dir}).Run(ctx, []string{"info"}, nil, &out, &out)
+	if err != context.DeadlineExceeded {
+		t.Fatalf("got %v", err)
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Fatal("Docker client did not stop promptly")
+	}
+}
+
+func TestDockerControlEnvironmentRejected(t *testing.T) {
+	cfg := testConfig(t)
+	for _, pair := range cfg.Environment {
+		if path, ok := strings.CutPrefix(pair, "BUILDKITE_ENV_JSON_FILE="); ok {
+			if err := os.WriteFile(path, []byte(`{"DOCKER_API_VERSION":"1.20"}`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	cfg.Environment = append(cfg.Environment, "DOCKER_API_VERSION=1.20")
+	if _, err := prepare(cfg); err == nil {
+		t.Fatal("job configured the Docker client")
+	}
+}

--- a/internal/dockerbootstrap/config.go
+++ b/internal/dockerbootstrap/config.go
@@ -138,9 +138,18 @@ func prepare(cfg Config) (jobConfig, error) {
 		return job, err
 	}
 	for _, name := range []string{"BUILDKITE_BUILD_PATH", "BUILDKITE_PLUGINS_PATH", "BUILDKITE_HOOKS_PATH", "BUILDKITE_GIT_MIRRORS_PATH", "BUILDKITE_ADDITIONAL_HOOKS_PATHS"} {
-		for _, path := range strings.Split(all[name], ",") {
+		paths := []string{all[name]}
+		if name == "BUILDKITE_ADDITIONAL_HOOKS_PATHS" {
+			paths = strings.Split(all[name], ",")
+		}
+		for _, path := range paths {
 			if path == "" {
 				continue
+			}
+			// Validate before cleaning or creating directories. Only additional
+			// hooks are a list; a comma in a scalar path must never add a mount.
+			if !filepath.IsAbs(path) || strings.ContainsAny(path, ",\r\n") {
+				return job, fmt.Errorf("%s requires absolute paths without commas or newlines", name)
 			}
 			path = filepath.Clean(path)
 			if path == "/tmp" || within(contextDir, path) || within(containerRoot, path) || within(path, containerRoot) {
@@ -153,9 +162,6 @@ func prepare(cfg Config) (jobConfig, error) {
 				}
 			}
 			if !readonly {
-				if !filepath.IsAbs(path) {
-					return job, fmt.Errorf("%s must be absolute", name)
-				}
 				if err := os.MkdirAll(path, 0o755); err != nil {
 					return job, err
 				}

--- a/internal/dockerbootstrap/config.go
+++ b/internal/dockerbootstrap/config.go
@@ -1,0 +1,204 @@
+// Package dockerbootstrap runs the normal bootstrap in a disposable Docker container.
+package dockerbootstrap
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultImage    = "buildkite/agent-base:ubuntu-noble-hosted"
+	ContextEnv      = "BUILDKITE_DOCKER_BOOTSTRAP_CONTEXT"
+	containerRoot   = "/buildkite-docker"
+	containerBinary = containerRoot + "/bin/buildkite-agent"
+)
+
+type Config struct {
+	Image            string
+	Binary           string
+	Environment      []string
+	CleanupMargin    time.Duration
+	OperationTimeout time.Duration
+	PullTimeout      time.Duration
+}
+
+type jobConfig struct {
+	env   map[string]string
+	args  []string
+	grace time.Duration
+}
+
+var envName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+func prepare(cfg Config) (jobConfig, error) {
+	var job jobConfig
+	if cfg.Image == "" || strings.HasPrefix(cfg.Image, "-") || strings.ContainsAny(cfg.Image, " \t\r\n") {
+		return job, fmt.Errorf("invalid Docker bootstrap image")
+	}
+	if cfg.CleanupMargin <= 0 || cfg.OperationTimeout <= 0 || cfg.PullTimeout <= 0 {
+		return job, fmt.Errorf("docker bootstrap timeouts must be positive")
+	}
+	all := make(map[string]string)
+	for _, pair := range cfg.Environment {
+		name, value, ok := strings.Cut(pair, "=")
+		if ok {
+			all[name] = value
+		}
+	}
+	outer, err := time.ParseDuration(all["BUILDKITE_CANCEL_SIGNAL_TIMEOUT"])
+	if err != nil || outer <= cfg.CleanupMargin {
+		return job, fmt.Errorf("cancel-signal-timeout must exceed Docker cleanup margin (%s)", cfg.CleanupMargin)
+	}
+	job.grace = outer - cfg.CleanupMargin
+	contextDir := all[ContextEnv]
+	if !filepath.IsAbs(contextDir) || filepath.Clean(contextDir) == "/" || filepath.Clean(contextDir) == "/tmp" {
+		return job, fmt.Errorf("docker-bootstrap requires a private job context created by agent start with --job-context-dir")
+	}
+	if within(contextDir, containerRoot) || within(containerRoot, contextDir) {
+		return job, fmt.Errorf("job context overlaps reserved Docker paths")
+	}
+	for _, name := range []string{"BUILDKITE_ENV_FILE", "BUILDKITE_ENV_JSON_FILE", "BUILDKITE_AGENT_JOB_TIMEOUT_FILE"} {
+		if filepath.Dir(all[name]) != contextDir {
+			return job, fmt.Errorf("%s must be inside the private job context", name)
+		}
+	}
+	data, err := os.ReadFile(all["BUILDKITE_ENV_JSON_FILE"])
+	if err != nil {
+		return job, fmt.Errorf("read job environment: %w", err)
+	}
+	var names map[string]string
+	if err := json.Unmarshal(data, &names); err != nil {
+		return job, fmt.Errorf("decode job environment: %w", err)
+	}
+	job.env = make(map[string]string)
+	for name, value := range all {
+		_, fromJob := names[name]
+		if fromJob || strings.HasPrefix(name, "BUILDKITE_") || strings.HasPrefix(name, "OTEL_EXPORTER_OTLP_") {
+			// --env NAME uses the Docker client's own environment. Reject its
+			// control variables rather than allowing jobs to configure the client.
+			if strings.HasPrefix(name, "DOCKER_") {
+				return job, fmt.Errorf("docker CLI control variables cannot be forwarded in the prototype")
+			}
+			if !envName.MatchString(name) {
+				return job, fmt.Errorf("invalid job environment variable name")
+			}
+			job.env[name] = value
+		}
+	}
+	for _, name := range []string{"BUILDKITE_AGENT_ENDPOINT", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"} {
+		u, err := url.Parse(job.env[name])
+		if err == nil && (strings.EqualFold(u.Hostname(), "localhost") || net.ParseIP(u.Hostname()).IsLoopback()) {
+			return job, fmt.Errorf("%s uses a loopback address unreachable from the job container", name)
+		}
+	}
+	for _, name := range []string{"PATH", "HOME", "USER", "LOGNAME", "TMPDIR", "BUILDKITE_JOB_LOG_TMPFILE", "BUILDKITE_CONFIG_PATH", ContextEnv} {
+		delete(job.env, name)
+	}
+	job.env["BUILDKITE_BIN_PATH"] = filepath.Dir(containerBinary)
+	job.env["BUILDKITE_SOCKETS_PATH"] = containerRoot + "/sockets"
+	job.env["BUILDKITE_CANCEL_SIGNAL_TIMEOUT"] = job.grace.String()
+	job.args = []string{"--init", "--rm", "--entrypoint", "/bin/sh", "--tmpfs", containerRoot + "/sockets:rw,nosuid,nodev,mode=1777"}
+	if all["BUILDKITE_PTY"] != "false" {
+		job.args = append(job.args, "--tty")
+		job.env["TERM"] = all["TERM"]
+		if job.env["TERM"] == "" {
+			job.env["TERM"] = "xterm-256color"
+		}
+	}
+	mounts := make(map[string]string)
+	addMount := func(source, target string, readonly bool) error {
+		if !filepath.IsAbs(source) || !filepath.IsAbs(target) || strings.ContainsAny(source+target, ",\r\n") || filepath.Clean(source) == "/" {
+			return fmt.Errorf("docker bind mounts require absolute, non-root paths without commas or newlines")
+		}
+		if _, err := os.Stat(source); err != nil {
+			return fmt.Errorf("docker mount source unavailable: %w", err)
+		}
+		arg := "type=bind,src=" + source + ",dst=" + target
+		if readonly {
+			arg += ",readonly"
+		}
+		if prior, ok := mounts[target]; ok && prior != arg {
+			return fmt.Errorf("conflicting Docker mounts at %s", target)
+		}
+		mounts[target] = arg
+		return nil
+	}
+	if err := addMount(cfg.Binary, containerBinary, true); err != nil {
+		return job, err
+	}
+	if err := addMount(contextDir, contextDir, true); err != nil {
+		return job, err
+	}
+	for _, name := range []string{"BUILDKITE_BUILD_PATH", "BUILDKITE_PLUGINS_PATH", "BUILDKITE_HOOKS_PATH", "BUILDKITE_GIT_MIRRORS_PATH", "BUILDKITE_ADDITIONAL_HOOKS_PATHS"} {
+		for _, path := range strings.Split(all[name], ",") {
+			if path == "" {
+				continue
+			}
+			path = filepath.Clean(path)
+			if path == "/tmp" || within(contextDir, path) || within(containerRoot, path) || within(path, containerRoot) {
+				return job, fmt.Errorf("%s overlaps private Docker paths", name)
+			}
+			readonly := strings.Contains(name, "HOOKS_PATH")
+			if readonly {
+				if _, err := os.Stat(path); os.IsNotExist(err) {
+					continue
+				}
+			}
+			if !readonly {
+				if !filepath.IsAbs(path) {
+					return job, fmt.Errorf("%s must be absolute", name)
+				}
+				if err := os.MkdirAll(path, 0o755); err != nil {
+					return job, err
+				}
+			}
+			if err := addMount(path, path, readonly); err != nil {
+				return job, err
+			}
+		}
+	}
+	if all["BUILDKITE_BUILD_PATH"] == "" {
+		return job, fmt.Errorf("BUILDKITE_BUILD_PATH is required")
+	}
+	job.args = append(job.args, "--workdir", all["BUILDKITE_BUILD_PATH"])
+	// Expose only the agent socket, never the shared sockets directory.
+	if base := all["BUILDKITE_SOCKETS_PATH"]; base != "" {
+		for _, name := range []string{"agent-" + all["BUILDKITE_AGENT_PID"], "agent-leader"} {
+			source := filepath.Join(base, name)
+			if info, err := os.Stat(source); err == nil && info.Mode()&os.ModeSocket != 0 {
+				if err := addMount(source, containerRoot+"/sockets/"+name, false); err != nil {
+					return job, err
+				}
+			}
+		}
+	}
+	keys := make([]string, 0, len(mounts))
+	for target := range mounts {
+		keys = append(keys, target)
+	}
+	slices.Sort(keys)
+	for _, target := range keys {
+		job.args = append(job.args, "--mount", mounts[target])
+	}
+	keys = keys[:0]
+	for name := range job.env {
+		keys = append(keys, name)
+	}
+	slices.Sort(keys)
+	for _, name := range keys {
+		job.args = append(job.args, "--env", name)
+	}
+	return job, nil
+}
+
+func within(path, parent string) bool {
+	return path == parent || strings.HasPrefix(path, parent+string(filepath.Separator))
+}

--- a/internal/dockerbootstrap/config.go
+++ b/internal/dockerbootstrap/config.go
@@ -82,8 +82,7 @@ func prepare(cfg Config) (jobConfig, error) {
 	for name, value := range all {
 		_, fromJob := names[name]
 		if fromJob || strings.HasPrefix(name, "BUILDKITE_") || strings.HasPrefix(name, "OTEL_EXPORTER_OTLP_") {
-			// --env NAME uses the Docker client's own environment. Reject its
-			// control variables rather than allowing jobs to configure the client.
+			// --env NAME also exposes these values to the host Docker client.
 			if strings.HasPrefix(name, "DOCKER_") {
 				return job, fmt.Errorf("docker CLI control variables cannot be forwarded in the prototype")
 			}
@@ -94,7 +93,12 @@ func prepare(cfg Config) (jobConfig, error) {
 		}
 	}
 	for _, name := range []string{"BUILDKITE_AGENT_ENDPOINT", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"} {
-		u, err := url.Parse(job.env[name])
+		value := job.env[name]
+		// Proxy clients also accept host:port without a URL scheme.
+		if value != "" && !strings.Contains(value, "://") && !strings.HasPrefix(value, "//") {
+			value = "//" + value
+		}
+		u, err := url.Parse(value)
 		if err == nil && (strings.EqualFold(u.Hostname(), "localhost") || net.ParseIP(u.Hostname()).IsLoopback()) {
 			return job, fmt.Errorf("%s uses a loopback address unreachable from the job container", name)
 		}
@@ -146,8 +150,7 @@ func prepare(cfg Config) (jobConfig, error) {
 			if path == "" {
 				continue
 			}
-			// Validate before cleaning or creating directories. Only additional
-			// hooks are a list; a comma in a scalar path must never add a mount.
+			// Splitting scalar paths on commas could expose unintended host directories.
 			if !filepath.IsAbs(path) || strings.ContainsAny(path, ",\r\n") {
 				return job, fmt.Errorf("%s requires absolute paths without commas or newlines", name)
 			}
@@ -175,7 +178,7 @@ func prepare(cfg Config) (jobConfig, error) {
 		return job, fmt.Errorf("BUILDKITE_BUILD_PATH is required")
 	}
 	job.args = append(job.args, "--workdir", all["BUILDKITE_BUILD_PATH"])
-	// Expose only the agent socket, never the shared sockets directory.
+	// Mounting the shared directory would expose other jobs' sockets.
 	if base := all["BUILDKITE_SOCKETS_PATH"]; base != "" {
 		for _, name := range []string{"agent-" + all["BUILDKITE_AGENT_PID"], "agent-leader"} {
 			source := filepath.Join(base, name)

--- a/internal/dockerbootstrap/config.go
+++ b/internal/dockerbootstrap/config.go
@@ -22,6 +22,11 @@ const (
 )
 
 type Config struct {
+	PullPolicy       string
+	DockerConfig     string
+	HelperEnvFile    string
+	User             string
+	RedactedValues   []string
 	Image            string
 	Binary           string
 	Environment      []string
@@ -31,9 +36,10 @@ type Config struct {
 }
 
 type jobConfig struct {
-	env   map[string]string
-	args  []string
-	grace time.Duration
+	env           map[string]string
+	args          []string
+	grace         time.Duration
+	userDirectory string
 }
 
 var envName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
@@ -42,6 +48,14 @@ func prepare(cfg Config) (jobConfig, error) {
 	var job jobConfig
 	if cfg.Image == "" || strings.HasPrefix(cfg.Image, "-") || strings.ContainsAny(cfg.Image, " \t\r\n") {
 		return job, fmt.Errorf("invalid Docker bootstrap image")
+	}
+	if _, _, err := containerUser(cfg.User); err != nil {
+		return job, err
+	}
+	switch cfg.PullPolicy {
+	case "", "missing", "always", "never":
+	default:
+		return job, fmt.Errorf("pull-policy must be always, missing, or never")
 	}
 	if cfg.CleanupMargin <= 0 || cfg.OperationTimeout <= 0 || cfg.PullTimeout <= 0 {
 		return job, fmt.Errorf("docker bootstrap timeouts must be positive")
@@ -125,6 +139,9 @@ func prepare(cfg Config) (jobConfig, error) {
 		if _, err := os.Stat(source); err != nil {
 			return fmt.Errorf("docker mount source unavailable: %w", err)
 		}
+		if err := rejectCredentialMount(source, cfg); err != nil {
+			return err
+		}
 		arg := "type=bind,src=" + source + ",dst=" + target
 		if readonly {
 			arg += ",readonly"
@@ -177,7 +194,7 @@ func prepare(cfg Config) (jobConfig, error) {
 	if all["BUILDKITE_BUILD_PATH"] == "" {
 		return job, fmt.Errorf("BUILDKITE_BUILD_PATH is required")
 	}
-	job.args = append(job.args, "--workdir", all["BUILDKITE_BUILD_PATH"])
+	job.args = append(job.args, "--workdir", containerRoot+"/home")
 	// Mounting the shared directory would expose other jobs' sockets.
 	if base := all["BUILDKITE_SOCKETS_PATH"]; base != "" {
 		for _, name := range []string{"agent-" + all["BUILDKITE_AGENT_PID"], "agent-leader"} {
@@ -188,6 +205,25 @@ func prepare(cfg Config) (jobConfig, error) {
 				}
 			}
 		}
+	}
+	userDir, uid, gid, err := prepareUser(cfg.User, contextDir)
+	if err != nil {
+		return job, err
+	}
+	job.userDirectory = userDir
+	for _, name := range []string{"passwd", "group"} {
+		if err := addMount(filepath.Join(userDir, name), "/etc/"+name, true); err != nil {
+			_ = os.RemoveAll(userDir)
+			return job, err
+		}
+	}
+	job.args = append(job.args, "--user", fmt.Sprintf("%d:%d", uid, gid), "--tmpfs", fmt.Sprintf("%s/home:rw,nosuid,nodev,mode=0700,uid=%d,gid=%d", containerRoot, uid, gid))
+	job.env["HOME"] = containerRoot + "/home"
+	job.env["USER"] = "buildkite"
+	job.env["LOGNAME"] = "buildkite"
+	if uid == 0 {
+		job.env["USER"] = "root"
+		job.env["LOGNAME"] = "root"
 	}
 	keys := make([]string, 0, len(mounts))
 	for target := range mounts {

--- a/internal/dockerbootstrap/diagnostics.go
+++ b/internal/dockerbootstrap/diagnostics.go
@@ -1,0 +1,121 @@
+package dockerbootstrap
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+
+	"github.com/buildkite/agent/v4/internal/redact"
+)
+
+const diagnosticLimit = 16 * 1024
+
+// Diagnostics are deliberately limited to stderr, never Docker's stdout (which
+// can contain inspection data). Redact before truncating, so a secret spanning
+// the capture limit cannot leak a prefix.
+type diagnosticClient struct {
+	Clienter
+	needles []string
+}
+
+func withDiagnostics(client Clienter, environment []string) Clienter {
+	patterns := []string{"*_TOKEN", "*_PASSWORD", "*_SECRET", "*_KEY", "*HEADERS*", "BUILDKITE_SECRETS_CONFIG"}
+	for _, pair := range environment {
+		if value, ok := strings.CutPrefix(pair, "BUILDKITE_REDACTED_VARS="); ok {
+			patterns = append(patterns, strings.Split(value, ",")...)
+		}
+	}
+	var needles []string
+	for _, pair := range environment {
+		name, value, ok := strings.Cut(pair, "=")
+		if !ok || value == "" {
+			continue
+		}
+		matched, err := redact.MatchAny(patterns, name)
+		// Fail closed on invalid redaction patterns. Unlike job log redaction,
+		// diagnostics also mask short secrets.
+		if matched || err != nil {
+			needles = append(needles, value)
+		}
+	}
+	return diagnosticClient{Clienter: client, needles: needles}
+}
+
+func (c diagnosticClient) Run(ctx context.Context, args []string, env map[string]string, stdout, stderr io.Writer) (int, error) {
+	// Attached stderr is job output, already streamed through JobRunner. Its
+	// nonzero exit is the bootstrap result, not necessarily a Docker failure.
+	if args[0] == "start" {
+		return c.Clienter.Run(ctx, args, env, stdout, stderr)
+	}
+	var capture diagnosticBuffer
+	filtered := redact.New(&capture, c.needles)
+	code, cause := c.Clienter.Run(ctx, args, env, stdout, filtered)
+	_ = filtered.Flush() // diagnosticBuffer.Write cannot fail.
+	if cause == nil && code == 0 {
+		return code, nil
+	}
+	action := args[0]
+	if action == "image" && len(args) > 1 {
+		action += " " + args[1]
+	}
+	message := fmt.Sprintf("docker %s failed (exit %d)", action, code)
+	if cause != nil {
+		message = fmt.Sprintf("docker %s failed: %s", action, sanitizeDiagnostic(redact.String(cause.Error(), c.needles)))
+	}
+	if detail := sanitizeDiagnostic(capture.String()); detail != "" {
+		message += ": " + detail
+	}
+	return code, &diagnosticError{message: message, cause: cause}
+}
+
+type diagnosticError struct {
+	message string
+	cause   error
+}
+
+func (e *diagnosticError) Error() string { return e.message }
+func (e *diagnosticError) Unwrap() error { return e.cause }
+
+type diagnosticBuffer struct {
+	data      []byte
+	truncated bool
+}
+
+func (b *diagnosticBuffer) Write(p []byte) (int, error) {
+	n := len(p)
+	remaining := diagnosticLimit - len(b.data)
+	if len(p) > remaining {
+		p = p[:remaining]
+		b.truncated = true
+	}
+	b.data = append(b.data, p...)
+	return n, nil
+}
+
+func (b *diagnosticBuffer) String() string {
+	s := string(b.data)
+	if b.truncated {
+		// Drop the last partial line: it might contain truncated URL credentials
+		// or an authorization header that the sanitizer cannot recognize.
+		if end := strings.LastIndexByte(s, '\n'); end >= 0 {
+			s = s[:end]
+		} else {
+			s = ""
+		}
+		s += "\n[Docker diagnostic truncated]"
+	}
+	return strings.TrimSpace(s)
+}
+
+var (
+	diagnosticURLUser = regexp.MustCompile(`(?i)([a-z][a-z0-9+.-]*://)[^\s/]*@`)
+	diagnosticAuth    = regexp.MustCompile(`(?i)\b(Bearer|Basic)\s+[^\s"']+`)
+)
+
+func sanitizeDiagnostic(s string) string {
+	s = diagnosticURLUser.ReplaceAllString(s, "${1}[REDACTED]@")
+	s = diagnosticAuth.ReplaceAllString(s, "${1} [REDACTED]")
+	return strings.TrimSpace(s)
+}

--- a/internal/dockerbootstrap/diagnostics.go
+++ b/internal/dockerbootstrap/diagnostics.go
@@ -54,7 +54,7 @@ func (c diagnosticClient) Run(ctx context.Context, args []string, env map[string
 		return code, nil
 	}
 	action := args[0]
-	if action == "image" && len(args) > 1 {
+	if (action == "image" || action == "network") && len(args) > 1 {
 		action += " " + args[1]
 	}
 	message := fmt.Sprintf("docker %s failed (exit %d)", action, code)

--- a/internal/dockerbootstrap/diagnostics.go
+++ b/internal/dockerbootstrap/diagnostics.go
@@ -12,9 +12,8 @@ import (
 
 const diagnosticLimit = 16 * 1024
 
-// Diagnostics are deliberately limited to stderr, never Docker's stdout (which
-// can contain inspection data). Redact before truncating, so a secret spanning
-// the capture limit cannot leak a prefix.
+// Docker stdout may contain sensitive inspection data. Capture only stderr,
+// redacting before truncation to avoid leaking partial secrets.
 type diagnosticClient struct {
 	Clienter
 	needles []string
@@ -34,8 +33,7 @@ func withDiagnostics(client Clienter, environment []string) Clienter {
 			continue
 		}
 		matched, err := redact.MatchAny(patterns, name)
-		// Fail closed on invalid redaction patterns. Unlike job log redaction,
-		// diagnostics also mask short secrets.
+		// Invalid patterns must not leave potential secrets unmasked.
 		if matched || err != nil {
 			needles = append(needles, value)
 		}
@@ -44,8 +42,7 @@ func withDiagnostics(client Clienter, environment []string) Clienter {
 }
 
 func (c diagnosticClient) Run(ctx context.Context, args []string, env map[string]string, stdout, stderr io.Writer) (int, error) {
-	// Attached stderr is job output, already streamed through JobRunner. Its
-	// nonzero exit is the bootstrap result, not necessarily a Docker failure.
+	// JobRunner handles attached logs; a nonzero job exit is not a CLI error.
 	if args[0] == "start" {
 		return c.Clienter.Run(ctx, args, env, stdout, stderr)
 	}
@@ -97,8 +94,7 @@ func (b *diagnosticBuffer) Write(p []byte) (int, error) {
 func (b *diagnosticBuffer) String() string {
 	s := string(b.data)
 	if b.truncated {
-		// Drop the last partial line: it might contain truncated URL credentials
-		// or an authorization header that the sanitizer cannot recognize.
+		// Truncated credentials may be unrecognizable to the sanitizer.
 		if end := strings.LastIndexByte(s, '\n'); end >= 0 {
 			s = s[:end]
 		} else {

--- a/internal/dockerbootstrap/diagnostics.go
+++ b/internal/dockerbootstrap/diagnostics.go
@@ -19,14 +19,14 @@ type diagnosticClient struct {
 	needles []string
 }
 
-func withDiagnostics(client Clienter, environment []string) Clienter {
+func withDiagnostics(client Clienter, environment []string, secrets ...string) Clienter {
 	patterns := []string{"*_TOKEN", "*_PASSWORD", "*_SECRET", "*_KEY", "*HEADERS*", "BUILDKITE_SECRETS_CONFIG"}
 	for _, pair := range environment {
 		if value, ok := strings.CutPrefix(pair, "BUILDKITE_REDACTED_VARS="); ok {
 			patterns = append(patterns, strings.Split(value, ",")...)
 		}
 	}
-	var needles []string
+	needles := append([]string(nil), secrets...)
 	for _, pair := range environment {
 		name, value, ok := strings.Cut(pair, "=")
 		if !ok || value == "" {

--- a/internal/dockerbootstrap/diagnostics_test.go
+++ b/internal/dockerbootstrap/diagnostics_test.go
@@ -1,0 +1,104 @@
+package dockerbootstrap
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestSetupFailureIncludesDockerDiagnostic(t *testing.T) {
+	for _, phase := range []string{"info", "pull", "image identity", "create", "rm"} {
+		t.Run(phase, func(t *testing.T) {
+			const detail = "permission denied while trying to connect to unix:///var/run/docker.sock"
+			f := &fakeClient{run: func(_ context.Context, args []string, _ map[string]string, stdout, stderr io.Writer) (int, error) {
+				if phase == "pull" && args[0] == "image" {
+					return 1, nil
+				}
+				fail := args[0] == phase || (phase == "image identity" && args[0] == "image" && len(args) > 3)
+				if fail {
+					_, _ = fmt.Fprintln(stdout, "sensitive inspection stdout")
+					_, _ = fmt.Fprintln(stderr, detail)
+					return 1, nil
+				}
+				if phase == "rm" && args[0] == "ps" {
+					_, _ = fmt.Fprintln(stdout, "still-exists")
+				}
+				return 0, nil
+			}}
+			code, err := (Runner{Client: f}).Run(t.Context(), testConfig(t))
+			if code != SetupFailure || err == nil {
+				t.Fatalf("got (%d,%v)", code, err)
+			}
+			if !strings.Contains(err.Error(), detail) || !strings.Contains(err.Error(), "exit 1") {
+				t.Fatalf("missing diagnostic: %v", err)
+			}
+			if strings.Contains(err.Error(), "sensitive inspection stdout") {
+				t.Fatal("included inspection stdout")
+			}
+		})
+	}
+}
+
+func TestDiagnosticRedaction(t *testing.T) {
+	f := &fakeClient{run: func(_ context.Context, _ []string, _ map[string]string, _, stderr io.Writer) (int, error) {
+		// Write across chunks as os/exec can do; include a quoted multiline value.
+		for _, part := range []string{"private-", "token custom-value short-key https://user:unknown-password@registry.test/v2/ Authorization: Bearer unknown-token ", `"line-one\nline-two"`} {
+			_, _ = io.WriteString(stderr, part)
+		}
+		return 1, nil
+	}}
+	c := withDiagnostics(f, []string{
+		"BUILDKITE_AGENT_ACCESS_TOKEN=private-token", "BUILDKITE_REDACTED_VARS=CUSTOM", "CUSTOM=custom-value",
+		"SSH_KEY=short-key", "MULTILINE_SECRET=line-one\nline-two",
+	})
+	_, err := c.Run(t.Context(), []string{"pull", "image"}, nil, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	for _, secret := range []string{"private-token", "custom-value", "short-key", "unknown-password", "unknown-token", "line-one", "line-two"} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("leaked %q: %v", secret, err)
+		}
+	}
+	if !strings.Contains(err.Error(), "registry.test/v2/") {
+		t.Fatal("lost registry diagnostic context")
+	}
+}
+
+func TestDiagnosticLimitRedactsBeforeTruncating(t *testing.T) {
+	var capture diagnosticBuffer
+	f := &fakeClient{run: func(_ context.Context, _ []string, _ map[string]string, _, stderr io.Writer) (int, error) {
+		_, _ = io.WriteString(stderr, "useful first line\n"+strings.Repeat("x", diagnosticLimit-30)+"secret-prefix\nsecret-suffix\n"+strings.Repeat("y", diagnosticLimit))
+		return 1, nil
+	}}
+	c := withDiagnostics(f, []string{"A_TOKEN=secret-prefix\nsecret-suffix"})
+	_, err := c.Run(t.Context(), []string{"info"}, nil, io.Discard, &capture)
+	if err == nil || !strings.Contains(err.Error(), "truncated") {
+		t.Fatalf("missing truncation marker: %v", err)
+	}
+	if len(err.Error()) > diagnosticLimit+100 || strings.Contains(err.Error(), "secret-prefix") || strings.Contains(err.Error(), "secret-suffix") {
+		t.Fatal("oversized or unredacted diagnostic")
+	}
+	if !strings.Contains(err.Error(), "useful first line") {
+		t.Fatal("lost complete diagnostic line")
+	}
+	_, _ = capture.Write(bytes.Repeat([]byte("x"), diagnosticLimit*2))
+	if len(capture.data) != diagnosticLimit {
+		t.Fatal("capture was not bounded")
+	}
+}
+
+func TestDiagnosticPreservesContextError(t *testing.T) {
+	f := &fakeClient{run: func(_ context.Context, _ []string, _ map[string]string, _, stderr io.Writer) (int, error) {
+		_, _ = io.WriteString(stderr, "waiting for daemon")
+		return 0, context.DeadlineExceeded
+	}}
+	_, err := withDiagnostics(f, nil).Run(t.Context(), []string{"info"}, nil, io.Discard, io.Discard)
+	if !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "waiting for daemon") {
+		t.Fatalf("got %v", err)
+	}
+}

--- a/internal/dockerbootstrap/diagnostics_test.go
+++ b/internal/dockerbootstrap/diagnostics_test.go
@@ -45,7 +45,7 @@ func TestSetupFailureIncludesDockerDiagnostic(t *testing.T) {
 
 func TestDiagnosticRedaction(t *testing.T) {
 	f := &fakeClient{run: func(_ context.Context, _ []string, _ map[string]string, _, stderr io.Writer) (int, error) {
-		// Write across chunks as os/exec can do; include a quoted multiline value.
+		// os/exec may split a secret across writes or report its escaped form.
 		for _, part := range []string{"private-", "token custom-value short-key https://user:unknown-password@registry.test/v2/ Authorization: Bearer unknown-token ", `"line-one\nline-two"`} {
 			_, _ = io.WriteString(stderr, part)
 		}

--- a/internal/dockerbootstrap/docker_integration_test.go
+++ b/internal/dockerbootstrap/docker_integration_test.go
@@ -106,9 +106,14 @@ echo workspace-ok > ownership-test
 					t.Fatalf("fixture cleanup: %v %s", err, out)
 				}
 			}
-			var remaining bytes.Buffer
-			if _, err := client.Run(t.Context(), []string{"ps", "-a", "-q", "--filter", "label=com.buildkite.job-id=user-integration"}, nil, &remaining, &remaining); err != nil || remaining.Len() != 0 {
-				t.Fatalf("containers remain: %v %s", err, remaining.String())
+			for _, args := range [][]string{
+				{"ps", "-a", "-q", "--filter", "label=com.buildkite.job-id=user-integration"},
+				{"network", "ls", "-q", "--filter", "label=com.buildkite.job-id=user-integration"},
+			} {
+				var remaining bytes.Buffer
+				if status, err := client.Run(t.Context(), args, nil, &remaining, &remaining); err != nil || status != 0 || remaining.Len() != 0 {
+					t.Fatalf("resources remain (%v): %v %s", args, err, remaining.String())
+				}
 			}
 		})
 	}

--- a/internal/dockerbootstrap/docker_integration_test.go
+++ b/internal/dockerbootstrap/docker_integration_test.go
@@ -1,0 +1,239 @@
+//go:build linux
+
+package dockerbootstrap
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// An explicit binary opts into tests that create resources on the local daemon.
+func TestDockerUserIntegration(t *testing.T) {
+	binary := os.Getenv("DOCKER_BOOTSTRAP_TEST_BINARY")
+	if binary == "" {
+		t.Skip("set DOCKER_BOOTSTRAP_TEST_BINARY to a static Linux agent binary")
+	}
+	users := []string{"", "0:0"}
+	if os.Getuid() == 0 {
+		users = append(users, "12345:12345")
+	}
+	for _, user := range users {
+		t.Run("user="+user, func(t *testing.T) {
+			cfg := testConfig(t)
+			cfg.Binary = binary
+			cfg.User = user
+			cfg.CleanupMargin = 3 * time.Second
+			cfg.OperationTimeout = 15 * time.Second
+			cfg.PullTimeout = time.Minute
+			build := filepath.Join(t.TempDir(), "workspace")
+			hooks := filepath.Join(build, ".buildkite", "hooks")
+			if err := os.MkdirAll(hooks, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			for name, script := range map[string]string{
+				"pre-command": "#!/bin/sh\ntest -f /.dockerenv || exit 99\nexport HOOK_WORKED=yes\n",
+				"pre-exit":    "#!/bin/sh\ntest -f /.dockerenv || exit 99\necho pre-exit-ok\n",
+			} {
+				if err := os.WriteFile(filepath.Join(hooks, name), []byte(script), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			uid, gid, err := containerUser(user)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if os.Getuid() == 0 && uid != 0 {
+				if err := os.Chown(build, uid, gid); err != nil {
+					t.Fatal(err)
+				}
+			}
+			command := fmt.Sprintf(`set -eu
+test -f /.dockerenv
+test "$(id -u)" = %d
+test "$(id -g)" = %d
+test "$HOOK_WORKED" = yes
+getent passwd "$(id -u)"
+getent group "$(id -g)"
+test -w "$HOME"
+touch "$HOME/home-test"
+echo workspace-ok > ownership-test
+`, uid, gid)
+			cfg.Environment = append(cfg.Environment, "BUILDKITE_BUILD_PATH="+build, "BUILDKITE_BUILD_CHECKOUT_PATH="+build, "BUILDKITE_BOOTSTRAP_PHASES=command", "BUILDKITE_COMMAND="+command, "BUILDKITE_JOB_ID=user-integration", "BUILDKITE_CANCEL_SIGNAL_TIMEOUT=10s", "BUILDKITE_PTY=false", "BUILDKITE_REPO=.", "BUILDKITE_COMMIT=HEAD", "BUILDKITE_BRANCH=main", "BUILDKITE_PIPELINE_PROVIDER=custom", "BUILDKITE_AGENT_NAME=test-agent", "BUILDKITE_ORGANIZATION_SLUG=test-org", "BUILDKITE_PIPELINE_SLUG=test-pipeline")
+			cfg.PullPolicy = "never"
+			client := CLI{Path: "/usr/bin/docker", ConfigDir: t.TempDir()}
+			for range 2 {
+				var output bytes.Buffer
+				code, err := (Runner{Client: client, Stdout: &output, Stderr: &output}).Run(t.Context(), cfg)
+				if err != nil || code != 0 || !strings.Contains(output.String(), "pre-exit-ok") {
+					t.Fatalf("code=%d err=%v\n%s", code, err, output.String())
+				}
+			}
+			if uid != 0 {
+				if err := os.Chmod(build, 0o555); err != nil {
+					t.Fatal(err)
+				}
+				var output bytes.Buffer
+				code, runErr := (Runner{Client: client, Stdout: &output, Stderr: &output}).Run(t.Context(), cfg)
+				if err := os.Chmod(build, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if runErr != nil || code != SetupFailure || !strings.Contains(output.String(), "cannot write directory") || strings.Contains(output.String(), "pre-exit-ok") {
+					t.Fatalf("permission preflight: code=%d err=%v %s", code, runErr, output.String())
+				}
+			}
+			info, err := os.Stat(filepath.Join(build, "ownership-test"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			stat := info.Sys().(*syscall.Stat_t)
+			if int(stat.Uid) != uid || int(stat.Gid) != gid {
+				t.Fatalf("owner=%d:%d want=%d:%d", stat.Uid, stat.Gid, uid, gid)
+			}
+			// Root-created fixtures need removal before the unprivileged test cleanup.
+			if uid == 0 && os.Getuid() != 0 {
+				cmd := exec.CommandContext(t.Context(), "docker", "run", "--rm", "--entrypoint", "/bin/sh", "--mount", "type=bind,src="+build+",dst=/workspace", DefaultImage, "-c", "rm -f /workspace/ownership-test")
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("fixture cleanup: %v %s", err, out)
+				}
+			}
+			var remaining bytes.Buffer
+			if _, err := client.Run(t.Context(), []string{"ps", "-a", "-q", "--filter", "label=com.buildkite.job-id=user-integration"}, nil, &remaining, &remaining); err != nil || remaining.Len() != 0 {
+				t.Fatalf("containers remain: %v %s", err, remaining.String())
+			}
+		})
+	}
+}
+
+func TestDockerRegistryIntegration(t *testing.T) {
+	binary, image, source := os.Getenv("DOCKER_BOOTSTRAP_TEST_BINARY"), os.Getenv("DOCKER_BOOTSTRAP_TEST_IMAGE"), os.Getenv("DOCKER_BOOTSTRAP_TEST_AUTH")
+	if binary == "" || image == "" || source == "" {
+		t.Skip("set Docker bootstrap binary, image and auth fixture variables")
+	}
+	auth, err := LoadAuthentication(source, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := t.TempDir()
+	if err := os.WriteFile(filepath.Join(config, "config.json"), auth.Config, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, policy               string
+		authenticated, wantFailure bool
+	}{
+		{"uncached never", "never", false, true},
+		{"uncached missing", "missing", false, true},
+		{"authenticated refresh", "always", true, false},
+		{"unauthenticated refresh with cache", "always", false, true},
+		{"cached missing policy", "missing", false, false},
+		{"cached never policy", "never", false, false},
+		{"authenticated missing policy", "missing", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.name == "authenticated missing policy" || tc.name == "uncached never" {
+				cmd := exec.CommandContext(t.Context(), "docker", "image", "rm", image)
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("remove test image tag: %v %s", err, out)
+				}
+			}
+			cfg := testConfig(t)
+			cfg.Binary = binary
+			cfg.Image = image
+			cfg.PullPolicy = tc.policy
+			cfg.DockerConfig = source
+			cfg.RedactedValues = auth.Secrets
+			cfg.CleanupMargin = 3 * time.Second
+			cfg.OperationTimeout = 15 * time.Second
+			cfg.PullTimeout = time.Minute
+			cfg.Environment = append(cfg.Environment, "BUILDKITE_CANCEL_SIGNAL_TIMEOUT=10s", "BUILDKITE_BOOTSTRAP_PHASES=command", "BUILDKITE_COMMAND=test -f /.dockerenv", "BUILDKITE_JOB_ID=registry-integration", "BUILDKITE_REPO=.", "BUILDKITE_COMMIT=HEAD", "BUILDKITE_BRANCH=main", "BUILDKITE_PIPELINE_PROVIDER=custom", "BUILDKITE_AGENT_NAME=test-agent", "BUILDKITE_ORGANIZATION_SLUG=test-org", "BUILDKITE_PIPELINE_SLUG=test-pipeline")
+			client := CLI{Path: "/usr/bin/docker", ConfigDir: t.TempDir()}
+			if tc.authenticated {
+				client.AuthConfigDir = config
+			}
+			var out bytes.Buffer
+			code, err := (Runner{Client: client, Stdout: &out, Stderr: &out}).Run(t.Context(), cfg)
+			if (err != nil) != tc.wantFailure || (code != 0) != tc.wantFailure {
+				t.Fatalf("code=%d err=%v\n%s", code, err, out.String())
+			}
+			for _, secret := range auth.Secrets {
+				if strings.Contains(out.String(), secret) || (err != nil && strings.Contains(err.Error(), secret)) {
+					t.Fatal("credential leaked in diagnostics")
+				}
+			}
+		})
+	}
+}
+
+func TestDockerCredentialHelperIntegration(t *testing.T) {
+	image, source := os.Getenv("DOCKER_BOOTSTRAP_TEST_IMAGE"), os.Getenv("DOCKER_BOOTSTRAP_TEST_AUTH")
+	if image == "" || source == "" {
+		t.Skip("requires private registry fixture")
+	}
+	data, err := os.ReadFile(filepath.Join(source, "config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sourceConfig struct {
+		Auths map[string]struct{ Auth string }
+	}
+	if err := json.Unmarshal(data, &sourceConfig); err != nil {
+		t.Fatal(err)
+	}
+	registry := strings.Split(image, "/")[0]
+	decoded, err := base64.StdEncoding.DecodeString(sourceConfig.Auths[registry].Auth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	username, password, ok := strings.Cut(string(decoded), ":")
+	if !ok {
+		t.Fatal("fixture requires basic auth")
+	}
+	credentials, err := json.Marshal(map[string]string{"Username": username, "Secret": password})
+	if err != nil {
+		t.Fatal(err)
+	}
+	helperDir, config := t.TempDir(), t.TempDir()
+	script := `#!/bin/sh
+if [ "${DELAY:-}" = yes ]; then sleep 60; fi
+printf '%s\n' "$CREDENTIAL_JSON"
+`
+	if err := os.WriteFile(filepath.Join(helperDir, "docker-credential-phase2-test"), []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	configData, _ := json.Marshal(map[string]any{"credHelpers": map[string]string{registry: "phase2-test"}})
+	if err := os.WriteFile(filepath.Join(config, "config.json"), configData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	client := CLI{Path: "/usr/bin/docker", ConfigDir: t.TempDir(), AuthConfigDir: config, HelperPath: helperDir + ":/usr/bin:/bin", HelperEnvironment: map[string]string{"CREDENTIAL_JSON": string(credentials)}}
+	var output bytes.Buffer
+	code, err := client.Run(t.Context(), []string{"pull", image}, nil, &output, &output)
+	if code != 0 || err != nil {
+		t.Fatalf("helper pull failed (status %d): %v", code, err)
+	}
+	if strings.Contains(output.String(), password) {
+		t.Fatal("helper credential leaked")
+	}
+	client.HelperEnvironment["CREDENTIAL_JSON"] = `{"Username":"test","Secret":"invalid-fixture-password"}`
+	code, err = client.Run(t.Context(), []string{"pull", image}, nil, &output, &output)
+	if err != nil || code == 0 {
+		t.Fatalf("invalid credential result: %d %v", code, err)
+	}
+	client.HelperEnvironment["DELAY"] = "yes"
+	ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_, err = client.Run(ctx, []string{"pull", image}, nil, &output, &output)
+	if err != context.DeadlineExceeded || time.Since(started) > 3*time.Second {
+		t.Fatalf("helper cancellation: %v after %v", err, time.Since(started))
+	}
+}

--- a/internal/dockerbootstrap/network_integration_test.go
+++ b/internal/dockerbootstrap/network_integration_test.go
@@ -1,0 +1,160 @@
+//go:build linux
+
+package dockerbootstrap
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDockerNetworkIntegration(t *testing.T) {
+	binary := os.Getenv("DOCKER_BOOTSTRAP_TEST_BINARY")
+	if binary == "" {
+		t.Skip("set DOCKER_BOOTSTRAP_TEST_BINARY to a static Linux agent binary")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+	defer cancel()
+	client := CLI{Path: "/usr/bin/docker", ConfigDir: t.TempDir()}
+	docker := func(args ...string) string {
+		t.Helper()
+		out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("docker %v: %v %s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	type result struct {
+		code int
+		err  error
+	}
+	type runningJob struct {
+		name, ip, network string
+		cancel            context.CancelFunc
+		done              chan result
+	}
+	var jobs []runningJob
+	for _, forced := range []bool{false, true} {
+		cfg := testConfig(t)
+		cfg.Binary, cfg.PullPolicy = binary, "never"
+		cfg.CleanupMargin, cfg.OperationTimeout = 3*time.Second, 15*time.Second
+		build := t.TempDir()
+		handler := "lambda *_: exit(0)"
+		if forced {
+			handler = "signal.SIG_IGN"
+		}
+		command := fmt.Sprintf("exec python3 -u - <<'PY'\n"+`
+import pathlib
+import signal
+import socket
+import urllib.request
+signal.signal(signal.SIGTERM, %s)
+signal.signal(signal.SIGINT, %s)
+with urllib.request.urlopen("https://example.com", timeout=15) as response:
+    assert response.status == 200
+server = socket.socket()
+server.bind(("0.0.0.0", 8765))
+server.listen()
+pathlib.Path("ready").touch()
+while True:
+    connection, _ = server.accept()
+    connection.close()
+PY
+`, handler, handler)
+		cfg.Environment = append(cfg.Environment,
+			"BUILDKITE_JOB_ID=network-"+filepath.Base(build),
+			"BUILDKITE_BUILD_PATH="+build, "BUILDKITE_BUILD_CHECKOUT_PATH="+build,
+			"BUILDKITE_BOOTSTRAP_PHASES=command", "BUILDKITE_COMMAND="+command,
+			"BUILDKITE_CANCEL_SIGNAL_TIMEOUT=5s", "BUILDKITE_PTY=false",
+			"BUILDKITE_REPO=.", "BUILDKITE_COMMIT=HEAD", "BUILDKITE_BRANCH=main",
+			"BUILDKITE_PIPELINE_PROVIDER=custom", "BUILDKITE_AGENT_NAME=test-agent",
+			"BUILDKITE_ORGANIZATION_SLUG=test-org", "BUILDKITE_PIPELINE_SLUG=test-pipeline")
+		log, err := os.CreateTemp(t.TempDir(), "job-log")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = log.Close() })
+		jobCtx, jobCancel := context.WithCancel(ctx)
+		done := make(chan result, 1)
+		go func() {
+			code, err := (Runner{Client: client, Stdout: log, Stderr: log}).Run(jobCtx, cfg)
+			done <- result{code, err}
+			close(done)
+		}()
+		// Drain supervisors before testing.T removes their bind-mounted fixtures.
+		t.Cleanup(func() {
+			jobCancel()
+			<-done
+		})
+		ready := filepath.Join(build, "ready")
+	waiting:
+		for {
+			if _, err := os.Stat(ready); err == nil {
+				break
+			}
+			select {
+			case result := <-done:
+				output, _ := os.ReadFile(log.Name())
+				t.Fatalf("job ended before ready: %+v\n%s", result, output)
+			case <-ctx.Done():
+				t.Fatal("timed out waiting for job readiness")
+			case <-time.After(100 * time.Millisecond):
+				continue waiting
+			}
+		}
+		output, err := os.ReadFile(log.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		var network string
+		for _, line := range strings.Split(string(output), "\n") {
+			if value, ok := strings.CutPrefix(line, "Docker bootstrap network: "); ok {
+				network = value
+			}
+		}
+		if !strings.HasPrefix(network, "buildkite_network_") {
+			t.Fatalf("network missing from log: %s", output)
+		}
+		name := strings.Replace(network, "buildkite_network_", "buildkite_job_", 1)
+		if got := docker("inspect", "--format", "{{len .NetworkSettings.Networks}}", name); got != "1" {
+			t.Fatalf("expected one network, got %s", got)
+		}
+		if got := docker("inspect", "--format", "{{json .HostConfig.PortBindings}}", name); got != "{}" && got != "null" {
+			t.Fatalf("unexpected published ports: %s", got)
+		}
+		ip := docker("inspect", "--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", name)
+		jobs = append(jobs, runningJob{name, ip, network, jobCancel, done})
+	}
+	if jobs[0].network == jobs[1].network {
+		t.Fatal("jobs share a network")
+	}
+	for i, job := range jobs {
+		docker("exec", job.name, "python3", "-c", `import socket; socket.create_connection(("127.0.0.1", 8765), timeout=2).close()`)
+		docker("exec", job.name, "python3", "-c", `import socket, sys
+try:
+    socket.create_connection((sys.argv[1], 8765), timeout=2).close()
+except OSError:
+    pass
+else:
+    raise SystemExit("cross-job connection succeeded")
+`, jobs[1-i].ip)
+	}
+	for i, job := range jobs {
+		job.cancel()
+		result := <-job.done
+		if result.err != nil || (i == 0 && result.code != 143 && result.code != 0) || (i == 1 && result.code != 137) {
+			t.Errorf("cancellation result: %+v", result)
+		}
+		if got := docker("ps", "-a", "-q", "--filter", "name=^/"+job.name+"$"); got != "" {
+			t.Errorf("container remains: %s", got)
+		}
+		if got := docker("network", "ls", "-q", "--filter", "name=^"+job.network+"$"); got != "" {
+			t.Errorf("network remains: %s", got)
+		}
+	}
+}

--- a/internal/dockerbootstrap/policy_test.go
+++ b/internal/dockerbootstrap/policy_test.go
@@ -1,0 +1,86 @@
+package dockerbootstrap
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestPullPolicies(t *testing.T) {
+	for _, policy := range []string{"", "missing", "always", "never"} {
+		for _, cached := range []bool{false, true} {
+			for _, pullFails := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/cached=%t/pullFails=%t", policy, cached, pullFails), func(t *testing.T) {
+					cfg := testConfig(t)
+					cfg.PullPolicy = policy
+					f := &fakeClient{run: func(_ context.Context, args []string, _ map[string]string, _, _ io.Writer) (int, error) {
+						if args[0] == "image" && !slices.Contains(args, "--format") && !cached {
+							return 1, nil
+						}
+						if args[0] == "pull" && pullFails {
+							return 1, nil
+						}
+						return 0, nil
+					}}
+					code, err := (Runner{Client: f}).Run(t.Context(), cfg)
+					wantPull := policy == "always" || (!cached && policy != "never")
+					wantFail := (!cached && policy == "never") || (wantPull && pullFails)
+					if f.called("pull") != wantPull || (err != nil) != wantFail {
+						t.Fatalf("pull=%t code=%d err=%v", f.called("pull"), code, err)
+					}
+					if wantFail && f.called("create") {
+						t.Fatal("created container after failed image resolution")
+					}
+				})
+			}
+		}
+	}
+	cfg := testConfig(t)
+	cfg.PullPolicy = "sometimes"
+	if _, err := prepare(cfg); err == nil {
+		t.Fatal("accepted invalid policy")
+	}
+}
+
+func TestContainerUser(t *testing.T) {
+	for _, value := range []string{"", "0:0", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())} {
+		t.Run(value, func(t *testing.T) {
+			cfg := testConfig(t)
+			cfg.User = value
+			job, err := prepare(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			uid, gid, err := containerUser(value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Contains(job.args, fmt.Sprintf("%d:%d", uid, gid)) {
+				t.Fatal("missing container user")
+			}
+			if job.env["HOME"] != containerRoot+"/home" {
+				t.Fatal("missing private home")
+			}
+			if !strings.Contains(strings.Join(job.args, " "), fmt.Sprintf("mode=0700,uid=%d,gid=%d", uid, gid)) {
+				t.Fatal("incorrect home ownership")
+			}
+			passwd, err := os.ReadFile(filepath.Join(job.userDirectory, "passwd"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(passwd), fmt.Sprintf(":%d:%d:", uid, gid)) {
+				t.Fatal("missing user identity")
+			}
+		})
+	}
+	for _, value := range []string{"root", "1000", "-1:0", "1:-1", "1:2:3", "4294967295:0"} {
+		if _, _, err := containerUser(value); err == nil {
+			t.Errorf("accepted %s", value)
+		}
+	}
+}

--- a/internal/dockerbootstrap/process_unix.go
+++ b/internal/dockerbootstrap/process_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package dockerbootstrap
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func isolateProcess(cmd *exec.Cmd) {
+	// JobRunner signals the supervisor's entire process group. Keep Docker
+	// clients outside it so only the supervisor forwards cancellation, once.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+}

--- a/internal/dockerbootstrap/process_unix.go
+++ b/internal/dockerbootstrap/process_unix.go
@@ -10,8 +10,9 @@ import (
 )
 
 func isolateProcess(cmd *exec.Cmd) {
-	// JobRunner signals the supervisor's entire process group. Keep Docker
-	// clients outside it so only the supervisor forwards cancellation, once.
+	// A separate group prevents duplicate cancellation from JobRunner's group
+	// signal and the supervisor. Supervisor SIGKILL can orphan both the client
+	// and container; recovery requires reconciliation.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
 		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)

--- a/internal/dockerbootstrap/process_windows.go
+++ b/internal/dockerbootstrap/process_windows.go
@@ -1,0 +1,6 @@
+package dockerbootstrap
+
+import "os/exec"
+
+// The command rejects non-Linux hosts. This stub keeps the agent portable.
+func isolateProcess(cmd *exec.Cmd) {}

--- a/internal/dockerbootstrap/process_windows.go
+++ b/internal/dockerbootstrap/process_windows.go
@@ -2,5 +2,5 @@ package dockerbootstrap
 
 import "os/exec"
 
-// The command rejects non-Linux hosts. This stub keeps the agent portable.
+// Windows builds include this package, but the command rejects non-Linux hosts.
 func isolateProcess(cmd *exec.Cmd) {}

--- a/internal/dockerbootstrap/resources.go
+++ b/internal/dockerbootstrap/resources.go
@@ -1,0 +1,47 @@
+package dockerbootstrap
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+)
+
+func resourceLabels(env map[string]string) []string {
+	args := []string{"--label", "com.buildkite.bootstrap=docker", "--label", "com.buildkite.agent=true"}
+	for _, label := range []struct{ key, variable string }{
+		{"com.buildkite.job-id", "BUILDKITE_JOB_ID"},
+		{"com.buildkite.agent-id", "BUILDKITE_AGENT_ID"},
+		{"com.buildkite.agent-name", "BUILDKITE_AGENT_NAME"},
+	} {
+		if value := env[label.variable]; value != "" {
+			args = append(args, "--label", label.key+"="+value)
+		}
+	}
+	return args
+}
+
+func (r Runner) removeResource(ctx context.Context, kind, name string) error {
+	remove := []string{"rm", "--force", name}
+	list := []string{"ps", "--all", "--quiet", "--filter", "name=^/" + name + "$"}
+	if kind == "network" {
+		remove = []string{"network", "rm", name}
+		list = []string{"network", "ls", "--quiet", "--filter", "name=^" + name + "$"}
+	}
+	status, removeErr := r.Client.Run(ctx, remove, nil, io.Discard, io.Discard)
+	if removeErr == nil && status == 0 {
+		return nil
+	}
+	// A failed remove can mean either an absent resource or daemon loss.
+	var found bytes.Buffer
+	status, listErr := r.Client.Run(ctx, list, nil, &found, io.Discard)
+	if listErr == nil && status == 0 && strings.TrimSpace(found.String()) == "" {
+		return nil
+	}
+	_, _ = fmt.Fprintf(r.Stderr, "Docker bootstrap cleanup failed; %s may remain: %s: %v\n", kind, name, removeErr)
+	if listErr != nil {
+		_, _ = fmt.Fprintf(r.Stderr, "Could not verify %s removal: %v\n", kind, listErr)
+	}
+	return fmt.Errorf("docker %s cleanup failed: %w", kind, removeErr)
+}

--- a/internal/dockerbootstrap/resources_test.go
+++ b/internal/dockerbootstrap/resources_test.go
@@ -1,0 +1,148 @@
+package dockerbootstrap
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNetworkLifecycle(t *testing.T) {
+	for _, failure := range []string{"", "network create", "create", "start"} {
+		t.Run("failure="+failure, func(t *testing.T) {
+			cfg := testConfig(t)
+			cfg.Environment = append(cfg.Environment, "BUILDKITE_JOB_ID=test-job", "BUILDKITE_AGENT_ID=test-agent", "BUILDKITE_AGENT_NAME=test-worker")
+			f := &fakeClient{run: func(_ context.Context, args []string, _ map[string]string, _, _ io.Writer) (int, error) {
+				action := args[0]
+				if action == "network" {
+					action += " " + args[1]
+				}
+				if action == failure {
+					return 1, fmt.Errorf("injected failure")
+				}
+				return 0, nil
+			}}
+			code, err := (Runner{Client: f}).Run(t.Context(), cfg)
+			if (failure == "" && (code != 0 || err != nil)) || (failure != "" && (code != SetupFailure || err == nil)) {
+				t.Fatalf("code=%d err=%v", code, err)
+			}
+			var network string
+			for i, args := range f.calls {
+				switch args[0] {
+				case "network":
+					if args[1] == "create" {
+						network = args[len(args)-1]
+						if !strings.HasPrefix(network, "buildkite_network_") || !slices.Contains(args, "bridge") {
+							t.Fatalf("unexpected network: %v", args)
+						}
+						for _, label := range []string{"com.buildkite.bootstrap=docker", "com.buildkite.agent=true", "com.buildkite.job-id=test-job", "com.buildkite.agent-id=test-agent", "com.buildkite.agent-name=test-worker"} {
+							if !slices.Contains(args, label) {
+								t.Errorf("missing network label %s", label)
+							}
+						}
+					}
+					if args[1] == "rm" && (i != len(f.calls)-1 || args[2] != network) {
+						t.Fatalf("network must be removed last: %v", f.calls)
+					}
+				case "create":
+					if network == "" || args[slices.Index(args, "--network")+1] != network {
+						t.Fatalf("container not attached to its network: %v", args)
+					}
+					if args[slices.Index(args, "--name")+1] != strings.Replace(network, "buildkite_network_", "buildkite_job_", 1) {
+						t.Fatalf("resource suffixes differ: %v", args)
+					}
+				}
+			}
+			last := f.calls[len(f.calls)-1]
+			if !slices.Equal(last, []string{"network", "rm", network}) {
+				t.Fatalf("network cleanup missing: %v", f.calls)
+			}
+			if f.called("rm") != (failure != "network create") {
+				t.Fatal("incorrect partial-container cleanup")
+			}
+		})
+	}
+}
+
+func TestNetworkCreateCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	f := &fakeClient{run: func(ctx context.Context, args []string, _ map[string]string, _, _ io.Writer) (int, error) {
+		if args[0] == "network" && args[1] == "create" {
+			cancel()
+			return 0, ctx.Err()
+		}
+		if args[0] == "network" && args[1] == "rm" && ctx.Err() != nil {
+			t.Error("network cleanup inherited cancellation")
+		}
+		return 0, nil
+	}}
+	code, err := (Runner{Client: f}).Run(ctx, testConfig(t))
+	if code != SetupFailure || err == nil || f.called("create") {
+		t.Fatalf("code=%d err=%v calls=%v", code, err, f.calls)
+	}
+	if last := f.calls[len(f.calls)-1]; !slices.Equal(last[:2], []string{"network", "rm"}) {
+		t.Fatal("missing network cleanup")
+	}
+}
+
+func TestNetworkCleanupFailure(t *testing.T) {
+	for _, jobCode := range []int{0, 42} {
+		for _, absent := range []bool{false, true} {
+			t.Run(fmt.Sprintf("exit=%d/absent=%t", jobCode, absent), func(t *testing.T) {
+				f := &fakeClient{run: func(_ context.Context, args []string, _ map[string]string, out, _ io.Writer) (int, error) {
+					if args[0] == "start" {
+						return jobCode, nil
+					}
+					if args[0] == "network" {
+						switch args[1] {
+						case "rm":
+							return 1, nil
+						case "ls":
+							if !absent {
+								_, _ = io.WriteString(out, "remaining-network")
+							}
+						}
+					}
+					return 0, nil
+				}}
+				var stderr bytes.Buffer
+				code, err := (Runner{Client: f, Stderr: &stderr}).Run(t.Context(), testConfig(t))
+				want := jobCode
+				if !absent && jobCode == 0 {
+					want = SetupFailure
+				}
+				if code != want || (err != nil) != (!absent && jobCode == 0) {
+					t.Fatalf("code=%d err=%v", code, err)
+				}
+				if strings.Contains(stderr.String(), "network may remain") == absent {
+					t.Fatalf("unexpected diagnostic: %s", stderr.String())
+				}
+			})
+		}
+	}
+}
+
+func TestContainerCleanupReservesNetworkBudget(t *testing.T) {
+	f := &fakeClient{run: func(ctx context.Context, args []string, _ map[string]string, _, _ io.Writer) (int, error) {
+		if args[0] == "rm" || args[0] == "ps" {
+			<-ctx.Done()
+			return 0, ctx.Err()
+		}
+		if args[0] == "network" && args[1] == "rm" {
+			deadline, ok := ctx.Deadline()
+			if !ok || time.Until(deadline) <= 0 {
+				t.Error("container cleanup exhausted network budget")
+			}
+		}
+		return 0, nil
+	}}
+	code, err := (Runner{Client: f}).Run(t.Context(), testConfig(t))
+	if code != SetupFailure || err == nil {
+		t.Fatalf("code=%d err=%v", code, err)
+	}
+}

--- a/internal/dockerbootstrap/runner.go
+++ b/internal/dockerbootstrap/runner.go
@@ -1,0 +1,267 @@
+package dockerbootstrap
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+const SetupFailure = 125
+
+// Runner owns one container, including cleanup after partially completed create
+// operations. Cancellation of ctx initiates graceful container cancellation;
+// cleanup uses a separate bounded context.
+type Runner struct {
+	Client Clienter
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+func (r Runner) Run(ctx context.Context, cfg Config) (code int, err error) {
+	job, err := prepare(cfg)
+	if err != nil {
+		return SetupFailure, err
+	}
+	if r.Stdout == nil {
+		r.Stdout = io.Discard
+	}
+	if r.Stderr == nil {
+		r.Stderr = io.Discard
+	}
+	// All cancellation cleanup shares one outer budget, including time spent
+	// waiting for a killed Docker client. Leave a little scheduling headroom
+	// before JobRunner SIGKILLs this supervisor.
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	defer shutdownCancel()
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-shutdownCtx.Done():
+			return
+		}
+		timer := time.NewTimer(job.grace + cfg.CleanupMargin - cfg.CleanupMargin/10)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			shutdownCancel()
+		case <-shutdownCtx.Done():
+		}
+	}()
+	var suffix [12]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		return SetupFailure, err
+	}
+	name := "buildkite-bootstrap-" + hex.EncodeToString(suffix[:])
+	operation := func(parent context.Context, timeout time.Duration, args ...string) error {
+		callCtx, cancel := context.WithTimeout(parent, timeout)
+		defer cancel()
+		status, err := r.Client.Run(callCtx, args, nil, io.Discard, io.Discard)
+		if err != nil {
+			return fmt.Errorf("docker %s failed: %w", args[0], err)
+		}
+		if status != 0 {
+			return fmt.Errorf("docker %s failed (exit %d)", args[0], status)
+		}
+		return nil
+	}
+	if err := operation(ctx, cfg.OperationTimeout, "info"); err != nil {
+		return SetupFailure, err
+	}
+	if err := operation(ctx, cfg.OperationTimeout, "image", "inspect", cfg.Image); err != nil {
+		if ctx.Err() != nil {
+			return SetupFailure, ctx.Err()
+		}
+		if err := operation(ctx, cfg.PullTimeout, "pull", cfg.Image); err != nil {
+			return SetupFailure, err
+		}
+	}
+	// Inspect only safe image identity fields, not image configuration or env.
+	var identity bytes.Buffer
+	inspectCtx, inspectCancel := context.WithTimeout(ctx, cfg.OperationTimeout)
+	status, inspectErr := r.Client.Run(inspectCtx, []string{"image", "inspect", "--format", "{{.Id}} {{json .RepoDigests}}", cfg.Image}, nil, &identity, io.Discard)
+	inspectCancel()
+	if inspectErr != nil || status != 0 {
+		return SetupFailure, fmt.Errorf("docker image identity inspection failed")
+	}
+	fields := strings.Fields(identity.String())
+	if len(fields) == 0 || !strings.HasPrefix(fields[0], "sha256:") {
+		return SetupFailure, fmt.Errorf("docker image inspection returned no image ID")
+	}
+	imageID := fields[0]
+	_, _ = fmt.Fprintf(r.Stdout, "Docker bootstrap image: %s (%s)\n", cfg.Image, strings.TrimSpace(identity.String()))
+
+	// Register cleanup before create: Docker may create the container but lose
+	// the response, leaving us with only its preallocated unique name.
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(shutdownCtx, cfg.CleanupMargin)
+		defer cancel()
+		status, removeErr := r.Client.Run(cleanupCtx, []string{"rm", "--force", name}, nil, io.Discard, io.Discard)
+		if removeErr == nil && status == 0 {
+			return
+		}
+		// Auto-remove commonly wins the race. A successful list with no matching
+		// resource distinguishes an already-removed container from daemon loss.
+		var found bytes.Buffer
+		status, listErr := r.Client.Run(cleanupCtx, []string{"ps", "--all", "--quiet", "--filter", "name=^/" + name + "$"}, nil, &found, io.Discard)
+		if listErr == nil && status == 0 && strings.TrimSpace(found.String()) == "" {
+			return
+		}
+		_, _ = fmt.Fprintln(r.Stderr, "Docker bootstrap cleanup failed; container may remain:", name)
+		if err == nil && code == 0 {
+			code, err = SetupFailure, fmt.Errorf("docker container cleanup failed")
+		}
+	}()
+	args := append([]string{"create", "--pull", "never", "--name", name, "--label", "com.buildkite.bootstrap=docker", "--label", "com.buildkite.agent=true"}, job.args...)
+	// Override the image entrypoint, validate the minimum image contract, and
+	// exec bootstrap so Docker's init forwards signals directly to it.
+	const script = `set -e
+if ! test -x /buildkite-docker/bin/buildkite-agent || ! command -v git >/dev/null || ! command -v ssh >/dev/null; then
+  echo 'Docker bootstrap image contract requires an executable agent binary, git, and ssh' >&2
+  exit 125
+fi
+if ! /buildkite-docker/bin/buildkite-agent --version >/dev/null; then
+  echo 'Docker bootstrap image contract: mounted agent binary cannot run' >&2
+  exit 125
+fi
+exec /buildkite-docker/bin/buildkite-agent bootstrap`
+	// Use the inspected immutable ID so a concurrent tag update cannot change
+	// which image runs after we have logged its identity.
+	args = append(args, imageID, "-c", script)
+	createCtx, createCancel := context.WithTimeout(ctx, cfg.OperationTimeout)
+	// Keep stdout connected to the supervisor PTY so Docker records its initial
+	// console size. The only create output is the new container ID.
+	status, createErr := r.Client.Run(createCtx, args, job.env, r.Stdout, io.Discard)
+	createCancel()
+	if createErr != nil || status != 0 {
+		return SetupFailure, fmt.Errorf("docker container create failed")
+	}
+	if ctx.Err() != nil {
+		return SetupFailure, ctx.Err()
+	}
+
+	// Docker start --attach performs attach, wait registration, and start in
+	// that order. Launching separate attach/wait CLI processes cannot establish
+	// that ordering and loses fast exits when --rm is enabled.
+	attachCtx, attachCancel := context.WithCancel(context.Background())
+	defer attachCancel()
+	type result struct {
+		code int
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		code, err := r.Client.Run(attachCtx, []string{"start", "--attach", name}, nil, r.Stdout, r.Stderr)
+		done <- result{code, err}
+	}()
+	// Bound start/attach without imposing a wall-clock limit on a running job.
+	startup := time.NewTimer(cfg.OperationTimeout)
+	defer startup.Stop()
+	startupDeadline := startup.C
+waiting:
+	for {
+		select {
+		case result := <-done:
+			if result.err != nil || result.code < 0 {
+				return SetupFailure, fmt.Errorf("docker attachment failed")
+			}
+			return r.completed(shutdownCtx, cfg.CleanupMargin/4, name, result.code)
+		case <-ctx.Done():
+			break waiting
+		case <-startupDeadline:
+			var state bytes.Buffer
+			probeCtx, probeCancel := context.WithTimeout(ctx, cfg.OperationTimeout)
+			status, probeErr := r.Client.Run(probeCtx, []string{"inspect", "--format", "{{.State.Running}}", name}, nil, &state, io.Discard)
+			probeCancel()
+			if ctx.Err() != nil {
+				break waiting
+			}
+			if probeErr != nil || status != 0 || strings.TrimSpace(state.String()) != "true" {
+				// Prefer a concurrently completed attachment, including fast exits.
+				select {
+				case result := <-done:
+					if result.err != nil || result.code < 0 {
+						return SetupFailure, fmt.Errorf("docker attachment failed")
+					}
+					return r.completed(shutdownCtx, cfg.CleanupMargin/4, name, result.code)
+				default:
+				}
+				attachCancel()
+				<-done
+				return SetupFailure, fmt.Errorf("docker container did not start within the operation timeout")
+			}
+			startupDeadline = nil
+		}
+	}
+
+	// Signal delivery may race with container startup. Retry until Docker
+	// accepts the signal, attachment finishes, or the inner grace expires.
+	graceCtx, graceCancel := context.WithTimeout(context.Background(), job.grace)
+	defer graceCancel()
+	signal := job.env["BUILDKITE_CANCEL_SIGNAL"]
+	if signal == "" || signal == "SIGKILL" {
+		signal = "SIGTERM"
+	}
+	for {
+		if err := operation(graceCtx, cfg.OperationTimeout, "kill", "--signal", signal, name); err == nil {
+			break
+		}
+		select {
+		case result := <-done:
+			if result.err != nil || result.code < 0 {
+				return SetupFailure, fmt.Errorf("docker attachment failed during cancellation")
+			}
+			return r.completed(shutdownCtx, cfg.CleanupMargin/4, name, result.code)
+		case <-graceCtx.Done():
+			goto force
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	select {
+	case result := <-done:
+		if result.err != nil || result.code < 0 {
+			return SetupFailure, fmt.Errorf("docker attachment failed during cancellation")
+		}
+		return r.completed(shutdownCtx, cfg.CleanupMargin/4, name, result.code)
+	case <-graceCtx.Done():
+	}
+force:
+	_, _ = fmt.Fprintln(r.Stderr, "Docker bootstrap cancellation grace expired; forcing container removal")
+	// Deferred force-remove kills the container as well as removing it. Stop
+	// the attached CLI now so it cannot outlive the supervisor.
+	attachCancel()
+	<-done
+	return 137, nil
+}
+
+// completed distinguishes known runtime/client failures from bootstrap exits.
+// Auto-remove can win the race, so a missing state preserves the CLI exit code.
+func (r Runner) completed(ctx context.Context, timeout time.Duration, name string, code int) (int, error) {
+	if code == 0 {
+		return 0, nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	var out bytes.Buffer
+	status, err := r.Client.Run(ctx, []string{"inspect", "--format", "{{json .State}}", name}, nil, &out, io.Discard)
+	var state struct {
+		Running   bool
+		Status    string
+		OOMKilled bool
+		Error     string
+	}
+	if err == nil && status == 0 && json.Unmarshal(out.Bytes(), &state) == nil {
+		if state.OOMKilled {
+			_, _ = fmt.Fprintln(r.Stderr, "Docker bootstrap container was OOM-killed")
+		}
+		if state.Running || state.Status == "created" || state.Error != "" {
+			return SetupFailure, fmt.Errorf("docker container failed to start or attachment ended while still running")
+		}
+	}
+	return code, nil
+}

--- a/internal/dockerbootstrap/runner.go
+++ b/internal/dockerbootstrap/runner.go
@@ -34,6 +34,7 @@ func (r Runner) Run(ctx context.Context, cfg Config) (code int, err error) {
 	if r.Stderr == nil {
 		r.Stderr = io.Discard
 	}
+	r.Client = withDiagnostics(r.Client, cfg.Environment)
 	// All cancellation cleanup shares one outer budget, including time spent
 	// waiting for a killed Docker client. Leave a little scheduling headroom
 	// before JobRunner SIGKILLs this supervisor.
@@ -61,14 +62,8 @@ func (r Runner) Run(ctx context.Context, cfg Config) (code int, err error) {
 	operation := func(parent context.Context, timeout time.Duration, args ...string) error {
 		callCtx, cancel := context.WithTimeout(parent, timeout)
 		defer cancel()
-		status, err := r.Client.Run(callCtx, args, nil, io.Discard, io.Discard)
-		if err != nil {
-			return fmt.Errorf("docker %s failed: %w", args[0], err)
-		}
-		if status != 0 {
-			return fmt.Errorf("docker %s failed (exit %d)", args[0], status)
-		}
-		return nil
+		_, err := r.Client.Run(callCtx, args, nil, io.Discard, io.Discard)
+		return err
 	}
 	if err := operation(ctx, cfg.OperationTimeout, "info"); err != nil {
 		return SetupFailure, err
@@ -84,10 +79,10 @@ func (r Runner) Run(ctx context.Context, cfg Config) (code int, err error) {
 	// Inspect only safe image identity fields, not image configuration or env.
 	var identity bytes.Buffer
 	inspectCtx, inspectCancel := context.WithTimeout(ctx, cfg.OperationTimeout)
-	status, inspectErr := r.Client.Run(inspectCtx, []string{"image", "inspect", "--format", "{{.Id}} {{json .RepoDigests}}", cfg.Image}, nil, &identity, io.Discard)
+	_, inspectErr := r.Client.Run(inspectCtx, []string{"image", "inspect", "--format", "{{.Id}} {{json .RepoDigests}}", cfg.Image}, nil, &identity, io.Discard)
 	inspectCancel()
-	if inspectErr != nil || status != 0 {
-		return SetupFailure, fmt.Errorf("docker image identity inspection failed")
+	if inspectErr != nil {
+		return SetupFailure, inspectErr
 	}
 	fields := strings.Fields(identity.String())
 	if len(fields) == 0 || !strings.HasPrefix(fields[0], "sha256:") {
@@ -112,9 +107,12 @@ func (r Runner) Run(ctx context.Context, cfg Config) (code int, err error) {
 		if listErr == nil && status == 0 && strings.TrimSpace(found.String()) == "" {
 			return
 		}
-		_, _ = fmt.Fprintln(r.Stderr, "Docker bootstrap cleanup failed; container may remain:", name)
+		_, _ = fmt.Fprintf(r.Stderr, "Docker bootstrap cleanup failed; container may remain: %s: %v\n", name, removeErr)
+		if listErr != nil {
+			_, _ = fmt.Fprintf(r.Stderr, "Could not verify container removal: %v\n", listErr)
+		}
 		if err == nil && code == 0 {
-			code, err = SetupFailure, fmt.Errorf("docker container cleanup failed")
+			code, err = SetupFailure, fmt.Errorf("docker container cleanup failed: %w", removeErr)
 		}
 	}()
 	args := append([]string{"create", "--pull", "never", "--name", name, "--label", "com.buildkite.bootstrap=docker", "--label", "com.buildkite.agent=true"}, job.args...)
@@ -136,10 +134,10 @@ exec /buildkite-docker/bin/buildkite-agent bootstrap`
 	createCtx, createCancel := context.WithTimeout(ctx, cfg.OperationTimeout)
 	// Keep stdout connected to the supervisor PTY so Docker records its initial
 	// console size. The only create output is the new container ID.
-	status, createErr := r.Client.Run(createCtx, args, job.env, r.Stdout, io.Discard)
+	_, createErr := r.Client.Run(createCtx, args, job.env, r.Stdout, io.Discard)
 	createCancel()
-	if createErr != nil || status != 0 {
-		return SetupFailure, fmt.Errorf("docker container create failed")
+	if createErr != nil {
+		return SetupFailure, createErr
 	}
 	if ctx.Err() != nil {
 		return SetupFailure, ctx.Err()
@@ -193,6 +191,9 @@ waiting:
 				}
 				attachCancel()
 				<-done
+				if probeErr != nil {
+					return SetupFailure, fmt.Errorf("docker startup check failed: %w", probeErr)
+				}
 				return SetupFailure, fmt.Errorf("docker container did not start within the operation timeout")
 			}
 			startupDeadline = nil

--- a/internal/dockerbootstrap/runner.go
+++ b/internal/dockerbootstrap/runner.go
@@ -161,6 +161,8 @@ exec /buildkite-docker/bin/buildkite-agent bootstrap`
 	startup := time.NewTimer(cfg.OperationTimeout)
 	defer startup.Stop()
 	startupDeadline := startup.C
+	draining := false
+	var drainProbeErr error
 waiting:
 	for {
 		select {
@@ -172,14 +174,22 @@ waiting:
 		case <-ctx.Done():
 			break waiting
 		case <-startupDeadline:
+			if draining {
+				attachCancel()
+				<-done
+				if drainProbeErr != nil {
+					return SetupFailure, fmt.Errorf("docker attachment did not finish within the drain timeout: %w", drainProbeErr)
+				}
+				return SetupFailure, fmt.Errorf("docker attachment did not finish within the drain timeout")
+			}
 			var state bytes.Buffer
 			probeCtx, probeCancel := context.WithTimeout(ctx, cfg.OperationTimeout)
-			status, probeErr := r.Client.Run(probeCtx, []string{"inspect", "--format", "{{.State.Running}}", name}, nil, &state, io.Discard)
+			_, probeErr := r.Client.Run(probeCtx, []string{"inspect", "--format", "{{.State.Status}}", name}, nil, &state, io.Discard)
 			probeCancel()
 			if ctx.Err() != nil {
 				break waiting
 			}
-			if probeErr != nil || status != 0 || strings.TrimSpace(state.String()) != "true" {
+			if probeErr == nil && strings.TrimSpace(state.String()) == "created" {
 				// Prefer a concurrently completed attachment, including fast exits.
 				select {
 				case result := <-done:
@@ -191,12 +201,18 @@ waiting:
 				}
 				attachCancel()
 				<-done
-				if probeErr != nil {
-					return SetupFailure, fmt.Errorf("docker startup check failed: %w", probeErr)
-				}
 				return SetupFailure, fmt.Errorf("docker container did not start within the operation timeout")
 			}
-			startupDeadline = nil
+			if status := strings.TrimSpace(state.String()); probeErr == nil && (status == "running" || status == "paused") {
+				startupDeadline = nil
+				continue
+			}
+			// An exited or auto-removed container can still have logs and exit
+			// status draining through start --attach. Even a failed inspection
+			// may race auto-removal; give attachment a bounded chance to finish.
+			draining, drainProbeErr = true, probeErr
+			startup.Reset(cfg.OperationTimeout)
+			startupDeadline = startup.C
 		}
 	}
 

--- a/internal/dockerbootstrap/runner.go
+++ b/internal/dockerbootstrap/runner.go
@@ -14,9 +14,7 @@ import (
 
 const SetupFailure = 125
 
-// Runner owns one container, including cleanup after partially completed create
-// operations. Cancellation of ctx initiates graceful container cancellation;
-// cleanup uses a separate bounded context.
+// Runner gives cancellation a grace period and reserves a separate cleanup budget.
 type Runner struct {
 	Client Clienter
 	Stdout io.Writer
@@ -35,9 +33,8 @@ func (r Runner) Run(ctx context.Context, cfg Config) (code int, err error) {
 		r.Stderr = io.Discard
 	}
 	r.Client = withDiagnostics(r.Client, cfg.Environment)
-	// All cancellation cleanup shares one outer budget, including time spent
-	// waiting for a killed Docker client. Leave a little scheduling headroom
-	// before JobRunner SIGKILLs this supervisor.
+	// Cleanup and client shutdown must finish before JobRunner's SIGKILL deadline.
+	// Reserve 10% of the cleanup margin for scheduling delays.
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	defer shutdownCancel()
 	go func() {
@@ -76,7 +73,7 @@ func (r Runner) Run(ctx context.Context, cfg Config) (code int, err error) {
 			return SetupFailure, err
 		}
 	}
-	// Inspect only safe image identity fields, not image configuration or env.
+	// Full inspection output could disclose image environment secrets in job logs.
 	var identity bytes.Buffer
 	inspectCtx, inspectCancel := context.WithTimeout(ctx, cfg.OperationTimeout)
 	_, inspectErr := r.Client.Run(inspectCtx, []string{"image", "inspect", "--format", "{{.Id}} {{json .RepoDigests}}", cfg.Image}, nil, &identity, io.Discard)
@@ -91,8 +88,8 @@ func (r Runner) Run(ctx context.Context, cfg Config) (code int, err error) {
 	imageID := fields[0]
 	_, _ = fmt.Fprintf(r.Stdout, "Docker bootstrap image: %s (%s)\n", cfg.Image, strings.TrimSpace(identity.String()))
 
-	// Register cleanup before create: Docker may create the container but lose
-	// the response, leaving us with only its preallocated unique name.
+	// Docker may create the container but lose the response; its name still
+	// allows cleanup after an apparently failed create.
 	defer func() {
 		cleanupCtx, cancel := context.WithTimeout(shutdownCtx, cfg.CleanupMargin)
 		defer cancel()
@@ -100,8 +97,7 @@ func (r Runner) Run(ctx context.Context, cfg Config) (code int, err error) {
 		if removeErr == nil && status == 0 {
 			return
 		}
-		// Auto-remove commonly wins the race. A successful list with no matching
-		// resource distinguishes an already-removed container from daemon loss.
+		// A failed remove can mean either auto-removal or daemon loss.
 		var found bytes.Buffer
 		status, listErr := r.Client.Run(cleanupCtx, []string{"ps", "--all", "--quiet", "--filter", "name=^/" + name + "$"}, nil, &found, io.Discard)
 		if listErr == nil && status == 0 && strings.TrimSpace(found.String()) == "" {
@@ -116,9 +112,19 @@ func (r Runner) Run(ctx context.Context, cfg Config) (code int, err error) {
 		}
 	}()
 	args := append([]string{"create", "--pull", "never", "--name", name, "--label", "com.buildkite.bootstrap=docker", "--label", "com.buildkite.agent=true"}, job.args...)
-	// Override the image entrypoint, validate the minimum image contract, and
-	// exec bootstrap so Docker's init forwards signals directly to it.
+	for _, label := range []struct{ key, variable string }{
+		{"com.buildkite.job-id", "BUILDKITE_JOB_ID"},
+		{"com.buildkite.agent-id", "BUILDKITE_AGENT_ID"},
+		{"com.buildkite.agent-name", "BUILDKITE_AGENT_NAME"},
+	} {
+		if value := job.env[label.variable]; value != "" {
+			args = append(args, "--label", label.key+"="+value)
+		}
+	}
+	// The mounted agent must take precedence over image binaries. exec lets
+	// Docker's init deliver signals directly to bootstrap.
 	const script = `set -e
+export PATH="/buildkite-docker/bin:$PATH"
 if ! test -x /buildkite-docker/bin/buildkite-agent || ! command -v git >/dev/null || ! command -v ssh >/dev/null; then
   echo 'Docker bootstrap image contract requires an executable agent binary, git, and ssh' >&2
   exit 125
@@ -128,12 +134,11 @@ if ! /buildkite-docker/bin/buildkite-agent --version >/dev/null; then
   exit 125
 fi
 exec /buildkite-docker/bin/buildkite-agent bootstrap`
-	// Use the inspected immutable ID so a concurrent tag update cannot change
-	// which image runs after we have logged its identity.
+	// A concurrent tag refresh must not change the image after inspection.
 	args = append(args, imageID, "-c", script)
 	createCtx, createCancel := context.WithTimeout(ctx, cfg.OperationTimeout)
-	// Keep stdout connected to the supervisor PTY so Docker records its initial
-	// console size. The only create output is the new container ID.
+	// Docker create reads console dimensions from stdout; capturing the ID
+	// through a pipe would lose the supervisor's PTY dimensions.
 	_, createErr := r.Client.Run(createCtx, args, job.env, r.Stdout, io.Discard)
 	createCancel()
 	if createErr != nil {
@@ -143,9 +148,8 @@ exec /buildkite-docker/bin/buildkite-agent bootstrap`
 		return SetupFailure, ctx.Err()
 	}
 
-	// Docker start --attach performs attach, wait registration, and start in
-	// that order. Launching separate attach/wait CLI processes cannot establish
-	// that ordering and loses fast exits when --rm is enabled.
+	// start --attach registers the exit observer before starting the container.
+	// Separate attach/wait processes can lose fast exits with --rm.
 	attachCtx, attachCancel := context.WithCancel(context.Background())
 	defer attachCancel()
 	type result struct {
@@ -157,7 +161,7 @@ exec /buildkite-docker/bin/buildkite-agent bootstrap`
 		code, err := r.Client.Run(attachCtx, []string{"start", "--attach", name}, nil, r.Stdout, r.Stderr)
 		done <- result{code, err}
 	}()
-	// Bound start/attach without imposing a wall-clock limit on a running job.
+	// The operation timeout must not limit a running job's duration.
 	startup := time.NewTimer(cfg.OperationTimeout)
 	defer startup.Stop()
 	startupDeadline := startup.C
@@ -190,7 +194,7 @@ waiting:
 				break waiting
 			}
 			if probeErr == nil && strings.TrimSpace(state.String()) == "created" {
-				// Prefer a concurrently completed attachment, including fast exits.
+				// Inspection may be stale by the time attachment completes.
 				select {
 				case result := <-done:
 					if result.err != nil || result.code < 0 {
@@ -207,23 +211,22 @@ waiting:
 				startupDeadline = nil
 				continue
 			}
-			// An exited or auto-removed container can still have logs and exit
-			// status draining through start --attach. Even a failed inspection
-			// may race auto-removal; give attachment a bounded chance to finish.
+			// Logs and exit status may still be draining after exit or auto-removal,
+			// including when inspection fails because the container is already gone.
 			draining, drainProbeErr = true, probeErr
 			startup.Reset(cfg.OperationTimeout)
 			startupDeadline = startup.C
 		}
 	}
 
-	// Signal delivery may race with container startup. Retry until Docker
-	// accepts the signal, attachment finishes, or the inner grace expires.
+	// Docker cannot signal a container that has not started yet.
 	graceCtx, graceCancel := context.WithTimeout(context.Background(), job.grace)
 	defer graceCancel()
 	signal := job.env["BUILDKITE_CANCEL_SIGNAL"]
 	if signal == "" || signal == "SIGKILL" {
 		signal = "SIGTERM"
 	}
+	retryDelay := 50 * time.Millisecond
 	for {
 		if err := operation(graceCtx, cfg.OperationTimeout, "kill", "--signal", signal, name); err == nil {
 			break
@@ -236,7 +239,8 @@ waiting:
 			return r.completed(shutdownCtx, cfg.CleanupMargin/4, name, result.code)
 		case <-graceCtx.Done():
 			goto force
-		case <-time.After(50 * time.Millisecond):
+		case <-time.After(retryDelay):
+			retryDelay = min(2*retryDelay, time.Second)
 		}
 	}
 	select {
@@ -249,15 +253,15 @@ waiting:
 	}
 force:
 	_, _ = fmt.Fprintln(r.Stderr, "Docker bootstrap cancellation grace expired; forcing container removal")
-	// Deferred force-remove kills the container as well as removing it. Stop
-	// the attached CLI now so it cannot outlive the supervisor.
+	// The deferred force-remove kills the container; the separate CLI process
+	// also needs cancellation to avoid outliving the supervisor.
 	attachCancel()
 	<-done
 	return 137, nil
 }
 
-// completed distinguishes known runtime/client failures from bootstrap exits.
-// Auto-remove can win the race, so a missing state preserves the CLI exit code.
+// Auto-removal can erase the evidence needed to distinguish a Docker failure
+// from a job exit; preserve the CLI status when inspection is unavailable.
 func (r Runner) completed(ctx context.Context, timeout time.Duration, name string, code int) (int, error) {
 	if code == 0 {
 		return 0, nil

--- a/internal/dockerbootstrap/runner.go
+++ b/internal/dockerbootstrap/runner.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 )
@@ -26,13 +27,14 @@ func (r Runner) Run(ctx context.Context, cfg Config) (code int, err error) {
 	if err != nil {
 		return SetupFailure, err
 	}
+	defer func() { _ = os.RemoveAll(job.userDirectory) }()
 	if r.Stdout == nil {
 		r.Stdout = io.Discard
 	}
 	if r.Stderr == nil {
 		r.Stderr = io.Discard
 	}
-	r.Client = withDiagnostics(r.Client, cfg.Environment)
+	r.Client = withDiagnostics(r.Client, cfg.Environment, cfg.RedactedValues...)
 	// Cleanup and client shutdown must finish before JobRunner's SIGKILL deadline.
 	// Reserve 10% of the cleanup margin for scheduling delays.
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
@@ -65,14 +67,22 @@ func (r Runner) Run(ctx context.Context, cfg Config) (code int, err error) {
 	if err := operation(ctx, cfg.OperationTimeout, "info"); err != nil {
 		return SetupFailure, err
 	}
-	if err := operation(ctx, cfg.OperationTimeout, "image", "inspect", cfg.Image); err != nil {
+	if cfg.PullPolicy == "always" {
+		if err := operation(ctx, cfg.PullTimeout, "pull", cfg.Image); err != nil {
+			return SetupFailure, err
+		}
+	} else if err := operation(ctx, cfg.OperationTimeout, "image", "inspect", cfg.Image); err != nil {
 		if ctx.Err() != nil {
 			return SetupFailure, ctx.Err()
+		}
+		if cfg.PullPolicy == "never" {
+			return SetupFailure, fmt.Errorf("pull-policy never requires a cached image: %w", err)
 		}
 		if err := operation(ctx, cfg.PullTimeout, "pull", cfg.Image); err != nil {
 			return SetupFailure, err
 		}
 	}
+
 	// Full inspection output could disclose image environment secrets in job logs.
 	var identity bytes.Buffer
 	inspectCtx, inspectCancel := context.WithTimeout(ctx, cfg.OperationTimeout)
@@ -125,6 +135,19 @@ func (r Runner) Run(ctx context.Context, cfg Config) (code int, err error) {
 	// Docker's init deliver signals directly to bootstrap.
 	const script = `set -e
 export PATH="/buildkite-docker/bin:$PATH"
+for path in "$BUILDKITE_ENV_FILE" "$BUILDKITE_ENV_JSON_FILE"; do
+  if ! test -r "$path"; then
+    echo "Docker bootstrap user cannot read private job context: $path" >&2
+    exit 125
+  fi
+done
+for path in "$HOME" "$BUILDKITE_BUILD_PATH" "${BUILDKITE_PLUGINS_PATH:-}" "${BUILDKITE_GIT_MIRRORS_PATH:-}" "${BUILDKITE_BUILD_CHECKOUT_PATH:-}"; do
+  if test -n "$path" && test -e "$path" && { ! test -w "$path" || ! test -x "$path"; }; then
+    echo "Docker bootstrap user cannot write directory: $path; provision permissions for the configured UID:GID" >&2
+    exit 125
+  fi
+done
+cd "$BUILDKITE_BUILD_PATH"
 if ! test -x /buildkite-docker/bin/buildkite-agent || ! command -v git >/dev/null || ! command -v ssh >/dev/null; then
   echo 'Docker bootstrap image contract requires an executable agent binary, git, and ssh' >&2
   exit 125

--- a/internal/dockerbootstrap/runner.go
+++ b/internal/dockerbootstrap/runner.go
@@ -57,7 +57,8 @@ func (r Runner) Run(ctx context.Context, cfg Config) (code int, err error) {
 	if _, err := rand.Read(suffix[:]); err != nil {
 		return SetupFailure, err
 	}
-	name := "buildkite-bootstrap-" + hex.EncodeToString(suffix[:])
+	id := hex.EncodeToString(suffix[:])
+	name, network := "buildkite_job_"+id, "buildkite_network_"+id
 	operation := func(parent context.Context, timeout time.Duration, args ...string) error {
 		callCtx, cancel := context.WithTimeout(parent, timeout)
 		defer cancel()
@@ -98,39 +99,32 @@ func (r Runner) Run(ctx context.Context, cfg Config) (code int, err error) {
 	imageID := fields[0]
 	_, _ = fmt.Fprintf(r.Stdout, "Docker bootstrap image: %s (%s)\n", cfg.Image, strings.TrimSpace(identity.String()))
 
-	// Docker may create the container but lose the response; its name still
-	// allows cleanup after an apparently failed create.
+	// Register cleanup before creation: Docker may succeed but lose the response.
+	containerAttempted := false
 	defer func() {
 		cleanupCtx, cancel := context.WithTimeout(shutdownCtx, cfg.CleanupMargin)
 		defer cancel()
-		status, removeErr := r.Client.Run(cleanupCtx, []string{"rm", "--force", name}, nil, io.Discard, io.Discard)
-		if removeErr == nil && status == 0 {
-			return
+		if containerAttempted {
+			containerCtx, containerCancel := context.WithTimeout(cleanupCtx, cfg.CleanupMargin/2)
+			cleanupErr := r.removeResource(containerCtx, "container", name)
+			containerCancel()
+			if cleanupErr != nil && err == nil && code == 0 {
+				code, err = SetupFailure, cleanupErr
+			}
 		}
-		// A failed remove can mean either auto-removal or daemon loss.
-		var found bytes.Buffer
-		status, listErr := r.Client.Run(cleanupCtx, []string{"ps", "--all", "--quiet", "--filter", "name=^/" + name + "$"}, nil, &found, io.Discard)
-		if listErr == nil && status == 0 && strings.TrimSpace(found.String()) == "" {
-			return
-		}
-		_, _ = fmt.Fprintf(r.Stderr, "Docker bootstrap cleanup failed; container may remain: %s: %v\n", name, removeErr)
-		if listErr != nil {
-			_, _ = fmt.Fprintf(r.Stderr, "Could not verify container removal: %v\n", listErr)
-		}
-		if err == nil && code == 0 {
-			code, err = SetupFailure, fmt.Errorf("docker container cleanup failed: %w", removeErr)
+		if cleanupErr := r.removeResource(cleanupCtx, "network", network); cleanupErr != nil && err == nil && code == 0 {
+			code, err = SetupFailure, cleanupErr
 		}
 	}()
-	args := append([]string{"create", "--pull", "never", "--name", name, "--label", "com.buildkite.bootstrap=docker", "--label", "com.buildkite.agent=true"}, job.args...)
-	for _, label := range []struct{ key, variable string }{
-		{"com.buildkite.job-id", "BUILDKITE_JOB_ID"},
-		{"com.buildkite.agent-id", "BUILDKITE_AGENT_ID"},
-		{"com.buildkite.agent-name", "BUILDKITE_AGENT_NAME"},
-	} {
-		if value := job.env[label.variable]; value != "" {
-			args = append(args, "--label", label.key+"="+value)
-		}
+	labels := resourceLabels(job.env)
+	networkArgs := append([]string{"network", "create", "--driver", "bridge"}, labels...)
+	networkArgs = append(networkArgs, network)
+	if err := operation(ctx, cfg.OperationTimeout, networkArgs...); err != nil {
+		return SetupFailure, err
 	}
+	_, _ = fmt.Fprintf(r.Stdout, "Docker bootstrap network: %s\n", network)
+	args := append([]string{"create", "--pull", "never", "--name", name, "--network", network}, labels...)
+	args = append(args, job.args...)
 	// The mounted agent must take precedence over image binaries. exec lets
 	// Docker's init deliver signals directly to bootstrap.
 	const script = `set -e
@@ -162,6 +156,7 @@ exec /buildkite-docker/bin/buildkite-agent bootstrap`
 	createCtx, createCancel := context.WithTimeout(ctx, cfg.OperationTimeout)
 	// Docker create reads console dimensions from stdout; capturing the ID
 	// through a pipe would lose the supervisor's PTY dimensions.
+	containerAttempted = true
 	_, createErr := r.Client.Run(createCtx, args, job.env, r.Stdout, io.Discard)
 	createCancel()
 	if createErr != nil {

--- a/internal/dockerbootstrap/runner_test.go
+++ b/internal/dockerbootstrap/runner_test.go
@@ -1,0 +1,321 @@
+package dockerbootstrap
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func testConfig(t *testing.T) Config {
+	t.Helper()
+	base := t.TempDir()
+	contextDir := filepath.Join(base, "context")
+	if err := os.Mkdir(contextDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	values := map[string]string{
+		ContextEnv:                         contextDir,
+		"BUILDKITE_ENV_FILE":               filepath.Join(contextDir, "env"),
+		"BUILDKITE_ENV_JSON_FILE":          filepath.Join(contextDir, "env.json"),
+		"BUILDKITE_AGENT_JOB_TIMEOUT_FILE": filepath.Join(contextDir, "timeout"),
+		"BUILDKITE_BUILD_PATH":             filepath.Join(base, "builds"),
+		"BUILDKITE_CANCEL_SIGNAL_TIMEOUT":  "200ms",
+		"BUILDKITE_CANCEL_SIGNAL":          "SIGTERM",
+		"BUILDKITE_AGENT_ACCESS_TOKEN":     "private-token",
+		"MULTILINE":                        "  hello\n世界\n",
+		"PATH":                             "/host/path",
+		"HOME":                             "/host/home",
+		"HOST_SECRET":                      "do-not-forward",
+	}
+	data, _ := json.Marshal(map[string]string{"MULTILINE": values["MULTILINE"], "PATH": values["PATH"], "HOME": values["HOME"]})
+	if err := os.WriteFile(values["BUILDKITE_ENV_JSON_FILE"], data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	binary := filepath.Join(base, "buildkite-agent")
+	if err := os.WriteFile(binary, []byte("test binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := Config{Image: DefaultImage, Binary: binary, CleanupMargin: 100 * time.Millisecond, OperationTimeout: time.Second, PullTimeout: time.Second}
+	for name, value := range values {
+		cfg.Environment = append(cfg.Environment, name+"="+value)
+	}
+	return cfg
+}
+
+type fakeClient struct {
+	mu    sync.Mutex
+	calls [][]string
+	run   func(context.Context, []string, map[string]string, io.Writer, io.Writer) (int, error)
+}
+
+func (f *fakeClient) Run(ctx context.Context, args []string, env map[string]string, out, stderr io.Writer) (int, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, slices.Clone(args))
+	f.mu.Unlock()
+	if args[0] == "image" && slices.Contains(args, "--format") {
+		_, _ = fmt.Fprintln(out, "sha256:"+strings.Repeat("a", 64)+" []")
+	}
+	if f.run != nil {
+		return f.run(ctx, args, env, out, stderr)
+	}
+	return 0, nil
+}
+
+func (f *fakeClient) called(command string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, call := range f.calls {
+		if call[0] == command {
+			return true
+		}
+	}
+	return false
+}
+
+func TestEnvironmentAndMounts(t *testing.T) {
+	cfg := testConfig(t)
+	job, err := prepare(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := job.env["MULTILINE"]; got != "  hello\n世界\n" {
+		t.Fatalf("multiline value changed: %q", got)
+	}
+	if job.env["BUILDKITE_AGENT_ACCESS_TOKEN"] != "private-token" {
+		t.Fatal("missing token")
+	}
+	for _, name := range []string{"HOST_SECRET", "HOME", "PATH", ContextEnv} {
+		if _, ok := job.env[name]; ok {
+			t.Errorf("forwarded host variable %s", name)
+		}
+	}
+	args := strings.Join(job.args, " ")
+	for _, forbidden := range []string{"private-token", "hello", "/var/run/docker.sock"} {
+		if strings.Contains(args, forbidden) {
+			t.Errorf("unexpected value in args: %s", forbidden)
+		}
+	}
+	if !strings.Contains(args, "dst="+containerBinary+",readonly") {
+		t.Fatal("missing read-only agent mount")
+	}
+	if job.env["BUILDKITE_CANCEL_SIGNAL_TIMEOUT"] != "100ms" {
+		t.Fatal("inner cancellation budget not reduced")
+	}
+}
+
+func TestValidation(t *testing.T) {
+	for _, tc := range []struct{ name, variable, value string }{
+		{"short cancellation", "BUILDKITE_CANCEL_SIGNAL_TIMEOUT", "50ms"},
+		{"shared context", ContextEnv, "/tmp"},
+		{"foreign timeout", "BUILDKITE_AGENT_JOB_TIMEOUT_FILE", "/other/job"},
+		{"broad build mount", "BUILDKITE_BUILD_PATH", "/tmp"},
+		{"relative build", "BUILDKITE_BUILD_PATH", "builds"},
+		{"loopback API", "BUILDKITE_AGENT_ENDPOINT", "http://127.0.0.1:3000"},
+		{"bad name", "BUILDKITE_BAD\nNAME", "secret"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := testConfig(t)
+			cfg.Environment = append(cfg.Environment, tc.variable+"="+tc.value)
+			if _, err := prepare(cfg); err == nil {
+				t.Fatal("expected rejection")
+			}
+		})
+	}
+}
+
+func TestExitStatusAndOutput(t *testing.T) {
+	for _, want := range []int{0, 1, 42, 125, 137, 143, 255} {
+		t.Run(fmt.Sprint(want), func(t *testing.T) {
+			cfg := testConfig(t)
+			f := &fakeClient{run: func(_ context.Context, args []string, _ map[string]string, out, stderr io.Writer) (int, error) {
+				if args[0] == "start" {
+					_, _ = fmt.Fprint(out, "job stdout")
+					_, _ = fmt.Fprint(stderr, "job stderr")
+					return want, nil
+				}
+				return 0, nil
+			}}
+			var out, stderr bytes.Buffer
+			code, err := (Runner{Client: f, Stdout: &out, Stderr: &stderr}).Run(t.Context(), cfg)
+			if code != want || err != nil {
+				t.Fatalf("got (%d, %v), want %d", code, err, want)
+			}
+			if !strings.Contains(out.String(), "job stdout") || !strings.Contains(stderr.String(), "job stderr") {
+				t.Fatal("lost output")
+			}
+			if !f.called("rm") {
+				t.Fatal("container not removed")
+			}
+		})
+	}
+}
+
+func TestPartialFailureCleanup(t *testing.T) {
+	for _, command := range []string{"info", "pull", "create", "start"} {
+		t.Run(command, func(t *testing.T) {
+			f := &fakeClient{run: func(_ context.Context, args []string, _ map[string]string, _, _ io.Writer) (int, error) {
+				if command == "pull" && args[0] == "image" {
+					return 1, nil
+				}
+				if args[0] == command {
+					return 0, errors.New("injected failure")
+				}
+				return 0, nil
+			}}
+			code, err := (Runner{Client: f}).Run(t.Context(), testConfig(t))
+			if code != SetupFailure || err == nil {
+				t.Fatalf("got (%d, %v)", code, err)
+			}
+			if want := command == "create" || command == "start"; f.called("rm") != want {
+				t.Fatalf("cleanup called = %t, want %t", f.called("rm"), want)
+			}
+		})
+	}
+}
+
+func TestCancellation(t *testing.T) {
+	for _, graceful := range []bool{true, false} {
+		t.Run(fmt.Sprintf("graceful=%t", graceful), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			signaled := make(chan struct{})
+			f := &fakeClient{run: func(ctx context.Context, args []string, _ map[string]string, _, _ io.Writer) (int, error) {
+				switch args[0] {
+				case "start":
+					cancel()
+					if graceful {
+						<-signaled
+						return 143, nil
+					}
+					<-ctx.Done()
+					return 0, ctx.Err()
+				case "kill":
+					if !slices.Contains(args, "SIGTERM") {
+						t.Error("missing cancellation signal")
+					}
+					close(signaled)
+				}
+				return 0, nil
+			}}
+			code, err := (Runner{Client: f}).Run(ctx, testConfig(t))
+			want := 137
+			if graceful {
+				want = 143
+			}
+			if err != nil || code != want {
+				t.Fatalf("got (%d, %v), want %d", code, err, want)
+			}
+			if !f.called("rm") {
+				t.Fatal("container not removed")
+			}
+		})
+	}
+}
+
+func TestAlreadyRemovedIsSuccess(t *testing.T) {
+	f := &fakeClient{run: func(_ context.Context, args []string, _ map[string]string, _, _ io.Writer) (int, error) {
+		if args[0] == "rm" {
+			return 1, nil
+		}
+		return 0, nil
+	}}
+	if code, err := (Runner{Client: f}).Run(t.Context(), testConfig(t)); code != 0 || err != nil {
+		t.Fatalf("got (%d, %v)", code, err)
+	}
+	if !f.called("ps") {
+		t.Fatal("missing removal verification")
+	}
+}
+
+func TestCancellationDuringSetup(t *testing.T) {
+	for _, phase := range []string{"pull", "create"} {
+		t.Run(phase, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			f := &fakeClient{run: func(ctx context.Context, args []string, _ map[string]string, _, _ io.Writer) (int, error) {
+				if phase == "pull" && args[0] == "image" {
+					return 1, nil
+				}
+				if args[0] == phase {
+					cancel()
+					<-ctx.Done()
+					return 0, ctx.Err()
+				}
+				if args[0] == "rm" && ctx.Err() != nil {
+					t.Error("cleanup inherited cancelled setup context")
+				}
+				return 0, nil
+			}}
+			code, err := (Runner{Client: f}).Run(ctx, testConfig(t))
+			if code != SetupFailure || err == nil {
+				t.Fatalf("got (%d, %v)", code, err)
+			}
+			if f.called("start") {
+				t.Fatal("started a cancelled job")
+			}
+			if f.called("rm") != (phase == "create") {
+				t.Fatal("incorrect partial-create cleanup")
+			}
+		})
+	}
+}
+
+func TestStartupTimeout(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.OperationTimeout = 20 * time.Millisecond
+	f := &fakeClient{run: func(ctx context.Context, args []string, _ map[string]string, _, _ io.Writer) (int, error) {
+		if args[0] == "start" {
+			<-ctx.Done()
+			return 0, ctx.Err()
+		}
+		return 0, nil
+	}}
+	code, err := (Runner{Client: f}).Run(t.Context(), cfg)
+	if code != SetupFailure || err == nil || !strings.Contains(err.Error(), "did not start") {
+		t.Fatalf("got (%d, %v)", code, err)
+	}
+	if !f.called("rm") {
+		t.Fatal("startup timeout left container behind")
+	}
+}
+
+func TestRuntimeFailureAndOOMDiagnostics(t *testing.T) {
+	for _, tc := range []struct {
+		name, state string
+		exit, want  int
+	}{
+		{"start failed", `{"Status":"created"}`, 1, SetupFailure},
+		{"lost attachment", `{"Running":true}`, 1, SetupFailure},
+		{"OOM", `{"OOMKilled":true,"Status":"exited"}`, 137, 137},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeClient{run: func(_ context.Context, args []string, _ map[string]string, out, _ io.Writer) (int, error) {
+				if args[0] == "start" {
+					return tc.exit, nil
+				}
+				if args[0] == "inspect" {
+					_, _ = fmt.Fprint(out, tc.state)
+				}
+				return 0, nil
+			}}
+			var stderr bytes.Buffer
+			code, _ := (Runner{Client: f, Stderr: &stderr}).Run(t.Context(), testConfig(t))
+			if code != tc.want {
+				t.Fatalf("got %d, want %d", code, tc.want)
+			}
+			if tc.name == "OOM" && !strings.Contains(stderr.String(), "OOM-killed") {
+				t.Fatal("missing OOM diagnostic")
+			}
+		})
+	}
+}

--- a/internal/dockerbootstrap/runner_test.go
+++ b/internal/dockerbootstrap/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -18,6 +19,9 @@ import (
 
 func testConfig(t *testing.T) Config {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("Docker bootstrap mounts require POSIX filesystem paths")
+	}
 	base := t.TempDir()
 	contextDir := filepath.Join(base, "context")
 	if err := os.Mkdir(contextDir, 0o700); err != nil {
@@ -273,10 +277,13 @@ func TestCancellationDuringSetup(t *testing.T) {
 func TestStartupTimeout(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.OperationTimeout = 20 * time.Millisecond
-	f := &fakeClient{run: func(ctx context.Context, args []string, _ map[string]string, _, _ io.Writer) (int, error) {
+	f := &fakeClient{run: func(ctx context.Context, args []string, _ map[string]string, out, _ io.Writer) (int, error) {
 		if args[0] == "start" {
 			<-ctx.Done()
 			return 0, ctx.Err()
+		}
+		if args[0] == "inspect" {
+			_, _ = io.WriteString(out, "created")
 		}
 		return 0, nil
 	}}
@@ -286,6 +293,118 @@ func TestStartupTimeout(t *testing.T) {
 	}
 	if !f.called("rm") {
 		t.Fatal("startup timeout left container behind")
+	}
+}
+
+func TestStartupProbePreservesDrainingCompletion(t *testing.T) {
+	for _, state := range []string{"exited", "removed", "running"} {
+		t.Run(state, func(t *testing.T) {
+			cfg := testConfig(t)
+			cfg.OperationTimeout = 100 * time.Millisecond
+			probed := make(chan struct{})
+			f := &fakeClient{run: func(ctx context.Context, args []string, _ map[string]string, out, _ io.Writer) (int, error) {
+				switch args[0] {
+				case "start":
+					select {
+					case <-probed:
+					case <-ctx.Done():
+						return 0, ctx.Err()
+					}
+					// Inspection finishes before attachment returns its final logs
+					// and status. Running jobs must outlive the drain timeout too.
+					delay := 20 * time.Millisecond
+					if state == "running" {
+						delay = 2 * cfg.OperationTimeout
+					}
+					select {
+					case <-time.After(delay):
+						_, _ = io.WriteString(out, "final job output\n")
+						return 42, nil
+					case <-ctx.Done():
+						return 0, ctx.Err()
+					}
+				case "inspect":
+					if slices.Contains(args, "{{.State.Status}}") {
+						close(probed)
+						if state == "removed" {
+							return 1, nil
+						}
+						_, _ = io.WriteString(out, state)
+					} else {
+						return 1, nil
+					} // Auto-remove wins final inspection.
+				}
+				return 0, nil
+			}}
+			var out bytes.Buffer
+			code, err := (Runner{Client: f, Stdout: &out}).Run(t.Context(), cfg)
+			if code != 42 || err != nil {
+				t.Fatalf("got (%d, %v), want (42, nil)", code, err)
+			}
+			if !strings.Contains(out.String(), "final job output") {
+				t.Fatal("lost final output")
+			}
+			if !f.called("rm") {
+				t.Fatal("container not removed")
+			}
+		})
+	}
+}
+
+func TestAttachmentDrainIsBounded(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.OperationTimeout = 20 * time.Millisecond
+	f := &fakeClient{run: func(ctx context.Context, args []string, _ map[string]string, out, _ io.Writer) (int, error) {
+		if args[0] == "start" {
+			<-ctx.Done()
+			return 0, ctx.Err()
+		}
+		if args[0] == "inspect" {
+			_, _ = io.WriteString(out, "exited")
+		}
+		return 0, nil
+	}}
+	code, err := (Runner{Client: f}).Run(t.Context(), cfg)
+	if code != SetupFailure || err == nil || !strings.Contains(err.Error(), "drain timeout") {
+		t.Fatalf("got (%d, %v)", code, err)
+	}
+	if !f.called("rm") {
+		t.Fatal("drain timeout left container behind")
+	}
+}
+
+func TestScalarMountPathsRejectCommasBeforeCreatingDirectories(t *testing.T) {
+	for _, name := range []string{"BUILDKITE_BUILD_PATH", "BUILDKITE_PLUGINS_PATH", "BUILDKITE_HOOKS_PATH", "BUILDKITE_GIT_MIRRORS_PATH"} {
+		t.Run(name, func(t *testing.T) {
+			cfg := testConfig(t)
+			base := t.TempDir()
+			left, right := filepath.Join(base, "left"), filepath.Join(base, "right")
+			cfg.Environment = append(cfg.Environment, name+"="+left+","+right)
+			if _, err := prepare(cfg); err == nil || !strings.Contains(err.Error(), name) {
+				t.Fatalf("expected scalar-path rejection, got %v", err)
+			}
+			for _, path := range []string{left, right, left + "," + right} {
+				if _, err := os.Stat(path); !os.IsNotExist(err) {
+					t.Errorf("unexpected filesystem change at %s: %v", path, err)
+				}
+			}
+		})
+	}
+}
+
+func TestAdditionalHooksPathsRemainAList(t *testing.T) {
+	cfg := testConfig(t)
+	first, second := t.TempDir(), t.TempDir()
+	cfg.Environment = append(cfg.Environment, "BUILDKITE_ADDITIONAL_HOOKS_PATHS="+first+","+second)
+	job, err := prepare(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{first, second} {
+		mount := "type=bind,src=" + path + ",dst=" + path + ",readonly"
+		if !slices.Contains(job.args, mount) {
+			t.Errorf("missing read-only hook mount %s", path)
+		}
 	}
 }
 

--- a/internal/dockerbootstrap/runner_test.go
+++ b/internal/dockerbootstrap/runner_test.go
@@ -165,6 +165,9 @@ func TestExitStatusAndOutput(t *testing.T) {
 			if !f.called("rm") {
 				t.Fatal("container not removed")
 			}
+			if last := f.calls[len(f.calls)-1]; !slices.Equal(last[:2], []string{"network", "rm"}) {
+				t.Fatal("network not removed")
+			}
 		})
 	}
 }
@@ -226,6 +229,9 @@ func TestCancellation(t *testing.T) {
 			}
 			if !f.called("rm") {
 				t.Fatal("container not removed")
+			}
+			if last := f.calls[len(f.calls)-1]; !slices.Equal(last[:2], []string{"network", "rm"}) {
+				t.Fatal("network not removed")
 			}
 		})
 	}
@@ -350,6 +356,9 @@ func TestStartupProbePreservesDrainingCompletion(t *testing.T) {
 			}
 			if !f.called("rm") {
 				t.Fatal("container not removed")
+			}
+			if last := f.calls[len(f.calls)-1]; !slices.Equal(last[:2], []string{"network", "rm"}) {
+				t.Fatal("network not removed")
 			}
 		})
 	}

--- a/internal/dockerbootstrap/runner_test.go
+++ b/internal/dockerbootstrap/runner_test.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -310,8 +312,7 @@ func TestStartupProbePreservesDrainingCompletion(t *testing.T) {
 					case <-ctx.Done():
 						return 0, ctx.Err()
 					}
-					// Inspection finishes before attachment returns its final logs
-					// and status. Running jobs must outlive the drain timeout too.
+					// Simulate buffered output arriving after inspection completes.
 					delay := 20 * time.Millisecond
 					if state == "running" {
 						delay = 2 * cfg.OperationTimeout
@@ -436,5 +437,116 @@ func TestRuntimeFailureAndOOMDiagnostics(t *testing.T) {
 				t.Fatal("missing OOM diagnostic")
 			}
 		})
+	}
+}
+
+func TestProxyLoopbackWithoutScheme(t *testing.T) {
+	for _, value := range []string{"localhost:3128", "127.0.0.1:3128", "[::1]:3128", "//localhost:3128", "http://localhost:3128", "proxy.example:3128"} {
+		t.Run(value, func(t *testing.T) {
+			cfg := testConfig(t)
+			cfg.Environment = append(cfg.Environment, "HTTP_PROXY="+value)
+			for _, entry := range cfg.Environment {
+				if filename, ok := strings.CutPrefix(entry, "BUILDKITE_ENV_JSON_FILE="); ok {
+					if err := os.WriteFile(filename, []byte(`{"HTTP_PROXY":""}`), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			_, err := prepare(cfg)
+			if (err != nil) != !strings.HasPrefix(value, "proxy.example") {
+				t.Fatalf("prepare: %v", err)
+			}
+		})
+	}
+}
+
+func TestNonPTY(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Environment = append(cfg.Environment, "BUILDKITE_PTY=false", "TERM=host-terminal")
+	job, err := prepare(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(job.args, "--tty") {
+		t.Fatal("non-PTY job requests a tty")
+	}
+	if _, ok := job.env["TERM"]; ok {
+		t.Fatal("inherited host TERM for non-PTY job")
+	}
+}
+
+func TestAgentSocketMounts(t *testing.T) {
+	cfg := testConfig(t)
+	// Keep Unix socket paths below the macOS length limit.
+	base, err := os.MkdirTemp("/tmp", "bk-sockets-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(base); err != nil {
+			t.Error(err)
+		}
+	})
+	for _, name := range []string{"agent-123", "agent-leader", "agent-456"} {
+		listener, err := net.Listen("unix", filepath.Join(base, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if err := listener.Close(); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+	cfg.Environment = append(cfg.Environment, "BUILDKITE_SOCKETS_PATH="+base, "BUILDKITE_AGENT_PID=123")
+	job, err := prepare(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"agent-123", "agent-leader"} {
+		want := "type=bind,src=" + filepath.Join(base, name) + ",dst=" + containerRoot + "/sockets/" + name
+		if !slices.Contains(job.args, want) {
+			t.Errorf("missing mount %s", name)
+		}
+	}
+	if strings.Contains(strings.Join(job.args, " "), "agent-456") {
+		t.Fatal("mounted another agent's socket")
+	}
+}
+
+func TestContainerLabelsAndBinaryPrecedence(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Environment = append(cfg.Environment, "BUILDKITE_JOB_ID=test-job", "BUILDKITE_AGENT_ID=test-agent", "BUILDKITE_AGENT_NAME=test-worker")
+	f := &fakeClient{run: func(_ context.Context, args []string, _ map[string]string, _, _ io.Writer) (int, error) {
+		if args[0] == "create" {
+			for _, label := range []string{"com.buildkite.job-id=test-job", "com.buildkite.agent-id=test-agent", "com.buildkite.agent-name=test-worker"} {
+				if !slices.Contains(args, label) {
+					t.Errorf("missing label %s", label)
+				}
+			}
+			script := args[len(args)-1]
+			mountedDir, imageDir := t.TempDir(), t.TempDir()
+			mounted := filepath.Join(mountedDir, "buildkite-agent")
+			for path, content := range map[string]string{
+				mounted: "#!/bin/sh\nif [ \"$1\" = --version ]; then exit 0; fi\ncommand -v buildkite-agent\n",
+				filepath.Join(imageDir, "buildkite-agent"): "#!/bin/sh\nexit 99\n",
+			} {
+				if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			// An image-provided agent must not shadow the mounted binary.
+			script = strings.ReplaceAll(script, filepath.Dir(containerBinary), mountedDir)
+			cmd := exec.CommandContext(t.Context(), "/bin/sh", "-c", script)
+			cmd.Env = []string{"PATH=" + imageDir + ":/usr/bin:/bin"}
+			output, err := cmd.CombinedOutput()
+			if err != nil || strings.TrimSpace(string(output)) != mounted {
+				t.Fatalf("agent resolution: %q, %v", output, err)
+			}
+		}
+		return 0, nil
+	}}
+	if _, err := (Runner{Client: f, Stdout: io.Discard, Stderr: io.Discard}).Run(t.Context(), cfg); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/dockerbootstrap/runner_test.go
+++ b/internal/dockerbootstrap/runner_test.go
@@ -47,6 +47,9 @@ func testConfig(t *testing.T) Config {
 	if err := os.WriteFile(values["BUILDKITE_ENV_JSON_FILE"], data, 0o600); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(values["BUILDKITE_ENV_FILE"], nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
 	binary := filepath.Join(base, "buildkite-agent")
 	if err := os.WriteFile(binary, []byte("test binary"), 0o755); err != nil {
 		t.Fatal(err)
@@ -100,7 +103,7 @@ func TestEnvironmentAndMounts(t *testing.T) {
 	if job.env["BUILDKITE_AGENT_ACCESS_TOKEN"] != "private-token" {
 		t.Fatal("missing token")
 	}
-	for _, name := range []string{"HOST_SECRET", "HOME", "PATH", ContextEnv} {
+	for _, name := range []string{"HOST_SECRET", "PATH", ContextEnv} {
 		if _, ok := job.env[name]; ok {
 			t.Errorf("forwarded host variable %s", name)
 		}
@@ -538,7 +541,7 @@ func TestContainerLabelsAndBinaryPrecedence(t *testing.T) {
 			// An image-provided agent must not shadow the mounted binary.
 			script = strings.ReplaceAll(script, filepath.Dir(containerBinary), mountedDir)
 			cmd := exec.CommandContext(t.Context(), "/bin/sh", "-c", script)
-			cmd.Env = []string{"PATH=" + imageDir + ":/usr/bin:/bin"}
+			cmd.Env = append(append([]string(nil), cfg.Environment...), "HOME="+mountedDir, "PATH="+imageDir+":/usr/bin:/bin")
 			output, err := cmd.CombinedOutput()
 			if err != nil || strings.TrimSpace(string(output)) != mounted {
 				t.Fatalf("agent resolution: %q, %v", output, err)

--- a/internal/dockerbootstrap/user.go
+++ b/internal/dockerbootstrap/user.go
@@ -1,0 +1,122 @@
+package dockerbootstrap
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func containerUser(value string) (int, int, error) {
+	if value == "" {
+		return os.Getuid(), os.Getgid(), nil
+	}
+	user, group, ok := strings.Cut(value, ":")
+	if !ok {
+		return 0, 0, fmt.Errorf("user must be a numeric UID:GID")
+	}
+	uid, err := parseUserID(user)
+	if err != nil {
+		return 0, 0, err
+	}
+	gid, err := parseUserID(group)
+	if err != nil {
+		return 0, 0, err
+	}
+	return uid, gid, nil
+}
+
+func parseUserID(value string) (int, error) {
+	if value == "" || strings.Trim(value, "0123456789") != "" {
+		return 0, fmt.Errorf("user must be a numeric UID:GID")
+	}
+	id, err := strconv.ParseUint(value, 10, 31)
+	if err != nil {
+		return 0, fmt.Errorf("user IDs must be between 0 and 2147483647")
+	}
+	return int(id), nil
+}
+
+func prepareUser(user, contextDir string) (string, int, int, error) {
+	uid, gid, err := containerUser(user)
+	if err != nil {
+		return "", 0, 0, err
+	}
+	if err := grantContextAccess(contextDir, uid, gid); err != nil {
+		return "", 0, 0, err
+	}
+	directory, err := createIdentityDirectory(contextDir, uid, gid)
+	if err != nil {
+		return directory, 0, 0, err
+	}
+	return directory, uid, gid, nil
+}
+
+func grantContextAccess(contextDir string, uid, gid int) error {
+	if uid == 0 || uid == os.Getuid() {
+		return nil
+	}
+	if os.Getuid() != 0 {
+		return fmt.Errorf("a different non-root container UID requires a root host agent to grant private context access")
+	}
+	entries, err := os.ReadDir(contextDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		path := filepath.Join(contextDir, entry.Name())
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("private context must contain only regular coordination files")
+		}
+		if err := os.Chown(path, uid, gid); err != nil {
+			return fmt.Errorf("grant container access to coordination file: %w", err)
+		}
+	}
+	if err := os.Chown(contextDir, uid, gid); err != nil {
+		return fmt.Errorf("grant container access to private context: %w", err)
+	}
+	return nil
+}
+
+func createIdentityDirectory(contextDir string, uid, gid int) (string, error) {
+	directory, err := os.MkdirTemp(contextDir, "identity-")
+	if err != nil {
+		return "", err
+	}
+	if err := writeIdentityFiles(directory, uid, gid); err != nil {
+		_ = os.RemoveAll(directory)
+		return directory, err
+	}
+	return directory, nil
+}
+
+func writeIdentityFiles(directory string, uid, gid int) error {
+	rootGID := 0
+	if uid == 0 {
+		rootGID = gid
+	}
+	passwd := fmt.Sprintf("root:x:0:%d:root:%s/home:/bin/sh\n", rootGID, containerRoot)
+	group := "root:x:0:\n"
+	if uid != 0 {
+		passwd += fmt.Sprintf("buildkite:x:%d:%d:Buildkite:%s/home:/bin/sh\n", uid, gid, containerRoot)
+	}
+	if gid != 0 {
+		group += fmt.Sprintf("buildkite:x:%d:\n", gid)
+	}
+	for name, contents := range map[string]string{"passwd": passwd, "group": group} {
+		path := filepath.Join(directory, name)
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			return err
+		}
+		// Lookup files must remain readable under restrictive host umasks.
+		if err := os.Chmod(path, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Add an experimental Linux-only `docker-bootstrap` command, enabled through `--bootstrap-script`. Each job runs its bootstrap lifecycle in a disposable container; the agent stays on the host. The default image is `buildkite/agent-base:ubuntu-noble-hosted`.

- Mount the host agent binary read-only; preserve job exit codes and support graceful and forced cancellation.
- Add operator pull policies (`always`, `missing`, `never`) and host-side registry authentication, including credential helpers.
- Default to the host agent UID:GID, with numeric overrides and a private home directory.
- Create a labelled bridge network per job and remove the container and network on completion.
- Include redacted diagnostics, tests, a design spec, and a validation runbook under `docs/docker*`.

Step-level images, resource limits, egress restrictions, and stale-resource reconciliation remain deferred. The host Docker socket is not mounted into jobs.

## Testing

Package tests with race detection, lint, and Windows cross-compilation pass. Live OrbStack tests cover exit codes, cancellation, hooks, artifacts, registry authentication, UID:GID handling, cross-job network isolation, and cleanup.

## Disclosures / Credits

Codex wrote the implementation, tests, and documentation, including a separate sub-agent review. The maintainer directed the design and performed manual pipeline validation.
