### PR TITLE
feat: backport cache save --force to v3

### DIFF
--- a/clicommand/cache_save.go
+++ b/clicommand/cache_save.go
@@ -39,7 +39,12 @@ You can also save specific caches by providing their names:
 The cache is stored at BUILDKITE_AGENT_CACHE_STORE_URL (or --cache-store-url).
 The registry is selected by BUILDKITE_AGENT_CACHE_REGISTRY (or --registry); '~'
 selects the cluster's default registry. If an entry already exists at the same
-address it is not overwritten.
+address it is not overwritten unless --force is specified:
+
+    $ buildkite-agent cache save --name "node" --force
+
+Force replaces the entire cache at the same save address, without merging files
+or bypassing registry access policies. Concurrent saves are last-write-wins.
 
 Configuration File Format:
 
@@ -63,13 +68,19 @@ type CacheSaveConfig struct {
 	GlobalConfig
 	APIConfig
 	CacheConfig
+	Force bool `cli:"force"`
 }
 
 var CacheSaveCommand = cli.Command{
 	Name:        "save",
 	Usage:       "Saves files to the cache",
 	Description: cacheSaveHelpDescription,
-	Flags:       slices.Concat(globalFlags(), apiFlags(), cacheFlags()),
+	Flags: slices.Concat(globalFlags(), apiFlags(), cacheFlags(), []cli.Flag{
+		cli.BoolFlag{
+			Name:  "force",
+			Usage: "Save even when an entry already exists at the same address",
+		},
+	}),
 	Action: func(c *cli.Context) error {
 		ctx := context.Background()
 		ctx, cfg, l, _, done := setupLoggerAndConfig[CacheSaveConfig](ctx, c)
@@ -101,6 +112,7 @@ var CacheSaveCommand = cli.Command{
 			CacheConfigFile: cacheConfigFile,
 			Names:           cfg.Names,
 			Concurrency:     cfg.Concurrency,
+			Force:           cfg.Force,
 		}
 
 		// Perform cache save (logging happens inside)

--- a/clicommand/cache_save_test.go
+++ b/clicommand/cache_save_test.go
@@ -1,0 +1,149 @@
+package clicommand
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/agent/v3/api"
+	"github.com/buildkite/agent/v3/internal/cache/archive"
+	"github.com/google/go-cmp/cmp"
+	"github.com/urfave/cli"
+)
+
+func TestCacheSaveForce(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		args     []string
+		exists   bool
+		denied   bool
+		wantSave bool
+		wantPeek bool
+	}{
+		{name: "existing entry is skipped", exists: true, wantPeek: true},
+		{name: "force replaces existing entry", args: []string{"--force"}, exists: true, wantSave: true},
+		{name: "force creates missing entry", args: []string{"--force"}, wantSave: true},
+		{name: "explicit false skips existing entry", args: []string{"--force=false"}, exists: true, wantPeek: true},
+		{name: "force respects policy denial", args: []string{"--force"}, exists: true, denied: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			if err := os.WriteFile("rubocop-cache", []byte("updated cache contents"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile("cache.yml", []byte("caches:\n  - name: rubocop\n    cache_key: [rubocop-v1]\n    target_paths: [rubocop-cache]\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			storageDir := t.TempDir()
+			storagePath := filepath.ToSlash(storageDir)
+			if !strings.HasPrefix(storagePath, "/") {
+				storagePath = "/" + storagePath
+			}
+			storageURL := (&url.URL{Scheme: "file", Path: storagePath}).String()
+			requests := make(chan string, 20)
+			var entry api.CacheEntryCreateReq
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests <- r.Method + " " + r.URL.Path
+				w.Header().Set("Content-Type", "application/json")
+				switch r.Method + " " + r.URL.Path {
+				case "POST /cache_registries/test/peek":
+					if !test.exists {
+						w.WriteHeader(http.StatusNotFound)
+						_, _ = io.WriteString(w, `{"message":"Cache entry not found"}`)
+						return
+					}
+					_, _ = io.WriteString(w, `{}`)
+				case "GET /cache_registries/test":
+					_, _ = io.WriteString(w, `{"store":"local_file"}`)
+				case "PUT /cache_registries/test/store":
+					if test.denied {
+						w.WriteHeader(http.StatusForbidden)
+						_, _ = io.WriteString(w, `{"message":"Cache save is not permitted by the registry policy"}`)
+						return
+					}
+					if err := json.NewDecoder(r.Body).Decode(&entry); err != nil {
+						t.Error(err)
+						w.WriteHeader(http.StatusBadRequest)
+						return
+					}
+					_, _ = io.WriteString(w, `{"upload_id":"upload-1"}`)
+				case "PUT /cache_registries/test/commit":
+					var commit api.CacheEntryCommitReq
+					if err := json.NewDecoder(r.Body).Decode(&commit); err != nil {
+						t.Error(err)
+					}
+					if commit.UploadID != "upload-1" {
+						t.Errorf("UploadID = %q, want upload-1", commit.UploadID)
+					}
+					_, _ = io.WriteString(w, `{}`)
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusBadRequest)
+				}
+			}))
+			t.Cleanup(server.Close)
+			app := cli.NewApp()
+			app.Commands = []cli.Command{CacheSaveCommand}
+			args := []string{"buildkite-agent", "save", "--endpoint", server.URL, "--agent-access-token", "test-token", "--registry", "test", "--cache-config-file", "cache.yml", "--cache-store-url", storageURL, "--name", "rubocop"}
+			err := app.Run(append(args, test.args...))
+			if (err != nil) != test.denied {
+				t.Fatalf("cache save error = %v, want error: %t", err, test.denied)
+			}
+			server.Close()
+			close(requests)
+			var gotRequests []string
+			for request := range requests {
+				gotRequests = append(gotRequests, request)
+			}
+			var wantRequests []string
+			if test.wantPeek {
+				wantRequests = append(wantRequests, "POST /cache_registries/test/peek")
+			}
+			if test.wantSave || test.denied {
+				wantRequests = append(wantRequests, "GET /cache_registries/test", "PUT /cache_registries/test/store")
+			}
+			if test.wantSave {
+				wantRequests = append(wantRequests, "PUT /cache_registries/test/commit")
+			}
+			if diff := cmp.Diff(wantRequests, gotRequests); diff != "" {
+				t.Errorf("requests mismatch (-want +got):\n%s", diff)
+			}
+			if !test.wantSave {
+				return
+			}
+			if diff := cmp.Diff([]string{"rubocop-cache"}, entry.TargetPaths); diff != "" {
+				t.Errorf("target paths mismatch (-want +got):\n%s", diff)
+			}
+			if len(entry.CacheKey) != 1 || entry.CacheKey[0].Value != "rubocop-v1" {
+				t.Errorf("cache key changed: %v", entry.CacheKey)
+			}
+			if len(entry.Blobs) != 1 {
+				t.Fatalf("blobs = %v, want one archive", entry.Blobs)
+			}
+			blob, err := os.Open(filepath.Join(storageDir, entry.Blobs[0].Digest.Value))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = blob.Close() }()
+			if err := os.Remove("rubocop-cache"); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := archive.ExtractFiles(t.Context(), blob, entry.Blobs[0].FileSize, entry.TargetPaths); err != nil {
+				t.Fatal(err)
+			}
+			contents, err := os.ReadFile("rubocop-cache")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(contents) != "updated cache contents" {
+				t.Errorf("archive contents = %q, want updated cache contents", contents)
+			}
+		})
+	}
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -24,6 +24,7 @@ type Config struct {
 	Names []string
 	// Concurrency is the number of concurrent cache operations
 	Concurrency int
+	Force       bool
 }
 
 // cacheOps is the subset of *client used by saveWithClient and restoreWithClient.
@@ -184,7 +185,7 @@ func saveWithClient(ctx context.Context, l logger.Logger, c cacheOps, cacheIDs [
 							logger.StringField("transfer_speed", fmt.Sprintf("%.2fMB/s", result.Transfer.TransferSpeed)),
 							logger.IntField("part_count", result.Transfer.PartCount),
 							logger.IntField("concurrency", result.Transfer.Concurrency),
-						).Infof("Cache created")
+						).Infof("Cache saved")
 					default:
 						l.WithFields(
 							logger.StringField("cache_id", cacheID),

--- a/internal/cache/client.go
+++ b/internal/cache/client.go
@@ -56,6 +56,7 @@ type client struct {
 	format     string
 	platform   string
 	registry   string
+	force      bool
 	caches     []configuration.Cache
 	onProgress ProgressCallback
 }
@@ -99,6 +100,7 @@ func newClient(l logger.Logger, apiClient cacheAPI, cfg Config) (*client, []stri
 		format:    "zip",
 		platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 		registry:  registry,
+		force:     cfg.Force,
 		caches:    expanded,
 		onProgress: func(cacheID, stage, message string, _, _ int) {
 			l.WithFields(

--- a/internal/cache/save.go
+++ b/internal/cache/save.go
@@ -19,17 +19,6 @@ import (
 
 // Save saves a cache to storage by ID.
 //
-// The function performs the following workflow:
-//  1. Validates the cache configuration and paths exist
-//  2. Checks if the cache already exists (early return if yes)
-//  3. Builds an archive of the cache paths
-//  4. Creates a cache entry in the Buildkite API
-//  5. Uploads the archive to cloud storage
-//  6. Commits the cache entry
-//
-// If the cache already exists, no upload is performed and the function returns
-// early with CacheEntryCreated=false and Transfer=nil.
-//
 // The operation respects context cancellation and will stop immediately when
 // ctx is cancelled, cleaning up any temporary resources.
 //
@@ -102,51 +91,53 @@ func (c *client) Save(ctx context.Context, cacheID string) (SaveResult, error) {
 		return result, fmt.Errorf("invalid cache paths: %w", err)
 	}
 
-	c.callProgress(cacheID, "checking_exists", "Checking if cache already exists", 0, 0)
+	if !c.force {
+		c.callProgress(cacheID, "checking_exists", "Checking if cache already exists", 0, 0)
 
-	// Check if cache already exists
-	var (
-		peekApiResp *api.Response
-		exists      bool
-	)
-
-	err = roko.NewRetrier(
-		roko.WithMaxAttempts(5),
-		roko.WithStrategy(roko.ExponentialSubsecond(500*time.Millisecond)),
-		roko.WithJitter(),
-	).DoWithContext(ctx, func(r *roko.Retrier) error {
-		var err error
-		_, exists, peekApiResp, err = c.api.CacheEntryPeekExists(ctx, c.registry, api.CacheEntryPeekReq{
-			TargetPaths: cacheConfig.TargetPaths,
-			CacheKey:    cacheKey,
-		})
-		if api.BreakOnNonRetryable(r, peekApiResp, err) {
-			return err
-		}
-		if err != nil {
-			slog.Warn("cache peek failed, retrying", "err", err, "retrier", r.String())
-			return err
-		}
-		return nil
-	})
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to check cache existence")
-		return result, fmt.Errorf("failed to check cache existence: %w", err)
-	}
-
-	if exists {
-		// Cache already exists, no need to upload
-		result.CacheEntryCreated = false
-		result.TotalDuration = time.Since(startTime)
-		span.SetAttributes(
-			attribute.Bool("cache.created", false),
-			attribute.Bool("cache.already_exists", true),
-			attribute.Int64("cache.duration_ms", result.TotalDuration.Milliseconds()),
+		// Check if cache already exists
+		var (
+			peekApiResp *api.Response
+			exists      bool
 		)
-		span.SetStatus(codes.Ok, "cache already exists")
-		c.callProgress(cacheID, "complete", "Cache already exists", 0, 0)
-		return result, nil
+
+		err = roko.NewRetrier(
+			roko.WithMaxAttempts(5),
+			roko.WithStrategy(roko.ExponentialSubsecond(500*time.Millisecond)),
+			roko.WithJitter(),
+		).DoWithContext(ctx, func(r *roko.Retrier) error {
+			var err error
+			_, exists, peekApiResp, err = c.api.CacheEntryPeekExists(ctx, c.registry, api.CacheEntryPeekReq{
+				TargetPaths: cacheConfig.TargetPaths,
+				CacheKey:    cacheKey,
+			})
+			if api.BreakOnNonRetryable(r, peekApiResp, err) {
+				return err
+			}
+			if err != nil {
+				slog.Warn("cache peek failed, retrying", "err", err, "retrier", r.String())
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "failed to check cache existence")
+			return result, fmt.Errorf("failed to check cache existence: %w", err)
+		}
+
+		if exists {
+			// Cache already exists, no need to upload
+			result.CacheEntryCreated = false
+			result.TotalDuration = time.Since(startTime)
+			span.SetAttributes(
+				attribute.Bool("cache.created", false),
+				attribute.Bool("cache.already_exists", true),
+				attribute.Int64("cache.duration_ms", result.TotalDuration.Milliseconds()),
+			)
+			span.SetStatus(codes.Ok, "cache already exists")
+			c.callProgress(cacheID, "complete", "Cache already exists", 0, 0)
+			return result, nil
+		}
 	}
 
 	c.callProgress(cacheID, "fetching_registry", "Looking up cache registry", 0, 0)


### PR DESCRIPTION
## Description

Backport of https://github.com/buildkite/agent/pull/4346 to `v3`, bringing opt-in cache replacement to stable v3 agents.

## Context

Cherry-picked `67eb014e4510aad18d83687efd8ffaac2a69d58c`.

## Changes

Translate the CLI flag and test harness to urfave/cli v1 and use agent/v3 imports. Save behaviour is otherwise identical to the original PR. No VERSION or dependency changes.

### Public documentation
- [ ] Ready for public documentation - document and publish
- [ ] Not ready for public docs - document and hold
- [x] Not applicable - covered by the original change and generated CLI docs

## Testing

- [x] Ran the full suite with `go test ./... -timeout 4m`; all packages passed except `internal/job`.
- [x] Code is formatted with `go tool gofumpt -extra`.
- Passed `go test -race ./clicommand -run "^TestCacheSaveForce$" -count=1`.
- Passed `golangci-lint run ./clicommand/... ./internal/cache/...`.

The full suite failure is `TestUpdateGitMirrorCreatesFromRemoteMirrorAndKeepsCanonicalOrigin`: the local directory lacks the expected setgid bit. It also fails in isolation. The Git-mirror code is unchanged by this backport.

## Rollback

Revert this commit; no migrations or backend changes.

## Disclosures / Credits

OpenCode applied and adapted the backport and ran verification with Grant’s direction.

@buildsworth-bk permission to approve if risk L2