### PR TITLE
Make cache save/restore fail-open by default

### DIFF
--- a/clicommand/cache_restore.go
+++ b/clicommand/cache_restore.go
@@ -109,6 +109,7 @@ var CacheRestoreCommand = &cli.Command{
 			BucketURL:       cfg.BucketURL,
 			CacheConfigFile: cacheConfigFile,
 			Names:           cfg.Names,
+			FailOnError:     cfg.FailOnError,
 		}
 
 		// Perform cache restore (logging happens inside)

--- a/clicommand/cache_save.go
+++ b/clicommand/cache_save.go
@@ -111,6 +111,7 @@ var CacheSaveCommand = &cli.Command{
 			CacheConfigFile: cacheConfigFile,
 			Names:           cfg.Names,
 			Concurrency:     cfg.Concurrency,
+			FailOnError:     cfg.FailOnError,
 			Force:           cfg.Force,
 		}
 

--- a/clicommand/cache_save_test.go
+++ b/clicommand/cache_save_test.go
@@ -30,7 +30,7 @@ func TestCacheSaveForce(t *testing.T) {
 		{name: "force replaces existing entry", args: []string{"--force"}, exists: true, wantSave: true},
 		{name: "force creates missing entry", args: []string{"--force"}, wantSave: true},
 		{name: "explicit false skips existing entry", args: []string{"--force=false"}, exists: true, wantPeek: true},
-		{name: "force respects policy denial", args: []string{"--force"}, exists: true, denied: true},
+		{name: "force respects policy denial", args: []string{"--force", "--cache-fail-on-error"}, exists: true, denied: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Chdir(t.TempDir())

--- a/clicommand/cache_shared.go
+++ b/clicommand/cache_shared.go
@@ -17,6 +17,7 @@ type CacheConfig struct {
 	BucketURL       string   `cli:"cache-store-url"`
 	CacheConfigFile string   `cli:"cache-config-file"`
 	Concurrency     int      `cli:"concurrency"`
+	FailOnError     bool     `cli:"cache-fail-on-error"`
 }
 
 func cacheFlags() []cli.Flag {
@@ -50,6 +51,12 @@ func cacheFlags() []cli.Flag {
 			Value:   2,
 			Usage:   "Number of concurrent cache operations",
 			Sources: cli.EnvVars("BUILDKITE_CACHE_CONCURRENCY"),
+		},
+		&cli.BoolFlag{
+			Name:    "cache-fail-on-error",
+			Value:   false,
+			Usage:   "Fail the command (non-zero exit) when a cache save or restore fails. By default a cache is best-effort: failures are logged and skipped so they never fail the build",
+			Sources: cli.EnvVars("BUILDKITE_AGENT_CACHE_FAIL_ON_ERROR"),
 		},
 	}
 }

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 	"sync"
@@ -24,7 +25,14 @@ type Config struct {
 	Names []string
 	// Concurrency is the number of concurrent cache operations
 	Concurrency int
-	Force       bool
+	// FailOnError makes a save/restore failure fatal (non-zero exit). When false
+	// (the default) a failure is logged and skipped so a cache problem never
+	// fails the build — a cache is an optimization, not a build input.
+	FailOnError bool
+	// Force replaces the entire cache at the same save address, without
+	// merging files or bypassing registry access policies, even if an entry
+	// already exists there.
+	Force bool
 }
 
 // cacheOps is the subset of *client used by saveWithClient and restoreWithClient.
@@ -46,7 +54,7 @@ func RunSave(ctx context.Context, l logger.Logger, apiClient *api.Client, cfg Co
 		l.Infof("No caches defined in the cache configuration file, nothing to save")
 		return nil
 	}
-	return saveWithClient(ctx, l, c, cacheIDs, cfg.Concurrency)
+	return saveWithClient(ctx, l, c, cacheIDs, cfg.Concurrency, cfg.FailOnError)
 }
 
 // RunRestore restores caches based on the provided configuration and logs results
@@ -60,7 +68,7 @@ func RunRestore(ctx context.Context, l logger.Logger, apiClient *api.Client, cfg
 		l.Infof("No caches defined in the cache configuration file, nothing to restore")
 		return nil
 	}
-	return restoreWithClient(ctx, l, c, cacheIDs, cfg.Concurrency)
+	return restoreWithClient(ctx, l, c, cacheIDs, cfg.Concurrency, cfg.FailOnError)
 }
 
 // ListCaches returns all cache definitions configured on the client.
@@ -69,7 +77,7 @@ func (c *client) ListCaches() []configuration.Cache {
 }
 
 // restoreWithClient performs the restore operation for the given cache IDs using the provided client.
-func restoreWithClient(ctx context.Context, l logger.Logger, c cacheOps, cacheIDs []string, concurrency int) error {
+func restoreWithClient(ctx context.Context, l logger.Logger, c cacheOps, cacheIDs []string, concurrency int, failOnError bool) error {
 	if concurrency <= 0 {
 		concurrency = runtime.GOMAXPROCS(0)
 	}
@@ -93,8 +101,25 @@ func restoreWithClient(ctx context.Context, l logger.Logger, c cacheOps, cacheID
 					l.Infof("Restoring cache: %s", cacheID)
 					result, err := c.Restore(wctx, cacheID)
 					if err != nil {
-						cancel(fmt.Errorf("failed to restore cache %q: %w", cacheID, err))
-						return
+						// A restore that failed after cleaning/extracting target paths
+						// leaves a partial workspace, which is not equivalent to a cache
+						// miss, so it stays fatal even when fail-open.
+						if failOnError || errors.Is(err, errRestoreMutatedTargets) {
+							cancel(fmt.Errorf("failed to restore cache %q: %w", cacheID, err))
+							return
+						}
+						if wctx.Err() != nil {
+							// Batch is being torn down (context cancelled); stop quietly.
+							return
+						}
+						// Fail-open: a restore that failed before touching the target
+						// paths is equivalent to a cache miss, so warn and carry on
+						// rather than failing the build.
+						l.WithFields(
+							logger.StringField("cache_id", cacheID),
+							logger.StringField("error", err.Error()),
+						).Warnf("Failed to restore cache; continuing without failing the build")
+						continue
 					}
 
 					switch {
@@ -145,7 +170,7 @@ sendLoop:
 }
 
 // saveWithClient performs the save operation for the given cache IDs using the provided client.
-func saveWithClient(ctx context.Context, l logger.Logger, c cacheOps, cacheIDs []string, concurrency int) error {
+func saveWithClient(ctx context.Context, l logger.Logger, c cacheOps, cacheIDs []string, concurrency int, failOnError bool) error {
 	if concurrency <= 0 {
 		concurrency = runtime.GOMAXPROCS(0)
 	}
@@ -169,8 +194,22 @@ func saveWithClient(ctx context.Context, l logger.Logger, c cacheOps, cacheIDs [
 					l.Infof("Saving cache: %s", cacheID)
 					result, err := c.Save(wctx, cacheID)
 					if err != nil {
-						cancel(fmt.Errorf("failed to save cache %q: %w", cacheID, err))
-						return
+						if failOnError {
+							cancel(fmt.Errorf("failed to save cache %q: %w", cacheID, err))
+							return
+						}
+						if wctx.Err() != nil {
+							// Batch is being torn down (context cancelled); stop quietly.
+							return
+						}
+						// Fail-open: the build's work is already done, so a failed save
+						// only costs a future cache hit. Warn and carry on rather than
+						// failing the build.
+						l.WithFields(
+							logger.StringField("cache_id", cacheID),
+							logger.StringField("error", err.Error()),
+						).Warnf("Failed to save cache; continuing without failing the build")
+						continue
 					}
 
 					switch {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -80,7 +80,7 @@ func TestSaveWithClient_CacheEntryCreated(t *testing.T) {
 		},
 	}
 
-	err := saveWithClient(ctx, logger.Discard, mock, []string{"cache1"}, 1)
+	err := saveWithClient(ctx, logger.Discard, mock, []string{"cache1"}, 1, false)
 	if err != nil {
 		t.Fatalf("saveWithClient(ctx, logger.Discard, mock, []string{\"cache1\"}, %d) error = %v, want nil", 1, err)
 	}
@@ -99,7 +99,7 @@ func TestSaveWithClient_CacheAlreadyExists(t *testing.T) {
 		},
 	}
 
-	err := saveWithClient(ctx, logger.Discard, mock, []string{"cache1"}, 1)
+	err := saveWithClient(ctx, logger.Discard, mock, []string{"cache1"}, 1, false)
 	if err != nil {
 		t.Fatalf("saveWithClient(ctx, logger.Discard, mock, []string{\"cache1\"}, %d) error = %v, want nil", 1, err)
 	}
@@ -129,7 +129,7 @@ func TestSaveWithClient_MultipleCaches(t *testing.T) {
 		},
 	}
 
-	err := saveWithClient(ctx, logger.Discard, mock, []string{"cache1", "cache2", "cache3"}, 1)
+	err := saveWithClient(ctx, logger.Discard, mock, []string{"cache1", "cache2", "cache3"}, 1, false)
 	if err != nil {
 		t.Fatalf("saveWithClient(ctx, logger.Discard, mock, []string{\"cache1\", \"cache2\", \"cache3\"}, %d) error = %v, want nil", 1, err)
 	}
@@ -149,7 +149,8 @@ func TestSaveWithClient_Error(t *testing.T) {
 		},
 	}
 
-	err := saveWithClient(ctx, logger.Discard, mock, []string{"cache1"}, 1)
+	// failOnError=true: a save failure is fatal and propagates.
+	err := saveWithClient(ctx, logger.Discard, mock, []string{"cache1"}, 1, true)
 	if err == nil {
 		t.Fatalf("saveWithClient(ctx, logger.Discard, mock, []string{\"cache1\"}, %d) error = %v, want non-nil error", 1, err)
 	}
@@ -172,7 +173,7 @@ func TestSaveWithClient_EmptyCacheIDs(t *testing.T) {
 		},
 	}
 
-	err := saveWithClient(ctx, logger.Discard, mock, []string{}, 1)
+	err := saveWithClient(ctx, logger.Discard, mock, []string{}, 1, false)
 	if err != nil {
 		t.Fatalf("saveWithClient(ctx, logger.Discard, mock, []string{}, %d) error = %v, want nil", 1, err)
 	}
@@ -204,7 +205,7 @@ func TestRestoreWithClient_CacheHit(t *testing.T) {
 		},
 	}
 
-	err := restoreWithClient(ctx, logger.Discard, mock, []string{"cache1"}, 1)
+	err := restoreWithClient(ctx, logger.Discard, mock, []string{"cache1"}, 1, false)
 	if err != nil {
 		t.Fatalf("restoreWithClient(ctx, logger.Discard, mock, []string{\"cache1\"}, %d) error = %v, want nil", 1, err)
 	}
@@ -234,7 +235,7 @@ func TestRestoreWithClient_FallbackUsed(t *testing.T) {
 		},
 	}
 
-	err := restoreWithClient(ctx, logger.Discard, mock, []string{"cache1"}, 1)
+	err := restoreWithClient(ctx, logger.Discard, mock, []string{"cache1"}, 1, false)
 	if err != nil {
 		t.Fatalf("restoreWithClient(ctx, logger.Discard, mock, []string{\"cache1\"}, %d) error = %v, want nil", 1, err)
 	}
@@ -255,7 +256,7 @@ func TestRestoreWithClient_CacheMiss(t *testing.T) {
 		},
 	}
 
-	err := restoreWithClient(ctx, logger.Discard, mock, []string{"cache1"}, 1)
+	err := restoreWithClient(ctx, logger.Discard, mock, []string{"cache1"}, 1, false)
 	if err != nil {
 		t.Fatalf("restoreWithClient(ctx, logger.Discard, mock, []string{\"cache1\"}, %d) error = %v, want nil", 1, err)
 	}
@@ -277,7 +278,7 @@ func TestRestoreWithClient_MultipleCaches(t *testing.T) {
 		},
 	}
 
-	err := restoreWithClient(ctx, logger.Discard, mock, []string{"cache1", "cache2", "cache3"}, 1)
+	err := restoreWithClient(ctx, logger.Discard, mock, []string{"cache1", "cache2", "cache3"}, 1, false)
 	if err != nil {
 		t.Fatalf("restoreWithClient(ctx, logger.Discard, mock, []string{\"cache1\", \"cache2\", \"cache3\"}, %d) error = %v, want nil", 1, err)
 	}
@@ -297,7 +298,8 @@ func TestRestoreWithClient_Error(t *testing.T) {
 		},
 	}
 
-	err := restoreWithClient(ctx, logger.Discard, mock, []string{"cache1"}, 1)
+	// failOnError=true: a restore failure is fatal and propagates.
+	err := restoreWithClient(ctx, logger.Discard, mock, []string{"cache1"}, 1, true)
 	if err == nil {
 		t.Fatalf("restoreWithClient(ctx, logger.Discard, mock, []string{\"cache1\"}, %d) error = %v, want non-nil error", 1, err)
 	}
@@ -320,9 +322,81 @@ func TestRestoreWithClient_EmptyCacheIDs(t *testing.T) {
 		},
 	}
 
-	err := restoreWithClient(ctx, logger.Discard, mock, []string{}, 1)
+	err := restoreWithClient(ctx, logger.Discard, mock, []string{}, 1, false)
 	if err != nil {
 		t.Fatalf("restoreWithClient(ctx, logger.Discard, mock, []string{}, %d) error = %v, want nil", 1, err)
+	}
+}
+
+// Fail-open behaviour (the default): a save/restore failure is logged and
+// skipped rather than failing the whole batch.
+
+func TestSaveWithClient_FailOpenSkipsError(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	callCount := 0
+	mock := &mockCacheClient{
+		saveFunc: func(ctx context.Context, cacheID string) (SaveResult, error) {
+			callCount++
+			if cacheID == "cache2" {
+				return SaveResult{}, errors.New("save failed")
+			}
+			return SaveResult{CacheEntryCreated: false, Key: cacheID}, nil
+		},
+	}
+
+	err := saveWithClient(ctx, logger.Discard, mock, []string{"cache1", "cache2", "cache3"}, 1, false)
+	if err != nil {
+		t.Fatalf("saveWithClient(..., failOnError=false) error = %v, want nil (failure should be skipped)", err)
+	}
+	if got, want := callCount, 3; got != want {
+		t.Fatalf("Save call count = %d, want %d (all caches processed despite one failing)", got, want)
+	}
+}
+
+func TestRestoreWithClient_FailOpenSkipsError(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	callCount := 0
+	mock := &mockCacheClient{
+		restoreFunc: func(ctx context.Context, cacheID string) (RestoreResult, error) {
+			callCount++
+			if cacheID == "cache2" {
+				return RestoreResult{}, errors.New("restore failed")
+			}
+			return RestoreResult{Key: cacheID}, nil
+		},
+	}
+
+	err := restoreWithClient(ctx, logger.Discard, mock, []string{"cache1", "cache2", "cache3"}, 1, false)
+	if err != nil {
+		t.Fatalf("restoreWithClient(..., failOnError=false) error = %v, want nil (failure should be skipped)", err)
+	}
+	if got, want := callCount, 3; got != want {
+		t.Fatalf("Restore call count = %d, want %d (all caches processed despite one failing)", got, want)
+	}
+}
+
+func TestRestoreWithClient_MutatedTargetsErrorIsFatal(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	mock := &mockCacheClient{
+		restoreFunc: func(ctx context.Context, cacheID string) (RestoreResult, error) {
+			return RestoreResult{}, errors.Join(errRestoreMutatedTargets, errors.New("failed to extract cache"))
+		},
+	}
+
+	// Even fail-open, a restore that already mutated target paths must fail the
+	// build rather than run against a partial workspace.
+	err := restoreWithClient(ctx, logger.Discard, mock, []string{"cache1"}, 1, false)
+	if err == nil {
+		t.Fatalf("restoreWithClient(..., failOnError=false) with a mutated-targets error = nil, want non-nil (must stay fatal)")
+	}
+	if !errors.Is(err, errRestoreMutatedTargets) {
+		t.Fatalf("restoreWithClient error = %v, want wrapped errRestoreMutatedTargets", err)
 	}
 }
 

--- a/internal/cache/restore.go
+++ b/internal/cache/restore.go
@@ -20,6 +20,13 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
+// errRestoreMutatedTargets marks a restore failure that happened after the
+// target paths were cleaned or extraction had begun, leaving the workspace in a
+// partial state. Unlike a pre-mutation failure it is not equivalent to a cache
+// miss, so it stays fatal even when cache errors are otherwise fail-open —
+// continuing would run the build against half-restored targets.
+var errRestoreMutatedTargets = errors.New("cache restore failed after modifying target paths")
+
 // Restore restores a cache from storage by ID.
 //
 // The function performs the following workflow:
@@ -297,7 +304,7 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to resolve target path")
-			return result, fmt.Errorf("failed to resolve target path %q: %w", path, err)
+			return result, errors.Join(errRestoreMutatedTargets, fmt.Errorf("failed to resolve target path %q: %w", path, err))
 		}
 
 		slog.Debug("cleaning path", "path", path, "extractedPath", extractedPath)
@@ -305,7 +312,7 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 		if err := cleanPath(ctx, extractedPath); err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to clean path")
-			return result, fmt.Errorf("failed to clean path %q: %w", extractedPath, err)
+			return result, errors.Join(errRestoreMutatedTargets, fmt.Errorf("failed to clean path %q: %w", extractedPath, err))
 		}
 	}
 
@@ -316,7 +323,7 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to extract cache")
-		return result, fmt.Errorf("failed to extract cache: %w", err)
+		return result, errors.Join(errRestoreMutatedTargets, fmt.Errorf("failed to extract cache: %w", err))
 	}
 
 	// Populate archive metrics


### PR DESCRIPTION
## Description

A cache is an optimization, not a build input — but today a `buildkite-agent cache save` or `cache restore` failure aborts the whole cache batch and exits non-zero, **failing the build**. That means a transient cache-backend blip fails otherwise-green builds, and for `save` it fails a build whose real work has already completed (the cache upload happens after the build step's work).

This changes the default to **fail-open**: a per-cache save/restore error is logged as a warning and skipped, so the build proceeds (cold, but green). It extends the philosophy already in `restore.go` — *"a bad cache must never block a build"*, currently applied to corrupt/mismatched restore blobs — to transient API errors and to save failures.

A new `--cache-fail-on-error` flag (`BUILDKITE_AGENT_CACHE_FAIL_ON_ERROR`) opts back into the previous strict/fatal behaviour.

**Key decision for reviewers:** this flips the *default* (fatal → fail-open). The alternative is to keep fatal-by-default and gate fail-open behind an opt-in flag — but that wouldn't fix the reported build failures for anyone who doesn't know to set it. Happy to invert if the team prefers.

Not changed: setup errors (missing token, bad cache config, unresolved config file) and context cancellation (e.g. a cancelled build) remain fatal — fail-open applies only to per-cache save/restore errors inside the dispatch loop.

## Context

Prompted by a build failure where `cache save` for a ~2.3 GB Go build cache returned repeated 500s and failed the step, even though the build + image push had already succeeded. (The server-side cause — a 4-byte `file_size` overflow — is being fixed separately in buildkite/buildkite#33851; this PR addresses the orthogonal question of whether a cache error should ever fail a build.)

## Changes

- `internal/cache`: add `Config.FailOnError`; thread it into `saveWithClient`/`restoreWithClient`. On a per-cache error, when `FailOnError` is false (default) log a warning and continue to the next cache instead of cancelling the batch. Context-cancellation still stops the loop quietly.
- `clicommand`: add the `--cache-fail-on-error` flag (env `BUILDKITE_AGENT_CACHE_FAIL_ON_ERROR`, default false) to the shared cache flags, wired into both `cache save` and `cache restore`.
- Tests: existing error-propagation tests now assert the strict path (`failOnError=true`); new tests assert fail-open skips a failing cache and still processes the rest.

`cache save --help` gains:
```
--cache-fail-on-error  Fail the command (non-zero exit) when a cache save or restore fails.
                       By default a cache is best-effort: failures are logged and skipped so
                       they never fail the build [$BUILDKITE_AGENT_CACHE_FAIL_ON_ERROR]
```

### Public documentation
- [ ] Ready for public documentation - document and publish
- [x] Not ready for public docs - document and hold
- [ ] Not applicable - docs not needed

## Testing
- [ ] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

Ran locally in a clean worktree: `go build ./internal/cache/... ./clicommand/...`, `go vet` on both, and `go test ./internal/cache/...` (pass, including the new fail-open tests). Did not run the full `go test ./...` suite locally — relying on CI for the remainder.

## Disclosures / Credits

Authored with Claude Code (Opus 4.8): it investigated the originating build failure, proposed the fail-open design, and wrote the implementation and tests. Reviewed by the PR author before submission.