### PR TITLE
Remove the agent xgboost metadata experiment

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -103,8 +103,7 @@ steps:
           config: .buildkite/docker-compose.yml
           cli-version: 2
           propagate-environment: true
-          # Mount the agent binary so the step can stash the xgboost plan
-          # identifier via `buildkite-agent meta-data set`. See TE-6071.
+          # bktec requests an OIDC token via the agent when no API token is set.
           mount-buildkite-agent: true
           run: agent
 

--- a/.buildkite/steps/collect-commit-metadata.sh
+++ b/.buildkite/steps/collect-commit-metadata.sh
@@ -3,24 +3,13 @@
 #
 # This is a metadata-only side-channel for the buildkite-agent Test Engine
 # suite. The plan output is discarded -- the existing test steps continue to
-# use their declared `parallelism:` values unchanged. The first purpose of
+# use their declared `parallelism:` values unchanged. The purpose of
 # this step is to ship commit / branch / diff metadata to the Test Engine
 # plan metadata pipeline on every build.
 #
 # See TE-5828 (and the bk/bk-rspec reference implementation in TE-5766) for
 # context. The step is soft-failed at the pipeline level so a Test Engine API
 # hiccup never blocks the build.
-#
-# Secondary purpose (TE-6071): on feature-branch builds, this step also
-# requests an xgboost-ordered test selection plan (--selection-strategy
-# xgboost --selection-param score_cutoff=0, mirroring the bk/bk-rspec
-# rspec_collect_metadata step in TE-5867). The selection request drives a
-# test-prediction inference for the buildkite-agent suite through the shared
-# `test-prediction-mme` Multi-Model Endpoint, against that suite's per-suite
-# TargetModel. Combined with the already-live bk/bk-rspec selection path,
-# this validates the MME serving multiple models for multiple suites (the
-# TE-5970 cutover goal). The plan output is still discarded -- the gotest
-# steps keep their declared `parallelism:`.
 #
 # Runs inside the `agent` docker-compose service (see
 # .buildkite/docker-compose.yml), which is a linux/amd64+arm64 golang image.
@@ -37,58 +26,9 @@ go tool test-engine-client --version
 
 echo "+++ :test_tube: Collecting git commit metadata via bktec plan (discarded)"
 
-# bktec needs a writable RESULT_PATH for plan-output config validation. It
-# is the run-results file, distinct from the plan's stdout we capture below
-# -- this file is never read.
-export BUILDKITE_TEST_ENGINE_RESULT_PATH=/tmp/bktec-plan-metadata.json
-
-# Feature-branch builds (TE-6071): also request an xgboost-ranked plan so the
-# request exercises the buildkite-agent TargetModel through the MME.
-#
-# Skipped on `main`: xgboost requires a non-empty `files_changed`. On `main`,
-# $BUILDKITE_PULL_REQUEST_BASE_BRANCH is unset and bktec falls back to
-# `origin/main`, producing an empty diff (HEAD == origin/main), which the
-# Test Engine API rejects. The metadata-only request still runs on `main`.
-# See the bk/bk-rspec rspec_collect_metadata / rspec_plan steps for the same
-# guard and the `--metadata base_branch=HEAD^` main workaround we deliberately
-# do not duplicate here (this validation is about feature-branch selection).
-#
-# `--selection-param score_cutoff=0` forces the server-side selector to admit
-# (rank) every candidate rather than capping at the default count_cutoff.
-# Mirrors the bk/bk-rspec xgboost path. Files are ranked, not filtered.
-selection_flags=()
-if [[ "${BUILDKITE_BRANCH:-}" != "main" ]]; then
-  selection_flags=(
-    --selection-strategy "xgboost"
-    --selection-param "score_cutoff=0"
-  )
-fi
-
-# `bktec plan --json` emits a JSON object to stdout of the shape:
-#   {"BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER":"<id>",
-#    "BUILDKITE_TEST_ENGINE_PARALLELISM":"<int-as-string>"}
-# Capture it so the plan identifier can be stashed as build metadata;
-# parallelism is ignored -- the gotest steps keep their declared values.
-plan_output=$(BKTEC_PREVIEW_SELECTION=1 go tool test-engine-client plan \
+# Git metadata collection still requires the client's selection preview flag.
+BKTEC_PREVIEW_SELECTION=1 go tool test-engine-client plan \
   --json \
-  --collect-git-metadata \
-  "${selection_flags[@]}")
+  --collect-git-metadata > /dev/null
 
 echo "Plan request issued -- git commit metadata sent to Test Engine."
-
-# TE-6071: when we requested an xgboost-ranked plan, stash the plan
-# identifier as build metadata so a follow-up can correlate the build with
-# the discarded plan it produced (mirrors the bk/bk-rspec
-# rspec_xgboost_plan_id metadata). Parse with ruby (present in this image;
-# jq is not) and skip silently if the field is absent -- this is a
-# measurement aid, not a build-correctness signal.
-if [[ ${#selection_flags[@]} -gt 0 ]]; then
-  plan_id="$(printf '%s' "${plan_output}" \
-    | ruby -rjson -e 'puts (JSON.parse(STDIN.read)["BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER"] rescue "")')"
-  if [[ -n "${plan_id}" ]]; then
-    buildkite-agent meta-data set "agent_xgboost_plan_id" "${plan_id}"
-    echo "Stashed xgboost plan id as build metadata: ${plan_id}"
-  else
-    echo "No plan identifier returned; skipping agent_xgboost_plan_id metadata."
-  fi
-fi


### PR DESCRIPTION
## Description

Retire the agent's discarded xgboost experiment while retaining commit metadata collection and ordinary full-suite Go tests. This does not enable Austral for agent.

The metadata command no longer requests xgboost/score_cutoff=0 or records `agent_xgboost_plan_id`. Keep the client's preview flag because v3.0.0 also gates `--collect-git-metadata` behind it, and keep the agent mount for OIDC fallback when no API token is set. Test steps and parallelism are unchanged.

## Context

Fixes [TE-7092](https://linear.app/buildkite/issue/TE-7092), part of [TE-7090](https://linear.app/buildkite/issue/TE-7090).

## Public documentation

**Status:** not needed

## Testing

- [x] Tests have run locally (with `go test ./...`).
- [x] Code is formatted (`go tool gofumpt -extra -l .` returned no files; no Go changes).

Main, feature, and unset-branch command capture passed, including discarded JSON, retained stderr, no plan-ID writes, and nonzero exit propagation. Bash syntax, ShellCheck, and YAML parsing passed; parsed pipeline configuration is identical to `origin/main`. Oracle reviewed the implementation before opening; no blockers remained.

## Disclosures / Credits

Amp implemented and validated this change, with Oracle review.
