### PR TITLE
Exit 27 when registration rejects an unacquirable job

### DIFF
--- a/clicommand/agent_start.go
+++ b/clicommand/agent_start.go
@@ -66,6 +66,8 @@ Example:
 
 const pingModePingOnly = "ping-only"
 
+const acquisitionFailedExitCode = 27 // chosen by fair dice roll
+
 var (
 	verificationFailureBehaviors = []string{agent.VerificationBehaviourBlock, agent.VerificationBehaviourWarn}
 
@@ -1311,6 +1313,9 @@ var AgentStartCommand = &cli.Command{
 				},
 			), nil
 		})
+		if errors.Is(err, core.ErrJobAcquisitionRejected) {
+			return cli.Exit(err, acquisitionFailedExitCode)
+		}
 		if err != nil {
 			return err
 		}
@@ -1355,7 +1360,6 @@ var AgentStartCommand = &cli.Command{
 			// If the agent tried to acquire a job, but it couldn't because the job was already taken, we should exit with a
 			// specific exit code so that the caller can know that this job can't be acquired.
 
-			const acquisitionFailedExitCode = 27 // chosen by fair dice roll
 			return cli.Exit(err, acquisitionFailedExitCode)
 
 		case errors.Is(err, core.ErrJobLocked):

--- a/clicommand/agent_start_test.go
+++ b/clicommand/agent_start_test.go
@@ -1,11 +1,16 @@
 package clicommand
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
+	"sync/atomic"
 	"testing"
 
 	"github.com/buildkite/agent/v4/agent"
@@ -341,6 +346,85 @@ func TestAgentShutdownHook(t *testing.T) {
 			t.Errorf("log.Messages diff (-got +want):\n%s", diff)
 		}
 	})
+}
+
+func TestAgentStartRegistrationRejected(t *testing.T) {
+	// Prevent token scrubbing from re-executing the test process.
+	t.Setenv("BUILDKITE_AGENT_TOKEN", "")
+
+	for _, tc := range []struct {
+		name     string
+		status   int
+		message  string
+		wantExit int
+	}{
+		{
+			name:     "job unacquirable",
+			status:   http.StatusUnprocessableEntity,
+			message:  "Job is not eligible for job acquisition registration",
+			wantExit: 27,
+		},
+		{
+			name:     "other validation failure",
+			status:   http.StatusUnprocessableEntity,
+			message:  "Job acquisition tokens require acquire-job mode",
+			wantExit: 1,
+		},
+		{
+			name:     "invalid token",
+			status:   http.StatusUnauthorized,
+			message:  "Invalid job acquisition token",
+			wantExit: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var requests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				if r.Method != http.MethodPost || r.URL.Path != "/register" {
+					t.Errorf("request = %s %s, want POST /register", r.Method, r.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = fmt.Fprintf(w, `{"message":%q}`, tc.message)
+			}))
+			defer server.Close()
+
+			configPath := filepath.Join(t.TempDir(), "buildkite-agent.cfg")
+			if err := os.WriteFile(configPath, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			// Clone the command: Run mutates it.
+			cmd := *AgentStartCommand
+			app := &cli.Command{
+				Name:           "buildkite-agent",
+				Commands:       []*cli.Command{&cmd},
+				ExitErrHandler: func(context.Context, *cli.Command, error) {},
+			}
+			err := app.Run(t.Context(), []string{
+				"buildkite-agent", "start",
+				"--config", configPath,
+				"--token", "test-token",
+				"--endpoint", server.URL,
+				"--build-path", t.TempDir(),
+				"--acquire-job", "job-123",
+			})
+			if err == nil {
+				t.Fatal("agent start succeeded, want registration failure")
+			}
+			gotExit := 1
+			var exitErr cli.ExitCoder
+			if errors.As(err, &exitErr) {
+				gotExit = exitErr.ExitCode()
+			}
+			if gotExit != tc.wantExit {
+				t.Errorf("exit code = %d, want %d (error: %v)", gotExit, tc.wantExit, err)
+			}
+			if got := requests.Load(); got != 1 {
+				t.Errorf("requests = %d, want 1 (no retries or job acquisition)", got)
+			}
+		})
+	}
 }
 
 func TestAgentStartJobLocked_ExitCode28(t *testing.T) {

--- a/core/client.go
+++ b/core/client.go
@@ -27,8 +27,8 @@ var (
 	osVersionDump        string
 )
 
-// ErrJobAcquisitionRejected is a sentinel error used when acquisition fails because
-// the job is already acquired/started/finished/cancelled.
+// ErrJobAcquisitionRejected is a sentinel error used when acquisition or
+// registration with a job acquisition token fails because the job is unacquirable.
 var ErrJobAcquisitionRejected = errors.New("job acquisition rejected")
 
 // ErrJobLocked is a sentinel error used when acquisition fails because
@@ -269,6 +269,13 @@ func (c *Client) Register(ctx context.Context, req api.AgentRegisterRequest) (*a
 		if err != nil {
 			if !api.BreakOnNonRetryable(r, resp, err) {
 				c.Logger.Warnf("%s (%s)", err, r)
+			}
+			// JAT registration checks job eligibility before acquisition. Other
+			// registration validation errors also use 422, so match the message.
+			var apiErr *api.ErrorResponse
+			if resp != nil && resp.StatusCode == http.StatusUnprocessableEntity &&
+				errors.As(err, &apiErr) && apiErr.Message == "Job is not eligible for job acquisition registration" {
+				return registered, fmt.Errorf("%w: %w", ErrJobAcquisitionRejected, err)
 			}
 			return registered, err
 		}


### PR DESCRIPTION
## Description

An agent using a job acquisition token can be rejected during registration because its job is no longer acquirable. This currently exits with status 1, whereas rejection during job acquisition exits with status 27.

Return 27 for the registration response `422: Job is not eligible for job acquisition registration`, so callers can handle an unacquirable job consistently. Match both the status and message: invalid tokens and unrelated registration validation failures must retain their existing behavior.

## Context

Job acquisition tokens allow the API to check job eligibility before the agent reaches the acquisition request.

## Public documentation

**Status:** not needed — restores the existing unacquirable-job exit status for registration-time rejection.

## Testing

- [ ] Full suite run locally with `go test ./...`.
- [x] Changed Go files formatted with `go tool gofumpt -extra -w`.

Passed `go test ./clicommand ./core ./api ./agent` and `golangci-lint run ./core/... ./clicommand/...`.

The new regression test exercises the real CLI and HTTP client. It failed with exit 1 before the fix and passes with exit 27 afterward. It also checks unrelated 422 and invalid-token 401 responses retain exit 1, with no retries or acquisition requests.

## Rollback

Revert this commit to restore the previous registration error handling. No migrations or configuration changes.

## Disclosures / Credits

Amp implemented the fix, wrote the regression test, and ran local validation.
