### PR TITLE
Add path-only cache defaults for end-to-end testing

### DIFF
--- a/clicommand/cache_restore.go
+++ b/clicommand/cache_restore.go
@@ -17,9 +17,9 @@ const cacheRestoreHelpDescription = `Usage:
 
 Description:
 
-Restores files from the cache for the current job based on the cache configuration
-defined in your cache config file (defaults to .buildkite/cache.yml or
-.buildkite/cache.yaml).
+Restores files from the cache for the current job. Provide --path to use the
+agent's built-in cache configuration, or define caches in a cache config file
+(defaults to .buildkite/cache.yml or .buildkite/cache.yaml).
 
 The cache configuration file defines which files or directories should be restored
 and their associated cache key. An entry is restored when its target_paths
@@ -31,6 +31,14 @@ Note: This feature is currently in development and subject to change. It is not
 yet available to all customers.
 
 Example:
+
+    $ buildkite-agent cache restore --path ~/.npm
+
+This restores one path using an OS- and architecture-compatible cache. The
+checked-out commit is preferred; on a miss, the newest compatible generation is
+restored. The target path is part of the cache address.
+
+For custom keys or multiple caches, use a cache configuration file:
 
     $ buildkite-agent cache restore
 
@@ -98,17 +106,20 @@ var CacheRestoreCommand = &cli.Command{
 		apiCfg := loadAPIClientConfig(cfg, "AgentAccessToken")
 		apiClient := api.NewClient(l, apiCfg)
 
-		cacheConfigFile, err := resolveCacheConfigFile(cfg.CacheConfigFile)
+		caches, err := resolveCacheConfiguration(cfg.CacheConfig)
 		if err != nil {
 			return err
+		}
+		if cfg.Path != "" {
+			fmt.Printf("Path: %q\n", cfg.Path)
 		}
 
 		// Build cache configuration
 		cacheCfg := cache.Config{
-			Registry:        cfg.Registry,
-			BucketURL:       cfg.BucketURL,
-			CacheConfigFile: cacheConfigFile,
-			Names:           cfg.Names,
+			Registry:  cfg.Registry,
+			BucketURL: cfg.BucketURL,
+			Caches:    caches,
+			Names:     cfg.Names,
 		}
 
 		// Perform cache restore (logging happens inside)

--- a/clicommand/cache_save.go
+++ b/clicommand/cache_save.go
@@ -17,9 +17,9 @@ const cacheSaveHelpDescription = `Usage:
 
 Description:
 
-Saves files to the cache for the current build based on the cache configuration
-defined in your cache config file (defaults to .buildkite/cache.yml or
-.buildkite/cache.yaml).
+Saves files to the cache for the current build. Provide --path to use the agent's
+built-in cache configuration, or define caches in a cache config file (defaults
+to .buildkite/cache.yml or .buildkite/cache.yaml).
 
 The cache configuration file defines which files or directories should be cached
 and their associated cache key.
@@ -28,6 +28,13 @@ Note: This feature is currently in development and subject to change. It is not
 yet available to all customers.
 
 Example:
+
+    $ buildkite-agent cache save --path ~/.npm
+
+This saves one path using an OS- and architecture-compatible cache keyed by the
+checked-out commit. The target path is part of the cache address.
+
+For custom keys or multiple caches, use a cache configuration file:
 
     $ buildkite-agent cache save
 
@@ -88,18 +95,21 @@ var CacheSaveCommand = &cli.Command{
 
 		apiClient := api.NewClient(l, apiCfg)
 
-		cacheConfigFile, err := resolveCacheConfigFile(cfg.CacheConfigFile)
+		caches, err := resolveCacheConfiguration(cfg.CacheConfig)
 		if err != nil {
 			return err
+		}
+		if cfg.Path != "" {
+			fmt.Printf("Path: %q\n", cfg.Path)
 		}
 
 		// Build cache configuration
 		cacheCfg := cache.Config{
-			Registry:        cfg.Registry,
-			BucketURL:       cfg.BucketURL,
-			CacheConfigFile: cacheConfigFile,
-			Names:           cfg.Names,
-			Concurrency:     cfg.Concurrency,
+			Registry:    cfg.Registry,
+			BucketURL:   cfg.BucketURL,
+			Caches:      caches,
+			Names:       cfg.Names,
+			Concurrency: cfg.Concurrency,
 		}
 
 		// Perform cache save (logging happens inside)

--- a/clicommand/cache_shared.go
+++ b/clicommand/cache_shared.go
@@ -3,10 +3,17 @@ package clicommand
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/buildkite/agent/v4/internal/cache/configuration"
 	"github.com/urfave/cli/v3"
+)
+
+const (
+	pathCacheName          = "path_cache"
+	pathCacheFormatVersion = "path-cache-v1"
 )
 
 // CacheConfig includes cache-related shared options for easy inclusion across
@@ -16,6 +23,7 @@ type CacheConfig struct {
 	Registry        string   `cli:"registry"`
 	BucketURL       string   `cli:"cache-store-url"`
 	CacheConfigFile string   `cli:"cache-config-file"`
+	Path            string   `cli:"path"`
 	Concurrency     int      `cli:"concurrency"`
 }
 
@@ -45,6 +53,11 @@ func cacheFlags() []cli.Flag {
 			Usage:   "Path to the cache configuration YAML file (defaults to .buildkite/cache.yml or .buildkite/cache.yaml)",
 			Sources: cli.EnvVars("BUILDKITE_CACHE_CONFIG_FILE"),
 		},
+		&cli.StringFlag{
+			Name:  "path",
+			Value: "",
+			Usage: "File or directory to cache using the agent's built-in cache configuration",
+		},
 		&cli.IntFlag{
 			Name:    "concurrency",
 			Value:   2,
@@ -52,6 +65,67 @@ func cacheFlags() []cli.Flag {
 			Sources: cli.EnvVars("BUILDKITE_CACHE_CONCURRENCY"),
 		},
 	}
+}
+
+// resolveCacheConfiguration selects one configuration source. Path mode builds
+// a single cache definition in memory and deliberately skips default config file
+// discovery. File mode preserves the existing explicit/default file behaviour.
+func resolveCacheConfiguration(cfg CacheConfig) ([]configuration.Cache, error) {
+	if cfg.Path != "" {
+		if cfg.CacheConfigFile != "" {
+			return nil, fmt.Errorf("--path and --cache-config-file are mutually exclusive")
+		}
+		if len(cfg.Names) != 0 {
+			return nil, fmt.Errorf("--path and --name are mutually exclusive")
+		}
+
+		generation, err := resolvePathCacheGeneration(os.Getenv("BUILDKITE_COMMIT"), func() (string, error) {
+			output, err := exec.Command("git", "rev-parse", "--verify", "HEAD").Output()
+			return string(output), err
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return []configuration.Cache{{
+			Name: pathCacheName,
+			CacheKey: []configuration.KeyPart{
+				{Source: configuration.SourceLiteral, Arg: pathCacheFormatVersion},
+				{Source: configuration.SourceAgent, Arg: "os"},
+				{Source: configuration.SourceAgent, Arg: "arch", FallbackLimit: true},
+				{Source: configuration.SourceLiteral, Arg: generation},
+			},
+			TargetPaths: []string{cfg.Path},
+		}}, nil
+	}
+
+	configFile, err := resolveCacheConfigFile(cfg.CacheConfigFile)
+	if err != nil {
+		return nil, err
+	}
+	caches, err := configuration.LoadFile(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load cache configuration: %w", err)
+	}
+	return caches, nil
+}
+
+// resolvePathCacheGeneration returns a stable generation for the checked-out
+// source. Buildkite normally provides the concrete commit; builds configured
+// with HEAD and local invocations fall back to the repository's checked-out HEAD.
+func resolvePathCacheGeneration(buildkiteCommit string, gitHead func() (string, error)) (string, error) {
+	if commit := strings.TrimSpace(buildkiteCommit); commit != "" && commit != "HEAD" {
+		return commit, nil
+	}
+
+	commit, err := gitHead()
+	if err != nil {
+		return "", fmt.Errorf("could not determine the checked-out commit for --path cache generation: %w", err)
+	}
+	if commit = strings.TrimSpace(commit); commit == "" {
+		return "", fmt.Errorf("could not determine the checked-out commit for --path cache generation")
+	}
+	return commit, nil
 }
 
 // defaultCacheConfigPaths lists the candidate cache configuration files, in

--- a/clicommand/cache_shared_test.go
+++ b/clicommand/cache_shared_test.go
@@ -1,10 +1,121 @@
 package clicommand
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/buildkite/agent/v4/internal/cache/configuration"
+	"github.com/google/go-cmp/cmp"
 )
+
+func TestResolveCacheConfiguration(t *testing.T) {
+	t.Run("path builds an in-memory cache and skips default file discovery", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, ".buildkite", "cache.yml"))
+		writeFile(t, filepath.Join(dir, ".buildkite", "cache.yaml"))
+		chdir(t, dir)
+		t.Setenv("BUILDKITE_COMMIT", "0123456789abcdef")
+
+		got, err := resolveCacheConfiguration(CacheConfig{Path: "~/.npm"})
+		if err != nil {
+			t.Fatalf("resolveCacheConfiguration() error = %v", err)
+		}
+
+		want := []configuration.Cache{{
+			Name: pathCacheName,
+			CacheKey: []configuration.KeyPart{
+				{Source: configuration.SourceLiteral, Arg: pathCacheFormatVersion},
+				{Source: configuration.SourceAgent, Arg: "os"},
+				{Source: configuration.SourceAgent, Arg: "arch", FallbackLimit: true},
+				{Source: configuration.SourceLiteral, Arg: "0123456789abcdef"},
+			},
+			TargetPaths: []string{"~/.npm"},
+		}}
+		if diff := cmp.Diff(got, want); diff != "" {
+			t.Fatalf("resolveCacheConfiguration() diff (-got +want):\n%s", diff)
+		}
+	})
+
+	t.Run("path and explicit config file are mutually exclusive", func(t *testing.T) {
+		_, err := resolveCacheConfiguration(CacheConfig{
+			Path:            "~/.npm",
+			CacheConfigFile: "custom/cache.yml",
+		})
+		if err == nil {
+			t.Fatal("resolveCacheConfiguration() error = nil, want error")
+		}
+	})
+
+	t.Run("path and name selection are mutually exclusive", func(t *testing.T) {
+		_, err := resolveCacheConfiguration(CacheConfig{
+			Path:  "~/.npm",
+			Names: []string{"npm"},
+		})
+		if err == nil {
+			t.Fatal("resolveCacheConfiguration() error = nil, want error")
+		}
+	})
+
+	t.Run("explicit config file is loaded", func(t *testing.T) {
+		dir := t.TempDir()
+		configFile := filepath.Join(dir, "cache.yml")
+		if err := os.WriteFile(configFile, []byte(`caches:
+  - name: npm
+    cache_key: [npm-v1]
+    target_paths: [~/.npm]
+`), 0o600); err != nil {
+			t.Fatalf("os.WriteFile() error = %v", err)
+		}
+
+		got, err := resolveCacheConfiguration(CacheConfig{CacheConfigFile: configFile})
+		if err != nil {
+			t.Fatalf("resolveCacheConfiguration() error = %v", err)
+		}
+		if len(got) != 1 || got[0].Name != "npm" {
+			t.Fatalf("resolveCacheConfiguration() = %#v, want npm cache", got)
+		}
+	})
+}
+
+func TestResolvePathCacheGeneration(t *testing.T) {
+	t.Run("uses a concrete Buildkite commit without invoking git", func(t *testing.T) {
+		got, err := resolvePathCacheGeneration("0123456789abcdef", func() (string, error) {
+			t.Fatal("git should not be invoked")
+			return "", nil
+		})
+		if err != nil {
+			t.Fatalf("resolvePathCacheGeneration() error = %v", err)
+		}
+		if want := "0123456789abcdef"; got != want {
+			t.Fatalf("resolvePathCacheGeneration() = %q, want %q", got, want)
+		}
+	})
+
+	for _, commit := range []string{"", "HEAD"} {
+		t.Run("uses git for Buildkite commit "+commit, func(t *testing.T) {
+			got, err := resolvePathCacheGeneration(commit, func() (string, error) {
+				return " fedcba9876543210\n", nil
+			})
+			if err != nil {
+				t.Fatalf("resolvePathCacheGeneration() error = %v", err)
+			}
+			if want := "fedcba9876543210"; got != want {
+				t.Fatalf("resolvePathCacheGeneration() = %q, want %q", got, want)
+			}
+		})
+	}
+
+	t.Run("errors when no checkout commit is available", func(t *testing.T) {
+		_, err := resolvePathCacheGeneration("HEAD", func() (string, error) {
+			return "", errors.New("not a git repository")
+		})
+		if err == nil {
+			t.Fatal("resolvePathCacheGeneration() error = nil, want error")
+		}
+	})
+}
 
 func TestResolveCacheConfigFile(t *testing.T) {
 	t.Run("explicit path is used as-is", func(t *testing.T) {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -18,8 +18,8 @@ type Config struct {
 	Registry string
 	// BucketURL is the URL of the bucket (e.g., s3://bucket-name)
 	BucketURL string
-	// CacheConfigFile is the path to the cache configuration YAML file
-	CacheConfigFile string
+	// Caches contains the cache definitions to process.
+	Caches []configuration.Cache
 	// Names is a list of cache names (if empty, processes all caches)
 	Names []string
 	// Concurrency is the number of concurrent cache operations
@@ -42,7 +42,7 @@ func RunSave(ctx context.Context, l logger.Logger, apiClient *api.Client, cfg Co
 		return err
 	}
 	if c == nil {
-		l.Infof("No caches defined in the cache configuration file, nothing to save")
+		l.Infof("No caches defined, nothing to save")
 		return nil
 	}
 	return saveWithClient(ctx, l, c, cacheIDs, cfg.Concurrency)
@@ -56,7 +56,7 @@ func RunRestore(ctx context.Context, l logger.Logger, apiClient *api.Client, cfg
 		return err
 	}
 	if c == nil {
-		l.Infof("No caches defined in the cache configuration file, nothing to restore")
+		l.Infof("No caches defined, nothing to restore")
 		return nil
 	}
 	return restoreWithClient(ctx, l, c, cacheIDs, cfg.Concurrency)

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -41,19 +39,6 @@ func (m *mockCacheClient) ListCaches() []configuration.Cache {
 		return m.listFunc()
 	}
 	return nil
-}
-
-// Test helpers
-
-func createTempCacheConfig(t *testing.T, content string) string {
-	t.Helper()
-	tmpDir := t.TempDir()
-	configFile := filepath.Join(tmpDir, "cache.yml")
-	err := os.WriteFile(configFile, []byte(content), 0o600)
-	if err != nil {
-		t.Fatalf("os.WriteFile(%q, []byte(content), %d) error = %v, want nil", configFile, 0o600, err)
-	}
-	return configFile
 }
 
 // Tests for saveWithClient
@@ -331,24 +316,13 @@ func TestRestoreWithClient_EmptyCacheIDs(t *testing.T) {
 func TestNewClient_InvalidCacheIDs(t *testing.T) {
 	t.Parallel()
 
-	config := `caches:
-  - name: cache1
-    cache_key:
-      - test-key-1
-    target_paths:
-      - path1
-  - name: cache2
-    cache_key:
-      - test-key-2
-    target_paths:
-      - path2
-`
-	configFile := createTempCacheConfig(t, config)
-
 	cfg := Config{
-		CacheConfigFile: configFile,
-		Names:           []string{"cache1", "invalid1", "cache2", "invalid2"},
-		BucketURL:       "s3://test-bucket",
+		Caches: []configuration.Cache{
+			{Name: "cache1", CacheKey: []configuration.KeyPart{{Source: configuration.SourceLiteral, Arg: "test-key-1"}}, TargetPaths: []string{"path1"}},
+			{Name: "cache2", CacheKey: []configuration.KeyPart{{Source: configuration.SourceLiteral, Arg: "test-key-2"}}, TargetPaths: []string{"path2"}},
+		},
+		Names:     []string{"cache1", "invalid1", "cache2", "invalid2"},
+		BucketURL: "s3://test-bucket",
 	}
 
 	_, _, err := newClient(logger.Discard, nil, cfg)
@@ -369,24 +343,13 @@ func TestNewClient_InvalidCacheIDs(t *testing.T) {
 func TestNewClient_ValidCacheIDs(t *testing.T) {
 	t.Parallel()
 
-	config := `caches:
-  - name: cache1
-    cache_key:
-      - test-key-1
-    target_paths:
-      - path1
-  - name: cache2
-    cache_key:
-      - test-key-2
-    target_paths:
-      - path2
-`
-	configFile := createTempCacheConfig(t, config)
-
 	cfg := Config{
-		CacheConfigFile: configFile,
-		Names:           []string{"cache1", "cache2"},
-		BucketURL:       "s3://test-bucket",
+		Caches: []configuration.Cache{
+			{Name: "cache1", CacheKey: []configuration.KeyPart{{Source: configuration.SourceLiteral, Arg: "test-key-1"}}, TargetPaths: []string{"path1"}},
+			{Name: "cache2", CacheKey: []configuration.KeyPart{{Source: configuration.SourceLiteral, Arg: "test-key-2"}}, TargetPaths: []string{"path2"}},
+		},
+		Names:     []string{"cache1", "cache2"},
+		BucketURL: "s3://test-bucket",
 	}
 
 	client, cacheIDs, err := newClient(logger.Discard, nil, cfg)
@@ -404,24 +367,13 @@ func TestNewClient_ValidCacheIDs(t *testing.T) {
 func TestNewClient_AllCaches(t *testing.T) {
 	t.Parallel()
 
-	config := `caches:
-  - name: cache1
-    cache_key:
-      - test-key-1
-    target_paths:
-      - path1
-  - name: cache2
-    cache_key:
-      - test-key-2
-    target_paths:
-      - path2
-`
-	configFile := createTempCacheConfig(t, config)
-
 	cfg := Config{
-		CacheConfigFile: configFile,
-		Names:           []string{},
-		BucketURL:       "s3://test-bucket",
+		Caches: []configuration.Cache{
+			{Name: "cache1", CacheKey: []configuration.KeyPart{{Source: configuration.SourceLiteral, Arg: "test-key-1"}}, TargetPaths: []string{"path1"}},
+			{Name: "cache2", CacheKey: []configuration.KeyPart{{Source: configuration.SourceLiteral, Arg: "test-key-2"}}, TargetPaths: []string{"path2"}},
+		},
+		Names:     []string{},
+		BucketURL: "s3://test-bucket",
 	}
 
 	client, cacheIDs, err := newClient(logger.Discard, nil, cfg)

--- a/internal/cache/client.go
+++ b/internal/cache/client.go
@@ -60,18 +60,15 @@ type client struct {
 	onProgress ProgressCallback
 }
 
-// newClient builds a client from apiClient and cfg: loads and expands the
-// cache configuration file, validates every cache definition, and returns the
+// newClient builds a client from apiClient and cfg: expands and validates every
+// cache definition, and returns the
 // client together with the cache names to operate on (filtered by cfg.Names if
 // non-empty).
 //
-// Returns (nil, nil, nil) when the configuration file has no caches.
+// Returns (nil, nil, nil) when the configuration has no caches.
 // Returns ErrInvalidConfiguration (wrapped) on expansion or validation failure.
 func newClient(l logger.Logger, apiClient cacheAPI, cfg Config) (*client, []string, error) {
-	caches, err := configuration.LoadFile(cfg.CacheConfigFile)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load cache configuration: %w", err)
-	}
+	caches := cfg.Caches
 	if len(caches) == 0 {
 		return nil, nil, nil
 	}

--- a/internal/cache/configuration/cache.go
+++ b/internal/cache/configuration/cache.go
@@ -2,6 +2,7 @@ package configuration
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -77,16 +78,27 @@ func (c Cache) Validate() error {
 // which refuses to clean those directories (see cleanPath's protectedDirs), so
 // it is rejected up front.
 func isWholeAnchorTarget(p string) bool {
-	switch filepath.Clean(p) {
+	clean := filepath.Clean(p)
+	switch clean {
 	case "~", ".", string(filepath.Separator):
 		return true
 	}
 	if filepath.IsAbs(p) {
-		c := filepath.Clean(p)
-		vol := filepath.VolumeName(c) // a bare volume root such as "C:\" on Windows
-		if c == vol+string(filepath.Separator) || c == vol {
+		vol := filepath.VolumeName(clean) // a bare volume root such as "C:\" on Windows
+		if clean == vol+string(filepath.Separator) || clean == vol {
 			return true
 		}
+	}
+
+	resolved, err := filepath.Abs(p)
+	if err != nil {
+		return false
+	}
+	if home, err := os.UserHomeDir(); err == nil && resolved == filepath.Clean(home) {
+		return true
+	}
+	if cwd, err := os.Getwd(); err == nil && resolved == filepath.Clean(cwd) {
+		return true
 	}
 	return false
 }
@@ -94,7 +106,7 @@ func isWholeAnchorTarget(p string) bool {
 // isValidPath checks if a path is valid (doesn't contain null bytes or other invalid characters).
 func isValidPath(path string) bool {
 	// Check for invalid characters (null bytes, etc.)
-	if strings.ContainsRune(path, 0) {
+	if strings.ContainsRune(path, 0) || strings.ContainsAny(path, "\r\n") {
 		return false
 	}
 

--- a/internal/cache/configuration/cache_test.go
+++ b/internal/cache/configuration/cache_test.go
@@ -1,6 +1,8 @@
 package configuration
 
 import (
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -225,6 +227,11 @@ func TestIsValidPath(t *testing.T) {
 			path: "invalid\x00path",
 			want: false,
 		},
+		{
+			name: "path with newline",
+			path: "invalid\npath",
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -232,6 +239,32 @@ func TestIsValidPath(t *testing.T) {
 			got := isValidPath(tt.path)
 			if got != tt.want {
 				t.Errorf("isValidPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCacheValidateRejectsResolvedProtectedDirectories(t *testing.T) {
+	parent := t.TempDir()
+	home := filepath.Join(parent, "home")
+	cwd := filepath.Join(parent, "work")
+	for _, dir := range []string{home, cwd} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatalf("os.Mkdir(%q) error = %v", dir, err)
+		}
+	}
+	t.Setenv("HOME", home)
+	t.Chdir(cwd)
+
+	for _, target := range []string{home, cwd, filepath.Join(cwd, "subdir", "..")} {
+		t.Run(target, func(t *testing.T) {
+			cache := Cache{
+				Name:        "path_cache",
+				CacheKey:    []KeyPart{{Source: SourceLiteral, Arg: "path-cache-v1"}},
+				TargetPaths: []string{target},
+			}
+			if err := cache.Validate(); err == nil {
+				t.Fatalf("Cache.Validate() error = nil for protected target %q", target)
 			}
 		})
 	}

--- a/internal/cache/configuration/cache_test.go
+++ b/internal/cache/configuration/cache_test.go
@@ -254,6 +254,7 @@ func TestCacheValidateRejectsResolvedProtectedDirectories(t *testing.T) {
 		}
 	}
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Chdir(cwd)
 
 	for _, target := range []string{home, cwd, filepath.Join(cwd, "subdir", "..")} {


### PR DESCRIPTION
## Description

This adds a path-only cache mode so we can test the simplest first-use experience end to end:

```sh
buildkite-agent cache restore --path ~/.npm
buildkite-agent cache save --path ~/.npm
```

When `--path` is provided, the agent builds one cache definition in memory. A plugin or pipeline no longer needs to create a temporary cache configuration file for this flow. File-based configuration remains available for custom keys and multiple caches.

This is intentionally a first cut for testing, not the final key-policy decision. The inferred key currently contains a format version, agent OS, agent architecture, and the checked-out commit. Restore prefers that exact generation, then falls back to the newest generation matching OS and architecture. The target path is also part of the cache address.

Pipeline and branch are not included in this prototype; registry policy continues to determine sharing and isolation. We should settle that choice after exercising the flow end to end.

## Context

- [A-1818: Define the simplest Buildkite Cache first-use experience](https://linear.app/buildkite/issue/A-1818/define-the-simplest-buildkite-cache-first-use-experience)
- [Cache defaults Slack thread](https://buildkite-corp.slack.com/archives/C091B8KFWQ7/p1788491997099769)

No plugin changes are included in this PR.

## Changes

- Add `--path` to `cache save` and `cache restore`.
- Construct the path-mode cache definition in memory inside the agent.
- Keep `.buildkite/cache.yml`, `.buildkite/cache.yaml`, and `--cache-config-file` behaviour for advanced configuration.
- Reject ambiguous combinations of `--path` with `--cache-config-file` or `--name`.
- Resolve a concrete checkout commit for the inferred cache generation.
- Reject root, working-directory, home-directory, and newline-containing cache targets before cache operations begin.
- Pass parsed cache definitions into the internal cache client instead of requiring it to load a file.

The new help entry is:

```text
--path string  File or directory to cache using the agent's built-in cache configuration
```

## Documentation and publication

**Does this change need public documentation?**

- [x] Yes
- [ ] No
- [ ] Unsure

**Is this change safe to document publicly when this PR merges?**

- [ ] Yes
- [ ] No, the documentation must be held
- [x] It can be documented as a limited-availability or preview feature
- [ ] Not applicable (docs not needed)

**Publication notes:**

The cache commands are already described as in development and not available to all customers. The `--path` flow can be documented with the same preview language. Broader guidance about the inferred key should wait until we have tested this flow and agreed on the policy.

## Testing

- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

Also verified:

- `mise run lint` — 0 issues
- `go tool gofumpt -extra -d` on all changed Go files — no diff
- A locally built agent shows `--path` in both `cache save --help` and `cache restore --help`

## Affiliation (optional, external contributors)

Buildkite.

## Disclosures / Credits

Codex implemented and tested this end-to-end prototype under Jamie's direction and drafted the PR. The inferred key policy has not been accepted as product consensus; this PR is intended to make that decision testable.
