### PR TITLE
Bound cache retrieval retry duration

### DIFF
--- a/internal/cache/client.go
+++ b/internal/cache/client.go
@@ -52,14 +52,15 @@ var (
 // bucket and the expanded, validated cache definitions used by every call.
 // Safe for concurrent use; honours context cancellation.
 type client struct {
-	api        cacheAPI
-	bucketURL  string
-	format     string
-	platform   string
-	registry   string
-	force      bool
-	caches     []configuration.Cache
-	onProgress ProgressCallback
+	api             cacheAPI
+	bucketURL       string
+	format          string
+	platform        string
+	registry        string
+	force           bool
+	caches          []configuration.Cache
+	onProgress      ProgressCallback
+	retrieveTimeout time.Duration
 }
 
 // newClient builds a client from apiClient and cfg: loads and expands the
@@ -96,13 +97,14 @@ func newClient(l logger.Logger, apiClient cacheAPI, cfg Config) (*client, []stri
 	}
 
 	c := &client{
-		api:       apiClient,
-		bucketURL: cfg.BucketURL,
-		format:    "zip",
-		platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
-		registry:  registry,
-		force:     cfg.Force,
-		caches:    expanded,
+		api:             apiClient,
+		bucketURL:       cfg.BucketURL,
+		format:          "zip",
+		platform:        fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		registry:        registry,
+		force:           cfg.Force,
+		caches:          expanded,
+		retrieveTimeout: cacheRetrieveTimeout,
 		onProgress: func(cacheID, stage, message string, _, _ int) {
 			l.WithFields(
 				logger.StringField("cache_id", cacheID),

--- a/internal/cache/restore.go
+++ b/internal/cache/restore.go
@@ -20,6 +20,8 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
+const cacheRetrieveTimeout = 15 * time.Second
+
 // Restore restores a cache from storage by ID.
 //
 // The function performs the following workflow:
@@ -107,19 +109,26 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 		apiResp      *api.Response
 		retrieveResp api.CacheEntryRetrieveResp
 		exists       bool
+		attempts     int
 	)
 
 	// Cache restore is latency-sensitive: it runs at the start of a job and
-	// blocks forward progress, so transient failures should retry quickly
-	// After ~5 attempts (~3.4s wall-clock with this curve),
-	// treat repeated failures as a cache miss.
+	// blocks forward progress. Share one deadline across all attempts so slow
+	// requests cannot multiply the API client's per-request timeout.
+	retrieveTimeout := c.retrieveTimeout
+	if retrieveTimeout == 0 {
+		retrieveTimeout = cacheRetrieveTimeout
+	}
+	retrieveCtx, cancelRetrieve := context.WithTimeout(ctx, retrieveTimeout)
+
 	err = roko.NewRetrier(
 		roko.WithMaxAttempts(5),
 		roko.WithStrategy(roko.ExponentialSubsecond(500*time.Millisecond)),
 		roko.WithJitter(),
-	).DoWithContext(ctx, func(r *roko.Retrier) error {
+	).DoWithContext(retrieveCtx, func(r *roko.Retrier) error {
+		attempts++
 		var err error
-		retrieveResp, exists, apiResp, err = c.api.CacheEntryRetrieve(ctx, c.registry, api.CacheEntryRetrieveReq{
+		retrieveResp, exists, apiResp, err = c.api.CacheEntryRetrieve(retrieveCtx, c.registry, api.CacheEntryRetrieveReq{
 			TargetPaths: cacheConfig.TargetPaths,
 			CacheKey:    cacheKey,
 		})
@@ -132,9 +141,19 @@ func (c *client) Restore(ctx context.Context, cacheID string) (RestoreResult, er
 		}
 		return nil
 	})
+	retrieveCtxErr := retrieveCtx.Err()
+	cancelRetrieve()
+
+	span.SetAttributes(attribute.Int("cache.retrieve_attempts", attempts))
 	if err != nil {
 		span.RecordError(err)
-		span.SetStatus(codes.Error, "failed to retrieve cache")
+		if ctx.Err() != nil {
+			span.SetStatus(codes.Error, "cache retrieval canceled")
+		} else if errors.Is(retrieveCtxErr, context.DeadlineExceeded) {
+			span.SetStatus(codes.Error, "cache retrieval timed out")
+		} else {
+			span.SetStatus(codes.Error, "failed to retrieve cache")
+		}
 		return result, fmt.Errorf("failed to retrieve cache: %w", err)
 	}
 

--- a/internal/cache/restore.go
+++ b/internal/cache/restore.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
-const cacheRetrieveTimeout = 60 * time.Second
+const cacheRetrieveTimeout = 2 * time.Minute
 
 // Restore restores a cache from storage by ID.
 //

--- a/internal/cache/restore.go
+++ b/internal/cache/restore.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
-const cacheRetrieveTimeout = 15 * time.Second
+const cacheRetrieveTimeout = 60 * time.Second
 
 // Restore restores a cache from storage by ID.
 //

--- a/internal/cache/restore_test.go
+++ b/internal/cache/restore_test.go
@@ -3,6 +3,8 @@ package cache
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -12,6 +14,7 @@ import (
 	"time"
 
 	"github.com/buildkite/agent/v4/api"
+	"github.com/buildkite/agent/v4/internal/cache/configuration"
 	"github.com/buildkite/agent/v4/internal/cache/store"
 )
 
@@ -178,6 +181,70 @@ func TestMissCompleteMessage(t *testing.T) {
 	}
 	if got, want := missCompleteMessage("missing blob", false), "Cache miss (missing blob, stale entry could not be invalidated)"; got != want {
 		t.Errorf("missCompleteMessage(invalidated=false) = %q, want %q", got, want)
+	}
+}
+
+type retrieveAPI struct {
+	cacheAPI
+	retrieveFn func(context.Context) (api.CacheEntryRetrieveResp, bool, *api.Response, error)
+}
+
+func (a retrieveAPI) CacheEntryRetrieve(ctx context.Context, _ string, _ api.CacheEntryRetrieveReq) (api.CacheEntryRetrieveResp, bool, *api.Response, error) {
+	return a.retrieveFn(ctx)
+}
+
+func restoreTestClient(apiClient cacheAPI, timeout time.Duration) *client {
+	return &client{
+		api:             apiClient,
+		registry:        "~",
+		retrieveTimeout: timeout,
+		caches: []configuration.Cache{{
+			Name:        "test-cache",
+			CacheKey:    []configuration.KeyPart{{Source: configuration.SourceLiteral, Arg: "v1"}},
+			TargetPaths: []string{"cache"},
+		}},
+	}
+}
+
+func TestRestoreBoundsAllRetrieveAttemptsWithOneDeadline(t *testing.T) {
+	var attempts int
+	apiClient := retrieveAPI{retrieveFn: func(ctx context.Context) (api.CacheEntryRetrieveResp, bool, *api.Response, error) {
+		attempts++
+		<-ctx.Done()
+		return api.CacheEntryRetrieveResp{}, false, nil, ctx.Err()
+	}}
+	c := restoreTestClient(apiClient, 20*time.Millisecond)
+
+	_, err := c.Restore(t.Context(), "test-cache")
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Restore error = %v, want context deadline exceeded", err)
+	}
+	if attempts != 1 {
+		t.Errorf("CacheEntryRetrieve attempts = %d, want 1", attempts)
+	}
+}
+
+func TestRestoreRetriesAQuickTransientRetrieveFailureWithinDeadline(t *testing.T) {
+	var attempts int
+	apiClient := retrieveAPI{retrieveFn: func(context.Context) (api.CacheEntryRetrieveResp, bool, *api.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return api.CacheEntryRetrieveResp{}, false, &api.Response{Response: &http.Response{StatusCode: http.StatusServiceUnavailable}}, fmt.Errorf("transient failure")
+		}
+		return api.CacheEntryRetrieveResp{Message: api.CacheEntryNotFound}, false, nil, nil
+	}}
+	c := restoreTestClient(apiClient, 3*time.Second)
+
+	result, err := c.Restore(t.Context(), "test-cache")
+	if err != nil {
+		t.Fatalf("Restore error = %v, want nil", err)
+	}
+	if result.CacheRestored {
+		t.Error("Restore CacheRestored = true, want false")
+	}
+	if attempts != 2 {
+		t.Errorf("CacheEntryRetrieve attempts = %d, want 2", attempts)
 	}
 }
 


### PR DESCRIPTION
## Description

A cache retrieval currently allows each of its five retry attempts to consume the server's full request timeout. During DynamoDB throttling, those nested retry budgets turned one retrieval into several minutes of waiting.

Give the complete cache-entry retrieval retry loop one two-minute deadline. This leaves flexibility for existing backend tail latency while preventing five slow requests from multiplying the operation to roughly five minutes. Fast retryable responses can still retry within that shared budget. Existing fatal failure semantics remain unchanged.

## Context

- [A-1905: Reddit Buildkite cache timeouts/throttling](https://linear.app/buildkite/issue/A-1905/3-reddit-buildkite-cache-timeoutsthrottling)
- Companion server PR: https://github.com/buildkite/buildkite/pull/34080
- E2E build 2578 showed a successful cache retrieval taking 12.99 seconds and other cache metadata operations taking 25–26 seconds, so the original 15-second deadline was below current legitimate backend latency.

## Changes

- Set a two-minute cache retrieval timeout on constructed clients.
- Share one child context across the Roko retry loop and every retrieval HTTP request.
- Distinguish parent cancellation, retrieval deadline exhaustion, and other failures in tracing.
- Test that a blocked request gets one attempt and that quick retryable 503s can still succeed within the deadline.

## Public documentation
**Status:** not needed

## Testing
- [ ] Tests have run locally (with `go test ./...`). Buildkite employees may check this if the pipeline has run automatically.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

Targeted checks passed with `go test ./api ./internal/cache`, `go test -race ./internal/cache`, and `golangci-lint run ./internal/cache/...`. Full `go test ./...` could not run to completion in this checkout because packages imported as `github.com/buildkite/agent/v4/agent` and `github.com/buildkite/agent/v4/agent/plugin` are absent; CI should provide the authoritative full-suite result.

## Affiliation (optional, external contributors)

Buildkite

## Disclosures / Credits

Amp assisted with investigation, implementation, tests, and PR preparation under human direction.
