### PR TITLE
PR template should not include needless check boxes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,11 +19,12 @@ List of what the PR changes. If the PR changes the CLI arguments, consider addin
 Can skip if changes are simple or clear from the commit messages.
 -->
 
-### Public documentation
-<!-- The docs bot will act according to the following -->
-- [ ] Ready for public documentation - document and publish
-- [ ] Not ready for public docs - document and hold
-- [ ] Not applicable - docs not needed
+## Public documentation
+<!-- Replace CHOOSE ONE with one of:
+- publish: Document and publish
+- hold: Document, but do not publish yet
+- not needed: Do not document -->
+**Status:** CHOOSE ONE
 
 ## Testing
 - [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.


### PR DESCRIPTION
### Description

And lo, on the third day, it was noted that check boxes in PR descriptions show up as "tasks:"

<img width="1402" height="436" alt="image" src="https://github.com/user-attachments/assets/e0bcc439-a4d2-43d2-94a0-5d8f08e7a520" />

And we did not want that. So we came up with another solution. Just type what you want. This is, again, a hint for the docs writer bot to know what to do when it looks at a PR.

### Context

Slack discussion.
