### PR TITLE
Avoid blob filtering sparse reference-mirror checkouts

### DIFF
--- a/internal/job/checkout.go
+++ b/internal/job/checkout.go
@@ -439,6 +439,7 @@ func (e *Executor) defaultCheckoutPhase(ctx context.Context, previousAttempts in
 
 	addBloblessFilter := sparse.active() &&
 		e.shell.Env.GetString("BUILDKITE_KUBERNETES_EXEC", "") != "true" &&
+		!e.usesOnHostReferenceMirror(mirrorDir) &&
 		!userSuppliedCloneFilter &&
 		!hasPartialFilterFlags(gitFetchFlags)
 	if err := e.fetchSource(ctx, addBloblessFilter, &attempt); err != nil {

--- a/internal/job/checkout_workdir.go
+++ b/internal/job/checkout_workdir.go
@@ -86,11 +86,16 @@ func (e *Executor) prepareCheckoutWorkdir(
 		}
 		if userSuppliedCloneFilter {
 			e.shell.Commentf("Sparse checkout is configured and BUILDKITE_GIT_CLONE_FLAGS already contains a --filter (preserving user-supplied filter).")
-		} else if e.shell.Env.GetString("BUILDKITE_KUBERNETES_EXEC", "") != "true" {
+		} else if e.shell.Env.GetString("BUILDKITE_KUBERNETES_EXEC", "") != "true" &&
+			!e.usesOnHostReferenceMirror(mirrorDir) {
 			// Kubernetes checkout and command phases can run in separate
 			// containers, with Git credentials available only during checkout.
 			// Avoid creating a promisor clone that may try to fetch missing
 			// objects after the checkout container has exited.
+			//
+			// A reference clone already reads objects from the on-host mirror
+			// through alternates. Combining --filter with --reference provides
+			// no transfer savings and can make Git repack referenced objects.
 			gitCloneFlags = append(gitCloneFlags, "--filter=blob:none")
 		}
 	}
@@ -206,6 +211,10 @@ func (e *Executor) prepareCheckoutWorkdir(
 		return fmt.Errorf("cloning git repository: %w", err)
 	}
 	return nil
+}
+
+func (e *Executor) usesOnHostReferenceMirror(mirrorDir string) bool {
+	return mirrorDir != "" && e.GitMirrorCheckoutMode == "reference"
 }
 
 func isFreshCloneRemoteMirrorAttempt(attempt *remoteMirrorAttempt) bool {

--- a/internal/job/integration/checkout_git_mirrors_integration_test.go
+++ b/internal/job/integration/checkout_git_mirrors_integration_test.go
@@ -158,6 +158,59 @@ func TestCheckingOutLocalGitProjectWithSparseCheckoutInKubernetesWithGitMirrors(
 	requireGitConfigAbsent(t, tester.CheckoutDir(), "remote.origin.partialclonefilter")
 }
 
+func TestCheckingOutLocalGitProjectWithSparseCheckoutWithReferenceGitMirrors(t *testing.T) {
+	t.Parallel()
+	skipIfGitSparseCheckoutUnsupported(t)
+
+	tester, err := NewExecutorTester(mainCtx)
+	if err != nil {
+		t.Fatalf("NewExecutorTester() error = %v", err)
+	}
+	defer tester.Close()
+	addSparseCheckoutFixture(t, tester.Repo)
+
+	if err := tester.EnableGitMirrors(); err != nil {
+		t.Fatalf("EnableGitMirrors() error = %v", err)
+	}
+
+	env := []string{
+		"BUILDKITE_GIT_CLONE_FLAGS=-v",
+		"BUILDKITE_GIT_CLONE_MIRROR_FLAGS=--bare",
+		"BUILDKITE_GIT_CLEAN_FLAGS=-fdq",
+		"BUILDKITE_GIT_FETCH_FLAGS=-v",
+		"BUILDKITE_GIT_SPARSE_CHECKOUT_PATHS=.buildkite/,src/",
+		"BUILDKITE_GIT_MIRROR_CHECKOUT_MODE=reference",
+	}
+
+	git := tester.
+		MustMock(t, "git").
+		PassthroughToLocalCommand()
+
+	git.ExpectAll([][]any{
+		{"clone", "--mirror", "--bare", "--", tester.Repo.Path, matchSubDir(tester.GitMirrorsDir)},
+		{"--version"},
+		{"clone", "-v", "--reference", matchSubDir(tester.GitMirrorsDir), "--sparse", "--", tester.Repo.Path, "."},
+		{"clean", "-fdq"},
+		{"fetch", "-v", "--", "origin", "main"},
+		{"sparse-checkout", "set", "--cone", "--", ".buildkite/", "src/"},
+		{"-c", "advice.detachedHead=false", "checkout", "-f", "FETCH_HEAD"},
+		{"clean", "-fdq"},
+		{"rev-parse", "HEAD"},
+		{"--no-pager", "log", "-1", "HEAD", "-s", "--no-color", gitShowFormatArg},
+	})
+
+	agent := tester.MockAgent(t)
+	agent.Expect("meta-data", "exists", job.CommitMetadataKey).AndExitWith(1)
+	agent.Expect("meta-data", "set", job.CommitMetadataKey).WithStdin(commitPattern)
+
+	tester.RunAndCheck(t, env...)
+	requireCheckoutPath(t, tester.CheckoutDir(), ".buildkite/pipeline.yml", true)
+	requireCheckoutPath(t, tester.CheckoutDir(), "src/main.txt", true)
+	requireCheckoutPath(t, tester.CheckoutDir(), "docs/readme.md", false)
+	requireGitConfigAbsent(t, tester.CheckoutDir(), "remote.origin.promisor")
+	requireGitConfigAbsent(t, tester.CheckoutDir(), "remote.origin.partialclonefilter")
+}
+
 func TestCheckingOutLocalGitProjectWithSparseCheckoutNoCone_WithGitMirrors(t *testing.T) {
 	t.Parallel()
 	skipIfGitSparseCheckoutNoConeUnsupported(t)


### PR DESCRIPTION
## Description

Avoid automatically adding `--filter=blob:none` to sparse clones and fetches that use an on-host mirror in `reference` mode.

A reference clone already reads objects from the mirror through Git alternates. Combining the automatic blobless filter with `--reference` can instead force expensive local object processing without reducing the transfer from the canonical repository.

This keeps the existing behavior for remote mirrors, checkouts without a mirror, and `dissociate` mode. User-supplied clone and fetch filters are still preserved.

## Context

We observed this on a large monorepo with agent v3.137.0. A sparse reference clone transferred about 596 KiB, then locally enumerated 1,500,947 objects and compressed 353,810 objects. The checkout took 11m45s. A full reference-mirror checkout on the same pipeline and agent fleet completed in about 21s.

## Changes

- Suppress the agent-added blobless filter for sparse on-host reference-mirror clones and fetches.
- Add an integration regression that exercises a real sparse reference checkout and verifies that it is not configured as a promisor clone.

## Public documentation

**Status:** not needed

## Testing

- [x] Tests have run locally. `go test ./internal/job/...` passes. `go test ./...` passed every package except one unrelated macOS temp-directory cleanup failure in `clicommand`; that individual failing test passed immediately when rerun.
- [x] Code is formatted (with `go tool gofumpt -extra -w .`)

## Affiliation (optional, external contributors)

Owner.com

## Disclosures / Credits

OpenAI Codex helped investigate the production checkout, implement the change, and write the regression test. I reviewed the diff and ran the tests locally.
