### PR TITLE
Avoid partial clones for Kubernetes sparse checkouts

### DIFF
--- a/docs/remote-git-mirrors.md
+++ b/docs/remote-git-mirrors.md
@@ -20,6 +20,12 @@ happens to share the word "mirror". This document uses:
 | **on-host mirror** | `--git-mirrors-path/<dir>` — the local bare clone shared between jobs on a host |
 | **checkout** | the working directory the job runs in |
 
+Throughout this document, statements that sparse checkout automatically adds
+`--filter=blob:none` apply only outside Kubernetes execution. Kubernetes
+checkout still uses `--sparse`, but does not add a filter unless the user
+supplies one, because later command containers may not have the credentials
+needed for lazy fetches.
+
 §§1–5 and §10 are durable: they describe the feature and the decisions behind
 it. §§6–9 and §11 are delivery-time content — once the stack has landed, fold
 anything still true into the durable sections and delete the rest rather than
@@ -1009,12 +1015,10 @@ as described below.
 
 **Use the flag list the canonical fetch would have used, not `e.GitFetchFlags`.**
 `fetchSource` receives `addBloblessFilter` and prepends `--filter=blob:none`
-itself, so for a non-Kubernetes sparse pipeline that did not supply its own
-filter — precisely the configuration the agent auto-adds the filter for —
-reading the raw config field would send an *unfiltered* mirror fetch and, on a
-hit, leave the checkout with every blob present. That is R3 violated, not merely
-slower. Kubernetes checkout deliberately skips the automatic filter because
-later command containers may not have the credentials needed for lazy fetches.
+itself, so for a sparse pipeline that did not supply its own filter — precisely
+the configuration the agent auto-adds the filter for — reading the raw config
+field would send an *unfiltered* mirror fetch and, on a hit, leave the checkout
+with every blob present. That is R3 violated, not merely slower.
 
 An existing partial clone has a second source of effective fetch behavior:
 `remote.origin.partialclonefilter`. Named-remote fetches inherit it implicitly,
@@ -1098,8 +1102,8 @@ mirror promisor section exists; it exits 128 when the section is absent.
 **Tests:** existing checkout advances via a mirror hit with canonical
 unreachable; unfiltered miss falls back with refs, worktree and config
 unchanged; filtered miss/error/timeout/cancel all remove mirror ownership and
-leave canonical promisor ownership; a non-Kubernetes sparse pipeline's mirror
-fetch carries `--filter=blob:none`; an existing origin filter is inherited unless
+leave canonical promisor ownership; a sparse pipeline's mirror fetch carries
+`--filter=blob:none`; an existing origin filter is inherited unless
 `--no-filter` (including accepted abbreviations) is explicit; cleanup failure
 cleans and retries canonically; no `remote.<mirrorURL>.*` survives any successful
 cleanup; marker write failure falls back canonically; marker-only interruption
@@ -1368,13 +1372,13 @@ objects are unreferenced and eligible for `gc` — and the default
 **C3 — A mirror that cannot serve `--filter` silently transfers everything.**
 `git clone --filter=…` against a server without `uploadpack.allowFilter` warns,
 exits 0, transfers the full object set, and still writes the promisor keys
-(G10). A non-Kubernetes sparse pipeline — where the agent adds
-`--filter=blob:none` itself — is both the most likely configuration and the one
-with the most to lose, and R2 is violated on a *hit*. `--depth` fails loudly in
-the same situation; `--filter` does not. The general rule this instance of:
-**the mirror must support at least the capabilities canonical does**, and where
-it does not, the degradation is silent. Detection after the fact does not
-recover the job's bytes, so the mitigation is telemetry plus §11.2 Q3, and a test
+(G10). A sparse pipeline — where the agent adds `--filter=blob:none` itself — is
+both the most likely configuration and the one with the most to lose, and R2 is
+violated on a *hit*. `--depth` fails loudly in the same situation; `--filter`
+does not. The general rule this instance of: **the mirror must support at least
+the capabilities canonical does**, and where it does not, the degradation is
+silent. Detection after the fact does not recover the job's bytes, so the
+mitigation is telemetry plus §11.2 Q3, and a test
 fixture that deliberately lacks the capability. *Comment: beside the mirror
 clone in `checkout_workdir.go`.*
 

--- a/docs/remote-git-mirrors.md
+++ b/docs/remote-git-mirrors.md
@@ -1009,10 +1009,12 @@ as described below.
 
 **Use the flag list the canonical fetch would have used, not `e.GitFetchFlags`.**
 `fetchSource` receives `addBloblessFilter` and prepends `--filter=blob:none`
-itself, so for a sparse pipeline that did not supply its own filter — precisely
-the configuration the agent auto-adds the filter for — reading the raw config
-field would send an *unfiltered* mirror fetch and, on a hit, leave the checkout
-with every blob present. That is R3 violated, not merely slower.
+itself, so for a non-Kubernetes sparse pipeline that did not supply its own
+filter — precisely the configuration the agent auto-adds the filter for —
+reading the raw config field would send an *unfiltered* mirror fetch and, on a
+hit, leave the checkout with every blob present. That is R3 violated, not merely
+slower. Kubernetes checkout deliberately skips the automatic filter because
+later command containers may not have the credentials needed for lazy fetches.
 
 An existing partial clone has a second source of effective fetch behavior:
 `remote.origin.partialclonefilter`. Named-remote fetches inherit it implicitly,
@@ -1096,8 +1098,8 @@ mirror promisor section exists; it exits 128 when the section is absent.
 **Tests:** existing checkout advances via a mirror hit with canonical
 unreachable; unfiltered miss falls back with refs, worktree and config
 unchanged; filtered miss/error/timeout/cancel all remove mirror ownership and
-leave canonical promisor ownership; a sparse pipeline's mirror fetch carries
-`--filter=blob:none`; an existing origin filter is inherited unless
+leave canonical promisor ownership; a non-Kubernetes sparse pipeline's mirror
+fetch carries `--filter=blob:none`; an existing origin filter is inherited unless
 `--no-filter` (including accepted abbreviations) is explicit; cleanup failure
 cleans and retries canonically; no `remote.<mirrorURL>.*` survives any successful
 cleanup; marker write failure falls back canonically; marker-only interruption
@@ -1366,13 +1368,13 @@ objects are unreferenced and eligible for `gc` — and the default
 **C3 — A mirror that cannot serve `--filter` silently transfers everything.**
 `git clone --filter=…` against a server without `uploadpack.allowFilter` warns,
 exits 0, transfers the full object set, and still writes the promisor keys
-(G10). A sparse pipeline — where the agent adds `--filter=blob:none` itself — is
-both the most likely configuration and the one with the most to lose, and R2 is
-violated on a *hit*. `--depth` fails loudly in the same situation; `--filter`
-does not. The general rule this instance of: **the mirror must support at least
-the capabilities canonical does**, and where it does not, the degradation is
-silent. Detection after the fact does not recover the job's bytes, so the
-mitigation is telemetry plus §11.2 Q3, and a test
+(G10). A non-Kubernetes sparse pipeline — where the agent adds
+`--filter=blob:none` itself — is both the most likely configuration and the one
+with the most to lose, and R2 is violated on a *hit*. `--depth` fails loudly in
+the same situation; `--filter` does not. The general rule this instance of:
+**the mirror must support at least the capabilities canonical does**, and where
+it does not, the degradation is silent. Detection after the fact does not
+recover the job's bytes, so the mitigation is telemetry plus §11.2 Q3, and a test
 fixture that deliberately lacks the capability. *Comment: beside the mirror
 clone in `checkout_workdir.go`.*
 

--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -437,6 +437,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context, previousAttempts in
 	}
 
 	addBloblessFilter := sparse.active() &&
+		e.shell.Env.GetString("BUILDKITE_KUBERNETES_EXEC", "") != "true" &&
 		!userSuppliedCloneFilter &&
 		!hasPartialFilterFlags(gitFetchFlags)
 	if err := e.fetchSource(ctx, addBloblessFilter, &attempt); err != nil {

--- a/internal/job/checkout_workdir.go
+++ b/internal/job/checkout_workdir.go
@@ -86,7 +86,11 @@ func (e *Executor) prepareCheckoutWorkdir(
 		}
 		if userSuppliedCloneFilter {
 			e.shell.Commentf("Sparse checkout is configured and BUILDKITE_GIT_CLONE_FLAGS already contains a --filter (preserving user-supplied filter).")
-		} else {
+		} else if e.shell.Env.GetString("BUILDKITE_KUBERNETES_EXEC", "") != "true" {
+			// Kubernetes checkout and command phases can run in separate
+			// containers, with Git credentials available only during checkout.
+			// Avoid creating a promisor clone that may try to fetch missing
+			// objects after the checkout container has exited.
 			gitCloneFlags = append(gitCloneFlags, "--filter=blob:none")
 		}
 	}

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -104,7 +104,7 @@ func TestCheckingOutLocalGitProject_WithGitMirrors(t *testing.T) {
 	tester.RunAndCheck(t, env...)
 }
 
-func TestCheckingOutLocalGitProjectWithSparseCheckout_WithGitMirrors(t *testing.T) {
+func TestCheckingOutLocalGitProjectWithSparseCheckoutInKubernetesWithGitMirrors(t *testing.T) {
 	t.Parallel()
 	skipIfGitSparseCheckoutUnsupported(t)
 
@@ -120,11 +120,12 @@ func TestCheckingOutLocalGitProjectWithSparseCheckout_WithGitMirrors(t *testing.
 	}
 
 	env := []string{
-		"BUILDKITE_GIT_CLONE_FLAGS=-v --filter=blob:none --sparse",
+		"BUILDKITE_GIT_CLONE_FLAGS=-v",
 		"BUILDKITE_GIT_CLONE_MIRROR_FLAGS=--bare",
 		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
-		"BUILDKITE_GIT_FETCH_FLAGS=-v --filter=blob:none",
+		"BUILDKITE_GIT_FETCH_FLAGS=-v",
 		"BUILDKITE_GIT_SPARSE_CHECKOUT_PATHS=.buildkite/,src/",
+		"BUILDKITE_KUBERNETES_EXEC=true",
 	}
 
 	git := tester.
@@ -134,9 +135,9 @@ func TestCheckingOutLocalGitProjectWithSparseCheckout_WithGitMirrors(t *testing.
 	git.ExpectAll([][]any{
 		{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
 		{"--version"},
-		{"clone", "-v", "--filter=blob:none", "--sparse", "--reference", matchSubDir(tester.GitMirrorsDir), "--", tester.Repo.Path, "."},
+		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--sparse", "--", tester.Repo.Path, "."},
 		{"clean", "-fdq"},
-		{"fetch", "-v", "--filter=blob:none", "--", "origin", "main"},
+		{"fetch", "-v", "--", "origin", "main"},
 		{"sparse-checkout", "set", "--cone", "--", ".buildkite/", "src/"},
 		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
 		{"clean", "-fdq"},
@@ -152,6 +153,8 @@ func TestCheckingOutLocalGitProjectWithSparseCheckout_WithGitMirrors(t *testing.
 	requireCheckoutPath(t, tester.CheckoutDir(), ".buildkite/pipeline.yml", true)
 	requireCheckoutPath(t, tester.CheckoutDir(), "src/main.txt", true)
 	requireCheckoutPath(t, tester.CheckoutDir(), "docs/readme.md", false)
+	requireGitConfigAbsent(t, tester.CheckoutDir(), "remote.origin.promisor")
+	requireGitConfigAbsent(t, tester.CheckoutDir(), "remote.origin.partialclonefilter")
 }
 
 func TestCheckingOutLocalGitProjectWithSparseCheckoutNoCone_WithGitMirrors(t *testing.T) {

--- a/internal/job/integration/checkout_integration_test.go
+++ b/internal/job/integration/checkout_integration_test.go
@@ -119,6 +119,17 @@ func requireCheckoutPath(t *testing.T, checkoutDir, name string, exists bool) {
 	}
 }
 
+func requireGitConfigAbsent(t *testing.T, checkoutDir, key string) {
+	t.Helper()
+
+	repo := &gitRepository{Path: checkoutDir}
+	output, err := repo.Execute("config", "--get", key)
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		t.Errorf("git config --get %s = %q, %v; want key absent", key, strings.TrimSpace(output), err)
+	}
+}
+
 func TestCheckingOutLocalGitProject(t *testing.T) {
 	t.Parallel()
 
@@ -377,13 +388,62 @@ func TestCheckingOutLocalGitProjectWithSparseCheckoutAutoAddsBlobNoneFilter(t *t
 	requireCheckoutPath(t, tester.CheckoutDir(), "docs/readme.md", false)
 }
 
-// TestCheckingOutLocalGitProjectWithSparseCheckoutPreservesUserFilter asserts
-// that when the user supplies their own --filter in BUILDKITE_GIT_CLONE_FLAGS,
-// sparse checkout preserves it on clone and does NOT prepend --filter=blob:none
-// to fetch. git clone --filter=X writes remote.origin.partialclonefilter=X into
-// the repo config, and subsequent fetches inherit it automatically — so
-// re-passing a filter on fetch would silently override the user's choice.
-func TestCheckingOutLocalGitProjectWithSparseCheckoutPreservesUserFilter(t *testing.T) {
+func TestCheckingOutLocalGitProjectWithSparseCheckoutInKubernetesDoesNotAddBlobNoneFilter(t *testing.T) {
+	t.Parallel()
+	skipIfGitSparseCheckoutUnsupported(t)
+
+	tester, err := NewExecutorTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewExecutorTester() error = %v", err)
+	}
+	defer tester.Close()
+	addSparseCheckoutFixture(t, tester.Repo)
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_FLAGS=-v",
+		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
+		"BUILDKITE_GIT_FETCH_FLAGS=-v",
+		"BUILDKITE_GIT_SPARSE_CHECKOUT_PATHS=.buildkite/,src/",
+		"BUILDKITE_KUBERNETES_EXEC=true",
+	}
+
+	git := tester.
+		MustMock(t, "git").
+		PassthroughToLocalCommand()
+
+	git.ExpectAll([][]any{
+		{"--version"},
+		{"clone", "-v", "--sparse", "--", tester.Repo.Path, "."},
+		{"clean", "-fdq"},
+		{"fetch", "-v", "--", "origin", "main"},
+		{"sparse-checkout", "set", "--cone", "--", ".buildkite/", "src/"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
+		{"clean", "-fdq"},
+		{"rev-parse", "HEAD"},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
+	})
+
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
+
+	tester.RunAndCheck(t, env...)
+
+	requireCheckoutPath(t, tester.CheckoutDir(), ".buildkite/pipeline.yml", true)
+	requireCheckoutPath(t, tester.CheckoutDir(), "src/main.txt", true)
+	requireCheckoutPath(t, tester.CheckoutDir(), "docs/readme.md", false)
+	requireGitConfigAbsent(t, tester.CheckoutDir(), "remote.origin.promisor")
+	requireGitConfigAbsent(t, tester.CheckoutDir(), "remote.origin.partialclonefilter")
+}
+
+// TestCheckingOutLocalGitProjectWithSparseCheckoutInKubernetesPreservesUserFilter
+// asserts that when the user supplies their own --filter in
+// BUILDKITE_GIT_CLONE_FLAGS, sparse checkout preserves it on clone and does NOT
+// prepend --filter=blob:none to fetch. git clone --filter=X writes
+// remote.origin.partialclonefilter=X into the repo config, and subsequent
+// fetches inherit it automatically — so re-passing our own filter would
+// override the user's choice for that fetch.
+func TestCheckingOutLocalGitProjectWithSparseCheckoutInKubernetesPreservesUserFilter(t *testing.T) {
 	t.Parallel()
 	skipIfGitSparseCheckoutUnsupported(t)
 
@@ -399,6 +459,7 @@ func TestCheckingOutLocalGitProjectWithSparseCheckoutPreservesUserFilter(t *test
 		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
 		"BUILDKITE_GIT_FETCH_FLAGS=-v",
 		"BUILDKITE_GIT_SPARSE_CHECKOUT_PATHS=.buildkite/,src/",
+		"BUILDKITE_KUBERNETES_EXEC=true",
 	}
 
 	git := tester.


### PR DESCRIPTION
## Description

Sparse checkout currently makes every fresh checkout a blobless partial clone. In Agent Stack for Kubernetes, checkout and command phases run in separate containers, and Git credentials are normally available only during checkout. A later command that needs an omitted object can therefore attempt an unauthenticated lazy fetch and fail or hang.

When `BUILDKITE_KUBERNETES_EXEC=true`, this stops automatically adding `--filter=blob:none` to clone and fetch while retaining `--sparse`. Non-Kubernetes checkouts keep the existing optimization, and an explicitly supplied filter remains authoritative in Kubernetes.

## Context

Fixes https://github.com/buildkite/agent/issues/4199

https://linear.app/buildkite/issue/A-1667/sparse-checkout-in-agent-stack-k8s-can-break-git-in-command-containers

## Changes

- avoid automatic partial clones for Kubernetes sparse checkouts
- cover ordinary, explicit-filter, and mirror-backed Kubernetes checkouts
- update the remote mirror design notes for the Kubernetes exception

Existing persisted partial-clone worktrees are unchanged; Agent Stack's default workspace is fresh per job.

### Public documentation
- [ ] Ready for public documentation - document and publish
- [ ] Not ready for public docs - document and hold
- [x] Not applicable - docs not needed

## Testing
- [x] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

Amp helped research, implement, review, and test this change.
