### PR TITLE
Guide AI agents to use private repository for staff docs PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,19 @@
 # Buildkite Agent Development Guide
 
+## Documentation contributions
+
+When creating a pull request for the Buildkite documentation site as part of a task
+that involves modifying or analyzing this repository, open it in
+`buildkite/docs-private` by default. This destination is required for Buildkite
+staff. For known external contributors, use `buildkite/docs` instead.
+
+Verify the push destination and pull request base repository before publishing.
+If the required destination is unavailable, ask for guidance rather than switching
+repositories.
+
+Documentation maintained in this repository, such as `README.md`, `CONTRIBUTING.md`,
+and `AGENTS.md`, stays in `buildkite/agent`.
+
 ## Build/Test/Lint Commands
 
 - **Build:** `go build -o buildkite-agent .` or `go run *.go <command>`


### PR DESCRIPTION
## Description

AI agents modifying or analyzing this repository may create follow-up PRs for the Buildkite documentation site. Those PRs must go to `buildkite/docs-private` when made on behalf of Buildkite staff.

Add guidance to `AGENTS.md` that defaults to `docs-private`, with `buildkite/docs` reserved for known external contributors. Require agents to verify the push destination and PR base repository, and ask for guidance if the required destination is unavailable.

Documentation maintained in this repository stays in `buildkite/agent`.

## Context

Applies the internal documentation contribution policy.

## Public documentation

**Status:** not needed

## Testing

Documentation-only change. `git diff --check` passed; Go tests and formatting were not run.

- [ ] Tests have run locally (with `go test ./...`).
- [ ] Code is formatted (with `go tool gofumpt -extra -w .`)

## Disclosures / Credits

Amp drafted the AGENTS.md guidance update and this PR description based on my initial instructions and further feedback.