### PR TITLE
Automatically merge approved Dependabot updates

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,20 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
## Description

Dependabot PRs currently remain open after receiving approval and passing CI. Enable GitHub native auto-merge for those PRs so they merge once all branch protection requirements are satisfied.

## Context

The repository already allows auto-merg; Dependabot manages Go and Docker updates for `main` and `v3`.

## Changes

- Enable merge-commit auto-merge when Dependabot opens, reopens, or updates a PR.
- Restrict the write-capable job to PRs authored by `dependabot[bot]`.

## Testing


- [x] Workflow passes `actionlint` v1.7.12.

## Disclosures / Credits

Amp implemented and validated the workflow under human direction.